### PR TITLE
Cut runtime reads over to recipe-backed sources

### DIFF
--- a/packages/control-plane/src/runtime/executor-tools.ts
+++ b/packages/control-plane/src/runtime/executor-tools.ts
@@ -8,6 +8,7 @@ import {
   type ToolPath,
 } from "@executor/codemode-core";
 import {
+  type AccountId,
   ExecutionIdSchema,
   ExecutionInteractionIdSchema,
   SourceSchema,
@@ -235,6 +236,7 @@ const promptForSourceCredentialSelection = (input: {
 
 export const createExecutorToolMap = (input: {
   workspaceId: WorkspaceId;
+  accountId: AccountId;
   sourceAuthService: RuntimeSourceAuthService;
 }): ToolMap => ({
   "executor.sources.add": toTool({
@@ -274,6 +276,7 @@ export const createExecutorToolMap = (input: {
             ? {
               ...args,
               workspaceId: input.workspaceId,
+              actorAccountId: input.accountId,
               executionId,
               interactionId,
             }
@@ -283,6 +286,7 @@ export const createExecutorToolMap = (input: {
               name: args.name ?? null,
               namespace: args.namespace ?? null,
               workspaceId: input.workspaceId,
+              actorAccountId: input.accountId,
               executionId,
               interactionId,
             };
@@ -389,6 +393,7 @@ export const createExecutorToolMap = (input: {
           input.sourceAuthService.getSourceById({
             workspaceId: input.workspaceId,
             sourceId: result.source.id,
+            actorAccountId: input.accountId,
           }),
         );
       },

--- a/packages/control-plane/src/runtime/source-inspection.ts
+++ b/packages/control-plane/src/runtime/source-inspection.ts
@@ -2,7 +2,6 @@ import { typeSignatureFromSchemaJson } from "@executor/codemode-core";
 import {
   buildOpenApiToolPresentation,
   compileOpenApiToolDefinitions,
-  extractOpenApiManifest,
   openApiOutputTypeSignatureFromSchemaJson,
   type OpenApiToolDefinition,
   type OpenApiToolManifest,
@@ -16,7 +15,6 @@ import type {
   SourceInspectionDiscoverResultItem,
   SourceInspectionToolDetail,
   SourceInspectionToolSummary,
-  StoredSourceRecord,
   WorkspaceId,
 } from "#schema";
 import {
@@ -31,12 +29,16 @@ import { formatJsonIfNeeded, formatWithPrettier } from "./prettier-format";
 import {
   buildGraphqlToolPresentation,
   compileGraphqlToolDefinitions,
-  extractGraphqlManifest,
   type GraphqlToolDefinition,
   type GraphqlToolManifest,
 } from "./graphql-tools";
-import { loadSourceById as loadStoredSourceById } from "./source-store";
-import { ControlPlaneStore, type ControlPlaneStoreShape } from "./store";
+import {
+  loadSourceRecipe,
+  recipePrimaryDocumentText,
+  recipeToolPath,
+  type LoadedSourceRecipe,
+} from "./source-recipes-runtime";
+import { ControlPlaneStore } from "./store";
 import { namespaceFromSourceName } from "./tool-artifacts";
 
 const sourceInspectOps = {
@@ -133,7 +135,18 @@ const formatInspectionToolRecord = (record: InspectionToolRecord) =>
     } satisfies InspectionToolRecord;
   });
 
-const loadSourceRecord = (input: {
+const loadStoredDocumentText = (recipe: LoadedSourceRecipe) => {
+  const rawDocumentText = recipePrimaryDocumentText({
+    source: recipe.source,
+    documents: recipe.documents,
+  });
+
+  return rawDocumentText === null
+    ? Effect.succeed<string | null>(null)
+    : Effect.promise(() => formatJsonIfNeeded(rawDocumentText));
+};
+
+const loadSourceRecipeRecord = (input: {
   workspaceId: WorkspaceId;
   sourceId: SourceId;
 }) =>
@@ -151,78 +164,69 @@ const loadSourceRecord = (input: {
         );
       }
 
-      const source = yield* loadStoredSourceById(store, {
+      const recipe = yield* loadSourceRecipe({
+        rows: store,
         workspaceId: input.workspaceId,
         sourceId: input.sourceId,
       }).pipe(
         Effect.mapError((cause) =>
           sourceInspectOps.bundle.unknownStorage(
             cause,
-            "Failed projecting stored source",
+            "Failed loading source recipe",
           ),
         ),
       );
 
       return {
         store,
-        source,
         sourceRecord: sourceRecord.value,
+        recipe,
       };
     }),
   );
 
-const persistedToolSummaryFromArtifact = (input: {
+const persistedToolSummaryFromRecipeOperation = (input: {
   source: Source;
-  artifact: {
-    path: string;
-    toolId: string;
-    title: string | null;
-    description: string | null;
-    providerKind: string;
-    openApiRawToolId: string | null;
-    openApiOperationId: string | null;
-    openApiTagsJson: string | null;
-    openApiMethod: SourceInspectionToolSummary["method"];
-    openApiPathTemplate: string | null;
-    inputSchemaJson: string | null;
-    outputSchemaJson: string | null;
-  };
+  operation: LoadedSourceRecipe["operations"][number];
 }): SourceInspectionToolSummary => ({
-  path: input.artifact.path,
+  path: recipeToolPath({
+    source: input.source,
+    operation: input.operation,
+  }),
   sourceKey: input.source.id,
-  ...(input.artifact.title ? { title: input.artifact.title } : {}),
-  ...(input.artifact.description ? { description: input.artifact.description } : {}),
-  providerKind: input.artifact.providerKind,
-  toolId: input.artifact.toolId,
-  rawToolId: input.artifact.openApiRawToolId,
-  operationId: input.artifact.openApiOperationId,
+  ...(input.operation.title ? { title: input.operation.title } : {}),
+  ...(input.operation.description ? { description: input.operation.description } : {}),
+  providerKind: input.operation.providerKind,
+  toolId: input.operation.toolId,
+  rawToolId: input.operation.openApiRawToolId,
+  operationId: input.operation.graphqlOperationName ?? input.operation.openApiOperationId,
   group: null,
   leaf: null,
-  tags: input.artifact.openApiTagsJson
-    ? ((JSON.parse(input.artifact.openApiTagsJson) as Array<string>) ?? [])
+  tags: input.operation.openApiTagsJson
+    ? ((JSON.parse(input.operation.openApiTagsJson) as Array<string>) ?? [])
     : [],
-  method: input.artifact.openApiMethod,
-  pathTemplate: input.artifact.openApiPathTemplate,
-  ...(input.artifact.inputSchemaJson
+  method: input.operation.openApiMethod,
+  pathTemplate: input.operation.openApiPathTemplate,
+  ...(input.operation.inputSchemaJson
     ? {
         inputType: typeSignatureFromSchemaJson(
-          input.artifact.inputSchemaJson,
+          input.operation.inputSchemaJson,
           "unknown",
           Infinity,
         ),
       }
     : {}),
-  ...(input.artifact.providerKind === "openapi"
+  ...(input.operation.providerKind === "openapi"
     ? {
         outputType: openApiOutputTypeSignatureFromSchemaJson(
-          input.artifact.outputSchemaJson ?? undefined,
+          input.operation.outputSchemaJson ?? undefined,
           Infinity,
         ),
       }
-    : input.artifact.outputSchemaJson
+    : input.operation.outputSchemaJson
       ? {
           outputType: typeSignatureFromSchemaJson(
-            input.artifact.outputSchemaJson,
+            input.operation.outputSchemaJson,
             "unknown",
             Infinity,
           ),
@@ -323,21 +327,15 @@ const graphqlToolRecord = (input: {
 };
 
 const loadPersistedInspection = (input: {
-  store: ControlPlaneStoreShape;
-  source: Source;
+  recipe: LoadedSourceRecipe;
 }): Effect.Effect<ResolvedSourceInspection, Error, never> =>
   Effect.gen(function* () {
-    const artifacts = yield* sourceInspectOps.bundle.child("artifacts").mapStorage(
-      input.store.toolArtifacts.listByWorkspaceId(input.source.workspaceId, {
-        sourceId: input.source.id,
-        limit: 1000,
-      }),
-    );
-    const namespace = input.source.namespace ?? namespaceFromSourceName(input.source.name);
-    const tools = yield* Effect.forEach(artifacts, (artifact) => {
-      const summary = persistedToolSummaryFromArtifact({
-        source: input.source,
-        artifact,
+    const namespace =
+      input.recipe.source.namespace ?? namespaceFromSourceName(input.recipe.source.name);
+    const tools = yield* Effect.forEach(input.recipe.operations, (operation) => {
+      const summary = persistedToolSummaryFromRecipeOperation({
+        source: input.recipe.source,
+        operation,
       });
       return formatInspectionToolRecord({
         summary,
@@ -345,70 +343,60 @@ const loadPersistedInspection = (input: {
           summary,
           definitionJson: null,
           documentationJson: null,
-          providerDataJson: null,
-          inputSchemaJson: artifact.inputSchemaJson,
-          outputSchemaJson: artifact.outputSchemaJson,
+          providerDataJson: operation.providerDataJson,
+          inputSchemaJson: operation.inputSchemaJson,
+          outputSchemaJson: operation.outputSchemaJson,
           exampleInputJson: null,
           exampleOutputJson: null,
         },
         searchText: searchTextFromSummary(summary),
       } satisfies InspectionToolRecord);
     });
+    const rawDocumentText = yield* loadStoredDocumentText(input.recipe);
+    const manifestJson = yield* formatOptionalJson(input.recipe.revision.manifestJson);
 
     return {
-      source: input.source,
+      source: input.recipe.source,
       namespace,
       pipelineKind: "persisted",
-      rawDocumentText: null,
-      manifestJson: null,
+      rawDocumentText,
+      manifestJson,
       definitionsJson: null,
       tools,
     } satisfies ResolvedSourceInspection;
   });
 
 const loadOpenApiInspection = (input: {
-  source: Source;
-  sourceRecord: StoredSourceRecord;
+  recipe: LoadedSourceRecipe;
 }): Effect.Effect<ResolvedSourceInspection, Error, never> =>
   Effect.gen(function* () {
-    const rawDocumentText = input.sourceRecord.sourceDocumentText;
-    if (!rawDocumentText) {
-      return yield* Effect.fail(new Error("Missing stored OpenAPI document"));
+    if (input.recipe.manifest === null) {
+      return yield* Effect.fail(new Error("Missing stored OpenAPI manifest"));
     }
 
-    const manifest = yield* extractOpenApiManifest(
-      input.source.name,
-      rawDocumentText,
-    ).pipe(
-      Effect.mapError((cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
-      ),
-    );
+    const manifest = input.recipe.manifest as OpenApiToolManifest;
     const definitions = compileOpenApiToolDefinitions(manifest);
-    const namespace = input.source.namespace ?? namespaceFromSourceName(input.source.name);
+    const namespace =
+      input.recipe.source.namespace ?? namespaceFromSourceName(input.recipe.source.name);
     const tools = yield* Effect.forEach(definitions, (definition) =>
       formatInspectionToolRecord(openApiToolRecord({
-        source: input.source,
+        source: input.recipe.source,
         namespace,
         manifest,
         definition,
       })),
     );
-    const manifestJson = yield* Effect.promise(() =>
-      formatWithPrettier(asPrettyJson(manifest), "json"),
-    );
+    const manifestJson = yield* formatOptionalJson(input.recipe.revision.manifestJson);
     const definitionsJson = yield* Effect.promise(() =>
       formatWithPrettier(asPrettyJson(definitions), "json"),
     );
-    const formattedRawDocumentText = yield* Effect.promise(() =>
-      formatJsonIfNeeded(rawDocumentText),
-    );
+    const rawDocumentText = yield* loadStoredDocumentText(input.recipe);
 
     return {
-      source: input.source,
+      source: input.recipe.source,
       namespace,
       pipelineKind: "openapi",
-      rawDocumentText: formattedRawDocumentText,
+      rawDocumentText,
       manifestJson,
       definitionsJson,
       tools,
@@ -416,48 +404,36 @@ const loadOpenApiInspection = (input: {
   });
 
 const loadGraphqlInspection = (input: {
-  source: Source;
-  sourceRecord: StoredSourceRecord;
+  recipe: LoadedSourceRecipe;
 }): Effect.Effect<ResolvedSourceInspection, Error, never> =>
   Effect.gen(function* () {
-    const rawDocumentText = input.sourceRecord.sourceDocumentText;
-    if (!rawDocumentText) {
-      return yield* Effect.fail(new Error("Missing stored GraphQL document"));
+    if (input.recipe.manifest === null) {
+      return yield* Effect.fail(new Error("Missing stored GraphQL manifest"));
     }
 
-    const manifest = yield* extractGraphqlManifest(
-      input.source.name,
-      rawDocumentText,
-    ).pipe(
-      Effect.mapError((cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
-      ),
-    );
+    const manifest = input.recipe.manifest as GraphqlToolManifest;
     const definitions = compileGraphqlToolDefinitions(manifest);
-    const namespace = input.source.namespace ?? namespaceFromSourceName(input.source.name);
+    const namespace =
+      input.recipe.source.namespace ?? namespaceFromSourceName(input.recipe.source.name);
     const tools = yield* Effect.forEach(definitions, (definition) =>
       formatInspectionToolRecord(graphqlToolRecord({
-        source: input.source,
+        source: input.recipe.source,
         namespace,
         manifest,
         definition,
       })),
     );
-    const manifestJson = yield* Effect.promise(() =>
-      formatWithPrettier(asPrettyJson(manifest), "json"),
-    );
+    const manifestJson = yield* formatOptionalJson(input.recipe.revision.manifestJson);
     const definitionsJson = yield* Effect.promise(() =>
       formatWithPrettier(asPrettyJson(definitions), "json"),
     );
-    const formattedRawDocumentText = yield* Effect.promise(() =>
-      formatJsonIfNeeded(rawDocumentText),
-    );
+    const rawDocumentText = yield* loadStoredDocumentText(input.recipe);
 
     return {
-      source: input.source,
+      source: input.recipe.source,
       namespace,
       pipelineKind: "graphql",
-      rawDocumentText: formattedRawDocumentText,
+      rawDocumentText,
       manifestJson,
       definitionsJson,
       tools,
@@ -469,39 +445,34 @@ const resolveSourceInspection = (input: {
   sourceId: SourceId;
 }) =>
   Effect.gen(function* () {
-    const { store, source, sourceRecord } = yield* loadSourceRecord(input);
+    const { recipe } = yield* loadSourceRecipeRecord(input);
 
-    if (source.kind === "openapi" && sourceRecord.sourceDocumentText) {
+    if (recipe.source.kind === "openapi" && recipe.manifest !== null) {
       return yield* loadOpenApiInspection({
-        source,
-        sourceRecord,
+        recipe,
       }).pipe(
         Effect.catchAll(() =>
           loadPersistedInspection({
-            store,
-            source,
+            recipe,
           }),
         ),
       );
     }
 
-    if (source.kind === "graphql" && sourceRecord.sourceDocumentText) {
+    if (recipe.source.kind === "graphql" && recipe.manifest !== null) {
       return yield* loadGraphqlInspection({
-        source,
-        sourceRecord,
+        recipe,
       }).pipe(
         Effect.catchAll(() =>
           loadPersistedInspection({
-            store,
-            source,
+            recipe,
           }),
         ),
       );
     }
 
     return yield* loadPersistedInspection({
-      store,
-      source,
+      recipe,
     });
   });
 

--- a/packages/control-plane/src/runtime/source-recipes-runtime.test.ts
+++ b/packages/control-plane/src/runtime/source-recipes-runtime.test.ts
@@ -1,0 +1,671 @@
+import { describe, expect, it } from "vitest";
+import * as Effect from "effect/Effect";
+import {
+  buildOpenApiToolPresentation,
+  compileOpenApiToolDefinitions,
+  extractOpenApiManifest,
+} from "@executor/codemode-openapi";
+
+import {
+  AccountIdSchema,
+  OrganizationIdSchema,
+  SourceIdSchema,
+  SourceRecipeIdSchema,
+  SourceRecipeRevisionIdSchema,
+  WorkspaceIdSchema,
+  type Source,
+  type StoredSourceRecipeOperationRecord,
+} from "#schema";
+import {
+  createSqlControlPlanePersistence,
+  type SqlControlPlanePersistence,
+} from "#persistence";
+
+import {
+  expandRecipeTools,
+  loadSourceRecipe,
+  loadWorkspaceSourceRecipes,
+  recipeToolDescriptor,
+  recipeToolPath,
+  recipeToolSearchNamespace,
+  type LoadedSourceRecipe,
+} from "./source-recipes-runtime";
+
+const makePersistence = () =>
+  Effect.runPromise(
+    createSqlControlPlanePersistence({
+      localDataDir: ":memory:",
+    }),
+  );
+
+const makeSource = (overrides: Partial<Source> = {}): Source => ({
+  id: SourceIdSchema.make("src_runtime_recipe"),
+  workspaceId: WorkspaceIdSchema.make("ws_runtime_recipe"),
+  name: "GitHub",
+  kind: "openapi",
+  endpoint: "https://api.github.com",
+  status: "connected",
+  enabled: true,
+  namespace: "github",
+  transport: null,
+  queryParams: null,
+  headers: null,
+  specUrl: "https://api.github.com/openapi.json",
+  defaultHeaders: null,
+  auth: { kind: "none" },
+  sourceHash: null,
+  lastError: null,
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+const makeOperation = (
+  overrides: Partial<StoredSourceRecipeOperationRecord> = {},
+): StoredSourceRecipeOperationRecord => ({
+  id: "src_recipe_op_runtime",
+  recipeRevisionId: SourceRecipeRevisionIdSchema.make("src_recipe_rev_runtime"),
+  operationKey: "getRepo",
+  transportKind: "http",
+  toolId: "getRepo",
+  title: "Get Repo",
+  description: "Read a repository",
+  operationKind: "read",
+  searchText: "get repo github",
+  inputSchemaJson: JSON.stringify({
+    type: "object",
+    additionalProperties: false,
+  }),
+  outputSchemaJson: JSON.stringify({
+    type: "object",
+    properties: {
+      full_name: { type: "string" },
+    },
+  }),
+  providerKind: "openapi",
+  providerDataJson: JSON.stringify({
+    kind: "openapi",
+  }),
+  mcpToolName: null,
+  openApiMethod: "get",
+  openApiPathTemplate: "/repos/{owner}/{repo}",
+  openApiOperationHash: "hash",
+  openApiRawToolId: "repos_getRepo",
+  openApiOperationId: "repos.getRepo",
+  openApiTagsJson: JSON.stringify(["repos"]),
+  openApiRequestBodyRequired: null,
+  graphqlOperationType: null,
+  graphqlOperationName: null,
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+const seedWorkspace = async (input: {
+  persistence: SqlControlPlanePersistence;
+  workspaceId: ReturnType<typeof WorkspaceIdSchema.make>;
+  organizationId: ReturnType<typeof OrganizationIdSchema.make>;
+  accountId: ReturnType<typeof AccountIdSchema.make>;
+}) => {
+  const now = 1000;
+  await Effect.runPromise(input.persistence.rows.organizations.insert({
+    id: input.organizationId,
+    slug: `org-${input.organizationId}`,
+    name: `Org ${input.organizationId}`,
+    status: "active",
+    createdByAccountId: input.accountId,
+    createdAt: now,
+    updatedAt: now,
+  }));
+  await Effect.runPromise(input.persistence.rows.workspaces.insert({
+    id: input.workspaceId,
+    organizationId: input.organizationId,
+    name: `Workspace ${input.workspaceId}`,
+    createdByAccountId: input.accountId,
+    createdAt: now,
+    updatedAt: now,
+  }));
+};
+
+describe("source-recipes-runtime", () => {
+  describe("recipe tool helpers", () => {
+    it("derives tool paths from explicit and implicit namespaces", () => {
+      const source = makeSource();
+      const operation = makeOperation();
+
+      expect(recipeToolPath({
+        source,
+        operation,
+      })).toBe("github.getRepo");
+      expect(recipeToolPath({
+        source: makeSource({
+          namespace: null,
+          name: "My GitHub",
+        }),
+        operation,
+      })).toBe("my.github.getRepo");
+      expect(recipeToolPath({
+        source: makeSource({
+          namespace: "",
+        }),
+        operation,
+      })).toBe("getRepo");
+    });
+
+    it("derives search namespaces from path segments and graphql namespaces", () => {
+      const openApiSource = makeSource();
+      const graphqlSource = makeSource({
+        kind: "graphql",
+        endpoint: "https://example.com/graphql",
+        specUrl: null,
+        namespace: "issues",
+      });
+
+      expect(recipeToolSearchNamespace({
+        source: openApiSource,
+        path: "github.getRepo",
+        operation: makeOperation(),
+      })).toBe("github.getRepo");
+      expect(recipeToolSearchNamespace({
+        source: openApiSource,
+        path: "a.b.c",
+        operation: makeOperation(),
+      })).toBe("a.b");
+      expect(recipeToolSearchNamespace({
+        source: graphqlSource,
+        path: "ignored.path",
+        operation: makeOperation({
+          providerKind: "graphql",
+          transportKind: "graphql",
+          openApiMethod: null,
+          graphqlOperationType: "query",
+          graphqlOperationName: "viewer",
+        }),
+      })).toBe("issues");
+    });
+
+    it("computes interaction modes and descriptor fields correctly", () => {
+      expect(recipeToolDescriptor({
+        source: makeSource(),
+        operation: makeOperation({
+          openApiMethod: "get",
+        }),
+        path: "github.getRepo",
+        includeSchemas: true,
+      }).interaction).toBe("auto");
+
+      expect(recipeToolDescriptor({
+        source: makeSource(),
+        operation: makeOperation({
+          openApiMethod: "delete",
+        }),
+        path: "github.deleteRepo",
+        includeSchemas: true,
+      }).interaction).toBe("required");
+
+      expect(recipeToolDescriptor({
+        source: makeSource({
+          kind: "graphql",
+          endpoint: "https://example.com/graphql",
+          specUrl: null,
+        }),
+        operation: makeOperation({
+          providerKind: "graphql",
+          transportKind: "graphql",
+          openApiMethod: null,
+          graphqlOperationType: "query",
+          graphqlOperationName: "viewer",
+        }),
+        path: "graphql.viewer",
+        includeSchemas: true,
+      }).interaction).toBe("auto");
+
+      expect(recipeToolDescriptor({
+        source: makeSource({
+          kind: "graphql",
+          endpoint: "https://example.com/graphql",
+          specUrl: null,
+        }),
+        operation: makeOperation({
+          providerKind: "graphql",
+          transportKind: "graphql",
+          openApiMethod: null,
+          graphqlOperationType: "mutation",
+          graphqlOperationName: "createIssue",
+        }),
+        path: "graphql.createIssue",
+        includeSchemas: true,
+      }).interaction).toBe("required");
+
+      expect(recipeToolDescriptor({
+        source: makeSource({
+          kind: "mcp",
+          endpoint: "https://example.com/mcp",
+          specUrl: null,
+          transport: "streamable-http",
+        }),
+        operation: makeOperation({
+          providerKind: "mcp",
+          transportKind: "mcp",
+          openApiMethod: null,
+          openApiPathTemplate: null,
+          openApiOperationHash: null,
+          openApiRawToolId: null,
+          openApiOperationId: null,
+          openApiTagsJson: null,
+          mcpToolName: "echo",
+        }),
+        path: "mcp.echo",
+        includeSchemas: true,
+      }).interaction).toBe("auto");
+
+      const descriptor = recipeToolDescriptor({
+        source: makeSource(),
+        operation: makeOperation({
+          description: null,
+          title: "Fallback Title",
+          providerDataJson: null,
+        }),
+        path: "github.getRepo",
+        includeSchemas: false,
+      });
+
+      expect(descriptor.description).toBe("Fallback Title");
+      expect(descriptor.inputSchemaJson).toBeUndefined();
+      expect(descriptor.outputSchemaJson).toBeUndefined();
+      expect(descriptor).not.toHaveProperty("providerDataJson");
+    });
+
+    it("expands recipes into lower-cased searchable tools and handles empty operation sets", () => {
+      const recipe: LoadedSourceRecipe = {
+        source: makeSource({
+          name: "GITHUB API",
+        }),
+        sourceRecord: {
+          id: SourceIdSchema.make("src_runtime_recipe"),
+          workspaceId: WorkspaceIdSchema.make("ws_runtime_recipe"),
+          recipeId: SourceRecipeIdSchema.make("src_recipe_runtime"),
+          recipeRevisionId: SourceRecipeRevisionIdSchema.make("src_recipe_rev_runtime"),
+          name: "GITHUB API",
+          kind: "openapi",
+          endpoint: "https://api.github.com",
+          status: "connected",
+          enabled: true,
+          namespace: "github",
+          bindingConfigJson: null,
+          transport: null,
+          queryParamsJson: null,
+          headersJson: null,
+          specUrl: "https://api.github.com/openapi.json",
+          defaultHeadersJson: null,
+          sourceHash: null,
+          sourceDocumentText: null,
+          lastError: null,
+          createdAt: 1000,
+          updatedAt: 1000,
+        },
+        revision: {
+          id: SourceRecipeRevisionIdSchema.make("src_recipe_rev_runtime"),
+          recipeId: SourceRecipeIdSchema.make("src_recipe_runtime"),
+          revisionNumber: 1,
+          sourceConfigJson: "{}",
+          manifestJson: null,
+          manifestHash: null,
+          createdAt: 1000,
+          updatedAt: 1000,
+        },
+        documents: [],
+        operations: [makeOperation({
+          searchText: "",
+        })],
+        manifest: null,
+      };
+
+      const expanded = expandRecipeTools({
+        recipes: [recipe],
+        includeSchemas: false,
+      });
+      expect(expanded).toHaveLength(1);
+      expect(expanded[0]?.searchText).toBe("github.getrepo github.getrepo github api");
+
+      expect(expandRecipeTools({
+        recipes: [{
+          ...recipe,
+          operations: [],
+        }],
+        includeSchemas: false,
+      })).toEqual([]);
+    });
+  });
+
+  describe("recipe loading", () => {
+    it("loads multiple sources sharing the same recipe revision", async () => {
+      const persistence = await makePersistence();
+      try {
+        const workspaceId = WorkspaceIdSchema.make("ws_shared_revision");
+        const organizationId = OrganizationIdSchema.make("org_shared_revision");
+        const accountId = AccountIdSchema.make("acc_shared_revision");
+        const recipeId = SourceRecipeIdSchema.make("src_recipe_shared_revision");
+        const recipeRevisionId = SourceRecipeRevisionIdSchema.make("src_recipe_rev_shared_revision");
+        const openApiDocument = JSON.stringify({
+          openapi: "3.0.3",
+          info: {
+            title: "GitHub",
+            version: "1.0.0",
+          },
+          paths: {
+            "/repos/{owner}/{repo}": {
+              get: {
+                operationId: "repos.getRepo",
+                parameters: [
+                  {
+                    name: "owner",
+                    in: "path",
+                    required: true,
+                    schema: { type: "string" },
+                  },
+                  {
+                    name: "repo",
+                    in: "path",
+                    required: true,
+                    schema: { type: "string" },
+                  },
+                ],
+                responses: {
+                  200: {
+                    description: "ok",
+                  },
+                },
+              },
+            },
+          },
+        });
+        const manifest = await Effect.runPromise(extractOpenApiManifest("GitHub", openApiDocument));
+        const definition = compileOpenApiToolDefinitions(manifest)[0]!;
+        const presentation = buildOpenApiToolPresentation({
+          manifest,
+          definition,
+        });
+
+        await seedWorkspace({
+          persistence,
+          workspaceId,
+          organizationId,
+          accountId,
+        });
+        await Effect.runPromise(persistence.rows.sourceRecipes.upsert({
+          id: recipeId,
+          kind: "http_recipe",
+          importerKind: "openapi",
+          providerKey: "generic_http",
+          name: "GitHub",
+          summary: null,
+          visibility: "workspace",
+          latestRevisionId: recipeRevisionId,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+        await Effect.runPromise(persistence.rows.sourceRecipeRevisions.upsert({
+          id: recipeRevisionId,
+          recipeId,
+          revisionNumber: 1,
+          sourceConfigJson: JSON.stringify({
+            kind: "openapi",
+            endpoint: "https://api.github.com",
+            specUrl: "https://api.github.com/openapi.json",
+            defaultHeaders: null,
+          }),
+          manifestJson: JSON.stringify(manifest),
+          manifestHash: manifest.sourceHash,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+        await Effect.runPromise(persistence.rows.sourceRecipeDocuments.replaceForRevision({
+          recipeRevisionId,
+          documents: [{
+            id: "src_recipe_doc_shared_revision",
+            recipeRevisionId,
+            documentKind: "openapi",
+            documentKey: "https://api.github.com/openapi.json",
+            contentText: openApiDocument,
+            contentHash: manifest.sourceHash,
+            fetchedAt: 1000,
+            createdAt: 1000,
+            updatedAt: 1000,
+          }],
+        }));
+        await Effect.runPromise(persistence.rows.sourceRecipeOperations.replaceForRevision({
+          recipeRevisionId,
+          operations: [makeOperation({
+            id: "src_recipe_op_shared_revision",
+            recipeRevisionId,
+            operationKey: definition.toolId,
+            toolId: definition.toolId,
+            title: definition.name,
+            description: definition.description,
+            searchText: `${definition.toolId} ${definition.name}`.toLowerCase(),
+            inputSchemaJson: presentation.inputSchemaJson ?? null,
+            outputSchemaJson: presentation.outputSchemaJson ?? null,
+            providerDataJson: presentation.providerDataJson,
+            openApiMethod: definition.method,
+            openApiPathTemplate: definition.path,
+            openApiOperationHash: definition.operationHash,
+            openApiRawToolId: definition.rawToolId,
+            openApiOperationId: definition.operationId ?? null,
+            openApiTagsJson: JSON.stringify(definition.tags),
+            openApiRequestBodyRequired: definition.invocation.requestBody?.required ?? null,
+          })],
+        }));
+
+        for (const [index, name] of ["GitHub One", "GitHub Two"].entries()) {
+          await Effect.runPromise(persistence.rows.sources.insert({
+            id: SourceIdSchema.make(`src_shared_revision_${index}`),
+            workspaceId,
+            recipeId,
+            recipeRevisionId,
+            name,
+            kind: "openapi",
+            endpoint: "https://api.github.com",
+            status: "connected",
+            enabled: true,
+            namespace: "github",
+            bindingConfigJson: null,
+            transport: null,
+            queryParamsJson: null,
+            headersJson: null,
+            specUrl: "https://api.github.com/openapi.json",
+            defaultHeadersJson: null,
+            sourceHash: manifest.sourceHash,
+            sourceDocumentText: null,
+            lastError: null,
+            createdAt: 1000 + index,
+            updatedAt: 1000 + index,
+          }));
+        }
+
+        const recipes = await Effect.runPromise(loadWorkspaceSourceRecipes({
+          rows: persistence.rows,
+          workspaceId,
+        }));
+
+        expect(recipes).toHaveLength(2);
+        expect(recipes[0]?.documents).toHaveLength(1);
+        expect(recipes[0]?.operations).toHaveLength(1);
+        expect(recipes[0]?.documents).toBe(recipes[1]?.documents);
+        expect(recipes[0]?.operations).toBe(recipes[1]?.operations);
+      } finally {
+        await persistence.close();
+      }
+    });
+
+    it("loads sources with empty recipe documents and operations", async () => {
+      const persistence = await makePersistence();
+      try {
+        const workspaceId = WorkspaceIdSchema.make("ws_empty_recipe_rows");
+        const organizationId = OrganizationIdSchema.make("org_empty_recipe_rows");
+        const accountId = AccountIdSchema.make("acc_empty_recipe_rows");
+        const sourceId = SourceIdSchema.make("src_empty_recipe_rows");
+        const recipeId = SourceRecipeIdSchema.make("src_recipe_empty_recipe_rows");
+        const recipeRevisionId = SourceRecipeRevisionIdSchema.make("src_recipe_rev_empty_recipe_rows");
+
+        await seedWorkspace({
+          persistence,
+          workspaceId,
+          organizationId,
+          accountId,
+        });
+        await Effect.runPromise(persistence.rows.sourceRecipes.upsert({
+          id: recipeId,
+          kind: "graphql_recipe",
+          importerKind: "graphql_introspection",
+          providerKey: "generic_graphql",
+          name: "GraphQL Demo",
+          summary: null,
+          visibility: "workspace",
+          latestRevisionId: recipeRevisionId,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+        await Effect.runPromise(persistence.rows.sourceRecipeRevisions.upsert({
+          id: recipeRevisionId,
+          recipeId,
+          revisionNumber: 1,
+          sourceConfigJson: JSON.stringify({
+            kind: "graphql",
+            endpoint: "https://example.com/graphql",
+            defaultHeaders: null,
+          }),
+          manifestJson: null,
+          manifestHash: null,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+        await Effect.runPromise(persistence.rows.sources.insert({
+          id: sourceId,
+          workspaceId,
+          recipeId,
+          recipeRevisionId,
+          name: "GraphQL Demo",
+          kind: "graphql",
+          endpoint: "https://example.com/graphql",
+          status: "connected",
+          enabled: true,
+          namespace: "graphql",
+          bindingConfigJson: null,
+          transport: null,
+          queryParamsJson: null,
+          headersJson: null,
+          specUrl: null,
+          defaultHeadersJson: null,
+          sourceHash: null,
+          sourceDocumentText: null,
+          lastError: null,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+
+        const recipes = await Effect.runPromise(loadWorkspaceSourceRecipes({
+          rows: persistence.rows,
+          workspaceId,
+        }));
+
+        expect(recipes).toHaveLength(1);
+        expect(recipes[0]?.documents).toEqual([]);
+        expect(recipes[0]?.operations).toEqual([]);
+        expect(recipes[0]?.manifest).toBeNull();
+      } finally {
+        await persistence.close();
+      }
+    });
+
+    it("fails clearly when loading a missing source, missing revision, or invalid manifest", async () => {
+      const persistence = await makePersistence();
+      try {
+        await expect(Effect.runPromise(loadSourceRecipe({
+          rows: persistence.rows,
+          workspaceId: WorkspaceIdSchema.make("ws_missing_source"),
+          sourceId: SourceIdSchema.make("src_missing_source"),
+        }))).rejects.toThrow("Source not found");
+
+        const workspaceId = WorkspaceIdSchema.make("ws_bad_recipe_runtime");
+        const organizationId = OrganizationIdSchema.make("org_bad_recipe_runtime");
+        const accountId = AccountIdSchema.make("acc_bad_recipe_runtime");
+        const sourceId = SourceIdSchema.make("src_bad_recipe_runtime");
+        const recipeId = SourceRecipeIdSchema.make("src_recipe_bad_recipe_runtime");
+        const recipeRevisionId = SourceRecipeRevisionIdSchema.make("src_recipe_rev_bad_recipe_runtime");
+
+        await seedWorkspace({
+          persistence,
+          workspaceId,
+          organizationId,
+          accountId,
+        });
+        await Effect.runPromise(persistence.rows.sourceRecipes.upsert({
+          id: recipeId,
+          kind: "http_recipe",
+          importerKind: "openapi",
+          providerKey: "generic_http",
+          name: "Broken GitHub",
+          summary: null,
+          visibility: "workspace",
+          latestRevisionId: recipeRevisionId,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+        await Effect.runPromise(persistence.rows.sources.insert({
+          id: sourceId,
+          workspaceId,
+          recipeId,
+          recipeRevisionId,
+          name: "Broken GitHub",
+          kind: "openapi",
+          endpoint: "https://api.github.com",
+          status: "connected",
+          enabled: true,
+          namespace: "github",
+          bindingConfigJson: null,
+          transport: null,
+          queryParamsJson: null,
+          headersJson: null,
+          specUrl: "https://api.github.com/openapi.json",
+          defaultHeadersJson: null,
+          sourceHash: null,
+          sourceDocumentText: null,
+          lastError: null,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+
+        await expect(Effect.runPromise(loadSourceRecipe({
+          rows: persistence.rows,
+          workspaceId,
+          sourceId,
+        }))).rejects.toThrow("Recipe revision missing");
+
+        await Effect.runPromise(persistence.rows.sourceRecipeRevisions.upsert({
+          id: recipeRevisionId,
+          recipeId,
+          revisionNumber: 1,
+          sourceConfigJson: JSON.stringify({
+            kind: "openapi",
+            endpoint: "https://api.github.com",
+            specUrl: "https://api.github.com/openapi.json",
+            defaultHeaders: null,
+          }),
+          manifestJson: "{bad-json",
+          manifestHash: null,
+          createdAt: 1000,
+          updatedAt: 1000,
+        }));
+
+        await expect(Effect.runPromise(loadSourceRecipe({
+          rows: persistence.rows,
+          workspaceId,
+          sourceId,
+        }))).rejects.toThrow(`Invalid OpenAPI manifest for ${sourceId}`);
+      } finally {
+        await persistence.close();
+      }
+    });
+  });
+});

--- a/packages/control-plane/src/runtime/source-recipes-runtime.ts
+++ b/packages/control-plane/src/runtime/source-recipes-runtime.ts
@@ -1,0 +1,362 @@
+import {
+  type ToolDescriptor,
+  type ToolPath,
+  typeSignatureFromSchemaJson,
+} from "@executor/codemode-core";
+import type {
+  McpToolManifest,
+} from "@executor/codemode-mcp";
+import {
+  openApiOutputTypeSignatureFromSchemaJson,
+  type OpenApiToolManifest,
+} from "@executor/codemode-openapi";
+import type { SqlControlPlaneRows } from "#persistence";
+import type {
+  AccountId,
+  Source,
+  StoredSourceRecord,
+  StoredSourceRecipeDocumentRecord,
+  StoredSourceRecipeOperationRecord,
+  StoredSourceRecipeRevisionRecord,
+  WorkspaceId,
+} from "#schema";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import type { GraphqlToolManifest } from "./graphql-tools";
+import { loadSourceById, loadSourcesInWorkspace } from "./source-store";
+import { namespaceFromSourceName } from "./tool-artifacts";
+
+type RecipeManifest =
+  | OpenApiToolManifest
+  | GraphqlToolManifest
+  | McpToolManifest
+  | null;
+
+const asToolPath = (value: string): ToolPath => value as ToolPath;
+
+export type LoadedSourceRecipe = {
+  source: Source;
+  sourceRecord: StoredSourceRecord;
+  revision: StoredSourceRecipeRevisionRecord;
+  documents: readonly StoredSourceRecipeDocumentRecord[];
+  operations: readonly StoredSourceRecipeOperationRecord[];
+  manifest: RecipeManifest;
+};
+
+export type LoadedSourceRecipeTool = {
+  path: string;
+  searchNamespace: string;
+  searchText: string;
+  source: Source;
+  sourceRecord: StoredSourceRecord;
+  revision: StoredSourceRecipeRevisionRecord;
+  operation: StoredSourceRecipeOperationRecord;
+  manifest: RecipeManifest;
+  descriptor: ToolDescriptor;
+};
+
+const parseJson = <T>(input: {
+  label: string;
+  value: string | null;
+}): Effect.Effect<T | null, Error, never> =>
+  input.value === null
+    ? Effect.succeed<T | null>(null)
+    : Effect.try({
+        try: () => {
+          const value = input.value!;
+          return JSON.parse(value) as T;
+        },
+        catch: (cause) =>
+          cause instanceof Error
+            ? new Error(`Invalid ${input.label}: ${cause.message}`)
+            : new Error(`Invalid ${input.label}: ${String(cause)}`),
+      });
+
+const parseManifestForRecipe = (input: {
+  source: Source;
+  revision: StoredSourceRecipeRevisionRecord;
+}): Effect.Effect<RecipeManifest, Error, never> =>
+  Effect.gen(function* () {
+    if (input.revision.manifestJson === null) {
+      return null;
+    }
+
+    if (input.source.kind === "openapi") {
+      return yield* parseJson<OpenApiToolManifest>({
+        label: `OpenAPI manifest for ${input.source.id}`,
+        value: input.revision.manifestJson,
+      });
+    }
+
+    if (input.source.kind === "graphql") {
+      return yield* parseJson<GraphqlToolManifest>({
+        label: `GraphQL manifest for ${input.source.id}`,
+        value: input.revision.manifestJson,
+      });
+    }
+
+    if (input.source.kind === "mcp") {
+      return yield* parseJson<McpToolManifest>({
+        label: `MCP manifest for ${input.source.id}`,
+        value: input.revision.manifestJson,
+      });
+    }
+
+    return null;
+  });
+
+const catalogNamespaceFromPath = (path: string): string => {
+  const [first, second] = path.split(".");
+  return second ? `${first}.${second}` : first;
+};
+
+export const recipeToolPath = (input: {
+  source: Source;
+  operation: StoredSourceRecipeOperationRecord;
+}): string => {
+  const namespace = input.source.namespace ?? namespaceFromSourceName(input.source.name);
+  return namespace ? `${namespace}.${input.operation.toolId}` : input.operation.toolId;
+};
+
+export const recipeToolSearchNamespace = (input: {
+  source: Source;
+  path: string;
+  operation: StoredSourceRecipeOperationRecord;
+}): string =>
+  input.operation.providerKind === "graphql"
+    ? (input.source.namespace ?? namespaceFromSourceName(input.source.name))
+    : catalogNamespaceFromPath(input.path);
+
+export const recipeToolDescriptor = (input: {
+  source: Source;
+  operation: StoredSourceRecipeOperationRecord;
+  path: string;
+  includeSchemas: boolean;
+}): ToolDescriptor => {
+  const interaction =
+    input.operation.providerKind === "openapi"
+      ? (
+        input.operation.openApiMethod?.toUpperCase() === "GET"
+        || input.operation.openApiMethod?.toUpperCase() === "HEAD"
+          ? "auto"
+          : "required"
+      )
+      : input.operation.providerKind === "graphql"
+        ? input.operation.graphqlOperationType === "query"
+          ? "auto"
+          : "required"
+        : "auto";
+
+  return {
+    path: asToolPath(input.path),
+    sourceKey: input.source.id,
+    description: input.operation.description ?? input.operation.title ?? undefined,
+    interaction,
+    inputType: typeSignatureFromSchemaJson(
+      input.operation.inputSchemaJson ?? undefined,
+      "unknown",
+      320,
+    ),
+    outputType:
+      input.operation.providerKind === "openapi"
+        ? openApiOutputTypeSignatureFromSchemaJson(
+            input.operation.outputSchemaJson ?? undefined,
+            320,
+          )
+        : typeSignatureFromSchemaJson(
+            input.operation.outputSchemaJson ?? undefined,
+            "unknown",
+            320,
+          ),
+    inputSchemaJson: input.includeSchemas ? input.operation.inputSchemaJson ?? undefined : undefined,
+    outputSchemaJson: input.includeSchemas ? input.operation.outputSchemaJson ?? undefined : undefined,
+    ...(input.operation.providerKind
+      ? { providerKind: input.operation.providerKind }
+      : {}),
+    ...(input.operation.providerDataJson
+      ? { providerDataJson: input.operation.providerDataJson }
+      : {}),
+  };
+};
+
+const sourceRecipeDocumentForSource = (input: {
+  source: Source;
+  documents: readonly StoredSourceRecipeDocumentRecord[];
+}): StoredSourceRecipeDocumentRecord | null => {
+  const preferredKind =
+    input.source.kind === "openapi"
+      ? "openapi"
+      : input.source.kind === "graphql"
+        ? "graphql_introspection"
+        : input.source.kind === "mcp"
+          ? "mcp_manifest"
+          : null;
+
+  if (preferredKind === null) {
+    return null;
+  }
+
+  return input.documents.find((document) => document.documentKind === preferredKind) ?? null;
+};
+
+export const recipePrimaryDocumentText = (input: {
+  source: Source;
+  documents: readonly StoredSourceRecipeDocumentRecord[];
+}): string | null =>
+  sourceRecipeDocumentForSource(input)?.contentText ?? null;
+
+export const loadWorkspaceSourceRecipes = (input: {
+  rows: SqlControlPlaneRows;
+  workspaceId: WorkspaceId;
+  actorAccountId?: AccountId | null;
+}): Effect.Effect<readonly LoadedSourceRecipe[], Error, never> =>
+  Effect.gen(function* () {
+    const sourceRecords = yield* input.rows.sources.listByWorkspaceId(input.workspaceId);
+    const sources = yield* loadSourcesInWorkspace(input.rows, input.workspaceId, {
+      actorAccountId: input.actorAccountId,
+    });
+
+    const sourceById = new Map(sources.map((source) => [source.id, source]));
+    const relevantSourceRecords = sourceRecords.filter((sourceRecord) => sourceById.has(sourceRecord.id));
+    const revisionIds = [...new Set(relevantSourceRecords.map((sourceRecord) => sourceRecord.recipeRevisionId))];
+
+    const revisions = yield* input.rows.sourceRecipeRevisions.listByIds(revisionIds);
+    const revisionById = new Map(revisions.map((revision) => [revision.id, revision]));
+    const documents = yield* input.rows.sourceRecipeDocuments.listByRevisionIds(revisionIds);
+    const documentsByRevisionId = new Map<string, StoredSourceRecipeDocumentRecord[]>();
+    for (const document of documents) {
+      const existing = documentsByRevisionId.get(document.recipeRevisionId) ?? [];
+      existing.push(document);
+      documentsByRevisionId.set(document.recipeRevisionId, existing);
+    }
+    const operations = yield* input.rows.sourceRecipeOperations.listByRevisionIds(revisionIds);
+    const operationsByRevisionId = new Map<string, StoredSourceRecipeOperationRecord[]>();
+    for (const operation of operations) {
+      const existing = operationsByRevisionId.get(operation.recipeRevisionId) ?? [];
+      existing.push(operation);
+      operationsByRevisionId.set(operation.recipeRevisionId, existing);
+    }
+
+    return yield* Effect.forEach(relevantSourceRecords, (sourceRecord) =>
+      Effect.gen(function* () {
+        const source = sourceById.get(sourceRecord.id);
+        if (!source) {
+          return yield* Effect.fail(
+            new Error(`Projected source missing for ${sourceRecord.id}`),
+          );
+        }
+
+        const revision = revisionById.get(sourceRecord.recipeRevisionId);
+        if (!revision) {
+          return yield* Effect.fail(
+            new Error(`Recipe revision missing for source ${sourceRecord.id}`),
+          );
+        }
+
+        const manifest = yield* parseManifestForRecipe({
+          source,
+          revision,
+        });
+
+        return {
+          source,
+          sourceRecord,
+          revision,
+          documents: documentsByRevisionId.get(sourceRecord.recipeRevisionId) ?? [],
+          operations: operationsByRevisionId.get(sourceRecord.recipeRevisionId) ?? [],
+          manifest,
+        } satisfies LoadedSourceRecipe;
+      }),
+    );
+  });
+
+export const loadSourceRecipe = (input: {
+  rows: SqlControlPlaneRows;
+  workspaceId: WorkspaceId;
+  sourceId: Source["id"];
+  actorAccountId?: AccountId | null;
+}): Effect.Effect<LoadedSourceRecipe, Error, never> =>
+  Effect.gen(function* () {
+    const sourceRecord = yield* input.rows.sources.getByWorkspaceAndId(
+      input.workspaceId,
+      input.sourceId,
+    );
+    if (Option.isNone(sourceRecord)) {
+      return yield* Effect.fail(
+        new Error(`Source not found: workspaceId=${input.workspaceId} sourceId=${input.sourceId}`),
+      );
+    }
+
+    const source = yield* loadSourceById(input.rows, {
+      workspaceId: input.workspaceId,
+      sourceId: input.sourceId,
+      actorAccountId: input.actorAccountId,
+    });
+    const revision = yield* input.rows.sourceRecipeRevisions.getById(sourceRecord.value.recipeRevisionId);
+    if (Option.isNone(revision)) {
+      return yield* Effect.fail(
+        new Error(`Recipe revision missing for source ${input.sourceId}`),
+      );
+    }
+    const [documents, operations, manifest] = yield* Effect.all([
+      input.rows.sourceRecipeDocuments.listByRevisionId(sourceRecord.value.recipeRevisionId),
+      input.rows.sourceRecipeOperations.listByRevisionId(sourceRecord.value.recipeRevisionId),
+      parseManifestForRecipe({
+        source,
+        revision: revision.value,
+      }),
+    ]);
+
+    return {
+      source,
+      sourceRecord: sourceRecord.value,
+      revision: revision.value,
+      documents,
+      operations,
+      manifest,
+    } satisfies LoadedSourceRecipe;
+  });
+
+export const expandRecipeTools = (input: {
+  recipes: readonly LoadedSourceRecipe[];
+  includeSchemas: boolean;
+}): readonly LoadedSourceRecipeTool[] =>
+  input.recipes.flatMap((recipe) =>
+    recipe.operations.map((operation) => {
+      const path = recipeToolPath({
+        source: recipe.source,
+        operation,
+      });
+      const searchNamespace = recipeToolSearchNamespace({
+        source: recipe.source,
+        path,
+        operation,
+      });
+
+      return {
+        path,
+        searchNamespace,
+        searchText: [
+          path,
+          searchNamespace,
+          recipe.source.name,
+          operation.searchText,
+        ]
+          .filter((part) => part.length > 0)
+          .join(" ")
+          .toLowerCase(),
+        source: recipe.source,
+        sourceRecord: recipe.sourceRecord,
+        revision: recipe.revision,
+        operation,
+        manifest: recipe.manifest,
+        descriptor: recipeToolDescriptor({
+          source: recipe.source,
+          operation,
+          path,
+          includeSchemas: input.includeSchemas,
+        }),
+      } satisfies LoadedSourceRecipeTool;
+    })
+  );

--- a/packages/control-plane/src/runtime/sources-operations.ts
+++ b/packages/control-plane/src/runtime/sources-operations.ts
@@ -2,7 +2,9 @@ import type {
   CreateSourcePayload,
   UpdateSourcePayload,
 } from "../api/sources/api";
+import { Actor } from "#domain";
 import {
+  type AccountId,
   SourceIdSchema,
   type Source,
   type SourceId,
@@ -51,6 +53,7 @@ const shouldAutoProbeSource = (source: Source): boolean =>
 const syncArtifactsForSource = (input: {
   store: ControlPlaneStoreShape;
   source: Source;
+  actorAccountId: AccountId;
   operation:
     | typeof sourceOps.create
     | typeof sourceOps.update;
@@ -95,7 +98,9 @@ const syncArtifactsForSource = (input: {
             );
             yield* mapPersistenceError(
               input.operation.child("source_connected"),
-              persistSource(input.store, connectedSource),
+              persistSource(input.store, connectedSource, {
+                actorAccountId: input.actorAccountId,
+              }),
             );
             return connectedSource;
           }
@@ -122,7 +127,9 @@ const syncArtifactsForSource = (input: {
 
             yield* mapPersistenceError(
               input.operation.child("source_error"),
-              persistSource(input.store, erroredSource),
+              persistSource(input.store, erroredSource, {
+                actorAccountId: input.actorAccountId,
+              }),
             );
           }
 
@@ -135,11 +142,15 @@ const syncArtifactsForSource = (input: {
 
 export const listSources = (workspaceId: WorkspaceId) =>
   Effect.flatMap(ControlPlaneStore, (store) =>
-    loadSourcesInWorkspace(store, workspaceId).pipe(
-      Effect.mapError((error) =>
-        sourceOps.list.unknownStorage(
-          error,
-          "Failed projecting stored sources",
+    Effect.flatMap(Actor, (actor) =>
+      loadSourcesInWorkspace(store, workspaceId, {
+        actorAccountId: actor.principal.accountId,
+      }).pipe(
+        Effect.mapError((error) =>
+          sourceOps.list.unknownStorage(
+            error,
+            "Failed projecting stored sources",
+          ),
         ),
       ),
     ));
@@ -149,53 +160,61 @@ export const createSource = (input: {
   payload: CreateSourcePayload;
 }) =>
   Effect.flatMap(ControlPlaneStore, (store) =>
-    Effect.gen(function* () {
-      const now = Date.now();
+    Effect.flatMap(Actor, (actor) =>
+      Effect.gen(function* () {
+        const now = Date.now();
 
-      const source = yield* createSourceFromPayload({
-        workspaceId: input.workspaceId,
-        sourceId: SourceIdSchema.make(`src_${crypto.randomUUID()}`),
-        payload: input.payload,
-        now,
-      }).pipe(
-        Effect.mapError((cause) =>
-          sourceOps.create.badRequest(
-            "Invalid source definition",
-            cause instanceof Error ? cause.message : String(cause),
+        const source = yield* createSourceFromPayload({
+          workspaceId: input.workspaceId,
+          sourceId: SourceIdSchema.make(`src_${crypto.randomUUID()}`),
+          payload: input.payload,
+          now,
+        }).pipe(
+          Effect.mapError((cause) =>
+            sourceOps.create.badRequest(
+              "Invalid source definition",
+              cause instanceof Error ? cause.message : String(cause),
+            ),
           ),
-        ),
-      );
+        );
 
-      yield* mapPersistenceError(
-        sourceOps.create.child("persist"),
-        persistSource(store, source),
-      );
+        yield* mapPersistenceError(
+          sourceOps.create.child("persist"),
+          persistSource(store, source, {
+            actorAccountId: actor.principal.accountId,
+          }),
+        );
 
-      return yield* syncArtifactsForSource({
-        store,
-        source,
-        operation: sourceOps.create,
-      });
-    }));
+        return yield* syncArtifactsForSource({
+          store,
+          source,
+          actorAccountId: actor.principal.accountId,
+          operation: sourceOps.create,
+        });
+      }),
+    ));
 
 export const getSource = (input: {
   workspaceId: WorkspaceId;
   sourceId: SourceId;
 }) =>
   Effect.flatMap(ControlPlaneStore, (store) =>
-    loadSourceById(store, {
-      workspaceId: input.workspaceId,
-      sourceId: input.sourceId,
-    }).pipe(
-      Effect.mapError((cause) =>
-        cause instanceof Error && cause.message.startsWith("Source not found:")
-          ? sourceOps.get.notFound(
-              "Source not found",
-              `workspaceId=${input.workspaceId} sourceId=${input.sourceId}`,
-            )
-          : sourceOps.get.unknownStorage(
-              cause,
-              "Failed projecting stored source",
+    Effect.flatMap(Actor, (actor) =>
+      loadSourceById(store, {
+        workspaceId: input.workspaceId,
+        sourceId: input.sourceId,
+        actorAccountId: actor.principal.accountId,
+      }).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof Error && cause.message.startsWith("Source not found:")
+            ? sourceOps.get.notFound(
+                "Source not found",
+                `workspaceId=${input.workspaceId} sourceId=${input.sourceId}`,
+              )
+            : sourceOps.get.unknownStorage(
+                cause,
+                "Failed projecting stored source",
+              ),
             ),
       ),
     ));
@@ -206,48 +225,54 @@ export const updateSource = (input: {
   payload: UpdateSourcePayload;
 }) =>
   Effect.flatMap(ControlPlaneStore, (store) =>
-    Effect.gen(function* () {
-      const existingSource = yield* loadSourceById(store, {
-        workspaceId: input.workspaceId,
-        sourceId: input.sourceId,
-      }).pipe(
-        Effect.mapError((cause) =>
-          cause instanceof Error && cause.message.startsWith("Source not found:")
-            ? sourceOps.update.notFound(
-                "Source not found",
-                `workspaceId=${input.workspaceId} sourceId=${input.sourceId}`,
-              )
-            : sourceOps.update.unknownStorage(
-                cause,
-                "Failed projecting stored source",
-              ),
-        ),
-      );
-
-      const updatedSource = yield* updateSourceFromPayload({
-        source: existingSource,
-        payload: input.payload,
-        now: Date.now(),
-      }).pipe(
-        Effect.mapError((cause) =>
-          sourceOps.update.badRequest(
-            "Invalid source definition",
-            cause instanceof Error ? cause.message : String(cause),
+    Effect.flatMap(Actor, (actor) =>
+      Effect.gen(function* () {
+        const existingSource = yield* loadSourceById(store, {
+          workspaceId: input.workspaceId,
+          sourceId: input.sourceId,
+          actorAccountId: actor.principal.accountId,
+        }).pipe(
+          Effect.mapError((cause) =>
+            cause instanceof Error && cause.message.startsWith("Source not found:")
+              ? sourceOps.update.notFound(
+                  "Source not found",
+                  `workspaceId=${input.workspaceId} sourceId=${input.sourceId}`,
+                )
+              : sourceOps.update.unknownStorage(
+                  cause,
+                  "Failed projecting stored source",
+                ),
           ),
-        ),
-      );
+        );
 
-      yield* mapPersistenceError(
-        sourceOps.update.child("persist"),
-        persistSource(store, updatedSource),
-      );
+        const updatedSource = yield* updateSourceFromPayload({
+          source: existingSource,
+          payload: input.payload,
+          now: Date.now(),
+        }).pipe(
+          Effect.mapError((cause) =>
+            sourceOps.update.badRequest(
+              "Invalid source definition",
+              cause instanceof Error ? cause.message : String(cause),
+            ),
+          ),
+        );
 
-      return yield* syncArtifactsForSource({
-        store,
-        source: updatedSource,
-        operation: sourceOps.update,
-      });
-    }));
+        yield* mapPersistenceError(
+          sourceOps.update.child("persist"),
+          persistSource(store, updatedSource, {
+            actorAccountId: actor.principal.accountId,
+          }),
+        );
+
+        return yield* syncArtifactsForSource({
+          store,
+          source: updatedSource,
+          actorAccountId: actor.principal.accountId,
+          operation: sourceOps.update,
+        });
+      }),
+    ));
 
 export const removeSource = (input: {
   workspaceId: WorkspaceId;
@@ -255,10 +280,6 @@ export const removeSource = (input: {
 }) =>
   Effect.flatMap(ControlPlaneStore, (store) =>
     Effect.gen(function* () {
-      yield* sourceOps.remove.child("artifacts").mapStorage(
-        store.toolArtifacts.removeByWorkspaceAndSourceId(input.workspaceId, input.sourceId),
-      );
-
       const removed = yield* sourceOps.remove.mapStorage(
         removeSourceById(store, {
           workspaceId: input.workspaceId,

--- a/packages/control-plane/src/runtime/tool-artifacts.test.ts
+++ b/packages/control-plane/src/runtime/tool-artifacts.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import * as Effect from "effect/Effect";
+
+import {
+  SourceIdSchema,
+  WorkspaceIdSchema,
+  type Source,
+} from "#schema";
+
+import { resolveSourceAuthMaterial } from "./tool-artifacts";
+
+const makeSource = (overrides: Partial<Source> = {}): Source => ({
+  id: SourceIdSchema.make("src_tool_artifacts"),
+  workspaceId: WorkspaceIdSchema.make("ws_tool_artifacts"),
+  name: "GitHub",
+  kind: "openapi",
+  endpoint: "https://api.github.com",
+  status: "connected",
+  enabled: true,
+  namespace: "github",
+  transport: null,
+  queryParams: null,
+  headers: null,
+  specUrl: "https://api.github.com/openapi.json",
+  defaultHeaders: null,
+  auth: { kind: "none" },
+  sourceHash: null,
+  lastError: null,
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+describe("tool-artifacts", () => {
+  describe("resolveSourceAuthMaterial", () => {
+    it("returns empty headers for auth.kind none", async () => {
+      const auth = await Effect.runPromise(resolveSourceAuthMaterial({
+        source: makeSource({
+          auth: { kind: "none" },
+        }),
+        resolveSecretMaterial: () => Effect.die("should not be called"),
+      }));
+
+      expect(auth).toEqual({ headers: {} });
+    });
+
+    it("resolves bearer auth headers from the configured token ref", async () => {
+      const calls: string[] = [];
+
+      const auth = await Effect.runPromise(resolveSourceAuthMaterial({
+        source: makeSource({
+          auth: {
+            kind: "bearer",
+            headerName: "X-Api-Key",
+            prefix: "Token ",
+            token: {
+              providerId: "postgres",
+              handle: "sec_bearer",
+            },
+          },
+        }),
+        resolveSecretMaterial: ({ ref }) => {
+          calls.push(`${ref.providerId}:${ref.handle}`);
+          return Effect.succeed("resolved-bearer-token");
+        },
+      }));
+
+      expect(calls).toEqual(["postgres:sec_bearer"]);
+      expect(auth).toEqual({
+        headers: {
+          "X-Api-Key": "Token resolved-bearer-token",
+        },
+      });
+    });
+
+    it("uses the oauth access token ref and ignores the refresh token", async () => {
+      const calls: string[] = [];
+
+      const auth = await Effect.runPromise(resolveSourceAuthMaterial({
+        source: makeSource({
+          kind: "graphql",
+          endpoint: "https://example.com/graphql",
+          specUrl: null,
+          auth: {
+            kind: "oauth2",
+            headerName: "Authorization",
+            prefix: "Bearer ",
+            accessToken: {
+              providerId: "postgres",
+              handle: "sec_access",
+            },
+            refreshToken: {
+              providerId: "postgres",
+              handle: "sec_refresh",
+            },
+          },
+        }),
+        resolveSecretMaterial: ({ ref }) => {
+          calls.push(`${ref.providerId}:${ref.handle}`);
+          return Effect.succeed("resolved-access-token");
+        },
+      }));
+
+      expect(calls).toEqual(["postgres:sec_access"]);
+      expect(auth).toEqual({
+        headers: {
+          Authorization: "Bearer resolved-access-token",
+        },
+      });
+    });
+  });
+});

--- a/packages/control-plane/src/runtime/tool-artifacts.ts
+++ b/packages/control-plane/src/runtime/tool-artifacts.ts
@@ -1,27 +1,34 @@
+import { createHash } from "node:crypto";
+
 import {
   FetchHttpClient,
   HttpClient,
   HttpClientRequest,
 } from "@effect/platform";
 import {
+  type McpToolManifest,
   createSdkMcpConnector,
   discoverMcpToolsFromConnector,
   type McpToolManifestEntry,
 } from "@executor/codemode-mcp";
-import { extractOpenApiManifest } from "@executor/codemode-openapi";
+import {
+  buildOpenApiToolPresentation,
+  compileOpenApiToolDefinitions,
+  extractOpenApiManifest,
+} from "@executor/codemode-openapi";
 import type { SqlControlPlaneRows } from "#persistence";
 import {
   type SecretRef,
   type Source,
-  type StoredToolArtifactParameterRecord,
-  type StoredToolArtifactRecord,
-  type StoredToolArtifactRefHintKeyRecord,
-  type StoredToolArtifactRequestBodyContentTypeRecord,
+  type StoredSourceRecipeDocumentRecord,
+  type StoredSourceRecipeOperationRecord,
 } from "#schema";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
 import {
+  buildGraphqlToolPresentation,
+  compileGraphqlToolDefinitions,
   extractGraphqlManifest,
   GRAPHQL_INTROSPECTION_QUERY,
 } from "./graphql-tools";
@@ -39,11 +46,6 @@ const trim = (value: string | undefined): string | undefined => {
   return candidate && candidate.length > 0 ? candidate : undefined;
 };
 
-const joinToolPath = (namespace: string | null, toolId: string): string => {
-  const normalizedNamespace = trim(namespace ?? undefined);
-  return normalizedNamespace ? `${normalizedNamespace}.${toolId}` : toolId;
-};
-
 const normalizeSearchText = (...parts: ReadonlyArray<string | null | undefined>): string =>
   parts
     .flatMap((part) => (part ? [part.trim()] : []))
@@ -51,65 +53,305 @@ const normalizeSearchText = (...parts: ReadonlyArray<string | null | undefined>)
     .join(" ")
     .toLowerCase();
 
-const catalogNamespaceFromPath = (path: string): string => {
-  const [first, second] = path.split(".");
-  return second ? `${first}.${second}` : first;
-};
+const contentHash = (value: string): string =>
+  createHash("sha256").update(value).digest("hex");
 
-type IndexedToolArtifactRecord = {
-  artifact: StoredToolArtifactRecord;
-  parameters?: readonly StoredToolArtifactParameterRecord[];
-  requestBodyContentTypes?: readonly StoredToolArtifactRequestBodyContentTypeRecord[];
-  refHintKeys?: readonly StoredToolArtifactRefHintKeyRecord[];
-};
+type SourceBindingRecord = Awaited<
+  ReturnType<SqlControlPlaneRows["sources"]["getByWorkspaceAndId"]>
+> extends Effect.Effect<Option.Option<infer T>, unknown, never>
+  ? T
+  : never;
 
-const toMcpToolArtifactRecord = (input: {
-  workspaceId: Source["workspaceId"];
+const loadSourceBindingRecord = (input: {
+  rows: SqlControlPlaneRows;
   source: Source;
-  entry: {
-    toolId: string;
-    toolName: string;
-    description: string | null;
-    inputSchemaJson?: string;
-    outputSchemaJson?: string;
-  };
+}): Effect.Effect<SourceBindingRecord, Error, never> =>
+  Effect.gen(function* () {
+    const sourceRecord = yield* input.rows.sources.getByWorkspaceAndId(
+      input.source.workspaceId,
+      input.source.id,
+    ).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof Error ? cause : new Error(String(cause)),
+      ),
+    );
+
+    if (Option.isNone(sourceRecord)) {
+      return yield* Effect.fail(
+        new Error(`Source disappeared while syncing recipe data for ${input.source.id}`),
+      );
+    }
+
+    return sourceRecord.value;
+  });
+
+const replaceRecipeRevisionContent = (input: {
+  rows: SqlControlPlaneRows;
+  source: Source;
+  manifestJson: string | null;
+  manifestHash: string | null;
+  documents: readonly StoredSourceRecipeDocumentRecord[];
+  operations: readonly StoredSourceRecipeOperationRecord[];
+  sourcePatch?: Partial<Pick<SourceBindingRecord, "sourceHash">>;
+}): Effect.Effect<void, Error, never> =>
+  Effect.gen(function* () {
+    const sourceRecord = yield* loadSourceBindingRecord({
+      rows: input.rows,
+      source: input.source,
+    });
+    const now = Date.now();
+
+    yield* input.rows.sourceRecipeRevisions.update(sourceRecord.recipeRevisionId, {
+      manifestJson: input.manifestJson,
+      manifestHash: input.manifestHash,
+      updatedAt: now,
+    }).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof Error ? cause : new Error(String(cause)),
+      ),
+    );
+
+    yield* input.rows.sourceRecipeDocuments.replaceForRevision({
+      recipeRevisionId: sourceRecord.recipeRevisionId,
+      documents: input.documents,
+    }).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof Error ? cause : new Error(String(cause)),
+      ),
+    );
+
+    yield* input.rows.sourceRecipeOperations.replaceForRevision({
+      recipeRevisionId: sourceRecord.recipeRevisionId,
+      operations: input.operations,
+    }).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof Error ? cause : new Error(String(cause)),
+      ),
+    );
+
+    if (input.sourcePatch) {
+      const updatedSource = yield* input.rows.sources.update(
+        input.source.workspaceId,
+        input.source.id,
+        {
+          ...input.sourcePatch,
+          updatedAt: now,
+        },
+      ).pipe(
+        Effect.mapError((cause) =>
+          cause instanceof Error ? cause : new Error(String(cause)),
+        ),
+      );
+
+      if (Option.isNone(updatedSource)) {
+        return yield* Effect.fail(
+          new Error(`Source disappeared while updating sync metadata for ${input.source.id}`),
+        );
+      }
+    }
+  });
+
+const toOpenApiRecipeOperationRecord = (input: {
+  recipeRevisionId: SourceBindingRecord["recipeRevisionId"];
+  definition: ReturnType<typeof compileOpenApiToolDefinitions>[number];
+  manifest: Parameters<typeof buildOpenApiToolPresentation>[0]["manifest"];
   now: number;
-}): IndexedToolArtifactRecord => {
-  const sourceNamespace = input.source.namespace ?? namespaceFromSourceName(input.source.name);
-  const path = joinToolPath(sourceNamespace, input.entry.toolId);
-  const searchNamespace = catalogNamespaceFromPath(path);
+}): StoredSourceRecipeOperationRecord => {
+  const presentation = buildOpenApiToolPresentation({
+    manifest: input.manifest,
+    definition: input.definition,
+  });
+  const method = input.definition.method.toUpperCase();
 
   return {
-    artifact: {
-      workspaceId: input.workspaceId,
-      path,
-      toolId: input.entry.toolId,
-      sourceId: input.source.id,
-      title: input.entry.toolName,
-      description: input.entry.description ?? null,
-      searchNamespace,
-      searchText: normalizeSearchText(
-        path,
-        searchNamespace,
-        input.entry.toolName,
-        input.entry.description ?? undefined,
-      ),
-      inputSchemaJson: input.entry.inputSchemaJson ?? null,
-      outputSchemaJson: input.entry.outputSchemaJson ?? null,
-      providerKind: "mcp",
-      mcpToolName: input.entry.toolName,
-      openApiMethod: null,
-      openApiPathTemplate: null,
-      openApiOperationHash: null,
-      openApiRawToolId: null,
-      openApiOperationId: null,
-      openApiTagsJson: null,
-      openApiRequestBodyRequired: null,
-      createdAt: input.now,
-      updatedAt: input.now,
-    },
+    id: `src_recipe_op_${crypto.randomUUID()}`,
+    recipeRevisionId: input.recipeRevisionId,
+    operationKey: input.definition.toolId,
+    transportKind: "http",
+    toolId: input.definition.toolId,
+    title: input.definition.name,
+    description: input.definition.description,
+    operationKind:
+      method === "GET" || method === "HEAD"
+        ? "read"
+        : method === "DELETE"
+          ? "delete"
+          : "write",
+    searchText: normalizeSearchText(
+      input.definition.toolId,
+      input.definition.name,
+      input.definition.description,
+      input.definition.rawToolId,
+      input.definition.operationId ?? undefined,
+      input.definition.method,
+      input.definition.path,
+      input.definition.group,
+      input.definition.leaf,
+      input.definition.tags.join(" "),
+    ),
+    inputSchemaJson: presentation.inputSchemaJson ?? null,
+    outputSchemaJson: presentation.outputSchemaJson ?? null,
+    providerKind: "openapi",
+    providerDataJson: presentation.providerDataJson,
+    mcpToolName: null,
+    openApiMethod: input.definition.method,
+    openApiPathTemplate: input.definition.path,
+    openApiOperationHash: input.definition.operationHash,
+    openApiRawToolId: input.definition.rawToolId,
+    openApiOperationId: input.definition.operationId ?? null,
+    openApiTagsJson: JSON.stringify(input.definition.tags),
+    openApiRequestBodyRequired: input.definition.invocation.requestBody?.required ?? null,
+    graphqlOperationType: null,
+    graphqlOperationName: null,
+    createdAt: input.now,
+    updatedAt: input.now,
   };
 };
+
+const toGraphqlRecipeOperationRecord = (input: {
+  recipeRevisionId: SourceBindingRecord["recipeRevisionId"];
+  definition: ReturnType<typeof compileGraphqlToolDefinitions>[number];
+  manifest: Parameters<typeof buildGraphqlToolPresentation>[0]["manifest"];
+  now: number;
+}): StoredSourceRecipeOperationRecord => {
+  const presentation = buildGraphqlToolPresentation({
+    manifest: input.manifest,
+    definition: input.definition,
+  });
+
+  return {
+    id: `src_recipe_op_${crypto.randomUUID()}`,
+    recipeRevisionId: input.recipeRevisionId,
+    operationKey: input.definition.toolId,
+    transportKind: "graphql",
+    toolId: input.definition.toolId,
+    title: input.definition.name,
+    description: input.definition.description,
+    operationKind:
+      input.definition.operationType === "query"
+        ? "read"
+        : input.definition.operationType === "mutation"
+          ? "write"
+          : "unknown",
+    searchText: normalizeSearchText(
+      input.definition.toolId,
+      input.definition.name,
+      input.definition.description,
+      input.definition.rawToolId,
+      input.definition.group,
+      input.definition.leaf,
+      input.definition.fieldName,
+      input.definition.operationType,
+      input.definition.operationName,
+      input.definition.searchTerms.join(" "),
+    ),
+    inputSchemaJson: presentation.inputSchemaJson ?? null,
+    outputSchemaJson: presentation.outputSchemaJson ?? null,
+    providerKind: "graphql",
+    providerDataJson: presentation.providerDataJson,
+    mcpToolName: null,
+    openApiMethod: null,
+    openApiPathTemplate: null,
+    openApiOperationHash: null,
+    openApiRawToolId: null,
+    openApiOperationId: null,
+    openApiTagsJson: null,
+    openApiRequestBodyRequired: null,
+    graphqlOperationType: input.definition.operationType,
+    graphqlOperationName: input.definition.operationName,
+    createdAt: input.now,
+    updatedAt: input.now,
+  };
+};
+
+const toMcpRecipeOperationRecord = (input: {
+  recipeRevisionId: SourceBindingRecord["recipeRevisionId"];
+  entry: McpToolManifestEntry;
+  now: number;
+}): StoredSourceRecipeOperationRecord => ({
+  id: `src_recipe_op_${crypto.randomUUID()}`,
+  recipeRevisionId: input.recipeRevisionId,
+  operationKey: input.entry.toolId,
+  transportKind: "mcp",
+  toolId: input.entry.toolId,
+  title: input.entry.toolName,
+  description: input.entry.description ?? null,
+  operationKind: "unknown",
+  searchText: normalizeSearchText(
+    input.entry.toolId,
+    input.entry.toolName,
+    input.entry.description ?? undefined,
+    "mcp",
+  ),
+  inputSchemaJson: input.entry.inputSchemaJson ?? null,
+  outputSchemaJson: input.entry.outputSchemaJson ?? null,
+  providerKind: "mcp",
+  providerDataJson: JSON.stringify({
+    kind: "mcp",
+    toolId: input.entry.toolId,
+    toolName: input.entry.toolName,
+    description: input.entry.description ?? null,
+  }),
+  mcpToolName: input.entry.toolName,
+  openApiMethod: null,
+  openApiPathTemplate: null,
+  openApiOperationHash: null,
+  openApiRawToolId: null,
+  openApiOperationId: null,
+  openApiTagsJson: null,
+  openApiRequestBodyRequired: null,
+  graphqlOperationType: null,
+  graphqlOperationName: null,
+  createdAt: input.now,
+  updatedAt: input.now,
+});
+
+const persistMcpRecipeRevision = (input: {
+  rows: SqlControlPlaneRows;
+  source: Source;
+  manifestEntries: readonly McpToolManifestEntry[];
+}): Effect.Effect<void, Error, never> =>
+  Effect.gen(function* () {
+    const sourceRecord = yield* loadSourceBindingRecord({
+      rows: input.rows,
+      source: input.source,
+    });
+    const now = Date.now();
+    const manifest: McpToolManifest = {
+      version: 1,
+      tools: input.manifestEntries,
+    };
+    const manifestJson = JSON.stringify(manifest);
+    const manifestHash = contentHash(manifestJson);
+
+    yield* replaceRecipeRevisionContent({
+      rows: input.rows,
+      source: input.source,
+      manifestJson,
+      manifestHash,
+      documents: [{
+        id: `src_recipe_doc_${crypto.randomUUID()}`,
+        recipeRevisionId: sourceRecord.recipeRevisionId,
+        documentKind: "mcp_manifest",
+        documentKey: input.source.endpoint,
+        contentText: manifestJson,
+        contentHash: manifestHash,
+        fetchedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }],
+      operations: input.manifestEntries.map((entry) =>
+        toMcpRecipeOperationRecord({
+          recipeRevisionId: sourceRecord.recipeRevisionId,
+          entry,
+          now,
+        })
+      ),
+      sourcePatch: {
+        sourceHash: manifestHash,
+      },
+    });
+  });
 
 
 const shouldIndexSource = (source: Source): boolean =>
@@ -226,19 +468,11 @@ const indexMcpSourceToolArtifacts = (input: {
   manifestEntries: readonly McpToolManifestEntry[];
 }): Effect.Effect<void, Error, never> =>
   Effect.gen(function* () {
-    const now = Date.now();
-    yield* input.rows.toolArtifacts.replaceForSource({
-      workspaceId: input.source.workspaceId,
-      sourceId: input.source.id,
-      artifacts: input.manifestEntries.map((entry) =>
-        toMcpToolArtifactRecord({
-          workspaceId: input.source.workspaceId,
-          source: input.source,
-          entry,
-          now,
-        })
-      ),
-    }).pipe(
+    yield* persistMcpRecipeRevision(input);
+    yield* input.rows.toolArtifacts.removeByWorkspaceAndSourceId(
+      input.source.workspaceId,
+      input.source.id,
+    ).pipe(
       Effect.mapError((cause) =>
         cause instanceof Error ? cause : new Error(String(cause)),
       ),
@@ -323,26 +557,41 @@ const indexOpenApiSourceToolArtifacts = (input: {
       ),
     );
 
+    const sourceRecord = yield* loadSourceBindingRecord({
+      rows: input.rows,
+      source: input.source,
+    });
+    const definitions = compileOpenApiToolDefinitions(manifest);
     const now = Date.now();
-    const updatedSource = yield* input.rows.sources.update(
-      input.source.workspaceId,
-      input.source.id,
-      {
-        sourceHash: manifest.sourceHash,
-        sourceDocumentText: openApiDocument,
-        updatedAt: now,
-      },
-    ).pipe(
-      Effect.mapError((cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
-      ),
-    );
 
-    if (Option.isNone(updatedSource)) {
-      return yield* Effect.fail(
-        new Error(`Source disappeared while storing OpenAPI document for ${input.source.id}`),
-      );
-    }
+    yield* replaceRecipeRevisionContent({
+      rows: input.rows,
+      source: input.source,
+      manifestJson: JSON.stringify(manifest),
+      manifestHash: manifest.sourceHash,
+      documents: [{
+        id: `src_recipe_doc_${crypto.randomUUID()}`,
+        recipeRevisionId: sourceRecord.recipeRevisionId,
+        documentKind: "openapi",
+        documentKey: input.source.specUrl ?? input.source.endpoint,
+        contentText: openApiDocument,
+        contentHash: contentHash(openApiDocument),
+        fetchedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }],
+      operations: definitions.map((definition) =>
+        toOpenApiRecipeOperationRecord({
+          recipeRevisionId: sourceRecord.recipeRevisionId,
+          definition,
+          manifest,
+          now,
+        })
+      ),
+      sourcePatch: {
+        sourceHash: manifest.sourceHash,
+      },
+    });
 
     yield* input.rows.toolArtifacts.removeByWorkspaceAndSourceId(
       input.source.workspaceId,
@@ -383,26 +632,41 @@ const indexGraphqlSourceToolArtifacts = (input: {
       ),
     );
 
+    const sourceRecord = yield* loadSourceBindingRecord({
+      rows: input.rows,
+      source: input.source,
+    });
+    const definitions = compileGraphqlToolDefinitions(manifest);
     const now = Date.now();
-    const updatedSource = yield* input.rows.sources.update(
-      input.source.workspaceId,
-      input.source.id,
-      {
-        sourceHash: manifest.sourceHash,
-        sourceDocumentText: graphqlDocument,
-        updatedAt: now,
-      },
-    ).pipe(
-      Effect.mapError((cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
-      ),
-    );
 
-    if (Option.isNone(updatedSource)) {
-      return yield* Effect.fail(
-        new Error(`Source disappeared while storing GraphQL document for ${input.source.id}`),
-      );
-    }
+    yield* replaceRecipeRevisionContent({
+      rows: input.rows,
+      source: input.source,
+      manifestJson: JSON.stringify(manifest),
+      manifestHash: manifest.sourceHash,
+      documents: [{
+        id: `src_recipe_doc_${crypto.randomUUID()}`,
+        recipeRevisionId: sourceRecord.recipeRevisionId,
+        documentKind: "graphql_introspection",
+        documentKey: input.source.endpoint,
+        contentText: graphqlDocument,
+        contentHash: contentHash(graphqlDocument),
+        fetchedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }],
+      operations: definitions.map((definition) =>
+        toGraphqlRecipeOperationRecord({
+          recipeRevisionId: sourceRecord.recipeRevisionId,
+          definition,
+          manifest,
+          now,
+        })
+      ),
+      sourcePatch: {
+        sourceHash: manifest.sourceHash,
+      },
+    });
 
     yield* input.rows.toolArtifacts.removeByWorkspaceAndSourceId(
       input.source.workspaceId,
@@ -463,9 +727,6 @@ export const syncSourceToolArtifacts = (input: {
 
     return;
   });
-
-export const storedToolIdFromArtifact = (artifact: StoredToolArtifactRecord): string =>
-  artifact.toolId;
 
 export const persistMcpToolArtifactsFromManifest = (input: {
   rows: SqlControlPlaneRows;

--- a/packages/control-plane/src/runtime/workspace-execution-environment.test.ts
+++ b/packages/control-plane/src/runtime/workspace-execution-environment.test.ts
@@ -13,6 +13,11 @@ import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  buildOpenApiToolPresentation,
+  compileOpenApiToolDefinitions,
+  extractOpenApiManifest,
+} from "@executor/codemode-openapi";
 import { describe, expect, it } from "@effect/vitest";
 import {
   graphql,
@@ -28,13 +33,11 @@ import {
 } from "graphql";
 import {
   AccountIdSchema,
-  CredentialIdSchema,
   ExecutionIdSchema,
   SecretMaterialIdSchema,
   SourceIdSchema,
-  SourceRecipeIdSchema,
-  SourceRecipeRevisionIdSchema,
   WorkspaceIdSchema,
+  type Source,
 } from "#schema";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -43,7 +46,7 @@ import * as Layer from "effect/Layer";
 import * as Scope from "effect/Scope";
 import * as Option from "effect/Option";
 import { Schema } from "effect";
-import { z } from "zod/v4";
+import * as z from "zod/v4";
 
 import {
   createSqlControlPlanePersistence,
@@ -56,6 +59,8 @@ import {
   type RuntimeSourceAuthService,
 } from "./source-auth-service";
 import { createLiveExecutionManager } from "./live-execution";
+import { persistSource } from "./source-store";
+import { persistMcpToolArtifactsFromManifest } from "./tool-artifacts";
 import { createWorkspaceExecutionEnvironmentResolver } from "./workspace-execution-environment";
 
 type CountedMcpServer = {
@@ -79,6 +84,13 @@ type GraphqlServer = {
   seenAuthHeaders: Array<string | null>;
   close: () => Promise<void>;
 };
+
+const normalizeSearchText = (...parts: ReadonlyArray<string | null | undefined>): string =>
+  parts
+    .flatMap((part) => (part ? [part.trim()] : []))
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
 
 const GraphqlUserType = new GraphQLObjectType({
   name: "User",
@@ -295,8 +307,6 @@ const makeCountedMcpServer = Effect.acquireRelease(
         };
         let closed = false;
         const app = createMcpExpressApp({ host: "127.0.0.1" });
-        const transports: Record<string, StreamableHTTPServerTransport> = {};
-        const servers: Record<string, McpServer> = {};
 
         const createServer = () => {
           const server = new McpServer(
@@ -343,105 +353,33 @@ const makeCountedMcpServer = Effect.acquireRelease(
           }
         };
 
-        app.post("/mcp", async (req: any, res: any) => {
-          countMethods(req.body);
+        const handle = async (req: any, res: any, parsedBody?: unknown) => {
+          countMethods(parsedBody);
 
-          const sessionIdHeader = req.headers["mcp-session-id"];
-          const sessionId =
-            typeof sessionIdHeader === "string"
-              ? sessionIdHeader
-              : Array.isArray(sessionIdHeader)
-                ? sessionIdHeader[0]
-                : undefined;
+          const server = createServer();
+          const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+          });
 
           try {
-            let transport: StreamableHTTPServerTransport;
-
-            if (sessionId && transports[sessionId]) {
-              transport = transports[sessionId];
-            } else {
-              transport = new StreamableHTTPServerTransport({
-                sessionIdGenerator: () => randomUUID(),
-                onsessioninitialized: (newSessionId) => {
-                  transports[newSessionId] = transport;
-                },
-              });
-
-              transport.onclose = () => {
-                const closedSessionId = transport.sessionId;
-                if (closedSessionId && transports[closedSessionId]) {
-                  delete transports[closedSessionId];
-                }
-                if (closedSessionId && servers[closedSessionId]) {
-                  void servers[closedSessionId].close().catch(() => undefined);
-                  delete servers[closedSessionId];
-                }
-              };
-
-              const server = createServer();
-              await server.connect(transport);
-              const newSessionId = transport.sessionId;
-              if (newSessionId) {
-                servers[newSessionId] = server;
-              }
-            }
-
-            await transport.handleRequest(req, res, req.body);
-          } catch (error) {
-            if (!res.headersSent) {
-              res.status(500).json({
-                jsonrpc: "2.0",
-                error: {
-                  code: -32603,
-                  message:
-                    error instanceof Error ? error.message : "Internal server error",
-                },
-                id: null,
-              });
-            }
+            await server.connect(transport);
+            await transport.handleRequest(req, res, parsedBody);
+          } finally {
+            await transport.close().catch(() => undefined);
+            await server.close().catch(() => undefined);
           }
+        };
+
+        app.post("/mcp", async (req: any, res: any) => {
+          await handle(req, res, req.body);
         });
 
         app.get("/mcp", async (req: any, res: any) => {
-          const sessionIdHeader = req.headers["mcp-session-id"];
-          const sessionId =
-            typeof sessionIdHeader === "string"
-              ? sessionIdHeader
-              : Array.isArray(sessionIdHeader)
-                ? sessionIdHeader[0]
-                : undefined;
-
-          if (!sessionId || !transports[sessionId]) {
-            res.status(400).send("Invalid or missing session ID");
-            return;
-          }
-
-          await transports[sessionId].handleRequest(req, res);
+          await handle(req, res);
         });
 
         app.delete("/mcp", async (req: any, res: any) => {
-          const sessionIdHeader = req.headers["mcp-session-id"];
-          const sessionId =
-            typeof sessionIdHeader === "string"
-              ? sessionIdHeader
-              : Array.isArray(sessionIdHeader)
-                ? sessionIdHeader[0]
-                : undefined;
-
-          if (!sessionId || !transports[sessionId]) {
-            res.status(400).send("Invalid or missing session ID");
-            return;
-          }
-
-          const transport = transports[sessionId];
-          await transport.handleRequest(req, res, req.body);
-          await transport.close();
-          delete transports[sessionId];
-
-          if (servers[sessionId]) {
-            await servers[sessionId].close().catch(() => undefined);
-            delete servers[sessionId];
-          }
+          await handle(req, res, req.body);
         });
 
         const listener = app.listen(0, "127.0.0.1", () => {
@@ -459,14 +397,6 @@ const makeCountedMcpServer = Effect.acquireRelease(
                 return;
               }
               closed = true;
-
-              for (const transport of Object.values(transports)) {
-                await transport.close().catch(() => undefined);
-              }
-
-              for (const server of Object.values(servers)) {
-                await server.close().catch(() => undefined);
-              }
 
               await new Promise<void>((closeResolve, closeReject) => {
                 listener.close((error: Error | undefined) => {
@@ -640,70 +570,48 @@ const persistConnectedEchoTool = (input: {
   endpoint: string;
   workspaceId: WorkspaceId;
   sourceId: SourceId;
-}) =>
+}): Effect.Effect<void, unknown, never> =>
   Effect.gen(function* () {
     const now = Date.now();
-
-    yield* input.persistence.rows.sources.insert({
+    const source: Source = {
       id: input.sourceId,
       workspaceId: input.workspaceId,
-      recipeId: SourceRecipeIdSchema.make(`src_recipe_${input.sourceId}`),
-      recipeRevisionId: SourceRecipeRevisionIdSchema.make(`src_recipe_rev_${input.sourceId}`),
       name: "Counted MCP",
       kind: "mcp",
       endpoint: input.endpoint,
       status: "connected",
       enabled: true,
       namespace: "counted",
-      bindingConfigJson: null,
-      transport: "auto",
-      queryParamsJson: null,
-      headersJson: null,
+      transport: "streamable-http",
+      queryParams: null,
+      headers: null,
       specUrl: null,
-      defaultHeadersJson: null,
+      defaultHeaders: null,
+      auth: { kind: "none" },
       sourceHash: null,
-      sourceDocumentText: null,
       lastError: null,
       createdAt: now,
       updatedAt: now,
-    });
+    };
 
-    yield* input.persistence.rows.toolArtifacts.replaceForSource({
-      workspaceId: input.workspaceId,
-      sourceId: input.sourceId,
-      artifacts: [{
-        artifact: {
-          workspaceId: input.workspaceId,
-          path: "counted.echo",
-          toolId: "echo",
-          sourceId: input.sourceId,
-          title: "echo",
-          description: "Echo the provided string",
-          searchNamespace: "counted.echo",
-          searchText: "counted.echo echo provided string",
-          inputSchemaJson: JSON.stringify({
-            type: "object",
-            properties: {
-              value: {
-                type: "string",
-              },
+    yield* persistSource(input.persistence.rows, source);
+    yield* persistMcpToolArtifactsFromManifest({
+      rows: input.persistence.rows,
+      source,
+      manifestEntries: [{
+        toolId: "echo",
+        toolName: "echo",
+        description: "Echo the provided string",
+        inputSchemaJson: JSON.stringify({
+          type: "object",
+          properties: {
+            value: {
+              type: "string",
             },
-            required: ["value"],
-            additionalProperties: false,
-          }),
-          outputSchemaJson: null,
-          providerKind: "mcp",
-          mcpToolName: "echo",
-          openApiMethod: null,
-          openApiPathTemplate: null,
-          openApiOperationHash: null,
-          openApiRawToolId: null,
-          openApiOperationId: null,
-          openApiTagsJson: null,
-          openApiRequestBodyRequired: null,
-          createdAt: now,
-          updatedAt: now,
-        },
+          },
+          required: ["value"],
+          additionalProperties: false,
+        }),
       }],
     });
   });
@@ -717,7 +625,7 @@ const persistConnectedGithubOpenApiSource = (input: {
     providerId: string;
     handle: string;
   } | null;
-}) =>
+}): Effect.Effect<void, unknown, never> =>
   Effect.gen(function* () {
     const now = Date.now();
     const openApiDocumentText = JSON.stringify({
@@ -819,49 +727,138 @@ const persistConnectedGithubOpenApiSource = (input: {
       },
     });
 
-    yield* input.persistence.rows.sources.insert({
+    const source: Source = {
       id: input.sourceId,
       workspaceId: input.workspaceId,
-      recipeId: SourceRecipeIdSchema.make(`src_recipe_${input.sourceId}`),
-      recipeRevisionId: SourceRecipeRevisionIdSchema.make(`src_recipe_rev_${input.sourceId}`),
       name: "GitHub",
       kind: "openapi",
       endpoint: input.endpoint ?? "https://api.github.com",
       status: "connected",
       enabled: true,
       namespace: "github",
-      bindingConfigJson: null,
       transport: null,
-      queryParamsJson: null,
-      headersJson: null,
+      queryParams: null,
+      headers: null,
       specUrl: "https://example.com/github-openapi.json",
-      defaultHeadersJson: null,
+      defaultHeaders: null,
+      auth: input.auth
+        ? {
+            kind: "bearer",
+            headerName: "Authorization",
+            prefix: "Bearer ",
+            token: {
+              providerId: input.auth.providerId,
+              handle: input.auth.handle,
+            },
+          }
+        : { kind: "none" },
       sourceHash: null,
-      sourceDocumentText: openApiDocumentText,
       lastError: null,
       createdAt: now,
       updatedAt: now,
-    });
-
-    if (input.auth) {
-      const credentialId = CredentialIdSchema.make(`cred_${randomUUID()}`);
-      yield* input.persistence.rows.credentials.upsert({
-        id: credentialId,
-        workspaceId: input.workspaceId,
-        sourceId: input.sourceId,
-        actorAccountId: null,
-        authKind: "bearer",
-        authHeaderName: "Authorization",
-        authPrefix: "Bearer ",
-        tokenProviderId: input.auth.providerId,
-        tokenHandle: input.auth.handle,
-        refreshTokenProviderId: null,
-        refreshTokenHandle: null,
-        createdAt: now,
-        updatedAt: now,
-      });
     };
 
+    yield* persistSource(input.persistence.rows, source);
+
+    const manifest = yield* extractOpenApiManifest(
+      source.name,
+      openApiDocumentText,
+    ).pipe(
+      Effect.mapError((cause) =>
+        cause instanceof Error ? cause : new Error(String(cause)),
+      ),
+    );
+    const definitions = compileOpenApiToolDefinitions(manifest);
+    const sourceRecord = yield* input.persistence.rows.sources.getByWorkspaceAndId(
+      input.workspaceId,
+      input.sourceId,
+    );
+    if (Option.isNone(sourceRecord)) {
+      return yield* Effect.fail(new Error(`Missing stored source ${input.sourceId}`));
+    }
+
+    yield* input.persistence.rows.sourceRecipeRevisions.update(
+      sourceRecord.value.recipeRevisionId,
+      {
+        manifestJson: JSON.stringify(manifest),
+        manifestHash: manifest.sourceHash,
+        updatedAt: now,
+      },
+    );
+    yield* input.persistence.rows.sourceRecipeDocuments.replaceForRevision({
+      recipeRevisionId: sourceRecord.value.recipeRevisionId,
+      documents: [{
+        id: `src_recipe_doc_${randomUUID()}`,
+        recipeRevisionId: sourceRecord.value.recipeRevisionId,
+        documentKind: "openapi",
+        documentKey: source.specUrl ?? source.endpoint,
+        contentText: openApiDocumentText,
+        contentHash: manifest.sourceHash,
+        fetchedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      }],
+    });
+    yield* input.persistence.rows.sourceRecipeOperations.replaceForRevision({
+      recipeRevisionId: sourceRecord.value.recipeRevisionId,
+      operations: definitions.map((definition) => {
+        const presentation = buildOpenApiToolPresentation({
+          manifest,
+          definition,
+        });
+        const method = definition.method.toUpperCase();
+
+        return {
+          id: `src_recipe_op_${randomUUID()}`,
+          recipeRevisionId: sourceRecord.value.recipeRevisionId,
+          operationKey: definition.toolId,
+          transportKind: "http",
+          toolId: definition.toolId,
+          title: definition.name,
+          description: definition.description,
+          operationKind:
+            method === "GET" || method === "HEAD"
+              ? "read"
+              : method === "DELETE"
+                ? "delete"
+                : "write",
+          searchText: normalizeSearchText(
+            definition.toolId,
+            definition.name,
+            definition.description,
+            definition.rawToolId,
+            definition.operationId ?? undefined,
+            definition.method,
+            definition.path,
+            definition.group,
+            definition.leaf,
+            definition.tags.join(" "),
+          ),
+          inputSchemaJson: presentation.inputSchemaJson ?? null,
+          outputSchemaJson: presentation.outputSchemaJson ?? null,
+          providerKind: "openapi",
+          providerDataJson: presentation.providerDataJson,
+          mcpToolName: null,
+          openApiMethod: definition.method,
+          openApiPathTemplate: definition.path,
+          openApiOperationHash: definition.operationHash,
+          openApiRawToolId: definition.rawToolId,
+          openApiOperationId: definition.operationId ?? null,
+          openApiTagsJson: JSON.stringify(definition.tags),
+          openApiRequestBodyRequired: definition.invocation.requestBody?.required ?? null,
+          graphqlOperationType: null,
+          graphqlOperationName: null,
+          createdAt: now,
+          updatedAt: now,
+        };
+      }),
+    });
+    yield* input.persistence.rows.sources.update(input.workspaceId, input.sourceId, {
+      sourceHash: manifest.sourceHash,
+      updatedAt: now,
+    });
+
+    return;
   });
 
 const makeResolver = (persistence: SqlControlPlanePersistence) =>
@@ -1111,12 +1108,15 @@ describe("workspace-execution-environment", () => {
       );
       expect(Option.isSome(storedSource)).toBe(true);
       if (Option.isSome(storedSource)) {
-        expect(storedSource.value.sourceDocumentText).toContain('"operationId":"repos.getRepo"');
+        const documents = yield* persistence.rows.sourceRecipeDocuments.listByRevisionId(
+          storedSource.value.recipeRevisionId,
+        );
+        expect(documents[0]?.contentText).toContain('"operationId":"repos.getRepo"');
       }
 
       const freshEnvironment = yield* resolveEnvironment({
         workspaceId,
-        accountId: AccountIdSchema.make("acc_add_openapi_fresh"),
+        accountId: AccountIdSchema.make("acc_add_openapi"),
         executionId: ExecutionIdSchema.make("exec_add_openapi_fresh"),
       });
 
@@ -1221,12 +1221,15 @@ describe("workspace-execution-environment", () => {
       );
       expect(Option.isSome(storedSource)).toBe(true);
       if (Option.isSome(storedSource)) {
-        expect(storedSource.value.sourceDocumentText).toContain('"__schema"');
+        const documents = yield* persistence.rows.sourceRecipeDocuments.listByRevisionId(
+          storedSource.value.recipeRevisionId,
+        );
+        expect(documents[0]?.contentText).toContain('"__schema"');
       }
 
       const freshEnvironment = yield* resolveEnvironment({
         workspaceId,
-        accountId: AccountIdSchema.make("acc_add_graphql_fresh"),
+        accountId: AccountIdSchema.make("acc_add_graphql"),
         executionId: ExecutionIdSchema.make("exec_add_graphql_fresh"),
         onElicitation: () =>
           Effect.succeed({

--- a/packages/control-plane/src/runtime/workspace-execution-environment.ts
+++ b/packages/control-plane/src/runtime/workspace-execution-environment.ts
@@ -4,23 +4,17 @@ import {
   makeToolInvokerFromTools,
   type SearchHit,
   type ToolCatalog,
-  type ToolDescriptor,
   type ToolInvoker,
   type ToolNamespace,
   type ToolPath,
-  typeSignatureFromSchemaJson,
 } from "@executor/codemode-core";
 import {
   createSdkMcpConnector,
   createMcpToolsFromManifest,
+  type McpToolManifest,
 } from "@executor/codemode-mcp";
 import {
-  buildOpenApiToolPresentation,
-  compileOpenApiToolDefinitions,
   createOpenApiToolsFromManifest,
-  extractOpenApiManifest,
-  openApiOutputTypeSignatureFromSchemaJson,
-  type OpenApiToolDefinition,
   type OpenApiToolManifest,
 } from "@executor/codemode-openapi";
 import { isDenoAvailable,
@@ -33,7 +27,6 @@ import {
 import type {
   AccountId,
   Source,
-  StoredToolArtifactRecord,
 } from "#schema";
 import * as Context from "effect/Context";
 import * as Either from "effect/Either";
@@ -49,20 +42,17 @@ import type {
 import { createExecutorToolMap } from "./executor-tools";
 import {
   createGraphqlToolsFromManifest,
-  extractGraphqlManifest,
-  graphqlToolDescriptorFromDefinition,
-  compileGraphqlToolDefinitions,
-  type GraphqlToolDefinition,
   type GraphqlToolManifest,
 } from "./graphql-tools";
-import {
-  loadSourceById as loadStoredSourceById,
-  loadSourcesInWorkspace,
-} from "./source-store";
 import {
   RuntimeSourceAuthServiceTag,
   type RuntimeSourceAuthService,
 } from "./source-auth-service";
+import {
+  expandRecipeTools,
+  loadWorkspaceSourceRecipes,
+  type LoadedSourceRecipeTool,
+} from "./source-recipes-runtime";
 import {
   createDefaultSecretMaterialResolver,
   type ResolveSecretMaterial,
@@ -71,7 +61,6 @@ import {
 import {
   namespaceFromSourceName,
   resolveSourceAuthMaterial,
-  storedToolIdFromArtifact,
 } from "./tool-artifacts";
 import {
   evaluateInvocationPolicy,
@@ -160,21 +149,42 @@ const toSecretResolutionContext = (
 const queryTokenWeight = (token: string): number =>
   LOW_SIGNAL_QUERY_TOKENS.has(token) ? 0.25 : 1;
 
-const scoreArtifact = (
-  queryTokens: readonly string[],
-  artifact: StoredToolArtifactRecord,
-): number => {
-  const pathText = artifact.path.toLowerCase();
-  const namespaceText = artifact.searchNamespace.toLowerCase();
-  const toolIdText = artifact.toolId.toLowerCase();
-  const titleText = artifact.title?.toLowerCase() ?? "";
-  const descriptionText = artifact.description?.toLowerCase() ?? "";
-  const templateText = artifact.openApiPathTemplate?.toLowerCase() ?? "";
+const loadWorkspaceRecipeTools = (input: {
+  rows: SqlControlPlaneRows;
+  workspaceId: Source["workspaceId"];
+  accountId: AccountId;
+  includeSchemas: boolean;
+}): Effect.Effect<readonly LoadedSourceRecipeTool[], Error, never> =>
+  Effect.gen(function* () {
+    const recipes = yield* loadWorkspaceSourceRecipes({
+      rows: input.rows,
+      workspaceId: input.workspaceId,
+      actorAccountId: input.accountId,
+    });
 
-  const pathTokens = tokenize(`${artifact.path} ${artifact.toolId}`);
-  const namespaceTokens = tokenize(artifact.searchNamespace);
-  const titleTokens = tokenize(artifact.title ?? "");
-  const templateTokens = tokenize(artifact.openApiPathTemplate ?? "");
+    return expandRecipeTools({
+      recipes: recipes.filter((recipe) =>
+        recipe.source.enabled && recipe.source.status === "connected"
+      ),
+      includeSchemas: input.includeSchemas,
+    });
+  });
+
+const scoreRecipeTool = (
+  queryTokens: readonly string[],
+  tool: LoadedSourceRecipeTool,
+): number => {
+  const pathText = tool.path.toLowerCase();
+  const namespaceText = tool.searchNamespace.toLowerCase();
+  const toolIdText = tool.operation.toolId.toLowerCase();
+  const titleText = tool.operation.title?.toLowerCase() ?? "";
+  const descriptionText = tool.operation.description?.toLowerCase() ?? "";
+  const templateText = tool.operation.openApiPathTemplate?.toLowerCase() ?? "";
+
+  const pathTokens = tokenize(`${tool.path} ${tool.operation.toolId}`);
+  const namespaceTokens = tokenize(tool.searchNamespace);
+  const titleTokens = tokenize(tool.operation.title ?? "");
+  const templateTokens = tokenize(tool.operation.openApiPathTemplate ?? "");
 
   let score = 0;
   let structuralHits = 0;
@@ -263,273 +273,6 @@ const scoreArtifact = (
   return score;
 };
 
-const catalogNamespaceFromPath = (path: string): string => {
-  const [first, second] = path.split(".");
-  return second ? `${first}.${second}` : first;
-};
-
-const toPersistedDescriptor = (input: {
-  artifact: StoredToolArtifactRecord;
-  includeSchemas: boolean;
-}): ToolDescriptor => ({
-  path: asToolPath(input.artifact.path),
-  sourceKey: input.artifact.sourceId,
-  description: input.artifact.description ?? input.artifact.title ?? undefined,
-  interaction: "auto",
-  inputType: typeSignatureFromSchemaJson(
-    input.artifact.inputSchemaJson ?? undefined,
-    "unknown",
-    320,
-  ),
-  outputType:
-    input.artifact.providerKind === "openapi"
-      ? openApiOutputTypeSignatureFromSchemaJson(
-        input.artifact.outputSchemaJson ?? undefined,
-        320,
-      )
-      : typeSignatureFromSchemaJson(
-        input.artifact.outputSchemaJson ?? undefined,
-        "unknown",
-        320,
-      ),
-  inputSchemaJson: input.includeSchemas ? input.artifact.inputSchemaJson ?? undefined : undefined,
-  outputSchemaJson: input.includeSchemas ? input.artifact.outputSchemaJson ?? undefined : undefined,
-  ...(input.artifact.providerKind ? { providerKind: input.artifact.providerKind } : {}),
-});
-
-type OpenApiWorkspaceTool = {
-  path: ToolPath;
-  source: Source;
-  manifest: OpenApiToolManifest;
-  definition: OpenApiToolDefinition;
-  descriptor: ToolDescriptor;
-  searchNamespace: string;
-  searchText: string;
-};
-
-type GraphqlWorkspaceTool = {
-  path: ToolPath;
-  source: Source;
-  manifest: GraphqlToolManifest;
-  definition: GraphqlToolDefinition;
-  descriptor: ToolDescriptor;
-  searchNamespace: string;
-  searchText: string;
-};
-
-const loadOpenApiWorkspaceTools = (input: {
-  rows: SqlControlPlaneRows;
-  workspaceId: Source["workspaceId"];
-  includeSchemas: boolean;
-}): Effect.Effect<ReadonlyArray<OpenApiWorkspaceTool>, Error, never> =>
-  Effect.gen(function* () {
-    const sourceRecords = yield* input.rows.sources.listByWorkspaceId(input.workspaceId).pipe(
-      Effect.mapError((cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
-      ),
-    );
-    const documentBySourceId = new Map(
-      sourceRecords.map((record) => [record.id, record.sourceDocumentText]),
-    );
-    const sources = yield* loadSourcesInWorkspace(input.rows, input.workspaceId);
-
-    const connectedOpenApiSources = sources.filter((source) =>
-      source.enabled
-      && source.status === "connected"
-      && source.kind === "openapi"
-      && typeof documentBySourceId.get(source.id) === "string"
-      && documentBySourceId.get(source.id)!.length > 0,
-    );
-
-    const toolGroups = yield* Effect.forEach(
-      connectedOpenApiSources,
-      (source) =>
-        Effect.gen(function* () {
-          const openApiDocument = documentBySourceId.get(source.id)!;
-          const manifest = yield* extractOpenApiManifest(
-            source.name,
-            openApiDocument,
-          ).pipe(
-            Effect.mapError((cause) =>
-              cause instanceof Error ? cause : new Error(String(cause)),
-            ),
-          );
-          const definitions = compileOpenApiToolDefinitions(manifest);
-          const namespace = source.namespace ?? namespaceFromSourceName(source.name);
-
-          return definitions.map((definition) => {
-            const presentation = buildOpenApiToolPresentation({
-              manifest,
-              definition,
-            });
-            const path = asToolPath(
-              namespace ? `${namespace}.${definition.toolId}` : definition.toolId,
-            );
-            const searchNamespace = catalogNamespaceFromPath(path);
-            const searchText = [
-              path,
-              searchNamespace,
-              definition.name,
-              definition.description,
-              definition.rawToolId,
-              definition.tags.join(" "),
-              definition.method.toUpperCase(),
-              definition.path,
-            ]
-              .filter((part): part is string => typeof part === "string" && part.length > 0)
-              .join(" ")
-              .toLowerCase();
-
-            return {
-              path,
-              source,
-              manifest,
-              definition,
-              descriptor: {
-                path,
-                sourceKey: source.id,
-                description: definition.description,
-                interaction:
-                  definition.method.toUpperCase() === "GET"
-                    || definition.method.toUpperCase() === "HEAD"
-                    ? "auto"
-                    : "required",
-                inputType: presentation.inputType,
-                outputType: presentation.outputType,
-                ...(input.includeSchemas && presentation.inputSchemaJson
-                  ? { inputSchemaJson: presentation.inputSchemaJson }
-                  : {}),
-                ...(input.includeSchemas && presentation.outputSchemaJson
-                  ? { outputSchemaJson: presentation.outputSchemaJson }
-                  : {}),
-                ...(presentation.exampleInputJson
-                  ? { exampleInputJson: presentation.exampleInputJson }
-                  : {}),
-                ...(presentation.exampleOutputJson
-                  ? { exampleOutputJson: presentation.exampleOutputJson }
-                  : {}),
-                providerKind: "openapi",
-                providerDataJson: presentation.providerDataJson,
-              } satisfies ToolDescriptor,
-              searchNamespace,
-              searchText,
-            } satisfies OpenApiWorkspaceTool;
-          });
-        }),
-      { concurrency: "unbounded" },
-    );
-
-    return toolGroups.flat();
-  });
-
-const loadGraphqlWorkspaceTools = (input: {
-  rows: SqlControlPlaneRows;
-  workspaceId: Source["workspaceId"];
-  includeSchemas: boolean;
-}): Effect.Effect<ReadonlyArray<GraphqlWorkspaceTool>, Error, never> =>
-  Effect.gen(function* () {
-    const sourceRecords = yield* input.rows.sources.listByWorkspaceId(input.workspaceId).pipe(
-      Effect.mapError((cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
-      ),
-    );
-    const documentBySourceId = new Map(
-      sourceRecords.map((record) => [record.id, record.sourceDocumentText]),
-    );
-    const sources = yield* loadSourcesInWorkspace(input.rows, input.workspaceId);
-
-    const connectedGraphqlSources = sources.filter((source) =>
-      source.enabled
-      && source.status === "connected"
-      && source.kind === "graphql"
-      && typeof documentBySourceId.get(source.id) === "string"
-      && documentBySourceId.get(source.id)!.length > 0,
-    );
-
-    const toolGroups = yield* Effect.forEach(
-      connectedGraphqlSources,
-      (source) =>
-        Effect.gen(function* () {
-          const graphqlDocument = documentBySourceId.get(source.id)!;
-          const manifest = yield* extractGraphqlManifest(
-            source.name,
-            graphqlDocument,
-          ).pipe(
-            Effect.mapError((cause) =>
-              cause instanceof Error ? cause : new Error(String(cause)),
-            ),
-          );
-          const definitions = compileGraphqlToolDefinitions(manifest);
-          const namespace = source.namespace ?? namespaceFromSourceName(source.name);
-
-          return definitions.map((definition) => {
-            const path = asToolPath(
-              namespace ? `${namespace}.${definition.toolId}` : definition.toolId,
-            );
-            const searchNamespace = namespace;
-            const descriptor = graphqlToolDescriptorFromDefinition({
-              manifest,
-              definition,
-              path,
-              sourceKey: source.id,
-              includeSchemas: input.includeSchemas,
-            });
-            const searchText = [
-              path,
-              searchNamespace,
-              source.name,
-              definition.name,
-              definition.description,
-              definition.rawToolId,
-              definition.fieldName,
-              definition.group,
-              definition.leaf,
-              definition.operationType,
-              definition.operationName,
-              definition.searchTerms.join(" "),
-              definition.toolId === "request"
-                ? "graphql request query mutation variables"
-                : "graphql field query mutation",
-              manifest.queryTypeName,
-              manifest.mutationTypeName,
-              manifest.subscriptionTypeName,
-            ]
-              .filter((part): part is string => typeof part === "string" && part.length > 0)
-              .join(" ")
-              .toLowerCase();
-
-            return {
-              path,
-              source,
-              manifest,
-              definition,
-              descriptor,
-              searchNamespace,
-              searchText,
-            } satisfies GraphqlWorkspaceTool;
-          });
-        }),
-      { concurrency: "unbounded" },
-    );
-
-    return toolGroups.flat();
-  });
-
-
-const loadSourceById = (input: {
-  rows: SqlControlPlaneRows;
-  workspaceId: Source["workspaceId"];
-  sourceId: Source["id"];
-}): Effect.Effect<Source, Error, never> =>
-  loadStoredSourceById(input.rows, {
-    workspaceId: input.workspaceId,
-    sourceId: input.sourceId,
-  }).pipe(
-    Effect.mapError((cause) =>
-      cause instanceof Error ? cause : new Error(String(cause)),
-    ),
-  );
-
 const approvalSchema = {
   type: "object",
   properties: {
@@ -554,61 +297,27 @@ const approvalMessageForInvocation = (descriptor: InvocationDescriptor): string 
   return `Allow tool call: ${descriptor.toolPath}?`;
 };
 
-const toInvocationDescriptorFromOpenApiTool = (input: {
-  tool: OpenApiWorkspaceTool;
-}): InvocationDescriptor => {
-  const method = input.tool.definition.method.toUpperCase();
-  return {
-    toolPath: input.tool.path,
-    sourceId: input.tool.source.id,
-    sourceName: input.tool.source.name,
-    sourceKind: input.tool.source.kind,
-    sourceNamespace: input.tool.source.namespace ?? namespaceFromSourceName(input.tool.source.name),
-    operationKind:
-      method === "GET" || method === "HEAD"
-        ? "read"
-        : method === "DELETE"
-          ? "delete"
-          : "write",
-    httpMethod: method,
-    httpPathTemplate: input.tool.definition.path,
-    graphqlOperationType: null,
-  };
-};
+const toGraphqlInvocationOperationType = (
+  value: string | null,
+): InvocationDescriptor["graphqlOperationType"] =>
+  value === "query" || value === "mutation" || value === "subscription"
+    ? value
+    : null;
 
-const toInvocationDescriptorFromGraphqlTool = (input: {
-  tool: GraphqlWorkspaceTool;
+const toInvocationDescriptorFromRecipeTool = (input: {
+  tool: LoadedSourceRecipeTool;
 }): InvocationDescriptor => ({
   toolPath: input.tool.path,
   sourceId: input.tool.source.id,
   sourceName: input.tool.source.name,
   sourceKind: input.tool.source.kind,
   sourceNamespace: input.tool.source.namespace ?? namespaceFromSourceName(input.tool.source.name),
-  operationKind:
-    input.tool.definition.operationType === "query"
-      ? "read"
-      : input.tool.definition.operationType === "mutation"
-        ? "write"
-        : "unknown",
-  httpMethod: null,
-  httpPathTemplate: null,
-  graphqlOperationType: input.tool.definition.operationType,
-});
-
-const toInvocationDescriptorFromArtifact = (input: {
-  toolPath: string;
-  source: Source;
-  artifact: StoredToolArtifactRecord;
-}): InvocationDescriptor => ({
-  toolPath: input.toolPath,
-  sourceId: input.source.id,
-  sourceName: input.source.name,
-  sourceKind: input.source.kind,
-  sourceNamespace: input.source.namespace ?? namespaceFromSourceName(input.source.name),
-  operationKind: "unknown",
-  httpMethod: input.artifact.openApiMethod?.toUpperCase() ?? null,
-  httpPathTemplate: input.artifact.openApiPathTemplate,
-  graphqlOperationType: null,
+  operationKind: input.tool.operation.operationKind,
+  httpMethod: input.tool.operation.openApiMethod?.toUpperCase() ?? null,
+  httpPathTemplate: input.tool.operation.openApiPathTemplate,
+  graphqlOperationType: toGraphqlInvocationOperationType(
+    input.tool.operation.graphqlOperationType,
+  ),
 });
 
 const authorizePersistedToolInvocation = (input: {
@@ -711,44 +420,24 @@ const authorizePersistedToolInvocation = (input: {
 
 const createWorkspaceToolCatalog = (input: {
   workspaceId: Source["workspaceId"];
+  accountId: AccountId;
   rows: SqlControlPlaneRows;
   executorCatalog: ToolCatalog;
 }): ToolCatalog => ({
   listNamespaces: ({ limit }) =>
     Effect.gen(function* () {
-      const [persisted, openApiTools, graphqlTools, executor] = yield* Effect.all([
-        input.rows.toolArtifacts.listNamespacesByWorkspaceId(input.workspaceId, {
-          limit,
-        }).pipe(
-          Effect.mapError((cause) =>
-            cause instanceof Error ? cause : new Error(String(cause)),
-          ),
-        ),
-        loadOpenApiWorkspaceTools({
+      const [recipeTools, executor] = yield* Effect.all([
+        loadWorkspaceRecipeTools({
           rows: input.rows,
           workspaceId: input.workspaceId,
-          includeSchemas: false,
-        }),
-        loadGraphqlWorkspaceTools({
-          rows: input.rows,
-          workspaceId: input.workspaceId,
+          accountId: input.accountId,
           includeSchemas: false,
         }),
         input.executorCatalog.listNamespaces({ limit }),
       ]);
 
       const merged = new Map<string, ToolNamespace>();
-      for (const namespace of persisted) {
-        merged.set(namespace.namespace, namespace);
-      }
-      for (const tool of openApiTools) {
-        const existing = merged.get(tool.searchNamespace);
-        merged.set(tool.searchNamespace, {
-          namespace: tool.searchNamespace,
-          toolCount: (existing?.toolCount ?? 0) + 1,
-        });
-      }
-      for (const tool of graphqlTools) {
+      for (const tool of recipeTools) {
         const existing = merged.get(tool.searchNamespace);
         merged.set(tool.searchNamespace, {
           namespace: tool.searchNamespace,
@@ -774,38 +463,11 @@ const createWorkspaceToolCatalog = (input: {
 
   listTools: ({ namespace, query, limit, includeSchemas = false }) =>
     Effect.gen(function* () {
-      const [persisted, openApiTools, graphqlTools, executor] = yield* Effect.all([
-        namespace?.startsWith("executor")
-          ? Effect.succeed([] as readonly StoredToolArtifactRecord[])
-          : input.rows.toolArtifacts.listByWorkspaceId(input.workspaceId, {
-            namespace,
-            query,
-            limit,
-          }).pipe(
-            Effect.mapError((cause) =>
-              cause instanceof Error ? cause : new Error(String(cause)),
-            ),
-          ),
-        loadOpenApiWorkspaceTools({
+      const [recipeTools, executor] = yield* Effect.all([
+        loadWorkspaceRecipeTools({
           rows: input.rows,
           workspaceId: input.workspaceId,
-          includeSchemas,
-        }).pipe(
-          Effect.map((tools) =>
-            tools.filter((tool) => {
-              if (namespace && tool.searchNamespace !== namespace) {
-                return false;
-              }
-              if (!query) {
-                return true;
-              }
-              return tokenize(query).every((token) => tool.searchText.includes(token));
-            }),
-          ),
-        ),
-        loadGraphqlWorkspaceTools({
-          rows: input.rows,
-          workspaceId: input.workspaceId,
+          accountId: input.accountId,
           includeSchemas,
         }).pipe(
           Effect.map((tools) =>
@@ -828,17 +490,8 @@ const createWorkspaceToolCatalog = (input: {
         }),
       ]);
 
-      const persistedDescriptors = persisted.map((artifact) =>
-        toPersistedDescriptor({
-          artifact,
-          includeSchemas,
-        }),
-      );
-
       return [
-        ...persistedDescriptors,
-        ...openApiTools.map((tool) => tool.descriptor),
-        ...graphqlTools.map((tool) => tool.descriptor),
+        ...recipeTools.map((tool) => tool.descriptor),
         ...executor,
       ]
         .sort((left, right) => left.path.localeCompare(right.path))
@@ -855,71 +508,23 @@ const createWorkspaceToolCatalog = (input: {
         return executor;
       }
 
-      const openApiTools = yield* loadOpenApiWorkspaceTools({
+      const recipeTools = yield* loadWorkspaceRecipeTools({
         rows: input.rows,
         workspaceId: input.workspaceId,
+        accountId: input.accountId,
         includeSchemas,
       });
-      const openApiTool = openApiTools.find((tool) => tool.path === path);
-      if (openApiTool) {
-        return openApiTool.descriptor;
-      }
-
-      const graphqlTools = yield* loadGraphqlWorkspaceTools({
-        rows: input.rows,
-        workspaceId: input.workspaceId,
-        includeSchemas,
-      });
-      const graphqlTool = graphqlTools.find((tool) => tool.path === path);
-      if (graphqlTool) {
-        return graphqlTool.descriptor;
-      }
-
-      const artifact = yield* input.rows.toolArtifacts.getByWorkspaceAndPath(
-        input.workspaceId,
-        path,
-      ).pipe(
-        Effect.mapError((cause) =>
-          cause instanceof Error ? cause : new Error(String(cause)),
-        ),
-      );
-
-      if (Option.isNone(artifact)) {
-        return null;
-      }
-
-      return toPersistedDescriptor({
-        artifact: artifact.value,
-        includeSchemas,
-      });
+      return recipeTools.find((tool) => tool.path === path)?.descriptor ?? null;
     }),
 
   searchTools: ({ query, namespace, limit }) =>
     Effect.gen(function* () {
       const queryTokens = tokenize(query);
-      const [persisted, openApiTools, graphqlTools, executor] = yield* Effect.all([
-        namespace?.startsWith("executor")
-          ? Effect.succeed([] as readonly StoredToolArtifactRecord[])
-          : input.rows.toolArtifacts.searchByWorkspaceId(input.workspaceId, {
-            namespace,
-            query,
-          }).pipe(
-            Effect.mapError((cause) =>
-              cause instanceof Error ? cause : new Error(String(cause)),
-            ),
-          ),
-        loadOpenApiWorkspaceTools({
+      const [recipeTools, executor] = yield* Effect.all([
+        loadWorkspaceRecipeTools({
           rows: input.rows,
           workspaceId: input.workspaceId,
-          includeSchemas: false,
-        }).pipe(
-          Effect.map((tools) =>
-            tools.filter((tool) => !namespace || tool.searchNamespace === namespace),
-          ),
-        ),
-        loadGraphqlWorkspaceTools({
-          rows: input.rows,
-          workspaceId: input.workspaceId,
+          accountId: input.accountId,
           includeSchemas: false,
         }).pipe(
           Effect.map((tools) =>
@@ -933,34 +538,14 @@ const createWorkspaceToolCatalog = (input: {
         }),
       ]);
 
-      const persistedHits: SearchHit[] = persisted
-        .map((artifact) => ({
-          path: asToolPath(artifact.path),
-          score: scoreArtifact(queryTokens, artifact),
-        }))
-        .filter((hit) => hit.score > 0);
-
-      const openApiHits: SearchHit[] = openApiTools
+      const recipeHits: SearchHit[] = recipeTools
         .map((tool) => ({
-          path: tool.path,
-          score: tokenize(query).reduce(
-            (total, token) => total + (tool.searchText.includes(token) ? 1 : 0),
-            0,
-          ),
+          path: asToolPath(tool.path),
+          score: scoreRecipeTool(queryTokens, tool),
         }))
         .filter((hit) => hit.score > 0);
 
-      const graphqlHits: SearchHit[] = graphqlTools
-        .map((tool) => ({
-          path: tool.path,
-          score: tokenize(query).reduce(
-            (total, token) => total + (tool.searchText.includes(token) ? 1 : 0),
-            0,
-          ),
-        }))
-        .filter((hit) => hit.score > 0);
-
-      return [...persistedHits, ...openApiHits, ...graphqlHits, ...executor]
+      return [...recipeHits, ...executor]
         .sort((left, right) =>
           right.score - left.score || left.path.localeCompare(right.path),
         )
@@ -978,9 +563,10 @@ const createWorkspaceToolInvoker = (input: {
 }): {
   catalog: ToolCatalog;
   toolInvoker: ToolInvoker;
-} => {
+  } => {
   const executorTools = createExecutorToolMap({
     workspaceId: input.workspaceId,
+    accountId: input.accountId,
     sourceAuthService: input.sourceAuthService,
   });
   const executorCatalog = createToolCatalogFromTools({
@@ -988,6 +574,7 @@ const createWorkspaceToolInvoker = (input: {
   });
   const catalog = createWorkspaceToolCatalog({
     workspaceId: input.workspaceId,
+    accountId: input.accountId,
     rows: input.rows,
     executorCatalog,
   });
@@ -1009,161 +596,106 @@ const createWorkspaceToolInvoker = (input: {
     context?: Record<string, unknown>;
   }) =>
     Effect.gen(function* () {
-      const openApiTools = yield* loadOpenApiWorkspaceTools({
+      const recipeTools = yield* loadWorkspaceRecipeTools({
         rows: input.rows,
         workspaceId: input.workspaceId,
+        accountId: input.accountId,
         includeSchemas: false,
       });
-      const openApiTool = openApiTools.find((tool) => tool.path === invocation.path);
-      if (openApiTool) {
-        yield* authorizePersistedToolInvocation({
-          rows: input.rows,
-          workspaceId: input.workspaceId,
-          accountId: input.accountId,
-          descriptor: toInvocationDescriptorFromOpenApiTool({ tool: openApiTool }),
-          args: invocation.args,
-          source: openApiTool.source,
-          context: invocation.context,
-          onElicitation: input.onElicitation,
-        });
-
-        const auth = yield* resolveSourceAuthMaterial({
-          source: openApiTool.source,
-          resolveSecretMaterial: input.resolveSecretMaterial,
-          context: toSecretResolutionContext(invocation.context),
-        });
-
-        const tools = createOpenApiToolsFromManifest({
-          manifest: openApiTool.manifest,
-          baseUrl: openApiTool.source.endpoint,
-          namespace: openApiTool.source.namespace ?? namespaceFromSourceName(openApiTool.source.name),
-          sourceKey: openApiTool.source.id,
-          defaultHeaders: openApiTool.source.defaultHeaders ?? {},
-          credentialHeaders: auth.headers,
-        });
-
-        return yield* makeToolInvokerFromTools({
-          tools,
-          onElicitation: input.onElicitation,
-        }).invoke({
-          path: invocation.path,
-          args: invocation.args,
-          context: invocation.context,
-        });
-      }
-
-      const graphqlTools = yield* loadGraphqlWorkspaceTools({
-        rows: input.rows,
-        workspaceId: input.workspaceId,
-        includeSchemas: false,
-      });
-      const graphqlTool = graphqlTools.find((tool) => tool.path === invocation.path);
-      if (graphqlTool) {
-        yield* authorizePersistedToolInvocation({
-          rows: input.rows,
-          workspaceId: input.workspaceId,
-          accountId: input.accountId,
-          descriptor: toInvocationDescriptorFromGraphqlTool({ tool: graphqlTool }),
-          args: invocation.args,
-          source: graphqlTool.source,
-          context: invocation.context,
-          onElicitation: input.onElicitation,
-        });
-
-        const auth = yield* resolveSourceAuthMaterial({
-          source: graphqlTool.source,
-          resolveSecretMaterial: input.resolveSecretMaterial,
-          context: toSecretResolutionContext(invocation.context),
-        });
-
-        const tools = createGraphqlToolsFromManifest({
-          manifest: graphqlTool.manifest,
-          endpoint: graphqlTool.source.endpoint,
-          namespace: graphqlTool.source.namespace ?? namespaceFromSourceName(graphqlTool.source.name),
-          sourceKey: graphqlTool.source.id,
-          defaultHeaders: graphqlTool.source.defaultHeaders ?? {},
-          credentialHeaders: auth.headers,
-        });
-
-        return yield* makeToolInvokerFromTools({
-          tools,
-          onElicitation: input.onElicitation,
-        }).invoke({
-          path: invocation.path,
-          args: invocation.args,
-          context: invocation.context,
-        });
-      }
-
-      const artifactOption = yield* input.rows.toolArtifacts
-        .getByWorkspaceAndPath(input.workspaceId, invocation.path)
-        .pipe(
-          Effect.mapError((cause) =>
-            cause instanceof Error ? cause : new Error(String(cause)),
-          ),
-        );
-
-      if (Option.isNone(artifactOption)) {
+      const recipeTool = recipeTools.find((tool) => tool.path === invocation.path);
+      if (!recipeTool) {
         return yield* Effect.fail(new Error(`Unknown tool path: ${invocation.path}`));
-      }
-
-      const artifact = artifactOption.value;
-      const source = yield* loadSourceById({
-        rows: input.rows,
-        workspaceId: input.workspaceId,
-        sourceId: artifact.sourceId,
-      });
-
-      if (!source.enabled || source.status !== "connected") {
-        return yield* Effect.fail(
-          new Error(`Source for tool path ${invocation.path} is not connected`),
-        );
       }
 
       yield* authorizePersistedToolInvocation({
         rows: input.rows,
         workspaceId: input.workspaceId,
         accountId: input.accountId,
-        descriptor: toInvocationDescriptorFromArtifact({
-          toolPath: invocation.path,
-          source,
-          artifact,
-        }),
+        descriptor: toInvocationDescriptorFromRecipeTool({ tool: recipeTool }),
         args: invocation.args,
-        source,
+        source: recipeTool.source,
         context: invocation.context,
         onElicitation: input.onElicitation,
       });
 
       const auth = yield* resolveSourceAuthMaterial({
-        source,
+        source: recipeTool.source,
         resolveSecretMaterial: input.resolveSecretMaterial,
         context: toSecretResolutionContext(invocation.context),
       });
 
-      if (artifact.providerKind === "mcp") {
+      if (recipeTool.operation.providerKind === "openapi") {
+        if (recipeTool.manifest === null) {
+          return yield* Effect.fail(
+            new Error(`Missing OpenAPI manifest for ${recipeTool.source.id}`),
+          );
+        }
+
+        const tools = createOpenApiToolsFromManifest({
+          manifest: recipeTool.manifest as OpenApiToolManifest,
+          baseUrl: recipeTool.source.endpoint,
+          namespace: recipeTool.source.namespace ?? namespaceFromSourceName(recipeTool.source.name),
+          sourceKey: recipeTool.source.id,
+          defaultHeaders: recipeTool.source.defaultHeaders ?? {},
+          credentialHeaders: auth.headers,
+        });
+
+        return yield* makeToolInvokerFromTools({
+          tools,
+          onElicitation: input.onElicitation,
+        }).invoke({
+          path: invocation.path,
+          args: invocation.args,
+          context: invocation.context,
+        });
+      }
+
+      if (recipeTool.operation.providerKind === "graphql") {
+        if (recipeTool.manifest === null) {
+          return yield* Effect.fail(
+            new Error(`Missing GraphQL manifest for ${recipeTool.source.id}`),
+          );
+        }
+
+        const tools = createGraphqlToolsFromManifest({
+          manifest: recipeTool.manifest as GraphqlToolManifest,
+          endpoint: recipeTool.source.endpoint,
+          namespace: recipeTool.source.namespace ?? namespaceFromSourceName(recipeTool.source.name),
+          sourceKey: recipeTool.source.id,
+          defaultHeaders: recipeTool.source.defaultHeaders ?? {},
+          credentialHeaders: auth.headers,
+        });
+
+        return yield* makeToolInvokerFromTools({
+          tools,
+          onElicitation: input.onElicitation,
+        }).invoke({
+          path: invocation.path,
+          args: invocation.args,
+          context: invocation.context,
+        });
+      }
+
+      if (recipeTool.operation.providerKind === "mcp") {
+        if (recipeTool.manifest === null) {
+          return yield* Effect.fail(
+            new Error(`Missing MCP manifest for ${recipeTool.source.id}`),
+          );
+        }
+
         const tools = createMcpToolsFromManifest({
-          manifest: {
-            version: 1,
-            tools: [{
-              toolId: storedToolIdFromArtifact(artifact),
-              toolName: artifact.mcpToolName ?? artifact.title ?? artifact.path,
-              description: artifact.description ?? null,
-              ...(artifact.inputSchemaJson ? { inputSchemaJson: artifact.inputSchemaJson } : {}),
-              ...(artifact.outputSchemaJson ? { outputSchemaJson: artifact.outputSchemaJson } : {}),
-            }],
-          },
+          manifest: recipeTool.manifest as McpToolManifest,
           connect: createSdkMcpConnector({
-            endpoint: source.endpoint,
-            transport: source.transport ?? undefined,
-            queryParams: source.queryParams ?? undefined,
+            endpoint: recipeTool.source.endpoint,
+            transport: recipeTool.source.transport ?? undefined,
+            queryParams: recipeTool.source.queryParams ?? undefined,
             headers: {
-              ...(source.headers ?? {}),
+              ...(recipeTool.source.headers ?? {}),
               ...auth.headers,
             },
           }),
-          namespace: source.namespace ?? namespaceFromSourceName(source.name),
-          sourceKey: source.id,
+          namespace: recipeTool.source.namespace ?? namespaceFromSourceName(recipeTool.source.name),
+          sourceKey: recipeTool.source.id,
         });
 
         return yield* makeToolInvokerFromTools({


### PR DESCRIPTION
## Summary
Move source execution and inspection onto recipe-backed data:
- load manifests, documents, and operations from recipe revisions
- build tool discovery and invocation from the recipe runtime loader
- stop depending on legacy per-source manifest reads in the execution environment

## Why
This is the runtime half of the cutover. After this branch, sources are executed from the canonical recipe model instead of the legacy per-source projection.

## Verification
- `bunx tsc --noEmit -p packages/control-plane/tsconfig.json`
- `bun node_modules/.bun/vitest@3.2.4+177b360525281f4c/node_modules/vitest/vitest.mjs run packages/control-plane/src/runtime/tool-artifacts.test.ts packages/control-plane/src/runtime/workspace-execution-environment.test.ts packages/control-plane/src/runtime/control-plane-runtime.test.ts`
- `bun node_modules/.bun/vitest@3.2.4+177b360525281f4c/node_modules/vitest/vitest.mjs run --maxWorkers 1 packages/control-plane/src/runtime/source-recipes-runtime.test.ts`