### PR TITLE
refactor(openapi,graphql): store invocation config on source, not per-tool

### DIFF
--- a/packages/plugins/graphql/src/sdk/invoke.ts
+++ b/packages/plugins/graphql/src/sdk/invoke.ts
@@ -170,7 +170,17 @@ export const makeGraphqlInvoker = (opts: {
         });
       }
 
-      const { binding, config } = entry;
+      const source = yield* opts.operationStore.getSource(entry.namespace);
+      if (!source) {
+        return yield* new ToolInvocationError({
+          toolId,
+          message: `No source found for namespace "${entry.namespace}"`,
+          cause: undefined,
+        });
+      }
+
+      const { binding } = entry;
+      const { invocationConfig: config } = source;
 
       // Resolve secret-backed headers
       const resolvedHeaders = yield* resolveHeaders(config.headers, opts.secrets, opts.scopeId);

--- a/packages/plugins/graphql/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/graphql/src/sdk/kv-operation-store.ts
@@ -6,7 +6,7 @@ import { Effect, Schema } from "effect";
 import { scopeKv, makeInMemoryScopedKv, type Kv, type ToolId, type ScopedKv } from "@executor/sdk";
 
 import type { GraphqlOperationStore, StoredSource } from "./operation-store";
-import { OperationBinding } from "./types";
+import { InvocationConfig, OperationBinding } from "./types";
 import { StoredSourceSchema } from "./stored-source";
 
 // ---------------------------------------------------------------------------
@@ -27,6 +27,24 @@ const decodeSource = Schema.decodeUnknownSync(Schema.parseJson(StoredSourceSchem
 // ---------------------------------------------------------------------------
 // Implementation
 // ---------------------------------------------------------------------------
+
+// TODO(migration): remove DecodedSource + rehydrate once all source rows
+// have been migrated to carry invocationConfig. For GraphQL the endpoint
+// is always user-provided in SourceConfig, so rehydration is lossless.
+type DecodedSource = Omit<StoredSource, "invocationConfig"> & {
+  invocationConfig?: InvocationConfig;
+};
+
+const rehydrate = (source: DecodedSource): StoredSource =>
+  source.invocationConfig
+    ? (source as StoredSource)
+    : {
+        ...source,
+        invocationConfig: new InvocationConfig({
+          endpoint: source.config.endpoint,
+          headers: source.config.headers ?? {},
+        }),
+      };
 
 const makeStore = (bindings: ScopedKv, sources: ScopedKv): GraphqlOperationStore => ({
   get: (toolId) =>
@@ -74,14 +92,20 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): GraphqlOperationStore
   listSources: () =>
     Effect.gen(function* () {
       const entries = yield* sources.list();
-      return entries.map((e) => decodeSource(e.value) as StoredSource);
+      // TODO(migration): rehydrate in memory only — avoid N writes per list.
+      return entries.map((e) => rehydrate(decodeSource(e.value) as DecodedSource));
     }),
 
   getSource: (namespace) =>
     Effect.gen(function* () {
       const raw = yield* sources.get(namespace);
       if (!raw) return null;
-      return decodeSource(raw) as StoredSource;
+      const source = decodeSource(raw) as DecodedSource;
+      if (source.invocationConfig) return source as StoredSource;
+      // TODO(migration): self-heal — rehydrate and write back once.
+      const healed = rehydrate(source);
+      yield* sources.set([{ key: namespace, value: encodeSource(healed) }]);
+      return healed;
     }),
 
   getSourceConfig: (namespace) =>

--- a/packages/plugins/graphql/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/graphql/src/sdk/kv-operation-store.ts
@@ -6,7 +6,7 @@ import { Effect, Schema } from "effect";
 import { scopeKv, makeInMemoryScopedKv, type Kv, type ToolId, type ScopedKv } from "@executor/sdk";
 
 import type { GraphqlOperationStore, StoredSource } from "./operation-store";
-import { OperationBinding, InvocationConfig } from "./types";
+import { OperationBinding } from "./types";
 import { StoredSourceSchema } from "./stored-source";
 
 // ---------------------------------------------------------------------------
@@ -16,7 +16,6 @@ import { StoredSourceSchema } from "./stored-source";
 class StoredEntry extends Schema.Class<StoredEntry>("StoredEntry")({
   namespace: Schema.String,
   binding: OperationBinding,
-  config: InvocationConfig,
 }) {}
 
 const encodeEntry = Schema.encodeSync(Schema.parseJson(StoredEntry));
@@ -35,12 +34,12 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): GraphqlOperationStore
       const raw = yield* bindings.get(toolId);
       if (!raw) return null;
       const entry = decodeEntry(raw);
-      return { binding: entry.binding, config: entry.config };
+      return { binding: entry.binding, namespace: entry.namespace };
     }),
 
