### PR TITLE
@executor/storage-postgres: relational storage for cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ executor.har
 
 # desktop app build artifacts
 apps/desktop/resources/
+
+# cloud local dev database
+.pglite

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@effect/vitest": "^0.27.0",
     "@types/node": "^24.3.1",
     "bun-types": "^1.2.22",
+    "drizzle-orm": "^0.44.0",
     "vitest": "^3.2.4"
   },
   "scripts": {

--- a/packages/core/storage-postgres/drizzle/0000_spicy_zemo.sql
+++ b/packages/core/storage-postgres/drizzle/0000_spicy_zemo.sql
@@ -1,0 +1,94 @@
+CREATE TABLE "invitations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"team_id" text NOT NULL,
+	"email" text NOT NULL,
+	"invited_by" text NOT NULL,
+	"status" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "plugin_kv" (
+	"team_id" text NOT NULL,
+	"namespace" text NOT NULL,
+	"key" text NOT NULL,
+	"value" text NOT NULL,
+	CONSTRAINT "plugin_kv_team_id_namespace_key_pk" PRIMARY KEY("team_id","namespace","key")
+);
+--> statement-breakpoint
+CREATE TABLE "policies" (
+	"id" text NOT NULL,
+	"team_id" text NOT NULL,
+	"name" text NOT NULL,
+	"action" text NOT NULL,
+	"match_tool_pattern" text,
+	"match_source_id" text,
+	"priority" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "policies_id_team_id_pk" PRIMARY KEY("id","team_id")
+);
+--> statement-breakpoint
+CREATE TABLE "secrets" (
+	"id" text NOT NULL,
+	"team_id" text NOT NULL,
+	"name" text NOT NULL,
+	"purpose" text,
+	"encrypted_value" "bytea" NOT NULL,
+	"iv" "bytea" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "secrets_id_team_id_pk" PRIMARY KEY("id","team_id")
+);
+--> statement-breakpoint
+CREATE TABLE "sources" (
+	"id" text NOT NULL,
+	"team_id" text NOT NULL,
+	"name" text NOT NULL,
+	"kind" text NOT NULL,
+	"config" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "sources_id_team_id_pk" PRIMARY KEY("id","team_id")
+);
+--> statement-breakpoint
+CREATE TABLE "team_members" (
+	"team_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"role" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "team_members_team_id_user_id_pk" PRIMARY KEY("team_id","user_id")
+);
+--> statement-breakpoint
+CREATE TABLE "teams" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "tool_definitions" (
+	"name" text NOT NULL,
+	"team_id" text NOT NULL,
+	"schema" jsonb NOT NULL,
+	CONSTRAINT "tool_definitions_name_team_id_pk" PRIMARY KEY("name","team_id")
+);
+--> statement-breakpoint
+CREATE TABLE "tools" (
+	"id" text NOT NULL,
+	"team_id" text NOT NULL,
+	"source_id" text NOT NULL,
+	"plugin_key" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"may_elicit" boolean,
+	"input_schema" jsonb,
+	"output_schema" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tools_id_team_id_pk" PRIMARY KEY("id","team_id")
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"email" text NOT NULL,
+	"name" text,
+	"avatar_url" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);

--- a/packages/core/storage-postgres/drizzle/meta/0000_snapshot.json
+++ b/packages/core/storage-postgres/drizzle/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "36e0d08d-3eb6-467a-8440-e39b7bfee61e",
+  "id": "ee7b4779-1928-46a3-bcb8-1a48898bec19",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -235,50 +235,6 @@
           ]
         }
       },
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.sessions": {
-      "name": "sessions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "user_id": {
-          "name": "user_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "team_id": {
-          "name": "team_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "expires_at": {
-          "name": "expires_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},
       "checkConstraints": {},

--- a/packages/core/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/core/storage-postgres/drizzle/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1775542409153,
-      "tag": "0000_great_speedball",
+      "when": 1775552333040,
+      "tag": "0000_spicy_zemo",
       "breakpoints": true
     }
   ]

--- a/packages/core/storage-postgres/package.json
+++ b/packages/core/storage-postgres/package.json
@@ -10,7 +10,7 @@
     "@effect/sql": "catalog:",
     "@effect/sql-pg": "^0.28.0",
     "@executor/sdk": "workspace:*",
-    "drizzle-orm": "^0.45.2",
+    "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "pg": "^8.16.0"
   },

--- a/packages/core/storage-postgres/src/index.test.ts
+++ b/packages/core/storage-postgres/src/index.test.ts
@@ -46,7 +46,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   await db.execute(
-    sql`TRUNCATE plugin_kv, policies, secrets, tool_definitions, tools, sources, sessions, invitations, team_members, teams, users`,
+    sql`TRUNCATE plugin_kv, policies, secrets, tool_definitions, tools, sources, invitations, team_members, teams, users`,
   );
 });
 
@@ -408,24 +408,4 @@ describe("UserStore", () => {
     expect(await store.getPendingInvitations("new@example.com")).toHaveLength(0);
   });
 
