### PR TITLE
refactor(mcp): adopt shared primitives in Add/Edit source forms

### DIFF
--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -1,15 +1,33 @@
-import { useReducer, useCallback, useEffect, useRef, useState } from "react";
+import { useReducer, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntry,
+  CardStackEntryActions,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+  CardStackEntryField,
+  CardStackEntryMedia,
+  CardStackEntryTitle,
+} from "@executor/react/components/card-stack";
+import { FieldError } from "@executor/react/components/field";
+import { FloatActions } from "@executor/react/components/float-actions";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
-import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
-import { Spinner } from "@executor/react/components/spinner";
+import { Skeleton } from "@executor/react/components/skeleton";
+import { SourceFavicon } from "@executor/react/components/source-favicon";
+import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
 import { Textarea } from "@executor/react/components/textarea";
-import { SecretHeaderAuthRow } from "@executor/react/plugins/secret-header-auth";
+import {
+  AuthenticationSection,
+  type AuthMethod,
+  type AuthHeaderEntry,
+} from "@executor/react/plugins/authentication-section";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { probeMcpEndpoint, addMcpSource, startMcpOAuth } from "./atoms";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
@@ -44,8 +62,6 @@ type ProbeResult = {
   serverName: string | null;
 };
 
-type RemoteAuthMode = "none" | "header" | "oauth2";
-
 type PlainHeader = {
   name: string;
   value: string;
@@ -56,9 +72,19 @@ type State =
   | { step: "probing"; url: string }
   | { step: "probed"; url: string; probe: ProbeResult }
   | { step: "oauth-starting"; url: string; probe: ProbeResult }
-  | { step: "oauth-waiting"; url: string; probe: ProbeResult; sessionId: string }
+  | {
+      step: "oauth-waiting";
+      url: string;
+      probe: ProbeResult;
+      sessionId: string;
+    }
   | { step: "oauth-done"; url: string; probe: ProbeResult; tokens: OAuthTokens }
-  | { step: "adding"; url: string; probe: ProbeResult; tokens: OAuthTokens | null }
+  | {
+      step: "adding";
+      url: string;
+      probe: ProbeResult;
+      tokens: OAuthTokens | null;
+    }
   | {
       step: "error";
       url: string;
@@ -95,7 +121,13 @@ function reducer(state: State, action: Action): State {
       return { step: "probed", url: state.url, probe: action.probe };
 
     case "probe-fail":
-      return { step: "error", url: state.url, probe: null, tokens: null, error: action.error };
+      return {
+        step: "error",
+        url: state.url,
+        probe: null,
+        tokens: null,
+        error: action.error,
+      };
 
     case "oauth-start":
       if (state.step !== "probed" && state.step !== "error") return state;
@@ -116,7 +148,12 @@ function reducer(state: State, action: Action): State {
 
     case "oauth-ok":
       if (state.step !== "oauth-waiting") return state;
-      return { step: "oauth-done", url: state.url, probe: state.probe, tokens: action.tokens };
+      return {
+        step: "oauth-done",
+        url: state.url,
+        probe: state.probe,
+        tokens: action.tokens,
+      };
 
     case "oauth-fail":
       if (state.step !== "oauth-starting" && state.step !== "oauth-waiting") return state;
@@ -154,7 +191,12 @@ function reducer(state: State, action: Action): State {
       if (state.step !== "error") return state;
       return state.probe
         ? state.tokens
-          ? { step: "oauth-done", url: state.url, probe: state.probe, tokens: state.tokens }
+          ? {
+              step: "oauth-done",
+              url: state.url,
+              probe: state.probe,
+              tokens: state.tokens,
+            }
           : { step: "probed", url: state.url, probe: state.probe }
         : { step: "url", url: state.url };
     }
@@ -169,8 +211,17 @@ function reducer(state: State, action: Action): State {
 // ---------------------------------------------------------------------------
 
 type OAuthPopupResult =
-  | ({ type: "executor:oauth-result"; ok: true; sessionId: string } & OAuthTokens)
-  | { type: "executor:oauth-result"; ok: false; sessionId: null; error: string };
+  | ({
+      type: "executor:oauth-result";
+      ok: true;
+      sessionId: string;
+    } & OAuthTokens)
+  | {
+      type: "executor:oauth-result";
+      ok: false;
+      sessionId: null;
+      error: string;
+    };
 
 const OAUTH_RESULT_CHANNEL = "executor:mcp-oauth-result";
 
@@ -267,28 +318,25 @@ export default function AddMcpSource(props: {
   const doStartOAuth = useAtomSet(startMcpOAuth, { mode: "promise" });
   const secretList = useSecretPickerSecrets();
 
-  const [remoteAuthMode, setRemoteAuthMode] = useState<RemoteAuthMode>("none");
-  const [remoteHeaderAuth, setRemoteHeaderAuth] = useState<{
-    name: string;
-    prefix?: string;
-    presetKey?: string;
-    secretId: string | null;
-  }>({
-    name: "Authorization",
-    prefix: "Bearer ",
-    presetKey: "bearer",
-    secretId: null,
-  });
+  const [remoteAuthMode, setRemoteAuthMode] = useState<AuthMethod>("none");
+  const [remoteAuthHeaders, setRemoteAuthHeaders] = useState<AuthHeaderEntry[]>([
+    {
+      name: "Authorization",
+      prefix: "Bearer ",
+      presetKey: "bearer",
+      secretId: null,
+    },
+  ]);
   const [remoteHeaders, setRemoteHeaders] = useState<PlainHeader[]>([]);
 
   const probe = "probe" in state ? state.probe : null;
   const tokens = "tokens" in state ? state.tokens : null;
-  const isIdle = state.step === "url";
   const isProbing = state.step === "probing";
   const isAdding = state.step === "adding";
   const isOAuthBusy = state.step === "oauth-starting" || state.step === "oauth-waiting";
   const canUseNone = probe?.requiresOAuth !== true;
-  const headerAuthComplete = Boolean(remoteHeaderAuth.name.trim() && remoteHeaderAuth.secretId);
+  const remoteAuthHeader = remoteAuthHeaders[0];
+  const headerAuthComplete = Boolean(remoteAuthHeader?.name.trim() && remoteAuthHeader?.secretId);
   const remoteHeadersComplete = remoteHeaders.every(
     (header) => header.name.trim() && header.value.trim(),
   );
@@ -299,7 +347,10 @@ export default function AddMcpSource(props: {
         ? headerAuthComplete
         : tokens !== null;
   const canAdd = Boolean(probe) && authReady && remoteHeadersComplete && !isAdding && !isOAuthBusy;
-  const error = state.step === "error" ? state.error : null;
+  // Probe failures are shown inline on the URL field; other failures
+  // (OAuth start, add source) render in the bottom error block.
+  const probeError = state.step === "error" && state.probe === null ? state.error : null;
+  const otherError = state.step === "error" && state.probe !== null ? state.error : null;
 
   // ---- Remote actions ----
 
@@ -313,17 +364,30 @@ export default function AddMcpSource(props: {
       setRemoteAuthMode(result.requiresOAuth ? "oauth2" : "none");
       dispatch({ type: "probe-ok", probe: result });
     } catch (e) {
-      dispatch({ type: "probe-fail", error: e instanceof Error ? e.message : "Failed to connect" });
+      dispatch({
+        type: "probe-fail",
+        error: e instanceof Error ? e.message : "Failed to connect",
+      });
     }
   }, [state.url, scopeId, doProbe]);
 
-  const autoProbed = useRef(false);
+  // Keep the latest handleProbe in a ref so the debounced effect can call it
+  // without depending on its identity (which changes every render).
+  const handleProbeRef = useRef(handleProbe);
+  handleProbeRef.current = handleProbe;
+
+  // Auto-probe whenever the URL changes (debounced) while we're on the
+  // remote transport and not already probing/probed.
   useEffect(() => {
-    if (transport === "remote" && remoteUrl && !autoProbed.current) {
-      autoProbed.current = true;
-      handleProbe();
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (transport !== "remote") return;
+    if (state.step !== "url") return;
+    const trimmed = state.url.trim();
+    if (!trimmed) return;
+    const handle = setTimeout(() => {
+      handleProbeRef.current();
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [transport, state.step, state.url]);
 
   const oauthCleanup = useRef<(() => void) | null>(null);
 
@@ -380,13 +444,14 @@ export default function AddMcpSource(props: {
     if (!probe) return;
     dispatch({ type: "add-start" });
     try {
+      const headerAuth = remoteAuthHeaders[0];
       const auth =
-        remoteAuthMode === "header"
+        remoteAuthMode === "header" && headerAuth?.secretId
           ? {
               kind: "header" as const,
-              headerName: remoteHeaderAuth.name.trim(),
-              secretId: remoteHeaderAuth.secretId!,
-              ...(remoteHeaderAuth.prefix ? { prefix: remoteHeaderAuth.prefix } : {}),
+              headerName: headerAuth.name.trim(),
+              secretId: headerAuth.secretId,
+              ...(headerAuth.prefix ? { prefix: headerAuth.prefix } : {}),
             }
           : remoteAuthMode === "oauth2" && tokens
             ? {
@@ -424,7 +489,7 @@ export default function AddMcpSource(props: {
   }, [
     probe,
     remoteAuthMode,
-    remoteHeaderAuth,
+    remoteAuthHeaders,
     remoteHeaders,
     tokens,
     state.url,
@@ -484,7 +549,7 @@ export default function AddMcpSource(props: {
   // ---- Render ----
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-1 flex-col gap-6">
       <div>
         <h1 className="text-xl font-semibold text-foreground">Add MCP Source</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
@@ -522,200 +587,123 @@ export default function AddMcpSource(props: {
 
       {transport === "remote" ? (
         <>
-          {/* URL input */}
-          <section className="space-y-2">
-            <Label>Server URL</Label>
-            <div className="flex gap-2">
-              <Input
-                value={state.url}
-                onChange={(e) =>
-                  dispatch({ type: "set-url", url: (e.target as HTMLInputElement).value })
-                }
-                placeholder="https://mcp.example.com"
-                className="flex-1 font-mono text-sm"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && state.url.trim() && isIdle) handleProbe();
-                }}
-                disabled={isProbing}
-              />
-              {!probe && (
-                <Button onClick={handleProbe} disabled={!state.url.trim() || isProbing}>
-                  {isProbing ? (
-                    <>
-                      <Spinner className="size-3.5" /> Connecting…
-                    </>
-                  ) : (
-                    "Connect"
-                  )}
-                </Button>
-              )}
-            </div>
-            <p className="text-[12px] text-muted-foreground">
-              Supports Streamable HTTP and SSE transports.
-            </p>
-          </section>
+          {/* Server info card (shown above URL input after probing) */}
+          {probe ? (
+            <CardStack>
+              <CardStackContent className="border-t-0">
+                <CardStackEntry>
+                  <CardStackEntryMedia>
+                    <SourceFavicon url={state.url} size={32} />
+                  </CardStackEntryMedia>
+                  <CardStackEntryContent>
+                    <CardStackEntryTitle>{probe.serverName ?? probe.name}</CardStackEntryTitle>
+                    <CardStackEntryDescription>
+                      {probe.connected
+                        ? `${probe.toolCount} tool${probe.toolCount !== 1 ? "s" : ""} available`
+                        : "OAuth required to discover tools"}
+                    </CardStackEntryDescription>
+                  </CardStackEntryContent>
+                  <CardStackEntryActions>
+                    {probe.connected ? (
+                      <Badge
+                        variant="outline"
+                        className="border-emerald-500/20 bg-emerald-500/10 text-[10px] text-emerald-600 dark:text-emerald-400"
+                      >
+                        Connected
+                      </Badge>
+                    ) : (
+                      <Badge
+                        variant="outline"
+                        className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
+                      >
+                        OAuth required
+                      </Badge>
+                    )}
+                  </CardStackEntryActions>
+                </CardStackEntry>
+              </CardStackContent>
+            </CardStack>
+          ) : isProbing ? (
+            <CardStack>
+              <CardStackContent className="border-t-0">
+                <CardStackEntry>
+                  <CardStackEntryMedia>
+                    <Skeleton className="size-4 rounded" />
+                  </CardStackEntryMedia>
+                  <CardStackEntryContent>
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="mt-1 h-3 w-32" />
+                  </CardStackEntryContent>
+                  <CardStackEntryActions>
+                    <Skeleton className="h-4 w-20 rounded-full" />
+                  </CardStackEntryActions>
+                </CardStackEntry>
+              </CardStackContent>
+            </CardStack>
+          ) : null}
 
-          {/* Server info card */}
-          {probe && (
-            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
-              <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                <svg viewBox="0 0 16 16" className="size-4" fill="none">
-                  <rect
-                    x="2"
-                    y="3"
-                    width="12"
-                    height="10"
-                    rx="2"
-                    stroke="currentColor"
-                    strokeWidth="1.2"
+          {/* URL input */}
+          <CardStack>
+            <CardStackContent className="border-t-0">
+              <CardStackEntryField
+                label="Server URL"
+                hint={probeError ? undefined : "Supports Streamable HTTP and SSE transports."}
+              >
+                <div className="relative">
+                  <Input
+                    value={state.url}
+                    onChange={(e) =>
+                      dispatch({
+                        type: "set-url",
+                        url: (e.target as HTMLInputElement).value,
+                      })
+                    }
+                    placeholder="https://mcp.example.com"
+                    className="w-full pr-9 font-mono text-sm"
+                    aria-invalid={probeError ? true : undefined}
                   />
-                  <path
-                    d="M5 7h6M5 9.5h4"
-                    stroke="currentColor"
-                    strokeWidth="1.2"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-semibold text-card-foreground leading-none">
-                  {probe.serverName ?? probe.name}
-                </p>
-                <p className="mt-1 text-[12px] text-muted-foreground leading-none">
-                  {probe.connected
-                    ? `${probe.toolCount} tool${probe.toolCount !== 1 ? "s" : ""} available`
-                    : "OAuth required to discover tools"}
-                </p>
-              </div>
-              {probe.connected ? (
-                <Badge
-                  variant="outline"
-                  className="border-emerald-500/20 bg-emerald-500/10 text-[10px] text-emerald-600 dark:text-emerald-400"
-                >
-                  Connected
-                </Badge>
-              ) : (
-                <Badge
-                  variant="outline"
-                  className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
-                >
-                  OAuth required
-                </Badge>
-              )}
-            </div>
-          )}
+                  {isProbing && (
+                    <div className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                      <IOSSpinner className="size-4" />
+                    </div>
+                  )}
+                </div>
+                {probeError && <FieldError>{probeError}</FieldError>}
+              </CardStackEntryField>
+            </CardStackContent>
+          </CardStack>
 
           {/* Authentication */}
           {probe && (
-            <section className="space-y-2.5">
-              <Label>Authentication</Label>
-
-              <RadioGroup
-                value={remoteAuthMode}
-                onValueChange={(value) => setRemoteAuthMode(value as RemoteAuthMode)}
-                className="gap-1.5"
-              >
-                {!probe.requiresOAuth && (
-                  <Label
-                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                      remoteAuthMode === "none"
-                        ? "border-primary/50 bg-primary/[0.03]"
-                        : "border-border hover:bg-accent/50"
-                    }`}
-                  >
-                    <RadioGroupItem value="none" />
-                    <span className="text-xs font-medium text-foreground">None</span>
-                    <span className="ml-auto text-[10px] text-muted-foreground">
-                      no auth header
-                    </span>
-                  </Label>
-                )}
-
-                <Label
-                  className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                    remoteAuthMode === "header"
-                      ? "border-primary/50 bg-primary/[0.03]"
-                      : "border-border hover:bg-accent/50"
-                  }`}
-                >
-                  <RadioGroupItem value="header" />
-                  <span className="text-xs font-medium text-foreground">Header</span>
-                  <span className="ml-auto text-[10px] text-muted-foreground">
-                    use a secret-backed auth header
-                  </span>
-                </Label>
-
-                {probe.requiresOAuth && (
-                  <Label
-                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                      remoteAuthMode === "oauth2"
-                        ? "border-primary/50 bg-primary/[0.03]"
-                        : "border-border hover:bg-accent/50"
-                    }`}
-                  >
-                    <RadioGroupItem value="oauth2" />
-                    <span className="text-xs font-medium text-foreground">OAuth</span>
-                    <span className="ml-auto text-[10px] text-muted-foreground">
-                      sign in with the server&apos;s OAuth flow
-                    </span>
-                  </Label>
-                )}
-              </RadioGroup>
-
-              {remoteAuthMode === "header" && (
-                <SecretHeaderAuthRow
-                  label="Auth header"
-                  name={remoteHeaderAuth.name}
-                  prefix={remoteHeaderAuth.prefix}
-                  presetKey={remoteHeaderAuth.presetKey}
-                  secretId={remoteHeaderAuth.secretId}
-                  onChange={(update) =>
-                    setRemoteHeaderAuth((current) => ({
-                      ...current,
-                      ...update,
-                    }))
-                  }
-                  onSelectSecret={(secretId) =>
-                    setRemoteHeaderAuth((current) => ({
-                      ...current,
-                      secretId,
-                    }))
-                  }
-                  existingSecrets={secretList}
-                />
-              )}
-
-              {probe.requiresOAuth && remoteAuthMode === "oauth2" && !tokens && (
+            <AuthenticationSection
+              methods={
+                probe.requiresOAuth
+                  ? (["header", "oauth2"] as const)
+                  : (["none", "header"] as const)
+              }
+              value={remoteAuthMode}
+              onChange={setRemoteAuthMode}
+              singleHeader
+              headers={remoteAuthHeaders}
+              onHeadersChange={setRemoteAuthHeaders}
+              existingSecrets={secretList}
+              oauth2Slot={
                 <>
-                  {state.step === "probed" && (
-                    <Button onClick={handleOAuth} className="w-full" variant="outline">
-                      <svg viewBox="0 0 16 16" fill="none" className="mr-1.5 size-3.5">
-                        <path
-                          d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1z"
-                          stroke="currentColor"
-                          strokeWidth="1.2"
-                        />
-                        <path
-                          d="M8 4v4l2.5 1.5"
-                          stroke="currentColor"
-                          strokeWidth="1.2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
-                      Sign in with OAuth
+                  {!tokens && state.step === "probed" && (
+                    <Button onClick={handleOAuth} className="w-full bg-white" variant="outline">
+                      Sign in
                     </Button>
                   )}
 
-                  {state.step === "oauth-starting" && (
-                    <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+                  {!tokens && state.step === "oauth-starting" && (
+                    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2.5">
                       <Spinner className="size-3.5" />
                       <span className="text-xs text-muted-foreground">Starting authorization…</span>
                     </div>
                   )}
 
-                  {state.step === "oauth-waiting" && (
-                    <div className="flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 px-3 py-2.5">
+                  {!tokens && state.step === "oauth-waiting" && (
+                    <div className="flex items-center gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2.5">
                       <Spinner className="size-3.5 text-blue-500" />
                       <span className="text-xs text-blue-600 dark:text-blue-400">
                         Waiting for authorization in popup…
@@ -730,138 +718,135 @@ export default function AddMcpSource(props: {
                       </Button>
                     </div>
                   )}
+
+                  {tokens && (
+                    <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5">
+                      <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
+                        <path
+                          d="M3 8.5l3 3 7-7"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                      <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                        Authenticated
+                      </span>
+                    </div>
+                  )}
                 </>
-              )}
-
-              {probe.requiresOAuth && remoteAuthMode === "oauth2" && tokens && (
-                <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5">
-                  <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
-                    <path
-                      d="M3 8.5l3 3 7-7"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                    Authenticated
-                  </span>
-                </div>
-              )}
-
-              {remoteAuthMode === "none" && probe.requiresOAuth && (
-                <p className="text-[12px] text-amber-600 dark:text-amber-400">
-                  This server requires authentication before it can be added.
-                </p>
-              )}
-            </section>
+              }
+            />
           )}
 
           {/* Additional headers */}
           {probe && (
             <section className="space-y-2.5">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <Label>Additional headers</Label>
-                  <p className="mt-1 text-[12px] text-muted-foreground">
-                    Plaintext headers sent with every request. Use authentication for secret-backed
-                    auth headers.
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() =>
-                    setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
-                  }
-                >
-                  + Add header
-                </Button>
+              <div>
+                <Label>Additional headers</Label>
+                <p className="mt-1 text-[12px] text-muted-foreground">
+                  Plaintext headers sent with every request. Use authentication for secret-backed
+                  auth headers.
+                </p>
               </div>
 
-              {remoteHeaders.length > 0 && (
-                <div className="space-y-2">
-                  {remoteHeaders.map((header, index) => (
-                    <div
-                      key={index}
-                      className="rounded-lg border border-border bg-card p-3 space-y-2"
-                    >
-                      <div className="flex items-center justify-between">
-                        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                          Header
-                        </Label>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="xs"
-                          className="text-muted-foreground hover:text-destructive"
-                          onClick={() =>
-                            setRemoteHeaders((headers) =>
-                              headers.filter((_, headerIndex) => headerIndex !== index),
-                            )
-                          }
-                        >
-                          Remove
-                        </Button>
-                      </div>
-                      <div className="grid grid-cols-2 gap-2">
-                        <div className="space-y-1">
-                          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                            Name
-                          </Label>
-                          <Input
-                            value={header.name}
-                            onChange={(event) =>
-                              setRemoteHeaders((headers) =>
-                                headers.map((current, headerIndex) =>
-                                  headerIndex === index
-                                    ? { ...current, name: (event.target as HTMLInputElement).value }
-                                    : current,
-                                ),
-                              )
-                            }
-                            placeholder="X-Organization-Id"
-                            className="h-8 text-xs font-mono"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                            Value
-                          </Label>
-                          <Input
-                            value={header.value}
-                            onChange={(event) =>
-                              setRemoteHeaders((headers) =>
-                                headers.map((current, headerIndex) =>
-                                  headerIndex === index
-                                    ? {
-                                        ...current,
-                                        value: (event.target as HTMLInputElement).value,
-                                      }
-                                    : current,
-                                ),
-                              )
-                            }
-                            placeholder="workspace-id"
-                            className="h-8 text-xs font-mono"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
+              <CardStack>
+                <CardStackContent>
+                  {remoteHeaders.length === 0 ? (
+                    <AddPlainHeaderRow
+                      leading={<span>No headers</span>}
+                      onClick={() =>
+                        setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
+                      }
+                    />
+                  ) : (
+                    <>
+                      {remoteHeaders.map((header, index) => (
+                        <CardStackEntry key={index} className="flex-col items-stretch gap-2">
+                          <div className="flex items-center justify-between">
+                            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                              Header
+                            </Label>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="xs"
+                              className="text-muted-foreground hover:text-destructive"
+                              onClick={() =>
+                                setRemoteHeaders((headers) =>
+                                  headers.filter((_, headerIndex) => headerIndex !== index),
+                                )
+                              }
+                            >
+                              Remove
+                            </Button>
+                          </div>
+                          <div className="grid grid-cols-2 gap-2">
+                            <div className="space-y-1">
+                              <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                Name
+                              </Label>
+                              <Input
+                                value={header.name}
+                                onChange={(event) =>
+                                  setRemoteHeaders((headers) =>
+                                    headers.map((current, headerIndex) =>
+                                      headerIndex === index
+                                        ? {
+                                            ...current,
+                                            name: (event.target as HTMLInputElement).value,
+                                          }
+                                        : current,
+                                    ),
+                                  )
+                                }
+                                placeholder="X-Organization-Id"
+                                className="h-8 text-xs font-mono"
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                Value
+                              </Label>
+                              <Input
+                                value={header.value}
+                                onChange={(event) =>
+                                  setRemoteHeaders((headers) =>
+                                    headers.map((current, headerIndex) =>
+                                      headerIndex === index
+                                        ? {
+                                            ...current,
+                                            value: (event.target as HTMLInputElement).value,
+                                          }
+                                        : current,
+                                    ),
+                                  )
+                                }
+                                placeholder="workspace-id"
+                                className="h-8 text-xs font-mono"
+                              />
+                            </div>
+                          </div>
+                        </CardStackEntry>
+                      ))}
+                      <AddPlainHeaderRow
+                        onClick={() =>
+                          setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
+                        }
+                      />
+                    </>
+                  )}
+                </CardStackContent>
+              </CardStack>
             </section>
           )}
 
-          {/* Error */}
-          {error && (
+          {/* Error (OAuth / add source). Probe errors show inline on the field. */}
+          {otherError && (
             <div className="space-y-2">
               <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-                <p className="text-[12px] text-destructive">{error}</p>
+                <p className="text-[12px] text-destructive">{otherError}</p>
               </div>
               <Button
                 variant="outline"
@@ -874,12 +859,11 @@ export default function AddMcpSource(props: {
             </div>
           )}
 
-          {/* Actions */}
-          {(probe || isProbing) && (
-            <div className="flex items-center justify-between border-t border-border pt-4">
-              <Button variant="ghost" onClick={props.onCancel} disabled={isAdding}>
-                Cancel
-              </Button>
+          <FloatActions>
+            <Button variant="ghost" onClick={props.onCancel} disabled={isAdding}>
+              Cancel
+            </Button>
+            {(probe || isProbing) && (
               <Button onClick={handleAddRemote} disabled={!canAdd}>
                 {isAdding ? (
                   <>
@@ -889,76 +873,62 @@ export default function AddMcpSource(props: {
                   "Add source"
                 )}
               </Button>
-            </div>
-          )}
-
-          {/* Cancel when nothing probed yet */}
-          {!probe && !isProbing && (
-            <div className="flex items-center justify-between pt-1">
-              <Button variant="ghost" onClick={props.onCancel}>
-                Cancel
-              </Button>
-              <div />
-            </div>
-          )}
+            )}
+          </FloatActions>
         </>
       ) : (
         <>
           {/* Stdio form */}
-          <section className="space-y-4">
-            <div className="space-y-2">
-              <Label>Command</Label>
-              <Input
-                value={stdioCommand}
-                onChange={(e) => setStdioCommand((e.target as HTMLInputElement).value)}
-                placeholder="npx"
-                className="font-mono text-sm"
-              />
-              <p className="text-[12px] text-muted-foreground">
-                The executable to run (e.g. npx, uvx, node).
-              </p>
-            </div>
+          <CardStack>
+            <CardStackContent className="border-t-0">
+              <CardStackEntryField
+                label="Command"
+                description="- The executable to run (e.g. npx, uvx, node)."
+              >
+                <Input
+                  value={stdioCommand}
+                  onChange={(e) => setStdioCommand((e.target as HTMLInputElement).value)}
+                  placeholder="npx"
+                  className="font-mono text-sm"
+                />
+              </CardStackEntryField>
 
-            <div className="space-y-2">
-              <Label>Arguments</Label>
-              <Input
-                value={stdioArgs}
-                onChange={(e) => setStdioArgs((e.target as HTMLInputElement).value)}
-                placeholder="-y chrome-devtools-mcp@latest"
-                className="font-mono text-sm"
-              />
-              <p className="text-[12px] text-muted-foreground">
-                Space-separated arguments passed to the command.
-              </p>
-            </div>
+              <CardStackEntryField
+                label="Arguments"
+                description="- Space-separated arguments passed to the command."
+              >
+                <Input
+                  value={stdioArgs}
+                  onChange={(e) => setStdioArgs((e.target as HTMLInputElement).value)}
+                  placeholder="-y chrome-devtools-mcp@latest"
+                  className="font-mono text-sm"
+                />
+              </CardStackEntryField>
 
-            <div className="space-y-2">
-              <Label>
-                Name <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Input
-                value={stdioName}
-                onChange={(e) => setStdioName((e.target as HTMLInputElement).value)}
-                placeholder="My MCP Server"
-                className="text-sm"
-              />
-            </div>
+              <CardStackEntryField label="Name" description="(optional)">
+                <Input
+                  value={stdioName}
+                  onChange={(e) => setStdioName((e.target as HTMLInputElement).value)}
+                  placeholder="My MCP Server"
+                  className="text-sm"
+                />
+              </CardStackEntryField>
 
-            <div className="space-y-2">
-              <Label>
-                Environment variables{" "}
-                <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Textarea
-                value={stdioEnv}
-                onChange={(e) => setStdioEnv((e.target as HTMLTextAreaElement).value)}
-                placeholder={"KEY=value\nANOTHER=value"}
-                rows={3}
-                className="font-mono text-sm"
-              />
-              <p className="text-[12px] text-muted-foreground">One per line, KEY=value format.</p>
-            </div>
-          </section>
+              <CardStackEntryField
+                label="Environment variables"
+                description="- One per line, KEY=value format."
+              >
+                <Textarea
+                  value={stdioEnv}
+                  onChange={(e) => setStdioEnv((e.target as HTMLTextAreaElement).value)}
+                  placeholder={"KEY=value\nANOTHER=value"}
+                  rows={3}
+                  maxRows={10}
+                  className="font-mono text-sm"
+                />
+              </CardStackEntryField>
+            </CardStackContent>
+          </CardStack>
 
           {/* Stdio error */}
           {stdioError && (
@@ -967,8 +937,7 @@ export default function AddMcpSource(props: {
             </div>
           )}
 
-          {/* Stdio actions */}
-          <div className="flex items-center justify-between border-t border-border pt-4">
+          <FloatActions>
             <Button variant="ghost" onClick={props.onCancel} disabled={stdioAdding}>
               Cancel
             </Button>
@@ -981,9 +950,35 @@ export default function AddMcpSource(props: {
                 "Add source"
               )}
             </Button>
-          </div>
+          </FloatActions>
         </>
       )}
     </div>
+  );
+}
+
+function AddPlainHeaderRow({
+  onClick,
+  leading,
+}: {
+  readonly onClick: () => void;
+  readonly leading?: ReactNode;
+}) {
+  return (
+    // oxlint-disable-next-line react/forbid-elements
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      aria-label="Add header"
+      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
+    >
+      <span className="min-w-0 flex-1 text-left">{leading}</span>
+      <svg aria-hidden viewBox="0 0 16 16" fill="none" className="size-4 shrink-0">
+        <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </button>
   );
 }

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -3,6 +3,11 @@ import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/a
 import { mcpSourceAtom, updateMcpSource } from "./atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "@executor/react/components/card-stack";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
@@ -104,18 +109,21 @@ function RemoteEditForm(props: {
       </div>
 
       {/* Endpoint */}
-      <section className="space-y-2">
-        <Label>Endpoint</Label>
-        <Input
-          value={endpoint}
-          onChange={(e) => {
-            setEndpoint((e.target as HTMLInputElement).value);
-            setDirty(true);
-          }}
-          placeholder="https://mcp.example.com"
-          className="font-mono text-sm"
-        />
-      </section>
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntryField label="Endpoint">
+            <Input
+              value={endpoint}
+              onChange={(e) => {
+                setEndpoint((e.target as HTMLInputElement).value);
+                setDirty(true);
+              }}
+              placeholder="https://mcp.example.com"
+              className="font-mono text-sm"
+            />
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
 
       {/* Headers */}
       <section className="space-y-2.5">

--- a/packages/react/src/components/filter-tabs.tsx
+++ b/packages/react/src/components/filter-tabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button } from "./button";
+import { cn } from "../lib/utils";
+
+export interface FilterTab<T extends string = string> {
+  label: ReactNode;
+  value: T;
+  count?: number;
+}
+
+interface FilterTabsProps<T extends string = string> {
+  tabs: FilterTab<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+export function FilterTabs<T extends string = string>({
+  tabs,
+  value,
+  onChange,
+}: FilterTabsProps<T>) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {tabs.map((tab) => {
+        const isActive = value === tab.value;
+        return (
+          <Button
+            variant="outline"
+            size="sm"
+            key={tab.value}
+            onClick={() => onChange(tab.value)}
+            className={cn(
+              "shadow-none",
+              isActive
+                ? "inline-flex items-center justify-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-1 text-sm font-medium text-foreground transition-transform duration-100 active:scale-[0.98]"
+                : "inline-flex items-center justify-center gap-1.5 rounded-full border border-transparent bg-transparent px-2.5 py-1 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-transform duration-100 active:scale-[0.98]",
+            )}
+          >
+            {tab.label}
+            {tab.count !== undefined && (
+              <span
+                className={`inline-flex items-center justify-center rounded-full text-xs tabular-nums min-w-[18px] h-[18px] px-1 ${isActive ? "bg-muted text-foreground" : "bg-muted/60 text-muted-foreground"}`}
+              >
+                {tab.count}
+              </span>
+            )}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/react/src/components/float-actions.tsx
+++ b/packages/react/src/components/float-actions.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { useRouterState } from "@tanstack/react-router";
+
+import { cn } from "../lib/utils";
+import { CardStack } from "./card-stack";
+
+/**
+ * A floating action bar that pins itself to the bottom of the nearest
+ * positioned ancestor (usually a scroll container with `position: relative`).
+ *
+ * Rendered as a `CardStack` so it picks up the card visual — wrap action
+ * buttons as children; they'll be right-aligned inside the card.
+ *
+ * To pin to the bottom even when content is short, the parent should be a
+ * flex column filling the scroll container (so `mt-auto` pushes the actions
+ * down). `sticky bottom-4` also keeps it visible while scrolling long content.
+ *
+ * Hidden while the router is navigating/loading so the actions don't flash
+ * on top of a loading state.
+ */
+function FloatActions({ className, children }: { className?: string; children: React.ReactNode }) {
+  const isLoading = useRouterState({ select: (s) => s.isLoading });
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <CardStack className={cn("sticky shadow-lg bottom-4 left-0 right-0 mt-auto w-full", className)}>
+      <div className="flex items-center justify-end gap-3 px-4 py-3">{children}</div>
+    </CardStack>
+  );
+}
+
+export { FloatActions };

--- a/packages/react/src/components/spinner.tsx
+++ b/packages/react/src/components/spinner.tsx
@@ -13,4 +13,36 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   );
 }
 
-export { Spinner };
+const IOS_SPINNER_BLADES = 12;
+
+function IOSSpinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <svg
+      role="status"
+      aria-label="Loading"
+      viewBox="0 0 24 24"
+      className={cn("size-4 text-muted-foreground", className)}
+      {...props}
+    >
+      {Array.from({ length: IOS_SPINNER_BLADES }).map((_, i) => (
+        <rect
+          key={i}
+          x="11"
+          y="2"
+          width="2"
+          height="6"
+          rx="1"
+          fill="currentColor"
+          transform={`rotate(${(360 / IOS_SPINNER_BLADES) * i} 12 12)`}
+          style={{
+            animation: "ios-spinner-fade 1s linear infinite",
+            animationDelay: `${(i / IOS_SPINNER_BLADES) * 1 - 1}s`,
+            opacity: 0.25,
+          }}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export { Spinner, IOSSpinner };

--- a/packages/react/src/components/textarea.tsx
+++ b/packages/react/src/components/textarea.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 
 import { cn } from "../lib/utils";
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({
+  className,
+  maxRows,
+  ...props
+}: React.ComponentProps<"textarea"> & { maxRows?: number }) {
   return (
     // oxlint-disable-next-line react/forbid-elements
     <textarea
@@ -12,6 +16,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
         className,
       )}
       {...props}
+      style={{ maxHeight: maxRows ? `${maxRows * 1.5}rem` : undefined }}
     />
   );
 }

--- a/packages/react/src/plugins/authentication-section.tsx
+++ b/packages/react/src/plugins/authentication-section.tsx
@@ -1,0 +1,245 @@
+import { useState, type ReactNode } from "react";
+import { PlusIcon } from "lucide-react";
+
+import { Button } from "../components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEmpty,
+  CardStackEntry,
+} from "../components/card-stack";
+import { FieldLabel } from "../components/field";
+import { FilterTabs } from "../components/filter-tabs";
+import {
+  defaultHeaderAuthPresets,
+  type HeaderAuthPreset,
+  SecretHeaderAuthRow,
+  type HeaderState,
+} from "./secret-header-auth";
+import type { SecretPickerSecret } from "./secret-picker";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AuthMethod = "none" | "header" | "oauth2";
+
+export type AuthHeaderEntry = HeaderState;
+
+const DEFAULT_METHOD_LABELS: Record<AuthMethod, string> = {
+  none: "None",
+  header: "Header",
+  oauth2: "OAuth",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface AuthenticationSectionProps {
+  /** Auth methods to expose as tabs (display order). */
+  readonly methods: readonly AuthMethod[];
+  readonly value: AuthMethod;
+  readonly onChange: (value: AuthMethod) => void;
+
+  /** Headers list — used when value === "header". */
+  readonly headers?: readonly AuthHeaderEntry[];
+  readonly onHeadersChange?: (headers: AuthHeaderEntry[]) => void;
+  readonly existingSecrets?: readonly SecretPickerSecret[];
+
+  /** Optional content rendered for the "oauth2" method. */
+  readonly oauth2Slot?: ReactNode;
+
+  /**
+   * When true, the headers list is constrained to a single entry: the
+   * "Add headers" button is hidden once one header exists and rows cannot
+   * be removed. Useful for consumers whose backend only supports a single
+   * auth header.
+   */
+  readonly singleHeader?: boolean;
+
+  readonly methodLabels?: Partial<Record<AuthMethod, string>>;
+  readonly label?: ReactNode;
+}
+
+export function AuthenticationSection(props: AuthenticationSectionProps) {
+  const {
+    methods,
+    value,
+    onChange,
+    headers = [],
+    onHeadersChange,
+    existingSecrets = [],
+    oauth2Slot,
+    singleHeader = false,
+    methodLabels,
+    label = "Authentication",
+  } = props;
+
+  const [picking, setPicking] = useState(false);
+
+  const getMethodLabel = (method: AuthMethod) =>
+    methodLabels?.[method] ?? DEFAULT_METHOD_LABELS[method];
+
+  // When both "none" and "header" are offered, collapse them into a single
+  // UI surface: the empty CardStack is the "none" state, and adding a header
+  // transitions `value` to "header" automatically.
+  const unifiesHeaders = methods.includes("none") && methods.includes("header");
+  const displayMethods = unifiesHeaders ? methods.filter((m) => m !== "none") : methods;
+  const displayValue: AuthMethod = unifiesHeaders && value === "none" ? "header" : value;
+
+  const showHeaders = value === "header" || (unifiesHeaders && value === "none");
+  const canAddMore = !singleHeader || headers.length === 0;
+
+  const addHeaderFromPreset = (preset: HeaderAuthPreset) => {
+    onHeadersChange?.([
+      ...headers,
+      {
+        name: preset.name,
+        prefix: preset.prefix,
+        presetKey: preset.key,
+        secretId: null,
+      },
+    ]);
+    setPicking(false);
+    if (unifiesHeaders && value === "none") {
+      onChange("header");
+    }
+  };
+
+  const updateHeader = (
+    index: number,
+    update: Partial<{
+      name: string;
+      secretId: string | null;
+      prefix?: string;
+      presetKey?: string;
+    }>,
+  ) => {
+    onHeadersChange?.(headers.map((entry, i) => (i === index ? { ...entry, ...update } : entry)));
+  };
+
+  const removeHeader = (index: number) => {
+    const next = headers.filter((_, i) => i !== index);
+    onHeadersChange?.(next);
+    if (unifiesHeaders && next.length === 0) {
+      onChange("none");
+    }
+  };
+
+  return (
+    <section className="space-y-2.5">
+      {displayMethods.length > 1 ? (
+        <div className="flex items-center justify-between gap-3">
+          <FieldLabel>{label}</FieldLabel>
+          <FilterTabs<AuthMethod>
+            tabs={displayMethods.map((method) => ({
+              value: method,
+              label: getMethodLabel(method),
+            }))}
+            value={displayValue}
+            onChange={onChange}
+          />
+        </div>
+      ) : (
+        <FieldLabel>{label}</FieldLabel>
+      )}
+
+      {showHeaders && (
+        <CardStack>
+          <CardStackContent className="[&>*+*]:before:inset-x-0">
+            {picking ? (
+              <HeaderPresetPicker onPick={addHeaderFromPreset} onCancel={() => setPicking(false)} />
+            ) : headers.length === 0 ? (
+              canAddMore ? (
+                <AddHeaderRow leading={<span>No headers</span>} onClick={() => setPicking(true)} />
+              ) : (
+                <CardStackEmpty>
+                  <span>No headers</span>
+                </CardStackEmpty>
+              )
+            ) : (
+              <>
+                {headers.map((header, index) => (
+                  <SecretHeaderAuthRow
+                    key={index}
+                    name={header.name}
+                    prefix={header.prefix}
+                    presetKey={header.presetKey}
+                    secretId={header.secretId}
+                    onChange={(update) => updateHeader(index, update)}
+                    onSelectSecret={(secretId) => updateHeader(index, { secretId })}
+                    onRemove={singleHeader ? undefined : () => removeHeader(index)}
+                    existingSecrets={existingSecrets}
+                  />
+                ))}
+                {canAddMore && <AddHeaderRow onClick={() => setPicking(true)} />}
+              </>
+            )}
+          </CardStackContent>
+        </CardStack>
+      )}
+
+      {value === "oauth2" && oauth2Slot}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal sub-components
+// ---------------------------------------------------------------------------
+
+interface AddHeaderRowProps {
+  readonly onClick: () => void;
+  readonly leading?: ReactNode;
+}
+
+function AddHeaderRow({ onClick, leading }: AddHeaderRowProps) {
+  return (
+    // oxlint-disable-next-line react/forbid-elements
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      aria-label="Add header"
+      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
+    >
+      <span className="min-w-0 flex-1 text-left">{leading}</span>
+      <PlusIcon aria-hidden className="size-4 shrink-0" />
+    </button>
+  );
+}
+
+interface HeaderPresetPickerProps {
+  readonly onPick: (preset: HeaderAuthPreset) => void;
+  readonly onCancel: () => void;
+}
+
+function HeaderPresetPicker({ onPick, onCancel }: HeaderPresetPickerProps) {
+  return (
+    <CardStackEntry className="flex-wrap gap-2">
+      {defaultHeaderAuthPresets.map((preset) => (
+        <Button
+          key={preset.key}
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onPick(preset)}
+        >
+          {preset.label}
+        </Button>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        className="text-muted-foreground"
+      >
+        Cancel
+      </Button>
+    </CardStackEntry>
+  );
+}

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useAtomRefresh, useAtomSet } from "@effect-atom/atom-react";
 
 import { secretsAtom, setSecret, resolveSecret } from "../api/atoms";
 import { useScope } from "../api/scope-context";
 import { Button } from "../components/button";
+import { Field, FieldError, FieldGroup, FieldLabel } from "../components/field";
 import { Input } from "../components/input";
-import { Label } from "../components/label";
 import { Spinner } from "../components/spinner";
 import { SecretPicker, type SecretPickerSecret } from "./secret-picker";
 import { SecretId } from "@executor/sdk";
@@ -74,6 +74,9 @@ function InlineCreateSecret(props: {
   const scopeId = useScope();
   const doSet = useAtomSet(setSecret, { mode: "promise" });
   const refreshSecrets = useAtomRefresh(secretsAtom(scopeId));
+  const secretIdInputId = useId();
+  const secretNameInputId = useId();
+  const secretValueInputId = useId();
 
   const handleSave = async () => {
     if (!secretId.trim() || !secretValue.trim()) return;
@@ -98,53 +101,55 @@ function InlineCreateSecret(props: {
   };
 
   return (
-    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-2.5">
+    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-3">
       <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
-      <div className="grid grid-cols-2 gap-2">
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">ID</Label>
-          <Input
-            value={secretId}
-            onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
-            placeholder="my-api-token"
-            className="h-8 text-xs font-mono"
-          />
+      <FieldGroup className="gap-3">
+        <div className="grid grid-cols-2 gap-3">
+          <Field>
+            <FieldLabel htmlFor={secretIdInputId}>ID</FieldLabel>
+            <Input
+              id={secretIdInputId}
+              value={secretId}
+              onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
+              placeholder="my-api-token"
+              className="font-mono"
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={secretNameInputId}>Label</FieldLabel>
+            <Input
+              id={secretNameInputId}
+              value={secretName}
+              onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
+              placeholder="API Token"
+            />
+          </Field>
         </div>
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-            Label
-          </Label>
-          <Input
-            value={secretName}
-            onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
-            placeholder="API Token"
-            className="h-8 text-xs"
-          />
-        </div>
-      </div>
-      <div className="space-y-1">
-        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Value</Label>
-        <div className="relative">
-          <Input
-            type={secretRevealed ? "text" : "password"}
-            value={secretValue}
-            onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
-            placeholder="paste your token or key…"
-            className="h-8 pr-8 text-xs font-mono"
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="absolute right-1 top-1/2 size-6 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            onClick={() => setSecretRevealed((revealed) => !revealed)}
-            aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
-          >
-            <SecretVisibilityIcon revealed={secretRevealed} />
-          </Button>
-        </div>
-      </div>
-      {error && <p className="text-[11px] text-destructive">{error}</p>}
+        <Field>
+          <FieldLabel htmlFor={secretValueInputId}>Value</FieldLabel>
+          <div className="relative">
+            <Input
+              id={secretValueInputId}
+              type={secretRevealed ? "text" : "password"}
+              value={secretValue}
+              onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
+              placeholder="paste your token or key…"
+              className="pr-9 font-mono"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="absolute right-1 top-1/2 size-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              onClick={() => setSecretRevealed((revealed) => !revealed)}
+              aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
+            >
+              <SecretVisibilityIcon revealed={secretRevealed} />
+            </Button>
+          </div>
+          {error && <FieldError>{error}</FieldError>}
+        </Field>
+      </FieldGroup>
       <div className="flex gap-1.5 pt-0.5">
         <Button variant="outline" size="xs" onClick={props.onCancel}>
           Cancel
@@ -286,12 +291,13 @@ export function SecretHeaderAuthRow(props: {
   onChange: (update: { name: string; prefix?: string; presetKey?: string }) => void;
   onSelectSecret: (secretId: string) => void;
   existingSecrets: readonly SecretPickerSecret[];
-  presets?: readonly HeaderAuthPreset[];
   onRemove?: () => void;
   removeLabel?: string;
   label?: string;
 }) {
   const [creating, setCreating] = useState(false);
+  const nameInputId = useId();
+  const prefixInputId = useId();
   const {
     name,
     prefix,
@@ -300,35 +306,34 @@ export function SecretHeaderAuthRow(props: {
     onChange,
     onSelectSecret,
     existingSecrets,
-    presets = defaultHeaderAuthPresets,
     onRemove,
     removeLabel = "Remove",
     label = "Header",
   } = props;
 
-  const isCustom = presetKey === "custom";
+  const isCustom = presetKey === "custom" || presetKey === undefined;
   const suggestedId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-") || "custom-header";
 
   if (creating) {
     return (
-      <InlineCreateSecret
-        headerName={name || "Custom Header"}
-        suggestedId={suggestedId}
-        onCreated={(id) => {
-          onSelectSecret(id);
-          setCreating(false);
-        }}
-        onCancel={() => setCreating(false)}
-      />
+      <div className="px-4 py-3">
+        <InlineCreateSecret
+          headerName={name || "Custom Header"}
+          suggestedId={suggestedId}
+          onCreated={(id) => {
+            onSelectSecret(id);
+            setCreating(false);
+          }}
+          onCancel={() => setCreating(false)}
+        />
+      </div>
     );
   }
 
   return (
-    <div className="rounded-lg border border-border bg-card p-3 space-y-2.5">
-      <div className="flex items-center justify-between">
-        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-          {label}
-        </Label>
+    <div className="space-y-2.5 px-4 py-3">
+      <div className="flex w-full items-center justify-between gap-4">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</span>
         {onRemove && (
           <Button
             variant="ghost"
@@ -341,74 +346,44 @@ export function SecretHeaderAuthRow(props: {
         )}
       </div>
 
-      <div className="flex flex-wrap gap-1">
-        {presets.map((preset) => (
-          <Button
-            key={preset.key}
-            variant="ghost"
-            size="sm"
-            type="button"
-            onClick={() =>
+      <FieldGroup className="grid grid-cols-2 gap-3">
+        <Field>
+          <FieldLabel htmlFor={nameInputId}>Name</FieldLabel>
+          <Input
+            id={nameInputId}
+            value={name}
+            onChange={(e) =>
               onChange({
-                name: preset.name,
-                prefix: preset.prefix,
-                presetKey: preset.key,
+                name: (e.target as HTMLInputElement).value,
+                prefix,
+                presetKey: isCustom ? "custom" : presetKey,
               })
             }
-            className={`rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
-              presetKey === preset.key
-                ? "border-primary/50 bg-primary/10 text-primary"
-                : "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            }`}
-          >
-            {preset.label}
-          </Button>
-        ))}
-      </div>
+            placeholder="Authorization"
+            className="font-mono"
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor={prefixInputId}>
+            Prefix <span className="font-normal text-muted-foreground/60">(optional)</span>
+          </FieldLabel>
+          <Input
+            id={prefixInputId}
+            value={prefix ?? ""}
+            onChange={(e) =>
+              onChange({
+                name,
+                prefix: (e.target as HTMLInputElement).value || undefined,
+                presetKey: isCustom ? "custom" : presetKey,
+              })
+            }
+            placeholder="Bearer "
+            className="font-mono"
+          />
+        </Field>
+      </FieldGroup>
 
-      {presetKey !== undefined && (
-        <div className="grid grid-cols-2 gap-2">
-          <div className="space-y-1">
-            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-              Name
-            </Label>
-            <Input
-              value={name}
-              onChange={(e) =>
-                onChange({
-                  name: (e.target as HTMLInputElement).value,
-                  prefix,
-                  presetKey: isCustom ? "custom" : presetKey,
-                })
-              }
-              placeholder="Authorization"
-              className="h-8 text-xs font-mono"
-            />
-          </div>
-          <div className="space-y-1">
-            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-              Prefix{" "}
-              <span className="normal-case tracking-normal font-normal text-muted-foreground/60">
-                (opt.)
-              </span>
-            </Label>
-            <Input
-              value={prefix ?? ""}
-              onChange={(e) =>
-                onChange({
-                  name,
-                  prefix: (e.target as HTMLInputElement).value || undefined,
-                  presetKey: isCustom ? "custom" : presetKey,
-                })
-              }
-              placeholder="Bearer "
-              className="h-8 text-xs font-mono"
-            />
-          </div>
-        </div>
-      )}
-
-      {presetKey !== undefined && name.trim() && (
+      {name.trim() && (
         <div className="flex items-center gap-1.5">
           <div className="flex-1 min-w-0">
             <SecretPicker value={secretId} onSelect={onSelectSecret} secrets={existingSecrets} />

--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -159,3 +159,12 @@
   --sidebar-border: hsl(240 3.7% 15.9%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
+
+@keyframes ios-spinner-fade {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.25;
+  }
+}


### PR DESCRIPTION
**3 of 5** — source-forms refactor split from #169. Stacks on #188.

Replaces the hand-rolled auth/URL/headers UI in the MCP Add/Edit forms with `<AuthenticationSection>`, wraps the save/cancel row in `<FloatActions>`, and uses `<IOSSpinner>` + `<Textarea maxRows>` for probe status and previews.

The biggest single form in the source-form suite (~820 LOC touched) — isolated here so reviewers can focus on it without context-switching between plugins.

## Stack

1. #187 `feat(react): add UI primitives for source forms`
2. #188 `feat(react): add <AuthenticationSection> primitive`
3. **(this PR)** `refactor(mcp): adopt shared primitives in Add/Edit source forms`
4. `refactor(sources): standardize openapi, graphql, google-discovery, onepassword forms`
5. `refactor(react): restructure sources list and sources-add container`

> Until #187 and #188 merge, this PR's diff includes the primitives from those PRs.