### PR TITLE
Redesign tools detail view with interactive schema explorer

### DIFF
--- a/apps/cloud/src/api.ts
+++ b/apps/cloud/src/api.ts
@@ -7,6 +7,7 @@ import {
   HttpApiBuilder,
   HttpApiSwagger,
   HttpMiddleware,
+  HttpRouter,
   HttpServer,
 } from "@effect/platform";
 import { Effect, Layer, Scope } from "effect";
@@ -76,6 +77,7 @@ const SharedServicesMemoized = Effect.runSync(
 const publicApiHandler = HttpApiBuilder.toWebHandler(
   PublicCloudApiLive.pipe(
     Layer.provideMerge(SharedServicesMemoized),
+    Layer.provideMerge(HttpRouter.setRouterConfig({ maxParamLength: 1000 })),
   ),
   { middleware: HttpMiddleware.logger },
 );
@@ -184,6 +186,7 @@ const createProtectedHandler = (
       Layer.provideMerge(ProtectedCloudApiLive),
       Layer.provideMerge(requestServices),
       Layer.provideMerge(SharedServicesMemoized),
+      Layer.provideMerge(HttpRouter.setRouterConfig({ maxParamLength: 1000 })),
     ),
     { middleware: HttpMiddleware.logger },
   );

--- a/apps/local/src/routes/__root.tsx
+++ b/apps/local/src/routes/__root.tsx
@@ -17,6 +17,9 @@ export const Route = createRootRoute({
       { rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=Instrument+Serif&family=JetBrains+Mono:wght@400;500&display=swap" },
       { rel: "stylesheet", href: appCss },
     ],
+    scripts: import.meta.env.DEV
+      ? [{ src: "https://ui.sh/ui-picker.js" }]
+      : [],
   }),
   component: RootComponent,
   shellComponent: RootDocument,

--- a/apps/local/src/server/main.ts
+++ b/apps/local/src/server/main.ts
@@ -2,6 +2,7 @@ import {
   HttpApiBuilder,
   HttpApiSwagger,
   HttpMiddleware,
+  HttpRouter,
   HttpServer,
 } from "@effect/platform";
 import { Context, Effect, Layer, ManagedRuntime } from "effect";
@@ -76,6 +77,7 @@ export const createServerHandlers = async (): Promise<ServerHandlers> => {
       Layer.provideMerge(Layer.succeed(ExecutorService, executor)),
       Layer.provideMerge(Layer.succeed(ExecutionEngineService, engine)),
       Layer.provideMerge(HttpServer.layerContext),
+      Layer.provideMerge(HttpRouter.setRouterConfig({ maxParamLength: 1000 })),
     ),
     { middleware: HttpMiddleware.logger },
   );

--- a/packages/core/api/src/tools/api.ts
+++ b/packages/core/api/src/tools/api.ts
@@ -33,6 +33,8 @@ const ToolSchemaResponse = Schema.Struct({
   typeScriptDefinitions: Schema.optional(
     Schema.Record({ key: Schema.String, value: Schema.String }),
   ),
+  inputSchema: Schema.optional(Schema.Unknown),
+  outputSchema: Schema.optional(Schema.Unknown),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/sdk/src/in-memory/tool-registry.ts
+++ b/packages/core/sdk/src/in-memory/tool-registry.ts
@@ -9,7 +9,7 @@ import type {
   InvokeOptions,
   RuntimeToolHandler,
 } from "../tools";
-import { normalizeRefs } from "../schema-refs";
+import { normalizeRefs, reattachDefs } from "../schema-refs";
 import { buildToolTypeScriptPreview } from "../schema-types";
 
 export const makeInMemoryToolRegistry = () => {
@@ -68,11 +68,19 @@ export const makeInMemoryToolRegistry = () => {
             inputSchema: t.inputSchema,
             outputSchema: t.outputSchema,
             defs,
+            options: {
+              maxLength: Infinity,
+              maxProperties: Infinity,
+              maxCompositeMembers: Infinity,
+              maxRefDepth: 20,
+            },
           });
 
           return {
             id: t.id,
             ...typeScriptPreview,
+            inputSchema: t.inputSchema ? reattachDefs(t.inputSchema, defs) : undefined,
+            outputSchema: t.outputSchema ? reattachDefs(t.outputSchema, defs) : undefined,
           };
         }),
       ),

--- a/packages/core/sdk/src/tools.ts
+++ b/packages/core/sdk/src/tools.ts
@@ -36,6 +36,8 @@ export class ToolSchema extends Schema.Class<ToolSchema>("ToolSchema")({
   typeScriptDefinitions: Schema.optional(
     Schema.Record({ key: Schema.String, value: Schema.String }),
   ),
+  inputSchema: Schema.optional(Schema.Unknown),
+  outputSchema: Schema.optional(Schema.Unknown),
 }) {}
 
 export class ToolInvocationResult extends Schema.Class<ToolInvocationResult>(

--- a/packages/core/storage-file/src/tool-registry.ts
+++ b/packages/core/storage-file/src/tool-registry.ts
@@ -12,7 +12,7 @@ import type {
   InvokeOptions,
   RuntimeToolHandler,
 } from "@executor/sdk";
-import { buildToolTypeScriptPreview } from "@executor/sdk";
+import { buildToolTypeScriptPreview, reattachDefs } from "@executor/sdk";
 
 // ---------------------------------------------------------------------------
 // Serialization — leverage ToolRegistration Schema.Class directly
@@ -101,11 +101,19 @@ export const makeKvToolRegistry = (
           inputSchema: t.inputSchema,
           outputSchema: t.outputSchema,
           defs,
+          options: {
+            maxLength: Infinity,
+            maxProperties: Infinity,
+            maxCompositeMembers: Infinity,
+            maxRefDepth: 20,
+          },
         });
 
         return {
           id: t.id,
           ...typeScriptPreview,
+          inputSchema: t.inputSchema ? reattachDefs(t.inputSchema, defs) : undefined,
+          outputSchema: t.outputSchema ? reattachDefs(t.outputSchema, defs) : undefined,
         };
       }),
 

