### PR TITLE
[codex] refactor plugin catalogs and registration

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -28,6 +28,7 @@
     "@executor/env": "workspace:*",
     "@executor/execution": "workspace:*",
     "@executor/host-mcp": "workspace:*",
+    "@executor/host-plugins": "workspace:*",
     "@executor/plugin-google-discovery": "workspace:*",
     "@executor/plugin-graphql": "workspace:*",
     "@executor/plugin-mcp": "workspace:*",

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -3,13 +3,6 @@ import { Effect, Layer } from "effect";
 
 import { CoreExecutorApi } from "@executor/api";
 import { CoreHandlers } from "@executor/api/server";
-import { OpenApiGroup, OpenApiHandlers } from "@executor/plugin-openapi/api";
-import { McpGroup, McpHandlers } from "@executor/plugin-mcp/api";
-import {
-  GoogleDiscoveryGroup,
-  GoogleDiscoveryHandlers,
-} from "@executor/plugin-google-discovery/api";
-import { GraphqlGroup, GraphqlHandlers } from "@executor/plugin-graphql/api";
 
 import { OrgAuth } from "../auth/middleware";
 import { OrgAuthLive, SessionAuthLive } from "../auth/middleware-live";
@@ -24,12 +17,9 @@ import { AutumnService } from "../services/autumn";
 import { DbService } from "../services/db";
 import { OrgHttpApi } from "../org/compose";
 import { OrgHandlers } from "../org/handlers";
+import { addCloudPluginGroups, CloudPluginHandlers } from "../server/plugin-registry";
 
-const ProtectedCloudApi = CoreExecutorApi.add(OpenApiGroup)
-  .add(McpGroup)
-  .add(GoogleDiscoveryGroup)
-  .add(GraphqlGroup)
-  .middleware(OrgAuth);
+const ProtectedCloudApi = addCloudPluginGroups(CoreExecutorApi).middleware(OrgAuth);
 
 const DbLive = DbService.Live;
 const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
