### PR TITLE
feat(react): add <AuthenticationSection> primitive

### DIFF
--- a/packages/react/src/plugins/headers-list.tsx
+++ b/packages/react/src/plugins/headers-list.tsx
@@ -1,0 +1,167 @@
+import { useState, type ReactNode } from "react";
+import { PlusIcon } from "lucide-react";
+
+import { Button } from "../components/button";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEmpty,
+  CardStackEntry,
+} from "../components/card-stack";
+import {
+  defaultHeaderAuthPresets,
+  type HeaderAuthPreset,
+  type HeaderState,
+  SecretHeaderAuthRow,
+} from "./secret-header-auth";
+import type { SecretPickerSecret } from "./secret-picker";
+
+export interface HeadersListProps {
+  readonly headers: readonly HeaderState[];
+  readonly onHeadersChange: (headers: HeaderState[]) => void;
+  readonly existingSecrets?: readonly SecretPickerSecret[];
+  /** Presets offered in the quick-add picker. Defaults to `defaultHeaderAuthPresets`. */
+  readonly presets?: readonly HeaderAuthPreset[];
+  /** When true, only allow a single header (hide add button, disable remove). */
+  readonly singleHeader?: boolean;
+  /** Text shown in the empty state. */
+  readonly emptyLabel?: ReactNode;
+}
+
+export function HeadersList({
+  headers,
+  onHeadersChange,
+  existingSecrets = [],
+  presets = defaultHeaderAuthPresets,
+  singleHeader = false,
+  emptyLabel = "No headers",
+}: HeadersListProps) {
+  const [picking, setPicking] = useState(false);
+  const canAddMore = !singleHeader || headers.length === 0;
+
+  const addHeaderFromPreset = (preset: HeaderAuthPreset) => {
+    onHeadersChange([
+      ...headers,
+      {
+        name: preset.name,
+        prefix: preset.prefix,
+        presetKey: preset.key,
+        secretId: null,
+      },
+    ]);
+    setPicking(false);
+  };
+
+  const updateHeader = (
+    index: number,
+    update: Partial<{
+      name: string;
+      secretId: string | null;
+      prefix?: string;
+      presetKey?: string;
+    }>,
+  ) => {
+    onHeadersChange(
+      headers.map((entry, i) => (i === index ? { ...entry, ...update } : entry)),
+    );
+  };
+
+  const removeHeader = (index: number) => {
+    onHeadersChange(headers.filter((_, i) => i !== index));
+  };
+
+  return (
+    <CardStack>
+      <CardStackContent className="[&>*+*]:before:inset-x-0">
+        {picking ? (
+          <HeaderPresetPicker
+            presets={presets}
+            onPick={addHeaderFromPreset}
+            onCancel={() => setPicking(false)}
+          />
+        ) : headers.length === 0 ? (
+          canAddMore ? (
+            <AddHeaderRow leading={<span>{emptyLabel}</span>} onClick={() => setPicking(true)} />
+          ) : (
+            <CardStackEmpty>
+              <span>{emptyLabel}</span>
+            </CardStackEmpty>
+          )
+        ) : (
+          <>
+            {headers.map((header, index) => (
+              <SecretHeaderAuthRow
+                key={index}
+                name={header.name}
+                prefix={header.prefix}
+                presetKey={header.presetKey}
+                secretId={header.secretId}
+                onChange={(update) => updateHeader(index, update)}
+                onSelectSecret={(secretId) => updateHeader(index, { secretId })}
+                onRemove={singleHeader ? undefined : () => removeHeader(index)}
+                existingSecrets={existingSecrets}
+              />
+            ))}
+            {canAddMore && <AddHeaderRow onClick={() => setPicking(true)} />}
+          </>
+        )}
+      </CardStackContent>
+    </CardStack>
+  );
+}
+
+interface AddHeaderRowProps {
+  readonly onClick: () => void;
+  readonly leading?: ReactNode;
+}
+
+function AddHeaderRow({ onClick, leading }: AddHeaderRowProps) {
+  return (
+    // oxlint-disable-next-line react/forbid-elements
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      aria-label="Add header"
+      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
+    >
+      <span className="min-w-0 flex-1 text-left">{leading}</span>
+      <PlusIcon aria-hidden className="size-4 shrink-0" />
+    </button>
+  );
+}
+
+interface HeaderPresetPickerProps {
+  readonly presets: readonly HeaderAuthPreset[];
+  readonly onPick: (preset: HeaderAuthPreset) => void;
+  readonly onCancel: () => void;
+}
+
+function HeaderPresetPicker({ presets, onPick, onCancel }: HeaderPresetPickerProps) {
+  return (
+    <CardStackEntry className="flex-wrap gap-2">
+      {presets.map((preset) => (
+        <Button
+          key={preset.key}
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onPick(preset)}
+        >
+          {preset.label}
+        </Button>
+      ))}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        className="text-muted-foreground"
+      >
+        Cancel
+      </Button>
+    </CardStackEntry>
+  );
+}

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useAtomRefresh, useAtomSet } from "@effect-atom/atom-react";
 
 import { secretsAtom, setSecret, resolveSecret } from "../api/atoms";
 import { useScope } from "../api/scope-context";
 import { Button } from "../components/button";
