### PR TITLE
feat(mcp): support manual headers for remote sources

### DIFF
--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
-import { useAtomSet, useAtomValue, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { useAtomSet } from "@effect-atom/atom-react";
 
-import { secretsAtom, setSecret } from "@executor/react/api/atoms";
 import { useScope } from "@executor/react/api/scope-context";
-import { SecretPicker, type SecretPickerSecret } from "@executor/react/plugins/secret-picker";
-import { SecretId } from "@executor/sdk";
+import { SecretHeaderAuthRow } from "@executor/react/plugins/secret-header-auth";
+import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor/react/components/button";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
@@ -12,144 +11,19 @@ import { Spinner } from "@executor/react/components/spinner";
 import { addGraphqlSource } from "./atoms";
 import type { HeaderValue } from "../sdk/types";
 
-// ---------------------------------------------------------------------------
-// Inline secret creation
-// ---------------------------------------------------------------------------
+type HeaderEntry = {
+  name: string;
+  prefix?: string;
+  presetKey?: string;
+  secretId: string | null;
+};
 
-function InlineCreateSecret(props: {
-  headerName: string;
-  suggestedId: string;
-  onCreated: (secretId: string) => void;
-  onCancel: () => void;
-}) {
-  const [secretId, setSecretId] = useState(props.suggestedId);
-  const [secretName, setSecretName] = useState(props.headerName);
-  const [secretValue, setSecretValue] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const scopeId = useScope();
-  const doSet = useAtomSet(setSecret, { mode: "promise" });
-  const refreshSecrets = useAtomRefresh(secretsAtom(scopeId));
-
-  const handleSave = async () => {
-    if (!secretId.trim() || !secretValue.trim()) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await doSet({
-        path: { scopeId },
-        payload: {
-          id: SecretId.make(secretId.trim()),
-          name: secretName.trim() || secretId.trim(),
-          value: secretValue.trim(),
-          purpose: `Auth header: ${props.headerName}`,
-        },
-      });
-      refreshSecrets();
-      props.onCreated(secretId.trim());
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save secret");
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-2.5">
-      <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
-      <div className="grid grid-cols-2 gap-2">
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">ID</Label>
-          <Input
-            value={secretId}
-            onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
-            placeholder="my-api-token"
-            className="h-8 text-xs font-mono"
-          />
-        </div>
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Label</Label>
-          <Input
-            value={secretName}
-            onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
-            placeholder="API Token"
-            className="h-8 text-xs"
-          />
-        </div>
-      </div>
-      <div className="space-y-1">
-        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Value</Label>
-        <Input
-          type="password"
-          value={secretValue}
-          onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
-          placeholder="paste your token or key..."
-          className="h-8 text-xs font-mono"
-        />
-      </div>
-      {error && <p className="text-[11px] text-destructive">{error}</p>}
-      <div className="flex gap-1.5 pt-0.5">
-        <Button variant="outline" size="xs" onClick={props.onCancel}>
-          Cancel
-        </Button>
-        <Button
-          size="xs"
-          onClick={handleSave}
-          disabled={!secretId.trim() || !secretValue.trim() || saving}
-        >
-          {saving ? "Saving..." : "Create & use"}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Auth header row
-// ---------------------------------------------------------------------------
-
-function AuthHeaderRow(props: {
-  selectedSecretId: string | null;
-  onSelect: (secretId: string) => void;
-  existingSecrets: readonly SecretPickerSecret[];
-}) {
-  const [creating, setCreating] = useState(false);
-  const { selectedSecretId, onSelect, existingSecrets } = props;
-
-  if (creating) {
-    return (
-      <InlineCreateSecret
-        headerName="Authorization"
-        suggestedId="graphql-auth-token"
-        onCreated={(id) => {
-          onSelect(id);
-          setCreating(false);
-        }}
-        onCancel={() => setCreating(false)}
-      />
-    );
-  }
-
-  return (
-    <div className="space-y-1.5">
-      <div className="flex items-center gap-1.5">
-        <div className="flex-1 min-w-0">
-          <SecretPicker
-            value={selectedSecretId}
-            onSelect={onSelect}
-            secrets={existingSecrets}
-          />
-        </div>
-        <Button variant="outline" size="sm" className="shrink-0" onClick={() => setCreating(true)}>
-          + New
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
+const initialHeader = (): HeaderEntry => ({
+  name: "Authorization",
+  prefix: "Bearer ",
+  presetKey: "bearer",
+  secretId: null,
+});
 
 export default function AddGraphqlSource(props: {
   onComplete: () => void;
@@ -158,34 +32,53 @@ export default function AddGraphqlSource(props: {
 }) {
   const [endpoint, setEndpoint] = useState(props.initialUrl ?? "");
   const [namespace, setNamespace] = useState("");
-  const [authSecretId, setAuthSecretId] = useState<string | null>(null);
+  const [headers, setHeaders] = useState<HeaderEntry[]>([initialHeader()]);
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
 
   const scopeId = useScope();
   const doAdd = useAtomSet(addGraphqlSource, { mode: "promise" });
-  const secrets = useAtomValue(secretsAtom(scopeId));
+  const secretList = useSecretPickerSecrets();
 
-  const secretList: readonly SecretPickerSecret[] = Result.match(secrets, {
-    onInitial: () => [] as SecretPickerSecret[],
-    onFailure: () => [] as SecretPickerSecret[],
-    onSuccess: ({ value }) =>
-      value.map((s) => ({
-        id: s.id,
-        name: s.name,
-        provider: s.provider ? String(s.provider) : undefined,
-      })),
-  });
+  const headersValid = headers.every(
+    (header) => header.name.trim() && header.secretId,
+  );
+  const canAdd =
+    endpoint.trim().length > 0 && (headers.length === 0 || headersValid);
 
-  const canAdd = endpoint.trim().length > 0;
+  const updateHeader = (
+    index: number,
+    update: Partial<{ name: string; prefix?: string; presetKey?: string; secretId: string | null }>,
+  ) => {
+    setHeaders((current) =>
+      current.map((header, i) => (i === index ? { ...header, ...update } : header)),
+    );
+  };
+
+  const removeHeader = (index: number) => {
+    setHeaders((current) => current.filter((_, i) => i !== index));
+  };
+
+  const addHeader = () => {
+    setHeaders((current) => [
+      ...current,
+      { name: "", prefix: undefined, presetKey: undefined, secretId: null },
+    ]);
+  };
 
   const handleAdd = async () => {
     setAdding(true);
     setAddError(null);
     try {
-      const headers: Record<string, HeaderValue> = {};
-      if (authSecretId) {
-        headers["Authorization"] = { secretId: authSecretId, prefix: "Bearer " };
+      const headerMap: Record<string, HeaderValue> = {};
+      for (const header of headers) {
+        const name = header.name.trim();
+        if (name && header.secretId) {
+          headerMap[name] = {
+            secretId: header.secretId,
+            ...(header.prefix ? { prefix: header.prefix } : {}),
+          };
+        }
       }
 
       await doAdd({
@@ -193,7 +86,7 @@ export default function AddGraphqlSource(props: {
         payload: {
           endpoint: endpoint.trim(),
           namespace: namespace.trim() || undefined,
-          ...(Object.keys(headers).length > 0 ? { headers } : {}),
+          ...(Object.keys(headerMap).length > 0 ? { headers: headerMap } : {}),
         },
       });
       props.onComplete();
@@ -239,17 +132,43 @@ export default function AddGraphqlSource(props: {
 
       {/* Authentication */}
       <section className="space-y-2.5">
-        <Label>
-          Authentication <span className="text-muted-foreground font-normal">(optional)</span>
-        </Label>
-        <p className="text-[12px] text-muted-foreground">
-          Select a secret for the Bearer token sent with every request, including introspection.
-        </p>
-        <AuthHeaderRow
-          selectedSecretId={authSecretId}
-          onSelect={setAuthSecretId}
-          existingSecrets={secretList}
-        />
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <Label>
+              Authentication <span className="text-muted-foreground font-normal">(optional)</span>
+            </Label>
+            <p className="mt-1 text-[12px] text-muted-foreground">
+              Secret-backed headers sent with every request, including introspection.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="shrink-0"
+            onClick={addHeader}
+          >
+            + Add header
+          </Button>
+        </div>
+
+        {headers.length > 0 && (
+          <div className="space-y-2">
+            {headers.map((header, index) => (
+              <SecretHeaderAuthRow
+                key={index}
+                name={header.name}
+                prefix={header.prefix}
+                presetKey={header.presetKey}
+                secretId={header.secretId}
+                onChange={(update) => updateHeader(index, update)}
+                onSelectSecret={(secretId) => updateHeader(index, { secretId })}
+                onRemove={() => removeHeader(index)}
+                existingSecrets={secretList}
+              />
+            ))}
+          </div>
+        )}
       </section>
 
       {/* Error */}

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -6,7 +6,10 @@ import { Button } from "@executor/react/components/button";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
+import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
 import { Spinner } from "@executor/react/components/spinner";
+import { SecretHeaderAuthRow } from "@executor/react/plugins/secret-header-auth";
+import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { probeMcpEndpoint, addMcpSource, startMcpOAuth } from "./atoms";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
 
@@ -38,6 +41,13 @@ type ProbeResult = {
   namespace: string;
   toolCount: number | null;
   serverName: string | null;
+};
+
+type RemoteAuthMode = "none" | "header" | "oauth2";
+
+type PlainHeader = {
+  name: string;
+  value: string;
 };
 
 type State =
@@ -230,6 +240,21 @@ export default function AddMcpSource(props: {
   const doProbe = useAtomSet(probeMcpEndpoint, { mode: "promise" });
   const doAdd = useAtomSet(addMcpSource, { mode: "promise" });
   const doStartOAuth = useAtomSet(startMcpOAuth, { mode: "promise" });
+  const secretList = useSecretPickerSecrets();
+
+  const [remoteAuthMode, setRemoteAuthMode] = useState<RemoteAuthMode>("none");
+  const [remoteHeaderAuth, setRemoteHeaderAuth] = useState<{
+    name: string;
+    prefix?: string;
+    presetKey?: string;
+    secretId: string | null;
+  }>({
+    name: "Authorization",
+    prefix: "Bearer ",
+    presetKey: "bearer",
+    secretId: null,
+  });
+  const [remoteHeaders, setRemoteHeaders] = useState<PlainHeader[]>([]);
 
   const probe = "probe" in state ? state.probe : null;
   const tokens = "tokens" in state ? state.tokens : null;
@@ -237,8 +262,16 @@ export default function AddMcpSource(props: {
   const isProbing = state.step === "probing";
   const isAdding = state.step === "adding";
   const isOAuthBusy = state.step === "oauth-starting" || state.step === "oauth-waiting";
-  const needsOAuth = probe?.requiresOAuth === true && !tokens;
-  const canAdd = probe && !needsOAuth && !isAdding && !isOAuthBusy;
+  const canUseNone = probe?.requiresOAuth !== true;
+  const headerAuthComplete = Boolean(remoteHeaderAuth.name.trim() && remoteHeaderAuth.secretId);
+  const remoteHeadersComplete = remoteHeaders.every(
+    (header) => header.name.trim() && header.value.trim(),
+  );
+  const authReady =
+    remoteAuthMode === "none" ? canUseNone
+    : remoteAuthMode === "header" ? headerAuthComplete
+    : tokens !== null;
+  const canAdd = Boolean(probe) && authReady && remoteHeadersComplete && !isAdding && !isOAuthBusy;
   const error = state.step === "error" ? state.error : null;
 
   // ---- Remote actions ----
@@ -250,6 +283,7 @@ export default function AddMcpSource(props: {
         path: { scopeId },
         payload: { endpoint: state.url.trim() },
       });
+      setRemoteAuthMode(result.requiresOAuth ? "oauth2" : "none");
       dispatch({ type: "probe-ok", probe: result });
     } catch (e) {
       dispatch({ type: "probe-fail", error: e instanceof Error ? e.message : "Failed to connect" });
@@ -316,13 +350,15 @@ export default function AddMcpSource(props: {
     if (!probe) return;
     dispatch({ type: "add-start" });
     try {
-      await doAdd({
-        path: { scopeId },
-        payload: {
-          transport: "remote" as const,
-          name: probe.serverName ?? probe.name,
-          endpoint: state.url.trim(),
-          auth: tokens
+      const auth =
+        remoteAuthMode === "header"
+          ? {
+              kind: "header" as const,
+              headerName: remoteHeaderAuth.name.trim(),
+              secretId: remoteHeaderAuth.secretId!,
+              ...(remoteHeaderAuth.prefix ? { prefix: remoteHeaderAuth.prefix } : {}),
+            }
+          : remoteAuthMode === "oauth2" && tokens
             ? {
                 kind: "oauth2" as const,
                 accessTokenSecretId: tokens.accessTokenSecretId,
@@ -331,14 +367,28 @@ export default function AddMcpSource(props: {
                 expiresAt: tokens.expiresAt,
                 scope: tokens.scope,
               }
-            : { kind: "none" as const },
+            : { kind: "none" as const };
+      const headers = Object.fromEntries(
+        remoteHeaders
+          .map((header) => [header.name.trim(), header.value.trim()] as const)
+          .filter(([name, value]) => name && value),
+      );
+
+      await doAdd({
+        path: { scopeId },
+        payload: {
+          transport: "remote" as const,
+          name: probe.serverName ?? probe.name,
+          endpoint: state.url.trim(),
+          auth,
+          ...(Object.keys(headers).length > 0 ? { headers } : {}),
         },
       });
       props.onComplete();
     } catch (e) {
       dispatch({ type: "add-fail", error: e instanceof Error ? e.message : "Failed to add source" });
     }
-  }, [probe, tokens, state.url, doAdd, props]);
+  }, [probe, remoteAuthMode, remoteHeaderAuth, remoteHeaders, tokens, state.url, doAdd, props]);
 
   // ---- Stdio actions ----
 
@@ -483,51 +533,217 @@ export default function AddMcpSource(props: {
             </div>
           )}
 
-          {/* OAuth section */}
-          {probe?.requiresOAuth && !tokens && (
+          {/* Authentication */}
+          {probe && (
             <section className="space-y-2.5">
-              {state.step === "probed" && (
-                <Button onClick={handleOAuth} className="w-full" variant="outline">
-                  <svg viewBox="0 0 16 16" fill="none" className="mr-1.5 size-3.5">
-                    <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1z" stroke="currentColor" strokeWidth="1.2" />
-                    <path d="M8 4v4l2.5 1.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                  Sign in with OAuth
-                </Button>
-              )}
+              <Label>Authentication</Label>
 
-              {state.step === "oauth-starting" && (
-                <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
-                  <Spinner className="size-3.5" />
-                  <span className="text-xs text-muted-foreground">Starting authorization…</span>
-                </div>
-              )}
-
-              {state.step === "oauth-waiting" && (
-                <div className="flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 px-3 py-2.5">
-                  <Spinner className="size-3.5 text-blue-500" />
-                  <span className="text-xs text-blue-600 dark:text-blue-400">Waiting for authorization in popup…</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleCancelOAuth}
-                    className="ml-auto h-7 px-2 text-xs"
+              <RadioGroup
+                value={remoteAuthMode}
+                onValueChange={(value) => setRemoteAuthMode(value as RemoteAuthMode)}
+                className="gap-1.5"
+              >
+                {!probe.requiresOAuth && (
+                  <label
+                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
+                      remoteAuthMode === "none"
+                        ? "border-primary/50 bg-primary/[0.03]"
+                        : "border-border hover:bg-accent/50"
+                    }`}
                   >
-                    Cancel
-                  </Button>
+                    <RadioGroupItem value="none" />
+                    <span className="text-xs font-medium text-foreground">None</span>
+                    <span className="ml-auto text-[10px] text-muted-foreground">no auth header</span>
+                  </label>
+                )}
+
+                <label
+                  className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
+                    remoteAuthMode === "header"
+                      ? "border-primary/50 bg-primary/[0.03]"
+                      : "border-border hover:bg-accent/50"
+                  }`}
+                >
+                  <RadioGroupItem value="header" />
+                  <span className="text-xs font-medium text-foreground">Header</span>
+                  <span className="ml-auto text-[10px] text-muted-foreground">use a secret-backed auth header</span>
+                </label>
+
+                {probe.requiresOAuth && (
+                  <label
+                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
+                      remoteAuthMode === "oauth2"
+                        ? "border-primary/50 bg-primary/[0.03]"
+                        : "border-border hover:bg-accent/50"
+                    }`}
+                  >
+                    <RadioGroupItem value="oauth2" />
+                    <span className="text-xs font-medium text-foreground">OAuth</span>
+                    <span className="ml-auto text-[10px] text-muted-foreground">sign in with the server&apos;s OAuth flow</span>
+                  </label>
+                )}
+              </RadioGroup>
+
+              {remoteAuthMode === "header" && (
+                <SecretHeaderAuthRow
+                  label="Auth header"
+                  name={remoteHeaderAuth.name}
+                  prefix={remoteHeaderAuth.prefix}
+                  presetKey={remoteHeaderAuth.presetKey}
+                  secretId={remoteHeaderAuth.secretId}
+                  onChange={(update) =>
+                    setRemoteHeaderAuth((current) => ({
+                      ...current,
+                      ...update,
+                    }))
+                  }
+                  onSelectSecret={(secretId) =>
+                    setRemoteHeaderAuth((current) => ({
+                      ...current,
+                      secretId,
+                    }))
+                  }
+                  existingSecrets={secretList}
+                />
+              )}
+
+              {probe.requiresOAuth && remoteAuthMode === "oauth2" && !tokens && (
+                <>
+                  {state.step === "probed" && (
+                    <Button onClick={handleOAuth} className="w-full" variant="outline">
+                      <svg viewBox="0 0 16 16" fill="none" className="mr-1.5 size-3.5">
+                        <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1z" stroke="currentColor" strokeWidth="1.2" />
+                        <path d="M8 4v4l2.5 1.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                      Sign in with OAuth
+                    </Button>
+                  )}
+
+                  {state.step === "oauth-starting" && (
+                    <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+                      <Spinner className="size-3.5" />
+                      <span className="text-xs text-muted-foreground">Starting authorization…</span>
+                    </div>
+                  )}
+
+                  {state.step === "oauth-waiting" && (
+                    <div className="flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 px-3 py-2.5">
+                      <Spinner className="size-3.5 text-blue-500" />
+                      <span className="text-xs text-blue-600 dark:text-blue-400">Waiting for authorization in popup…</span>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={handleCancelOAuth}
+                        className="ml-auto h-7 px-2 text-xs"
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  )}
+                </>
+              )}
+
+              {probe.requiresOAuth && remoteAuthMode === "oauth2" && tokens && (
+                <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5">
+                  <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
+                    <path d="M3 8.5l3 3 7-7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">Authenticated</span>
                 </div>
+              )}
+
+              {remoteAuthMode === "none" && probe.requiresOAuth && (
+                <p className="text-[12px] text-amber-600 dark:text-amber-400">
+                  This server requires authentication before it can be added.
+                </p>
               )}
             </section>
           )}
 
-          {/* OAuth success */}
-          {tokens && (
-            <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5">
-              <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
-                <path d="M3 8.5l3 3 7-7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-              <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">Authenticated</span>
-            </div>
+          {/* Additional headers */}
+          {probe && (
+            <section className="space-y-2.5">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <Label>Additional headers</Label>
+                  <p className="mt-1 text-[12px] text-muted-foreground">
+                    Plaintext headers sent with every request. Use authentication for secret-backed auth headers.
+                  </p>
+                </div>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])}
+                >
+                  + Add header
+                </Button>
+              </div>
+
+              {remoteHeaders.length > 0 && (
+                <div className="space-y-2">
+                  {remoteHeaders.map((header, index) => (
+                    <div key={index} className="rounded-lg border border-border bg-card p-3 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                          Header
+                        </Label>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          className="text-muted-foreground hover:text-destructive"
+                          onClick={() =>
+                            setRemoteHeaders((headers) =>
+                              headers.filter((_, headerIndex) => headerIndex !== index),
+                            )
+                          }
+                        >
+                          Remove
+                        </Button>
+                      </div>
+                      <div className="grid grid-cols-2 gap-2">
+                        <div className="space-y-1">
+                          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Name</Label>
+                          <Input
+                            value={header.name}
+                            onChange={(event) =>
+                              setRemoteHeaders((headers) =>
+                                headers.map((current, headerIndex) =>
+                                  headerIndex === index
+                                    ? { ...current, name: (event.target as HTMLInputElement).value }
+                                    : current,
+                                ),
+                              )
+                            }
+                            placeholder="X-Organization-Id"
+                            className="h-8 text-xs font-mono"
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Value</Label>
+                          <Input
+                            value={header.value}
+                            onChange={(event) =>
+                              setRemoteHeaders((headers) =>
+                                headers.map((current, headerIndex) =>
+                                  headerIndex === index
+                                    ? { ...current, value: (event.target as HTMLInputElement).value }
+                                    : current,
+                                ),
+                              )
+                            }
+                            placeholder="workspace-id"
+                            className="h-8 text-xs font-mono"
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
           )}
 
           {/* Error */}

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect, useRef } from "react";
-import { useAtomSet, useAtomValue, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { useAtomSet } from "@effect-atom/atom-react";
 import { Option } from "effect";
 
-import { secretsAtom, setSecret, resolveSecret } from "@executor/react/api/atoms";
 import { useScope } from "@executor/react/api/scope-context";
-import { SecretPicker, type SecretPickerSecret } from "@executor/react/plugins/secret-picker";
-import { SecretId } from "@executor/sdk";
+import { SecretHeaderAuthRow, defaultHeaderAuthPresets } from "@executor/react/plugins/secret-header-auth";
+import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor/react/components/button";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
@@ -16,309 +15,6 @@ import { Spinner } from "@executor/react/components/spinner";
 import { previewOpenApiSpec, addOpenApiSpec } from "./atoms";
 import type { SpecPreview, HeaderPreset } from "../sdk/preview";
 import type { HeaderValue } from "../sdk/types";
-
-// ---------------------------------------------------------------------------
-// Inline secret creation
-// ---------------------------------------------------------------------------
-
-function InlineCreateSecret(props: {
-  headerName: string;
-  suggestedId: string;
-  onCreated: (secretId: string) => void;
-  onCancel: () => void;
-}) {
-  const [secretId, setSecretId] = useState(props.suggestedId);
-  const [secretName, setSecretName] = useState(props.headerName);
-  const [secretValue, setSecretValue] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const scopeId = useScope();
-  const doSet = useAtomSet(setSecret, { mode: "promise" });
-  const refreshSecrets = useAtomRefresh(secretsAtom(scopeId));
-
-  const handleSave = async () => {
-    if (!secretId.trim() || !secretValue.trim()) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await doSet({
-        path: { scopeId },
-        payload: {
-          id: SecretId.make(secretId.trim()),
-          name: secretName.trim() || secretId.trim(),
-          value: secretValue.trim(),
-          purpose: `Auth header: ${props.headerName}`,
-        },
-      });
-      refreshSecrets();
-      props.onCreated(secretId.trim());
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save secret");
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-2.5">
-      <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
-      <div className="grid grid-cols-2 gap-2">
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">ID</Label>
-          <Input
-            value={secretId}
-            onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
-            placeholder="my-api-token"
-            className="h-8 text-xs font-mono"
-          />
-        </div>
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Label</Label>
-          <Input
-            value={secretName}
-            onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
-            placeholder="API Token"
-            className="h-8 text-xs"
-          />
-        </div>
-      </div>
-      <div className="space-y-1">
-        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Value</Label>
-        <Input
-          type="password"
-          value={secretValue}
-          onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
-          placeholder="paste your token or key…"
-          className="h-8 text-xs font-mono"
-        />
-      </div>
-      {error && <p className="text-[11px] text-destructive">{error}</p>}
-      <div className="flex gap-1.5 pt-0.5">
-        <Button variant="outline" size="xs" onClick={props.onCancel}>
-          Cancel
-        </Button>
-        <Button
-          size="xs"
-          onClick={handleSave}
-          disabled={!secretId.trim() || !secretValue.trim() || saving}
-        >
-          {saving ? "Saving…" : "Create & use"}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Header value preview — shows what the header will look like
-// ---------------------------------------------------------------------------
-
-type ResolveState =
-  | { status: "hidden" }
-  | { status: "loading" }
-  | { status: "revealed"; value: string }
-  | { status: "error" };
-
-function HeaderValuePreview(props: {
-  headerName: string;
-  secretId: string;
-  prefix?: string;
-}) {
-  const { headerName, secretId, prefix } = props;
-  const scopeId = useScope();
-  const [state, setState] = useState<ResolveState>({ status: "hidden" });
-  const doResolve = useAtomSet(resolveSecret, { mode: "promise" });
-
-  const handleToggle = async () => {
-    if (state.status === "revealed") {
-      setState({ status: "hidden" });
-      return;
-    }
-    setState({ status: "loading" });
-    try {
-      const result = await doResolve({
-        path: {
-          scopeId,
-          secretId: SecretId.make(secretId),
-        },
-      });
-      setState({ status: "revealed", value: result.value });
-    } catch {
-      setState({ status: "error" });
-    }
-  };
-
-  const displayValue =
-    state.status === "revealed" ? state.value
-    : state.status === "error" ? "failed to resolve"
-    : "•".repeat(12);
-  const isLoading = state.status === "loading";
-  const isRevealed = state.status === "revealed";
-
-  return (
-    <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 font-mono text-xs">
-      <span className="text-muted-foreground shrink-0">{headerName}:</span>
-      <span className="text-foreground truncate">
-        {prefix && <span className="text-muted-foreground">{prefix}</span>}
-        {displayValue}
-      </span>
-      <Button
-        variant="ghost"
-        size="icon-xs"
-        className="ml-auto shrink-0"
-        onClick={handleToggle}
-        disabled={isLoading}
-      >
-        {isLoading ? (
-          <Spinner className="size-3" />
-        ) : isRevealed ? (
-          <svg viewBox="0 0 16 16" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M2 2l12 12" />
-            <path d="M6.5 6.5a2 2 0 0 0 3 3" />
-            <path d="M3.5 5.5C2.3 6.7 1.5 8 1.5 8s2.5 4.5 6.5 4.5c1 0 1.9-.3 2.7-.7" />
-            <path d="M10.7 10.7c2-1.4 3.3-3.2 3.8-3.7 0 0-2.5-5-6.5-5-.7 0-1.4.1-2 .4" />
-          </svg>
-        ) : (
-          <svg viewBox="0 0 16 16" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8s-2.5 4.5-6.5 4.5S1.5 8 1.5 8z" />
-            <circle cx="8" cy="8" r="2" />
-          </svg>
-        )}
-      </Button>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Header presets
-// ---------------------------------------------------------------------------
-
-const HEADER_PRESETS = [
-  { key: "bearer", label: "Bearer Token", name: "Authorization", prefix: "Bearer " },
-  { key: "basic", label: "Basic Auth", name: "Authorization", prefix: "Basic " },
-  { key: "api-key", label: "API Key", name: "X-API-Key" },
-  { key: "auth-token", label: "Auth Token", name: "X-Auth-Token" },
-  { key: "access-token", label: "Access Token", name: "X-Access-Token" },
-  { key: "cookie", label: "Cookie", name: "Cookie" },
-  { key: "custom", label: "Custom", name: "" },
-] as const;
-
-// ---------------------------------------------------------------------------
-// Custom header row — pick a preset, then pick a secret
-// ---------------------------------------------------------------------------
-
-function CustomHeaderRow(props: {
-  name: string;
-  prefix?: string;
-  presetKey?: string;
-  secretId: string | null;
-  onChange: (update: { name: string; prefix?: string; presetKey?: string }) => void;
-  onSelectSecret: (secretId: string) => void;
-  onRemove: () => void;
-  existingSecrets: readonly SecretPickerSecret[];
-}) {
-  const [creating, setCreating] = useState(false);
-  const { name, prefix, presetKey, secretId, onChange, onSelectSecret, onRemove, existingSecrets } = props;
-
-  const isCustom = presetKey === "custom";
-  const suggestedId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-") || "custom-header";
-
-  if (creating) {
-    return (
-      <InlineCreateSecret
-        headerName={name || "Custom Header"}
-        suggestedId={suggestedId}
-        onCreated={(id) => {
-          onSelectSecret(id);
-          setCreating(false);
-        }}
-        onCancel={() => setCreating(false)}
-      />
-    );
-  }
-
-  return (
-    <div className="rounded-lg border border-border bg-card p-3 space-y-2.5">
-      <div className="flex items-center justify-between">
-        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Header</Label>
-        <Button variant="ghost" size="xs" className="text-muted-foreground hover:text-destructive" onClick={onRemove}>
-          Remove
-        </Button>
-      </div>
-
-      {/* Preset chips */}
-      <div className="flex flex-wrap gap-1">
-        {HEADER_PRESETS.map((p) => (
-          <button
-            key={p.key}
-            onClick={() =>
-              onChange({
-                name: p.name,
-                prefix: (p as { prefix?: string }).prefix,
-                presetKey: p.key,
-              })
-            }
-            className={`rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
-              presetKey === p.key
-                ? "border-primary/50 bg-primary/10 text-primary"
-                : "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            }`}
-          >
-            {p.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Name + prefix fields — always visible once a preset is picked */}
-      {presetKey !== undefined && (
-        <div className="grid grid-cols-2 gap-2">
-          <div className="space-y-1">
-            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Name</Label>
-            <Input
-              value={name}
-              onChange={(e) => onChange({ name: (e.target as HTMLInputElement).value, prefix, presetKey: isCustom ? "custom" : presetKey })}
-              placeholder="Authorization"
-              className="h-8 text-xs font-mono"
-            />
-          </div>
-          <div className="space-y-1">
-            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Prefix <span className="normal-case tracking-normal font-normal text-muted-foreground/60">(opt.)</span></Label>
-            <Input
-              value={prefix ?? ""}
-              onChange={(e) => onChange({ name, prefix: (e.target as HTMLInputElement).value || undefined, presetKey: isCustom ? "custom" : presetKey })}
-              placeholder="Bearer "
-              className="h-8 text-xs font-mono"
-            />
-          </div>
-        </div>
-      )}
-
-      {/* Secret picker */}
-      {presetKey !== undefined && name.trim() && (
-        <div className="flex items-center gap-1.5">
-          <div className="flex-1 min-w-0">
-            <SecretPicker
-              value={secretId}
-              onSelect={onSelectSecret}
-              secrets={existingSecrets}
-            />
-          </div>
-          <Button variant="outline" size="sm" className="shrink-0" onClick={() => setCreating(true)}>
-            + New
-          </Button>
-        </div>
-      )}
-
-      {/* Preview */}
-      {secretId && name.trim() && (
-        <HeaderValuePreview
-          headerName={name.trim()}
-          secretId={secretId}
-          prefix={prefix}
-        />
-      )}
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -334,13 +30,11 @@ function prefixForHeader(preset: HeaderPreset, headerName: string): string | und
 }
 
 function matchPresetKey(name: string, prefix?: string): string {
-  if (name === "Authorization" && prefix === "Bearer ") return "bearer";
-  if (name === "Authorization" && prefix === "Basic ") return "basic";
-  if (name === "X-API-Key") return "api-key";
-  if (name === "X-Auth-Token") return "auth-token";
-  if (name === "X-Access-Token") return "access-token";
-  if (name === "Cookie") return "cookie";
-  return "custom";
+  const preset =
+    defaultHeaderAuthPresets.find((entry) => entry.name === name && entry.prefix === prefix)
+    ?? defaultHeaderAuthPresets.find((entry) => entry.name === name && entry.prefix === undefined);
+
+  return preset?.key ?? "custom";
 }
 
 function presetEntriesFromHeaderPreset(preset: HeaderPreset) {
@@ -385,7 +79,7 @@ export default function AddOpenApiSource(props: {
   const scopeId = useScope();
   const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promise" });
   const doAdd = useAtomSet(addOpenApiSpec, { mode: "promise" });
-  const secrets = useAtomValue(secretsAtom(scopeId));
+  const secretList = useSecretPickerSecrets();
   const autoAnalyzed = useRef(false);
 
   useEffect(() => {
@@ -394,17 +88,6 @@ export default function AddOpenApiSource(props: {
       handleAnalyze();
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const secretList: readonly SecretPickerSecret[] = Result.match(secrets, {
-    onInitial: () => [] as SecretPickerSecret[],
-    onFailure: () => [] as SecretPickerSecret[],
-    onSuccess: ({ value }) =>
-      value.map((s) => ({
-        id: s.id,
-        name: s.name,
-        provider: s.provider ? String(s.provider) : undefined,
-      })),
-  });
 
   // ---- Derived state ----
 
@@ -695,7 +378,7 @@ export default function AddOpenApiSource(props: {
             {presetIndex !== -1 && customHeaders.length > 0 && (
               <div className="space-y-2">
                 {customHeaders.map((ch, i) => (
-                  <CustomHeaderRow
+                  <SecretHeaderAuthRow
                     key={i}
                     name={ch.name}
                     prefix={ch.prefix}

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -1,0 +1,350 @@
+import { useState } from "react";
+import { useAtomRefresh, useAtomSet } from "@effect-atom/atom-react";
+
+import { secretsAtom, setSecret, resolveSecret } from "../api/atoms";
+import { useScope } from "../api/scope-context";
+import { Button } from "../components/button";
+import { Input } from "../components/input";
+import { Label } from "../components/label";
+import { Spinner } from "../components/spinner";
+import { SecretPicker, type SecretPickerSecret } from "./secret-picker";
+import { SecretId } from "@executor/sdk";
+
+export interface HeaderAuthPreset {
+  readonly key: string;
+  readonly label: string;
+  readonly name: string;
+  readonly prefix?: string;
+}
+
+export const defaultHeaderAuthPresets: readonly HeaderAuthPreset[] = [
+  { key: "bearer", label: "Bearer Token", name: "Authorization", prefix: "Bearer " },
+  { key: "basic", label: "Basic Auth", name: "Authorization", prefix: "Basic " },
+  { key: "api-key", label: "API Key", name: "X-API-Key" },
+  { key: "auth-token", label: "Auth Token", name: "X-Auth-Token" },
+  { key: "access-token", label: "Access Token", name: "X-Access-Token" },
+  { key: "cookie", label: "Cookie", name: "Cookie" },
+  { key: "custom", label: "Custom", name: "" },
+];
+
+function SecretVisibilityIcon(props: { revealed: boolean }) {
+  return props.revealed ? (
+    <svg viewBox="0 0 16 16" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M2 2l12 12" />
+      <path d="M6.5 6.5a2 2 0 0 0 3 3" />
+      <path d="M3.5 5.5C2.3 6.7 1.5 8 1.5 8s2.5 4.5 6.5 4.5c1 0 1.9-.3 2.7-.7" />
+      <path d="M10.7 10.7c2-1.4 3.3-3.2 3.8-3.7 0 0-2.5-5-6.5-5-.7 0-1.4.1-2 .4" />
+    </svg>
+  ) : (
+    <svg viewBox="0 0 16 16" className="size-3.5" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8s-2.5 4.5-6.5 4.5S1.5 8 1.5 8z" />
+      <circle cx="8" cy="8" r="2" />
+    </svg>
+  );
+}
+
+function InlineCreateSecret(props: {
+  headerName: string;
+  suggestedId: string;
+  onCreated: (secretId: string) => void;
+  onCancel: () => void;
+}) {
+  const [secretId, setSecretId] = useState(props.suggestedId);
+  const [secretName, setSecretName] = useState(props.headerName);
+  const [secretValue, setSecretValue] = useState("");
+  const [secretRevealed, setSecretRevealed] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scopeId = useScope();
+  const doSet = useAtomSet(setSecret, { mode: "promise" });
+  const refreshSecrets = useAtomRefresh(secretsAtom(scopeId));
+
+  const handleSave = async () => {
+    if (!secretId.trim() || !secretValue.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await doSet({
+        path: { scopeId },
+        payload: {
+          id: SecretId.make(secretId.trim()),
+          name: secretName.trim() || secretId.trim(),
+          value: secretValue.trim(),
+          purpose: `Auth header: ${props.headerName}`,
+        },
+      });
+      refreshSecrets();
+      props.onCreated(secretId.trim());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save secret");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-2.5">
+      <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="space-y-1">
+          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">ID</Label>
+          <Input
+            value={secretId}
+            onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
+            placeholder="my-api-token"
+            className="h-8 text-xs font-mono"
+          />
+        </div>
+        <div className="space-y-1">
+          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Label</Label>
+          <Input
+            value={secretName}
+            onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
+            placeholder="API Token"
+            className="h-8 text-xs"
+          />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Value</Label>
+        <div className="relative">
+          <Input
+            type={secretRevealed ? "text" : "password"}
+            value={secretValue}
+            onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
+            placeholder="paste your token or key…"
+            className="h-8 pr-8 text-xs font-mono"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="absolute right-1 top-1/2 size-6 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            onClick={() => setSecretRevealed((revealed) => !revealed)}
+            aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
+          >
+            <SecretVisibilityIcon revealed={secretRevealed} />
+          </Button>
+        </div>
+      </div>
+      {error && <p className="text-[11px] text-destructive">{error}</p>}
+      <div className="flex gap-1.5 pt-0.5">
+        <Button variant="outline" size="xs" onClick={props.onCancel}>
+          Cancel
+        </Button>
+        <Button
+          size="xs"
+          onClick={handleSave}
+          disabled={!secretId.trim() || !secretValue.trim() || saving}
+        >
+          {saving ? "Saving…" : "Create & use"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type ResolveState =
+  | { status: "hidden" }
+  | { status: "loading" }
+  | { status: "revealed"; value: string }
+  | { status: "error" };
+
+function HeaderValuePreview(props: {
+  headerName: string;
+  secretId: string;
+  prefix?: string;
+}) {
+  const { headerName, secretId, prefix } = props;
+  const scopeId = useScope();
+  const [state, setState] = useState<ResolveState>({ status: "hidden" });
+  const doResolve = useAtomSet(resolveSecret, { mode: "promise" });
+
+  const handleToggle = async () => {
+    if (state.status === "revealed") {
+      setState({ status: "hidden" });
+      return;
+    }
+    setState({ status: "loading" });
+    try {
+      const result = await doResolve({
+        path: {
+          scopeId,
+          secretId: SecretId.make(secretId),
+        },
+      });
+      setState({ status: "revealed", value: result.value });
+    } catch {
+      setState({ status: "error" });
+    }
+  };
+
+  const displayValue =
+    state.status === "revealed" ? state.value
+    : state.status === "error" ? "failed to resolve"
+    : "•".repeat(12);
+  const isLoading = state.status === "loading";
+  const isRevealed = state.status === "revealed";
+
+  return (
+    <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 font-mono text-xs">
+      <span className="text-muted-foreground shrink-0">{headerName}:</span>
+      <span className="text-foreground truncate">
+        {prefix && <span className="text-muted-foreground">{prefix}</span>}
+        {displayValue}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon-xs"
+        className="ml-auto shrink-0"
+        onClick={handleToggle}
+        disabled={isLoading}
+      >
+        {isLoading ? (
+          <Spinner className="size-3" />
+        ) : (
+          <SecretVisibilityIcon revealed={isRevealed} />
+        )}
+      </Button>
+    </div>
+  );
+}
+
+export function SecretHeaderAuthRow(props: {
+  name: string;
+  prefix?: string;
+  presetKey?: string;
+  secretId: string | null;
+  onChange: (update: { name: string; prefix?: string; presetKey?: string }) => void;
+  onSelectSecret: (secretId: string) => void;
+  existingSecrets: readonly SecretPickerSecret[];
+  presets?: readonly HeaderAuthPreset[];
+  onRemove?: () => void;
+  removeLabel?: string;
+  label?: string;
+}) {
+  const [creating, setCreating] = useState(false);
+  const {
+    name,
+    prefix,
+    presetKey,
+    secretId,
+    onChange,
+    onSelectSecret,
+    existingSecrets,
+    presets = defaultHeaderAuthPresets,
+    onRemove,
+    removeLabel = "Remove",
+    label = "Header",
+  } = props;
+
+  const isCustom = presetKey === "custom";
+  const suggestedId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-") || "custom-header";
+
+  if (creating) {
+    return (
+      <InlineCreateSecret
+        headerName={name || "Custom Header"}
+        suggestedId={suggestedId}
+        onCreated={(id) => {
+          onSelectSecret(id);
+          setCreating(false);
+        }}
+        onCancel={() => setCreating(false)}
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-3 space-y-2.5">
+      <div className="flex items-center justify-between">
+        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</Label>
+        {onRemove && (
+          <Button variant="ghost" size="xs" className="text-muted-foreground hover:text-destructive" onClick={onRemove}>
+            {removeLabel}
+          </Button>
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {presets.map((preset) => (
+          <button
+            key={preset.key}
+            type="button"
+            onClick={() =>
+              onChange({
+                name: preset.name,
+                prefix: preset.prefix,
+                presetKey: preset.key,
+              })
+            }
+            className={`rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
+              presetKey === preset.key
+                ? "border-primary/50 bg-primary/10 text-primary"
+                : "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            }`}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      {presetKey !== undefined && (
+        <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-1">
+            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Name</Label>
+            <Input
+              value={name}
+              onChange={(e) =>
+                onChange({
+                  name: (e.target as HTMLInputElement).value,
+                  prefix,
+                  presetKey: isCustom ? "custom" : presetKey,
+                })
+              }
+              placeholder="Authorization"
+              className="h-8 text-xs font-mono"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Prefix <span className="normal-case tracking-normal font-normal text-muted-foreground/60">(opt.)</span></Label>
+            <Input
+              value={prefix ?? ""}
+              onChange={(e) =>
+                onChange({
+                  name,
+                  prefix: (e.target as HTMLInputElement).value || undefined,
+                  presetKey: isCustom ? "custom" : presetKey,
+                })
+              }
+              placeholder="Bearer "
+              className="h-8 text-xs font-mono"
+            />
+          </div>
+        </div>
+      )}
+
+      {presetKey !== undefined && name.trim() && (
+        <div className="flex items-center gap-1.5">
+          <div className="flex-1 min-w-0">
+            <SecretPicker
+              value={secretId}
+              onSelect={onSelectSecret}
+              secrets={existingSecrets}
+            />
+          </div>
+          <Button variant="outline" size="sm" className="shrink-0" onClick={() => setCreating(true)}>
+            + New
+          </Button>
+        </div>
+      )}
+
+      {secretId && name.trim() && (
+        <HeaderValuePreview
+          headerName={name.trim()}
+          secretId={secretId}
+          prefix={prefix}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/react/src/plugins/use-secret-picker-secrets.tsx
+++ b/packages/react/src/plugins/use-secret-picker-secrets.tsx
@@ -1,0 +1,21 @@
+import { useAtomValue, Result } from "@effect-atom/atom-react";
+
+import { secretsAtom } from "../api/atoms";
+import { useScope } from "../api/scope-context";
+import type { SecretPickerSecret } from "./secret-picker";
+
+export function useSecretPickerSecrets(): readonly SecretPickerSecret[] {
+  const scopeId = useScope();
+  const secrets = useAtomValue(secretsAtom(scopeId));
+
+  return Result.match(secrets, {
+    onInitial: () => [] as SecretPickerSecret[],
+    onFailure: () => [] as SecretPickerSecret[],
+    onSuccess: ({ value }) =>
+      value.map((secret) => ({
+        id: secret.id,
+        name: secret.name,
+        provider: secret.provider ? String(secret.provider) : undefined,
+      })),
+  });
+}


### PR DESCRIPTION
## Summary
- extract reusable secret-backed header auth UI from the OpenAPI add flow
- reuse the shared header auth UI in OpenAPI
- add remote MCP auth mode selection with secret-backed auth headers
- add plaintext additional headers for remote MCP sources

## Verification
- bun --cwd packages/react typecheck
- bun --cwd packages/plugins/openapi typecheck
- bun --cwd packages/plugins/mcp typecheck