### PR TITLE
chore(ui): switch sans font from DM Sans to Inter

### DIFF
--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -20,7 +20,7 @@ export const Route = createRootRoute({
       { rel: "preconnect", href: "https://fonts.gstatic.com", crossOrigin: "anonymous" },
       {
         rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=Instrument+Serif&family=JetBrains+Mono:wght@400;500&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Instrument+Serif&family=JetBrains+Mono:wght@400;500&display=swap",
       },
       { rel: "stylesheet", href: appCss },
     ],

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -510,12 +510,12 @@ const loadingHTML = (scopePath: string): string => {
 <head>
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500&family=Instrument+Serif&display=swap" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Instrument+Serif&display=swap" rel="stylesheet" />
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   body {
-    font-family: "DM Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
     display: flex; align-items: center; justify-content: center;
     height: 100vh;
     background: ${bg};

--- a/apps/local/index.html
+++ b/apps/local/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..700;1,9..40,300..700&family=Instrument+Serif&family=JetBrains+Mono:wght@400;500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&family=Instrument+Serif&family=JetBrains+Mono:wght@400;500&display=swap"
     />
     <script type="module">
       if (import.meta.env.DEV) {

--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -8,7 +8,7 @@
 @source "../../../plugins/*/src/react/**/*.{ts,tsx}";
 
 @theme inline {
-  --font-sans: "DM Sans", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
   --font-display: "Instrument Serif", Georgia, serif;
 


### PR DESCRIPTION
## Summary

- Swaps the primary sans font from DM Sans to Inter.
- DM Sans had rendering issues on external monitors; Inter is a more common choice and ships in the same variable-font format.

## Changes

- `packages/react/src/styles/globals.css` — `--font-sans` token
- `apps/local/index.html` — Google Fonts `<link>`
- `apps/cloud/src/routes/__root.tsx` — Google Fonts `<link>` head entry
- `apps/desktop/src/main.ts` — Electron loading page font