### PR TITLE
feat(graphql): add edit source configuration support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -441,6 +441,7 @@
       "dependencies": {
         "@effect/platform": "catalog:",
         "@effect/platform-node": "catalog:",
+        "@executor/config": "workspace:*",
         "@executor/sdk": "workspace:*",
         "effect": "catalog:",
       },

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@effect/platform": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@executor/config": "workspace:*",
     "@executor/sdk": "workspace:*",
     "effect": "catalog:"
   },

--- a/packages/plugins/graphql/src/api/group.ts
+++ b/packages/plugins/graphql/src/api/group.ts
@@ -6,12 +6,14 @@ import {
   GraphqlIntrospectionError,
   GraphqlExtractionError,
 } from "../sdk/errors";
+import { StoredSourceSchema } from "../sdk/stored-source";
 
 // ---------------------------------------------------------------------------
 // Params
 // ---------------------------------------------------------------------------
 
 const scopeIdParam = HttpApiSchema.param("scopeId", ScopeId);
+const namespaceParam = HttpApiSchema.param("namespace", Schema.String);
 
 // ---------------------------------------------------------------------------
 // Payloads
@@ -24,6 +26,17 @@ const AddSourcePayload = Schema.Struct({
   headers: Schema.optional(
     Schema.Record({ key: Schema.String, value: Schema.Unknown }),
   ),
+});
+
+const UpdateSourcePayload = Schema.Struct({
+  endpoint: Schema.optional(Schema.String),
+  headers: Schema.optional(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  ),
+});
+
+const UpdateSourceResponse = Schema.Struct({
+  updated: Schema.Boolean,
 });
 
 // ---------------------------------------------------------------------------
@@ -57,5 +70,14 @@ export class GraphqlGroup extends HttpApiGroup.make("graphql")
       .addSuccess(AddSourceResponse)
       .addError(IntrospectionError)
       .addError(ExtractionError),
+  )
+  .add(
+    HttpApiEndpoint.get("getSource")`/scopes/${scopeIdParam}/graphql/sources/${namespaceParam}`
+      .addSuccess(Schema.NullOr(StoredSourceSchema)),
+  )
+  .add(
+    HttpApiEndpoint.patch("updateSource")`/scopes/${scopeIdParam}/graphql/sources/${namespaceParam}`
+      .setPayload(UpdateSourcePayload)
+      .addSuccess(UpdateSourceResponse),
   )
   {}

--- a/packages/plugins/graphql/src/api/handlers.ts
+++ b/packages/plugins/graphql/src/api/handlers.ts
@@ -2,7 +2,7 @@ import { HttpApiBuilder } from "@effect/platform";
 import { Context, Effect } from "effect";
 
 import { addGroup } from "@executor/api";
-import type { GraphqlPluginExtension, HeaderValue } from "../sdk/plugin";
+import type { GraphqlPluginExtension, HeaderValue, GraphqlUpdateSourceInput } from "../sdk/plugin";
 import { GraphqlGroup } from "./group";
 
 // ---------------------------------------------------------------------------