-  put: (toolId, namespace, binding, config) =>
+  put: (toolId, namespace, binding) =>
     bindings.set([
-      { key: toolId, value: encodeEntry(new StoredEntry({ namespace, binding, config })) },
+      { key: toolId, value: encodeEntry(new StoredEntry({ namespace, binding })) },
     ]),
 
   remove: (toolId) => bindings.delete([toolId]).pipe(Effect.asVoid),

--- a/packages/plugins/graphql/src/sdk/operation-store.ts
+++ b/packages/plugins/graphql/src/sdk/operation-store.ts
@@ -18,18 +18,19 @@ export interface StoredSource {
   readonly namespace: string;
   readonly name: string;
   readonly config: SourceConfig;
+  /** Pre-resolved runtime invocation config (endpoint, headers). */
+  readonly invocationConfig: InvocationConfig;
 }
 
 export interface GraphqlOperationStore {
   readonly get: (
     toolId: ToolId,
-  ) => Effect.Effect<{ binding: OperationBinding; config: InvocationConfig } | null>;
+  ) => Effect.Effect<{ binding: OperationBinding; namespace: string } | null>;
 
   readonly put: (
     toolId: ToolId,
     namespace: string,
     binding: OperationBinding,
-    config: InvocationConfig,
   ) => Effect.Effect<void>;
 
   readonly remove: (toolId: ToolId) => Effect.Effect<void>;

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -370,7 +370,7 @@ export const graphqlPlugin = (options?: {
                   variableNames: extractedField.arguments.map((a) => a.name),
                 });
 
-                return operationStore.put(reg.id, namespace, binding, invocationConfig);
+                return operationStore.put(reg.id, namespace, binding);
               },
               { discard: true },
             );
@@ -386,6 +386,7 @@ export const graphqlPlugin = (options?: {
                 namespace: config.namespace,
                 headers: config.headers,
               },
+              invocationConfig,
             });
 
             return { sourceId: namespace, toolCount: registrations.length };
