### PR TITLE
fix(plugins): correct and backfill preset icon URLs

### DIFF
--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -44,7 +44,7 @@ export const mcpPresets: readonly McpPreset[] = [
     name: "Browserbase",
     summary: "Cloud browser sessions for web scraping and automation.",
     url: "https://mcp.browserbase.com/mcp",
-    icon: "https://www.browserbase.com/icon.svg",
+    icon: "https://www.browserbase.com/favicon.ico",
     featured: true,
   },
   {
@@ -92,7 +92,7 @@ export const mcpPresets: readonly McpPreset[] = [
     name: "Sentry",
     summary: "Error monitoring, issues, and performance data.",
     url: "https://mcp.sentry.dev/mcp",
-    icon: "https://sentry.io/_assets/favicon.ico",
+    icon: "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png",
   },
   {
     id: "cloudflare",

--- a/packages/plugins/openapi/src/sdk/presets.ts
+++ b/packages/plugins/openapi/src/sdk/presets.ts
@@ -74,23 +74,27 @@ export const openApiPresets: readonly OpenApiPreset[] = [
     name: "DigitalOcean",
     summary: "Droplets, Kubernetes, databases, and networking.",
     url: "https://raw.githubusercontent.com/digitalocean/openapi/main/specification/DigitalOcean-public.v2.yaml",
+    icon: "https://assets.digitalocean.com/favicon.ico",
   },
   {
     id: "petstore",
     name: "Petstore",
     summary: "Classic OpenAPI demo — no auth required.",
     url: "https://petstore3.swagger.io/api/v3/openapi.json",
+    icon: "https://petstore3.swagger.io/favicon-32x32.png",
   },
   {
     id: "val-town",
     name: "Val Town",
     summary: "Vals, runs, blobs, and email/web endpoints.",
     url: "https://api.val.town/openapi.json",
+    icon: "https://www.val.town/favicon.svg",
   },
   {
     id: "resend",
     name: "Resend",
     summary: "Transactional email sending and domain management.",
     url: "https://raw.githubusercontent.com/resend/resend-openapi/main/resend.yaml",
+    icon: "https://resend.com/static/favicons/favicon.ico",
   },
 ];


### PR DESCRIPTION
## Summary

- Fixes two broken/inconsistent preset icons (Browserbase, Sentry) in the MCP preset catalog.
- Adds missing icons to the four OpenAPI presets that shipped without one (DigitalOcean, Petstore, Val Town, Resend), so the add-source picker renders them consistently.

## Changes

- `packages/plugins/mcp/src/sdk/presets.ts`
- `packages/plugins/openapi/src/sdk/presets.ts`