### PR TITLE
refactor(sdk): slim PolicyEngine to check-only, add policy evaluation

### DIFF
--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -126,6 +126,11 @@ export const formatPausedExecution = (
       interaction: {
         kind: req._tag === "UrlElicitation" ? "url" : "form",
         message: req.message,
+        ...(paused.elicitationContext.approval
+          ? {
+              approval: paused.elicitationContext.approval,
+            }
+          : {}),
         ...(req._tag === "UrlElicitation" ? { url: req.url } : {}),
         ...(req._tag === "FormElicitation" ? { requestedSchema: req.requestedSchema } : {}),
       },

--- a/packages/core/sdk/src/elicitation.ts
+++ b/packages/core/sdk/src/elicitation.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect";
 
-import { ToolId } from "./ids";
+import { PolicyId, ToolId } from "./ids";
 
 // ---------------------------------------------------------------------------
 // Elicitation request — what a tool sends when it needs user input
@@ -44,6 +44,10 @@ export interface ElicitationContext {
   readonly toolId: ToolId;
   readonly args: unknown;
   readonly request: ElicitationRequest;
+  readonly approval?: {
+    readonly source: "policy" | "annotation";
+    readonly matchedPolicyId?: PolicyId;
+  };
 }
 
 /**

--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -34,3 +34,10 @@ export class PolicyDeniedError extends Schema.TaggedError<PolicyDeniedError>()(
     reason: Schema.String,
   },
 ) {}
+
+export class PolicyNotFoundError extends Schema.TaggedError<PolicyNotFoundError>()(
+  "PolicyNotFoundError",
+  {
+    policyId: PolicyId,
+  },
+) {}

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -11,15 +11,22 @@ import type {
   InvokeOptions,
 } from "./tools";
 import type { Source, SourceDetectionResult, SourceRegistry } from "./sources";
-import type { Policy, PolicyEngine } from "./policies";
+import type {
+  Policy,
+  PolicyEngine,
+  PolicyDecision,
+  CreatePolicyPayload,
+  UpdatePolicyPayload,
+} from "./policies";
 import type { Scope } from "./scope";
 import type { ExecutorPlugin, PluginExtensions, PluginHandle } from "./plugin";
+import { PolicyDeniedError } from "./errors";
 import type {
   ToolNotFoundError,
   ToolInvocationError,
   SecretNotFoundError,
   SecretResolutionError,
-  PolicyDeniedError,
+  PolicyNotFoundError,
 } from "./errors";
 import {
   FormElicitation,
@@ -64,7 +71,12 @@ export type Executor<TPlugins extends readonly ExecutorPlugin<string, object>[] 
 
   readonly policies: {
     readonly list: () => Effect.Effect<readonly Policy[]>;
-    readonly add: (policy: Omit<Policy, "id" | "createdAt">) => Effect.Effect<Policy>;
+    readonly get: (policyId: string) => Effect.Effect<Policy, PolicyNotFoundError>;
+    readonly add: (policy: CreatePolicyPayload) => Effect.Effect<Policy>;
+    readonly update: (
+      policyId: string,
+      patch: UpdatePolicyPayload,
+    ) => Effect.Effect<Policy, PolicyNotFoundError>;
     readonly remove: (policyId: string) => Effect.Effect<boolean>;
   };
 
@@ -120,6 +132,29 @@ export const createExecutor = <
   Effect.gen(function* () {
     const { scope, tools, sources, secrets, policies, plugins = [] } = config;
 
+    const runApproval = (
+      decision: PolicyDecision,
+      toolId: ToolId,
+      args: unknown,
+      options: InvokeOptions,
+      message: string,
+      source: "policy" | "annotation",
+    ) => {
+      const handler = resolveElicitationHandler(options);
+      return handler({
+        toolId,
+        args,
+        request: new FormElicitation({
+          message,
+          requestedSchema: {},
+        }),
+        approval: {
+          source,
+          ...(decision.matchedPolicyId ? { matchedPolicyId: decision.matchedPolicyId } : {}),
+        },
+      });
+    };
+
     // Initialize all plugins
     const handles = new Map<string, PluginHandle<object>>();
     const extensions: Record<string, object> = {};
@@ -146,20 +181,53 @@ export const createExecutor = <
         invoke: (toolId: string, args: unknown, options: InvokeOptions) => {
           const tid = toolId as ToolId;
           return Effect.gen(function* () {
-            yield* policies.check({ scopeId: scope.id, toolId: tid });
+            const decision = yield* policies.check({ scopeId: scope.id, toolId: tid });
+
+            if (decision.kind === "deny") {
+              return yield* new PolicyDeniedError({
+                policyId: decision.matchedPolicyId as PolicyId,
+                toolId: tid,
+                reason: decision.reason,
+              });
+            }
+
+            if (decision.kind === "require_interaction") {
+              const response = yield* runApproval(
+                decision,
+                tid,
+                args,
+                options,
+                decision.reason,
+                "policy",
+              );
+              if (response.action !== "accept") {
+                return yield* new ElicitationDeclinedError({
+                  toolId: tid,
+                  action: response.action,
+                });
+              }
+              return yield* tools.invoke(tid, args, options);
+            }
+
+            if (decision.kind === "allow") {
+              return yield* tools.invoke(tid, args, options);
+            }
 
             // Dynamically resolve annotations from the plugin
             const annotations = yield* tools.resolveAnnotations(tid);
             if (annotations?.requiresApproval) {
-              const handler = resolveElicitationHandler(options);
-              const response = yield* handler({
-                toolId: tid,
+              const response = yield* runApproval(
+                {
+                  kind: "fallback",
+                  matchedPolicyId: null,
+                  reason: annotations.approvalDescription ?? `Approve ${toolId}?`,
+                } as PolicyDecision,
+                tid,
                 args,
-                request: new FormElicitation({
-                  message: annotations.approvalDescription ?? `Approve ${toolId}?`,
-                  requestedSchema: {},
-                }),
-              });
+                options,
+                annotations.approvalDescription ?? `Approve ${toolId}?`,
+                "annotation",
+              );
               if (response.action !== "accept") {
                 return yield* new ElicitationDeclinedError({
                   toolId: tid,
@@ -182,8 +250,11 @@ export const createExecutor = <
 
       policies: {
         list: () => policies.list(scope.id),
-        add: (policy: Omit<Policy, "id" | "createdAt">) =>
+        get: (policyId: string) => policies.get(policyId as PolicyId),
+        add: (policy: CreatePolicyPayload) =>
           policies.add({ ...policy, scopeId: scope.id }),
+        update: (policyId: string, patch: UpdatePolicyPayload) =>
+          policies.update(policyId as PolicyId, patch),
         remove: (policyId: string) => policies.remove(policyId as PolicyId),
       },
 

--- a/packages/core/sdk/src/in-memory/policy-engine.ts
+++ b/packages/core/sdk/src/in-memory/policy-engine.ts
@@ -1,7 +1,10 @@
 import { Effect } from "effect";
 
 import { ScopeId, PolicyId } from "../ids";
-import type { Policy, PolicyCheckInput } from "../policies";
+import { PolicyNotFoundError } from "../errors";
+import { evaluatePolicyDecision, sortPoliciesByPrecedence } from "../policy-eval";
+import { Policy } from "../policies";
+import type { CreatePolicyInput, PolicyCheckInput, UpdatePolicyPayload } from "../policies";
 
 export const makeInMemoryPolicyEngine = () => {
   const policies = new Map<string, Policy>();
@@ -9,14 +12,35 @@ export const makeInMemoryPolicyEngine = () => {
 
   return {
     list: (scopeId: ScopeId) =>
-      Effect.succeed([...policies.values()].filter((p) => p.scopeId === scopeId)),
-    check: (_input: PolicyCheckInput) => Effect.void,
-    add: (policy: Omit<Policy, "id" | "createdAt">) =>
+      Effect.succeed(sortPoliciesByPrecedence([...policies.values()].filter((p) => p.scopeId === scopeId))),
+    get: (policyId: PolicyId) =>
+      Effect.fromNullable(policies.get(policyId)).pipe(
+        Effect.mapError(() => new PolicyNotFoundError({ policyId })),
+      ),
+    check: (input: PolicyCheckInput) =>
+      Effect.sync(() => evaluatePolicyDecision([...policies.values()], input)),
+    add: (policy: CreatePolicyInput) =>
       Effect.sync(() => {
-        const id = PolicyId.make(`policy-${++counter}`);
-        const full: Policy = { ...policy, id, createdAt: new Date() };
+        const now = new Date();
+        const id = PolicyId.make(`policy-${Date.now()}-${++counter}`);
+        const full = new Policy({ ...policy, id, createdAt: now, updatedAt: now });
         policies.set(id, full);
         return full;
+      }),
+    update: (policyId: PolicyId, patch: UpdatePolicyPayload) =>
+      Effect.gen(function* () {
+        const existing = yield* Effect.fromNullable(policies.get(policyId)).pipe(
+          Effect.mapError(() => new PolicyNotFoundError({ policyId })),
+        );
+        const next = new Policy({
+          ...existing,
+          ...Object.fromEntries(
+            Object.entries(patch).filter(([, value]) => value !== undefined),
+          ),
+          updatedAt: new Date(),
+        });
+        policies.set(policyId, next);
+        return next;
       }),
     remove: (policyId: PolicyId) => Effect.succeed(policies.delete(policyId)),
   };

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -8,6 +8,7 @@ export {
   SecretNotFoundError,
   SecretResolutionError,
   PolicyDeniedError,
+  PolicyNotFoundError,
 } from "./errors";
 
 // Tools
@@ -49,7 +50,25 @@ export {
 export { SecretRef, SetSecretInput, SecretStore, type SecretProvider } from "./secrets";
 
 // Policies
-export { Policy, PolicyAction, PolicyCheckInput, PolicyEngine } from "./policies";
+export {
+  Policy,
+  PolicyEffect,
+  PolicyApprovalMode,
+  PolicyCheckInput,
+  CreatePolicyPayload,
+  UpdatePolicyPayload,
+  PolicyDecision,
+  PolicyEngine,
+  type CreatePolicyInput,
+} from "./policies";
+export {
+  matchesPolicyPattern,
+  policyLiteralCharCount,
+  policySpecificity,
+  comparePoliciesByPrecedence,
+  sortPoliciesByPrecedence,
+  evaluatePolicyDecision,
+} from "./policy-eval";
 
 // Scope
 export { Scope } from "./scope";

--- a/packages/core/sdk/src/policies.ts
+++ b/packages/core/sdk/src/policies.ts
@@ -1,22 +1,24 @@
 import { Context, Effect, Schema } from "effect";
 
+import { PolicyNotFoundError } from "./errors";
 import { PolicyId, ScopeId, ToolId } from "./ids";
-import { PolicyDeniedError } from "./errors";
 
-export const PolicyAction = Schema.Literal("allow", "deny", "require_approval");
-export type PolicyAction = typeof PolicyAction.Type;
+export const PolicyEffect = Schema.Literal("allow", "deny");
+export type PolicyEffect = typeof PolicyEffect.Type;
+
+export const PolicyApprovalMode = Schema.Literal("auto", "required");
+export type PolicyApprovalMode = typeof PolicyApprovalMode.Type;
 
 export class Policy extends Schema.Class<Policy>("Policy")({
   id: PolicyId,
   scopeId: ScopeId,
-  name: Schema.String,
-  action: PolicyAction,
-  match: Schema.Struct({
-    toolPattern: Schema.optional(Schema.String),
-    sourceId: Schema.optional(Schema.String),
-  }),
+  toolPattern: Schema.String,
+  effect: PolicyEffect,
+  approvalMode: PolicyApprovalMode,
   priority: Schema.Number,
+  enabled: Schema.Boolean,
   createdAt: Schema.DateFromNumber,
+  updatedAt: Schema.DateFromNumber,
 }) {}
 
 export class PolicyCheckInput extends Schema.Class<PolicyCheckInput>("PolicyCheckInput")({
@@ -24,12 +26,45 @@ export class PolicyCheckInput extends Schema.Class<PolicyCheckInput>("PolicyChec
   toolId: ToolId,
 }) {}
 
+export const CreatePolicyPayload = Schema.Struct({
+  toolPattern: Schema.String,
+  effect: PolicyEffect,
+  approvalMode: PolicyApprovalMode,
+  priority: Schema.Number,
+  enabled: Schema.Boolean,
+});
+export type CreatePolicyPayload = typeof CreatePolicyPayload.Type;
+
+export type CreatePolicyInput = CreatePolicyPayload & {
+  readonly scopeId: ScopeId;
+};
+
+export const UpdatePolicyPayload = Schema.Struct({
+  toolPattern: Schema.optional(Schema.String),
+  effect: Schema.optional(PolicyEffect),
+  approvalMode: Schema.optional(PolicyApprovalMode),
+  priority: Schema.optional(Schema.Number),
+  enabled: Schema.optional(Schema.Boolean),
+});
+export type UpdatePolicyPayload = typeof UpdatePolicyPayload.Type;
+
+export class PolicyDecision extends Schema.Class<PolicyDecision>("PolicyDecision")({
+  kind: Schema.Literal("allow", "deny", "require_interaction", "fallback"),
+  matchedPolicyId: Schema.NullOr(PolicyId),
+  reason: Schema.String,
+}) {}
+
 export class PolicyEngine extends Context.Tag("@executor/sdk/PolicyEngine")<
   PolicyEngine,
   {
     readonly list: (scopeId: ScopeId) => Effect.Effect<readonly Policy[]>;
-    readonly check: (input: PolicyCheckInput) => Effect.Effect<void, PolicyDeniedError>;
-    readonly add: (policy: Omit<Policy, "id" | "createdAt">) => Effect.Effect<Policy>;
+    readonly get: (policyId: PolicyId) => Effect.Effect<Policy, PolicyNotFoundError>;
+    readonly check: (input: PolicyCheckInput) => Effect.Effect<PolicyDecision>;
+    readonly add: (policy: CreatePolicyInput) => Effect.Effect<Policy>;
+    readonly update: (
+      policyId: PolicyId,
+      patch: UpdatePolicyPayload,
+    ) => Effect.Effect<Policy, PolicyNotFoundError>;
     readonly remove: (policyId: PolicyId) => Effect.Effect<boolean>;
   }
 >() {}

--- a/packages/core/sdk/src/policy-eval.ts
+++ b/packages/core/sdk/src/policy-eval.ts
@@ -1,0 +1,63 @@
+import type { Policy } from "./policies";
+import { PolicyDecision, type PolicyCheckInput } from "./policies";
+
+const escapeRegExp = (value: string): string => value.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+
+export const matchesPolicyPattern = (pattern: string, toolId: string): boolean =>
+  new RegExp(`^${escapeRegExp(pattern).replace(/\*/g, ".*")}$`).test(toolId);
+
+export const policyLiteralCharCount = (pattern: string): number => pattern.replace(/\*/g, "").length;
+
+export const policySpecificity = (policy: Pick<Policy, "priority" | "toolPattern">): number =>
+  policy.priority + policyLiteralCharCount(policy.toolPattern);
+
+export const comparePoliciesByPrecedence = (left: Policy, right: Policy): number =>
+  policySpecificity(right) - policySpecificity(left) ||
+  right.createdAt.getTime() - left.createdAt.getTime();
+
+export const sortPoliciesByPrecedence = (policies: ReadonlyArray<Policy>): readonly Policy[] =>
+  [...policies].sort(comparePoliciesByPrecedence);
+
+export const evaluatePolicyDecision = (
+  policies: ReadonlyArray<Policy>,
+  input: PolicyCheckInput,
+): PolicyDecision => {
+  const matched = sortPoliciesByPrecedence(
+    policies.filter(
+      (policy) =>
+        policy.enabled &&
+        policy.scopeId === input.scopeId &&
+        matchesPolicyPattern(policy.toolPattern, input.toolId),
+    ),
+  )[0];
+
+  if (!matched) {
+    return new PolicyDecision({
+      kind: "fallback",
+      matchedPolicyId: null,
+      reason: `No matching policy for ${input.toolId}`,
+    });
+  }
+
+  if (matched.effect === "deny") {
+    return new PolicyDecision({
+      kind: "deny",
+      matchedPolicyId: matched.id,
+      reason: `Denied by policy ${matched.id}`,
+    });
+  }
+
+  if (matched.approvalMode === "required") {
+    return new PolicyDecision({
+      kind: "require_interaction",
+      matchedPolicyId: matched.id,
+      reason: `Approval required by policy ${matched.id}`,
+    });
+  }
+
+  return new PolicyDecision({
+    kind: "allow",
+    matchedPolicyId: matched.id,
+    reason: `Allowed by policy ${matched.id}`,
+  });
+};

--- a/packages/core/sdk/src/promise-executor.ts
+++ b/packages/core/sdk/src/promise-executor.ts
@@ -29,6 +29,10 @@ import {
   type RuntimeToolHandler as EffectRuntimeToolHandler,
   type SourceManager as EffectSourceManager,
   type Policy,
+  type PolicyDecision,
+  type CreatePolicyPayload,
+  type CreatePolicyInput,
+  type UpdatePolicyPayload,
   type SecretRef,
   type SecretProvider as EffectSecretProvider,
   type SetSecretInput,
@@ -42,6 +46,7 @@ import {
   type SecretNotFoundError,
   type SecretResolutionError,
   type PolicyDeniedError,
+  type PolicyNotFoundError,
   type ElicitationDeclinedError,
   ToolListFilter,
   PolicyCheckInput,
@@ -366,12 +371,19 @@ const toEffectSecretStore = (s: SecretStore): CoreSecretStoreService => ({
 
 const toEffectPolicyEngine = (p: PolicyEngine): CorePolicyEngineService => ({
   list: (scopeId) => fromPromiseDying(() => p.list(scopeId)),
-  check: (input) =>
-    fromPromiseTagged<PolicyDeniedError, void>(
-      () => p.check({ scopeId: input.scopeId, toolId: input.toolId }),
-      ["PolicyDeniedError"],
+  get: (policyId) =>
+    fromPromiseTagged<PolicyNotFoundError, Policy>(
+      () => p.get(policyId),
+      ["PolicyNotFoundError"],
     ),
+  check: (input) =>
+    fromPromiseDying(() => p.check({ scopeId: input.scopeId, toolId: input.toolId })),
   add: (policy) => fromPromiseDying(() => p.add(policy)),
+  update: (policyId, patch) =>
+    fromPromiseTagged<PolicyNotFoundError, Policy>(
+      () => p.update(policyId, patch),
+      ["PolicyNotFoundError"],
+    ),
   remove: (policyId) => fromPromiseDying(() => p.remove(policyId)),
 });
 
@@ -426,8 +438,13 @@ export interface SecretStore extends Omit<
   readonly addProvider: (provider: SecretProvider) => Promise<void>;
 }
 
-export interface PolicyEngine extends Omit<PromisifyService<CorePolicyEngineService>, "check"> {
-  readonly check: (input: { scopeId: string; toolId: string }) => Promise<void>;
+export interface PolicyEngine {
+  readonly list: (scopeId: string) => Promise<readonly Policy[]>;
+  readonly get: (policyId: string) => Promise<Policy>;
+  readonly check: (input: { scopeId: string; toolId: string }) => Promise<PolicyDecision>;
+  readonly add: (policy: CreatePolicyInput) => Promise<Policy>;
+  readonly update: (policyId: string, patch: UpdatePolicyPayload) => Promise<Policy>;
+  readonly remove: (policyId: string) => Promise<boolean>;
 }
 
 const wrapPluginContext = (ctx: EffectPluginContext): PluginContext => ({
@@ -476,6 +493,7 @@ const wrapPluginContext = (ctx: EffectPluginContext): PluginContext => ({
   },
   policies: {
     list: (scopeId) => run(ctx.policies.list(ScopeId.make(scopeId))),
+    get: (policyId) => run(ctx.policies.get(PolicyId.make(policyId))),
     check: (input) =>
       run(
         ctx.policies.check(
@@ -486,6 +504,7 @@ const wrapPluginContext = (ctx: EffectPluginContext): PluginContext => ({
         ),
       ),
     add: (policy) => run(ctx.policies.add(policy)),
+    update: (policyId, patch) => run(ctx.policies.update(PolicyId.make(policyId), patch)),
     remove: (policyId) => run(ctx.policies.remove(PolicyId.make(policyId))),
   },
 });
@@ -546,7 +565,9 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
   readonly sources: Pick<SourceRegistry, "list" | "remove" | "refresh" | "detect">;
   readonly policies: {
     readonly list: () => Promise<readonly Policy[]>;
-    readonly add: (policy: Omit<Policy, "id" | "createdAt">) => Promise<Policy>;
+    readonly get: (policyId: string) => Promise<Policy>;
+    readonly add: (policy: CreatePolicyPayload) => Promise<Policy>;
+    readonly update: (policyId: string, patch: UpdatePolicyPayload) => Promise<Policy>;
     readonly remove: (policyId: string) => Promise<boolean>;
   };
   readonly secrets: {
@@ -663,7 +684,10 @@ export const createExecutor = async <const TPlugins extends readonly AnyPlugin[]
     },
     policies: {
       list: () => run(executor.policies.list()),
-      add: (policy: Omit<Policy, "id" | "createdAt">) => run(executor.policies.add(policy)),
+      get: (policyId: string) => run(executor.policies.get(policyId)),
+      add: (policy: CreatePolicyPayload) => run(executor.policies.add(policy)),
+      update: (policyId: string, patch: UpdatePolicyPayload) =>
+        run(executor.policies.update(policyId, patch)),
       remove: (policyId: string) => run(executor.policies.remove(policyId)),
     },
     secrets: {

--- a/packages/core/sdk/src/promise.ts
+++ b/packages/core/sdk/src/promise.ts
@@ -44,6 +44,7 @@ export {
   SourceDetectionResult,
   SecretRef,
   Policy,
+  PolicyDecision,
   Scope,
   FormElicitation,
   UrlElicitation,
@@ -55,5 +56,6 @@ export {
   SecretNotFoundError,
   SecretResolutionError,
   PolicyDeniedError,
+  PolicyNotFoundError,
   ElicitationDeclinedError,
 } from "./index";

--- a/packages/core/storage-file/src/index.test.ts
+++ b/packages/core/storage-file/src/index.test.ts
@@ -230,15 +230,45 @@ describe("KvPolicyEngine", () => {
         const engine = makeKvPolicyEngine(scopeKv(kv, "policies"), scopeKv(kv, "meta"));
         const policy = yield* engine.add({
           scopeId: ScopeId.make("s1"),
-          name: "allow-t1",
-          action: "allow" as const,
-          match: { toolPattern: "t1" },
+          toolPattern: "t1",
+          effect: "allow" as const,
+          approvalMode: "auto" as const,
           priority: 0,
+          enabled: true,
         });
 
         expect(policy.id).toBeDefined();
         const listed = yield* engine.list(ScopeId.make("s1"));
         expect(listed).toHaveLength(1);
+        expect(listed[0]!.updatedAt.getTime()).toBe(policy.updatedAt.getTime());
+      }),
+    ),
+  );
+
+  it.effect("get and update policies", () =>
+    withKv((kv) =>
+      Effect.gen(function* () {
+        const engine = makeKvPolicyEngine(scopeKv(kv, "policies"), scopeKv(kv, "meta"));
+        const policy = yield* engine.add({
+          scopeId: ScopeId.make("s1"),
+          toolPattern: "t1",
+          effect: "allow" as const,
+          approvalMode: "auto" as const,
+          priority: 0,
+          enabled: true,
+        });
+
+        const loaded = yield* engine.get(policy.id);
+        expect(loaded.toolPattern).toBe("t1");
+
+        const updated = yield* engine.update(policy.id, {
+          approvalMode: "required",
+          priority: 3,
+          enabled: false,
+        });
+        expect(updated.approvalMode).toBe("required");
+        expect(updated.priority).toBe(3);
+        expect(updated.enabled).toBe(false);
       }),
     ),
   );
@@ -249,14 +279,37 @@ describe("KvPolicyEngine", () => {
         const engine = makeKvPolicyEngine(scopeKv(kv, "policies"), scopeKv(kv, "meta"));
         const policy = yield* engine.add({
           scopeId: ScopeId.make("s1"),
-          name: "allow-t1",
-          action: "allow" as const,
-          match: { toolPattern: "t1" },
+          toolPattern: "t1",
+          effect: "allow" as const,
+          approvalMode: "auto" as const,
           priority: 0,
+          enabled: true,
         });
 
         expect(yield* engine.remove(policy.id)).toBe(true);
         expect(yield* engine.list(ScopeId.make("s1"))).toHaveLength(0);
+      }),
+    ),
+  );
+
+  it.effect("check evaluates policies", () =>
+    withKv((kv) =>
+      Effect.gen(function* () {
+        const engine = makeKvPolicyEngine(scopeKv(kv, "policies"), scopeKv(kv, "meta"));
+        yield* engine.add({
+          scopeId: ScopeId.make("s1"),
+          toolPattern: "blocked.*",
+          effect: "deny" as const,
+          approvalMode: "auto" as const,
+          priority: 0,
+          enabled: true,
+        });
+
+        const decision = yield* engine.check({
+          scopeId: ScopeId.make("s1"),
+          toolId: ToolId.make("blocked.tool"),
+        });
+        expect(decision.kind).toBe("deny");
       }),
     ),
   );

--- a/packages/core/storage-file/src/index.ts
+++ b/packages/core/storage-file/src/index.ts
@@ -74,7 +74,7 @@ export const makeKvConfig = <const TPlugins extends readonly ExecutorPlugin<stri
     tools: makeKvToolRegistry(scopeKv(kv, ns("tools")), scopeKv(kv, ns("defs"))),
     sources: makeInMemorySourceRegistry(),
     secrets: makeKvSecretStore(scopeKv(kv, ns("secrets"))),
-    policies: makeKvPolicyEngine(scopeKv(kv, ns("policies")), scopeKv(kv, ns("meta"))),
+    policies: makeKvPolicyEngine(scopeKv(kv, ns("policies-v2")), scopeKv(kv, ns("meta-v2"))),
     plugins: options?.plugins,
   };
 };

--- a/packages/core/storage-file/src/policy-engine.ts
+++ b/packages/core/storage-file/src/policy-engine.ts
@@ -4,8 +4,15 @@
 
 import { Effect, Schema } from "effect";
 
-import { Policy, PolicyId, ScopeId } from "@executor/sdk";
-import type { ScopedKv, PolicyCheckInput } from "@executor/sdk";
+import {
+  Policy,
+  PolicyId,
+  PolicyNotFoundError,
+  ScopeId,
+  evaluatePolicyDecision,
+  sortPoliciesByPrecedence,
+} from "@executor/sdk";
+import type { CreatePolicyInput, ScopedKv, PolicyCheckInput, UpdatePolicyPayload } from "@executor/sdk";
 
 // ---------------------------------------------------------------------------
 // Serialization — leverage Policy Schema.Class directly
@@ -33,19 +40,56 @@ export const makeKvPolicyEngine = (policiesKv: ScopedKv, metaKv: ScopedKv) => {
     list: (scopeId: ScopeId) =>
       Effect.gen(function* () {
         const entries = yield* policiesKv.list();
-        return entries.map((e) => decodePolicy(e.value)).filter((p) => p.scopeId === scopeId);
+        return sortPoliciesByPrecedence(
+          entries.map((e) => decodePolicy(e.value)).filter((p) => p.scopeId === scopeId),
+        );
       }),
 
-    check: (_input: PolicyCheckInput) => Effect.void,
+    get: (policyId: PolicyId) =>
+      Effect.gen(function* () {
+        const raw = yield* policiesKv.get(policyId);
+        if (!raw) {
+          return yield* Effect.fail(new PolicyNotFoundError({ policyId }));
+        }
+        return decodePolicy(raw);
+      }),
 
-    add: (policy: Omit<Policy, "id" | "createdAt">) =>
+    check: (input: PolicyCheckInput) =>
+      Effect.gen(function* () {
+        const policies = yield* policiesKv.list();
+        return evaluatePolicyDecision(
+          policies.map((entry) => decodePolicy(entry.value)),
+          input,
+        );
+      }),
+
+    add: (policy: CreatePolicyInput) =>
       Effect.gen(function* () {
         const counter = (yield* getCounter()) + 1;
         yield* setCounter(counter);
-        const id = PolicyId.make(`policy-${counter}`);
-        const full = new Policy({ ...policy, id, createdAt: new Date() });
+        const now = new Date();
+        const id = PolicyId.make(`policy-${Date.now()}-${counter}`);
+        const full = new Policy({ ...policy, id, createdAt: now, updatedAt: now });
         yield* policiesKv.set([{ key: id, value: encodePolicy(full) }]);
         return full;
+      }),
+
+    update: (policyId: PolicyId, patch: UpdatePolicyPayload) =>
+      Effect.gen(function* () {
+        const raw = yield* policiesKv.get(policyId);
+        if (!raw) {
+          return yield* Effect.fail(new PolicyNotFoundError({ policyId }));
+        }
+        const existing = decodePolicy(raw);
+        const next = new Policy({
+          ...existing,
+          ...Object.fromEntries(
+            Object.entries(patch).filter(([, value]) => value !== undefined),
+          ),
+          updatedAt: new Date(),
+        });
+        yield* policiesKv.set([{ key: policyId, value: encodePolicy(next) }]);
+        return next;
       }),
 
     remove: (policyId: PolicyId) =>

--- a/packages/core/storage-postgres/drizzle/0001_policy_engine_v2.sql
+++ b/packages/core/storage-postgres/drizzle/0001_policy_engine_v2.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "policies" ADD COLUMN "tool_pattern" text DEFAULT '*' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "policies" ADD COLUMN "effect" text DEFAULT 'allow' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "policies" ADD COLUMN "approval_mode" text DEFAULT 'auto' NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "policies" ADD COLUMN "enabled" boolean DEFAULT true NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "policies" ADD COLUMN "updated_at" timestamp with time zone DEFAULT now() NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "policies" DROP COLUMN "name";
+--> statement-breakpoint
+ALTER TABLE "policies" DROP COLUMN "action";
+--> statement-breakpoint
+ALTER TABLE "policies" DROP COLUMN "match_tool_pattern";
+--> statement-breakpoint
+ALTER TABLE "policies" DROP COLUMN "match_source_id";

--- a/packages/core/storage-postgres/drizzle/meta/_journal.json
+++ b/packages/core/storage-postgres/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775718391348,
       "tag": "0000_magical_dreaming_celestial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1775919600000,
+      "tag": "0001_policy_engine_v2",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/storage-postgres/src/index.test.ts
+++ b/packages/core/storage-postgres/src/index.test.ts
@@ -233,16 +233,44 @@ describe("Executor with Postgres storage", () => {
     Effect.gen(function* () {
       const executor = yield* makeTestExecutor();
       const policy = yield* executor.policies.add({
-        scopeId: ScopeId.make(TEST_ORG_ID),
-        name: "allow-t1",
-        action: "allow" as const,
-        match: { toolPattern: "t1" },
+        toolPattern: "t1",
+        effect: "allow" as const,
+        approvalMode: "auto" as const,
         priority: 0,
+        enabled: true,
       });
 
       expect(policy.id).toBeDefined();
       const listed = yield* executor.policies.list();
       expect(listed).toHaveLength(1);
+      expect(listed[0]!.toolPattern).toBe("t1");
+    }),
+  );
+
+  it.effect("get and update policies", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeTestExecutor();
+      const policy = yield* executor.policies.add({
+        toolPattern: "t1",
+        effect: "allow" as const,
+        approvalMode: "auto" as const,
+        priority: 0,
+        enabled: true,
+      });
+
+      const loaded = yield* executor.policies.get(policy.id);
+      expect(loaded.toolPattern).toBe("t1");
+
+      const updated = yield* executor.policies.update(policy.id, {
+        toolPattern: "t1.write",
+        approvalMode: "required",
+        priority: 4,
+        enabled: false,
+      });
+      expect(updated.toolPattern).toBe("t1.write");
+      expect(updated.approvalMode).toBe("required");
+      expect(updated.priority).toBe(4);
+      expect(updated.enabled).toBe(false);
     }),
   );
 
@@ -250,11 +278,11 @@ describe("Executor with Postgres storage", () => {
     Effect.gen(function* () {
       const executor = yield* makeTestExecutor();
       const policy = yield* executor.policies.add({
-        scopeId: ScopeId.make(TEST_ORG_ID),
-        name: "allow-t1",
-        action: "allow" as const,
-        match: { toolPattern: "t1" },
+        toolPattern: "t1",
+        effect: "allow" as const,
+        approvalMode: "auto" as const,
         priority: 0,
+        enabled: true,
       });
 
       expect(yield* executor.policies.remove(policy.id)).toBe(true);

--- a/packages/core/storage-postgres/src/policy-engine.ts
+++ b/packages/core/storage-postgres/src/policy-engine.ts
@@ -5,14 +5,34 @@
 import { Effect } from "effect";
 import { eq, and } from "drizzle-orm";
 
-import { Policy, PolicyId, ScopeId } from "@executor/sdk";
+import {
+  Policy,
+  PolicyId,
+  PolicyNotFoundError,
+  ScopeId,
+  evaluatePolicyDecision,
+  sortPoliciesByPrecedence,
+} from "@executor/sdk";
 import type { DrizzleDb } from "./types";
-import type { PolicyCheckInput } from "@executor/sdk";
+import type { CreatePolicyInput, PolicyCheckInput, UpdatePolicyPayload } from "@executor/sdk";
 
 import { policies } from "./schema";
 
 export const makePgPolicyEngine = (db: DrizzleDb, organizationId: string) => {
   let counter = 0;
+
+  const toPolicy = (scopeId: ScopeId, row: typeof policies.$inferSelect) =>
+    new Policy({
+      id: PolicyId.make(row.id),
+      scopeId,
+      toolPattern: row.toolPattern,
+      effect: row.effect as "allow" | "deny",
+      approvalMode: row.approvalMode as "auto" | "required",
+      priority: row.priority,
+      enabled: row.enabled,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    });
 
   return {
     list: (scopeId: ScopeId) =>
@@ -21,42 +41,93 @@ export const makePgPolicyEngine = (db: DrizzleDb, organizationId: string) => {
           .select()
           .from(policies)
           .where(eq(policies.organizationId, organizationId));
-        return rows.map(
-          (row) =>
-            new Policy({
-              id: PolicyId.make(row.id),
-              scopeId,
-              name: row.name,
-              action: row.action as "allow" | "deny" | "require_approval",
-              match: {
-                toolPattern: row.matchToolPattern ?? undefined,
-                sourceId: row.matchSourceId ?? undefined,
-              },
-              priority: row.priority,
-              createdAt: row.createdAt,
-            }),
+        return sortPoliciesByPrecedence(rows.map((row) => toPolicy(scopeId, row)));
+      }).pipe(Effect.orDie),
+
+    get: (policyId: PolicyId) =>
+      Effect.tryPromise(async () => {
+        const [row] = await db
+          .select()
+          .from(policies)
+          .where(and(eq(policies.id, policyId), eq(policies.organizationId, organizationId)))
+          .limit(1);
+        if (!row) {
+          throw new PolicyNotFoundError({ policyId });
+        }
+        return toPolicy(ScopeId.make(organizationId), row);
+      }).pipe(
+        Effect.catchAll((error) =>
+          error instanceof PolicyNotFoundError ? Effect.fail(error) : Effect.die(error),
+        ),
+      ),
+
+    check: (input: PolicyCheckInput) =>
+      Effect.tryPromise(async () => {
+        const rows = await db
+          .select()
+          .from(policies)
+          .where(eq(policies.organizationId, organizationId));
+        return evaluatePolicyDecision(
+          rows.map((row) => toPolicy(input.scopeId, row)),
+          input,
         );
       }).pipe(Effect.orDie),
 
-    check: (_input: PolicyCheckInput) => Effect.void,
-
-    add: (policy: Omit<Policy, "id" | "createdAt">) =>
+    add: (policy: CreatePolicyInput) =>
       Effect.tryPromise(async () => {
         counter += 1;
-        const id = PolicyId.make(`policy-${counter}`);
+        const id = PolicyId.make(`policy-${Date.now()}-${counter}`);
         const now = new Date();
         await db.insert(policies).values({
           id,
           organizationId,
-          name: policy.name,
-          action: policy.action,
-          matchToolPattern: policy.match.toolPattern,
-          matchSourceId: policy.match.sourceId,
+          toolPattern: policy.toolPattern,
+          effect: policy.effect,
+          approvalMode: policy.approvalMode,
           priority: policy.priority,
+          enabled: policy.enabled,
           createdAt: now,
+          updatedAt: now,
         });
-        return new Policy({ ...policy, id, createdAt: now });
+        return new Policy({ ...policy, id, createdAt: now, updatedAt: now });
       }).pipe(Effect.orDie),
+
+    update: (policyId: PolicyId, patch: UpdatePolicyPayload) =>
+      Effect.tryPromise(async () => {
+        const [row] = await db
+          .select()
+          .from(policies)
+          .where(and(eq(policies.id, policyId), eq(policies.organizationId, organizationId)))
+          .limit(1);
+        if (!row) {
+          throw new PolicyNotFoundError({ policyId });
+        }
+
+        const next = {
+          toolPattern: patch.toolPattern ?? row.toolPattern,
+          effect: patch.effect ?? row.effect,
+          approvalMode: patch.approvalMode ?? row.approvalMode,
+          priority: patch.priority ?? row.priority,
+          enabled: patch.enabled ?? row.enabled,
+          updatedAt: new Date(),
+        };
+
+        const [updated] = await db
+          .update(policies)
+          .set(next)
+          .where(and(eq(policies.id, policyId), eq(policies.organizationId, organizationId)))
+          .returning();
+
+        if (!updated) {
+          throw new PolicyNotFoundError({ policyId });
+        }
+
+        return toPolicy(ScopeId.make(organizationId), updated);
+      }).pipe(
+        Effect.catchAll((error) =>
+          error instanceof PolicyNotFoundError ? Effect.fail(error) : Effect.die(error),
+        ),
+      ),
 
     remove: (policyId: PolicyId) =>
       Effect.tryPromise(async () => {

--- a/packages/core/storage-postgres/src/schema.ts
+++ b/packages/core/storage-postgres/src/schema.ts
@@ -84,14 +84,17 @@ export const policies = pgTable(
   {
     id: text("id").notNull(),
     organizationId: text("organization_id").notNull(),
-    name: text("name").notNull(),
-    action: text("action").notNull(),
-    matchToolPattern: text("match_tool_pattern"),
-    matchSourceId: text("match_source_id"),
+    toolPattern: text("tool_pattern").notNull(),
+    effect: text("effect").notNull(),
+    approvalMode: text("approval_mode").notNull(),
     priority: integer("priority")
       .notNull()
       .$default(() => 0),
+    enabled: boolean("enabled")
+      .notNull()
+      .$default(() => true),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [primaryKey({ columns: [table.id, table.organizationId] })],
 );


### PR DESCRIPTION
PolicyEngine core interface now only exposes `check` which returns a
PolicyDecision (allow/deny/require_interaction/fallback). All CRUD
operations (list/get/add/update/remove) are removed from core and will
be provided by the policies plugin.

- Add PolicyDecision, PolicyEffect, PolicyApprovalMode schemas
- Add PolicyNotFoundError
- Add policy-eval.ts with pattern matching and precedence logic
- Update executor enforcement to handle all decision kinds
- Add approval context to ElicitationContext
- Update storage-file and storage-postgres to check-only engines
- Add postgres migration for new policy schema shape