--- a/packages/react/src/components/expandable-code-block.tsx
+++ b/packages/react/src/components/expandable-code-block.tsx
@@ -1,0 +1,380 @@
+import { useCallback, useEffect, useMemo, useState, startTransition } from "react";
+import { getHighlighter, THEME } from "../lib/shiki";
+import { cn } from "../lib/utils";
+import type { ThemedToken } from "shiki/core";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Definition = {
+  readonly name: string;
+  /** The full type body string, e.g. `{ login: string; id: number }` */
+  readonly code: string;
+};
+
+// ---------------------------------------------------------------------------
+// Simple TypeScript formatter — expands single-line types into readable form
+// ---------------------------------------------------------------------------
+
+const formatTypeScript = (code: string): string => {
+  let result = "";
+  let indent = 0;
+  let i = 0;
+  const len = code.length;
+
+  // Track brace depth so we only break `|` and `&` at the top level of a union
+  let braceDepth = 0;
+
+  while (i < len) {
+    const ch = code[i]!;
+
+    if (ch === "{") {
+      braceDepth++;
+      indent++;
+      result += "{\n" + "  ".repeat(indent);
+      i++;
+      while (i < len && code[i] === " ") i++;
+    } else if (ch === "}") {
+      braceDepth = Math.max(0, braceDepth - 1);
+      indent = Math.max(0, indent - 1);
+      result += "\n" + "  ".repeat(indent) + "}";
+      i++;
+    } else if (ch === ";" && i + 1 < len && code[i + 1] === " ") {
+      result += ";\n" + "  ".repeat(indent);
+      i += 2;
+    } else if (ch === ";" && indent > 0) {
+      result += ";\n" + "  ".repeat(indent);
+      i++;
+      while (i < len && code[i] === " ") i++;
+    } else if (ch === "|" && i > 0 && code[i - 1] === " " && i + 1 < len && code[i + 1] === " ") {
+      // Union operator ` | ` — break onto new line
+      result += "\n" + "  ".repeat(indent) + "| ";
+      i += 2; // skip the operator and trailing space
+    } else {
+      result += ch;
+      i++;
+    }
+  }
+
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Copy icons
+// ---------------------------------------------------------------------------
+
+const CopyIcon = () => (
+  <svg viewBox="0 0 16 16" className="size-3">
+    <rect x="5" y="5" width="8" height="8" rx="1" fill="none" stroke="currentColor" strokeWidth="1.2" />
+    <path d="M3 11V3h8" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+  </svg>
+);
+
+const CheckIcon = () => (
+  <svg viewBox="0 0 16 16" className="size-3">
+    <path d="M3 8l3 3 7-7" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+// ---------------------------------------------------------------------------
+// Shiki tokenization hook — non-blocking
+// ---------------------------------------------------------------------------
+
+function useTokens(code: string): ThemedToken[][] | null {
+  const [tokens, setTokens] = useState<ThemedToken[][] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getHighlighter().then((highlighter) => {
+      if (cancelled) return;
+      const result = highlighter.codeToTokens(code, {
+        lang: "typescript",
+        theme: THEME,
+      });
+      if (!cancelled) {
+        startTransition(() => setTokens(result.tokens));
+      }
+    });
+    return () => { cancelled = true; };
+  }, [code]);
+
+  return tokens;
+}
+
+// ---------------------------------------------------------------------------
+// Inline-expand logic
+//
+// When a user clicks a ref name like `NonEmptyTrimmedString`, we replace
+// that name with the resolved body inline. So `firstName: NonEmptyTrimmedString`
+// becomes `firstName: string`.
+//
+// We rebuild the full code string with expansions applied, then re-tokenize.
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a code string, a set of ref names to expand, and their definitions,
+ * produce a new code string with each expanded ref replaced by its body.
+ * Applies recursively — if an expanded body itself contains expanded refs,
+ * those get replaced too. Tracks ancestors to prevent infinite loops.
+ */
+const applyExpansions = (
+  code: string,
+  expanded: ReadonlySet<string>,
+  definitions: ReadonlyMap<string, string>,
+  ancestors: ReadonlySet<string>,
+): string => {
+  if (expanded.size === 0) return code;
+
+  let result = "";
+  let i = 0;
+
+  // Sort expanded names longest-first to match greedily
+  const sortedNames = [...expanded].filter((n) => !ancestors.has(n)).sort((a, b) => b.length - a.length);
+
+  while (i < code.length) {
+    let matched = false;
+
+    for (const name of sortedNames) {
+      if (code.startsWith(name, i)) {
+        const body = definitions.get(name);
+        if (body) {
+          // Recursively expand the body, adding this name to ancestors
+          const childAncestors = new Set(ancestors);
+          childAncestors.add(name);
+          result += applyExpansions(body, expanded, definitions, childAncestors);
+          i += name.length;
+          matched = true;
+          break;
+        }
+      }
+    }
+
+    if (!matched) {
+      result += code[i];
+      i++;
+    }
+  }
+
+  return result;
+};
+
+// ---------------------------------------------------------------------------
+// Split tokens to find ref names that can be clicked
+// ---------------------------------------------------------------------------
+
+type RenderToken =
+  | { kind: "text"; content: string; color?: string }
+  | { kind: "ref"; name: string; color?: string };
+
+const splitToken = (
+  token: ThemedToken,
+  clickableNames: ReadonlySet<string>,
+): RenderToken[] => {
+  if (clickableNames.size === 0) {
+    return [{ kind: "text", content: token.content, color: token.color }];
+  }
+
+  const text = token.content;
+  const results: RenderToken[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    let earliest = -1;
+    let matchedName = "";
+    for (const name of clickableNames) {
+      const idx = remaining.indexOf(name);
+      if (idx !== -1 && (earliest === -1 || idx < earliest || (idx === earliest && name.length > matchedName.length))) {
+        earliest = idx;
+        matchedName = name;
+      }
+    }
+
+    if (earliest === -1) {
+      results.push({ kind: "text", content: remaining, color: token.color });
+      break;
+    }
+
+    if (earliest > 0) {
+      results.push({ kind: "text", content: remaining.slice(0, earliest), color: token.color });
+    }
+    results.push({ kind: "ref", name: matchedName, color: token.color });
+    remaining = remaining.slice(earliest + matchedName.length);
+  }
+
+  return results;
+};
+
+// ---------------------------------------------------------------------------
+// HighlightedCode — renders tokenized code with clickable unexpanded refs
+// ---------------------------------------------------------------------------
+
+function HighlightedCode(props: {
+  tokens: ThemedToken[][];
+  /** Ref names that are NOT yet expanded and can be clicked */
+  clickableNames: ReadonlySet<string>;
+  onToggle: (name: string) => void;
+  expanded: ReadonlySet<string>;
+}) {
+  const { tokens, clickableNames, onToggle, expanded } = props;
+
+  return (
+    <>
+      {tokens.map((line, li) => (
+        <span key={li}>
+          {li > 0 && "\n"}
+          {line.map((token, ti) => {
+            const parts = splitToken(token, clickableNames);
+            return parts.map((part, pi) => {
+              if (part.kind === "text") {
+                return (
+                  <span key={`${ti}-${pi}`} style={part.color ? { color: part.color } : undefined}>
+                    {part.content}
+                  </span>
+                );
+              }
+
+              const isExpanded = expanded.has(part.name);
+
+              return (
+                <span
+                  key={`${ti}-${pi}`}
+                  role="button"
+                  tabIndex={0}
+                  onClick={(e) => { e.stopPropagation(); onToggle(part.name); }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onToggle(part.name);
+                    }
+                  }}
+                  className={cn(
+                    "cursor-pointer underline underline-offset-2 hover:opacity-80",
+                    isExpanded
+                      ? "decoration-current/50"
+                      : "decoration-current/30",
+                  )}
+                  style={part.color ? { color: part.color } : undefined}
+                  title={isExpanded ? `Collapse ${part.name}` : `Expand ${part.name}`}
+                >
+                  {part.name}
+                </span>
+              );
+            });
+          })}
+        </span>
+      ))}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ExpandableCodeBlock — main export
+// ---------------------------------------------------------------------------
+
+export function ExpandableCodeBlock(props: {
+  code: string;
+  definitions?: readonly Definition[];
+  className?: string;
+}) {
+  const { code, definitions = [], className } = props;
+  // Auto-expand trivial aliases (primitives, simple unions, string literals)
+  const trivialNames = useMemo(() => {
+    const trivial = new Set<string>();
+    const trivialPattern = /^(?:string|number|boolean|null|undefined|void|never|unknown|any|true|false|(?:"[^"]*"(?:\s*\|\s*"[^"]*")*))$/;
+    for (const d of definitions) {
+      const body = d.code.trim();
+      if (trivialPattern.test(body)) {
+        trivial.add(d.name);
+      }
+    }
+    return trivial;
+  }, [definitions]);
+
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  const [copied, setCopied] = useState(false);
+
+  const definitionMap = useMemo(
+    () => new Map(definitions.map((d) => [d.name, d.code])),
+    [definitions],
+  );
+
+  const definitionNames = useMemo(
+    () => new Set(definitions.map((d) => d.name)),
+    [definitions],
+  );
+
+  // Names that can be clicked — exclude trivial aliases (already inlined)
+  const clickableNames = useMemo(() => {
+    const names = new Set(definitionNames);
+    for (const name of trivialNames) names.delete(name);
+    return names;
+  }, [definitionNames, trivialNames]);
+
+  const emptyAncestors = useMemo(() => new Set<string>(), []);
+
+  // Merge user-expanded + trivial auto-expanded
+  const allExpanded = useMemo(() => {
+    const merged = new Set(expanded);
+    for (const name of trivialNames) merged.add(name);
+    return merged;
+  }, [expanded, trivialNames]);
+
+  // Build the display code: start with raw code, apply expansions, then format
+  const displayCode = useMemo(() => {
+    const withExpansions = applyExpansions(code, allExpanded, definitionMap, emptyAncestors);
+    return formatTypeScript(withExpansions);
+  }, [code, allExpanded, definitionMap, emptyAncestors]);
+
+  const tokens = useTokens(displayCode);
+
+  const handleToggle = useCallback((name: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText(displayCode).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, [displayCode]);
+
+  return (
+    <div className={cn("rounded-lg border border-border/40 bg-card/60 overflow-hidden", className)}>
+      <div className="group relative">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="absolute right-2 top-2 z-10 rounded-md border border-border bg-card/90 p-1.5 text-muted-foreground/40 opacity-0 backdrop-blur-sm hover:text-foreground group-hover:opacity-100 transition-opacity"
+          title="Copy to clipboard"
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+        </button>
+
+        <pre className="overflow-auto p-3 font-mono text-[0.75rem] leading-6 !bg-transparent">
+          <code>
+            {tokens
+              ? (
+                <HighlightedCode
+                  tokens={tokens}
+                  clickableNames={clickableNames}
+                  onToggle={handleToggle}
+                  expanded={allExpanded}
+                />
+              )
+              : <span className="text-foreground/60">{displayCode}</span>
+            }
+          </code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/components/schema-explorer.tsx
+++ b/packages/react/src/components/schema-explorer.tsx
@@ -1,0 +1,443 @@
+import { useState, useCallback } from "react";
+import { ChevronRight } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// JSON Schema types (subset we render)
+// ---------------------------------------------------------------------------
+
+type JsonSchema = {
+  type?: string | string[];
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  items?: JsonSchema | JsonSchema[];
+  additionalProperties?: boolean | JsonSchema;
+  oneOf?: JsonSchema[];
+  anyOf?: JsonSchema[];
+  allOf?: JsonSchema[];
+  enum?: unknown[];
+  const?: unknown;
+  $ref?: string;
+  $defs?: Record<string, JsonSchema>;
+  description?: string;
+  title?: string;
+  default?: unknown;
+  nullable?: boolean;
+  format?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Ref resolution — lazy, only on expand
+// ---------------------------------------------------------------------------
+
+const resolveRef = (ref: string, root: JsonSchema): JsonSchema | null => {
+  const name = ref.match(/^#\/\$defs\/(.+)$/)?.[1];
+  if (!name || !root.$defs) return null;
+  return root.$defs[name] ?? null;
+};
+
+const getRefName = (ref: string): string | undefined =>
+  ref.match(/^#\/\$defs\/(.+)$/)?.[1];
+
+/**
+ * Fully resolve a schema, following $ref and unwrapping single-variant
+ * oneOf/anyOf so we can inspect the concrete shape.
+ */
+const deepResolve = (schema: JsonSchema, root: JsonSchema): JsonSchema => {
+  let s = schema;
+  if (s.$ref) {
+    const resolved = resolveRef(s.$ref, root);
+    if (resolved) s = resolved;
+  }
+  // Unwrap single-variant unions
+  if (s.oneOf?.length === 1) s = deepResolve(s.oneOf[0]!, root);
+  if (s.anyOf?.length === 1) s = deepResolve(s.anyOf[0]!, root);
+  return s;
+};
+
+// ---------------------------------------------------------------------------
+// Type label — human readable, shows ref names
+// ---------------------------------------------------------------------------
+
+const getTypeLabel = (schema: JsonSchema, root: JsonSchema): string => {
+  if (schema.$ref) {
+    return getRefName(schema.$ref) ?? "ref";
+  }
+
+  if (schema.const !== undefined) return JSON.stringify(schema.const);
+
+  if (schema.enum) {
+    if (schema.enum.length <= 3) {
+      return schema.enum.map((v) => JSON.stringify(v)).join(" | ");
+    }
+    return `enum (${schema.enum.length})`;
+  }
+
+  if (schema.oneOf) {
+    if (schema.oneOf.length === 1) return getTypeLabel(schema.oneOf[0]!, root);
+    const labels = schema.oneOf.slice(0, 3).map((s) => getTypeLabel(s, root));
+    if (schema.oneOf.length > 3) labels.push("…");
+    return labels.join(" | ");
+  }
+
+  if (schema.anyOf) {
+    if (schema.anyOf.length === 1) return getTypeLabel(schema.anyOf[0]!, root);
+    const labels = schema.anyOf.slice(0, 3).map((s) => getTypeLabel(s, root));
+    if (schema.anyOf.length > 3) labels.push("…");
+    return labels.join(" | ");
+  }
+
+  if (schema.allOf) {
+    // If any allOf member is a named ref, show that
+    for (const s of schema.allOf) {
+      if (s.$ref) {
+        const name = getRefName(s.$ref);
+        if (name) return name;
+      }
+    }
+    return "object";
+  }
+
+  const types = Array.isArray(schema.type)
+    ? schema.type
+    : schema.type
+      ? [schema.type]
+      : [];
+
+  if (types.includes("array")) {
+    if (schema.items && !Array.isArray(schema.items)) {
+      return `${getTypeLabel(schema.items, root)}[]`;
+    }
+    return "array";
+  }
+
+  if (types.includes("object")) {
+    if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+      return `Record<string, ${getTypeLabel(schema.additionalProperties, root)}>`;
+    }
+    return "object";
+  }
+
+  if (types.length === 1) {
+    const t = types[0]!;
+    if (schema.format) return `${t}<${schema.format}>`;
+    return t;
+  }
+  if (types.length > 1) return types.join(" | ");
+
+  return "any";
+};
+
+// ---------------------------------------------------------------------------
+// Expandability check — conservative, resolves deeply
+// ---------------------------------------------------------------------------
+
+const getChildCount = (schema: JsonSchema, root: JsonSchema): number => {
+  const s = deepResolve(schema, root);
+
+  if (s.properties) return Object.keys(s.properties).length;
+
+  if (s.items && !Array.isArray(s.items)) {
+    const itemResolved = deepResolve(s.items, root);
+    if (itemResolved.properties) return Object.keys(itemResolved.properties).length;
+    return 0;
+  }
+
+  if (s.allOf) {
+    const merged = mergeAllOf(s.allOf, root);
+    if (merged.properties) return Object.keys(merged.properties).length;
+    return 0;
+  }
+
+  if (s.oneOf && s.oneOf.length > 1) return s.oneOf.length;
+  if (s.anyOf && s.anyOf.length > 1) return s.anyOf.length;
+
+  if (s.additionalProperties && typeof s.additionalProperties === "object") return 1;
+
+  return 0;
+};
+
+const isExpandable = (schema: JsonSchema, root: JsonSchema): boolean =>
+  getChildCount(schema, root) > 0;
+
+// ---------------------------------------------------------------------------
+// Merge allOf
+// ---------------------------------------------------------------------------
+
+const mergeAllOf = (schemas: JsonSchema[], root: JsonSchema): JsonSchema => {
+  const merged: JsonSchema = { type: "object", properties: {}, required: [] };
+  for (const s of schemas) {
+    const resolved = deepResolve(s, root);
+    if (resolved.properties) {
+      merged.properties = { ...merged.properties, ...resolved.properties };
+    }
+    if (resolved.required) {
+      merged.required = [...(merged.required ?? []), ...resolved.required];
+    }
+    if (resolved.description && !merged.description) {
+      merged.description = resolved.description;
+    }
+  }
+  return merged;
+};
+
+// ---------------------------------------------------------------------------
+// Type label styling — plain text, no colored pills
+// ---------------------------------------------------------------------------
+
+const typeClasses = "font-mono text-[0.6875rem] leading-5 text-muted-foreground/50";
+
+// ---------------------------------------------------------------------------
+// PropertyRow
+// ---------------------------------------------------------------------------
+
+function PropertyRow(props: {
+  name: string;
+  schema: JsonSchema;
+  root: JsonSchema;
+  required: boolean;
+  depth: number;
+  isLast?: boolean;
+  /** Hide the required/optional badge entirely (e.g. for union variants) */
+  hideRequiredBadge?: boolean;
+}) {
+  const { name, schema, root, required, depth, hideRequiredBadge } = props;
+  const [open, setOpen] = useState(false);
+  const [resolved, setResolved] = useState<JsonSchema | null>(null);
+
+  const expandable = isExpandable(schema, root);
+  const typeLabel = getTypeLabel(schema, root);
+  const description = schema.description
+    ?? (schema.$ref ? (resolveRef(schema.$ref, root)?.description) : undefined);
+
+  const handleToggle = useCallback(() => {
+    if (!open && !resolved && schema.$ref) {
+      setResolved(resolveRef(schema.$ref, root));
+    }
+    setOpen((v) => !v);
+  }, [open, resolved, schema, root]);
+
+  const childSchema = schema.$ref
+    ? resolved ?? resolveRef(schema.$ref, root) ?? schema
+    : schema;
+
+  return (
+    <div>
+      <div
+        role={expandable ? "button" : undefined}
+        tabIndex={expandable ? 0 : undefined}
+        onClick={expandable ? handleToggle : undefined}
+        onKeyDown={
+          expandable
+            ? (e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  handleToggle();
+                }
+              }
+            : undefined
+        }
+        className={[
+          "flex items-start gap-2 py-2.5 px-3",
+          expandable
+            ? "cursor-pointer hover:bg-accent/30 transition-colors"
+            : "",
+        ].join(" ")}
+        style={depth > 0 ? { paddingLeft: `${depth * 16 + 12}px` } : undefined}
+      >
+        {/* Chevron or dot */}
+        <div className="mt-0.5 flex size-4 shrink-0 items-center justify-center">
+          {expandable ? (
+            <ChevronRight
+              className="size-3 shrink-0 text-muted-foreground/30 transition-transform duration-150"
+              style={open ? { transform: "rotate(90deg)" } : undefined}
+            />
+          ) : (
+            <span className="size-1 rounded-full bg-muted-foreground/15" />
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          <p className="font-medium text-foreground text-sm">{name}</p>
+          <p className={typeClasses}>{typeLabel}</p>
+          {!hideRequiredBadge && (
+            required ? (
+              <p className="text-[0.6875rem] leading-5 text-orange-600/60 dark:text-orange-400/60">
+                required
+              </p>
+            ) : (
+              <p className="text-[0.6875rem] leading-5 text-muted-foreground/25">
+                optional
+              </p>
+            )
+          )}
+          {schema.default !== undefined && (
+            <p className="text-[0.6875rem] leading-5 text-muted-foreground/30">
+              = {JSON.stringify(schema.default)}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Description — below the row */}
+      {description && (
+        <p
+          className="px-3 pb-2 text-[0.8125rem] leading-5 text-muted-foreground/50"
+          style={{ paddingLeft: `${(depth * 16) + 32}px` }}
+        >
+          {description}
+        </p>
+      )}
+
+      {/* Children — rendered lazily on expand */}
+      {open && expandable && (
+        <div
+          className="border-l border-border/30"
+          style={{ marginLeft: `${depth * 16 + 20}px` }}
+        >
+          <PropertyChildren schema={childSchema} root={root} depth={depth + 1} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PropertyChildren — renders sub-properties
+// ---------------------------------------------------------------------------
+
+function PropertyChildren(props: {
+  schema: JsonSchema;
+  root: JsonSchema;
+  depth: number;
+}) {
+  const { schema: rawSchema, root, depth } = props;
+
+  if (depth > 6) {
+    return (
+      <p className="px-3 py-2 text-[0.8125rem] text-muted-foreground/30">
+        Nested too deep to display.
+      </p>
+    );
+  }
+
+  const schema = deepResolve(rawSchema, root);
+  const required = new Set(schema.required ?? []);
+
+  // Object properties
+  if (schema.properties && Object.keys(schema.properties).length > 0) {
+    const entries = Object.entries(schema.properties);
+    entries.sort(([a], [b]) => {
+      const ar = required.has(a);
+      const br = required.has(b);
+      if (ar !== br) return ar ? -1 : 1;
+      return a.localeCompare(b);
+    });
+    return (
+      <div className="divide-y divide-border/20">
+        {entries.map(([key, value], i) => (
+          <PropertyRow
+            key={key}
+            name={key}
+            schema={value}
+            root={root}
+            required={required.has(key)}
+            depth={depth}
+            isLast={i === entries.length - 1}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // Array items
+  if (schema.items && !Array.isArray(schema.items)) {
+    const itemSchema = deepResolve(schema.items, root);
+    if (itemSchema.properties && Object.keys(itemSchema.properties).length > 0) {
+      return <PropertyChildren schema={itemSchema} root={root} depth={depth} />;
+    }
+    return (
+      <PropertyRow name="items" schema={schema.items} root={root} required depth={depth} />
+    );
+  }
+
+  // allOf
+  if (schema.allOf) {
+    const merged = mergeAllOf(schema.allOf, root);
+    if (merged.properties && Object.keys(merged.properties).length > 0) {
+      return <PropertyChildren schema={merged} root={root} depth={depth} />;
+    }
+  }
+
+  // oneOf / anyOf (only if multiple) — these are choices, not required fields
+  const variants = schema.oneOf ?? schema.anyOf;
+  if (variants && variants.length > 1) {
+    const label = schema.oneOf ? "One of" : "Any of";
+    return (
+      <div>
+        <p
+          className="px-3 py-2 text-[0.6875rem] font-medium uppercase tracking-widest text-muted-foreground/30"
+          style={depth > 0 ? { paddingLeft: `${depth * 16 + 12}px` } : undefined}
+        >
+          {label}
+        </p>
+        <div className="divide-y divide-border/20">
+          {variants.map((variant, i) => (
+            <PropertyRow
+              key={i}
+              name={variant.title ?? `option ${i + 1}`}
+              schema={variant}
+              root={root}
+              required={false}
+              depth={depth}
+              hideRequiredBadge
+            />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // Record / additionalProperties
+  if (schema.additionalProperties && typeof schema.additionalProperties === "object") {
+    return (
+      <PropertyRow
+        name="[key]"
+        schema={schema.additionalProperties}
+        root={root}
+        required
+        depth={depth}
+      />
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// SchemaExplorer — main export
+// ---------------------------------------------------------------------------
+
+export function SchemaExplorer(props: { schema: unknown }) {
+  const schema = props.schema as JsonSchema | undefined;
+  if (!schema) return null;
+
+  const hasContent = isExpandable(schema, schema);
+
+  if (!hasContent) {
+    const typeLabel = getTypeLabel(schema, schema);
+    return (
+      <div className="rounded-lg border border-border/40 px-4 py-3">
+        <p className="text-sm text-muted-foreground/50">
+          <span className={typeClasses}>{typeLabel}</span>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border/40 overflow-hidden divide-y divide-border/20">
+      <PropertyChildren schema={schema} root={schema} depth={0} />
+    </div>
+  );
+}

--- a/packages/react/src/components/tool-detail.tsx
+++ b/packages/react/src/components/tool-detail.tsx
@@ -2,10 +2,10 @@ import { useMemo, useState } from "react";
 import { useAtomValue, Result } from "@effect-atom/atom-react";
 import { toolSchemaAtom } from "../api/atoms";
 import { ScopeId, ToolId } from "@executor/sdk";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "./accordion";
-import { Badge } from "./badge";
-import { CodeBlock } from "./code-block";
 import { Markdown } from "./markdown";
+import { SchemaExplorer } from "./schema-explorer";
+import { ExpandableCodeBlock } from "./expandable-code-block";
+import { Copy, Check, ChevronRight } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Copy button
@@ -27,48 +27,32 @@ function CopyButton(props: { text: string; label?: string }) {
       title={props.label ?? "Copy"}
     >
       {copied ? (
-        <svg viewBox="0 0 16 16" className="size-3.5">
-          <path d="M3 8l3 3 7-7" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
+        <Check className="size-3.5 shrink-0" />
       ) : (
-        <svg viewBox="0 0 16 16" className="size-3.5">
-          <rect x="5" y="5" width="8" height="8" rx="1" fill="none" stroke="currentColor" strokeWidth="1.2" />
-          <path d="M3 11V3h8" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-        </svg>
+        <Copy className="size-3.5 shrink-0" />
       )}
     </button>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Build type declarations from tool TypeScript previews
+// Helpers
 // ---------------------------------------------------------------------------
 
-const buildCallSignature = (
-  toolName: string,
-  inputTypeScript?: string,
-  outputTypeScript?: string,
-): string => {
-  const inputType = inputTypeScript ?? "void";
-  const outputType = outputTypeScript ?? "void";
-
-  const leaf = toolName.split(".").pop() ?? toolName;
-  return `declare function ${leaf}(input: ${inputType}): ${outputType}`;
+const friendlyName = (name: string): string => {
+  const leaf = name.split(".").pop() ?? name;
+  return leaf
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/[_.-]/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
 };
 
-const buildPrimaryContract = (input: {
-  toolName: string;
-  inputTypeScript?: string;
-  outputTypeScript?: string;
-}): string => {
-  const sections = [
-    buildCallSignature(input.toolName, input.inputTypeScript, input.outputTypeScript),
-    input.inputTypeScript ? `type Input = ${input.inputTypeScript}` : "type Input = void",
-    input.outputTypeScript ? `type Output = ${input.outputTypeScript}` : "type Output = void",
-  ];
-
-  return sections.join("\n\n");
-};
+const breadcrumbParts = (name: string): string[] =>
+  name.split(".").map((p) =>
+    p.replace(/([a-z])([A-Z])/g, "$1 $2")
+      .replace(/[_-]/g, " ")
+      .replace(/\b\w/g, (c) => c.toUpperCase()),
+  );
 
 // ---------------------------------------------------------------------------
 // ToolDetail
@@ -83,162 +67,166 @@ export function ToolDetail(props: {
   const toolContract = useAtomValue(
     toolSchemaAtom(props.scopeId, props.toolId as ToolId),
   );
+  const [tab, setTab] = useState<"schema" | "typescript">("schema");
 
-  const types = useMemo(() => {
+  const data = useMemo(() => {
     if (!Result.isSuccess(toolContract)) return null;
     const v = toolContract.value;
     const definitions = Object.entries(v.typeScriptDefinitions ?? {}).map(([name, body]) => ({
       name,
-      code: `type ${name} = ${body}`,
+      code: body,
     }));
 
     return {
-      inputTypeScript: v.inputTypeScript,
-      outputTypeScript: v.outputTypeScript,
-      contract: buildPrimaryContract({
-        toolName: props.toolName,
-        inputTypeScript: v.inputTypeScript,
-        outputTypeScript: v.outputTypeScript,
-      }),
+      inputSchema: v.inputSchema,
+      outputSchema: v.outputSchema,
+      inputTypeScript: v.inputTypeScript
+        ? `type Input = ${v.inputTypeScript}`
+        : null,
+      outputTypeScript: v.outputTypeScript
+        ? `type Output = ${v.outputTypeScript}`
+        : null,
       definitions,
     };
   }, [toolContract, props.toolName]);
 
-  const namespace = props.toolName.split(".").slice(0, -1).join(".") || "global";
+  const crumbs = breadcrumbParts(props.toolName);
+  const displayName = friendlyName(props.toolName);
 
   return (
-    <div className="flex h-full flex-col overflow-hidden bg-[radial-gradient(circle_at_top,rgba(120,119,198,0.08),transparent_32%),linear-gradient(to_bottom,rgba(255,255,255,0.02),transparent_24%)]">
-      <div className="shrink-0 border-b border-border/70 bg-background/90 backdrop-blur-xl">
-        <div className="px-5 py-4">
-          <div className="flex items-start gap-4">
-            <div className="relative mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-2xl border border-primary/20 bg-primary/10 text-primary shadow-[0_10px_30px_rgba(120,119,198,0.12)]">
-              <div className="absolute inset-0 rounded-2xl bg-[linear-gradient(135deg,rgba(255,255,255,0.14),transparent_55%)]" />
-              <svg viewBox="0 0 16 16" className="relative size-4">
-                <path
-                  d="M4 2h8l1 3H3l1-3zM3 6h10v8H3V6z"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.2"
-                />
-              </svg>
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header + tabs */}
+      <div className="shrink-0 border-b border-border/40">
+        <div className="px-5 pt-4 pb-0">
+          {crumbs.length > 1 && (
+            <div className="flex items-center gap-1 text-sm text-muted-foreground/40">
+              {crumbs.slice(0, -1).map((part, i) => (
+                <span key={i} className="flex items-center gap-1">
+                  {i > 0 && <ChevronRight className="size-3 shrink-0" />}
+                  <span>{part}</span>
+                </span>
+              ))}
             </div>
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="outline" className="rounded-full border-primary/20 bg-primary/5 px-2.5 py-1 font-mono text-[10px] tracking-[0.18em] text-primary/80 uppercase">
-                  {namespace}
-                </Badge>
-                <Badge variant="outline" className="rounded-full px-2.5 py-1 text-[10px] uppercase tracking-[0.18em] text-muted-foreground/80">
-                  {types?.definitions.length ?? 0} shared type{(types?.definitions.length ?? 0) === 1 ? "" : "s"}
-                </Badge>
-              </div>
-              <div className="mt-2 flex items-start gap-2">
-                <h3 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground font-mono leading-6">
-                  {props.toolName}
-                </h3>
-                <CopyButton text={props.toolId} label="Copy tool ID" />
-              </div>
-              {props.toolDescription && (
-                <div className="mt-2 max-w-2xl text-sm text-muted-foreground/90">
-                  <Markdown>{props.toolDescription}</Markdown>
-                </div>
-              )}
+          )}
+          <div className="mt-1 flex items-center gap-2">
+            <h3 className="text-base font-semibold text-foreground truncate">
+              {displayName}
+            </h3>
+            <CopyButton text={props.toolId} label="Copy tool ID" />
+          </div>
+          {props.toolDescription && (
+            <div className="mt-1.5 max-w-lg text-sm text-muted-foreground/70 line-clamp-2">
+              <Markdown>{props.toolDescription}</Markdown>
             </div>
+          )}
+
+          {/* Tabs */}
+          <div className="mt-3 flex gap-4" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "schema"}
+              onClick={() => setTab("schema")}
+              className={[
+                "border-b-2 pb-2.5 text-sm font-medium transition-colors",
+                tab === "schema"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground/50 hover:text-muted-foreground",
+              ].join(" ")}
+            >
+              Schema
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "typescript"}
+              onClick={() => setTab("typescript")}
+              className={[
+                "border-b-2 pb-2.5 text-sm font-medium transition-colors",
+                tab === "typescript"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground/50 hover:text-muted-foreground",
+              ].join(" ")}
+            >
+              TypeScript
+            </button>
           </div>
         </div>
       </div>
 
+      {/* Content */}
       <div className="flex-1 overflow-y-auto">
         {Result.match(toolContract, {
           onInitial: () => (
-            <div className="p-5 text-sm text-muted-foreground">Loading tool contract…</div>
+            <div className="p-5 text-sm text-muted-foreground">Loading…</div>
           ),
           onFailure: () => (
-            <div className="p-5 text-sm text-destructive">Failed to load tool contract</div>
+            <div className="p-5 text-sm text-destructive">Something went wrong</div>
           ),
-          onSuccess: () => (
-            <div className="space-y-4 px-5 py-4">
-              <div className="rounded-2xl border border-border/70 bg-card/70 shadow-[0_12px_40px_rgba(0,0,0,0.04)] overflow-hidden">
-                <div className="flex items-center justify-between border-b border-border/70 bg-muted/30 px-4 py-3">
-                  <div>
-                    <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground/75">
-                      Primary contract
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground/80">
-                      One compact view for the call signature, input, and output.
-                    </p>
+          onSuccess: () =>
+            tab === "schema" ? (
+              <div className="px-5 py-5 space-y-6">
+                <section>
+                  <h4 className="text-[0.6875rem] font-medium uppercase tracking-widest text-muted-foreground/40">
+                    Parameters
+                  </h4>
+                  <div className="mt-2.5">
+                    {data?.inputSchema ? (
+                      <SchemaExplorer schema={data.inputSchema} />
+                    ) : (
+                      <p className="py-2 text-sm text-muted-foreground/40">None</p>
+                    )}
                   </div>
-                  <div className="hidden items-center gap-2 sm:flex">
-                    <Badge variant="outline" className="rounded-full px-2.5 py-1 text-[10px] uppercase tracking-[0.16em]">
-                      {types?.inputTypeScript ? "input" : "no input"}
-                    </Badge>
-                    <Badge variant="outline" className="rounded-full px-2.5 py-1 text-[10px] uppercase tracking-[0.16em]">
-                      {types?.outputTypeScript ? "output" : "no output"}
-                    </Badge>
-                  </div>
-                </div>
-                <div className="p-4">
-                  {types?.contract && (
-                    <CodeBlock
-                      code={types.contract}
-                      lang="typescript"
-                      className="rounded-xl border-border/60 bg-background/70"
-                    />
-                  )}
-                </div>
-              </div>
+                </section>
 
-              <div className="rounded-2xl border border-border/70 bg-card/50 px-4 py-3 shadow-[0_8px_30px_rgba(0,0,0,0.03)]">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground/75">
-                      Shared definitions
-                    </p>
-                    <p className="mt-1 text-xs text-muted-foreground/80">
-                      Referenced types stay tucked away until you need them.
-                    </p>
+                <section>
+                  <h4 className="text-[0.6875rem] font-medium uppercase tracking-widest text-muted-foreground/40">
+                    Response
+                  </h4>
+                  <div className="mt-2.5">
+                    {data?.outputSchema ? (
+                      <SchemaExplorer schema={data.outputSchema} />
+                    ) : (
+                      <p className="py-2 text-sm text-muted-foreground/40">None</p>
+                    )}
                   </div>
-                  <Badge variant="outline" className="rounded-full px-2.5 py-1 text-[10px] uppercase tracking-[0.16em]">
-                    {types?.definitions.length ?? 0}
-                  </Badge>
-                </div>
-
-                {types && types.definitions.length > 0 ? (
-                  <Accordion type="multiple" className="mt-3 divide-y divide-border/60">
-                    {types.definitions.map((definition) => (
-                      <AccordionItem key={definition.name} value={definition.name} className="border-none">
-                        <AccordionTrigger className="py-3 hover:no-underline">
-                          <div className="flex min-w-0 items-center gap-3">
-                            <div className="flex size-8 shrink-0 items-center justify-center rounded-xl border border-border/70 bg-background/80 text-[11px] font-medium text-muted-foreground">
-                              TS
-                            </div>
-                            <div className="min-w-0">
-                              <div className="truncate font-mono text-sm text-foreground">
-                                {definition.name}
-                              </div>
-                              <div className="text-xs text-muted-foreground/75">
-                                Referenced by the primary contract
-                              </div>
-                            </div>
-                          </div>
-                        </AccordionTrigger>
-                        <AccordionContent className="pb-1">
-                          <CodeBlock
-                            code={definition.code}
-                            lang="typescript"
-                            className="rounded-xl border-border/60 bg-background/70"
-                          />
-                        </AccordionContent>
-                      </AccordionItem>
-                    ))}
-                  </Accordion>
-                ) : (
-                  <div className="mt-3 rounded-xl border border-dashed border-border/70 bg-background/40 px-4 py-5 text-center text-[13px] text-muted-foreground/65">
-                    This contract is self-contained — no extra referenced types.
-                  </div>
-                )}
+                </section>
               </div>
-            </div>
-          ),
+            ) : (
+              <div className="px-5 py-5 space-y-6">
+                <section>
+                  <h4 className="text-[0.6875rem] font-medium uppercase tracking-widest text-muted-foreground/40">
+                    Input
+                  </h4>
+                  <div className="mt-2.5">
+                    {data?.inputTypeScript ? (
+                      <ExpandableCodeBlock
+                        code={data.inputTypeScript}
+                        definitions={data.definitions}
+                      />
+                    ) : (
+                      <p className="py-2 text-sm text-muted-foreground/40">void</p>
+                    )}
+                  </div>
+                </section>
+
+                <section>
+                  <h4 className="text-[0.6875rem] font-medium uppercase tracking-widest text-muted-foreground/40">
+                    Output
+                  </h4>
+                  <div className="mt-2.5">
+                    {data?.outputTypeScript ? (
+                      <ExpandableCodeBlock
+                        code={data.outputTypeScript}
+                        definitions={data.definitions}
+                      />
+                    ) : (
+                      <p className="py-2 text-sm text-muted-foreground/40">void</p>
+                    )}
+                  </div>
+                </section>
+              </div>
+            ),
         })}
       </div>
     </div>
@@ -257,12 +245,8 @@ export function ToolDetailEmpty(props: { hasTools: boolean }) {
           {props.hasTools ? "Select a tool" : "No tools available"}
         </p>
         {props.hasTools && (
-          <p className="mt-1 text-xs text-muted-foreground">
-            Choose from the list or press{" "}
-            <kbd className="rounded border border-border bg-muted px-1 py-px text-[10px]">
-              /
-            </kbd>{" "}
-            to search.
+          <p className="mt-1.5 text-sm text-muted-foreground/50">
+            Choose from the list to see what it does.
           </p>
         )}
       </div>


### PR DESCRIPTION
## Summary

- **Interactive schema explorer** — JSON Schema rendered as an expandable property tree with lazy `$ref` resolution, type labels, required/optional badges, and `oneOf`/`anyOf` displayed as choices
- **Expandable TypeScript code blocks** — clickable type references that inline-expand with syntax highlighting; trivial aliases (`string`, `number`, etc.) auto-expanded
- **Tabbed layout** — Schema and TypeScript tabs with sticky header, breadcrumbs, and human-readable tool names
- **Raw JSON Schema in API** — `inputSchema` and `outputSchema` fields added to schema endpoint with `$defs` reattached
- **No more truncation** — TypeScript preview limits removed for the schema endpoint so types render complete
- **Router fix** — `maxParamLength` bumped from default 100 to 1000, fixing 94 tools with long IDs that returned 400 errors
- **Dev-only picker script** — `ui.sh/ui-picker.js` loaded conditionally via `import.meta.env.DEV`

## Test plan

- [ ] Navigate to a source, select a tool — verify Schema tab shows expandable property tree
- [ ] Click properties with `$ref` types — verify they expand lazily, show nested properties
- [ ] Switch to TypeScript tab — verify formatted code with syntax highlighting
- [ ] Click a type reference in TypeScript view — verify it expands inline with its resolved body
- [ ] Test a tool with ID > 100 chars (e.g. Cloudflare bookmark tools) — verify schema loads
- [ ] Verify `oneOf`/`anyOf` variants show as choices without required/optional badges
- [ ] Check trivial type aliases auto-expand (e.g. `NonEmptyTrimmedString` → `string`)