### PR TITLE
[codex] clean up plugin-based secret management

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -571,6 +571,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@executor/platform-sdk": "workspace:*",
+        "@napi-rs/keyring": "^1.2.0",
         "effect": "catalog:",
       },
       "devDependencies": {
@@ -1201,6 +1202,32 @@
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
+
+    "@napi-rs/keyring": ["@napi-rs/keyring@1.2.0", "", { "optionalDependencies": { "@napi-rs/keyring-darwin-arm64": "1.2.0", "@napi-rs/keyring-darwin-x64": "1.2.0", "@napi-rs/keyring-freebsd-x64": "1.2.0", "@napi-rs/keyring-linux-arm-gnueabihf": "1.2.0", "@napi-rs/keyring-linux-arm64-gnu": "1.2.0", "@napi-rs/keyring-linux-arm64-musl": "1.2.0", "@napi-rs/keyring-linux-riscv64-gnu": "1.2.0", "@napi-rs/keyring-linux-x64-gnu": "1.2.0", "@napi-rs/keyring-linux-x64-musl": "1.2.0", "@napi-rs/keyring-win32-arm64-msvc": "1.2.0", "@napi-rs/keyring-win32-ia32-msvc": "1.2.0", "@napi-rs/keyring-win32-x64-msvc": "1.2.0" } }, "sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg=="],
+
+    "@napi-rs/keyring-darwin-arm64": ["@napi-rs/keyring-darwin-arm64@1.2.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA=="],
+
+    "@napi-rs/keyring-darwin-x64": ["@napi-rs/keyring-darwin-x64@1.2.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA=="],
+
+    "@napi-rs/keyring-freebsd-x64": ["@napi-rs/keyring-freebsd-x64@1.2.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q=="],
+
+    "@napi-rs/keyring-linux-arm-gnueabihf": ["@napi-rs/keyring-linux-arm-gnueabihf@1.2.0", "", { "os": "linux", "cpu": "arm" }, "sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ=="],
+
+    "@napi-rs/keyring-linux-arm64-gnu": ["@napi-rs/keyring-linux-arm64-gnu@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA=="],
+
+    "@napi-rs/keyring-linux-arm64-musl": ["@napi-rs/keyring-linux-arm64-musl@1.2.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw=="],
+
+    "@napi-rs/keyring-linux-riscv64-gnu": ["@napi-rs/keyring-linux-riscv64-gnu@1.2.0", "", { "os": "linux", "cpu": "none" }, "sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw=="],
+
+    "@napi-rs/keyring-linux-x64-gnu": ["@napi-rs/keyring-linux-x64-gnu@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ=="],
+
+    "@napi-rs/keyring-linux-x64-musl": ["@napi-rs/keyring-linux-x64-musl@1.2.0", "", { "os": "linux", "cpu": "x64" }, "sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA=="],
+
+    "@napi-rs/keyring-win32-arm64-msvc": ["@napi-rs/keyring-win32-arm64-msvc@1.2.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ=="],
+
+    "@napi-rs/keyring-win32-ia32-msvc": ["@napi-rs/keyring-win32-ia32-msvc@1.2.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A=="],
+
+    "@napi-rs/keyring-win32-x64-msvc": ["@napi-rs/keyring-win32-x64-msvc@1.2.0", "", { "os": "win32", "cpu": "x64" }, "sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
 

--- a/examples/sqlite-sdk-consumer/src/sqlite-backend.ts
+++ b/examples/sqlite-sdk-consumer/src/sqlite-backend.ts
@@ -65,6 +65,10 @@ type SecretMaterialSummary = {
   updatedAt: number;
 };
 
+type SqliteSecretStoredData = {
+  value: string;
+};
+
 const SQLITE_SECRET_STORE_KIND = "sqlite";
 const SQLITE_SECRET_STORE_ID = "sts_sqlite";
 
@@ -92,11 +96,16 @@ const sourceArtifacts = sqliteTable("source_artifacts", {
 
 const secretMaterials = sqliteTable("secret_materials", {
   id: text("id").primaryKey(),
-  providerId: text("provider_id").notNull(),
+  storeId: text("store_id").notNull(),
   name: text("name"),
   purpose: text("purpose").notNull(),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
+  json: text("json").notNull(),
+});
+
+const secretMaterialStoredData = sqliteTable("secret_material_stored_data", {
+  secretId: text("secret_id").primaryKey(),
   json: text("json").notNull(),
 });
 
@@ -213,11 +222,16 @@ const openSqliteStore = (databasePath: string) => {
 
       CREATE TABLE IF NOT EXISTS secret_materials (
         id TEXT PRIMARY KEY NOT NULL,
-        provider_id TEXT NOT NULL,
+        store_id TEXT NOT NULL,
         name TEXT,
         purpose TEXT NOT NULL,
         created_at INTEGER NOT NULL,
         updated_at INTEGER NOT NULL,
+        json TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS secret_material_stored_data (
+        secret_id TEXT PRIMARY KEY NOT NULL,
         json TEXT NOT NULL
       );
 
@@ -241,6 +255,7 @@ const openSqliteStore = (databasePath: string) => {
         json TEXT NOT NULL
       );
     `);
+
   return {
     sqlite,
     db,
@@ -292,7 +307,7 @@ const createStorageDomains = (
     listAll: (): readonly SecretMaterialSummary[] =>
       store.db.select().from(secretMaterials).all().map((row) => ({
         id: row.id,
-        storeId: row.providerId,
+        storeId: row.storeId,
         name: row.name,
         purpose: row.purpose,
         createdAt: row.createdAt,
@@ -301,7 +316,7 @@ const createStorageDomains = (
     upsert: (material: SecretMaterial) =>
       store.db.insert(secretMaterials).values({
         id: material.id,
-        providerId: material.storeId,
+        storeId: material.storeId,
         name: material.name,
         purpose: material.purpose,
         createdAt: material.createdAt,
@@ -310,7 +325,7 @@ const createStorageDomains = (
       }).onConflictDoUpdate({
         target: secretMaterials.id,
         set: {
-          providerId: material.storeId,
+          storeId: material.storeId,
           name: material.name,
           purpose: material.purpose,
           createdAt: material.createdAt,
@@ -320,7 +335,7 @@ const createStorageDomains = (
       }).run(),
     updateById: (
       id: SecretMaterial["id"],
-      update: { name?: string | null; value?: string },
+      update: { name?: string | null },
     ) => {
       const row = store.db.select().from(secretMaterials).where(eq(secretMaterials.id, id)).get();
       if (!row) return null;
@@ -328,11 +343,10 @@ const createStorageDomains = (
       const next = {
         ...current,
         name: update.name === undefined ? current.name : update.name,
-        value: update.value === undefined ? current.value : update.value,
         updatedAt: Date.now(),
       };
       store.db.update(secretMaterials).set({
-        providerId: next.storeId,
+        storeId: next.storeId,
         name: next.name,
         purpose: next.purpose,
         createdAt: next.createdAt,
@@ -355,6 +369,40 @@ const createStorageDomains = (
       if (!row) return false;
       store.db.delete(secretMaterials).where(eq(secretMaterials.id, id)).run();
       return true;
+    },
+    secretMaterialStoredData: {
+      getBySecretId: (secretId: SecretMaterial["id"]) => {
+        const row = store.db.select().from(secretMaterialStoredData).where(
+          eq(secretMaterialStoredData.secretId, secretId),
+        ).get();
+        return row
+          ? {
+              secretId,
+              data: parseJson<SqliteSecretStoredData>(row.json),
+            }
+          : null;
+      },
+      upsert: (record: { secretId: SecretMaterial["id"]; data: unknown }) => {
+        store.db.insert(secretMaterialStoredData).values({
+          secretId: record.secretId,
+          json: JSON.stringify(record.data),
+        }).onConflictDoUpdate({
+          target: secretMaterialStoredData.secretId,
+          set: {
+            json: JSON.stringify(record.data),
+          },
+        }).run();
+      },
+      removeBySecretId: (secretId: SecretMaterial["id"]) => {
+        const row = store.db.select({ secretId: secretMaterialStoredData.secretId }).from(
+          secretMaterialStoredData,
+        ).where(eq(secretMaterialStoredData.secretId, secretId)).get();
+        if (!row) return false;
+        store.db.delete(secretMaterialStoredData).where(
+          eq(secretMaterialStoredData.secretId, secretId),
+        ).run();
+        return true;
+      },
     },
   },
   executions: {
@@ -612,14 +660,18 @@ export const createSqliteExecutorBackend = (
         secrets: {
           ...secrets,
           secretStores: secrets.secretStores,
+          secretMaterialStoredData: secrets.secretMaterialStoredData,
           resolve: ({ ref }) => {
             const material = secrets.getById(
               ref.secretId as SecretMaterial["id"],
             );
-            if (!material || material.value === null) {
+            const stored = secrets.secretMaterialStoredData.getBySecretId(
+              ref.secretId as SecretMaterial["id"],
+            );
+            if (!material || !stored) {
               throw new Error(`Missing secret material ${ref.secretId}`);
             }
-            return material.value;
+            return (stored.data as SqliteSecretStoredData).value;
           },
           store: ({ purpose, value, name, storeId }) => {
             const now = Date.now();
@@ -627,27 +679,43 @@ export const createSqliteExecutorBackend = (
             const material: SecretMaterial = {
               id,
               storeId: (storeId ?? SQLITE_SECRET_STORE_ID) as SecretMaterial["storeId"],
-              handle: id,
               name: name ?? null,
               purpose,
-              value,
               createdAt: now,
               updatedAt: now,
             };
             secrets.upsert(material);
+            secrets.secretMaterialStoredData.upsert({
+              secretId: id,
+              data: {
+                value,
+              } satisfies SqliteSecretStoredData,
+            });
             return {
               secretId: material.id,
             } satisfies SecretRef;
           },
-          delete: (ref) =>
-            secrets.removeById(ref.secretId as SecretMaterial["id"]),
+          delete: (ref) => {
+            secrets.secretMaterialStoredData.removeBySecretId(
+              ref.secretId as SecretMaterial["id"],
+            );
+            return secrets.removeById(ref.secretId as SecretMaterial["id"]);
+          },
           update: ({ ref, name, value }) => {
             const updated = secrets.updateById(
               ref.secretId as SecretMaterial["id"],
-              { name, value },
+              { name },
             );
             if (!updated) {
               throw new Error(`Missing secret material ${ref.secretId}`);
+            }
+            if (value !== undefined) {
+              secrets.secretMaterialStoredData.upsert({
+                secretId: ref.secretId as SecretMaterial["id"],
+                data: {
+                  value,
+                } satisfies SqliteSecretStoredData,
+              });
             }
             return updated;
           },

--- a/packages/platform/sdk-file/src/config.ts
+++ b/packages/platform/sdk-file/src/config.ts
@@ -11,7 +11,6 @@ import {
   LocalExecutorConfigSchema,
   type LocalExecutorConfig,
   type LocalConfigPolicy,
-  type LocalConfigSecretProvider,
   type LocalConfigSource,
 } from "@executor/platform-sdk/schema";
 import type { LoadedLocalExecutorConfig } from "@executor/platform-sdk/runtime";
@@ -249,19 +248,6 @@ const mergePolicyMaps = (
   };
 };
 
-const mergeSecretProviderMaps = (
-  base: Record<string, LocalConfigSecretProvider> | undefined,
-  extra: Record<string, LocalConfigSecretProvider> | undefined,
-): Record<string, LocalConfigSecretProvider> | undefined => {
-  if (!base && !extra) {
-    return undefined;
-  }
-  return {
-    ...base,
-    ...extra,
-  };
-};
-
 export const mergeLocalExecutorConfigs = (
   base: LocalExecutorConfig | null,
   extra: LocalExecutorConfig | null,
@@ -278,16 +264,6 @@ export const mergeLocalExecutorConfigs = (
     },
     sources: mergeSourceMaps(base?.sources, extra?.sources),
     policies: mergePolicyMaps(base?.policies, extra?.policies),
-    secrets: {
-      providers: mergeSecretProviderMaps(
-        base?.secrets?.providers,
-        extra?.secrets?.providers,
-      ),
-      defaults: {
-        ...base?.secrets?.defaults,
-        ...extra?.secrets?.defaults,
-      },
-    },
   });
 };
 

--- a/packages/platform/sdk-file/src/executor-state-store.ts
+++ b/packages/platform/sdk-file/src/executor-state-store.ts
@@ -26,13 +26,21 @@ import {
   unknownLocalErrorDetails,
 } from "./errors";
 
-const LOCAL_EXECUTOR_STATE_VERSION = 1 as const;
+const LOCAL_EXECUTOR_STATE_VERSION = 2 as const;
 const LOCAL_EXECUTOR_STATE_BASENAME = "executor-state.json";
+
+const SecretMaterialStoredDataRecordSchema = Schema.Struct({
+  secretId: Schema.String,
+  data: Schema.Unknown,
+});
+
+type SecretMaterialStoredDataRecord = typeof SecretMaterialStoredDataRecordSchema.Type;
 
 const LocalExecutorStateSnapshotSchema = Schema.Struct({
   version: Schema.Literal(LOCAL_EXECUTOR_STATE_VERSION),
   secretStores: Schema.Array(SecretStoreSchema),
   secretMaterials: Schema.Array(SecretMaterialSchema),
+  secretMaterialStoredData: Schema.Array(SecretMaterialStoredDataRecordSchema),
   executions: Schema.Array(ExecutionSchema),
   executionInteractions: Schema.Array(ExecutionInteractionSchema),
   executionSteps: Schema.Array(ExecutionStepSchema),
@@ -53,6 +61,7 @@ const defaultLocalExecutorStateSnapshot = (): LocalExecutorStateSnapshot => ({
   version: LOCAL_EXECUTOR_STATE_VERSION,
   secretStores: [],
   secretMaterials: [],
+  secretMaterialStoredData: [],
   executions: [],
   executionInteractions: [],
   executionSteps: [],
@@ -60,7 +69,6 @@ const defaultLocalExecutorStateSnapshot = (): LocalExecutorStateSnapshot => ({
 
 const cloneValue = <T>(value: T): T =>
   JSON.parse(JSON.stringify(value)) as T;
-
 const mapFileSystemError = (path: string, action: string) => (cause: unknown) =>
   new LocalFileSystemError({
     message: `Failed to ${action} ${path}: ${unknownLocalErrorDetails(cause)}`,
@@ -156,18 +164,19 @@ export const writeLocalExecutorStateSnapshot = (input: {
 }): Effect.Effect<void, LocalFileSystemError> =>
   bindNodeFileSystem(writeStateToDisk(input.context, input.state));
 
-const mergeById = <T extends { id: string }>(
+const mergeByKey = <T>(
   current: readonly T[],
   imported: readonly T[],
+  getKey: (value: T) => string,
 ): T[] => {
   const merged = new Map<string, T>();
 
   for (const item of imported) {
-    merged.set(item.id, cloneValue(item));
+    merged.set(getKey(item), cloneValue(item));
   }
 
   for (const item of current) {
-    merged.set(item.id, cloneValue(item));
+    merged.set(getKey(item), cloneValue(item));
   }
 
   return [...merged.values()];
@@ -178,22 +187,35 @@ export const mergeImportedLocalExecutorStateSnapshot = (input: {
   imported: Partial<Omit<LocalExecutorStateSnapshot, "version">>;
 }): LocalExecutorStateSnapshot => ({
   version: LOCAL_EXECUTOR_STATE_VERSION,
-  secretStores: mergeById(
+  secretStores: mergeByKey(
     input.current.secretStores,
     input.imported.secretStores ?? [],
+    (item) => item.id,
   ),
-  secretMaterials: mergeById(
+  secretMaterials: mergeByKey(
     input.current.secretMaterials,
     input.imported.secretMaterials ?? [],
+    (item) => item.id,
   ),
-  executions: mergeById(input.current.executions, input.imported.executions ?? []),
-  executionInteractions: mergeById(
+  secretMaterialStoredData: mergeByKey(
+    input.current.secretMaterialStoredData,
+    input.imported.secretMaterialStoredData ?? [],
+    (item) => item.secretId,
+  ),
+  executions: mergeByKey(
+    input.current.executions,
+    input.imported.executions ?? [],
+    (item) => item.id,
+  ),
+  executionInteractions: mergeByKey(
     input.current.executionInteractions,
     input.imported.executionInteractions ?? [],
+    (item) => item.id,
   ),
-  executionSteps: mergeById(
+  executionSteps: mergeByKey(
     input.current.executionSteps,
     input.imported.executionSteps ?? [],
+    (item) => item.id,
   ),
 });
 
@@ -390,7 +412,7 @@ export const createLocalExecutorStateStore = (
 
       updateById: (
         id: SecretMaterial["id"],
-        update: { name?: string | null; value?: string },
+        update: { name?: string | null },
       ) =>
         stateManager.mutate((state) => {
           let updated: SecretMaterial | null = null;
@@ -402,7 +424,6 @@ export const createLocalExecutorStateStore = (
             updated = {
               ...material,
               ...(update.name !== undefined ? { name: update.name } : {}),
-              ...(update.value !== undefined ? { value: update.value } : {}),
               updatedAt: Date.now(),
             } satisfies SecretMaterial;
             return updated;
@@ -429,6 +450,48 @@ export const createLocalExecutorStateStore = (
               secretMaterials: nextMaterials,
             },
             value: nextMaterials.length !== state.secretMaterials.length,
+          } satisfies StateMutationResult<boolean>;
+        }),
+    },
+    secretMaterialStoredData: {
+      getBySecretId: (secretId: SecretMaterial["id"]) =>
+        stateManager.read((state) => {
+          const record = state.secretMaterialStoredData.find(
+            (candidate) => candidate.secretId === secretId,
+          );
+          return record
+            ? Option.some(cloneValue(record))
+            : Option.none<SecretMaterialStoredDataRecord>();
+        }),
+
+      upsert: (record: SecretMaterialStoredDataRecord) =>
+        stateManager.mutate((state) => {
+          const nextRecords = state.secretMaterialStoredData.filter(
+            (candidate) => candidate.secretId !== record.secretId,
+          );
+          nextRecords.push(cloneValue(record));
+
+          return {
+            state: {
+              ...state,
+              secretMaterialStoredData: nextRecords,
+            },
+            value: undefined,
+          } satisfies StateMutationResult<void>;
+        }),
+
+      removeBySecretId: (secretId: SecretMaterial["id"]) =>
+        stateManager.mutate((state) => {
+          const nextRecords = state.secretMaterialStoredData.filter(
+            (candidate) => candidate.secretId !== secretId,
+          );
+
+          return {
+            state: {
+              ...state,
+              secretMaterialStoredData: nextRecords,
+            },
+            value: nextRecords.length !== state.secretMaterialStoredData.length,
           } satisfies StateMutationResult<boolean>;
         }),
     },

--- a/packages/platform/sdk-file/src/index.ts
+++ b/packages/platform/sdk-file/src/index.ts
@@ -25,9 +25,9 @@ import type {
 } from "@executor/platform-sdk/schema";
 import {
   type ExecutorRuntime,
+  emptyExecutorPluginRegistry,
   type ExecutorRuntimeOptions,
   type ResolveSecretMaterial,
-  emptyExecutorPluginRegistry,
 } from "@executor/platform-sdk/runtime";
 import * as Effect from "effect/Effect";
 import {
@@ -283,6 +283,8 @@ export const createLocalExecutorRepositoriesEffect = (
       },
       secrets: {
         secretStores: executorStateStorage.executorState.secretStores,
+        secretMaterialStoredData:
+          executorStateStorage.executorState.secretMaterialStoredData,
         ...executorStateStorage.executorState.secretMaterials,
         resolve: resolveSecretMaterial,
         store: createDefaultSecretMaterialStorer({

--- a/packages/platform/sdk-file/src/secret-material-providers.ts
+++ b/packages/platform/sdk-file/src/secret-material-providers.ts
@@ -255,15 +255,17 @@ export const createDefaultSecretMaterialStorer = (input: {
       const material: SecretMaterial = {
         id: `sec_${randomUUID()}` as SecretMaterial["id"],
         storeId: store.id,
-        handle: created.handle,
         name: created.name,
         purpose,
-        value: created.value ?? null,
         createdAt: now,
         updatedAt: now,
       };
 
       yield* input.executorState.secretMaterials.upsert(material);
+      yield* input.executorState.secretMaterialStoredData.upsert({
+        secretId: material.id,
+        data: created.secretStored,
+      });
 
       return {
         secretId: material.id,
@@ -309,12 +311,16 @@ export const createDefaultSecretMaterialUpdater = (input: {
 
       const nextMaterial: SecretMaterial = {
         ...material,
-        ...(updated.handle ? { handle: updated.handle } : {}),
         name: updated.name,
-        value: updated.value ?? material.value,
         updatedAt: Date.now(),
       };
       yield* input.executorState.secretMaterials.upsert(nextMaterial);
+      if (updated.secretStored !== undefined) {
+        yield* input.executorState.secretMaterialStoredData.upsert({
+          secretId: nextMaterial.id,
+          data: updated.secretStored,
+        });
+      }
 
       return {
         id: nextMaterial.id,
@@ -359,6 +365,7 @@ export const createDefaultSecretMaterialDeleter = (input: {
         return false;
       }
 
+      yield* input.executorState.secretMaterialStoredData.removeBySecretId(material.id);
       return yield* input.executorState.secretMaterials.removeById(material.id);
     });
 };
@@ -442,6 +449,7 @@ export const SecretMaterialLive = (input: {
     SecretMaterialResolverLive(input),
     SecretMaterialStorerLive({
       executorState: input.executorState,
+      pluginRegistry: input.pluginRegistry,
       resolveSecretMaterial:
         input.resolveSecretMaterial
         ?? createDefaultSecretMaterialResolver({
@@ -449,11 +457,11 @@ export const SecretMaterialLive = (input: {
           pluginRegistry: input.pluginRegistry,
           keychainServiceName: input.keychainServiceName,
         }),
-      pluginRegistry: input.pluginRegistry,
       keychainServiceName: input.keychainServiceName,
     }),
     SecretMaterialDeleterLive({
       executorState: input.executorState,
+      pluginRegistry: input.pluginRegistry,
       resolveSecretMaterial:
         input.resolveSecretMaterial
         ?? createDefaultSecretMaterialResolver({
@@ -461,11 +469,11 @@ export const SecretMaterialLive = (input: {
           pluginRegistry: input.pluginRegistry,
           keychainServiceName: input.keychainServiceName,
         }),
-      pluginRegistry: input.pluginRegistry,
       keychainServiceName: input.keychainServiceName,
     }),
     SecretMaterialUpdaterLive({
       executorState: input.executorState,
+      pluginRegistry: input.pluginRegistry,
       resolveSecretMaterial:
         input.resolveSecretMaterial
         ?? createDefaultSecretMaterialResolver({
@@ -473,7 +481,6 @@ export const SecretMaterialLive = (input: {
           pluginRegistry: input.pluginRegistry,
           keychainServiceName: input.keychainServiceName,
         }),
-      pluginRegistry: input.pluginRegistry,
       keychainServiceName: input.keychainServiceName,
     }),
   );

--- a/packages/platform/sdk/src/backend.ts
+++ b/packages/platform/sdk/src/backend.ts
@@ -176,6 +176,13 @@ const toSecretsBackend = (
       toOptionEffect(input.secretStores.updateById(id, patch)),
     removeById: (id) => toEffect(input.secretStores.removeById(id)),
   },
+  secretMaterialStoredData: {
+    getBySecretId: (secretId) =>
+      toOptionEffect(input.secretMaterialStoredData.getBySecretId(secretId)),
+    upsert: (record) => toEffect(input.secretMaterialStoredData.upsert(record)),
+    removeBySecretId: (secretId) =>
+      toEffect(input.secretMaterialStoredData.removeBySecretId(secretId)),
+  },
   getById: (id) => toOptionEffect(input.getById(id)),
   listAll: () => toEffect(input.listAll()),
   upsert: (material) => toEffect(input.upsert(material)),

--- a/packages/platform/sdk/src/local/secret-stores.ts
+++ b/packages/platform/sdk/src/local/secret-stores.ts
@@ -82,7 +82,7 @@ const getSecretStoreContributionOption = (kind: string) =>
     try {
       return Option.some(getSecretStoreContribution(pluginRegistry, kind));
     } catch {
-      return Option.none<typeof getSecretStoreContribution extends (registry: any, kind: string) => infer T ? T : never>();
+      return Option.none<any>();
     }
   });
 
@@ -125,10 +125,9 @@ const toSecretStoreContract = (
 
 const createImportedSecretRecord = (input: {
   store: SecretStore;
-  handle: string;
+  secretStored: unknown;
   name: string | null;
   purpose: SecretMaterialPurpose;
-  value?: string | null;
 }) =>
   Effect.gen(function* () {
     const executorState = yield* ExecutorStateStore;
@@ -136,15 +135,17 @@ const createImportedSecretRecord = (input: {
     const material: SecretMaterial = {
       id: SecretMaterialIdSchema.make(`sec_${crypto.randomUUID()}`),
       storeId: input.store.id,
-      handle: input.handle,
       name: input.name,
       purpose: input.purpose,
-      value: input.value ?? null,
       createdAt: now,
       updatedAt: now,
     };
 
     yield* executorState.secretMaterials.upsert(material);
+    yield* executorState.secretMaterialStoredData.upsert({
+      secretId: material.id,
+      data: input.secretStored,
+    });
 
     return {
       id: material.id,
@@ -384,7 +385,7 @@ export const browseLocalSecretStore = (input: {
           cause instanceof Error ? cause.message : "Failed browsing secret store.",
         ),
       ),
-      Effect.map((result) => result satisfies BrowseSecretStoreResult),
+      Effect.map((result) => result as BrowseSecretStoreResult),
     );
   });
 
@@ -437,9 +438,8 @@ export const importLocalSecretFromStore = (input: {
 
     return yield* createImportedSecretRecord({
       store,
-      handle: created.handle,
+      secretStored: created.secretStored,
       name: created.name,
       purpose: input.payload.purpose ?? "auth_material",
-      value: created.value,
     });
   });

--- a/packages/platform/sdk/src/plugins.ts
+++ b/packages/platform/sdk/src/plugins.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 
 import type { SourceCatalogSyncResult } from "@executor/source-core";
 import type {
@@ -21,6 +22,9 @@ import type {
 } from "@executor/source-core";
 import type * as Schema from "effect/Schema";
 import { runtimeEffectError } from "./runtime/effect-errors";
+import {
+  ExecutorStateStore,
+} from "./runtime/executor-state-store";
 import { ScopeConfigStore } from "./runtime/scope/storage";
 
 export type PluginCleanup = {
@@ -329,6 +333,7 @@ export type ExecutorSecretStorePluginDefinition<
   TConnectInput,
   TStoreConfig,
   TStored,
+  TSecretStored,
   _TUpdateInput extends {
     storeId: string;
     config: TStoreConfig;
@@ -369,6 +374,7 @@ export type ExecutorSecretStorePluginDefinition<
     }) => Effect.Effect<void, Error, any>;
     resolveSecret: (input: {
       secret: SecretMaterial;
+      secretStored: TSecretStored;
       store: SecretStore;
       stored: TStored | null;
       context?: {
@@ -382,23 +388,23 @@ export type ExecutorSecretStorePluginDefinition<
       value: string;
       name?: string | null;
     }) => Effect.Effect<{
-      handle: string;
       name: string | null;
-      value?: string | null;
+      secretStored: TSecretStored;
     }, Error, any>;
     updateSecret?: (input: {
       secret: SecretMaterial;
+      secretStored: TSecretStored;
       store: SecretStore;
       stored: TStored | null;
       name?: string | null;
       value?: string;
     }) => Effect.Effect<{
-      handle?: string;
       name: string | null;
-      value?: string | null;
+      secretStored?: TSecretStored;
     }, Error, any>;
     deleteSecret?: (input: {
       secret: SecretMaterial;
+      secretStored: TSecretStored;
       store: SecretStore;
       stored: TStored | null;
     }) => Effect.Effect<boolean, Error, any>;
@@ -417,9 +423,8 @@ export type ExecutorSecretStorePluginDefinition<
       purpose: SecretMaterialPurpose;
       name?: string | null;
     }) => Effect.Effect<{
-      handle: string;
       name: string | null;
-      value?: string | null;
+      secretStored: TSecretStored;
     }, Error, any>;
     capabilities?: (input: {
       store: SecretStore;
@@ -479,6 +484,7 @@ export type ExecutorSecretStorePluginInput<
   TConnectInput = unknown,
   TStoreConfig = unknown,
   TStored = unknown,
+  TSecretStored = unknown,
   TUpdateInput extends {
     storeId: string;
     config: TStoreConfig;
@@ -494,6 +500,7 @@ export type ExecutorSecretStorePluginInput<
     TConnectInput,
     TStoreConfig,
     TStored,
+    TSecretStored,
     TUpdateInput
   >;
   extendExecutor?: (input: ExecutorSdkPluginContext & {
@@ -771,7 +778,7 @@ const createExecutorSourcePluginApi = <
 const loadStoreOfKind = (
   storeId: SecretStore["id"],
   input: {
-    definition: ExecutorSecretStorePluginDefinition<any, any, any, any, any>;
+    definition: ExecutorSecretStorePluginDefinition<any, any, any, any, any, any>;
     host: ExecutorSecretStorePluginInternalHost;
   },
 ): Effect.Effect<SecretStore, Error, any> =>
@@ -787,11 +794,28 @@ const loadStoreOfKind = (
     return store;
   });
 
+const loadSecretMaterialStoredData = <TSecretStored>(
+  secretId: SecretMaterial["id"],
+): Effect.Effect<TSecretStored, Error, any> =>
+  Effect.gen(function* () {
+    const executorState = yield* ExecutorStateStore;
+    const stored = yield* executorState.secretMaterialStoredData.getBySecretId(secretId);
+    if (Option.isNone(stored)) {
+      return yield* runtimeEffectError(
+        "plugins",
+        `Secret storage missing for ${secretId}.`,
+      );
+    }
+
+    return stored.value.data as TSecretStored;
+  });
+
 const createExecutorSecretStorePluginApi = <
   TAddInput,
   TConnectInput,
   TStoreConfig,
   TStored,
+  TSecretStored,
   _TUpdateInput extends {
     storeId: string;
     config: TStoreConfig;
@@ -802,6 +826,7 @@ const createExecutorSecretStorePluginApi = <
     TConnectInput,
     TStoreConfig,
     TStored,
+    TSecretStored,
     _TUpdateInput
   >,
   host: ExecutorSecretStorePluginInternalHost,
@@ -962,9 +987,8 @@ type ExecutorSecretStoreContribution<TInput = unknown> = {
     value: string;
     name?: string | null;
   }) => Effect.Effect<{
-    handle: string;
     name: string | null;
-    value?: string | null;
+    secretStored: unknown;
   }, Error, any>;
   updateSecret: (input: {
     secret: SecretMaterial;
@@ -972,9 +996,8 @@ type ExecutorSecretStoreContribution<TInput = unknown> = {
     name?: string | null;
     value?: string;
   }) => Effect.Effect<{
-    handle?: string;
     name: string | null;
-    value?: string | null;
+    secretStored?: unknown;
   }, Error, any>;
   deleteSecret: (input: {
     secret: SecretMaterial;
@@ -993,9 +1016,8 @@ type ExecutorSecretStoreContribution<TInput = unknown> = {
     purpose: SecretMaterialPurpose;
     name?: string | null;
   }) => Effect.Effect<{
-    handle: string;
     name: string | null;
-    value?: string | null;
+    secretStored: unknown;
   }, Error, any>;
 };
 
@@ -1076,6 +1098,7 @@ const createExecutorSecretStoreContribution = <
   TConnectInput,
   TStoreConfig,
   TStored,
+  TSecretStored,
   TUpdateInput extends {
     storeId: string;
     config: TStoreConfig;
@@ -1086,6 +1109,7 @@ const createExecutorSecretStoreContribution = <
     TConnectInput,
     TStoreConfig,
     TStored,
+    TSecretStored,
     TUpdateInput
   >,
 ): ExecutorSecretStoreContribution<TAddInput> => ({
@@ -1153,13 +1177,17 @@ const createExecutorSecretStoreContribution = <
     ),
   resolveSecret: ({ secret, store, context }) =>
     Effect.flatMap(
-      definition.storage.get({
-        scopeId: store.scopeId,
-        storeId: store.id,
+      Effect.all({
+        stored: definition.storage.get({
+          scopeId: store.scopeId,
+          storeId: store.id,
+        }),
+        secretStored: loadSecretMaterialStoredData<TSecretStored>(secret.id),
       }),
-      (stored) =>
+      ({ stored, secretStored }) =>
         definition.store.resolveSecret({
           secret,
+          secretStored,
           store,
           stored,
           context,
@@ -1188,13 +1216,17 @@ const createExecutorSecretStoreContribution = <
   updateSecret: ({ secret, store, name, value }) =>
     definition.store.updateSecret
       ? Effect.flatMap(
-          definition.storage.get({
-            scopeId: store.scopeId,
-            storeId: store.id,
+          Effect.all({
+            stored: definition.storage.get({
+              scopeId: store.scopeId,
+              storeId: store.id,
+            }),
+            secretStored: loadSecretMaterialStoredData<TSecretStored>(secret.id),
           }),
-          (stored) =>
+          ({ stored, secretStored }) =>
             definition.store.updateSecret!({
               secret,
+              secretStored,
               store,
               stored,
               name,
@@ -1208,13 +1240,17 @@ const createExecutorSecretStoreContribution = <
   deleteSecret: ({ secret, store }) =>
     definition.store.deleteSecret
       ? Effect.flatMap(
-          definition.storage.get({
-            scopeId: store.scopeId,
-            storeId: store.id,
+          Effect.all({
+            stored: definition.storage.get({
+              scopeId: store.scopeId,
+              storeId: store.id,
+            }),
+            secretStored: loadSecretMaterialStoredData<TSecretStored>(secret.id),
           }),
-          (stored) =>
+          ({ stored, secretStored }) =>
             definition.store.deleteSecret!({
               secret,
+              secretStored,
               store,
               stored,
             }),
@@ -1377,6 +1413,7 @@ export const defineExecutorSecretStorePlugin = <
   TConnectInput,
   TStoreConfig,
   TStored,
+  TSecretStored,
   TUpdateInput extends {
     storeId: string;
     config: TStoreConfig;
@@ -1389,6 +1426,7 @@ export const defineExecutorSecretStorePlugin = <
     TConnectInput,
     TStoreConfig,
     TStored,
+    TSecretStored,
     TUpdateInput,
     TExtension
   >,

--- a/packages/platform/sdk/src/runtime/execution/live.test.ts
+++ b/packages/platform/sdk/src/runtime/execution/live.test.ts
@@ -14,9 +14,8 @@ describe("live-execution", () => {
       action: "accept",
       content: {
         authKind: "bearer",
-        tokenRef: {
-          providerId: "local",
-          handle: "sec_123",
+        tokenSecretRef: {
+          secretId: "sec_123",
         },
       },
     });

--- a/packages/platform/sdk/src/runtime/execution/live.ts
+++ b/packages/platform/sdk/src/runtime/execution/live.ts
@@ -71,7 +71,10 @@ const serializeJson = (value: unknown): string | null => {
 };
 
 const SENSITIVE_INTERACTION_CONTENT_KEYS = new Set([
-  "tokenRef",
+  "tokenSecretRef",
+  "accessTokenRef",
+  "refreshTokenRef",
+  "clientSecretRef",
   "tokenSecretMaterialId",
 ]);
 

--- a/packages/platform/sdk/src/runtime/executor-state-store.ts
+++ b/packages/platform/sdk/src/runtime/executor-state-store.ts
@@ -18,6 +18,11 @@ type SecretMaterialSummary = {
   updatedAt: number;
 };
 
+export type SecretMaterialStoredDataRecord = {
+  secretId: string;
+  data: unknown;
+};
+
 type SecretStoreSummary = {
   id: string;
   scopeId: string;
@@ -56,13 +61,28 @@ export type ExecutorStateStoreShape = {
     upsert: (material: SecretMaterial) => Effect.Effect<void, Error, never>;
     updateById: (
       id: SecretMaterial["id"],
-      update: { name?: string | null; value?: string },
+      update: { name?: string | null },
     ) => Effect.Effect<
       import("effect/Option").Option<SecretMaterialSummary>,
       Error,
       never
     >;
     removeById: (id: SecretMaterial["id"]) => Effect.Effect<boolean, Error, never>;
+  };
+  secretMaterialStoredData: {
+    getBySecretId: (
+      secretId: SecretMaterial["id"],
+    ) => Effect.Effect<
+      import("effect/Option").Option<SecretMaterialStoredDataRecord>,
+      Error,
+      never
+    >;
+    upsert: (
+      record: SecretMaterialStoredDataRecord,
+    ) => Effect.Effect<void, Error, never>;
+    removeBySecretId: (
+      secretId: SecretMaterial["id"],
+    ) => Effect.Effect<boolean, Error, never>;
   };
   executions: {
     listByScope: (

--- a/packages/platform/sdk/src/runtime/index.ts
+++ b/packages/platform/sdk/src/runtime/index.ts
@@ -112,7 +112,6 @@ export * from "./execution/service";
 export * from "./source-artifacts";
 export * from "./scope-config";
 export * from "./scope-state";
-export * from "./scope/config-secrets";
 export * from "./sources/source-store/config";
 export * from "./sources/source-store/plugin-local-config";
 export {
@@ -244,6 +243,7 @@ export const prewarmWorkspaceSourceCatalogToolIndex = (input: {
 export type RuntimeSecretsStorageServices =
   & {
     secretStores: ExecutorStateStoreShape["secretStores"];
+    secretMaterialStoredData: ExecutorStateStoreShape["secretMaterialStoredData"];
   }
   & ExecutorStateStoreShape["secretMaterials"]
   & RuntimeSecretMaterialServices;
@@ -343,7 +343,14 @@ const toExecutorStateStoreShape = (
   input: RuntimeStorageServices,
 ): ExecutorStateStoreShape => ({
   secretStores: input.secrets.secretStores,
-  secretMaterials: input.secrets,
+  secretMaterials: {
+    getById: input.secrets.getById,
+    listAll: input.secrets.listAll,
+    upsert: input.secrets.upsert,
+    updateById: input.secrets.updateById,
+    removeById: input.secrets.removeById,
+  },
+  secretMaterialStoredData: input.secrets.secretMaterialStoredData,
   executions: input.executions.runs,
   executionInteractions: input.executions.interactions,
   executionSteps: input.executions.steps,

--- a/packages/platform/sdk/src/runtime/scope/config-secrets.ts
+++ b/packages/platform/sdk/src/runtime/scope/config-secrets.ts
@@ -1,9 +1,0 @@
-export const CONFIG_SECRET_PROVIDER_PREFIX = "config:";
-
-export const toConfigSecretProviderId = (providerAlias: string): string =>
-  `${CONFIG_SECRET_PROVIDER_PREFIX}${providerAlias}`;
-
-export const fromConfigSecretProviderId = (providerId: string): string | null =>
-  providerId.startsWith(CONFIG_SECRET_PROVIDER_PREFIX)
-    ? providerId.slice(CONFIG_SECRET_PROVIDER_PREFIX.length)
-    : null;

--- a/packages/platform/sdk/src/runtime/sources/source-store/plugin-local-config.ts
+++ b/packages/platform/sdk/src/runtime/sources/source-store/plugin-local-config.ts
@@ -3,7 +3,6 @@ import type {
   Source,
 } from "#schema";
 import * as Schema from "effect/Schema";
-
 import {
   cloneJson,
   configSourceBaseFromLocalSource,

--- a/packages/platform/sdk/src/schema/models/local-config.ts
+++ b/packages/platform/sdk/src/schema/models/local-config.ts
@@ -8,54 +8,6 @@ export const LocalExecutorRuntimeSchema = Schema.Literal(
   "deno",
 );
 
-export const LocalConfigSecretProviderSourceSchema = Schema.Literal(
-  "env",
-  "file",
-  "exec",
-  "params",
-);
-
-export const LocalConfigEnvSecretProviderSchema = Schema.Struct({
-  source: Schema.Literal("env"),
-});
-
-export const LocalConfigFileSecretProviderModeSchema = Schema.Literal(
-  "singleValue",
-  "json",
-);
-
-export const LocalConfigFileSecretProviderSchema = Schema.Struct({
-  source: Schema.Literal("file"),
-  path: Schema.String,
-  mode: Schema.optional(LocalConfigFileSecretProviderModeSchema),
-});
-
-export const LocalConfigExecSecretProviderSchema = Schema.Struct({
-  source: Schema.Literal("exec"),
-  command: Schema.String,
-  args: Schema.optional(Schema.Array(Schema.String)),
-  env: Schema.optional(Schema.Record({ key: Schema.String, value: Schema.String })),
-  allowSymlinkCommand: Schema.optional(Schema.Boolean),
-  trustedDirs: Schema.optional(Schema.Array(Schema.String)),
-});
-
-export const LocalConfigSecretProviderSchema = Schema.Union(
-  LocalConfigEnvSecretProviderSchema,
-  LocalConfigFileSecretProviderSchema,
-  LocalConfigExecSecretProviderSchema,
-);
-
-export const LocalConfigExplicitSecretRefSchema = Schema.Struct({
-  source: LocalConfigSecretProviderSourceSchema,
-  provider: Schema.String,
-  id: Schema.String,
-});
-
-export const LocalConfigSecretInputSchema = Schema.Union(
-  Schema.String,
-  LocalConfigExplicitSecretRefSchema,
-);
-
 export const LocalConfigSourceConnectionSchema = Schema.Struct({
   endpoint: Schema.optional(Schema.NullOr(Schema.String)),
   auth: Schema.optional(Schema.Unknown),
@@ -90,22 +42,6 @@ export const LocalConfigPolicySchema = Schema.Struct({
   priority: Schema.optional(Schema.Number),
 });
 
-export const LocalConfigSecretsSchema = Schema.Struct({
-  providers: Schema.optional(
-    Schema.Record({
-      key: Schema.String,
-      value: LocalConfigSecretProviderSchema,
-    }),
-  ),
-  defaults: Schema.optional(
-    Schema.Struct({
-      env: Schema.optional(Schema.String),
-      file: Schema.optional(Schema.String),
-      exec: Schema.optional(Schema.String),
-    }),
-  ),
-});
-
 export const LocalConfigWorkspaceSchema = Schema.Struct({
   name: Schema.optional(Schema.String),
 });
@@ -125,17 +61,8 @@ export const LocalExecutorConfigSchema = Schema.Struct({
       value: LocalConfigPolicySchema,
     }),
   ),
-  secrets: Schema.optional(LocalConfigSecretsSchema),
 });
 
-export type LocalConfigSecretProviderSource =
-  typeof LocalConfigSecretProviderSourceSchema.Type;
-export type LocalConfigSecretProvider =
-  typeof LocalConfigSecretProviderSchema.Type;
-export type LocalConfigExplicitSecretRef =
-  typeof LocalConfigExplicitSecretRefSchema.Type;
-export type LocalConfigSecretInput = typeof LocalConfigSecretInputSchema.Type;
 export type LocalConfigPolicy = typeof LocalConfigPolicySchema.Type;
-export type LocalConfigSecrets = typeof LocalConfigSecretsSchema.Type;
 export type LocalExecutorRuntime = typeof LocalExecutorRuntimeSchema.Type;
 export type LocalExecutorConfig = typeof LocalExecutorConfigSchema.Type;

--- a/packages/platform/sdk/src/schema/models/secret-material.ts
+++ b/packages/platform/sdk/src/schema/models/secret-material.ts
@@ -22,8 +22,6 @@ export const SecretMaterialSchema = Schema.Struct({
   name: Schema.NullOr(Schema.String),
   purpose: SecretMaterialPurposeSchema,
   storeId: SecretStoreIdSchema,
-  handle: Schema.String,
-  value: Schema.NullOr(Schema.String),
   createdAt: TimestampMsSchema,
   updatedAt: TimestampMsSchema,
 });

--- a/packages/sources/core/src/source-models.ts
+++ b/packages/sources/core/src/source-models.ts
@@ -1,8 +1,7 @@
 import * as Schema from "effect/Schema";
 
 export const SecretRefSchema = Schema.Struct({
-  providerId: Schema.String,
-  handle: Schema.String,
+  secretId: Schema.String,
 });
 
 export const CredentialSlotSchema = Schema.Literal("runtime", "import");

--- a/plugins/google-discovery/sdk/index.ts
+++ b/plugins/google-discovery/sdk/index.ts
@@ -557,7 +557,6 @@ const googleDiscoveryStoredSourceDataFromLocalConfig = (input: {
   if (Option.isSome(current)) {
     return current.value.config;
   }
-
   throw new Error("Unsupported Google Discovery local source config.");
 };
 

--- a/plugins/graphql/sdk/index.ts
+++ b/plugins/graphql/sdk/index.ts
@@ -342,7 +342,6 @@ const graphqlStoredSourceDataFromLocalConfig = (input: {
   if (Option.isSome(current)) {
     return normalizeStoredSourceData(current.value.config);
   }
-
   throw new Error("Unsupported GraphQL local source config.");
 };
 

--- a/plugins/keychain-secret-store/sdk/index.ts
+++ b/plugins/keychain-secret-store/sdk/index.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
-import { spawn } from "node:child_process";
+import {
+  Entry,
+} from "@napi-rs/keyring";
 
 import * as Effect from "effect/Effect";
 
@@ -13,15 +15,12 @@ import {
 export const KEYCHAIN_SECRET_STORE_KIND = "keychain";
 export const KEYCHAIN_SECRET_STORE_ID = "sts_builtin_keychain";
 
-const DEFAULT_KEYCHAIN_SERVICE_NAME = "executor";
-const KEYCHAIN_COMMAND_TIMEOUT_MS = 5_000;
-const KEYCHAIN_SERVICE_NAME_ENV = "EXECUTOR_KEYCHAIN_SERVICE_NAME";
-
-type SpawnResult = {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
+type KeychainSecretStoredData = {
+  account: string;
 };
+
+const DEFAULT_KEYCHAIN_SERVICE_NAME = "executor";
+const KEYCHAIN_SERVICE_NAME_ENV = "EXECUTOR_KEYCHAIN_SERVICE_NAME";
 
 const toError = (cause: unknown): Error =>
   cause instanceof Error ? cause : new Error(String(cause));
@@ -35,280 +34,99 @@ const trimOrNull = (value: string | null | undefined): string | null => {
   return trimmed.length > 0 ? trimmed : null;
 };
 
-const ensureNonEmptyString = (value: string | undefined | null): string | null => {
-  const trimmed = value?.trim();
-  return trimmed && trimmed.length > 0 ? trimmed : null;
-};
-
 const resolveKeychainServiceName = (value: string | undefined): string =>
   trimOrNull(value)
   ?? trimOrNull(process.env[KEYCHAIN_SERVICE_NAME_ENV])
   ?? DEFAULT_KEYCHAIN_SERVICE_NAME;
 
-const runCommand = (input: {
-  command: string;
-  args: ReadonlyArray<string>;
-  stdin?: string;
-  operation: string;
-  timeoutMs?: number;
-}): Effect.Effect<SpawnResult, Error, never> =>
-  Effect.tryPromise({
-    try: () =>
-      new Promise<SpawnResult>((resolve, reject) => {
-        const child = spawn(input.command, [...input.args], {
-          stdio: "pipe",
-          env: process.env,
-        });
+const isSupportedPlatform = () =>
+  process.platform === "darwin"
+  || process.platform === "linux"
+  || process.platform === "win32";
 
-        let stdout = "";
-        let stderr = "";
-        let settled = false;
-        const timeout = input.timeoutMs === undefined
-          ? null
-          : setTimeout(() => {
-            if (settled) {
-              return;
-            }
+const keychainDisplayName = () =>
+  process.platform === "darwin"
+    ? "macOS Keychain"
+    : process.platform === "win32"
+      ? "Windows Credential Manager"
+      : "Desktop Keyring";
 
-            settled = true;
-            child.kill("SIGKILL");
-            reject(
-              new Error(
-                `${input.operation}: '${input.command}' timed out after ${input.timeoutMs}ms`,
-              ),
-            );
-          }, input.timeoutMs);
+const createKeyringEntry = (input: {
+  providerHandle: string;
+  keychainServiceName: string;
+}) =>
+  Effect.try({
+    try: () => {
+      if (!isSupportedPlatform()) {
+        throw runtimeEffectError(
+          "plugin-keychain-secret-store",
+          `system-keyring: unsupported on platform '${process.platform}'`,
+        );
+      }
 
-        child.stdout.on("data", (chunk) => {
-          stdout += chunk.toString("utf8");
-        });
-
-        child.stderr.on("data", (chunk) => {
-          stderr += chunk.toString("utf8");
-        });
-
-        child.on("error", (error) => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          if (timeout) {
-            clearTimeout(timeout);
-          }
-          reject(error);
-        });
-
-        child.on("close", (code) => {
-          if (settled) {
-            return;
-          }
-          settled = true;
-          if (timeout) {
-            clearTimeout(timeout);
-          }
-          resolve({
-            exitCode: code ?? 0,
-            stdout,
-            stderr,
-          });
-        });
-
-        if (input.stdin !== undefined) {
-          child.stdin.write(input.stdin);
-        }
-
-        child.stdin.end();
-      }),
+      return new Entry(input.keychainServiceName, input.providerHandle);
+    },
     catch: toError,
   });
-
-const ensureCommandSuccess = (input: {
-  result: SpawnResult;
-  operation: string;
-  message: string;
-}): Effect.Effect<SpawnResult, Error, never> => {
-  if (input.result.exitCode === 0) {
-    return Effect.succeed(input.result);
-  }
-
-  const details = ensureNonEmptyString(input.result.stderr)
-    ?? ensureNonEmptyString(input.result.stdout)
-    ?? "command returned non-zero exit code";
-
-  return Effect.fail(
-    runtimeEffectError(
-      "plugin-keychain-secret-store",
-      `${input.operation}: ${input.message}: ${details}`,
-    ),
-  );
-};
 
 const readKeychainSecretValue = (input: {
   providerHandle: string;
   keychainServiceName: string;
-}) => {
-  switch (process.platform) {
-    case "darwin":
-      return runCommand({
-        command: "security",
-        args: [
-          "find-generic-password",
-          "-a",
-          input.providerHandle,
-          "-s",
-          input.keychainServiceName,
-          "-w",
-        ],
-        operation: "keychain.get",
-        timeoutMs: KEYCHAIN_COMMAND_TIMEOUT_MS,
+}) =>
+  Effect.flatMap(
+    createKeyringEntry(input),
+    (entry) =>
+      Effect.try({
+        try: () => entry.getPassword(),
+        catch: toError,
       }).pipe(
-        Effect.flatMap((result) =>
-          ensureCommandSuccess({
-            result,
-            operation: "keychain.get",
-            message: "Failed loading secret from macOS keychain",
-          })),
-        Effect.map((result) => result.stdout.trimEnd()),
-      );
-    case "linux":
-      return runCommand({
-        command: "secret-tool",
-        args: [
-          "lookup",
-          "service",
-          input.keychainServiceName,
-          "account",
-          input.providerHandle,
-        ],
-        operation: "keychain.get",
-        timeoutMs: KEYCHAIN_COMMAND_TIMEOUT_MS,
-      }).pipe(
-        Effect.flatMap((result) =>
-          ensureCommandSuccess({
-            result,
-            operation: "keychain.get",
-            message: "Failed loading secret from desktop keyring",
-          })),
-        Effect.map((result) => result.stdout.trimEnd()),
-      );
-    default:
-      return Effect.fail(
-        runtimeEffectError(
-          "plugin-keychain-secret-store",
-          `keychain.get: unsupported on platform '${process.platform}'`,
-        ),
-      );
-  }
-};
+        Effect.flatMap((value) =>
+          value !== null
+            ? Effect.succeed(value)
+            : Effect.fail(
+                runtimeEffectError(
+                  "plugin-keychain-secret-store",
+                  `keychain.get: secret not found for service '${input.keychainServiceName}' and account '${input.providerHandle}'`,
+                ),
+              )),
+      ),
+  );
 
 const writeKeychainSecretValue = (input: {
   providerHandle: string;
   name?: string | null;
   value: string;
   keychainServiceName: string;
-}) => {
-  const secretName = trimOrNull(input.name);
-
-  switch (process.platform) {
-    case "darwin":
-      return runCommand({
-        command: "security",
-        args: [
-          "add-generic-password",
-          "-a",
-          input.providerHandle,
-          "-s",
-          input.keychainServiceName,
-          "-w",
-          input.value,
-          "-U",
-          ...(secretName ? ["-l", secretName] : []),
-        ],
-        operation: "keychain.put",
-        timeoutMs: KEYCHAIN_COMMAND_TIMEOUT_MS,
-      }).pipe(
-        Effect.flatMap((result) =>
-          ensureCommandSuccess({
-            result,
-            operation: "keychain.put",
-            message: "Failed storing secret in macOS keychain",
-          })),
-        Effect.asVoid,
-      );
-    case "linux":
-      return runCommand({
-        command: "secret-tool",
-        args: [
-          "store",
-          "--label",
-          secretName ?? input.keychainServiceName,
-          "service",
-          input.keychainServiceName,
-          "account",
-          input.providerHandle,
-        ],
-        stdin: input.value,
-        operation: "keychain.put",
-        timeoutMs: KEYCHAIN_COMMAND_TIMEOUT_MS,
-      }).pipe(
-        Effect.flatMap((result) =>
-          ensureCommandSuccess({
-            result,
-            operation: "keychain.put",
-            message: "Failed storing secret in desktop keyring",
-          })),
-        Effect.asVoid,
-      );
-    default:
-      return Effect.fail(
-        runtimeEffectError(
-          "plugin-keychain-secret-store",
-          `keychain.put: unsupported on platform '${process.platform}'`,
-        ),
-      );
-  }
-};
+}) =>
+  Effect.flatMap(
+    createKeyringEntry(input),
+    (entry) =>
+      Effect.try({
+        try: () => entry.setPassword(input.value),
+        catch: (cause) =>
+          runtimeEffectError(
+            "plugin-keychain-secret-store",
+            `keychain.put: Failed storing secret in ${keychainDisplayName().toLowerCase()}: ${toError(cause).message}`,
+          ),
+      }).pipe(Effect.asVoid),
+  );
 
 const deleteKeychainSecretValue = (input: {
   providerHandle: string;
   keychainServiceName: string;
-}) => {
-  switch (process.platform) {
-    case "darwin":
-      return runCommand({
-        command: "security",
-        args: [
-          "delete-generic-password",
-          "-a",
-          input.providerHandle,
-          "-s",
-          input.keychainServiceName,
-        ],
-        operation: "keychain.delete",
-        timeoutMs: KEYCHAIN_COMMAND_TIMEOUT_MS,
-      }).pipe(Effect.map((result) => result.exitCode === 0));
-    case "linux":
-      return runCommand({
-        command: "secret-tool",
-        args: [
-          "clear",
-          "service",
-          input.keychainServiceName,
-          "account",
-          input.providerHandle,
-        ],
-        operation: "keychain.delete",
-        timeoutMs: KEYCHAIN_COMMAND_TIMEOUT_MS,
-      }).pipe(Effect.map((result) => result.exitCode === 0));
-    default:
-      return Effect.fail(
-        runtimeEffectError(
-          "plugin-keychain-secret-store",
-          `keychain.delete: unsupported on platform '${process.platform}'`,
-        ),
-      );
-  }
-};
+}) =>
+  Effect.flatMap(
+    createKeyringEntry(input),
+    (entry) =>
+      Effect.try({
+        try: () => entry.deletePassword(),
+        catch: (cause) =>
+          runtimeEffectError(
+            "plugin-keychain-secret-store",
+            `keychain.delete: Failed deleting secret from ${keychainDisplayName().toLowerCase()}: ${toError(cause).message}`,
+          ),
+      }),
+  );
 
 const builtinSecretStoreStorage = <TStored>(value: TStored) => ({
   get: () => Effect.succeed(value),
@@ -316,19 +134,29 @@ const builtinSecretStoreStorage = <TStored>(value: TStored) => ({
   remove: () => Effect.void,
 });
 
-export const keychainSecretStoreSdkPlugin = defineExecutorSecretStorePlugin({
+export const keychainSecretStoreSdkPlugin = defineExecutorSecretStorePlugin<
+  typeof KEYCHAIN_SECRET_STORE_KIND,
+  unknown,
+  { name: string },
+  { kind: typeof KEYCHAIN_SECRET_STORE_KIND; name: string },
+  {},
+  KeychainSecretStoredData,
+  {
+    storeId: string;
+    config: { kind: typeof KEYCHAIN_SECRET_STORE_KIND; name: string };
+  }
+>({
   key: KEYCHAIN_SECRET_STORE_KIND,
   secretStore: {
     kind: KEYCHAIN_SECRET_STORE_KIND,
-    displayName:
-      process.platform === "darwin" ? "macOS Keychain" : "Desktop Keyring",
+    displayName: keychainDisplayName(),
     builtin: {
       storeId: KEYCHAIN_SECRET_STORE_ID,
       defaultPriority: 10,
-      enabled: () => process.platform === "darwin" || process.platform === "linux",
+      enabled: isSupportedPlatform,
       createStore: () => ({
         kind: KEYCHAIN_SECRET_STORE_KIND,
-        name: process.platform === "darwin" ? "macOS Keychain" : "Desktop Keyring",
+        name: keychainDisplayName(),
         status: "connected",
         enabled: true,
       }),
@@ -352,50 +180,50 @@ export const keychainSecretStoreSdkPlugin = defineExecutorSecretStorePlugin({
         kind: KEYCHAIN_SECRET_STORE_KIND,
         name: store.name,
       }),
-      resolveSecret: ({ secret }) =>
+      resolveSecret: ({ secretStored }) =>
         readKeychainSecretValue({
-          providerHandle: secret.handle,
+          providerHandle: secretStored.account,
           keychainServiceName: resolveKeychainServiceName(undefined),
         }),
       createSecret: ({ value, name }) =>
         Effect.gen(function* () {
-          const providerHandle = randomUUID();
+          const account = randomUUID();
           yield* writeKeychainSecretValue({
-            providerHandle,
+            providerHandle: account,
             name,
             value,
             keychainServiceName: resolveKeychainServiceName(undefined),
           });
           return {
-            handle: providerHandle,
             name: trimOrNull(name),
-            value: null,
+            secretStored: {
+              account,
+            } satisfies KeychainSecretStoredData,
           };
         }),
-      updateSecret: ({ secret, name, value }) =>
+      updateSecret: ({ secret, secretStored, name, value }) =>
         Effect.gen(function* () {
           const keychainServiceName = resolveKeychainServiceName(undefined);
           const nextName = trimOrNull(name ?? secret.name);
           const nextValue = value
             ?? (yield* readKeychainSecretValue({
-              providerHandle: secret.handle,
+              providerHandle: secretStored.account,
               keychainServiceName,
             }));
           yield* writeKeychainSecretValue({
-            providerHandle: secret.handle,
+            providerHandle: secretStored.account,
             name: nextName,
             value: nextValue,
             keychainServiceName,
           });
           return {
-            handle: secret.handle,
             name: nextName,
-            value: null,
+            secretStored,
           };
         }),
-      deleteSecret: ({ secret }) =>
+      deleteSecret: ({ secretStored }) =>
         deleteKeychainSecretValue({
-          providerHandle: secret.handle,
+          providerHandle: secretStored.account,
           keychainServiceName: resolveKeychainServiceName(undefined),
         }),
       capabilities: () => ({

--- a/plugins/keychain-secret-store/sdk/package.json
+++ b/plugins/keychain-secret-store/sdk/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@executor/platform-sdk": "workspace:*",
+    "@napi-rs/keyring": "^1.2.0",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/plugins/local-secret-store/sdk/index.ts
+++ b/plugins/local-secret-store/sdk/index.ts
@@ -1,16 +1,15 @@
-import { randomUUID } from "node:crypto";
-
 import * as Effect from "effect/Effect";
 
 import {
   defineExecutorSecretStorePlugin,
 } from "@executor/platform-sdk/plugins";
-import {
-  runtimeEffectError,
-} from "@executor/platform-sdk/runtime";
 
 export const LOCAL_SECRET_STORE_KIND = "local";
 export const LOCAL_SECRET_STORE_ID = "sts_builtin_local";
+
+type LocalSecretStoredData = {
+  value: string;
+};
 
 const builtinSecretStoreStorage = <TStored>(value: TStored) => ({
   get: () => Effect.succeed(value),
@@ -27,7 +26,18 @@ const trimOrNull = (value: string | null | undefined): string | null => {
   return trimmed.length > 0 ? trimmed : null;
 };
 
-export const localSecretStoreSdkPlugin = defineExecutorSecretStorePlugin({
+export const localSecretStoreSdkPlugin = defineExecutorSecretStorePlugin<
+  typeof LOCAL_SECRET_STORE_KIND,
+  unknown,
+  { name: string },
+  { kind: typeof LOCAL_SECRET_STORE_KIND; name: string },
+  {},
+  LocalSecretStoredData,
+  {
+    storeId: string;
+    config: { kind: typeof LOCAL_SECRET_STORE_KIND; name: string };
+  }
+>({
   key: LOCAL_SECRET_STORE_KIND,
   secretStore: {
     kind: LOCAL_SECRET_STORE_KIND,
@@ -61,29 +71,20 @@ export const localSecretStoreSdkPlugin = defineExecutorSecretStorePlugin({
         kind: LOCAL_SECRET_STORE_KIND,
         name: store.name,
       }),
-      resolveSecret: ({ secret }) => {
-        if (secret.value === null) {
-          return Effect.fail(
-            runtimeEffectError(
-              "plugin-local-secret-store",
-              `Local secret ${secret.id} does not have a stored value`,
-            ),
-          );
-        }
-
-        return Effect.succeed(secret.value);
-      },
+      resolveSecret: ({ secretStored }) => Effect.succeed(secretStored.value),
       createSecret: ({ value, name }) =>
         Effect.succeed({
-          handle: `local:${randomUUID()}`,
           name: trimOrNull(name),
-          value,
+          secretStored: {
+            value,
+          } satisfies LocalSecretStoredData,
         }),
-      updateSecret: ({ secret, name, value }) =>
+      updateSecret: ({ secret, secretStored, name, value }) =>
         Effect.succeed({
-          handle: secret.handle,
           name: trimOrNull(name ?? secret.name),
-          ...(value !== undefined ? { value } : {}),
+          secretStored: {
+            value: value ?? secretStored.value,
+          } satisfies LocalSecretStoredData,
         }),
       deleteSecret: () => Effect.succeed(true),
       capabilities: () => ({

--- a/plugins/onepassword/sdk/index.ts
+++ b/plugins/onepassword/sdk/index.ts
@@ -58,6 +58,10 @@ export type OnePasswordStoreStorage = {
   }) => Effect.Effect<void, Error, never>;
 };
 
+type OnePasswordSecretStoredData = {
+  uri: string;
+};
+
 const ONEPASSWORD_REQUEST_TIMEOUT_MS = 15_000;
 
 const timedOutOnePasswordRequestError = (operation: string) =>
@@ -373,9 +377,10 @@ const importSecretFromSelection = (input: {
     }
 
     return {
-      handle: `op://${input.stored!.vaultId}/${item.id}/${field.id}`,
+      secretStored: {
+        uri: `op://${input.stored!.vaultId}/${item.id}/${field.id}`,
+      } satisfies OnePasswordSecretStoredData,
       name: input.name?.trim() || `${item.title} · ${field.title}`,
-      value: null,
     };
   });
 
@@ -385,29 +390,37 @@ const createImportedSecretRecord = (input: {
       storage: {
         secrets: {
           upsert: (value: SecretMaterial) => Effect.Effect<void, Error, never>;
+          secretMaterialStoredData: {
+            upsert: (value: {
+              secretId: SecretMaterial["id"];
+              data: OnePasswordSecretStoredData;
+            }) => Effect.Effect<void, Error, never>;
+          };
         };
       };
     };
   };
   store: SecretStore;
-  handle: string;
+  secretStored: OnePasswordSecretStoredData;
   name: string | null;
   purpose?: SecretMaterialPurpose;
-}): Effect.Effect<OnePasswordImportSecretResult, Error, never> =>
+}): Effect.Effect<OnePasswordImportSecretResult, Error, any> =>
   Effect.gen(function* () {
     const now = Date.now();
     const secret: SecretMaterial = {
       id: SecretMaterialIdSchema.make(`sec_${crypto.randomUUID()}`),
       storeId: input.store.id,
-      handle: input.handle,
       name: input.name,
       purpose: input.purpose ?? "auth_material",
-      value: null,
       createdAt: now,
       updatedAt: now,
     };
 
     yield* input.executor.runtime.storage.secrets.upsert(secret);
+    yield* input.executor.runtime.storage.secrets.secretMaterialStoredData.upsert({
+      secretId: secret.id,
+      data: input.secretStored,
+    });
 
     return {
       id: secret.id,
@@ -419,14 +432,14 @@ const createImportedSecretRecord = (input: {
     };
   });
 
-const parseSecretReference = (handle: string): {
+const parseSecretReference = (uri: string): {
   vaultId: string;
   itemId: string;
   fieldId: string;
 } => {
-  const match = /^op:\/\/([^/]+)\/([^/]+)\/([^/]+)$/.exec(handle);
+  const match = /^op:\/\/([^/]+)\/([^/]+)\/([^/]+)$/.exec(uri);
   if (!match) {
-    throw new Error(`Invalid 1Password secret reference: ${handle}`);
+    throw new Error(`Invalid 1Password secret reference: ${uri}`);
   }
 
   return {
@@ -461,6 +474,7 @@ export const onePasswordSdkPlugin = (input: {
     OnePasswordConnectInput,
     OnePasswordStoreConfigPayload,
     OnePasswordStoredStoreData,
+    OnePasswordSecretStoredData,
     OnePasswordUpdateStoreInput
   >({
     key: ONEPASSWORD_SECRET_STORE_KIND,
@@ -502,12 +516,12 @@ export const onePasswordSdkPlugin = (input: {
           vaultId: stored.vaultId,
           auth: stored.auth,
         } satisfies OnePasswordStoreConfigPayload),
-        resolveSecret: ({ secret, stored }) =>
+        resolveSecret: ({ secretStored, stored }) =>
           Effect.flatMap(makeClient(stored), (client) =>
             Effect.tryPromise({
               try: () =>
                 runOnePasswordRequest("secret resolution", () =>
-                  client.secrets.resolve(secret.handle)
+                  client.secrets.resolve(secretStored.uri)
                 ),
               catch: (cause) =>
                 cause instanceof Error ? cause : new Error(String(cause)),
@@ -533,18 +547,20 @@ export const onePasswordSdkPlugin = (input: {
                 );
 
                 return {
-                  handle: `op://${stored!.vaultId}/${item.id}/${ONEPASSWORD_SECRET_FIELD_ID}`,
+                  secretStored: {
+                    uri: `op://${stored!.vaultId}/${item.id}/${ONEPASSWORD_SECRET_FIELD_ID}`,
+                  } satisfies OnePasswordSecretStoredData,
                   name: item.title,
                 };
               },
               catch: (cause) =>
                 cause instanceof Error ? cause : new Error(String(cause)),
             })),
-        updateSecret: ({ secret, stored, name, value }) =>
+        updateSecret: ({ secret, secretStored, stored, name, value }) =>
           Effect.flatMap(makeClient(stored), (client) =>
             Effect.tryPromise({
               try: async () => {
-                const parsed = parseSecretReference(secret.handle);
+                const parsed = parseSecretReference(secretStored.uri);
                 const item = await runOnePasswordRequest("secret update", () =>
                   client.items.get(parsed.vaultId, parsed.itemId)
                 );
@@ -559,16 +575,17 @@ export const onePasswordSdkPlugin = (input: {
                 );
                 return {
                   name: updated.title,
+                  secretStored,
                 };
               },
               catch: (cause) =>
                 cause instanceof Error ? cause : new Error(String(cause)),
             })),
-        deleteSecret: ({ secret, stored }) =>
+        deleteSecret: ({ secretStored, stored }) =>
           Effect.flatMap(makeClient(stored), (client) =>
             Effect.tryPromise({
               try: async () => {
-                const parsed = parseSecretReference(secret.handle);
+                const parsed = parseSecretReference(secretStored.uri);
                 await runOnePasswordRequest("secret deletion", () =>
                   client.items.delete(parsed.vaultId, parsed.itemId)
                 );
@@ -662,7 +679,7 @@ export const onePasswordSdkPlugin = (input: {
           return yield* createImportedSecretRecord({
             executor,
             store,
-            handle: imported.handle,
+            secretStored: imported.secretStored,
             name: imported.name,
           });
         }),

--- a/plugins/openapi/sdk/index.ts
+++ b/plugins/openapi/sdk/index.ts
@@ -202,7 +202,6 @@ const openApiStoredSourceDataFromLocalConfig = (input: {
       lastSyncAt: null,
     });
   }
-
   throw new Error("Unsupported OpenAPI local source config.");
 };
 


### PR DESCRIPTION
## What changed

This refactor removes the remaining core-owned secret payload path and makes secret storage plugin-owned end to end.

- removed `handle` and inline `value` from core `SecretMaterial`
- changed secret-store plugins to own per-secret stored data via `secretStored`
- added persisted plugin secret data to the file backend and runtime secret storage path
- updated the built-in local, keychain, and 1Password secret stores to use plugin-owned secret data
- removed the shared `decodeLocalConfigAuth` helper so source plugins decode their own auth directly
- updated the SQLite example backend to match the new metadata/plugin-data split
- kept the earlier keychain move to `@napi-rs/keyring`

## Why

Secret management still had a mixed model where core persisted store-specific fields like secret handles and sometimes the secret bytes themselves. That made the boundary between core and secret-store plugins messy, and `decodeLocalConfigAuth` was another sign that core still knew too much about plugin auth/config details.

This change makes the model greenfield-clean:

- core owns secret metadata and refs
- secret-store plugins own store-specific secret data
- source plugins own auth decoding

## Impact

This is intentionally breaking.

- old persisted `executor-state.json` secret data is no longer supported
- old local source configs that depended on the removed compat paths are no longer supported
- a one-shot migration will be needed separately if you want to carry older installs forward

## Validation

- `bun run --filter @executor/platform-sdk typecheck`
- `bun run --filter @executor/platform-sdk-file typecheck`
- `bun run --filter @executor/plugin-onepassword-sdk typecheck`
- `bun run --filter @executor/plugin-keychain-secret-store-sdk typecheck`
- `bun run --filter @executor/plugin-local-secret-store-sdk typecheck`
- `bun run test -- --run src/runtime/execution/live.test.ts`
- `rg -n "decodeLocalConfigAuth|handle: Schema.String|value: Schema.NullOr\(Schema.String\)|secret\.handle|secret\.value" packages plugins examples apps -g '*.ts'`