-  it("session management", async () => {
-    const store = makeUserStore(db);
-    await store.upsertUser({ id: "u1", email: "a@example.com" });
-    const team = await store.createTeam("Team");
-
-    const session = await store.createSession("u1", team.id, new Date(Date.now() + 3600_000));
-    expect((await store.getSession(session.id))!.userId).toBe("u1");
-
-    await store.deleteSession(session.id);
-    expect(await store.getSession(session.id)).toBeNull();
-  });
-
-  it("expired sessions return null", async () => {
-    const store = makeUserStore(db);
-    await store.upsertUser({ id: "u1", email: "a@example.com" });
-    const team = await store.createTeam("Team");
-
-    const session = await store.createSession("u1", team.id, new Date(Date.now() - 1000));
-    expect(await store.getSession(session.id)).toBeNull();
-  });
 });

--- a/packages/core/storage-postgres/src/index.ts
+++ b/packages/core/storage-postgres/src/index.ts
@@ -17,9 +17,9 @@
 //
 // ---------------------------------------------------------------------------
 
-import type { PgDatabase } from "drizzle-orm/pg-core";
 import { ScopeId, makeInMemorySourceRegistry } from "@executor/sdk";
 import type { Scope, ExecutorConfig, ExecutorPlugin } from "@executor/sdk";
+import type { DrizzleDb } from "./types";
 
 import { makePgToolRegistry } from "./tool-registry";
 import { makePgSecretStore } from "./secret-store";
@@ -30,8 +30,9 @@ export { makePgToolRegistry } from "./tool-registry";
 export { makePgSecretStore } from "./secret-store";
 export { makePgPolicyEngine } from "./policy-engine";
 export { makeUserStore } from "./user-store";
-export type { User, Team, TeamMember, Invitation, Session } from "./user-store";
+export type { User, Team, TeamMember, Invitation } from "./user-store";
 export { encrypt, decrypt } from "./crypto";
+export type { DrizzleDb } from "./types";
 export * from "./schema";
 
 // ---------------------------------------------------------------------------