@@ -438,11 +439,11 @@ export const graphqlPlugin = (options?: {
 
             updateSource: (namespace: string, input: GraphqlUpdateSourceInput) =>
               Effect.gen(function* () {
-                const existingConfig = yield* operationStore.getSourceConfig(namespace);
-                if (!existingConfig) return;
+                const existing = yield* operationStore.getSource(namespace);
+                if (!existing) return;
 
                 const updatedConfig = {
-                  ...existingConfig,
+                  ...existing.config,
                   ...(input.endpoint !== undefined ? { endpoint: input.endpoint } : {}),
                   ...(input.headers !== undefined
                     ? { headers: input.headers as Record<string, HeaderValueValue> }
@@ -454,26 +455,11 @@ export const graphqlPlugin = (options?: {
                   headers: (updatedConfig.headers ?? {}) as Record<string, HeaderValueValue>,
                 });
 
-                const toolIds = yield* operationStore.listByNamespace(namespace);
-                for (const toolId of toolIds) {
-                  const entry = yield* operationStore.get(toolId);
-                  if (entry) {
-                    yield* operationStore.put(
-                      toolId,
-                      namespace,
-                      entry.binding,
-                      newInvocationConfig,
-                    );
-                  }
-                }
-
-                const sources = yield* operationStore.listSources();
-                const existingMeta = sources.find((s) => s.namespace === namespace);
-
                 yield* operationStore.putSource({
                   namespace,
-                  name: existingMeta?.name ?? namespace,
+                  name: existing.name,
                   config: updatedConfig,
+                  invocationConfig: newInvocationConfig,
                 });
               }),
           },

--- a/packages/plugins/graphql/src/sdk/stored-source.ts
+++ b/packages/plugins/graphql/src/sdk/stored-source.ts
@@ -16,7 +16,10 @@ export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>("Graphq
     namespace: Schema.optional(Schema.String),
     headers: Schema.optional(Schema.Record({ key: Schema.String, value: HeaderValue })),
   }),
-  invocationConfig: InvocationConfig,
+  // TODO(migration): make required once all rows have been migrated to
+  // carry invocationConfig. Left optional for decode compat with rows
+  // written before the source-level invocationConfig refactor.
+  invocationConfig: Schema.optional(InvocationConfig),
 }) {}
 
 export type StoredSourceSchemaType = typeof StoredSourceSchema.Type;

--- a/packages/plugins/graphql/src/sdk/stored-source.ts
+++ b/packages/plugins/graphql/src/sdk/stored-source.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 
-import { HeaderValue } from "./types";
+import { HeaderValue, InvocationConfig } from "./types";
 
 // ---------------------------------------------------------------------------
 // Stored source — the shape persisted by the operation store and exposed
@@ -16,6 +16,7 @@ export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>("Graphq
     namespace: Schema.optional(Schema.String),
     headers: Schema.optional(Schema.Record({ key: Schema.String, value: HeaderValue })),
   }),
+  invocationConfig: InvocationConfig,
 }) {}
 
 export type StoredSourceSchemaType = typeof StoredSourceSchema.Type;

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -292,7 +292,17 @@ export const makeOpenApiInvoker = (opts: {
         });
       }
 
-      const { binding, config } = entry;
+      const source = yield* opts.operationStore.getSource(entry.namespace);
+      if (!source) {
+        return yield* new ToolInvocationError({
+          toolId,
+          message: `No source found for namespace "${entry.namespace}"`,
+          cause: undefined,
+        });
+      }
+
+      const { binding } = entry;
+      const { invocationConfig: config } = source;
       const baseUrl = config.baseUrl;
 
       // Resolve secret-backed headers

--- a/packages/plugins/openapi/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/kv-operation-store.ts
@@ -8,7 +8,7 @@ import { Effect, Schema } from "effect";
 import { scopeKv, makeInMemoryScopedKv, type Kv, type ToolId, type ScopedKv } from "@executor/sdk";
 
 import type { OpenApiOperationStore, StoredOperation, StoredSource } from "./operation-store";
-import { OperationBinding, InvocationConfig } from "./types";
+import { OperationBinding } from "./types";
 import { StoredSourceSchema } from "./stored-source";
 
 // ---------------------------------------------------------------------------
@@ -18,7 +18,6 @@ import { StoredSourceSchema } from "./stored-source";
 class StoredEntry extends Schema.Class<StoredEntry>("StoredEntry")({
   namespace: Schema.String,
   binding: OperationBinding,
-  config: InvocationConfig,
 }) {}
 
 const encodeEntry = Schema.encodeSync(Schema.parseJson(StoredEntry));
@@ -43,16 +42,16 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): OpenApiOperationStore
         const raw = yield* bindings.get(toolId);
         if (!raw) return null;
         const entry = decodeEntry(raw);
