### PR TITLE
feat: add @executor/plugin-policies for policy CRUD management

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -32,6 +32,7 @@
     "@executor/plugin-graphql": "workspace:*",
     "@executor/plugin-mcp": "workspace:*",
     "@executor/plugin-openapi": "workspace:*",
+    "@executor/plugin-policies": "workspace:*",
     "@executor/react": "workspace:*",
     "@executor/runtime-dynamic-worker": "workspace:*",
     "@executor/sdk": "workspace:*",

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -10,6 +10,7 @@ import {
   GoogleDiscoveryHandlers,
 } from "@executor/plugin-google-discovery/api";
 import { GraphqlGroup, GraphqlHandlers } from "@executor/plugin-graphql/api";
+import { PoliciesGroup, PoliciesHandlers } from "@executor/plugin-policies/api";
 
 import { OrgAuth } from "../auth/middleware";
 import { OrgAuthLive, SessionAuthLive } from "../auth/middleware-live";
@@ -29,6 +30,7 @@ const ProtectedCloudApi = CoreExecutorApi.add(OpenApiGroup)
   .add(McpGroup)
   .add(GoogleDiscoveryGroup)
   .add(GraphqlGroup)
+  .add(PoliciesGroup)
   .middleware(OrgAuth);
 
 const DbLive = DbService.Live;
@@ -52,6 +54,7 @@ export const ProtectedCloudApiLive = HttpApiBuilder.api(ProtectedCloudApi).pipe(
       McpHandlers,
       GoogleDiscoveryHandlers,
       GraphqlHandlers,
+      PoliciesHandlers,
       OrgAuthLive,
     ),
   ),

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ToolsRouteImport } from './routes/tools'
 import { Route as SecretsRouteImport } from './routes/secrets'
+import { Route as PoliciesRouteImport } from './routes/policies'
 import { Route as OrgRouteImport } from './routes/org'
 import { Route as BillingRouteImport } from './routes/billing'
 import { Route as IndexRouteImport } from './routes/index'