@@ -27,19 +27,36 @@ export const GraphqlHandlers = HttpApiBuilder.group(
   ExecutorApiWithGraphql,
   "graphql",
   (handlers) =>
-    handlers.handle("addSource", ({ payload }) =>
-      Effect.gen(function* () {
-        const ext = yield* GraphqlExtensionService;
-        const result = yield* ext.addSource({
-          endpoint: payload.endpoint,
-          introspectionJson: payload.introspectionJson,
-          namespace: payload.namespace,
-          headers: payload.headers as Record<string, HeaderValue> | undefined,
-        });
-        return {
-          toolCount: result.toolCount,
-          namespace: payload.namespace ?? "graphql",
-        };
-      }).pipe(Effect.orDie),
-    ),
+    handlers
+      .handle("addSource", ({ payload }) =>
+        Effect.gen(function* () {
+          const ext = yield* GraphqlExtensionService;
+          const result = yield* ext.addSource({
+            endpoint: payload.endpoint,
+            introspectionJson: payload.introspectionJson,
+            namespace: payload.namespace,
+            headers: payload.headers as Record<string, HeaderValue> | undefined,
+          });
+          return {
+            toolCount: result.toolCount,
+            namespace: payload.namespace ?? "graphql",
+          };
+        }).pipe(Effect.orDie),
+      )
+      .handle("getSource", ({ path }) =>
+        Effect.gen(function* () {
+          const ext = yield* GraphqlExtensionService;
+          return yield* ext.getSource(path.namespace);
+        }).pipe(Effect.orDie),
+      )
+      .handle("updateSource", ({ path, payload }) =>
+        Effect.gen(function* () {
+          const ext = yield* GraphqlExtensionService;
+          yield* ext.updateSource(path.namespace, {
+            endpoint: payload.endpoint,
+            headers: payload.headers as Record<string, HeaderValue> | undefined,
+          } as GraphqlUpdateSourceInput);
+          return { updated: true };
+        }).pipe(Effect.orDie),
+      ),
 );

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -1,12 +1,153 @@
+import { useState } from "react";
+import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { graphqlSourceAtom, updateGraphqlSource } from "./atoms";
+import { useScope } from "@executor/react/api/scope-context";
+import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
+import {
+  SecretHeaderAuthRow,
+  headerValueToState,
+  headersFromState,
+  type HeaderState,
+} from "@executor/react/plugins/secret-header-auth";
+import { Button } from "@executor/react/components/button";
+import { Input } from "@executor/react/components/input";
+import { Label } from "@executor/react/components/label";
+import { Badge } from "@executor/react/components/badge";
+import type { StoredSourceSchemaType } from "../sdk/stored-source";
+
+// ---------------------------------------------------------------------------
+// Edit form
+// ---------------------------------------------------------------------------
+
+function EditForm(props: {
+  sourceId: string;
+  initial: StoredSourceSchemaType;
+  onSave: () => void;
+}) {
+  const scopeId = useScope();
+  const doUpdate = useAtomSet(updateGraphqlSource, { mode: "promise" });
+  const refreshSource = useAtomRefresh(graphqlSourceAtom(scopeId, props.sourceId));
+  const secretList = useSecretPickerSecrets();
+
+  const [endpoint, setEndpoint] = useState(props.initial.config.endpoint);
+  const [headers, setHeaders] = useState<HeaderState[]>(() =>
+    Object.entries(props.initial.config.headers ?? {}).map(([name, value]) =>
+      headerValueToState(name, value),
+    ),
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  const updateHeader = (index: number, update: Partial<HeaderState>) => {
+    setHeaders((prev) => prev.map((h, i) => (i === index ? { ...h, ...update } : h)));
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await doUpdate({
+        path: { scopeId, namespace: props.sourceId },
+        payload: {
+          endpoint: endpoint.trim() || undefined,
+          headers: headersFromState(headers),
+        },
+      });
+      refreshSource();
+      setDirty(false);
+      props.onSave();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update source");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold text-foreground">Edit GraphQL Source</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">
+          Update the endpoint and authentication headers for this source.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-card-foreground">{props.sourceId}</p>
+        </div>
+        <Badge variant="secondary" className="text-[10px]">GraphQL</Badge>
+      </div>
+
+      <section className="space-y-2">
+        <Label>Endpoint</Label>
+        <Input
+          value={endpoint}
+          onChange={(e) => { setEndpoint((e.target as HTMLInputElement).value); setDirty(true); }}
+          placeholder="https://api.example.com/graphql"
+          className="font-mono text-sm"
+        />
+      </section>
+
+      <section className="space-y-2.5">
+        <Label>Headers</Label>
+        {headers.map((h, i) => (
+          <SecretHeaderAuthRow
+            key={i}
+            name={h.name}
+            prefix={h.prefix}
+            presetKey={h.presetKey}
+            secretId={h.secretId}
+            onChange={(update) => updateHeader(i, update)}
+            onSelectSecret={(secretId) => updateHeader(i, { secretId })}
+            onRemove={() => { setHeaders((prev) => prev.filter((_, j) => j !== i)); setDirty(true); }}
+            existingSecrets={secretList}
+          />
+        ))}
+        <Button variant="outline" size="sm" className="w-full border-dashed" onClick={() => { setHeaders((prev) => [...prev, { name: "", secretId: null }]); setDirty(true); }}>
+          + Add header
+        </Button>
+      </section>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+          <p className="text-[12px] text-destructive">{error}</p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between border-t border-border pt-4">
+        <Button variant="ghost" onClick={props.onSave}>Cancel</Button>
+        <Button onClick={handleSave} disabled={!dirty || saving}>
+          {saving ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
 export default function EditGraphqlSource(props: {
   sourceId: string;
   onSave: () => void;
 }) {
-  return (
-    <div>
-      <h3>Edit GraphQL Source</h3>
-      <p>Source: {props.sourceId}</p>
-      <button onClick={props.onSave}>Save</button>
-    </div>
-  );
+  const scopeId = useScope();
+  const sourceResult = useAtomValue(graphqlSourceAtom(scopeId, props.sourceId));
+
+  if (!Result.isSuccess(sourceResult) || !sourceResult.value) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Edit GraphQL Source</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">Loading configuration…</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <EditForm sourceId={props.sourceId} initial={sourceResult.value} onSave={props.onSave} />;
 }

--- a/packages/plugins/graphql/src/react/atoms.ts
+++ b/packages/plugins/graphql/src/react/atoms.ts
@@ -1,7 +1,20 @@
+import type { ScopeId } from "@executor/sdk";
 import { GraphqlClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Query atoms
+// ---------------------------------------------------------------------------
+
+export const graphqlSourceAtom = (scopeId: ScopeId, namespace: string) =>
+  GraphqlClient.query("graphql", "getSource", {
+    path: { scopeId, namespace },
+    timeToLive: "15 seconds",
+  });
 
 // ---------------------------------------------------------------------------
 // Mutation atoms
 // ---------------------------------------------------------------------------
 
 export const addGraphqlSource = GraphqlClient.mutation("graphql", "addSource");
+
+export const updateGraphqlSource = GraphqlClient.mutation("graphql", "updateSource");

--- a/packages/plugins/graphql/src/sdk/config-file-store.ts
+++ b/packages/plugins/graphql/src/sdk/config-file-store.ts
@@ -1,0 +1,69 @@
+/**
+ * Config-file wrapper for GraphqlOperationStore.
+ *
+ * Decorates an underlying store so that `putSource` and `removeSource` also
+ * write to executor.jsonc.
+ */
+
+import { Effect } from "effect";
+import { FileSystem } from "@effect/platform";
+import type { Layer } from "effect";
+
+import {
+  addSourceToConfig,
+  removeSourceFromConfig,
+  SECRET_REF_PREFIX,
+} from "@executor/config";
+import type { SourceConfig as ConfigFileSourceConfig, ConfigHeaderValue } from "@executor/config";
+
+import type { GraphqlOperationStore, StoredSource } from "./operation-store";
+
+type PluginHeaderValue = string | { readonly secretId: string; readonly prefix?: string };
+
+const translateSecretHeaders = (
+  headers: Readonly<Record<string, PluginHeaderValue>> | undefined,
+): Record<string, ConfigHeaderValue> | undefined => {
+  if (!headers) return undefined;
+  const result: Record<string, ConfigHeaderValue> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof value === "string") {
+      result[key] = value;
+      continue;
+    }
+    const ref = `${SECRET_REF_PREFIX}${value.secretId}`;
+    result[key] = value.prefix ? { value: ref, prefix: value.prefix } : ref;
+  }
+  return result;
+};
+
+const toSourceConfig = (source: StoredSource): ConfigFileSourceConfig => ({
+  kind: "graphql",
+  endpoint: source.config.endpoint,
+  introspectionJson: source.config.introspectionJson,
+  namespace: source.namespace,
+  headers: translateSecretHeaders(source.config.headers),
+});
+
+export const withConfigFile = (
+  inner: GraphqlOperationStore,
+  configPath: string,
+  fsLayer: Layer.Layer<FileSystem.FileSystem>,
+): GraphqlOperationStore => ({
+  ...inner,
+  putSource: (source) =>
+    Effect.gen(function* () {
+      yield* inner.putSource(source);
+      yield* addSourceToConfig(configPath, toSourceConfig(source)).pipe(
+        Effect.provide(fsLayer),
+        Effect.catchAll(() => Effect.void),
+      );
+    }),
+  removeSource: (namespace) =>
+    Effect.gen(function* () {
+      yield* inner.removeSource(namespace);
+      yield* removeSourceFromConfig(configPath, namespace).pipe(
+        Effect.provide(fsLayer),
+        Effect.catchAll(() => Effect.void),
+      );
+    }),
+});

--- a/packages/plugins/graphql/src/sdk/index.ts
+++ b/packages/plugins/graphql/src/sdk/index.ts
@@ -15,6 +15,7 @@ export {
   makeKvOperationStore,
   makeInMemoryOperationStore,
 } from "./kv-operation-store";
+export { withConfigFile } from "./config-file-store";
 
 export {
   GraphqlIntrospectionError,

--- a/packages/plugins/graphql/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/graphql/src/sdk/kv-operation-store.ts
@@ -6,7 +6,8 @@ import { Effect, Schema } from "effect";
 import { scopeKv, makeInMemoryScopedKv, type Kv, type ToolId, type ScopedKv } from "@executor/sdk";
 
 import type { GraphqlOperationStore, StoredSource } from "./operation-store";
-import { OperationBinding, InvocationConfig, HeaderValue } from "./types";
+import { OperationBinding, InvocationConfig } from "./types";
+import { StoredSourceSchema } from "./stored-source";
 
 // ---------------------------------------------------------------------------
 // Stored schemas
@@ -21,18 +22,6 @@ class StoredEntry extends Schema.Class<StoredEntry>("StoredEntry")({
 const encodeEntry = Schema.encodeSync(Schema.parseJson(StoredEntry));
 const decodeEntry = Schema.decodeUnknownSync(Schema.parseJson(StoredEntry));
 
-const StoredSourceSchema = Schema.Struct({
-  namespace: Schema.String,
-  name: Schema.String,
-  config: Schema.Struct({
-    endpoint: Schema.String,
-    introspectionJson: Schema.optional(Schema.String),
-    namespace: Schema.optional(Schema.String),
-    headers: Schema.optional(
-      Schema.Record({ key: Schema.String, value: HeaderValue }),
-    ),
-  }),
-});
 const encodeSource = Schema.encodeSync(Schema.parseJson(StoredSourceSchema));
 const decodeSource = Schema.decodeUnknownSync(Schema.parseJson(StoredSourceSchema));
 
@@ -95,6 +84,21 @@ const makeStore = (
     Effect.gen(function* () {
       const entries = yield* sources.list();
       return entries.map((e) => decodeSource(e.value) as StoredSource);
+    }),
+
+  getSource: (namespace) =>
+    Effect.gen(function* () {
+      const raw = yield* sources.get(namespace);
+      if (!raw) return null;
+      return decodeSource(raw) as StoredSource;
+    }),
+
+  getSourceConfig: (namespace) =>
+    Effect.gen(function* () {
+      const raw = yield* sources.get(namespace);
+      if (!raw) return null;
+      const source = decodeSource(raw) as StoredSource;
+      return source.config;
     }),
 });
 

--- a/packages/plugins/graphql/src/sdk/operation-store.ts
+++ b/packages/plugins/graphql/src/sdk/operation-store.ts
@@ -43,4 +43,12 @@ export interface GraphqlOperationStore {
   readonly removeSource: (namespace: string) => Effect.Effect<void>;
 
   readonly listSources: () => Effect.Effect<readonly StoredSource[]>;
+
+  readonly getSource: (
+    namespace: string,
+  ) => Effect.Effect<StoredSource | null>;
+
+  readonly getSourceConfig: (
+    namespace: string,
+  ) => Effect.Effect<SourceConfig | null>;
 }

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -21,7 +21,7 @@ import {
   GraphqlExtractionError,
 } from "./errors";
 import { makeGraphqlInvoker } from "./invoke";
-import type { GraphqlOperationStore } from "./operation-store";
+import type { GraphqlOperationStore, StoredSource } from "./operation-store";
 import { makeInMemoryOperationStore } from "./kv-operation-store";
 import {
   ExtractedField,
@@ -53,6 +53,11 @@ export interface GraphqlSourceConfig {
 // Plugin extension
 // ---------------------------------------------------------------------------
 
+export interface GraphqlUpdateSourceInput {
+  readonly endpoint?: string;
+  readonly headers?: Record<string, HeaderValue>;
+}
+
 export interface GraphqlPluginExtension {
   /** Add a GraphQL endpoint and register its operations as tools */
   readonly addSource: (
@@ -61,6 +66,17 @@ export interface GraphqlPluginExtension {
 
   /** Remove all tools from a previously added GraphQL source by namespace */
   readonly removeSource: (namespace: string) => Effect.Effect<void>;
+
+  /** Fetch the full stored source by namespace (or null if missing) */
+  readonly getSource: (
+    namespace: string,
+  ) => Effect.Effect<StoredSource | null>;
+
+  /** Update config (endpoint, headers) for an existing GraphQL source */
+  readonly updateSource: (
+    namespace: string,
+    input: GraphqlUpdateSourceInput,
+  ) => Effect.Effect<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -226,6 +242,7 @@ export const graphqlPlugin = (options?: {
                       runtime: false,
                       canRemove: true,
                       canRefresh: false,
+                      canEdit: true,
                     }),
                 ),
               ),
@@ -420,6 +437,43 @@ export const graphqlPlugin = (options?: {
                   yield* ctx.tools.unregister(toolIds);
                 }
                 yield* operationStore.removeSource(namespace);
+              }),
+
+            getSource: (namespace: string) =>
+              operationStore.getSource(namespace),
+
+            updateSource: (namespace: string, input: GraphqlUpdateSourceInput) =>
+              Effect.gen(function* () {
+                const existingConfig = yield* operationStore.getSourceConfig(namespace);
+                if (!existingConfig) return;
+
+                const updatedConfig = {
+                  ...existingConfig,
+                  ...(input.endpoint !== undefined ? { endpoint: input.endpoint } : {}),
+                  ...(input.headers !== undefined ? { headers: input.headers as Record<string, HeaderValueValue> } : {}),
+                };
+
+                const newInvocationConfig = new InvocationConfig({
+                  endpoint: updatedConfig.endpoint,
+                  headers: (updatedConfig.headers ?? {}) as Record<string, HeaderValueValue>,
+                });
+
+                const toolIds = yield* operationStore.listByNamespace(namespace);
+                for (const toolId of toolIds) {
+                  const entry = yield* operationStore.get(toolId);
+                  if (entry) {
+                    yield* operationStore.put(toolId, namespace, entry.binding, newInvocationConfig);
+                  }
+                }
+
+                const sources = yield* operationStore.listSources();
+                const existingMeta = sources.find((s) => s.namespace === namespace);
+
+                yield* operationStore.putSource({
+                  namespace,
+                  name: existingMeta?.name ?? namespace,
+                  config: updatedConfig,
+                });
               }),
           },
 

--- a/packages/plugins/graphql/src/sdk/stored-source.ts
+++ b/packages/plugins/graphql/src/sdk/stored-source.ts
@@ -1,0 +1,25 @@
+import { Schema } from "effect";
+
+import { HeaderValue } from "./types";
+
+// ---------------------------------------------------------------------------
+// Stored source — the shape persisted by the operation store and exposed
+// via the getSource HTTP endpoint.
+// ---------------------------------------------------------------------------
+
+export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>(
+  "GraphqlStoredSource",
+)({
+  namespace: Schema.String,
+  name: Schema.String,
+  config: Schema.Struct({
+    endpoint: Schema.String,
+    introspectionJson: Schema.optional(Schema.String),
+    namespace: Schema.optional(Schema.String),
+    headers: Schema.optional(
+      Schema.Record({ key: Schema.String, value: HeaderValue }),
+    ),
+  }),
+}) {}
+
+export type StoredSourceSchemaType = typeof StoredSourceSchema.Type;


### PR DESCRIPTION
Implement getSource/update for the GraphQL plugin with typed API routes,
config-file store, stored-source schema, and edit UI for endpoint, headers,
and auth settings.