### PR TITLE
feat(openapi): add edit source configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,16 @@ apps/desktop/resources/
 
 # cloud local dev database
 .pglite
+apps/cloud/.dev-db/
 .claude/
 .nitro/
 .output/
 .tanstack/
 .env*
 !.env.example
+
+# local user config
+apps/local/executor.jsonc
+
+# VS Code (per-workspace user settings)
+.vscode/mcp.json

--- a/apps/cloud/src/routes/sources.$namespace.tsx
+++ b/apps/cloud/src/routes/sources.$namespace.tsx
@@ -1,9 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SourceDetailPage } from "@executor/react/pages/source-detail";
+import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
+import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
+import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
+import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
+
+const sourcePlugins = [
+  openApiSourcePlugin,
+  mcpSourcePlugin,
+  googleDiscoverySourcePlugin,
+  graphqlSourcePlugin,
+];
 
 export const Route = createFileRoute("/sources/$namespace")({
   component: () => {
     const { namespace } = Route.useParams();
-    return <SourceDetailPage namespace={namespace} />;
+    return <SourceDetailPage namespace={namespace} sourcePlugins={sourcePlugins} />;
   },
 });

--- a/apps/local/src/routes/sources.$namespace.tsx
+++ b/apps/local/src/routes/sources.$namespace.tsx
@@ -1,9 +1,20 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SourceDetailPage } from "@executor/react/pages/source-detail";
+import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
+import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
+import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
+import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
+
+const sourcePlugins = [
+  openApiSourcePlugin,
+  mcpSourcePlugin,
+  googleDiscoverySourcePlugin,
+  graphqlSourcePlugin,
+];
 
 export const Route = createFileRoute("/sources/$namespace")({
   component: () => {
     const { namespace } = Route.useParams();
-    return <SourceDetailPage namespace={namespace} />;
+    return <SourceDetailPage namespace={namespace} sourcePlugins={sourcePlugins} />;
   },
 });

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -13,14 +13,15 @@ import {
   makeScopedKv,
   migrate,
 } from "@executor/storage-file";
