### PR TITLE
fix: resolve CI test failures

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -30,7 +30,5 @@
     "@executor/plugin-openapi": "0.0.1-beta.5",
     "@executor/react": "1.4.2"
   },
-  "changesets": [
-    "tiny-keys-check"
-  ]
+  "changesets": ["tiny-keys-check"]
 }

--- a/packages/core/storage-postgres/vitest.config.ts
+++ b/packages/core/storage-postgres/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    hookTimeout: 30_000,
   },
 });

--- a/packages/plugins/keychain/src/index.test.ts
+++ b/packages/plugins/keychain/src/index.test.ts
@@ -21,9 +21,9 @@ describe("keychain plugin", () => {
   );
 
   // The tests below exercise the real system keychain.
-  // Run manually on a supported platform.
+  // They are skipped in CI because there is no keychain service available.
 
-  it.effect("stores and checks secret via system keychain", () =>
+  it.effect.skipIf(!!process.env.CI)("stores and checks secret via system keychain", () =>
     Effect.gen(function* () {
       const testId = SecretId.make(`test-keychain-${Date.now()}`);
       const executor = yield* createExecutor(
@@ -54,7 +54,7 @@ describe("keychain plugin", () => {
     }),
   );
 
-  it.effect("has returns false for missing secret", () =>
+  it.effect.skipIf(!!process.env.CI)("has returns false for missing secret", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({


### PR DESCRIPTION
## Summary
- Increase `hookTimeout` to 30s for storage-postgres tests — PGlite initialization + Drizzle migrations exceed the 10s default in CI
- Skip keychain system-keychain tests in CI (`it.effect.skipIf(!!process.env.CI)`) since there's no keychain service available

## Test plan
- [x] `storage-postgres` tests pass locally
- [x] `keychain` tests skip correctly with `CI=1`
- [ ] CI passes on this PR