### PR TITLE
Add regression coverage for the source recipe cutover

### DIFF
--- a/apps/executor/src/server/server.test.ts
+++ b/apps/executor/src/server/server.test.ts
@@ -20,6 +20,8 @@ import {
   type ControlPlaneClient,
   type ResolveExecutionEnvironment,
   SourceIdSchema,
+  SourceRecipeIdSchema,
+  SourceRecipeRevisionIdSchema,
 } from "@executor/control-plane";
 import { makeSesExecutor } from "@executor/runtime-ses";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -1346,10 +1348,61 @@ describe("local-executor-server", () => {
       });
 
       const sourceId = SourceIdSchema.make("src_invalid_mcp_endpoint");
+      const recipeId = SourceRecipeIdSchema.make(`src_recipe_${sourceId}`);
+      const recipeRevisionId = SourceRecipeRevisionIdSchema.make(`src_recipe_rev_${sourceId}`);
       const now = Date.now();
+      const manifest = {
+        version: 1 as const,
+        tools: [{
+          toolId: "gated_echo",
+          toolName: "gated_echo",
+          description: "Asks for approval before echoing a value",
+          inputSchemaJson: JSON.stringify({
+            type: "object",
+            properties: {
+              value: {
+                type: "string",
+              },
+            },
+            required: ["value"],
+            additionalProperties: false,
+          }),
+        }],
+      };
+      const manifestJson = JSON.stringify(manifest);
+      yield* server.runtime.persistence.rows.sourceRecipes.upsert({
+        id: recipeId,
+        kind: "mcp_recipe",
+        importerKind: "mcp_manifest",
+        providerKey: "generic_mcp",
+        name: "Demo",
+        summary: null,
+        visibility: "workspace",
+        latestRevisionId: recipeRevisionId,
+        createdAt: now,
+        updatedAt: now,
+      });
+      yield* server.runtime.persistence.rows.sourceRecipeRevisions.upsert({
+        id: recipeRevisionId,
+        recipeId,
+        revisionNumber: 1,
+        sourceConfigJson: JSON.stringify({
+          kind: "mcp",
+          endpoint: "http://127.0.0.1:PORT/mcp",
+          transport: "streamable-http",
+          queryParams: null,
+          headers: null,
+        }),
+        manifestJson,
+        manifestHash: null,
+        createdAt: now,
+        updatedAt: now,
+      });
       yield* server.runtime.persistence.rows.sources.insert({
         id: sourceId,
         workspaceId: installation.workspaceId,
+        recipeId,
+        recipeRevisionId,
         name: "Demo",
         kind: "mcp",
         endpoint: "http://127.0.0.1:PORT/mcp",
@@ -1357,6 +1410,7 @@ describe("local-executor-server", () => {
         enabled: true,
         namespace: "demo",
         transport: "streamable-http",
+        bindingConfigJson: null,
         queryParamsJson: null,
         headersJson: null,
         specUrl: null,
@@ -1367,42 +1421,48 @@ describe("local-executor-server", () => {
         createdAt: now,
         updatedAt: now,
       });
-      yield* server.runtime.persistence.rows.toolArtifacts.replaceForSource({
-        workspaceId: installation.workspaceId,
-        sourceId,
-        artifacts: [{
-          artifact: {
-            workspaceId: installation.workspaceId,
-            path: "demo.gated_echo",
-            toolId: "gated_echo",
-            sourceId,
-            title: "gated_echo",
-            description: "Asks for approval before echoing a value",
-            searchNamespace: "demo.gated_echo",
-            searchText: "demo.gated_echo gated echo approval",
-            inputSchemaJson: JSON.stringify({
-              type: "object",
-              properties: {
-                value: {
-                  type: "string",
-                },
-              },
-              required: ["value"],
-              additionalProperties: false,
-            }),
-            outputSchemaJson: null,
-            providerKind: "mcp",
-            mcpToolName: "gated_echo",
-            openApiMethod: null,
-            openApiPathTemplate: null,
-            openApiOperationHash: null,
-            openApiRawToolId: null,
-            openApiOperationId: null,
-            openApiTagsJson: null,
-            openApiRequestBodyRequired: null,
-            createdAt: now,
-            updatedAt: now,
-          },
+      yield* server.runtime.persistence.rows.sourceRecipeDocuments.replaceForRevision({
+        recipeRevisionId,
+        documents: [{
+          id: `src_recipe_doc_${sourceId}`,
+          recipeRevisionId,
+          documentKind: "mcp_manifest",
+          documentKey: "manifest",
+          contentText: manifestJson,
+          contentHash: `manifest_${sourceId}`,
+          fetchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        }],
+      });
+      yield* server.runtime.persistence.rows.sourceRecipeOperations.replaceForRevision({
+        recipeRevisionId,
+        operations: [{
+          id: `src_recipe_op_${sourceId}`,
+          recipeRevisionId,
+          operationKey: "gated_echo",
+          transportKind: "mcp",
+          toolId: "gated_echo",
+          title: "gated_echo",
+          description: "Asks for approval before echoing a value",
+          operationKind: "unknown",
+          searchText: "demo.gated_echo gated echo approval",
+          inputSchemaJson: manifest.tools[0]!.inputSchemaJson ?? null,
+          outputSchemaJson: null,
+          providerKind: "mcp",
+          providerDataJson: null,
+          mcpToolName: "gated_echo",
+          openApiMethod: null,
+          openApiPathTemplate: null,
+          openApiOperationHash: null,
+          openApiRawToolId: null,
+          openApiOperationId: null,
+          openApiTagsJson: null,
+          openApiRequestBodyRequired: null,
+          graphqlOperationType: null,
+          graphqlOperationName: null,
+          createdAt: now,
+          updatedAt: now,
         }],
       });
 

--- a/packages/control-plane/src/persistence/repos/tool-artifacts-repo.ts
+++ b/packages/control-plane/src/persistence/repos/tool-artifacts-repo.ts
@@ -26,34 +26,15 @@ import { firstOption } from "./shared";
 const decodeStoredToolArtifactRecord = Schema.decodeUnknownSync(
   StoredToolArtifactRecordSchema,
 );
-const encodeStoredToolArtifactRecord = Schema.encodeSync(
-  StoredToolArtifactRecordSchema,
-);
 const decodeStoredToolArtifactParameterRecord = Schema.decodeUnknownSync(
-  StoredToolArtifactParameterRecordSchema,
-);
-const encodeStoredToolArtifactParameterRecord = Schema.encodeSync(
   StoredToolArtifactParameterRecordSchema,
 );
 const decodeStoredToolArtifactRequestBodyContentTypeRecord = Schema.decodeUnknownSync(
   StoredToolArtifactRequestBodyContentTypeRecordSchema,
 );
-const encodeStoredToolArtifactRequestBodyContentTypeRecord = Schema.encodeSync(
-  StoredToolArtifactRequestBodyContentTypeRecordSchema,
-);
 const decodeStoredToolArtifactRefHintKeyRecord = Schema.decodeUnknownSync(
   StoredToolArtifactRefHintKeyRecordSchema,
 );
-const encodeStoredToolArtifactRefHintKeyRecord = Schema.encodeSync(
-  StoredToolArtifactRefHintKeyRecordSchema,
-);
-
-type ReplaceableToolArtifactRecord = {
-  artifact: StoredToolArtifactRecord;
-  parameters?: readonly StoredToolArtifactParameterRecord[];
-  requestBodyContentTypes?: readonly StoredToolArtifactRequestBodyContentTypeRecord[];
-  refHintKeys?: readonly StoredToolArtifactRefHintKeyRecord[];
-};
 
 const tokenizeQuery = (value: string | undefined): string[] =>
   value
@@ -295,103 +276,6 @@ export const createToolArtifactsRepo = (
         .orderBy(asc(tables.toolArtifactRefHintKeysTable.position));
 
       return rows.map((row) => decodeStoredToolArtifactRefHintKeyRecord(row));
-    }),
-
-  replaceForSource: (input: {
-    workspaceId: StoredToolArtifactRecord["workspaceId"];
-    sourceId: StoredToolArtifactRecord["sourceId"];
-    artifacts: readonly ReplaceableToolArtifactRecord[];
-  }) =>
-    client.useTx("rows.tool_artifacts.replace_for_source", async (tx) => {
-      const existingPaths = (
-        await tx
-          .select({
-            path: tables.toolArtifactsTable.path,
-          })
-          .from(tables.toolArtifactsTable)
-          .where(
-            and(
-              eq(tables.toolArtifactsTable.workspaceId, input.workspaceId),
-              eq(tables.toolArtifactsTable.sourceId, input.sourceId),
-            ),
-          )
-      ).map((row) => row.path);
-
-      if (existingPaths.length > 0) {
-        await tx
-          .delete(tables.toolArtifactParametersTable)
-          .where(
-            and(
-              eq(tables.toolArtifactParametersTable.workspaceId, input.workspaceId),
-              or(...existingPaths.map((path) => eq(tables.toolArtifactParametersTable.path, path))),
-            ),
-          );
-        await tx
-          .delete(tables.toolArtifactRequestBodyContentTypesTable)
-          .where(
-            and(
-              eq(
-                tables.toolArtifactRequestBodyContentTypesTable.workspaceId,
-                input.workspaceId,
-              ),
-              or(
-                ...existingPaths.map((path) =>
-                  eq(tables.toolArtifactRequestBodyContentTypesTable.path, path)
-                ),
-              ),
-            ),
-          );
-        await tx
-          .delete(tables.toolArtifactRefHintKeysTable)
-          .where(
-            and(
-              eq(tables.toolArtifactRefHintKeysTable.workspaceId, input.workspaceId),
-              or(...existingPaths.map((path) => eq(tables.toolArtifactRefHintKeysTable.path, path))),
-            ),
-          );
-      }
-
-      await tx
-        .delete(tables.toolArtifactsTable)
-        .where(
-          and(
-            eq(tables.toolArtifactsTable.workspaceId, input.workspaceId),
-            eq(tables.toolArtifactsTable.sourceId, input.sourceId),
-          ),
-        );
-
-      if (input.artifacts.length === 0) {
-        return;
-      }
-
-      await tx.insert(tables.toolArtifactsTable).values(
-        input.artifacts.map(({ artifact }) => encodeStoredToolArtifactRecord(artifact)),
-      );
-
-      const parameterRows = input.artifacts.flatMap(({ parameters = [] }) => parameters);
-      if (parameterRows.length > 0) {
-        await tx.insert(tables.toolArtifactParametersTable).values(
-          parameterRows.map((record) => encodeStoredToolArtifactParameterRecord(record)),
-        );
-      }
-
-      const requestBodyContentTypeRows = input.artifacts.flatMap(
-        ({ requestBodyContentTypes = [] }) => requestBodyContentTypes,
-      );
-      if (requestBodyContentTypeRows.length > 0) {
-        await tx.insert(tables.toolArtifactRequestBodyContentTypesTable).values(
-          requestBodyContentTypeRows.map((record) =>
-            encodeStoredToolArtifactRequestBodyContentTypeRecord(record)
-          ),
-        );
-      }
-
-      const refHintKeyRows = input.artifacts.flatMap(({ refHintKeys = [] }) => refHintKeys);
-      if (refHintKeyRows.length > 0) {
-        await tx.insert(tables.toolArtifactRefHintKeysTable).values(
-          refHintKeyRows.map((record) => encodeStoredToolArtifactRefHintKeyRecord(record)),
-        );
-      }
     }),
 
   removeByWorkspaceAndSourceId: (

--- a/packages/control-plane/src/runtime/source-recipes-runtime.test.ts
+++ b/packages/control-plane/src/runtime/source-recipes-runtime.test.ts
@@ -61,8 +61,8 @@ const makeSource = (overrides: Partial<Source> = {}): Source => ({
 });
 
 const makeOperation = (
-  overrides: Partial<StoredSourceRecipeOperationRecord> = {},
-): StoredSourceRecipeOperationRecord => ({
+  overrides: Partial<Extract<StoredSourceRecipeOperationRecord, { providerKind: "openapi" }>> = {},
+): Extract<StoredSourceRecipeOperationRecord, { providerKind: "openapi" }> => ({
   id: "src_recipe_op_runtime",
   recipeRevisionId: SourceRecipeRevisionIdSchema.make("src_recipe_rev_runtime"),
   operationKey: "getRepo",
@@ -93,6 +93,80 @@ const makeOperation = (
   openApiRawToolId: "repos_getRepo",
   openApiOperationId: "repos.getRepo",
   openApiTagsJson: JSON.stringify(["repos"]),
+  openApiRequestBodyRequired: null,
+  graphqlOperationType: null,
+  graphqlOperationName: null,
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+const makeGraphqlOperation = (
+  overrides: Partial<Extract<StoredSourceRecipeOperationRecord, { providerKind: "graphql" }>> = {},
+): Extract<StoredSourceRecipeOperationRecord, { providerKind: "graphql" }> => ({
+  id: "src_recipe_op_graphql_runtime",
+  recipeRevisionId: SourceRecipeRevisionIdSchema.make("src_recipe_rev_runtime"),
+  operationKey: "viewer",
+  transportKind: "graphql",
+  toolId: "viewer",
+  title: "Viewer",
+  description: "Query the current viewer",
+  operationKind: "read",
+  searchText: "viewer graphql query",
+  inputSchemaJson: JSON.stringify({
+    type: "object",
+    additionalProperties: false,
+  }),
+  outputSchemaJson: JSON.stringify({
+    type: "object",
+    properties: {
+      login: { type: "string" },
+    },
+  }),
+  providerKind: "graphql",
+  providerDataJson: JSON.stringify({
+    kind: "graphql",
+  }),
+  mcpToolName: null,
+  openApiMethod: null,
+  openApiPathTemplate: null,
+  openApiOperationHash: null,
+  openApiRawToolId: null,
+  openApiOperationId: null,
+  openApiTagsJson: null,
+  openApiRequestBodyRequired: null,
+  graphqlOperationType: "query",
+  graphqlOperationName: "viewer",
+  createdAt: 1000,
+  updatedAt: 1000,
+  ...overrides,
+});
+
+const makeMcpOperation = (
+  overrides: Partial<Extract<StoredSourceRecipeOperationRecord, { providerKind: "mcp" }>> = {},
+): Extract<StoredSourceRecipeOperationRecord, { providerKind: "mcp" }> => ({
+  id: "src_recipe_op_mcp_runtime",
+  recipeRevisionId: SourceRecipeRevisionIdSchema.make("src_recipe_rev_runtime"),
+  operationKey: "echo",
+  transportKind: "mcp",
+  toolId: "echo",
+  title: "Echo",
+  description: "Echo a value",
+  operationKind: "unknown",
+  searchText: "echo mcp",
+  inputSchemaJson: null,
+  outputSchemaJson: null,
+  providerKind: "mcp",
+  providerDataJson: JSON.stringify({
+    kind: "mcp",
+  }),
+  mcpToolName: "echo",
+  openApiMethod: null,
+  openApiPathTemplate: null,
+  openApiOperationHash: null,
+  openApiRawToolId: null,
+  openApiOperationId: null,
+  openApiTagsJson: null,
   openApiRequestBodyRequired: null,
   graphqlOperationType: null,
   graphqlOperationName: null,
@@ -174,10 +248,7 @@ describe("source-recipes-runtime", () => {
       expect(recipeToolSearchNamespace({
         source: graphqlSource,
         path: "ignored.path",
-        operation: makeOperation({
-          providerKind: "graphql",
-          transportKind: "graphql",
-          openApiMethod: null,
+        operation: makeGraphqlOperation({
           graphqlOperationType: "query",
           graphqlOperationName: "viewer",
         }),
@@ -209,10 +280,7 @@ describe("source-recipes-runtime", () => {
           endpoint: "https://example.com/graphql",
           specUrl: null,
         }),
-        operation: makeOperation({
-          providerKind: "graphql",
-          transportKind: "graphql",
-          openApiMethod: null,
+        operation: makeGraphqlOperation({
           graphqlOperationType: "query",
           graphqlOperationName: "viewer",
         }),
@@ -226,10 +294,7 @@ describe("source-recipes-runtime", () => {
           endpoint: "https://example.com/graphql",
           specUrl: null,
         }),
-        operation: makeOperation({
-          providerKind: "graphql",
-          transportKind: "graphql",
-          openApiMethod: null,
+        operation: makeGraphqlOperation({
           graphqlOperationType: "mutation",
           graphqlOperationName: "createIssue",
         }),
@@ -244,15 +309,7 @@ describe("source-recipes-runtime", () => {
           specUrl: null,
           transport: "streamable-http",
         }),
-        operation: makeOperation({
-          providerKind: "mcp",
-          transportKind: "mcp",
-          openApiMethod: null,
-          openApiPathTemplate: null,
-          openApiOperationHash: null,
-          openApiRawToolId: null,
-          openApiOperationId: null,
-          openApiTagsJson: null,
+        operation: makeMcpOperation({
           mcpToolName: "echo",
         }),
         path: "mcp.echo",

--- a/packages/control-plane/src/schema/models/source-recipe.ts
+++ b/packages/control-plane/src/schema/models/source-recipe.ts
@@ -67,6 +67,23 @@ export const SourceRecipeOperationProviderKindSchema = Schema.Literal(
   "internal",
 );
 
+export const SourceRecipeOpenApiMethodSchema = Schema.Literal(
+  "get",
+  "put",
+  "post",
+  "delete",
+  "patch",
+  "head",
+  "options",
+  "trace",
+);
+
+export const SourceRecipeGraphqlOperationTypeSchema = Schema.Literal(
+  "query",
+  "mutation",
+  "subscription",
+);
+
 const recipeRowSchemaOverrides = {
   id: SourceRecipeIdSchema,
   kind: SourceRecipeKindSchema,
@@ -93,14 +110,13 @@ const recipeDocumentRowSchemaOverrides = {
   updatedAt: TimestampMsSchema,
 } as const;
 
-const recipeOperationRowSchemaOverrides = {
+const sourceRecipeOperationRowSchemaOverrides = {
   recipeRevisionId: SourceRecipeRevisionIdSchema,
   transportKind: SourceRecipeTransportKindSchema,
   operationKind: SourceRecipeOperationKindSchema,
   providerKind: SourceRecipeOperationProviderKindSchema,
-  openApiMethod: Schema.NullOr(
-    Schema.Literal("get", "put", "post", "delete", "patch", "head", "options", "trace"),
-  ),
+  openApiMethod: Schema.NullOr(SourceRecipeOpenApiMethodSchema),
+  graphqlOperationType: Schema.NullOr(SourceRecipeGraphqlOperationTypeSchema),
   createdAt: TimestampMsSchema,
   updatedAt: TimestampMsSchema,
 } as const;
@@ -120,10 +136,99 @@ export const StoredSourceRecipeDocumentRecordSchema = createSelectSchema(
   recipeDocumentRowSchemaOverrides,
 );
 
-export const StoredSourceRecipeOperationRecordSchema = createSelectSchema(
+export const StoredSourceRecipeOperationRowSchema = createSelectSchema(
   sourceRecipeOperationsTable,
-  recipeOperationRowSchemaOverrides,
+  sourceRecipeOperationRowSchemaOverrides,
 );
+
+const sourceRecipeOperationCommonFields = {
+  id: Schema.String,
+  recipeRevisionId: SourceRecipeRevisionIdSchema,
+  operationKey: Schema.String,
+  toolId: Schema.String,
+  title: Schema.NullOr(Schema.String),
+  description: Schema.NullOr(Schema.String),
+  operationKind: SourceRecipeOperationKindSchema,
+  searchText: Schema.String,
+  inputSchemaJson: Schema.NullOr(Schema.String),
+  outputSchemaJson: Schema.NullOr(Schema.String),
+  providerDataJson: Schema.NullOr(Schema.String),
+  createdAt: TimestampMsSchema,
+  updatedAt: TimestampMsSchema,
+} as const;
+
+export const StoredOpenApiSourceRecipeOperationRecordSchema = Schema.Struct({
+  ...sourceRecipeOperationCommonFields,
+  transportKind: Schema.Literal("http"),
+  providerKind: Schema.Literal("openapi"),
+  mcpToolName: Schema.Null,
+  openApiMethod: SourceRecipeOpenApiMethodSchema,
+  openApiPathTemplate: Schema.String,
+  openApiOperationHash: Schema.String,
+  openApiRawToolId: Schema.String,
+  openApiOperationId: Schema.NullOr(Schema.String),
+  openApiTagsJson: Schema.String,
+  openApiRequestBodyRequired: Schema.NullOr(Schema.Boolean),
+  graphqlOperationType: Schema.Null,
+  graphqlOperationName: Schema.Null,
+});
+
+export const StoredGraphqlSourceRecipeOperationRecordSchema = Schema.Struct({
+  ...sourceRecipeOperationCommonFields,
+  transportKind: Schema.Literal("graphql"),
+  providerKind: Schema.Literal("graphql"),
+  mcpToolName: Schema.Null,
+  openApiMethod: Schema.Null,
+  openApiPathTemplate: Schema.Null,
+  openApiOperationHash: Schema.Null,
+  openApiRawToolId: Schema.Null,
+  openApiOperationId: Schema.Null,
+  openApiTagsJson: Schema.Null,
+  openApiRequestBodyRequired: Schema.Null,
+  graphqlOperationType: Schema.NullOr(SourceRecipeGraphqlOperationTypeSchema),
+  graphqlOperationName: Schema.NullOr(Schema.String),
+});
+
+export const StoredMcpSourceRecipeOperationRecordSchema = Schema.Struct({
+  ...sourceRecipeOperationCommonFields,
+  transportKind: Schema.Literal("mcp"),
+  providerKind: Schema.Literal("mcp"),
+  mcpToolName: Schema.String,
+  openApiMethod: Schema.Null,
+  openApiPathTemplate: Schema.Null,
+  openApiOperationHash: Schema.Null,
+  openApiRawToolId: Schema.Null,
+  openApiOperationId: Schema.Null,
+  openApiTagsJson: Schema.Null,
+  openApiRequestBodyRequired: Schema.Null,
+  graphqlOperationType: Schema.Null,
+  graphqlOperationName: Schema.Null,
+});
+
+export const StoredInternalSourceRecipeOperationRecordSchema = Schema.Struct({
+  ...sourceRecipeOperationCommonFields,
+  transportKind: Schema.Literal("internal"),
+  providerKind: Schema.Literal("internal"),
+  mcpToolName: Schema.Null,
+  openApiMethod: Schema.Null,
+  openApiPathTemplate: Schema.Null,
+  openApiOperationHash: Schema.Null,
+  openApiRawToolId: Schema.Null,
+  openApiOperationId: Schema.Null,
+  openApiTagsJson: Schema.Null,
+  openApiRequestBodyRequired: Schema.Null,
+  graphqlOperationType: Schema.Null,
+  graphqlOperationName: Schema.Null,
+});
+
+export const StoredSourceRecipeOperationRecordSchema = Schema.Union(
+  StoredOpenApiSourceRecipeOperationRecordSchema,
+  StoredGraphqlSourceRecipeOperationRecordSchema,
+  StoredMcpSourceRecipeOperationRecordSchema,
+  StoredInternalSourceRecipeOperationRecordSchema,
+).annotations({
+  identifier: "StoredSourceRecipeOperationRecord",
+});
 
 export type SourceRecipeKind = typeof SourceRecipeKindSchema.Type;
 export type SourceRecipeImporterKind = typeof SourceRecipeImporterKindSchema.Type;
@@ -133,8 +238,20 @@ export type SourceRecipeTransportKind = typeof SourceRecipeTransportKindSchema.T
 export type SourceRecipeOperationKind = typeof SourceRecipeOperationKindSchema.Type;
 export type SourceRecipeOperationProviderKind =
   typeof SourceRecipeOperationProviderKindSchema.Type;
+export type SourceRecipeOpenApiMethod = typeof SourceRecipeOpenApiMethodSchema.Type;
+export type SourceRecipeGraphqlOperationType =
+  typeof SourceRecipeGraphqlOperationTypeSchema.Type;
 export type StoredSourceRecipeRecord = typeof StoredSourceRecipeRecordSchema.Type;
 export type StoredSourceRecipeRevisionRecord = typeof StoredSourceRecipeRevisionRecordSchema.Type;
 export type StoredSourceRecipeDocumentRecord = typeof StoredSourceRecipeDocumentRecordSchema.Type;
+export type StoredSourceRecipeOperationRow = typeof StoredSourceRecipeOperationRowSchema.Type;
+export type StoredOpenApiSourceRecipeOperationRecord =
+  typeof StoredOpenApiSourceRecipeOperationRecordSchema.Type;
+export type StoredGraphqlSourceRecipeOperationRecord =
+  typeof StoredGraphqlSourceRecipeOperationRecordSchema.Type;
+export type StoredMcpSourceRecipeOperationRecord =
+  typeof StoredMcpSourceRecipeOperationRecordSchema.Type;
+export type StoredInternalSourceRecipeOperationRecord =
+  typeof StoredInternalSourceRecipeOperationRecordSchema.Type;
 export type StoredSourceRecipeOperationRecord =
   typeof StoredSourceRecipeOperationRecordSchema.Type;

--- a/packages/control-plane/src/schema/schema.test.ts
+++ b/packages/control-plane/src/schema/schema.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "@effect/vitest";
+import * as Either from "effect/Either";
+import * as Schema from "effect/Schema";
 
 import {
   PermissionValues,
   RolePermissions,
+  StoredSourceRecipeOperationRecordSchema,
 } from "./index";
 
 describe("control-plane-schema", () => {
@@ -11,5 +14,69 @@ describe("control-plane-schema", () => {
     expect(RolePermissions.viewer).toContain("workspace:read");
     expect(RolePermissions.editor).toContain("sources:write");
     expect(RolePermissions.owner).toContain("policies:manage");
+  });
+
+  it("enforces provider-specific source recipe operation shapes", () => {
+    const decode = Schema.decodeUnknownEither(StoredSourceRecipeOperationRecordSchema);
+
+    const openApiRecord = decode({
+      id: "src_recipe_op_1",
+      recipeRevisionId: "src_recipe_rev_1",
+      operationKey: "getRepo",
+      transportKind: "http",
+      toolId: "getRepo",
+      title: "Get Repo",
+      description: "Read a repository",
+      operationKind: "read",
+      searchText: "get repo",
+      inputSchemaJson: null,
+      outputSchemaJson: null,
+      providerKind: "openapi",
+      providerDataJson: null,
+      mcpToolName: null,
+      openApiMethod: "get",
+      openApiPathTemplate: "/repos/{owner}/{repo}",
+      openApiOperationHash: "hash",
+      openApiRawToolId: "repos_getRepo",
+      openApiOperationId: "repos.getRepo",
+      openApiTagsJson: "[]",
+      openApiRequestBodyRequired: null,
+      graphqlOperationType: null,
+      graphqlOperationName: null,
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    expect(Either.isRight(openApiRecord)).toBe(true);
+
+    const invalidGraphqlRecord = decode({
+      id: "src_recipe_op_2",
+      recipeRevisionId: "src_recipe_rev_1",
+      operationKey: "viewer",
+      transportKind: "graphql",
+      toolId: "viewer",
+      title: "Viewer",
+      description: null,
+      operationKind: "read",
+      searchText: "viewer",
+      inputSchemaJson: null,
+      outputSchemaJson: null,
+      providerKind: "graphql",
+      providerDataJson: null,
+      mcpToolName: null,
+      openApiMethod: "get",
+      openApiPathTemplate: null,
+      openApiOperationHash: null,
+      openApiRawToolId: null,
+      openApiOperationId: null,
+      openApiTagsJson: null,
+      openApiRequestBodyRequired: null,
+      graphqlOperationType: "query",
+      graphqlOperationName: "viewer",
+      createdAt: 1,
+      updatedAt: 1,
+    });
+
+    expect(Either.isLeft(invalidGraphqlRecord)).toBe(true);
   });
 });

--- a/packages/react/src/index.test.tsx
+++ b/packages/react/src/index.test.tsx
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
 
 import { HttpApiBuilder, HttpServer, OpenApi } from "@effect/platform";
@@ -9,7 +8,6 @@ import {
   createSqlControlPlaneRuntime,
   type LocalInstallation,
   type Source,
-  SourceIdSchema,
   type SqlControlPlaneRuntime,
 } from "@executor/control-plane";
 import * as Context from "effect/Context";
@@ -329,8 +327,6 @@ const seedStoredOpenApiSource = async (input: {
   name: string;
   specUrl?: string;
 }): Promise<Source> => {
-  const now = Date.now();
-  const sourceId = SourceIdSchema.make(`src_${randomUUID()}`);
   const sourceDocumentText = JSON.stringify({
     openapi: "3.0.3",
     info: {
@@ -362,33 +358,23 @@ const seedStoredOpenApiSource = async (input: {
   });
   const specUrl = input.specUrl ?? `data:application/json,${encodeURIComponent(sourceDocumentText)}`;
 
-  await Effect.runPromise(
-    input.server.runtime.persistence.rows.sources.insert({
-      id: sourceId,
-      workspaceId: input.installation.workspaceId,
+  return requestJson<Source>({
+    baseUrl: input.server.baseUrl,
+    path: `/v1/workspaces/${input.installation.workspaceId}/sources`,
+    method: "POST",
+    accountId: input.installation.accountId,
+    payload: {
       name: input.name,
       kind: "openapi",
       endpoint: "https://example.com/api",
       status: "connected",
       enabled: true,
       namespace: "hooks-test",
-      transport: null,
-      queryParamsJson: null,
-      headersJson: null,
       specUrl,
-      defaultHeadersJson: null,
-      sourceHash: null,
-      sourceDocumentText,
-      lastError: null,
-      createdAt: now,
-      updatedAt: now,
-    }),
-  );
-
-  return requestJson<Source>({
-    baseUrl: input.server.baseUrl,
-    path: `/v1/workspaces/${input.installation.workspaceId}/sources/${sourceId}`,
-    accountId: input.installation.accountId,
+      auth: {
+        kind: "none",
+      },
+    },
   });
 };
 


### PR DESCRIPTION
## Summary
Finish the stack with integration fallout and cleanup:
- update executor server and React integration tests for the recipe-backed runtime
- remove the leftover `replaceForSource` path from `tool-artifacts-repo`
- keep the full stack green after the read-path cutover

## Why
These changes are small on their own, but they keep app-level fallout and dead-code cleanup out of the core storage/runtime PRs so the stack is easier to review.

## Verification
- `bun run test`