### PR TITLE
Expose the control plane OpenAPI spec at /v1/openapi.json

### DIFF
--- a/apps/executor/src/server/server.test.ts
+++ b/apps/executor/src/server/server.test.ts
@@ -17,6 +17,7 @@ import { startMcpElicitationDemoServer } from "@executor/mcp-elicitation-demo";
 import { makeToolInvokerFromTools, toTool } from "@executor/codemode-core";
 import {
   createControlPlaneClient,
+  controlPlaneOpenApiSpec,
   type ControlPlaneClient,
   type ResolveExecutionEnvironment,
   SourceIdSchema,
@@ -599,6 +600,24 @@ const waitForExecutionCompletion = (input: {
   });
 
 describe("local-executor-server", () => {
+  it.scoped("serves the control-plane OpenAPI spec at /v1/openapi.json", () =>
+    Effect.gen(function* () {
+      const server = yield* makeServer;
+      const response = yield* Effect.promise(() =>
+        fetch(`${server.baseUrl}/v1/openapi.json`, {
+          headers: {
+            accept: "application/json",
+          },
+        }),
+      );
+      const spec = yield* Effect.promise(() => response.json());
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toContain("application/json");
+      expect(spec).toEqual(controlPlaneOpenApiSpec);
+    }),
+  );
+
   it.scoped("serves the control-plane API and executes code", () =>
     Effect.gen(function* () {
       const server = yield* makeServer;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -212,7 +212,9 @@ const createControlPlaneWebHandler = (runtime: SqlControlPlaneRuntime) =>
     Effect.sync(() =>
       HttpApiBuilder.toWebHandler(
         Layer.merge(
-          createControlPlaneApiLayer(runtime.runtimeLayer),
+          HttpApiBuilder.middlewareOpenApi({ path: "/v1/openapi.json" }).pipe(
+            Layer.provideMerge(createControlPlaneApiLayer(runtime.runtimeLayer))
+          ),
           HttpServer.layerContext,
         ),
       ),


### PR DESCRIPTION
## Summary
- expose the Effect-generated control plane OpenAPI document from the local server
- serve it at `/v1/openapi.json` so it lines up with the current `v1` API surface
- add a server regression test that boots a real local Executor instance and verifies the returned spec matches `controlPlaneOpenApiSpec`

## Testing
- bun run --cwd packages/server typecheck
- bun run --cwd apps/executor typecheck
- bun run --cwd apps/executor test -- src/server/server.test.ts -t "serves the control-plane OpenAPI spec at /v1/openapi.json"