### PR TITLE
refactor(sources): standardize openapi, graphql, google-discovery, onepassword forms

### DIFF
--- a/packages/plugins/google-discovery/src/api/group.ts
+++ b/packages/plugins/google-discovery/src/api/group.ts
@@ -30,6 +30,13 @@ const ProbePayload = Schema.Struct({
   discoveryUrl: Schema.String,
 });
 
+const ProbeOperation = Schema.Struct({
+  toolPath: Schema.String,
+  method: Schema.String,
+  pathTemplate: Schema.String,
+  description: Schema.NullOr(Schema.String),
+});
+
 const ProbeResponse = Schema.Struct({
   name: Schema.String,
   title: Schema.NullOr(Schema.String),
@@ -37,6 +44,7 @@ const ProbeResponse = Schema.Struct({
   version: Schema.String,
   toolCount: Schema.Number,
   scopes: Schema.Array(Schema.String),
+  operations: Schema.Array(ProbeOperation),
 });
 
 const AddSourcePayload = Schema.Struct({

--- a/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
@@ -8,15 +8,57 @@ import { SecretId } from "@executor/sdk";
 import { Badge } from "@executor/react/components/badge";
 import { Button } from "@executor/react/components/button";
 import {
+  CardStack,
+  CardStackContent,
+  CardStackEntry,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+  CardStackEntryField,
+  CardStackEntryTitle,
+  CardStackHeader,
+} from "@executor/react/components/card-stack";
+import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@executor/react/components/collapsible";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  FieldTitle,
+} from "@executor/react/components/field";
+import { FloatActions } from "@executor/react/components/float-actions";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
+import { cn } from "@executor/react/lib/utils";
 import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
-import { Spinner } from "@executor/react/components/spinner";
+import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
+import {
+  AuthenticationSection,
+  type AuthMethod,
+} from "@executor/react/plugins/authentication-section";
 import { addGoogleDiscoverySource, probeGoogleDiscovery, startGoogleDiscoveryOAuth } from "./atoms";
+
+function methodBadgeClasses(method: string): string {
+  switch (method.toLowerCase()) {
+    case "get":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
+    case "post":
+      return "bg-blue-500/10 text-blue-700 dark:text-blue-400";
+    case "put":
+    case "patch":
+      return "bg-amber-500/10 text-amber-700 dark:text-amber-400";
+    case "delete":
+      return "bg-red-500/10 text-red-600 dark:text-red-400";
+    default:
+      return "bg-muted text-muted-foreground";
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Inline secret creation
@@ -315,6 +357,13 @@ function GoogleServiceIcon(props: { readonly service: string; readonly className
   );
 }
 
+type ProbeOperation = {
+  toolPath: string;
+  method: string;
+  pathTemplate: string;
+  description: string | null;
+};
+
 type ProbeResult = {
   name: string;
   title: string | null;
@@ -322,6 +371,7 @@ type ProbeResult = {
   version: string;
   toolCount: number;
   scopes: readonly string[];
+  operations: readonly ProbeOperation[];
 };
 
 type OAuthAuth = {
@@ -417,7 +467,7 @@ export default function AddGoogleDiscoverySource(props: {
   );
   const selectedTemplate =
     GOOGLE_DISCOVERY_TEMPLATES.find((template) => template.id === selectedTemplateId) ?? null;
-  const [authKind, setAuthKind] = useState<"none" | "oauth2">("oauth2");
+  const [authKind, setAuthKind] = useState<AuthMethod>("oauth2");
   const [clientId, setClientId] = useState("");
   const [clientSecretSecretId, setClientSecretSecretId] = useState<string | null>(null);
   const [probe, setProbe] = useState<ProbeResult | null>(null);
@@ -468,7 +518,11 @@ export default function AddGoogleDiscoverySource(props: {
         path: { scopeId },
         payload: { discoveryUrl: discoveryUrl.trim() },
       });
-      setProbe({ ...result, scopes: [...result.scopes] });
+      setProbe({
+        ...result,
+        scopes: [...result.scopes],
+        operations: [...result.operations],
+      });
       if (!name.trim()) {
         setName(result.name);
       }
@@ -483,13 +537,23 @@ export default function AddGoogleDiscoverySource(props: {
     }
   }, [discoveryUrl, doProbe, name, scopeId]);
 
-  const autoProbed = useRef(false);
+  // Keep the latest handleProbe in a ref so the debounced effect can call it
+  // without depending on its identity (which changes every render).
+  const handleProbeRef = useRef(handleProbe);
+  handleProbeRef.current = handleProbe;
+
+  // Auto-probe whenever the discovery URL changes (debounced). Clearing the
+  // previous probe in the onChange handler resets the preview so a new run
+  // will be triggered.
   useEffect(() => {
-    if (props.initialUrl && !autoProbed.current) {
-      autoProbed.current = true;
-      handleProbe();
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    const trimmed = discoveryUrl.trim();
+    if (!trimmed) return;
+    if (probe) return;
+    const handle = setTimeout(() => {
+      handleProbeRef.current();
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [discoveryUrl, probe]);
 
   const oauthCleanup = useRef<(() => void) | null>(null);
 
@@ -579,7 +643,7 @@ export default function AddGoogleDiscoverySource(props: {
     !probe || adding || (authKind === "oauth2" && (!canUseOAuth || oauthAuth === null));
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-1 flex-col gap-6">
       <div>
         <h1 className="text-xl font-semibold text-foreground">Add Google Discovery Source</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
@@ -587,86 +651,72 @@ export default function AddGoogleDiscoverySource(props: {
         </p>
       </div>
 
-      <section className="space-y-2">
-        <div className="flex items-center justify-between gap-3">
-          <Label>Presets</Label>
-          <span className="text-xs text-muted-foreground">
-            Select a Google API to prefill the source.
-          </span>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-          {GOOGLE_DISCOVERY_TEMPLATES.map((template) => {
-            const selected = template.id === selectedTemplateId;
-            return (
-              <Button
-                key={template.id}
-                variant="ghost"
-                type="button"
-                onClick={() => applyTemplate(template)}
-                className={`relative h-auto rounded-xl border px-4 py-3 text-left transition-colors ${
-                  selected
-                    ? "border-primary bg-primary/5 shadow-[0_0_0_1px_rgba(0,0,0,0.02)]"
-                    : "border-border bg-card hover:border-primary/30 hover:bg-card/80"
-                }`}
-              >
-                {selected && (
-                  <Badge variant="secondary" className="absolute top-3 right-3">
-                    Selected
-                  </Badge>
-                )}
-                <div className="flex min-w-0 gap-3 pr-20">
-                  <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-border/60 bg-background/80 shadow-xs">
-                    <GoogleServiceIcon service={template.service} className="size-6" />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-semibold text-foreground">{template.name}</p>
-                    <p className="mt-1 text-xs text-muted-foreground">{template.summary}</p>
-                  </div>
-                </div>
-                <div className="mt-3 flex items-center justify-between gap-3">
-                  <p className="text-[11px] font-mono text-muted-foreground">
-                    {template.service} · {template.version}
-                  </p>
-                  <div className="h-px flex-1 bg-border/70" />
-                </div>
-              </Button>
-            );
-          })}
-        </div>
-      </section>
-
-      <section className="space-y-2">
-        <Label>Discovery URL</Label>
-        <div className="flex gap-2">
-          <Input
-            value={discoveryUrl}
-            onChange={(e) => {
-              setSelectedTemplateId("");
-              setDiscoveryUrl((e.target as HTMLInputElement).value);
+      <FieldGroup>
+        <FieldSet>
+          <FieldLegend variant="label">Presets</FieldLegend>
+          <FieldDescription>Select a Google API to prefill the source.</FieldDescription>
+          <RadioGroup
+            value={selectedTemplateId}
+            onValueChange={(value) => {
+              const template = GOOGLE_DISCOVERY_TEMPLATES.find((t) => t.id === value);
+              if (template) applyTemplate(template);
             }}
-            placeholder="https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest"
-            className="flex-1 font-mono text-sm"
-          />
-          <Button onClick={handleProbe} disabled={!discoveryUrl.trim() || loadingProbe}>
-            {loadingProbe ? (
-              <>
-                <Spinner className="size-3.5" /> Inspecting…
-              </>
-            ) : (
-              "Inspect"
-            )}
-          </Button>
-        </div>
-      </section>
+            className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3"
+          >
+            {GOOGLE_DISCOVERY_TEMPLATES.map((template) => {
+              const inputId = `google-discovery-preset-${template.id}`;
+              return (
+                <FieldLabel key={template.id} htmlFor={inputId}>
+                  <Field orientation="horizontal">
+                    <GoogleServiceIcon service={template.service} className="size-8" />
+                    <FieldContent>
+                      <FieldTitle>{template.name}</FieldTitle>
+                      <FieldDescription className="line-clamp-2">
+                        {template.summary}
+                      </FieldDescription>
+                    </FieldContent>
+                    <RadioGroupItem id={inputId} value={template.id} />
+                  </Field>
+                </FieldLabel>
+              );
+            })}
+          </RadioGroup>
+        </FieldSet>
+      </FieldGroup>
 
-      <section className="space-y-2">
-        <Label>Display Name</Label>
-        <Input
-          value={name}
-          onChange={(e) => setName((e.target as HTMLInputElement).value)}
-          placeholder="Google Sheets"
-        />
-      </section>
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntryField label="Discovery URL">
+            <div className="relative">
+              <Input
+                value={discoveryUrl}
+                onChange={(e) => {
+                  setSelectedTemplateId("");
+                  setDiscoveryUrl((e.target as HTMLInputElement).value);
+                  setProbe(null);
+                  setOauthAuth(null);
+                  setError(null);
+                }}
+                placeholder="https://www.googleapis.com/discovery/v1/apis/sheets/v4/rest"
+                className="w-full pr-9 font-mono text-sm"
+              />
+              {loadingProbe && (
+                <div className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                  <IOSSpinner className="size-4" />
+                </div>
+              )}
+            </div>
+          </CardStackEntryField>
+
+          <CardStackEntryField label="Display Name">
+            <Input
+              value={name}
+              onChange={(e) => setName((e.target as HTMLInputElement).value)}
+              placeholder="Google Sheets"
+            />
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
 
       {probe && (
         <section className="space-y-3 rounded-xl border border-border bg-card px-4 py-4">
@@ -693,27 +743,11 @@ export default function AddGoogleDiscoverySource(props: {
         </section>
       )}
 
-      <section className="space-y-3">
-        <RadioGroup
-          value={authKind}
-          onValueChange={(value) => setAuthKind(value as "none" | "oauth2")}
-          className="flex items-center gap-4"
-        >
-          <div className="flex items-center gap-2">
-            <RadioGroupItem id="google-discovery-auth-none" value="none" />
-            <Label htmlFor="google-discovery-auth-none" className="text-sm">
-              No auth
-            </Label>
-          </div>
-          <div className="flex items-center gap-2">
-            <RadioGroupItem id="google-discovery-auth-oauth2" value="oauth2" />
-            <Label htmlFor="google-discovery-auth-oauth2" className="text-sm">
-              OAuth 2.0
-            </Label>
-          </div>
-        </RadioGroup>
-
-        {authKind === "oauth2" && (
+      <AuthenticationSection
+        methods={["none", "oauth2"]}
+        value={authKind}
+        onChange={setAuthKind}
+        oauth2Slot={
           <div className="space-y-3 rounded-xl border border-border bg-card px-4 py-4">
             <div className="space-y-2">
               <Label>OAuth Client ID</Label>
@@ -797,8 +831,45 @@ export default function AddGoogleDiscoverySource(props: {
               </div>
             )}
           </div>
-        )}
-      </section>
+        }
+      />
+
+      {probe && probe.operations.length > 0 && (
+        <CardStack searchable className="opacity-50 hover:opacity-100 transition-opacity">
+          <CardStackHeader>
+            {probe.operations.length} operation
+            {probe.operations.length !== 1 ? "s" : ""}
+          </CardStackHeader>
+          <CardStackContent>
+            {probe.operations.map((op) => (
+              <CardStackEntry
+                key={op.toolPath}
+                searchText={`${op.method} ${op.pathTemplate} ${op.toolPath} ${op.description ?? ""}`}
+              >
+                <CardStackEntryContent>
+                  <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+                    <span
+                      className={cn(
+                        "shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase",
+                        methodBadgeClasses(op.method),
+                      )}
+                    >
+                      {op.method}
+                    </span>
+                    <span className="truncate font-mono">{op.pathTemplate}</span>
+                  </CardStackEntryTitle>
+                  <CardStackEntryDescription className="font-mono">
+                    {op.toolPath}
+                  </CardStackEntryDescription>
+                  {op.description && (
+                    <CardStackEntryDescription>{op.description}</CardStackEntryDescription>
+                  )}
+                </CardStackEntryContent>
+              </CardStackEntry>
+            ))}
+          </CardStackContent>
+        </CardStack>
+      )}
 
       {error && (
         <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-sm text-destructive">
@@ -806,14 +877,15 @@ export default function AddGoogleDiscoverySource(props: {
         </div>
       )}
 
-      <div className="flex items-center justify-between border-t border-border pt-4">
-        <Button variant="outline" onClick={props.onCancel}>
+      <FloatActions>
+        <Button variant="ghost" onClick={props.onCancel} disabled={adding}>
           Cancel
         </Button>
         <Button onClick={handleAdd} disabled={addDisabled}>
+          {adding && <Spinner className="size-3.5" />}
           {adding ? "Adding…" : "Add Source"}
         </Button>
-      </div>
+      </FloatActions>
     </div>
   );
 }

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -36,6 +36,13 @@ import type {
 } from "./types";
 import { GoogleDiscoveryStoredSourceData as GoogleDiscoveryStoredSourceDataSchema } from "./types";
 
+export interface GoogleDiscoveryProbeOperation {
+  readonly toolPath: string;
+  readonly method: string;
+  readonly pathTemplate: string;
+  readonly description: string | null;
+}
+
 export interface GoogleDiscoveryProbeResult {
   readonly name: string;
   readonly title: string | null;
@@ -43,6 +50,7 @@ export interface GoogleDiscoveryProbeResult {
   readonly version: string;
   readonly toolCount: number;
   readonly scopes: readonly string[];
+  readonly operations: readonly GoogleDiscoveryProbeOperation[];
 }
 
 export interface GoogleDiscoveryAddSourceInput {
@@ -370,6 +378,12 @@ export const googleDiscoveryPlugin = (options?: {
               const scopes = Object.keys(
                 manifest.oauthScopes._tag === "Some" ? manifest.oauthScopes.value : {},
               ).sort();
+              const operations = manifest.methods.map((method) => ({
+                toolPath: method.toolPath,
+                method: method.binding.method,
+                pathTemplate: method.binding.pathTemplate,
+                description: method.description._tag === "Some" ? method.description.value : null,
+              }));
               return {
                 name:
                   manifest.title._tag === "Some"
@@ -380,6 +394,7 @@ export const googleDiscoveryPlugin = (options?: {
                 version: manifest.version,
                 toolCount: manifest.methods.length,
                 scopes,
+                operations,
               };
             }),
 

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -2,21 +2,24 @@ import { useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 
 import { useScope } from "@executor/react/api/scope-context";
-import { SecretHeaderAuthRow } from "@executor/react/plugins/secret-header-auth";
+import {
+  AuthenticationSection,
+  type AuthHeaderEntry,
+} from "@executor/react/plugins/authentication-section";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "@executor/react/components/card-stack";
+import { FloatActions } from "@executor/react/components/float-actions";
 import { Input } from "@executor/react/components/input";
-import { Label } from "@executor/react/components/label";
 import { Spinner } from "@executor/react/components/spinner";
 import { addGraphqlSource } from "./atoms";
 import type { HeaderValue } from "../sdk/types";
 
-type HeaderEntry = {
-  name: string;
-  prefix?: string;
-  presetKey?: string;
-  secretId: string | null;
-};
+type HeaderEntry = AuthHeaderEntry;
 
 const initialHeader = (): HeaderEntry => ({
   name: "Authorization",
@@ -42,26 +45,6 @@ export default function AddGraphqlSource(props: {
 
   const headersValid = headers.every((header) => header.name.trim() && header.secretId);
   const canAdd = endpoint.trim().length > 0 && (headers.length === 0 || headersValid);
-
-  const updateHeader = (
-    index: number,
-    update: Partial<{ name: string; prefix?: string; presetKey?: string; secretId: string | null }>,
-  ) => {
-    setHeaders((current) =>
-      current.map((header, i) => (i === index ? { ...header, ...update } : header)),
-    );
-  };
-
-  const removeHeader = (index: number) => {
-    setHeaders((current) => current.filter((_, i) => i !== index));
-  };
-
-  const addHeader = () => {
-    setHeaders((current) => [
-      ...current,
-      { name: "", prefix: undefined, presetKey: undefined, secretId: null },
-    ]);
-  };
 
   const handleAdd = async () => {
     setAdding(true);
@@ -94,79 +77,46 @@ export default function AddGraphqlSource(props: {
   };
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-1 flex-col gap-6">
       <h1 className="text-xl font-semibold text-foreground">Add GraphQL Source</h1>
 
-      {/* Endpoint */}
-      <section className="space-y-2">
-        <Label>GraphQL Endpoint</Label>
-        <Input
-          value={endpoint}
-          onChange={(e) => setEndpoint((e.target as HTMLInputElement).value)}
-          placeholder="https://api.example.com/graphql"
-          className="font-mono text-sm"
-        />
-        <p className="text-[12px] text-muted-foreground">
-          The endpoint will be introspected to discover available queries and mutations.
-        </p>
-      </section>
-
-      {/* Namespace */}
-      <section className="space-y-2">
-        <Label>
-          Namespace <span className="text-muted-foreground font-normal">(optional)</span>
-        </Label>
-        <Input
-          value={namespace}
-          onChange={(e) => setNamespace((e.target as HTMLInputElement).value)}
-          placeholder="my_api"
-          className="font-mono text-sm"
-        />
-        <p className="text-[12px] text-muted-foreground">
-          A prefix for the tool names. Derived from the endpoint hostname if not provided.
-        </p>
-      </section>
-
-      {/* Authentication */}
-      <section className="space-y-2.5">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <Label>
-              Authentication <span className="text-muted-foreground font-normal">(optional)</span>
-            </Label>
-            <p className="mt-1 text-[12px] text-muted-foreground">
-              Secret-backed headers sent with every request, including introspection.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="shrink-0"
-            onClick={addHeader}
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntryField
+            label="Endpoint"
+            hint="The endpoint will be introspected to discover available queries and mutations."
           >
-            + Add header
-          </Button>
-        </div>
+            <Input
+              value={endpoint}
+              onChange={(e) => setEndpoint((e.target as HTMLInputElement).value)}
+              placeholder="https://api.example.com/graphql"
+              className="font-mono text-sm"
+            />
+          </CardStackEntryField>
 
-        {headers.length > 0 && (
-          <div className="space-y-2">
-            {headers.map((header, index) => (
-              <SecretHeaderAuthRow
-                key={index}
-                name={header.name}
-                prefix={header.prefix}
-                presetKey={header.presetKey}
-                secretId={header.secretId}
-                onChange={(update) => updateHeader(index, update)}
-                onSelectSecret={(secretId) => updateHeader(index, { secretId })}
-                onRemove={() => removeHeader(index)}
-                existingSecrets={secretList}
-              />
-            ))}
-          </div>
-        )}
-      </section>
+          <CardStackEntryField
+            label="Namespace"
+            description="(optional)"
+            hint="A prefix for the tool names. Derived from the endpoint hostname if not provided."
+          >
+            <Input
+              value={namespace}
+              onChange={(e) => setNamespace((e.target as HTMLInputElement).value)}
+              placeholder="my_api"
+              className="font-mono text-sm"
+            />
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
+
+      <AuthenticationSection
+        methods={["header"]}
+        value="header"
+        onChange={() => {}}
+        headers={headers}
+        onHeadersChange={setHeaders}
+        existingSecrets={secretList}
+      />
 
       {/* Error */}
       {addError && (
@@ -175,8 +125,7 @@ export default function AddGraphqlSource(props: {
         </div>
       )}
 
-      {/* Actions */}
-      <div className="flex items-center justify-between border-t border-border pt-4">
+      <FloatActions>
         <Button variant="ghost" onClick={props.onCancel} disabled={adding}>
           Cancel
         </Button>
@@ -184,7 +133,7 @@ export default function AddGraphqlSource(props: {
           {adding && <Spinner className="size-3.5" />}
           {adding ? "Adding..." : "Add source"}
         </Button>
-      </div>
+      </FloatActions>
     </div>
   );
 }

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -4,14 +4,18 @@ import { graphqlSourceAtom, updateGraphqlSource } from "./atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import {
-  SecretHeaderAuthRow,
   headerValueToState,
   headersFromState,
   type HeaderState,
 } from "@executor/react/plugins/secret-header-auth";
+import { AuthenticationSection } from "@executor/react/plugins/authentication-section";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "@executor/react/components/card-stack";
 import { Input } from "@executor/react/components/input";
-import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
 import type { StoredSourceSchemaType } from "../sdk/stored-source";
 
@@ -39,8 +43,8 @@ function EditForm(props: {
   const [error, setError] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
 
-  const updateHeader = (index: number, update: Partial<HeaderState>) => {
-    setHeaders((prev) => prev.map((h, i) => (i === index ? { ...h, ...update } : h)));
+  const handleHeadersChange = (next: HeaderState[]) => {
+    setHeaders(next);
     setDirty(true);
   };
 
@@ -83,49 +87,31 @@ function EditForm(props: {
         </Badge>
       </div>
 
-      <section className="space-y-2">
-        <Label>Endpoint</Label>
-        <Input
-          value={endpoint}
-          onChange={(e) => {
-            setEndpoint((e.target as HTMLInputElement).value);
-            setDirty(true);
-          }}
-          placeholder="https://api.example.com/graphql"
-          className="font-mono text-sm"
-        />
-      </section>
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntryField label="Endpoint">
+            <Input
+              value={endpoint}
+              onChange={(e) => {
+                setEndpoint((e.target as HTMLInputElement).value);
+                setDirty(true);
+              }}
+              placeholder="https://api.example.com/graphql"
+              className="font-mono text-sm"
+            />
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
 
-      <section className="space-y-2.5">
-        <Label>Headers</Label>
-        {headers.map((h, i) => (
-          <SecretHeaderAuthRow
-            key={i}
-            name={h.name}
-            prefix={h.prefix}
-            presetKey={h.presetKey}
-            secretId={h.secretId}
-            onChange={(update) => updateHeader(i, update)}
-            onSelectSecret={(secretId) => updateHeader(i, { secretId })}
-            onRemove={() => {
-              setHeaders((prev) => prev.filter((_, j) => j !== i));
-              setDirty(true);
-            }}
-            existingSecrets={secretList}
-          />
-        ))}
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full border-dashed"
-          onClick={() => {
-            setHeaders((prev) => [...prev, { name: "", secretId: null }]);
-            setDirty(true);
-          }}
-        >
-          + Add header
-        </Button>
-      </section>
+      <AuthenticationSection
+        methods={["header"]}
+        value="header"
+        onChange={() => {}}
+        label="Headers"
+        headers={headers}
+        onHeadersChange={handleHeadersChange}
+        existingSecrets={secretList}
+      />
 
       {error && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -1,15 +1,33 @@
-import { useReducer, useCallback, useEffect, useRef, useState } from "react";
+import { useReducer, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntry,
+  CardStackEntryActions,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+  CardStackEntryField,
+  CardStackEntryMedia,
+  CardStackEntryTitle,
+} from "@executor/react/components/card-stack";
+import { FieldError } from "@executor/react/components/field";
+import { FloatActions } from "@executor/react/components/float-actions";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
-import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
-import { Spinner } from "@executor/react/components/spinner";
+import { Skeleton } from "@executor/react/components/skeleton";
+import { SourceFavicon } from "@executor/react/components/source-favicon";
+import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
 import { Textarea } from "@executor/react/components/textarea";
-import { SecretHeaderAuthRow } from "@executor/react/plugins/secret-header-auth";
+import {
+  AuthenticationSection,
+  type AuthMethod,
+  type AuthHeaderEntry,
+} from "@executor/react/plugins/authentication-section";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { probeMcpEndpoint, addMcpSource, startMcpOAuth } from "./atoms";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
@@ -44,8 +62,6 @@ type ProbeResult = {
   serverName: string | null;
 };
 
-type RemoteAuthMode = "none" | "header" | "oauth2";
-
 type PlainHeader = {
   name: string;
   value: string;
@@ -56,9 +72,19 @@ type State =
   | { step: "probing"; url: string }
   | { step: "probed"; url: string; probe: ProbeResult }
   | { step: "oauth-starting"; url: string; probe: ProbeResult }
-  | { step: "oauth-waiting"; url: string; probe: ProbeResult; sessionId: string }
+  | {
+      step: "oauth-waiting";
+      url: string;
+      probe: ProbeResult;
+      sessionId: string;
+    }
   | { step: "oauth-done"; url: string; probe: ProbeResult; tokens: OAuthTokens }
-  | { step: "adding"; url: string; probe: ProbeResult; tokens: OAuthTokens | null }
+  | {
+      step: "adding";
+      url: string;
+      probe: ProbeResult;
+      tokens: OAuthTokens | null;
+    }
   | {
       step: "error";
       url: string;
@@ -95,7 +121,13 @@ function reducer(state: State, action: Action): State {
       return { step: "probed", url: state.url, probe: action.probe };
 
     case "probe-fail":
-      return { step: "error", url: state.url, probe: null, tokens: null, error: action.error };
+      return {
+        step: "error",
+        url: state.url,
+        probe: null,
+        tokens: null,
+        error: action.error,
+      };
 
     case "oauth-start":
       if (state.step !== "probed" && state.step !== "error") return state;
@@ -116,7 +148,12 @@ function reducer(state: State, action: Action): State {
 
     case "oauth-ok":
       if (state.step !== "oauth-waiting") return state;
-      return { step: "oauth-done", url: state.url, probe: state.probe, tokens: action.tokens };
+      return {
+        step: "oauth-done",
+        url: state.url,
+        probe: state.probe,
+        tokens: action.tokens,
+      };
 
     case "oauth-fail":
       if (state.step !== "oauth-starting" && state.step !== "oauth-waiting") return state;
@@ -154,7 +191,12 @@ function reducer(state: State, action: Action): State {
       if (state.step !== "error") return state;
       return state.probe
         ? state.tokens
-          ? { step: "oauth-done", url: state.url, probe: state.probe, tokens: state.tokens }
+          ? {
+              step: "oauth-done",
+              url: state.url,
+              probe: state.probe,
+              tokens: state.tokens,
+            }
           : { step: "probed", url: state.url, probe: state.probe }
         : { step: "url", url: state.url };
     }
@@ -169,8 +211,17 @@ function reducer(state: State, action: Action): State {
 // ---------------------------------------------------------------------------
 
 type OAuthPopupResult =
-  | ({ type: "executor:oauth-result"; ok: true; sessionId: string } & OAuthTokens)
-  | { type: "executor:oauth-result"; ok: false; sessionId: null; error: string };
+  | ({
+      type: "executor:oauth-result";
+      ok: true;
+      sessionId: string;
+    } & OAuthTokens)
+  | {
+      type: "executor:oauth-result";
+      ok: false;
+      sessionId: null;
+      error: string;
+    };
 
 const OAUTH_RESULT_CHANNEL = "executor:mcp-oauth-result";
 
@@ -267,28 +318,25 @@ export default function AddMcpSource(props: {
   const doStartOAuth = useAtomSet(startMcpOAuth, { mode: "promise" });
   const secretList = useSecretPickerSecrets();
 
-  const [remoteAuthMode, setRemoteAuthMode] = useState<RemoteAuthMode>("none");
-  const [remoteHeaderAuth, setRemoteHeaderAuth] = useState<{
-    name: string;
-    prefix?: string;
-    presetKey?: string;
-    secretId: string | null;
-  }>({
-    name: "Authorization",
-    prefix: "Bearer ",
-    presetKey: "bearer",
-    secretId: null,
-  });
+  const [remoteAuthMode, setRemoteAuthMode] = useState<AuthMethod>("none");
+  const [remoteAuthHeaders, setRemoteAuthHeaders] = useState<AuthHeaderEntry[]>([
+    {
+      name: "Authorization",
+      prefix: "Bearer ",
+      presetKey: "bearer",
+      secretId: null,
+    },
+  ]);
   const [remoteHeaders, setRemoteHeaders] = useState<PlainHeader[]>([]);
 
   const probe = "probe" in state ? state.probe : null;
   const tokens = "tokens" in state ? state.tokens : null;
-  const isIdle = state.step === "url";
   const isProbing = state.step === "probing";
   const isAdding = state.step === "adding";
   const isOAuthBusy = state.step === "oauth-starting" || state.step === "oauth-waiting";
   const canUseNone = probe?.requiresOAuth !== true;
-  const headerAuthComplete = Boolean(remoteHeaderAuth.name.trim() && remoteHeaderAuth.secretId);
+  const remoteAuthHeader = remoteAuthHeaders[0];
+  const headerAuthComplete = Boolean(remoteAuthHeader?.name.trim() && remoteAuthHeader?.secretId);
   const remoteHeadersComplete = remoteHeaders.every(
     (header) => header.name.trim() && header.value.trim(),
   );
@@ -299,7 +347,10 @@ export default function AddMcpSource(props: {
         ? headerAuthComplete
         : tokens !== null;
   const canAdd = Boolean(probe) && authReady && remoteHeadersComplete && !isAdding && !isOAuthBusy;
-  const error = state.step === "error" ? state.error : null;
+  // Probe failures are shown inline on the URL field; other failures
+  // (OAuth start, add source) render in the bottom error block.
+  const probeError = state.step === "error" && state.probe === null ? state.error : null;
+  const otherError = state.step === "error" && state.probe !== null ? state.error : null;
 
   // ---- Remote actions ----
 
@@ -313,17 +364,30 @@ export default function AddMcpSource(props: {
       setRemoteAuthMode(result.requiresOAuth ? "oauth2" : "none");
       dispatch({ type: "probe-ok", probe: result });
     } catch (e) {
-      dispatch({ type: "probe-fail", error: e instanceof Error ? e.message : "Failed to connect" });
+      dispatch({
+        type: "probe-fail",
+        error: e instanceof Error ? e.message : "Failed to connect",
+      });
     }
   }, [state.url, scopeId, doProbe]);
 
-  const autoProbed = useRef(false);
+  // Keep the latest handleProbe in a ref so the debounced effect can call it
+  // without depending on its identity (which changes every render).
+  const handleProbeRef = useRef(handleProbe);
+  handleProbeRef.current = handleProbe;
+
+  // Auto-probe whenever the URL changes (debounced) while we're on the
+  // remote transport and not already probing/probed.
   useEffect(() => {
-    if (transport === "remote" && remoteUrl && !autoProbed.current) {
-      autoProbed.current = true;
-      handleProbe();
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    if (transport !== "remote") return;
+    if (state.step !== "url") return;
+    const trimmed = state.url.trim();
+    if (!trimmed) return;
+    const handle = setTimeout(() => {
+      handleProbeRef.current();
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [transport, state.step, state.url]);
 
   const oauthCleanup = useRef<(() => void) | null>(null);
 
@@ -380,13 +444,14 @@ export default function AddMcpSource(props: {
     if (!probe) return;
     dispatch({ type: "add-start" });
     try {
+      const headerAuth = remoteAuthHeaders[0];
       const auth =
-        remoteAuthMode === "header"
+        remoteAuthMode === "header" && headerAuth?.secretId
           ? {
               kind: "header" as const,
-              headerName: remoteHeaderAuth.name.trim(),
-              secretId: remoteHeaderAuth.secretId!,
-              ...(remoteHeaderAuth.prefix ? { prefix: remoteHeaderAuth.prefix } : {}),
+              headerName: headerAuth.name.trim(),
+              secretId: headerAuth.secretId,
+              ...(headerAuth.prefix ? { prefix: headerAuth.prefix } : {}),
             }
           : remoteAuthMode === "oauth2" && tokens
             ? {
@@ -424,7 +489,7 @@ export default function AddMcpSource(props: {
   }, [
     probe,
     remoteAuthMode,
-    remoteHeaderAuth,
+    remoteAuthHeaders,
     remoteHeaders,
     tokens,
     state.url,
@@ -484,7 +549,7 @@ export default function AddMcpSource(props: {
   // ---- Render ----
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-1 flex-col gap-6">
       <div>
         <h1 className="text-xl font-semibold text-foreground">Add MCP Source</h1>
         <p className="mt-1 text-[13px] text-muted-foreground">
@@ -522,200 +587,123 @@ export default function AddMcpSource(props: {
 
       {transport === "remote" ? (
         <>
-          {/* URL input */}
-          <section className="space-y-2">
-            <Label>Server URL</Label>
-            <div className="flex gap-2">
-              <Input
-                value={state.url}
-                onChange={(e) =>
-                  dispatch({ type: "set-url", url: (e.target as HTMLInputElement).value })
-                }
-                placeholder="https://mcp.example.com"
-                className="flex-1 font-mono text-sm"
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" && state.url.trim() && isIdle) handleProbe();
-                }}
-                disabled={isProbing}
-              />
-              {!probe && (
-                <Button onClick={handleProbe} disabled={!state.url.trim() || isProbing}>
-                  {isProbing ? (
-                    <>
-                      <Spinner className="size-3.5" /> Connecting…
-                    </>
-                  ) : (
-                    "Connect"
-                  )}
-                </Button>
-              )}
-            </div>
-            <p className="text-[12px] text-muted-foreground">
-              Supports Streamable HTTP and SSE transports.
-            </p>
-          </section>
+          {/* Server info card (shown above URL input after probing) */}
+          {probe ? (
+            <CardStack>
+              <CardStackContent className="border-t-0">
+                <CardStackEntry>
+                  <CardStackEntryMedia>
+                    <SourceFavicon url={state.url} size={32} />
+                  </CardStackEntryMedia>
+                  <CardStackEntryContent>
+                    <CardStackEntryTitle>{probe.serverName ?? probe.name}</CardStackEntryTitle>
+                    <CardStackEntryDescription>
+                      {probe.connected
+                        ? `${probe.toolCount} tool${probe.toolCount !== 1 ? "s" : ""} available`
+                        : "OAuth required to discover tools"}
+                    </CardStackEntryDescription>
+                  </CardStackEntryContent>
+                  <CardStackEntryActions>
+                    {probe.connected ? (
+                      <Badge
+                        variant="outline"
+                        className="border-emerald-500/20 bg-emerald-500/10 text-[10px] text-emerald-600 dark:text-emerald-400"
+                      >
+                        Connected
+                      </Badge>
+                    ) : (
+                      <Badge
+                        variant="outline"
+                        className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
+                      >
+                        OAuth required
+                      </Badge>
+                    )}
+                  </CardStackEntryActions>
+                </CardStackEntry>
+              </CardStackContent>
+            </CardStack>
+          ) : isProbing ? (
+            <CardStack>
+              <CardStackContent className="border-t-0">
+                <CardStackEntry>
+                  <CardStackEntryMedia>
+                    <Skeleton className="size-4 rounded" />
+                  </CardStackEntryMedia>
+                  <CardStackEntryContent>
+                    <Skeleton className="h-4 w-40" />
+                    <Skeleton className="mt-1 h-3 w-32" />
+                  </CardStackEntryContent>
+                  <CardStackEntryActions>
+                    <Skeleton className="h-4 w-20 rounded-full" />
+                  </CardStackEntryActions>
+                </CardStackEntry>
+              </CardStackContent>
+            </CardStack>
+          ) : null}
 
-          {/* Server info card */}
-          {probe && (
-            <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
-              <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                <svg viewBox="0 0 16 16" className="size-4" fill="none">
-                  <rect
-                    x="2"
-                    y="3"
-                    width="12"
-                    height="10"
-                    rx="2"
-                    stroke="currentColor"
-                    strokeWidth="1.2"
+          {/* URL input */}
+          <CardStack>
+            <CardStackContent className="border-t-0">
+              <CardStackEntryField
+                label="Server URL"
+                hint={probeError ? undefined : "Supports Streamable HTTP and SSE transports."}
+              >
+                <div className="relative">
+                  <Input
+                    value={state.url}
+                    onChange={(e) =>
+                      dispatch({
+                        type: "set-url",
+                        url: (e.target as HTMLInputElement).value,
+                      })
+                    }
+                    placeholder="https://mcp.example.com"
+                    className="w-full pr-9 font-mono text-sm"
+                    aria-invalid={probeError ? true : undefined}
                   />
-                  <path
-                    d="M5 7h6M5 9.5h4"
-                    stroke="currentColor"
-                    strokeWidth="1.2"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </div>
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-semibold text-card-foreground leading-none">
-                  {probe.serverName ?? probe.name}
-                </p>
-                <p className="mt-1 text-[12px] text-muted-foreground leading-none">
-                  {probe.connected
-                    ? `${probe.toolCount} tool${probe.toolCount !== 1 ? "s" : ""} available`
-                    : "OAuth required to discover tools"}
-                </p>
-              </div>
-              {probe.connected ? (
-                <Badge
-                  variant="outline"
-                  className="border-emerald-500/20 bg-emerald-500/10 text-[10px] text-emerald-600 dark:text-emerald-400"
-                >
-                  Connected
-                </Badge>
-              ) : (
-                <Badge
-                  variant="outline"
-                  className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
-                >
-                  OAuth required
-                </Badge>
-              )}
-            </div>
-          )}
+                  {isProbing && (
+                    <div className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                      <IOSSpinner className="size-4" />
+                    </div>
+                  )}
+                </div>
+                {probeError && <FieldError>{probeError}</FieldError>}
+              </CardStackEntryField>
+            </CardStackContent>
+          </CardStack>
 
           {/* Authentication */}
           {probe && (
-            <section className="space-y-2.5">
-              <Label>Authentication</Label>
-
-              <RadioGroup
-                value={remoteAuthMode}
-                onValueChange={(value) => setRemoteAuthMode(value as RemoteAuthMode)}
-                className="gap-1.5"
-              >
-                {!probe.requiresOAuth && (
-                  <Label
-                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                      remoteAuthMode === "none"
-                        ? "border-primary/50 bg-primary/[0.03]"
-                        : "border-border hover:bg-accent/50"
-                    }`}
-                  >
-                    <RadioGroupItem value="none" />
-                    <span className="text-xs font-medium text-foreground">None</span>
-                    <span className="ml-auto text-[10px] text-muted-foreground">
-                      no auth header
-                    </span>
-                  </Label>
-                )}
-
-                <Label
-                  className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                    remoteAuthMode === "header"
-                      ? "border-primary/50 bg-primary/[0.03]"
-                      : "border-border hover:bg-accent/50"
-                  }`}
-                >
-                  <RadioGroupItem value="header" />
-                  <span className="text-xs font-medium text-foreground">Header</span>
-                  <span className="ml-auto text-[10px] text-muted-foreground">
-                    use a secret-backed auth header
-                  </span>
-                </Label>
-
-                {probe.requiresOAuth && (
-                  <Label
-                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                      remoteAuthMode === "oauth2"
-                        ? "border-primary/50 bg-primary/[0.03]"
-                        : "border-border hover:bg-accent/50"
-                    }`}
-                  >
-                    <RadioGroupItem value="oauth2" />
-                    <span className="text-xs font-medium text-foreground">OAuth</span>
-                    <span className="ml-auto text-[10px] text-muted-foreground">
-                      sign in with the server&apos;s OAuth flow
-                    </span>
-                  </Label>
-                )}
-              </RadioGroup>
-
-              {remoteAuthMode === "header" && (
-                <SecretHeaderAuthRow
-                  label="Auth header"
-                  name={remoteHeaderAuth.name}
-                  prefix={remoteHeaderAuth.prefix}
-                  presetKey={remoteHeaderAuth.presetKey}
-                  secretId={remoteHeaderAuth.secretId}
-                  onChange={(update) =>
-                    setRemoteHeaderAuth((current) => ({
-                      ...current,
-                      ...update,
-                    }))
-                  }
-                  onSelectSecret={(secretId) =>
-                    setRemoteHeaderAuth((current) => ({
-                      ...current,
-                      secretId,
-                    }))
-                  }
-                  existingSecrets={secretList}
-                />
-              )}
-
-              {probe.requiresOAuth && remoteAuthMode === "oauth2" && !tokens && (
+            <AuthenticationSection
+              methods={
+                probe.requiresOAuth
+                  ? (["header", "oauth2"] as const)
+                  : (["none", "header"] as const)
+              }
+              value={remoteAuthMode}
+              onChange={setRemoteAuthMode}
+              singleHeader
+              headers={remoteAuthHeaders}
+              onHeadersChange={setRemoteAuthHeaders}
+              existingSecrets={secretList}
+              oauth2Slot={
                 <>
-                  {state.step === "probed" && (
-                    <Button onClick={handleOAuth} className="w-full" variant="outline">
-                      <svg viewBox="0 0 16 16" fill="none" className="mr-1.5 size-3.5">
-                        <path
-                          d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1z"
-                          stroke="currentColor"
-                          strokeWidth="1.2"
-                        />
-                        <path
-                          d="M8 4v4l2.5 1.5"
-                          stroke="currentColor"
-                          strokeWidth="1.2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
-                      Sign in with OAuth
+                  {!tokens && state.step === "probed" && (
+                    <Button onClick={handleOAuth} className="w-full bg-white" variant="outline">
+                      Sign in
                     </Button>
                   )}
 
-                  {state.step === "oauth-starting" && (
-                    <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+                  {!tokens && state.step === "oauth-starting" && (
+                    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2.5">
                       <Spinner className="size-3.5" />
                       <span className="text-xs text-muted-foreground">Starting authorization…</span>
                     </div>
                   )}
 
-                  {state.step === "oauth-waiting" && (
-                    <div className="flex items-center gap-2 rounded-lg border border-blue-500/30 bg-blue-500/5 px-3 py-2.5">
+                  {!tokens && state.step === "oauth-waiting" && (
+                    <div className="flex items-center gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2.5">
                       <Spinner className="size-3.5 text-blue-500" />
                       <span className="text-xs text-blue-600 dark:text-blue-400">
                         Waiting for authorization in popup…
@@ -730,138 +718,135 @@ export default function AddMcpSource(props: {
                       </Button>
                     </div>
                   )}
+
+                  {tokens && (
+                    <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5">
+                      <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
+                        <path
+                          d="M3 8.5l3 3 7-7"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
+                      </svg>
+                      <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                        Authenticated
+                      </span>
+                    </div>
+                  )}
                 </>
-              )}
-
-              {probe.requiresOAuth && remoteAuthMode === "oauth2" && tokens && (
-                <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5">
-                  <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
-                    <path
-                      d="M3 8.5l3 3 7-7"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                    Authenticated
-                  </span>
-                </div>
-              )}
-
-              {remoteAuthMode === "none" && probe.requiresOAuth && (
-                <p className="text-[12px] text-amber-600 dark:text-amber-400">
-                  This server requires authentication before it can be added.
-                </p>
-              )}
-            </section>
+              }
+            />
           )}
 
           {/* Additional headers */}
           {probe && (
             <section className="space-y-2.5">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <Label>Additional headers</Label>
-                  <p className="mt-1 text-[12px] text-muted-foreground">
-                    Plaintext headers sent with every request. Use authentication for secret-backed
-                    auth headers.
-                  </p>
-                </div>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="shrink-0"
-                  onClick={() =>
-                    setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
-                  }
-                >
-                  + Add header
-                </Button>
+              <div>
+                <Label>Additional headers</Label>
+                <p className="mt-1 text-[12px] text-muted-foreground">
+                  Plaintext headers sent with every request. Use authentication for secret-backed
+                  auth headers.
+                </p>
               </div>
 
-              {remoteHeaders.length > 0 && (
-                <div className="space-y-2">
-                  {remoteHeaders.map((header, index) => (
-                    <div
-                      key={index}
-                      className="rounded-lg border border-border bg-card p-3 space-y-2"
-                    >
-                      <div className="flex items-center justify-between">
-                        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                          Header
-                        </Label>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="xs"
-                          className="text-muted-foreground hover:text-destructive"
-                          onClick={() =>
-                            setRemoteHeaders((headers) =>
-                              headers.filter((_, headerIndex) => headerIndex !== index),
-                            )
-                          }
-                        >
-                          Remove
-                        </Button>
-                      </div>
-                      <div className="grid grid-cols-2 gap-2">
-                        <div className="space-y-1">
-                          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                            Name
-                          </Label>
-                          <Input
-                            value={header.name}
-                            onChange={(event) =>
-                              setRemoteHeaders((headers) =>
-                                headers.map((current, headerIndex) =>
-                                  headerIndex === index
-                                    ? { ...current, name: (event.target as HTMLInputElement).value }
-                                    : current,
-                                ),
-                              )
-                            }
-                            placeholder="X-Organization-Id"
-                            className="h-8 text-xs font-mono"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                            Value
-                          </Label>
-                          <Input
-                            value={header.value}
-                            onChange={(event) =>
-                              setRemoteHeaders((headers) =>
-                                headers.map((current, headerIndex) =>
-                                  headerIndex === index
-                                    ? {
-                                        ...current,
-                                        value: (event.target as HTMLInputElement).value,
-                                      }
-                                    : current,
-                                ),
-                              )
-                            }
-                            placeholder="workspace-id"
-                            className="h-8 text-xs font-mono"
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              )}
+              <CardStack>
+                <CardStackContent>
+                  {remoteHeaders.length === 0 ? (
+                    <AddPlainHeaderRow
+                      leading={<span>No headers</span>}
+                      onClick={() =>
+                        setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
+                      }
+                    />
+                  ) : (
+                    <>
+                      {remoteHeaders.map((header, index) => (
+                        <CardStackEntry key={index} className="flex-col items-stretch gap-2">
+                          <div className="flex items-center justify-between">
+                            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                              Header
+                            </Label>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="xs"
+                              className="text-muted-foreground hover:text-destructive"
+                              onClick={() =>
+                                setRemoteHeaders((headers) =>
+                                  headers.filter((_, headerIndex) => headerIndex !== index),
+                                )
+                              }
+                            >
+                              Remove
+                            </Button>
+                          </div>
+                          <div className="grid grid-cols-2 gap-2">
+                            <div className="space-y-1">
+                              <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                Name
+                              </Label>
+                              <Input
+                                value={header.name}
+                                onChange={(event) =>
+                                  setRemoteHeaders((headers) =>
+                                    headers.map((current, headerIndex) =>
+                                      headerIndex === index
+                                        ? {
+                                            ...current,
+                                            name: (event.target as HTMLInputElement).value,
+                                          }
+                                        : current,
+                                    ),
+                                  )
+                                }
+                                placeholder="X-Organization-Id"
+                                className="h-8 text-xs font-mono"
+                              />
+                            </div>
+                            <div className="space-y-1">
+                              <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                Value
+                              </Label>
+                              <Input
+                                value={header.value}
+                                onChange={(event) =>
+                                  setRemoteHeaders((headers) =>
+                                    headers.map((current, headerIndex) =>
+                                      headerIndex === index
+                                        ? {
+                                            ...current,
+                                            value: (event.target as HTMLInputElement).value,
+                                          }
+                                        : current,
+                                    ),
+                                  )
+                                }
+                                placeholder="workspace-id"
+                                className="h-8 text-xs font-mono"
+                              />
+                            </div>
+                          </div>
+                        </CardStackEntry>
+                      ))}
+                      <AddPlainHeaderRow
+                        onClick={() =>
+                          setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
+                        }
+                      />
+                    </>
+                  )}
+                </CardStackContent>
+              </CardStack>
             </section>
           )}
 
-          {/* Error */}
-          {error && (
+          {/* Error (OAuth / add source). Probe errors show inline on the field. */}
+          {otherError && (
             <div className="space-y-2">
               <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-                <p className="text-[12px] text-destructive">{error}</p>
+                <p className="text-[12px] text-destructive">{otherError}</p>
               </div>
               <Button
                 variant="outline"
@@ -874,12 +859,11 @@ export default function AddMcpSource(props: {
             </div>
           )}
 
-          {/* Actions */}
-          {(probe || isProbing) && (
-            <div className="flex items-center justify-between border-t border-border pt-4">
-              <Button variant="ghost" onClick={props.onCancel} disabled={isAdding}>
-                Cancel
-              </Button>
+          <FloatActions>
+            <Button variant="ghost" onClick={props.onCancel} disabled={isAdding}>
+              Cancel
+            </Button>
+            {(probe || isProbing) && (
               <Button onClick={handleAddRemote} disabled={!canAdd}>
                 {isAdding ? (
                   <>
@@ -889,76 +873,62 @@ export default function AddMcpSource(props: {
                   "Add source"
                 )}
               </Button>
-            </div>
-          )}
-
-          {/* Cancel when nothing probed yet */}
-          {!probe && !isProbing && (
-            <div className="flex items-center justify-between pt-1">
-              <Button variant="ghost" onClick={props.onCancel}>
-                Cancel
-              </Button>
-              <div />
-            </div>
-          )}
+            )}
+          </FloatActions>
         </>
       ) : (
         <>
           {/* Stdio form */}
-          <section className="space-y-4">
-            <div className="space-y-2">
-              <Label>Command</Label>
-              <Input
-                value={stdioCommand}
-                onChange={(e) => setStdioCommand((e.target as HTMLInputElement).value)}
-                placeholder="npx"
-                className="font-mono text-sm"
-              />
-              <p className="text-[12px] text-muted-foreground">
-                The executable to run (e.g. npx, uvx, node).
-              </p>
-            </div>
+          <CardStack>
+            <CardStackContent className="border-t-0">
+              <CardStackEntryField
+                label="Command"
+                description="- The executable to run (e.g. npx, uvx, node)."
+              >
+                <Input
+                  value={stdioCommand}
+                  onChange={(e) => setStdioCommand((e.target as HTMLInputElement).value)}
+                  placeholder="npx"
+                  className="font-mono text-sm"
+                />
+              </CardStackEntryField>
 
-            <div className="space-y-2">
-              <Label>Arguments</Label>
-              <Input
-                value={stdioArgs}
-                onChange={(e) => setStdioArgs((e.target as HTMLInputElement).value)}
-                placeholder="-y chrome-devtools-mcp@latest"
-                className="font-mono text-sm"
-              />
-              <p className="text-[12px] text-muted-foreground">
-                Space-separated arguments passed to the command.
-              </p>
-            </div>
+              <CardStackEntryField
+                label="Arguments"
+                description="- Space-separated arguments passed to the command."
+              >
+                <Input
+                  value={stdioArgs}
+                  onChange={(e) => setStdioArgs((e.target as HTMLInputElement).value)}
+                  placeholder="-y chrome-devtools-mcp@latest"
+                  className="font-mono text-sm"
+                />
+              </CardStackEntryField>
 
-            <div className="space-y-2">
-              <Label>
-                Name <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Input
-                value={stdioName}
-                onChange={(e) => setStdioName((e.target as HTMLInputElement).value)}
-                placeholder="My MCP Server"
-                className="text-sm"
-              />
-            </div>
+              <CardStackEntryField label="Name" description="(optional)">
+                <Input
+                  value={stdioName}
+                  onChange={(e) => setStdioName((e.target as HTMLInputElement).value)}
+                  placeholder="My MCP Server"
+                  className="text-sm"
+                />
+              </CardStackEntryField>
 
-            <div className="space-y-2">
-              <Label>
-                Environment variables{" "}
-                <span className="text-muted-foreground font-normal">(optional)</span>
-              </Label>
-              <Textarea
-                value={stdioEnv}
-                onChange={(e) => setStdioEnv((e.target as HTMLTextAreaElement).value)}
-                placeholder={"KEY=value\nANOTHER=value"}
-                rows={3}
-                className="font-mono text-sm"
-              />
-              <p className="text-[12px] text-muted-foreground">One per line, KEY=value format.</p>
-            </div>
-          </section>
+              <CardStackEntryField
+                label="Environment variables"
+                description="- One per line, KEY=value format."
+              >
+                <Textarea
+                  value={stdioEnv}
+                  onChange={(e) => setStdioEnv((e.target as HTMLTextAreaElement).value)}
+                  placeholder={"KEY=value\nANOTHER=value"}
+                  rows={3}
+                  maxRows={10}
+                  className="font-mono text-sm"
+                />
+              </CardStackEntryField>
+            </CardStackContent>
+          </CardStack>
 
           {/* Stdio error */}
           {stdioError && (
@@ -967,8 +937,7 @@ export default function AddMcpSource(props: {
             </div>
           )}
 
-          {/* Stdio actions */}
-          <div className="flex items-center justify-between border-t border-border pt-4">
+          <FloatActions>
             <Button variant="ghost" onClick={props.onCancel} disabled={stdioAdding}>
               Cancel
             </Button>
@@ -981,9 +950,35 @@ export default function AddMcpSource(props: {
                 "Add source"
               )}
             </Button>
-          </div>
+          </FloatActions>
         </>
       )}
     </div>
+  );
+}
+
+function AddPlainHeaderRow({
+  onClick,
+  leading,
+}: {
+  readonly onClick: () => void;
+  readonly leading?: ReactNode;
+}) {
+  return (
+    // oxlint-disable-next-line react/forbid-elements
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      aria-label="Add header"
+      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
+    >
+      <span className="min-w-0 flex-1 text-left">{leading}</span>
+      <svg aria-hidden viewBox="0 0 16 16" fill="none" className="size-4 shrink-0">
+        <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </button>
   );
 }

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -3,6 +3,11 @@ import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/a
 import { mcpSourceAtom, updateMcpSource } from "./atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "@executor/react/components/card-stack";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
@@ -104,18 +109,21 @@ function RemoteEditForm(props: {
       </div>
 
       {/* Endpoint */}
-      <section className="space-y-2">
-        <Label>Endpoint</Label>
-        <Input
-          value={endpoint}
-          onChange={(e) => {
-            setEndpoint((e.target as HTMLInputElement).value);
-            setDirty(true);
-          }}
-          placeholder="https://mcp.example.com"
-          className="font-mono text-sm"
-        />
-      </section>
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntryField label="Endpoint">
+            <Input
+              value={endpoint}
+              onChange={(e) => {
+                setEndpoint((e.target as HTMLInputElement).value);
+                setDirty(true);
+              }}
+              placeholder="https://mcp.example.com"
+              className="font-mono text-sm"
+            />
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
 
       {/* Headers */}
       <section className="space-y-2.5">

--- a/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
+++ b/packages/plugins/onepassword/src/react/OnePasswordSettings.tsx
@@ -21,6 +21,12 @@ import {
   DialogFooter,
   DialogClose,
 } from "@executor/react/components/dialog";
+import {
+  CardStackEntry,
+  CardStackEntryActions,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+} from "@executor/react/components/card-stack";
 
 import {
   onepasswordConfigAtom,
@@ -317,92 +323,70 @@ export default function OnePasswordSettings() {
   });
 
   return (
-    <div className="rounded-xl border border-border/60 bg-card overflow-hidden transition-all hover:border-border">
-      {/* Header */}
-      <div className="flex items-center gap-3 px-5 py-4 border-b border-border/40">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <h3 className="text-[13px] font-semibold text-foreground leading-none">1Password</h3>
-            {isLoading ? (
-              <span className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
-            ) : isError ? (
-              <span className="rounded-full bg-destructive/15 px-2 py-0.5 text-[10px] font-medium text-destructive leading-none">
-                Error
+    <>
+      <CardStackEntry>
+        <CardStackEntryContent>
+          {isLoading ? (
+            <CardStackEntryDescription>Loading…</CardStackEntryDescription>
+          ) : isError ? (
+            <CardStackEntryDescription className="text-destructive">
+              Failed to load configuration
+            </CardStackEntryDescription>
+          ) : config ? (
+            <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1 text-[12px]">
+              <span className="text-muted-foreground/60">Auth</span>
+              <span className="font-mono text-foreground/80 truncate">
+                {config.auth.kind === "desktop-app" ? config.auth.accountName : "service-account"}
               </span>
-            ) : config ? (
-              <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400 leading-none">
-                Connected
-              </span>
-            ) : (
-              <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground leading-none">
-                Not configured
-              </span>
-            )}
-          </div>
-        </div>
-        {config && (
-          <div className="flex items-center gap-1">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2.5 text-[12px]"
-              onClick={() => setConfigOpen(true)}
-            >
-              Edit
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 px-2.5 text-[12px] text-destructive/70 hover:text-destructive"
-              onClick={handleRemove}
-            >
-              Disconnect
-            </Button>
-          </div>
-        )}
-      </div>
-
-      {/* Body */}
-      <div className="px-5 py-4">
-        {isLoading ? (
-          <div className="flex items-center gap-2">
-            <div className="size-1.5 rounded-full bg-muted-foreground/30 animate-pulse" />
-            <p className="text-[12px] text-muted-foreground/50">Loading…</p>
-          </div>
-        ) : isError ? (
-          <div className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2">
-            <p className="text-[12px] text-destructive">Failed to load configuration</p>
-          </div>
-        ) : config ? (
-          <div className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-2 text-[12px]">
-            <span className="text-muted-foreground/60">Auth</span>
-            <span className="font-mono text-foreground/80">
-              {config.auth.kind === "desktop-app" ? config.auth.accountName : "service-account"}
-            </span>
-            <span className="text-muted-foreground/60">Vault</span>
-            <div className="flex items-center gap-2">
-              <span className="text-foreground/80">{config.name}</span>
-              <span className="font-mono text-[10px] text-muted-foreground/40">
-                {config.vaultId}
-              </span>
+              <span className="text-muted-foreground/60">Vault</span>
+              <div className="flex items-center gap-2 min-w-0">
+                <span className="text-foreground/80 truncate">{config.name}</span>
+                <span className="font-mono text-[10px] text-muted-foreground/40 truncate">
+                  {config.vaultId}
+                </span>
+              </div>
             </div>
-          </div>
-        ) : (
-          <div className="flex items-center justify-between">
-            <p className="text-[12px] text-muted-foreground/60 leading-relaxed">
+          ) : (
+            <CardStackEntryDescription>
               Resolve secrets from your 1Password vault.
-            </p>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 text-[12px] shrink-0"
-              onClick={() => setConfigOpen(true)}
-            >
-              Connect
-            </Button>
-          </div>
-        )}
-      </div>
+            </CardStackEntryDescription>
+          )}
+        </CardStackEntryContent>
+        <CardStackEntryActions>
+          {config ? (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2.5 text-[12px]"
+                onClick={() => setConfigOpen(true)}
+              >
+                Edit
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2.5 text-[12px] text-destructive/70 hover:text-destructive"
+                onClick={handleRemove}
+              >
+                Disconnect
+              </Button>
+            </>
+          ) : (
+            !isLoading &&
+            !isError && (
+              <Button
+                variant="link"
+                size="sm"
+                className="h-7 px-0 text-[12px] shrink-0"
+                onClick={() => setConfigOpen(true)}
+              >
+                Add 1Password
+              </Button>
+            )
+          )}
+        </CardStackEntryActions>
+      </CardStackEntry>
 
       {configOpen && (
         <ConfigDialog
@@ -423,6 +407,6 @@ export default function OnePasswordSettings() {
           }
         />
       )}
-    </div>
+    </>
   );
 }

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,20 +1,35 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 import { Option } from "effect";
 
 import { useScope } from "@executor/react/api/scope-context";
+import { defaultHeaderAuthPresets } from "@executor/react/plugins/secret-header-auth";
 import {
-  SecretHeaderAuthRow,
-  defaultHeaderAuthPresets,
-} from "@executor/react/plugins/secret-header-auth";
+  AuthenticationSection,
+  type AuthMethod,
+} from "@executor/react/plugins/authentication-section";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntry,
+  CardStackEntryActions,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+  CardStackEntryField,
+  CardStackEntryTitle,
+  CardStackHeader,
+} from "@executor/react/components/card-stack";
+import { FloatActions } from "@executor/react/components/float-actions";
+import { cn } from "@executor/react/lib/utils";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { Textarea } from "@executor/react/components/textarea";
 import { Badge } from "@executor/react/components/badge";
 import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
-import { Spinner } from "@executor/react/components/spinner";
+import { Skeleton } from "@executor/react/components/skeleton";
+import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
 import { previewOpenApiSpec, addOpenApiSpec } from "./atoms";
 import type { SpecPreview, HeaderPreset } from "../sdk/preview";
 import type { HeaderValue } from "../sdk/types";
@@ -40,6 +55,22 @@ function matchPresetKey(name: string, prefix?: string): string {
   return preset?.key ?? "custom";
 }
 
+function methodBadgeClasses(method: string): string {
+  switch (method) {
+    case "get":
+      return "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400";
+    case "post":
+      return "bg-blue-500/10 text-blue-700 dark:text-blue-400";
+    case "put":
+    case "patch":
+      return "bg-amber-500/10 text-amber-700 dark:text-amber-400";
+    case "delete":
+      return "bg-red-500/10 text-red-600 dark:text-red-400";
+    default:
+      return "bg-muted text-muted-foreground";
+  }
+}
+
 function presetEntriesFromHeaderPreset(preset: HeaderPreset) {
   return preset.secretHeaders.map((headerName) => {
     const prefix = prefixForHeader(preset, headerName);
@@ -48,7 +79,6 @@ function presetEntriesFromHeaderPreset(preset: HeaderPreset) {
       secretId: null as string | null,
       prefix,
       presetKey: matchPresetKey(headerName, prefix),
-      fromPreset: true,
     };
   });
 }
@@ -75,14 +105,13 @@ export default function AddOpenApiSource(props: {
   const [sourceName, setSourceName] = useState("");
 
   // Auth
-  const [presetIndex, setPresetIndex] = useState(0);
+  const [authMode, setAuthMode] = useState<AuthMethod>("none");
   const [customHeaders, setCustomHeaders] = useState<
     Array<{
       name: string;
       secretId: string | null;
       prefix?: string;
       presetKey?: string;
-      fromPreset?: boolean;
     }>
   >([]);
 
@@ -94,20 +123,46 @@ export default function AddOpenApiSource(props: {
   const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promise" });
   const doAdd = useAtomSet(addOpenApiSpec, { mode: "promise" });
   const secretList = useSecretPickerSecrets();
-  const autoAnalyzed = useRef(false);
 
+  // Keep the latest handleAnalyze in a ref so the debounced effect doesn't
+  // need it as a dependency (it closes over fresh state).
+  const handleAnalyzeRef = useRef<() => void>(() => {});
+
+  // Auto-analyze whenever the spec input changes, with a short debounce so
+  // typing/pasting doesn't fire a request on every keystroke.
   useEffect(() => {
-    if (props.initialUrl && !autoAnalyzed.current) {
-      autoAnalyzed.current = true;
-      handleAnalyze();
-    }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    const trimmed = specUrl.trim();
+    if (!trimmed) return;
+    if (preview) return;
+    const handle = setTimeout(() => {
+      handleAnalyzeRef.current();
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [specUrl, preview]);
 
   // ---- Derived state ----
 
-  const presets = preview?.headerPresets ?? [];
-  const hasAuth = presets.length > 0;
   const servers = (preview?.servers ?? []) as Array<{ url?: string }>;
+
+  // Derive a favicon URL from the spec URL (if the user entered one — raw
+  // JSON/YAML content will fail URL parsing and yield null). Uses Google's
+  // favicon service so we don't depend on the domain serving /favicon.ico.
+  const faviconUrl = useMemo(() => {
+    try {
+      const trimmed = specUrl.trim();
+      if (!trimmed) return null;
+      const u = new URL(trimmed);
+      if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+      return `https://www.google.com/s2/favicons?domain=${u.hostname}&sz=64`;
+    } catch {
+      return null;
+    }
+  }, [specUrl]);
+
+  const [faviconFailed, setFaviconFailed] = useState(false);
+  useEffect(() => {
+    setFaviconFailed(false);
+  }, [faviconUrl]);
 
   const allHeaders: Record<string, HeaderValue> = {};
   for (const ch of customHeaders) {
@@ -155,13 +210,14 @@ export default function AddOpenApiSource(props: {
       const firstUrl = (result.servers as Array<{ url?: string }>)?.[0]?.url;
       if (firstUrl) setBaseUrl(firstUrl);
 
-      const newPresetIndex = result.headerPresets.length > 0 ? 0 : -1;
-      setPresetIndex(newPresetIndex);
-      setCustomHeaders(
-        newPresetIndex >= 0
-          ? presetEntriesFromHeaderPreset(result.headerPresets[newPresetIndex])
-          : [],
-      );
+      const firstPreset = result.headerPresets[0];
+      if (firstPreset) {
+        setAuthMode("header");
+        setCustomHeaders(presetEntriesFromHeaderPreset(firstPreset));
+      } else {
+        setAuthMode("none");
+        setCustomHeaders([]);
+      }
     } catch (e) {
       setAnalyzeError(e instanceof Error ? e.message : "Failed to parse spec");
     } finally {
@@ -169,41 +225,13 @@ export default function AddOpenApiSource(props: {
     }
   };
 
-  const selectPreset = (index: number) => {
-    setPresetIndex(index);
-    if (index === -1) {
-      // "None" — clear everything
+  handleAnalyzeRef.current = handleAnalyze;
+
+  const handleAuthModeChange = (mode: AuthMethod) => {
+    setAuthMode(mode);
+    if (mode === "none") {
       setCustomHeaders([]);
-    } else if (index === -2) {
-      // "Custom" — keep user headers, drop preset-derived, seed if empty
-      const userHeaders = customHeaders.filter((h) => !h.fromPreset);
-      setCustomHeaders(
-        userHeaders.length > 0 ? userHeaders : [{ name: "", secretId: null, presetKey: undefined }],
-      );
-    } else {
-      // Preset strategy — replace preset-derived headers, keep user headers
-      const preset = presets[index];
-      const userHeaders = customHeaders.filter((h) => !h.fromPreset);
-      setCustomHeaders(
-        preset ? [...presetEntriesFromHeaderPreset(preset), ...userHeaders] : userHeaders,
-      );
     }
-  };
-
-  const addCustomHeader = () => {
-    if (presetIndex === -1) setPresetIndex(-2);
-    setCustomHeaders([...customHeaders, { name: "", secretId: null, presetKey: undefined }]);
-  };
-
-  const updateCustomHeader = (
-    index: number,
-    update: Partial<{ name: string; secretId: string | null; prefix?: string; presetKey?: string }>,
-  ) => {
-    setCustomHeaders(customHeaders.map((ch, i) => (i === index ? { ...ch, ...update } : ch)));
-  };
-
-  const removeCustomHeader = (index: number) => {
-    setCustomHeaders(customHeaders.filter((_, i) => i !== index));
   };
 
   const handleAdd = async () => {
@@ -230,244 +258,196 @@ export default function AddOpenApiSource(props: {
   // ---- Render ----
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-1 flex-col gap-6">
       <h1 className="text-xl font-semibold text-foreground">Add OpenAPI Source</h1>
 
+      {/* ── Title card (shown above text area after analysis) ── */}
+      {preview ? (
+        <CardStack>
+          <CardStackContent className="border-t-0">
+            <CardStackEntry>
+              {faviconUrl && !faviconFailed && (
+                <img
+                  src={faviconUrl}
+                  alt=""
+                  className="size-4 shrink-0 object-contain"
+                  onError={() => setFaviconFailed(true)}
+                />
+              )}
+              <CardStackEntryContent>
+                <CardStackEntryTitle>
+                  {Option.getOrElse(preview.title, () => "API")}
+                </CardStackEntryTitle>
+                <CardStackEntryDescription>
+                  {Option.getOrElse(preview.version, () => "")}
+                  {Option.isSome(preview.version) && " · "}
+                  {preview.operationCount} operation
+                  {preview.operationCount !== 1 ? "s" : ""}
+                  {preview.tags.length > 0 &&
+                    ` · ${preview.tags.length} tag${preview.tags.length !== 1 ? "s" : ""}`}
+                </CardStackEntryDescription>
+              </CardStackEntryContent>
+            </CardStackEntry>
+          </CardStackContent>
+        </CardStack>
+      ) : analyzing ? (
+        <CardStack>
+          <CardStackContent className="border-t-0">
+            <CardStackEntry>
+              <Skeleton className="size-4 shrink-0 rounded" />
+              <CardStackEntryContent>
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="mt-1 h-3 w-56" />
+              </CardStackEntryContent>
+            </CardStackEntry>
+          </CardStackContent>
+        </CardStack>
+      ) : null}
+
       {/* ── Spec input ── */}
-      <section className="space-y-2">
-        <Label>OpenAPI Spec</Label>
-        <Textarea
-          value={specUrl}
-          onChange={(e) => {
-            setSpecUrl((e.target as HTMLTextAreaElement).value);
-            if (preview) {
-              setPreview(null);
-              setBaseUrl("");
-              setCustomHeaders([]);
-            }
-          }}
-          placeholder="https://api.example.com/openapi.json"
-          rows={3}
-          className="font-mono text-sm"
-        />
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntryField
+            label="OpenAPI Spec"
+            hint={!preview ? "Paste a URL or raw JSON/YAML content." : undefined}
+          >
+            <div className="relative">
+              <Textarea
+                value={specUrl}
+                onChange={(e) => {
+                  setSpecUrl((e.target as HTMLTextAreaElement).value);
+                  if (preview) {
+                    setPreview(null);
+                    setBaseUrl("");
+                    setCustomHeaders([]);
+                    setAuthMode("none");
+                  }
+                }}
+                placeholder="https://api.example.com/openapi.json"
+                rows={3}
+                maxRows={10}
+                className="font-mono text-sm"
+              />
+              {analyzing && (
+                <div className="pointer-events-none absolute right-2 top-2">
+                  <IOSSpinner className="size-4" />
+                </div>
+              )}
+            </div>
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
 
-        {analyzeError && (
-          <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-            <p className="text-[12px] text-destructive">{analyzeError}</p>
-          </div>
-        )}
-
-        {!preview && (
-          <div className="flex items-center justify-between">
-            <p className="text-[12px] text-muted-foreground">
-              Paste a URL or raw JSON/YAML content.
-            </p>
-            <Button disabled={!specUrl.trim() || analyzing} onClick={handleAnalyze}>
-              {analyzing && <Spinner className="size-3.5" />}
-              {analyzing ? "Analyzing…" : "Analyze"}
-            </Button>
-          </div>
-        )}
-      </section>
+      {analyzeError && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+          <p className="text-[12px] text-destructive">{analyzeError}</p>
+        </div>
+      )}
 
       {/* ── Everything below appears after analysis ── */}
       {preview && (
         <>
-          {/* API info */}
-          <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
-            <div className="min-w-0 flex-1">
-              <p className="text-sm font-semibold text-card-foreground leading-none truncate">
-                {Option.getOrElse(preview.title, () => "API")}
-              </p>
-              <p className="mt-1 text-[12px] text-muted-foreground leading-none">
-                {Option.getOrElse(preview.version, () => "")}
-                {Option.isSome(preview.version) && " · "}
-                {preview.operationCount} operation{preview.operationCount !== 1 ? "s" : ""}
-                {preview.tags.length > 0 &&
-                  ` · ${preview.tags.length} tag${preview.tags.length !== 1 ? "s" : ""}`}
-              </p>
-            </div>
-            {preview.tags.length > 0 && (
-              <div className="hidden sm:flex flex-wrap gap-1 max-w-[200px] justify-end">
-                {preview.tags.slice(0, 4).map((tag) => (
-                  <Badge key={tag} variant="secondary" className="text-[10px]">
-                    {tag}
-                  </Badge>
-                ))}
-                {preview.tags.length > 4 && (
-                  <span className="text-[10px] text-muted-foreground">
-                    +{preview.tags.length - 4}
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Name */}
-          <section className="space-y-2">
-            <Label>Name</Label>
-            <Input
-              value={sourceName}
-              onChange={(e) => setSourceName((e.target as HTMLInputElement).value)}
-              placeholder="e.g. Sentry API"
-              className="text-[0.8125rem]"
-            />
-          </section>
-
-          {/* Namespace */}
-          <section className="space-y-2">
-            <Label>Namespace</Label>
-            <Input
-              value={namespace}
-              onChange={(e) =>
-                setNamespace(
-                  (e.target as HTMLInputElement).value.toLowerCase().replace(/[^a-z0-9_-]/g, "_"),
-                )
-              }
-              placeholder="e.g. sentry, stripe, github"
-              className="font-mono text-[0.8125rem]"
-            />
-            <p className="text-[0.75rem] text-muted-foreground">
-              Unique identifier for this source. Used in tool names.
-            </p>
-          </section>
-
           {/* Base URL */}
-          <section className="space-y-2">
-            <Label>Base URL</Label>
-
-            {servers.length > 1 ? (
-              <div className="space-y-2">
-                <RadioGroup value={baseUrl} onValueChange={setBaseUrl} className="gap-1.5">
-                  {servers.map((s, i) => {
-                    const url = s.url ?? "";
-                    return (
-                      <Label
-                        key={i}
-                        className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                          baseUrl === url
-                            ? "border-primary/50 bg-primary/[0.03]"
-                            : "border-border hover:bg-accent/50"
-                        }`}
-                      >
-                        <RadioGroupItem value={url} />
-                        <span className="font-mono text-xs text-foreground truncate">{url}</span>
-                      </Label>
-                    );
-                  })}
-                </RadioGroup>
-                <Input
-                  value={baseUrl}
-                  onChange={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
-                  placeholder="Or enter a custom URL…"
-                  className="font-mono text-sm"
-                />
-              </div>
-            ) : (
-              <Input
-                value={baseUrl}
-                onChange={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
-                placeholder="https://api.example.com"
-                className="font-mono text-sm"
-              />
-            )}
-
-            {!baseUrl.trim() && (
-              <p className="text-[11px] text-amber-600 dark:text-amber-400">
-                A base URL is required to make requests.
-              </p>
-            )}
-          </section>
-
-          {/* Authentication */}
-          <section className="space-y-2.5">
-            <Label>Authentication</Label>
-
-            {/* Strategy picker */}
-            {hasAuth && (
-              <RadioGroup
-                value={String(presetIndex)}
-                onValueChange={(v) => selectPreset(Number(v))}
-                className="gap-1.5"
-              >
-                {presets.map((preset, i) => (
-                  <Label
-                    key={i}
-                    className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                      presetIndex === i
-                        ? "border-primary/50 bg-primary/[0.03]"
-                        : "border-border hover:bg-accent/50"
-                    }`}
-                  >
-                    <RadioGroupItem value={String(i)} />
-                    <span className="text-xs font-medium text-foreground">{preset.label}</span>
-                    {preset.secretHeaders.length > 0 && (
-                      <span className="ml-auto text-[10px] text-muted-foreground">
-                        {preset.secretHeaders.length} header
-                        {preset.secretHeaders.length > 1 ? "s" : ""}
-                      </span>
-                    )}
-                  </Label>
-                ))}
-
-                <Label
-                  className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                    presetIndex === -2
-                      ? "border-primary/50 bg-primary/[0.03]"
-                      : "border-border hover:bg-accent/50"
-                  }`}
-                >
-                  <RadioGroupItem value="-2" />
-                  <span className="text-xs font-medium text-foreground">Custom</span>
-                  <span className="ml-auto text-[10px] text-muted-foreground">
-                    configure manually
-                  </span>
-                </Label>
-
-                <Label
-                  className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                    presetIndex === -1
-                      ? "border-primary/50 bg-primary/[0.03]"
-                      : "border-border hover:bg-accent/50"
-                  }`}
-                >
-                  <RadioGroupItem value="-1" />
-                  <span className="text-xs font-medium text-foreground">None</span>
-                  <span className="ml-auto text-[10px] text-muted-foreground">skip auth</span>
-                </Label>
-              </RadioGroup>
-            )}
-
-            {/* All headers — preset-derived and user-added (hidden when None) */}
-            {presetIndex !== -1 && customHeaders.length > 0 && (
-              <div className="space-y-2">
-                {customHeaders.map((ch, i) => (
-                  <SecretHeaderAuthRow
-                    key={i}
-                    name={ch.name}
-                    prefix={ch.prefix}
-                    presetKey={ch.presetKey}
-                    secretId={ch.secretId}
-                    onChange={(update) => updateCustomHeader(i, update)}
-                    onSelectSecret={(secretId) => updateCustomHeader(i, { secretId })}
-                    onRemove={() => removeCustomHeader(i)}
-                    existingSecrets={secretList}
+          <CardStack>
+            <CardStackContent className="border-t-0">
+              <CardStackEntryField label="Base URL">
+                {servers.length > 1 ? (
+                  <div className="space-y-2">
+                    <RadioGroup value={baseUrl} onValueChange={setBaseUrl} className="gap-1.5">
+                      {servers.map((s, i) => {
+                        const url = s.url ?? "";
+                        return (
+                          <Label
+                            key={i}
+                            className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
+                              baseUrl === url
+                                ? "border-primary/50 bg-primary/[0.03]"
+                                : "border-border hover:bg-accent/50"
+                            }`}
+                          >
+                            <RadioGroupItem value={url} />
+                            <span className="font-mono text-xs text-foreground truncate">
+                              {url}
+                            </span>
+                          </Label>
+                        );
+                      })}
+                    </RadioGroup>
+                    <Input
+                      value={baseUrl}
+                      onChange={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
+                      placeholder="Or enter a custom URL…"
+                      className="font-mono text-sm"
+                    />
+                  </div>
+                ) : (
+                  <Input
+                    value={baseUrl}
+                    onChange={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
+                    placeholder="https://api.example.com"
+                    className="font-mono text-sm"
                   />
-                ))}
-              </div>
-            )}
+                )}
 
-            {(!hasAuth || presetIndex === -2) && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="w-full border-dashed"
-                onClick={addCustomHeader}
-              >
-                + Add header
-              </Button>
-            )}
-          </section>
+                {!baseUrl.trim() && (
+                  <p className="text-[11px] text-amber-600 dark:text-amber-400">
+                    A base URL is required to make requests.
+                  </p>
+                )}
+              </CardStackEntryField>
+            </CardStackContent>
+          </CardStack>
+
+          <AuthenticationSection
+            methods={["none", "header"]}
+            value={authMode}
+            onChange={handleAuthModeChange}
+            headers={customHeaders}
+            onHeadersChange={setCustomHeaders}
+            existingSecrets={secretList}
+          />
+
+          {/* Operations */}
+          {preview.operations.length > 0 && (
+            <CardStack searchable className="opacity-50 hover:opacity-100 transition-opacity">
+              <CardStackHeader>
+                {preview.operations.length} operation
+                {preview.operations.length !== 1 ? "s" : ""}
+              </CardStackHeader>
+              <CardStackContent>
+                {preview.operations.map((op) => (
+                  <CardStackEntry
+                    key={op.operationId}
+                    searchText={`${op.method} ${op.path} ${Option.getOrElse(op.summary, () => "")} ${op.tags.join(" ")}`}
+                  >
+                    <CardStackEntryContent>
+                      <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+                        <span
+                          className={cn(
+                            "shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase",
+                            methodBadgeClasses(op.method),
+                          )}
+                        >
+                          {op.method}
+                        </span>
+                        <span className="truncate font-mono">{op.path}</span>
+                      </CardStackEntryTitle>
+                      {Option.isSome(op.summary) && (
+                        <CardStackEntryDescription>{op.summary.value}</CardStackEntryDescription>
+                      )}
+                    </CardStackEntryContent>
+                    {op.deprecated && (
+                      <CardStackEntryActions>
+                        <Badge variant="outline" className="text-[10px]">
+                          Deprecated
+                        </Badge>
+                      </CardStackEntryActions>
+                    )}
+                  </CardStackEntry>
+                ))}
+              </CardStackContent>
+            </CardStack>
+          )}
 
           {/* Add error */}
           {addError && (
@@ -475,29 +455,20 @@ export default function AddOpenApiSource(props: {
               <p className="text-[12px] text-destructive">{addError}</p>
             </div>
           )}
-
-          {/* Actions */}
-          <div className="flex items-center justify-between border-t border-border pt-4">
-            <Button variant="ghost" onClick={props.onCancel} disabled={adding}>
-              Cancel
-            </Button>
-            <Button onClick={handleAdd} disabled={!canAdd || adding}>
-              {adding && <Spinner className="size-3.5" />}
-              {adding ? "Adding…" : "Add source"}
-            </Button>
-          </div>
         </>
       )}
 
-      {/* Cancel when no preview yet */}
-      {!preview && (
-        <div className="flex items-center justify-between pt-1">
-          <Button variant="ghost" onClick={props.onCancel}>
-            Cancel
+      <FloatActions>
+        <Button variant="ghost" onClick={props.onCancel} disabled={adding}>
+          Cancel
+        </Button>
+        {preview && (
+          <Button onClick={handleAdd} disabled={!canAdd || adding}>
+            {adding && <Spinner className="size-3.5" />}
+            {adding ? "Adding…" : "Add source"}
           </Button>
-          <div />
-        </div>
-      )}
+        )}
+      </FloatActions>
     </div>
   );
 }

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -4,14 +4,18 @@ import { openApiSourceAtom, updateOpenApiSource } from "./atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import {
-  SecretHeaderAuthRow,
   headerValueToState,
   headersFromState,
   type HeaderState,
 } from "@executor/react/plugins/secret-header-auth";
+import { AuthenticationSection } from "@executor/react/plugins/authentication-section";
 import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "@executor/react/components/card-stack";
 import { Input } from "@executor/react/components/input";
-import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
 import type { StoredSourceSchemaType } from "../sdk/stored-source";
 
@@ -39,8 +43,8 @@ function EditForm(props: {
   const [error, setError] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
 
-  const updateHeader = (index: number, update: Partial<HeaderState>) => {
-    setHeaders((prev) => prev.map((h, i) => (i === index ? { ...h, ...update } : h)));
+  const handleHeadersChange = (next: HeaderState[]) => {
+    setHeaders(next);
     setDirty(true);
   };
 
@@ -83,49 +87,31 @@ function EditForm(props: {
         </Badge>
       </div>
 
-      <section className="space-y-2">
-        <Label>Base URL</Label>
-        <Input
-          value={baseUrl}
-          onChange={(e) => {
-            setBaseUrl((e.target as HTMLInputElement).value);
-            setDirty(true);
-          }}
-          placeholder="https://api.example.com"
-          className="font-mono text-sm"
-        />
-      </section>
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntryField label="Base URL">
+            <Input
+              value={baseUrl}
+              onChange={(e) => {
+                setBaseUrl((e.target as HTMLInputElement).value);
+                setDirty(true);
+              }}
+              placeholder="https://api.example.com"
+              className="font-mono text-sm"
+            />
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
 
-      <section className="space-y-2.5">
-        <Label>Headers</Label>
-        {headers.map((h, i) => (
-          <SecretHeaderAuthRow
-            key={i}
-            name={h.name}
-            prefix={h.prefix}
-            presetKey={h.presetKey}
-            secretId={h.secretId}
-            onChange={(update) => updateHeader(i, update)}
-            onSelectSecret={(secretId) => updateHeader(i, { secretId })}
-            onRemove={() => {
-              setHeaders((prev) => prev.filter((_, j) => j !== i));
-              setDirty(true);
-            }}
-            existingSecrets={secretList}
-          />
-        ))}
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full border-dashed"
-          onClick={() => {
-            setHeaders((prev) => [...prev, { name: "", secretId: null }]);
-            setDirty(true);
-          }}
-        >
-          + Add header
-        </Button>
-      </section>
+      <AuthenticationSection
+        methods={["header"]}
+        value="header"
+        onChange={() => {}}
+        label="Headers"
+        headers={headers}
+        onHeadersChange={handleHeadersChange}
+        existingSecrets={secretList}
+      />
 
       {error && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -10,7 +10,14 @@ export {
 } from "./operation-store";
 export { makeKvOperationStore, makeInMemoryOperationStore } from "./kv-operation-store";
 export { withConfigFile } from "./config-file-store";
-export { previewSpec, SecurityScheme, AuthStrategy, HeaderPreset, SpecPreview } from "./preview";
+export {
+  previewSpec,
+  SecurityScheme,
+  AuthStrategy,
+  HeaderPreset,
+  PreviewOperation,
+  SpecPreview,
+} from "./preview";
 export { DocResolver, resolveBaseUrl, preferredContent } from "./openapi-utils";
 
 export { OpenApiParseError, OpenApiExtractionError, OpenApiInvocationError } from "./errors";

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -3,7 +3,7 @@ import { Schema } from "effect";
 
 import { parse } from "./parse";
 import { extract } from "./extract";
-import type { ExtractionResult } from "./types";
+import { HttpMethod, type ExtractionResult } from "./types";
 
 // ---------------------------------------------------------------------------
 // Security scheme — what the spec declares it needs
@@ -46,6 +46,19 @@ export class HeaderPreset extends Schema.Class<HeaderPreset>("HeaderPreset")({
 }) {}
 
 // ---------------------------------------------------------------------------
+// Preview operation — lightweight shape for the add-source UI list
+// ---------------------------------------------------------------------------
+
+export class PreviewOperation extends Schema.Class<PreviewOperation>("PreviewOperation")({
+  operationId: Schema.String,
+  method: HttpMethod,
+  path: Schema.String,
+  summary: Schema.optionalWith(Schema.String, { as: "Option" }),
+  tags: Schema.Array(Schema.String),
+  deprecated: Schema.Boolean,
+}) {}
+
+// ---------------------------------------------------------------------------
 // Spec preview — everything the frontend needs
 // ---------------------------------------------------------------------------
 
@@ -55,6 +68,8 @@ export class SpecPreview extends Schema.Class<SpecPreview>("SpecPreview")({
   /** Reuses ServerInfo from extraction */
   servers: Schema.Array(Schema.Unknown),
   operationCount: Schema.Number,
+  /** Lightweight operation list for the add-source UI */
+  operations: Schema.Array(PreviewOperation),
   tags: Schema.Array(Schema.String),
   securitySchemes: Schema.Array(SecurityScheme),
   /** Valid auth strategies (each is a set of schemes used together) */
@@ -172,6 +187,17 @@ export const previewSpec = Effect.fn("OpenApi.previewSpec")(function* (specText:
     version: result.version,
     servers: result.servers as unknown as readonly unknown[],
     operationCount: result.operations.length,
+    operations: result.operations.map(
+      (op) =>
+        new PreviewOperation({
+          operationId: op.operationId,
+          method: op.method,
+          path: op.pathTemplate,
+          summary: op.summary,
+          tags: op.tags,
+          deprecated: op.deprecated,
+        }),
+    ),
     tags: collectTags(result),
     securitySchemes,
     authStrategies,

--- a/packages/react/src/components/filter-tabs.tsx
+++ b/packages/react/src/components/filter-tabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Button } from "./button";
+import { cn } from "../lib/utils";
+
+export interface FilterTab<T extends string = string> {
+  label: ReactNode;
+  value: T;
+  count?: number;
+}
+
+interface FilterTabsProps<T extends string = string> {
+  tabs: FilterTab<T>[];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+export function FilterTabs<T extends string = string>({
+  tabs,
+  value,
+  onChange,
+}: FilterTabsProps<T>) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {tabs.map((tab) => {
+        const isActive = value === tab.value;
+        return (
+          <Button
+            variant="outline"
+            size="sm"
+            key={tab.value}
+            onClick={() => onChange(tab.value)}
+            className={cn(
+              "shadow-none",
+              isActive
+                ? "inline-flex items-center justify-center gap-1.5 rounded-full border border-border bg-white px-2.5 py-1 text-sm font-medium text-foreground transition-transform duration-100 active:scale-[0.98]"
+                : "inline-flex items-center justify-center gap-1.5 rounded-full border border-transparent bg-transparent px-2.5 py-1 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-transform duration-100 active:scale-[0.98]",
+            )}
+          >
+            {tab.label}
+            {tab.count !== undefined && (
+              <span
+                className={`inline-flex items-center justify-center rounded-full text-xs tabular-nums min-w-[18px] h-[18px] px-1 ${isActive ? "bg-muted text-foreground" : "bg-muted/60 text-muted-foreground"}`}
+              >
+                {tab.count}
+              </span>
+            )}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/react/src/components/float-actions.tsx
+++ b/packages/react/src/components/float-actions.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { useRouterState } from "@tanstack/react-router";
+
+import { cn } from "../lib/utils";
+import { CardStack } from "./card-stack";
+
+/**
+ * A floating action bar that pins itself to the bottom of the nearest
+ * positioned ancestor (usually a scroll container with `position: relative`).
+ *
+ * Rendered as a `CardStack` so it picks up the card visual — wrap action
+ * buttons as children; they'll be right-aligned inside the card.
+ *
+ * To pin to the bottom even when content is short, the parent should be a
+ * flex column filling the scroll container (so `mt-auto` pushes the actions
+ * down). `sticky bottom-4` also keeps it visible while scrolling long content.
+ *
+ * Hidden while the router is navigating/loading so the actions don't flash
+ * on top of a loading state.
+ */
+function FloatActions({ className, children }: { className?: string; children: React.ReactNode }) {
+  const isLoading = useRouterState({ select: (s) => s.isLoading });
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <CardStack className={cn("sticky shadow-lg bottom-4 left-0 right-0 mt-auto w-full", className)}>
+      <div className="flex items-center justify-end gap-3 px-4 py-3">{children}</div>
+    </CardStack>
+  );
+}
+
+export { FloatActions };

--- a/packages/react/src/components/spinner.tsx
+++ b/packages/react/src/components/spinner.tsx
@@ -13,4 +13,36 @@ function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   );
 }
 
-export { Spinner };
+const IOS_SPINNER_BLADES = 12;
+
+function IOSSpinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <svg
+      role="status"
+      aria-label="Loading"
+      viewBox="0 0 24 24"
+      className={cn("size-4 text-muted-foreground", className)}
+      {...props}
+    >
+      {Array.from({ length: IOS_SPINNER_BLADES }).map((_, i) => (
+        <rect
+          key={i}
+          x="11"
+          y="2"
+          width="2"
+          height="6"
+          rx="1"
+          fill="currentColor"
+          transform={`rotate(${(360 / IOS_SPINNER_BLADES) * i} 12 12)`}
+          style={{
+            animation: "ios-spinner-fade 1s linear infinite",
+            animationDelay: `${(i / IOS_SPINNER_BLADES) * 1 - 1}s`,
+            opacity: 0.25,
+          }}
+        />
+      ))}
+    </svg>
+  );
+}
+
+export { Spinner, IOSSpinner };

--- a/packages/react/src/components/textarea.tsx
+++ b/packages/react/src/components/textarea.tsx
@@ -2,7 +2,11 @@ import * as React from "react";
 
 import { cn } from "../lib/utils";
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({
+  className,
+  maxRows,
+  ...props
+}: React.ComponentProps<"textarea"> & { maxRows?: number }) {
   return (
     // oxlint-disable-next-line react/forbid-elements
     <textarea
@@ -12,6 +16,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
         className,
       )}
       {...props}
+      style={{ maxHeight: maxRows ? `${maxRows * 1.5}rem` : undefined }}
     />
   );
 }

--- a/packages/react/src/plugins/authentication-section.tsx
+++ b/packages/react/src/plugins/authentication-section.tsx
@@ -1,0 +1,245 @@
+import { useState, type ReactNode } from "react";
+import { PlusIcon } from "lucide-react";
+
+import { Button } from "../components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEmpty,
+  CardStackEntry,
+} from "../components/card-stack";
+import { FieldLabel } from "../components/field";
+import { FilterTabs } from "../components/filter-tabs";
+import {
+  defaultHeaderAuthPresets,
+  type HeaderAuthPreset,
+  SecretHeaderAuthRow,
+  type HeaderState,
+} from "./secret-header-auth";
+import type { SecretPickerSecret } from "./secret-picker";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type AuthMethod = "none" | "header" | "oauth2";
+
+export type AuthHeaderEntry = HeaderState;
+
+const DEFAULT_METHOD_LABELS: Record<AuthMethod, string> = {
+  none: "None",
+  header: "Header",
+  oauth2: "OAuth",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface AuthenticationSectionProps {
+  /** Auth methods to expose as tabs (display order). */
+  readonly methods: readonly AuthMethod[];
+  readonly value: AuthMethod;
+  readonly onChange: (value: AuthMethod) => void;
+
+  /** Headers list — used when value === "header". */
+  readonly headers?: readonly AuthHeaderEntry[];
+  readonly onHeadersChange?: (headers: AuthHeaderEntry[]) => void;
+  readonly existingSecrets?: readonly SecretPickerSecret[];
+
+  /** Optional content rendered for the "oauth2" method. */
+  readonly oauth2Slot?: ReactNode;
+
+  /**
+   * When true, the headers list is constrained to a single entry: the
+   * "Add headers" button is hidden once one header exists and rows cannot
+   * be removed. Useful for consumers whose backend only supports a single
+   * auth header.
+   */
+  readonly singleHeader?: boolean;
+
+  readonly methodLabels?: Partial<Record<AuthMethod, string>>;
+  readonly label?: ReactNode;
+}
+
+export function AuthenticationSection(props: AuthenticationSectionProps) {
+  const {
+    methods,
+    value,
+    onChange,
+    headers = [],
+    onHeadersChange,
+    existingSecrets = [],
+    oauth2Slot,
+    singleHeader = false,
+    methodLabels,
+    label = "Authentication",
+  } = props;
+
+  const [picking, setPicking] = useState(false);
+
+  const getMethodLabel = (method: AuthMethod) =>
+    methodLabels?.[method] ?? DEFAULT_METHOD_LABELS[method];
+
+  // When both "none" and "header" are offered, collapse them into a single
+  // UI surface: the empty CardStack is the "none" state, and adding a header
+  // transitions `value` to "header" automatically.
+  const unifiesHeaders = methods.includes("none") && methods.includes("header");
+  const displayMethods = unifiesHeaders ? methods.filter((m) => m !== "none") : methods;
+  const displayValue: AuthMethod = unifiesHeaders && value === "none" ? "header" : value;
+
+  const showHeaders = value === "header" || (unifiesHeaders && value === "none");
+  const canAddMore = !singleHeader || headers.length === 0;
+
+  const addHeaderFromPreset = (preset: HeaderAuthPreset) => {
+    onHeadersChange?.([
+      ...headers,
+      {
+        name: preset.name,
+        prefix: preset.prefix,
+        presetKey: preset.key,
+        secretId: null,
+      },
+    ]);
+    setPicking(false);
+    if (unifiesHeaders && value === "none") {
+      onChange("header");
+    }
+  };
+
+  const updateHeader = (
+    index: number,
+    update: Partial<{
+      name: string;
+      secretId: string | null;
+      prefix?: string;
+      presetKey?: string;
+    }>,
+  ) => {
+    onHeadersChange?.(headers.map((entry, i) => (i === index ? { ...entry, ...update } : entry)));
+  };
+
+  const removeHeader = (index: number) => {
+    const next = headers.filter((_, i) => i !== index);
+    onHeadersChange?.(next);
+    if (unifiesHeaders && next.length === 0) {
+      onChange("none");
+    }
+  };
+
+  return (
+    <section className="space-y-2.5">
+      {displayMethods.length > 1 ? (
+        <div className="flex items-center justify-between gap-3">
+          <FieldLabel>{label}</FieldLabel>
+          <FilterTabs<AuthMethod>
+            tabs={displayMethods.map((method) => ({
+              value: method,
+              label: getMethodLabel(method),
+            }))}
+            value={displayValue}
+            onChange={onChange}
+          />
+        </div>
+      ) : (
+        <FieldLabel>{label}</FieldLabel>
+      )}
+
+      {showHeaders && (
+        <CardStack>
+          <CardStackContent className="[&>*+*]:before:inset-x-0">
+            {picking ? (
+              <HeaderPresetPicker onPick={addHeaderFromPreset} onCancel={() => setPicking(false)} />
+            ) : headers.length === 0 ? (
+              canAddMore ? (
+                <AddHeaderRow leading={<span>No headers</span>} onClick={() => setPicking(true)} />
+              ) : (
+                <CardStackEmpty>
+                  <span>No headers</span>
+                </CardStackEmpty>
+              )
+            ) : (
+              <>
+                {headers.map((header, index) => (
+                  <SecretHeaderAuthRow
+                    key={index}
+                    name={header.name}
+                    prefix={header.prefix}
+                    presetKey={header.presetKey}
+                    secretId={header.secretId}
+                    onChange={(update) => updateHeader(index, update)}
+                    onSelectSecret={(secretId) => updateHeader(index, { secretId })}
+                    onRemove={singleHeader ? undefined : () => removeHeader(index)}
+                    existingSecrets={existingSecrets}
+                  />
+                ))}
+                {canAddMore && <AddHeaderRow onClick={() => setPicking(true)} />}
+              </>
+            )}
+          </CardStackContent>
+        </CardStack>
+      )}
+
+      {value === "oauth2" && oauth2Slot}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal sub-components
+// ---------------------------------------------------------------------------
+
+interface AddHeaderRowProps {
+  readonly onClick: () => void;
+  readonly leading?: ReactNode;
+}
+
+function AddHeaderRow({ onClick, leading }: AddHeaderRowProps) {
+  return (
+    // oxlint-disable-next-line react/forbid-elements
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      aria-label="Add header"
+      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
+    >
+      <span className="min-w-0 flex-1 text-left">{leading}</span>
+      <PlusIcon aria-hidden className="size-4 shrink-0" />
+    </button>
+  );
+}
+
+interface HeaderPresetPickerProps {
+  readonly onPick: (preset: HeaderAuthPreset) => void;
+  readonly onCancel: () => void;
+}
+
+function HeaderPresetPicker({ onPick, onCancel }: HeaderPresetPickerProps) {
+  return (
+    <CardStackEntry className="flex-wrap gap-2">
+      {defaultHeaderAuthPresets.map((preset) => (
+        <Button
+          key={preset.key}
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onPick(preset)}
+        >
+          {preset.label}
+        </Button>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        className="text-muted-foreground"
+      >
+        Cancel
+      </Button>
+    </CardStackEntry>
+  );
+}

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useAtomRefresh, useAtomSet } from "@effect-atom/atom-react";
 
 import { secretsAtom, setSecret, resolveSecret } from "../api/atoms";
 import { useScope } from "../api/scope-context";
 import { Button } from "../components/button";
+import { Field, FieldError, FieldGroup, FieldLabel } from "../components/field";
 import { Input } from "../components/input";
-import { Label } from "../components/label";
 import { Spinner } from "../components/spinner";
 import { SecretPicker, type SecretPickerSecret } from "./secret-picker";
 import { SecretId } from "@executor/sdk";
@@ -74,6 +74,9 @@ function InlineCreateSecret(props: {
   const scopeId = useScope();
   const doSet = useAtomSet(setSecret, { mode: "promise" });
   const refreshSecrets = useAtomRefresh(secretsAtom(scopeId));
+  const secretIdInputId = useId();
+  const secretNameInputId = useId();
+  const secretValueInputId = useId();
 
   const handleSave = async () => {
     if (!secretId.trim() || !secretValue.trim()) return;
@@ -98,53 +101,55 @@ function InlineCreateSecret(props: {
   };
 
   return (
-    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-2.5">
+    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-3">
       <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
-      <div className="grid grid-cols-2 gap-2">
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">ID</Label>
-          <Input
-            value={secretId}
-            onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
-            placeholder="my-api-token"
-            className="h-8 text-xs font-mono"
-          />
+      <FieldGroup className="gap-3">
+        <div className="grid grid-cols-2 gap-3">
+          <Field>
+            <FieldLabel htmlFor={secretIdInputId}>ID</FieldLabel>
+            <Input
+              id={secretIdInputId}
+              value={secretId}
+              onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
+              placeholder="my-api-token"
+              className="font-mono"
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={secretNameInputId}>Label</FieldLabel>
+            <Input
+              id={secretNameInputId}
+              value={secretName}
+              onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
+              placeholder="API Token"
+            />
+          </Field>
         </div>
-        <div className="space-y-1">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-            Label
-          </Label>
-          <Input
-            value={secretName}
-            onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
-            placeholder="API Token"
-            className="h-8 text-xs"
-          />
-        </div>
-      </div>
-      <div className="space-y-1">
-        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">Value</Label>
-        <div className="relative">
-          <Input
-            type={secretRevealed ? "text" : "password"}
-            value={secretValue}
-            onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
-            placeholder="paste your token or key…"
-            className="h-8 pr-8 text-xs font-mono"
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="absolute right-1 top-1/2 size-6 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            onClick={() => setSecretRevealed((revealed) => !revealed)}
-            aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
-          >
-            <SecretVisibilityIcon revealed={secretRevealed} />
-          </Button>
-        </div>
-      </div>
-      {error && <p className="text-[11px] text-destructive">{error}</p>}
+        <Field>
+          <FieldLabel htmlFor={secretValueInputId}>Value</FieldLabel>
+          <div className="relative">
+            <Input
+              id={secretValueInputId}
+              type={secretRevealed ? "text" : "password"}
+              value={secretValue}
+              onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
+              placeholder="paste your token or key…"
+              className="pr-9 font-mono"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="absolute right-1 top-1/2 size-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              onClick={() => setSecretRevealed((revealed) => !revealed)}
+              aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
+            >
+              <SecretVisibilityIcon revealed={secretRevealed} />
+            </Button>
+          </div>
+          {error && <FieldError>{error}</FieldError>}
+        </Field>
+      </FieldGroup>
       <div className="flex gap-1.5 pt-0.5">
         <Button variant="outline" size="xs" onClick={props.onCancel}>
           Cancel
@@ -286,12 +291,13 @@ export function SecretHeaderAuthRow(props: {
   onChange: (update: { name: string; prefix?: string; presetKey?: string }) => void;
   onSelectSecret: (secretId: string) => void;
   existingSecrets: readonly SecretPickerSecret[];
-  presets?: readonly HeaderAuthPreset[];
   onRemove?: () => void;
   removeLabel?: string;
   label?: string;
 }) {
   const [creating, setCreating] = useState(false);
+  const nameInputId = useId();
+  const prefixInputId = useId();
   const {
     name,
     prefix,
@@ -300,35 +306,34 @@ export function SecretHeaderAuthRow(props: {
     onChange,
     onSelectSecret,
     existingSecrets,
-    presets = defaultHeaderAuthPresets,
     onRemove,
     removeLabel = "Remove",
     label = "Header",
   } = props;
 
-  const isCustom = presetKey === "custom";
+  const isCustom = presetKey === "custom" || presetKey === undefined;
   const suggestedId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-") || "custom-header";
 
   if (creating) {
     return (
-      <InlineCreateSecret
-        headerName={name || "Custom Header"}
-        suggestedId={suggestedId}
-        onCreated={(id) => {
-          onSelectSecret(id);
-          setCreating(false);
-        }}
-        onCancel={() => setCreating(false)}
-      />
+      <div className="px-4 py-3">
+        <InlineCreateSecret
+          headerName={name || "Custom Header"}
+          suggestedId={suggestedId}
+          onCreated={(id) => {
+            onSelectSecret(id);
+            setCreating(false);
+          }}
+          onCancel={() => setCreating(false)}
+        />
+      </div>
     );
   }
 
   return (
-    <div className="rounded-lg border border-border bg-card p-3 space-y-2.5">
-      <div className="flex items-center justify-between">
-        <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-          {label}
-        </Label>
+    <div className="space-y-2.5 px-4 py-3">
+      <div className="flex w-full items-center justify-between gap-4">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</span>
         {onRemove && (
           <Button
             variant="ghost"
@@ -341,74 +346,44 @@ export function SecretHeaderAuthRow(props: {
         )}
       </div>
 
-      <div className="flex flex-wrap gap-1">
-        {presets.map((preset) => (
-          <Button
-            key={preset.key}
-            variant="ghost"
-            size="sm"
-            type="button"
-            onClick={() =>
+      <FieldGroup className="grid grid-cols-2 gap-3">
+        <Field>
+          <FieldLabel htmlFor={nameInputId}>Name</FieldLabel>
+          <Input
+            id={nameInputId}
+            value={name}
+            onChange={(e) =>
               onChange({
-                name: preset.name,
-                prefix: preset.prefix,
-                presetKey: preset.key,
+                name: (e.target as HTMLInputElement).value,
+                prefix,
+                presetKey: isCustom ? "custom" : presetKey,
               })
             }
-            className={`rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
-              presetKey === preset.key
-                ? "border-primary/50 bg-primary/10 text-primary"
-                : "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            }`}
-          >
-            {preset.label}
-          </Button>
-        ))}
-      </div>
+            placeholder="Authorization"
+            className="font-mono"
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor={prefixInputId}>
+            Prefix <span className="font-normal text-muted-foreground/60">(optional)</span>
+          </FieldLabel>
+          <Input
+            id={prefixInputId}
+            value={prefix ?? ""}
+            onChange={(e) =>
+              onChange({
+                name,
+                prefix: (e.target as HTMLInputElement).value || undefined,
+                presetKey: isCustom ? "custom" : presetKey,
+              })
+            }
+            placeholder="Bearer "
+            className="font-mono"
+          />
+        </Field>
+      </FieldGroup>
 
-      {presetKey !== undefined && (
-        <div className="grid grid-cols-2 gap-2">
-          <div className="space-y-1">
-            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-              Name
-            </Label>
-            <Input
-              value={name}
-              onChange={(e) =>
-                onChange({
-                  name: (e.target as HTMLInputElement).value,
-                  prefix,
-                  presetKey: isCustom ? "custom" : presetKey,
-                })
-              }
-              placeholder="Authorization"
-              className="h-8 text-xs font-mono"
-            />
-          </div>
-          <div className="space-y-1">
-            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-              Prefix{" "}
-              <span className="normal-case tracking-normal font-normal text-muted-foreground/60">
-                (opt.)
-              </span>
-            </Label>
-            <Input
-              value={prefix ?? ""}
-              onChange={(e) =>
-                onChange({
-                  name,
-                  prefix: (e.target as HTMLInputElement).value || undefined,
-                  presetKey: isCustom ? "custom" : presetKey,
-                })
-              }
-              placeholder="Bearer "
-              className="h-8 text-xs font-mono"
-            />
-          </div>
-        </div>
-      )}
-
-      {presetKey !== undefined && name.trim() && (
+      {name.trim() && (
         <div className="flex items-center gap-1.5">
           <div className="flex-1 min-w-0">
             <SecretPicker value={secretId} onSelect={onSelectSecret} secrets={existingSecrets} />

--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -159,3 +159,12 @@
   --sidebar-border: hsl(240 3.7% 15.9%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
+
+@keyframes ios-spinner-fade {
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.25;
+  }
+}


### PR DESCRIPTION
**4 of 5** — source-forms refactor split from #169. Stacks on #189.

Adopts `<AuthenticationSection>` + `<FloatActions>` + `<IOSSpinner>` + `<Textarea maxRows>` across the remaining source-form surfaces:

- **openapi**: Add/Edit forms pick up the shared auth block; `sdk/preview` exposes a new `PreviewOperation` class and `sdk/index` re-exports it so the Add form can render search + an opacity-50 operation list.
- **graphql**: Add/Edit forms adopt the shared primitives.
- **google-discovery**: Add form rewritten to match the standard shape; the API probe (\`api/group\`, \`sdk/plugin\`) now also returns a list of operations (path + method + description) so the form can display them inline.
- **onepassword**: settings form picks up the shared `<Field>` components for consistency with the other plugin forms.

## Stack

1. #187 `feat(react): add UI primitives for source forms`
2. #188 `feat(react): add <AuthenticationSection> primitive`
3. #189 `refactor(mcp): adopt shared primitives in Add/Edit source forms`
4. **(this PR)** `refactor(sources): standardize openapi, graphql, google-discovery, onepassword forms`
5. `refactor(react): restructure sources list and sources-add container`

> Until the earlier PRs merge, this PR's diff includes their changes.