### PR TITLE
[codex] Move cloud secret values to WorkOS Vault

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -32,6 +32,7 @@
     "@executor/plugin-graphql": "workspace:*",
     "@executor/plugin-mcp": "workspace:*",
     "@executor/plugin-openapi": "workspace:*",
+    "@executor/plugin-workos-vault": "workspace:*",
     "@executor/react": "workspace:*",
     "@executor/runtime-dynamic-worker": "workspace:*",
     "@executor/sdk": "workspace:*",

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -12,7 +12,6 @@ import { GraphqlExtensionService } from "@executor/plugin-graphql/api";
 
 import { UserStoreService } from "../auth/context";
 import { WorkOSAuth } from "../auth/workos";
-import { server } from "../env";
 import { AutumnService } from "../services/autumn";
 import { createOrgExecutor } from "../services/executor";
 import { makeTrackExecutionUsage } from "./autumn";

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -41,11 +41,7 @@ const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
 
 const createProtectedApp = (organizationId: string, organizationName: string) =>
   Effect.gen(function* () {
-    const executor = yield* createOrgExecutor(
-      organizationId,
-      organizationName,
-      server.ENCRYPTION_KEY,
-    );
+    const executor = yield* createOrgExecutor(organizationId, organizationName);
     const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
     const autumn = yield* AutumnService;
     const engine = withExecutionUsageTracking(

--- a/apps/cloud/src/env.ts
+++ b/apps/cloud/src/env.ts
@@ -6,7 +6,6 @@ const sharedShape = {
 
 const serverShape = {
   DATABASE_URL: Env.stringOr("DATABASE_URL", ""),
-  ENCRYPTION_KEY: Env.string("ENCRYPTION_KEY"),
   WORKOS_API_KEY: Env.string("WORKOS_API_KEY"),
   WORKOS_CLIENT_ID: Env.string("WORKOS_CLIENT_ID"),
   WORKOS_COOKIE_PASSWORD: Env.string("WORKOS_COOKIE_PASSWORD"),
@@ -24,7 +23,6 @@ type SharedEnv = Readonly<{
 type ServerEnv = SharedEnv &
   Readonly<{
     DATABASE_URL: string;
-    ENCRYPTION_KEY: string;
     WORKOS_API_KEY: string;
     WORKOS_CLIENT_ID: string;
     WORKOS_COOKIE_PASSWORD: string;

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -113,7 +113,7 @@ export class McpSessionDO extends DurableObject {
       if (!org)
         return yield* new OrganizationNotFoundError({ organizationId: token.organizationId });
 
-      const executor = yield* createOrgExecutor(org.id, org.name, server.ENCRYPTION_KEY);
+      const executor = yield* createOrgExecutor(org.id, org.name);
       const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
       return yield* Effect.promise(() => createExecutorMcpServer({ executor, codeExecutor }));
     }).pipe(Effect.provide(Services));

--- a/apps/cloud/src/routes/secrets.tsx
+++ b/apps/cloud/src/routes/secrets.tsx
@@ -2,5 +2,12 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SecretsPage } from "@executor/react/pages/secrets";
 
 export const Route = createFileRoute("/secrets")({
-  component: () => <SecretsPage secretProviderPlugins={[]} />,
+  component: () => (
+    <SecretsPage
+      secretProviderPlugins={[]}
+      addSecretDescription="Store a credential or API key for this workspace."
+      showProviderInfo={false}
+      storageOptions={[{ value: "workos-vault", label: "WorkOS Vault" }]}
+    />
+  ),
 });

--- a/apps/cloud/src/services/executor.ts
+++ b/apps/cloud/src/services/executor.ts
@@ -32,7 +32,6 @@ import { server } from "../env";
 export const createOrgExecutor = (
   organizationId: string,
   organizationName: string,
-  _encryptionKey: string,
 ) =>
   Effect.gen(function* () {
     const db = yield* DbService;

--- a/apps/cloud/src/services/executor.ts
+++ b/apps/cloud/src/services/executor.ts
@@ -1,11 +1,12 @@
 // ---------------------------------------------------------------------------
-// Cloud executor — stateless, per-request, from Postgres
+// Cloud executor — stateless, per-request, with Vault-backed secrets
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
+import { WorkOS } from "@workos-inc/node/worker";
 
-import { createExecutor } from "@executor/sdk";
-import { makePgConfig, makePgKv } from "@executor/storage-postgres";
+import { ScopeId, createExecutor, makeInMemorySourceRegistry, scopeKv } from "@executor/sdk";
+import { makePgKv, makePgPolicyEngine, makePgToolRegistry } from "@executor/storage-postgres";
 import { openApiPlugin, makeKvOperationStore } from "@executor/plugin-openapi";
 import { mcpPlugin, makeKvBindingStore } from "@executor/plugin-mcp";
 import {
@@ -16,7 +17,13 @@ import {
   graphqlPlugin,
   makeKvOperationStore as makeKvGraphqlOperationStore,
 } from "@executor/plugin-graphql";
+import {
+  makeWorkOSVaultClient,
+  makeWorkOSVaultSecretStore,
+  workosVaultPlugin,
+} from "@executor/plugin-workos-vault";
 import { DbService } from "./db";
+import { server } from "../env";
 
 // ---------------------------------------------------------------------------
 // Create a fresh executor for an organization (stateless, per-request)
@@ -25,15 +32,31 @@ import { DbService } from "./db";
 export const createOrgExecutor = (
   organizationId: string,
   organizationName: string,
-  encryptionKey: string,
+  _encryptionKey: string,
 ) =>
   Effect.gen(function* () {
     const db = yield* DbService;
     const kv = makePgKv(db, organizationId);
-    const config = makePgConfig(db, {
-      organizationId,
-      organizationName,
-      encryptionKey,
+    const workos = new WorkOS({
+      apiKey: server.WORKOS_API_KEY,
+      clientId: server.WORKOS_CLIENT_ID,
+    });
+    const vaultClient = makeWorkOSVaultClient(workos);
+
+    return yield* createExecutor({
+      scope: {
+        id: ScopeId.make(organizationId),
+        name: organizationName,
+        createdAt: new Date(),
+      },
+      tools: makePgToolRegistry(db, organizationId),
+      sources: makeInMemorySourceRegistry(),
+      secrets: makeWorkOSVaultSecretStore({
+        client: vaultClient,
+        metadataStore: scopeKv(kv, "secrets"),
+        scopeId: organizationId,
+      }),
+      policies: makePgPolicyEngine(db, organizationId),
       plugins: [
         openApiPlugin({
           operationStore: makeKvOperationStore(kv, "openapi"),
@@ -47,8 +70,7 @@ export const createOrgExecutor = (
         graphqlPlugin({
           operationStore: makeKvGraphqlOperationStore(kv, "graphql"),
         }),
+        workosVaultPlugin(),
       ] as const,
     });
-
-    return yield* createExecutor(config);
   });

--- a/apps/cloud/src/services/executor.ts
+++ b/apps/cloud/src/services/executor.ts
@@ -3,7 +3,6 @@
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
-import { WorkOS } from "@workos-inc/node/worker";
 
 import { ScopeId, createExecutor, makeInMemorySourceRegistry, scopeKv } from "@executor/sdk";
 import { makePgKv, makePgPolicyEngine, makePgToolRegistry } from "@executor/storage-postgres";
@@ -18,8 +17,7 @@ import {
   makeKvOperationStore as makeKvGraphqlOperationStore,
 } from "@executor/plugin-graphql";
 import {
-  makeWorkOSVaultClient,
-  makeWorkOSVaultSecretStore,
+  makeConfiguredWorkOSVaultSecretStore,
   workosVaultPlugin,
 } from "@executor/plugin-workos-vault";
 import { DbService } from "./db";
@@ -36,11 +34,14 @@ export const createOrgExecutor = (
   Effect.gen(function* () {
     const db = yield* DbService;
     const kv = makePgKv(db, organizationId);
-    const workos = new WorkOS({
-      apiKey: server.WORKOS_API_KEY,
-      clientId: server.WORKOS_CLIENT_ID,
-    });
-    const vaultClient = makeWorkOSVaultClient(workos);
+    const secrets = yield* makeConfiguredWorkOSVaultSecretStore({
+      credentials: {
+        apiKey: server.WORKOS_API_KEY,
+        clientId: server.WORKOS_CLIENT_ID,
+      },
+      metadataStore: scopeKv(kv, "secrets"),
+      scopeId: organizationId,
+    }).pipe(Effect.orDie);
 
     return yield* createExecutor({
       scope: {
@@ -50,11 +51,7 @@ export const createOrgExecutor = (
       },
       tools: makePgToolRegistry(db, organizationId),
       sources: makeInMemorySourceRegistry(),
-      secrets: makeWorkOSVaultSecretStore({
-        client: vaultClient,
-        metadataStore: scopeKv(kv, "secrets"),
-        scopeId: organizationId,
-      }),
+      secrets,
       policies: makePgPolicyEngine(db, organizationId),
       plugins: [
         openApiPlugin({

--- a/apps/cloud/wrangler.test.jsonc
+++ b/apps/cloud/wrangler.test.jsonc
@@ -17,7 +17,6 @@
     "WORKOS_API_KEY": "test_api_key",
     "WORKOS_CLIENT_ID": "test_client_id",
     "WORKOS_COOKIE_PASSWORD": "test_cookie_password_at_least_32_chars!",
-    "ENCRYPTION_KEY": "test-encryption-key",
     "NODE_ENV": "test",
   },
 }

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "@executor/plugin-graphql": "workspace:*",
         "@executor/plugin-mcp": "workspace:*",
         "@executor/plugin-openapi": "workspace:*",
+        "@executor/plugin-workos-vault": "workspace:*",
         "@executor/react": "workspace:*",
         "@executor/runtime-dynamic-worker": "workspace:*",
         "@executor/sdk": "workspace:*",
@@ -614,6 +615,30 @@
         "react",
       ],
     },
+    "packages/plugins/workos-vault": {
+      "name": "@executor/plugin-workos-vault",
+      "version": "0.0.1-beta.0",
+      "dependencies": {
+        "@executor/sdk": "workspace:*",
+        "@workos-inc/node": "^8.11.1",
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@types/node": "catalog:",
+        "@types/react": "catalog:",
+        "react": "catalog:",
+        "tsup": "catalog:",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "@executor/react": "workspace:*",
+        "react": ">=18",
+      },
+      "optionalPeers": [
+        "@executor/react",
+        "react",
+      ],
+    },
     "packages/react": {
       "name": "@executor/react",
       "version": "1.4.3-beta.0",
@@ -1106,6 +1131,8 @@
     "@executor/plugin-onepassword": ["@executor/plugin-onepassword@workspace:packages/plugins/onepassword"],
 
     "@executor/plugin-openapi": ["@executor/plugin-openapi@workspace:packages/plugins/openapi"],
+
+    "@executor/plugin-workos-vault": ["@executor/plugin-workos-vault@workspace:packages/plugins/workos-vault"],
 
     "@executor/react": ["@executor/react@workspace:packages/react"],
 

--- a/packages/plugins/workos-vault/package.json
+++ b/packages/plugins/workos-vault/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@executor/plugin-workos-vault",
+  "version": "0.0.1-beta.0",
+  "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/workos-vault",
+  "bugs": {
+    "url": "https://github.com/RhysSullivan/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RhysSullivan/executor.git",
+    "directory": "packages/plugins/workos-vault"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/sdk/index.ts",
+    "./promise": "./src/promise.ts",
+    "./react": "./src/react/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/promise.d.ts",
+          "default": "./dist/index.js"
+        }
+      },
+      "./core": {
+        "import": {
+          "types": "./dist/sdk/index.d.ts",
+          "default": "./dist/core.js"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@executor/sdk": "workspace:*",
+    "@workos-inc/node": "^8.11.1",
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "react": "catalog:",
+    "tsup": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@executor/react": "workspace:*",
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "@executor/react": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
+  }
+}

--- a/packages/plugins/workos-vault/src/promise.ts
+++ b/packages/plugins/workos-vault/src/promise.ts
@@ -1,0 +1,1 @@
+export * from "./sdk/index";

--- a/packages/plugins/workos-vault/src/react/WorkOSVaultSettings.tsx
+++ b/packages/plugins/workos-vault/src/react/WorkOSVaultSettings.tsx
@@ -1,0 +1,22 @@
+export default function WorkOSVaultSettings() {
+  return (
+    <div className="rounded-xl border border-border/60 bg-card overflow-hidden transition-all hover:border-border">
+      <div className="flex items-center gap-3 px-5 py-4 border-b border-border/40">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <h3 className="text-xs font-semibold text-foreground leading-none">WorkOS Vault</h3>
+            <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400 leading-none">
+              Active
+            </span>
+          </div>
+        </div>
+      </div>
+      <div className="px-5 py-4">
+        <p className="text-xs text-muted-foreground leading-relaxed">
+          Cloud secrets are stored directly in WorkOS Vault for this workspace. Postgres is not
+          used for secret persistence.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/plugins/workos-vault/src/react/index.ts
+++ b/packages/plugins/workos-vault/src/react/index.ts
@@ -1,0 +1,2 @@
+export { default as WorkOSVaultSettings } from "./WorkOSVaultSettings";
+export { workosVaultSecretProviderPlugin } from "./secret-provider-plugin";

--- a/packages/plugins/workos-vault/src/react/secret-provider-plugin.ts
+++ b/packages/plugins/workos-vault/src/react/secret-provider-plugin.ts
@@ -1,0 +1,8 @@
+import { lazy } from "react";
+import type { SecretProviderPlugin } from "@executor/react/plugins/secret-provider-plugin";
+
+export const workosVaultSecretProviderPlugin: SecretProviderPlugin = {
+  key: "workosVault",
+  label: "WorkOS Vault",
+  settings: lazy(() => import("./WorkOSVaultSettings")),
+};

--- a/packages/plugins/workos-vault/src/sdk/client.ts
+++ b/packages/plugins/workos-vault/src/sdk/client.ts
@@ -1,0 +1,39 @@
+import type { WorkOS } from "@workos-inc/node/worker";
+
+export interface WorkOSVaultObjectMetadata {
+  readonly context: Record<string, unknown>;
+  readonly id: string;
+  readonly updatedAt: Date;
+  readonly versionId: string;
+}
+
+export interface WorkOSVaultObject {
+  readonly id: string;
+  readonly metadata: WorkOSVaultObjectMetadata;
+  readonly name: string;
+  readonly value?: string;
+}
+
+export interface WorkOSVaultClient {
+  readonly createObject: (options: {
+    readonly name: string;
+    readonly value: string;
+    readonly context: Record<string, string>;
+  }) => Promise<WorkOSVaultObjectMetadata>;
+  readonly readObjectByName: (name: string) => Promise<WorkOSVaultObject>;
+  readonly updateObject: (options: {
+    readonly id: string;
+    readonly value: string;
+    readonly versionCheck?: string;
+  }) => Promise<WorkOSVaultObject>;
+  readonly deleteObject: (options: { readonly id: string }) => Promise<void>;
+}
+
+export const makeWorkOSVaultClient = (
+  workos: Pick<WorkOS, "vault">,
+): WorkOSVaultClient => ({
+  createObject: (options) => workos.vault.createObject(options),
+  readObjectByName: (name) => workos.vault.readObjectByName(name),
+  updateObject: (options) => workos.vault.updateObject(options),
+  deleteObject: (options) => workos.vault.deleteObject(options),
+});

--- a/packages/plugins/workos-vault/src/sdk/client.ts
+++ b/packages/plugins/workos-vault/src/sdk/client.ts
@@ -1,4 +1,5 @@
 import type { WorkOS } from "@workos-inc/node/worker";
+import { Data, Effect } from "effect";
 
 export interface WorkOSVaultObjectMetadata {
   readonly context: Record<string, unknown>;
@@ -14,26 +15,55 @@ export interface WorkOSVaultObject {
   readonly value?: string;
 }
 
+export class WorkOSVaultClientError extends Data.TaggedError("WorkOSVaultClientError")<{
+  readonly cause: unknown;
+  readonly operation: string;
+}> {}
+
+type WorkOSVaultSdk = Pick<WorkOS, "vault">["vault"];
+
 export interface WorkOSVaultClient {
+  readonly use: <A>(
+    operation: string,
+    fn: (client: WorkOSVaultSdk) => Promise<A>,
+  ) => Effect.Effect<A, WorkOSVaultClientError, never>;
   readonly createObject: (options: {
     readonly name: string;
     readonly value: string;
     readonly context: Record<string, string>;
-  }) => Promise<WorkOSVaultObjectMetadata>;
-  readonly readObjectByName: (name: string) => Promise<WorkOSVaultObject>;
+  }) => Effect.Effect<WorkOSVaultObjectMetadata, WorkOSVaultClientError, never>;
+  readonly readObjectByName: (
+    name: string,
+  ) => Effect.Effect<WorkOSVaultObject, WorkOSVaultClientError, never>;
   readonly updateObject: (options: {
     readonly id: string;
     readonly value: string;
     readonly versionCheck?: string;
-  }) => Promise<WorkOSVaultObject>;
-  readonly deleteObject: (options: { readonly id: string }) => Promise<void>;
+  }) => Effect.Effect<WorkOSVaultObject, WorkOSVaultClientError, never>;
+  readonly deleteObject: (options: {
+    readonly id: string;
+  }) => Effect.Effect<void, WorkOSVaultClientError, never>;
 }
 
 export const makeWorkOSVaultClient = (
   workos: Pick<WorkOS, "vault">,
-): WorkOSVaultClient => ({
-  createObject: (options) => workos.vault.createObject(options),
-  readObjectByName: (name) => workos.vault.readObjectByName(name),
-  updateObject: (options) => workos.vault.updateObject(options),
-  deleteObject: (options) => workos.vault.deleteObject(options),
-});
+): WorkOSVaultClient => {
+  const client = workos.vault;
+
+  const use = <A>(
+    operation: string,
+    fn: (vault: WorkOSVaultSdk) => Promise<A>,
+  ): Effect.Effect<A, WorkOSVaultClientError, never> =>
+    Effect.tryPromise({
+      try: () => fn(client),
+      catch: (cause) => new WorkOSVaultClientError({ cause, operation }),
+    }).pipe(Effect.withSpan(`workos_vault.${operation}`));
+
+  return {
+    use,
+    createObject: (options) => use("create_object", (vault) => vault.createObject(options)),
+    readObjectByName: (name) => use("read_object_by_name", (vault) => vault.readObjectByName(name)),
+    updateObject: (options) => use("update_object", (vault) => vault.updateObject(options)),
+    deleteObject: (options) => use("delete_object", (vault) => vault.deleteObject(options)),
+  };
+};

--- a/packages/plugins/workos-vault/src/sdk/client.ts
+++ b/packages/plugins/workos-vault/src/sdk/client.ts
@@ -1,4 +1,5 @@
 import type { WorkOS } from "@workos-inc/node/worker";
+import { WorkOS as WorkOSClient } from "@workos-inc/node/worker";
 import { Data, Effect } from "effect";
 
 export interface WorkOSVaultObjectMetadata {
@@ -20,7 +21,18 @@ export class WorkOSVaultClientError extends Data.TaggedError("WorkOSVaultClientE
   readonly operation: string;
 }> {}
 
+export class WorkOSVaultClientInstantiationError extends Data.TaggedError(
+  "WorkOSVaultClientInstantiationError",
+)<{
+  readonly cause: unknown;
+}> {}
+
 type WorkOSVaultSdk = Pick<WorkOS, "vault">["vault"];
+
+export interface WorkOSVaultCredentials {
+  readonly apiKey: string;
+  readonly clientId: string;
+}
 
 export interface WorkOSVaultClient {
   readonly use: <A>(
@@ -67,3 +79,17 @@ export const makeWorkOSVaultClient = (
     deleteObject: (options) => use("delete_object", (vault) => vault.deleteObject(options)),
   };
 };
+
+export const makeConfiguredWorkOSVaultClient = (
+  credentials: WorkOSVaultCredentials,
+): Effect.Effect<WorkOSVaultClient, WorkOSVaultClientInstantiationError, never> =>
+  Effect.try({
+    try: () =>
+      makeWorkOSVaultClient(
+        new WorkOSClient({
+          apiKey: credentials.apiKey,
+          clientId: credentials.clientId,
+        }),
+      ),
+    catch: (cause) => new WorkOSVaultClientInstantiationError({ cause }),
+  }).pipe(Effect.withSpan("workos_vault.make_client"));

--- a/packages/plugins/workos-vault/src/sdk/client.ts
+++ b/packages/plugins/workos-vault/src/sdk/client.ts
@@ -27,7 +27,20 @@ export class WorkOSVaultClientInstantiationError extends Data.TaggedError(
   readonly cause: unknown;
 }> {}
 
-type WorkOSVaultSdk = Pick<WorkOS, "vault">["vault"];
+export interface WorkOSVaultSdk {
+  readonly createObject: (options: {
+    readonly name: string;
+    readonly value: string;
+    readonly context: Record<string, string>;
+  }) => Promise<WorkOSVaultObjectMetadata>;
+  readonly readObjectByName: (name: string) => Promise<WorkOSVaultObject>;
+  readonly updateObject: (options: {
+    readonly id: string;
+    readonly value: string;
+    readonly versionCheck?: string;
+  }) => Promise<WorkOSVaultObject>;
+  readonly deleteObject: (options: { readonly id: string }) => Promise<void>;
+}
 
 export interface WorkOSVaultCredentials {
   readonly apiKey: string;
@@ -60,7 +73,7 @@ export interface WorkOSVaultClient {
 export const makeWorkOSVaultClient = (
   workos: Pick<WorkOS, "vault">,
 ): WorkOSVaultClient => {
-  const client = workos.vault;
+  const client: WorkOSVaultSdk = workos.vault;
 
   const use = <A>(
     operation: string,

--- a/packages/plugins/workos-vault/src/sdk/index.ts
+++ b/packages/plugins/workos-vault/src/sdk/index.ts
@@ -1,0 +1,7 @@
+export { makeWorkOSVaultClient, type WorkOSVaultClient } from "./client";
+export { workosVaultPlugin, type WorkOSVaultExtension } from "./plugin";
+export {
+  WORKOS_VAULT_PROVIDER_KEY,
+  makeWorkOSVaultSecretStore,
+  type WorkOSVaultSecretStoreOptions,
+} from "./secret-store";

--- a/packages/plugins/workos-vault/src/sdk/index.ts
+++ b/packages/plugins/workos-vault/src/sdk/index.ts
@@ -1,7 +1,15 @@
-export { makeWorkOSVaultClient, type WorkOSVaultClient } from "./client";
+export {
+  makeConfiguredWorkOSVaultClient,
+  makeWorkOSVaultClient,
+  WorkOSVaultClientInstantiationError,
+  type WorkOSVaultClient,
+  type WorkOSVaultCredentials,
+} from "./client";
 export { workosVaultPlugin, type WorkOSVaultExtension } from "./plugin";
 export {
   WORKOS_VAULT_PROVIDER_KEY,
+  makeConfiguredWorkOSVaultSecretStore,
   makeWorkOSVaultSecretStore,
+  type ConfiguredWorkOSVaultSecretStoreOptions,
   type WorkOSVaultSecretStoreOptions,
 } from "./secret-store";

--- a/packages/plugins/workos-vault/src/sdk/plugin.ts
+++ b/packages/plugins/workos-vault/src/sdk/plugin.ts
@@ -1,0 +1,33 @@
+import { Effect } from "effect";
+
+import { definePlugin, type ExecutorPlugin } from "@executor/sdk";
+
+import { WORKOS_VAULT_PROVIDER_KEY } from "./secret-store";
+
+const PLUGIN_KEY = "workosVault";
+
+export interface WorkOSVaultExtension {
+  readonly providerKey: typeof WORKOS_VAULT_PROVIDER_KEY;
+}
+
+export const workosVaultPlugin = (): ExecutorPlugin<typeof PLUGIN_KEY, WorkOSVaultExtension> =>
+  definePlugin({
+    key: PLUGIN_KEY,
+    init: (ctx) =>
+      Effect.gen(function* () {
+        const providers = yield* ctx.secrets.providers();
+        if (!providers.includes(WORKOS_VAULT_PROVIDER_KEY)) {
+          return yield* Effect.fail(
+            new Error(
+              `WorkOS Vault plugin requires the "${WORKOS_VAULT_PROVIDER_KEY}" secret store`,
+            ),
+          );
+        }
+
+        return {
+          extension: {
+            providerKey: WORKOS_VAULT_PROVIDER_KEY,
+          },
+        };
+      }),
+  });

--- a/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
@@ -7,8 +7,11 @@ import {
   WORKOS_VAULT_PROVIDER_KEY,
   makeWorkOSVaultSecretStore,
 } from "./secret-store";
-import type {
+import {
   WorkOSVaultClient,
+  WorkOSVaultClientError,
+} from "./client";
+import type {
   WorkOSVaultObject,
   WorkOSVaultObjectMetadata,
 } from "./client";
@@ -29,16 +32,32 @@ const makeMetadata = (id: string, context: Record<string, string>): WorkOSVaultO
 });
 
 const makeFakeClient = (
-  options?: { readonly conflictOnNextRegistryUpdate?: boolean },
+  options?: { readonly conflictOnNextSecretUpdate?: boolean },
 ): WorkOSVaultClient => {
   const objects = new Map<string, WorkOSVaultObject>();
   let sequence = 0;
-  let conflictOnNextRegistryUpdate = options?.conflictOnNextRegistryUpdate ?? false;
+  let conflictOnNextSecretUpdate = options?.conflictOnNextSecretUpdate ?? false;
 
   const nextId = () => `obj_${sequence += 1}`;
+  const wrap = <A>(
+    operation: string,
+    fn: () => Promise<A>,
+  ): Effect.Effect<A, WorkOSVaultClientError, never> =>
+    Effect.tryPromise({
+      try: fn,
+      catch: (cause) => new WorkOSVaultClientError({ cause, operation }),
+    });
 
-  return {
-    createObject: async ({ name, value, context }) => {
+  const rawClient = {
+    createObject: async ({
+      name,
+      value,
+      context,
+    }: {
+      readonly name: string;
+      readonly value: string;
+      readonly context: Record<string, string>;
+    }) => {
       if (objects.has(name)) {
         throw new FakeConflictError(`Object "${name}" already exists`);
       }
@@ -49,20 +68,28 @@ const makeFakeClient = (
       return metadata;
     },
 
-    readObjectByName: async (name) => {
+    readObjectByName: async (name: string) => {
       const object = objects.get(name);
       if (!object) throw new FakeNotFoundError(`Object "${name}" not found`);
       return object;
     },
 
-    updateObject: async ({ id, value, versionCheck }) => {
+    updateObject: async ({
+      id,
+      value,
+      versionCheck,
+    }: {
+      readonly id: string;
+      readonly value: string;
+      readonly versionCheck?: string;
+    }) => {
       const current = [...objects.values()].find((object) => object.id === id);
       if (!current) throw new FakeNotFoundError(`Object "${id}" not found`);
       if (versionCheck && current.metadata.versionId !== versionCheck) {
         throw new FakeConflictError(`Version mismatch for "${id}"`);
       }
-      if (conflictOnNextRegistryUpdate && current.name.endsWith("/secrets/conflict")) {
-        conflictOnNextRegistryUpdate = false;
+      if (conflictOnNextSecretUpdate && current.name.endsWith("/secrets/conflict")) {
+        conflictOnNextSecretUpdate = false;
         throw new FakeConflictError(`Injected conflict for "${id}"`);
       }
 
@@ -82,11 +109,23 @@ const makeFakeClient = (
       return next;
     },
 
-    deleteObject: async ({ id }) => {
+    deleteObject: async ({ id }: { readonly id: string }) => {
       const current = [...objects.entries()].find(([, object]) => object.id === id);
       if (!current) throw new FakeNotFoundError(`Object "${id}" not found`);
       objects.delete(current[0]);
     },
+  };
+
+  return {
+    use: (operation, fn) =>
+      Effect.tryPromise({
+        try: () => fn(rawClient),
+        catch: (cause) => new WorkOSVaultClientError({ cause, operation }),
+      }),
+    createObject: (options) => wrap("create_object", () => rawClient.createObject(options)),
+    readObjectByName: (name) => wrap("read_object_by_name", () => rawClient.readObjectByName(name)),
+    updateObject: (options) => wrap("update_object", () => rawClient.updateObject(options)),
+    deleteObject: (options) => wrap("delete_object", () => rawClient.deleteObject(options)),
   };
 };
 
@@ -170,7 +209,7 @@ describe("WorkOS Vault secret store", () => {
 
   it.effect("retries secret value writes on version conflicts", () =>
     Effect.gen(function* () {
-      const store = makeStore(makeFakeClient({ conflictOnNextRegistryUpdate: true }));
+      const store = makeStore(makeFakeClient({ conflictOnNextSecretUpdate: true }));
 
       yield* store.set({
         id: SecretId.make("conflict"),

--- a/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { ScopeId, SecretId, makeInMemoryScopedKv } from "@executor/sdk";
+
+import {
+  WORKOS_VAULT_PROVIDER_KEY,
+  makeWorkOSVaultSecretStore,
+} from "./secret-store";
+import type {
+  WorkOSVaultClient,
+  WorkOSVaultObject,
+  WorkOSVaultObjectMetadata,
+} from "./client";
+
+class FakeNotFoundError extends Error {
+  readonly status = 404;
+}
+
+class FakeConflictError extends Error {
+  readonly status = 409;
+}
+
+const makeMetadata = (id: string, context: Record<string, string>): WorkOSVaultObjectMetadata => ({
+  id,
+  context,
+  updatedAt: new Date(),
+  versionId: `${id}-v1`,
+});
+
+const makeFakeClient = (
+  options?: { readonly conflictOnNextRegistryUpdate?: boolean },
+): WorkOSVaultClient => {
+  const objects = new Map<string, WorkOSVaultObject>();
+  let sequence = 0;
+  let conflictOnNextRegistryUpdate = options?.conflictOnNextRegistryUpdate ?? false;
+
+  const nextId = () => `obj_${sequence += 1}`;
+
+  return {
+    createObject: async ({ name, value, context }) => {
+      if (objects.has(name)) {
+        throw new FakeConflictError(`Object "${name}" already exists`);
+      }
+
+      const id = nextId();
+      const metadata = makeMetadata(id, context);
+      objects.set(name, { id, name, value, metadata });
+      return metadata;
+    },
+
+    readObjectByName: async (name) => {
+      const object = objects.get(name);
+      if (!object) throw new FakeNotFoundError(`Object "${name}" not found`);
+      return object;
+    },
+
+    updateObject: async ({ id, value, versionCheck }) => {
+      const current = [...objects.values()].find((object) => object.id === id);
+      if (!current) throw new FakeNotFoundError(`Object "${id}" not found`);
+      if (versionCheck && current.metadata.versionId !== versionCheck) {
+        throw new FakeConflictError(`Version mismatch for "${id}"`);
+      }
+      if (conflictOnNextRegistryUpdate && current.name.endsWith("/secrets/conflict")) {
+        conflictOnNextRegistryUpdate = false;
+        throw new FakeConflictError(`Injected conflict for "${id}"`);
+      }
+
+      const nextVersion = current.metadata.versionId.replace(/v(\d+)$/, (_, version) => {
+        return `v${Number(version) + 1}`;
+      });
+      const next: WorkOSVaultObject = {
+        ...current,
+        value,
+        metadata: {
+          ...current.metadata,
+          updatedAt: new Date(),
+          versionId: nextVersion,
+        },
+      };
+      objects.set(current.name, next);
+      return next;
+    },
+
+    deleteObject: async ({ id }) => {
+      const current = [...objects.entries()].find(([, object]) => object.id === id);
+      if (!current) throw new FakeNotFoundError(`Object "${id}" not found`);
+      objects.delete(current[0]);
+    },
+  };
+};
+
+const makeStore = (client: WorkOSVaultClient) =>
+  makeWorkOSVaultSecretStore({
+    client,
+    metadataStore: makeInMemoryScopedKv(),
+    scopeId: "org_123",
+  });
+
+describe("WorkOS Vault secret store", () => {
+  it.effect("stores and resolves secrets from WorkOS Vault", () =>
+    Effect.gen(function* () {
+      const store = makeStore(makeFakeClient());
+
+      const ref = yield* store.set({
+        id: SecretId.make("github-token"),
+        scopeId: ScopeId.make("org_123"),
+        name: "GitHub Token",
+        value: "ghp_secret",
+        purpose: "GitHub API auth",
+      });
+
+      expect(ref.provider._tag).toBe("Some");
+      expect(ref.provider.value).toBe(WORKOS_VAULT_PROVIDER_KEY);
+      expect(yield* store.resolve(SecretId.make("github-token"), ScopeId.make("org_123"))).toBe(
+        "ghp_secret",
+      );
+
+      const listed = yield* store.list(ScopeId.make("org_123"));
+      expect(listed).toHaveLength(1);
+      expect(listed[0]!.name).toBe("GitHub Token");
+    }),
+  );
+
+  it.effect("updates metadata and secret values in place", () =>
+    Effect.gen(function* () {
+      const store = makeStore(makeFakeClient());
+
+      yield* store.set({
+        id: SecretId.make("api-key"),
+        scopeId: ScopeId.make("org_123"),
+        name: "Initial",
+        value: "v1",
+      });
+
+      const updated = yield* store.set({
+        id: SecretId.make("api-key"),
+        scopeId: ScopeId.make("org_123"),
+        name: "Updated",
+        value: "v2",
+        purpose: "rotated",
+      });
+
+      expect(updated.name).toBe("Updated");
+      expect(updated.purpose).toBe("rotated");
+      expect(yield* store.resolve(SecretId.make("api-key"), ScopeId.make("org_123"))).toBe("v2");
+    }),
+  );
+
+  it.effect("removes secrets and reports missing status", () =>
+    Effect.gen(function* () {
+      const store = makeStore(makeFakeClient());
+
+      yield* store.set({
+        id: SecretId.make("remove-me"),
+        scopeId: ScopeId.make("org_123"),
+        name: "Remove Me",
+        value: "gone soon",
+      });
+
+      expect(yield* store.status(SecretId.make("remove-me"), ScopeId.make("org_123"))).toBe(
+        "resolved",
+      );
+      expect(yield* store.remove(SecretId.make("remove-me"))).toBe(true);
+      expect(yield* store.status(SecretId.make("remove-me"), ScopeId.make("org_123"))).toBe(
+        "missing",
+      );
+    }),
+  );
+
+  it.effect("retries secret value writes on version conflicts", () =>
+    Effect.gen(function* () {
+      const store = makeStore(makeFakeClient({ conflictOnNextRegistryUpdate: true }));
+
+      yield* store.set({
+        id: SecretId.make("conflict"),
+        scopeId: ScopeId.make("org_123"),
+        name: "Conflict",
+        value: "retry-me",
+      });
+
+      const listed = yield* store.list(ScopeId.make("org_123"));
+      expect(listed.map((secret) => secret.id)).toEqual(["conflict"]);
+    }),
+  );
+});

--- a/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Option } from "effect";
 
 import { ScopeId, SecretId, makeInMemoryScopedKv } from "@executor/sdk";
 
@@ -149,8 +149,7 @@ describe("WorkOS Vault secret store", () => {
         purpose: "GitHub API auth",
       });
 
-      expect(ref.provider._tag).toBe("Some");
-      expect(ref.provider.value).toBe(WORKOS_VAULT_PROVIDER_KEY);
+      expect(Option.getOrUndefined(ref.provider)).toBe(WORKOS_VAULT_PROVIDER_KEY);
       expect(yield* store.resolve(SecretId.make("github-token"), ScopeId.make("org_123"))).toBe(
         "ghp_secret",
       );

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -12,7 +12,11 @@ import {
   type SetSecretInput,
 } from "@executor/sdk";
 
-import type { WorkOSVaultClient, WorkOSVaultObject } from "./client";
+import {
+  WorkOSVaultClientError,
+  type WorkOSVaultClient,
+  type WorkOSVaultObject,
+} from "./client";
 
 export const WORKOS_VAULT_PROVIDER_KEY = "workos-vault";
 
@@ -32,14 +36,22 @@ export interface WorkOSVaultSecretStoreOptions {
   readonly scopeId: string;
 }
 
-const isStatusError = (error: unknown, status: number): boolean =>
-  ((error instanceof GenericServerException || error instanceof NotFoundException) &&
-    error.status === status) ||
-  (typeof error === "object" &&
-    error !== null &&
-    "status" in error &&
-    typeof error.status === "number" &&
-    error.status === status);
+const unwrapVaultError = (error: unknown): unknown =>
+  error instanceof WorkOSVaultClientError ? error.cause : error;
+
+const isStatusError = (error: unknown, status: number): boolean => {
+  const cause = unwrapVaultError(error);
+
+  return (
+    ((cause instanceof GenericServerException || cause instanceof NotFoundException) &&
+      cause.status === status) ||
+    (typeof cause === "object" &&
+      cause !== null &&
+      "status" in cause &&
+      typeof cause.status === "number" &&
+      cause.status === status)
+  );
+};
 
 const objectContext = (scopeId: string): Record<string, string> => ({
   app: "executor",
@@ -79,77 +91,79 @@ const toSecretRef = (
     createdAt: new Date(secret.createdAt),
   });
 
-const loadSecretObject = async (
+const loadSecretObject = (
   client: WorkOSVaultClient,
   prefix: string,
   scopeId: string,
   secretId: string,
-): Promise<WorkOSVaultObject | null> => {
-  try {
-    return await client.readObjectByName(secretObjectName(prefix, scopeId, secretId));
-  } catch (error) {
-    if (isStatusError(error, 404)) return null;
-    throw error;
-  }
-};
+): Effect.Effect<WorkOSVaultObject | null, WorkOSVaultClientError, never> =>
+  client.readObjectByName(secretObjectName(prefix, scopeId, secretId)).pipe(
+    Effect.catchAll((error) => (isStatusError(error, 404) ? Effect.succeed(null) : Effect.fail(error))),
+  );
 
-const upsertSecretValue = async (
+const upsertSecretValue = (
   client: WorkOSVaultClient,
   prefix: string,
   scopeId: string,
   secretId: string,
   value: string,
-): Promise<void> => {
-  let lastError: unknown;
+): Effect.Effect<void, WorkOSVaultClientError, never> => {
+  const attemptWrite = (
+    remainingAttempts: number,
+  ): Effect.Effect<void, WorkOSVaultClientError, never> =>
+    Effect.gen(function* () {
+      const existing = yield* loadSecretObject(client, prefix, scopeId, secretId);
 
-  for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt += 1) {
-    const existing = await loadSecretObject(client, prefix, scopeId, secretId);
-
-    try {
       if (existing) {
-        await client.updateObject({
+        yield* client.updateObject({
           id: existing.id,
           value,
           versionCheck: existing.metadata.versionId,
         });
-      } else {
-        await client.createObject({
-          name: secretObjectName(prefix, scopeId, secretId),
-          value,
-          context: objectContext(scopeId),
-        });
+        return;
       }
 
-      return;
-    } catch (error) {
-      if (isStatusError(error, 409)) {
-        lastError = error;
-        continue;
-      }
-      throw error;
-    }
-  }
+      yield* client.createObject({
+        name: secretObjectName(prefix, scopeId, secretId),
+        value,
+        context: objectContext(scopeId),
+      });
+    }).pipe(
+      Effect.catchAll((error) => {
+        if (remainingAttempts > 1 && isStatusError(error, 409)) {
+          return attemptWrite(remainingAttempts - 1);
+        }
 
-  throw lastError ?? new Error(`Failed to write WorkOS Vault secret "${secretId}"`);
+        return Effect.fail(error);
+      }),
+    );
+
+  return attemptWrite(MAX_WRITE_ATTEMPTS);
 };
 
-const deleteSecretValue = async (
+const deleteSecretValue = (
   client: WorkOSVaultClient,
   prefix: string,
   scopeId: string,
   secretId: string,
-): Promise<boolean> => {
-  const existing = await loadSecretObject(client, prefix, scopeId, secretId);
-  if (!existing) return false;
+): Effect.Effect<boolean, WorkOSVaultClientError, never> =>
+  Effect.gen(function* () {
+    const existing = yield* loadSecretObject(client, prefix, scopeId, secretId);
+    if (!existing) return false;
 
-  await client.deleteObject({ id: existing.id });
-  return true;
+    yield* client.deleteObject({ id: existing.id });
+    return true;
+  });
+
+const formatVaultError = (error: unknown): string => {
+  const cause = unwrapVaultError(error);
+  return cause instanceof Error ? cause.message : String(cause);
 };
 
 const mapVaultError = (secretId: SecretId, error: unknown): SecretResolutionError =>
   new SecretResolutionError({
     secretId,
-    message: error instanceof Error ? error.message : String(error),
+    message: formatVaultError(error),
   });
 
 export const makeWorkOSVaultSecretStore = (
@@ -190,9 +204,9 @@ export const makeWorkOSVaultSecretStore = (
           return yield* new SecretNotFoundError({ secretId });
         }
 
-        const object = yield* Effect.tryPromise(() =>
-          loadSecretObject(options.client, prefix, options.scopeId, secretId),
-        ).pipe(Effect.mapError((error) => mapVaultError(secretId, error)));
+        const object = yield* loadSecretObject(options.client, prefix, options.scopeId, secretId).pipe(
+          Effect.mapError((error) => mapVaultError(secretId, error)),
+        );
 
         if (!object?.value) {
           return yield* new SecretResolutionError({
@@ -209,9 +223,9 @@ export const makeWorkOSVaultSecretStore = (
         const secret = yield* options.metadataStore.get(secretId).pipe(Effect.orDie);
         if (!decodeSecretRef(secret)) return "missing" as const;
 
-        const object = yield* Effect.tryPromise(() =>
-          loadSecretObject(options.client, prefix, options.scopeId, secretId),
-        ).pipe(Effect.orDie);
+        const object = yield* loadSecretObject(options.client, prefix, options.scopeId, secretId).pipe(
+          Effect.orDie,
+        );
 
         return object?.value ? ("resolved" as const) : ("missing" as const);
       }),
@@ -228,9 +242,9 @@ export const makeWorkOSVaultSecretStore = (
         const existing = yield* options.metadataStore.get(input.id).pipe(Effect.orDie);
         const existingSecret = decodeSecretRef(existing);
 
-        yield* Effect.tryPromise(() =>
-          upsertSecretValue(options.client, prefix, options.scopeId, input.id, input.value),
-        ).pipe(Effect.mapError((error) => mapVaultError(input.id, error)));
+        yield* upsertSecretValue(options.client, prefix, options.scopeId, input.id, input.value).pipe(
+          Effect.mapError((error) => mapVaultError(input.id, error)),
+        );
 
         const storedSecret: StoredSecretRef = {
           createdAt: existingSecret?.createdAt ?? Date.now(),
@@ -252,9 +266,7 @@ export const makeWorkOSVaultSecretStore = (
           return yield* new SecretNotFoundError({ secretId });
         }
 
-        yield* Effect.tryPromise(() =>
-          deleteSecretValue(options.client, prefix, options.scopeId, secretId),
-        ).pipe(Effect.orDie);
+        yield* deleteSecretValue(options.client, prefix, options.scopeId, secretId).pipe(Effect.orDie);
 
         yield* options.metadataStore.delete([secretId]).pipe(Effect.orDie);
 

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -1,0 +1,268 @@
+import { type Context, Effect, Option } from "effect";
+import { GenericServerException, NotFoundException } from "@workos-inc/node/worker";
+
+import {
+  SecretId,
+  SecretNotFoundError,
+  SecretRef,
+  SecretResolutionError,
+  type ScopeId,
+  type ScopedKv,
+  type SecretStore,
+  type SetSecretInput,
+} from "@executor/sdk";
+
+import type { WorkOSVaultClient, WorkOSVaultObject } from "./client";
+
+export const WORKOS_VAULT_PROVIDER_KEY = "workos-vault";
+
+const DEFAULT_OBJECT_PREFIX = "executor";
+const MAX_WRITE_ATTEMPTS = 3;
+
+type StoredSecretRef = {
+  readonly createdAt: number;
+  readonly name: string;
+  readonly purpose?: string;
+};
+
+export interface WorkOSVaultSecretStoreOptions {
+  readonly client: WorkOSVaultClient;
+  readonly metadataStore: ScopedKv;
+  readonly objectPrefix?: string;
+  readonly scopeId: string;
+}
+
+const isStatusError = (error: unknown, status: number): boolean =>
+  ((error instanceof GenericServerException || error instanceof NotFoundException) &&
+    error.status === status) ||
+  (typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    typeof error.status === "number" &&
+    error.status === status);
+
+const objectContext = (scopeId: string): Record<string, string> => ({
+  app: "executor",
+  organization_id: scopeId,
+  scope_id: scopeId,
+});
+
+const secretObjectName = (prefix: string, scopeId: string, secretId: string): string =>
+  `${prefix}/${scopeId}/secrets/${secretId}`;
+
+const decodeSecretRef = (raw: string | null): StoredSecretRef | null => {
+  if (raw === null) return null;
+
+  const parsed = JSON.parse(raw) as Partial<StoredSecretRef>;
+  if (typeof parsed.name !== "string" || typeof parsed.createdAt !== "number") return null;
+
+  return {
+    name: parsed.name,
+    createdAt: parsed.createdAt,
+    purpose: typeof parsed.purpose === "string" ? parsed.purpose : undefined,
+  };
+};
+
+const encodeSecretRef = (secret: StoredSecretRef): string => JSON.stringify(secret);
+
+const toSecretRef = (
+  scopeId: ScopeId,
+  secretId: string,
+  secret: StoredSecretRef,
+): SecretRef =>
+  new SecretRef({
+    id: SecretId.make(secretId),
+    scopeId,
+    name: secret.name,
+    provider: Option.some(WORKOS_VAULT_PROVIDER_KEY),
+    purpose: secret.purpose,
+    createdAt: new Date(secret.createdAt),
+  });
+
+const loadSecretObject = async (
+  client: WorkOSVaultClient,
+  prefix: string,
+  scopeId: string,
+  secretId: string,
+): Promise<WorkOSVaultObject | null> => {
+  try {
+    return await client.readObjectByName(secretObjectName(prefix, scopeId, secretId));
+  } catch (error) {
+    if (isStatusError(error, 404)) return null;
+    throw error;
+  }
+};
+
+const upsertSecretValue = async (
+  client: WorkOSVaultClient,
+  prefix: string,
+  scopeId: string,
+  secretId: string,
+  value: string,
+): Promise<void> => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < MAX_WRITE_ATTEMPTS; attempt += 1) {
+    const existing = await loadSecretObject(client, prefix, scopeId, secretId);
+
+    try {
+      if (existing) {
+        await client.updateObject({
+          id: existing.id,
+          value,
+          versionCheck: existing.metadata.versionId,
+        });
+      } else {
+        await client.createObject({
+          name: secretObjectName(prefix, scopeId, secretId),
+          value,
+          context: objectContext(scopeId),
+        });
+      }
+
+      return;
+    } catch (error) {
+      if (isStatusError(error, 409)) {
+        lastError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw lastError ?? new Error(`Failed to write WorkOS Vault secret "${secretId}"`);
+};
+
+const deleteSecretValue = async (
+  client: WorkOSVaultClient,
+  prefix: string,
+  scopeId: string,
+  secretId: string,
+): Promise<boolean> => {
+  const existing = await loadSecretObject(client, prefix, scopeId, secretId);
+  if (!existing) return false;
+
+  await client.deleteObject({ id: existing.id });
+  return true;
+};
+
+const mapVaultError = (secretId: SecretId, error: unknown): SecretResolutionError =>
+  new SecretResolutionError({
+    secretId,
+    message: error instanceof Error ? error.message : String(error),
+  });
+
+export const makeWorkOSVaultSecretStore = (
+  options: WorkOSVaultSecretStoreOptions,
+): Context.Tag.Service<typeof SecretStore> => {
+  const prefix = options.objectPrefix ?? DEFAULT_OBJECT_PREFIX;
+  const scopeId = options.scopeId as ScopeId;
+
+  return {
+    list: (requestedScopeId: ScopeId) =>
+      options.metadataStore.list().pipe(
+        Effect.orDie,
+        Effect.map((entries) =>
+          entries
+            .map(({ key, value }) => {
+              const secret = decodeSecretRef(value);
+              return secret ? toSecretRef(requestedScopeId, key, secret) : null;
+            })
+            .filter((secret): secret is SecretRef => secret !== null)
+            .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime()),
+        ),
+      ),
+
+    get: (secretId: SecretId) =>
+      options.metadataStore.get(secretId).pipe(
+        Effect.orDie,
+        Effect.flatMap((raw) => {
+          const secret = decodeSecretRef(raw);
+          if (!secret) return Effect.fail(new SecretNotFoundError({ secretId }));
+          return Effect.succeed(toSecretRef(scopeId, secretId, secret));
+        }),
+      ),
+
+    resolve: (secretId: SecretId, _requestedScopeId: ScopeId) =>
+      Effect.gen(function* () {
+        const secret = yield* options.metadataStore.get(secretId).pipe(Effect.orDie);
+        if (!decodeSecretRef(secret)) {
+          return yield* new SecretNotFoundError({ secretId });
+        }
+
+        const object = yield* Effect.tryPromise(() =>
+          loadSecretObject(options.client, prefix, options.scopeId, secretId),
+        ).pipe(Effect.mapError((error) => mapVaultError(secretId, error)));
+
+        if (!object?.value) {
+          return yield* new SecretResolutionError({
+            secretId,
+            message: `Secret "${secretId}" is missing a value`,
+          });
+        }
+
+        return object.value;
+      }),
+
+    status: (secretId: SecretId, _requestedScopeId: ScopeId) =>
+      Effect.gen(function* () {
+        const secret = yield* options.metadataStore.get(secretId).pipe(Effect.orDie);
+        if (!decodeSecretRef(secret)) return "missing" as const;
+
+        const object = yield* Effect.tryPromise(() =>
+          loadSecretObject(options.client, prefix, options.scopeId, secretId),
+        ).pipe(Effect.orDie);
+
+        return object?.value ? ("resolved" as const) : ("missing" as const);
+      }),
+
+    set: (input: SetSecretInput) =>
+      Effect.gen(function* () {
+        if (input.provider && input.provider !== WORKOS_VAULT_PROVIDER_KEY) {
+          return yield* new SecretResolutionError({
+            secretId: input.id,
+            message: `Only the default secret store is writable in cloud`,
+          });
+        }
+
+        const existing = yield* options.metadataStore.get(input.id).pipe(Effect.orDie);
+        const existingSecret = decodeSecretRef(existing);
+
+        yield* Effect.tryPromise(() =>
+          upsertSecretValue(options.client, prefix, options.scopeId, input.id, input.value),
+        ).pipe(Effect.mapError((error) => mapVaultError(input.id, error)));
+
+        const storedSecret: StoredSecretRef = {
+          createdAt: existingSecret?.createdAt ?? Date.now(),
+          name: input.name,
+          purpose: input.purpose,
+        };
+
+        yield* options.metadataStore
+          .set([{ key: input.id, value: encodeSecretRef(storedSecret) }])
+          .pipe(Effect.orDie);
+
+        return toSecretRef(input.scopeId, input.id, storedSecret);
+      }),
+
+    remove: (secretId: SecretId) =>
+      Effect.gen(function* () {
+        const secret = yield* options.metadataStore.get(secretId).pipe(Effect.orDie);
+        if (!decodeSecretRef(secret)) {
+          return yield* new SecretNotFoundError({ secretId });
+        }
+
+        yield* Effect.tryPromise(() =>
+          deleteSecretValue(options.client, prefix, options.scopeId, secretId),
+        ).pipe(Effect.orDie);
+
+        yield* options.metadataStore.delete([secretId]).pipe(Effect.orDie);
+
+        return true;
+      }),
+
+    addProvider: (_provider) => Effect.succeed(undefined),
+
+    providers: () => Effect.succeed([WORKOS_VAULT_PROVIDER_KEY] as const),
+  };
+};

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -13,7 +13,10 @@ import {
 } from "@executor/sdk";
 
 import {
+  WorkOSVaultClientInstantiationError,
   WorkOSVaultClientError,
+  makeConfiguredWorkOSVaultClient,
+  type WorkOSVaultCredentials,
   type WorkOSVaultClient,
   type WorkOSVaultObject,
 } from "./client";
@@ -31,6 +34,13 @@ type StoredSecretRef = {
 
 export interface WorkOSVaultSecretStoreOptions {
   readonly client: WorkOSVaultClient;
+  readonly metadataStore: ScopedKv;
+  readonly objectPrefix?: string;
+  readonly scopeId: string;
+}
+
+export interface ConfiguredWorkOSVaultSecretStoreOptions {
+  readonly credentials: WorkOSVaultCredentials;
   readonly metadataStore: ScopedKv;
   readonly objectPrefix?: string;
   readonly scopeId: string;
@@ -278,3 +288,22 @@ export const makeWorkOSVaultSecretStore = (
     providers: () => Effect.succeed([WORKOS_VAULT_PROVIDER_KEY] as const),
   };
 };
+
+export const makeConfiguredWorkOSVaultSecretStore = (
+  options: ConfiguredWorkOSVaultSecretStoreOptions,
+): Effect.Effect<
+  Context.Tag.Service<typeof SecretStore>,
+  WorkOSVaultClientInstantiationError,
+  never
+> =>
+  makeConfiguredWorkOSVaultClient(options.credentials).pipe(
+    Effect.map((client) =>
+      makeWorkOSVaultSecretStore({
+        client,
+        metadataStore: options.metadataStore,
+        objectPrefix: options.objectPrefix,
+        scopeId: options.scopeId,
+      }),
+    ),
+    Effect.withSpan("workos_vault.make_secret_store"),
+  );

--- a/packages/plugins/workos-vault/tsconfig.json
+++ b/packages/plugins/workos-vault/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "noUnusedLocals": true,
+    "noImplicitOverride": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "preferSchemaOverJson": "off"
+        }
+      }
+    ]
+  },
+  "include": ["src/sdk/**/*.ts"]
+}

--- a/packages/plugins/workos-vault/tsup.config.ts
+++ b/packages/plugins/workos-vault/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/promise.ts",
+    core: "src/sdk/index.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  external: [/^@executor\//, /^effect/, /^@workos-inc\/node/],
+});

--- a/packages/plugins/workos-vault/vitest.config.ts
+++ b/packages/plugins/workos-vault/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -41,16 +41,33 @@ import {
 } from "../components/card-stack";
 import { Badge } from "../components/badge";
 
+type SecretStorageOption = {
+  readonly label: string;
+  readonly value: string;
+};
+
+const defaultStorageOptions: readonly SecretStorageOption[] = [
+  { value: "auto", label: "Auto" },
+  { value: "keychain", label: "Keychain" },
+  { value: "file", label: "File" },
+];
+
 // ---------------------------------------------------------------------------
 // Add secret dialog
 // ---------------------------------------------------------------------------
 
-function AddSecretDialog(props: { open: boolean; onOpenChange: (v: boolean) => void }) {
+function AddSecretDialog(props: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  description: string;
+  storageOptions: readonly SecretStorageOption[];
+}) {
+  const initialProvider = props.storageOptions[0]?.value ?? "auto";
   const [id, setId] = useState("");
   const [name, setName] = useState("");
   const [value, setValue] = useState("");
   const [purpose, setPurpose] = useState("");
-  const [provider, setProvider] = useState("auto");
+  const [provider, setProvider] = useState(initialProvider);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -63,7 +80,7 @@ function AddSecretDialog(props: { open: boolean; onOpenChange: (v: boolean) => v
     setName("");
     setValue("");
     setPurpose("");
-    setProvider("auto");
+    setProvider(initialProvider);
     setError(null);
     setSaving(false);
   };
@@ -104,8 +121,7 @@ function AddSecretDialog(props: { open: boolean; onOpenChange: (v: boolean) => v
         <DialogHeader>
           <DialogTitle className="font-display text-xl">New secret</DialogTitle>
           <DialogDescription className="text-sm leading-relaxed">
-            Store a credential or API key. Values are kept in your system keychain when available,
-            with a local encrypted file fallback.
+            {props.description}
           </DialogDescription>
         </DialogHeader>
 
@@ -160,7 +176,9 @@ function AddSecretDialog(props: { open: boolean; onOpenChange: (v: boolean) => v
             />
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
+          <div
+            className={props.storageOptions.length > 1 ? "grid grid-cols-2 gap-3" : "grid gap-3"}
+          >
             <div className="grid gap-1.5">
               <Label
                 htmlFor="secret-purpose"
@@ -179,24 +197,28 @@ function AddSecretDialog(props: { open: boolean; onOpenChange: (v: boolean) => v
                 className="text-sm h-9"
               />
             </div>
-            <div className="grid gap-1.5">
-              <Label
-                htmlFor="secret-provider"
-                className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
-              >
-                Storage
-              </Label>
-              <Select value={provider} onValueChange={setProvider}>
-                <SelectTrigger id="secret-provider" className="h-9 text-sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="auto">Auto</SelectItem>
-                  <SelectItem value="keychain">Keychain</SelectItem>
-                  <SelectItem value="file">File</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            {props.storageOptions.length > 1 && (
+              <div className="grid gap-1.5">
+                <Label
+                  htmlFor="secret-provider"
+                  className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
+                >
+                  Storage
+                </Label>
+                <Select value={provider} onValueChange={setProvider}>
+                  <SelectTrigger id="secret-provider" className="h-9 text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {props.storageOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
           </div>
 
           {error && (
@@ -230,10 +252,11 @@ function AddSecretDialog(props: { open: boolean; onOpenChange: (v: boolean) => v
 // ---------------------------------------------------------------------------
 
 function SecretRow(props: {
+  showProvider: boolean;
   secret: { id: string; name: string; purpose?: string; provider?: string };
   onRemove: () => void;
 }) {
-  const { secret } = props;
+  const { secret, showProvider } = props;
 
   return (
     <CardStackEntry>
@@ -248,7 +271,7 @@ function SecretRow(props: {
         )}
       </CardStackEntryContent>
       <CardStackEntryActions>
-        {secret.provider && <Badge variant="outline">{secret.provider}</Badge>}
+        {showProvider && secret.provider && <Badge variant="outline">{secret.provider}</Badge>}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -281,7 +304,17 @@ function SecretRow(props: {
 // Page
 // ---------------------------------------------------------------------------
 
-export function SecretsPage(props: { secretProviderPlugins: readonly SecretProviderPlugin[] }) {
+export function SecretsPage(props: {
+  addSecretDescription?: string;
+  showProviderInfo?: boolean;
+  secretProviderPlugins: readonly SecretProviderPlugin[];
+  storageOptions?: readonly SecretStorageOption[];
+}) {
+  const storageOptions = props.storageOptions ?? defaultStorageOptions;
+  const showProviderInfo = props.showProviderInfo ?? true;
+  const addSecretDescription =
+    props.addSecretDescription ??
+    "Store a credential or API key. Values are kept in your system keychain when available, with a local encrypted file fallback.";
   const { secretProviderPlugins } = props;
   const [addOpen, setAddOpen] = useState(false);
   const scopeId = useScope();
@@ -322,7 +355,7 @@ export function SecretsPage(props: { secretProviderPlugins: readonly SecretProvi
         </div>
 
         {/* Provider plugins */}
-        {secretProviderPlugins.length > 0 && (
+        {showProviderInfo && secretProviderPlugins.length > 0 && (
           <div className="mb-10">
             <CardStack>
               <CardStackHeader>Providers</CardStackHeader>
@@ -383,6 +416,7 @@ export function SecretsPage(props: { secretProviderPlugins: readonly SecretProvi
                   value.map((s) => (
                     <SecretRow
                       key={s.id}
+                      showProvider={showProviderInfo}
                       secret={{
                         id: s.id,
                         name: s.name,
@@ -398,7 +432,12 @@ export function SecretsPage(props: { secretProviderPlugins: readonly SecretProvi
           ),
         })}
 
-        <AddSecretDialog open={addOpen} onOpenChange={setAddOpen} />
+        <AddSecretDialog
+          open={addOpen}
+          onOpenChange={setAddOpen}
+          description={addSecretDescription}
+          storageOptions={storageOptions}
+        />
       </div>
     </div>
   );

--- a/packages/react/src/plugins/secret-picker.tsx
+++ b/packages/react/src/plugins/secret-picker.tsx
@@ -57,6 +57,7 @@ export function SecretPicker(props: {
       [...items].sort((a, b) => a.name.localeCompare(b.name)),
     ])
     .sort(([a], [b]) => a.localeCompare(b));
+  const showGroupHeadings = groups.length > 1;
 
   return (
     <div className="relative w-full">
@@ -104,7 +105,7 @@ export function SecretPicker(props: {
                   : items;
                 if (filtered.length === 0) return null;
                 return (
-                  <CommandGroup key={label} heading={label}>
+                  <CommandGroup key={label} heading={showGroupHeadings ? label : undefined}>
                     {filtered.map((secret) => (
                       <CommandItem
                         key={secret.id}
@@ -116,9 +117,6 @@ export function SecretPicker(props: {
                         }}
                       >
                         <span className="truncate">{secret.name}</span>
-                        <span className="ml-auto truncate text-xs font-mono text-muted-foreground">
-                          {secret.id}
-                        </span>
                       </CommandItem>
                     ))}
                   </CommandGroup>


### PR DESCRIPTION
## What changed

This switches the cloud app to use WorkOS Vault for secret values and adds a dedicated `@executor/plugin-workos-vault` package.

It also cleans up the cloud secrets UI so storage/provider implementation details are not exposed to users:
- the cloud secrets page no longer mentions providers or backend storage
- the secret selector no longer shows provider section labels when there is only one store
- the secret selector no longer shows secret IDs on the right

## Why

Cloud secret values should live in WorkOS Vault, while the app should treat Vault as a simple value store.

The previous implementation wrote app-managed registry state into Vault, which made the integration more complex than necessary. This change keeps secret refs/metadata in Postgres-backed KV and uses Vault only for secret values.

## Impact

- cloud secret values are written to WorkOS Vault
- secret metadata stays in app storage for listing and reference management
- cloud users no longer see storage/provider internals in the UI
- local secret-provider UX remains intact

## Root cause

The initial Vault integration used Vault for both value storage and app-level registry metadata, which created unnecessary coupling and leaked implementation details into the product UI.

## Validation

- `bun run --filter='@executor/plugin-workos-vault' test`
- `bun run --filter='@executor/cloud' typecheck`
- `bunx vitest run --config vitest.unit.config.ts` (from `apps/cloud`)
