### PR TITLE
feat(execution-history): redesign UI to list-with-drawer pattern

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "executor",
       "devDependencies": {
         "@changesets/cli": "^2.30.0",
+        "@oxlint/plugins": "^1.57.0",
         "knip": "^5.85.0",
         "oxlint": "^1.56.0",
         "turbo": "^2.5.6",
@@ -18,7 +19,7 @@
     },
     "apps/executor": {
       "name": "executor",
-      "version": "1.2.6",
+      "version": "1.3.0-beta.0",
       "bin": {
         "executor": "bin/executor",
       },
@@ -1356,6 +1357,8 @@
     "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.56.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-PTRy6sIEPqy2x8PTP1baBNReN/BNEFmde0L+mYeHmjXE1Vlcc9+I5nsqENsB2yAm5wLkzPoTNCMY/7AnabT4/A=="],
 
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.56.0", "", { "os": "win32", "cpu": "x64" }, "sha512-ZHa0clocjLmIDr+1LwoWtxRcoYniAvERotvwKUYKhH41NVfl0Y4LNbyQkwMZzwDvKklKGvGZ5+DAG58/Ik47tQ=="],
+
+    "@oxlint/plugins": ["@oxlint/plugins@1.57.0", "", {}, "sha512-4mAGdfUZNQSZwUbHs0xoUcKjByrdBSJ9iaCI3STn/d1ZVRKhW/82oCA6rdfSzO4vxrWH3/l+qYWh/tyrwPSpag=="],
 
     "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",
+    "@oxlint/plugins": "^1.57.0",
     "knip": "^5.85.0",
     "oxlint": "^1.56.0",
     "turbo": "^2.5.6",

--- a/packages/clients/react/src/plugins/components/ui/dialog.tsx
+++ b/packages/clients/react/src/plugins/components/ui/dialog.tsx
@@ -145,6 +145,10 @@ function DialogDescription({
   )
 }
 