@@ -41,7 +42,7 @@ export * from "./schema";
 export const makePgConfig = <
   const TPlugins extends readonly ExecutorPlugin<string, object>[] = [],
 >(
-  db: PgDatabase<any, any, any>,
+  db: DrizzleDb,
   options: {
     readonly teamId: string;
     readonly teamName: string;

--- a/packages/core/storage-postgres/src/pg-kv.ts
+++ b/packages/core/storage-postgres/src/pg-kv.ts
@@ -4,12 +4,12 @@
 
 import { Effect } from "effect";
 import { eq, and } from "drizzle-orm";
-import type { PgDatabase } from "drizzle-orm/pg-core";
 import type { Kv } from "@executor/sdk";
 
 import { pluginKv } from "./schema";
+import type { DrizzleDb } from "./types";
 
-export const makePgKv = (db: PgDatabase<any, any, any>, teamId: string): Kv => ({
+export const makePgKv = (db: DrizzleDb, teamId: string): Kv => ({
   get: (namespace, key) =>
     Effect.tryPromise(async () => {
       const rows = await db

--- a/packages/core/storage-postgres/src/policy-engine.ts
+++ b/packages/core/storage-postgres/src/policy-engine.ts
@@ -4,15 +4,15 @@
 
 import { Effect } from "effect";
 import { eq, and } from "drizzle-orm";
-import type { PgDatabase } from "drizzle-orm/pg-core";
 
 import { Policy, PolicyId, ScopeId } from "@executor/sdk";
+import type { DrizzleDb } from "./types";
 import type { PolicyCheckInput } from "@executor/sdk";
 
 import { policies } from "./schema";
 
 export const makePgPolicyEngine = (
-  db: PgDatabase<any, any, any>,
+  db: DrizzleDb,
   teamId: string,
 ) => {
   let counter = 0;

--- a/packages/core/storage-postgres/src/schema.ts
+++ b/packages/core/storage-postgres/src/schema.ts
@@ -58,14 +58,6 @@ export const invitations = pgTable("invitations", {
   expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
 });
 
-export const sessions = pgTable("sessions", {
-  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
-  userId: text("user_id").notNull(),
-  teamId: text("team_id").notNull(),
-  expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-});
-
 // ---------------------------------------------------------------------------
 // Domain data — all team-scoped
 // ---------------------------------------------------------------------------

--- a/packages/core/storage-postgres/src/secret-store.ts
+++ b/packages/core/storage-postgres/src/secret-store.ts
@@ -4,9 +4,9 @@
 
 import { Effect, Option } from "effect";
 import { eq, and } from "drizzle-orm";
-import type { PgDatabase } from "drizzle-orm/pg-core";
 
 import { SecretRef, SecretId, ScopeId } from "@executor/sdk";
+import type { DrizzleDb } from "./types";
 import { SecretNotFoundError, SecretResolutionError } from "@executor/sdk";
 import type { SecretProvider, SetSecretInput } from "@executor/sdk";
 
@@ -14,7 +14,7 @@ import { secrets } from "./schema";
 import { encrypt, decrypt } from "./crypto";
 
 export const makePgSecretStore = (
-  db: PgDatabase<any, any, any>,
+  db: DrizzleDb,
   teamId: string,
   encryptionKey: string,
 ) => {
@@ -99,14 +99,15 @@ export const makePgSecretStore = (
 
         const row = rows[0];
         if (row) {
-          try {
-            return decrypt(row.encryptedValue, row.iv, encryptionKey);
-          } catch {
-            return yield* new SecretResolutionError({
-              secretId,
-              message: `Failed to decrypt secret "${secretId}"`,
-            });
-          }
+          const decrypted = yield* Effect.try({
+            try: () => decrypt(row.encryptedValue, row.iv, encryptionKey),
+            catch: () =>
+              new SecretResolutionError({
+                secretId,
+                message: `Failed to decrypt secret "${secretId}"`,
+              }),
+          });
+          return decrypted;
         }
 
         // Fall back to registered providers

--- a/packages/core/storage-postgres/src/tool-registry.ts
+++ b/packages/core/storage-postgres/src/tool-registry.ts
@@ -3,10 +3,10 @@
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
-import { eq, and, or, ilike } from "drizzle-orm";
-import type { PgDatabase } from "drizzle-orm/pg-core";
+import { eq, and } from "drizzle-orm";
 
 import type { ToolId } from "@executor/sdk";
+import type { DrizzleDb } from "./types";
 import { ToolNotFoundError, ToolInvocationError, ToolRegistration } from "@executor/sdk";
 import { buildToolTypeScriptPreview } from "@executor/sdk";
 import type {
@@ -19,7 +19,7 @@ import type {
 import { tools, toolDefinitions } from "./schema";
 
 export const makePgToolRegistry = (
-  db: PgDatabase<any, any, any>,
+  db: DrizzleDb,
   teamId: string,
 ) => {
   const runtimeTools = new Map<string, ToolRegistration>();

--- a/packages/core/storage-postgres/src/types.ts
+++ b/packages/core/storage-postgres/src/types.ts
@@ -1,0 +1,7 @@
+// ---------------------------------------------------------------------------
+// Shared Drizzle DB type
+// ---------------------------------------------------------------------------
+
+import type { PgDatabase } from "drizzle-orm/pg-core";
+
+export type DrizzleDb = PgDatabase<any, any, any>;

--- a/packages/core/storage-postgres/src/user-store.ts
+++ b/packages/core/storage-postgres/src/user-store.ts
@@ -3,17 +3,16 @@
 // ---------------------------------------------------------------------------
 
 import { eq, and } from "drizzle-orm";
-import type { PgDatabase } from "drizzle-orm/pg-core";
 
-import { users, teams, teamMembers, invitations, sessions } from "./schema";
+import { users, teams, teamMembers, invitations } from "./schema";
+import type { DrizzleDb } from "./types";
 
 export type User = typeof users.$inferSelect;
 export type Team = typeof teams.$inferSelect;
 export type TeamMember = typeof teamMembers.$inferSelect;
 export type Invitation = typeof invitations.$inferSelect;
-export type Session = typeof sessions.$inferSelect;
 
-export const makeUserStore = (db: PgDatabase<any, any, any>) => ({
+export const makeUserStore = (db: DrizzleDb) => ({
   // --- Users ---
 
   upsertUser: async (user: { id: string; email: string; name?: string; avatarUrl?: string }) => {
@@ -133,29 +132,4 @@ export const makeUserStore = (db: PgDatabase<any, any, any>) => ({
     return updated ?? null;
   },
 
-  // --- Sessions ---
-
-  createSession: async (userId: string, teamId: string, expiresAt: Date) => {
-    const [session] = await db
-      .insert(sessions)
-      .values({ userId, teamId, expiresAt })
-      .returning();
-    return session!;
-  },
-
-  getSession: async (sessionId: string) => {
-    const rows = await db.select().from(sessions).where(eq(sessions.id, sessionId));
-    const session = rows[0];
-    if (!session) return null;
-    if (session.expiresAt < new Date()) return null;
-    return session;
-  },
-
-  deleteSession: async (sessionId: string) => {
-    await db.delete(sessions).where(eq(sessions.id, sessionId));
-  },
-
-  deleteUserSessions: async (userId: string) => {
-    await db.delete(sessions).where(eq(sessions.userId, userId));
-  },
 });


### PR DESCRIPTION
- Drizzle schema: users, teams, team_members, invitations, sources, tools, secrets, policies, plugin_kv (no FKs for PlanetScale)
- Implements ToolRegistryService, SecretStoreService, PolicyEngineService
- AES-256-GCM encrypted secrets in DB
- makePgKv for plugin compatibility via ScopedKv
- User/team/invitation CRUD
- 17 tests against PGlite (in-memory Postgres)
- drizzle-orm in root catalog for single workspace copy