### PR TITLE
feat: add native stdio MCP support

### DIFF
--- a/apps/web/src/views/add-source.tsx
+++ b/apps/web/src/views/add-source.tsx
@@ -41,6 +41,16 @@ import {
   sourceTemplates,
   type SourceTemplate,
 } from "./source-templates";
+import {
+  asMcpRemoteTransportValue,
+  defaultMcpRemoteTransportFields,
+  defaultMcpStdioTransportFields,
+  setMcpTransportFieldsTransport,
+  type McpRemoteTransportFields,
+  type McpStdioTransportFields,
+  type McpTransportFields,
+  type McpTransportValue,
+} from "./mcp-transport-state";
 import { getDomain } from "tldts";
 
 // ---------------------------------------------------------------------------
@@ -68,7 +78,7 @@ type ProbeAuthState = {
   headersText: string;
 };
 
-type ConnectFormState = {
+type ConnectFormBase = {
   kind: "mcp" | "openapi" | "graphql" | "google_discovery";
   endpoint: string;
   specUrl: string;
@@ -77,7 +87,6 @@ type ConnectFormState = {
   discoveryUrl: string;
   name: string;
   namespace: string;
-  transport: "" | "auto" | "streamable-http" | "sse" | "stdio";
   authKind: "none" | "bearer" | "oauth2";
   authHeaderName: string;
   authPrefix: string;
@@ -87,13 +96,9 @@ type ConnectFormState = {
   workspaceOauthClientId: string;
   oauthClientId: string;
   oauthClientSecret: string;
-  queryParamsText: string;
-  headersText: string;
-  command: string;
-  argsText: string;
-  envText: string;
-  cwd: string;
 };
+
+type ConnectFormState = ConnectFormBase & McpTransportFields;
 
 type OAuthRequiredInfo = {
   source: Source;
@@ -118,9 +123,12 @@ const kindOptions: ReadonlyArray<ConnectFormState["kind"]> = [
   "google_discovery",
 ];
 
-const transportOptions: ReadonlyArray<
-  "auto" | "streamable-http" | "sse" | "stdio"
-> = ["auto", "streamable-http", "sse", "stdio"];
+const transportOptions: ReadonlyArray<Exclude<McpTransportValue, "">> = [
+  "auto",
+  "streamable-http",
+  "sse",
+  "stdio",
+];
 
 const authOptions: ReadonlyArray<ConnectFormState["authKind"]> = [
   "none",
@@ -316,7 +324,6 @@ const defaultConnectForm = (
       name: discovery?.name ?? "",
       namespace:
         discovery?.namespace || namespaceFromUrl(discovery?.endpoint ?? ""),
-      transport: "",
       authKind: "none",
       authHeaderName: "Authorization",
       authPrefix: "Bearer ",
@@ -326,12 +333,7 @@ const defaultConnectForm = (
       workspaceOauthClientId: "",
       oauthClientId: "",
       oauthClientSecret: "",
-      queryParamsText: "",
-      headersText: "",
-      command: "",
-      argsText: "",
-      envText: "",
-      cwd: "",
+      ...defaultMcpRemoteTransportFields(),
     };
   }
 
@@ -374,7 +376,6 @@ const defaultConnectForm = (
     discoveryUrl: googleDiscoveryDefaults?.discoveryUrl ?? "",
     name: discovery.name ?? "",
     namespace: discovery.namespace || namespaceFromUrl(discovery.endpoint),
-    transport: kind === "mcp" ? (discovery.transport ?? "auto") : "",
     authKind,
     authHeaderName,
     authPrefix,
@@ -384,12 +385,9 @@ const defaultConnectForm = (
     workspaceOauthClientId: "",
     oauthClientId: "",
     oauthClientSecret: "",
-    queryParamsText: "",
-    headersText: "",
-    command: "",
-    argsText: "",
-    envText: "",
-    cwd: "",
+    ...defaultMcpRemoteTransportFields(
+      kind === "mcp" ? asMcpRemoteTransportValue(discovery.transport) : "",
+    ),
   };
 };
 
@@ -409,18 +407,20 @@ const connectFormFromTemplate = (
     ("service" in template
       ? googleDiscoveryNamespace(template.service)
       : namespaceFromUrl(template.endpoint ?? "")),
-  transport:
-    template.kind === "mcp"
-      ? template.connectionType === "command"
-        ? (template.transport ?? "stdio")
-        : (template.transport ?? "auto")
-      : "",
   authKind: template.kind === "google_discovery" ? "oauth2" : "none",
   workspaceOauthClientId: "",
-  command: template.kind === "mcp" ? (template.command ?? "") : "",
-  argsText: template.kind === "mcp" ? stringifyStringArray(template.args) : "",
-  envText: template.kind === "mcp" ? stringifyStringMap(template.env) : "",
-  cwd: template.kind === "mcp" ? (template.cwd ?? "") : "",
+  ...(template.kind === "mcp" && template.connectionType === "command"
+    ? defaultMcpStdioTransportFields({
+        command: template.command ?? "",
+        argsText: stringifyStringArray(template.args),
+        envText: stringifyStringMap(template.env),
+        cwd: template.cwd ?? "",
+      })
+    : defaultMcpRemoteTransportFields(
+        template.kind === "mcp"
+          ? asMcpRemoteTransportValue(template.transport)
+          : "",
+      )),
 });
 
 const authKindForSourceKind = (
@@ -463,34 +463,44 @@ const buildProbeAuth = (
 
 const buildConnectPayload = (form: ConnectFormState): ConnectSourcePayload => {
   if (form.kind === "mcp") {
-    const transport = form.transport === "" ? "auto" : form.transport;
-    const isStdio = transport === "stdio";
-    const endpoint = isStdio
-      ? buildSyntheticMcpStdioEndpoint({
-          name: form.name,
-          endpoint: form.endpoint,
-          command: form.command,
-        })
-      : form.endpoint.trim();
-    if (!isStdio && !endpoint) throw new Error("Endpoint is required.");
-    if (isStdio && !form.command.trim())
-      throw new Error("Command is required for stdio MCP sources.");
+    if (form.transport === "stdio") {
+      const endpoint = buildSyntheticMcpStdioEndpoint({
+        name: form.name,
+        endpoint: form.endpoint,
+        command: form.command,
+      });
+      if (!form.command.trim()) {
+        throw new Error("Command is required for stdio MCP sources.");
+      }
+      return {
+        kind: "mcp",
+        endpoint,
+        name: trimToNull(form.name),
+        namespace: trimToNull(form.namespace),
+        transport: "stdio",
+        queryParams: null,
+        headers: null,
+        command: form.command.trim(),
+        args: parseJsonStringArray("Args", form.argsText),
+        env: parseJsonStringMap("Environment", form.envText),
+        cwd: trimToNull(form.cwd),
+      };
+    }
+
+    const endpoint = form.endpoint.trim();
+    if (!endpoint) throw new Error("Endpoint is required.");
     return {
       kind: "mcp",
       endpoint,
       name: trimToNull(form.name),
       namespace: trimToNull(form.namespace),
-      transport,
-      queryParams: isStdio
-        ? null
-        : parseJsonStringMap("Query params", form.queryParamsText),
-      headers: isStdio
-        ? null
-        : parseJsonStringMap("Request headers", form.headersText),
-      command: isStdio ? form.command.trim() : null,
-      args: isStdio ? parseJsonStringArray("Args", form.argsText) : null,
-      env: isStdio ? parseJsonStringMap("Environment", form.envText) : null,
-      cwd: isStdio ? trimToNull(form.cwd) : null,
+      transport: form.transport === "" ? "auto" : form.transport,
+      queryParams: parseJsonStringMap("Query params", form.queryParamsText),
+      headers: parseJsonStringMap("Request headers", form.headersText),
+      command: null,
+      args: null,
+      env: null,
+      cwd: null,
     };
   }
 
@@ -831,11 +841,40 @@ export function AddSourcePage() {
     text: string;
   } | null>(null);
 
-  const setFormField = <K extends keyof ConnectFormState>(
+  const setFormField = <K extends keyof ConnectFormBase>(
     key: K,
-    value: ConnectFormState[K],
+    value: ConnectFormBase[K],
   ) => {
     setConnectForm((current) => ({ ...current, [key]: value }));
+  };
+
+  const setTransport = (transport: McpTransportValue) => {
+    setConnectForm((current) => ({
+      ...current,
+      ...setMcpTransportFieldsTransport(current, transport),
+    }));
+  };
+
+  const setRemoteTransportField = <
+    K extends Exclude<keyof McpRemoteTransportFields, "transport">,
+  >(
+    key: K,
+    value: McpRemoteTransportFields[K],
+  ) => {
+    setConnectForm((current) =>
+      current.transport === "stdio" ? current : { ...current, [key]: value },
+    );
+  };
+
+  const setStdioTransportField = <
+    K extends Exclude<keyof McpStdioTransportFields, "transport">,
+  >(
+    key: K,
+    value: McpStdioTransportFields[K],
+  ) => {
+    setConnectForm((current) =>
+      current.transport === "stdio" ? { ...current, [key]: value } : current,
+    );
   };
 
   const setSourceKind = (kind: ConnectFormState["kind"]) => {
@@ -943,24 +982,32 @@ export function AddSourcePage() {
 
     try {
       const result = await discoverSource.mutateAsync({ url: discoveryUrl });
-      const form = defaultConnectForm(result);
-      // Prefer the template's own values over whatever discover returned
-      form.name = template.name;
-      form.endpoint = template.endpoint ?? "";
-      form.namespace =
-        template.namespace ?? namespaceFromUrl(template.endpoint ?? "");
+      let form: ConnectFormState = {
+        ...defaultConnectForm(result),
+        name: template.name,
+        endpoint: template.endpoint ?? "",
+        namespace: template.namespace ?? namespaceFromUrl(template.endpoint ?? ""),
+      };
       if (template.kind === "mcp") {
-        form.transport =
-          template.connectionType === "command"
-            ? (template.transport ?? "stdio")
-            : (template.transport ?? form.transport);
-        form.command = template.command ?? "";
-        form.argsText = stringifyStringArray(template.args);
-        form.envText = stringifyStringMap(template.env);
-        form.cwd = template.cwd ?? "";
+        form = {
+          ...form,
+          ...(template.connectionType === "command"
+            ? defaultMcpStdioTransportFields({
+                command: template.command ?? "",
+                argsText: stringifyStringArray(template.args),
+                envText: stringifyStringMap(template.env),
+                cwd: template.cwd ?? "",
+              })
+            : defaultMcpRemoteTransportFields(
+                asMcpRemoteTransportValue(template.transport),
+              )),
+        };
       }
       if ("specUrl" in template) {
-        form.specUrl = template.specUrl;
+        form = {
+          ...form,
+          specUrl: template.specUrl,
+        };
       }
       setConnectForm(form);
       setPhase("editing");
@@ -1804,12 +1851,7 @@ export function AddSourcePage() {
                   <Field label="Transport mode">
                     <SelectInput
                       value={connectForm.transport || "auto"}
-                      onChange={(v) =>
-                        setFormField(
-                          "transport",
-                          v as ConnectFormState["transport"],
-                        )
-                      }
+                      onChange={(v) => setTransport(v as McpTransportValue)}
                       options={transportOptions.map((v) => ({
                         value: v,
                         label: v,
@@ -1821,7 +1863,7 @@ export function AddSourcePage() {
                       <Field label="Command">
                         <TextInput
                           value={connectForm.command}
-                          onChange={(v) => setFormField("command", v)}
+                          onChange={(v) => setStdioTransportField("command", v)}
                           placeholder="npx"
                           mono
                         />
@@ -1829,7 +1871,7 @@ export function AddSourcePage() {
                       <Field label="Working directory (optional)">
                         <TextInput
                           value={connectForm.cwd}
-                          onChange={(v) => setFormField("cwd", v)}
+                          onChange={(v) => setStdioTransportField("cwd", v)}
                           placeholder="/path/to/project"
                           mono
                         />
@@ -1837,7 +1879,9 @@ export function AddSourcePage() {
                       <Field label="Args (JSON)" className="sm:col-span-2">
                         <CodeEditor
                           value={connectForm.argsText}
-                          onChange={(v) => setFormField("argsText", v)}
+                          onChange={(v) =>
+                            setStdioTransportField("argsText", v)
+                          }
                           placeholder={
                             '[\n  "-y",\n  "chrome-devtools-mcp@latest"\n]'
                           }
@@ -1849,7 +1893,7 @@ export function AddSourcePage() {
                       >
                         <CodeEditor
                           value={connectForm.envText}
-                          onChange={(v) => setFormField("envText", v)}
+                          onChange={(v) => setStdioTransportField("envText", v)}
                           placeholder={
                             '{\n  "CHROME_PATH": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"\n}'
                           }
@@ -1861,14 +1905,18 @@ export function AddSourcePage() {
                       <Field label="Query params (JSON)">
                         <CodeEditor
                           value={connectForm.queryParamsText}
-                          onChange={(v) => setFormField("queryParamsText", v)}
+                          onChange={(v) =>
+                            setRemoteTransportField("queryParamsText", v)
+                          }
                           placeholder={'{\n  "workspace": "demo"\n}'}
                         />
                       </Field>
                       <Field label="Headers (JSON)">
                         <CodeEditor
                           value={connectForm.headersText}
-                          onChange={(v) => setFormField("headersText", v)}
+                          onChange={(v) =>
+                            setRemoteTransportField("headersText", v)
+                          }
                           placeholder={'{\n  "x-api-key": "..."\n}'}
                         />
                       </Field>

--- a/apps/web/src/views/add-source.tsx
+++ b/apps/web/src/views/add-source.tsx
@@ -51,6 +51,7 @@ import {
   type McpTransportFields,
   type McpTransportValue,
 } from "./mcp-transport-state";
+import { parseJsonStringArray, parseJsonStringMap } from "./json-form";
 import { getDomain } from "tldts";
 
 // ---------------------------------------------------------------------------
@@ -212,68 +213,6 @@ const googleDiscoveryDefaultsFromUrl = (
   } catch {
     return null;
   }
-};
-
-const parseJsonStringMap = (
-  label: string,
-  text: string,
-): Record<string, string> | null => {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    throw new Error(`${label} must be valid JSON.`);
-  }
-
-  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
-    throw new Error(`${label} must be a JSON object with string values.`);
-  }
-
-  const entries = Object.entries(parsed as Record<string, unknown>);
-  const normalized: Record<string, string> = {};
-  for (const [key, value] of entries) {
-    if (typeof value !== "string") {
-      throw new Error(`${label} must only contain string values.`);
-    }
-    normalized[key] = value;
-  }
-
-  return Object.keys(normalized).length === 0 ? null : normalized;
-};
-
-const parseJsonStringArray = (
-  label: string,
-  text: string,
-): Array<string> | null => {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    throw new Error(`${label} must be valid JSON.`);
-  }
-
-  if (
-    !Array.isArray(parsed) ||
-    !parsed.every((value) => typeof value === "string")
-  ) {
-    throw new Error(`${label} must be a JSON array of strings.`);
-  }
-
-  const normalized = parsed
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0);
-
-  return normalized.length > 0 ? normalized : null;
 };
 
 const stringifyStringMap = (

--- a/apps/web/src/views/add-source.tsx
+++ b/apps/web/src/views/add-source.tsx
@@ -36,7 +36,11 @@ import {
   IconSpinner,
 } from "../components/icons";
 import { cn } from "../lib/utils";
-import { sourceTemplates, type SourceTemplate } from "./source-templates";
+import {
+  isStdioMcpSourceTemplate,
+  sourceTemplates,
+  type SourceTemplate,
+} from "./source-templates";
 import { getDomain } from "tldts";
 
 // ---------------------------------------------------------------------------
@@ -73,7 +77,7 @@ type ConnectFormState = {
   discoveryUrl: string;
   name: string;
   namespace: string;
-  transport: "" | "auto" | "streamable-http" | "sse";
+  transport: "" | "auto" | "streamable-http" | "sse" | "stdio";
   authKind: "none" | "bearer" | "oauth2";
   authHeaderName: string;
   authPrefix: string;
@@ -85,6 +89,10 @@ type ConnectFormState = {
   oauthClientSecret: string;
   queryParamsText: string;
   headersText: string;
+  command: string;
+  argsText: string;
+  envText: string;
+  cwd: string;
 };
 
 type OAuthRequiredInfo = {
@@ -110,15 +118,22 @@ const kindOptions: ReadonlyArray<ConnectFormState["kind"]> = [
   "google_discovery",
 ];
 
-const transportOptions: ReadonlyArray<"auto" | "streamable-http" | "sse"> = [
-  "auto",
-  "streamable-http",
-  "sse",
+const transportOptions: ReadonlyArray<
+  "auto" | "streamable-http" | "sse" | "stdio"
+> = ["auto", "streamable-http", "sse", "stdio"];
+
+const authOptions: ReadonlyArray<ConnectFormState["authKind"]> = [
+  "none",
+  "bearer",
+  "oauth2",
 ];
 
-const authOptions: ReadonlyArray<ConnectFormState["authKind"]> = ["none", "bearer", "oauth2"];
-
-const probeAuthOptions: ReadonlyArray<ProbeAuthKind> = ["none", "bearer", "basic", "headers"];
+const probeAuthOptions: ReadonlyArray<ProbeAuthKind> = [
+  "none",
+  "bearer",
+  "basic",
+  "headers",
+];
 
 const SOURCE_OAUTH_POPUP_RESULT_TIMEOUT_MS = 2 * 60_000;
 const SOURCE_OAUTH_POPUP_RESULT_STORAGE_KEY_PREFIX = "executor:oauth-result:";
@@ -145,16 +160,24 @@ const namespaceFromUrl = (url: string): string => {
 };
 
 const googleDiscoveryNamespace = (service: string): string =>
-  `google.${service.trim().toLowerCase().replace(/[^a-z0-9]+/g, ".").replace(/^\.+|\.+$/g, "")}`;
+  `google.${service
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ".")
+    .replace(/^\.+|\.+$/g, "")}`;
 
-const googleDiscoveryDefaultsFromUrl = (value: string): {
+const googleDiscoveryDefaultsFromUrl = (
+  value: string,
+): {
   service: string;
   version: string;
   discoveryUrl: string;
 } | null => {
   try {
     const url = new URL(value);
-    const byDirectory = url.pathname.match(/^\/discovery\/v1\/apis\/([^/]+)\/([^/]+)\/rest$/);
+    const byDirectory = url.pathname.match(
+      /^\/discovery\/v1\/apis\/([^/]+)\/([^/]+)\/rest$/,
+    );
     if (byDirectory) {
       return {
         service: decodeURIComponent(byDirectory[1] ?? ""),
@@ -165,9 +188,10 @@ const googleDiscoveryDefaultsFromUrl = (value: string): {
 
     const versionParam = url.searchParams.get("version");
     const version = versionParam ? trimToNull(versionParam) : null;
-    const isHostScopedDiscovery = url.pathname === "/$discovery/rest"
-      && url.hostname.endsWith(".googleapis.com")
-      && url.hostname !== "www.googleapis.com";
+    const isHostScopedDiscovery =
+      url.pathname === "/$discovery/rest" &&
+      url.hostname.endsWith(".googleapis.com") &&
+      url.hostname !== "www.googleapis.com";
     if (version && isHostScopedDiscovery) {
       return {
         service: url.hostname.split(".")[0] ?? "",
@@ -182,7 +206,10 @@ const googleDiscoveryDefaultsFromUrl = (value: string): {
   }
 };
 
-const parseJsonStringMap = (label: string, text: string): Record<string, string> | null => {
+const parseJsonStringMap = (
+  label: string,
+  text: string,
+): Record<string, string> | null => {
   const trimmed = text.trim();
   if (trimmed.length === 0) {
     return null;
@@ -211,11 +238,73 @@ const parseJsonStringMap = (label: string, text: string): Record<string, string>
   return Object.keys(normalized).length === 0 ? null : normalized;
 };
 
+const parseJsonStringArray = (
+  label: string,
+  text: string,
+): Array<string> | null => {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error(`${label} must be valid JSON.`);
+  }
+
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every((value) => typeof value === "string")
+  ) {
+    throw new Error(`${label} must be a JSON array of strings.`);
+  }
+
+  const normalized = parsed
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  return normalized.length > 0 ? normalized : null;
+};
+
+const stringifyStringMap = (
+  value: Readonly<Record<string, string>> | null | undefined,
+): string =>
+  !value || Object.keys(value).length === 0
+    ? ""
+    : JSON.stringify(value, null, 2);
+
+const stringifyStringArray = (
+  value: ReadonlyArray<string> | null | undefined,
+): string =>
+  !value || value.length === 0 ? "" : JSON.stringify(value, null, 2);
+
+const buildSyntheticMcpStdioEndpoint = (input: {
+  name?: string | null;
+  endpoint?: string | null;
+  command?: string | null;
+}): string => {
+  const label =
+    input.name?.trim() ||
+    input.endpoint?.trim() ||
+    input.command?.trim() ||
+    "mcp";
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return `stdio://local/${slug || "mcp"}`;
+};
+
 // ---------------------------------------------------------------------------
 // Derived defaults from discovery result
 // ---------------------------------------------------------------------------
 
-const defaultConnectForm = (discovery?: SourceDiscoveryResult): ConnectFormState => {
+const defaultConnectForm = (
+  discovery?: SourceDiscoveryResult,
+): ConnectFormState => {
   if (!discovery || discovery.detectedKind === "unknown") {
     return {
       kind: "openapi",
@@ -225,7 +314,8 @@ const defaultConnectForm = (discovery?: SourceDiscoveryResult): ConnectFormState
       version: "",
       discoveryUrl: "",
       name: discovery?.name ?? "",
-      namespace: discovery?.namespace || namespaceFromUrl(discovery?.endpoint ?? ""),
+      namespace:
+        discovery?.namespace || namespaceFromUrl(discovery?.endpoint ?? ""),
       transport: "",
       authKind: "none",
       authHeaderName: "Authorization",
@@ -238,6 +328,10 @@ const defaultConnectForm = (discovery?: SourceDiscoveryResult): ConnectFormState
       oauthClientSecret: "",
       queryParamsText: "",
       headersText: "",
+      command: "",
+      argsText: "",
+      envText: "",
+      cwd: "",
     };
   }
 
@@ -266,9 +360,10 @@ const defaultConnectForm = (discovery?: SourceDiscoveryResult): ConnectFormState
     }
   }
 
-  const googleDiscoveryDefaults = kind === "google_discovery"
-    ? googleDiscoveryDefaultsFromUrl(discovery.specUrl ?? discovery.endpoint)
-    : null;
+  const googleDiscoveryDefaults =
+    kind === "google_discovery"
+      ? googleDiscoveryDefaultsFromUrl(discovery.specUrl ?? discovery.endpoint)
+      : null;
 
   return {
     kind,
@@ -291,24 +386,41 @@ const defaultConnectForm = (discovery?: SourceDiscoveryResult): ConnectFormState
     oauthClientSecret: "",
     queryParamsText: "",
     headersText: "",
+    command: "",
+    argsText: "",
+    envText: "",
+    cwd: "",
   };
 };
 
-const connectFormFromTemplate = (template: SourceTemplate): ConnectFormState => ({
+const connectFormFromTemplate = (
+  template: SourceTemplate,
+): ConnectFormState => ({
   ...defaultConnectForm(),
   kind: template.kind as ConnectFormState["kind"],
-  endpoint: template.endpoint,
+  endpoint: template.endpoint ?? "",
   specUrl: "specUrl" in template ? template.specUrl : "",
   service: "service" in template ? template.service : "",
   version: "version" in template ? template.version : "",
   discoveryUrl: "discoveryUrl" in template ? template.discoveryUrl : "",
   name: template.name,
-  namespace: "service" in template
-    ? googleDiscoveryNamespace(template.service)
-    : namespaceFromUrl(template.endpoint),
-  transport: template.kind === "mcp" ? "auto" : "",
+  namespace:
+    template.namespace ??
+    ("service" in template
+      ? googleDiscoveryNamespace(template.service)
+      : namespaceFromUrl(template.endpoint ?? "")),
+  transport:
+    template.kind === "mcp"
+      ? template.connectionType === "command"
+        ? (template.transport ?? "stdio")
+        : (template.transport ?? "auto")
+      : "",
   authKind: template.kind === "google_discovery" ? "oauth2" : "none",
   workspaceOauthClientId: "",
+  command: template.kind === "mcp" ? (template.command ?? "") : "",
+  argsText: template.kind === "mcp" ? stringifyStringArray(template.args) : "",
+  envText: template.kind === "mcp" ? stringifyStringMap(template.env) : "",
+  cwd: template.kind === "mcp" ? (template.cwd ?? "") : "",
 });
 
 const authKindForSourceKind = (
@@ -319,10 +431,13 @@ const authKindForSourceKind = (
     ? "oauth2"
     : currentAuthKind;
 
-const buildProbeAuth = (state: ProbeAuthState): DiscoverSourcePayload["probeAuth"] => {
+const buildProbeAuth = (
+  state: ProbeAuthState,
+): DiscoverSourcePayload["probeAuth"] => {
   if (state.kind === "none") return { kind: "none" };
   if (state.kind === "bearer") {
-    if (!state.token.trim()) throw new Error("Token is required for bearer probe auth.");
+    if (!state.token.trim())
+      throw new Error("Token is required for bearer probe auth.");
     return {
       kind: "bearer",
       headerName: trimToNull(state.headerName),
@@ -331,7 +446,8 @@ const buildProbeAuth = (state: ProbeAuthState): DiscoverSourcePayload["probeAuth
     };
   }
   if (state.kind === "basic") {
-    if (!state.username.trim()) throw new Error("Username is required for basic probe auth.");
+    if (!state.username.trim())
+      throw new Error("Username is required for basic probe auth.");
     return {
       kind: "basic",
       username: state.username.trim(),
@@ -340,22 +456,41 @@ const buildProbeAuth = (state: ProbeAuthState): DiscoverSourcePayload["probeAuth
   }
   // headers
   const headers = parseJsonStringMap("Probe headers", state.headersText);
-  if (!headers) throw new Error("At least one header is required for headers probe auth.");
+  if (!headers)
+    throw new Error("At least one header is required for headers probe auth.");
   return { kind: "headers", headers };
 };
 
 const buildConnectPayload = (form: ConnectFormState): ConnectSourcePayload => {
   if (form.kind === "mcp") {
-    const endpoint = form.endpoint.trim();
-    if (!endpoint) throw new Error("Endpoint is required.");
+    const transport = form.transport === "" ? "auto" : form.transport;
+    const isStdio = transport === "stdio";
+    const endpoint = isStdio
+      ? buildSyntheticMcpStdioEndpoint({
+          name: form.name,
+          endpoint: form.endpoint,
+          command: form.command,
+        })
+      : form.endpoint.trim();
+    if (!isStdio && !endpoint) throw new Error("Endpoint is required.");
+    if (isStdio && !form.command.trim())
+      throw new Error("Command is required for stdio MCP sources.");
     return {
       kind: "mcp",
       endpoint,
       name: trimToNull(form.name),
       namespace: trimToNull(form.namespace),
-      transport: form.transport === "" ? "auto" : form.transport,
-      queryParams: parseJsonStringMap("Query params", form.queryParamsText),
-      headers: parseJsonStringMap("Request headers", form.headersText),
+      transport,
+      queryParams: isStdio
+        ? null
+        : parseJsonStringMap("Query params", form.queryParamsText),
+      headers: isStdio
+        ? null
+        : parseJsonStringMap("Request headers", form.headersText),
+      command: isStdio ? form.command.trim() : null,
+      args: isStdio ? parseJsonStringArray("Args", form.argsText) : null,
+      env: isStdio ? parseJsonStringMap("Environment", form.envText) : null,
+      cwd: isStdio ? trimToNull(form.cwd) : null,
     };
   }
 
@@ -380,14 +515,18 @@ const buildConnectPayload = (form: ConnectFormState): ConnectSourcePayload => {
   if (form.kind === "google_discovery") {
     const service = form.service.trim();
     const version = form.version.trim();
-    if (!service) throw new Error("Google Discovery sources require a service name.");
-    if (!version) throw new Error("Google Discovery sources require a version.");
+    if (!service)
+      throw new Error("Google Discovery sources require a service name.");
+    if (!version)
+      throw new Error("Google Discovery sources require a version.");
     if (
-      form.authKind === "oauth2"
-      && form.workspaceOauthClientId.trim().length === 0
-      && form.oauthClientId.trim().length === 0
+      form.authKind === "oauth2" &&
+      form.workspaceOauthClientId.trim().length === 0 &&
+      form.oauthClientId.trim().length === 0
     ) {
-      throw new Error("Google OAuth requires a workspace OAuth client or a new client ID.");
+      throw new Error(
+        "Google OAuth requires a workspace OAuth client or a new client ID.",
+      );
     }
     return {
       kind: "google_discovery",
@@ -397,11 +536,13 @@ const buildConnectPayload = (form: ConnectFormState): ConnectSourcePayload => {
       name: trimToNull(form.name),
       namespace: trimToNull(form.namespace),
       workspaceOauthClientId:
-        form.authKind === "oauth2" && form.workspaceOauthClientId.trim().length > 0
+        form.authKind === "oauth2" &&
+        form.workspaceOauthClientId.trim().length > 0
           ? form.workspaceOauthClientId.trim()
           : undefined,
       oauthClient:
-        form.authKind === "oauth2" && form.workspaceOauthClientId.trim().length === 0
+        form.authKind === "oauth2" &&
+        form.workspaceOauthClientId.trim().length === 0
           ? {
               clientId: form.oauthClientId.trim(),
               clientSecret: trimToNull(form.oauthClientSecret),
@@ -424,7 +565,16 @@ const buildConnectPayload = (form: ConnectFormState): ConnectSourcePayload => {
 
 const buildHttpAuth = (
   form: ConnectFormState,
-): { kind: "none" } | { kind: "bearer"; headerName?: string | null; prefix?: string | null; token?: string | null; tokenRef?: { providerId: string; handle: string } | null } | undefined => {
+):
+  | { kind: "none" }
+  | {
+      kind: "bearer";
+      headerName?: string | null;
+      prefix?: string | null;
+      token?: string | null;
+      tokenRef?: { providerId: string; handle: string } | null;
+    }
+  | undefined => {
   if (form.authKind === "none") return { kind: "none" };
 
   if (form.authKind === "bearer") {
@@ -454,7 +604,9 @@ const buildHttpAuth = (
       };
     }
 
-    throw new Error("Bearer auth requires a token. Select or create a secret, or enter a token directly.");
+    throw new Error(
+      "Bearer auth requires a token. Select or create a secret, or enter a token directly.",
+    );
   }
 
   // oauth2 is handled via the connect result flow, not pre-filled
@@ -489,7 +641,9 @@ type SourceOAuthPopupMessage =
       error: string;
     };
 
-const readStoredSourceOAuthPopupResult = (sessionId: string): SourceOAuthPopupMessage | null => {
+const readStoredSourceOAuthPopupResult = (
+  sessionId: string,
+): SourceOAuthPopupMessage | null => {
   if (typeof window === "undefined") return null;
   const raw = window.localStorage.getItem(
     `${SOURCE_OAUTH_POPUP_RESULT_STORAGE_KEY_PREFIX}${sessionId}`,
@@ -504,7 +658,9 @@ const readStoredSourceOAuthPopupResult = (sessionId: string): SourceOAuthPopupMe
 
 const clearStoredSourceOAuthPopupResult = (sessionId: string): void => {
   if (typeof window === "undefined") return;
-  window.localStorage.removeItem(`${SOURCE_OAUTH_POPUP_RESULT_STORAGE_KEY_PREFIX}${sessionId}`);
+  window.localStorage.removeItem(
+    `${SOURCE_OAUTH_POPUP_RESULT_STORAGE_KEY_PREFIX}${sessionId}`,
+  );
 };
 
 const startSourceOAuthPopup = async (input: {
@@ -566,7 +722,12 @@ const startSourceOAuthPopup = async (input: {
       if (!data) return;
       if (data.type === "executor:oauth-result") {
         if (data.ok && data.sessionId !== input.sessionId) return;
-        if (!data.ok && data.sessionId !== null && data.sessionId !== input.sessionId) return;
+        if (
+          !data.ok &&
+          data.sessionId !== null &&
+          data.sessionId !== input.sessionId
+        )
+          return;
       } else if (data.type !== "executor:source-oauth-result") {
         return;
       }
@@ -576,7 +737,9 @@ const startSourceOAuthPopup = async (input: {
     window.addEventListener("message", onMessage);
 
     resultTimeout = window.setTimeout(() => {
-      settleWithError("OAuth popup timed out before completion. Please try again.");
+      settleWithError(
+        "OAuth popup timed out before completion. Please try again.",
+      );
     }, SOURCE_OAUTH_POPUP_RESULT_TIMEOUT_MS);
 
     closedPoll = window.setInterval(() => {
@@ -591,7 +754,9 @@ const startSourceOAuthPopup = async (input: {
         window.clearInterval(closedPoll);
         closedPoll = 0;
         window.setTimeout(() => {
-          const delayedStored = readStoredSourceOAuthPopupResult(input.sessionId);
+          const delayedStored = readStoredSourceOAuthPopupResult(
+            input.sessionId,
+          );
           if (delayedStored) {
             settleFromPayload(delayedStored);
             return;
@@ -606,8 +771,6 @@ const startSourceOAuthPopup = async (input: {
 // ---------------------------------------------------------------------------
 // Confidence badge helper
 // ---------------------------------------------------------------------------
-
-
 
 // ---------------------------------------------------------------------------
 // Page
@@ -645,17 +808,22 @@ export function AddSourcePage() {
 
   // Discovery result
   // Editable connect form (populated after discovery)
-  const [connectForm, setConnectForm] = useState<ConnectFormState>(defaultConnectForm());
+  const [connectForm, setConnectForm] =
+    useState<ConnectFormState>(defaultConnectForm());
 
   // Connect result
-  const [connectResult, setConnectResult] = useState<ConnectSourceResult | null>(null);
+  const [connectResult, setConnectResult] =
+    useState<ConnectSourceResult | null>(null);
 
   // OAuth required state
   const [oauthInfo, setOauthInfo] = useState<OAuthRequiredInfo | null>(null);
-  const [batchOauthInfo, setBatchOauthInfo] = useState<BatchOAuthRequiredInfo | null>(null);
+  const [batchOauthInfo, setBatchOauthInfo] =
+    useState<BatchOAuthRequiredInfo | null>(null);
   const [oauthBusy, setOauthBusy] = useState(false);
   const [batchConnecting, setBatchConnecting] = useState(false);
-  const [selectedGoogleTemplateIds, setSelectedGoogleTemplateIds] = useState<ReadonlyArray<string>>([]);
+  const [selectedGoogleTemplateIds, setSelectedGoogleTemplateIds] = useState<
+    ReadonlyArray<string>
+  >([]);
 
   // Status banner
   const [statusBanner, setStatusBanner] = useState<{
@@ -663,7 +831,10 @@ export function AddSourcePage() {
     text: string;
   } | null>(null);
 
-  const setFormField = <K extends keyof ConnectFormState>(key: K, value: ConnectFormState[K]) => {
+  const setFormField = <K extends keyof ConnectFormState>(
+    key: K,
+    value: ConnectFormState[K],
+  ) => {
     setConnectForm((current) => ({ ...current, [key]: value }));
   };
 
@@ -672,11 +843,15 @@ export function AddSourcePage() {
       ...current,
       kind,
       authKind: authKindForSourceKind(current.authKind, kind),
-      workspaceOauthClientId: kind === "google_discovery" ? current.workspaceOauthClientId : "",
+      workspaceOauthClientId:
+        kind === "google_discovery" ? current.workspaceOauthClientId : "",
     }));
   };
 
-  const setProbeField = <K extends keyof ProbeAuthState>(key: K, value: ProbeAuthState[K]) => {
+  const setProbeField = <K extends keyof ProbeAuthState>(
+    key: K,
+    value: ProbeAuthState[K],
+  ) => {
     setProbeAuth((current) => ({ ...current, [key]: value }));
   };
 
@@ -692,7 +867,10 @@ export function AddSourcePage() {
     setStatusBanner(null);
     const trimmedUrl = url.trim();
     if (!trimmedUrl) {
-      setStatusBanner({ tone: "error", text: "Please enter a URL to discover." });
+      setStatusBanner({
+        tone: "error",
+        text: "Please enter a URL to discover.",
+      });
       return;
     }
 
@@ -746,8 +924,20 @@ export function AddSourcePage() {
       return;
     }
 
-    const discoveryUrl = "specUrl" in template ? template.specUrl : template.endpoint;
-    setUrl(template.endpoint);
+    if (isStdioMcpSourceTemplate(template)) {
+      setUrl("");
+      setConnectForm(connectFormFromTemplate(template));
+      setPhase("editing");
+      setStatusBanner({
+        tone: "info",
+        text: `${template.name} loaded. Review the local command, then connect.`,
+      });
+      return;
+    }
+
+    const discoveryUrl =
+      "specUrl" in template ? template.specUrl : (template.endpoint ?? "");
+    setUrl(template.endpoint ?? "");
     setStatusBanner(null);
     setPhase("discovering");
 
@@ -756,8 +946,19 @@ export function AddSourcePage() {
       const form = defaultConnectForm(result);
       // Prefer the template's own values over whatever discover returned
       form.name = template.name;
-      form.endpoint = template.endpoint;
-      form.namespace = namespaceFromUrl(template.endpoint);
+      form.endpoint = template.endpoint ?? "";
+      form.namespace =
+        template.namespace ?? namespaceFromUrl(template.endpoint ?? "");
+      if (template.kind === "mcp") {
+        form.transport =
+          template.connectionType === "command"
+            ? (template.transport ?? "stdio")
+            : (template.transport ?? form.transport);
+        form.command = template.command ?? "";
+        form.argsText = stringifyStringArray(template.args);
+        form.envText = stringifyStringMap(template.env);
+        form.cwd = template.cwd ?? "";
+      }
       if ("specUrl" in template) {
         form.specUrl = template.specUrl;
       }
@@ -846,7 +1047,8 @@ export function AddSourcePage() {
 
     try {
       await startSourceOAuthPopup({
-        authorizationUrl: oauthInfo?.authorizationUrl ?? batchOauthInfo!.authorizationUrl,
+        authorizationUrl:
+          oauthInfo?.authorizationUrl ?? batchOauthInfo!.authorizationUrl,
         sessionId: oauthInfo?.sessionId ?? batchOauthInfo!.sessionId,
       });
 
@@ -892,7 +1094,9 @@ export function AddSourcePage() {
 
     const clientId = connectForm.oauthClientId.trim();
     if (clientId.length === 0) {
-      throw new Error("Choose an existing Google workspace OAuth client or enter a new client ID.");
+      throw new Error(
+        "Choose an existing Google workspace OAuth client or enter a new client ID.",
+      );
     }
 
     const created = await createWorkspaceOauthClient.mutateAsync({
@@ -918,11 +1122,14 @@ export function AddSourcePage() {
     try {
       const workspaceOauthClientId = await ensureGoogleWorkspaceOauthClientId();
       const selectedTemplates = googleTemplates.filter(
-        (template): template is Extract<SourceTemplate, { kind: "google_discovery" }> =>
+        (
+          template,
+        ): template is Extract<SourceTemplate, { kind: "google_discovery" }> =>
           selectedGoogleTemplateIds.includes(template.id),
       );
       const payload: ConnectSourceBatchPayload = {
-        workspaceOauthClientId: workspaceOauthClientId as WorkspaceOauthClient["id"],
+        workspaceOauthClientId:
+          workspaceOauthClientId as WorkspaceOauthClient["id"],
         sources: selectedTemplates.map((template) => ({
           service: template.service,
           version: template.version,
@@ -964,7 +1171,8 @@ export function AddSourcePage() {
       setPhase("idle");
       setStatusBanner({
         tone: "error",
-        text: error instanceof Error ? error.message : "Batch connection failed.",
+        text:
+          error instanceof Error ? error.message : "Batch connection failed.",
       });
     }
   };
@@ -984,11 +1192,11 @@ export function AddSourcePage() {
   const isDiscovering = phase === "discovering";
   const isConnecting = phase === "connecting";
   const isBusy =
-    isDiscovering
-    || isConnecting
-    || oauthBusy
-    || connectSourceBatch.status === "pending"
-    || createWorkspaceOauthClient.status === "pending";
+    isDiscovering ||
+    isConnecting ||
+    oauthBusy ||
+    connectSourceBatch.status === "pending" ||
+    createWorkspaceOauthClient.status === "pending";
 
   // -------------------------------------------------------------------------
   // Render
@@ -1032,19 +1240,23 @@ export function AddSourcePage() {
               return (
                 <div key={step} className="flex items-center gap-1.5">
                   {i > 0 && (
-                    <div className={cn(
-                      "h-px w-6 transition-colors",
-                      isComplete || isCurrent ? "bg-primary/40" : "bg-border",
-                    )} />
+                    <div
+                      className={cn(
+                        "h-px w-6 transition-colors",
+                        isComplete || isCurrent ? "bg-primary/40" : "bg-border",
+                      )}
+                    />
                   )}
-                  <div className={cn(
-                    "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.06em] transition-colors",
-                    isComplete
-                      ? "text-primary"
-                      : isCurrent
-                        ? "text-foreground bg-muted/50"
-                        : "text-muted-foreground/40",
-                  )}>
+                  <div
+                    className={cn(
+                      "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.06em] transition-colors",
+                      isComplete
+                        ? "text-primary"
+                        : isCurrent
+                          ? "text-foreground bg-muted/50"
+                          : "text-muted-foreground/40",
+                    )}
+                  >
                     {isComplete ? (
                       <IconCheck className="size-2.5" />
                     ) : (
@@ -1062,7 +1274,6 @@ export function AddSourcePage() {
 
         {statusBanner && <StatusBanner state={statusBanner} className="mb-6" />}
 
-
         {(phase === "idle" || phase === "discovering") && (
           <LocalMcpInstallCard
             className="mb-6 rounded-xl border border-border bg-card/80 p-5"
@@ -1076,7 +1287,8 @@ export function AddSourcePage() {
             <Section title="Discover">
               <div className="space-y-4">
                 <p className="text-[13px] text-muted-foreground">
-                  Enter a URL and we'll auto-detect the source type, endpoint, auth requirements, and more.
+                  Enter a URL and we'll auto-detect the source type, endpoint,
+                  auth requirements, and more.
                 </p>
 
                 <Field label="URL">
@@ -1094,13 +1306,23 @@ export function AddSourcePage() {
                         className="h-9 flex-1 rounded-lg border border-input bg-background px-3 font-mono text-[12px] text-foreground outline-none transition-colors placeholder:text-muted-foreground/35 focus:border-ring focus:ring-1 focus:ring-ring/25"
                       />
                       <Button onClick={handleDiscover} disabled={isBusy}>
-                        {isDiscovering ? <IconSpinner className="size-3.5" /> : <IconDiscover className="size-3.5" />}
+                        {isDiscovering ? (
+                          <IconSpinner className="size-3.5" />
+                        ) : (
+                          <IconDiscover className="size-3.5" />
+                        )}
                         {isDiscovering ? "Discovering\u2026" : "Discover"}
                       </Button>
                     </div>
                     {isDiscovering && (
                       <div className="mt-1.5 h-0.5 w-full overflow-hidden rounded-full bg-muted">
-                        <div className="h-full w-1/4 rounded-full bg-primary/60" style={{ animation: "indeterminate-progress 1.2s ease-in-out infinite" }} />
+                        <div
+                          className="h-full w-1/4 rounded-full bg-primary/60"
+                          style={{
+                            animation:
+                              "indeterminate-progress 1.2s ease-in-out infinite",
+                          }}
+                        />
                       </div>
                     )}
                   </div>
@@ -1113,7 +1335,9 @@ export function AddSourcePage() {
                     onClick={() => setShowProbeAuth(!showProbeAuth)}
                     className="text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
                   >
-                    {showProbeAuth ? "Hide probe auth" : "Need auth to discover?"}
+                    {showProbeAuth
+                      ? "Hide probe auth"
+                      : "Need auth to discover?"}
                   </button>
                 </div>
 
@@ -1122,8 +1346,13 @@ export function AddSourcePage() {
                     <Field label="Auth type">
                       <SelectInput
                         value={probeAuth.kind}
-                        onChange={(v) => setProbeField("kind", v as ProbeAuthKind)}
-                        options={probeAuthOptions.map((v) => ({ value: v, label: v }))}
+                        onChange={(v) =>
+                          setProbeField("kind", v as ProbeAuthKind)
+                        }
+                        options={probeAuthOptions.map((v) => ({
+                          value: v,
+                          label: v,
+                        }))}
                       />
                     </Field>
 
@@ -1200,48 +1429,70 @@ export function AddSourcePage() {
                 {/* ---- Template catalogue ---- */}
                 <div className="space-y-5 border-t border-border pt-5">
                   <div>
-                    <p className="text-[13px] font-medium text-foreground">Start from a template</p>
+                    <p className="text-[13px] font-medium text-foreground">
+                      Start from a template
+                    </p>
                     <p className="mt-0.5 text-[12px] text-muted-foreground">
-                      Pick a known source to skip discovery, or select multiple Google APIs for batch connect.
+                      Pick a known source to skip discovery, or select multiple
+                      Google APIs for batch connect.
                     </p>
                   </div>
 
                   {/* -- Popular / non-Google templates -- */}
                   {(() => {
-                    const popularTemplates = sourceTemplates.filter((t) => t.groupId !== "google_workspace");
-                    return popularTemplates.length > 0 && (
-                      <div className="space-y-2.5">
-                        <p className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/50">Popular</p>
-                        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                          {popularTemplates.map((template) => (
-                            <button
-                              key={template.id}
-                              type="button"
-                              onClick={() => applyTemplate(template)}
-                              disabled={isBusy}
-                              className="group rounded-xl border border-border bg-card/70 px-4 py-3 text-left transition-all hover:bg-accent/50 hover:border-primary/20 hover:shadow-sm disabled:opacity-60"
-                            >
-                              <div className="mb-1.5 flex items-center gap-2.5">
-                                <div className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted/50">
-                                  <SourceFavicon endpoint={template.endpoint} kind={template.kind} className="size-3.5" />
+                    const popularTemplates = sourceTemplates.filter(
+                      (t) => t.groupId !== "google_workspace",
+                    );
+                    return (
+                      popularTemplates.length > 0 && (
+                        <div className="space-y-2.5">
+                          <p className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/50">
+                            Popular
+                          </p>
+                          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                            {popularTemplates.map((template) => (
+                              <button
+                                key={template.id}
+                                type="button"
+                                onClick={() => applyTemplate(template)}
+                                disabled={isBusy}
+                                className="group rounded-xl border border-border bg-card/70 px-4 py-3 text-left transition-all hover:bg-accent/50 hover:border-primary/20 hover:shadow-sm disabled:opacity-60"
+                              >
+                                <div className="mb-1.5 flex items-center gap-2.5">
+                                  <div className="flex size-5 shrink-0 items-center justify-center rounded-md bg-muted/50">
+                                    <SourceFavicon
+                                      endpoint={template.endpoint}
+                                      kind={template.kind}
+                                      className="size-3.5"
+                                    />
+                                  </div>
+                                  <span className="flex-1 truncate text-[13px] font-medium text-foreground group-hover:text-primary transition-colors">
+                                    {template.name}
+                                  </span>
+                                  <Badge
+                                    variant="outline"
+                                    className="text-[9px] opacity-60 group-hover:opacity-100 transition-opacity"
+                                  >
+                                    {template.kind}
+                                  </Badge>
                                 </div>
-                                <span className="flex-1 truncate text-[13px] font-medium text-foreground group-hover:text-primary transition-colors">{template.name}</span>
-                                <Badge variant="outline" className="text-[9px] opacity-60 group-hover:opacity-100 transition-opacity">{template.kind}</Badge>
-                              </div>
-                              <span className="line-clamp-1 text-[11px] text-muted-foreground/70">
-                                {template.summary}
-                              </span>
-                            </button>
-                          ))}
+                                <span className="line-clamp-1 text-[11px] text-muted-foreground/70">
+                                  {template.summary}
+                                </span>
+                              </button>
+                            ))}
+                          </div>
                         </div>
-                      </div>
+                      )
                     );
                   })()}
 
                   {/* -- Google Workspace batch section -- */}
                   <div className="space-y-3">
                     <div className="flex items-center justify-between gap-3">
-                      <p className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/50">Google Workspace</p>
+                      <p className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground/50">
+                        Google Workspace
+                      </p>
                       {googleTemplates.length > 0 && (
                         <div className="flex items-center gap-2">
                           {selectedGoogleTemplateIds.length > 0 && (
@@ -1258,7 +1509,8 @@ export function AddSourcePage() {
                             type="button"
                             onClick={() =>
                               setSelectedGoogleTemplateIds(
-                                selectedGoogleTemplateIds.length === googleTemplates.length
+                                selectedGoogleTemplateIds.length ===
+                                  googleTemplates.length
                                   ? []
                                   : googleTemplates.map((t) => t.id),
                               )
@@ -1266,14 +1518,19 @@ export function AddSourcePage() {
                             disabled={isBusy}
                             className="text-[11px] font-medium text-muted-foreground/60 transition-colors hover:text-foreground"
                           >
-                            {selectedGoogleTemplateIds.length === googleTemplates.length ? "Deselect all" : "Select all"}
+                            {selectedGoogleTemplateIds.length ===
+                            googleTemplates.length
+                              ? "Deselect all"
+                              : "Select all"}
                           </button>
                         </div>
                       )}
                     </div>
                     <div className="grid gap-1.5 sm:grid-cols-2 lg:grid-cols-3">
                       {googleTemplates.map((template) => {
-                        const selected = selectedGoogleTemplateIds.includes(template.id);
+                        const selected = selectedGoogleTemplateIds.includes(
+                          template.id,
+                        );
                         return (
                           <button
                             key={template.id}
@@ -1287,23 +1544,33 @@ export function AddSourcePage() {
                                 : "border-border bg-card/50 hover:bg-accent/40 hover:border-border",
                             )}
                           >
-                            <div className={cn(
-                              "flex size-4 shrink-0 items-center justify-center rounded transition-colors",
-                              selected
-                                ? "text-primary"
-                                : "text-muted-foreground/30 group-hover:text-muted-foreground/50",
-                            )}>
+                            <div
+                              className={cn(
+                                "flex size-4 shrink-0 items-center justify-center rounded transition-colors",
+                                selected
+                                  ? "text-primary"
+                                  : "text-muted-foreground/30 group-hover:text-muted-foreground/50",
+                              )}
+                            >
                               {selected ? (
                                 <IconCheck className="size-3.5" />
                               ) : (
-                                <SourceFavicon endpoint={template.endpoint} kind={template.kind} className="size-3.5" />
+                                <SourceFavicon
+                                  endpoint={template.endpoint}
+                                  kind={template.kind}
+                                  className="size-3.5"
+                                />
                               )}
                             </div>
                             <div className="min-w-0 flex-1">
-                              <span className={cn(
-                                "block truncate text-[12px] font-medium transition-colors",
-                                selected ? "text-foreground" : "text-foreground/80",
-                              )}>
+                              <span
+                                className={cn(
+                                  "block truncate text-[12px] font-medium transition-colors",
+                                  selected
+                                    ? "text-foreground"
+                                    : "text-foreground/80",
+                                )}
+                              >
                                 {template.name}
                               </span>
                               <span className="block truncate text-[10px] text-muted-foreground/60">
@@ -1322,10 +1589,15 @@ export function AddSourcePage() {
                         <div className="flex items-center justify-between gap-3 border-b border-primary/10 px-5 py-3">
                           <div className="flex items-center gap-2.5">
                             <div className="flex size-6 items-center justify-center rounded-md bg-primary/10 text-primary">
-                              <span className="text-[11px] font-bold tabular-nums">{selectedGoogleTemplateIds.length}</span>
+                              <span className="text-[11px] font-bold tabular-nums">
+                                {selectedGoogleTemplateIds.length}
+                              </span>
                             </div>
                             <p className="text-[13px] font-medium text-foreground">
-                              Connect Google API{selectedGoogleTemplateIds.length === 1 ? "" : "s"}
+                              Connect Google API
+                              {selectedGoogleTemplateIds.length === 1
+                                ? ""
+                                : "s"}
                             </p>
                           </div>
                           <p className="hidden text-[11px] text-muted-foreground/60 sm:block">
@@ -1338,41 +1610,71 @@ export function AddSourcePage() {
                           <Field label="Workspace OAuth client">
                             <select
                               value={connectForm.workspaceOauthClientId}
-                              onChange={(event) => setFormField("workspaceOauthClientId", event.target.value)}
+                              onChange={(event) =>
+                                setFormField(
+                                  "workspaceOauthClientId",
+                                  event.target.value,
+                                )
+                              }
                               className="h-9 w-full rounded-lg border border-input bg-background px-3 text-[13px] text-foreground outline-none transition-colors focus:border-ring focus:ring-1 focus:ring-ring/25"
                             >
-                              <option value="">Enter new client credentials</option>
-                              {workspaceOauthClients.status === "ready" && workspaceOauthClients.data.map((client) => (
-                                <option key={client.id} value={client.id}>
-                                  {client.label ?? client.clientId}
-                                </option>
-                              ))}
+                              <option value="">
+                                Enter new client credentials
+                              </option>
+                              {workspaceOauthClients.status === "ready" &&
+                                workspaceOauthClients.data.map((client) => (
+                                  <option key={client.id} value={client.id}>
+                                    {client.label ?? client.clientId}
+                                  </option>
+                                ))}
                             </select>
                           </Field>
-                          {connectForm.workspaceOauthClientId.trim().length === 0 && (
+                          {connectForm.workspaceOauthClientId.trim().length ===
+                            0 && (
                             <div className="grid gap-3 sm:grid-cols-2">
-                              <Field label="Client ID" className="sm:col-span-2">
+                              <Field
+                                label="Client ID"
+                                className="sm:col-span-2"
+                              >
                                 <TextInput
                                   type="password"
                                   value={connectForm.oauthClientId}
-                                  onChange={(v) => setFormField("oauthClientId", v)}
+                                  onChange={(v) =>
+                                    setFormField("oauthClientId", v)
+                                  }
                                   placeholder="1234567890-abcdef.apps.googleusercontent.com"
                                 />
                               </Field>
-                              <Field label="Client secret" className="sm:col-span-2">
+                              <Field
+                                label="Client secret"
+                                className="sm:col-span-2"
+                              >
                                 <TextInput
                                   type="password"
                                   value={connectForm.oauthClientSecret}
-                                  onChange={(v) => setFormField("oauthClientSecret", v)}
+                                  onChange={(v) =>
+                                    setFormField("oauthClientSecret", v)
+                                  }
                                   placeholder="GOCSPX-..."
                                 />
                               </Field>
                             </div>
                           )}
                           <div className="flex items-center justify-end pt-1">
-                            <Button type="button" onClick={handleConnectGoogleBatch} disabled={isBusy}>
-                              {isBusy ? <IconSpinner className="size-3.5" /> : <IconPlus className="size-3.5" />}
-                              Connect {selectedGoogleTemplateIds.length} source{selectedGoogleTemplateIds.length === 1 ? "" : "s"}
+                            <Button
+                              type="button"
+                              onClick={handleConnectGoogleBatch}
+                              disabled={isBusy}
+                            >
+                              {isBusy ? (
+                                <IconSpinner className="size-3.5" />
+                              ) : (
+                                <IconPlus className="size-3.5" />
+                              )}
+                              Connect {selectedGoogleTemplateIds.length} source
+                              {selectedGoogleTemplateIds.length === 1
+                                ? ""
+                                : "s"}
                             </Button>
                           </div>
                         </div>
@@ -1385,8 +1687,6 @@ export function AddSourcePage() {
           </div>
         )}
 
-
-
         {/* Batch connecting interstitial */}
         {batchConnecting && phase === "connecting" && (
           <div className="flex flex-col items-center justify-center py-20">
@@ -1396,16 +1696,21 @@ export function AddSourcePage() {
               </div>
               <div className="space-y-1.5">
                 <h2 className="font-display text-xl tracking-tight text-foreground">
-                  Connecting {selectedGoogleTemplateIds.length} source{selectedGoogleTemplateIds.length === 1 ? "" : "s"}
+                  Connecting {selectedGoogleTemplateIds.length} source
+                  {selectedGoogleTemplateIds.length === 1 ? "" : "s"}
                 </h2>
-                <p className="text-[13px] text-muted-foreground/70">Setting up Google Workspace APIs\u2026</p>
+                <p className="text-[13px] text-muted-foreground/70">
+                  Setting up Google Workspace APIs\u2026
+                </p>
               </div>
             </div>
           </div>
         )}
 
         {/* Step 2-4: Editing / Connecting */}
-        {(phase === "editing" || (phase === "connecting" && !batchConnecting) || phase === "credential_required") && (
+        {(phase === "editing" ||
+          (phase === "connecting" && !batchConnecting) ||
+          phase === "credential_required") && (
           <div className="space-y-6">
             <Section title="Configuration">
               <div className="grid gap-4 sm:grid-cols-2">
@@ -1419,20 +1724,26 @@ export function AddSourcePage() {
                 <Field label="Kind">
                   <SelectInput
                     value={connectForm.kind}
-                    onChange={(v) => setSourceKind(v as ConnectFormState["kind"])}
+                    onChange={(v) =>
+                      setSourceKind(v as ConnectFormState["kind"])
+                    }
                     options={kindOptions.map((v) => ({ value: v, label: v }))}
                   />
                 </Field>
-                {connectForm.kind !== "google_discovery" && (
-                  <Field label="Endpoint" className="sm:col-span-2">
-                    <TextInput
-                      value={connectForm.endpoint}
-                      onChange={(v) => setFormField("endpoint", v)}
-                      placeholder="https://api.example.com"
-                      mono
-                    />
-                  </Field>
-                )}
+                {connectForm.kind !== "google_discovery" &&
+                  !(
+                    connectForm.kind === "mcp" &&
+                    connectForm.transport === "stdio"
+                  ) && (
+                    <Field label="Endpoint" className="sm:col-span-2">
+                      <TextInput
+                        value={connectForm.endpoint}
+                        onChange={(v) => setFormField("endpoint", v)}
+                        placeholder="https://api.example.com"
+                        mono
+                      />
+                    </Field>
+                  )}
                 <Field label="Namespace">
                   <TextInput
                     value={connectForm.namespace}
@@ -1466,7 +1777,10 @@ export function AddSourcePage() {
                         placeholder="v4"
                       />
                     </Field>
-                    <Field label="Discovery URL (optional)" className="sm:col-span-2">
+                    <Field
+                      label="Discovery URL (optional)"
+                      className="sm:col-span-2"
+                    >
                       <TextInput
                         value={connectForm.discoveryUrl}
                         onChange={(v) => setFormField("discoveryUrl", v)}
@@ -1475,7 +1789,8 @@ export function AddSourcePage() {
                       />
                     </Field>
                     <div className="sm:col-span-2 rounded-lg border border-border bg-card/60 px-3 py-2 text-[12px] text-muted-foreground">
-                      Common Google API versions: Gmail `v1`, Sheets `v4`, Drive `v3`, Calendar `v3`, Docs `v1`.
+                      Common Google API versions: Gmail `v1`, Sheets `v4`, Drive
+                      `v3`, Calendar `v3`, Docs `v1`.
                     </div>
                   </>
                 )}
@@ -1489,26 +1804,76 @@ export function AddSourcePage() {
                   <Field label="Transport mode">
                     <SelectInput
                       value={connectForm.transport || "auto"}
-                      onChange={(v) => setFormField("transport", v as ConnectFormState["transport"])}
-                      options={transportOptions.map((v) => ({ value: v, label: v }))}
+                      onChange={(v) =>
+                        setFormField(
+                          "transport",
+                          v as ConnectFormState["transport"],
+                        )
+                      }
+                      options={transportOptions.map((v) => ({
+                        value: v,
+                        label: v,
+                      }))}
                     />
                   </Field>
-                  <div className="sm:col-span-2 grid gap-4 sm:grid-cols-2">
-                    <Field label="Query params (JSON)">
-                      <CodeEditor
-                        value={connectForm.queryParamsText}
-                        onChange={(v) => setFormField("queryParamsText", v)}
-                        placeholder={'{\n  "workspace": "demo"\n}'}
-                      />
-                    </Field>
-                    <Field label="Headers (JSON)">
-                      <CodeEditor
-                        value={connectForm.headersText}
-                        onChange={(v) => setFormField("headersText", v)}
-                        placeholder={'{\n  "x-api-key": "..."\n}'}
-                      />
-                    </Field>
-                  </div>
+                  {connectForm.transport === "stdio" ? (
+                    <div className="sm:col-span-2 grid gap-4 sm:grid-cols-2">
+                      <Field label="Command">
+                        <TextInput
+                          value={connectForm.command}
+                          onChange={(v) => setFormField("command", v)}
+                          placeholder="npx"
+                          mono
+                        />
+                      </Field>
+                      <Field label="Working directory (optional)">
+                        <TextInput
+                          value={connectForm.cwd}
+                          onChange={(v) => setFormField("cwd", v)}
+                          placeholder="/path/to/project"
+                          mono
+                        />
+                      </Field>
+                      <Field label="Args (JSON)" className="sm:col-span-2">
+                        <CodeEditor
+                          value={connectForm.argsText}
+                          onChange={(v) => setFormField("argsText", v)}
+                          placeholder={
+                            '[\n  "-y",\n  "chrome-devtools-mcp@latest"\n]'
+                          }
+                        />
+                      </Field>
+                      <Field
+                        label="Environment (JSON)"
+                        className="sm:col-span-2"
+                      >
+                        <CodeEditor
+                          value={connectForm.envText}
+                          onChange={(v) => setFormField("envText", v)}
+                          placeholder={
+                            '{\n  "CHROME_PATH": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"\n}'
+                          }
+                        />
+                      </Field>
+                    </div>
+                  ) : (
+                    <div className="sm:col-span-2 grid gap-4 sm:grid-cols-2">
+                      <Field label="Query params (JSON)">
+                        <CodeEditor
+                          value={connectForm.queryParamsText}
+                          onChange={(v) => setFormField("queryParamsText", v)}
+                          placeholder={'{\n  "workspace": "demo"\n}'}
+                        />
+                      </Field>
+                      <Field label="Headers (JSON)">
+                        <CodeEditor
+                          value={connectForm.headersText}
+                          onChange={(v) => setFormField("headersText", v)}
+                          placeholder={'{\n  "x-api-key": "..."\n}'}
+                        />
+                      </Field>
+                    </div>
+                  )}
                 </div>
               </Section>
             )}
@@ -1517,15 +1882,28 @@ export function AddSourcePage() {
             {phase === "credential_required" && (
               <div className="flex items-start gap-3 rounded-xl border border-amber-300/40 bg-amber-50/50 px-4 py-3.5 dark:border-amber-500/20 dark:bg-amber-950/20">
                 <div className="flex size-7 shrink-0 items-center justify-center rounded-md bg-amber-100/80 dark:bg-amber-900/40">
-                  <svg className="size-3.5 text-amber-600 dark:text-amber-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M12 9v4" /><path d="M12 17h.01" />
+                  <svg
+                    className="size-3.5 text-amber-600 dark:text-amber-400"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M12 9v4" />
+                    <path d="M12 17h.01" />
                     <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
                   </svg>
                 </div>
                 <div className="space-y-0.5">
-                  <p className="text-[12px] font-medium text-amber-900 dark:text-amber-200">Credentials required</p>
+                  <p className="text-[12px] font-medium text-amber-900 dark:text-amber-200">
+                    Credentials required
+                  </p>
                   <p className="text-[11px] leading-relaxed text-amber-800/70 dark:text-amber-300/60">
-                    The server responded that this source requires authentication. Add a token or secret below, then try connecting again.
+                    The server responded that this source requires
+                    authentication. Add a token or secret below, then try
+                    connecting again.
                   </p>
                 </div>
               </div>
@@ -1536,7 +1914,12 @@ export function AddSourcePage() {
                   <Field label="Auth mode">
                     <SelectInput
                       value={connectForm.authKind}
-                      onChange={(v) => setFormField("authKind", v as ConnectFormState["authKind"])}
+                      onChange={(v) =>
+                        setFormField(
+                          "authKind",
+                          v as ConnectFormState["authKind"],
+                        )
+                      }
                       options={authOptions.map((v) => ({ value: v, label: v }))}
                     />
                   </Field>
@@ -1547,45 +1930,62 @@ export function AddSourcePage() {
                         : "Choosing auth mode 'none' skips the Google OAuth popup. Use 'oauth2' if you want executor to start the sign-in flow for you."}
                     </div>
                   )}
-                  {connectForm.kind === "google_discovery" && connectForm.authKind === "oauth2" && (
-                    <>
-                      <Field label="Workspace OAuth client" className="sm:col-span-2">
-                        <SelectInput
-                          value={connectForm.workspaceOauthClientId}
-                          onChange={(value) => setFormField("workspaceOauthClientId", value)}
-                          options={[
-                            { value: "", label: "Enter new client" },
-                            ...(workspaceOauthClients.status === "ready"
-                              ? workspaceOauthClients.data.map((client) => ({
-                                  value: client.id,
-                                  label: client.label ?? client.clientId,
-                                }))
-                              : []),
-                          ]}
-                        />
-                      </Field>
-                      {connectForm.workspaceOauthClientId.trim().length === 0 && (
-                        <>
-                          <Field label="New client ID" className="sm:col-span-2">
-                            <TextInput
-                              type="password"
-                              value={connectForm.oauthClientId}
-                              onChange={(v) => setFormField("oauthClientId", v)}
-                              placeholder="1234567890-abcdef.apps.googleusercontent.com"
-                            />
-                          </Field>
-                          <Field label="New client secret" className="sm:col-span-2">
-                            <TextInput
-                              type="password"
-                              value={connectForm.oauthClientSecret}
-                              onChange={(v) => setFormField("oauthClientSecret", v)}
-                              placeholder="GOCSPX-..."
-                            />
-                          </Field>
-                        </>
-                      )}
-                    </>
-                  )}
+                  {connectForm.kind === "google_discovery" &&
+                    connectForm.authKind === "oauth2" && (
+                      <>
+                        <Field
+                          label="Workspace OAuth client"
+                          className="sm:col-span-2"
+                        >
+                          <SelectInput
+                            value={connectForm.workspaceOauthClientId}
+                            onChange={(value) =>
+                              setFormField("workspaceOauthClientId", value)
+                            }
+                            options={[
+                              { value: "", label: "Enter new client" },
+                              ...(workspaceOauthClients.status === "ready"
+                                ? workspaceOauthClients.data.map((client) => ({
+                                    value: client.id,
+                                    label: client.label ?? client.clientId,
+                                  }))
+                                : []),
+                            ]}
+                          />
+                        </Field>
+                        {connectForm.workspaceOauthClientId.trim().length ===
+                          0 && (
+                          <>
+                            <Field
+                              label="New client ID"
+                              className="sm:col-span-2"
+                            >
+                              <TextInput
+                                type="password"
+                                value={connectForm.oauthClientId}
+                                onChange={(v) =>
+                                  setFormField("oauthClientId", v)
+                                }
+                                placeholder="1234567890-abcdef.apps.googleusercontent.com"
+                              />
+                            </Field>
+                            <Field
+                              label="New client secret"
+                              className="sm:col-span-2"
+                            >
+                              <TextInput
+                                type="password"
+                                value={connectForm.oauthClientSecret}
+                                onChange={(v) =>
+                                  setFormField("oauthClientSecret", v)
+                                }
+                                placeholder="GOCSPX-..."
+                              />
+                            </Field>
+                          </>
+                        )}
+                      </>
+                    )}
                   {connectForm.authKind !== "none" && (
                     <>
                       <Field label="Header name">
@@ -1631,18 +2031,32 @@ export function AddSourcePage() {
             {/* Actions */}
             <div className="flex items-center justify-end gap-3 border-t border-border pt-5">
               {phase === "credential_required" && (
-                <Button variant="ghost" type="button" onClick={handleBackToEditing}>
+                <Button
+                  variant="ghost"
+                  type="button"
+                  onClick={handleBackToEditing}
+                >
                   Back to edit
                 </Button>
               )}
               <Link to="/" className="inline-flex">
-                <Button variant="ghost" type="button">Cancel</Button>
+                <Button variant="ghost" type="button">
+                  Cancel
+                </Button>
               </Link>
               <Button
-                onClick={phase === "credential_required" ? handleCredentialConnect : handleConnect}
+                onClick={
+                  phase === "credential_required"
+                    ? handleCredentialConnect
+                    : handleConnect
+                }
                 disabled={isBusy}
               >
-                {isConnecting ? <IconSpinner className="size-3.5" /> : <IconPlus className="size-3.5" />}
+                {isConnecting ? (
+                  <IconSpinner className="size-3.5" />
+                ) : (
+                  <IconPlus className="size-3.5" />
+                )}
                 {isConnecting ? "Connecting\u2026" : "Connect"}
               </Button>
             </div>
@@ -1658,7 +2072,15 @@ export function AddSourcePage() {
                 {oauthBusy ? (
                   <IconSpinner className="size-6 text-primary" />
                 ) : (
-                  <svg className="size-6 text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <svg
+                    className="size-6 text-primary"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
                     <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
                     <path d="M7 11V7a5 5 0 0110 0v4" />
                   </svg>
@@ -1667,24 +2089,36 @@ export function AddSourcePage() {
 
               <div className="space-y-2">
                 <h2 className="font-display text-xl tracking-tight text-foreground">
-                  {oauthBusy ? "Waiting for sign-in\u2026" : "Sign in to continue"}
+                  {oauthBusy
+                    ? "Waiting for sign-in\u2026"
+                    : "Sign in to continue"}
                 </h2>
                 <p className="text-[13px] leading-relaxed text-muted-foreground">
-                  {oauthInfo
-                    ? <>
-                        <strong className="text-foreground">{oauthInfo.source.name}</strong> requires OAuth authentication.
-                        A popup will open for you to authorize access.
-                      </>
-                    : <>
-                        {batchOauthInfo!.sourceIds.length} Google source{batchOauthInfo!.sourceIds.length === 1 ? "" : "s"} need{batchOauthInfo!.sourceIds.length === 1 ? "s" : ""} OAuth.
-                        One consent screen covers all selected APIs.
-                      </>
-                  }
+                  {oauthInfo ? (
+                    <>
+                      <strong className="text-foreground">
+                        {oauthInfo.source.name}
+                      </strong>{" "}
+                      requires OAuth authentication. A popup will open for you
+                      to authorize access.
+                    </>
+                  ) : (
+                    <>
+                      {batchOauthInfo!.sourceIds.length} Google source
+                      {batchOauthInfo!.sourceIds.length === 1 ? "" : "s"} need
+                      {batchOauthInfo!.sourceIds.length === 1 ? "s" : ""} OAuth.
+                      One consent screen covers all selected APIs.
+                    </>
+                  )}
                 </p>
               </div>
 
               <div className="flex flex-col items-center gap-3">
-                <Button onClick={handleOAuthPopup} disabled={oauthBusy} className="w-full max-w-xs">
+                <Button
+                  onClick={handleOAuthPopup}
+                  disabled={oauthBusy}
+                  className="w-full max-w-xs"
+                >
                   {oauthBusy ? <IconSpinner className="size-3.5" /> : null}
                   {oauthBusy ? "Authenticating\u2026" : "Open sign-in"}
                 </Button>
@@ -1715,10 +2149,12 @@ export function AddSourcePage() {
                     ? connectResult.source.name
                     : batchOauthInfo
                       ? `${batchOauthInfo.sourceIds.length} source${batchOauthInfo.sourceIds.length === 1 ? "" : "s"}`
-                      : "Source"}
-                  {" "}connected
+                      : "Source"}{" "}
+                  connected
                 </h2>
-                <p className="text-[13px] text-muted-foreground/70">Redirecting\u2026</p>
+                <p className="text-[13px] text-muted-foreground/70">
+                  Redirecting\u2026
+                </p>
               </div>
             </div>
           </div>
@@ -1732,9 +2168,18 @@ export function AddSourcePage() {
 // Form building blocks
 // ---------------------------------------------------------------------------
 
-function Section(props: { title: string; children: ReactNode; className?: string }) {
+function Section(props: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <section className={cn("rounded-xl border border-border bg-card/80", props.className)}>
+    <section
+      className={cn(
+        "rounded-xl border border-border bg-card/80",
+        props.className,
+      )}
+    >
       <div className="border-b border-border px-5 py-3">
         <h2 className="text-sm font-semibold text-foreground">{props.title}</h2>
       </div>
@@ -1750,7 +2195,9 @@ function Field(props: {
 }) {
   return (
     <label className={cn("block space-y-1.5", props.className)}>
-      <span className="text-[12px] font-medium text-foreground">{props.label}</span>
+      <span className="text-[12px] font-medium text-foreground">
+        {props.label}
+      </span>
       {props.children}
     </label>
   );
@@ -1813,27 +2260,55 @@ function CodeEditor(props: {
   );
 }
 
-function StatusBanner(props: { state: { tone: "info" | "success" | "error"; text: string }; className?: string }) {
+function StatusBanner(props: {
+  state: { tone: "info" | "success" | "error"; text: string };
+  className?: string;
+}) {
   return (
     <div
       className={cn(
         "flex items-start gap-2.5 rounded-lg border px-4 py-3 text-[13px]",
-        props.state.tone === "success" && "border-primary/30 bg-primary/8 text-foreground",
-        props.state.tone === "info" && "border-border bg-card text-muted-foreground",
-        props.state.tone === "error" && "border-destructive/30 bg-destructive/8 text-destructive",
+        props.state.tone === "success" &&
+          "border-primary/30 bg-primary/8 text-foreground",
+        props.state.tone === "info" &&
+          "border-border bg-card text-muted-foreground",
+        props.state.tone === "error" &&
+          "border-destructive/30 bg-destructive/8 text-destructive",
         props.className,
       )}
     >
       <span className="mt-0.5 shrink-0">
-        {props.state.tone === "success" && <IconCheck className="size-3.5 text-primary" />}
+        {props.state.tone === "success" && (
+          <IconCheck className="size-3.5 text-primary" />
+        )}
         {props.state.tone === "error" && (
-          <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10" /><path d="M15 9l-6 6" /><path d="M9 9l6 6" />
+          <svg
+            className="size-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M15 9l-6 6" />
+            <path d="M9 9l6 6" />
           </svg>
         )}
         {props.state.tone === "info" && (
-          <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10" /><path d="M12 16v-4" /><path d="M12 8h.01" />
+          <svg
+            className="size-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 16v-4" />
+            <path d="M12 8h.01" />
           </svg>
         )}
       </span>
@@ -1841,8 +2316,6 @@ function StatusBanner(props: { state: { tone: "info" | "success" | "error"; text
     </div>
   );
 }
-
-
 
 // ---------------------------------------------------------------------------
 // Secret or inline token picker
@@ -1876,7 +2349,9 @@ function SecretOrTokenInput(props: {
   const [createError, setCreateError] = useState<string | null>(null);
   const storableProviders =
     instanceConfig.status === "ready"
-      ? instanceConfig.data.secretProviders.filter((provider) => provider.canStore)
+      ? instanceConfig.data.secretProviders.filter(
+          (provider) => provider.canStore,
+        )
       : [];
 
   useEffect(() => {
@@ -1888,7 +2363,11 @@ function SecretOrTokenInput(props: {
     }
   }, [instanceConfig, newProviderId]);
 
-  const selectedValue = showCreate ? CREATE_NEW_VALUE : useInline ? INLINE_TOKEN_VALUE : (handle || "");
+  const selectedValue = showCreate
+    ? CREATE_NEW_VALUE
+    : useInline
+      ? INLINE_TOKEN_VALUE
+      : handle || "";
 
   const handleSelectChange = (value: string) => {
     if (value === CREATE_NEW_VALUE) {
@@ -1918,9 +2397,10 @@ function SecretOrTokenInput(props: {
     }
     setUseInline(false);
     setShowCreate(false);
-    const matchedSecret = secrets.status === "ready"
-      ? secrets.data.find((secret) => secret.id === value)
-      : null;
+    const matchedSecret =
+      secrets.status === "ready"
+        ? secrets.data.find((secret) => secret.id === value)
+        : null;
     onSelectSecret(matchedSecret?.providerId ?? "local", value);
   };
 
@@ -1945,7 +2425,9 @@ function SecretOrTokenInput(props: {
       onSelectSecret(result.providerId, result.id);
       setShowCreate(false);
     } catch (err) {
-      setCreateError(err instanceof Error ? err.message : "Failed creating secret.");
+      setCreateError(
+        err instanceof Error ? err.message : "Failed creating secret.",
+      );
     }
   };
 
@@ -1999,7 +2481,9 @@ function SecretOrTokenInput(props: {
           )}
           <div className="grid gap-3 sm:grid-cols-2">
             <label className="block space-y-1">
-              <span className="text-[11px] font-medium text-muted-foreground">Name</span>
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Name
+              </span>
               <input
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
@@ -2009,7 +2493,9 @@ function SecretOrTokenInput(props: {
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[11px] font-medium text-muted-foreground">Value</span>
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Value
+              </span>
               <input
                 type="password"
                 value={newValue}
@@ -2019,7 +2505,9 @@ function SecretOrTokenInput(props: {
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[11px] font-medium text-muted-foreground">Store in</span>
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Store in
+              </span>
               <select
                 value={newProviderId}
                 onChange={(e) => setNewProviderId(e.target.value)}
@@ -2046,7 +2534,9 @@ function SecretOrTokenInput(props: {
               onClick={handleCreate}
               disabled={createSecret.status === "pending"}
             >
-              {createSecret.status === "pending" && <IconSpinner className="size-3" />}
+              {createSecret.status === "pending" && (
+                <IconSpinner className="size-3" />
+              )}
               Store & use
             </Button>
           </div>

--- a/apps/web/src/views/json-form.ts
+++ b/apps/web/src/views/json-form.ts
@@ -1,0 +1,74 @@
+import * as Either from "effect/Either";
+import * as ParseResult from "effect/ParseResult";
+import * as Schema from "effect/Schema";
+
+const JsonStringMapSchema = Schema.parseJson(
+  Schema.Record({
+    key: Schema.String,
+    value: Schema.String,
+  }),
+);
+
+const JsonStringArraySchema = Schema.parseJson(
+  Schema.Array(Schema.String),
+);
+
+const formatJsonFieldError = (
+  label: string,
+  error: ParseResult.ParseError,
+): Error =>
+  new Error(
+    `${label} is invalid: ${ParseResult.TreeFormatter.formatErrorSync(error)}`,
+  );
+
+const decodeJsonField = <A>(input: {
+  label: string;
+  text: string;
+  schema: Schema.Schema<A, string>;
+}): A | null => {
+  const trimmed = input.text.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const decoded = Schema.decodeUnknownEither(input.schema)(trimmed);
+  if (Either.isLeft(decoded)) {
+    throw formatJsonFieldError(input.label, decoded.left);
+  }
+
+  return decoded.right;
+};
+
+export const parseJsonStringMap = (
+  label: string,
+  text: string,
+): Record<string, string> | null => {
+  const decoded = decodeJsonField({
+    label,
+    text,
+    schema: JsonStringMapSchema,
+  });
+
+  return decoded && Object.keys(decoded).length > 0 ? decoded : null;
+};
+
+export const parseJsonStringArray = (
+  label: string,
+  text: string,
+): Array<string> | null => {
+  const decoded = decodeJsonField({
+    label,
+    text,
+    schema: JsonStringArraySchema,
+  });
+
+  if (!decoded) {
+    return null;
+  }
+
+  const normalized = decoded
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  return normalized.length > 0 ? normalized : null;
+};

--- a/apps/web/src/views/mcp-transport-state.ts
+++ b/apps/web/src/views/mcp-transport-state.ts
@@ -1,0 +1,62 @@
+export type McpRemoteTransportValue = "" | "auto" | "streamable-http" | "sse";
+
+export type McpTransportValue = McpRemoteTransportValue | "stdio";
+
+export type McpRemoteTransportFields = {
+  transport: McpRemoteTransportValue;
+  queryParamsText: string;
+  headersText: string;
+};
+
+export type McpStdioTransportFields = {
+  transport: "stdio";
+  command: string;
+  argsText: string;
+  envText: string;
+  cwd: string;
+};
+
+export type McpTransportFields =
+  | McpRemoteTransportFields
+  | McpStdioTransportFields;
+
+export const defaultMcpRemoteTransportFields = (
+  transport: McpRemoteTransportValue = "",
+): McpRemoteTransportFields => ({
+  transport,
+  queryParamsText: "",
+  headersText: "",
+});
+
+export const defaultMcpStdioTransportFields = (
+  input?: Partial<Omit<McpStdioTransportFields, "transport">>,
+): McpStdioTransportFields => ({
+  transport: "stdio",
+  command: input?.command ?? "",
+  argsText: input?.argsText ?? "",
+  envText: input?.envText ?? "",
+  cwd: input?.cwd ?? "",
+});
+
+export const asMcpRemoteTransportValue = (
+  transport: McpTransportValue | null | undefined,
+): McpRemoteTransportValue =>
+  transport === "stdio" ? "auto" : (transport ?? "");
+
+export const setMcpTransportFieldsTransport = (
+  current: McpTransportFields,
+  transport: McpTransportValue,
+): McpTransportFields => {
+  if (transport === "stdio") {
+    return current.transport === "stdio"
+      ? current
+      : defaultMcpStdioTransportFields();
+  }
+
+  return current.transport === "stdio"
+    ? defaultMcpRemoteTransportFields(transport)
+    : {
+        ...current,
+        transport,
+      };
+};

--- a/apps/web/src/views/source-editor.tsx
+++ b/apps/web/src/views/source-editor.tsx
@@ -60,10 +60,10 @@ const SOURCE_OAUTH_POPUP_RESULT_TIMEOUT_MS = 2 * 60_000;
 const SOURCE_OAUTH_POPUP_RESULT_STORAGE_KEY_PREFIX = "executor:oauth-result:";
 
 const isSourceNotFoundLoadable = (loadable: Loadable<unknown>): boolean =>
-  loadable.status === "error"
-  && loadable.error.message.toLowerCase().includes("source not found");
+  loadable.status === "error" &&
+  loadable.error.message.toLowerCase().includes("source not found");
 
-type TransportValue = "" | "auto" | "streamable-http" | "sse";
+type TransportValue = "" | "auto" | "streamable-http" | "sse" | "stdio";
 
 type SourceFormState = {
   name: string;
@@ -74,6 +74,10 @@ type SourceFormState = {
   transport: TransportValue;
   queryParamsText: string;
   headersText: string;
+  command: string;
+  argsText: string;
+  envText: string;
+  cwd: string;
   specUrl: string;
   service: string;
   version: string;
@@ -87,7 +91,10 @@ type SourceFormState = {
   oauthAccessHandle: string;
   oauthRefreshProviderId: string;
   oauthRefreshHandle: string;
-  managedAuth: Extract<Source["auth"], { kind: "provider_grant_ref" | "mcp_oauth" }> | null;
+  managedAuth: Extract<
+    Source["auth"],
+    { kind: "provider_grant_ref" | "mcp_oauth" }
+  > | null;
 };
 
 const kindOptions: ReadonlyArray<Source["kind"]> = [
@@ -102,6 +109,7 @@ const transportOptions: ReadonlyArray<Exclude<TransportValue, "">> = [
   "auto",
   "streamable-http",
   "sse",
+  "stdio",
 ];
 
 const authOptions: ReadonlyArray<Source["auth"]["kind"]> = [
@@ -129,9 +137,15 @@ const namespaceFromUrl = (url: string): string => {
 };
 
 const googleDiscoveryNamespace = (service: string): string =>
-  `google.${service.trim().toLowerCase().replace(/[^a-z0-9]+/g, ".").replace(/^\.+|\.+$/g, "")}`;
+  `google.${service
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ".")
+    .replace(/^\.+|\.+$/g, "")}`;
 
-const readStoredSourceOAuthPopupResult = (sessionId: string): SourceOAuthPopupMessage | null => {
+const readStoredSourceOAuthPopupResult = (
+  sessionId: string,
+): SourceOAuthPopupMessage | null => {
   if (typeof window === "undefined") {
     return null;
   }
@@ -155,7 +169,9 @@ const clearStoredSourceOAuthPopupResult = (sessionId: string): void => {
     return;
   }
 
-  window.localStorage.removeItem(`${SOURCE_OAUTH_POPUP_RESULT_STORAGE_KEY_PREFIX}${sessionId}`);
+  window.localStorage.removeItem(
+    `${SOURCE_OAUTH_POPUP_RESULT_STORAGE_KEY_PREFIX}${sessionId}`,
+  );
 };
 
 const startSourceOAuthPopup = async (input: {
@@ -180,110 +196,130 @@ const startSourceOAuthPopup = async (input: {
 
   popup.focus();
 
-  return await new Promise<CompleteSourceOAuthResult["auth"]>((resolve, reject) => {
-    let settled = false;
-    let closedPoll = 0;
-    let resultTimeout = 0;
+  return await new Promise<CompleteSourceOAuthResult["auth"]>(
+    (resolve, reject) => {
+      let settled = false;
+      let closedPoll = 0;
+      let resultTimeout = 0;
 
-    const cleanup = () => {
-      window.removeEventListener("message", onMessage);
-      if (closedPoll) {
-        window.clearInterval(closedPoll);
-      }
-      if (resultTimeout) {
-        window.clearTimeout(resultTimeout);
-      }
-      if (!popup.closed) {
-        popup.close();
-      }
-      clearStoredSourceOAuthPopupResult(input.sessionId);
-    };
+      const cleanup = () => {
+        window.removeEventListener("message", onMessage);
+        if (closedPoll) {
+          window.clearInterval(closedPoll);
+        }
+        if (resultTimeout) {
+          window.clearTimeout(resultTimeout);
+        }
+        if (!popup.closed) {
+          popup.close();
+        }
+        clearStoredSourceOAuthPopupResult(input.sessionId);
+      };
 
-    const settleWithError = (message: string) => {
-      if (settled) {
-        return;
-      }
+      const settleWithError = (message: string) => {
+        if (settled) {
+          return;
+        }
 
-      settled = true;
-      cleanup();
-      reject(new Error(message));
-    };
+        settled = true;
+        cleanup();
+        reject(new Error(message));
+      };
 
-    const settleFromPayload = (data: SourceOAuthPopupMessage) => {
-      if (!data.ok) {
-        settleWithError(data.error || "OAuth failed");
-        return;
-      }
+      const settleFromPayload = (data: SourceOAuthPopupMessage) => {
+        if (!data.ok) {
+          settleWithError(data.error || "OAuth failed");
+          return;
+        }
 
-      if (settled) {
-        return;
-      }
+        if (settled) {
+          return;
+        }
 
-      settled = true;
-      cleanup();
-      resolve(data.auth);
-    };
+        settled = true;
+        cleanup();
+        resolve(data.auth);
+      };
 
-    const onMessage = (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) {
-        return;
-      }
+      const onMessage = (event: MessageEvent) => {
+        if (event.origin !== window.location.origin) {
+          return;
+        }
 
-      const data = event.data as SourceOAuthPopupMessage | undefined;
-      if (!data || data.type !== "executor:oauth-result") {
-        return;
-      }
+        const data = event.data as SourceOAuthPopupMessage | undefined;
+        if (!data || data.type !== "executor:oauth-result") {
+          return;
+        }
 
-      if (data.ok && data.sessionId !== input.sessionId) {
-        return;
-      }
+        if (data.ok && data.sessionId !== input.sessionId) {
+          return;
+        }
 
-      if (!data.ok && data.sessionId !== null && data.sessionId !== input.sessionId) {
-        return;
-      }
+        if (
+          !data.ok &&
+          data.sessionId !== null &&
+          data.sessionId !== input.sessionId
+        ) {
+          return;
+        }
 
-      settleFromPayload(data);
-    };
+        settleFromPayload(data);
+      };
 
-    window.addEventListener("message", onMessage);
+      window.addEventListener("message", onMessage);
 
-    resultTimeout = window.setTimeout(() => {
-      settleWithError("OAuth popup timed out before completion. Please try again.");
-    }, SOURCE_OAUTH_POPUP_RESULT_TIMEOUT_MS);
+      resultTimeout = window.setTimeout(() => {
+        settleWithError(
+          "OAuth popup timed out before completion. Please try again.",
+        );
+      }, SOURCE_OAUTH_POPUP_RESULT_TIMEOUT_MS);
 
-    closedPoll = window.setInterval(() => {
-      const stored = readStoredSourceOAuthPopupResult(input.sessionId);
-      if (stored) {
-        settleFromPayload(stored);
-        return;
-      }
-      if (popup.closed) {
-        // Stop polling — only run one final deferred check to give the
-        // callback page time to write localStorage before we give up.
-        window.clearInterval(closedPoll);
-        closedPoll = 0;
-        window.setTimeout(() => {
-          const delayedStored = readStoredSourceOAuthPopupResult(input.sessionId);
-          if (delayedStored) {
-            settleFromPayload(delayedStored);
-            return;
-          }
-          settleWithError("OAuth popup was closed before completion.");
-        }, 1500);
-      }
-    }, 300);
-  });
+      closedPoll = window.setInterval(() => {
+        const stored = readStoredSourceOAuthPopupResult(input.sessionId);
+        if (stored) {
+          settleFromPayload(stored);
+          return;
+        }
+        if (popup.closed) {
+          // Stop polling — only run one final deferred check to give the
+          // callback page time to write localStorage before we give up.
+          window.clearInterval(closedPoll);
+          closedPoll = 0;
+          window.setTimeout(() => {
+            const delayedStored = readStoredSourceOAuthPopupResult(
+              input.sessionId,
+            );
+            if (delayedStored) {
+              settleFromPayload(delayedStored);
+              return;
+            }
+            settleWithError("OAuth popup was closed before completion.");
+          }, 1500);
+        }
+      }, 300);
+    },
+  );
 };
 
 const stringMapToEditor = (value: Record<string, string> | null): string =>
   value === null ? "" : JSON.stringify(value, null, 2);
+
+const stringArrayToEditor = (
+  value: ReadonlyArray<string> | null | undefined,
+): string =>
+  !value || value.length === 0 ? "" : JSON.stringify(value, null, 2);
 
 const readBindingStringMap = (
   source: Source,
   key: string,
 ): Record<string, string> | null => {
   const candidate = source.binding[key];
-  if (candidate === null || candidate === undefined || typeof candidate !== "object" || Array.isArray(candidate)) {
+  if (
+    candidate === null ||
+    candidate === undefined ||
+    typeof candidate !== "object" ||
+    Array.isArray(candidate)
+  ) {
     return null;
   }
 
@@ -293,14 +329,77 @@ const readBindingStringMap = (
     : null;
 };
 
+const readBindingStringArray = (
+  source: Source,
+  key: string,
+): Array<string> | null => {
+  const candidate = source.binding[key];
+  return Array.isArray(candidate) &&
+    candidate.every((value) => typeof value === "string")
+    ? [...candidate]
+    : null;
+};
+
 const readBindingString = (source: Source, key: string): string =>
   typeof source.binding[key] === "string" ? String(source.binding[key]) : "";
 
 const readBindingTransport = (source: Source): TransportValue => {
   const candidate = source.binding.transport;
-  return typeof candidate === "string" && (candidate === "auto" || candidate === "streamable-http" || candidate === "sse")
+  return typeof candidate === "string" &&
+    (candidate === "auto" ||
+      candidate === "streamable-http" ||
+      candidate === "sse" ||
+      candidate === "stdio")
     ? candidate
     : "";
+};
+
+const parseJsonStringArray = (
+  label: string,
+  text: string,
+): Array<string> | null => {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error(`${label} must be valid JSON.`);
+  }
+
+  if (
+    !Array.isArray(parsed) ||
+    !parsed.every((value) => typeof value === "string")
+  ) {
+    throw new Error(`${label} must be a JSON array of strings.`);
+  }
+
+  const normalized = parsed
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  return normalized.length > 0 ? normalized : null;
+};
+
+const buildSyntheticMcpStdioEndpoint = (input: {
+  name?: string | null;
+  endpoint?: string | null;
+  command?: string | null;
+}): string => {
+  const label =
+    input.name?.trim() ||
+    input.endpoint?.trim() ||
+    input.command?.trim() ||
+    "mcp";
+  const slug = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return `stdio://local/${slug || "mcp"}`;
 };
 
 const defaultFormState = (template?: SourceTemplate): SourceFormState => ({
@@ -308,14 +407,25 @@ const defaultFormState = (template?: SourceTemplate): SourceFormState => ({
   kind: template?.kind ?? "openapi",
   endpoint: template?.endpoint ?? "",
   namespace: template
-    ? "service" in template
-      ? googleDiscoveryNamespace(template.service)
-      : namespaceFromUrl(template.endpoint)
+    ? (template.namespace ??
+      ("service" in template
+        ? googleDiscoveryNamespace(template.service)
+        : namespaceFromUrl(template.endpoint ?? "")))
     : "",
   enabled: true,
-  transport: template?.kind === "mcp" ? "auto" : "",
+  transport:
+    template?.kind === "mcp"
+      ? template.connectionType === "command"
+        ? (template.transport ?? "stdio")
+        : (template.transport ?? "auto")
+      : "",
   queryParamsText: "",
   headersText: "",
+  command: template?.kind === "mcp" ? (template.command ?? "") : "",
+  argsText: template?.kind === "mcp" ? stringArrayToEditor(template.args) : "",
+  envText:
+    template?.kind === "mcp" ? stringMapToEditor(template.env ?? null) : "",
+  cwd: template?.kind === "mcp" ? (template.cwd ?? "") : "",
   specUrl: template && "specUrl" in template ? template.specUrl : "",
   service: template && "service" in template ? template.service : "",
   version: template && "version" in template ? template.version : "",
@@ -338,13 +448,22 @@ const formStateFromSource = (source: Source): SourceFormState => ({
   endpoint: source.endpoint,
   namespace: source.namespace ?? "",
   enabled: source.enabled,
-  transport: source.kind === "mcp" ? (readBindingTransport(source) || "auto") : "",
-  queryParamsText: stringMapToEditor(readBindingStringMap(source, "queryParams")),
+  transport:
+    source.kind === "mcp" ? readBindingTransport(source) || "auto" : "",
+  queryParamsText: stringMapToEditor(
+    readBindingStringMap(source, "queryParams"),
+  ),
   headersText: stringMapToEditor(readBindingStringMap(source, "headers")),
+  command: readBindingString(source, "command"),
+  argsText: stringArrayToEditor(readBindingStringArray(source, "args")),
+  envText: stringMapToEditor(readBindingStringMap(source, "env")),
+  cwd: readBindingString(source, "cwd"),
   specUrl: readBindingString(source, "specUrl"),
   service: readBindingString(source, "service"),
   version: readBindingString(source, "version"),
-  defaultHeadersText: stringMapToEditor(readBindingStringMap(source, "defaultHeaders")),
+  defaultHeadersText: stringMapToEditor(
+    readBindingStringMap(source, "defaultHeaders"),
+  ),
   authKind: source.auth.kind,
   authHeaderName:
     source.auth.kind === "none" || source.auth.kind === "mcp_oauth"
@@ -354,10 +473,13 @@ const formStateFromSource = (source: Source): SourceFormState => ({
     source.auth.kind === "none" || source.auth.kind === "mcp_oauth"
       ? "Bearer "
       : source.auth.prefix,
-  bearerProviderId: source.auth.kind === "bearer" ? source.auth.token.providerId : "",
+  bearerProviderId:
+    source.auth.kind === "bearer" ? source.auth.token.providerId : "",
   bearerHandle: source.auth.kind === "bearer" ? source.auth.token.handle : "",
-  oauthAccessProviderId: source.auth.kind === "oauth2" ? source.auth.accessToken.providerId : "",
-  oauthAccessHandle: source.auth.kind === "oauth2" ? source.auth.accessToken.handle : "",
+  oauthAccessProviderId:
+    source.auth.kind === "oauth2" ? source.auth.accessToken.providerId : "",
+  oauthAccessHandle:
+    source.auth.kind === "oauth2" ? source.auth.accessToken.handle : "",
   oauthRefreshProviderId:
     source.auth.kind === "oauth2" && source.auth.refreshToken !== null
       ? source.auth.refreshToken.providerId
@@ -367,12 +489,16 @@ const formStateFromSource = (source: Source): SourceFormState => ({
       ? source.auth.refreshToken.handle
       : "",
   managedAuth:
-    source.auth.kind === "provider_grant_ref" || source.auth.kind === "mcp_oauth"
+    source.auth.kind === "provider_grant_ref" ||
+    source.auth.kind === "mcp_oauth"
       ? source.auth
       : null,
 });
 
-const parseJsonStringMap = (label: string, text: string): Record<string, string> | null => {
+const parseJsonStringMap = (
+  label: string,
+  text: string,
+): Record<string, string> | null => {
   const trimmed = text.trim();
   if (trimmed.length === 0) {
     return null;
@@ -401,12 +527,18 @@ const parseJsonStringMap = (label: string, text: string): Record<string, string>
   return Object.keys(normalized).length === 0 ? null : normalized;
 };
 
-const buildAuthPayload = (state: SourceFormState): CreateSourcePayload["auth"] => {
+const buildAuthPayload = (
+  state: SourceFormState,
+): CreateSourcePayload["auth"] => {
   if (state.authKind === "none") {
     return { kind: "none" };
   }
 
-  if ((state.authKind === "provider_grant_ref" || state.authKind === "mcp_oauth") && state.managedAuth !== null) {
+  if (
+    (state.authKind === "provider_grant_ref" ||
+      state.authKind === "mcp_oauth") &&
+    state.managedAuth !== null
+  ) {
     return state.managedAuth;
   }
 
@@ -417,7 +549,9 @@ const buildAuthPayload = (state: SourceFormState): CreateSourcePayload["auth"] =
     const providerId = state.bearerProviderId.trim();
     const handle = state.bearerHandle.trim();
     if (!providerId || !handle) {
-      throw new Error("Bearer auth requires a token. Select or create a secret.");
+      throw new Error(
+        "Bearer auth requires a token. Select or create a secret.",
+      );
     }
 
     return {
@@ -434,13 +568,17 @@ const buildAuthPayload = (state: SourceFormState): CreateSourcePayload["auth"] =
   const accessProviderId = state.oauthAccessProviderId.trim();
   const accessHandle = state.oauthAccessHandle.trim();
   if (!accessProviderId || !accessHandle) {
-    throw new Error("OAuth2 auth requires an access token. Select or create a secret.");
+    throw new Error(
+      "OAuth2 auth requires an access token. Select or create a secret.",
+    );
   }
 
   const refreshProviderId = trimToNull(state.oauthRefreshProviderId);
   const refreshHandle = trimToNull(state.oauthRefreshHandle);
   if ((refreshProviderId === null) !== (refreshHandle === null)) {
-    throw new Error("OAuth2 refresh token provider ID and handle must be set together.");
+    throw new Error(
+      "OAuth2 refresh token provider ID and handle must be set together.",
+    );
   }
 
   return {
@@ -461,8 +599,14 @@ const buildAuthPayload = (state: SourceFormState): CreateSourcePayload["auth"] =
   };
 };
 
-const buildRequestedSourceStatus = (state: SourceFormState): CreateSourcePayload["status"] => {
-  if (state.kind !== "mcp" && state.kind !== "openapi" && state.kind !== "graphql") {
+const buildRequestedSourceStatus = (
+  state: SourceFormState,
+): CreateSourcePayload["status"] => {
+  if (
+    state.kind !== "mcp" &&
+    state.kind !== "openapi" &&
+    state.kind !== "graphql"
+  ) {
     return undefined;
   }
 
@@ -471,7 +615,14 @@ const buildRequestedSourceStatus = (state: SourceFormState): CreateSourcePayload
 
 const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
   const name = state.name.trim();
-  const endpoint = state.endpoint.trim();
+  const isMcpStdio = state.kind === "mcp" && state.transport === "stdio";
+  const endpoint = isMcpStdio
+    ? buildSyntheticMcpStdioEndpoint({
+        name: state.name,
+        endpoint: state.endpoint,
+        command: state.command,
+      })
+    : state.endpoint.trim();
 
   if (!name) {
     throw new Error("Source name is required.");
@@ -479,6 +630,9 @@ const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
 
   if (!endpoint) {
     throw new Error("Source endpoint is required.");
+  }
+  if (isMcpStdio && !state.command.trim()) {
+    throw new Error("MCP stdio transport requires a command.");
   }
 
   const shared = {
@@ -488,16 +642,35 @@ const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
     status: buildRequestedSourceStatus(state),
     enabled: state.enabled,
     namespace: trimToNull(state.namespace),
-    auth: buildAuthPayload(state),
-  } satisfies Pick<CreateSourcePayload, "name" | "kind" | "endpoint" | "status" | "enabled" | "namespace" | "auth">;
+    auth: isMcpStdio ? { kind: "none" as const } : buildAuthPayload(state),
+  } satisfies Pick<
+    CreateSourcePayload,
+    "name" | "kind" | "endpoint" | "status" | "enabled" | "namespace" | "auth"
+  >;
 
   if (state.kind === "mcp") {
     return {
       ...shared,
       binding: {
         transport: state.transport === "" ? "auto" : state.transport,
-        queryParams: parseJsonStringMap("Query params", state.queryParamsText),
-        headers: parseJsonStringMap("Request headers", state.headersText),
+        queryParams:
+          state.transport === "stdio"
+            ? null
+            : parseJsonStringMap("Query params", state.queryParamsText),
+        headers:
+          state.transport === "stdio"
+            ? null
+            : parseJsonStringMap("Request headers", state.headersText),
+        command: state.transport === "stdio" ? state.command.trim() : null,
+        args:
+          state.transport === "stdio"
+            ? parseJsonStringArray("Args", state.argsText)
+            : null,
+        env:
+          state.transport === "stdio"
+            ? parseJsonStringMap("Environment", state.envText)
+            : null,
+        cwd: state.transport === "stdio" ? trimToNull(state.cwd) : null,
       },
     };
   }
@@ -512,7 +685,10 @@ const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
       ...shared,
       binding: {
         specUrl,
-        defaultHeaders: parseJsonStringMap("Default headers", state.defaultHeadersText),
+        defaultHeaders: parseJsonStringMap(
+          "Default headers",
+          state.defaultHeadersText,
+        ),
       },
     };
   }
@@ -521,7 +697,10 @@ const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
     return {
       ...shared,
       binding: {
-        defaultHeaders: parseJsonStringMap("Default headers", state.defaultHeadersText),
+        defaultHeaders: parseJsonStringMap(
+          "Default headers",
+          state.defaultHeadersText,
+        ),
       },
     };
   }
@@ -542,7 +721,10 @@ const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
         service,
         version,
         discoveryUrl: endpoint,
-        defaultHeaders: parseJsonStringMap("Default headers", state.defaultHeadersText),
+        defaultHeaders: parseJsonStringMap(
+          "Default headers",
+          state.defaultHeadersText,
+        ),
       },
     };
   }
@@ -557,9 +739,14 @@ const buildUpdatePayload = (state: SourceFormState): UpdateSourcePayload => ({
   ...buildSourcePayload(state),
 });
 
-const buildStartSourceOAuthPayload = (state: SourceFormState): StartSourceOAuthPayload => {
+const buildStartSourceOAuthPayload = (
+  state: SourceFormState,
+): StartSourceOAuthPayload => {
   if (state.kind !== "mcp") {
     throw new Error("OAuth sign-in is only available for MCP sources.");
+  }
+  if (state.transport === "stdio") {
+    throw new Error("OAuth sign-in is not available for MCP stdio sources.");
   }
 
   const endpoint = state.endpoint.trim();
@@ -585,9 +772,9 @@ export function EditSourcePage(props: { sourceId: string }) {
   const sources = useSources();
   const source = useSource(props.sourceId);
   const missingSource =
-    (sources.status === "ready"
-      && !sources.data.some((candidate) => candidate.id === props.sourceId))
-    || isSourceNotFoundLoadable(source);
+    (sources.status === "ready" &&
+      !sources.data.some((candidate) => candidate.id === props.sourceId)) ||
+    isSourceNotFoundLoadable(source);
 
   if (missingSource) {
     return <SourceNotFoundState />;
@@ -619,23 +806,35 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
   const [formState, setFormState] = useState<SourceFormState>(() =>
     props.source ? formStateFromSource(props.source) : defaultFormState(),
   );
-  const [statusBanner, setStatusBanner] = useState<StatusBannerState | null>(null);
-  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
+  const [statusBanner, setStatusBanner] = useState<StatusBannerState | null>(
+    null,
+  );
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(
+    null,
+  );
   const [oauthPopupBusy, setOauthPopupBusy] = useState(false);
-  const [expandedOauthSecretRefTarget, setExpandedOauthSecretRefTarget] = useState<string | null>(null);
+  const [expandedOauthSecretRefTarget, setExpandedOauthSecretRefTarget] =
+    useState<string | null>(null);
 
-  const isSubmitting = createSource.status === "pending" || updateSource.status === "pending";
+  const isSubmitting =
+    createSource.status === "pending" || updateSource.status === "pending";
   const isDeleting = removeSource.status === "pending";
   const isRevokingGrant = removeProviderAuthGrant.status === "pending";
-  const isOAuthSubmitting = startSourceOAuth.status === "pending" || oauthPopupBusy;
+  const isOAuthSubmitting =
+    startSourceOAuth.status === "pending" || oauthPopupBusy;
   const oauthSecretRefTarget =
-    formState.authKind === "oauth2" && formState.oauthAccessHandle.trim().length > 0
+    formState.authKind === "oauth2" &&
+    formState.oauthAccessHandle.trim().length > 0
       ? `${formState.oauthAccessProviderId}:${formState.oauthAccessHandle}:${formState.oauthRefreshProviderId}:${formState.oauthRefreshHandle}`
       : null;
   const showOauthSecretRefs =
-    oauthSecretRefTarget !== null && expandedOauthSecretRefTarget === oauthSecretRefTarget;
+    oauthSecretRefTarget !== null &&
+    expandedOauthSecretRefTarget === oauthSecretRefTarget;
 
-  const setField = <K extends keyof SourceFormState>(key: K, value: SourceFormState[K]) => {
+  const setField = <K extends keyof SourceFormState>(
+    key: K,
+    value: SourceFormState[K],
+  ) => {
     setFormState((current) => ({ ...current, [key]: value }));
   };
 
@@ -657,7 +856,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
 
     try {
       if (props.mode === "create") {
-        const createdSource = await createSource.mutateAsync(buildSourcePayload(formState));
+        const createdSource = await createSource.mutateAsync(
+          buildSourcePayload(formState),
+        );
         void navigate({
           to: "/sources/$sourceId",
           params: { sourceId: createdSource.id },
@@ -691,7 +892,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
     setStatusBanner(null);
 
     try {
-      const result = await startSourceOAuth.mutateAsync(buildStartSourceOAuthPayload(formState));
+      const result = await startSourceOAuth.mutateAsync(
+        buildStartSourceOAuthPayload(formState),
+      );
 
       setStatusBanner({
         tone: "info",
@@ -735,7 +938,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
       return;
     }
 
-    const confirmed = window.confirm(`Remove "${props.source.name}" and its indexed tools?`);
+    const confirmed = window.confirm(
+      `Remove "${props.source.name}" and its indexed tools?`,
+    );
     if (!confirmed) {
       return;
     }
@@ -751,16 +956,17 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
     } catch (error) {
       setStatusBanner({
         tone: "error",
-        text: error instanceof Error ? error.message : "Failed removing source.",
+        text:
+          error instanceof Error ? error.message : "Failed removing source.",
       });
     }
   };
 
   const handleRevokeProviderGrant = async () => {
     if (
-      !props.source
-      || isRevokingGrant
-      || formState.managedAuth?.kind !== "provider_grant_ref"
+      !props.source ||
+      isRevokingGrant ||
+      formState.managedAuth?.kind !== "provider_grant_ref"
     ) {
       return;
     }
@@ -775,7 +981,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
     setStatusBanner(null);
 
     try {
-      const result = await removeProviderAuthGrant.mutateAsync(formState.managedAuth.grantId);
+      const result = await removeProviderAuthGrant.mutateAsync(
+        formState.managedAuth.grantId,
+      );
       if (!result.removed) {
         throw new Error("Shared provider grant was not removed.");
       }
@@ -787,14 +995,22 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
     } catch (error) {
       setStatusBanner({
         tone: "error",
-        text: error instanceof Error ? error.message : "Failed revoking shared provider grant.",
+        text:
+          error instanceof Error
+            ? error.message
+            : "Failed revoking shared provider grant.",
       });
     }
   };
 
-  const backLink = props.mode === "edit" && props.source
-    ? { to: "/sources/$sourceId" as const, params: { sourceId: props.source.id }, search: { tab: "model" as const } }
-    : { to: "/" as const };
+  const backLink =
+    props.mode === "edit" && props.source
+      ? {
+          to: "/sources/$sourceId" as const,
+          params: { sourceId: props.source.id },
+          search: { tab: "model" as const },
+        }
+      : { to: "/" as const };
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -841,11 +1057,19 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                   <div className="mb-1 flex items-center justify-between gap-2">
                     <div className="flex min-w-0 items-center gap-2">
                       <div className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
-                        <SourceFavicon endpoint={template.endpoint} kind={template.kind} className="size-4" />
+                        <SourceFavicon
+                          endpoint={template.endpoint}
+                          kind={template.kind}
+                          className="size-4"
+                        />
                       </div>
-                      <span className="truncate text-[13px] font-medium text-foreground">{template.name}</span>
+                      <span className="truncate text-[13px] font-medium text-foreground">
+                        {template.name}
+                      </span>
                     </div>
-                    <Badge variant="outline" className="text-[9px]">{template.kind}</Badge>
+                    <Badge variant="outline" className="text-[9px]">
+                      {template.kind}
+                    </Badge>
                   </div>
                   <span className="text-[11px] text-muted-foreground line-clamp-1">
                     {template.summary}
@@ -870,29 +1094,35 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
               <Field label="Kind">
                 <SelectInput
                   value={formState.kind}
-                  onChange={(value) => setField("kind", value as Source["kind"])}
-                  options={kindOptions.map((value) => ({ value, label: value }))}
-                />
-              </Field>
-              <Field
-                label="Endpoint"
-                className="sm:col-span-2"
-              >
-                <TextInput
-                  value={formState.endpoint}
-                  onChange={(value) => setField("endpoint", value)}
-                  placeholder={
-                    formState.kind === "openapi"
-                      ? "https://api.github.com"
-                      : formState.kind === "graphql"
-                        ? "https://api.linear.app/graphql"
-                        : formState.kind === "google_discovery"
-                          ? "https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest"
-                        : "https://mcp.deepwiki.com/mcp"
+                  onChange={(value) =>
+                    setField("kind", value as Source["kind"])
                   }
-                  mono
+                  options={kindOptions.map((value) => ({
+                    value,
+                    label: value,
+                  }))}
                 />
               </Field>
+              {!(
+                formState.kind === "mcp" && formState.transport === "stdio"
+              ) && (
+                <Field label="Endpoint" className="sm:col-span-2">
+                  <TextInput
+                    value={formState.endpoint}
+                    onChange={(value) => setField("endpoint", value)}
+                    placeholder={
+                      formState.kind === "openapi"
+                        ? "https://api.github.com"
+                        : formState.kind === "graphql"
+                          ? "https://api.linear.app/graphql"
+                          : formState.kind === "google_discovery"
+                            ? "https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest"
+                            : "https://mcp.deepwiki.com/mcp"
+                    }
+                    mono
+                  />
+                </Field>
+              )}
               <Field label="Namespace">
                 <TextInput
                   value={formState.namespace}
@@ -915,26 +1145,70 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                 <Field label="Transport mode">
                   <SelectInput
                     value={formState.transport || "auto"}
-                    onChange={(value) => setField("transport", value as TransportValue)}
-                    options={transportOptions.map((value) => ({ value, label: value }))}
+                    onChange={(value) =>
+                      setField("transport", value as TransportValue)
+                    }
+                    options={transportOptions.map((value) => ({
+                      value,
+                      label: value,
+                    }))}
                   />
                 </Field>
-                <div className="sm:col-span-2 grid gap-4 sm:grid-cols-2">
-                  <Field label="Query params (JSON)">
-                    <CodeEditor
-                      value={formState.queryParamsText}
-                      onChange={(value) => setField("queryParamsText", value)}
-                      placeholder={'{\n  "workspace": "demo"\n}'}
-                    />
-                  </Field>
-                  <Field label="Headers (JSON)">
-                    <CodeEditor
-                      value={formState.headersText}
-                      onChange={(value) => setField("headersText", value)}
-                      placeholder={'{\n  "x-api-key": "..."\n}'}
-                    />
-                  </Field>
-                </div>
+                {formState.transport === "stdio" ? (
+                  <div className="sm:col-span-2 grid gap-4 sm:grid-cols-2">
+                    <Field label="Command">
+                      <TextInput
+                        value={formState.command}
+                        onChange={(value) => setField("command", value)}
+                        placeholder="npx"
+                        mono
+                      />
+                    </Field>
+                    <Field label="Working directory (optional)">
+                      <TextInput
+                        value={formState.cwd}
+                        onChange={(value) => setField("cwd", value)}
+                        placeholder="/path/to/project"
+                        mono
+                      />
+                    </Field>
+                    <Field label="Args (JSON)" className="sm:col-span-2">
+                      <CodeEditor
+                        value={formState.argsText}
+                        onChange={(value) => setField("argsText", value)}
+                        placeholder={
+                          '[\n  "-y",\n  "chrome-devtools-mcp@latest"\n]'
+                        }
+                      />
+                    </Field>
+                    <Field label="Environment (JSON)" className="sm:col-span-2">
+                      <CodeEditor
+                        value={formState.envText}
+                        onChange={(value) => setField("envText", value)}
+                        placeholder={
+                          '{\n  "CHROME_PATH": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"\n}'
+                        }
+                      />
+                    </Field>
+                  </div>
+                ) : (
+                  <div className="sm:col-span-2 grid gap-4 sm:grid-cols-2">
+                    <Field label="Query params (JSON)">
+                      <CodeEditor
+                        value={formState.queryParamsText}
+                        onChange={(value) => setField("queryParamsText", value)}
+                        placeholder={'{\n  "workspace": "demo"\n}'}
+                      />
+                    </Field>
+                    <Field label="Headers (JSON)">
+                      <CodeEditor
+                        value={formState.headersText}
+                        onChange={(value) => setField("headersText", value)}
+                        placeholder={'{\n  "x-api-key": "..."\n}'}
+                      />
+                    </Field>
+                  </div>
+                )}
               </div>
             </Section>
           )}
@@ -1005,20 +1279,38 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
 
           <Section title="Authentication">
             <div className="grid gap-4 sm:grid-cols-2">
-              {formState.kind === "mcp" && (
+              {formState.kind === "mcp" && formState.transport !== "stdio" && (
                 <div className="sm:col-span-2 rounded-xl border border-border bg-gradient-to-b from-card/90 to-card/50 overflow-hidden">
                   <div className="flex items-start gap-3 px-4 py-3.5">
                     <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/8 text-primary mt-0.5">
-                      <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                        <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+                      <svg
+                        className="size-4"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <rect
+                          x="3"
+                          y="11"
+                          width="18"
+                          height="11"
+                          rx="2"
+                          ry="2"
+                        />
                         <path d="M7 11V7a5 5 0 0110 0v4" />
                       </svg>
                     </div>
                     <div className="flex-1 min-w-0 space-y-2">
                       <div className="space-y-0.5">
-                        <p className="text-[12px] font-medium text-foreground">MCP OAuth</p>
+                        <p className="text-[12px] font-medium text-foreground">
+                          MCP OAuth
+                        </p>
                         <p className="text-[11px] text-muted-foreground">
-                          Opens the server's built-in OAuth flow to authenticate this source.
+                          Opens the server's built-in OAuth flow to authenticate
+                          this source.
                         </p>
                       </div>
                       <Button
@@ -1026,155 +1318,219 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                         variant="outline"
                         size="sm"
                         onClick={handleMcpOAuthConnect}
-                        disabled={isSubmitting || isDeleting || isOAuthSubmitting}
+                        disabled={
+                          isSubmitting || isDeleting || isOAuthSubmitting
+                        }
                       >
-                        {isOAuthSubmitting ? <IconSpinner className="size-3" /> : null}
-                        {formState.authKind === "oauth2" && formState.oauthAccessHandle.trim().length > 0
+                        {isOAuthSubmitting ? (
+                          <IconSpinner className="size-3" />
+                        ) : null}
+                        {formState.authKind === "oauth2" &&
+                        formState.oauthAccessHandle.trim().length > 0
                           ? "Reconnect"
                           : "Sign in with OAuth"}
                       </Button>
                     </div>
                   </div>
-                  {formState.authKind === "oauth2" && formState.oauthAccessHandle.trim().length > 0 && (
-                    <div className="flex items-center justify-between gap-3 border-t border-border/50 px-4 py-2.5">
-                      <p className="text-[11px] text-muted-foreground/70">
-                        Token refs attached to this draft
-                      </p>
-                      <button
-                        type="button"
-                        className="text-[11px] font-medium text-muted-foreground/60 transition-colors hover:text-foreground"
-                        onClick={() =>
-                          setExpandedOauthSecretRefTarget((current) =>
-                            current === oauthSecretRefTarget ? null : oauthSecretRefTarget,
-                          )}
-                      >
-                        {showOauthSecretRefs ? "Hide refs" : "Show refs"}
-                      </button>
-                    </div>
-                  )}
+                  {formState.authKind === "oauth2" &&
+                    formState.oauthAccessHandle.trim().length > 0 && (
+                      <div className="flex items-center justify-between gap-3 border-t border-border/50 px-4 py-2.5">
+                        <p className="text-[11px] text-muted-foreground/70">
+                          Token refs attached to this draft
+                        </p>
+                        <button
+                          type="button"
+                          className="text-[11px] font-medium text-muted-foreground/60 transition-colors hover:text-foreground"
+                          onClick={() =>
+                            setExpandedOauthSecretRefTarget((current) =>
+                              current === oauthSecretRefTarget
+                                ? null
+                                : oauthSecretRefTarget,
+                            )
+                          }
+                        >
+                          {showOauthSecretRefs ? "Hide refs" : "Show refs"}
+                        </button>
+                      </div>
+                    )}
                 </div>
               )}
-              <Field label="Auth mode">
-                <SelectInput
-                  value={formState.authKind}
-                  onChange={(value) => setField("authKind", value as Source["auth"]["kind"])}
-                  disabled={formState.managedAuth !== null}
-                  options={authOptions.map((value) => ({ value, label: value }))}
-                />
-              </Field>
-              {formState.managedAuth !== null && (
-                <div className="sm:col-span-2 rounded-xl border border-border bg-gradient-to-b from-muted/40 to-transparent overflow-hidden">
-                  <div className="flex items-start gap-3 px-4 py-3.5">
-                    <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/8 text-primary mt-0.5">
-                      {formState.managedAuth.kind === "provider_grant_ref" ? (
-                        <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                          <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
-                          <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" />
-                        </svg>
-                      ) : (
-                        <svg className="size-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-                          <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-                          <path d="M7 11V7a5 5 0 0110 0v4" />
-                        </svg>
-                      )}
-                    </div>
-                    <div className="flex-1 min-w-0 space-y-1">
-                      <p className="text-[12px] font-medium text-foreground">
-                        {formState.managedAuth.kind === "provider_grant_ref"
-                          ? "Shared provider grant"
-                          : "Managed MCP OAuth"}
-                      </p>
-                      <p className="text-[11px] leading-relaxed text-muted-foreground">
-                        {formState.managedAuth.kind === "provider_grant_ref"
-                          ? "This source uses a shared Google auth grant. Reconnect from Add Source to change the linked account or scopes."
-                          : "Authenticated through a persisted MCP OAuth session. Reconnect the source to refresh or replace the binding."}
-                      </p>
-                    </div>
-                  </div>
-                  {formState.managedAuth.kind === "provider_grant_ref" && props.mode === "edit" && (
-                    <div className="flex items-center justify-end border-t border-border/50 px-4 py-2.5">
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="text-destructive/70 hover:text-destructive hover:bg-destructive/8"
-                        onClick={handleRevokeProviderGrant}
-                        disabled={isRevokingGrant}
-                      >
-                        <IconTrash className="size-3" />
-                        {isRevokingGrant ? "Revoking\u2026" : "Revoke shared auth"}
-                      </Button>
-                    </div>
-                  )}
+              {formState.kind === "mcp" && formState.transport === "stdio" ? (
+                <div className="sm:col-span-2 rounded-xl border border-border bg-muted/40 px-4 py-3 text-[12px] text-muted-foreground">
+                  Local MCP stdio sources do not use executor-managed HTTP or
+                  OAuth credentials.
                 </div>
-              )}
-              {formState.authKind !== "none" && formState.managedAuth === null && (
-                <>
-                  <Field label="Header name">
-                    <TextInput
-                      value={formState.authHeaderName}
-                      onChange={(value) => setField("authHeaderName", value)}
-                      placeholder="Authorization"
-                    />
-                  </Field>
-                  <Field label="Prefix">
-                    <TextInput
-                      value={formState.authPrefix}
-                      onChange={(value) => setField("authPrefix", value)}
-                      placeholder="Bearer "
-                    />
-                  </Field>
-                </>
-              )}
-
-              {formState.authKind === "bearer" && formState.managedAuth === null && (
-                <Field label="Token" className="sm:col-span-2">
-                  <SecretPicker
-                    instanceConfig={instanceConfig}
-                    secrets={secrets}
-                    providerId={formState.bearerProviderId}
-                    handle={formState.bearerHandle}
-                    onSelect={(providerId, handle) => {
-                      setField("bearerProviderId", providerId);
-                      setField("bearerHandle", handle);
-                    }}
+              ) : (
+                <Field label="Auth mode">
+                  <SelectInput
+                    value={formState.authKind}
+                    onChange={(value) =>
+                      setField("authKind", value as Source["auth"]["kind"])
+                    }
+                    disabled={formState.managedAuth !== null}
+                    options={authOptions.map((value) => ({
+                      value,
+                      label: value,
+                    }))}
                   />
                 </Field>
               )}
+              {formState.managedAuth !== null &&
+                !(
+                  formState.kind === "mcp" && formState.transport === "stdio"
+                ) && (
+                  <div className="sm:col-span-2 rounded-xl border border-border bg-gradient-to-b from-muted/40 to-transparent overflow-hidden">
+                    <div className="flex items-start gap-3 px-4 py-3.5">
+                      <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/8 text-primary mt-0.5">
+                        {formState.managedAuth.kind === "provider_grant_ref" ? (
+                          <svg
+                            className="size-4"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71" />
+                            <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71" />
+                          </svg>
+                        ) : (
+                          <svg
+                            className="size-4"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <rect
+                              x="3"
+                              y="11"
+                              width="18"
+                              height="11"
+                              rx="2"
+                              ry="2"
+                            />
+                            <path d="M7 11V7a5 5 0 0110 0v4" />
+                          </svg>
+                        )}
+                      </div>
+                      <div className="flex-1 min-w-0 space-y-1">
+                        <p className="text-[12px] font-medium text-foreground">
+                          {formState.managedAuth.kind === "provider_grant_ref"
+                            ? "Shared provider grant"
+                            : "Managed MCP OAuth"}
+                        </p>
+                        <p className="text-[11px] leading-relaxed text-muted-foreground">
+                          {formState.managedAuth.kind === "provider_grant_ref"
+                            ? "This source uses a shared Google auth grant. Reconnect from Add Source to change the linked account or scopes."
+                            : "Authenticated through a persisted MCP OAuth session. Reconnect the source to refresh or replace the binding."}
+                        </p>
+                      </div>
+                    </div>
+                    {formState.managedAuth.kind === "provider_grant_ref" &&
+                      props.mode === "edit" && (
+                        <div className="flex items-center justify-end border-t border-border/50 px-4 py-2.5">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="text-destructive/70 hover:text-destructive hover:bg-destructive/8"
+                            onClick={handleRevokeProviderGrant}
+                            disabled={isRevokingGrant}
+                          >
+                            <IconTrash className="size-3" />
+                            {isRevokingGrant
+                              ? "Revoking\u2026"
+                              : "Revoke shared auth"}
+                          </Button>
+                        </div>
+                      )}
+                  </div>
+                )}
+              {formState.authKind !== "none" &&
+                formState.managedAuth === null &&
+                !(
+                  formState.kind === "mcp" && formState.transport === "stdio"
+                ) && (
+                  <>
+                    <Field label="Header name">
+                      <TextInput
+                        value={formState.authHeaderName}
+                        onChange={(value) => setField("authHeaderName", value)}
+                        placeholder="Authorization"
+                      />
+                    </Field>
+                    <Field label="Prefix">
+                      <TextInput
+                        value={formState.authPrefix}
+                        onChange={(value) => setField("authPrefix", value)}
+                        placeholder="Bearer "
+                      />
+                    </Field>
+                  </>
+                )}
 
-              {formState.authKind === "oauth2"
-                && formState.managedAuth === null
-                && (formState.kind !== "mcp"
-                  || formState.oauthAccessHandle.trim().length === 0
-                  || showOauthSecretRefs) && (
-                <>
-                  <Field label="Access token" className="sm:col-span-2">
+              {formState.authKind === "bearer" &&
+                formState.managedAuth === null &&
+                !(
+                  formState.kind === "mcp" && formState.transport === "stdio"
+                ) && (
+                  <Field label="Token" className="sm:col-span-2">
                     <SecretPicker
                       instanceConfig={instanceConfig}
                       secrets={secrets}
-                      providerId={formState.oauthAccessProviderId}
-                      handle={formState.oauthAccessHandle}
+                      providerId={formState.bearerProviderId}
+                      handle={formState.bearerHandle}
                       onSelect={(providerId, handle) => {
-                        setField("oauthAccessProviderId", providerId);
-                        setField("oauthAccessHandle", handle);
+                        setField("bearerProviderId", providerId);
+                        setField("bearerHandle", handle);
                       }}
                     />
                   </Field>
-                  <Field label="Refresh token (optional)" className="sm:col-span-2">
-                    <SecretPicker
-                      instanceConfig={instanceConfig}
-                      secrets={secrets}
-                      providerId={formState.oauthRefreshProviderId}
-                      handle={formState.oauthRefreshHandle}
-                      onSelect={(providerId, handle) => {
-                        setField("oauthRefreshProviderId", providerId);
-                        setField("oauthRefreshHandle", handle);
-                      }}
-                      allowEmpty
-                    />
-                  </Field>
-                </>
-              )}
+                )}
+
+              {formState.authKind === "oauth2" &&
+                formState.managedAuth === null &&
+                !(
+                  formState.kind === "mcp" && formState.transport === "stdio"
+                ) &&
+                (formState.kind !== "mcp" ||
+                  formState.oauthAccessHandle.trim().length === 0 ||
+                  showOauthSecretRefs) && (
+                  <>
+                    <Field label="Access token" className="sm:col-span-2">
+                      <SecretPicker
+                        instanceConfig={instanceConfig}
+                        secrets={secrets}
+                        providerId={formState.oauthAccessProviderId}
+                        handle={formState.oauthAccessHandle}
+                        onSelect={(providerId, handle) => {
+                          setField("oauthAccessProviderId", providerId);
+                          setField("oauthAccessHandle", handle);
+                        }}
+                      />
+                    </Field>
+                    <Field
+                      label="Refresh token (optional)"
+                      className="sm:col-span-2"
+                    >
+                      <SecretPicker
+                        instanceConfig={instanceConfig}
+                        secrets={secrets}
+                        providerId={formState.oauthRefreshProviderId}
+                        handle={formState.oauthRefreshHandle}
+                        onSelect={(providerId, handle) => {
+                          setField("oauthRefreshProviderId", providerId);
+                          setField("oauthRefreshHandle", handle);
+                        }}
+                        allowEmpty
+                      />
+                    </Field>
+                  </>
+                )}
             </div>
           </Section>
 
@@ -1196,10 +1552,19 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
           {/* Actions */}
           <div className="flex items-center justify-end gap-3 border-t border-border pt-5">
             <Link {...backLink} className="inline-flex">
-              <Button variant="ghost" type="button">Cancel</Button>
+              <Button variant="ghost" type="button">
+                Cancel
+              </Button>
             </Link>
-            <Button onClick={handleSubmit} disabled={isSubmitting || isRevokingGrant}>
-              {props.mode === "edit" ? <IconPencil className="size-3.5" /> : <IconPlus className="size-3.5" />}
+            <Button
+              onClick={handleSubmit}
+              disabled={isSubmitting || isRevokingGrant}
+            >
+              {props.mode === "edit" ? (
+                <IconPencil className="size-3.5" />
+              ) : (
+                <IconPlus className="size-3.5" />
+              )}
               {isSubmitting
                 ? props.mode === "edit"
                   ? "Saving\u2026"
@@ -1219,9 +1584,18 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
 // Form building blocks
 // ---------------------------------------------------------------------------
 
-function Section(props: { title: string; children: ReactNode; className?: string }) {
+function Section(props: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) {
   return (
-    <section className={cn("rounded-xl border border-border bg-card/80", props.className)}>
+    <section
+      className={cn(
+        "rounded-xl border border-border bg-card/80",
+        props.className,
+      )}
+    >
       <div className="border-b border-border px-5 py-3">
         <h2 className="text-sm font-semibold text-foreground">{props.title}</h2>
       </div>
@@ -1237,7 +1611,9 @@ function Field(props: {
 }) {
   return (
     <label className={cn("block space-y-1.5", props.className)}>
-      <span className="text-[12px] font-medium text-foreground">{props.label}</span>
+      <span className="text-[12px] font-medium text-foreground">
+        {props.label}
+      </span>
       {props.children}
     </label>
   );
@@ -1300,7 +1676,10 @@ function CodeEditor(props: {
   );
 }
 
-function ToggleButton(props: { checked: boolean; onChange: (checked: boolean) => void }) {
+function ToggleButton(props: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}) {
   return (
     <button
       type="button"
@@ -1328,9 +1707,12 @@ function StatusBanner(props: { state: StatusBannerState; className?: string }) {
     <div
       className={cn(
         "rounded-lg border px-4 py-3 text-[13px]",
-        props.state.tone === "success" && "border-primary/30 bg-primary/8 text-foreground",
-        props.state.tone === "info" && "border-border bg-card text-muted-foreground",
-        props.state.tone === "error" && "border-destructive/30 bg-destructive/8 text-destructive",
+        props.state.tone === "success" &&
+          "border-primary/30 bg-primary/8 text-foreground",
+        props.state.tone === "info" &&
+          "border-border bg-card text-muted-foreground",
+        props.state.tone === "error" &&
+          "border-destructive/30 bg-destructive/8 text-destructive",
         props.className,
       )}
     >
@@ -1349,7 +1731,8 @@ function SecretPicker(props: {
   onSelect: (providerId: string, handle: string) => void;
   allowEmpty?: boolean;
 }) {
-  const { instanceConfig, secrets, providerId, handle, onSelect, allowEmpty } = props;
+  const { instanceConfig, secrets, providerId, handle, onSelect, allowEmpty } =
+    props;
   const createSecret = useCreateSecret();
   const [showCreate, setShowCreate] = useState(false);
   const [newName, setNewName] = useState("");
@@ -1358,7 +1741,9 @@ function SecretPicker(props: {
   const [createError, setCreateError] = useState<string | null>(null);
   const storableProviders =
     instanceConfig.status === "ready"
-      ? instanceConfig.data.secretProviders.filter((provider) => provider.canStore)
+      ? instanceConfig.data.secretProviders.filter(
+          (provider) => provider.canStore,
+        )
       : [];
 
   useEffect(() => {
@@ -1390,9 +1775,10 @@ function SecretPicker(props: {
       onSelect("", "");
       return;
     }
-    const matchedSecret = secrets.status === "ready"
-      ? secrets.data.find((secret) => secret.id === value)
-      : null;
+    const matchedSecret =
+      secrets.status === "ready"
+        ? secrets.data.find((secret) => secret.id === value)
+        : null;
     onSelect(matchedSecret?.providerId ?? "local", value);
   };
 
@@ -1417,7 +1803,9 @@ function SecretPicker(props: {
       onSelect(result.providerId, result.id);
       setShowCreate(false);
     } catch (err) {
-      setCreateError(err instanceof Error ? err.message : "Failed creating secret.");
+      setCreateError(
+        err instanceof Error ? err.message : "Failed creating secret.",
+      );
     }
   };
 
@@ -1446,7 +1834,9 @@ function SecretPicker(props: {
         className="h-9 w-full rounded-lg border border-input bg-background px-3 text-[13px] text-foreground outline-none transition-colors focus:border-ring focus:ring-1 focus:ring-ring/25"
       >
         {allowEmpty && <option value="">None</option>}
-        {!allowEmpty && !selectedValue && <option value="">Select a secret…</option>}
+        {!allowEmpty && !selectedValue && (
+          <option value="">Select a secret…</option>
+        )}
         {items.map((secret) => (
           <option key={secret.id} value={secret.id}>
             {secret.name || secret.id} ({secret.providerId})
@@ -1469,7 +1859,9 @@ function SecretPicker(props: {
           )}
           <div className="grid gap-3 sm:grid-cols-2">
             <label className="block space-y-1">
-              <span className="text-[11px] font-medium text-muted-foreground">Name</span>
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Name
+              </span>
               <input
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
@@ -1479,7 +1871,9 @@ function SecretPicker(props: {
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[11px] font-medium text-muted-foreground">Value</span>
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Value
+              </span>
               <input
                 type="password"
                 value={newValue}
@@ -1489,7 +1883,9 @@ function SecretPicker(props: {
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[11px] font-medium text-muted-foreground">Store in</span>
+              <span className="text-[11px] font-medium text-muted-foreground">
+                Store in
+              </span>
               <select
                 value={newProviderId}
                 onChange={(e) => setNewProviderId(e.target.value)}
@@ -1516,7 +1912,9 @@ function SecretPicker(props: {
               onClick={handleCreate}
               disabled={createSecret.status === "pending"}
             >
-              {createSecret.status === "pending" && <IconSpinner className="size-3" />}
+              {createSecret.status === "pending" && (
+                <IconSpinner className="size-3" />
+              )}
               Store & use
             </Button>
           </div>

--- a/apps/web/src/views/source-editor.tsx
+++ b/apps/web/src/views/source-editor.tsx
@@ -34,6 +34,16 @@ import {
   IconTrash,
 } from "../components/icons";
 import { cn } from "../lib/utils";
+import {
+  asMcpRemoteTransportValue,
+  defaultMcpRemoteTransportFields,
+  defaultMcpStdioTransportFields,
+  setMcpTransportFieldsTransport,
+  type McpRemoteTransportFields,
+  type McpStdioTransportFields,
+  type McpTransportFields,
+  type McpTransportValue,
+} from "./mcp-transport-state";
 import { sourceTemplates, type SourceTemplate } from "./source-templates";
 import { getDomain } from "tldts";
 
@@ -63,21 +73,12 @@ const isSourceNotFoundLoadable = (loadable: Loadable<unknown>): boolean =>
   loadable.status === "error" &&
   loadable.error.message.toLowerCase().includes("source not found");
 
-type TransportValue = "" | "auto" | "streamable-http" | "sse" | "stdio";
-
-type SourceFormState = {
+type SourceFormBase = {
   name: string;
   kind: Source["kind"];
   endpoint: string;
   namespace: string;
   enabled: boolean;
-  transport: TransportValue;
-  queryParamsText: string;
-  headersText: string;
-  command: string;
-  argsText: string;
-  envText: string;
-  cwd: string;
   specUrl: string;
   service: string;
   version: string;
@@ -97,6 +98,8 @@ type SourceFormState = {
   > | null;
 };
 
+type SourceFormState = SourceFormBase & McpTransportFields;
+
 const kindOptions: ReadonlyArray<Source["kind"]> = [
   "mcp",
   "openapi",
@@ -105,7 +108,7 @@ const kindOptions: ReadonlyArray<Source["kind"]> = [
   "internal",
 ];
 
-const transportOptions: ReadonlyArray<Exclude<TransportValue, "">> = [
+const transportOptions: ReadonlyArray<Exclude<McpTransportValue, "">> = [
   "auto",
   "streamable-http",
   "sse",
@@ -343,7 +346,7 @@ const readBindingStringArray = (
 const readBindingString = (source: Source, key: string): string =>
   typeof source.binding[key] === "string" ? String(source.binding[key]) : "";
 
-const readBindingTransport = (source: Source): TransportValue => {
+const readBindingTransport = (source: Source): McpTransportValue => {
   const candidate = source.binding.transport;
   return typeof candidate === "string" &&
     (candidate === "auto" ||
@@ -413,19 +416,6 @@ const defaultFormState = (template?: SourceTemplate): SourceFormState => ({
         : namespaceFromUrl(template.endpoint ?? "")))
     : "",
   enabled: true,
-  transport:
-    template?.kind === "mcp"
-      ? template.connectionType === "command"
-        ? (template.transport ?? "stdio")
-        : (template.transport ?? "auto")
-      : "",
-  queryParamsText: "",
-  headersText: "",
-  command: template?.kind === "mcp" ? (template.command ?? "") : "",
-  argsText: template?.kind === "mcp" ? stringArrayToEditor(template.args) : "",
-  envText:
-    template?.kind === "mcp" ? stringMapToEditor(template.env ?? null) : "",
-  cwd: template?.kind === "mcp" ? (template.cwd ?? "") : "",
   specUrl: template && "specUrl" in template ? template.specUrl : "",
   service: template && "service" in template ? template.service : "",
   version: template && "version" in template ? template.version : "",
@@ -440,6 +430,18 @@ const defaultFormState = (template?: SourceTemplate): SourceFormState => ({
   oauthRefreshProviderId: "",
   oauthRefreshHandle: "",
   managedAuth: null,
+  ...(template?.kind === "mcp" && template.connectionType === "command"
+    ? defaultMcpStdioTransportFields({
+        command: template.command ?? "",
+        argsText: stringArrayToEditor(template.args),
+        envText: stringMapToEditor(template.env ?? null),
+        cwd: template.cwd ?? "",
+      })
+    : defaultMcpRemoteTransportFields(
+        template?.kind === "mcp"
+          ? asMcpRemoteTransportValue(template.transport)
+          : "",
+      )),
 });
 
 const formStateFromSource = (source: Source): SourceFormState => ({
@@ -448,16 +450,6 @@ const formStateFromSource = (source: Source): SourceFormState => ({
   endpoint: source.endpoint,
   namespace: source.namespace ?? "",
   enabled: source.enabled,
-  transport:
-    source.kind === "mcp" ? readBindingTransport(source) || "auto" : "",
-  queryParamsText: stringMapToEditor(
-    readBindingStringMap(source, "queryParams"),
-  ),
-  headersText: stringMapToEditor(readBindingStringMap(source, "headers")),
-  command: readBindingString(source, "command"),
-  argsText: stringArrayToEditor(readBindingStringArray(source, "args")),
-  envText: stringMapToEditor(readBindingStringMap(source, "env")),
-  cwd: readBindingString(source, "cwd"),
   specUrl: readBindingString(source, "specUrl"),
   service: readBindingString(source, "service"),
   version: readBindingString(source, "version"),
@@ -493,6 +485,26 @@ const formStateFromSource = (source: Source): SourceFormState => ({
     source.auth.kind === "mcp_oauth"
       ? source.auth
       : null,
+  ...(source.kind === "mcp" && readBindingTransport(source) === "stdio"
+    ? defaultMcpStdioTransportFields({
+        command: readBindingString(source, "command"),
+        argsText: stringArrayToEditor(readBindingStringArray(source, "args")),
+        envText: stringMapToEditor(readBindingStringMap(source, "env")),
+        cwd: readBindingString(source, "cwd"),
+      })
+    : defaultMcpRemoteTransportFields(
+        source.kind === "mcp"
+          ? asMcpRemoteTransportValue(readBindingTransport(source) || "auto")
+          : "",
+      )),
+  ...(source.kind === "mcp" && readBindingTransport(source) !== "stdio"
+    ? {
+        queryParamsText: stringMapToEditor(
+          readBindingStringMap(source, "queryParams"),
+        ),
+        headersText: stringMapToEditor(readBindingStringMap(source, "headers")),
+      }
+    : {}),
 });
 
 const parseJsonStringMap = (
@@ -616,13 +628,14 @@ const buildRequestedSourceStatus = (
 const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
   const name = state.name.trim();
   const isMcpStdio = state.kind === "mcp" && state.transport === "stdio";
-  const endpoint = isMcpStdio
-    ? buildSyntheticMcpStdioEndpoint({
-        name: state.name,
-        endpoint: state.endpoint,
-        command: state.command,
-      })
-    : state.endpoint.trim();
+  const endpoint =
+    state.kind === "mcp" && state.transport === "stdio"
+      ? buildSyntheticMcpStdioEndpoint({
+          name: state.name,
+          endpoint: state.endpoint,
+          command: state.command,
+        })
+      : state.endpoint.trim();
 
   if (!name) {
     throw new Error("Source name is required.");
@@ -649,28 +662,31 @@ const buildSourcePayload = (state: SourceFormState): CreateSourcePayload => {
   >;
 
   if (state.kind === "mcp") {
+    if (state.transport === "stdio") {
+      return {
+        ...shared,
+        binding: {
+          transport: "stdio",
+          queryParams: null,
+          headers: null,
+          command: state.command.trim(),
+          args: parseJsonStringArray("Args", state.argsText),
+          env: parseJsonStringMap("Environment", state.envText),
+          cwd: trimToNull(state.cwd),
+        },
+      };
+    }
+
     return {
       ...shared,
       binding: {
         transport: state.transport === "" ? "auto" : state.transport,
-        queryParams:
-          state.transport === "stdio"
-            ? null
-            : parseJsonStringMap("Query params", state.queryParamsText),
-        headers:
-          state.transport === "stdio"
-            ? null
-            : parseJsonStringMap("Request headers", state.headersText),
-        command: state.transport === "stdio" ? state.command.trim() : null,
-        args:
-          state.transport === "stdio"
-            ? parseJsonStringArray("Args", state.argsText)
-            : null,
-        env:
-          state.transport === "stdio"
-            ? parseJsonStringMap("Environment", state.envText)
-            : null,
-        cwd: state.transport === "stdio" ? trimToNull(state.cwd) : null,
+        queryParams: parseJsonStringMap("Query params", state.queryParamsText),
+        headers: parseJsonStringMap("Request headers", state.headersText),
+        command: null,
+        args: null,
+        env: null,
+        cwd: null,
       },
     };
   }
@@ -831,11 +847,40 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
     oauthSecretRefTarget !== null &&
     expandedOauthSecretRefTarget === oauthSecretRefTarget;
 
-  const setField = <K extends keyof SourceFormState>(
+  const setField = <K extends keyof SourceFormBase>(
     key: K,
-    value: SourceFormState[K],
+    value: SourceFormBase[K],
   ) => {
     setFormState((current) => ({ ...current, [key]: value }));
+  };
+
+  const setTransport = (transport: McpTransportValue) => {
+    setFormState((current) => ({
+      ...current,
+      ...setMcpTransportFieldsTransport(current, transport),
+    }));
+  };
+
+  const setRemoteTransportField = <
+    K extends Exclude<keyof McpRemoteTransportFields, "transport">,
+  >(
+    key: K,
+    value: McpRemoteTransportFields[K],
+  ) => {
+    setFormState((current) =>
+      current.transport === "stdio" ? current : { ...current, [key]: value },
+    );
+  };
+
+  const setStdioTransportField = <
+    K extends Exclude<keyof McpStdioTransportFields, "transport">,
+  >(
+    key: K,
+    value: McpStdioTransportFields[K],
+  ) => {
+    setFormState((current) =>
+      current.transport === "stdio" ? { ...current, [key]: value } : current,
+    );
   };
 
   const applyTemplate = (template: SourceTemplate) => {
@@ -1145,9 +1190,7 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                 <Field label="Transport mode">
                   <SelectInput
                     value={formState.transport || "auto"}
-                    onChange={(value) =>
-                      setField("transport", value as TransportValue)
-                    }
+                    onChange={(value) => setTransport(value as McpTransportValue)}
                     options={transportOptions.map((value) => ({
                       value,
                       label: value,
@@ -1159,7 +1202,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                     <Field label="Command">
                       <TextInput
                         value={formState.command}
-                        onChange={(value) => setField("command", value)}
+                        onChange={(value) =>
+                          setStdioTransportField("command", value)
+                        }
                         placeholder="npx"
                         mono
                       />
@@ -1167,7 +1212,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                     <Field label="Working directory (optional)">
                       <TextInput
                         value={formState.cwd}
-                        onChange={(value) => setField("cwd", value)}
+                        onChange={(value) =>
+                          setStdioTransportField("cwd", value)
+                        }
                         placeholder="/path/to/project"
                         mono
                       />
@@ -1175,7 +1222,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                     <Field label="Args (JSON)" className="sm:col-span-2">
                       <CodeEditor
                         value={formState.argsText}
-                        onChange={(value) => setField("argsText", value)}
+                        onChange={(value) =>
+                          setStdioTransportField("argsText", value)
+                        }
                         placeholder={
                           '[\n  "-y",\n  "chrome-devtools-mcp@latest"\n]'
                         }
@@ -1184,7 +1233,9 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                     <Field label="Environment (JSON)" className="sm:col-span-2">
                       <CodeEditor
                         value={formState.envText}
-                        onChange={(value) => setField("envText", value)}
+                        onChange={(value) =>
+                          setStdioTransportField("envText", value)
+                        }
                         placeholder={
                           '{\n  "CHROME_PATH": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"\n}'
                         }
@@ -1196,14 +1247,18 @@ function SourceEditor(props: { mode: "create" | "edit"; source?: Source }) {
                     <Field label="Query params (JSON)">
                       <CodeEditor
                         value={formState.queryParamsText}
-                        onChange={(value) => setField("queryParamsText", value)}
+                        onChange={(value) =>
+                          setRemoteTransportField("queryParamsText", value)
+                        }
                         placeholder={'{\n  "workspace": "demo"\n}'}
                       />
                     </Field>
                     <Field label="Headers (JSON)">
                       <CodeEditor
                         value={formState.headersText}
-                        onChange={(value) => setField("headersText", value)}
+                        onChange={(value) =>
+                          setRemoteTransportField("headersText", value)
+                        }
                         placeholder={'{\n  "x-api-key": "..."\n}'}
                       />
                     </Field>

--- a/apps/web/src/views/source-editor.tsx
+++ b/apps/web/src/views/source-editor.tsx
@@ -44,6 +44,7 @@ import {
   type McpTransportFields,
   type McpTransportValue,
 } from "./mcp-transport-state";
+import { parseJsonStringArray, parseJsonStringMap } from "./json-form";
 import { sourceTemplates, type SourceTemplate } from "./source-templates";
 import { getDomain } from "tldts";
 
@@ -357,36 +358,6 @@ const readBindingTransport = (source: Source): McpTransportValue => {
     : "";
 };
 
-const parseJsonStringArray = (
-  label: string,
-  text: string,
-): Array<string> | null => {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    throw new Error(`${label} must be valid JSON.`);
-  }
-
-  if (
-    !Array.isArray(parsed) ||
-    !parsed.every((value) => typeof value === "string")
-  ) {
-    throw new Error(`${label} must be a JSON array of strings.`);
-  }
-
-  const normalized = parsed
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0);
-
-  return normalized.length > 0 ? normalized : null;
-};
-
 const buildSyntheticMcpStdioEndpoint = (input: {
   name?: string | null;
   endpoint?: string | null;
@@ -506,38 +477,6 @@ const formStateFromSource = (source: Source): SourceFormState => ({
       }
     : {}),
 });
-
-const parseJsonStringMap = (
-  label: string,
-  text: string,
-): Record<string, string> | null => {
-  const trimmed = text.trim();
-  if (trimmed.length === 0) {
-    return null;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(trimmed);
-  } catch {
-    throw new Error(`${label} must be valid JSON.`);
-  }
-
-  if (parsed === null || Array.isArray(parsed) || typeof parsed !== "object") {
-    throw new Error(`${label} must be a JSON object with string values.`);
-  }
-
-  const entries = Object.entries(parsed as Record<string, unknown>);
-  const normalized: Record<string, string> = {};
-  for (const [key, value] of entries) {
-    if (typeof value !== "string") {
-      throw new Error(`${label} must only contain string values.`);
-    }
-    normalized[key] = value;
-  }
-
-  return Object.keys(normalized).length === 0 ? null : normalized;
-};
 
 const buildAuthPayload = (
   state: SourceFormState,

--- a/apps/web/src/views/source-templates.ts
+++ b/apps/web/src/views/source-templates.ts
@@ -1,13 +1,22 @@
-import type { Source } from "@executor/react";
-
 type SourceTemplateBase = {
   id: string;
   name: string;
   summary: string;
-  endpoint: string;
+  endpoint?: string;
+  namespace?: string;
   groupId?: string;
   groupLabel?: string;
   batchable?: boolean;
+};
+
+export type McpSourceTemplate = SourceTemplateBase & {
+  kind: "mcp";
+  connectionType?: "endpoint" | "command";
+  transport?: "auto" | "streamable-http" | "sse" | "stdio";
+  command?: string;
+  args?: ReadonlyArray<string>;
+  env?: Record<string, string>;
+  cwd?: string;
 };
 
 export type OpenApiSourceTemplate = SourceTemplateBase & {
@@ -22,14 +31,22 @@ export type GoogleDiscoverySourceTemplate = SourceTemplateBase & {
   discoveryUrl: string;
 };
 
-export type NonOpenApiSourceTemplate = SourceTemplateBase & {
-  kind: Exclude<Source["kind"], "openapi" | "google_discovery" | "internal">;
+export type GraphqlSourceTemplate = SourceTemplateBase & {
+  kind: "graphql";
 };
 
 export type SourceTemplate =
+  | McpSourceTemplate
   | OpenApiSourceTemplate
   | GoogleDiscoverySourceTemplate
-  | NonOpenApiSourceTemplate;
+  | GraphqlSourceTemplate;
+
+export const isStdioMcpSourceTemplate = (
+  template: SourceTemplate,
+): template is McpSourceTemplate & { transport: "stdio" } =>
+  template.kind === "mcp" &&
+  template.connectionType === "command" &&
+  template.transport === "stdio";
 
 const googleDiscoveryUrl = (service: string, version: string): string =>
   `https://www.googleapis.com/discovery/v1/apis/${encodeURIComponent(service)}/${encodeURIComponent(version)}/rest`;
@@ -42,7 +59,8 @@ const googleDiscoveryTemplate = (input: {
   version: string;
   discoveryUrl?: string;
 }): GoogleDiscoverySourceTemplate => {
-  const discoveryUrl = input.discoveryUrl ?? googleDiscoveryUrl(input.service, input.version);
+  const discoveryUrl =
+    input.discoveryUrl ?? googleDiscoveryUrl(input.service, input.version);
   return {
     id: input.id,
     name: input.name,
@@ -81,6 +99,18 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
     endpoint: "https://mcp.neon.tech/mcp",
   },
   {
+    id: "chrome-devtools-mcp",
+    name: "Chrome DevTools MCP",
+    summary:
+      "Debug a live Chrome browser session over a local MCP stdio transport.",
+    kind: "mcp",
+    namespace: "chrome.devtools",
+    connectionType: "command",
+    transport: "stdio",
+    command: "npx",
+    args: ["-y", "chrome-devtools-mcp@latest"],
+  },
+  {
     id: "neon-api",
     name: "Neon API",
     summary: "Projects, branches, endpoints, databases, and API keys.",
@@ -94,7 +124,8 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
     summary: "Repos, issues, pull requests, actions, and org settings.",
     kind: "openapi",
     endpoint: "https://api.github.com",
-    specUrl: "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml",
+    specUrl:
+      "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.yaml",
     groupId: "github",
     groupLabel: "GitHub",
     batchable: false,
@@ -102,7 +133,8 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
   {
     id: "github-graphql",
     name: "GitHub GraphQL",
-    summary: "Issues, pull requests, discussions, and repository objects via GraphQL.",
+    summary:
+      "Issues, pull requests, discussions, and repository objects via GraphQL.",
     kind: "graphql",
     endpoint: "https://api.github.com/graphql",
     groupId: "github",
@@ -122,7 +154,8 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
     summary: "Models, files, responses, and fine-tuning.",
     kind: "openapi",
     endpoint: "https://api.openai.com/v1",
-    specUrl: "https://app.stainless.com/api/spec/documented/openai/openapi.documented.yml",
+    specUrl:
+      "https://app.stainless.com/api/spec/documented/openai/openapi.documented.yml",
   },
   {
     id: "vercel-api",
@@ -138,7 +171,8 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
     summary: "Payments, billing, subscriptions, and invoices.",
     kind: "openapi",
     endpoint: "https://api.stripe.com",
-    specUrl: "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
+    specUrl:
+      "https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json",
   },
   {
     id: "linear-graphql",
@@ -167,7 +201,8 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
     summary: "Calendars, events, ACLs, and scheduling workflows.",
     service: "calendar",
     version: "v3",
-    discoveryUrl: "https://calendar-json.googleapis.com/$discovery/rest?version=v3",
+    discoveryUrl:
+      "https://calendar-json.googleapis.com/$discovery/rest?version=v3",
   }),
   googleDiscoveryTemplate({
     id: "google-drive",
@@ -219,10 +254,12 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
   googleDiscoveryTemplate({
     id: "google-search-console",
     name: "Google Search Console",
-    summary: "Sites, sitemaps, URL inspection, and search and Discover performance.",
+    summary:
+      "Sites, sitemaps, URL inspection, and search and Discover performance.",
     service: "searchconsole",
     version: "v1",
-    discoveryUrl: "https://searchconsole.googleapis.com/$discovery/rest?version=v1",
+    discoveryUrl:
+      "https://searchconsole.googleapis.com/$discovery/rest?version=v1",
   }),
   googleDiscoveryTemplate({
     id: "google-people",
@@ -270,7 +307,8 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
     summary: "Users, groups, org units, roles, and domain directory resources.",
     service: "admin",
     version: "directory_v1",
-    discoveryUrl: "https://admin.googleapis.com/$discovery/rest?version=directory_v1",
+    discoveryUrl:
+      "https://admin.googleapis.com/$discovery/rest?version=directory_v1",
   }),
   googleDiscoveryTemplate({
     id: "google-admin-reports",
@@ -278,12 +316,14 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
     summary: "Audit events, usage reports, and admin activity logs.",
     service: "admin",
     version: "reports_v1",
-    discoveryUrl: "https://admin.googleapis.com/$discovery/rest?version=reports_v1",
+    discoveryUrl:
+      "https://admin.googleapis.com/$discovery/rest?version=reports_v1",
   }),
   googleDiscoveryTemplate({
     id: "google-apps-script",
     name: "Google Apps Script",
-    summary: "Projects, deployments, script execution, and Apps Script metadata.",
+    summary:
+      "Projects, deployments, script execution, and Apps Script metadata.",
     service: "script",
     version: "v1",
     discoveryUrl: "https://script.googleapis.com/$discovery/rest?version=v1",
@@ -291,7 +331,8 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
   googleDiscoveryTemplate({
     id: "google-bigquery",
     name: "Google BigQuery",
-    summary: "Datasets, tables, jobs, routines, and analytical query workflows.",
+    summary:
+      "Datasets, tables, jobs, routines, and analytical query workflows.",
     service: "bigquery",
     version: "v2",
     discoveryUrl: "https://bigquery.googleapis.com/$discovery/rest?version=v2",
@@ -299,10 +340,12 @@ export const sourceTemplates: ReadonlyArray<SourceTemplate> = [
   googleDiscoveryTemplate({
     id: "google-cloud-resource-manager",
     name: "Google Cloud Resource Manager",
-    summary: "Projects, folders, organizations, and IAM-oriented resource hierarchy.",
+    summary:
+      "Projects, folders, organizations, and IAM-oriented resource hierarchy.",
     service: "cloudresourcemanager",
     version: "v3",
-    discoveryUrl: "https://cloudresourcemanager.googleapis.com/$discovery/rest?version=v3",
+    discoveryUrl:
+      "https://cloudresourcemanager.googleapis.com/$discovery/rest?version=v3",
   }),
   googleDiscoveryTemplate({
     id: "google-youtube-data",

--- a/packages/platform/control-plane/src/api/sources/http.ts
+++ b/packages/platform/control-plane/src/api/sources/http.ts
@@ -687,6 +687,10 @@ export const ControlPlaneSourcesLive = HttpApiBuilder.group(
                   transport: payload.transport,
                   queryParams: payload.queryParams,
                   headers: payload.headers,
+                  command: payload.command,
+                  args: payload.args,
+                  env: payload.env,
+                  cwd: payload.cwd,
                   baseUrl,
                 });
               }

--- a/packages/platform/control-plane/src/runtime/execution/live.ts
+++ b/packages/platform/control-plane/src/runtime/execution/live.ts
@@ -193,31 +193,40 @@ export const createLiveExecutionManager = () => {
             response,
           };
 
-          yield* publishState({
-            executionId,
-            state: "waiting_for_interaction",
-          });
+          return yield* Effect.gen(function* () {
+            yield* publishState({
+              executionId,
+              state: "waiting_for_interaction",
+            });
 
-          const resolved = yield* Deferred.await(response);
-          const resolvedAt = Date.now();
+            const resolved = yield* Deferred.await(response);
+            const resolvedAt = Date.now();
 
-          yield* rows.executionInteractions.update(interaction.id, {
-            status: resolved.action === "cancel" ? "cancelled" : "resolved",
-            responseJson: serializeJson(sanitizePersistedElicitationResponse(resolved)),
-            responsePrivateJson: serializeJson(resolved),
-            updatedAt: resolvedAt,
-          });
-          yield* rows.executions.update(executionId, {
-            status: "running",
-            updatedAt: resolvedAt,
-          });
-          yield* publishState({
-            executionId,
-            state: "running",
-          });
+            yield* rows.executionInteractions.update(interaction.id, {
+              status: resolved.action === "cancel" ? "cancelled" : "resolved",
+              responseJson: serializeJson(sanitizePersistedElicitationResponse(resolved)),
+              responsePrivateJson: serializeJson(resolved),
+              updatedAt: resolvedAt,
+            });
+            yield* rows.executions.update(executionId, {
+              status: "running",
+              updatedAt: resolvedAt,
+            });
+            yield* publishState({
+              executionId,
+              state: "running",
+            });
 
-          run.currentInteraction = null;
-          return resolved;
+            return resolved;
+          }).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                if (run.currentInteraction?.interactionId === interaction.id) {
+                  run.currentInteraction = null;
+                }
+              }),
+            ),
+          );
         }),
 
     resolveInteraction: ({ executionId, response }) =>
@@ -234,20 +243,21 @@ export const createLiveExecutionManager = () => {
 
     finishRun: ({ executionId, state }) =>
       publishState({ executionId, state }).pipe(
-        Effect.zipRight(
-          clearMcpConnectionPoolRun(executionId).pipe(
-            Effect.zipRight(Effect.sync(() => {
-              runs.delete(executionId);
-            })),
-          ),
+        Effect.zipRight(clearMcpConnectionPoolRun(executionId)),
+        Effect.ensuring(
+          Effect.sync(() => {
+            runs.delete(executionId);
+          }),
         ),
       ),
 
     clearRun: (executionId) =>
       clearMcpConnectionPoolRun(executionId).pipe(
-        Effect.zipRight(Effect.sync(() => {
-          runs.delete(executionId);
-        })),
+        Effect.ensuring(
+          Effect.sync(() => {
+            runs.delete(executionId);
+          }),
+        ),
       ),
   } satisfies LiveExecutionManagerShape;
 

--- a/packages/platform/control-plane/src/runtime/execution/live.ts
+++ b/packages/platform/control-plane/src/runtime/execution/live.ts
@@ -2,6 +2,7 @@ import type {
   ElicitationResponse,
   OnElicitation,
 } from "@executor/codemode-core";
+import { clearMcpConnectionPoolRun } from "@executor/source-mcp";
 import {
   ExecutionInteractionIdSchema,
   type Execution,
@@ -233,15 +234,21 @@ export const createLiveExecutionManager = () => {
 
     finishRun: ({ executionId, state }) =>
       publishState({ executionId, state }).pipe(
+        Effect.zipRight(
+          clearMcpConnectionPoolRun(executionId).pipe(
+            Effect.zipRight(Effect.sync(() => {
+              runs.delete(executionId);
+            })),
+          ),
+        ),
+      ),
+
+    clearRun: (executionId) =>
+      clearMcpConnectionPoolRun(executionId).pipe(
         Effect.zipRight(Effect.sync(() => {
           runs.delete(executionId);
         })),
       ),
-
-    clearRun: (executionId) =>
-      Effect.sync(() => {
-        runs.delete(executionId);
-      }),
   } satisfies LiveExecutionManagerShape;
 
   return manager;

--- a/packages/platform/control-plane/src/runtime/execution/mcp-resume.test.ts
+++ b/packages/platform/control-plane/src/runtime/execution/mcp-resume.test.ts
@@ -244,24 +244,28 @@ const makeMcpExecutionResolver = (
   ({ onElicitation }) =>
     (Effect.gen(function* () {
       const discovered = yield* discoverMcpToolsFromConnector({
-        connect: async () => {
-          const client = new Client(
-            {
-              name: "control-plane-mcp-execution-client",
-              version: "1.0.0",
-            },
-            { capabilities: { elicitation: { form: {} } } },
-          );
-          const transport = new StreamableHTTPClientTransport(new URL(endpoint));
-          await client.connect(transport);
+        connect: Effect.tryPromise({
+          try: async () => {
+            const client = new Client(
+              {
+                name: "control-plane-mcp-execution-client",
+                version: "1.0.0",
+              },
+              { capabilities: { elicitation: { form: {} } } },
+            );
+            const transport = new StreamableHTTPClientTransport(new URL(endpoint));
+            await client.connect(transport);
 
-          return {
-            client,
-            close: async () => {
-              await client.close();
-            },
-          };
-        },
+            return {
+              client,
+              close: async () => {
+                await client.close();
+              },
+            };
+          },
+          catch: (cause) =>
+            cause instanceof Error ? cause : new Error(String(cause)),
+        }),
         namespace: "source.form",
         sourceKey: "mcp.form",
       });

--- a/packages/platform/control-plane/src/runtime/index.ts
+++ b/packages/platform/control-plane/src/runtime/index.ts
@@ -283,7 +283,7 @@ export const createControlPlaneRuntime = (
       managedRuntime,
       runtimeLayer: concreteRuntimeLayer as RuntimeControlPlaneLayer,
       close: async () => {
-        await clearAllMcpConnectionPools().catch(() => undefined);
+        await Effect.runPromise(clearAllMcpConnectionPools()).catch(() => undefined);
         await managedRuntime.dispose().catch(() => undefined);
       },
     };

--- a/packages/platform/control-plane/src/runtime/sources/source-adapters/mcp.test.ts
+++ b/packages/platform/control-plane/src/runtime/sources/source-adapters/mcp.test.ts
@@ -335,6 +335,233 @@ const makeAuthenticatedMcpServer = (expectedAuthorization: string) =>
       }).pipe(Effect.orDie),
   );
 
+const makeStatefulMcpServer = Effect.acquireRelease(
+  Effect.promise<RealMcpServer>(
+    () =>
+      new Promise<RealMcpServer>((resolve, reject) => {
+        const transports: Record<string, StreamableHTTPServerTransport> = {};
+        const servers: Record<string, McpServer> = {};
+
+        const createServer = () => {
+          let counter = 0;
+          const mcp = new McpServer(
+            {
+              name: "mcp-stateful-test-server",
+              version: "1.0.0",
+            },
+            {
+              capabilities: {
+                tools: {
+                  listChanged: true,
+                },
+              },
+            },
+          );
+
+          mcp.registerTool(
+            "increment_session",
+            {
+              title: "Increment Session",
+              description: "Increment session state",
+              inputSchema: {},
+            },
+            async () => {
+              counter += 1;
+              return {
+                content: [{
+                  type: "text",
+                  text: String(counter),
+                }],
+              };
+            },
+          );
+
+          mcp.registerTool(
+            "read_session",
+            {
+              title: "Read Session",
+              description: "Read current session state",
+              inputSchema: {},
+            },
+            async () => ({
+              content: [{
+                type: "text",
+                text: String(counter),
+              }],
+            }),
+          );
+
+          return mcp;
+        };
+
+        const app = createMcpExpressApp({ host: "127.0.0.1" });
+
+        app.post("/mcp", async (req: any, res: any) => {
+          const sessionIdHeader = req.headers["mcp-session-id"];
+          const sessionId =
+            typeof sessionIdHeader === "string"
+              ? sessionIdHeader
+              : Array.isArray(sessionIdHeader)
+                ? sessionIdHeader[0]
+                : undefined;
+
+          try {
+            let transport: StreamableHTTPServerTransport;
+
+            if (sessionId && transports[sessionId]) {
+              transport = transports[sessionId];
+            } else {
+              transport = new StreamableHTTPServerTransport({
+                sessionIdGenerator: () => randomUUID(),
+                onsessioninitialized: (newSessionId) => {
+                  transports[newSessionId] = transport;
+                },
+              });
+
+              transport.onclose = () => {
+                const closedSessionId = transport.sessionId;
+                if (closedSessionId && transports[closedSessionId]) {
+                  delete transports[closedSessionId];
+                }
+                if (closedSessionId && servers[closedSessionId]) {
+                  void servers[closedSessionId].close().catch(() => undefined);
+                  delete servers[closedSessionId];
+                }
+              };
+
+              const server = createServer();
+              await server.connect(transport);
+              const newSessionId = transport.sessionId;
+              if (newSessionId) {
+                servers[newSessionId] = server;
+              }
+            }
+
+            await transport.handleRequest(req, res, req.body);
+          } catch (error) {
+            if (!res.headersSent) {
+              res.status(500).json({
+                jsonrpc: "2.0",
+                error: {
+                  code: -32603,
+                  message: error instanceof Error ? error.message : "Internal server error",
+                },
+                id: null,
+              });
+            }
+          }
+        });
+
+        app.get("/mcp", async (req: any, res: any) => {
+          const sessionIdHeader = req.headers["mcp-session-id"];
+          const sessionId =
+            typeof sessionIdHeader === "string"
+              ? sessionIdHeader
+              : Array.isArray(sessionIdHeader)
+                ? sessionIdHeader[0]
+                : undefined;
+
+          if (!sessionId || !transports[sessionId]) {
+            res.status(400).send("Invalid or missing session ID");
+            return;
+          }
+
+          await transports[sessionId].handleRequest(req, res);
+        });
+
+        app.delete("/mcp", async (req: any, res: any) => {
+          const sessionIdHeader = req.headers["mcp-session-id"];
+          const sessionId =
+            typeof sessionIdHeader === "string"
+              ? sessionIdHeader
+              : Array.isArray(sessionIdHeader)
+                ? sessionIdHeader[0]
+                : undefined;
+
+          if (!sessionId || !transports[sessionId]) {
+            res.status(400).send("Invalid or missing session ID");
+            return;
+          }
+
+          const transport = transports[sessionId];
+          await transport.handleRequest(req, res, req.body);
+          await transport.close();
+          delete transports[sessionId];
+
+          if (servers[sessionId]) {
+            await servers[sessionId].close().catch(() => undefined);
+            delete servers[sessionId];
+          }
+        });
+
+        const listener = app.listen(0, "127.0.0.1", () => {
+          const address = listener.address();
+          if (!address || typeof address === "string") {
+            reject(new Error("failed to resolve stateful MCP test server address"));
+            return;
+          }
+
+          resolve({
+            endpoint: `http://127.0.0.1:${address.port}/mcp`,
+            close: async () => {
+              for (const transport of Object.values(transports)) {
+                await transport.close().catch(() => undefined);
+              }
+              for (const server of Object.values(servers)) {
+                await server.close().catch(() => undefined);
+              }
+              await new Promise<void>((closeResolve, closeReject) => {
+                listener.close((error: Error | undefined) => {
+                  if (error) {
+                    closeReject(error);
+                    return;
+                  }
+                  closeResolve();
+                });
+              });
+            },
+          });
+        });
+
+        listener.once("error", reject);
+      }),
+  ),
+  (server: RealMcpServer) =>
+    Effect.tryPromise({
+      try: () => server.close(),
+      catch: (error: unknown) =>
+        error instanceof Error ? error : new Error(String(error)),
+    }).pipe(Effect.orDie),
+);
+
+const STDIO_TEST_SERVER_SCRIPT = `
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod/v4";
+
+const server = new McpServer(
+  { name: "mcp-stdio-test-server", version: "1.0.0" },
+  { capabilities: { tools: { listChanged: true } } },
+);
+
+server.registerTool(
+  "echo_stdio",
+  {
+    title: "Echo Stdio",
+    description: "Echo a value over stdio",
+    inputSchema: {
+      value: z.string(),
+    },
+  },
+  async ({ value }) => ({
+    content: [{ type: "text", text: "stdio:" + value }],
+  }),
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+`;
+
 const makeStaticAuthProvider = (accessToken: string): OAuthClientProvider => ({
   get redirectUrl() {
     return "http://127.0.0.1/oauth/callback";
@@ -609,6 +836,220 @@ describe("mcp source adapter", () => {
           content: [{
             type: "text",
             text: "secure:ok",
+          }],
+        },
+        error: null,
+        headers: {},
+        status: null,
+      });
+    }),
+  );
+
+  it.scoped("reuses a stateful MCP session across invocations in the same run", () =>
+    Effect.gen(function* () {
+      const realServer = yield* makeStatefulMcpServer;
+      const source = yield* createSourceFromPayload({
+        workspaceId: "ws_test" as any,
+        sourceId: SourceIdSchema.make(`src_${randomUUID()}`),
+        payload: {
+          name: "Stateful MCP Demo",
+          kind: "mcp",
+          endpoint: realServer.endpoint,
+          namespace: "mcp.stateful.demo",
+          binding: {
+            transport: "streamable-http",
+            queryParams: null,
+            headers: null,
+          },
+          importAuthPolicy: "reuse_runtime",
+          importAuth: { kind: "none" },
+          auth: { kind: "none" },
+          status: "connected",
+          enabled: true,
+        },
+        now: Date.now(),
+      });
+
+      const syncResult = yield* mcpSourceAdapter.syncCatalog({
+        source,
+        resolveSecretMaterial: () =>
+          Effect.fail(runtimeEffectError("sources/source-adapters/mcp.test", "unexpected secret lookup")),
+        resolveAuthMaterialForSlot: () =>
+          Effect.succeed({
+            placements: [],
+            headers: {},
+            queryParams: {},
+            cookies: {},
+            bodyValues: {},
+            expiresAt: null,
+            refreshAfter: null,
+          }),
+      });
+      const snapshot = snapshotFromSourceCatalogSyncResult(syncResult);
+      const catalog = makeLoadedCatalog({
+        source,
+        snapshot,
+      });
+
+      const incrementTool = yield* expandCatalogToolByPath({
+        catalogs: [catalog],
+        path: "mcp.stateful.demo.increment_session",
+      });
+      const readTool = yield* expandCatalogToolByPath({
+        catalogs: [catalog],
+        path: "mcp.stateful.demo.read_session",
+      });
+
+      if (!incrementTool || !readTool) {
+        throw new Error("Expected stateful MCP tools to resolve");
+      }
+
+      const incrementResult = yield* invokeIrTool({
+        workspaceId: source.workspaceId,
+        accountId: "acct_test" as any,
+        tool: incrementTool,
+        auth: {
+          placements: [],
+          headers: {},
+          queryParams: {},
+          cookies: {},
+          bodyValues: {},
+          expiresAt: null,
+          refreshAfter: null,
+        },
+        args: {},
+        context: {
+          runId: "exec_mcp_stateful",
+        },
+      });
+
+      const readResult = yield* invokeIrTool({
+        workspaceId: source.workspaceId,
+        accountId: "acct_test" as any,
+        tool: readTool,
+        auth: {
+          placements: [],
+          headers: {},
+          queryParams: {},
+          cookies: {},
+          bodyValues: {},
+          expiresAt: null,
+          refreshAfter: null,
+        },
+        args: {},
+        context: {
+          runId: "exec_mcp_stateful",
+        },
+      });
+
+      expect(incrementResult).toEqual({
+        data: {
+          content: [{
+            type: "text",
+            text: "1",
+          }],
+        },
+        error: null,
+        headers: {},
+        status: null,
+      });
+      expect(readResult).toEqual({
+        data: {
+          content: [{
+            type: "text",
+            text: "1",
+          }],
+        },
+        error: null,
+        headers: {},
+        status: null,
+      });
+    }),
+  );
+
+  it.scoped("supports stdio MCP sources", () =>
+    Effect.gen(function* () {
+      const source = yield* createSourceFromPayload({
+        workspaceId: "ws_test" as any,
+        sourceId: SourceIdSchema.make(`src_${randomUUID()}`),
+        payload: {
+          name: "Stdio MCP Demo",
+          kind: "mcp",
+          endpoint: "stdio://local/mcp-stdio-demo",
+          namespace: "mcp.stdio.demo",
+          binding: {
+            transport: "stdio",
+            queryParams: null,
+            headers: null,
+            command: "node",
+            args: ["--input-type=module", "-e", STDIO_TEST_SERVER_SCRIPT],
+            env: null,
+            cwd: process.cwd(),
+          },
+          importAuthPolicy: "reuse_runtime",
+          importAuth: { kind: "none" },
+          auth: { kind: "none" },
+          status: "connected",
+          enabled: true,
+        },
+        now: Date.now(),
+      });
+
+      const syncResult = yield* mcpSourceAdapter.syncCatalog({
+        source,
+        resolveSecretMaterial: () =>
+          Effect.fail(runtimeEffectError("sources/source-adapters/mcp.test", "unexpected secret lookup")),
+        resolveAuthMaterialForSlot: () =>
+          Effect.succeed({
+            placements: [],
+            headers: {},
+            queryParams: {},
+            cookies: {},
+            bodyValues: {},
+            expiresAt: null,
+            refreshAfter: null,
+          }),
+      });
+      const snapshot = snapshotFromSourceCatalogSyncResult(syncResult);
+
+      const tool = yield* expandCatalogToolByPath({
+        catalogs: [makeLoadedCatalog({
+          source,
+          snapshot,
+        })],
+        path: "mcp.stdio.demo.echo_stdio",
+      });
+
+      if (!tool) {
+        throw new Error("Expected stdio MCP tool to resolve");
+      }
+
+      const result = yield* invokeIrTool({
+        workspaceId: source.workspaceId,
+        accountId: "acct_test" as any,
+        tool,
+        auth: {
+          placements: [],
+          headers: {},
+          queryParams: {},
+          cookies: {},
+          bodyValues: {},
+          expiresAt: null,
+          refreshAfter: null,
+        },
+        args: {
+          value: "ok",
+        },
+        context: {
+          runId: "exec_mcp_stdio",
+        },
+      });
+
+      expect(result).toEqual({
+        data: {
+          content: [{
+            type: "text",
+            text: "stdio:ok",
           }],
         },
         error: null,

--- a/packages/platform/control-plane/src/runtime/sources/source-auth-service.ts
+++ b/packages/platform/control-plane/src/runtime/sources/source-auth-service.ts
@@ -165,10 +165,10 @@ const createSyntheticMcpStdioEndpoint = (input: {
   command?: string | null;
 }): string => {
   const label =
-    trimOrNull(input.name)
-    ?? trimOrNull(input.endpoint)
-    ?? trimOrNull(input.command)
-    ?? "mcp";
+    trimOrNull(input.name) ??
+    trimOrNull(input.endpoint) ??
+    trimOrNull(input.command) ??
+    "mcp";
 
   return `stdio://local/${slugifySourceLabel(label)}`;
 };
@@ -287,20 +287,15 @@ const probeMcpSourceWithoutAuth = (
     }
     const bindingState = yield* sourceBindingStateFromSource(source);
 
-    const connector = yield* Effect.try({
-      try: () =>
-        createSdkMcpConnector({
-          endpoint: source.endpoint,
-          transport: bindingState.transport ?? undefined,
-          queryParams: bindingState.queryParams ?? undefined,
-          headers: bindingState.headers ?? undefined,
-          command: bindingState.command ?? undefined,
-          args: bindingState.args ?? undefined,
-          env: bindingState.env ?? undefined,
-          cwd: bindingState.cwd ?? undefined,
-        }),
-      catch: (cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
+    const connector = createSdkMcpConnector({
+      endpoint: source.endpoint,
+      transport: bindingState.transport ?? undefined,
+      queryParams: bindingState.queryParams ?? undefined,
+      headers: bindingState.headers ?? undefined,
+      command: bindingState.command ?? undefined,
+      args: bindingState.args ?? undefined,
+      env: bindingState.env ?? undefined,
+      cwd: bindingState.cwd ?? undefined,
     });
 
     return yield* discoverMcpToolsFromConnector({
@@ -1647,6 +1642,14 @@ const connectMcpSourceInternal = (input: {
   resolveSecretMaterial: ResolveSecretMaterial;
 }): Effect.Effect<McpSourceConnectResult, Error, WorkspaceStorageServices> =>
   Effect.gen(function* () {
+    const lookupEndpoint = input.sourceId
+      ? null
+      : normalizeMcpEndpoint({
+          endpoint: input.endpoint ?? null,
+          transport: input.transport ?? null,
+          command: input.command ?? null,
+          name: input.name ?? null,
+        });
     const existing = yield* (
       input.sourceId
         ? input.sourceStore.loadSourceById({
@@ -1667,7 +1670,8 @@ const connectMcpSourceInternal = (input: {
               sources.find(
                 (source) =>
                   sourceAdapterRequiresInteractiveConnect(source.kind)
-                  && normalizeEndpoint(source.endpoint) === normalizedEndpoint,
+                  && lookupEndpoint !== null
+                  && normalizeEndpoint(source.endpoint) === lookupEndpoint,
               ),
             ),
           )

--- a/packages/platform/control-plane/src/runtime/sources/source-definitions.test.ts
+++ b/packages/platform/control-plane/src/runtime/sources/source-definitions.test.ts
@@ -32,13 +32,21 @@ const graphqlBinding = (defaultHeaders: Record<string, string> | null = null) =>
 });
 
 const mcpBinding = (input: {
-  transport?: "auto" | "streamable-http" | "sse" | null;
+  transport?: "auto" | "streamable-http" | "sse" | "stdio" | null;
   queryParams?: Record<string, string> | null;
   headers?: Record<string, string> | null;
+  command?: string | null;
+  args?: ReadonlyArray<string> | null;
+  env?: Record<string, string> | null;
+  cwd?: string | null;
 } = {}) => ({
   transport: input.transport ?? null,
   queryParams: input.queryParams ?? null,
   headers: input.headers ?? null,
+  command: input.command ?? null,
+  args: input.args ?? null,
+  env: input.env ?? null,
+  cwd: input.cwd ?? null,
 });
 
 const makeSource = (overrides: Partial<Source> = {}): Source => ({

--- a/packages/platform/control-plane/src/runtime/sources/source-definitions.test.ts
+++ b/packages/platform/control-plane/src/runtime/sources/source-definitions.test.ts
@@ -31,23 +31,51 @@ const graphqlBinding = (defaultHeaders: Record<string, string> | null = null) =>
   defaultHeaders,
 });
 
-const mcpBinding = (input: {
-  transport?: "auto" | "streamable-http" | "sse" | "stdio" | null;
+type McpRemoteBindingInput = {
+  transport?: "auto" | "streamable-http" | "sse" | null;
   queryParams?: Record<string, string> | null;
   headers?: Record<string, string> | null;
+  command?: never;
+  args?: never;
+  env?: never;
+  cwd?: never;
+};
+
+type McpStdioBindingInput = {
+  transport: "stdio";
   command?: string | null;
   args?: ReadonlyArray<string> | null;
   env?: Record<string, string> | null;
   cwd?: string | null;
-} = {}) => ({
-  transport: input.transport ?? null,
-  queryParams: input.queryParams ?? null,
-  headers: input.headers ?? null,
-  command: input.command ?? null,
-  args: input.args ?? null,
-  env: input.env ?? null,
-  cwd: input.cwd ?? null,
-});
+  queryParams?: never;
+  headers?: never;
+};
+
+const mcpBinding = (
+  input: McpRemoteBindingInput | McpStdioBindingInput = {},
+) => {
+  if (input.transport === "stdio") {
+    return {
+      transport: "stdio" as const,
+      queryParams: null,
+      headers: null,
+      command: input.command ?? null,
+      args: input.args ?? null,
+      env: input.env ?? null,
+      cwd: input.cwd ?? null,
+    };
+  }
+
+  return {
+    transport: input.transport ?? null,
+    queryParams: input.queryParams ?? null,
+    headers: input.headers ?? null,
+    command: null,
+    args: null,
+    env: null,
+    cwd: null,
+  };
+};
 
 const makeSource = (overrides: Partial<Source> = {}): Source => ({
   id: SourceIdSchema.make("src_source_definitions"),
@@ -445,6 +473,44 @@ describe("source-definitions", () => {
 
         expect(projected).toEqual(source);
       }
+    });
+
+    it("roundtrips stdio MCP bindings without remote fields", async () => {
+      const source = makeSource({
+        kind: "mcp",
+        endpoint: "stdio://local/chrome-devtools-mcp",
+        binding: mcpBinding({
+          transport: "stdio",
+          command: "npx",
+          args: ["-y", "chrome-devtools-mcp@latest"],
+          env: {
+            CHROME_PATH: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+          },
+          cwd: "/tmp/chrome-devtools",
+        }),
+        auth: { kind: "none" },
+      });
+
+      const { sourceRecord, runtimeAuthArtifact } = splitSourceForStorage({
+        source,
+        catalogId: stableSourceCatalogId(source),
+        catalogRevisionId: stableSourceCatalogRevisionId(source),
+      });
+
+      expect(runtimeAuthArtifact).toBeNull();
+      expect(JSON.parse(sourceRecord.bindingConfigJson ?? "{}")).toEqual({
+        adapterKey: "mcp",
+        version: 1,
+        payload: source.binding,
+      });
+
+      const projected = await Effect.runPromise(projectSourceFromStorage({
+        sourceRecord,
+        runtimeAuthArtifact: null,
+        importAuthArtifact: null,
+      }));
+
+      expect(projected).toEqual(source);
     });
 
     it("stores no credential for auth.kind none and projects back correctly", async () => {

--- a/packages/sources/core/src/shared.ts
+++ b/packages/sources/core/src/shared.ts
@@ -8,11 +8,13 @@ import {
   SourceBindingVersionSchema,
   SourceImportAuthPolicySchema,
   SourceOauthClientInputSchema,
+  StringArraySchema,
   SourceTransportSchema,
   StringMapSchema,
   type CredentialSlot,
   type SecretRef,
   type SourceBinding,
+  type StringArray,
   type SourceTransport,
   type StringMap,
 } from "./source-models";
@@ -72,6 +74,10 @@ export const McpConnectFieldsSchema = Schema.Struct({
   transport: Schema.optional(Schema.NullOr(SourceTransportSchema)),
   queryParams: Schema.optional(Schema.NullOr(StringMapSchema)),
   headers: Schema.optional(Schema.NullOr(StringMapSchema)),
+  command: Schema.optional(Schema.NullOr(Schema.String)),
+  args: Schema.optional(Schema.NullOr(StringArraySchema)),
+  env: Schema.optional(Schema.NullOr(StringMapSchema)),
+  cwd: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 export const parseJsonValue = <T>(input: {
@@ -111,12 +117,20 @@ export const emptySourceBindingState = {
   transport: null,
   queryParams: null,
   headers: null,
+  command: null,
+  args: null,
+  env: null,
+  cwd: null,
   specUrl: null,
   defaultHeaders: null,
 } satisfies {
   transport: SourceTransport | null;
   queryParams: StringMap | null;
   headers: StringMap | null;
+  command: string | null;
+  args: StringArray | null;
+  env: StringMap | null;
+  cwd: string | null;
   specUrl: string | null;
   defaultHeaders: StringMap | null;
 };

--- a/packages/sources/core/src/source-models.ts
+++ b/packages/sources/core/src/source-models.ts
@@ -26,6 +26,7 @@ export const SourceTransportSchema = Schema.Literal(
   "auto",
   "streamable-http",
   "sse",
+  "stdio",
 );
 
 export const SourceImportAuthPolicySchema = Schema.Literal(
@@ -38,6 +39,8 @@ export const StringMapSchema = Schema.Record({
   key: Schema.String,
   value: Schema.String,
 });
+
+export const StringArraySchema = Schema.Array(Schema.String);
 
 export type JsonValue =
   | string
@@ -177,6 +180,7 @@ export type SourceStatus = typeof SourceStatusSchema.Type;
 export type SourceTransport = typeof SourceTransportSchema.Type;
 export type SourceImportAuthPolicy = typeof SourceImportAuthPolicySchema.Type;
 export type StringMap = typeof StringMapSchema.Type;
+export type StringArray = typeof StringArraySchema.Type;
 export type SourceAuth = typeof SourceAuthSchema.Type;
 export type SourceBinding = typeof SourceBindingSchema.Type;
 export type Source = typeof SourceSchema.Type;

--- a/packages/sources/core/src/types.ts
+++ b/packages/sources/core/src/types.ts
@@ -17,6 +17,7 @@ import type {
   SourceCatalogKind,
   SourceImportAuthPolicy,
   SourceOauthClientInput,
+  StringArray,
   SourceTransport,
   StoredSourceRecord,
   StringMap,
@@ -77,6 +78,10 @@ export type SourceBindingState = {
   transport: SourceTransport | null;
   queryParams: StringMap | null;
   headers: StringMap | null;
+  command: string | null;
+  args: StringArray | null;
+  env: StringMap | null;
+  cwd: string | null;
   specUrl: string | null;
   defaultHeaders: StringMap | null;
 };

--- a/packages/sources/mcp/src/adapter.ts
+++ b/packages/sources/mcp/src/adapter.ts
@@ -71,6 +71,14 @@ const namespaceFromSourceName = (name: string): string => {
   return normalized.length > 0 ? normalized : "source";
 };
 
+const mcpAdapterError = (message: string, cause?: unknown): Error =>
+  sourceCoreEffectError(
+    "mcp/adapter",
+    cause === undefined
+      ? message
+      : `${message}: ${cause instanceof Error ? cause.message : String(cause)}`,
+  );
+
 const OptionalNullableStringArraySchema = Schema.optional(
   Schema.NullOr(StringArraySchema),
 );
@@ -208,9 +216,13 @@ const normalizeMcpBindingConfig = (
         cwd: trimOrNull(bindingConfig.cwd),
       } satisfies McpBindingConfig;
     }
-
-    if (command !== null || bindingConfig.args || bindingConfig.env || trimOrNull(bindingConfig.cwd) !== null) {
-      return yield* sourceCoreEffectError("mcp/adapter", "MCP process settings require transport: \"stdio\"");
+    if (
+      command !== null ||
+      bindingConfig.args ||
+      bindingConfig.env ||
+      trimOrNull(bindingConfig.cwd) !== null
+    ) {
+      return yield* sourceCoreEffectError("mcp/adapter", 'MCP process settings require transport: "stdio"');
     }
 
     return {
@@ -400,28 +412,23 @@ export const mcpSourceAdapter: SourceAdapter = {
     Effect.gen(function* () {
       const bindingConfig = yield* mcpBindingConfigFromSource(source);
       const auth = yield* resolveAuthMaterialForSlot("import");
-      const connector = yield* Effect.try({
-        try: () =>
-          createSdkMcpConnector({
-            endpoint: source.endpoint,
-            transport: bindingConfig.transport ?? undefined,
-            queryParams: {
-              ...bindingConfig.queryParams,
-              ...auth.queryParams,
-            },
-            headers: headersWithAuthCookies({
-              headers: bindingConfig.headers ?? {},
-              authHeaders: auth.headers,
-              authCookies: auth.cookies,
-            }),
-            authProvider: auth.authProvider,
-            command: bindingConfig.command ?? undefined,
-            args: bindingConfig.args ?? undefined,
-            env: bindingConfig.env ?? undefined,
-            cwd: bindingConfig.cwd ?? undefined,
-          }),
-        catch: (cause) =>
-          cause instanceof Error ? cause : new Error(String(cause)),
+      const connector = createSdkMcpConnector({
+        endpoint: source.endpoint,
+        transport: bindingConfig.transport ?? undefined,
+        queryParams: {
+          ...bindingConfig.queryParams,
+          ...auth.queryParams,
+        },
+        headers: headersWithAuthCookies({
+          headers: bindingConfig.headers ?? {},
+          authHeaders: auth.headers,
+          authCookies: auth.cookies,
+        }),
+        authProvider: auth.authProvider,
+        command: bindingConfig.command ?? undefined,
+        args: bindingConfig.args ?? undefined,
+        env: bindingConfig.env ?? undefined,
+        cwd: bindingConfig.cwd ?? undefined,
       });
 
       const discovered = yield* discoverMcpToolsFromConnector({
@@ -444,25 +451,28 @@ export const mcpSourceAdapter: SourceAdapter = {
       });
     }),
   invoke: (input) =>
-    Effect.tryPromise({
-      try: async () => {
+    Effect.gen(function* () {
         if (input.executable.adapterKey !== "mcp") {
-          throw new Error(
+          return yield* sourceCoreEffectError(
+            "mcp/adapter",
             `Expected MCP executable binding, got ${input.executable.adapterKey}`,
           );
         }
-        const providerData = decodeExecutableBindingPayload({
-          executableId: input.executable.id,
-          label: "MCP",
-          version: input.executable.bindingVersion,
-          expectedVersion: EXECUTABLE_BINDING_VERSION,
-          schema: McpExecutableBindingSchema,
-          value: input.executable.binding,
-        }) as McpExecutableBinding;
+        const providerData = (yield* Effect.try({
+          try: () =>
+            decodeExecutableBindingPayload({
+              executableId: input.executable.id,
+              label: "MCP",
+              version: input.executable.bindingVersion,
+              expectedVersion: EXECUTABLE_BINDING_VERSION,
+              schema: McpExecutableBindingSchema,
+              value: input.executable.binding,
+            }) as McpExecutableBinding,
+          catch: (cause) =>
+            mcpAdapterError("Failed decoding MCP executable binding", cause),
+        })) as McpExecutableBinding;
 
-        const bindingConfig = Effect.runSync(
-          mcpBindingConfigFromSource(input.source),
-        );
+        const bindingConfig = yield* mcpBindingConfigFromSource(input.source);
         const connector = createPooledMcpConnector({
           connect: createSdkMcpConnector({
             endpoint: input.source.endpoint,
@@ -531,7 +541,8 @@ export const mcpSourceAdapter: SourceAdapter = {
             : entry;
 
         if (!definition) {
-          throw new Error(
+          return yield* sourceCoreEffectError(
+            "mcp/adapter",
             `Missing MCP tool definition for ${providerData.toolName}`,
           );
         }
@@ -566,10 +577,18 @@ export const mcpSourceAdapter: SourceAdapter = {
                 onElicitation: input.onElicitation,
               }
             : undefined;
-        const result = await definition.execute(
-          asRecord(payload),
-          executionContext,
-        );
+        const result = yield* Effect.tryPromise({
+          try: async () =>
+            await definition.execute(
+              asRecord(payload),
+              executionContext,
+            ),
+          catch: (cause) =>
+            mcpAdapterError(
+              `Failed invoking MCP tool ${providerData.toolName}`,
+              cause,
+            ),
+        });
         const resultRecord = asRecord(result);
         const isError = resultRecord.isError === true;
 
@@ -579,8 +598,5 @@ export const mcpSourceAdapter: SourceAdapter = {
           headers: {},
           status: null,
         };
-      },
-      catch: (cause) =>
-        cause instanceof Error ? cause : new Error(String(cause)),
     }),
 };

--- a/packages/sources/mcp/src/connection-pool.ts
+++ b/packages/sources/mcp/src/connection-pool.ts
@@ -1,0 +1,151 @@
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Scope from "effect/Scope";
+
+import type { McpConnection, McpConnector } from "./tools";
+
+export class McpConnectionPoolError extends Data.TaggedError("McpConnectionPoolError")<{
+  readonly operation: "connect" | "close";
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
+
+type PoolEntry = {
+  scope: Scope.CloseableScope;
+  connection: McpConnector;
+};
+
+const pooledRuns = new Map<string, Map<string, PoolEntry>>();
+
+const mcpConnectionPoolError = (input: {
+  operation: "connect" | "close";
+  message: string;
+  cause: unknown;
+}): McpConnectionPoolError => new McpConnectionPoolError(input);
+
+const deletePoolEntry = (runId: string, sourceKey: string, entry: PoolEntry) => {
+  const runEntries = pooledRuns.get(runId);
+  if (!runEntries || runEntries.get(sourceKey) !== entry) {
+    return;
+  }
+
+  runEntries.delete(sourceKey);
+  if (runEntries.size === 0) {
+    pooledRuns.delete(runId);
+  }
+};
+
+const closePooledConnection = (
+  connection: McpConnection,
+): Effect.Effect<void, never, never> =>
+  Effect.tryPromise({
+    try: () => Promise.resolve(connection.close?.()),
+    catch: (cause) =>
+      mcpConnectionPoolError({
+        operation: "close",
+        message: "Failed closing pooled MCP connection",
+        cause,
+      }),
+  }).pipe(Effect.ignore);
+
+const createPoolEntry = (connect: McpConnector): PoolEntry => {
+  const scope = Effect.runSync(Scope.make());
+  const connection = Effect.runSync(
+    Effect.cached(
+      Effect.acquireRelease(
+        connect.pipe(
+          Effect.mapError((cause) =>
+            mcpConnectionPoolError({
+              operation: "connect",
+              message: "Failed creating pooled MCP connection",
+              cause,
+            })),
+        ),
+        closePooledConnection,
+      ).pipe(Scope.extend(scope)),
+    ),
+  );
+
+  return {
+    scope,
+    connection,
+  };
+};
+
+const getOrCreatePoolEntry = (input: {
+  runId: string;
+  sourceKey: string;
+  connect: McpConnector;
+}): PoolEntry => {
+  const existing = pooledRuns.get(input.runId)?.get(input.sourceKey);
+  if (existing) {
+    return existing;
+  }
+
+  let runEntries = pooledRuns.get(input.runId);
+  if (!runEntries) {
+    runEntries = new Map<string, PoolEntry>();
+    pooledRuns.set(input.runId, runEntries);
+  }
+
+  const entry = createPoolEntry(input.connect);
+  entry.connection = entry.connection.pipe(
+    Effect.tapError(() =>
+      Effect.sync(() => {
+        deletePoolEntry(input.runId, input.sourceKey, entry);
+      }).pipe(
+        Effect.zipRight(closePoolEntry(entry)),
+      )),
+  );
+  runEntries.set(input.sourceKey, entry);
+  return entry;
+};
+
+const closePoolEntry = (entry: PoolEntry): Effect.Effect<void, never, never> =>
+  Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
+
+export const createPooledMcpConnector = (input: {
+  connect: McpConnector;
+  runId?: string;
+  sourceKey?: string;
+}): McpConnector => {
+  if (!input.runId || !input.sourceKey) {
+    return input.connect;
+  }
+
+  return Effect.gen(function* () {
+    const entry = getOrCreatePoolEntry({
+      runId: input.runId!,
+      sourceKey: input.sourceKey!,
+      connect: input.connect,
+    });
+    const connection = yield* entry.connection;
+    return {
+      client: connection.client,
+      close: async () => undefined,
+    };
+  });
+};
+
+export const clearMcpConnectionPoolRun = (
+  runId: string,
+): Effect.Effect<void, never, never> => {
+  const runEntries = pooledRuns.get(runId);
+  if (!runEntries) {
+    return Effect.void;
+  }
+
+  pooledRuns.delete(runId);
+  return Effect.forEach([...runEntries.values()], closePoolEntry, {
+    discard: true,
+  });
+};
+
+export const clearAllMcpConnectionPools = (): Effect.Effect<void, never, never> => {
+  const runEntries = [...pooledRuns.values()].flatMap((entries) => [...entries.values()]);
+  pooledRuns.clear();
+  return Effect.forEach(runEntries, closePoolEntry, {
+    discard: true,
+  });
+};

--- a/packages/sources/mcp/src/connection.ts
+++ b/packages/sources/mcp/src/connection.ts
@@ -2,33 +2,71 @@ import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
 
 import type { McpConnection, McpConnector } from "./tools";
 
-export type McpTransportPreference = "auto" | "streamable-http" | "sse";
+export type McpTransportPreference = "auto" | "streamable-http" | "sse" | "stdio";
 
 export type CreateSdkMcpConnectorInput = {
-  endpoint: string;
+  endpoint?: string;
   transport?: McpTransportPreference;
   queryParams?: Record<string, string>;
   headers?: Record<string, string>;
   authProvider?: OAuthClientProvider;
   clientName?: string;
   clientVersion?: string;
+  command?: string;
+  args?: ReadonlyArray<string>;
+  env?: Record<string, string>;
+  cwd?: string;
 };
 
-const createEndpoint = (
-  endpoint: string,
-  queryParams: Record<string, string>,
-): URL => {
-  const url = new URL(endpoint);
+export class McpConnectionError extends Data.TaggedError("McpConnectionError")<{
+  readonly transport: McpTransportPreference;
+  readonly message: string;
+  readonly cause: unknown;
+}> {}
 
-  for (const [key, value] of Object.entries(queryParams)) {
-    url.searchParams.set(key, value);
-  }
+export const isMcpStdioTransport = (
+  input: Pick<CreateSdkMcpConnectorInput, "transport" | "command">,
+): boolean =>
+  input.transport === "stdio"
+  || (typeof input.command === "string" && input.command.trim().length > 0);
 
-  return url;
-};
+const mcpConnectionError = (input: {
+  transport: McpTransportPreference;
+  message: string;
+  cause: unknown;
+}): McpConnectionError => new McpConnectionError(input);
+
+const createEndpoint = (input: {
+  endpoint: string | undefined;
+  queryParams: Record<string, string>;
+  transport: Exclude<McpTransportPreference, "stdio">;
+}): Effect.Effect<URL, McpConnectionError, never> =>
+  Effect.try({
+    try: () => {
+      if (!input.endpoint) {
+        throw new Error("MCP endpoint is required for HTTP/SSE transports");
+      }
+
+      const url = new URL(input.endpoint);
+
+      for (const [key, value] of Object.entries(input.queryParams)) {
+        url.searchParams.set(key, value);
+      }
+
+      return url;
+    },
+    catch: (cause) =>
+      mcpConnectionError({
+        transport: input.transport,
+        message: "Failed building MCP endpoint URL",
+        cause,
+      }),
+  });
 
 type FetchInput = Parameters<typeof fetch>[0];
 type FetchInit = Parameters<typeof fetch>[1];
@@ -55,12 +93,72 @@ const connectionFromClient = (client: Client): McpConnection => ({
   close: () => client.close(),
 });
 
+const closeClient = (client: Client): Effect.Effect<void, never, never> =>
+  Effect.tryPromise({
+    try: () => client.close(),
+    catch: (cause) =>
+      mcpConnectionError({
+        transport: "auto",
+        message: "Failed closing MCP client",
+        cause,
+      }),
+  }).pipe(Effect.ignore);
+
+type DynamicImport = <TModule>(specifier: string) => Promise<TModule>;
+
+const dynamicImport = new Function(
+  "specifier",
+  "return import(specifier)",
+) as DynamicImport;
+
+const loadStdioClientTransport = (): Effect.Effect<
+  typeof import("@modelcontextprotocol/sdk/client/stdio.js").StdioClientTransport,
+  McpConnectionError,
+  never
+> =>
+  Effect.tryPromise({
+    try: async () =>
+      (await dynamicImport<typeof import("@modelcontextprotocol/sdk/client/stdio.js")>(
+        "@modelcontextprotocol/sdk/client/stdio.js",
+      )).StdioClientTransport,
+    catch: (cause) =>
+      mcpConnectionError({
+        transport: "stdio",
+        message: "Failed loading MCP stdio transport",
+        cause,
+      }),
+  });
+
+const connectClient = (input: {
+  createClient: () => Client;
+  transport: McpTransportPreference;
+  createTransport: () => Parameters<Client["connect"]>[0];
+}): Effect.Effect<McpConnection, McpConnectionError, never> =>
+  Effect.gen(function* () {
+    const client = input.createClient();
+    const transportInstance = input.createTransport();
+
+    return yield* Effect.tryPromise({
+      try: () => client.connect(transportInstance),
+      catch: (cause) =>
+        mcpConnectionError({
+          transport: input.transport,
+          message: `Failed connecting to MCP server via ${input.transport}`,
+          cause,
+        }),
+    }).pipe(
+      Effect.as(connectionFromClient(client)),
+      Effect.onError(() => closeClient(client)),
+    );
+  });
+
 export const createSdkMcpConnector = (
   input: CreateSdkMcpConnectorInput,
 ): McpConnector => {
-  const endpoint = createEndpoint(input.endpoint, input.queryParams ?? {});
   const headers = input.headers ?? {};
-  const transport = input.transport ?? "auto";
+  const transport = isMcpStdioTransport(input)
+    ? "stdio"
+    : (input.transport ?? "auto");
   const requestInit = Object.keys(headers).length > 0
     ? { headers }
     : undefined;
@@ -74,49 +172,75 @@ export const createSdkMcpConnector = (
       { capabilities: { elicitation: { form: {}, url: {} } } },
     );
 
-  return async () => {
-    const client = createClient();
+  return Effect.gen(function* () {
+    if (transport === "stdio") {
+      const command = input.command?.trim();
+      if (!command) {
+        return yield* Effect.fail(
+          mcpConnectionError({
+            transport: "stdio",
+            message: "MCP stdio transport requires a command",
+            cause: new Error("Missing MCP stdio command"),
+          }),
+        );
+      }
+
+      const StdioClientTransport = yield* loadStdioClientTransport();
+      return yield* connectClient({
+        createClient,
+        transport: "stdio",
+        createTransport: () =>
+          new StdioClientTransport({
+            command,
+            args: input.args ? [...input.args] : undefined,
+            env: input.env,
+            cwd: input.cwd?.trim().length ? input.cwd.trim() : undefined,
+          }),
+      });
+    }
+
+    const endpoint = yield* createEndpoint({
+      endpoint: input.endpoint,
+      queryParams: input.queryParams ?? {},
+      transport,
+    });
+
+    const connectStreamableHttp = connectClient({
+      createClient,
+      transport: "streamable-http",
+      createTransport: () =>
+        new StreamableHTTPClientTransport(endpoint, {
+          requestInit,
+          authProvider: input.authProvider,
+        }),
+    });
 
     if (transport === "streamable-http") {
-      await client.connect(new StreamableHTTPClientTransport(endpoint, {
-        requestInit,
-        authProvider: input.authProvider,
-      }));
-      return connectionFromClient(client);
+      return yield* connectStreamableHttp;
     }
+
+    const connectSse = connectClient({
+      createClient,
+      transport: "sse",
+      createTransport: () =>
+        new SSEClientTransport(endpoint, {
+          authProvider: input.authProvider,
+          requestInit,
+          eventSourceInit: requestInit
+            ? {
+                fetch: (requestInput: FetchInput, requestOptions: FetchInit) =>
+                  mergeHeadersForFetch(requestInput, requestOptions, headers),
+              }
+            : undefined,
+        }),
+    });
 
     if (transport === "sse") {
-      await client.connect(new SSEClientTransport(endpoint, {
-        authProvider: input.authProvider,
-        requestInit,
-        eventSourceInit: requestInit
-          ? {
-              fetch: (requestInput: FetchInput, requestOptions: FetchInit) =>
-                mergeHeadersForFetch(requestInput, requestOptions, headers),
-            }
-          : undefined,
-      }));
-      return connectionFromClient(client);
+      return yield* connectSse;
     }
 
-    try {
-      await client.connect(new StreamableHTTPClientTransport(endpoint, {
-        requestInit,
-        authProvider: input.authProvider,
-      }));
-      return connectionFromClient(client);
-    } catch {
-      await client.connect(new SSEClientTransport(endpoint, {
-        authProvider: input.authProvider,
-        requestInit,
-        eventSourceInit: requestInit
-          ? {
-              fetch: (requestInput: FetchInput, requestOptions: FetchInit) =>
-                mergeHeadersForFetch(requestInput, requestOptions, headers),
-            }
-          : undefined,
-      }));
-      return connectionFromClient(client);
-    }
-  };
+    return yield* connectStreamableHttp.pipe(
+      Effect.catchAll(() => connectSse),
+    );
+  });
 };

--- a/packages/sources/mcp/src/index.ts
+++ b/packages/sources/mcp/src/index.ts
@@ -1,7 +1,15 @@
 export {
+  clearAllMcpConnectionPools,
+  clearMcpConnectionPoolRun,
+  createPooledMcpConnector,
+  McpConnectionPoolError,
+} from "./connection-pool";
+export {
   createSdkMcpConnector,
   type CreateSdkMcpConnectorInput,
+  McpConnectionError,
   type McpTransportPreference,
+  isMcpStdioTransport,
 } from "./connection";
 export { detectMcpSource } from "./discovery";
 export { McpLocalConfigBindingSchema } from "./local-config";

--- a/packages/sources/mcp/src/local-config.ts
+++ b/packages/sources/mcp/src/local-config.ts
@@ -2,6 +2,7 @@ import * as Schema from "effect/Schema";
 
 import {
   SourceTransportSchema,
+  StringArraySchema,
   StringMapSchema,
 } from "@executor/source-core";
 
@@ -9,4 +10,8 @@ export const McpLocalConfigBindingSchema = Schema.Struct({
   transport: Schema.optional(Schema.NullOr(SourceTransportSchema)),
   queryParams: Schema.optional(Schema.NullOr(StringMapSchema)),
   headers: Schema.optional(Schema.NullOr(StringMapSchema)),
+  command: Schema.optional(Schema.NullOr(Schema.String)),
+  args: Schema.optional(Schema.NullOr(StringArraySchema)),
+  env: Schema.optional(Schema.NullOr(StringMapSchema)),
+  cwd: Schema.optional(Schema.NullOr(Schema.String)),
 });

--- a/packages/sources/mcp/src/tools.test.ts
+++ b/packages/sources/mcp/src/tools.test.ts
@@ -306,7 +306,7 @@ describe("codemode-mcp", () => {
       let closeCalls = 0;
       const callInputs: Array<{ name: string; arguments: Record<string, unknown> }> = [];
 
-      const connect = async () => {
+      const connect = Effect.sync(() => {
         connectCalls += 1;
 
         return {
@@ -360,7 +360,7 @@ describe("codemode-mcp", () => {
             closeCalls += 1;
           },
         };
-      };
+      });
 
       const discovered = yield* discoverMcpToolsFromConnector({
         connect,
@@ -432,7 +432,7 @@ describe("codemode-mcp", () => {
     Effect.gen(function* () {
       const outcome = yield* Effect.either(
         discoverMcpToolsFromConnector({
-          connect: async () => ({
+          connect: Effect.succeed({
             client: {
               listTools: async () => {
                 throw new Error("nope");
@@ -456,7 +456,7 @@ describe("codemode-mcp", () => {
       const elicitationMessages: Array<string> = [];
 
       const discovered = yield* discoverMcpToolsFromConnector({
-        connect: async () => ({
+        connect: Effect.succeed({
           client: {
             listTools: async () => {
               attempts += 1;

--- a/packages/sources/mcp/src/tools.ts
+++ b/packages/sources/mcp/src/tools.ts
@@ -53,7 +53,7 @@ export type McpConnection = {
   close?: () => Promise<void>;
 };
 
-export type McpConnector = () => Promise<McpConnection>;
+export type McpConnector = Effect.Effect<McpConnection, unknown, never>;
 
 export type McpDiscoveryElicitationContext = {
   onElicitation: NonNullable<ToolExecutionContext["onElicitation"]>;
@@ -127,10 +127,7 @@ const withConnectionEffect = <A, E>(input: {
   run: (connection: McpConnection) => Effect.Effect<A, E>;
 }): Effect.Effect<A, E | McpToolsError> =>
   Effect.acquireUseRelease(
-    Effect.tryPromise({
-      try: input.connect,
-      catch: input.onConnectError,
-    }),
+    input.connect.pipe(Effect.mapError(input.onConnectError)),
     input.run,
     closeConnection,
   );
@@ -447,7 +444,7 @@ const runMcpToolCallEffect = (input: {
 export const createMcpConnectorFromClient = (
   client: McpClientLike,
 ): McpConnector =>
-  async () => ({
+  Effect.succeed({
     client,
     close: async () => undefined,
   });


### PR DESCRIPTION
## Summary
- add native MCP stdio transport support, including command-backed source configuration
- pool MCP connections per run/source using Effect scopes and reuse that path for regular MCP servers too
- add a Chrome DevTools MCP preset and update the source UI to support command-based MCP templates

## Verification
- bun run --filter='@executor/source-mcp' typecheck
- bun run --filter='@executor/control-plane' typecheck
- bun run --filter='@executor/web' build
- bun run --filter='@executor/source-mcp' test
- bun run --filter='@executor/control-plane' test -- src/runtime/sources/source-adapters/mcp.test.ts src/runtime/execution/mcp-resume.test.ts src/runtime/sources/source-definitions.test.ts