### PR TITLE
feat(mcp): add edit source configuration support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -494,6 +494,7 @@
       "dependencies": {
         "@effect/platform": "catalog:",
         "@effect/platform-node": "catalog:",
+        "@executor/config": "workspace:*",
         "@executor/sdk": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "effect": "catalog:",

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@effect/platform": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@executor/config": "workspace:*",
     "@executor/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "effect": "catalog:"

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -2,6 +2,8 @@ import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
 import { Schema } from "effect";
 import { ScopeId } from "@executor/sdk";
 
+import { McpStoredSourceSchema } from "../sdk/stored-source";
+
 // Re-export for handler use
 export { HttpApiSchema };
 
@@ -10,6 +12,7 @@ export { HttpApiSchema };
 // ---------------------------------------------------------------------------
 
 const scopeIdParam = HttpApiSchema.param("scopeId", ScopeId);
+const namespaceParam = HttpApiSchema.param("namespace", Schema.String);
 
 // ---------------------------------------------------------------------------
 // Auth payload (only for remote)
@@ -70,6 +73,17 @@ const AddSourcePayload = Schema.Union(
 // ---------------------------------------------------------------------------
 // Other payloads
 // ---------------------------------------------------------------------------
+
+const UpdateSourcePayload = Schema.Struct({
+  endpoint: Schema.optional(Schema.String),
+  headers: Schema.optional(StringMap),
+  queryParams: Schema.optional(StringMap),
+  auth: Schema.optional(AuthPayload),
+});
+
+const UpdateSourceResponse = Schema.Struct({
+  updated: Schema.Boolean,
+});
 
 const ProbeEndpointPayload = Schema.Struct({
   endpoint: Schema.String,
@@ -192,6 +206,17 @@ export class McpGroup extends HttpApiGroup.make("mcp")
     HttpApiEndpoint.get("oauthCallback")`/mcp/oauth/callback`
       .setUrlParams(OAuthCallbackParams)
       .addSuccess(HtmlResponse)
+      .addError(McpApiError),
+  )
+  .add(
+    HttpApiEndpoint.get("getSource")`/scopes/${scopeIdParam}/mcp/sources/${namespaceParam}`
+      .addSuccess(Schema.NullOr(McpStoredSourceSchema))
+      .addError(McpApiError),
+  )
+  .add(
+    HttpApiEndpoint.patch("updateSource")`/scopes/${scopeIdParam}/mcp/sources/${namespaceParam}`
+      .setPayload(UpdateSourcePayload)
+      .addSuccess(UpdateSourceResponse)
       .addError(McpApiError),
   )
   {}

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -2,7 +2,7 @@ import { HttpApiBuilder, HttpServerResponse } from "@effect/platform";
 import { Context, Effect } from "effect";
 
 import { addGroup } from "@executor/api";
-import type { McpPluginExtension, McpSourceConfig } from "../sdk/plugin";
+import type { McpPluginExtension, McpSourceConfig, McpUpdateSourceInput } from "../sdk/plugin";
 import { McpGroup } from "./group";
 
 // ---------------------------------------------------------------------------
@@ -194,6 +194,24 @@ export const McpHandlers = HttpApiBuilder.group(
             code: payload.code,
             error: payload.error,
           });
+        }).pipe(Effect.orDie),
+      )
+      .handle("getSource", ({ path }) =>
+        Effect.gen(function* () {
+          const ext = yield* McpExtensionService;
+          return yield* ext.getSource(path.namespace);
+        }).pipe(Effect.orDie),
+      )
+      .handle("updateSource", ({ path, payload }) =>
+        Effect.gen(function* () {
+          const ext = yield* McpExtensionService;
+          yield* ext.updateSource(path.namespace, {
+            endpoint: payload.endpoint,
+            headers: payload.headers,
+            queryParams: payload.queryParams,
+            auth: payload.auth as McpUpdateSourceInput["auth"],
+          });
+          return { updated: true };
         }).pipe(Effect.orDie),
       )
       .handle("oauthCallback", ({ urlParams }) =>

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -1,8 +1,219 @@
+import { useState } from "react";
+import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { mcpSourceAtom, updateMcpSource } from "./atoms";
+import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import { Input } from "@executor/react/components/input";
+import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
+import type { McpStoredSourceSchemaType } from "../sdk/stored-source";
 
 // ---------------------------------------------------------------------------
-// Edit MCP Source — config view for an existing MCP source
+// Editable header entry
+// ---------------------------------------------------------------------------
+
+type HeaderEntry = {
+  readonly name: string;
+  readonly value: string;
+};
+
+// ---------------------------------------------------------------------------
+// Remote edit form
+// ---------------------------------------------------------------------------
+
+function RemoteEditForm(props: {
+  sourceId: string;
+  initial: McpStoredSourceSchemaType & { config: { transport: "remote" } };
+  onSave: () => void;
+}) {
+  const scopeId = useScope();
+  const doUpdate = useAtomSet(updateMcpSource, { mode: "promise" });
+  const refreshSource = useAtomRefresh(mcpSourceAtom(scopeId, props.sourceId));
+
+  const [endpoint, setEndpoint] = useState(props.initial.config.endpoint);
+  const [headerEntries, setHeaderEntries] = useState<HeaderEntry[]>(() =>
+    Object.entries(props.initial.config.headers ?? {}).map(([name, value]) => ({
+      name,
+      value,
+    })),
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+
+  const updateHeader = (index: number, field: "name" | "value", val: string) => {
+    setHeaderEntries((prev) =>
+      prev.map((entry, i) =>
+        i === index ? { ...entry, [field]: val } : entry,
+      ),
+    );
+    setDirty(true);
+  };
+
+  const removeHeader = (index: number) => {
+    setHeaderEntries((prev) => prev.filter((_, i) => i !== index));
+    setDirty(true);
+  };
+
+  const addHeader = () => {
+    setHeaderEntries((prev) => [...prev, { name: "", value: "" }]);
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const headersObj: Record<string, string> = {};
+      for (const entry of headerEntries) {
+        const name = entry.name.trim();
+        if (name) headersObj[name] = entry.value;
+      }
+
+      await doUpdate({
+        path: { scopeId, namespace: props.sourceId },
+        payload: {
+          endpoint: endpoint.trim() || undefined,
+          headers: headersObj,
+        },
+      });
+      refreshSource();
+      setDirty(false);
+      props.onSave();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update source");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold text-foreground">Edit MCP Source</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">
+          Update the endpoint and headers for this MCP connection.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-card-foreground">{props.sourceId}</p>
+        </div>
+        <Badge variant="secondary" className="text-[10px]">
+          remote
+        </Badge>
+      </div>
+
+      {/* Endpoint */}
+      <section className="space-y-2">
+        <Label>Endpoint</Label>
+        <Input
+          value={endpoint}
+          onChange={(e) => {
+            setEndpoint((e.target as HTMLInputElement).value);
+            setDirty(true);
+          }}
+          placeholder="https://mcp.example.com"
+          className="font-mono text-sm"
+        />
+      </section>
+
+      {/* Headers */}
+      <section className="space-y-2.5">
+        <Label>Headers</Label>
+        {headerEntries.map((entry, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <Input
+              value={entry.name}
+              onChange={(e) => updateHeader(i, "name", (e.target as HTMLInputElement).value)}
+              placeholder="Header name"
+              className="h-8 text-xs font-mono flex-1"
+            />
+            <Input
+              value={entry.value}
+              onChange={(e) => updateHeader(i, "value", (e.target as HTMLInputElement).value)}
+              placeholder="Header value"
+              className="h-8 text-xs font-mono flex-1"
+            />
+            <Button
+              variant="ghost"
+              size="xs"
+              className="text-muted-foreground hover:text-destructive shrink-0"
+              onClick={() => removeHeader(i)}
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full border-dashed"
+          onClick={addHeader}
+        >
+          + Add header
+        </Button>
+      </section>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+          <p className="text-[12px] text-destructive">{error}</p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between border-t border-border pt-4">
+        <Button variant="ghost" onClick={props.onSave}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} disabled={!dirty || saving}>
+          {saving ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stdio read-only view
+// ---------------------------------------------------------------------------
+
+function StdioReadOnly(props: {
+  sourceId: string;
+  initial: McpStoredSourceSchemaType & { config: { transport: "stdio" } };
+  onSave: () => void;
+}) {
+  const { command, args } = props.initial.config;
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold text-foreground">Edit MCP Source</h1>
+        <p className="mt-1 text-[13px] text-muted-foreground">
+          Stdio MCP sources cannot be edited in the UI. Modify the executor.jsonc config file directly.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-card-foreground">{props.sourceId}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground font-mono">
+            {command} {(args ?? []).join(" ")}
+          </p>
+        </div>
+        <Badge variant="secondary" className="text-[10px]">
+          stdio
+        </Badge>
+      </div>
+
+      <div className="flex items-center justify-end border-t border-border pt-4">
+        <Button onClick={props.onSave}>Done</Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
 // ---------------------------------------------------------------------------
 
 export default function EditMcpSource({
@@ -12,34 +223,37 @@ export default function EditMcpSource({
   readonly sourceId: string;
   readonly onSave: () => void;
 }) {
+  const scopeId = useScope();
+  const sourceResult = useAtomValue(mcpSourceAtom(scopeId, sourceId));
+
+  if (!Result.isSuccess(sourceResult) || !sourceResult.value) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold text-foreground">Edit MCP Source</h1>
+          <p className="mt-1 text-[13px] text-muted-foreground">Loading configuration…</p>
+        </div>
+      </div>
+    );
+  }
+
+  const source = sourceResult.value;
+
+  if (source.config.transport === "stdio") {
+    return (
+      <StdioReadOnly
+        sourceId={sourceId}
+        initial={source as McpStoredSourceSchemaType & { config: { transport: "stdio" } }}
+        onSave={onSave}
+      />
+    );
+  }
+
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-semibold text-foreground">Edit MCP Source</h1>
-        <p className="mt-1 text-[13px] text-muted-foreground">
-          Manage settings for this MCP connection.
-        </p>
-      </div>
-
-      <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
-        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-          <svg viewBox="0 0 16 16" className="size-4">
-            <circle cx="8" cy="8" r="6" fill="none" stroke="currentColor" strokeWidth="1.2" />
-            <path d="M8 5v6M5 8h6" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-          </svg>
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-semibold text-card-foreground">{sourceId}</p>
-        </div>
-        <Badge variant="secondary" className="text-[10px]">
-          MCP
-        </Badge>
-      </div>
-
-      <div className="flex items-center justify-between border-t border-border pt-4">
-        <div />
-        <Button onClick={onSave}>Done</Button>
-      </div>
-    </div>
+    <RemoteEditForm
+      sourceId={sourceId}
+      initial={source as McpStoredSourceSchemaType & { config: { transport: "remote" } }}
+      onSave={onSave}
+    />
   );
 }

--- a/packages/plugins/mcp/src/react/atoms.ts
+++ b/packages/plugins/mcp/src/react/atoms.ts
@@ -1,4 +1,15 @@
+import type { ScopeId } from "@executor/sdk";
 import { McpClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Query atoms
+// ---------------------------------------------------------------------------
+
+export const mcpSourceAtom = (scopeId: ScopeId, namespace: string) =>
+  McpClient.query("mcp", "getSource", {
+    path: { scopeId, namespace },
+    timeToLive: "15 seconds",
+  });
 
 // ---------------------------------------------------------------------------
 // Mutation atoms
@@ -10,3 +21,4 @@ export const removeMcpSource = McpClient.mutation("mcp", "removeSource");
 export const refreshMcpSource = McpClient.mutation("mcp", "refreshSource");
 export const startMcpOAuth = McpClient.mutation("mcp", "startOAuth");
 export const completeMcpOAuth = McpClient.mutation("mcp", "completeOAuth");
+export const updateMcpSource = McpClient.mutation("mcp", "updateSource");

--- a/packages/plugins/mcp/src/sdk/binding-store.ts
+++ b/packages/plugins/mcp/src/sdk/binding-store.ts
@@ -73,6 +73,9 @@ export interface McpBindingStore {
   readonly putSource: (source: McpStoredSource) => Effect.Effect<void>;
   readonly removeSource: (namespace: string) => Effect.Effect<void>;
   readonly listSources: () => Effect.Effect<readonly McpStoredSource[]>;
+  readonly getSource: (
+    namespace: string,
+  ) => Effect.Effect<McpStoredSource | null>;
   readonly getSourceConfig: (
     namespace: string,
   ) => Effect.Effect<McpStoredSourceData | null>;
@@ -144,6 +147,14 @@ const makeStore = (
     Effect.gen(function* () {
       const entries = yield* sources.list();
       return entries.map((e) => JSON.parse(e.value) as McpStoredSource);
+    }),
+
+  getSource: (namespace) =>
+    Effect.gen(function* () {
+      const raw = yield* sources.get(namespace);
+      if (!raw) return null;
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      return JSON.parse(raw) as McpStoredSource;
     }),
 
   getSourceConfig: (namespace) =>

--- a/packages/plugins/mcp/src/sdk/config-file-store.ts
+++ b/packages/plugins/mcp/src/sdk/config-file-store.ts
@@ -1,0 +1,70 @@
+/**
+ * Config-file wrapper for McpBindingStore.
+ *
+ * Decorates an underlying store so that `putSource` and `removeSource` also
+ * write to executor.jsonc.
+ */
+
+import { Effect } from "effect";
+import { FileSystem } from "@effect/platform";
+import type { Layer } from "effect";
+
+import {
+  addSourceToConfig,
+  removeSourceFromConfig,
+} from "@executor/config";
+import type { SourceConfig as ConfigFileSourceConfig } from "@executor/config";
+
+import type { McpBindingStore, McpStoredSource } from "./binding-store";
+
+const toSourceConfig = (source: McpStoredSource): ConfigFileSourceConfig => {
+  if (source.config.transport === "stdio") {
+    const d = source.config;
+    return {
+      kind: "mcp",
+      transport: "stdio",
+      name: source.name,
+      command: d.command,
+      args: d.args ? [...d.args] : undefined,
+      env: d.env,
+      cwd: d.cwd,
+      namespace: source.namespace,
+    };
+  }
+
+  const d = source.config;
+  return {
+    kind: "mcp",
+    transport: "remote",
+    name: source.name,
+    endpoint: d.endpoint,
+    remoteTransport: d.remoteTransport,
+    queryParams: d.queryParams,
+    headers: d.headers,
+    namespace: source.namespace,
+  };
+};
+
+export const withConfigFile = (
+  inner: McpBindingStore,
+  configPath: string,
+  fsLayer: Layer.Layer<FileSystem.FileSystem>,
+): McpBindingStore => ({
+  ...inner,
+  putSource: (source) =>
+    Effect.gen(function* () {
+      yield* inner.putSource(source);
+      yield* addSourceToConfig(configPath, toSourceConfig(source)).pipe(
+        Effect.provide(fsLayer),
+        Effect.catchAll(() => Effect.void),
+      );
+    }),
+  removeSource: (namespace) =>
+    Effect.gen(function* () {
+      yield* inner.removeSource(namespace);
+      yield* removeSourceFromConfig(configPath, namespace).pipe(
+        Effect.provide(fsLayer),
+        Effect.catchAll(() => Effect.void),
+      );
+    }),
+});

--- a/packages/plugins/mcp/src/sdk/index.ts
+++ b/packages/plugins/mcp/src/sdk/index.ts
@@ -3,4 +3,9 @@ export {
   type McpPluginExtension,
 } from "./plugin";
 
-export { makeKvBindingStore } from "./binding-store";
+export {
+  makeKvBindingStore,
+  type McpBindingStore,
+  type McpStoredSource,
+} from "./binding-store";
+export { withConfigFile } from "./config-file-store";

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -21,6 +21,7 @@ import {
 import {
   makeInMemoryBindingStore,
   type McpBindingStore,
+  type McpStoredSource,
 } from "./binding-store";
 import {
   createMcpConnector,
@@ -110,6 +111,13 @@ export interface McpProbeResult {
   readonly serverName: string | null;
 }
 
+export interface McpUpdateSourceInput {
+  readonly endpoint?: string;
+  readonly headers?: Record<string, string>;
+  readonly queryParams?: Record<string, string>;
+  readonly auth?: McpConnectionAuth;
+}
+
 export interface McpPluginExtension {
   readonly probeEndpoint: (
     endpoint: string,
@@ -135,6 +143,17 @@ export interface McpPluginExtension {
   readonly completeOAuth: (
     input: McpOAuthCompleteInput,
   ) => Effect.Effect<McpOAuthCompleteResponse, Error>;
+
+  /** Fetch the full stored source by namespace (or null if missing) */
+  readonly getSource: (
+    namespace: string,
+  ) => Effect.Effect<McpStoredSource | null>;
+
+  /** Update config for an existing remote MCP source */
+  readonly updateSource: (
+    namespace: string,
+    input: McpUpdateSourceInput,
+  ) => Effect.Effect<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -296,9 +315,15 @@ export const mcpPlugin = (options?: {
         // Restore source metadata
         const savedSources = yield* bindingStore.listSources();
         for (const s of savedSources) {
+          const isRemote = s.config.transport === "remote";
           addedSources.set(
             s.namespace,
-            new Source({ id: s.namespace, name: s.name, kind: "mcp" }),
+            new Source({
+              id: s.namespace,
+              name: s.name,
+              kind: "mcp",
+              canEdit: isRemote,
+            }),
           );
         }
 
@@ -594,6 +619,7 @@ export const mcpPlugin = (options?: {
                 id: namespace,
                 name: sourceName,
                 kind: "mcp",
+                canEdit: config.transport === "remote",
               }),
             );
 
@@ -769,6 +795,41 @@ export const mcpPlugin = (options?: {
             };
           });
 
+        const updateSource = (namespace: string, input: McpUpdateSourceInput) =>
+          Effect.gen(function* () {
+            const existingConfig = yield* bindingStore.getSourceConfig(namespace);
+            if (!existingConfig || existingConfig.transport !== "remote") return;
+
+            const remote = existingConfig as Extract<McpStoredSourceData, { transport: "remote" }>;
+            const updatedConfig: McpStoredSourceData = {
+              ...remote,
+              ...(input.endpoint !== undefined ? { endpoint: input.endpoint } : {}),
+              ...(input.headers !== undefined ? { headers: input.headers } : {}),
+              ...(input.auth !== undefined ? { auth: input.auth } : {}),
+              ...(input.queryParams !== undefined ? { queryParams: input.queryParams } : {}),
+            };
+
+            const sources = yield* bindingStore.listSources();
+            const existingMeta = sources.find((s) => s.namespace === namespace);
+
+            yield* bindingStore.putSource({
+              namespace,
+              name: existingMeta?.name ?? namespace,
+              config: updatedConfig,
+            });
+
+            const toolIds = yield* bindingStore.listByNamespace(namespace);
+            for (const toolId of toolIds) {
+              const entry = yield* bindingStore.get(toolId);
+              if (entry) {
+                yield* bindingStore.put(toolId, namespace, entry.binding, updatedConfig);
+              }
+            }
+          });
+
+        const getSource = (namespace: string) =>
+          bindingStore.getSource(namespace);
+
         return {
           extension: {
             probeEndpoint,
@@ -777,6 +838,8 @@ export const mcpPlugin = (options?: {
             refreshSource,
             startOAuth,
             completeOAuth,
+            getSource,
+            updateSource,
           },
 
           close: () =>

--- a/packages/plugins/mcp/src/sdk/stored-source.ts
+++ b/packages/plugins/mcp/src/sdk/stored-source.ts
@@ -1,0 +1,18 @@
+import { Schema } from "effect";
+
+import { McpStoredSourceData } from "./types";
+
+// ---------------------------------------------------------------------------
+// Stored source — the shape persisted by the binding store and exposed
+// via the getSource HTTP endpoint.
+// ---------------------------------------------------------------------------
+
+export class McpStoredSourceSchema extends Schema.Class<McpStoredSourceSchema>(
+  "McpStoredSource",
+)({
+  namespace: Schema.String,
+  name: Schema.String,
+  config: McpStoredSourceData,
+}) {}
+
+export type McpStoredSourceSchemaType = typeof McpStoredSourceSchema.Type;


### PR DESCRIPTION
Implement getSource/update for the MCP plugin with typed API routes,
config-file store, stored-source schema, and edit UI for remote source
URL, headers, and auth settings.