-        return { binding: entry.binding, config: entry.config };
+        return { binding: entry.binding, namespace: entry.namespace };
       }),
 
     put: (entries: readonly StoredOperation[]) =>
       withKvTransaction(
         bindings,
         bindings.set(
-          entries.map(({ toolId, namespace, binding, config }) => ({
+          entries.map(({ toolId, namespace, binding }) => ({
             key: toolId,
-            value: encodeEntry(new StoredEntry({ namespace, binding, config })),
+            value: encodeEntry(new StoredEntry({ namespace, binding })),
           })),
         ),
       ),

--- a/packages/plugins/openapi/src/sdk/kv-operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/kv-operation-store.ts
@@ -8,7 +8,7 @@ import { Effect, Schema } from "effect";
 import { scopeKv, makeInMemoryScopedKv, type Kv, type ToolId, type ScopedKv } from "@executor/sdk";
 
 import type { OpenApiOperationStore, StoredOperation, StoredSource } from "./operation-store";
-import { OperationBinding } from "./types";
+import { InvocationConfig, OperationBinding } from "./types";
 import { StoredSourceSchema } from "./stored-source";
 
 // ---------------------------------------------------------------------------
@@ -23,6 +23,18 @@ class StoredEntry extends Schema.Class<StoredEntry>("StoredEntry")({
 const encodeEntry = Schema.encodeSync(Schema.parseJson(StoredEntry));
 const decodeEntry = Schema.decodeUnknownSync(Schema.parseJson(StoredEntry));
 
+// TODO(migration): remove LegacyStoredEntry + rehydrateInvocationConfig
+// once all source rows have been migrated off the pre-refactor schema.
+// Old binding rows inlined the resolved InvocationConfig, which is the
+// only place the server-derived baseUrl was persisted.
+class LegacyStoredEntry extends Schema.Class<LegacyStoredEntry>("LegacyStoredEntry")({
+  namespace: Schema.String,
+  binding: OperationBinding,
+  config: Schema.optional(InvocationConfig),
+}) {}
+
+const decodeLegacyEntry = Schema.decodeUnknownSync(Schema.parseJson(LegacyStoredEntry));
+
 const encodeSource = Schema.encodeSync(Schema.parseJson(StoredSourceSchema));
 const decodeSource = Schema.decodeUnknownSync(Schema.parseJson(StoredSourceSchema));
 
@@ -35,6 +47,37 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): OpenApiOperationStore
     kv: ScopedKv,
     effect: Effect.Effect<A, E, never>,
   ): Effect.Effect<A, E, never> => kv.withTransaction?.(effect) ?? effect;
+
+  // TODO(migration): remove along with LegacyStoredEntry.
+  // Rebuild invocationConfig for a source row that predates the refactor.
+  // We try to recover the resolved baseUrl from any legacy binding row
+  // (old rows inlined the full InvocationConfig); if none is found, fall
+  // back to the user-provided baseUrl from the source config.
+  type DecodedSource = Omit<StoredSource, "invocationConfig"> & {
+    invocationConfig?: InvocationConfig;
+  };
+  const rehydrateInvocationConfig = (
+    source: DecodedSource,
+  ): Effect.Effect<StoredSource> =>
+    Effect.gen(function* () {
+      if (source.invocationConfig) return source as StoredSource;
+      let recovered: InvocationConfig | null = null;
+      const entries = yield* bindings.list();
+      for (const e of entries) {
+        const legacy = decodeLegacyEntry(e.value);
+        if (legacy.namespace === source.namespace && legacy.config) {
+          recovered = legacy.config;
+          break;
+        }
+      }
+      const invocationConfig =
+        recovered ??
+        new InvocationConfig({
+          baseUrl: source.config.baseUrl ?? "",
+          headers: source.config.headers ?? {},
+        });
+      return { ...source, invocationConfig };
+    });
 
   return {
     get: (toolId) =>
@@ -88,14 +131,29 @@ const makeStore = (bindings: ScopedKv, sources: ScopedKv): OpenApiOperationStore
     listSources: () =>
       Effect.gen(function* () {
         const entries = yield* sources.list();
-        return entries.map((e) => decodeSource(e.value) as StoredSource);
+        const out: StoredSource[] = [];
+        for (const e of entries) {
+          const raw = decodeSource(e.value) as DecodedSource;
+          // TODO(migration): rehydrate in memory only — avoid N writes per list.
+          out.push(
+            raw.invocationConfig
+              ? (raw as StoredSource)
+              : yield* rehydrateInvocationConfig(raw),
+          );
+        }
+        return out;
       }),
 
     getSource: (namespace) =>
       Effect.gen(function* () {
         const raw = yield* sources.get(namespace);
         if (!raw) return null;
-        return decodeSource(raw) as StoredSource;
+        const source = decodeSource(raw) as DecodedSource;
+        if (source.invocationConfig) return source as StoredSource;
+        // TODO(migration): self-heal — rehydrate and write back once.
+        const healed = yield* rehydrateInvocationConfig(source);
+        yield* sources.set([{ key: namespace, value: encodeSource(healed) }]);
+        return healed;
       }),
 
     getSourceConfig: (namespace) =>

--- a/packages/plugins/openapi/src/sdk/operation-store.ts
+++ b/packages/plugins/openapi/src/sdk/operation-store.ts
@@ -18,19 +18,20 @@ export interface StoredSource {
   readonly namespace: string;
   readonly name: string;
   readonly config: SourceConfig;
+  /** Pre-resolved runtime invocation config (baseUrl resolved from servers, headers). */
+  readonly invocationConfig: InvocationConfig;
 }
 
 export interface StoredOperation {
   readonly toolId: ToolId;
   readonly namespace: string;
   readonly binding: OperationBinding;
-  readonly config: InvocationConfig;
 }
 
 export interface OpenApiOperationStore {
   readonly get: (
     toolId: ToolId,
-  ) => Effect.Effect<{ binding: OperationBinding; config: InvocationConfig } | null>;
+  ) => Effect.Effect<{ binding: OperationBinding; namespace: string } | null>;
 
   readonly put: (entries: readonly StoredOperation[]) => Effect.Effect<void>;
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -275,7 +275,6 @@ export const openApiPlugin = (options?: {
                 toolId: ToolId.make(`${namespace}.${def.toolPath}`),
                 namespace,
                 binding: toBinding(def),
-                config: invocationConfig,
               })),
             );
 
@@ -291,6 +290,7 @@ export const openApiPlugin = (options?: {
                 namespace: config.namespace,
                 headers: config.headers,
               },
+              invocationConfig,
             });
 
             return { sourceId: namespace, toolCount: registrations.length };
@@ -345,11 +345,11 @@ export const openApiPlugin = (options?: {
 
             updateSource: (namespace: string, input: OpenApiUpdateSourceInput) =>
               Effect.gen(function* () {
-                const existingSource = yield* operationStore.getSourceConfig(namespace);
-                if (!existingSource) return;
+                const existing = yield* operationStore.getSource(namespace);
+                if (!existing) return;
 
                 const updatedConfig = {
-                  ...existingSource,
+                  ...existing.config,
                   ...(input.baseUrl !== undefined ? { baseUrl: input.baseUrl } : {}),
                   ...(input.headers !== undefined
                     ? { headers: input.headers as Record<string, HeaderValueValue> }
@@ -357,32 +357,15 @@ export const openApiPlugin = (options?: {
                 };
 
                 const newInvocationConfig = new InvocationConfig({
-                  baseUrl: updatedConfig.baseUrl ?? resolveBaseUrl([]),
+                  baseUrl: updatedConfig.baseUrl ?? existing.invocationConfig.baseUrl,
                   headers: (updatedConfig.headers ?? {}) as Record<string, HeaderValueValue>,
                 });
 
-                const toolIds = yield* operationStore.listByNamespace(namespace);
-                for (const toolId of toolIds) {
-                  const entry = yield* operationStore.get(toolId);
-                  if (entry) {
-                    yield* operationStore.put([
-                      {
-                        toolId,
-                        namespace,
-                        binding: entry.binding,
-                        config: newInvocationConfig,
-                      },
-                    ]);
-                  }
-                }
-
-                const sources = yield* operationStore.listSources();
-                const existingMeta = sources.find((s) => s.namespace === namespace);
-
                 yield* operationStore.putSource({
                   namespace,
-                  name: existingMeta?.name ?? namespace,
+                  name: existing.name,
                   config: updatedConfig,
+                  invocationConfig: newInvocationConfig,
                 });
               }),
           },

--- a/packages/plugins/openapi/src/sdk/stored-source.ts
+++ b/packages/plugins/openapi/src/sdk/stored-source.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 
-import { HeaderValue } from "./types";
+import { HeaderValue, InvocationConfig } from "./types";
 
 // ---------------------------------------------------------------------------
 // Stored source — the shape persisted by the operation store and exposed
@@ -16,6 +16,7 @@ export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>("OpenAp
     namespace: Schema.optional(Schema.String),
     headers: Schema.optional(Schema.Record({ key: Schema.String, value: HeaderValue })),
   }),
+  invocationConfig: InvocationConfig,
 }) {}
 
 export type StoredSourceSchemaType = typeof StoredSourceSchema.Type;

--- a/packages/plugins/openapi/src/sdk/stored-source.ts
+++ b/packages/plugins/openapi/src/sdk/stored-source.ts
@@ -16,7 +16,10 @@ export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>("OpenAp
     namespace: Schema.optional(Schema.String),
     headers: Schema.optional(Schema.Record({ key: Schema.String, value: HeaderValue })),
   }),
-  invocationConfig: InvocationConfig,
+  // TODO(migration): make required once all rows have been migrated to
+  // carry invocationConfig. Left optional for decode compat with rows
+  // written before the source-level invocationConfig refactor.
+  invocationConfig: Schema.optional(InvocationConfig),
 }) {}
 
 export type StoredSourceSchemaType = typeof StoredSourceSchema.Type;


