### PR TITLE
Remove PGlite from cloud app

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -28,7 +28,6 @@
     "react-dom": "catalog:"
   },
   "devDependencies": {
-    "@electric-sql/pglite": "^0.4.3",
     "@tailwindcss/vite": "catalog:",
     "@types/pg": "^8.15.4",
     "@types/react": "catalog:",

--- a/apps/cloud/src/env.ts
+++ b/apps/cloud/src/env.ts
@@ -12,7 +12,6 @@ const sharedShape = {
 
 const serverShape = {
   DATABASE_URL: Env.stringOr("DATABASE_URL", ""),
-  PGLITE_DATA_DIR: Env.stringOr("PGLITE_DATA_DIR", ".pglite"),
   ENCRYPTION_KEY: Env.stringOr(
     "ENCRYPTION_KEY",
     "local-dev-encryption-key",
@@ -28,7 +27,6 @@ type SharedEnv = Readonly<{
 
 type ServerEnv = SharedEnv & Readonly<{
   DATABASE_URL: string;
-  PGLITE_DATA_DIR: string;
   ENCRYPTION_KEY: string;
   WORKOS_API_KEY: string;
   WORKOS_CLIENT_ID: string;

--- a/apps/cloud/src/services/db.ts
+++ b/apps/cloud/src/services/db.ts
@@ -30,6 +30,11 @@ const resolveHyperdriveUrl = Effect.tryPromise({
 
 const resolveConnectionString = resolveHyperdriveUrl.pipe(
   Effect.map((url) => url ?? (server.DATABASE_URL || undefined)),
+  Effect.flatMap((url) =>
+    url
+      ? Effect.succeed(url)
+      : Effect.fail(new Error("No database connection string available (set DATABASE_URL or configure Hyperdrive)")),
+  ),
 );
 
 // ---------------------------------------------------------------------------
@@ -48,22 +53,6 @@ const releasePostgres = ({ pool }: { pool: { end: () => Promise<void> } }) =>
   Effect.promise(() => pool.end()).pipe(Effect.orElseSucceed(() => undefined));
 
 // ---------------------------------------------------------------------------
-// PGlite — local dev fallback
-// ---------------------------------------------------------------------------
-
-const acquirePglite = Effect.tryPromise(async () => {
-  const { PGlite } = await import("@electric-sql/pglite");
-  const { drizzle } = await import("drizzle-orm/pglite");
-  const client = new PGlite(server.PGLITE_DATA_DIR);
-  return { db: drizzle(client, { schema }) as DrizzleDb, client };
-});
-
-const releasePglite = ({ client }: { client: { close?: () => Promise<void> } }) =>
-  Effect.promise(() => client.close?.() ?? Promise.resolve()).pipe(
-    Effect.orElseSucceed(() => undefined),
-  );
-
-// ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
@@ -75,16 +64,10 @@ export class DbService extends Context.Tag("@executor/cloud/DbService")<
     this,
     Effect.gen(function* () {
       const connectionString = yield* resolveConnectionString;
-
-      if (connectionString) {
-        const { db } = yield* Effect.acquireRelease(
-          acquirePostgres(connectionString),
-          releasePostgres,
-        );
-        return db;
-      }
-
-      const { db } = yield* Effect.acquireRelease(acquirePglite, releasePglite);
+      const { db } = yield* Effect.acquireRelease(
+        acquirePostgres(connectionString),
+        releasePostgres,
+      );
       return db;
     }),
   );


### PR DESCRIPTION
## Summary

- Remove PGlite dev fallback from cloud app — always uses Postgres via Hyperdrive or DATABASE_URL
- Remove `PGLITE_DATA_DIR` env var
- Remove `@electric-sql/pglite` dev dependency
- Fail explicitly if no database connection string is available

## Test plan

- [ ] Verify cloud app connects to Postgres via Hyperdrive on CF
- [ ] Verify local dev works with DATABASE_URL set