@@ -45,16 +35,9 @@ export const SharedServices = Layer.mergeAll(
 export const RouterConfig = HttpRouter.setRouterConfig({ maxParamLength: 1000 });
 
 export const ProtectedCloudApiLive = HttpApiBuilder.api(ProtectedCloudApi).pipe(
-  Layer.provide(
-    Layer.mergeAll(
-      CoreHandlers,
-      OpenApiHandlers,
-      McpHandlers,
-      GoogleDiscoveryHandlers,
-      GraphqlHandlers,
-      OrgAuthLive,
-    ),
-  ),
+  Layer.provide(CoreHandlers),
+  Layer.provide(CloudPluginHandlers),
+  Layer.provideMerge(OrgAuthLive),
 );
 
 const NonProtectedApiLive = HttpApiBuilder.api(NonProtectedApi).pipe(

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -5,10 +5,6 @@ import { Effect, Layer } from "effect";
 import { ExecutorService, ExecutionEngineService } from "@executor/api/server";
 import { createExecutionEngine } from "@executor/execution";
 import { makeDynamicWorkerExecutor } from "@executor/runtime-dynamic-worker";
-import { OpenApiExtensionService } from "@executor/plugin-openapi/api";
-import { McpExtensionService } from "@executor/plugin-mcp/api";
-import { GoogleDiscoveryExtensionService } from "@executor/plugin-google-discovery/api";
-import { GraphqlExtensionService } from "@executor/plugin-graphql/api";
 
 import { UserStoreService } from "../auth/context";
 import { WorkOSAuth } from "../auth/workos";
@@ -19,6 +15,7 @@ import { makeTrackExecutionUsage } from "./autumn";
 import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
 import { withExecutionUsageTracking } from "./execution-usage";
 import { ProtectedCloudApiLive, RouterConfig, SharedServices } from "./layers";
+import { createCloudPluginExtensions } from "../server/plugin-registry";
 
 const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
   Effect.gen(function* () {
@@ -57,10 +54,7 @@ const createProtectedApp = (organizationId: string, organizationName: string) =>
     const requestServices = Layer.mergeAll(
       Layer.succeed(ExecutorService, executor),
       Layer.succeed(ExecutionEngineService, engine),
-      Layer.succeed(OpenApiExtensionService, executor.openapi),
-      Layer.succeed(McpExtensionService, executor.mcp),
-      Layer.succeed(GoogleDiscoveryExtensionService, executor.googleDiscovery),
-      Layer.succeed(GraphqlExtensionService, executor.graphql),
+      createCloudPluginExtensions(executor),
     );
 
     return yield* HttpApiBuilder.httpApp.pipe(

--- a/apps/cloud/src/plugin-catalog.ts
+++ b/apps/cloud/src/plugin-catalog.ts
@@ -1,0 +1,6 @@
+import type { SecretProviderPlugin } from "@executor/react/plugins/secret-provider-plugin";
+import { firstPartySourcePlugins } from "@executor/host-plugins/ui";
+
+export const cloudSourcePlugins = firstPartySourcePlugins;
+
+export const cloudSecretProviderPlugins = [] as const satisfies readonly SecretProviderPlugin[];

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -8,6 +8,7 @@ import { AuthProvider, useAuth } from "../web/auth";
 import { LoginPage } from "../web/pages/login";
 import { Shell } from "../web/shell";
 import appCss from "@executor/react/globals.css?url";
+import { cloudSecretProviderPlugins, cloudSourcePlugins } from "../plugin-catalog";
 
 if (typeof window !== "undefined" && import.meta.env.VITE_PUBLIC_SENTRY_DSN) {
   Sentry.init({
@@ -80,7 +81,10 @@ function AuthGate() {
 
   return (
     <AutumnProvider pathPrefix="/api/autumn">
-      <ExecutorProvider>
+      <ExecutorProvider
+        sourcePlugins={cloudSourcePlugins}
+        secretProviderPlugins={cloudSecretProviderPlugins}
+      >
         <Shell />
         <Toaster />
       </ExecutorProvider>

--- a/apps/cloud/src/routes/index.tsx
+++ b/apps/cloud/src/routes/index.tsx
@@ -1,17 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SourcesPage } from "@executor/react/pages/sources";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 export const Route = createFileRoute("/")({
-  component: () => <SourcesPage sourcePlugins={sourcePlugins} />,
+  component: () => <SourcesPage />,
 });

--- a/apps/cloud/src/routes/secrets.tsx
+++ b/apps/cloud/src/routes/secrets.tsx
@@ -2,5 +2,5 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SecretsPage } from "@executor/react/pages/secrets";
 
 export const Route = createFileRoute("/secrets")({
-  component: () => <SecretsPage secretProviderPlugins={[]} />,
+  component: () => <SecretsPage />,
 });

--- a/apps/cloud/src/routes/sources.$namespace.tsx
+++ b/apps/cloud/src/routes/sources.$namespace.tsx
@@ -1,20 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SourceDetailPage } from "@executor/react/pages/source-detail";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 export const Route = createFileRoute("/sources/$namespace")({
   component: () => {
     const { namespace } = Route.useParams();
-    return <SourceDetailPage namespace={namespace} sourcePlugins={sourcePlugins} />;
+    return <SourceDetailPage namespace={namespace} />;
   },
 });

--- a/apps/cloud/src/routes/sources.add.$pluginKey.tsx
+++ b/apps/cloud/src/routes/sources.add.$pluginKey.tsx
@@ -1,17 +1,6 @@
 import { Schema } from "effect";
 import { createFileRoute } from "@tanstack/react-router";
 import { SourcesAddPage } from "@executor/react/pages/sources-add";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 const SearchParams = Schema.standardSchemaV1(
   Schema.Struct({
@@ -32,7 +21,6 @@ export const Route = createFileRoute("/sources/add/$pluginKey")({
         url={url}
         preset={preset}
         namespace={namespace}
-        sourcePlugins={sourcePlugins}
       />
     );
   },

--- a/apps/cloud/src/server/plugin-registry.ts
+++ b/apps/cloud/src/server/plugin-registry.ts
@@ -1,0 +1,32 @@
+import {
+  addFirstPartyPluginGroups,
+  createFirstPartyPluginExtensions,
+  FirstPartyPluginHandlers,
+} from "@executor/host-plugins/server";
+import { googleDiscoveryPlugin, makeKvBindingStore as makeKvGoogleDiscoveryBindingStore } from "@executor/plugin-google-discovery";
+import { graphqlPlugin, makeKvOperationStore as makeKvGraphqlOperationStore } from "@executor/plugin-graphql";
+import { mcpPlugin, makeKvBindingStore } from "@executor/plugin-mcp";
+import { openApiPlugin, makeKvOperationStore } from "@executor/plugin-openapi";
+import type { Kv } from "@executor/sdk";
+
+export const createCloudRuntimePlugins = (kv: Kv) =>
+  [
+    openApiPlugin({
+      operationStore: makeKvOperationStore(kv, "openapi"),
+    }),
+    mcpPlugin({
+      bindingStore: makeKvBindingStore(kv, "mcp"),
+    }),
+    googleDiscoveryPlugin({
+      bindingStore: makeKvGoogleDiscoveryBindingStore(kv, "google-discovery"),
+    }),
+    graphqlPlugin({
+      operationStore: makeKvGraphqlOperationStore(kv, "graphql"),
+    }),
+  ] as const;
+
+export const addCloudPluginGroups = addFirstPartyPluginGroups;
+
+export const CloudPluginHandlers = FirstPartyPluginHandlers;
+
+export const createCloudPluginExtensions = createFirstPartyPluginExtensions;

--- a/apps/cloud/src/services/executor.ts
+++ b/apps/cloud/src/services/executor.ts
@@ -6,17 +6,8 @@ import { Effect } from "effect";
 
 import { createExecutor } from "@executor/sdk";
 import { makePgConfig, makePgKv } from "@executor/storage-postgres";
-import { openApiPlugin, makeKvOperationStore } from "@executor/plugin-openapi";
-import { mcpPlugin, makeKvBindingStore } from "@executor/plugin-mcp";
-import {
-  googleDiscoveryPlugin,
-  makeKvBindingStore as makeKvGoogleDiscoveryBindingStore,
-} from "@executor/plugin-google-discovery";
-import {
-  graphqlPlugin,
-  makeKvOperationStore as makeKvGraphqlOperationStore,
-} from "@executor/plugin-graphql";
 import { DbService } from "./db";
+import { createCloudRuntimePlugins } from "../server/plugin-registry";
 
 // ---------------------------------------------------------------------------
 // Create a fresh executor for an organization (stateless, per-request)
@@ -34,20 +25,7 @@ export const createOrgExecutor = (
       organizationId,
       organizationName,
       encryptionKey,
-      plugins: [
-        openApiPlugin({
-          operationStore: makeKvOperationStore(kv, "openapi"),
-        }),
-        mcpPlugin({
-          bindingStore: makeKvBindingStore(kv, "mcp"),
-        }),
-        googleDiscoveryPlugin({
-          bindingStore: makeKvGoogleDiscoveryBindingStore(kv, "google-discovery"),
-        }),
-        graphqlPlugin({
-          operationStore: makeKvGraphqlOperationStore(kv, "graphql"),
-        }),
-      ] as const,
+      plugins: createCloudRuntimePlugins(kv),
     });
 
     return yield* createExecutor(config);

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -6,19 +6,8 @@ import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
 import { SourceFavicon } from "@executor/react/components/source-favicon";
 import { CommandPalette } from "@executor/react/components/command-palette";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
 import { AUTH_PATHS } from "../auth/api";
 import { useAuth } from "./auth";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 // ── NavItem ──────────────────────────────────────────────────────────────
 
@@ -206,7 +195,7 @@ export function Shell() {
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <CommandPalette sourcePlugins={sourcePlugins} />
+      <CommandPalette />
       {/* Desktop sidebar */}
       <aside className="hidden w-52 shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col lg:w-56">
         <SidebarContent pathname={pathname} />

--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -23,6 +23,7 @@
     "@executor/config": "workspace:*",
     "@executor/execution": "workspace:*",
     "@executor/host-mcp": "workspace:*",
+    "@executor/host-plugins": "workspace:*",
     "@executor/plugin-file-secrets": "workspace:*",
     "@executor/plugin-google-discovery": "workspace:*",
     "@executor/plugin-graphql": "workspace:*",

--- a/apps/local/src/plugin-catalog.ts
+++ b/apps/local/src/plugin-catalog.ts
@@ -1,0 +1,9 @@
+import type { SecretProviderPlugin } from "@executor/react/plugins/secret-provider-plugin";
+import { firstPartySourcePlugins } from "@executor/host-plugins/ui";
+import { onePasswordSecretProviderPlugin } from "@executor/plugin-onepassword/react";
+
+export const localSourcePlugins = firstPartySourcePlugins;
+
+export const localSecretProviderPlugins = [
+  onePasswordSecretProviderPlugin,
+] as const satisfies readonly SecretProviderPlugin[];

--- a/apps/local/src/routes/__root.tsx
+++ b/apps/local/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRootRoute } from "@tanstack/react-router";
 import { ExecutorProvider } from "@executor/react/api/provider";
 import { Shell } from "../web/shell";
+import { localSecretProviderPlugins, localSourcePlugins } from "../plugin-catalog";
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -9,7 +10,10 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <ExecutorProvider>
+    <ExecutorProvider
+      sourcePlugins={localSourcePlugins}
+      secretProviderPlugins={localSecretProviderPlugins}
+    >
       <Shell />
     </ExecutorProvider>
   );

--- a/apps/local/src/routes/index.tsx
+++ b/apps/local/src/routes/index.tsx
@@ -1,17 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SourcesPage } from "@executor/react/pages/sources";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 export const Route = createFileRoute("/")({
-  component: () => <SourcesPage sourcePlugins={sourcePlugins} />,
+  component: () => <SourcesPage />,
 });

--- a/apps/local/src/routes/secrets.tsx
+++ b/apps/local/src/routes/secrets.tsx
@@ -1,9 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SecretsPage } from "@executor/react/pages/secrets";
-import { onePasswordSecretProviderPlugin } from "@executor/plugin-onepassword/react";
-
-const secretProviderPlugins = [onePasswordSecretProviderPlugin];
 
 export const Route = createFileRoute("/secrets")({
-  component: () => <SecretsPage secretProviderPlugins={secretProviderPlugins} />,
+  component: () => <SecretsPage />,
 });

--- a/apps/local/src/routes/sources.$namespace.tsx
+++ b/apps/local/src/routes/sources.$namespace.tsx
@@ -1,20 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SourceDetailPage } from "@executor/react/pages/source-detail";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 export const Route = createFileRoute("/sources/$namespace")({
   component: () => {
     const { namespace } = Route.useParams();
-    return <SourceDetailPage namespace={namespace} sourcePlugins={sourcePlugins} />;
+    return <SourceDetailPage namespace={namespace} />;
   },
 });

--- a/apps/local/src/routes/sources.add.$pluginKey.tsx
+++ b/apps/local/src/routes/sources.add.$pluginKey.tsx
@@ -1,17 +1,6 @@
 import { Schema } from "effect";
 import { createFileRoute } from "@tanstack/react-router";
 import { SourcesAddPage } from "@executor/react/pages/sources-add";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 const SearchParams = Schema.standardSchemaV1(
   Schema.Struct({
@@ -30,7 +19,6 @@ export const Route = createFileRoute("/sources/add/$pluginKey")({
         pluginKey={pluginKey}
         url={url}
         preset={preset}
-        sourcePlugins={sourcePlugins}
       />
     );
   },

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -6,30 +6,9 @@ import * as fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { createExecutor, scopeKv } from "@executor/sdk";
+import { createExecutor } from "@executor/sdk";
 import { makeSqliteKv, makeKvConfig, makeScopedKv, migrate } from "@executor/storage-file";
-import {
-  openApiPlugin,
-  makeKvOperationStore,
-  withConfigFile as withOpenApiConfigFile,
-} from "@executor/plugin-openapi";
-import {
-  mcpPlugin,
-  makeKvBindingStore,
-  withConfigFile as withMcpConfigFile,
-} from "@executor/plugin-mcp";
-import {
-  googleDiscoveryPlugin,
-  makeKvBindingStore as makeKvGoogleDiscoveryBindingStore,
-} from "@executor/plugin-google-discovery";
-import {
-  graphqlPlugin,
-  makeKvOperationStore as makeKvGraphqlOperationStore,
-  withConfigFile as withGraphqlConfigFile,
-} from "@executor/plugin-graphql";
-import { keychainPlugin } from "@executor/plugin-keychain";
-import { fileSecretsPlugin } from "@executor/plugin-file-secrets";
-import { onepasswordPlugin } from "@executor/plugin-onepassword";
+import { createLocalRuntimePlugins } from "./plugin-registry";
 
 // ---------------------------------------------------------------------------
 // Data directory
@@ -45,41 +24,8 @@ const resolveDbPath = (): string => {
 // Local plugins — defined once, used for both the layer and type inference
 // ---------------------------------------------------------------------------
 
-const createLocalPlugins = (
-  scopedKv: ReturnType<typeof makeScopedKv>,
-  configPath: string,
-  fsLayer: typeof NodeFileSystem.layer,
-) =>
-  [
-    openApiPlugin({
-      operationStore: withOpenApiConfigFile(
-        makeKvOperationStore(scopedKv, "openapi"),
-        configPath,
-        fsLayer,
-      ),
-    }),
-    mcpPlugin({
-      bindingStore: withMcpConfigFile(makeKvBindingStore(scopedKv, "mcp"), configPath, fsLayer),
-    }),
-    googleDiscoveryPlugin({
-      bindingStore: makeKvGoogleDiscoveryBindingStore(scopedKv, "google-discovery"),
-    }),
-    graphqlPlugin({
-      operationStore: withGraphqlConfigFile(
-        makeKvGraphqlOperationStore(scopedKv, "graphql"),
-        configPath,
-        fsLayer,
-      ),
-    }),
-    keychainPlugin(),
-    fileSecretsPlugin(),
-    onepasswordPlugin({
-      kv: scopeKv(scopedKv, "onepassword"),
-    }),
-  ] as const;
-
 // Full typed executor — inferred from plugin list
-type LocalPlugins = ReturnType<typeof createLocalPlugins>;
+type LocalPlugins = ReturnType<typeof createLocalRuntimePlugins>;
 
 // Private tag preserving the full plugin type
 class LocalExecutorTag extends Context.Tag("@executor/local/Executor")<
@@ -112,7 +58,7 @@ const createLocalExecutorLayer = () => {
 
       return yield* createExecutor({
         ...config,
-        plugins: createLocalPlugins(scopedKv, configPath, fsLayer),
+        plugins: createLocalRuntimePlugins({ scopedKv, configPath, fsLayer }),
       });
     }),
   ).pipe(Layer.provide(SqliteClient.layer({ filename: dbPath })));

--- a/apps/local/src/server/main.ts
+++ b/apps/local/src/server/main.ts
@@ -7,54 +7,19 @@ import {
 } from "@effect/platform";
 import { Context, Effect, Layer, ManagedRuntime } from "effect";
 
-import { addGroup } from "@executor/api";
 import { CoreHandlers, ExecutorService, ExecutionEngineService } from "@executor/api/server";
 import { createExecutionEngine } from "@executor/execution";
-import {
-  OpenApiGroup,
-  OpenApiHandlers,
-  OpenApiExtensionService,
-} from "@executor/plugin-openapi/api";
-import { McpGroup, McpHandlers, McpExtensionService } from "@executor/plugin-mcp/api";
-import {
-  GoogleDiscoveryGroup,
-  GoogleDiscoveryHandlers,
-  GoogleDiscoveryExtensionService,
-} from "@executor/plugin-google-discovery/api";
-import {
-  OnePasswordGroup,
-  OnePasswordHandlers,
-  OnePasswordExtensionService,
-} from "@executor/plugin-onepassword/api";
-import {
-  GraphqlGroup,
-  GraphqlHandlers,
-  GraphqlExtensionService,
-} from "@executor/plugin-graphql/api";
 import { getExecutor } from "./executor";
 import { createMcpRequestHandler, type McpRequestHandler } from "./mcp";
+import { createLocalPluginExtensions, LocalApi, LocalPluginHandlers } from "./plugin-registry";
 
 // ---------------------------------------------------------------------------
 // Local server API — core + all plugin groups
 // ---------------------------------------------------------------------------
 
-const LocalApi = addGroup(OpenApiGroup)
-  .add(McpGroup)
-  .add(GoogleDiscoveryGroup)
-  .add(OnePasswordGroup)
-  .add(GraphqlGroup);
-
 const LocalApiBase = HttpApiBuilder.api(LocalApi).pipe(
   Layer.provide(CoreHandlers),
-  Layer.provide(
-    Layer.mergeAll(
-      OpenApiHandlers,
-      McpHandlers,
-      GoogleDiscoveryHandlers,
-      OnePasswordHandlers,
-      GraphqlHandlers,
-    ),
-  ),
+  Layer.provide(LocalPluginHandlers),
 );
 
 // ---------------------------------------------------------------------------
@@ -80,13 +45,7 @@ export const createServerHandlers = async (): Promise<ServerHandlers> => {
   const executor = await getExecutor();
   const engine = createExecutionEngine({ executor });
 
-  const pluginExtensions = Layer.mergeAll(
-    Layer.succeed(OpenApiExtensionService, executor.openapi),
-    Layer.succeed(McpExtensionService, executor.mcp),
-    Layer.succeed(GoogleDiscoveryExtensionService, executor.googleDiscovery),
-    Layer.succeed(OnePasswordExtensionService, executor.onepassword),
-    Layer.succeed(GraphqlExtensionService, executor.graphql),
-  );
+  const pluginExtensions = createLocalPluginExtensions(executor);
 
   const api = HttpApiBuilder.toWebHandler(
     HttpApiSwagger.layer({ path: "/docs" }).pipe(

--- a/apps/local/src/server/plugin-registry.ts
+++ b/apps/local/src/server/plugin-registry.ts
@@ -1,0 +1,79 @@
+import { Layer } from "effect";
+import { NodeFileSystem } from "@effect/platform-node";
+
+import { CoreExecutorApi } from "@executor/api";
+import {
+  addFirstPartyPluginGroups,
+  createFirstPartyPluginExtensions,
+  FirstPartyPluginHandlers,
+} from "@executor/host-plugins/server";
+import { googleDiscoveryPlugin, makeKvBindingStore as makeKvGoogleDiscoveryBindingStore } from "@executor/plugin-google-discovery";
+import { graphqlPlugin, makeKvOperationStore as makeKvGraphqlOperationStore, withConfigFile as withGraphqlConfigFile } from "@executor/plugin-graphql";
+import { keychainPlugin } from "@executor/plugin-keychain";
+import { mcpPlugin, makeKvBindingStore, withConfigFile as withMcpConfigFile } from "@executor/plugin-mcp";
+import { onepasswordPlugin } from "@executor/plugin-onepassword";
+import { OnePasswordExtensionService, OnePasswordGroup, OnePasswordHandlers } from "@executor/plugin-onepassword/api";
+import { openApiPlugin, makeKvOperationStore, withConfigFile as withOpenApiConfigFile } from "@executor/plugin-openapi";
+import { fileSecretsPlugin } from "@executor/plugin-file-secrets";
+import { scopeKv } from "@executor/sdk";
+import { makeScopedKv } from "@executor/storage-file";
+
+type LocalRuntimePluginFactoryOptions = {
+  readonly scopedKv: ReturnType<typeof makeScopedKv>;
+  readonly configPath: string;
+  readonly fsLayer: typeof NodeFileSystem.layer;
+};
+
+const mergeLayers = <T extends Layer.Layer<any, any, any>>(layers: readonly [T, ...Array<T>]) => {
+  const [first, ...rest] = layers;
+  return rest.reduce((current, layer) => Layer.merge(current, layer) as T, first);
+};
+
+export const createLocalRuntimePlugins = (options: LocalRuntimePluginFactoryOptions) =>
+  [
+    openApiPlugin({
+      operationStore: withOpenApiConfigFile(
+        makeKvOperationStore(options.scopedKv, "openapi"),
+        options.configPath,
+        options.fsLayer,
+      ),
+    }),
+    mcpPlugin({
+      bindingStore: withMcpConfigFile(
+        makeKvBindingStore(options.scopedKv, "mcp"),
+        options.configPath,
+        options.fsLayer,
+      ),
+    }),
+    googleDiscoveryPlugin({
+      bindingStore: makeKvGoogleDiscoveryBindingStore(options.scopedKv, "google-discovery"),
+    }),
+    graphqlPlugin({
+      operationStore: withGraphqlConfigFile(
+        makeKvGraphqlOperationStore(options.scopedKv, "graphql"),
+        options.configPath,
+        options.fsLayer,
+      ),
+    }),
+    keychainPlugin(),
+    fileSecretsPlugin(),
+    onepasswordPlugin({
+      kv: scopeKv(options.scopedKv, "onepassword"),
+    }),
+  ] as const;
+
+export const LocalApi = addFirstPartyPluginGroups(CoreExecutorApi).add(OnePasswordGroup);
+
+export const LocalPluginHandlers = mergeLayers(
+  [FirstPartyPluginHandlers, OnePasswordHandlers] as const,
+);
+
+export const createLocalPluginExtensions = (
+  executor: Parameters<typeof createFirstPartyPluginExtensions>[0] & { readonly onepassword: unknown },
+) =>
+  mergeLayers(
+    [
+      createFirstPartyPluginExtensions(executor),
+      Layer.succeed(OnePasswordExtensionService, executor.onepassword as never),
+    ] as const,
+  );

--- a/apps/local/src/web/shell.tsx
+++ b/apps/local/src/web/shell.tsx
@@ -6,17 +6,6 @@ import { useScope, useScopeInfo } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
 import { SourceFavicon } from "@executor/react/components/source-favicon";
 import { CommandPalette } from "@executor/react/components/command-palette";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
-
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
 
 // ── Env ─────────────────────────────────────────────────────────────────
 
@@ -403,7 +392,7 @@ export function Shell() {
 
   return (
     <div className="flex h-screen overflow-hidden">
-      <CommandPalette sourcePlugins={sourcePlugins} />
+      <CommandPalette />
       {/* Desktop sidebar */}
       <aside className="hidden w-52 shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col lg:w-56">
         <SidebarContent

--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,7 @@
         "@executor/env": "workspace:*",
         "@executor/execution": "workspace:*",
         "@executor/host-mcp": "workspace:*",
+        "@executor/host-plugins": "workspace:*",
         "@executor/plugin-google-discovery": "workspace:*",
         "@executor/plugin-graphql": "workspace:*",
         "@executor/plugin-mcp": "workspace:*",
@@ -128,6 +129,7 @@
         "@executor/config": "workspace:*",
         "@executor/execution": "workspace:*",
         "@executor/host-mcp": "workspace:*",
+        "@executor/host-plugins": "workspace:*",
         "@executor/plugin-file-secrets": "workspace:*",
         "@executor/plugin-google-discovery": "workspace:*",
         "@executor/plugin-graphql": "workspace:*",
@@ -316,6 +318,24 @@
         "@types/node": "catalog:",
         "bun-types": "catalog:",
         "vitest": "catalog:",
+      },
+    },
+    "packages/hosts/plugins": {
+      "name": "@executor/host-plugins",
+      "version": "1.4.2",
+      "dependencies": {
+        "@executor/api": "workspace:*",
+        "@executor/plugin-google-discovery": "workspace:*",
+        "@executor/plugin-graphql": "workspace:*",
+        "@executor/plugin-mcp": "workspace:*",
+        "@executor/plugin-openapi": "workspace:*",
+        "@executor/react": "workspace:*",
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@types/react": "catalog:",
+        "@types/react-dom": "catalog:",
+        "bun-types": "catalog:",
       },
     },
     "packages/kernel/core": {
@@ -1086,6 +1106,8 @@
     "@executor/execution": ["@executor/execution@workspace:packages/core/execution"],
 
     "@executor/host-mcp": ["@executor/host-mcp@workspace:packages/hosts/mcp"],
+
+    "@executor/host-plugins": ["@executor/host-plugins@workspace:packages/hosts/plugins"],
 
     "@executor/ir": ["@executor/ir@workspace:packages/kernel/ir"],
 

--- a/packages/hosts/plugins/package.json
+++ b/packages/hosts/plugins/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@executor/host-plugins",
+  "version": "1.4.2",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server.ts",
+    "./ui": "./src/ui.ts"
+  },
+  "scripts": {
+    "typecheck": "tsgo --noEmit",
+    "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@executor/api": "workspace:*",
+    "@executor/plugin-google-discovery": "workspace:*",
+    "@executor/plugin-graphql": "workspace:*",
+    "@executor/plugin-mcp": "workspace:*",
+    "@executor/plugin-openapi": "workspace:*",
+    "@executor/react": "workspace:*",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "bun-types": "catalog:"
+  }
+}

--- a/packages/hosts/plugins/src/index.ts
+++ b/packages/hosts/plugins/src/index.ts
@@ -1,0 +1,7 @@
+export { firstPartySourcePlugins } from "./ui";
+export {
+  addFirstPartyPluginGroups,
+  FirstPartyPluginHandlers,
+  createFirstPartyPluginExtensions,
+  type FirstPartyPluginExecutor,
+} from "./server";

--- a/packages/hosts/plugins/src/server.ts
+++ b/packages/hosts/plugins/src/server.ts
@@ -1,0 +1,75 @@
+import { Layer } from "effect";
+
+import { GoogleDiscoveryExtensionService, GoogleDiscoveryGroup, GoogleDiscoveryHandlers } from "@executor/plugin-google-discovery/api";
+import { GraphqlExtensionService, GraphqlGroup, GraphqlHandlers } from "@executor/plugin-graphql/api";
+import { McpExtensionService, McpGroup, McpHandlers } from "@executor/plugin-mcp/api";
+import { OpenApiExtensionService, OpenApiGroup, OpenApiHandlers } from "@executor/plugin-openapi/api";
+
+export type FirstPartyPluginExecutor = {
+  readonly openapi: unknown;
+  readonly mcp: unknown;
+  readonly googleDiscovery: unknown;
+  readonly graphql: unknown;
+};
+
+type FirstPartyServerPlugin = {
+  readonly addToApi: (api: unknown) => unknown;
+  readonly handlersLayer: Layer.Layer<any, any, any>;
+  readonly extensionLayer: (executor: FirstPartyPluginExecutor) => Layer.Layer<any, any, never>;
+};
+
+type ApiWithAdd = {
+  readonly add: (group: unknown) => unknown;
+};
+
+const mergeLayers = <T extends Layer.Layer<any, any, any>>(layers: readonly [T, ...Array<T>]) => {
+  const [first, ...rest] = layers;
+  return rest.reduce((current, layer) => Layer.merge(current, layer) as T, first);
+};
+
+const firstPartyServerPlugins: readonly FirstPartyServerPlugin[] = [
+  {
+    addToApi: (api) => (api as ApiWithAdd).add(OpenApiGroup),
+    handlersLayer: OpenApiHandlers,
+    extensionLayer: (executor) =>
+      Layer.succeed(OpenApiExtensionService, executor.openapi as never),
+  },
+  {
+    addToApi: (api) => (api as ApiWithAdd).add(McpGroup),
+    handlersLayer: McpHandlers,
+    extensionLayer: (executor) => Layer.succeed(McpExtensionService, executor.mcp as never),
+  },
+  {
+    addToApi: (api) => (api as ApiWithAdd).add(GoogleDiscoveryGroup),
+    handlersLayer: GoogleDiscoveryHandlers,
+    extensionLayer: (executor) =>
+      Layer.succeed(GoogleDiscoveryExtensionService, executor.googleDiscovery as never),
+  },
+  {
+    addToApi: (api) => (api as ApiWithAdd).add(GraphqlGroup),
+    handlersLayer: GraphqlHandlers,
+    extensionLayer: (executor) =>
+      Layer.succeed(GraphqlExtensionService, executor.graphql as never),
+  },
+];
+
+export const addFirstPartyPluginGroups = <T>(api: T) =>
+  firstPartyServerPlugins.reduce(
+    (current, plugin) => plugin.addToApi(current) as T,
+    api,
+  );
+
+export const FirstPartyPluginHandlers = mergeLayers(
+  firstPartyServerPlugins.map((plugin) => plugin.handlersLayer) as [
+    Layer.Layer<any, any, any>,
+    ...Array<Layer.Layer<any, any, any>>,
+  ],
+);
+
+export const createFirstPartyPluginExtensions = (executor: FirstPartyPluginExecutor) =>
+  mergeLayers(
+    firstPartyServerPlugins.map((plugin) => plugin.extensionLayer(executor)) as [
+      Layer.Layer<any, any, never>,
+      ...Array<Layer.Layer<any, any, never>>,
+    ],
+  );

--- a/packages/hosts/plugins/src/ui.ts
+++ b/packages/hosts/plugins/src/ui.ts
@@ -1,0 +1,12 @@
+import type { SourcePlugin } from "@executor/react/plugins/source-plugin";
+import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
+import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
+import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
+import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
+
+export const firstPartySourcePlugins = [
+  openApiSourcePlugin,
+  mcpSourcePlugin,
+  googleDiscoverySourcePlugin,
+  graphqlSourcePlugin,
+] as const satisfies readonly SourcePlugin[];

--- a/packages/hosts/plugins/tsconfig.json
+++ b/packages/hosts/plugins/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["bun-types", "react", "react-dom"],
+    "noUnusedLocals": true,
+    "noImplicitOverride": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service"
+      }
+    ]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/react/src/api/provider.tsx
+++ b/packages/react/src/api/provider.tsx
@@ -1,9 +1,24 @@
 import { RegistryProvider } from "@effect-atom/atom-react";
 import * as React from "react";
+import { PluginCatalogProvider } from "../plugins/plugin-catalog";
+import type { SecretProviderPlugin } from "../plugins/secret-provider-plugin";
+import type { SourcePlugin } from "../plugins/source-plugin";
 import { ScopeProvider } from "./scope-context";
 
-export const ExecutorProvider = (props: React.PropsWithChildren) => (
+export const ExecutorProvider = (
+  props: React.PropsWithChildren<{
+    readonly sourcePlugins?: readonly SourcePlugin[];
+    readonly secretProviderPlugins?: readonly SecretProviderPlugin[];
+  }>,
+) => (
   <RegistryProvider>
-    <ScopeProvider>{props.children}</ScopeProvider>
+    <ScopeProvider>
+      <PluginCatalogProvider
+        sourcePlugins={props.sourcePlugins}
+        secretProviderPlugins={props.secretProviderPlugins}
+      >
+        {props.children}
+      </PluginCatalogProvider>
+    </ScopeProvider>
   </RegistryProvider>
 );

--- a/packages/react/src/components/command-palette.tsx
+++ b/packages/react/src/components/command-palette.tsx
@@ -5,7 +5,7 @@ import { PlusIcon } from "lucide-react";
 import { SourceFavicon } from "./source-favicon";
 import { sourcesAtom } from "../api/atoms";
 import { useScope } from "../hooks/use-scope";
-import type { SourcePlugin } from "../plugins/source-plugin";
+import { useSourcePlugins } from "../plugins/plugin-catalog";
 import {
   CommandDialog,
   CommandEmpty,
@@ -26,8 +26,8 @@ import {
 //   3. Popular sources (plugin presets)
 // ---------------------------------------------------------------------------
 
-export function CommandPalette(props: { sourcePlugins: readonly SourcePlugin[] }) {
-  const { sourcePlugins } = props;
+export function CommandPalette() {
+  const sourcePlugins = useSourcePlugins();
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
   const scopeId = useScope();

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -40,6 +40,7 @@ import {
   CardStackHeader,
 } from "../components/card-stack";
 import { Badge } from "../components/badge";
+import { useSecretProviderPlugins } from "../plugins/plugin-catalog";
 
 // ---------------------------------------------------------------------------
 // Add secret dialog
@@ -281,8 +282,8 @@ function SecretRow(props: {
 // Page
 // ---------------------------------------------------------------------------
 
-export function SecretsPage(props: { secretProviderPlugins: readonly SecretProviderPlugin[] }) {
-  const { secretProviderPlugins } = props;
+export function SecretsPage() {
+  const secretProviderPlugins = useSecretProviderPlugins();
   const [addOpen, setAddOpen] = useState(false);
   const scopeId = useScope();
   const secrets = useAtomValue(secretsAtom(scopeId));

--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -12,15 +12,13 @@ import { ToolTree } from "../components/tool-tree";
 import { ToolDetail, ToolDetailEmpty } from "../components/tool-detail";
 import type { ToolSummary } from "../components/tool-tree";
 import { useScope } from "../hooks/use-scope";
-import type { SourcePlugin } from "../plugins/source-plugin";
+import { useSourcePlugins } from "../plugins/plugin-catalog";
 import { Button } from "../components/button";
 import { Badge } from "../components/badge";
 
-export function SourceDetailPage(props: {
-  namespace: string;
-  sourcePlugins?: readonly SourcePlugin[];
-}) {
-  const { namespace, sourcePlugins } = props;
+export function SourceDetailPage(props: { namespace: string }) {
+  const { namespace } = props;
+  const sourcePlugins = useSourcePlugins();
   const scopeId = useScope();
   const source = useAtomValue(sourceAtom(namespace, scopeId));
   const tools = useAtomValue(sourceToolsAtom(namespace, scopeId));
@@ -56,7 +54,7 @@ export function SourceDetailPage(props: {
 
   // Find the plugin edit component based on source kind
   const editPlugin = useMemo(() => {
-    if (!sourceData || !sourcePlugins) return null;
+    if (!sourceData) return null;
     return sourcePlugins.find((p) => p.key === sourceData.kind) ?? null;
   }, [sourceData, sourcePlugins]);
 

--- a/packages/react/src/pages/sources-add.tsx
+++ b/packages/react/src/pages/sources-add.tsx
@@ -1,9 +1,9 @@
 import { Suspense } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
-import type { SourcePlugin } from "../plugins/source-plugin";
 import { useAtomRefresh } from "@effect-atom/atom-react";
 import { sourcesAtom } from "../api/atoms";
 import { useScope } from "../hooks/use-scope";
+import { useSourcePlugins } from "../plugins/plugin-catalog";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -14,9 +14,9 @@ export function SourcesAddPage(props: {
   url?: string;
   preset?: string;
   namespace?: string;
-  sourcePlugins: readonly SourcePlugin[];
 }) {
-  const { pluginKey, url, preset, namespace, sourcePlugins } = props;
+  const { pluginKey, url, preset, namespace } = props;
+  const sourcePlugins = useSourcePlugins();
   const scopeId = useScope();
   const refreshSources = useAtomRefresh(sourcesAtom(scopeId));
   const navigate = useNavigate();

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -4,6 +4,7 @@ import { Result, useAtomValue, useAtomSet } from "@effect-atom/atom-react";
 import { sourcesAtom, detectSource } from "../api/atoms";
 import { useScope } from "../hooks/use-scope";
 import type { SourcePlugin, SourcePreset } from "../plugins/source-plugin";
+import { useSourcePlugins } from "../plugins/plugin-catalog";
 import { McpInstallCard } from "../components/mcp-install-card";
 import { Button } from "../components/button";
 import { Input } from "../components/input";
@@ -19,8 +20,8 @@ const KIND_TO_PLUGIN_KEY: Record<string, string> = {
 // Page
 // ---------------------------------------------------------------------------
 
-export function SourcesPage(props: { sourcePlugins: readonly SourcePlugin[] }) {
-  const { sourcePlugins } = props;
+export function SourcesPage() {
+  const sourcePlugins = useSourcePlugins();
   const [url, setUrl] = useState("");
   const [detecting, setDetecting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/packages/react/src/plugins/plugin-catalog.tsx
+++ b/packages/react/src/plugins/plugin-catalog.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+
+import type { SecretProviderPlugin } from "./secret-provider-plugin";
+import type { SourcePlugin } from "./source-plugin";
+
+type PluginCatalogValue = {
+  readonly sourcePlugins: readonly SourcePlugin[];
+  readonly secretProviderPlugins: readonly SecretProviderPlugin[];
+};
+
+const PluginCatalogContext = React.createContext<PluginCatalogValue>({
+  sourcePlugins: [],
+  secretProviderPlugins: [],
+});
+
+export function PluginCatalogProvider(
+  props: React.PropsWithChildren<{
+    readonly sourcePlugins?: readonly SourcePlugin[];
+    readonly secretProviderPlugins?: readonly SecretProviderPlugin[];
+  }>,
+) {
+  const value = React.useMemo<PluginCatalogValue>(
+    () => ({
+      sourcePlugins: props.sourcePlugins ?? [],
+      secretProviderPlugins: props.secretProviderPlugins ?? [],
+    }),
+    [props.secretProviderPlugins, props.sourcePlugins],
+  );
+
+  return <PluginCatalogContext.Provider value={value}>{props.children}</PluginCatalogContext.Provider>;
+}
+
+export const useSourcePlugins = () => React.useContext(PluginCatalogContext).sourcePlugins;
+
+export const useSecretProviderPlugins = () =>
+  React.useContext(PluginCatalogContext).secretProviderPlugins;


### PR DESCRIPTION
## What changed

This refactors plugin composition so hosts register first-party plugins in one place instead of repeating the same lists across runtime setup, API wiring, routes, and shell components.

It introduces a shared `@executor/host-plugins` package for first-party source plugin metadata and server-side plugin wiring, plus a React-side plugin catalog provider so source and secret-provider plugins are registered once at the app root.

## Why this changed

The plugin system had good runtime primitives, but the host integration points were still hand-assembled in multiple files. That made it easy for runtime, API, and UI plugin registration to drift apart and added a lot of boilerplate whenever a plugin changed.

## User and developer impact

Hosts now define plugin participation once at the root/provider and once in the server registry layer.

This reduces repeated wiring in local and cloud, removes plugin catalog prop plumbing from page and shell components, and makes the remaining plugin registration points much clearer.

## Root cause

The architecture separated runtime plugins, API groups, and React source/secret-provider plugins, but the host apps were manually stitching those pieces together in parallel instead of consuming a shared manifest.

## Validation

- `bun install`
- `bunx tsc --noEmit -p packages/hosts/plugins/tsconfig.json`
- `bunx tsc --noEmit -p apps/cloud/tsconfig.json`
- `bunx tsc --noEmit -p apps/local/tsconfig.json` still stops on the pre-existing warning in `packages/core/storage-file/src/tool-registry.ts:122`
