### PR TITLE
Add API key support to the control plane client

### DIFF
--- a/packages/control-plane/src/client.ts
+++ b/packages/control-plane/src/client.ts
@@ -12,19 +12,28 @@ import { ControlPlaneAuthHeaders } from "./auth-headers";
 export const createControlPlaneClient = (input: {
   baseUrl: string;
   accountId?: string;
+  apiKey?: string;
 }) => {
-  const accountId = input.accountId;
+  const headers = {
+    ...(input.accountId
+      ? {
+          [ControlPlaneAuthHeaders.accountId]: input.accountId,
+        }
+      : {}),
+    ...(input.apiKey
+      ? {
+          authorization: `Bearer ${input.apiKey}`,
+        }
+      : {}),
+  };
 
   return HttpApiClient.make(ControlPlaneApi, {
     baseUrl: input.baseUrl,
-    transformClient: accountId
+    transformClient: Object.keys(headers).length > 0
       ? (client) =>
           client.pipe(
-            HttpClient.mapRequest(
-              HttpClientRequest.setHeader(
-                ControlPlaneAuthHeaders.accountId,
-                accountId,
-              ),
+            HttpClient.mapRequest((request) =>
+              HttpClientRequest.setHeaders(request, headers)
             ),
           )
       : undefined,


### PR DESCRIPTION
## Summary
- add optional apiKey support to createControlPlaneClient
- send both the bearer token and account header when present
- keep the client helper usable for authenticated local control-plane calls

## Why
The control-plane API expects bearer auth for local workspace operations, but the exported client helper only attached the account header. 
