### PR TITLE
fix(ci): typecheck and format fixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+**/routeTree.gen.ts

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -49,7 +49,7 @@ function PlansPage() {
   const isLoading = customerLoading || plansLoading;
 
   const paidPlans = (plans ?? ([] as Plan[])).filter(
-    (p) => p.id === "hobby" || p.id === "professional",
+    (p: Plan) => p.id === "hobby" || p.id === "professional",
   );
 
   return (
@@ -91,7 +91,7 @@ function PlansPage() {
               isFetching ? "opacity-50 pointer-events-none" : "",
             ].join(" ")}
           >
-            {paidPlans.map((plan) => {
+            {paidPlans.map((plan: Plan) => {
               const meta = PLAN_META[plan.id];
               if (!meta) return null;
 

--- a/bun.lock
+++ b/bun.lock
@@ -655,6 +655,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "postgres@3.4.9": "patches/postgres@3.4.9.patch",
+  },
   "catalog": {
     "@effect/cli": "^0.73.2",
     "@effect/experimental": "^0.60.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "release:publish": "bun run --cwd apps/cli release:publish",
     "release:publish:packages": "bun run scripts/publish-packages.ts",
     "release:publish:packages:dry-run": "bun run scripts/publish-packages.ts --dry-run",
+    "clean": "rm -rf node_modules .turbo .astro dist && find apps packages -maxdepth 5 \\( -name node_modules -o -name dist -o -name .turbo -o -name .output -o -name .astro -o -name '*.tsbuildinfo' \\) -not -path '*/node_modules/*' -exec rm -rf {} +",
     "prepare": "effect-language-service patch"
   },
   "dependencies": {},
@@ -100,5 +101,8 @@
     "quickjs-emscripten": "^0.31.0",
     "@jitl/quickjs-wasmfile-release-sync": "0.31.0",
     "tsup": "^8.5.0"
+  },
+  "patchedDependencies": {
+    "postgres@3.4.9": "patches/postgres@3.4.9.patch"
   }
 }

--- a/packages/react/src/lib/shiki.ts
+++ b/packages/react/src/lib/shiki.ts
@@ -103,9 +103,7 @@ export type SupportedTheme = (typeof SUPPORTED_THEMES)[number];
 export const DEFAULT_LIGHT_THEME: SupportedTheme = "github-light";
 export const DEFAULT_DARK_THEME: SupportedTheme = "github-dark";
 
-export type ShikiThemeProp =
-  | SupportedTheme
-  | { light: SupportedTheme; dark: SupportedTheme };
+export type ShikiThemeProp = SupportedTheme | { light: SupportedTheme; dark: SupportedTheme };
 
 /**
  * Resolve a `ShikiThemeProp` (either a single theme or a `{ light, dark }`
@@ -143,10 +141,7 @@ let _promise: Promise<HighlighterCore> | null = null;
 export function getHighlighter(): Promise<HighlighterCore> {
   if (!_promise) {
     _promise = createHighlighterCore({
-      themes: [
-        import("@shikijs/themes/github-dark"),
-        import("@shikijs/themes/github-light"),
-      ],
+      themes: [import("@shikijs/themes/github-dark"), import("@shikijs/themes/github-light")],
       langs: Object.values(LANG_LOADERS).map((loader) => loader()),
       engine: jsEngine,
     });
@@ -178,10 +173,7 @@ export function createCodeHighlighterPlugin(): CodeHighlighterPlugin {
     name: "shiki" as const,
     type: "code-highlighter" as const,
     getSupportedLanguages: () => [...SUPPORTED_LANGS] as string[] as never,
-    getThemes: () => [
-      DEFAULT_LIGHT_THEME as ThemeInput,
-      DEFAULT_DARK_THEME as ThemeInput,
-    ],
+    getThemes: () => [DEFAULT_LIGHT_THEME as ThemeInput, DEFAULT_DARK_THEME as ThemeInput],
     supportsLanguage: (language: string) => isSupportedLang(language),
     highlight(options, callback) {
       const resolved = resolveLang(options.language);

--- a/patches/postgres@3.4.9.patch
+++ b/patches/postgres@3.4.9.patch
@@ -1,0 +1,75 @@
+diff --git a/Users/rhyssullivan/src/executor/node_modules/postgres/.bun-tag-143b5ae176ff48e1 b/.bun-tag-143b5ae176ff48e1
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/Users/rhyssullivan/src/executor/node_modules/postgres/.bun-tag-4eedc358e39b7c2a b/.bun-tag-4eedc358e39b7c2a
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/Users/rhyssullivan/src/executor/node_modules/postgres/.bun-tag-9ff967fa16bcf459 b/.bun-tag-9ff967fa16bcf459
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/Users/rhyssullivan/src/executor/node_modules/postgres/.bun-tag-a742c4db68849f09 b/.bun-tag-a742c4db68849f09
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/cf/polyfills.js b/cf/polyfills.js
+index 53c5203dd5b057d741d14d708ba83b27751b527c..9e5db3cde4e2a17c6e45b28621058259c193f1a6 100644
+--- a/cf/polyfills.js
++++ b/cf/polyfills.js
+@@ -116,7 +116,10 @@ export const tls = {
+     tcp.raw = tcp.raw.startTls({ servername })
+     tcp.raw.closed.then(
+       () => tcp.emit('close'),
+-      (e) => tcp.emit('error', e)
++      (e) => {
++        if (e && e.message === 'Stream was cancelled.') return tcp.emit('close')
++        tcp.emit('error', e)
++      }
+     )
+     tcp.writer = tcp.raw.writable.getWriter()
+     tcp.reader = tcp.raw.readable.getReader()
+@@ -155,7 +158,10 @@ function Socket() {
+             ? close()
+             : ((tcp.readyState = 'open'), tcp.emit('secureConnect'))
+         },
+-        (e) => tcp.emit('error', e)
++        (e) => {
++          if (e && e.message === 'Stream was cancelled.') return close()
++          tcp.emit('error', e)
++        }
+       )
+       tcp.writer = tcp.raw.writable.getWriter()
+       tcp.reader = tcp.raw.readable.getReader()
+@@ -179,7 +185,10 @@ function Socket() {
+   }
+ 
+   function write(data, cb) {
+-    tcp.writer.write(data).then(cb, error)
++    tcp.writer.write(data).then(cb, (err) => {
++      if (err && err.message === 'Stream was cancelled.') return
++      error(err)
++    })
+     return true
+   }
+ 
+@@ -201,13 +210,19 @@ function Socket() {
+       while (({ done, value } = await tcp.reader.read(), !done))
+         tcp.emit('data', Buffer.from(value))
+     } catch (err) {
+-      error(err)
++      if (!(err && err.message === 'Stream was cancelled.'))
++        error(err)
+     }
+   }
+ 
+   async function readFirst() {
+-    const { value } = await tcp.reader.read()
+-    tcp.emit('data', Buffer.from(value))
++    try {
++      const { value } = await tcp.reader.read()
++      tcp.emit('data', Buffer.from(value))
++    } catch (err) {
++      if (!(err && err.message === 'Stream was cancelled.'))
++        error(err)
++    }
+   }
+ 
+   function error(err) {


### PR DESCRIPTION
## Summary

- Annotate callback params in billing plans page so tsgo can infer types
- Add `.prettierignore` to exclude `routeTree.gen.ts` from `oxfmt` formatting
- Patch postgres.js CF polyfill to suppress "Stream was cancelled" teardown noise
- Add root `clean` script to wipe build artifacts across all packages

## Test plan

- [x] `bun run ci` passes (lint, typecheck, test all green)