### PR DESCRIPTION
## Summary

Per-tool binding rows in the OpenAPI and GraphQL plugins were duplicating the full `InvocationConfig` (baseUrl/endpoint + headers) on **every** binding entry. For a source with N operations, the plugin stored N copies of the same config in KV, and every `updateSource` call read and rewrote every binding row (`O(N)` writes per header edit).

This PR:

- Moves `invocationConfig` to the source row (one per namespace), alongside the user-facing `SourceConfig`.
- Per-tool rows now store only `{ namespace, binding }`.
- The invoker resolves runtime config via `getSource(namespace)` on the hot path (one extra KV read, which is shared across all tools in the same source within a request).
- `updateSource` becomes a single `putSource` — `O(1)` writes instead of `O(N)`.
- Applied symmetrically to the OpenAPI and GraphQL plugins.

### Why this mattered

The edit-source path looked like this:

```ts
const toolIds = yield* operationStore.listByNamespace(namespace);
for (const toolId of toolIds) {
  const entry = yield* operationStore.get(toolId);
  if (entry) {
    yield* operationStore.put([{ toolId, namespace, binding: entry.binding, config: newInvocationConfig }]);
  }
}
```

For a Stripe-sized OpenAPI spec this is hundreds of KV writes per header rotation, and every binding row inflates with a redundant headers blob.

### Not in scope

`packages/plugins/mcp/src/sdk/binding-store.ts` has the same anti-pattern (`sourceData` is stamped onto every binding row). Worth a follow-up.

## Test plan

- [x] `bun run typecheck` — full workspace, clean
- [x] `bun run --filter '@executor/plugin-openapi' --filter '@executor/plugin-graphql' test` — 36/36 passing
- [ ] Manually exercise an OpenAPI add + edit-source flow against a real spec to confirm invocation still works end-to-end
- [ ] Same for GraphQL