### PR TITLE
fix: two independent hanging-write bugs in the execution engine and local Bun server

### DIFF
--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -106,10 +106,8 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
   const server = Bun.serve({
     port,
     hostname: "127.0.0.1",
-    // Disable Bun's default 10s idle timeout. `/mcp` elicitation round-trips
-    // and `/api/executions` pause/resume can legitimately keep the socket
-    // idle longer than that. `0` is the "no timeout" sentinel per Bun's
-    // uSockets; MCP/HTTP clients enforce their own per-request timeouts.
+    // Disable Bun's default 10s idle timeout. MCP elicitation and pause/resume
+    // can idle longer during human approval; `0` disables the socket timeout.
     idleTimeout: 0,
     routes: { ...staticRoutes },
     async fetch(req) {

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -106,6 +106,17 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
   const server = Bun.serve({
     port,
     hostname: "127.0.0.1",
+    // Bun's default idleTimeout is 10 seconds (see `ServerConfig.zig`), which
+    // is too short for the MCP streamable-HTTP transport on `/mcp` and the
+    // executor's own `/api/executions` pause/resume flow: a single tool call
+    // may legitimately spend longer than that awaiting an elicitation
+    // response, running a long sandboxed computation, or holding the
+    // connection open while a human approves. `idleTimeout: 0` disables the
+    // idle timeout entirely — verified in `bun-usockets/src/socket.c`'s
+    // `us_socket_timeout`, where `seconds == 0` sets the internal timeout
+    // field to the sentinel 255 which never fires. The MCP/HTTP clients are
+    // responsible for their own per-request timeouts.
+    idleTimeout: 0,
     routes: { ...staticRoutes },
     async fetch(req) {
       if (!isAllowedHost(req)) {

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -106,16 +106,10 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
   const server = Bun.serve({
     port,
     hostname: "127.0.0.1",
-    // Bun's default idleTimeout is 10 seconds (see `ServerConfig.zig`), which
-    // is too short for the MCP streamable-HTTP transport on `/mcp` and the
-    // executor's own `/api/executions` pause/resume flow: a single tool call
-    // may legitimately spend longer than that awaiting an elicitation
-    // response, running a long sandboxed computation, or holding the
-    // connection open while a human approves. `idleTimeout: 0` disables the
-    // idle timeout entirely — verified in `bun-usockets/src/socket.c`'s
-    // `us_socket_timeout`, where `seconds == 0` sets the internal timeout
-    // field to the sentinel 255 which never fires. The MCP/HTTP clients are
-    // responsible for their own per-request timeouts.
+    // Disable Bun's default 10s idle timeout. `/mcp` elicitation round-trips
+    // and `/api/executions` pause/resume can legitimately keep the socket
+    // idle longer than that. `0` is the "no timeout" sentinel per Bun's
+    // uSockets; MCP/HTTP clients enforce their own per-request timeouts.
     idleTimeout: 0,
     routes: { ...staticRoutes },
     async fetch(req) {

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -320,6 +320,37 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
    * Start an execution in the pause/resume mode. Forks the sandbox
    * onto its own fiber and waits for either completion or the first
    * elicitation pause.
+   *
+   * The sandbox fiber MUST outlive the outer `runPromise` that drives this
+   * effect. Over HTTP (and any host that drives `executeWithPause` and
+   * `resume` from separate contexts) each call runs in its own top-level
+   * `Effect.runPromise`. If we used `Effect.fork`, the sandbox fiber would
+   * attach to the first runPromise's root fiber via a `Local` `FiberScope`,
+   * and that root fiber's `FiberRuntime.evaluateEffect` would call
+   * `interruptAllChildren()` on exit — sending an interrupt signal to the
+   * sandbox before the pause result is even returned to the caller.
+   *
+   * The subsequent `resume` would then race `Fiber.join(paused.fiber)`
+   * against `Deferred.await(nextSignal)`. With a dead sandbox, join returns
+   * the interrupt exit (converted to a defect by `Effect.orDie` in
+   * `awaitCompletionOrPause`). `Effect.race`'s `onSelfDone` on failure
+   * waits for the loser, but nothing ever signals the next pause Deferred:
+   * the tool's continuation runs on a SEPARATE root fiber that the quickjs
+   * sandbox bridge spawns per tool call via its own `Effect.runPromise`
+   * (see `__executor_invokeTool` in `@executor/runtime-quickjs`), and once
+   * that completes with no further elicitations, `nextSignal` is never
+   * filled. The resume HTTP call hangs forever. The underlying HTTP side
+   * effect of the tool can still succeed in this window — producing
+   * "phantom writes" where the upstream observes the mutation but the
+   * caller never sees the response.
+   *
+   * `Effect.forkDaemon` attaches the sandbox fiber to the global
+   * `FiberScope` instead of the parent's children set, so the parent's
+   * `interruptAllChildren` on exit does not touch it. FiberRefs and
+   * Context are copied at fork time, so the daemon is fully independent
+   * of the driving runPromise's lifetime. Regression test: `"resume
+   * returns across separate runPromise boundaries for a single-elicit
+   * tool"` in `tool-invoker.test.ts`.
    */
   const startPausableExecution = (code: string): Effect.Effect<ExecutionResult> =>
     Effect.gen(function* () {
@@ -353,7 +384,7 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
         });
 
       const invoker = makeFullInvoker(executor, { onElicitation: elicitationHandler });
-      fiber = yield* Effect.fork(codeExecutor.execute(code, invoker));
+      fiber = yield* Effect.forkDaemon(codeExecutor.execute(code, invoker));
 
       const initialSignal = yield* Ref.get(pauseSignalRef);
       return yield* awaitCompletionOrPause(fiber, initialSignal);

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -317,40 +317,13 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
     );
 
   /**
-   * Start an execution in the pause/resume mode. Forks the sandbox
-   * onto its own fiber and waits for either completion or the first
-   * elicitation pause.
-   *
-   * The sandbox fiber MUST outlive the outer `runPromise` that drives this
-   * effect. Over HTTP (and any host that drives `executeWithPause` and
-   * `resume` from separate contexts) each call runs in its own top-level
-   * `Effect.runPromise`. If we used `Effect.fork`, the sandbox fiber would
-   * attach to the first runPromise's root fiber via a `Local` `FiberScope`,
-   * and that root fiber's `FiberRuntime.evaluateEffect` would call
-   * `interruptAllChildren()` on exit — sending an interrupt signal to the
-   * sandbox before the pause result is even returned to the caller.
-   *
-   * The subsequent `resume` would then race `Fiber.join(paused.fiber)`
-   * against `Deferred.await(nextSignal)`. With a dead sandbox, join returns
-   * the interrupt exit (converted to a defect by `Effect.orDie` in
-   * `awaitCompletionOrPause`). `Effect.race`'s `onSelfDone` on failure
-   * waits for the loser, but nothing ever signals the next pause Deferred:
-   * the tool's continuation runs on a SEPARATE root fiber that the quickjs
-   * sandbox bridge spawns per tool call via its own `Effect.runPromise`
-   * (see `__executor_invokeTool` in `@executor/runtime-quickjs`), and once
-   * that completes with no further elicitations, `nextSignal` is never
-   * filled. The resume HTTP call hangs forever. The underlying HTTP side
-   * effect of the tool can still succeed in this window — producing
-   * "phantom writes" where the upstream observes the mutation but the
-   * caller never sees the response.
-   *
-   * `Effect.forkDaemon` attaches the sandbox fiber to the global
-   * `FiberScope` instead of the parent's children set, so the parent's
-   * `interruptAllChildren` on exit does not touch it. FiberRefs and
-   * Context are copied at fork time, so the daemon is fully independent
-   * of the driving runPromise's lifetime. Regression test: `"resume
-   * returns across separate runPromise boundaries for a single-elicit
-   * tool"` in `tool-invoker.test.ts`.
+   * Start an execution in the pause/resume mode. Forks the sandbox as a
+   * daemon (not a regular `Effect.fork`) because the logical lifetime of a
+   * paused execution outlives any single `runPromise` that drives it — each
+   * HTTP call (`executeWithPause`, `resume`) is its own top-level
+   * `runPromise`, and a local-scoped fork would be interrupted by the
+   * parent's `interruptAllChildren` the moment the first call returns. See
+   * the `"HTTP-like"` regression test in `tool-invoker.test.ts`.
    */
   const startPausableExecution = (code: string): Effect.Effect<ExecutionResult> =>
     Effect.gen(function* () {

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -317,13 +317,10 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
     );
 
   /**
-   * Start an execution in the pause/resume mode. Forks the sandbox as a
-   * daemon (not a regular `Effect.fork`) because the logical lifetime of a
-   * paused execution outlives any single `runPromise` that drives it — each
-   * HTTP call (`executeWithPause`, `resume`) is its own top-level
-   * `runPromise`, and a local-scoped fork would be interrupted by the
-   * parent's `interruptAllChildren` the moment the first call returns. See
-   * the `"HTTP-like"` regression test in `tool-invoker.test.ts`.
+   * Start an execution in pause/resume mode.
+   *
+   * The sandbox is forked as a daemon because paused executions can outlive the
+   * caller scope that returned the first pause, such as an HTTP request handler.
    */
   const startPausableExecution = (code: string): Effect.Effect<ExecutionResult> =>
     Effect.gen(function* () {

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Schema } from "effect";
+import { Effect, Fiber, Schema } from "effect";
 
 import {
   ElicitationResponse,
@@ -293,6 +293,22 @@ describe("pause/resume with multiple elicitations", () => {
                     return { first: r1, second: r2 };
                   }),
               }),
+              tool({
+                name: "singleApproval",
+                description:
+                  "A tool that elicits exactly once and then returns a value. Mirrors the shape of a typical `gmail.users.labels.create` style operation: one approval, one side effect, one success response.",
+                inputSchema: EmptyInput,
+                handler: (_args, ctx) =>
+                  Effect.gen(function* () {
+                    const r = yield* ctx.elicit(
+                      new FormElicitation({
+                        message: "Only approval",
+                        requestedSchema: {},
+                      }),
+                    );
+                    return { ok: true, response: r };
+                  }),
+              }),
             ],
           }),
         ] as const,
@@ -345,5 +361,96 @@ describe("pause/resume with multiple elicitations", () => {
         expect(outcome2).not.toBeNull();
       }),
     { timeout: 10000 },
+  );
+
+  // Regression test for a fiber-scoping bug that the `it.effect` test above
+  // does NOT catch, for two reasons stacked on each other:
+  //
+  //   1. `it.effect` wraps the whole body in a single `Effect.gen` → single
+  //      `Effect.runPromise`, so the first call's root fiber is still alive
+  //      when resume runs. The HTTP API (and any host that drives
+  //      `executeWithPause` and `resume` from separate contexts) runs each
+  //      call in its own top-level `runPromise`.
+  //
+  //   2. `multiApproval` elicits twice. If the sandbox fiber were attached
+  //      to the first runPromise's scope (via `Effect.fork`), it would be
+  //      interrupted between the two calls. The resume's
+  //      `awaitCompletionOrPause` would then race a dead `Fiber.join`
+  //      against `Deferred.await(nextSignal)`. With a double-elicit tool
+  //      the second elicit eventually fills `nextSignal` (from the invoker
+  //      fiber spawned on a separate root by the quickjs sandbox bridge)
+  //      and the race completes — hiding the bug.
+  //
+  // A single-elicit tool (matching the Gmail shape) has nothing to produce
+  // a second pause signal, so with `Effect.fork` the resume hangs forever
+  // waiting on a Deferred that will never be filled. The fix is to use
+  // `Effect.forkDaemon` at the fork site in engine.ts; see the JSDoc on
+  // `startPausableExecution` for the full trace.
+  it(
+    "resume returns across separate runPromise boundaries for a single-elicit tool (HTTP-like)",
+    async () => {
+      const executor = await Effect.runPromise(makeElicitingExecutor());
+      const engine = createExecutionEngine({ executor });
+
+      const code = "return await tools.api.singleApproval({});";
+
+      // First call — own runPromise. Sandbox fiber is forked here.
+      const outcome1 = await engine.executeWithPause(code);
+      expect(outcome1.status).toBe("paused");
+      const paused1 = outcome1 as Extract<typeof outcome1, { status: "paused" }>;
+      expect(paused1.execution.elicitationContext.request.message).toBe("Only approval");
+
+      // Assert the sandbox fiber is still alive across the runPromise
+      // boundary. Under `Effect.fork`, it would already be `Done` with an
+      // `Interrupt` exit cause here (its parent's `interruptAllChildren()`
+      // ran on exit). Under `Effect.forkDaemon`, it is attached to the
+      // global FiberScope and remains suspended on the response Deferred
+      // inside the elicitation handler.
+      //
+      // `execution.fiber` is on the internal paused shape, not the public
+      // `PausedExecution` type exported from the engine — cast to read it.
+      const sandboxFiber = (
+        paused1.execution as unknown as {
+          readonly fiber: Fiber.Fiber<unknown, unknown>;
+        }
+      ).fiber;
+      const exitProbe = await Effect.runPromise(
+        Effect.race(
+          Fiber.await(sandboxFiber),
+          Effect.map(Effect.sleep("50 millis"), () => "still-running" as const),
+        ),
+      );
+      expect(exitProbe).toBe("still-running");
+
+      // Second call — another top-level runPromise. With the tool only
+      // eliciting once, the only way this can return is for `Fiber.join`
+      // inside `awaitCompletionOrPause` to see a CLEAN completion from the
+      // sandbox fiber. That requires the sandbox fiber to still be alive
+      // going into resume.
+      const outcome2 = await Promise.race([
+        engine.resume(paused1.execution.id, { action: "accept" }),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () =>
+              reject(
+                new Error(
+                  "resume hung across runPromise boundaries — sandbox fiber was interrupted by the first runPromise's exit. Fix: use Effect.forkDaemon in startPausableExecution.",
+                ),
+              ),
+            2000,
+          ),
+        ),
+      ]);
+
+      expect(outcome2).not.toBeNull();
+      const resumed = outcome2 as NonNullable<typeof outcome2>;
+      // Single-elicit tool completes after one approval.
+      expect(resumed.status).toBe("completed");
+      if (resumed.status === "completed") {
+        expect(resumed.result.error).toBeUndefined();
+        expect(resumed.result.result).toMatchObject({ ok: true });
+      }
+    },
+    10000,
   );
 });

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -363,11 +363,9 @@ describe("pause/resume with multiple elicitations", () => {
     { timeout: 10000 },
   );
 
-  // Regression: each engine call must run in its own top-level
-  // `runPromise` to reproduce the HTTP shape. Uses a single-elicit tool so
-  // nothing can accidentally unstick a dead-fiber race via a second
-  // elicitation (which is what masks the bug in the `multiApproval` test
-  // above).
+  // Regression: use separate top-level runPromise calls to match HTTP/CLI
+  // pause/resume, and a single-elicit tool so no later pause can mask a dead
+  // sandbox fiber.
   it(
     "resume returns across separate runPromise boundaries for a single-elicit tool (HTTP-like)",
     async () => {

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -363,29 +363,11 @@ describe("pause/resume with multiple elicitations", () => {
     { timeout: 10000 },
   );
 
-  // Regression test for a fiber-scoping bug that the `it.effect` test above
-  // does NOT catch, for two reasons stacked on each other:
-  //
-  //   1. `it.effect` wraps the whole body in a single `Effect.gen` → single
-  //      `Effect.runPromise`, so the first call's root fiber is still alive
-  //      when resume runs. The HTTP API (and any host that drives
-  //      `executeWithPause` and `resume` from separate contexts) runs each
-  //      call in its own top-level `runPromise`.
-  //
-  //   2. `multiApproval` elicits twice. If the sandbox fiber were attached
-  //      to the first runPromise's scope (via `Effect.fork`), it would be
-  //      interrupted between the two calls. The resume's
-  //      `awaitCompletionOrPause` would then race a dead `Fiber.join`
-  //      against `Deferred.await(nextSignal)`. With a double-elicit tool
-  //      the second elicit eventually fills `nextSignal` (from the invoker
-  //      fiber spawned on a separate root by the quickjs sandbox bridge)
-  //      and the race completes — hiding the bug.
-  //
-  // A single-elicit tool (matching the Gmail shape) has nothing to produce
-  // a second pause signal, so with `Effect.fork` the resume hangs forever
-  // waiting on a Deferred that will never be filled. The fix is to use
-  // `Effect.forkDaemon` at the fork site in engine.ts; see the JSDoc on
-  // `startPausableExecution` for the full trace.
+  // Regression: each engine call must run in its own top-level
+  // `runPromise` to reproduce the HTTP shape. Uses a single-elicit tool so
+  // nothing can accidentally unstick a dead-fiber race via a second
+  // elicitation (which is what masks the bug in the `multiApproval` test
+  // above).
   it(
     "resume returns across separate runPromise boundaries for a single-elicit tool (HTTP-like)",
     async () => {
@@ -394,21 +376,13 @@ describe("pause/resume with multiple elicitations", () => {
 
       const code = "return await tools.api.singleApproval({});";
 
-      // First call — own runPromise. Sandbox fiber is forked here.
       const outcome1 = await engine.executeWithPause(code);
       expect(outcome1.status).toBe("paused");
       const paused1 = outcome1 as Extract<typeof outcome1, { status: "paused" }>;
       expect(paused1.execution.elicitationContext.request.message).toBe("Only approval");
 
-      // Assert the sandbox fiber is still alive across the runPromise
-      // boundary. Under `Effect.fork`, it would already be `Done` with an
-      // `Interrupt` exit cause here (its parent's `interruptAllChildren()`
-      // ran on exit). Under `Effect.forkDaemon`, it is attached to the
-      // global FiberScope and remains suspended on the response Deferred
-      // inside the elicitation handler.
-      //
-      // `execution.fiber` is on the internal paused shape, not the public
-      // `PausedExecution` type exported from the engine — cast to read it.
+      // `execution.fiber` is on `InternalPausedExecution`; the exported
+      // `PausedExecution` type doesn't carry it. Cast to read.
       const sandboxFiber = (
         paused1.execution as unknown as {
           readonly fiber: Fiber.Fiber<unknown, unknown>;
@@ -422,21 +396,11 @@ describe("pause/resume with multiple elicitations", () => {
       );
       expect(exitProbe).toBe("still-running");
 
-      // Second call — another top-level runPromise. With the tool only
-      // eliciting once, the only way this can return is for `Fiber.join`
-      // inside `awaitCompletionOrPause` to see a CLEAN completion from the
-      // sandbox fiber. That requires the sandbox fiber to still be alive
-      // going into resume.
       const outcome2 = await Promise.race([
         engine.resume(paused1.execution.id, { action: "accept" }),
         new Promise<never>((_, reject) =>
           setTimeout(
-            () =>
-              reject(
-                new Error(
-                  "resume hung across runPromise boundaries — sandbox fiber was interrupted by the first runPromise's exit. Fix: use Effect.forkDaemon in startPausableExecution.",
-                ),
-              ),
+            () => reject(new Error("resume hung across runPromise boundaries")),
             2000,
           ),
         ),
@@ -444,7 +408,6 @@ describe("pause/resume with multiple elicitations", () => {
 
       expect(outcome2).not.toBeNull();
       const resumed = outcome2 as NonNullable<typeof outcome2>;
-      // Single-elicit tool completes after one approval.
       expect(resumed.status).toBe("completed");
       if (resumed.status === "completed") {
         expect(resumed.result.error).toBeUndefined();


### PR DESCRIPTION
## Summary

Fixes two independent causes of hung non-SAFE tool calls that could still complete upstream, producing phantom writes where the mutation succeeded but the caller never received a response.

## Changes

- Use `Effect.forkDaemon` for pausable sandbox executions.
  - `executeWithPause` and `resume` are often driven by separate top-level `Effect.runPromise` calls, such as HTTP requests or CLI invocations.
  - A regular `Effect.fork` ties the sandbox fiber to the first caller scope, so it can be interrupted as soon as the paused result is returned.
  - `forkDaemon` lets the paused execution survive across the resume boundary.

- Set `Bun.serve({ idleTimeout: 0 })` for the local server.
  - Bun's default 10s idle timeout is too short for MCP elicitation and pause/resume flows involving human approval.
  - Disabling the Bun-level socket timeout prevents the server from closing the connection mid-flow.
  - MCP and HTTP clients still enforce their own request timeouts.

## Tests

- Added a regression test for a single-elicit tool across separate `runPromise` boundaries.
- Verified the regression fails with `Effect.fork` and passes with `Effect.forkDaemon`.

## Validation

- [x] `bun run typecheck` and `bun x vitest run` in `packages/core/execution`
- [x] `bun run typecheck` in `apps/local`
- [x] End-to-end check against Gmail `labels.create`
