### PR TITLE
WorkOS auth: sealed sessions for cloud app

### DIFF
--- a/apps/cloud/src/auth/context.ts
+++ b/apps/cloud/src/auth/context.ts
@@ -1,0 +1,10 @@
+import { Context } from "effect";
+
+export class AuthContext extends Context.Tag("@executor/cloud/AuthContext")<
+  AuthContext,
+  {
+    readonly userId: string;
+    readonly teamId: string;
+    readonly email: string;
+  }
+>() {}

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------------
+// WorkOS AuthKit integration — sealed sessions, no server-side session store
+// ---------------------------------------------------------------------------
+
+import { WorkOS } from "@workos-inc/node";
+
+const COOKIE_NAME = "wos-session";
+
+let workos: WorkOS | null = null;
+
+export const getWorkOS = (): WorkOS => {
+  if (!workos) {
+    workos = new WorkOS(process.env.WORKOS_API_KEY!);
+  }
+  return workos;
+};
+
+const getCookiePassword = (): string => {
+  const password = process.env.WORKOS_COOKIE_PASSWORD;
+  if (!password || password.length < 32) {
+    throw new Error("WORKOS_COOKIE_PASSWORD must be at least 32 characters");
+  }
+  return password;
+};
+
+export const getAuthorizationUrl = (redirectUri: string): string => {
+  const wos = getWorkOS();
+  return wos.userManagement.getAuthorizationUrl({
+    provider: "authkit",
+    redirectUri,
+    clientId: process.env.WORKOS_CLIENT_ID!,
+  });
+};
+
+export const authenticateWithCode = async (code: string) => {
+  const wos = getWorkOS();
+  return wos.userManagement.authenticateWithCode({
+    code,
+    clientId: process.env.WORKOS_CLIENT_ID!,
+    session: {
+      sealSession: true,
+      cookiePassword: getCookiePassword(),
+    },
+  });
+};
+
+/**
+ * Authenticate a request using the sealed session cookie.
+ * Returns user info or null if not authenticated.
+ */
+export const authenticateRequest = async (request: Request) => {
+  const cookieHeader = request.headers.get("cookie");
+  const sessionData = parseCookie(cookieHeader, COOKIE_NAME);
+  if (!sessionData) return null;
+
+  const wos = getWorkOS();
+  const session = wos.userManagement.loadSealedSession({
+    sessionData,
+    cookiePassword: getCookiePassword(),
+  });
+
+  const result = await session.authenticate();
+  if (!result.authenticated) return null;
+
+  return {
+    userId: result.user.id,
+    email: result.user.email,
+    firstName: result.user.firstName,
+    lastName: result.user.lastName,
+    avatarUrl: result.user.profilePictureUrl,
+    sessionId: result.sessionId,
+  };
+};
+
+/**
+ * Refresh the sealed session cookie. Returns new cookie value or null.
+ */
+export const refreshSession = async (request: Request) => {
+  const cookieHeader = request.headers.get("cookie");
+  const sessionData = parseCookie(cookieHeader, COOKIE_NAME);
+  if (!sessionData) return null;
+
+  const wos = getWorkOS();
+  const session = wos.userManagement.loadSealedSession({
+    sessionData,
+    cookiePassword: getCookiePassword(),
+  });
+
+  const result = await session.refresh();
+  if (!result.authenticated || !result.sealedSession) return null;
+
+  return {
+    sealedSession: result.sealedSession,
+    cookie: makeSessionCookie(result.sealedSession),
+  };
+};
+
+/**
+ * Get logout URL for the current session.
+ */
+export const getLogoutUrl = async (request: Request) => {
+  const cookieHeader = request.headers.get("cookie");
+  const sessionData = parseCookie(cookieHeader, COOKIE_NAME);
+  if (!sessionData) return null;
+
+  const wos = getWorkOS();
+  const session = wos.userManagement.loadSealedSession({
+    sessionData,
+    cookiePassword: getCookiePassword(),
+  });
+
+  return session.getLogoutUrl();
+};
+
+// ---------------------------------------------------------------------------
+// Cookie helpers
+// ---------------------------------------------------------------------------
+
+export const makeSessionCookie = (sealedSession: string): string => {
+  const parts = [
+    `${COOKIE_NAME}=${sealedSession}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+    "Max-Age=604800", // 7 days
+  ];
+  if (process.env.NODE_ENV === "production") parts.push("Secure");
+  return parts.join("; ");
+};
+
+export const clearSessionCookie = (): string =>
+  `${COOKIE_NAME}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`;
+
+const parseCookie = (cookieHeader: string | null, name: string): string | null => {
+  if (!cookieHeader) return null;
+  const match = cookieHeader
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${name}=`));
+  if (!match) return null;
+  return match.slice(name.length + 1) || null;
+};

