### PR TITLE
Polish hero catalog

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -480,7 +480,6 @@ import Layout from '../layouts/Layout.astro'
 
             detectStatus.className = 'absolute left-0 right-0 -bottom-7 text-[11px] font-mono text-center text-teal';
             detectStatus.textContent = `${data.kind} detected — ${data.count} tools found`;
-            detectExamples.classList.add('hidden');
 
             // Clear input
             detectInput.value = '';

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -91,10 +91,10 @@ import Layout from '../layouts/Layout.astro'
           </div>
 
           <!-- Content: sidebar + main -->
-          <div class="flex">
+          <div class="flex h-[400px]">
 
             <!-- Sidebar: sources -->
-            <div class="w-[200px] shrink-0 border-r border-rule p-3 space-y-1 hidden sm:block">
+            <div class="w-[200px] h-full shrink-0 border-r border-rule p-3 space-y-1 overflow-y-auto scrollbar-thin sm:block">
               <div class="text-[10px] font-mono text-ink-faint uppercase tracking-[0.1em] mb-2.5 px-2">Connected</div>
               <button data-source="github" class="catalog-source w-full flex items-center gap-2.5 px-2 py-2 rounded-md text-left transition-colors bg-teal/[0.08] border border-teal/15">
                 <div class="w-5 h-5 rounded bg-orange-400/15 flex items-center justify-center text-[9px] text-orange-400 font-mono font-medium shrink-0">G</div>
@@ -158,7 +158,7 @@ import Layout from '../layouts/Layout.astro'
 
               <!-- Scrollable tool tree with bottom fade -->
               <div class="relative flex-1 min-h-0">
-                <div class="overflow-y-auto h-[340px] scrollbar-thin" data-tool-list>
+                <div class="overflow-y-auto h-full scrollbar-thin" data-tool-list>
                   <!-- Populated by JS -->
                 </div>
                 <div class="absolute bottom-0 left-0 right-0 h-16 bg-gradient-to-t from-surface-raised to-transparent pointer-events-none transition-opacity duration-300" data-fade></div>
@@ -475,8 +475,9 @@ import Layout from '../layouts/Layout.astro'
             `;
             btn.addEventListener('click', () => renderSource(key));
             sidebar.appendChild(btn);
-
-            renderSource(key);
+            sidebar.scrollTop = sidebar.scrollHeight;
+            
+            setTimeout(() => renderSource(key), 150);
 
             detectStatus.className = 'absolute left-0 right-0 -bottom-7 text-[11px] font-mono text-center text-teal';
             detectStatus.textContent = `${data.kind} detected — ${data.count} tools found`;


### PR DESCRIPTION
### `#1` Keep examples visible (https://github.com/RhysSullivan/executor/commit/32aae0aee218b55de08764d30855e1cbb5a70cab)

I don't think you have to hide button when added to sources and it's annoying to see layout shift. It might better to keep it.

### `#2` Fix layout shift (https://github.com/RhysSullivan/executor/commit/6694386bcbd18950027fd9a9bd35e1b776c35ff7)

https://github.com/user-attachments/assets/93131e71-2b08-4710-834a-490e2d65666c

When source is added page automatically scrolls a bit, and left pane grows but right pane doesn't. This commit fixes them with no layout shift.

https://github.com/user-attachments/assets/2953288b-c717-476c-ab2f-5d273afe34dd

