### PR TITLE
Fix cloud app hanging on Cloudflare Workers

### DIFF
--- a/apps/cloud/src/api.ts
+++ b/apps/cloud/src/api.ts
@@ -10,7 +10,7 @@ import {
   HttpRouter,
   HttpServer,
 } from "@effect/platform";
-import { Effect, Layer, Scope } from "effect";
+import { Effect, Layer } from "effect";
 import { setCookie } from "@tanstack/react-start/server";
 
 import { addGroup } from "@executor/api";
@@ -69,20 +69,19 @@ const SharedServices = Layer.mergeAll(
   HttpServer.layerContext,
 );
 
-const sharedServicesScope = Effect.runSync(Scope.make());
-const SharedServicesMemoized = Effect.runSync(
-  Layer.memoize(SharedServices).pipe(
-    Scope.extend(sharedServicesScope),
-  ),
-);
-
-const publicApiHandler = HttpApiBuilder.toWebHandler(
-  PublicCloudApiLive.pipe(
-    Layer.provideMerge(SharedServicesMemoized),
-    Layer.provideMerge(HttpRouter.setRouterConfig({ maxParamLength: 1000 })),
-  ),
-  { middleware: HttpMiddleware.logger },
-);
+let _publicApiHandler: ReturnType<typeof HttpApiBuilder.toWebHandler> | null = null;
+const getPublicApiHandler = () => {
+  if (!_publicApiHandler) {
+    _publicApiHandler = HttpApiBuilder.toWebHandler(
+      PublicCloudApiLive.pipe(
+        Layer.provideMerge(SharedServices),
+        Layer.provideMerge(HttpRouter.setRouterConfig({ maxParamLength: 1000 })),
+      ),
+      { middleware: HttpMiddleware.logger },
+    );
+  }
+  return _publicApiHandler;
+};
 
 const parseCookie = (cookieHeader: string | null, name: string): string | null => {
   if (!cookieHeader) return null;
@@ -187,7 +186,7 @@ const createProtectedHandler = (
       Layer.provideMerge(HttpApiBuilder.middlewareOpenApi()),
       Layer.provideMerge(ProtectedCloudApiLive),
       Layer.provideMerge(requestServices),
-      Layer.provideMerge(SharedServicesMemoized),
+      Layer.provideMerge(SharedServices),
       Layer.provideMerge(HttpRouter.setRouterConfig({ maxParamLength: 1000 })),
     ),
     { middleware: HttpMiddleware.logger },
@@ -210,7 +209,7 @@ export const handleApiRequest = async (request: Request): Promise<Response> => {
   const pathname = new URL(request.url).pathname;
 
   if (isPublicPath(pathname)) {
-    return publicApiHandler.handler(request);
+    return getPublicApiHandler().handler(request);
   }
 
   const requestProgram = Effect.gen(function* () {
@@ -248,7 +247,7 @@ export const handleApiRequest = async (request: Request): Promise<Response> => {
 
   return Effect.runPromise(
     requestProgram.pipe(
-      Effect.provide(SharedServicesMemoized),
+      Effect.provide(SharedServices),
       Effect.scoped,
     ),
   );

--- a/apps/cloud/src/services/db.ts
+++ b/apps/cloud/src/services/db.ts
@@ -44,13 +44,15 @@ const resolveConnectionString = resolveHyperdriveUrl.pipe(
 const acquirePostgres = (connectionString: string) =>
   Effect.tryPromise(async () => {
     const { drizzle } = await import("drizzle-orm/node-postgres");
-    const { Pool } = await import("pg");
-    const pool = new Pool({ connectionString });
-    return { db: drizzle(pool, { schema }) as DrizzleDb, pool };
+    const { Client } = await import("pg");
+    // Use Client (not Pool) — Hyperdrive manages connection pooling externally.
+    const client = new Client({ connectionString });
+    await client.connect();
+    return { db: drizzle(client, { schema }) as DrizzleDb, client };
   });
 
-const releasePostgres = ({ pool }: { pool: { end: () => Promise<void> } }) =>
-  Effect.promise(() => pool.end()).pipe(Effect.orElseSucceed(() => undefined));
+const releasePostgres = ({ client }: { client: { end: () => Promise<void> } }) =>
+  Effect.promise(() => client.end()).pipe(Effect.orElseSucceed(() => undefined));
 
 // ---------------------------------------------------------------------------
 // Service


### PR DESCRIPTION
## Summary

- Use `pg.Client` instead of `pg.Pool` — Hyperdrive manages connection pooling externally
- Remove `Effect.runSync(Scope.make())` and `Layer.memoize` at module top level — this pattern holds resources across the module lifecycle which causes the DB connection to hang during Workers' restricted init context
- Make public API handler construction lazy (deferred to first request)

## Root cause

`Layer.memoize` with a top-level `Scope` attempted to establish and hold a DB connection during module initialization. Workers restrict I/O during init, causing the connection to hang indefinitely and triggering "Worker's code had hung" errors.

## Test plan

- [x] `/api/auth/me` returns 401 (no hang)
- [x] `/api/auth/login` redirects to WorkOS with HTTPS callback URL
- [x] `/api/debug/db` confirmed Hyperdrive → Planetscale connection works
- [ ] Full sign-in flow on executor.sh