### PR TITLE
refactor: move source add flows to proper subpage routes

### DIFF
--- a/apps/web/src/pages/sources-add.tsx
+++ b/apps/web/src/pages/sources-add.tsx
@@ -1,0 +1,80 @@
+import { Suspense } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import type { SourcePlugin } from "@executor/react";
+import { useAtomRefresh, sourcesAtom } from "@executor/react";
+import { useScope } from "../lib/use-scope";
+import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
+import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
+import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
+import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
+
+// ---------------------------------------------------------------------------
+// Registered source plugins
+// ---------------------------------------------------------------------------
+
+const sourcePlugins: SourcePlugin[] = [
+  openApiSourcePlugin,
+  mcpSourcePlugin,
+  googleDiscoverySourcePlugin,
+  graphqlSourcePlugin,
+];
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function SourcesAddPage(props: {
+  pluginKey: string;
+  url?: string;
+}) {
+  const { pluginKey, url } = props;
+  const scopeId = useScope();
+  const refreshSources = useAtomRefresh(sourcesAtom(scopeId));
+  const navigate = useNavigate();
+
+  const plugin = sourcePlugins.find((p) => p.key === pluginKey);
+
+  if (!plugin) {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">
+          <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border py-20">
+            <p className="text-[14px] font-medium text-foreground/70 mb-1">
+              Unknown source type: {pluginKey}
+            </p>
+            <p className="text-[13px] text-muted-foreground/60 mb-5">
+              This source plugin is not registered.
+            </p>
+            <Link
+              to="/"
+              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              Back to sources
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const AddComponent = plugin.add;
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">
+        <Suspense fallback={<p className="text-sm text-muted-foreground">Loading…</p>}>
+          <AddComponent
+            initialUrl={url}
+            onComplete={() => {
+              refreshSources();
+              void navigate({ to: "/" });
+            }}
+            onCancel={() => {
+              void navigate({ to: "/" });
+            }}
+          />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/sources.tsx
+++ b/apps/web/src/pages/sources.tsx
@@ -1,6 +1,6 @@
-import { useReducer, useCallback, useMemo, Suspense } from "react";
-import { Link } from "@tanstack/react-router";
-import { Result, useAtomValue, useAtomRefresh, useAtomSet, sourcesAtom, detectSource } from "@executor/react";
+import { useState, useCallback, useMemo } from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { Result, useAtomValue, useAtomSet, sourcesAtom, detectSource } from "@executor/react";
 import { useScope } from "../lib/use-scope";
 import type { SourcePlugin, SourcePreset } from "@executor/react";
 import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
@@ -28,122 +28,50 @@ const KIND_TO_PLUGIN_KEY: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// State machine
-// ---------------------------------------------------------------------------
-
-type State = {
-  step: "list" | "detecting" | "adding";
-  url: string;
-  error: string | null;
-  pluginKey: string | null;
-  initialUrl: string | undefined;
-};
-
-type Action =
-  | { type: "set-url"; url: string }
-  | { type: "detect-start" }
-  | { type: "detect-ok"; pluginKey: string; url: string }
-  | { type: "detect-no-match" }
-  | { type: "detect-unknown-kind"; kind: string }
-  | { type: "detect-fail" }
-  | { type: "add-manual"; pluginKey: string }
-  | { type: "add-preset"; pluginKey: string; url: string }
-  | { type: "back" };
-
-const init: State = { step: "list", url: "", error: null, pluginKey: null, initialUrl: undefined };
-
-function reducer(state: State, action: Action): State {
-  switch (action.type) {
-    case "set-url":
-      return { ...state, step: "list", url: action.url, error: null };
-    case "detect-start":
-      return { ...state, step: "detecting", error: null };
-    case "detect-ok":
-      return { ...state, step: "adding", pluginKey: action.pluginKey, initialUrl: action.url };
-    case "detect-no-match":
-      return { ...state, step: "list", error: "Could not detect a source type from this URL. Try adding manually." };
-    case "detect-unknown-kind":
-      return { ...state, step: "list", error: `Detected source type "${action.kind}" but no plugin is available for it.` };
-    case "detect-fail":
-      return { ...state, step: "list", error: "Detection failed. Try adding a source manually." };
-    case "add-manual":
-      return { ...state, step: "adding", pluginKey: action.pluginKey, initialUrl: undefined };
-    case "add-preset":
-      return { ...state, step: "adding", pluginKey: action.pluginKey, initialUrl: action.url };
-    case "back":
-      return init;
-    default:
-      return state;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
 export function SourcesPage() {
-  const [state, dispatch] = useReducer(reducer, init);
+  const [url, setUrl] = useState("");
+  const [detecting, setDetecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const scopeId = useScope();
   const sources = useAtomValue(sourcesAtom(scopeId));
-  const refreshSources = useAtomRefresh(sourcesAtom(scopeId));
   const doDetect = useAtomSet(detectSource, { mode: "promise" });
+  const navigate = useNavigate();
 
   const handleDetect = useCallback(async () => {
-    const trimmed = state.url.trim();
+    const trimmed = url.trim();
     if (!trimmed) return;
-    dispatch({ type: "detect-start" });
+    setDetecting(true);
+    setError(null);
     try {
       const results = await doDetect({
         path: { scopeId },
         payload: { url: trimmed },
       });
       if (results.length === 0) {
-        dispatch({ type: "detect-no-match" });
+        setError("Could not detect a source type from this URL. Try adding manually.");
+        setDetecting(false);
         return;
       }
       const pluginKey = KIND_TO_PLUGIN_KEY[results[0].kind];
       if (pluginKey) {
-        dispatch({ type: "detect-ok", pluginKey, url: trimmed });
+        void navigate({
+          to: "/sources/add/$pluginKey",
+          params: { pluginKey },
+          search: { url: trimmed },
+        });
       } else {
-        dispatch({ type: "detect-unknown-kind", kind: results[0].kind });
+        setError(`Detected source type "${results[0].kind}" but no plugin is available for it.`);
       }
     } catch {
-      dispatch({ type: "detect-fail" });
+      setError("Detection failed. Try adding a source manually.");
+    } finally {
+      setDetecting(false);
     }
-  }, [state.url, doDetect]);
-
-  // ---------------------------------------------------------------------------
-  // Adding view
-  // ---------------------------------------------------------------------------
-
-  if (state.step === "adding" && state.pluginKey) {
-    const plugin = sourcePlugins.find((p) => p.key === state.pluginKey);
-    if (!plugin) return null;
-    const AddComponent = plugin.add;
-    return (
-      <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">
-          <Suspense fallback={<p className="text-sm text-muted-foreground">Loading…</p>}>
-            <AddComponent
-              initialUrl={state.initialUrl}
-              onComplete={() => {
-                dispatch({ type: "back" });
-                refreshSources();
-              }}
-              onCancel={() => dispatch({ type: "back" })}
-            />
-          </Suspense>
-        </div>
-      </div>
-    );
-  }
-
-  // ---------------------------------------------------------------------------
-  // List view
-  // ---------------------------------------------------------------------------
-
-  const isDetecting = state.step === "detecting";
-  const error = state.step === "list" ? state.error : null;
+  }, [url, doDetect, navigate, scopeId]);
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
@@ -166,19 +94,22 @@ export function SourcesPage() {
             <div className="flex gap-2">
               <input
                 type="url"
-                value={state.url}
-                onChange={(e) => dispatch({ type: "set-url", url: e.target.value })}
+                value={url}
+                onChange={(e) => {
+                  setUrl(e.target.value);
+                  setError(null);
+                }}
                 onKeyDown={(e) => { if (e.key === "Enter") handleDetect(); }}
                 placeholder="Paste a URL to auto-detect source type..."
-                disabled={isDetecting}
+                disabled={detecting}
                 className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
               />
               <button
                 onClick={handleDetect}
-                disabled={isDetecting || !state.url.trim()}
+                disabled={detecting || !url.trim()}
                 className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none"
               >
-                {isDetecting ? "Detecting..." : "Detect"}
+                {detecting ? "Detecting..." : "Detect"}
               </button>
             </div>
             {error && (
@@ -187,13 +118,14 @@ export function SourcesPage() {
             <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
               <span>Or add manually:</span>
               {sourcePlugins.map((p) => (
-                <button
+                <Link
                   key={p.key}
-                  onClick={() => dispatch({ type: "add-manual", pluginKey: p.key })}
+                  to="/sources/add/$pluginKey"
+                  params={{ pluginKey: p.key }}
                   className="rounded-md border border-border px-2 py-1 text-xs font-medium transition-colors hover:bg-muted"
                 >
                   {p.label}
-                </button>
+                </Link>
               ))}
             </div>
           </div>
@@ -201,7 +133,7 @@ export function SourcesPage() {
 
         <McpInstallCard className="mb-8 rounded-2xl border border-border bg-card/80 p-5" />
 
-        <PresetGrid plugins={sourcePlugins} dispatch={dispatch} />
+        <PresetGrid plugins={sourcePlugins} />
 
         {Result.match(sources, {
           onInitial: () => (
@@ -272,7 +204,6 @@ export function SourcesPage() {
 
 function PresetGrid(props: {
   plugins: readonly SourcePlugin[];
-  dispatch: React.Dispatch<Action>;
 }) {
   const allPresets = useMemo(() => {
     const out: { preset: SourcePreset; pluginKey: string; pluginLabel: string }[] = [];
@@ -296,9 +227,11 @@ function PresetGrid(props: {
       </div>
       <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {allPresets.map(({ preset, pluginKey, pluginLabel }) => (
-          <button
+          <Link
             key={`${pluginKey}-${preset.id}`}
-            onClick={() => props.dispatch({ type: "add-preset", pluginKey, url: preset.url })}
+            to="/sources/add/$pluginKey"
+            params={{ pluginKey }}
+            search={{ url: preset.url }}
             className="flex items-start gap-3 rounded-xl border border-border bg-card px-4 py-3 text-left transition-colors hover:border-primary/25 hover:bg-card/90"
           >
             <div className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground overflow-hidden">
@@ -319,7 +252,7 @@ function PresetGrid(props: {
               </div>
               <p className="mt-0.5 text-xs text-muted-foreground line-clamp-1">{preset.summary}</p>
             </div>
-          </button>
+          </Link>
         ))}
       </div>
     </section>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -6,6 +6,7 @@ import {
 import { ExecutorProvider } from "@executor/react";
 import { ToolsPage } from "./pages/tools";
 import { SourcesPage } from "./pages/sources";
+import { SourcesAddPage } from "./pages/sources-add";
 import { SourceDetailPage } from "./pages/source-detail";
 import { SecretsPage } from "./pages/secrets";
 import { Shell } from "./shell";
@@ -38,6 +39,19 @@ const toolsRoute = createRoute({
   component: ToolsPage,
 });
 
+const sourcesAddRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/sources/add/$pluginKey",
+  validateSearch: (search: Record<string, unknown>): { url?: string } => ({
+    url: typeof search.url === "string" ? search.url : undefined,
+  }),
+  component: () => {
+    const { pluginKey } = sourcesAddRoute.useParams();
+    const { url } = sourcesAddRoute.useSearch();
+    return <SourcesAddPage pluginKey={pluginKey} url={url} />;
+  },
+});
+
 const sourceDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/sources/$namespace",
@@ -60,6 +74,7 @@ const secretsRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   indexRoute,
   toolsRoute,
+  sourcesAddRoute,
   sourceDetailRoute,
   secretsRoute,
 ]);


### PR DESCRIPTION
## Problem

All "add source" flows were handled by a `useReducer` state machine inside `SourcesPage` on `/`. This meant:
- No real URL for the add flow — couldn't link to it or use back/forward
- Clicking "Sources" in the sidebar didn't give fresh state
- Navigation felt broken

## Solution

Move add flows to their own route: `/sources/add/$pluginKey` with optional `?url=` search param.

### Route structure

| Route | Page |
|---|---|
| `/` | Sources list (always clean) |
| `/sources/add/$pluginKey` | Add source wizard (e.g. `/sources/add/openapi?url=...`) |
| `/sources/$namespace` | Source detail |
| `/tools` | Tools list |
| `/secrets` | Secrets management |

### Changes

- **`sources-add.tsx`** (new) — Reads `$pluginKey` from URL path and optional `?url=` search param, finds matching plugin, renders its add component. On complete/cancel navigates back to `/`.
- **`sources.tsx`** (simplified) — Removed `useReducer` state machine. Detection navigates to add route. Manual add buttons and presets are now `<Link>` elements.
- **`router.tsx`** — Added `/sources/add/$pluginKey` route with search param validation.