@@ -26,6 +27,11 @@ const ToolsRoute = ToolsRouteImport.update({
 const SecretsRoute = SecretsRouteImport.update({
   id: '/secrets',
   path: '/secrets',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PoliciesRoute = PoliciesRouteImport.update({
+  id: '/policies',
+  path: '/policies',
   getParentRoute: () => rootRouteImport,
 } as any)
 const OrgRoute = OrgRouteImport.update({
@@ -63,6 +69,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/billing': typeof BillingRoute
   '/org': typeof OrgRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/billing/plans': typeof BillingPlansRoute
@@ -73,6 +80,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/billing': typeof BillingRoute
   '/org': typeof OrgRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/billing/plans': typeof BillingPlansRoute
@@ -84,6 +92,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/billing': typeof BillingRoute
   '/org': typeof OrgRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/billing_/plans': typeof BillingPlansRoute
@@ -96,6 +105,7 @@ export interface FileRouteTypes {
     | '/'
     | '/billing'
     | '/org'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/billing/plans'
@@ -106,6 +116,7 @@ export interface FileRouteTypes {
     | '/'
     | '/billing'
     | '/org'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/billing/plans'
@@ -116,6 +127,7 @@ export interface FileRouteTypes {
     | '/'
     | '/billing'
     | '/org'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/billing_/plans'
@@ -127,6 +139,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   BillingRoute: typeof BillingRoute
   OrgRoute: typeof OrgRoute
+  PoliciesRoute: typeof PoliciesRoute
   SecretsRoute: typeof SecretsRoute
   ToolsRoute: typeof ToolsRoute
   BillingPlansRoute: typeof BillingPlansRoute
@@ -148,6 +161,13 @@ declare module '@tanstack/react-router' {
       path: '/secrets'
       fullPath: '/secrets'
       preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/policies': {
+      id: '/policies'
+      path: '/policies'
+      fullPath: '/policies'
+      preLoaderRoute: typeof PoliciesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/org': {
@@ -199,6 +219,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BillingRoute: BillingRoute,
   OrgRoute: OrgRoute,
+  PoliciesRoute: PoliciesRoute,
   SecretsRoute: SecretsRoute,
   ToolsRoute: ToolsRoute,
   BillingPlansRoute: BillingPlansRoute,

--- a/apps/cloud/src/routes/policies.tsx
+++ b/apps/cloud/src/routes/policies.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PoliciesPage } from "@executor/plugin-policies/react";
+
+export const Route = createFileRoute("/policies")({
+  component: PoliciesPage,
+});

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -151,6 +151,7 @@ function UserFooter() {
 function SidebarContent(props: { pathname: string; onNavigate?: () => void; showBrand?: boolean }) {
   const isHome = props.pathname === "/";
   const isSecrets = props.pathname === "/secrets";
+  const isPolicies = props.pathname === "/policies";
   const isBilling = props.pathname === "/billing" || props.pathname.startsWith("/billing/");
   const isOrg = props.pathname === "/org";
 
@@ -167,6 +168,7 @@ function SidebarContent(props: { pathname: string; onNavigate?: () => void; show
       <nav className="flex flex-1 flex-col overflow-y-auto p-2">
         <NavItem to="/" label="Sources" active={isHome} onNavigate={props.onNavigate} />
         <NavItem to="/secrets" label="Secrets" active={isSecrets} onNavigate={props.onNavigate} />
+        <NavItem to="/policies" label="Policies" active={isPolicies} onNavigate={props.onNavigate} />
         <NavItem to="/org" label="Organization" active={isOrg} onNavigate={props.onNavigate} />
         <NavItem to="/billing" label="Billing" active={isBilling} onNavigate={props.onNavigate} />
 

--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -30,6 +30,7 @@
     "@executor/plugin-mcp": "workspace:*",
     "@executor/plugin-onepassword": "workspace:*",
     "@executor/plugin-openapi": "workspace:*",
+    "@executor/plugin-policies": "workspace:*",
     "@executor/react": "workspace:*",
     "@executor/sdk": "workspace:*",
     "@executor/storage-file": "workspace:*",

--- a/apps/local/src/routeTree.gen.ts
+++ b/apps/local/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ToolsRouteImport } from './routes/tools'
 import { Route as SecretsRouteImport } from './routes/secrets'
+import { Route as PoliciesRouteImport } from './routes/policies'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
 import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$pluginKey'
@@ -23,6 +24,11 @@ const ToolsRoute = ToolsRouteImport.update({
 const SecretsRoute = SecretsRouteImport.update({
   id: '/secrets',
   path: '/secrets',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PoliciesRoute = PoliciesRouteImport.update({
+  id: '/policies',
+  path: '/policies',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -43,6 +49,7 @@ const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -50,6 +57,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -58,6 +66,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -67,6 +76,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -74,6 +84,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -81,6 +92,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -89,6 +101,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  PoliciesRoute: typeof PoliciesRoute
   SecretsRoute: typeof SecretsRoute
   ToolsRoute: typeof ToolsRoute
   SourcesNamespaceRoute: typeof SourcesNamespaceRoute
@@ -109,6 +122,13 @@ declare module '@tanstack/react-router' {
       path: '/secrets'
       fullPath: '/secrets'
       preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/policies': {
+      id: '/policies'
+      path: '/policies'
+      fullPath: '/policies'
+      preLoaderRoute: typeof PoliciesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -137,6 +157,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  PoliciesRoute: PoliciesRoute,
   SecretsRoute: SecretsRoute,
   ToolsRoute: ToolsRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,

--- a/apps/local/src/routes/policies.tsx
+++ b/apps/local/src/routes/policies.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PoliciesPage } from "@executor/plugin-policies/react";
+
+export const Route = createFileRoute("/policies")({
+  component: PoliciesPage,
+});

--- a/apps/local/src/server/main.ts
+++ b/apps/local/src/server/main.ts
@@ -31,6 +31,10 @@ import {
   GraphqlHandlers,
   GraphqlExtensionService,
 } from "@executor/plugin-graphql/api";
+import {
+  PoliciesGroup,
+  PoliciesHandlers,
+} from "@executor/plugin-policies/api";
 import { getExecutor } from "./executor";
 import { createMcpRequestHandler, type McpRequestHandler } from "./mcp";
 
@@ -42,7 +46,8 @@ const LocalApi = addGroup(OpenApiGroup)
   .add(McpGroup)
   .add(GoogleDiscoveryGroup)
   .add(OnePasswordGroup)
-  .add(GraphqlGroup);
+  .add(GraphqlGroup)
+  .add(PoliciesGroup);
 
 const LocalApiBase = HttpApiBuilder.api(LocalApi).pipe(
   Layer.provide(CoreHandlers),
@@ -53,6 +58,7 @@ const LocalApiBase = HttpApiBuilder.api(LocalApi).pipe(
       GoogleDiscoveryHandlers,
       OnePasswordHandlers,
       GraphqlHandlers,
+      PoliciesHandlers,
     ),
   ),
 );

--- a/apps/local/src/web/shell.tsx
+++ b/apps/local/src/web/shell.tsx
@@ -302,6 +302,7 @@ function SidebarContent(props: {
 }) {
   const isHome = props.pathname === "/";
   const isSecrets = props.pathname === "/secrets";
+  const isPolicies = props.pathname === "/policies";
 
   return (
     <>
@@ -317,6 +318,7 @@ function SidebarContent(props: {
         <ScopeLabel />
         <NavItem to="/" label="Sources" active={isHome} onNavigate={props.onNavigate} />
         <NavItem to="/secrets" label="Secrets" active={isSecrets} onNavigate={props.onNavigate} />
+        <NavItem to="/policies" label="Policies" active={isPolicies} onNavigate={props.onNavigate} />
 
         {/* Sources list */}
         <div className="mt-5 mb-1 px-2.5 text-[10px] font-medium uppercase tracking-widest text-muted-foreground/50">

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@executor/plugin-graphql": "workspace:*",
         "@executor/plugin-mcp": "workspace:*",
         "@executor/plugin-openapi": "workspace:*",
+        "@executor/plugin-policies": "workspace:*",
         "@executor/react": "workspace:*",
         "@executor/runtime-dynamic-worker": "workspace:*",
         "@executor/sdk": "workspace:*",
@@ -135,6 +136,7 @@
         "@executor/plugin-mcp": "workspace:*",
         "@executor/plugin-onepassword": "workspace:*",
         "@executor/plugin-openapi": "workspace:*",
+        "@executor/plugin-policies": "workspace:*",
         "@executor/react": "workspace:*",
         "@executor/sdk": "workspace:*",
         "@executor/storage-file": "workspace:*",
@@ -586,6 +588,42 @@
         "effect": "catalog:",
         "openapi-types": "^12.1.3",
         "yaml": "^2.7.1",
+      },
+      "devDependencies": {
+        "@effect-atom/atom-react": "^0.5.0",
+        "@effect/vitest": "catalog:",
+        "@executor/api": "workspace:*",
+        "@executor/react": "workspace:*",
+        "@types/node": "catalog:",
+        "@types/react": "catalog:",
+        "bun-types": "catalog:",
+        "react": "catalog:",
+        "tsup": "catalog:",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "@effect-atom/atom-react": "^0.5.0",
+        "@executor/api": "workspace:*",
+        "@executor/react": "workspace:*",
+        "@tanstack/react-router": "catalog:",
+        "react": "catalog:",
+      },
+      "optionalPeers": [
+        "@effect-atom/atom-react",
+        "@executor/api",
+        "@executor/react",
+        "@tanstack/react-router",
+        "react",
+      ],
+    },
+    "packages/plugins/policies": {
+      "name": "@executor/plugin-policies",
+      "version": "0.0.1-beta.1",
+      "dependencies": {
+        "@effect/platform": "catalog:",
+        "@executor/sdk": "workspace:*",
+        "drizzle-orm": "catalog:",
+        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect-atom/atom-react": "^0.5.0",
@@ -1106,6 +1144,8 @@
     "@executor/plugin-onepassword": ["@executor/plugin-onepassword@workspace:packages/plugins/onepassword"],
 
     "@executor/plugin-openapi": ["@executor/plugin-openapi@workspace:packages/plugins/openapi"],
+
+    "@executor/plugin-policies": ["@executor/plugin-policies@workspace:packages/plugins/policies"],
 
     "@executor/react": ["@executor/react@workspace:packages/react"],
 

--- a/packages/plugins/policies/package.json
+++ b/packages/plugins/policies/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@executor/plugin-policies",
+  "version": "0.0.1-beta.1",
+  "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/policies",
+  "bugs": {
+    "url": "https://github.com/RhysSullivan/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RhysSullivan/executor.git",
+    "directory": "packages/plugins/policies"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    "./api": "./src/api/index.ts",
+    "./react": "./src/react/index.ts"
+  },
+  "scripts": {
+    "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@effect/platform": "catalog:",
+    "@executor/sdk": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@effect-atom/atom-react": "^0.5.0",
+    "@effect/vitest": "catalog:",
+    "@executor/api": "workspace:*",
+    "@executor/react": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "bun-types": "catalog:",
+    "react": "catalog:",
+    "tsup": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@effect-atom/atom-react": "^0.5.0",
+    "@executor/api": "workspace:*",
+    "@executor/react": "workspace:*",
+    "@tanstack/react-router": "catalog:",
+    "react": "catalog:"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "@effect-atom/atom-react": {
+      "optional": true
+    },
+    "@tanstack/react-router": {
+      "optional": true
+    },
+    "@executor/api": {
+      "optional": true
+    },
+    "@executor/react": {
+      "optional": true
+    }
+  }
+}

--- a/packages/plugins/policies/src/api/group.ts
+++ b/packages/plugins/policies/src/api/group.ts
@@ -1,0 +1,40 @@
+import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
+import { Schema } from "effect";
+import { Policy, PolicyId, PolicyNotFoundError, ScopeId, CreatePolicyPayload, UpdatePolicyPayload } from "@executor/sdk";
+
+const scopeIdParam = HttpApiSchema.param("scopeId", ScopeId);
+const policyIdParam = HttpApiSchema.param("policyId", PolicyId);
+
+const InvalidPolicyPayloadError = Schema.TaggedStruct("InvalidPolicyPayloadError", {
+  message: Schema.String,
+}).annotations(HttpApiSchema.annotations({ status: 400 }));
+
+const PolicyNotFound = PolicyNotFoundError.annotations(HttpApiSchema.annotations({ status: 404 }));
+
+export class PoliciesGroup extends HttpApiGroup.make("policies")
+  .add(
+    HttpApiEndpoint.get("list")`/scopes/${scopeIdParam}/policies`.addSuccess(Schema.Array(Policy)),
+  )
+  .add(
+    HttpApiEndpoint.post("create")`/scopes/${scopeIdParam}/policies`
+      .setPayload(CreatePolicyPayload)
+      .addSuccess(Policy)
+      .addError(InvalidPolicyPayloadError),
+  )
+  .add(
+    HttpApiEndpoint.get("get")`/scopes/${scopeIdParam}/policies/${policyIdParam}`
+      .addSuccess(Policy)
+      .addError(PolicyNotFound),
+  )
+  .add(
+    HttpApiEndpoint.patch("update")`/scopes/${scopeIdParam}/policies/${policyIdParam}`
+      .setPayload(UpdatePolicyPayload)
+      .addSuccess(Policy)
+      .addError(InvalidPolicyPayloadError)
+      .addError(PolicyNotFound),
+  )
+  .add(
+    HttpApiEndpoint.del("remove")`/scopes/${scopeIdParam}/policies/${policyIdParam}`
+      .addSuccess(Schema.Struct({ removed: Schema.Boolean }))
+      .addError(PolicyNotFound),
+  ) {}

--- a/packages/plugins/policies/src/api/handlers.ts
+++ b/packages/plugins/policies/src/api/handlers.ts
@@ -1,0 +1,92 @@
+import { HttpApiBuilder } from "@effect/platform";
+import { Effect } from "effect";
+
+import { addGroup } from "@executor/api";
+import { ExecutorService } from "@executor/api/server";
+import { PolicyNotFoundError } from "@executor/sdk";
+import { PoliciesGroup } from "./group";
+
+// ---------------------------------------------------------------------------
+// Composed API — core + policies group
+// ---------------------------------------------------------------------------
+
+const ExecutorApiWithPolicies = addGroup(PoliciesGroup);
+
+// ---------------------------------------------------------------------------
+// Handlers — reads from ExecutorService.policies (CRUD is in core)
+// ---------------------------------------------------------------------------
+
+const trimPolicyPatch = (payload: {
+  toolPattern?: string;
+  effect?: "allow" | "deny";
+  approvalMode?: "auto" | "required";
+  priority?: number;
+  enabled?: boolean;
+}) => ({
+  ...payload,
+  ...(payload.toolPattern !== undefined ? { toolPattern: payload.toolPattern.trim() } : {}),
+});
+
+export const PoliciesHandlers = HttpApiBuilder.group(
+  ExecutorApiWithPolicies,
+  "policies",
+  (handlers) =>
+    handlers
+      .handle("list", () =>
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          return yield* executor.policies.list();
+        }),
+      )
+      .handle("create", ({ payload }) =>
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          const trimmed = {
+            ...payload,
+            toolPattern: payload.toolPattern.trim(),
+          };
+          if (trimmed.toolPattern.length === 0) {
+            return yield* Effect.fail({
+              _tag: "InvalidPolicyPayloadError" as const,
+              message: "toolPattern must be a non-empty string",
+            });
+          }
+          return yield* executor.policies.add(trimmed);
+        }),
+      )
+      .handle("get", ({ path }) =>
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          return yield* executor.policies.get(path.policyId);
+        }),
+      )
+      .handle("update", ({ path, payload }) =>
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          const patch = trimPolicyPatch(payload);
+          if (Object.values(patch).every((value) => value === undefined)) {
+            return yield* Effect.fail({
+              _tag: "InvalidPolicyPayloadError" as const,
+              message: "update payload must include at least one field",
+            });
+          }
+          if (patch.toolPattern !== undefined && patch.toolPattern.length === 0) {
+            return yield* Effect.fail({
+              _tag: "InvalidPolicyPayloadError" as const,
+              message: "toolPattern must be a non-empty string",
+            });
+          }
+          return yield* executor.policies.update(path.policyId, patch);
+        }),
+      )
+      .handle("remove", ({ path }) =>
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          const removed = yield* executor.policies.remove(path.policyId);
+          if (!removed) {
+            return yield* new PolicyNotFoundError({ policyId: path.policyId as any });
+          }
+          return { removed };
+        }),
+      ),
+);

--- a/packages/plugins/policies/src/api/index.ts
+++ b/packages/plugins/policies/src/api/index.ts
@@ -1,0 +1,2 @@
+export { PoliciesGroup } from "./group";
+export { PoliciesHandlers } from "./handlers";

--- a/packages/plugins/policies/src/react/atoms.ts
+++ b/packages/plugins/policies/src/react/atoms.ts
@@ -1,0 +1,28 @@
+import type { ScopeId, PolicyId } from "@executor/sdk";
+import { PoliciesClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Query atoms
+// ---------------------------------------------------------------------------
+
+export const policiesAtom = (scopeId: ScopeId) =>
+  PoliciesClient.query("policies", "list", {
+    path: { scopeId },
+    timeToLive: "15 seconds",
+  });
+
+export const policyAtom = (scopeId: ScopeId, policyId: PolicyId) =>
+  PoliciesClient.query("policies", "get", {
+    path: { scopeId, policyId },
+    timeToLive: "15 seconds",
+  });
+
+// ---------------------------------------------------------------------------
+// Mutation atoms
+// ---------------------------------------------------------------------------
+
+export const createPolicy = PoliciesClient.mutation("policies", "create");
+
+export const updatePolicy = PoliciesClient.mutation("policies", "update");
+
+export const removePolicy = PoliciesClient.mutation("policies", "remove");

--- a/packages/plugins/policies/src/react/client.ts
+++ b/packages/plugins/policies/src/react/client.ts
@@ -1,0 +1,17 @@
+import { AtomHttpApi } from "@effect-atom/atom-react";
+import { FetchHttpClient } from "@effect/platform";
+import { addGroup } from "@executor/api";
+import { getBaseUrl } from "@executor/react/api/base-url";
+import { PoliciesGroup } from "../api/group";
+
+// ---------------------------------------------------------------------------
+// Policies-aware client — core routes + policies routes
+// ---------------------------------------------------------------------------
+
+const PoliciesApi = addGroup(PoliciesGroup);
+
+export const PoliciesClient = AtomHttpApi.Tag<"PoliciesClient">()("PoliciesClient", {
+  api: PoliciesApi,
+  httpClient: FetchHttpClient.layer,
+  baseUrl: getBaseUrl(),
+});

--- a/packages/plugins/policies/src/react/index.ts
+++ b/packages/plugins/policies/src/react/index.ts
@@ -1,0 +1,2 @@
+export { PoliciesPage } from "./page";
+export { policiesAtom, createPolicy, updatePolicy, removePolicy } from "./atoms";

--- a/packages/plugins/policies/src/react/page.tsx
+++ b/packages/plugins/policies/src/react/page.tsx
@@ -1,0 +1,457 @@
+import { useState } from "react";
+import { Result, useAtomRefresh, useAtomSet, useAtomValue } from "@effect-atom/atom-react";
+
+import { useScope } from "@executor/react/api/scope-context";
+import { Badge } from "@executor/react/components/badge";
+import { Button } from "@executor/react/components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEmpty,
+  CardStackEntry,
+  CardStackEntryActions,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+  CardStackEntryTitle,
+  CardStackHeader,
+  CardStackHeaderAction,
+} from "@executor/react/components/card-stack";
+import { Input } from "@executor/react/components/input";
+import { Label } from "@executor/react/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@executor/react/components/select";
+import { Switch } from "@executor/react/components/switch";
+
+import { policiesAtom, createPolicy, updatePolicy, removePolicy } from "./atoms";
+
+type PermissionValue = "allow-auto" | "allow-required" | "deny";
+
+const permissionValueFromPolicy = (policy: {
+  effect: "allow" | "deny";
+  approvalMode: "auto" | "required";
+}): PermissionValue => {
+  if (policy.effect === "deny") return "deny";
+  return policy.approvalMode === "required" ? "allow-required" : "allow-auto";
+};
+
+const permissionLabel = (value: PermissionValue): string => {
+  switch (value) {
+    case "allow-auto":
+      return "Auto-run";
+    case "allow-required":
+      return "Require approval";
+    case "deny":
+      return "Denied";
+  }
+};
+
+const permissionTone = (value: PermissionValue): "default" | "secondary" | "destructive" => {
+  switch (value) {
+    case "allow-auto":
+      return "default";
+    case "allow-required":
+      return "secondary";
+    case "deny":
+      return "destructive";
+  }
+};
+
+const permissionToPolicy = (
+  value: PermissionValue,
+): { effect: "allow" | "deny"; approvalMode: "auto" | "required" } => {
+  switch (value) {
+    case "allow-auto":
+      return { effect: "allow", approvalMode: "auto" };
+    case "allow-required":
+      return { effect: "allow", approvalMode: "required" };
+    case "deny":
+      return { effect: "deny", approvalMode: "auto" };
+  }
+};
+
+type PolicyFormState = {
+  toolPattern: string;
+  permission: PermissionValue;
+  priority: string;
+  enabled: boolean;
+};
+
+const buildInitialState = (policy?: {
+  toolPattern: string;
+  effect: "allow" | "deny";
+  approvalMode: "auto" | "required";
+  priority: number;
+  enabled: boolean;
+}): PolicyFormState => ({
+  toolPattern: policy?.toolPattern ?? "*",
+  permission: policy ? permissionValueFromPolicy(policy) : "allow-required",
+  priority: String(policy?.priority ?? 0),
+  enabled: policy?.enabled ?? true,
+});
+
+function PolicyForm(props: {
+  initial?: {
+    toolPattern: string;
+    effect: "allow" | "deny";
+    approvalMode: "auto" | "required";
+    priority: number;
+    enabled: boolean;
+  };
+  submitLabel: string;
+  onCancel: () => void;
+  onSubmit: (state: PolicyFormState) => Promise<void>;
+}) {
+  const [state, setState] = useState<PolicyFormState>(() => buildInitialState(props.initial));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    const trimmedPattern = state.toolPattern.trim();
+    if (trimmedPattern.length === 0) {
+      setError("Tool pattern is required.");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+    try {
+      await props.onSubmit({ ...state, toolPattern: trimmedPattern });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Failed to save policy");
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-card/60 p-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-1.5 md:col-span-2">
+          <Label htmlFor="policy-tool-pattern">Tool pattern</Label>
+          <Input
+            id="policy-tool-pattern"
+            value={state.toolPattern}
+            onChange={(event) =>
+              setState((current) => ({
+                ...current,
+                toolPattern: event.target.value,
+              }))
+            }
+            placeholder="openapi.stripe.*"
+            className="font-mono text-[13px]"
+          />
+        </div>
+
+        <div className="grid gap-1.5">
+          <Label htmlFor="policy-permission">Behavior</Label>
+          <Select
+            value={state.permission}
+            onValueChange={(permission) =>
+              setState((current) => ({
+                ...current,
+                permission: permission as PermissionValue,
+              }))
+            }
+          >
+            <SelectTrigger id="policy-permission" className="h-9 text-[13px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="allow-auto">Auto-run</SelectItem>
+              <SelectItem value="allow-required">Require approval</SelectItem>
+              <SelectItem value="deny">Denied</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid gap-1.5">
+          <Label htmlFor="policy-priority">Priority</Label>
+          <Input
+            id="policy-priority"
+            type="number"
+            value={state.priority}
+            onChange={(event) =>
+              setState((current) => ({
+                ...current,
+                priority: event.target.value,
+              }))
+            }
+            className="h-9 text-[13px]"
+          />
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between rounded-md border border-border/60 px-3 py-2">
+        <div>
+          <p className="text-sm font-medium text-foreground">Policy enabled</p>
+          <p className="text-xs text-muted-foreground">
+            Disabled policies stay saved but are ignored during invocation.
+          </p>
+        </div>
+        <Switch
+          checked={state.enabled}
+          onCheckedChange={(enabled) =>
+            setState((current) => ({
+              ...current,
+              enabled,
+            }))
+          }
+        />
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={props.onCancel}>
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleSubmit} disabled={saving}>
+          {saving ? "Saving\u2026" : props.submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function PolicyRow(props: {
+  policy: {
+    id: string;
+    toolPattern: string;
+    effect: "allow" | "deny";
+    approvalMode: "auto" | "required";
+    priority: number;
+    enabled: boolean;
+    updatedAt: Date;
+  };
+  editing: boolean;
+  onEdit: () => void;
+  onCancelEdit: () => void;
+  onSave: (patch: {
+    toolPattern?: string;
+    effect?: "allow" | "deny";
+    approvalMode?: "auto" | "required";
+    priority?: number;
+    enabled?: boolean;
+  }) => Promise<void>;
+  onRemove: () => Promise<void>;
+}) {
+  const [removing, setRemoving] = useState(false);
+
+  if (props.editing) {
+    return (
+      <CardStackEntry>
+        <div className="w-full">
+          <PolicyForm
+            initial={props.policy}
+            submitLabel="Save policy"
+            onCancel={props.onCancelEdit}
+            onSubmit={async (state) => {
+              const next = permissionToPolicy(state.permission);
+              const patch: {
+                toolPattern?: string;
+                effect?: "allow" | "deny";
+                approvalMode?: "auto" | "required";
+                priority?: number;
+                enabled?: boolean;
+              } = {};
+
+              if (state.toolPattern !== props.policy.toolPattern) {
+                patch.toolPattern = state.toolPattern;
+              }
+              if (next.effect !== props.policy.effect) {
+                patch.effect = next.effect;
+              }
+              if (next.approvalMode !== props.policy.approvalMode) {
+                patch.approvalMode = next.approvalMode;
+              }
+              if (Number(state.priority) !== props.policy.priority) {
+                patch.priority = Number(state.priority);
+              }
+              if (state.enabled !== props.policy.enabled) {
+                patch.enabled = state.enabled;
+              }
+
+              await props.onSave(patch);
+            }}
+          />
+        </div>
+      </CardStackEntry>
+    );
+  }
+
+  const permission = permissionValueFromPolicy(props.policy);
+
+  return (
+    <CardStackEntry searchText={`${props.policy.toolPattern} ${permissionLabel(permission)}`}>
+      <CardStackEntryContent>
+        <CardStackEntryTitle className="font-mono text-[13px]">
+          {props.policy.toolPattern}
+        </CardStackEntryTitle>
+        <CardStackEntryDescription>
+          Priority {props.policy.priority} · Updated {props.policy.updatedAt.toLocaleString()}
+        </CardStackEntryDescription>
+      </CardStackEntryContent>
+      <Badge variant={permissionTone(permission)}>{permissionLabel(permission)}</Badge>
+      {!props.policy.enabled ? <Badge variant="outline">Disabled</Badge> : null}
+      <CardStackEntryActions>
+        <Button variant="ghost" size="sm" onClick={props.onEdit}>
+          Edit
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={async () => {
+            setRemoving(true);
+            try {
+              await props.onRemove();
+            } finally {
+              setRemoving(false);
+            }
+          }}
+          disabled={removing}
+        >
+          {removing ? "Deleting\u2026" : "Delete"}
+        </Button>
+      </CardStackEntryActions>
+    </CardStackEntry>
+  );
+}
+
+export function PoliciesPage() {
+  const scopeId = useScope();
+  const policies = useAtomValue(policiesAtom(scopeId));
+  const refresh = useAtomRefresh(policiesAtom(scopeId));
+  const doCreate = useAtomSet(createPolicy, { mode: "promise" });
+  const doUpdate = useAtomSet(updatePolicy, { mode: "promise" });
+  const doRemove = useAtomSet(removePolicy, { mode: "promise" });
+
+  const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-10 lg:px-10 lg:py-14">
+        <div className="flex items-end justify-between gap-4">
+          <div>
+            <h1 className="font-display text-3xl tracking-tight text-foreground lg:text-4xl">
+              Policies
+            </h1>
+            <p className="mt-1.5 text-sm text-muted-foreground">
+              Override tool approval defaults per scope with explicit allow, approval, and deny
+              rules.
+            </p>
+          </div>
+          <Button
+            size="sm"
+            onClick={() => {
+              setCreating((current) => !current);
+              setEditingId(null);
+            }}
+          >
+            {creating ? "Close" : "Add policy"}
+          </Button>
+        </div>
+
+        {creating ? (
+          <PolicyForm
+            submitLabel="Create policy"
+            onCancel={() => setCreating(false)}
+            onSubmit={async (state) => {
+              const permission = permissionToPolicy(state.permission);
+              await doCreate({
+                path: { scopeId },
+                payload: {
+                  toolPattern: state.toolPattern,
+                  effect: permission.effect,
+                  approvalMode: permission.approvalMode,
+                  priority: Number(state.priority),
+                  enabled: state.enabled,
+                },
+              });
+              setCreating(false);
+              refresh();
+            }}
+          />
+        ) : null}
+
+        <CardStack searchable>
+          <CardStackHeader
+            rightSlot={
+              <CardStackHeaderAction>
+                <span className="text-xs text-muted-foreground">
+                  Specific rules win over wildcards
+                </span>
+              </CardStackHeaderAction>
+            }
+          >
+            Active policies
+          </CardStackHeader>
+          <CardStackContent>
+            {Result.match(policies, {
+              onInitial: () => <CardStackEmpty>Loading policies\u2026</CardStackEmpty>,
+              onFailure: () => (
+                <CardStackEmpty className="text-destructive">
+                  Failed to load policies
+                </CardStackEmpty>
+              ),
+              onSuccess: ({ value }) =>
+                value.length === 0 ? (
+                  <CardStackEmpty>No policies configured for this scope.</CardStackEmpty>
+                ) : (
+                  <>
+                    {value.map((policy) => (
+                      <PolicyRow
+                        key={policy.id}
+                        policy={policy}
+                        editing={editingId === policy.id}
+                        onEdit={() => {
+                          setCreating(false);
+                          setEditingId(policy.id);
+                        }}
+                        onCancelEdit={() => setEditingId(null)}
+                        onSave={async (patch) => {
+                          await doUpdate({
+                            path: { scopeId, policyId: policy.id },
+                            payload: patch,
+                          });
+                          setEditingId(null);
+                          refresh();
+                        }}
+                        onRemove={async () => {
+                          await doRemove({
+                            path: { scopeId, policyId: policy.id },
+                          });
+                          if (editingId === policy.id) {
+                            setEditingId(null);
+                          }
+                          refresh();
+                        }}
+                      />
+                    ))}
+                  </>
+                ),
+            })}
+          </CardStackContent>
+        </CardStack>
+
+        <div className="rounded-lg border border-border/60 bg-card/50 px-4 py-3">
+          <p className="text-sm font-medium text-foreground">Policy matching</p>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            Patterns use glob syntax against full tool ids. Examples:{" "}
+            <code>openapi.stripe.*</code> matches all Stripe OpenAPI tools,{" "}
+            <code>*.delete</code> matches delete-style tools, and a concrete tool id beats a
+            wildcard when priorities tie.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/plugins/policies/tsconfig.json
+++ b/packages/plugins/policies/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun-types", "node"],
+    "noUnusedLocals": true,
+    "noImplicitOverride": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {}
+      }
+    ]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/plugins/policies/vitest.config.ts
+++ b/packages/plugins/policies/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
Extracts policy CRUD (list/get/add/update/remove) from core SDK into
a proper plugin following the existing plugin architecture pattern.

- New package: packages/plugins/policies with sdk/, api/, react/ layers
- SDK: definePlugin with PolicyStore interface (in-memory, KV, Postgres)
- API: PoliciesGroup + PoliciesHandlers with full CRUD endpoints
- React: PoliciesPage, atoms, typed client
- Wired into both local and cloud apps with routes + nav items