### PR TITLE
Speed up OpenAPI source registration writes

### DIFF
--- a/packages/core/sdk/src/plugin-kv.ts
+++ b/packages/core/sdk/src/plugin-kv.ts
@@ -18,6 +18,9 @@ export interface Kv {
   readonly delete: (namespace: string, key: string) => Effect.Effect<boolean>;
   readonly list: (namespace: string) => Effect.Effect<readonly { key: string; value: string }[]>;
   readonly deleteAll: (namespace: string) => Effect.Effect<number>;
+  readonly withTransaction?: <A, E>(
+    effect: Effect.Effect<A, E, never>,
+  ) => Effect.Effect<A, E, never>;
 }
 
 /**
@@ -30,6 +33,9 @@ export interface ScopedKv {
   readonly delete: (key: string) => Effect.Effect<boolean>;
   readonly list: () => Effect.Effect<readonly { key: string; value: string }[]>;
   readonly deleteAll: () => Effect.Effect<number>;
+  readonly withTransaction?: <A, E>(
+    effect: Effect.Effect<A, E, never>,
+  ) => Effect.Effect<A, E, never>;
 }
 
 /**
@@ -41,6 +47,7 @@ export const scopeKv = (kv: Kv, namespace: string): ScopedKv => ({
   delete: (key) => kv.delete(namespace, key),
   list: () => kv.list(namespace),
   deleteAll: () => kv.deleteAll(namespace),
+  withTransaction: kv.withTransaction,
 });
 
 /**
@@ -62,5 +69,6 @@ export const makeInMemoryScopedKv = (): ScopedKv => {
         store.clear();
         return n;
       }),
+    withTransaction: (effect) => effect,
   };
 };

--- a/packages/core/storage-file/src/index.ts
+++ b/packages/core/storage-file/src/index.ts
@@ -99,4 +99,5 @@ export const makeScopedKv = (kv: Kv, folder: string): Kv => ({
   delete: (namespace, key) => kv.delete(`${folder}::${namespace}`, key),
   list: (namespace) => kv.list(`${folder}::${namespace}`),
   deleteAll: (namespace) => kv.deleteAll(`${folder}::${namespace}`),
+  withTransaction: kv.withTransaction,
 });

--- a/packages/core/storage-file/src/plugin-kv.ts
+++ b/packages/core/storage-file/src/plugin-kv.ts
@@ -2,7 +2,7 @@
 // Kv implementations — SQLite and in-memory
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
 import type * as SqlClient from "@effect/sql/SqlClient";
 import type { Kv } from "@executor/sdk";
 
@@ -58,6 +58,27 @@ export const makeSqliteKv = (sql: SqlClient.SqlClient): Kv => ({
       yield* sql`DELETE FROM kv WHERE namespace = ${namespace}`;
       return before[0]?.c ?? 0;
     })),
+
+  withTransaction: <A, E>(effect: Effect.Effect<A, E, never>) =>
+    absorbSql(
+      Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          yield* sql`BEGIN`;
+          const exit = yield* restore(effect).pipe(Effect.exit);
+
+          if (Exit.isSuccess(exit)) {
+            yield* sql`COMMIT`;
+          } else {
+            yield* sql`ROLLBACK`;
+          }
+
+          return yield* Exit.matchEffect(exit, {
+            onFailure: Effect.failCause,
+            onSuccess: Effect.succeed,
+          });
+        }),
+      ),
+    ),
 });
 
 // ---------------------------------------------------------------------------
@@ -95,5 +116,7 @@ export const makeInMemoryKv = (): Kv => {
         store.delete(namespace);
         return count;
       }),
+
+    withTransaction: (effect) => effect,
   };
 };

--- a/packages/core/storage-file/src/tool-registry.ts
+++ b/packages/core/storage-file/src/tool-registry.ts
@@ -30,6 +30,11 @@ export const makeKvToolRegistry = (
   toolsKv: ScopedKv,
   defsKv: ScopedKv,
 ) => {
+  const withKvTransaction = <A, E>(
+    kv: ScopedKv,
+    effect: Effect.Effect<A, E, never>,
+  ): Effect.Effect<A, E, never> => kv.withTransaction?.(effect) ?? effect;
+
   const runtimeTools = new Map<string, ToolRegistration>();
   const runtimeHandlers = new Map<string, RuntimeToolHandler>();
   const runtimeDefs = new Map<string, unknown>();
@@ -104,11 +109,14 @@ export const makeKvToolRegistry = (
       }),
 
     registerDefinitions: (newDefs: Record<string, unknown>) =>
-      Effect.gen(function* () {
-        for (const [name, schema] of Object.entries(newDefs)) {
-          yield* defsKv.set(name, JSON.stringify(schema));
-        }
-      }),
+      withKvTransaction(
+        defsKv,
+        Effect.gen(function* () {
+          for (const [name, schema] of Object.entries(newDefs)) {
+            yield* defsKv.set(name, JSON.stringify(schema));
+          }
+        }),
+      ),
 
     registerRuntimeDefinitions: (newDefs: Record<string, unknown>) =>
       Effect.sync(() => {
@@ -160,11 +168,14 @@ export const makeKvToolRegistry = (
       }),
 
     register: (newTools: readonly ToolRegistration[]) =>
-      Effect.gen(function* () {
-        for (const t of newTools) {
-          yield* toolsKv.set(t.id, encodeTool(t));
-        }
-      }),
+      withKvTransaction(
+        toolsKv,
+        Effect.gen(function* () {
+          for (const t of newTools) {
+            yield* toolsKv.set(t.id, encodeTool(t));
+          }
+        }),
+      ),
 
     registerRuntime: (newTools: readonly ToolRegistration[]) =>
       Effect.sync(() => {

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./plugin";
 export {
   type OpenApiOperationStore,
+  type StoredOperation,
   type StoredSource,
   type SourceConfig,
 } from "./operation-store";

--- a/packages/plugins/openapi/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/kv-operation-store.ts
@@ -7,7 +7,7 @@
 import { Effect, Schema } from "effect";
 import { scopeKv, makeInMemoryScopedKv, type Kv, type ToolId, type ScopedKv } from "@executor/sdk";
 
-import type { OpenApiOperationStore, StoredSource } from "./operation-store";
+import type { OpenApiOperationStore, StoredOperation, StoredSource } from "./operation-store";
 import { OperationBinding, InvocationConfig, HeaderValue } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -45,7 +45,13 @@ const decodeSource = Schema.decodeUnknownSync(Schema.parseJson(StoredSourceSchem
 const makeStore = (
   bindings: ScopedKv,
   sources: ScopedKv,
-): OpenApiOperationStore => ({
+): OpenApiOperationStore => {
+  const withKvTransaction = <A, E>(
+    kv: ScopedKv,
+    effect: Effect.Effect<A, E, never>,
+  ): Effect.Effect<A, E, never> => kv.withTransaction?.(effect) ?? effect;
+
+  return ({
   get: (toolId) =>
     Effect.gen(function* () {
       const raw = yield* bindings.get(toolId);
@@ -54,10 +60,18 @@ const makeStore = (
       return { binding: entry.binding, config: entry.config };
     }),
 
-  put: (toolId, namespace, binding, config) =>
-    bindings.set(
-      toolId,
-      encodeEntry(new StoredEntry({ namespace, binding, config })),
+  put: (entries: readonly StoredOperation[]) =>
+    withKvTransaction(
+      bindings,
+      Effect.forEach(
+        entries,
+        ({ toolId, namespace, binding, config }) =>
+          bindings.set(
+            toolId,
+            encodeEntry(new StoredEntry({ namespace, binding, config })),
+          ),
+        { discard: true },
+      ),
     ),
 
   remove: (toolId) => bindings.delete(toolId).pipe(Effect.asVoid),
@@ -98,7 +112,8 @@ const makeStore = (
       const entries = yield* sources.list();
       return entries.map((e) => decodeSource(e.value) as StoredSource);
     }),
-});
+  });
+};
 
 // ---------------------------------------------------------------------------
 // Factory from global Kv

--- a/packages/plugins/openapi/src/sdk/operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/operation-store.ts
@@ -20,17 +20,19 @@ export interface StoredSource {
   readonly config: SourceConfig;
 }
 
+export interface StoredOperation {
+  readonly toolId: ToolId;
+  readonly namespace: string;
+  readonly binding: OperationBinding;
+  readonly config: InvocationConfig;
+}
+
 export interface OpenApiOperationStore {
   readonly get: (
     toolId: ToolId,
   ) => Effect.Effect<{ binding: OperationBinding; config: InvocationConfig } | null>;
 
-  readonly put: (
-    toolId: ToolId,
-    namespace: string,
-    binding: OperationBinding,
-    config: InvocationConfig,
-  ) => Effect.Effect<void>;
+  readonly put: (entries: readonly StoredOperation[]) => Effect.Effect<void>;
 
   readonly remove: (toolId: ToolId) => Effect.Effect<void>;
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -271,16 +271,13 @@ export const openApiPlugin = (options?: {
               toRegistration(def, namespace),
             );
 
-            yield* Effect.forEach(
-              definitions,
-              (def) =>
-                operationStore.put(
-                  ToolId.make(`${namespace}.${def.toolPath}`),
-                  namespace,
-                  toBinding(def),
-                  invocationConfig,
-                ),
-              { discard: true },
+            yield* operationStore.put(
+              definitions.map((def) => ({
+                toolId: ToolId.make(`${namespace}.${def.toolPath}`),
+                namespace,
+                binding: toBinding(def),
+                config: invocationConfig,
+              })),
             );
 
             yield* ctx.tools.register(registrations);


### PR DESCRIPTION
## Summary
- add optional transaction support to KV / scoped KV implementations
- batch OpenAPI operation-store writes into a single `put([...])` call
- wrap SQLite-backed tool-definition, tool-registration, and OpenAPI binding writes in transactions when available

## Why
Adding the Stripe OpenAPI source was slow because registration performed thousands of small SQLite writes sequentially:
- shared schema definitions
- operation bindings
- tool registrations
- source metadata

This change keeps the API batch-oriented and lets each storage implementation decide how to optimize writes, without introducing parallel `putMany` / `registerMany` APIs.

## Profiling
Measured on latest `main` before this change:
- `POST /v1/scopes/:id/openapi/specs` with Stripe: ~23.8s

Measured after this change:
- same request with Stripe: ~2.4s

So this brings Stripe source registration down by roughly 10x in the real server path.

## Validation
- `cd packages/core/storage-file && bun run typecheck`
- `cd packages/core/sdk && bun run typecheck`
- `cd packages/plugins/openapi && bun run typecheck`
- `cd packages/plugins/openapi && bun run test -- src/sdk/plugin.test.ts`
