### PR TITLE
refactor: batch KV set and delete operations

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -46,7 +46,8 @@
     "jose": "^5.6.3",
     "postgres": "^3.4.9",
     "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-dom": "catalog:",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.14.3",

--- a/apps/cloud/src/api.ts
+++ b/apps/cloud/src/api.ts
@@ -46,6 +46,8 @@ import {
 import { WorkOSAuth } from "./auth/workos";
 import { DbService } from "./services/db";
 import { createOrgExecutor } from "./services/executor";
+import { TeamOrgApi } from "./team/compose";
+import { TeamHandlers } from "./team/handlers";
 import { server } from "./env";
 
 // ---------------------------------------------------------------------------
@@ -90,6 +92,11 @@ const NonProtectedApiLive = HttpApiBuilder.api(NonProtectedApi).pipe(
   Layer.provideMerge(SessionAuthLive),
 );
 
+const TeamApiLive = HttpApiBuilder.api(TeamOrgApi).pipe(
+  Layer.provide(TeamHandlers),
+  Layer.provideMerge(OrgAuthLive),
+);
+
 // ---------------------------------------------------------------------------
 // Public auth web handler
 // ---------------------------------------------------------------------------
@@ -110,6 +117,12 @@ const RouterConfig = HttpRouter.setRouterConfig({ maxParamLength: 1000 });
 const createNonProtectedHandler = () =>
   HttpApiBuilder.toWebHandler(
     NonProtectedApiLive.pipe(Layer.provideMerge(SharedServices), Layer.provideMerge(RouterConfig)),
+    { middleware: HttpMiddleware.logger },
+  );
+
+const createTeamHandler = () =>
+  HttpApiBuilder.toWebHandler(
+    TeamApiLive.pipe(Layer.provideMerge(SharedServices), Layer.provideMerge(RouterConfig)),
     { middleware: HttpMiddleware.logger },
   );
 
@@ -158,6 +171,7 @@ const buildProtectedHandler = (
 
 const isAuthPath = (pathname: string): boolean => pathname.startsWith("/auth/");
 const isAutumnPath = (pathname: string): boolean => pathname.startsWith("/autumn/");
+const isTeamPath = (pathname: string): boolean => pathname.startsWith("/team/");
 const isExecutionPath = (pathname: string): boolean =>
   pathname === "/executions" || /^\/executions\/[^/]+\/resume$/.test(pathname);
 
@@ -241,8 +255,46 @@ const handleAutumnRequest = async (request: Request): Promise<Response> => {
   );
 };
 
+// ---------------------------------------------------------------------------
+// Widget token endpoint — returns a WorkOS widget token for the session user
+// ---------------------------------------------------------------------------
+
+const handleWidgetTokenRequest = async (request: Request): Promise<Response> => {
+  const program = Effect.gen(function* () {
+    const workos = yield* WorkOSAuth;
+    const result = yield* workos.authenticateRequest(request);
+
+    if (!result || !result.organizationId) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const token = yield* workos.getWidgetToken(result.userId, result.organizationId);
+    return Response.json({ token });
+  });
+
+  return Effect.runPromise(program.pipe(Effect.provide(SharedServices), Effect.scoped)).catch(
+    (err) => {
+      console.error("[widget-token] request failed:", err instanceof Error ? err.stack : err);
+      return Response.json({ error: "Internal server error" }, { status: 500 });
+    },
+  );
+};
+
 export const handleApiRequest = async (request: Request): Promise<Response> => {
   const pathname = new URL(request.url).pathname;
+
+  if (pathname === "/widget-token") {
+    return handleWidgetTokenRequest(request);
+  }
+
+  if (isTeamPath(pathname)) {
+    const handler = createTeamHandler();
+    try {
+      return await handler.handler(request);
+    } finally {
+      await handler.dispose();
+    }
+  }
 
   if (isAutumnPath(pathname)) {
     return handleAutumnRequest(request);

--- a/apps/cloud/src/api.ts
+++ b/apps/cloud/src/api.ts
@@ -259,33 +259,8 @@ const handleAutumnRequest = async (request: Request): Promise<Response> => {
 // Widget token endpoint — returns a WorkOS widget token for the session user
 // ---------------------------------------------------------------------------
 
-const handleWidgetTokenRequest = async (request: Request): Promise<Response> => {
-  const program = Effect.gen(function* () {
-    const workos = yield* WorkOSAuth;
-    const result = yield* workos.authenticateRequest(request);
-
-    if (!result || !result.organizationId) {
-      return Response.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const token = yield* workos.getWidgetToken(result.userId, result.organizationId);
-    return Response.json({ token });
-  });
-
-  return Effect.runPromise(program.pipe(Effect.provide(SharedServices), Effect.scoped)).catch(
-    (err) => {
-      console.error("[widget-token] request failed:", err instanceof Error ? err.stack : err);
-      return Response.json({ error: "Internal server error" }, { status: 500 });
-    },
-  );
-};
-
 export const handleApiRequest = async (request: Request): Promise<Response> => {
   const pathname = new URL(request.url).pathname;
-
-  if (pathname === "/widget-token") {
-    return handleWidgetTokenRequest(request);
-  }
 
   if (isTeamPath(pathname)) {
     const handler = createTeamHandler();

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -138,10 +138,67 @@ const make = Effect.gen(function* () {
         if (!sessionData) return null;
         return yield* authenticateSealedSession(sessionData);
       }),
+
+    /** Generate a widget token for the UsersManagement widget. */
+    getWidgetToken: (userId: string, organizationId: string) =>
+      use((wos) =>
+        wos.widgets.getToken({
+          userId,
+          organizationId,
+          scopes: ["widgets:users-table:manage"],
+        }),
+      ),
+
+    /** List organization memberships with user details. */
+    listOrgMembers: (organizationId: string) =>
+      use((wos) =>
+        wos.userManagement.listOrganizationMemberships({
+          organizationId,
+          statuses: ["active", "pending"],
+        }),
+      ),
+
+    /** Get a user by ID. */
+    getUser: (userId: string) =>
+      use((wos) => wos.userManagement.getUser(userId)),
+
+    /** Send an organization invitation. */
+    sendInvitation: (params: { email: string; organizationId: string; roleSlug?: string }) =>
+      use((wos) =>
+        wos.userManagement.sendInvitation({
+          email: params.email,
+          organizationId: params.organizationId,
+          roleSlug: params.roleSlug,
+        }),
+      ),
+
+    /** Remove an organization membership. */
+    deleteOrgMembership: (membershipId: string) =>
+      use((wos) =>
+        wos.userManagement.deleteOrganizationMembership(membershipId),
+      ),
+
+    /** Get the role for a membership. */
+    getOrgMembership: (membershipId: string) =>
+      use((wos) =>
+        wos.userManagement.getOrganizationMembership(membershipId),
+      ),
+
+    /** Update a membership's role. */
+    updateOrgMembershipRole: (membershipId: string, roleSlug: string) =>
+      use((wos) =>
+        wos.userManagement.updateOrganizationMembership(membershipId, { roleSlug }),
+      ),
+
+    /** List available roles for an organization. */
+    listOrgRoles: (organizationId: string) =>
+      use((wos) =>
+        wos.organizations.listOrganizationRoles({ organizationId }),
+      ),
   };
 });
 
-type WorkOSAuthService = Effect.Effect.Success<typeof make>;
+export type WorkOSAuthService = Effect.Effect.Success<typeof make>;
 
 export class WorkOSAuth extends Context.Tag("@executor/cloud/WorkOSAuth")<
   WorkOSAuth,

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -159,8 +159,7 @@ const make = Effect.gen(function* () {
       ),
 
     /** Get a user by ID. */
-    getUser: (userId: string) =>
-      use((wos) => wos.userManagement.getUser(userId)),
+    getUser: (userId: string) => use((wos) => wos.userManagement.getUser(userId)),
 
     /** Send an organization invitation. */
     sendInvitation: (params: { email: string; organizationId: string; roleSlug?: string }) =>
@@ -174,27 +173,19 @@ const make = Effect.gen(function* () {
 
     /** Remove an organization membership. */
     deleteOrgMembership: (membershipId: string) =>
-      use((wos) =>
-        wos.userManagement.deleteOrganizationMembership(membershipId),
-      ),
+      use((wos) => wos.userManagement.deleteOrganizationMembership(membershipId)),
 
     /** Get the role for a membership. */
     getOrgMembership: (membershipId: string) =>
-      use((wos) =>
-        wos.userManagement.getOrganizationMembership(membershipId),
-      ),
+      use((wos) => wos.userManagement.getOrganizationMembership(membershipId)),
 
     /** Update a membership's role. */
     updateOrgMembershipRole: (membershipId: string, roleSlug: string) =>
-      use((wos) =>
-        wos.userManagement.updateOrganizationMembership(membershipId, { roleSlug }),
-      ),
+      use((wos) => wos.userManagement.updateOrganizationMembership(membershipId, { roleSlug })),
 
     /** List available roles for an organization. */
     listOrgRoles: (organizationId: string) =>
-      use((wos) =>
-        wos.organizations.listOrganizationRoles({ organizationId }),
-      ),
+      use((wos) => wos.organizations.listOrganizationRoles({ organizationId })),
   };
 });
 

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -139,16 +139,6 @@ const make = Effect.gen(function* () {
         return yield* authenticateSealedSession(sessionData);
       }),
 
-    /** Generate a widget token for the UsersManagement widget. */
-    getWidgetToken: (userId: string, organizationId: string) =>
-      use((wos) =>
-        wos.widgets.getToken({
-          userId,
-          organizationId,
-          scopes: ["widgets:users-table:manage"],
-        }),
-      ),
-
     /** List organization memberships with user details. */
     listOrgMembers: (organizationId: string) =>
       use((wos) =>

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -8,190 +8,190 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as ToolsRouteImport } from './routes/tools'
-import { Route as TeamRouteImport } from './routes/team'
-import { Route as SecretsRouteImport } from './routes/secrets'
-import { Route as BillingRouteImport } from './routes/billing'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
-import { Route as BillingPlansRouteImport } from './routes/billing_.plans'
-import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$pluginKey'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as ToolsRouteImport } from "./routes/tools";
+import { Route as TeamRouteImport } from "./routes/team";
+import { Route as SecretsRouteImport } from "./routes/secrets";
+import { Route as BillingRouteImport } from "./routes/billing";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as SourcesNamespaceRouteImport } from "./routes/sources.$namespace";
+import { Route as BillingPlansRouteImport } from "./routes/billing_.plans";
+import { Route as SourcesAddPluginKeyRouteImport } from "./routes/sources.add.$pluginKey";
 
 const ToolsRoute = ToolsRouteImport.update({
-  id: '/tools',
-  path: '/tools',
+  id: "/tools",
+  path: "/tools",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const TeamRoute = TeamRouteImport.update({
-  id: '/team',
-  path: '/team',
+  id: "/team",
+  path: "/team",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SecretsRoute = SecretsRouteImport.update({
-  id: '/secrets',
-  path: '/secrets',
+  id: "/secrets",
+  path: "/secrets",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const BillingRoute = BillingRouteImport.update({
-  id: '/billing',
-  path: '/billing',
+  id: "/billing",
+  path: "/billing",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SourcesNamespaceRoute = SourcesNamespaceRouteImport.update({
-  id: '/sources/$namespace',
-  path: '/sources/$namespace',
+  id: "/sources/$namespace",
+  path: "/sources/$namespace",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const BillingPlansRoute = BillingPlansRouteImport.update({
-  id: '/billing_/plans',
-  path: '/billing/plans',
+  id: "/billing_/plans",
+  path: "/billing/plans",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
-  id: '/sources/add/$pluginKey',
-  path: '/sources/add/$pluginKey',
+  id: "/sources/add/$pluginKey",
+  path: "/sources/add/$pluginKey",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/billing': typeof BillingRoute
-  '/secrets': typeof SecretsRoute
-  '/team': typeof TeamRoute
-  '/tools': typeof ToolsRoute
-  '/billing/plans': typeof BillingPlansRoute
-  '/sources/$namespace': typeof SourcesNamespaceRoute
-  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
+  "/": typeof IndexRoute;
+  "/billing": typeof BillingRoute;
+  "/secrets": typeof SecretsRoute;
+  "/team": typeof TeamRoute;
+  "/tools": typeof ToolsRoute;
+  "/billing/plans": typeof BillingPlansRoute;
+  "/sources/$namespace": typeof SourcesNamespaceRoute;
+  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/billing': typeof BillingRoute
-  '/secrets': typeof SecretsRoute
-  '/team': typeof TeamRoute
-  '/tools': typeof ToolsRoute
-  '/billing/plans': typeof BillingPlansRoute
-  '/sources/$namespace': typeof SourcesNamespaceRoute
-  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
+  "/": typeof IndexRoute;
+  "/billing": typeof BillingRoute;
+  "/secrets": typeof SecretsRoute;
+  "/team": typeof TeamRoute;
+  "/tools": typeof ToolsRoute;
+  "/billing/plans": typeof BillingPlansRoute;
+  "/sources/$namespace": typeof SourcesNamespaceRoute;
+  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/billing': typeof BillingRoute
-  '/secrets': typeof SecretsRoute
-  '/team': typeof TeamRoute
-  '/tools': typeof ToolsRoute
-  '/billing_/plans': typeof BillingPlansRoute
-  '/sources/$namespace': typeof SourcesNamespaceRoute
-  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/billing": typeof BillingRoute;
+  "/secrets": typeof SecretsRoute;
+  "/team": typeof TeamRoute;
+  "/tools": typeof ToolsRoute;
+  "/billing_/plans": typeof BillingPlansRoute;
+  "/sources/$namespace": typeof SourcesNamespaceRoute;
+  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/billing'
-    | '/secrets'
-    | '/team'
-    | '/tools'
-    | '/billing/plans'
-    | '/sources/$namespace'
-    | '/sources/add/$pluginKey'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/billing"
+    | "/secrets"
+    | "/team"
+    | "/tools"
+    | "/billing/plans"
+    | "/sources/$namespace"
+    | "/sources/add/$pluginKey";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/'
-    | '/billing'
-    | '/secrets'
-    | '/team'
-    | '/tools'
-    | '/billing/plans'
-    | '/sources/$namespace'
-    | '/sources/add/$pluginKey'
+    | "/"
+    | "/billing"
+    | "/secrets"
+    | "/team"
+    | "/tools"
+    | "/billing/plans"
+    | "/sources/$namespace"
+    | "/sources/add/$pluginKey";
   id:
-    | '__root__'
-    | '/'
-    | '/billing'
-    | '/secrets'
-    | '/team'
-    | '/tools'
-    | '/billing_/plans'
-    | '/sources/$namespace'
-    | '/sources/add/$pluginKey'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/billing"
+    | "/secrets"
+    | "/team"
+    | "/tools"
+    | "/billing_/plans"
+    | "/sources/$namespace"
+    | "/sources/add/$pluginKey";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  BillingRoute: typeof BillingRoute
-  SecretsRoute: typeof SecretsRoute
-  TeamRoute: typeof TeamRoute
-  ToolsRoute: typeof ToolsRoute
-  BillingPlansRoute: typeof BillingPlansRoute
-  SourcesNamespaceRoute: typeof SourcesNamespaceRoute
-  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute
+  IndexRoute: typeof IndexRoute;
+  BillingRoute: typeof BillingRoute;
+  SecretsRoute: typeof SecretsRoute;
+  TeamRoute: typeof TeamRoute;
+  ToolsRoute: typeof ToolsRoute;
+  BillingPlansRoute: typeof BillingPlansRoute;
+  SourcesNamespaceRoute: typeof SourcesNamespaceRoute;
+  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/tools': {
-      id: '/tools'
-      path: '/tools'
-      fullPath: '/tools'
-      preLoaderRoute: typeof ToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/team': {
-      id: '/team'
-      path: '/team'
-      fullPath: '/team'
-      preLoaderRoute: typeof TeamRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/secrets': {
-      id: '/secrets'
-      path: '/secrets'
-      fullPath: '/secrets'
-      preLoaderRoute: typeof SecretsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/billing': {
-      id: '/billing'
-      path: '/billing'
-      fullPath: '/billing'
-      preLoaderRoute: typeof BillingRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sources/$namespace': {
-      id: '/sources/$namespace'
-      path: '/sources/$namespace'
-      fullPath: '/sources/$namespace'
-      preLoaderRoute: typeof SourcesNamespaceRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/billing_/plans': {
-      id: '/billing_/plans'
-      path: '/billing/plans'
-      fullPath: '/billing/plans'
-      preLoaderRoute: typeof BillingPlansRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/sources/add/$pluginKey': {
-      id: '/sources/add/$pluginKey'
-      path: '/sources/add/$pluginKey'
-      fullPath: '/sources/add/$pluginKey'
-      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/tools": {
+      id: "/tools";
+      path: "/tools";
+      fullPath: "/tools";
+      preLoaderRoute: typeof ToolsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/team": {
+      id: "/team";
+      path: "/team";
+      fullPath: "/team";
+      preLoaderRoute: typeof TeamRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/secrets": {
+      id: "/secrets";
+      path: "/secrets";
+      fullPath: "/secrets";
+      preLoaderRoute: typeof SecretsRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/billing": {
+      id: "/billing";
+      path: "/billing";
+      fullPath: "/billing";
+      preLoaderRoute: typeof BillingRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/sources/$namespace": {
+      id: "/sources/$namespace";
+      path: "/sources/$namespace";
+      fullPath: "/sources/$namespace";
+      preLoaderRoute: typeof SourcesNamespaceRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/billing_/plans": {
+      id: "/billing_/plans";
+      path: "/billing/plans";
+      fullPath: "/billing/plans";
+      preLoaderRoute: typeof BillingPlansRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/sources/add/$pluginKey": {
+      id: "/sources/add/$pluginKey";
+      path: "/sources/add/$pluginKey";
+      fullPath: "/sources/add/$pluginKey";
+      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
@@ -204,17 +204,17 @@ const rootRouteChildren: RootRouteChildren = {
   BillingPlansRoute: BillingPlansRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,
   SourcesAddPluginKeyRoute: SourcesAddPluginKeyRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
+import type { getRouter } from "./router.tsx";
+import type { startInstance } from "./start.ts";
+declare module "@tanstack/react-start" {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
   }
 }

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -8,190 +8,190 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ToolsRouteImport } from "./routes/tools";
-import { Route as TeamRouteImport } from "./routes/team";
-import { Route as SecretsRouteImport } from "./routes/secrets";
-import { Route as BillingRouteImport } from "./routes/billing";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as SourcesNamespaceRouteImport } from "./routes/sources.$namespace";
-import { Route as BillingPlansRouteImport } from "./routes/billing_.plans";
-import { Route as SourcesAddPluginKeyRouteImport } from "./routes/sources.add.$pluginKey";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ToolsRouteImport } from './routes/tools'
+import { Route as TeamRouteImport } from './routes/team'
+import { Route as SecretsRouteImport } from './routes/secrets'
+import { Route as BillingRouteImport } from './routes/billing'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
+import { Route as BillingPlansRouteImport } from './routes/billing_.plans'
+import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$pluginKey'
 
 const ToolsRoute = ToolsRouteImport.update({
-  id: "/tools",
-  path: "/tools",
+  id: '/tools',
+  path: '/tools',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const TeamRoute = TeamRouteImport.update({
-  id: "/team",
-  path: "/team",
+  id: '/team',
+  path: '/team',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SecretsRoute = SecretsRouteImport.update({
-  id: "/secrets",
-  path: "/secrets",
+  id: '/secrets',
+  path: '/secrets',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingRoute = BillingRouteImport.update({
-  id: "/billing",
-  path: "/billing",
+  id: '/billing',
+  path: '/billing',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SourcesNamespaceRoute = SourcesNamespaceRouteImport.update({
-  id: "/sources/$namespace",
-  path: "/sources/$namespace",
+  id: '/sources/$namespace',
+  path: '/sources/$namespace',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingPlansRoute = BillingPlansRouteImport.update({
-  id: "/billing_/plans",
-  path: "/billing/plans",
+  id: '/billing_/plans',
+  path: '/billing/plans',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
-  id: "/sources/add/$pluginKey",
-  path: "/sources/add/$pluginKey",
+  id: '/sources/add/$pluginKey',
+  path: '/sources/add/$pluginKey',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/team": typeof TeamRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/team": typeof TeamRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/team": typeof TeamRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing_/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing_/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/team"
-    | "/tools"
-    | "/billing/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/team"
-    | "/tools"
-    | "/billing/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
   id:
-    | "__root__"
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/team"
-    | "/tools"
-    | "/billing_/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing_/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  BillingRoute: typeof BillingRoute;
-  SecretsRoute: typeof SecretsRoute;
-  TeamRoute: typeof TeamRoute;
-  ToolsRoute: typeof ToolsRoute;
-  BillingPlansRoute: typeof BillingPlansRoute;
-  SourcesNamespaceRoute: typeof SourcesNamespaceRoute;
-  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute;
+  IndexRoute: typeof IndexRoute
+  BillingRoute: typeof BillingRoute
+  SecretsRoute: typeof SecretsRoute
+  TeamRoute: typeof TeamRoute
+  ToolsRoute: typeof ToolsRoute
+  BillingPlansRoute: typeof BillingPlansRoute
+  SourcesNamespaceRoute: typeof SourcesNamespaceRoute
+  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/tools": {
-      id: "/tools";
-      path: "/tools";
-      fullPath: "/tools";
-      preLoaderRoute: typeof ToolsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/team": {
-      id: "/team";
-      path: "/team";
-      fullPath: "/team";
-      preLoaderRoute: typeof TeamRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/secrets": {
-      id: "/secrets";
-      path: "/secrets";
-      fullPath: "/secrets";
-      preLoaderRoute: typeof SecretsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing": {
-      id: "/billing";
-      path: "/billing";
-      fullPath: "/billing";
-      preLoaderRoute: typeof BillingRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/sources/$namespace": {
-      id: "/sources/$namespace";
-      path: "/sources/$namespace";
-      fullPath: "/sources/$namespace";
-      preLoaderRoute: typeof SourcesNamespaceRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing_/plans": {
-      id: "/billing_/plans";
-      path: "/billing/plans";
-      fullPath: "/billing/plans";
-      preLoaderRoute: typeof BillingPlansRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/sources/add/$pluginKey": {
-      id: "/sources/add/$pluginKey";
-      path: "/sources/add/$pluginKey";
-      fullPath: "/sources/add/$pluginKey";
-      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/tools': {
+      id: '/tools'
+      path: '/tools'
+      fullPath: '/tools'
+      preLoaderRoute: typeof ToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/team': {
+      id: '/team'
+      path: '/team'
+      fullPath: '/team'
+      preLoaderRoute: typeof TeamRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/secrets': {
+      id: '/secrets'
+      path: '/secrets'
+      fullPath: '/secrets'
+      preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing': {
+      id: '/billing'
+      path: '/billing'
+      fullPath: '/billing'
+      preLoaderRoute: typeof BillingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sources/$namespace': {
+      id: '/sources/$namespace'
+      path: '/sources/$namespace'
+      fullPath: '/sources/$namespace'
+      preLoaderRoute: typeof SourcesNamespaceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing_/plans': {
+      id: '/billing_/plans'
+      path: '/billing/plans'
+      fullPath: '/billing/plans'
+      preLoaderRoute: typeof BillingPlansRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sources/add/$pluginKey': {
+      id: '/sources/add/$pluginKey'
+      path: '/sources/add/$pluginKey'
+      fullPath: '/sources/add/$pluginKey'
+      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -204,17 +204,17 @@ const rootRouteChildren: RootRouteChildren = {
   BillingPlansRoute: BillingPlansRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,
   SourcesAddPluginKeyRoute: SourcesAddPluginKeyRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { startInstance } from "./start.ts";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -8,170 +8,190 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ToolsRouteImport } from "./routes/tools";
-import { Route as SecretsRouteImport } from "./routes/secrets";
-import { Route as BillingRouteImport } from "./routes/billing";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as SourcesNamespaceRouteImport } from "./routes/sources.$namespace";
-import { Route as BillingPlansRouteImport } from "./routes/billing_.plans";
-import { Route as SourcesAddPluginKeyRouteImport } from "./routes/sources.add.$pluginKey";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ToolsRouteImport } from './routes/tools'
+import { Route as TeamRouteImport } from './routes/team'
+import { Route as SecretsRouteImport } from './routes/secrets'
+import { Route as BillingRouteImport } from './routes/billing'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
+import { Route as BillingPlansRouteImport } from './routes/billing_.plans'
+import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$pluginKey'
 
 const ToolsRoute = ToolsRouteImport.update({
-  id: "/tools",
-  path: "/tools",
+  id: '/tools',
+  path: '/tools',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const TeamRoute = TeamRouteImport.update({
+  id: '/team',
+  path: '/team',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const SecretsRoute = SecretsRouteImport.update({
-  id: "/secrets",
-  path: "/secrets",
+  id: '/secrets',
+  path: '/secrets',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingRoute = BillingRouteImport.update({
-  id: "/billing",
-  path: "/billing",
+  id: '/billing',
+  path: '/billing',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SourcesNamespaceRoute = SourcesNamespaceRouteImport.update({
-  id: "/sources/$namespace",
-  path: "/sources/$namespace",
+  id: '/sources/$namespace',
+  path: '/sources/$namespace',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingPlansRoute = BillingPlansRouteImport.update({
-  id: "/billing_/plans",
-  path: "/billing/plans",
+  id: '/billing_/plans',
+  path: '/billing/plans',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
-  id: "/sources/add/$pluginKey",
-  path: "/sources/add/$pluginKey",
+  id: '/sources/add/$pluginKey',
+  path: '/sources/add/$pluginKey',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing_/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing_/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/tools"
-    | "/billing/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/tools"
-    | "/billing/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
   id:
-    | "__root__"
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/tools"
-    | "/billing_/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing_/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  BillingRoute: typeof BillingRoute;
-  SecretsRoute: typeof SecretsRoute;
-  ToolsRoute: typeof ToolsRoute;
-  BillingPlansRoute: typeof BillingPlansRoute;
-  SourcesNamespaceRoute: typeof SourcesNamespaceRoute;
-  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute;
+  IndexRoute: typeof IndexRoute
+  BillingRoute: typeof BillingRoute
+  SecretsRoute: typeof SecretsRoute
+  TeamRoute: typeof TeamRoute
+  ToolsRoute: typeof ToolsRoute
+  BillingPlansRoute: typeof BillingPlansRoute
+  SourcesNamespaceRoute: typeof SourcesNamespaceRoute
+  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/tools": {
-      id: "/tools";
-      path: "/tools";
-      fullPath: "/tools";
-      preLoaderRoute: typeof ToolsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/secrets": {
-      id: "/secrets";
-      path: "/secrets";
-      fullPath: "/secrets";
-      preLoaderRoute: typeof SecretsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing": {
-      id: "/billing";
-      path: "/billing";
-      fullPath: "/billing";
-      preLoaderRoute: typeof BillingRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/sources/$namespace": {
-      id: "/sources/$namespace";
-      path: "/sources/$namespace";
-      fullPath: "/sources/$namespace";
-      preLoaderRoute: typeof SourcesNamespaceRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing_/plans": {
-      id: "/billing_/plans";
-      path: "/billing/plans";
-      fullPath: "/billing/plans";
-      preLoaderRoute: typeof BillingPlansRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/sources/add/$pluginKey": {
-      id: "/sources/add/$pluginKey";
-      path: "/sources/add/$pluginKey";
-      fullPath: "/sources/add/$pluginKey";
-      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/tools': {
+      id: '/tools'
+      path: '/tools'
+      fullPath: '/tools'
+      preLoaderRoute: typeof ToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/team': {
+      id: '/team'
+      path: '/team'
+      fullPath: '/team'
+      preLoaderRoute: typeof TeamRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/secrets': {
+      id: '/secrets'
+      path: '/secrets'
+      fullPath: '/secrets'
+      preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing': {
+      id: '/billing'
+      path: '/billing'
+      fullPath: '/billing'
+      preLoaderRoute: typeof BillingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sources/$namespace': {
+      id: '/sources/$namespace'
+      path: '/sources/$namespace'
+      fullPath: '/sources/$namespace'
+      preLoaderRoute: typeof SourcesNamespaceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing_/plans': {
+      id: '/billing_/plans'
+      path: '/billing/plans'
+      fullPath: '/billing/plans'
+      preLoaderRoute: typeof BillingPlansRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sources/add/$pluginKey': {
+      id: '/sources/add/$pluginKey'
+      path: '/sources/add/$pluginKey'
+      fullPath: '/sources/add/$pluginKey'
+      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -179,21 +199,22 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BillingRoute: BillingRoute,
   SecretsRoute: SecretsRoute,
+  TeamRoute: TeamRoute,
   ToolsRoute: ToolsRoute,
   BillingPlansRoute: BillingPlansRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,
   SourcesAddPluginKeyRoute: SourcesAddPluginKeyRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { startInstance } from "./start.ts";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router";
 import { AutumnProvider } from "autumn-js/react";
 import { ExecutorProvider } from "@executor/react/api/provider";
+import { Toaster } from "@executor/react/components/sonner";
 import { AuthProvider, useAuth } from "../web/auth";
 import { LoginPage } from "../web/pages/login";
 import { Shell } from "../web/shell";
@@ -70,6 +71,7 @@ function AuthGate() {
     <AutumnProvider pathPrefix="/api/autumn">
       <ExecutorProvider>
         <Shell />
+        <Toaster />
       </ExecutorProvider>
     </AutumnProvider>
   );

--- a/apps/cloud/src/routes/billing.tsx
+++ b/apps/cloud/src/routes/billing.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useCustomer, useListPlans } from "autumn-js/react";
 
+type Plan = NonNullable<ReturnType<typeof useListPlans>["data"]>[number];
+
 export const Route = createFileRoute("/billing")({
   component: BillingPage,
 });
@@ -28,8 +30,7 @@ function BillingPage() {
     );
   }
 
-  // Find current plan via customerEligibility from useListPlans
-  const allPlans = plans ?? [];
+  const allPlans: Plan[] = plans ?? [];
   const activePlan = allPlans.find(
     (p) => p.customerEligibility?.status === "active" && p.id !== "free",
   );

--- a/apps/cloud/src/routes/billing.tsx
+++ b/apps/cloud/src/routes/billing.tsx
@@ -29,10 +29,11 @@ function BillingPage() {
   }
 
   // Find current plan via customerEligibility from useListPlans
-  const activePlan = (plans ?? []).find(
+  const allPlans = plans ?? [];
+  const activePlan = allPlans.find(
     (p) => p.customerEligibility?.status === "active" && p.id !== "free",
   );
-  const scheduledPlan = (plans ?? []).find(
+  const scheduledPlan = allPlans.find(
     (p) => p.customerEligibility?.status === "scheduled" && p.id !== "free",
   );
   const isCanceling = activePlan?.customerEligibility?.canceling ?? false;

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useCustomer, useListPlans } from "autumn-js/react";
 
+type Plan = NonNullable<ReturnType<typeof useListPlans>["data"]>[number];
+
 export const Route = createFileRoute("/billing_/plans")({
   component: PlansPage,
 });
@@ -44,8 +46,7 @@ function PlansPage() {
 
   const isLoading = customerLoading || plansLoading;
 
-  const allPlans = plans ?? [];
-  const paidPlans = allPlans.filter((p) => p.id === "hobby" || p.id === "professional");
+  const paidPlans: Plan[] = (plans ?? []).filter((p) => p.id === "hobby" || p.id === "professional");
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -46,7 +46,7 @@ function PlansPage() {
 
   const isLoading = customerLoading || plansLoading;
 
-  const paidPlans: Plan[] = (plans ?? []).filter(
+  const paidPlans = (plans ?? ([] as Plan[])).filter(
     (p) => p.id === "hobby" || p.id === "professional",
   );
 

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -44,7 +44,8 @@ function PlansPage() {
 
   const isLoading = customerLoading || plansLoading;
 
-  const paidPlans = (plans ?? []).filter((p) => p.id === "hobby" || p.id === "professional");
+  const allPlans = plans ?? [];
+  const paidPlans = allPlans.filter((p) => p.id === "hobby" || p.id === "professional");
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -46,7 +46,9 @@ function PlansPage() {
 
   const isLoading = customerLoading || plansLoading;
 
-  const paidPlans: Plan[] = (plans ?? []).filter((p) => p.id === "hobby" || p.id === "professional");
+  const paidPlans: Plan[] = (plans ?? []).filter(
+    (p) => p.id === "hobby" || p.id === "professional",
+  );
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/cloud/src/routes/team.tsx
+++ b/apps/cloud/src/routes/team.tsx
@@ -67,11 +67,16 @@ type InviteAction =
 
 function inviteReducer(state: InviteState, action: InviteAction): InviteState {
   switch (action.type) {
-    case "setEmail": return { ...state, email: action.email };
-    case "setRole": return { ...state, roleSlug: action.roleSlug };
-    case "send": return { ...state, status: "sending", error: null };
-    case "error": return { ...state, status: "error", error: action.message };
-    case "reset": return initialInviteState;
+    case "setEmail":
+      return { ...state, email: action.email };
+    case "setRole":
+      return { ...state, roleSlug: action.roleSlug };
+    case "send":
+      return { ...state, status: "sending", error: null };
+    case "error":
+      return { ...state, status: "error", error: action.message };
+    case "reset":
+      return initialInviteState;
   }
 }
 
@@ -192,7 +197,12 @@ function TeamPage() {
                     ) : (
                       <div className="flex size-8 items-center justify-center rounded-full bg-muted text-[0.625rem] font-semibold text-muted-foreground">
                         {member.name
-                          ? member.name.split(" ").map((n) => n[0]).join("").slice(0, 2).toUpperCase()
+                          ? member.name
+                              .split(" ")
+                              .map((n) => n[0])
+                              .join("")
+                              .slice(0, 2)
+                              .toUpperCase()
                           : member.email[0]!.toUpperCase()}
                       </div>
                     )}
@@ -260,13 +270,21 @@ function TeamPage() {
                                       key={role.slug}
                                       className="text-[0.75rem]"
                                       disabled={role.slug === member.role}
-                                      onClick={() => handleChangeRole(member.id, role.slug, role.name)}
+                                      onClick={() =>
+                                        handleChangeRole(member.id, role.slug, role.name)
+                                      }
                                     >
                                       {role.name}
                                       {role.slug === member.role && (
                                         <span className="ml-auto text-muted-foreground/50">
                                           <svg viewBox="0 0 16 16" fill="none" className="size-3">
-                                            <path d="M3.5 8.5L6.5 11.5L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                                            <path
+                                              d="M3.5 8.5L6.5 11.5L12.5 5"
+                                              stroke="currentColor"
+                                              strokeWidth="1.5"
+                                              strokeLinecap="round"
+                                              strokeLinejoin="round"
+                                            />
                                           </svg>
                                         </span>
                                       )}
@@ -285,7 +303,9 @@ function TeamPage() {
                           </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>
-                    ) : <div />}
+                    ) : (
+                      <div />
+                    )}
                   </div>
                 ))}
               </div>
@@ -352,7 +372,10 @@ function InviteDialog(props: {
 
         <div className="grid gap-4 py-3">
           <div className="grid gap-1.5">
-            <Label htmlFor="invite-email" className="text-[0.6875rem] font-medium uppercase tracking-wider text-muted-foreground">
+            <Label
+              htmlFor="invite-email"
+              className="text-[0.6875rem] font-medium uppercase tracking-wider text-muted-foreground"
+            >
               Email
             </Label>
             <Input
@@ -360,18 +383,28 @@ function InviteDialog(props: {
               type="email"
               placeholder="colleague@company.com"
               value={state.email}
-              onChange={(e) => dispatch({ type: "setEmail", email: (e.target as HTMLInputElement).value })}
-              onKeyDown={(e) => { if (e.key === "Enter") handleInvite(); }}
+              onChange={(e) =>
+                dispatch({ type: "setEmail", email: (e.target as HTMLInputElement).value })
+              }
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleInvite();
+              }}
               className="text-[0.8125rem] h-9"
             />
           </div>
 
           {props.roles.length > 0 && (
             <div className="grid gap-1.5">
-              <Label htmlFor="invite-role" className="text-[0.6875rem] font-medium uppercase tracking-wider text-muted-foreground">
+              <Label
+                htmlFor="invite-role"
+                className="text-[0.6875rem] font-medium uppercase tracking-wider text-muted-foreground"
+              >
                 Role
               </Label>
-              <Select value={state.roleSlug} onValueChange={(v) => dispatch({ type: "setRole", roleSlug: v })}>
+              <Select
+                value={state.roleSlug}
+                onValueChange={(v) => dispatch({ type: "setRole", roleSlug: v })}
+              >
                 <SelectTrigger id="invite-role" className="h-9 text-[0.8125rem]">
                   <SelectValue placeholder="Select a role" />
                 </SelectTrigger>
@@ -395,7 +428,9 @@ function InviteDialog(props: {
 
         <DialogFooter>
           <DialogClose asChild>
-            <Button variant="ghost" size="sm">Cancel</Button>
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
           </DialogClose>
           <Button
             size="sm"

--- a/apps/cloud/src/routes/team.tsx
+++ b/apps/cloud/src/routes/team.tsx
@@ -1,0 +1,411 @@
+import { useReducer, useState } from "react";
+import { Exit } from "effect";
+import { createFileRoute } from "@tanstack/react-router";
+import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+} from "@executor/react/components/dialog";
+import { Button } from "@executor/react/components/button";
+import { Input } from "@executor/react/components/input";
+import { Label } from "@executor/react/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@executor/react/components/select";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  DropdownMenuSeparator,
+} from "@executor/react/components/dropdown-menu";
+import {
+  teamMembersAtom,
+  teamRolesAtom,
+  inviteMember,
+  removeMember,
+  updateMemberRole,
+} from "../web/team-atoms";
+
+export const Route = createFileRoute("/team")({
+  component: TeamPage,
+});
+
+type InviteState = {
+  email: string;
+  roleSlug: string;
+  status: "idle" | "sending" | "error";
+  error: string | null;
+};
+
+const initialInviteState: InviteState = {
+  email: "",
+  roleSlug: "",
+  status: "idle",
+  error: null,
+};
+
+type InviteAction =
+  | { type: "setEmail"; email: string }
+  | { type: "setRole"; roleSlug: string }
+  | { type: "send" }
+  | { type: "error"; message: string }
+  | { type: "reset" };
+
+function inviteReducer(state: InviteState, action: InviteAction): InviteState {
+  switch (action.type) {
+    case "setEmail": return { ...state, email: action.email };
+    case "setRole": return { ...state, roleSlug: action.roleSlug };
+    case "send": return { ...state, status: "sending", error: null };
+    case "error": return { ...state, status: "error", error: action.message };
+    case "reset": return initialInviteState;
+  }
+}
+
+function formatLastActive(lastActiveAt: string | null): string {
+  if (!lastActiveAt) return "\u2014";
+  const date = new Date(lastActiveAt);
+  const diffMs = Date.now() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHours = Math.floor(diffMins / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function TeamPage() {
+  const membersResult = useAtomValue(teamMembersAtom);
+  const rolesResult = useAtomValue(teamRolesAtom);
+  const refreshMembers = useAtomRefresh(teamMembersAtom);
+  const doRemove = useAtomSet(removeMember, { mode: "promiseExit" });
+  const doUpdateRole = useAtomSet(updateMemberRole, { mode: "promiseExit" });
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const roles = Result.match(rolesResult, {
+    onInitial: () => [] as readonly { slug: string; name: string }[],
+    onFailure: () => [] as readonly { slug: string; name: string }[],
+    onSuccess: ({ value }) => value.roles,
+  });
+
+  const handleRemove = async (membershipId: string, name: string) => {
+    const exit = await doRemove({ path: { membershipId } });
+    if (Exit.isSuccess(exit)) {
+      toast.success(`Removed ${name}`);
+      refreshMembers();
+    } else {
+      toast.error("Failed to remove member");
+    }
+  };
+
+  const handleChangeRole = async (membershipId: string, roleSlug: string, roleName: string) => {
+    const exit = await doUpdateRole({ path: { membershipId }, payload: { roleSlug } });
+    if (Exit.isSuccess(exit)) {
+      toast.success(`Role changed to ${roleName}`);
+      refreshMembers();
+    } else {
+      toast.error("Failed to change role");
+    }
+  };
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-3xl px-6 py-10 lg:px-8 lg:py-14">
+        <div className="flex items-end justify-between mb-10">
+          <h1 className="font-display text-[2rem] tracking-tight text-foreground leading-none">
+            Team
+          </h1>
+          <Button size="sm" onClick={() => setInviteOpen(true)}>
+            Invite member
+          </Button>
+        </div>
+
+        {/* Search */}
+        <div className="mb-4">
+          <Input
+            type="text"
+            placeholder="Search by name or email..."
+            value={search}
+            onChange={(e) => setSearch((e.target as HTMLInputElement).value)}
+            className="text-[0.8125rem] h-9"
+          />
+        </div>
+
+        {/* Members */}
+        {Result.match(membersResult, {
+          onInitial: () => (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+              ))}
+            </div>
+          ),
+          onFailure: () => (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
+              <p className="text-[0.8125rem] text-destructive">Failed to load team members</p>
+            </div>
+          ),
+          onSuccess: ({ value }) => {
+            const members = value.members;
+            const filtered = search
+              ? members.filter(
+                  (m) =>
+                    m.email.toLowerCase().includes(search.toLowerCase()) ||
+                    (m.name?.toLowerCase().includes(search.toLowerCase()) ?? false),
+                )
+              : members;
+
+            if (filtered.length === 0) {
+              return (
+                <p className="py-8 text-center text-[0.8125rem] text-muted-foreground/60">
+                  {search ? "No matching members" : "No team members yet"}
+                </p>
+              );
+            }
+
+            return (
+              <div className="space-y-px">
+                {filtered.map((member) => (
+                  <div
+                    key={member.id}
+                    className="group relative grid grid-cols-[2rem_1fr_6rem_5rem_2rem] items-center gap-3 rounded-lg border border-transparent px-4 py-3 transition-all hover:bg-muted/30"
+                  >
+                    {/* Avatar */}
+                    {member.avatarUrl ? (
+                      <img src={member.avatarUrl} alt="" className="size-8 rounded-full" />
+                    ) : (
+                      <div className="flex size-8 items-center justify-center rounded-full bg-muted text-[0.625rem] font-semibold text-muted-foreground">
+                        {member.name
+                          ? member.name.split(" ").map((n) => n[0]).join("").slice(0, 2).toUpperCase()
+                          : member.email[0]!.toUpperCase()}
+                      </div>
+                    )}
+
+                    {/* Name + email */}
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate text-[0.8125rem] font-medium text-foreground leading-none">
+                          {member.name ?? member.email}
+                        </p>
+                        {member.isCurrentUser && (
+                          <span className="rounded bg-muted px-1.5 py-0.5 text-[0.625rem] font-medium text-muted-foreground leading-none">
+                            You
+                          </span>
+                        )}
+                        {member.status === "pending" && (
+                          <span className="rounded bg-amber-500/10 px-1.5 py-0.5 text-[0.625rem] font-medium text-amber-600 dark:text-amber-400 leading-none">
+                            Invited
+                          </span>
+                        )}
+                      </div>
+                      {member.name && (
+                        <p className="mt-0.5 truncate text-[0.75rem] text-muted-foreground/70 leading-none">
+                          {member.email}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* Role */}
+                    <p className="text-[0.8125rem] text-muted-foreground capitalize leading-none">
+                      {member.role}
+                    </p>
+
+                    {/* Last active */}
+                    <p className="text-[0.75rem] text-muted-foreground/60 leading-none">
+                      {formatLastActive(member.lastActiveAt)}
+                    </p>
+
+                    {/* Actions */}
+                    {!member.isCurrentUser ? (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="size-7 opacity-0 group-hover:opacity-100 transition-opacity"
+                          >
+                            <svg viewBox="0 0 16 16" className="size-3">
+                              <circle cx="8" cy="3" r="1.2" fill="currentColor" />
+                              <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+                              <circle cx="8" cy="13" r="1.2" fill="currentColor" />
+                            </svg>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-44">
+                          {roles.length > 0 && (
+                            <>
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger className="text-[0.75rem]">
+                                  Change role
+                                </DropdownMenuSubTrigger>
+                                <DropdownMenuSubContent>
+                                  {roles.map((role) => (
+                                    <DropdownMenuItem
+                                      key={role.slug}
+                                      className="text-[0.75rem]"
+                                      disabled={role.slug === member.role}
+                                      onClick={() => handleChangeRole(member.id, role.slug, role.name)}
+                                    >
+                                      {role.name}
+                                      {role.slug === member.role && (
+                                        <span className="ml-auto text-muted-foreground/50">
+                                          <svg viewBox="0 0 16 16" fill="none" className="size-3">
+                                            <path d="M3.5 8.5L6.5 11.5L12.5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                                          </svg>
+                                        </span>
+                                      )}
+                                    </DropdownMenuItem>
+                                  ))}
+                                </DropdownMenuSubContent>
+                              </DropdownMenuSub>
+                              <DropdownMenuSeparator />
+                            </>
+                          )}
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive text-[0.75rem]"
+                            onClick={() => handleRemove(member.id, member.name ?? member.email)}
+                          >
+                            Remove member
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    ) : <div />}
+                  </div>
+                ))}
+              </div>
+            );
+          },
+        })}
+
+        <InviteDialog
+          open={inviteOpen}
+          onOpenChange={setInviteOpen}
+          onInvited={refreshMembers}
+          roles={roles}
+        />
+      </div>
+    </div>
+  );
+}
+
+function InviteDialog(props: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onInvited: () => void;
+  roles: readonly { slug: string; name: string }[];
+}) {
+  const [state, dispatch] = useReducer(inviteReducer, initialInviteState);
+  const doInvite = useAtomSet(inviteMember, { mode: "promiseExit" });
+
+  const handleInvite = async () => {
+    if (!state.email.trim()) return;
+    dispatch({ type: "send" });
+
+    const exit = await doInvite({
+      payload: {
+        email: state.email.trim(),
+        ...(state.roleSlug ? { roleSlug: state.roleSlug } : {}),
+      },
+    });
+
+    if (Exit.isSuccess(exit)) {
+      toast.success(`Invitation sent to ${state.email.trim()}`);
+      dispatch({ type: "reset" });
+      props.onOpenChange(false);
+      props.onInvited();
+    } else {
+      dispatch({ type: "error", message: "Failed to send invitation" });
+    }
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(v) => {
+        if (!v) dispatch({ type: "reset" });
+        props.onOpenChange(v);
+      }}
+    >
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle className="font-display text-xl">Invite member</DialogTitle>
+          <DialogDescription className="text-[0.8125rem] leading-relaxed">
+            Send an email invitation to join your team.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-3">
+          <div className="grid gap-1.5">
+            <Label htmlFor="invite-email" className="text-[0.6875rem] font-medium uppercase tracking-wider text-muted-foreground">
+              Email
+            </Label>
+            <Input
+              id="invite-email"
+              type="email"
+              placeholder="colleague@company.com"
+              value={state.email}
+              onChange={(e) => dispatch({ type: "setEmail", email: (e.target as HTMLInputElement).value })}
+              onKeyDown={(e) => { if (e.key === "Enter") handleInvite(); }}
+              className="text-[0.8125rem] h-9"
+            />
+          </div>
+
+          {props.roles.length > 0 && (
+            <div className="grid gap-1.5">
+              <Label htmlFor="invite-role" className="text-[0.6875rem] font-medium uppercase tracking-wider text-muted-foreground">
+                Role
+              </Label>
+              <Select value={state.roleSlug} onValueChange={(v) => dispatch({ type: "setRole", roleSlug: v })}>
+                <SelectTrigger id="invite-role" className="h-9 text-[0.8125rem]">
+                  <SelectValue placeholder="Select a role" />
+                </SelectTrigger>
+                <SelectContent>
+                  {props.roles.map((role) => (
+                    <SelectItem key={role.slug} value={role.slug}>
+                      {role.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {state.status === "error" && state.error && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+              <p className="text-[0.75rem] text-destructive">{state.error}</p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">Cancel</Button>
+          </DialogClose>
+          <Button
+            size="sm"
+            onClick={handleInvite}
+            disabled={!state.email.trim() || state.status === "sending"}
+          >
+            {state.status === "sending" ? "Sending…" : "Send invite"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/cloud/src/team/api.ts
+++ b/apps/cloud/src/team/api.ts
@@ -1,0 +1,92 @@
+import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
+import { Schema } from "effect";
+import { WorkOSError } from "../auth/errors";
+
+export class Forbidden extends Schema.TaggedError<Forbidden>()(
+  "Forbidden",
+  {},
+  HttpApiSchema.annotations({ status: 403 }),
+) {}
+
+const TeamMember = Schema.Struct({
+  id: Schema.String,
+  userId: Schema.String,
+  email: Schema.String,
+  name: Schema.NullOr(Schema.String),
+  avatarUrl: Schema.NullOr(Schema.String),
+  role: Schema.String,
+  status: Schema.String,
+  lastActiveAt: Schema.NullOr(Schema.String),
+  isCurrentUser: Schema.Boolean,
+});
+
+const TeamMembersResponse = Schema.Struct({
+  members: Schema.Array(TeamMember),
+});
+
+const TeamRole = Schema.Struct({
+  slug: Schema.String,
+  name: Schema.String,
+});
+
+const TeamRolesResponse = Schema.Struct({
+  roles: Schema.Array(TeamRole),
+});
+
+const InviteBody = Schema.Struct({
+  email: Schema.String,
+  roleSlug: Schema.optional(Schema.String),
+});
+
+const InviteResponse = Schema.Struct({
+  id: Schema.String,
+  email: Schema.String,
+});
+
+const membershipIdParam = HttpApiSchema.param("membershipId", Schema.String);
+
+const RemoveResponse = Schema.Struct({
+  success: Schema.Boolean,
+});
+
+const UpdateRoleBody = Schema.Struct({
+  roleSlug: Schema.String,
+});
+
+const UpdateRoleResponse = Schema.Struct({
+  success: Schema.Boolean,
+});
+
+export { TeamMember, TeamMembersResponse };
+
+export class TeamApi extends HttpApiGroup.make("team")
+  .add(
+    HttpApiEndpoint.get("listMembers")`/team/members`
+      .addSuccess(TeamMembersResponse)
+      .addError(WorkOSError),
+  )
+  .add(
+    HttpApiEndpoint.get("listRoles")`/team/roles`
+      .addSuccess(TeamRolesResponse)
+      .addError(WorkOSError),
+  )
+  .add(
+    HttpApiEndpoint.post("invite")`/team/invite`
+      .setPayload(InviteBody)
+      .addSuccess(InviteResponse)
+      .addError(WorkOSError)
+      .addError(Forbidden),
+  )
+  .add(
+    HttpApiEndpoint.del("removeMember")`/team/members/${membershipIdParam}`
+      .addSuccess(RemoveResponse)
+      .addError(WorkOSError)
+      .addError(Forbidden),
+  )
+  .add(
+    HttpApiEndpoint.patch("updateMemberRole")`/team/members/${membershipIdParam}/role`
+      .setPayload(UpdateRoleBody)
+      .addSuccess(UpdateRoleResponse)
+      .addError(WorkOSError)
+      .addError(Forbidden),
+  ) {}

--- a/apps/cloud/src/team/compose.ts
+++ b/apps/cloud/src/team/compose.ts
@@ -1,0 +1,6 @@
+import { HttpApi } from "@effect/platform";
+import { OrgAuth } from "../auth/middleware";
+import { TeamApi } from "./api";
+
+/** Team API with org-level auth — requires authenticated session with an org. */
+export const TeamOrgApi = HttpApi.make("teamOrg").add(TeamApi).middleware(OrgAuth);

--- a/apps/cloud/src/team/handlers.test.ts
+++ b/apps/cloud/src/team/handlers.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { AuthContext } from "../auth/middleware";
+import { WorkOSAuth } from "../auth/workos";
+import { Forbidden } from "./api";
+
+// ---------------------------------------------------------------------------
+// Stub factory — only implement what each test calls
+// ---------------------------------------------------------------------------
+
+type StubOverrides = {
+  listOrgMembers?: (...args: any[]) => Effect.Effect<any>;
+  getUser?: (...args: any[]) => Effect.Effect<any>;
+  sendInvitation?: (...args: any[]) => Effect.Effect<any>;
+  deleteOrgMembership?: (...args: any[]) => Effect.Effect<any>;
+  updateOrgMembershipRole?: (...args: any[]) => Effect.Effect<any>;
+  listOrgRoles?: (...args: any[]) => Effect.Effect<any>;
+};
+
+const stubWorkOS = (overrides: StubOverrides = {}) =>
+  Layer.succeed(WorkOSAuth, new Proxy({} as WorkOSAuth["Type"], {
+    get: (_target, prop) => {
+      if (prop in overrides) return (overrides as Record<string, unknown>)[prop as string];
+      return () => { throw new Error(`WorkOSAuth.${String(prop)} not stubbed`); };
+    },
+  }));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const adminAuth = {
+  accountId: "user_admin",
+  organizationId: "org_1",
+  email: "admin@test.com",
+  name: "Admin",
+  avatarUrl: null,
+};
+
+const memberAuth = {
+  accountId: "user_member",
+  organizationId: "org_1",
+  email: "member@test.com",
+  name: "Member",
+  avatarUrl: null,
+};
+
+const fakeMemberships = [
+  { id: "mem_admin", userId: "user_admin", status: "active", role: { slug: "admin" } },
+  { id: "mem_member", userId: "user_member", status: "active", role: { slug: "member" } },
+];
+
+const fakeUsers: Record<string, any> = {
+  user_admin: { email: "admin@test.com", firstName: "Admin", lastName: null, profilePictureUrl: null, lastSignInAt: "2026-04-09T00:00:00Z" },
+  user_member: { email: "member@test.com", firstName: "Member", lastName: null, profilePictureUrl: null, lastSignInAt: null },
+};
+
+const fakeRoles = [
+  { slug: "admin", name: "Admin" },
+  { slug: "member", name: "Member" },
+];
+
+// ---------------------------------------------------------------------------
+// The admin guard — mirrors handlers.ts
+// ---------------------------------------------------------------------------
+
+const requireAdmin = Effect.gen(function* () {
+  const auth = yield* AuthContext;
+  const workos = yield* WorkOSAuth;
+  const memberships = yield* workos.listOrgMembers(auth.organizationId);
+  const current = memberships.data.find((m: any) => m.userId === auth.accountId);
+  if (!current || current.role?.slug !== "admin") {
+    return yield* new Forbidden();
+  }
+});
+
+const provide = (auth: typeof adminAuth, workosOverrides: StubOverrides = {}) =>
+  Layer.mergeAll(
+    Layer.succeed(AuthContext, auth),
+    stubWorkOS(workosOverrides),
+  );
+
+const withMembers: StubOverrides = {
+  listOrgMembers: () => Effect.succeed({ data: fakeMemberships }),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Team handlers", () => {
+  describe("listMembers", () => {
+    it.effect("returns members with isCurrentUser set correctly", () =>
+      Effect.gen(function* () {
+        const auth = yield* AuthContext;
+        const workos = yield* WorkOSAuth;
+        const result = yield* workos.listOrgMembers(auth.organizationId);
+        const members = yield* Effect.all(
+          result.data.map((m: any) =>
+            Effect.gen(function* () {
+              const user = yield* workos.getUser(m.userId);
+              return {
+                id: m.id,
+                email: user.email,
+                role: m.role?.slug ?? "member",
+                isCurrentUser: m.userId === auth.accountId,
+              };
+            }),
+          ),
+        );
+
+        expect(members).toHaveLength(2);
+        expect(members[0]).toMatchObject({ email: "admin@test.com", isCurrentUser: true });
+        expect(members[1]).toMatchObject({ email: "member@test.com", isCurrentUser: false });
+      }).pipe(
+        Effect.provide(provide(adminAuth, {
+          ...withMembers,
+          getUser: (id: string) => Effect.succeed(fakeUsers[id]),
+        })),
+      ),
+    );
+  });
+
+  describe("listRoles", () => {
+    it.effect("returns available roles", () =>
+      Effect.gen(function* () {
+        const auth = yield* AuthContext;
+        const workos = yield* WorkOSAuth;
+        const result = yield* workos.listOrgRoles(auth.organizationId);
+        const roles = result.data.map((r: any) => ({ slug: r.slug, name: r.name }));
+
+        expect(roles).toEqual(fakeRoles);
+      }).pipe(
+        Effect.provide(provide(adminAuth, {
+          listOrgRoles: () => Effect.succeed({ data: fakeRoles }),
+        })),
+      ),
+    );
+  });
+
+  describe("requireAdmin", () => {
+    it.effect("passes for admin user", () =>
+      requireAdmin.pipe(Effect.provide(provide(adminAuth, withMembers))),
+    );
+
+    it.effect("rejects non-admin with Forbidden", () =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip(requireAdmin);
+        expect(error).toBeInstanceOf(Forbidden);
+      }).pipe(Effect.provide(provide(memberAuth, withMembers))),
+    );
+  });
+
+  describe("invite (admin-gated)", () => {
+    it.effect("admin can invite", () =>
+      Effect.gen(function* () {
+        yield* requireAdmin;
+        const auth = yield* AuthContext;
+        const workos = yield* WorkOSAuth;
+        const result = yield* workos.sendInvitation({
+          email: "new@test.com",
+          organizationId: auth.organizationId,
+        });
+
+        expect(result.email).toBe("new@test.com");
+      }).pipe(
+        Effect.provide(provide(adminAuth, {
+          ...withMembers,
+          sendInvitation: (p: any) => Effect.succeed({ id: "inv_1", email: p.email }),
+        })),
+      ),
+    );
+
+    it.effect("member cannot invite", () =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip(
+          Effect.gen(function* () {
+            yield* requireAdmin;
+            const workos = yield* WorkOSAuth;
+            yield* workos.sendInvitation({ email: "x", organizationId: "org_1" });
+          }),
+        );
+        expect(error).toBeInstanceOf(Forbidden);
+      }).pipe(Effect.provide(provide(memberAuth, withMembers))),
+    );
+  });
+
+  describe("removeMember (admin-gated)", () => {
+    it.effect("admin can remove", () =>
+      Effect.gen(function* () {
+        yield* requireAdmin;
+        const workos = yield* WorkOSAuth;
+        yield* workos.deleteOrgMembership("mem_member");
+      }).pipe(
+        Effect.provide(provide(adminAuth, {
+          ...withMembers,
+          deleteOrgMembership: () => Effect.void,
+        })),
+      ),
+    );
+
+    it.effect("member cannot remove", () =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip(
+          Effect.gen(function* () {
+            yield* requireAdmin;
+            const workos = yield* WorkOSAuth;
+            yield* workos.deleteOrgMembership("mem_admin");
+          }),
+        );
+        expect(error).toBeInstanceOf(Forbidden);
+      }).pipe(Effect.provide(provide(memberAuth, withMembers))),
+    );
+  });
+
+  describe("updateMemberRole (admin-gated)", () => {
+    it.effect("admin can change role", () =>
+      Effect.gen(function* () {
+        yield* requireAdmin;
+        const workos = yield* WorkOSAuth;
+        yield* workos.updateOrgMembershipRole("mem_member", "admin");
+      }).pipe(
+        Effect.provide(provide(adminAuth, {
+          ...withMembers,
+          updateOrgMembershipRole: () => Effect.void,
+        })),
+      ),
+    );
+
+    it.effect("member cannot change role", () =>
+      Effect.gen(function* () {
+        const error = yield* Effect.flip(
+          Effect.gen(function* () {
+            yield* requireAdmin;
+            const workos = yield* WorkOSAuth;
+            yield* workos.updateOrgMembershipRole("mem_admin", "member");
+          }),
+        );
+        expect(error).toBeInstanceOf(Forbidden);
+      }).pipe(Effect.provide(provide(memberAuth, withMembers))),
+    );
+  });
+});

--- a/apps/cloud/src/team/handlers.test.ts
+++ b/apps/cloud/src/team/handlers.test.ts
@@ -19,12 +19,17 @@ type StubOverrides = {
 };
 
 const stubWorkOS = (overrides: StubOverrides = {}) =>
-  Layer.succeed(WorkOSAuth, new Proxy({} as WorkOSAuth["Type"], {
-    get: (_target, prop) => {
-      if (prop in overrides) return (overrides as Record<string, unknown>)[prop as string];
-      return () => { throw new Error(`WorkOSAuth.${String(prop)} not stubbed`); };
-    },
-  }));
+  Layer.succeed(
+    WorkOSAuth,
+    new Proxy({} as WorkOSAuth["Type"], {
+      get: (_target, prop) => {
+        if (prop in overrides) return (overrides as Record<string, unknown>)[prop as string];
+        return () => {
+          throw new Error(`WorkOSAuth.${String(prop)} not stubbed`);
+        };
+      },
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -52,8 +57,20 @@ const fakeMemberships = [
 ];
 
 const fakeUsers: Record<string, any> = {
-  user_admin: { email: "admin@test.com", firstName: "Admin", lastName: null, profilePictureUrl: null, lastSignInAt: "2026-04-09T00:00:00Z" },
-  user_member: { email: "member@test.com", firstName: "Member", lastName: null, profilePictureUrl: null, lastSignInAt: null },
+  user_admin: {
+    email: "admin@test.com",
+    firstName: "Admin",
+    lastName: null,
+    profilePictureUrl: null,
+    lastSignInAt: "2026-04-09T00:00:00Z",
+  },
+  user_member: {
+    email: "member@test.com",
+    firstName: "Member",
+    lastName: null,
+    profilePictureUrl: null,
+    lastSignInAt: null,
+  },
 };
 
 const fakeRoles = [
@@ -76,10 +93,7 @@ const requireAdmin = Effect.gen(function* () {
 });
 
 const provide = (auth: typeof adminAuth, workosOverrides: StubOverrides = {}) =>
-  Layer.mergeAll(
-    Layer.succeed(AuthContext, auth),
-    stubWorkOS(workosOverrides),
-  );
+  Layer.mergeAll(Layer.succeed(AuthContext, auth), stubWorkOS(workosOverrides));
 
 const withMembers: StubOverrides = {
   listOrgMembers: () => Effect.succeed({ data: fakeMemberships }),
@@ -114,10 +128,12 @@ describe("Team handlers", () => {
         expect(members[0]).toMatchObject({ email: "admin@test.com", isCurrentUser: true });
         expect(members[1]).toMatchObject({ email: "member@test.com", isCurrentUser: false });
       }).pipe(
-        Effect.provide(provide(adminAuth, {
-          ...withMembers,
-          getUser: (id: string) => Effect.succeed(fakeUsers[id]),
-        })),
+        Effect.provide(
+          provide(adminAuth, {
+            ...withMembers,
+            getUser: (id: string) => Effect.succeed(fakeUsers[id]),
+          }),
+        ),
       ),
     );
   });
@@ -132,9 +148,11 @@ describe("Team handlers", () => {
 
         expect(roles).toEqual(fakeRoles);
       }).pipe(
-        Effect.provide(provide(adminAuth, {
-          listOrgRoles: () => Effect.succeed({ data: fakeRoles }),
-        })),
+        Effect.provide(
+          provide(adminAuth, {
+            listOrgRoles: () => Effect.succeed({ data: fakeRoles }),
+          }),
+        ),
       ),
     );
   });
@@ -165,10 +183,12 @@ describe("Team handlers", () => {
 
         expect(result.email).toBe("new@test.com");
       }).pipe(
-        Effect.provide(provide(adminAuth, {
-          ...withMembers,
-          sendInvitation: (p: any) => Effect.succeed({ id: "inv_1", email: p.email }),
-        })),
+        Effect.provide(
+          provide(adminAuth, {
+            ...withMembers,
+            sendInvitation: (p: any) => Effect.succeed({ id: "inv_1", email: p.email }),
+          }),
+        ),
       ),
     );
 
@@ -193,10 +213,12 @@ describe("Team handlers", () => {
         const workos = yield* WorkOSAuth;
         yield* workos.deleteOrgMembership("mem_member");
       }).pipe(
-        Effect.provide(provide(adminAuth, {
-          ...withMembers,
-          deleteOrgMembership: () => Effect.void,
-        })),
+        Effect.provide(
+          provide(adminAuth, {
+            ...withMembers,
+            deleteOrgMembership: () => Effect.void,
+          }),
+        ),
       ),
     );
 
@@ -221,10 +243,12 @@ describe("Team handlers", () => {
         const workos = yield* WorkOSAuth;
         yield* workos.updateOrgMembershipRole("mem_member", "admin");
       }).pipe(
-        Effect.provide(provide(adminAuth, {
-          ...withMembers,
-          updateOrgMembershipRole: () => Effect.void,
-        })),
+        Effect.provide(
+          provide(adminAuth, {
+            ...withMembers,
+            updateOrgMembershipRole: () => Effect.void,
+          }),
+        ),
       ),
     );
 

--- a/apps/cloud/src/team/handlers.test.ts
+++ b/apps/cloud/src/team/handlers.test.ts
@@ -9,13 +9,16 @@ import { Forbidden } from "./api";
 // Stub factory — only implement what each test calls
 // ---------------------------------------------------------------------------
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- test stub needs wide function types
+type StubFn = (...args: never[]) => Effect.Effect<any>;
+
 type StubOverrides = {
-  listOrgMembers?: (...args: unknown[]) => Effect.Effect<unknown>;
-  getUser?: (...args: unknown[]) => Effect.Effect<unknown>;
-  sendInvitation?: (...args: unknown[]) => Effect.Effect<unknown>;
-  deleteOrgMembership?: (...args: unknown[]) => Effect.Effect<unknown>;
-  updateOrgMembershipRole?: (...args: unknown[]) => Effect.Effect<unknown>;
-  listOrgRoles?: (...args: unknown[]) => Effect.Effect<unknown>;
+  listOrgMembers?: StubFn;
+  getUser?: StubFn;
+  sendInvitation?: StubFn;
+  deleteOrgMembership?: StubFn;
+  updateOrgMembershipRole?: StubFn;
+  listOrgRoles?: StubFn;
 };
 
 const stubWorkOS = (overrides: StubOverrides = {}) =>

--- a/apps/cloud/src/team/handlers.test.ts
+++ b/apps/cloud/src/team/handlers.test.ts
@@ -51,7 +51,12 @@ const memberAuth = {
   avatarUrl: null,
 };
 
-type FakeMembership = { id: string; userId: string; status: string; role: { slug: string } };
+type FakeMembership = {
+  id: string;
+  userId: string;
+  status: string;
+  role: { slug: string };
+};
 type FakeUser = {
   email: string;
   firstName: string | null;
@@ -62,8 +67,18 @@ type FakeUser = {
 type FakeRole = { slug: string; name: string };
 
 const fakeMemberships: FakeMembership[] = [
-  { id: "mem_admin", userId: "user_admin", status: "active", role: { slug: "admin" } },
-  { id: "mem_member", userId: "user_member", status: "active", role: { slug: "member" } },
+  {
+    id: "mem_admin",
+    userId: "user_admin",
+    status: "active",
+    role: { slug: "admin" },
+  },
+  {
+    id: "mem_member",
+    userId: "user_member",
+    status: "active",
+    role: { slug: "member" },
+  },
 ];
 
 const fakeUsers: Record<string, FakeUser> = {
@@ -135,8 +150,14 @@ describe("Team handlers", () => {
         );
 
         expect(members).toHaveLength(2);
-        expect(members[0]).toMatchObject({ email: "admin@test.com", isCurrentUser: true });
-        expect(members[1]).toMatchObject({ email: "member@test.com", isCurrentUser: false });
+        expect(members[0]).toMatchObject({
+          email: "admin@test.com",
+          isCurrentUser: true,
+        });
+        expect(members[1]).toMatchObject({
+          email: "member@test.com",
+          isCurrentUser: false,
+        });
       }).pipe(
         Effect.provide(
           provide(adminAuth, {
@@ -154,7 +175,10 @@ describe("Team handlers", () => {
         const auth = yield* AuthContext;
         const workos = yield* WorkOSAuth;
         const result = yield* workos.listOrgRoles(auth.organizationId);
-        const roles = result.data.map((r: FakeRole) => ({ slug: r.slug, name: r.name }));
+        const roles = result.data.map((r: FakeRole) => ({
+          slug: r.slug,
+          name: r.name,
+        }));
 
         expect(roles).toEqual(fakeRoles);
       }).pipe(
@@ -209,7 +233,10 @@ describe("Team handlers", () => {
           Effect.gen(function* () {
             yield* requireAdmin;
             const workos = yield* WorkOSAuth;
-            yield* workos.sendInvitation({ email: "x", organizationId: "org_1" });
+            yield* workos.sendInvitation({
+              email: "x",
+              organizationId: "org_1",
+            });
           }),
         );
         expect(error).toBeInstanceOf(Forbidden);

--- a/apps/cloud/src/team/handlers.test.ts
+++ b/apps/cloud/src/team/handlers.test.ts
@@ -52,7 +52,13 @@ const memberAuth = {
 };
 
 type FakeMembership = { id: string; userId: string; status: string; role: { slug: string } };
-type FakeUser = { email: string; firstName: string | null; lastName: string | null; profilePictureUrl: string | null; lastSignInAt: string | null };
+type FakeUser = {
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  profilePictureUrl: string | null;
+  lastSignInAt: string | null;
+};
 type FakeRole = { slug: string; name: string };
 
 const fakeMemberships: FakeMembership[] = [
@@ -190,7 +196,8 @@ describe("Team handlers", () => {
         Effect.provide(
           provide(adminAuth, {
             ...withMembers,
-            sendInvitation: (p: { email: string }) => Effect.succeed({ id: "inv_1", email: p.email }),
+            sendInvitation: (p: { email: string }) =>
+              Effect.succeed({ id: "inv_1", email: p.email }),
           }),
         ),
       ),

--- a/apps/cloud/src/team/handlers.test.ts
+++ b/apps/cloud/src/team/handlers.test.ts
@@ -10,12 +10,12 @@ import { Forbidden } from "./api";
 // ---------------------------------------------------------------------------
 
 type StubOverrides = {
-  listOrgMembers?: (...args: any[]) => Effect.Effect<any>;
-  getUser?: (...args: any[]) => Effect.Effect<any>;
-  sendInvitation?: (...args: any[]) => Effect.Effect<any>;
-  deleteOrgMembership?: (...args: any[]) => Effect.Effect<any>;
-  updateOrgMembershipRole?: (...args: any[]) => Effect.Effect<any>;
-  listOrgRoles?: (...args: any[]) => Effect.Effect<any>;
+  listOrgMembers?: (...args: unknown[]) => Effect.Effect<unknown>;
+  getUser?: (...args: unknown[]) => Effect.Effect<unknown>;
+  sendInvitation?: (...args: unknown[]) => Effect.Effect<unknown>;
+  deleteOrgMembership?: (...args: unknown[]) => Effect.Effect<unknown>;
+  updateOrgMembershipRole?: (...args: unknown[]) => Effect.Effect<unknown>;
+  listOrgRoles?: (...args: unknown[]) => Effect.Effect<unknown>;
 };
 
 const stubWorkOS = (overrides: StubOverrides = {}) =>
@@ -51,12 +51,16 @@ const memberAuth = {
   avatarUrl: null,
 };
 
-const fakeMemberships = [
+type FakeMembership = { id: string; userId: string; status: string; role: { slug: string } };
+type FakeUser = { email: string; firstName: string | null; lastName: string | null; profilePictureUrl: string | null; lastSignInAt: string | null };
+type FakeRole = { slug: string; name: string };
+
+const fakeMemberships: FakeMembership[] = [
   { id: "mem_admin", userId: "user_admin", status: "active", role: { slug: "admin" } },
   { id: "mem_member", userId: "user_member", status: "active", role: { slug: "member" } },
 ];
 
-const fakeUsers: Record<string, any> = {
+const fakeUsers: Record<string, FakeUser> = {
   user_admin: {
     email: "admin@test.com",
     firstName: "Admin",
@@ -73,7 +77,7 @@ const fakeUsers: Record<string, any> = {
   },
 };
 
-const fakeRoles = [
+const fakeRoles: FakeRole[] = [
   { slug: "admin", name: "Admin" },
   { slug: "member", name: "Member" },
 ];
@@ -86,7 +90,7 @@ const requireAdmin = Effect.gen(function* () {
   const auth = yield* AuthContext;
   const workos = yield* WorkOSAuth;
   const memberships = yield* workos.listOrgMembers(auth.organizationId);
-  const current = memberships.data.find((m: any) => m.userId === auth.accountId);
+  const current = memberships.data.find((m: FakeMembership) => m.userId === auth.accountId);
   if (!current || current.role?.slug !== "admin") {
     return yield* new Forbidden();
   }
@@ -111,7 +115,7 @@ describe("Team handlers", () => {
         const workos = yield* WorkOSAuth;
         const result = yield* workos.listOrgMembers(auth.organizationId);
         const members = yield* Effect.all(
-          result.data.map((m: any) =>
+          result.data.map((m: FakeMembership) =>
             Effect.gen(function* () {
               const user = yield* workos.getUser(m.userId);
               return {
@@ -144,7 +148,7 @@ describe("Team handlers", () => {
         const auth = yield* AuthContext;
         const workos = yield* WorkOSAuth;
         const result = yield* workos.listOrgRoles(auth.organizationId);
-        const roles = result.data.map((r: any) => ({ slug: r.slug, name: r.name }));
+        const roles = result.data.map((r: FakeRole) => ({ slug: r.slug, name: r.name }));
 
         expect(roles).toEqual(fakeRoles);
       }).pipe(
@@ -186,7 +190,7 @@ describe("Team handlers", () => {
         Effect.provide(
           provide(adminAuth, {
             ...withMembers,
-            sendInvitation: (p: any) => Effect.succeed({ id: "inv_1", email: p.email }),
+            sendInvitation: (p: { email: string }) => Effect.succeed({ id: "inv_1", email: p.email }),
           }),
         ),
       ),

--- a/apps/cloud/src/team/handlers.ts
+++ b/apps/cloud/src/team/handlers.ts
@@ -1,0 +1,97 @@
+import { HttpApiBuilder } from "@effect/platform";
+import { Effect } from "effect";
+
+import { AuthContext } from "../auth/middleware";
+import { WorkOSAuth } from "../auth/workos";
+import { TeamOrgApi } from "./compose";
+import { Forbidden } from "./api";
+
+const requireAdmin = Effect.gen(function* () {
+  const auth = yield* AuthContext;
+  const workos = yield* WorkOSAuth;
+  const memberships = yield* workos.listOrgMembers(auth.organizationId);
+  const currentMembership = memberships.data.find((m) => m.userId === auth.accountId);
+  if (!currentMembership || currentMembership.role?.slug !== "admin") {
+    return yield* new Forbidden();
+  }
+});
+
+export const TeamHandlers = HttpApiBuilder.group(TeamOrgApi, "team", (handlers) =>
+  handlers
+    .handle("listMembers", () =>
+      Effect.gen(function* () {
+        const auth = yield* AuthContext;
+        const workos = yield* WorkOSAuth;
+
+        const memberships = yield* workos.listOrgMembers(auth.organizationId);
+
+        const members = yield* Effect.all(
+          memberships.data.map((m) =>
+            Effect.gen(function* () {
+              const user = yield* workos.getUser(m.userId);
+              return {
+                id: m.id,
+                userId: m.userId,
+                email: user.email,
+                name: [user.firstName, user.lastName].filter(Boolean).join(" ") || null,
+                avatarUrl: user.profilePictureUrl ?? null,
+                role: m.role?.slug ?? "member",
+                status: m.status,
+                lastActiveAt: user.lastSignInAt ?? null,
+                isCurrentUser: m.userId === auth.accountId,
+              };
+            }),
+          ),
+          { concurrency: 5 },
+        );
+
+        return { members };
+      }),
+    )
+    .handle("listRoles", () =>
+      Effect.gen(function* () {
+        const auth = yield* AuthContext;
+        const workos = yield* WorkOSAuth;
+
+        const result = yield* workos.listOrgRoles(auth.organizationId);
+
+        return {
+          roles: result.data.map((r) => ({
+            slug: r.slug,
+            name: r.name,
+          })),
+        };
+      }),
+    )
+    .handle("invite", ({ payload }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin;
+        const auth = yield* AuthContext;
+        const workos = yield* WorkOSAuth;
+
+        const invitation = yield* workos.sendInvitation({
+          email: payload.email,
+          organizationId: auth.organizationId,
+          roleSlug: payload.roleSlug,
+        });
+
+        return { id: invitation.id, email: invitation.email };
+      }),
+    )
+    .handle("removeMember", ({ path }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin;
+        const workos = yield* WorkOSAuth;
+        yield* workos.deleteOrgMembership(path.membershipId);
+        return { success: true };
+      }),
+    )
+    .handle("updateMemberRole", ({ path, payload }) =>
+      Effect.gen(function* () {
+        yield* requireAdmin;
+        const workos = yield* WorkOSAuth;
+        yield* workos.updateOrgMembershipRole(path.membershipId, payload.roleSlug);
+        return { success: true };
+      }),
+    ),
+);

--- a/apps/cloud/src/web/client.tsx
+++ b/apps/cloud/src/web/client.tsx
@@ -3,12 +3,13 @@ import { FetchHttpClient } from "@effect/platform";
 import { addGroup } from "@executor/api";
 import { getBaseUrl } from "@executor/react/api/base-url";
 import { CloudAuthApi } from "../auth/api";
+import { TeamApi } from "../team/api";
 
 // ---------------------------------------------------------------------------
-// Cloud API client — core API + cloud auth
+// Cloud API client — core API + cloud auth + team
 // ---------------------------------------------------------------------------
 
-const CloudApi = addGroup(CloudAuthApi);
+const CloudApi = addGroup(CloudAuthApi).add(TeamApi);
 
 class CloudApiClient extends AtomHttpApi.Tag<CloudApiClient>()("CloudApiClient", {
   api: CloudApi,

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -136,6 +136,7 @@ function SidebarContent(props: { pathname: string; onNavigate?: () => void; show
   const isHome = props.pathname === "/";
   const isSecrets = props.pathname === "/secrets";
   const isBilling = props.pathname === "/billing" || props.pathname.startsWith("/billing/");
+  const isTeam = props.pathname === "/team";
 
   return (
     <>
@@ -150,6 +151,7 @@ function SidebarContent(props: { pathname: string; onNavigate?: () => void; show
       <nav className="flex flex-1 flex-col overflow-y-auto p-2">
         <NavItem to="/" label="Sources" active={isHome} onNavigate={props.onNavigate} />
         <NavItem to="/secrets" label="Secrets" active={isSecrets} onNavigate={props.onNavigate} />
+        <NavItem to="/team" label="Team" active={isTeam} onNavigate={props.onNavigate} />
         <NavItem to="/billing" label="Billing" active={isBilling} onNavigate={props.onNavigate} />
 
         <div className="mt-5 mb-1 px-2.5 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/50">

--- a/apps/cloud/src/web/team-atoms.ts
+++ b/apps/cloud/src/web/team-atoms.ts
@@ -1,0 +1,15 @@
+import { CloudApiClient } from "./client";
+
+export const teamMembersAtom = CloudApiClient.query("team", "listMembers", {
+  timeToLive: "30 seconds",
+});
+
+export const teamRolesAtom = CloudApiClient.query("team", "listRoles", {
+  timeToLive: "5 minutes",
+});
+
+export const inviteMember = CloudApiClient.mutation("team", "invite");
+
+export const removeMember = CloudApiClient.mutation("team", "removeMember");
+
+export const updateMemberRole = CloudApiClient.mutation("team", "updateMemberRole");

--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,7 @@
         "postgres": "^3.4.9",
         "react": "catalog:",
         "react-dom": "catalog:",
+        "sonner": "^2.0.7",
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.14.3",
@@ -622,7 +623,6 @@
         "embla-carousel-react": "^8.6.0",
         "input-otp": "^1.4.2",
         "lucide-react": "^1.7.0",
-        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "catalog:",
         "react-day-picker": "^9.14.0",
@@ -3033,8 +3033,6 @@
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
-
-    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -283,6 +283,7 @@
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@electric-sql/pglite": "^0.4.3",
+        "@types/node": "^25.6.0",
         "@types/pg": "^8.15.4",
         "drizzle-kit": "^0.31.0",
         "typescript": "catalog:",
@@ -3878,6 +3879,8 @@
 
     "@executor/example-promise-sdk/typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
+    "@executor/storage-postgres/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
@@ -4305,6 +4308,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@executor/storage-postgres/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -101,4 +101,4 @@ export { makeInMemoryPolicyEngine } from "./in-memory/policy-engine";
 
 // Testing
 export { makeTestConfig } from "./testing";
-export { type Kv, type ScopedKv, scopeKv, makeInMemoryScopedKv } from "./plugin-kv";
+export { type Kv, type KvEntry, type ScopedKv, scopeKv, makeInMemoryScopedKv } from "./plugin-kv";

--- a/packages/core/sdk/src/plugin-kv.ts
+++ b/packages/core/sdk/src/plugin-kv.ts
@@ -8,14 +8,21 @@
 
 import { Effect } from "effect";
 
+export interface KvEntry {
+  readonly key: string;
+  readonly value: string;
+}
+
 /**
  * Global KV — requires a namespace on every call.
  * Implementations: makeSqliteKv, makeInMemoryKv
  */
 export interface Kv {
   readonly get: (namespace: string, key: string) => Effect.Effect<string | null>;
-  readonly set: (namespace: string, key: string, value: string) => Effect.Effect<void>;
-  readonly delete: (namespace: string, key: string) => Effect.Effect<boolean>;
+  /** Batch upsert — inserts or updates one or more key-value pairs. */
+  readonly set: (namespace: string, entries: readonly KvEntry[]) => Effect.Effect<void>;
+  /** Batch delete — removes one or more keys. */
+  readonly delete: (namespace: string, keys: readonly string[]) => Effect.Effect<number>;
   readonly list: (namespace: string) => Effect.Effect<readonly { key: string; value: string }[]>;
   readonly deleteAll: (namespace: string) => Effect.Effect<number>;
   readonly withTransaction?: <A, E>(
@@ -29,8 +36,10 @@ export interface Kv {
  */
 export interface ScopedKv {
   readonly get: (key: string) => Effect.Effect<string | null>;
-  readonly set: (key: string, value: string) => Effect.Effect<void>;
-  readonly delete: (key: string) => Effect.Effect<boolean>;
+  /** Batch upsert — inserts or updates one or more key-value pairs. */
+  readonly set: (entries: readonly KvEntry[]) => Effect.Effect<void>;
+  /** Batch delete — removes one or more keys. */
+  readonly delete: (keys: readonly string[]) => Effect.Effect<number>;
   readonly list: () => Effect.Effect<readonly { key: string; value: string }[]>;
   readonly deleteAll: () => Effect.Effect<number>;
   readonly withTransaction?: <A, E>(
@@ -43,8 +52,8 @@ export interface ScopedKv {
  */
 export const scopeKv = (kv: Kv, namespace: string): ScopedKv => ({
   get: (key) => kv.get(namespace, key),
-  set: (key, value) => kv.set(namespace, key, value),
-  delete: (key) => kv.delete(namespace, key),
+  set: (entries) => kv.set(namespace, entries),
+  delete: (keys) => kv.delete(namespace, keys),
   list: () => kv.list(namespace),
   deleteAll: () => kv.deleteAll(namespace),
   withTransaction: kv.withTransaction,
@@ -57,11 +66,16 @@ export const makeInMemoryScopedKv = (): ScopedKv => {
   const store = new Map<string, string>();
   return {
     get: (key) => Effect.succeed(store.get(key) ?? null),
-    set: (key, value) =>
+    set: (entries) =>
       Effect.sync(() => {
-        store.set(key, value);
+        for (const { key, value } of entries) store.set(key, value);
       }),
-    delete: (key) => Effect.sync(() => store.delete(key)),
+    delete: (keys) =>
+      Effect.sync(() => {
+        let count = 0;
+        for (const key of keys) if (store.delete(key)) count++;
+        return count;
+      }),
     list: () => Effect.sync(() => [...store.entries()].map(([key, value]) => ({ key, value }))),
     deleteAll: () =>
       Effect.sync(() => {

--- a/packages/core/storage-file/src/index.ts
+++ b/packages/core/storage-file/src/index.ts
@@ -85,8 +85,8 @@ export const makeKvConfig = <const TPlugins extends readonly ExecutorPlugin<stri
  */
 export const makeScopedKv = (kv: Kv, folder: string): Kv => ({
   get: (namespace, key) => kv.get(`${folder}::${namespace}`, key),
-  set: (namespace, key, value) => kv.set(`${folder}::${namespace}`, key, value),
-  delete: (namespace, key) => kv.delete(`${folder}::${namespace}`, key),
+  set: (namespace, entries) => kv.set(`${folder}::${namespace}`, entries),
+  delete: (namespace, keys) => kv.delete(`${folder}::${namespace}`, keys),
   list: (namespace) => kv.list(`${folder}::${namespace}`),
   deleteAll: (namespace) => kv.deleteAll(`${folder}::${namespace}`),
   withTransaction: kv.withTransaction,

--- a/packages/core/storage-file/src/plugin-kv.ts
+++ b/packages/core/storage-file/src/plugin-kv.ts
@@ -29,22 +29,30 @@ export const makeSqliteKv = (sql: SqlClient.SqlClient): Kv => ({
       }),
     ),
 
-  set: (namespace, key, value) =>
-    absorbSql(
-      sql`
-      INSERT OR REPLACE INTO kv (namespace, key, value)
-      VALUES (${namespace}, ${key}, ${value})
-    `.pipe(Effect.asVoid),
-    ),
-
-  delete: (namespace, key) =>
+  set: (namespace, entries) =>
     absorbSql(
       Effect.gen(function* () {
-        const before = yield* sql<{ c: number }>`
-        SELECT COUNT(*) as c FROM kv WHERE namespace = ${namespace} AND key = ${key}
-      `;
-        yield* sql`DELETE FROM kv WHERE namespace = ${namespace} AND key = ${key}`;
-        return (before[0]?.c ?? 0) > 0;
+        for (const { key, value } of entries) {
+          yield* sql`
+            INSERT OR REPLACE INTO kv (namespace, key, value)
+            VALUES (${namespace}, ${key}, ${value})
+          `;
+        }
+      }),
+    ),
+
+  delete: (namespace, keys) =>
+    absorbSql(
+      Effect.gen(function* () {
+        let count = 0;
+        for (const key of keys) {
+          const before = yield* sql<{ c: number }>`
+            SELECT COUNT(*) as c FROM kv WHERE namespace = ${namespace} AND key = ${key}
+          `;
+          yield* sql`DELETE FROM kv WHERE namespace = ${namespace} AND key = ${key}`;
+          if ((before[0]?.c ?? 0) > 0) count++;
+        }
+        return count;
       }),
     ),
 
@@ -110,12 +118,19 @@ export const makeInMemoryKv = (): Kv => {
   return {
     get: (namespace, key) => Effect.succeed(bucket(namespace).get(key) ?? null),
 
-    set: (namespace, key, value) =>
+    set: (namespace, entries) =>
       Effect.sync(() => {
-        bucket(namespace).set(key, value);
+        const b = bucket(namespace);
+        for (const { key, value } of entries) b.set(key, value);
       }),
 
-    delete: (namespace, key) => Effect.sync(() => bucket(namespace).delete(key)),
+    delete: (namespace, keys) =>
+      Effect.sync(() => {
+        const b = bucket(namespace);
+        let count = 0;
+        for (const key of keys) if (b.delete(key)) count++;
+        return count;
+      }),
 
     list: (namespace) =>
       Effect.sync(() => [...bucket(namespace).entries()].map(([key, value]) => ({ key, value }))),

--- a/packages/core/storage-file/src/policy-engine.ts
+++ b/packages/core/storage-file/src/policy-engine.ts
@@ -26,7 +26,8 @@ export const makeKvPolicyEngine = (policiesKv: ScopedKv, metaKv: ScopedKv) => {
       return raw ? parseInt(raw, 10) : 0;
     });
 
-  const setCounter = (n: number): Effect.Effect<void> => metaKv.set("policy_counter", String(n));
+  const setCounter = (n: number): Effect.Effect<void> =>
+    metaKv.set([{ key: "policy_counter", value: String(n) }]);
 
   return {
     list: (scopeId: ScopeId) =>
@@ -43,7 +44,7 @@ export const makeKvPolicyEngine = (policiesKv: ScopedKv, metaKv: ScopedKv) => {
         yield* setCounter(counter);
         const id = PolicyId.make(`policy-${counter}`);
         const full = new Policy({ ...policy, id, createdAt: new Date() });
-        yield* policiesKv.set(id, encodePolicy(full));
+        yield* policiesKv.set([{ key: id, value: encodePolicy(full) }]);
         return full;
       }),
 
@@ -51,7 +52,7 @@ export const makeKvPolicyEngine = (policiesKv: ScopedKv, metaKv: ScopedKv) => {
       Effect.gen(function* () {
         const raw = yield* policiesKv.get(policyId);
         if (!raw) return false;
-        yield* policiesKv.delete(policyId);
+        yield* policiesKv.delete([policyId]);
         return true;
       }),
   };

--- a/packages/core/storage-file/src/secret-store.ts
+++ b/packages/core/storage-file/src/secret-store.ts
@@ -150,7 +150,7 @@ export const makeKvSecretStore = (refsKv: ScopedKv) => {
           createdAt: new Date(),
         });
 
-        yield* refsKv.set(input.id, encodeRef(ref));
+        yield* refsKv.set([{ key: input.id, value: encodeRef(ref) }]);
         return ref;
       }),
 
@@ -164,7 +164,7 @@ export const makeKvSecretStore = (refsKv: ScopedKv) => {
         const provider = findWritableProvider(providerKey);
         if (provider?.delete) yield* provider.delete(secretId);
 
-        yield* refsKv.delete(secretId);
+        yield* refsKv.delete([secretId]);
         return true;
       }),
 

--- a/packages/core/storage-file/src/tool-registry.ts
+++ b/packages/core/storage-file/src/tool-registry.ts
@@ -116,12 +116,13 @@ export const makeKvToolRegistry = (toolsKv: ScopedKv, defsKv: ScopedKv) => {
     registerDefinitions: (newDefs: Record<string, unknown>) =>
       withKvTransaction(
         defsKv,
-        Effect.gen(function* () {
-          for (const [name, schema] of Object.entries(newDefs)) {
+        defsKv.set(
+          Object.entries(newDefs).map(([name, schema]) => ({
+            key: name,
             // @effect-diagnostics-next-line preferSchemaOverJson:off
-            yield* defsKv.set(name, JSON.stringify(schema));
-          }
-        }),
+            value: JSON.stringify(schema),
+          })),
+        ),
       ),
 
     registerRuntimeDefinitions: (newDefs: Record<string, unknown>) =>
@@ -178,11 +179,7 @@ export const makeKvToolRegistry = (toolsKv: ScopedKv, defsKv: ScopedKv) => {
     register: (newTools: readonly ToolRegistration[]) =>
       withKvTransaction(
         toolsKv,
-        Effect.gen(function* () {
-          for (const t of newTools) {
-            yield* toolsKv.set(t.id, encodeTool(t));
-          }
-        }),
+        toolsKv.set(newTools.map((t) => ({ key: t.id, value: encodeTool(t) }))),
       ),
 
     registerRuntime: (newTools: readonly ToolRegistration[]) =>
@@ -210,18 +207,15 @@ export const makeKvToolRegistry = (toolsKv: ScopedKv, defsKv: ScopedKv) => {
         for (const id of toolIds) {
           runtimeTools.delete(id);
           runtimeHandlers.delete(id);
-          yield* toolsKv.delete(id);
         }
+        yield* toolsKv.delete([...toolIds]);
       }),
 
     unregisterBySource: (sourceId: string) =>
       Effect.gen(function* () {
         const allTools = yield* getAllTools();
-        for (const t of allTools) {
-          if (t.sourceId === sourceId) {
-            yield* toolsKv.delete(t.id);
-          }
-        }
+        const idsToDelete = allTools.filter((t) => t.sourceId === sourceId).map((t) => t.id);
+        if (idsToDelete.length > 0) yield* toolsKv.delete(idsToDelete);
         for (const [id, t] of runtimeTools) {
           if (t.sourceId === sourceId) {
             runtimeTools.delete(id);

--- a/packages/core/storage-postgres/package.json
+++ b/packages/core/storage-postgres/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@electric-sql/pglite": "^0.4.3",
+    "@types/node": "^25.6.0",
     "@types/pg": "^8.15.4",
     "drizzle-kit": "^0.31.0",
     "typescript": "catalog:",

--- a/packages/core/storage-postgres/src/index.test.ts
+++ b/packages/core/storage-postgres/src/index.test.ts
@@ -335,13 +335,13 @@ describe("Executor with Postgres storage", () => {
       const kv = makePgKv(db, TEST_ORG_ID);
       const scoped = scopeKv(kv, "my-plugin");
 
-      yield* scoped.set("k1", "v1");
+      yield* scoped.set([{ key: "k1", value: "v1" }]);
       expect(yield* scoped.get("k1")).toBe("v1");
 
       const items = yield* scoped.list();
       expect(items).toHaveLength(1);
 
-      yield* scoped.delete("k1");
+      yield* scoped.delete(["k1"]);
       expect(yield* scoped.get("k1")).toBeNull();
     }),
   );
@@ -351,8 +351,8 @@ describe("Executor with Postgres storage", () => {
       const kv1 = makePgKv(db, "org-a");
       const kv2 = makePgKv(db, "org-b");
 
-      yield* kv1.set("ns", "key", "org-a-value");
-      yield* kv2.set("ns", "key", "org-b-value");
+      yield* kv1.set("ns", [{ key: "key", value: "org-a-value" }]);
+      yield* kv2.set("ns", [{ key: "key", value: "org-b-value" }]);
 
       expect(yield* kv1.get("ns", "key")).toBe("org-a-value");
       expect(yield* kv2.get("ns", "key")).toBe("org-b-value");

--- a/packages/core/storage-postgres/src/pg-kv.ts
+++ b/packages/core/storage-postgres/src/pg-kv.ts
@@ -3,7 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql, inArray } from "drizzle-orm";
 import type { Kv } from "@executor/sdk";
 
 import { pluginKv } from "./schema";
@@ -25,30 +25,38 @@ export const makePgKv = (db: DrizzleDb, organizationId: string): Kv => ({
       return rows[0]?.value ?? null;
     }).pipe(Effect.orDie),
 
-  set: (namespace, key, value) =>
+  set: (namespace, entries) =>
     Effect.tryPromise(async () => {
+      if (entries.length === 0) return;
+      const values = entries.map(({ key, value }) => ({
+        organizationId,
+        namespace,
+        key,
+        value,
+      }));
       await db
         .insert(pluginKv)
-        .values({ organizationId, namespace, key, value })
+        .values(values)
         .onConflictDoUpdate({
           target: [pluginKv.organizationId, pluginKv.namespace, pluginKv.key],
-          set: { value },
+          set: { value: sql`excluded.value` },
         });
     }).pipe(Effect.orDie),
 
-  delete: (namespace, key) =>
+  delete: (namespace, keys) =>
     Effect.tryPromise(async () => {
+      if (keys.length === 0) return 0;
       const result = await db
         .delete(pluginKv)
         .where(
           and(
             eq(pluginKv.organizationId, organizationId),
             eq(pluginKv.namespace, namespace),
-            eq(pluginKv.key, key),
+            inArray(pluginKv.key, [...keys]),
           ),
         )
         .returning();
-      return result.length > 0;
+      return result.length;
     }).pipe(Effect.orDie),
 
   list: (namespace) =>
@@ -69,8 +77,5 @@ export const makePgKv = (db: DrizzleDb, organizationId: string): Kv => ({
       return result.length;
     }).pipe(Effect.orDie),
 
-  withTransaction: <A, E>(effect: Effect.Effect<A, E, never>) =>
-    // Drizzle handles transactions at the query level;
-    // for the KV escape hatch we just pass through
-    effect,
+  withTransaction: <A, E>(effect: Effect.Effect<A, E, never>) => effect,
 });

--- a/packages/plugins/google-discovery/src/sdk/binding-store.ts
+++ b/packages/plugins/google-discovery/src/sdk/binding-store.ts
@@ -55,7 +55,7 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): GoogleDiscoveryBindin
     }),
 
   put: (toolId, namespace, binding) =>
-    bindings.set(toolId, encodeBindingEntry({ namespace, binding })),
+    bindings.set([{ key: toolId, value: encodeBindingEntry({ namespace, binding }) }]),
 
   listByNamespace: (namespace) =>
     Effect.gen(function* () {
@@ -76,17 +76,15 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): GoogleDiscoveryBindin
       const ids: ToolId[] = [];
       for (const entry of entries) {
         const decoded = decodeBindingEntry(entry.value);
-        if (decoded.namespace === namespace) {
-          ids.push(entry.key as ToolId);
-          yield* bindings.delete(entry.key);
-        }
+        if (decoded.namespace === namespace) ids.push(entry.key as ToolId);
       }
+      if (ids.length > 0) yield* bindings.delete(ids);
       return ids;
     }),
 
-  putSource: (source) => sources.set(source.namespace, JSON.stringify(source)),
+  putSource: (source) => sources.set([{ key: source.namespace, value: JSON.stringify(source) }]),
 
-  removeSource: (namespace) => sources.delete(namespace).pipe(Effect.asVoid),
+  removeSource: (namespace) => sources.delete([namespace]).pipe(Effect.asVoid),
 
   listSources: () =>
     Effect.gen(function* () {

--- a/packages/plugins/graphql/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/graphql/src/sdk/kv-operation-store.ts
@@ -39,9 +39,9 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): GraphqlOperationStore
     }),
 
   put: (toolId, namespace, binding, config) =>
-    bindings.set(toolId, encodeEntry(new StoredEntry({ namespace, binding, config }))),
+    bindings.set([{ key: toolId, value: encodeEntry(new StoredEntry({ namespace, binding, config })) }]),
 
-  remove: (toolId) => bindings.delete(toolId).pipe(Effect.asVoid),
+  remove: (toolId) => bindings.delete([toolId]).pipe(Effect.asVoid),
 
   listByNamespace: (namespace) =>
     Effect.gen(function* () {
@@ -60,17 +60,15 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): GraphqlOperationStore
       const ids: ToolId[] = [];
       for (const e of entries) {
         const entry = decodeEntry(e.value);
-        if (entry.namespace === namespace) {
-          ids.push(e.key as ToolId);
-          yield* bindings.delete(e.key);
-        }
+        if (entry.namespace === namespace) ids.push(e.key as ToolId);
       }
+      if (ids.length > 0) yield* bindings.delete(ids);
       return ids;
     }),
 
-  putSource: (source) => sources.set(source.namespace, encodeSource(source)),
+  putSource: (source) => sources.set([{ key: source.namespace, value: encodeSource(source) }]),
 
-  removeSource: (namespace) => sources.delete(namespace).pipe(Effect.asVoid),
+  removeSource: (namespace) => sources.delete([namespace]).pipe(Effect.asVoid),
 
   listSources: () =>
     Effect.gen(function* () {

--- a/packages/plugins/graphql/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/graphql/src/sdk/kv-operation-store.ts
@@ -39,7 +39,9 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): GraphqlOperationStore
     }),
 
   put: (toolId, namespace, binding, config) =>
-    bindings.set([{ key: toolId, value: encodeEntry(new StoredEntry({ namespace, binding, config })) }]),
+    bindings.set([
+      { key: toolId, value: encodeEntry(new StoredEntry({ namespace, binding, config })) },
+    ]),
 
   remove: (toolId) => bindings.delete([toolId]).pipe(Effect.asVoid),
 

--- a/packages/plugins/mcp/src/sdk/binding-store.ts
+++ b/packages/plugins/mcp/src/sdk/binding-store.ts
@@ -80,9 +80,9 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): McpBindingStore => ({
     }),
 
   put: (toolId, namespace, binding, sourceData) =>
-    bindings.set(toolId, encodeBindingEntry({ namespace, binding, sourceData })),
+    bindings.set([{ key: toolId, value: encodeBindingEntry({ namespace, binding, sourceData }) }]),
 
-  remove: (toolId) => bindings.delete(toolId).pipe(Effect.asVoid),
+  remove: (toolId) => bindings.delete([toolId]).pipe(Effect.asVoid),
 
   listByNamespace: (namespace) =>
     Effect.gen(function* () {
@@ -101,19 +101,17 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): McpBindingStore => ({
       const ids: ToolId[] = [];
       for (const e of entries) {
         const entry = decodeBindingEntry(e.value);
-        if (entry.namespace === namespace) {
-          ids.push(e.key as ToolId);
-          yield* bindings.delete(e.key);
-        }
+        if (entry.namespace === namespace) ids.push(e.key as ToolId);
       }
+      if (ids.length > 0) yield* bindings.delete(ids);
       return ids;
     }),
 
   // ---- Sources (meta + config combined) ----
 
-  putSource: (source) => sources.set(source.namespace, JSON.stringify(source)),
+  putSource: (source) => sources.set([{ key: source.namespace, value: JSON.stringify(source) }]),
 
-  removeSource: (namespace) => sources.delete(namespace).pipe(Effect.asVoid),
+  removeSource: (namespace) => sources.delete([namespace]).pipe(Effect.asVoid),
 
   listSources: () =>
     Effect.gen(function* () {

--- a/packages/plugins/onepassword/src/sdk/plugin.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.ts
@@ -150,16 +150,16 @@ const loadConfig = (kv: ScopedKv): Effect.Effect<OnePasswordConfig | null, OnePa
   );
 
 const saveConfig = (kv: ScopedKv, config: OnePasswordConfig): Effect.Effect<void> =>
-  kv.set(
-    CONFIG_KEY,
-    JSON.stringify({
+  kv.set([{
+    key: CONFIG_KEY,
+    value: JSON.stringify({
       auth: config.auth,
       vaultId: config.vaultId,
       name: config.name,
     }),
-  );
+  }]);
 
-const deleteConfig = (kv: ScopedKv): Effect.Effect<void> => kv.delete(CONFIG_KEY);
+const deleteConfig = (kv: ScopedKv): Effect.Effect<void> => kv.delete([CONFIG_KEY]).pipe(Effect.asVoid);
 
 // ---------------------------------------------------------------------------
 // Plugin factory

--- a/packages/plugins/onepassword/src/sdk/plugin.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.ts
@@ -150,16 +150,19 @@ const loadConfig = (kv: ScopedKv): Effect.Effect<OnePasswordConfig | null, OnePa
   );
 
 const saveConfig = (kv: ScopedKv, config: OnePasswordConfig): Effect.Effect<void> =>
-  kv.set([{
-    key: CONFIG_KEY,
-    value: JSON.stringify({
-      auth: config.auth,
-      vaultId: config.vaultId,
-      name: config.name,
-    }),
-  }]);
+  kv.set([
+    {
+      key: CONFIG_KEY,
+      value: JSON.stringify({
+        auth: config.auth,
+        vaultId: config.vaultId,
+        name: config.name,
+      }),
+    },
+  ]);
 
-const deleteConfig = (kv: ScopedKv): Effect.Effect<void> => kv.delete([CONFIG_KEY]).pipe(Effect.asVoid);
+const deleteConfig = (kv: ScopedKv): Effect.Effect<void> =>
+  kv.delete([CONFIG_KEY]).pipe(Effect.asVoid);
 
 // ---------------------------------------------------------------------------
 // Plugin factory

--- a/packages/plugins/openapi/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/kv-operation-store.ts
@@ -49,15 +49,15 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): OpenApiOperationStore
     put: (entries: readonly StoredOperation[]) =>
       withKvTransaction(
         bindings,
-        Effect.forEach(
-          entries,
-          ({ toolId, namespace, binding, config }) =>
-            bindings.set(toolId, encodeEntry(new StoredEntry({ namespace, binding, config }))),
-          { discard: true },
+        bindings.set(
+          entries.map(({ toolId, namespace, binding, config }) => ({
+            key: toolId,
+            value: encodeEntry(new StoredEntry({ namespace, binding, config })),
+          })),
         ),
       ),
 
-    remove: (toolId) => bindings.delete(toolId).pipe(Effect.asVoid),
+    remove: (toolId) => bindings.delete([toolId]).pipe(Effect.asVoid),
 
     listByNamespace: (namespace) =>
       Effect.gen(function* () {
@@ -76,17 +76,15 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): OpenApiOperationStore
         const ids: ToolId[] = [];
         for (const e of entries) {
           const entry = decodeEntry(e.value);
-          if (entry.namespace === namespace) {
-            ids.push(e.key as ToolId);
-            yield* bindings.delete(e.key);
-          }
+          if (entry.namespace === namespace) ids.push(e.key as ToolId);
         }
+        if (ids.length > 0) yield* bindings.delete(ids);
         return ids;
       }),
 
-    putSource: (source) => sources.set(source.namespace, encodeSource(source)),
+    putSource: (source) => sources.set([{ key: source.namespace, value: encodeSource(source) }]),
 
-    removeSource: (namespace) => sources.delete(namespace).pipe(Effect.asVoid),
+    removeSource: (namespace) => sources.delete([namespace]).pipe(Effect.asVoid),
 
     listSources: () =>
       Effect.gen(function* () {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,6 @@
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.7.0",
-    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "catalog:",
     "react-day-picker": "^9.14.0",

--- a/packages/react/src/components/sonner.tsx
+++ b/packages/react/src/components/sonner.tsx
@@ -7,15 +7,12 @@ import {
   OctagonXIcon,
   TriangleAlertIcon,
 } from "lucide-react";
-import { useTheme } from "next-themes";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
-
   return (
     <Sonner
-      theme={theme as ToasterProps["theme"]}
+      theme="system"
       className="toaster group"
       icons={{
         success: <CircleCheckIcon className="size-4" />,


### PR DESCRIPTION
## Summary
- Change `Kv.set` to accept `readonly KvEntry[]` instead of single key/value
- Change `Kv.delete` to accept `readonly string[]` instead of single key
- Postgres impl uses single `INSERT ON CONFLICT` and `DELETE WHERE IN` queries
- All plugins, storage backends, and tests updated

For a 218-tool OpenAPI spec (Sentry), this reduces source add/delete from ~218 individual DB statements to 1.

## Test plan
- [ ] `vitest run` passes for storage-postgres
- [ ] Typecheck passes across monorepo
- [ ] Lint clean