-import { withConfigFile } from "@executor/config";
 import {
   openApiPlugin,
   makeKvOperationStore,
+  withConfigFile as withOpenApiConfigFile,
 } from "@executor/plugin-openapi";
 import {
   mcpPlugin,
   makeKvBindingStore,
+  withConfigFile as withMcpConfigFile,
 } from "@executor/plugin-mcp";
 import {
   googleDiscoveryPlugin,
@@ -29,6 +30,7 @@ import {
 import {
   graphqlPlugin,
   makeKvOperationStore as makeKvGraphqlOperationStore,
+  withConfigFile as withGraphqlConfigFile,
 } from "@executor/plugin-graphql";
 import { keychainPlugin } from "@executor/plugin-keychain";
 import { fileSecretsPlugin } from "@executor/plugin-file-secrets";
@@ -55,14 +57,14 @@ const createLocalPlugins = (
 ) =>
   [
     openApiPlugin({
-      operationStore: withConfigFile.openapi(
+      operationStore: withOpenApiConfigFile(
         makeKvOperationStore(scopedKv, "openapi"),
         configPath,
         fsLayer,
       ),
     }),
     mcpPlugin({
-      bindingStore: withConfigFile.mcp(
+      bindingStore: withMcpConfigFile(
         makeKvBindingStore(scopedKv, "mcp"),
         configPath,
         fsLayer,
@@ -75,7 +77,7 @@ const createLocalPlugins = (
       ),
     }),
     graphqlPlugin({
-      operationStore: withConfigFile.graphql(
+      operationStore: withGraphqlConfigFile(
         makeKvGraphqlOperationStore(scopedKv, "graphql"),
         configPath,
         fsLayer,

--- a/bun.lock
+++ b/bun.lock
@@ -562,6 +562,7 @@
         "@apidevtools/swagger-parser": "^12.1.0",
         "@effect/platform": "catalog:",
         "@effect/platform-node": "catalog:",
+        "@executor/config": "workspace:*",
         "@executor/sdk": "workspace:*",
         "effect": "catalog:",
         "openapi-types": "^12.1.3",

--- a/packages/core/api/src/handlers/sources.ts
+++ b/packages/core/api/src/handlers/sources.ts
@@ -20,6 +20,7 @@ export const SourcesHandlers = HttpApiBuilder.group(
             runtime: s.runtime,
             canRemove: s.canRemove,
             canRefresh: s.canRefresh,
+            canEdit: s.canEdit,
           }));
         }),
       )

--- a/packages/core/api/src/sources/api.ts
+++ b/packages/core/api/src/sources/api.ts
@@ -20,6 +20,7 @@ const SourceResponse = Schema.Struct({
   runtime: Schema.optional(Schema.Boolean),
   canRemove: Schema.optional(Schema.Boolean),
   canRefresh: Schema.optional(Schema.Boolean),
+  canEdit: Schema.optional(Schema.Boolean),
 });
 
 const SourceRemoveResponse = Schema.Struct({

--- a/packages/core/config/src/index.ts
+++ b/packages/core/config/src/index.ts
@@ -20,5 +20,3 @@ export {
   addSecretToConfig,
   removeSecretFromConfig,
 } from "./write";
-
-export { withConfigFile } from "./config-store";

--- a/packages/core/sdk/src/sources.ts
+++ b/packages/core/sdk/src/sources.ts
@@ -17,6 +17,8 @@ export class Source extends Schema.Class<Source>("Source")({
   canRemove: Schema.optional(Schema.Boolean),
   /** Whether the source supports refresh */
   canRefresh: Schema.optional(Schema.Boolean),
+  /** Whether the source supports editing (config changes) */
+  canEdit: Schema.optional(Schema.Boolean),
 }) {}
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -29,6 +29,7 @@
     "@apidevtools/swagger-parser": "^12.1.0",
     "@effect/platform": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@executor/config": "workspace:*",
     "@executor/sdk": "workspace:*",
     "effect": "catalog:",
     "openapi-types": "^12.1.3",

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -7,12 +7,14 @@ import {
   OpenApiExtractionError,
 } from "../sdk/errors";
 import { SpecPreview } from "../sdk/preview";
+import { StoredSourceSchema } from "../sdk/stored-source";
 
 // ---------------------------------------------------------------------------
 // Params
 // ---------------------------------------------------------------------------
 
 const scopeIdParam = HttpApiSchema.param("scopeId", ScopeId);
+const namespaceParam = HttpApiSchema.param("namespace", Schema.String);
 
 // ---------------------------------------------------------------------------
 // Payloads
@@ -29,6 +31,17 @@ const AddSpecPayload = Schema.Struct({
 
 const PreviewSpecPayload = Schema.Struct({
   spec: Schema.String,
+});
+
+const UpdateSourcePayload = Schema.Struct({
+  baseUrl: Schema.optional(Schema.String),
+  headers: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  ),
+});
+
+const UpdateSourceResponse = Schema.Struct({
+  updated: Schema.Boolean,
 });
 
 // ---------------------------------------------------------------------------
@@ -69,5 +82,14 @@ export class OpenApiGroup extends HttpApiGroup.make("openapi")
       .addSuccess(AddSpecResponse)
       .addError(ParseError)
       .addError(ExtractionError),
+  )
+  .add(
+    HttpApiEndpoint.get("getSource")`/scopes/${scopeIdParam}/openapi/sources/${namespaceParam}`
+      .addSuccess(Schema.NullOr(StoredSourceSchema)),
+  )
+  .add(
+    HttpApiEndpoint.patch("updateSource")`/scopes/${scopeIdParam}/openapi/sources/${namespaceParam}`
+      .setPayload(UpdateSourcePayload)
+      .addSuccess(UpdateSourceResponse),
   )
   {}

--- a/packages/plugins/openapi/src/api/handlers.ts
+++ b/packages/plugins/openapi/src/api/handlers.ts
@@ -2,7 +2,7 @@ import { HttpApiBuilder } from "@effect/platform";
 import { Context, Effect } from "effect";
 
 import { addGroup } from "@executor/api";
-import type { OpenApiPluginExtension, HeaderValue } from "../sdk/plugin";
+import type { OpenApiPluginExtension, HeaderValue, OpenApiUpdateSourceInput } from "../sdk/plugin";
 import { OpenApiGroup } from "./group";
 
 // ---------------------------------------------------------------------------
@@ -49,5 +49,20 @@ export const OpenApiHandlers = HttpApiBuilder.group(
           };
         }).pipe(Effect.orDie),
       )
-      ,
+      .handle("getSource", ({ path }) =>
+        Effect.gen(function* () {
+          const ext = yield* OpenApiExtensionService;
+          return yield* ext.getSource(path.namespace);
+        }).pipe(Effect.orDie),
+      )
+      .handle("updateSource", ({ path, payload }) =>
+        Effect.gen(function* () {
+          const ext = yield* OpenApiExtensionService;
+          yield* ext.updateSource(path.namespace, {
+            baseUrl: payload.baseUrl,
+            headers: payload.headers as Record<string, HeaderValue> | undefined,
+          } as OpenApiUpdateSourceInput);
+          return { updated: true };
+        }).pipe(Effect.orDie),
+      ),
 );

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -1,13 +1,153 @@
+import { useState } from "react";
+import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { openApiSourceAtom, updateOpenApiSource } from "./atoms";
+import { useScope } from "@executor/react/api/scope-context";
+import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
+import {
+  SecretHeaderAuthRow,
+  headerValueToState,
+  headersFromState,
+  type HeaderState,
+} from "@executor/react/plugins/secret-header-auth";
+import { Button } from "@executor/react/components/button";
+import { Input } from "@executor/react/components/input";
+import { Label } from "@executor/react/components/label";
+import { Badge } from "@executor/react/components/badge";
+import type { StoredSourceSchemaType } from "../sdk/stored-source";
+
+// ---------------------------------------------------------------------------
+// Edit form
+// ---------------------------------------------------------------------------
+
+function EditForm(props: {
+  sourceId: string;
+  initial: StoredSourceSchemaType;
+  onSave: () => void;
+}) {
+  const scopeId = useScope();
+  const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promise" });
+  const refreshSource = useAtomRefresh(openApiSourceAtom(scopeId, props.sourceId));
+  const secretList = useSecretPickerSecrets();
+
+  const [baseUrl, setBaseUrl] = useState(props.initial.config.baseUrl ?? "");
+  const [headers, setHeaders] = useState<HeaderState[]>(() =>
+    Object.entries(props.initial.config.headers ?? {}).map(([name, value]) =>
+      headerValueToState(name, value),
+    ),
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  const updateHeader = (index: number, update: Partial<HeaderState>) => {
+    setHeaders((prev) => prev.map((h, i) => (i === index ? { ...h, ...update } : h)));
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await doUpdate({
+        path: { scopeId, namespace: props.sourceId },
+        payload: {
+          baseUrl: baseUrl.trim() || undefined,
+          headers: headersFromState(headers),
+        },
+      });
+      refreshSource();
+      setDirty(false);
+      props.onSave();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update source");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold text-foreground">Edit OpenAPI Source</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">
+          Update the base URL and authentication headers for this source.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-card-foreground">{props.sourceId}</p>
+        </div>
+        <Badge variant="secondary" className="text-[10px]">OpenAPI</Badge>
+      </div>
+
+      <section className="space-y-2">
+        <Label>Base URL</Label>
+        <Input
+          value={baseUrl}
+          onChange={(e) => { setBaseUrl((e.target as HTMLInputElement).value); setDirty(true); }}
+          placeholder="https://api.example.com"
+          className="font-mono text-sm"
+        />
+      </section>
+
+      <section className="space-y-2.5">
+        <Label>Headers</Label>
+        {headers.map((h, i) => (
+          <SecretHeaderAuthRow
+            key={i}
+            name={h.name}
+            prefix={h.prefix}
+            presetKey={h.presetKey}
+            secretId={h.secretId}
+            onChange={(update) => updateHeader(i, update)}
+            onSelectSecret={(secretId) => updateHeader(i, { secretId })}
+            onRemove={() => { setHeaders((prev) => prev.filter((_, j) => j !== i)); setDirty(true); }}
+            existingSecrets={secretList}
+          />
+        ))}
+        <Button variant="outline" size="sm" className="w-full border-dashed" onClick={() => { setHeaders((prev) => [...prev, { name: "", secretId: null }]); setDirty(true); }}>
+          + Add header
+        </Button>
+      </section>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+          <p className="text-[12px] text-destructive">{error}</p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between border-t border-border pt-4">
+        <Button variant="ghost" onClick={props.onSave}>Cancel</Button>
+        <Button onClick={handleSave} disabled={!dirty || saving}>
+          {saving ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
 export default function EditOpenApiSource(props: {
   sourceId: string;
   onSave: () => void;
 }) {
-  return (
-    <div>
-      <h3>Edit OpenAPI Source</h3>
-      <p>Source: {props.sourceId}</p>
-      {/* TODO: show spec info, auth config, operation list */}
-      <button onClick={props.onSave}>Save</button>
-    </div>
-  );
+  const scopeId = useScope();
+  const sourceResult = useAtomValue(openApiSourceAtom(scopeId, props.sourceId));
+
+  if (!Result.isSuccess(sourceResult) || !sourceResult.value) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Edit OpenAPI Source</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">Loading configuration…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <EditForm sourceId={props.sourceId} initial={sourceResult.value} onSave={props.onSave} />;
 }

--- a/packages/plugins/openapi/src/react/atoms.ts
+++ b/packages/plugins/openapi/src/react/atoms.ts
@@ -1,4 +1,15 @@
+import type { ScopeId } from "@executor/sdk";
 import { OpenApiClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Query atoms
+// ---------------------------------------------------------------------------
+
+export const openApiSourceAtom = (scopeId: ScopeId, namespace: string) =>
+  OpenApiClient.query("openapi", "getSource", {
+    path: { scopeId, namespace },
+    timeToLive: "15 seconds",
+  });
 
 // ---------------------------------------------------------------------------
 // Mutation atoms
@@ -10,3 +21,5 @@ export const previewOpenApiSpec = OpenApiClient.mutation(
 );
 
 export const addOpenApiSpec = OpenApiClient.mutation("openapi", "addSpec");
+
+export const updateOpenApiSource = OpenApiClient.mutation("openapi", "updateSource");

--- a/packages/plugins/openapi/src/sdk/config-file-store.ts
+++ b/packages/plugins/openapi/src/sdk/config-file-store.ts
@@ -1,0 +1,69 @@
+/**
+ * Config-file wrapper for OpenApiOperationStore.
+ *
+ * Decorates an underlying store so that `putSource` and `removeSource` also
+ * write to executor.jsonc.
+ */
+
+import { Effect } from "effect";
+import { FileSystem } from "@effect/platform";
+import type { Layer } from "effect";
+
+import {
+  addSourceToConfig,
+  removeSourceFromConfig,
+  SECRET_REF_PREFIX,
+} from "@executor/config";
+import type { SourceConfig as ConfigFileSourceConfig, ConfigHeaderValue } from "@executor/config";
+
+import type { OpenApiOperationStore, StoredSource } from "./operation-store";
+
+type PluginHeaderValue = string | { readonly secretId: string; readonly prefix?: string };
+
+const translateSecretHeaders = (
+  headers: Readonly<Record<string, PluginHeaderValue>> | undefined,
+): Record<string, ConfigHeaderValue> | undefined => {
+  if (!headers) return undefined;
+  const result: Record<string, ConfigHeaderValue> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      result[key] = value;
+      continue;
+    }
+    const ref = `${SECRET_REF_PREFIX}${value.secretId}`;
+    result[key] = value.prefix ? { value: ref, prefix: value.prefix } : ref;
+  }
+  return result;
+};
+
+const toSourceConfig = (source: StoredSource): ConfigFileSourceConfig => ({
+  kind: "openapi",
+  spec: source.config.spec,
+  baseUrl: source.config.baseUrl,
+  namespace: source.namespace,
+  headers: translateSecretHeaders(source.config.headers),
+});
+
+export const withConfigFile = (
+  inner: OpenApiOperationStore,
+  configPath: string,
+  fsLayer: Layer.Layer<FileSystem.FileSystem>,
+): OpenApiOperationStore => ({
+  ...inner,
+  putSource: (source) =>
+    Effect.gen(function* () {
+      yield* inner.putSource(source);
+      yield* addSourceToConfig(configPath, toSourceConfig(source)).pipe(
+        Effect.provide(fsLayer),
+        Effect.catchAll(() => Effect.void),
+      );
+    }),
+  removeSource: (namespace) =>
+    Effect.gen(function* () {
+      yield* inner.removeSource(namespace);
+      yield* removeSourceFromConfig(configPath, namespace).pipe(
+        Effect.provide(fsLayer),
+        Effect.catchAll(() => Effect.void),
+      );
+    }),
+});

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -16,6 +16,7 @@ export {
   makeKvOperationStore,
   makeInMemoryOperationStore,
 } from "./kv-operation-store";
+export { withConfigFile } from "./config-file-store";
 export {
   previewSpec,
   SecurityScheme,

--- a/packages/plugins/openapi/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/kv-operation-store.ts
@@ -8,7 +8,8 @@ import { Effect, Schema } from "effect";
 import { scopeKv, makeInMemoryScopedKv, type Kv, type ToolId, type ScopedKv } from "@executor/sdk";
 
 import type { OpenApiOperationStore, StoredOperation, StoredSource } from "./operation-store";
-import { OperationBinding, InvocationConfig, HeaderValue } from "./types";
+import { OperationBinding, InvocationConfig } from "./types";
+import { StoredSourceSchema } from "./stored-source";
 
 // ---------------------------------------------------------------------------
 // Stored schemas
@@ -23,18 +24,6 @@ class StoredEntry extends Schema.Class<StoredEntry>("StoredEntry")({
 const encodeEntry = Schema.encodeSync(Schema.parseJson(StoredEntry));
 const decodeEntry = Schema.decodeUnknownSync(Schema.parseJson(StoredEntry));
 
-const StoredSourceSchema = Schema.Struct({
-  namespace: Schema.String,
-  name: Schema.String,
-  config: Schema.Struct({
-    spec: Schema.String,
-    baseUrl: Schema.optional(Schema.String),
-    namespace: Schema.optional(Schema.String),
-    headers: Schema.optional(
-      Schema.Record({ key: Schema.String, value: HeaderValue }),
-    ),
-  }),
-});
 const encodeSource = Schema.encodeSync(Schema.parseJson(StoredSourceSchema));
 const decodeSource = Schema.decodeUnknownSync(Schema.parseJson(StoredSourceSchema));
 
@@ -111,6 +100,21 @@ const makeStore = (
     Effect.gen(function* () {
       const entries = yield* sources.list();
       return entries.map((e) => decodeSource(e.value) as StoredSource);
+    }),
+
+  getSource: (namespace) =>
+    Effect.gen(function* () {
+      const raw = yield* sources.get(namespace);
+      if (!raw) return null;
+      return decodeSource(raw) as StoredSource;
+    }),
+
+  getSourceConfig: (namespace) =>
+    Effect.gen(function* () {
+      const raw = yield* sources.get(namespace);
+      if (!raw) return null;
+      const source = decodeSource(raw) as StoredSource;
+      return source.config;
     }),
   });
 };

--- a/packages/plugins/openapi/src/sdk/operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/operation-store.ts
@@ -45,4 +45,12 @@ export interface OpenApiOperationStore {
   readonly removeSource: (namespace: string) => Effect.Effect<void>;
 
   readonly listSources: () => Effect.Effect<readonly StoredSource[]>;
+
+  readonly getSource: (
+    namespace: string,
+  ) => Effect.Effect<StoredSource | null>;
+
+  readonly getSourceConfig: (
+    namespace: string,
+  ) => Effect.Effect<SourceConfig | null>;
 }

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -19,7 +19,7 @@ import { extract } from "./extract";
 import { compileToolDefinitions, type ToolDefinition } from "./definitions";
 import { makeOpenApiInvoker } from "./invoke";
 import { resolveBaseUrl } from "./openapi-utils";
-import type { OpenApiOperationStore } from "./operation-store";
+import type { OpenApiOperationStore, StoredSource } from "./operation-store";
 import { makeInMemoryOperationStore } from "./kv-operation-store";
 import { previewSpec, SpecPreview } from "./preview";
 import {
@@ -48,6 +48,11 @@ export interface OpenApiSpecConfig {
 // Plugin extension
 // ---------------------------------------------------------------------------
 
+export interface OpenApiUpdateSourceInput {
+  readonly baseUrl?: string;
+  readonly headers?: Record<string, HeaderValue>;
+}
+
 export interface OpenApiPluginExtension {
   /** Preview a spec without registering — returns metadata, auth strategies, header presets */
   readonly previewSpec: (specText: string) => Effect.Effect<SpecPreview, Error>;
@@ -59,6 +64,17 @@ export interface OpenApiPluginExtension {
 
   /** Remove all tools from a previously added spec by namespace */
   readonly removeSpec: (namespace: string) => Effect.Effect<void>;
+
+  /** Fetch the full stored source by namespace (or null if missing) */
+  readonly getSource: (
+    namespace: string,
+  ) => Effect.Effect<StoredSource | null>;
+
+  /** Update config (baseUrl, headers) for an existing OpenAPI source */
+  readonly updateSource: (
+    namespace: string,
+    input: OpenApiUpdateSourceInput,
+  ) => Effect.Effect<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -190,6 +206,7 @@ export const openApiPlugin = (options?: {
                       runtime: false,
                       canRemove: true,
                       canRefresh: false,
+                      canEdit: true,
                     }),
                 ),
               ),
@@ -342,6 +359,48 @@ export const openApiPlugin = (options?: {
                   yield* ctx.tools.unregister(toolIds);
                 }
                 yield* operationStore.removeSource(namespace);
+              }),
+
+            getSource: (namespace: string) =>
+              operationStore.getSource(namespace),
+
+            updateSource: (namespace: string, input: OpenApiUpdateSourceInput) =>
+              Effect.gen(function* () {
+                const existingSource = yield* operationStore.getSourceConfig(namespace);
+                if (!existingSource) return;
+
+                const updatedConfig = {
+                  ...existingSource,
+                  ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
+                  ...(input.headers !== undefined ? { headers: input.headers as Record<string, HeaderValueValue> } : {}),
+                };
+
+                const newInvocationConfig = new InvocationConfig({
+                  baseUrl: updatedConfig.baseUrl ?? resolveBaseUrl([]),
+                  headers: (updatedConfig.headers ?? {}) as Record<string, HeaderValueValue>,
+                });
+
+                const toolIds = yield* operationStore.listByNamespace(namespace);
+                for (const toolId of toolIds) {
+                  const entry = yield* operationStore.get(toolId);
+                  if (entry) {
+                    yield* operationStore.put([{
+                      toolId,
+                      namespace,
+                      binding: entry.binding,
+                      config: newInvocationConfig,
+                    }]);
+                  }
+                }
+
+                const sources = yield* operationStore.listSources();
+                const existingMeta = sources.find((s) => s.namespace === namespace);
+
+                yield* operationStore.putSource({
+                  namespace,
+                  name: existingMeta?.name ?? namespace,
+                  config: updatedConfig,
+                });
               }),
           },
 

--- a/packages/plugins/openapi/src/sdk/stored-source.ts
+++ b/packages/plugins/openapi/src/sdk/stored-source.ts
@@ -1,0 +1,25 @@
+import { Schema } from "effect";
+
+import { HeaderValue } from "./types";
+
+// ---------------------------------------------------------------------------
+// Stored source — the shape persisted by the operation store and exposed
+// via the getSource HTTP endpoint.
+// ---------------------------------------------------------------------------
+
+export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>(
+  "OpenApiStoredSource",
+)({
+  namespace: Schema.String,
+  name: Schema.String,
+  config: Schema.Struct({
+    spec: Schema.String,
+    baseUrl: Schema.optional(Schema.String),
+    namespace: Schema.optional(Schema.String),
+    headers: Schema.optional(
+      Schema.Record({ key: Schema.String, value: HeaderValue }),
+    ),
+  }),
+}) {}
+
+export type StoredSourceSchemaType = typeof StoredSourceSchema.Type;

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -76,3 +76,4 @@ export const removeSource = ExecutorApiClient.mutation("sources", "remove");
 export const refreshSource = ExecutorApiClient.mutation("sources", "refresh");
 
 export const detectSource = ExecutorApiClient.mutation("sources", "detect");
+

--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
 import { sourceToolsAtom, sourcesAtom, sourceAtom, removeSource, refreshSource } from "../api/atoms";
@@ -6,9 +6,13 @@ import { ToolTree } from "../components/tool-tree";
 import { ToolDetail, ToolDetailEmpty } from "../components/tool-detail";
 import type { ToolSummary } from "../components/tool-tree";
 import { useScope } from "../hooks/use-scope";
+import type { SourcePlugin } from "../plugins/source-plugin";
 
-export function SourceDetailPage(props: { namespace: string }) {
-  const { namespace } = props;
+export function SourceDetailPage(props: {
+  namespace: string;
+  sourcePlugins?: readonly SourcePlugin[];
+}) {
+  const { namespace, sourcePlugins } = props;
   const scopeId = useScope();
   const source = useAtomValue(sourceAtom(namespace, scopeId));
   const tools = useAtomValue(sourceToolsAtom(namespace, scopeId));
@@ -30,10 +34,18 @@ export function SourceDetailPage(props: { namespace: string }) {
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+  const [editing, setEditing] = useState(false);
 
   const sourceData = Result.isSuccess(source) ? source.value : null;
   const canRefresh = sourceData ? (sourceData.canRefresh ?? true) : false;
   const canRemove = sourceData ? (sourceData.canRemove ?? true) : false;
+  const canEdit = sourceData ? (sourceData.canEdit ?? false) : false;
+
+  // Find the plugin edit component based on source kind
+  const editPlugin = useMemo(() => {
+    if (!sourceData || !sourcePlugins) return null;
+    return sourcePlugins.find((p) => p.key === sourceData.kind) ?? null;
+  }, [sourceData, sourcePlugins]);
 
   const sourceTools: ToolSummary[] = useMemo(() => {
     if (!Result.isSuccess(tools)) return [];
@@ -77,6 +89,12 @@ export function SourceDetailPage(props: { namespace: string }) {
     }
   };
 
+  const handleEditSave = () => {
+    setEditing(false);
+    refreshSources();
+    refreshTools();
+  };
+
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       {/* Header bar */}
@@ -93,7 +111,7 @@ export function SourceDetailPage(props: { namespace: string }) {
           <span className="rounded bg-secondary px-1.5 py-0.5 text-[10px] font-medium text-secondary-foreground">
             {sourceData?.kind ?? "source"}
           </span>
-          {Result.isSuccess(tools) && (
+          {Result.isSuccess(tools) && !editing && (
             <span className="hidden text-[11px] tabular-nums text-muted-foreground/50 sm:block">
               {sourceTools.length} {sourceTools.length === 1 ? "tool" : "tools"}
             </span>
@@ -101,18 +119,38 @@ export function SourceDetailPage(props: { namespace: string }) {
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          {canRefresh && (
+          {canEdit && editPlugin && !editing && (
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-[12px] font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50"
+            >
+              Edit
+            </button>
+          )}
+
+          {editing && (
+            <button
+              type="button"
+              onClick={() => setEditing(false)}
+              className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-[12px] font-medium text-foreground transition-colors hover:bg-accent"
+            >
+              Back to tools
+            </button>
+          )}
+
+          {canRefresh && !editing && (
             <button
               type="button"
               onClick={() => void handleRefresh()}
               disabled={refreshing}
               className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1 text-[12px] font-medium text-foreground transition-colors hover:bg-accent disabled:opacity-50"
             >
-              {refreshing ? "Refreshing…" : "Refresh"}
+              {refreshing ? "Refreshing..." : "Refresh"}
             </button>
           )}
 
-          {canRemove && (confirmDelete ? (
+          {canRemove && !editing && (confirmDelete ? (
             <div className="flex items-center gap-2">
               <span className="text-[11px] font-medium text-destructive">
                 Confirm?
@@ -131,7 +169,7 @@ export function SourceDetailPage(props: { namespace: string }) {
                 disabled={deleting}
                 className="inline-flex items-center rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-1 text-[12px] font-medium text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
               >
-                {deleting ? "Deleting…" : "Delete"}
+                {deleting ? "Deleting..." : "Delete"}
               </button>
             </div>
           ) : (
@@ -146,41 +184,52 @@ export function SourceDetailPage(props: { namespace: string }) {
         </div>
       </div>
 
-      {/* Content — split pane */}
-      {Result.match(tools, {
-        onInitial: () => (
-          <div className="p-6 text-sm text-muted-foreground">Loading…</div>
-        ),
-        onFailure: () => (
-          <div className="p-6 text-sm text-destructive">Failed to load tools</div>
-        ),
-        onSuccess: () => (
-          <div className="flex min-h-0 flex-1 overflow-hidden">
-            {/* Left: tool tree */}
-            <div className="flex w-72 shrink-0 flex-col border-r border-border bg-card/30 lg:w-80 xl:w-[22rem]">
-              <ToolTree
-                tools={sourceTools}
-                selectedToolId={selectedToolId}
-                onSelect={setSelectedToolId}
-              />
-            </div>
-
-            {/* Right: tool detail */}
-            <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-              {selectedTool ? (
-                <ToolDetail
-                  toolId={selectedTool.id}
-                  toolName={selectedTool.name}
-                  toolDescription={selectedTool.description}
-                  scopeId={scopeId}
-                />
-              ) : (
-                <ToolDetailEmpty hasTools={sourceTools.length > 0} />
-              )}
-            </div>
+      {/* Edit view */}
+      {editing && editPlugin ? (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="mx-auto max-w-2xl px-6 py-8">
+            <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Loading...</div>}>
+              <editPlugin.edit sourceId={namespace} onSave={handleEditSave} />
+            </Suspense>
           </div>
-        ),
-      })}
+        </div>
+      ) : (
+        /* Content -- split pane */
+        Result.match(tools, {
+          onInitial: () => (
+            <div className="p-6 text-sm text-muted-foreground">Loading...</div>
+          ),
+          onFailure: () => (
+            <div className="p-6 text-sm text-destructive">Failed to load tools</div>
+          ),
+          onSuccess: () => (
+            <div className="flex min-h-0 flex-1 overflow-hidden">
+              {/* Left: tool tree */}
+              <div className="flex w-72 shrink-0 flex-col border-r border-border bg-card/30 lg:w-80 xl:w-[22rem]">
+                <ToolTree
+                  tools={sourceTools}
+                  selectedToolId={selectedToolId}
+                  onSelect={setSelectedToolId}
+                />
+              </div>
+
+              {/* Right: tool detail */}
+              <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                {selectedTool ? (
+                  <ToolDetail
+                    toolId={selectedTool.id}
+                    toolName={selectedTool.name}
+                    toolDescription={selectedTool.description}
+                    scopeId={scopeId}
+                  />
+                ) : (
+                  <ToolDetailEmpty hasTools={sourceTools.length > 0} />
+                )}
+              </div>
+            </div>
+          ),
+        })
+      )}
     </div>
   );
 }

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -209,6 +209,59 @@ function HeaderValuePreview(props: {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Header state helpers — shared by edit forms
+// ---------------------------------------------------------------------------
+
+export type HeaderState = {
+  name: string;
+  secretId: string | null;
+  prefix?: string;
+  presetKey?: string;
+  fromPreset?: boolean;
+};
+
+export function matchPresetKey(name: string, prefix?: string): string {
+  const preset =
+    defaultHeaderAuthPresets.find((p) => p.name === name && p.prefix === prefix)
+    ?? defaultHeaderAuthPresets.find((p) => p.name === name && p.prefix === undefined);
+  return preset?.key ?? "custom";
+}
+
+export function headerValueToState(
+  name: string,
+  value: { secretId: string; prefix?: string } | string,
+): HeaderState {
+  if (typeof value === "string") {
+    return { name, secretId: null, presetKey: matchPresetKey(name, undefined) };
+  }
+  return {
+    name,
+    secretId: value.secretId,
+    prefix: value.prefix,
+    presetKey: matchPresetKey(name, value.prefix),
+  };
+}
+
+export function headersFromState(
+  entries: readonly HeaderState[],
+): Record<string, { secretId: string; prefix?: string }> {
+  const result: Record<string, { secretId: string; prefix?: string }> = {};
+  for (const entry of entries) {
+    const name = entry.name.trim();
+    if (!name || !entry.secretId) continue;
+    result[name] = {
+      secretId: entry.secretId,
+      ...(entry.prefix ? { prefix: entry.prefix } : {}),
+    };
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Secret header auth row
+// ---------------------------------------------------------------------------
+
 export function SecretHeaderAuthRow(props: {
   name: string;
   prefix?: string;


### PR DESCRIPTION
Add core infrastructure for plugin-specific source editing (getSource/update
endpoints in SDK and API layers) and implement it for the OpenAPI plugin.
Includes typed API routes, config-file store, stored-source schema, and
edit UI with header auth management.