+function DialogPopup({ ...props }: DialogPrimitive.Popup.Props) {
+  return <DialogPrimitive.Popup data-slot="dialog-popup" {...props} />
+}
+
 export {
   Dialog,
   DialogClose,
@@ -153,6 +157,7 @@ export {
   DialogFooter,
   DialogHeader,
   DialogOverlay,
+  DialogPopup,
   DialogPortal,
   DialogTitle,
   DialogTrigger,

--- a/packages/clients/react/src/plugins/index.ts
+++ b/packages/clients/react/src/plugins/index.ts
@@ -116,3 +116,4 @@ export { Separator } from "./components/ui/separator";
 export { Textarea } from "./components/ui/textarea";
 export { Popover, PopoverContent, PopoverTrigger } from "./components/ui/popover";
 export { Command, CommandInput, CommandList, CommandEmpty, CommandGroup, CommandItem, CommandShortcut, CommandSeparator } from "./components/ui/command";
+export { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPopup, DialogPortal, DialogTitle, DialogTrigger } from "./components/ui/dialog";

--- a/plugins/execution-history/react/components.tsx
+++ b/plugins/execution-history/react/components.tsx
@@ -329,8 +329,21 @@ const ExecutionDetailDrawer = (props: {
 
   const handleCopy = useCallback(
     (envelope: ExecutionEnvelope) => {
+      const tryParse = (v: string | null) => {
+        if (v === null) return null;
+        try { return JSON.parse(v); } catch { return v; }
+      };
+      const cleaned = {
+        ...envelope,
+        execution: {
+          ...envelope.execution,
+          resultJson: tryParse(envelope.execution.resultJson),
+          logsJson: tryParse(envelope.execution.logsJson),
+          errorText: envelope.execution.errorText,
+        },
+      };
       void navigator.clipboard
-        .writeText(JSON.stringify(envelope, null, 2))
+        .writeText(JSON.stringify(cleaned, null, 2))
         .then(() => {
           setCopied(true);
           setTimeout(() => setCopied(false), 1500);

--- a/plugins/execution-history/react/components.tsx
+++ b/plugins/execution-history/react/components.tsx
@@ -72,7 +72,7 @@ const STATUS_STYLES = {
 const statusDot = (status: ExecutionStatus): string => STATUS_STYLES[status].dot;
 const statusText = (status: ExecutionStatus): string => STATUS_STYLES[status].text;
 
-const STATUS_OPTIONS: Array<{ value: string; label: string }> = [
+const STATUS_OPTIONS: Array<{ value: "all" | ExecutionStatus; label: string }> = [
   { value: "all", label: "All" },
   { value: "completed", label: "Completed" },
   { value: "failed", label: "Failed" },

--- a/plugins/execution-history/react/components.tsx
+++ b/plugins/execution-history/react/components.tsx
@@ -1,3 +1,4 @@
+import { useState, useMemo, useCallback } from "react";
 import type {
   Execution,
   ExecutionEnvelope,
@@ -7,56 +8,52 @@ import {
   useExecutions,
 } from "@executor/react";
 import {
-  Alert,
   Badge,
   Button,
-  Card,
+  cn,
+  Dialog,
+  DialogOverlay,
+  DialogPopup,
+  DialogPortal,
   DocumentPanel,
   EmptyState,
+  IconClose,
+  Input,
   LoadableBlock,
+  Select,
   useExecutorPluginNavigation,
   useExecutorPluginRouteParams,
+  useExecutorPluginSearch,
 } from "@executor/react/plugins";
 
-const formatTimestamp = (value: number | null): string => {
-  if (value === null) {
-    return "—";
-  }
+// ── Helpers ──────────────────────────────────────────────────────────────
 
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(value);
+type ExecutionStatus = Execution["status"];
+
+const formatTimestamp = (value: number | null): string => {
+  if (value === null) return "—";
+  const d = new Date(value);
+  const month = d.toLocaleString(undefined, { month: "short" });
+  const day = d.getDate();
+  const h = d.getHours().toString().padStart(2, "0");
+  const m = d.getMinutes().toString().padStart(2, "0");
+  const s = d.getSeconds().toString().padStart(2, "0");
+  return `${month} ${day}, ${h}:${m}:${s}`;
 };
 
 const formatDuration = (execution: Execution): string | null => {
-  if (execution.startedAt === null || execution.completedAt === null) {
-    return null;
-  }
-
-  const durationMs = Math.max(0, execution.completedAt - execution.startedAt);
-  if (durationMs < 1_000) {
-    return `${durationMs} ms`;
-  }
-
-  if (durationMs < 60_000) {
-    return `${(durationMs / 1_000).toFixed(1)} s`;
-  }
-
-  return `${(durationMs / 60_000).toFixed(1)} min`;
+  if (execution.startedAt === null || execution.completedAt === null) return null;
+  const ms = Math.max(0, execution.completedAt - execution.startedAt);
+  if (ms < 1_000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1_000).toFixed(1)}s`;
+  return `${(ms / 60_000).toFixed(1)}m`;
 };
 
-const summarizeCode = (code: string): string =>
-  code
-    .trim()
-    .replace(/\s+/g, " ")
-    .slice(0, 220);
+const truncateCode = (code: string, max = 80): string =>
+  code.trim().replace(/\s+/g, " ").slice(0, max);
 
 const formatJsonDocument = (value: string | null): string | null => {
-  if (value === null) {
-    return null;
-  }
-
+  if (value === null) return null;
   try {
     return JSON.stringify(JSON.parse(value), null, 2);
   } catch {
@@ -64,136 +61,160 @@ const formatJsonDocument = (value: string | null): string | null => {
   }
 };
 
-const statusVariant = (
-  status: Execution["status"],
-): "default" | "muted" | "outline" | "destructive" => {
+const statusDotColor = (status: ExecutionStatus): string => {
   switch (status) {
     case "completed":
-      return "default";
+      return "bg-emerald-400";
     case "failed":
-      return "destructive";
+      return "bg-red-400";
     case "running":
+      return "bg-blue-400 animate-pulse";
     case "waiting_for_interaction":
-      return "outline";
-    default:
-      return "muted";
+      return "bg-amber-400 animate-pulse";
+    case "pending":
+      return "bg-zinc-500";
+    case "cancelled":
+      return "bg-zinc-500";
   }
 };
 
-const MetadataItem = (props: {
-  label: string;
-  value: string;
-}) => (
-  <Card className="bg-card/60 px-3 py-2">
-    <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
-      {props.label}
-    </div>
-    <div className="mt-1 text-sm text-foreground">{props.value}</div>
-  </Card>
+const STATUS_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "completed", label: "Completed" },
+  { value: "failed", label: "Failed" },
+  { value: "running", label: "Running" },
+  { value: "waiting_for_interaction", label: "Waiting" },
+  { value: "pending", label: "Pending" },
+  { value: "cancelled", label: "Cancelled" },
+];
+
+const formatDurationMs = (execution: Execution): string | null => {
+  if (execution.startedAt === null || execution.completedAt === null) return null;
+  const ms = Math.max(0, execution.completedAt - execution.startedAt);
+  return ms.toLocaleString();
+};
+
+const statusColor = (status: ExecutionStatus): string => {
+  switch (status) {
+    case "completed":
+      return "text-emerald-400";
+    case "failed":
+      return "text-red-400";
+    case "running":
+      return "text-blue-400";
+    case "waiting_for_interaction":
+      return "text-amber-400";
+    default:
+      return "text-zinc-400";
+  }
+};
+
+// ── Execution Row ────────────────────────────────────────────────────────
+
+const KeyValue = (props: { k: string; v: string; vClass?: string }) => (
+  <>
+    <span className="text-muted-foreground/60">{props.k}:</span>{" "}
+    <span className={props.vClass ?? "text-emerald-400"}>{props.v}</span>{" "}
+  </>
 );
 
-const ExecutionCard = (props: {
+const ExecutionRow = (props: {
   execution: Execution;
-  onOpen: () => void;
+  isSelected: boolean;
+  onSelect: () => void;
 }) => {
-  const { execution } = props;
+  const { execution, isSelected } = props;
+  const durationMs = formatDurationMs(execution);
 
   return (
-    <Button
-      variant="ghost"
+    <button
       type="button"
-      onClick={props.onOpen}
-      className="h-auto w-full rounded-2xl border border-border bg-card px-5 py-4 text-left transition-colors hover:border-primary/25 hover:bg-card/90"
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <div className="truncate text-sm font-semibold text-foreground">
-              {execution.id}
-            </div>
-            <Badge variant={statusVariant(execution.status)}>
-              {execution.status.replaceAll("_", " ")}
-            </Badge>
-          </div>
-          <div className="mt-1 text-xs text-muted-foreground">
-            Created {formatTimestamp(execution.createdAt)}
-            {formatDuration(execution) ? ` • ${formatDuration(execution)}` : ""}
-          </div>
-          <p className="mt-3 line-clamp-3 text-sm leading-6 text-muted-foreground">
-            {summarizeCode(execution.code) || "No code captured."}
-          </p>
-        </div>
-      </div>
-
-      {execution.errorText && (
-        <Alert variant="destructive" className="mt-3 text-xs">
-          {execution.errorText}
-        </Alert>
+      onClick={props.onSelect}
+      className={cn(
+        "group flex w-full items-start gap-3 border-b border-border/50 px-4 py-2 text-left font-mono text-xs transition-colors hover:bg-white/[0.04]",
+        isSelected && "bg-white/[0.06]",
       )}
-    </Button>
+    >
+      <span
+        className={cn(
+          "mt-1.5 size-2 shrink-0 rounded-full",
+          statusDotColor(execution.status),
+        )}
+      />
+      <span className="w-[120px] shrink-0 tabular-nums text-muted-foreground">
+        {formatTimestamp(execution.createdAt)}
+      </span>
+      <span className="inline-flex w-[130px] shrink-0">
+        <span className="text-muted-foreground/60">status:</span>
+        <span className={statusColor(execution.status)}>{execution.status.replaceAll("_", " ")}</span>
+      </span>
+      <span className="inline-flex w-[110px] shrink-0">
+        <span className="text-muted-foreground/60">duration_ms:</span>{" "}
+        <span className={durationMs && Number(durationMs.replace(/,/g, "")) > 5000 ? "text-red-400" : "text-emerald-400"}>{durationMs ?? "—"}</span>
+      </span>
+      <span className="min-w-0 flex-1 truncate">
+        <span className="text-muted-foreground/60">code:</span>{" "}
+        <span className="text-muted-foreground">&quot;{truncateCode(execution.code, 120)}…&quot;</span>
+      </span>
+    </button>
   );
 };
 
-export function ExecutionHistoryPage() {
-  const executions = useExecutions();
-  const navigation = useExecutorPluginNavigation();
+// ── Detail Drawer ────────────────────────────────────────────────────────
 
-  return (
-    <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-5xl px-6 py-10 lg:px-10 lg:py-14">
-        <div className="mb-8">
-          <h1 className="font-display text-3xl tracking-tight text-foreground lg:text-4xl">
-            Execution history
-          </h1>
-          <p className="mt-1.5 text-[14px] text-muted-foreground">
-            Every execution recorded for this workspace, newest first.
-          </p>
-        </div>
+type DetailTab = "properties" | "logs";
 
-        <LoadableBlock loadable={executions} loading="Loading executions...">
-          {(items) =>
-            items.length === 0 ? (
-              <div className="rounded-2xl border border-dashed border-border py-20">
-                <EmptyState
-                  title="No executions yet"
-                  description="Run something and it will show up here."
-                />
-              </div>
-            ) : (
-              <div className="grid gap-3">
-                {items.map((execution) => (
-                  <ExecutionCard
-                    key={execution.id}
-                    execution={execution}
-                    onOpen={() => {
-                      void navigation.route(execution.id);
-                    }}
-                  />
-                ))}
-              </div>
-            )
-          }
-        </LoadableBlock>
-      </div>
-    </div>
-  );
-}
+const DetailTabButton = (props: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={props.onClick}
+    className={cn(
+      "px-3 py-1.5 text-sm font-medium transition-colors",
+      props.active
+        ? "border-b-2 border-primary text-foreground"
+        : "text-muted-foreground hover:text-foreground",
+    )}
+  >
+    {props.label}
+  </button>
+);
 
-const ExecutionDetailSections = (props: {
-  envelope: ExecutionEnvelope;
-}) => {
+const PropertiesTab = (props: { envelope: ExecutionEnvelope }) => {
   const { execution, pendingInteraction } = props.envelope;
 
   return (
-    <div className="space-y-6">
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <MetadataItem label="Status" value={execution.status.replaceAll("_", " ")} />
-        <MetadataItem label="Created" value={formatTimestamp(execution.createdAt)} />
-        <MetadataItem label="Started" value={formatTimestamp(execution.startedAt)} />
-        <MetadataItem
-          label="Completed"
-          value={formatTimestamp(execution.completedAt)}
-        />
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg border border-border/50 px-3 py-2">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
+            Status
+          </div>
+          <div className="mt-1 flex items-center gap-2">
+            <span className={cn("size-2 rounded-full", statusDotColor(execution.status))} />
+            <span className="text-sm">{execution.status.replaceAll("_", " ")}</span>
+          </div>
+        </div>
+        <div className="rounded-lg border border-border/50 px-3 py-2">
+          <div className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
+            Duration
+          </div>
+          <div className="mt-1 text-sm">{formatDuration(execution) ?? "—"}</div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 text-xs text-muted-foreground">
+        <div>
+          <span className="text-muted-foreground/60">Created </span>
+          {formatTimestamp(execution.createdAt)}
+        </div>
+        <div>
+          <span className="text-muted-foreground/60">Started </span>
+          {formatTimestamp(execution.startedAt)}
+        </div>
       </div>
 
       <DocumentPanel
@@ -203,20 +224,12 @@ const ExecutionDetailSections = (props: {
         empty="No code captured."
       />
 
-      <div className="grid gap-4 xl:grid-cols-2">
-        <DocumentPanel
-          title="Result"
-          body={formatJsonDocument(execution.resultJson)}
-          lang="json"
-          empty="No result recorded."
-        />
-        <DocumentPanel
-          title="Logs"
-          body={formatJsonDocument(execution.logsJson)}
-          lang="json"
-          empty="No logs recorded."
-        />
-      </div>
+      <DocumentPanel
+        title="Result"
+        body={formatJsonDocument(execution.resultJson)}
+        lang="json"
+        empty="No result recorded."
+      />
 
       {execution.errorText && (
         <DocumentPanel
@@ -228,40 +241,337 @@ const ExecutionDetailSections = (props: {
       )}
 
       {pendingInteraction && (
-        <div className="space-y-4">
-          <div>
-            <h2 className="text-sm font-semibold text-foreground">
-              Pending interaction
-            </h2>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {pendingInteraction.kind} • {pendingInteraction.purpose}
-            </p>
+        <div className="space-y-3">
+          <div className="text-sm font-medium text-foreground">
+            Pending interaction
+            <span className="ml-2 text-xs text-muted-foreground">
+              {pendingInteraction.kind} — {pendingInteraction.purpose}
+            </span>
           </div>
-
-          <div className="grid gap-3 sm:grid-cols-3">
-            <MetadataItem label="Kind" value={pendingInteraction.kind} />
-            <MetadataItem label="Purpose" value={pendingInteraction.purpose} />
-            <MetadataItem
-              label="Status"
-              value={pendingInteraction.status.replaceAll("_", " ")}
-            />
-          </div>
-
-          <div className="grid gap-4 xl:grid-cols-2">
+          <div className="grid gap-3 xl:grid-cols-2">
             <DocumentPanel
               title="Request"
               body={formatJsonDocument(pendingInteraction.payloadJson)}
               lang="json"
-              empty="No interaction request recorded."
+              empty="No request payload."
             />
             <DocumentPanel
               title="Response"
               body={formatJsonDocument(pendingInteraction.responseJson)}
               lang="json"
-              empty="No interaction response recorded."
+              empty="No response yet."
             />
           </div>
         </div>
+      )}
+    </div>
+  );
+};
+
+const LogsTab = (props: { logsJson: string | null }) => {
+  const parsed = useMemo(() => {
+    if (!props.logsJson) return null;
+    try {
+      const arr = JSON.parse(props.logsJson);
+      if (!Array.isArray(arr)) return null;
+      return arr as string[];
+    } catch {
+      return null;
+    }
+  }, [props.logsJson]);
+
+  if (!parsed) {
+    return (
+      <DocumentPanel
+        title="Logs"
+        body={formatJsonDocument(props.logsJson)}
+        lang="json"
+        empty="No logs recorded."
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-card/40 p-3">
+      <div className="mb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">
+        Logs
+      </div>
+      <div className="space-y-0.5 font-mono text-xs">
+        {parsed.map((line, i) => {
+          const isError = typeof line === "string" && /\[error]/i.test(line);
+          const isWarn = typeof line === "string" && /\[warn]/i.test(line);
+          return (
+            <div
+              key={i}
+              className={cn(
+                "whitespace-pre-wrap break-all",
+                isError && "text-red-400",
+                isWarn && "text-amber-400",
+                !isError && !isWarn && "text-foreground/80",
+              )}
+            >
+              {typeof line === "string" ? line : JSON.stringify(line)}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const ExecutionDetailDrawer = (props: {
+  executionId: string;
+  onClose: () => void;
+}) => {
+  const [tab, setTab] = useState<DetailTab>("properties");
+  const execution = useExecution(props.executionId);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(
+    (envelope: ExecutionEnvelope) => {
+      void navigator.clipboard
+        .writeText(JSON.stringify(envelope, null, 2))
+        .then(() => {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        });
+    },
+    [],
+  );
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && props.onClose()}>
+      <DialogPortal>
+        <DialogOverlay />
+        <DialogPopup
+          className="fixed inset-y-0 right-0 z-50 flex w-full max-w-3xl flex-col bg-popover text-popover-foreground ring-1 ring-foreground/10 outline-none duration-150 data-open:animate-in data-open:slide-in-from-right data-closed:animate-out data-closed:slide-out-to-right"
+        >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border/50 px-5 py-3">
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium text-foreground">
+              {props.executionId}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <LoadableBlock loadable={execution} loading="">
+              {(envelope) => (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleCopy(envelope)}
+                  className="text-xs text-muted-foreground"
+                >
+                  {copied ? "Copied" : "Copy JSON"}
+                </Button>
+              )}
+            </LoadableBlock>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={props.onClose}
+            >
+              <IconClose className="size-3.5" />
+            </Button>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 border-b border-border/50 px-5">
+          <DetailTabButton
+            label="Properties"
+            active={tab === "properties"}
+            onClick={() => setTab("properties")}
+          />
+          <DetailTabButton
+            label="Logs"
+            active={tab === "logs"}
+            onClick={() => setTab("logs")}
+          />
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          <LoadableBlock loadable={execution} loading="Loading execution...">
+            {(envelope) =>
+              tab === "properties" ? (
+                <PropertiesTab envelope={envelope} />
+              ) : (
+                <LogsTab logsJson={envelope.execution.logsJson} />
+              )
+            }
+          </LoadableBlock>
+        </div>
+        </DialogPopup>
+      </DialogPortal>
+    </Dialog>
+  );
+};
+
+// ── List Page ────────────────────────────────────────────────────────────
+
+type ExecutionHistorySearch = {
+  executionId?: string;
+};
+
+export function ExecutionHistoryPage() {
+  const executions = useExecutions();
+  const navigation = useExecutorPluginNavigation();
+  const searchState = useExecutorPluginSearch<ExecutionHistorySearch>();
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [search, setSearch] = useState("");
+  const selectedId =
+    typeof searchState.executionId === "string"
+      ? searchState.executionId
+      : null;
+
+  const setSelectedId = useCallback(
+    (executionId: string | null) => {
+      if (executionId === null) {
+        const { executionId: _, ...nextSearch } = searchState;
+        void navigation.updateSearch(nextSearch);
+        return;
+      }
+
+      void navigation.updateSearch({
+        ...searchState,
+        executionId,
+      });
+    },
+    [navigation, searchState],
+  );
+
+  const filtered = useMemo(() => {
+    if (executions.status !== "ready") return [];
+    let items = [...executions.data];
+    if (statusFilter !== "all") {
+      items = items.filter((e) => e.status === statusFilter);
+    }
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      items = items.filter(
+        (e) =>
+          e.code.toLowerCase().includes(q) ||
+          (e.errorText && e.errorText.toLowerCase().includes(q)),
+      );
+    }
+    return items;
+  }, [executions, statusFilter, search]);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="shrink-0 border-b border-border/50 px-6 py-5">
+        <h1 className="font-display text-2xl tracking-tight text-foreground">
+          Execution history
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Every execution recorded for this workspace, newest first.
+        </p>
+
+        {/* Filter bar */}
+        <div className="mt-4 flex items-center gap-3">
+          <Select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="w-[140px]"
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </Select>
+          <Input
+            type="text"
+            placeholder="Search code or errors..."
+            value={search}
+            onChange={(e) => setSearch((e.target as HTMLInputElement).value)}
+            className="flex-1"
+          />
+        </div>
+      </div>
+
+      {/* Column headers */}
+      <div className="flex items-center gap-3 border-b border-border/50 px-4 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/60">
+        <span className="size-2 shrink-0" />
+        <span className="w-[120px] shrink-0">_time</span>
+        <span>Raw Data</span>
+      </div>
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto">
+        <LoadableBlock loadable={executions} loading="Loading executions...">
+          {() =>
+            filtered.length === 0 ? (
+              <div className="py-20">
+                <EmptyState
+                  title={
+                    statusFilter !== "all" || search.trim()
+                      ? "No matching executions"
+                      : "No executions yet"
+                  }
+                  description={
+                    statusFilter !== "all" || search.trim()
+                      ? "Try adjusting your filters."
+                      : "Run something and it will show up here."
+                  }
+                />
+              </div>
+            ) : (
+              <div>
+                {filtered.map((execution) => (
+                  <ExecutionRow
+                    key={execution.id}
+                    execution={execution}
+                    isSelected={selectedId === execution.id}
+                    onSelect={() =>
+                      setSelectedId(
+                        selectedId === execution.id ? null : execution.id,
+                      )
+                    }
+                  />
+                ))}
+              </div>
+            )
+          }
+        </LoadableBlock>
+      </div>
+
+      {/* Drawer */}
+      {selectedId && (
+        <ExecutionDetailDrawer
+          executionId={selectedId}
+          onClose={() => setSelectedId(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Detail Page (deep-link) ──────────────────────────────────────────────
+
+const ExecutionDetailInline = (props: { envelope: ExecutionEnvelope }) => {
+  const [tab, setTab] = useState<DetailTab>("properties");
+
+  return (
+    <div>
+      <div className="mb-4 flex gap-1 border-b border-border/50">
+        <DetailTabButton
+          label="Properties"
+          active={tab === "properties"}
+          onClick={() => setTab("properties")}
+        />
+        <DetailTabButton
+          label="Logs"
+          active={tab === "logs"}
+          onClick={() => setTab("logs")}
+        />
+      </div>
+      {tab === "properties" ? (
+        <PropertiesTab envelope={props.envelope} />
+      ) : (
+        <LogsTab logsJson={props.envelope.execution.logsJson} />
       )}
     </div>
   );
@@ -276,29 +586,29 @@ export function ExecutionHistoryDetailPage() {
 
   return (
     <div className="h-full overflow-y-auto">
-      <div className="mx-auto max-w-6xl px-6 py-10 lg:px-10 lg:py-14">
-        <div className="mb-8 flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <Button
-              variant="ghost"
-              type="button"
-              onClick={() => {
-                void navigation.route();
-              }}
-              className="mb-3 h-auto p-0 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
-            >
-              Back to history
-            </Button>
-            <div className="flex items-center gap-3">
-              <h1 className="font-display text-2xl tracking-tight text-foreground lg:text-3xl">
-                {executionId}
-              </h1>
-            </div>
+      <div className="mx-auto max-w-5xl px-6 py-10 lg:px-10 lg:py-14">
+        <div className="mb-8">
+          <Button
+            variant="ghost"
+            type="button"
+            onClick={() => {
+              void navigation.route();
+            }}
+            className="mb-3 h-auto p-0 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Back to history
+          </Button>
+          <div className="flex items-center gap-3">
+            <h1 className="font-display text-2xl tracking-tight text-foreground lg:text-3xl">
+              {executionId}
+            </h1>
           </div>
         </div>
 
         <LoadableBlock loadable={execution} loading="Loading execution...">
-          {(envelope) => <ExecutionDetailSections envelope={envelope} />}
+          {(envelope) => (
+            <ExecutionDetailInline envelope={envelope} />
+          )}
         </LoadableBlock>
       </div>
     </div>

--- a/plugins/execution-history/react/components.tsx
+++ b/plugins/execution-history/react/components.tsx
@@ -60,22 +60,17 @@ const formatJsonDocument = (value: string | null): string | null => {
   }
 };
 
-const statusDotColor = (status: ExecutionStatus): string => {
-  switch (status) {
-    case "completed":
-      return "bg-primary";
-    case "failed":
-      return "bg-destructive";
-    case "running":
-      return "bg-blue-400 animate-pulse";
-    case "waiting_for_interaction":
-      return "bg-amber-400 animate-pulse";
-    case "pending":
-      return "bg-muted";
-    case "cancelled":
-      return "bg-muted";
-  }
-};
+const STATUS_STYLES = {
+  completed: { dot: "bg-primary", text: "text-primary" },
+  failed: { dot: "bg-destructive", text: "text-destructive" },
+  running: { dot: "bg-blue-400 animate-pulse", text: "text-blue-400" },
+  waiting_for_interaction: { dot: "bg-amber-400 animate-pulse", text: "text-amber-400" },
+  pending: { dot: "bg-muted", text: "text-muted-foreground" },
+  cancelled: { dot: "bg-muted", text: "text-muted-foreground" },
+} as const satisfies Record<ExecutionStatus, { dot: string; text: string }>;
+
+const statusDot = (status: ExecutionStatus): string => STATUS_STYLES[status].dot;
+const statusText = (status: ExecutionStatus): string => STATUS_STYLES[status].text;
 
 const STATUS_OPTIONS: Array<{ value: string; label: string }> = [
   { value: "all", label: "All" },
@@ -91,21 +86,6 @@ const formatDurationMs = (execution: Execution): string | null => {
   if (execution.startedAt === null || execution.completedAt === null) return null;
   const ms = Math.max(0, execution.completedAt - execution.startedAt);
   return ms.toLocaleString();
-};
-
-const statusColor = (status: ExecutionStatus): string => {
-  switch (status) {
-    case "completed":
-      return "text-primary";
-    case "failed":
-      return "text-destructive";
-    case "running":
-      return "text-blue-400";
-    case "waiting_for_interaction":
-      return "text-amber-400";
-    default:
-      return "text-muted-foreground";
-  }
 };
 
 // ── Execution Row ────────────────────────────────────────────────────────
@@ -130,7 +110,7 @@ const ExecutionRow = (props: {
       <span
         className={cn(
           "mt-1.5 size-2 shrink-0 rounded-full",
-          statusDotColor(execution.status),
+          statusDot(execution.status),
         )}
       />
       <span className="w-[120px] shrink-0 tabular-nums text-muted-foreground">
@@ -138,11 +118,11 @@ const ExecutionRow = (props: {
       </span>
       <span className="inline-flex w-[130px] shrink-0">
         <span className="text-muted-foreground/60">status:</span>
-        <span className={statusColor(execution.status)}>{execution.status.replaceAll("_", " ")}</span>
+        <span className={statusText(execution.status)}>{execution.status.replaceAll("_", " ")}</span>
       </span>
       <span className="inline-flex w-[110px] shrink-0">
         <span className="text-muted-foreground/60">duration_ms:</span>{" "}
-        <span className={durationMs && Number(durationMs.replace(/,/g, "")) > 5000 ? "text-red-400" : "text-emerald-400"}>{durationMs ?? "—"}</span>
+        <span className={durationMs && Number(durationMs.replace(/,/g, "")) > 5000 ? "text-destructive" : "text-primary"}>{durationMs ?? "—"}</span>
       </span>
       <span className="min-w-0 flex-1 truncate">
         <span className="text-muted-foreground/60">code:</span>{" "}
@@ -186,7 +166,7 @@ const PropertiesTab = (props: { envelope: ExecutionEnvelope }) => {
             Status
           </div>
           <div className="mt-1 flex items-center gap-2">
-            <span className={cn("size-2 rounded-full", statusDotColor(execution.status))} />
+            <span className={cn("size-2 rounded-full", statusDot(execution.status))} />
             <span className="text-sm">{execution.status.replaceAll("_", " ")}</span>
           </div>
         </div>

--- a/plugins/execution-history/react/components.tsx
+++ b/plugins/execution-history/react/components.tsx
@@ -120,7 +120,7 @@ const ExecutionRow = (props: {
         <span className="text-muted-foreground/60">status:</span>
         <span className={statusText(execution.status)}>{execution.status.replaceAll("_", " ")}</span>
       </span>
-      <span className="inline-flex w-[110px] shrink-0">
+      <span className="inline-flex w-[150px] shrink-0">
         <span className="text-muted-foreground/60">duration_ms:</span>{" "}
         <span className={durationMs && Number(durationMs.replace(/,/g, "")) > 5000 ? "text-destructive" : "text-primary"}>{durationMs ?? "—"}</span>
       </span>

--- a/plugins/execution-history/react/components.tsx
+++ b/plugins/execution-history/react/components.tsx
@@ -63,17 +63,17 @@ const formatJsonDocument = (value: string | null): string | null => {
 const statusDotColor = (status: ExecutionStatus): string => {
   switch (status) {
     case "completed":
-      return "bg-emerald-400";
+      return "bg-primary";
     case "failed":
-      return "bg-red-400";
+      return "bg-destructive";
     case "running":
       return "bg-blue-400 animate-pulse";
     case "waiting_for_interaction":
       return "bg-amber-400 animate-pulse";
     case "pending":
-      return "bg-zinc-500";
+      return "bg-muted";
     case "cancelled":
-      return "bg-zinc-500";
+      return "bg-muted";
   }
 };
 
@@ -96,15 +96,15 @@ const formatDurationMs = (execution: Execution): string | null => {
 const statusColor = (status: ExecutionStatus): string => {
   switch (status) {
     case "completed":
-      return "text-emerald-400";
+      return "text-primary";
     case "failed":
-      return "text-red-400";
+      return "text-destructive";
     case "running":
       return "text-blue-400";
     case "waiting_for_interaction":
       return "text-amber-400";
     default:
-      return "text-zinc-400";
+      return "text-muted-foreground";
   }
 };
 
@@ -245,13 +245,13 @@ const PropertiesTab = (props: { envelope: ExecutionEnvelope }) => {
               title="Request"
               body={formatJsonDocument(pendingInteraction.payloadJson)}
               lang="json"
-              empty="No request payload."
+              empty="No interaction request recorded."
             />
             <DocumentPanel
               title="Response"
               body={formatJsonDocument(pendingInteraction.responseJson)}
               lang="json"
-              empty="No response yet."
+              empty="No interaction response recorded."
             />
           </div>
         </div>
@@ -292,9 +292,12 @@ const LogsTab = (props: { logsJson: string | null }) => {
         {parsed.map((line, i) => {
           const isError = typeof line === "string" && /\[error]/i.test(line);
           const isWarn = typeof line === "string" && /\[warn]/i.test(line);
+          const lineKey = typeof line === "string"
+            ? `line-${i}-${line.slice(0, 50).replace(/\s+/g, "-")}`
+            : `line-${i}-${JSON.stringify(line).slice(0, 50)}`;
           return (
             <div
-              key={i}
+              key={lineKey}
               className={cn(
                 "whitespace-pre-wrap break-all",
                 isError && "text-red-400",

--- a/plugins/execution-history/react/components.tsx
+++ b/plugins/execution-history/react/components.tsx
@@ -8,7 +8,6 @@ import {
   useExecutions,
 } from "@executor/react";
 import {
-  Badge,
   Button,
   cn,
   Dialog,
@@ -110,13 +109,6 @@ const statusColor = (status: ExecutionStatus): string => {
 };
 
 // ── Execution Row ────────────────────────────────────────────────────────
-
-const KeyValue = (props: { k: string; v: string; vClass?: string }) => (
-  <>
-    <span className="text-muted-foreground/60">{props.k}:</span>{" "}
-    <span className={props.vClass ?? "text-emerald-400"}>{props.v}</span>{" "}
-  </>
-);
 
 const ExecutionRow = (props: {
   execution: Execution;


### PR DESCRIPTION
## Summary

- Axiom inspired redesign of execution history UI from card-based list + page navigation to table-row list with inline status dots and faster dialog based detail view
- Add status filter dropdown and text search for code/errors
- Implement slide-in drawer (Dialog) for execution details replacing page navigation
- Split detail view into Properties and Logs tabs
- Add Copy JSON action with copied feedback
- Highlight durations >5000ms in red for visibility
- Add DialogPopup component to plugins UI

related to #37

## Test plan

- [x] Verify execution history list renders correctly with new row-based layout
- [x] Test status filter dropdown filters executions correctly
- [x] Test text search filters by code/error content
- [x] Open execution detail drawer and verify Properties and Logs tabs
- [x] Verify Copy JSON action copies correct data and shows feedback
- [x] Verify long durations (>5000ms) are highlighted in red

## Screenshots

| Before | After |
|--------|-------|
| <img width="500" alt="Old detail - execution cards" src="https://github.com/user-attachments/assets/a6d54ff4-e88d-4bf7-a6d0-a8702dd1ceed" /> | <img width="500" alt="New list - row layout" src="https://github.com/user-attachments/assets/7d37adb3-a5aa-4951-9126-a27735641e62" /> |
| <img width="500" alt="Old detail - full page" src="https://github.com/user-attachments/assets/4de6ef09-97a7-46fa-9428-2c59d1c2e010" /> | <img width="500" alt="New detail - drawer" src="https://github.com/user-attachments/assets/0c439e55-742b-407e-811c-c9f3c4cc4e85" /> |