+import { Field, FieldError, FieldGroup, FieldLabel } from "../components/field";
 import { Input } from "../components/input";
-import { Label } from "../components/label";
 import { Spinner } from "../components/spinner";
 import { SecretPicker, type SecretPickerSecret } from "./secret-picker";
 import { SecretId } from "@executor/sdk";
@@ -74,6 +74,9 @@ function InlineCreateSecret(props: {
   const scopeId = useScope();
   const doSet = useAtomSet(setSecret, { mode: "promise" });
   const refreshSecrets = useAtomRefresh(secretsAtom(scopeId));
+  const secretIdInputId = useId();
+  const secretNameInputId = useId();
+  const secretValueInputId = useId();
 
   const handleSave = async () => {
     if (!secretId.trim() || !secretValue.trim()) return;
@@ -98,53 +101,55 @@ function InlineCreateSecret(props: {
   };
 
   return (
-    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-2.5">
-      <p className="text-xs font-semibold text-primary tracking-wide uppercase">New secret</p>
-      <div className="grid grid-cols-2 gap-2">
-        <div className="space-y-1">
-          <Label className="text-xs uppercase tracking-wider text-muted-foreground">ID</Label>
-          <Input
-            value={secretId}
-            onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
-            placeholder="my-api-token"
-            className="h-8 text-sm font-mono"
-          />
+    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-3">
+      <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
+      <FieldGroup className="gap-3">
+        <div className="grid grid-cols-2 gap-3">
+          <Field>
+            <FieldLabel htmlFor={secretIdInputId}>ID</FieldLabel>
+            <Input
+              id={secretIdInputId}
+              value={secretId}
+              onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
+              placeholder="my-api-token"
+              className="font-mono"
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={secretNameInputId}>Label</FieldLabel>
+            <Input
+              id={secretNameInputId}
+              value={secretName}
+              onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
+              placeholder="API Token"
+            />
+          </Field>
         </div>
-        <div className="space-y-1">
-          <Label className="text-xs uppercase tracking-wider text-muted-foreground">
-            Label
-          </Label>
-          <Input
-            value={secretName}
-            onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
-            placeholder="API Token"
-            className="h-8 text-sm"
-          />
-        </div>
-      </div>
-      <div className="space-y-1">
-        <Label className="text-xs uppercase tracking-wider text-muted-foreground">Value</Label>
-        <div className="relative">
-          <Input
-            type={secretRevealed ? "text" : "password"}
-            value={secretValue}
-            onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
-            placeholder="paste your token or key…"
-            className="h-8 pr-8 text-xs font-mono"
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="absolute right-1 top-1/2 size-6 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            onClick={() => setSecretRevealed((revealed) => !revealed)}
-            aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
-          >
-            <SecretVisibilityIcon revealed={secretRevealed} />
-          </Button>
-        </div>
-      </div>
-      {error && <p className="text-sm text-destructive">{error}</p>}
+        <Field>
+          <FieldLabel htmlFor={secretValueInputId}>Value</FieldLabel>
+          <div className="relative">
+            <Input
+              id={secretValueInputId}
+              type={secretRevealed ? "text" : "password"}
+              value={secretValue}
+              onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
+              placeholder="paste your token or key…"
+              className="pr-9 font-mono"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="absolute right-1 top-1/2 size-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              onClick={() => setSecretRevealed((revealed) => !revealed)}
+              aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
+            >
+              <SecretVisibilityIcon revealed={secretRevealed} />
+            </Button>
+          </div>
+          {error && <FieldError>{error}</FieldError>}
+        </Field>
+      </FieldGroup>
       <div className="flex gap-1.5 pt-0.5">
         <Button variant="outline" size="xs" onClick={props.onCancel}>
           Cancel
@@ -286,12 +291,13 @@ export function SecretHeaderAuthRow(props: {
   onChange: (update: { name: string; prefix?: string; presetKey?: string }) => void;
   onSelectSecret: (secretId: string) => void;
   existingSecrets: readonly SecretPickerSecret[];
-  presets?: readonly HeaderAuthPreset[];
   onRemove?: () => void;
   removeLabel?: string;
   label?: string;
 }) {
   const [creating, setCreating] = useState(false);
+  const nameInputId = useId();
+  const prefixInputId = useId();
   const {
     name,
     prefix,
@@ -300,35 +306,34 @@ export function SecretHeaderAuthRow(props: {
     onChange,
     onSelectSecret,
     existingSecrets,
-    presets = defaultHeaderAuthPresets,
     onRemove,
     removeLabel = "Remove",
     label = "Header",
   } = props;
 
-  const isCustom = presetKey === "custom";
+  const isCustom = presetKey === "custom" || presetKey === undefined;
   const suggestedId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-") || "custom-header";
 
   if (creating) {
     return (
-      <InlineCreateSecret
-        headerName={name || "Custom Header"}
-        suggestedId={suggestedId}
-        onCreated={(id) => {
-          onSelectSecret(id);
-          setCreating(false);
-        }}
-        onCancel={() => setCreating(false)}
-      />
+      <div className="px-4 py-3">
+        <InlineCreateSecret
+          headerName={name || "Custom Header"}
+          suggestedId={suggestedId}
+          onCreated={(id) => {
+            onSelectSecret(id);
+            setCreating(false);
+          }}
+          onCancel={() => setCreating(false)}
+        />
+      </div>
     );
   }
 
   return (
-    <div className="rounded-lg border border-border bg-card p-3 space-y-2.5">
-      <div className="flex items-center justify-between">
-        <Label className="text-xs uppercase tracking-wider text-muted-foreground">
-          {label}
-        </Label>
+    <div className="space-y-2.5 px-4 py-3">
+      <div className="flex w-full items-center justify-between gap-4">
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</span>
         {onRemove && (
           <Button
             variant="ghost"
@@ -341,88 +346,56 @@ export function SecretHeaderAuthRow(props: {
         )}
       </div>
 
-      <div className="flex flex-wrap gap-1">
-        {presets.map((preset) => (
-          <Button
-            key={preset.key}
-            variant="ghost"
-            size="sm"
-            type="button"
-            onClick={() =>
+      <FieldGroup className="grid grid-cols-2 gap-3">
+        <Field>
+          <FieldLabel htmlFor={nameInputId}>Name</FieldLabel>
+          <Input
+            id={nameInputId}
+            value={name}
+            onChange={(e) =>
               onChange({
-                name: preset.name,
-                prefix: preset.prefix,
-                presetKey: preset.key,
+                name: (e.target as HTMLInputElement).value,
+                prefix,
+                presetKey: isCustom ? "custom" : presetKey,
               })
             }
-            className={`rounded-md border px-2 py-1 text-xs font-medium transition-colors ${
-              presetKey === preset.key
-                ? "border-primary/50 bg-primary/10 text-primary"
-                : "border-border bg-background text-muted-foreground hover:text-foreground hover:bg-accent/50"
-            }`}
-          >
-            {preset.label}
-          </Button>
-        ))}
+            placeholder="Authorization"
+            className="font-mono"
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor={prefixInputId}>
+            Prefix <span className="font-normal text-muted-foreground/60">(optional)</span>
+          </FieldLabel>
+          <Input
+            id={prefixInputId}
+            value={prefix ?? ""}
+            onChange={(e) =>
+              onChange({
+                name,
+                prefix: (e.target as HTMLInputElement).value || undefined,
+                presetKey: isCustom ? "custom" : presetKey,
+              })
+            }
+            placeholder="Bearer "
+            className="font-mono"
+          />
+        </Field>
+      </FieldGroup>
+
+      <div className="flex items-center gap-1.5">
+        <div className="flex-1 min-w-0">
+          <SecretPicker value={secretId} onSelect={onSelectSecret} secrets={existingSecrets} />
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => setCreating(true)}
+        >
+          + New
+        </Button>
       </div>
-
-      {presetKey !== undefined && (
-        <div className="grid grid-cols-2 gap-2">
-          <div className="space-y-1">
-            <Label className="text-xs uppercase tracking-wider text-muted-foreground">
-              Name
-            </Label>
-            <Input
-              value={name}
-              onChange={(e) =>
-                onChange({
-                  name: (e.target as HTMLInputElement).value,
-                  prefix,
-                  presetKey: isCustom ? "custom" : presetKey,
-                })
-              }
-              placeholder="Authorization"
-              className="h-8 text-sm font-mono"
-            />
-          </div>
-          <div className="space-y-1">
-            <Label className="text-xs uppercase tracking-wider text-muted-foreground">
-              Prefix{" "}
-              <span className="normal-case tracking-normal font-normal text-muted-foreground">
-                (opt.)
-              </span>
-            </Label>
-            <Input
-              value={prefix ?? ""}
-              onChange={(e) =>
-                onChange({
-                  name,
-                  prefix: (e.target as HTMLInputElement).value || undefined,
-                  presetKey: isCustom ? "custom" : presetKey,
-                })
-              }
-              placeholder="Bearer "
-              className="h-8 text-sm font-mono"
-            />
-          </div>
-        </div>
-      )}
-
-      {presetKey !== undefined && name.trim() && (
-        <div className="flex items-center gap-1.5">
-          <div className="flex-1 min-w-0">
-            <SecretPicker value={secretId} onSelect={onSelectSecret} secrets={existingSecrets} />
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="shrink-0"
-            onClick={() => setCreating(true)}
-          >
-            + New
-          </Button>
-        </div>
-      )}
 
       {secretId && name.trim() && (
         <HeaderValuePreview headerName={name.trim()} secretId={secretId} prefix={prefix} />

--- a/packages/react/src/plugins/source-identity.tsx
+++ b/packages/react/src/plugins/source-identity.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useState } from "react";
+import { parse } from "tldts";
+
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "../components/card-stack";
+import { Input } from "../components/input";
+
+// ---------------------------------------------------------------------------
+// Slug helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalizes a display name into a valid namespace identifier: lowercase
+ * snake_case, only `[a-z0-9_]`, no leading/trailing underscores. Produces
+ * strings that are safe to use as TypeScript/tool-name prefixes.
+ */
+export function slugifyNamespace(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+/**
+ * Derives a display-name candidate from a URL by extracting its apex domain
+ * label (e.g. `https://api.shopify.com/graphql` → `"Shopify"`) and
+ * title-casing it. Returns `null` if the URL has no parseable domain.
+ */
+export function displayNameFromUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  const parsed = parse(trimmed);
+  const label = parsed.domainWithoutSuffix;
+  if (!label) return null;
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+// ---------------------------------------------------------------------------
+// Hook — owns the name + namespace state with namespace auto-derivation
+// ---------------------------------------------------------------------------
+
+export interface SourceIdentity {
+  /** Display name — the user's override if they've typed one, otherwise the fallback. */
+  readonly name: string;
+  /** Namespace — the user's override if they've typed one, otherwise slugified from `name`. */
+  readonly namespace: string;
+  readonly setName: (name: string) => void;
+  readonly setNamespace: (namespace: string) => void;
+  /** Clears any user overrides so both fields return to deriving from the fallback. */
+  readonly reset: () => void;
+}
+
+export interface UseSourceIdentityOptions {
+  /**
+   * Fallback display name — used when the user hasn't typed one. Pass a
+   * value computed from the caller's reactive state (probe result, URL
+   * apex domain, template default, etc.) and it'll flow through to `name`
+   * automatically.
+   */
+  readonly fallbackName?: string;
+  /** Fallback namespace — defaults to `slugifyNamespace(fallbackName ?? "")`. */
+  readonly fallbackNamespace?: string;
+}
+
+/**
+ * Manages a display name and a derived namespace. Both fields are pure
+ * derived state: the user's `setName` / `setNamespace` call stores an
+ * override, otherwise the hook returns the caller-supplied fallback
+ * (passed fresh on every render). Call `reset()` to drop overrides.
+ */
+export function useSourceIdentity(options?: UseSourceIdentityOptions): SourceIdentity {
+  const [nameOverride, setNameOverride] = useState<string | null>(null);
+  const [namespaceOverride, setNamespaceOverride] = useState<string | null>(null);
+
+  const fallbackName = options?.fallbackName ?? "";
+  const name = nameOverride ?? fallbackName;
+  const fallbackNamespace = options?.fallbackNamespace ?? slugifyNamespace(name);
+  const namespace = namespaceOverride ?? fallbackNamespace;
+
+  const setName = useCallback((next: string) => {
+    setNameOverride(next);
+  }, []);
+
+  const setNamespace = useCallback((next: string) => {
+    setNamespaceOverride(slugifyNamespace(next));
+  }, []);
+
+  const reset = useCallback(() => {
+    setNameOverride(null);
+    setNamespaceOverride(null);
+  }, []);
+
+  return { name, namespace, setName, setNamespace, reset };
+}
+
+// ---------------------------------------------------------------------------
+// UI — two fields, wrapped in a shared CardStack
+// ---------------------------------------------------------------------------
+
+export interface SourceIdentityFieldsProps {
+  readonly identity: SourceIdentity;
+  readonly namePlaceholder?: string;
+  readonly namespacePlaceholder?: string;
+  readonly nameLabel?: string;
+  readonly namespaceHint?: string;
+  /**
+   * When true, the namespace field is rendered disabled — useful on Edit
+   * forms, where the namespace is the source's identity and changing it
+   * would require a delete + recreate flow.
+   */
+  readonly namespaceReadOnly?: boolean;
+}
+
+export function SourceIdentityFields({
+  identity,
+  namePlaceholder = "e.g. Sentry API",
+  namespacePlaceholder = "sentry_api",
+  nameLabel = "Display Name",
+  namespaceHint,
+  namespaceReadOnly = false,
+}: SourceIdentityFieldsProps) {
+  const effectiveNamespaceHint =
+    namespaceHint ??
+    (namespaceReadOnly
+      ? "The namespace is part of the source's identity and cannot be changed."
+      : "Prefix for the tool names. Auto-derived from the display name.");
+
+  return (
+    <CardStack>
+      <CardStackContent className="border-t-0">
+        <CardStackEntryField label={nameLabel}>
+          <Input
+            value={identity.name}
+            onChange={(e) => identity.setName((e.target as HTMLInputElement).value)}
+            placeholder={namePlaceholder}
+            className="text-sm"
+          />
+        </CardStackEntryField>
+        <CardStackEntryField
+          label="Namespace"
+          description={namespaceReadOnly ? undefined : "(optional)"}
+          hint={effectiveNamespaceHint}
+        >
+          <Input
+            value={identity.namespace}
+            onChange={(e) => identity.setNamespace((e.target as HTMLInputElement).value)}
+            placeholder={namespacePlaceholder}
+            className="font-mono text-sm"
+            disabled={namespaceReadOnly}
+          />
+        </CardStackEntryField>
+      </CardStackContent>
+    </CardStack>
+  );
+}


### PR DESCRIPTION
**2 of 5** — source-forms refactor stack (graphite copy of #188 by @mrzmyr). Stacks on #216.

Shared auth block that every source plugin's Add/Edit form can reuse instead of rolling its own None / Bearer / Header / Basic UI. Handles field-level validation via `<FieldLabel>` / `<FieldError>` and exposes a `<FilterTabs>`-based picker for the auth method.

Also refreshes `secret-header-auth.tsx` to render errors inline on the field.

See #188 for full discussion.

## Stack

1. #216 `feat(react): add UI primitives for source forms`
2. **(this PR)** `feat(react): add <AuthenticationSection> primitive`
3. `refactor(mcp): adopt shared primitives in Add/Edit source forms`
4. `refactor(sources): standardize openapi, graphql, google-discovery, onepassword forms`
5. `refactor(react): restructure sources list and sources-add container`