--- a/apps/cloud/src/handlers/auth.ts
+++ b/apps/cloud/src/handlers/auth.ts
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------------
+// Auth handlers — login, callback, logout, me
+// ---------------------------------------------------------------------------
+
+import { makeUserStore } from "@executor/storage-postgres";
+import {
+  getAuthorizationUrl,
+  authenticateWithCode,
+  authenticateRequest,
+  getLogoutUrl,
+  makeSessionCookie,
+  clearSessionCookie,
+} from "../auth/workos";
+import type { DrizzleDb } from "../services/db";
+
+export const createAuthHandlers = (db: DrizzleDb) => {
+  const userStore = makeUserStore(db);
+
+  const getBaseUrl = (): string => {
+    if (process.env.APP_URL) return process.env.APP_URL;
+    const port = process.env.PORT ?? "3000";
+    return `http://localhost:${port}`;
+  };
+
+  return {
+    login: async (_request: Request): Promise<Response> => {
+      const redirectUri = `${getBaseUrl()}/auth/callback`;
+      const url = getAuthorizationUrl(redirectUri);
+      return Response.redirect(url, 302);
+    },
+
+    callback: async (request: Request): Promise<Response> => {
+      const url = new URL(request.url);
+      const code = url.searchParams.get("code");
+      if (!code) {
+        return new Response("Missing code parameter", { status: 400 });
+      }
+
+      try {
+        const result = await authenticateWithCode(code);
+        const workosUser = result.user;
+
+        // Upsert user
+        const user = await userStore.upsertUser({
+          id: workosUser.id,
+          email: workosUser.email,
+          name: `${workosUser.firstName ?? ""} ${workosUser.lastName ?? ""}`.trim() || undefined,
+          avatarUrl: workosUser.profilePictureUrl ?? undefined,
+        });
+
+        // Check for pending invitations
+        const pendingInvitations = await userStore.getPendingInvitations(user.email);
+        let teamId: string;
+
+        if (pendingInvitations.length > 0) {
+          const invitation = pendingInvitations[0]!;
+          await userStore.acceptInvitation(invitation.id);
+          await userStore.addMember(invitation.teamId, user.id, "member");
+          teamId = invitation.teamId;
+        } else {
+          const teams = await userStore.getTeamsForUser(user.id);
+          if (teams.length > 0) {
+            teamId = teams[0]!.teamId;
+          } else {
+            const team = await userStore.createTeam(`${user.name ?? user.email}'s Team`);
+            await userStore.addMember(team.id, user.id, "owner");
+            teamId = team.id;
+          }
+        }
+
+        // Store teamId in a separate cookie (WorkOS sealed session doesn't carry app-specific data)
+        const sealedSession = result.sealedSession;
+        if (!sealedSession) {
+          return new Response("Failed to create session", { status: 500 });
+        }
+
+        return new Response(null, {
+          status: 302,
+          headers: [
+            ["Location", "/"],
+            ["Set-Cookie", makeSessionCookie(sealedSession)],
+            ["Set-Cookie", `executor_team=${teamId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=604800`],
+          ],
+        });
+      } catch (error) {
+        console.error("Auth callback error:", error);
+        return new Response("Authentication failed", { status: 500 });
+      }
+    },
+
+    logout: async (request: Request): Promise<Response> => {
+      const logoutUrl = await getLogoutUrl(request);
+      const headers: [string, string][] = [
+        ["Set-Cookie", clearSessionCookie()],
+        ["Set-Cookie", "executor_team=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"],
+      ];
+
+      if (logoutUrl) {
+        headers.push(["Location", logoutUrl]);
+        return new Response(null, { status: 302, headers });
+      }
+
+      headers.push(["Location", "/login"]);
+      return new Response(null, { status: 302, headers });
+    },
+
+    me: async (request: Request): Promise<Response> => {
+      const auth = await authenticateRequest(request);
+      if (!auth) {
+        return Response.json({ error: "Not authenticated" }, { status: 401 });
+      }
+
+      const user = await userStore.getUser(auth.userId);
+      if (!user) {
+        return Response.json({ error: "User not found" }, { status: 401 });
+      }
+
+      // Read teamId from cookie
+      const teamId = parseCookie(request.headers.get("cookie"), "executor_team");
+      const team = teamId ? await userStore.getTeam(teamId) : null;
+
+      return Response.json({
+        user: {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          avatarUrl: user.avatarUrl,
+        },
+        team: team ? { id: team.id, name: team.name } : null,
+      });
+    },
+  };
+};
+
+const parseCookie = (cookieHeader: string | null, name: string): string | null => {
+  if (!cookieHeader) return null;
+  const match = cookieHeader
+    .split(";")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${name}=`));
+  if (!match) return null;
+  return match.slice(name.length + 1) || null;
+};


### PR DESCRIPTION
- WorkOS AuthKit OAuth flow (login redirect, callback, code exchange)
- Sealed session cookies via @workos-inc/node (no server-side session table)
- Auto-refresh expired tokens on requests
- Team ID stored in separate app cookie
- Auth handlers: login, callback, logout, me