### PR TITLE
fix(cloud): harden API/plugin error boundaries and prevent MCP leaks

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": []
+  "ignorePatterns": ["**/routeTree.gen.ts"]
 }

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "ignorePatterns": [".astro/"],
+  "ignorePatterns": [".astro/", "**/routeTree.gen.ts"],
 }

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -60,8 +60,8 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.14.3",
-    "@effect/platform-node": "catalog:",
     "@cloudflare/workers-types": "^4.20250620.0",
+    "@effect/platform-node": "catalog:",
     "@effect/vitest": "^0.29.0",
     "@electric-sql/pglite": "^0.4.3",
     "@electric-sql/pglite-socket": "^0.1.3",

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.14.3",
+    "@effect/platform-node": "catalog:",
     "@cloudflare/workers-types": "^4.20250620.0",
     "@effect/vitest": "^0.29.0",
     "@electric-sql/pglite": "^0.4.3",

--- a/apps/cloud/src/api/error-response.ts
+++ b/apps/cloud/src/api/error-response.ts
@@ -24,6 +24,7 @@ export const toErrorResponse = (error: unknown): Response => {
 };
 
 export const toErrorServerResponse = (error: unknown): HttpServerResponse.HttpServerResponse => {
+  console.error("[api] toErrorServerResponse error:", error instanceof Error ? error.stack : error);
   const mapped = toHttpResponseError(error);
   return HttpServerResponse.unsafeJson(
     { error: mapped.message, code: mapped.code },

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -5,7 +5,6 @@ import { setCookie, deleteCookie } from "@tanstack/react-start/server";
 import { AUTH_PATHS, CloudAuthApi, CloudAuthPublicApi } from "./api";
 import { SessionContext } from "./middleware";
 import { UserStoreService } from "./context";
-import { UserStoreError, WorkOSError } from "./errors";
 import { WorkOSAuth } from "./workos";
 import { server } from "../env";
 

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -143,7 +143,7 @@ export class McpSessionDO extends DurableObject {
       return await this.transport.handleRequest(request);
     } catch (err) {
       console.error("[mcp-session] handleRequest error:", err instanceof Error ? err.stack : err);
-      return jsonRpcError(500, -32603, err instanceof Error ? err.message : "Internal error");
+      return jsonRpcError(500, -32603, "Internal error");
     }
   }
 

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -128,7 +128,7 @@ const handleMcpRequest_POST = async (request: Request, token: VerifiedToken): Pr
     return await stub.handleRequest(request);
   } catch (err) {
     console.error("[mcp] POST handler error:", err instanceof Error ? err.stack : err);
-    return jsonRpcError(500, -32603, err instanceof Error ? err.message : "Internal server error");
+    return jsonRpcError(500, -32603, "Internal server error");
   }
 };
 

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -8,190 +8,190 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ToolsRouteImport } from "./routes/tools";
-import { Route as TeamRouteImport } from "./routes/team";
-import { Route as SecretsRouteImport } from "./routes/secrets";
-import { Route as BillingRouteImport } from "./routes/billing";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as SourcesNamespaceRouteImport } from "./routes/sources.$namespace";
-import { Route as BillingPlansRouteImport } from "./routes/billing_.plans";
-import { Route as SourcesAddPluginKeyRouteImport } from "./routes/sources.add.$pluginKey";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ToolsRouteImport } from './routes/tools'
+import { Route as TeamRouteImport } from './routes/team'
+import { Route as SecretsRouteImport } from './routes/secrets'
+import { Route as BillingRouteImport } from './routes/billing'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
+import { Route as BillingPlansRouteImport } from './routes/billing_.plans'
+import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$pluginKey'
 
 const ToolsRoute = ToolsRouteImport.update({
-  id: "/tools",
-  path: "/tools",
+  id: '/tools',
+  path: '/tools',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const TeamRoute = TeamRouteImport.update({
-  id: "/team",
-  path: "/team",
+  id: '/team',
+  path: '/team',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SecretsRoute = SecretsRouteImport.update({
-  id: "/secrets",
-  path: "/secrets",
+  id: '/secrets',
+  path: '/secrets',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingRoute = BillingRouteImport.update({
-  id: "/billing",
-  path: "/billing",
+  id: '/billing',
+  path: '/billing',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SourcesNamespaceRoute = SourcesNamespaceRouteImport.update({
-  id: "/sources/$namespace",
-  path: "/sources/$namespace",
+  id: '/sources/$namespace',
+  path: '/sources/$namespace',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingPlansRoute = BillingPlansRouteImport.update({
-  id: "/billing_/plans",
-  path: "/billing/plans",
+  id: '/billing_/plans',
+  path: '/billing/plans',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
-  id: "/sources/add/$pluginKey",
-  path: "/sources/add/$pluginKey",
+  id: '/sources/add/$pluginKey',
+  path: '/sources/add/$pluginKey',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/team": typeof TeamRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/team": typeof TeamRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRoute;
-  "/secrets": typeof SecretsRoute;
-  "/team": typeof TeamRoute;
-  "/tools": typeof ToolsRoute;
-  "/billing_/plans": typeof BillingPlansRoute;
-  "/sources/$namespace": typeof SourcesNamespaceRoute;
-  "/sources/add/$pluginKey": typeof SourcesAddPluginKeyRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRoute
+  '/secrets': typeof SecretsRoute
+  '/team': typeof TeamRoute
+  '/tools': typeof ToolsRoute
+  '/billing_/plans': typeof BillingPlansRoute
+  '/sources/$namespace': typeof SourcesNamespaceRoute
+  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/team"
-    | "/tools"
-    | "/billing/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/team"
-    | "/tools"
-    | "/billing/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
   id:
-    | "__root__"
-    | "/"
-    | "/billing"
-    | "/secrets"
-    | "/team"
-    | "/tools"
-    | "/billing_/plans"
-    | "/sources/$namespace"
-    | "/sources/add/$pluginKey";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/billing'
+    | '/secrets'
+    | '/team'
+    | '/tools'
+    | '/billing_/plans'
+    | '/sources/$namespace'
+    | '/sources/add/$pluginKey'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  BillingRoute: typeof BillingRoute;
-  SecretsRoute: typeof SecretsRoute;
-  TeamRoute: typeof TeamRoute;
-  ToolsRoute: typeof ToolsRoute;
-  BillingPlansRoute: typeof BillingPlansRoute;
-  SourcesNamespaceRoute: typeof SourcesNamespaceRoute;
-  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute;
+  IndexRoute: typeof IndexRoute
+  BillingRoute: typeof BillingRoute
+  SecretsRoute: typeof SecretsRoute
+  TeamRoute: typeof TeamRoute
+  ToolsRoute: typeof ToolsRoute
+  BillingPlansRoute: typeof BillingPlansRoute
+  SourcesNamespaceRoute: typeof SourcesNamespaceRoute
+  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/tools": {
-      id: "/tools";
-      path: "/tools";
-      fullPath: "/tools";
-      preLoaderRoute: typeof ToolsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/team": {
-      id: "/team";
-      path: "/team";
-      fullPath: "/team";
-      preLoaderRoute: typeof TeamRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/secrets": {
-      id: "/secrets";
-      path: "/secrets";
-      fullPath: "/secrets";
-      preLoaderRoute: typeof SecretsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing": {
-      id: "/billing";
-      path: "/billing";
-      fullPath: "/billing";
-      preLoaderRoute: typeof BillingRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/sources/$namespace": {
-      id: "/sources/$namespace";
-      path: "/sources/$namespace";
-      fullPath: "/sources/$namespace";
-      preLoaderRoute: typeof SourcesNamespaceRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing_/plans": {
-      id: "/billing_/plans";
-      path: "/billing/plans";
-      fullPath: "/billing/plans";
-      preLoaderRoute: typeof BillingPlansRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/sources/add/$pluginKey": {
-      id: "/sources/add/$pluginKey";
-      path: "/sources/add/$pluginKey";
-      fullPath: "/sources/add/$pluginKey";
-      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/tools': {
+      id: '/tools'
+      path: '/tools'
+      fullPath: '/tools'
+      preLoaderRoute: typeof ToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/team': {
+      id: '/team'
+      path: '/team'
+      fullPath: '/team'
+      preLoaderRoute: typeof TeamRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/secrets': {
+      id: '/secrets'
+      path: '/secrets'
+      fullPath: '/secrets'
+      preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing': {
+      id: '/billing'
+      path: '/billing'
+      fullPath: '/billing'
+      preLoaderRoute: typeof BillingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sources/$namespace': {
+      id: '/sources/$namespace'
+      path: '/sources/$namespace'
+      fullPath: '/sources/$namespace'
+      preLoaderRoute: typeof SourcesNamespaceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing_/plans': {
+      id: '/billing_/plans'
+      path: '/billing/plans'
+      fullPath: '/billing/plans'
+      preLoaderRoute: typeof BillingPlansRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/sources/add/$pluginKey': {
+      id: '/sources/add/$pluginKey'
+      path: '/sources/add/$pluginKey'
+      fullPath: '/sources/add/$pluginKey'
+      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -204,17 +204,17 @@ const rootRouteChildren: RootRouteChildren = {
   BillingPlansRoute: BillingPlansRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,
   SourcesAddPluginKeyRoute: SourcesAddPluginKeyRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { startInstance } from "./start.ts";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/apps/local/src/server/mcp.ts
+++ b/apps/local/src/server/mcp.ts
@@ -69,15 +69,12 @@ export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpReq
         }
         return response;
       } catch (error) {
+        console.error("[mcp] handleRequest error:", error instanceof Error ? error.stack : error);
         if (!transport.sessionId) {
           await transport.close().catch(() => undefined);
           await created?.close().catch(() => undefined);
         }
-        return jsonError(
-          500,
-          -32603,
-          error instanceof Error ? error.message : "Internal server error",
-        );
+        return jsonError(500, -32603, "Internal server error");
       }
     },
 

--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.14.3",
         "@cloudflare/workers-types": "^4.20250620.0",
+        "@effect/platform-node": "catalog:",
         "@effect/vitest": "^0.29.0",
         "@electric-sql/pglite": "^0.4.3",
         "@electric-sql/pglite-socket": "^0.1.3",
@@ -3867,7 +3868,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
@@ -3921,13 +3922,11 @@
 
     "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@cloudflare/vite-plugin/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
     "@cloudflare/vitest-pool-workers/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@develar/schema-utils/ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
-
-    "@effect/platform-node/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
-
-    "@effect/platform-node-shared/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
@@ -4228,6 +4227,8 @@
     "mimetext/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "miniflare/undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
+
+    "miniflare/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 

--- a/packages/plugins/google-discovery/src/api/group.ts
+++ b/packages/plugins/google-discovery/src/api/group.ts
@@ -93,45 +93,63 @@ const OAuthCallbackParams = Schema.Struct({
 
 const HtmlResponse = HttpApiSchema.Text({ contentType: "text/html" });
 
-const ApiError = Schema.Struct({
-  message: Schema.String,
-}).annotations(HttpApiSchema.annotations({ status: 400 }));
+export class GoogleDiscoveryApiError extends Schema.TaggedError<GoogleDiscoveryApiError>()(
+  "GoogleDiscoveryApiError",
+  {
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 400 }),
+) {}
+
+export class GoogleDiscoveryInternalError extends Schema.TaggedError<GoogleDiscoveryInternalError>()(
+  "GoogleDiscoveryInternalError",
+  {
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 500 }),
+) {}
 
 export class GoogleDiscoveryGroup extends HttpApiGroup.make("googleDiscovery")
   .add(
     HttpApiEndpoint.post("probeDiscovery")`/scopes/${scopeIdParam}/google-discovery/probe`
       .setPayload(ProbePayload)
       .addSuccess(ProbeResponse)
-      .addError(ApiError),
+      .addError(GoogleDiscoveryApiError)
+      .addError(GoogleDiscoveryInternalError),
   )
   .add(
     HttpApiEndpoint.post("addSource")`/scopes/${scopeIdParam}/google-discovery/sources`
       .setPayload(AddSourcePayload)
       .addSuccess(AddSourceResponse)
-      .addError(ApiError),
+      .addError(GoogleDiscoveryApiError)
+      .addError(GoogleDiscoveryInternalError),
   )
   .add(
     HttpApiEndpoint.post("startOAuth")`/scopes/${scopeIdParam}/google-discovery/oauth/start`
       .setPayload(StartOAuthPayload)
       .addSuccess(StartOAuthResponse)
-      .addError(ApiError),
+      .addError(GoogleDiscoveryApiError)
+      .addError(GoogleDiscoveryInternalError),
   )
   .add(
     HttpApiEndpoint.post("completeOAuth")`/scopes/${scopeIdParam}/google-discovery/oauth/complete`
       .setPayload(CompleteOAuthPayload)
       .addSuccess(CompleteOAuthResponse)
-      .addError(ApiError),
+      .addError(GoogleDiscoveryApiError)
+      .addError(GoogleDiscoveryInternalError),
   )
   .add(
     HttpApiEndpoint.get("oauthCallback")`/google-discovery/oauth/callback`
       .setUrlParams(OAuthCallbackParams)
       .addSuccess(HtmlResponse)
-      .addError(ApiError),
+      .addError(GoogleDiscoveryApiError)
+      .addError(GoogleDiscoveryInternalError),
   )
   .add(
     HttpApiEndpoint.get(
       "getSource",
     )`/scopes/${scopeIdParam}/google-discovery/sources/${namespaceParam}`
       .addSuccess(Schema.NullOr(GoogleDiscoveryStoredSourceSchema))
-      .addError(ApiError),
+      .addError(GoogleDiscoveryApiError)
+      .addError(GoogleDiscoveryInternalError),
   ) {}

--- a/packages/plugins/google-discovery/src/api/handlers.test.ts
+++ b/packages/plugins/google-discovery/src/api/handlers.test.ts
@@ -1,0 +1,78 @@
+import { HttpApiBuilder, HttpServer } from "@effect/platform";
+import { describe, expect, it } from "vitest";
+import { Effect, Layer } from "effect";
+
+import { addGroup } from "@executor/api";
+import {
+  CoreHandlers,
+  ExecutionEngineService,
+  ExecutorService,
+} from "@executor/api/server";
+import type { GoogleDiscoveryPluginExtension } from "../sdk/plugin";
+import {
+  GoogleDiscoveryExtensionService,
+  GoogleDiscoveryHandlers,
+} from "./handlers";
+import { GoogleDiscoveryGroup } from "./group";
+
+const unused = Effect.dieMessage("unused");
+
+const createFailingExtension = (): GoogleDiscoveryPluginExtension => ({
+  probeDiscovery: () => Effect.die(new Error("Not implemented")),
+  addSource: () => unused,
+  removeSource: () => unused,
+  startOAuth: () => unused,
+  completeOAuth: () => Effect.die(new Error("Not implemented")),
+  getSource: () => Effect.succeed(null),
+});
+
+const Api = addGroup(GoogleDiscoveryGroup);
+
+const fakeExecutor = {} as any;
+const fakeExecutionEngine = {} as any;
+
+const createHandler = () =>
+  HttpApiBuilder.toWebHandler(
+    HttpApiBuilder.api(Api).pipe(
+      Layer.provide(CoreHandlers),
+      Layer.provide(GoogleDiscoveryHandlers),
+      Layer.provide(Layer.succeed(ExecutorService, fakeExecutor)),
+      Layer.provide(Layer.succeed(ExecutionEngineService, fakeExecutionEngine)),
+      Layer.provide(
+        Layer.succeed(
+          GoogleDiscoveryExtensionService,
+          createFailingExtension(),
+        ),
+      ),
+      Layer.provideMerge(HttpServer.layerContext),
+      Layer.provideMerge(HttpApiBuilder.Router.Live),
+      Layer.provideMerge(HttpApiBuilder.Middleware.layer),
+    ),
+  );
+
+describe("GoogleDiscoveryHandlers", () => {
+  it("sanitizes unknown endpoint failures", async () => {
+    const web = createHandler();
+    try {
+      const response = await web.handler(
+        new Request("http://localhost/scopes/scope_1/google-discovery/probe", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            discoveryUrl: "https://example.googleapis.com/$discovery/rest?version=v1",
+          }),
+        }),
+      );
+
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body).toEqual({
+        _tag: "GoogleDiscoveryInternalError",
+        message: "Internal server error",
+      });
+      expect(JSON.stringify(body)).not.toContain("Not implemented");
+    } finally {
+      await web.dispose();
+    }
+  });
+});

--- a/packages/plugins/google-discovery/src/api/handlers.test.ts
+++ b/packages/plugins/google-discovery/src/api/handlers.test.ts
@@ -3,16 +3,9 @@ import { describe, expect, it } from "vitest";
 import { Effect, Layer } from "effect";
 
 import { addGroup } from "@executor/api";
-import {
-  CoreHandlers,
-  ExecutionEngineService,
-  ExecutorService,
-} from "@executor/api/server";
+import { CoreHandlers, ExecutionEngineService, ExecutorService } from "@executor/api/server";
 import type { GoogleDiscoveryPluginExtension } from "../sdk/plugin";
-import {
-  GoogleDiscoveryExtensionService,
-  GoogleDiscoveryHandlers,
-} from "./handlers";
+import { GoogleDiscoveryExtensionService, GoogleDiscoveryHandlers } from "./handlers";
 import { GoogleDiscoveryGroup } from "./group";
 
 const unused = Effect.dieMessage("unused");
@@ -38,12 +31,7 @@ const createHandler = () =>
       Layer.provide(GoogleDiscoveryHandlers),
       Layer.provide(Layer.succeed(ExecutorService, fakeExecutor)),
       Layer.provide(Layer.succeed(ExecutionEngineService, fakeExecutionEngine)),
-      Layer.provide(
-        Layer.succeed(
-          GoogleDiscoveryExtensionService,
-          createFailingExtension(),
-        ),
-      ),
+      Layer.provide(Layer.succeed(GoogleDiscoveryExtensionService, createFailingExtension())),
       Layer.provideMerge(HttpServer.layerContext),
       Layer.provideMerge(HttpApiBuilder.Router.Live),
       Layer.provideMerge(HttpApiBuilder.Middleware.layer),

--- a/packages/plugins/google-discovery/src/api/handlers.ts
+++ b/packages/plugins/google-discovery/src/api/handlers.ts
@@ -1,5 +1,5 @@
 import { HttpApiBuilder, HttpServerResponse } from "@effect/platform";
-import { Context, Effect } from "effect";
+import { Cause, Context, Effect } from "effect";
 
 import { addGroup } from "@executor/api";
 import type {
@@ -7,7 +7,17 @@ import type {
   GoogleDiscoveryOAuthAuthResult,
   GoogleDiscoveryPluginExtension,
 } from "../sdk/plugin";
-import { GoogleDiscoveryGroup } from "./group";
+import {
+  GoogleDiscoveryInvocationError,
+  GoogleDiscoveryOAuthError,
+  GoogleDiscoveryParseError,
+  GoogleDiscoverySourceError,
+} from "../sdk/errors";
+import {
+  GoogleDiscoveryApiError,
+  GoogleDiscoveryGroup,
+  GoogleDiscoveryInternalError,
+} from "./group";
 
 export class GoogleDiscoveryExtensionService extends Context.Tag("GoogleDiscoveryExtensionService")<
   GoogleDiscoveryExtensionService,
@@ -66,6 +76,37 @@ const popupDocument = (payload: OAuthPopupResult): string => {
 </body></html>`;
 };
 
+const toPopupErrorMessage = (error: unknown): string => {
+  if (error instanceof GoogleDiscoveryOAuthError) {
+    return error.message;
+  }
+  return "Authentication failed";
+};
+
+const toGoogleDiscoveryApiError = (
+  error: unknown,
+): GoogleDiscoveryApiError | GoogleDiscoveryInternalError => {
+  if (error instanceof GoogleDiscoveryApiError || error instanceof GoogleDiscoveryInternalError) {
+    return error;
+  }
+  if (
+    error instanceof GoogleDiscoveryParseError ||
+    error instanceof GoogleDiscoverySourceError ||
+    error instanceof GoogleDiscoveryOAuthError ||
+    error instanceof GoogleDiscoveryInvocationError
+  ) {
+    return new GoogleDiscoveryApiError({ message: error.message });
+  }
+  return new GoogleDiscoveryInternalError({ message: "Internal server error" });
+};
+
+const sanitizeGoogleDiscoveryFailure = <A, R>(
+  effect: Effect.Effect<A, unknown, R>,
+): Effect.Effect<A, GoogleDiscoveryApiError | GoogleDiscoveryInternalError, R> =>
+  Effect.catchAllCause(effect, (cause) =>
+    Effect.fail(toGoogleDiscoveryApiError(Cause.squash(cause))),
+  );
+
 export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
   ExecutorApiWithGoogleDiscovery,
   "googleDiscovery",
@@ -75,13 +116,13 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
         Effect.gen(function* () {
           const ext = yield* GoogleDiscoveryExtensionService;
           return yield* ext.probeDiscovery(payload.discoveryUrl);
-        }).pipe(Effect.orDie),
+        }).pipe(sanitizeGoogleDiscoveryFailure),
       )
       .handle("addSource", ({ payload }) =>
         Effect.gen(function* () {
           const ext = yield* GoogleDiscoveryExtensionService;
           return yield* ext.addSource(payload as GoogleDiscoveryAddSourceInput);
-        }).pipe(Effect.orDie),
+        }).pipe(sanitizeGoogleDiscoveryFailure),
       )
       .handle("startOAuth", ({ payload }) =>
         Effect.gen(function* () {
@@ -94,7 +135,7 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
             redirectUrl: payload.redirectUrl,
             scopes: payload.scopes,
           });
-        }).pipe(Effect.orDie),
+        }).pipe(sanitizeGoogleDiscoveryFailure),
       )
       .handle("completeOAuth", ({ payload }) =>
         Effect.gen(function* () {
@@ -104,13 +145,13 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
             code: payload.code,
             error: payload.error,
           });
-        }).pipe(Effect.orDie),
+        }).pipe(sanitizeGoogleDiscoveryFailure),
       )
       .handle("getSource", ({ path }) =>
         Effect.gen(function* () {
           const ext = yield* GoogleDiscoveryExtensionService;
           return yield* ext.getSource(path.namespace);
-        }).pipe(Effect.orDie),
+        }).pipe(sanitizeGoogleDiscoveryFailure),
       )
       .handle("oauthCallback", ({ urlParams }) =>
         Effect.gen(function* () {
@@ -130,16 +171,16 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
                   ...auth,
                 }),
               ),
-              Effect.catchAll((error) =>
+              Effect.catchAllCause((cause) =>
                 Effect.succeed<OAuthPopupResult>({
                   type: "executor:oauth-result",
                   ok: false,
                   sessionId: null,
-                  error: error instanceof Error ? error.message : String(error),
+                  error: toPopupErrorMessage(Cause.squash(cause)),
                 }),
               ),
             );
           return yield* HttpServerResponse.html(popupDocument(result));
-        }).pipe(Effect.orDie),
+        }).pipe(sanitizeGoogleDiscoveryFailure),
       ),
 );

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -152,9 +152,21 @@ const CompleteOAuthResponse = Schema.Struct({
 // Error
 // ---------------------------------------------------------------------------
 
-const McpApiError = Schema.Struct({
-  message: Schema.String,
-}).annotations(HttpApiSchema.annotations({ status: 400 }));
+export class McpApiError extends Schema.TaggedError<McpApiError>()(
+  "McpApiError",
+  {
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 400 }),
+) {}
+
+export class McpInternalError extends Schema.TaggedError<McpInternalError>()(
+  "McpInternalError",
+  {
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 500 }),
+) {}
 
 // ---------------------------------------------------------------------------
 // Group
@@ -165,52 +177,61 @@ export class McpGroup extends HttpApiGroup.make("mcp")
     HttpApiEndpoint.post("probeEndpoint")`/scopes/${scopeIdParam}/mcp/probe`
       .setPayload(ProbeEndpointPayload)
       .addSuccess(ProbeEndpointResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.post("addSource")`/scopes/${scopeIdParam}/mcp/sources`
       .setPayload(AddSourcePayload)
       .addSuccess(AddSourceResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.post("removeSource")`/scopes/${scopeIdParam}/mcp/sources/remove`
       .setPayload(NamespacePayload)
       .addSuccess(RemoveSourceResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.post("refreshSource")`/scopes/${scopeIdParam}/mcp/sources/refresh`
       .setPayload(NamespacePayload)
       .addSuccess(RefreshSourceResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.post("startOAuth")`/scopes/${scopeIdParam}/mcp/oauth/start`
       .setPayload(StartOAuthPayload)
       .addSuccess(StartOAuthResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.post("completeOAuth")`/scopes/${scopeIdParam}/mcp/oauth/complete`
       .setPayload(CompleteOAuthPayload)
       .addSuccess(CompleteOAuthResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.get("oauthCallback")`/mcp/oauth/callback`
       .setUrlParams(OAuthCallbackParams)
       .addSuccess(HtmlResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.get("getSource")`/scopes/${scopeIdParam}/mcp/sources/${namespaceParam}`
       .addSuccess(Schema.NullOr(McpStoredSourceSchema))
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   )
   .add(
     HttpApiEndpoint.patch("updateSource")`/scopes/${scopeIdParam}/mcp/sources/${namespaceParam}`
       .setPayload(UpdateSourcePayload)
       .addSuccess(UpdateSourceResponse)
-      .addError(McpApiError),
+      .addError(McpApiError)
+      .addError(McpInternalError),
   ) {}

--- a/packages/plugins/mcp/src/api/handlers.test.ts
+++ b/packages/plugins/mcp/src/api/handlers.test.ts
@@ -1,0 +1,70 @@
+import { HttpApiBuilder, HttpServer } from "@effect/platform";
+import { describe, expect, it } from "vitest";
+import { Effect, Layer } from "effect";
+
+import { addGroup } from "@executor/api";
+import {
+  CoreHandlers,
+  ExecutionEngineService,
+  ExecutorService,
+} from "@executor/api/server";
+import type { McpPluginExtension } from "../sdk/plugin";
+import { McpExtensionService, McpHandlers } from "./handlers";
+import { McpGroup } from "./group";
+
+const unused = Effect.dieMessage("unused");
+
+const createFailingExtension = (): McpPluginExtension => ({
+  probeEndpoint: () => Effect.die(new Error("Not implemented")),
+  addSource: () => unused,
+  removeSource: () => unused,
+  refreshSource: () => unused,
+  startOAuth: () => unused,
+  completeOAuth: () => Effect.die(new Error("Not implemented")),
+  getSource: () => Effect.succeed(null),
+  updateSource: () => unused,
+});
+
+const Api = addGroup(McpGroup);
+
+const fakeExecutor = {} as any;
+const fakeExecutionEngine = {} as any;
+
+const createHandler = () =>
+  HttpApiBuilder.toWebHandler(
+    HttpApiBuilder.api(Api).pipe(
+      Layer.provide(CoreHandlers),
+      Layer.provide(McpHandlers),
+      Layer.provide(Layer.succeed(ExecutorService, fakeExecutor)),
+      Layer.provide(Layer.succeed(ExecutionEngineService, fakeExecutionEngine)),
+      Layer.provide(Layer.succeed(McpExtensionService, createFailingExtension())),
+      Layer.provideMerge(HttpServer.layerContext),
+      Layer.provideMerge(HttpApiBuilder.Router.Live),
+      Layer.provideMerge(HttpApiBuilder.Middleware.layer),
+    ),
+  );
+
+describe("McpHandlers", () => {
+  it("sanitizes unknown endpoint failures", async () => {
+    const web = createHandler();
+    try {
+      const response = await web.handler(
+        new Request("http://localhost/scopes/scope_1/mcp/probe", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ endpoint: "https://example.com/mcp" }),
+        }),
+      );
+
+      expect(response.status).toBe(500);
+      const body = await response.json();
+      expect(body).toEqual({
+        _tag: "McpInternalError",
+        message: "Internal server error",
+      });
+      expect(JSON.stringify(body)).not.toContain("Not implemented");
+    } finally {
+      await web.dispose();
+    }
+  });
+});

--- a/packages/plugins/mcp/src/api/handlers.test.ts
+++ b/packages/plugins/mcp/src/api/handlers.test.ts
@@ -3,11 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Effect, Layer } from "effect";
 
 import { addGroup } from "@executor/api";
-import {
-  CoreHandlers,
-  ExecutionEngineService,
-  ExecutorService,
-} from "@executor/api/server";
+import { CoreHandlers, ExecutionEngineService, ExecutorService } from "@executor/api/server";
 import type { McpPluginExtension } from "../sdk/plugin";
 import { McpExtensionService, McpHandlers } from "./handlers";
 import { McpGroup } from "./group";

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -1,9 +1,15 @@
 import { HttpApiBuilder, HttpServerResponse } from "@effect/platform";
-import { Context, Effect } from "effect";
+import { Cause, Context, Effect } from "effect";
 
 import { addGroup } from "@executor/api";
 import type { McpPluginExtension, McpSourceConfig, McpUpdateSourceInput } from "../sdk/plugin";
-import { McpGroup } from "./group";
+import {
+  McpConnectionError,
+  McpInvocationError,
+  McpOAuthError,
+  McpToolDiscoveryError,
+} from "../sdk/errors";
+import { McpApiError, McpGroup, McpInternalError } from "./group";
 
 // ---------------------------------------------------------------------------
 // Service tag
@@ -79,6 +85,33 @@ const popupDocument = (payload: OAuthPopupResult): string => {
 </body></html>`;
 };
 
+const toPopupErrorMessage = (error: unknown): string => {
+  if (error instanceof McpOAuthError) {
+    return error.message;
+  }
+  return "Authentication failed";
+};
+
+const toMcpApiError = (error: unknown): McpApiError | McpInternalError => {
+  if (error instanceof McpApiError || error instanceof McpInternalError) {
+    return error;
+  }
+  if (
+    error instanceof McpConnectionError ||
+    error instanceof McpToolDiscoveryError ||
+    error instanceof McpInvocationError ||
+    error instanceof McpOAuthError
+  ) {
+    return new McpApiError({ message: error.message });
+  }
+  return new McpInternalError({ message: "Internal server error" });
+};
+
+const sanitizeMcpFailure = <A, R>(
+  effect: Effect.Effect<A, unknown, R>,
+): Effect.Effect<A, McpApiError | McpInternalError, R> =>
+  Effect.catchAllCause(effect, (cause) => Effect.fail(toMcpApiError(Cause.squash(cause))));
+
 // ---------------------------------------------------------------------------
 // Convert API payload → McpSourceConfig
 // ---------------------------------------------------------------------------
@@ -150,7 +183,7 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
       Effect.gen(function* () {
         const ext = yield* McpExtensionService;
         return yield* ext.probeEndpoint(payload.endpoint);
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("addSource", ({ payload }) =>
       Effect.gen(function* () {
@@ -158,20 +191,20 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
         return yield* ext.addSource(
           toSourceConfig(payload as Parameters<typeof toSourceConfig>[0]),
         );
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("removeSource", ({ payload }) =>
       Effect.gen(function* () {
         const ext = yield* McpExtensionService;
         yield* ext.removeSource(payload.namespace);
         return { removed: true };
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("refreshSource", ({ payload }) =>
       Effect.gen(function* () {
         const ext = yield* McpExtensionService;
         return yield* ext.refreshSource(payload.namespace);
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("startOAuth", ({ payload }) =>
       Effect.gen(function* () {
@@ -181,7 +214,7 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
           redirectUrl: payload.redirectUrl,
           queryParams: payload.queryParams,
         });
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("completeOAuth", ({ payload }) =>
       Effect.gen(function* () {
@@ -191,13 +224,13 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
           code: payload.code,
           error: payload.error,
         });
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("getSource", ({ path }) =>
       Effect.gen(function* () {
         const ext = yield* McpExtensionService;
         return yield* ext.getSource(path.namespace);
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("updateSource", ({ path, payload }) =>
       Effect.gen(function* () {
@@ -209,7 +242,7 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
           auth: payload.auth as McpUpdateSourceInput["auth"],
         });
         return { updated: true };
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     )
     .handle("oauthCallback", ({ urlParams }) =>
       Effect.gen(function* () {
@@ -233,16 +266,16 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
                 scope: c.scope,
               }),
             ),
-            Effect.catchAll((error) =>
-              Effect.succeed<OAuthPopupResult>({
-                type: "executor:oauth-result",
-                ok: false,
-                sessionId: null,
-                error: error instanceof Error ? error.message : String(error),
-              }),
-            ),
-          );
+              Effect.catchAllCause((cause) =>
+                Effect.succeed<OAuthPopupResult>({
+                  type: "executor:oauth-result",
+                  ok: false,
+                  sessionId: null,
+                  error: toPopupErrorMessage(Cause.squash(cause)),
+                }),
+              ),
+            );
         return yield* HttpServerResponse.html(popupDocument(result));
-      }).pipe(Effect.orDie),
+      }).pipe(sanitizeMcpFailure),
     ),
 );

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -266,15 +266,15 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
                 scope: c.scope,
               }),
             ),
-              Effect.catchAllCause((cause) =>
-                Effect.succeed<OAuthPopupResult>({
-                  type: "executor:oauth-result",
-                  ok: false,
-                  sessionId: null,
-                  error: toPopupErrorMessage(Cause.squash(cause)),
-                }),
-              ),
-            );
+            Effect.catchAllCause((cause) =>
+              Effect.succeed<OAuthPopupResult>({
+                type: "executor:oauth-result",
+                ok: false,
+                sessionId: null,
+                error: toPopupErrorMessage(Cause.squash(cause)),
+              }),
+            ),
+          );
         return yield* HttpServerResponse.html(popupDocument(result));
       }).pipe(sanitizeMcpFailure),
     ),


### PR DESCRIPTION
## Summary
Follow-up cleanup after #182 (already in `main`). This PR now only contains incremental hardening changes:
- harden plugin HTTP API error boundaries so unknown failures are sanitized
- prevent raw internal exception messages from leaking in cloud/local MCP JSON-RPC responses
- small cloud auth lint cleanup

## What Changed
- MCP + Google Discovery API groups now use explicit tagged API/internal error types instead of permissive structural `{ message: string }` errors
- MCP + Google Discovery handlers sanitize unknown failures/defects into safe internal errors
- OAuth popup callback paths sanitize unknown errors to a generic user-facing message
- cloud/local MCP request handlers now return generic internal JSON-RPC errors while logging full server-side details
- removed unused imports in cloud auth handlers

## Verification
- bun run lint
- bun run typecheck
- bun x vitest run src/api/handlers.test.ts src/sdk/plugin.test.ts (packages/plugins/mcp)
- bun x vitest run src/api/handlers.test.ts src/sdk/plugin.test.ts (packages/plugins/google-discovery)
- bun x vitest run src/index.test.ts (packages/core/sdk)