### PR TITLE
feat(react): use favicon on connected source list items

### DIFF
--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -20,6 +20,7 @@ import {
   CardStackEntryDescription,
   CardStackEntryActions,
 } from "../components/card-stack";
+import { SourceFavicon } from "../components/source-favicon";
 
 const KIND_TO_PLUGIN_KEY: Record<string, string> = {
   openapi: "openapi",
@@ -267,6 +268,7 @@ function SourceGrid(props: {
     id: string;
     name: string;
     kind: string;
+    url?: string;
     runtime?: boolean;
   }[];
 }) {
@@ -278,15 +280,7 @@ function SourceGrid(props: {
           <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
             <Link to="/sources/$namespace" params={{ namespace: s.id }}>
               <CardStackEntryMedia>
-                <svg viewBox="0 0 16 16" className="size-3.5" fill="none">
-                  <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="1.2" />
-                  <path
-                    d="M8 5v6M5 8h6"
-                    stroke="currentColor"
-                    strokeWidth="1.2"
-                    strokeLinecap="round"
-                  />
-                </svg>
+                <SourceFavicon url={s.url} size={16} />
               </CardStackEntryMedia>
               <CardStackEntryContent>
                 <CardStackEntryTitle>{s.name}</CardStackEntryTitle>

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -280,7 +280,7 @@ function SourceGrid(props: {
           <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
             <Link to="/sources/$namespace" params={{ namespace: s.id }}>
               <CardStackEntryMedia>
-                <SourceFavicon url={s.url} size={16} />
+                <SourceFavicon url={s.url} size={20} />
               </CardStackEntryMedia>
               <CardStackEntryContent>
                 <CardStackEntryTitle>{s.name}</CardStackEntryTitle>

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -280,7 +280,7 @@ function SourceGrid(props: {
           <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
             <Link to="/sources/$namespace" params={{ namespace: s.id }}>
               <CardStackEntryMedia>
-                <SourceFavicon url={s.url} size={20} />
+                <SourceFavicon url={s.url} size={32} />
               </CardStackEntryMedia>
               <CardStackEntryContent>
                 <CardStackEntryTitle>{s.name}</CardStackEntryTitle>


### PR DESCRIPTION
## Summary
- Replace the generic SVG icon in the connected sources list with `SourceFavicon`, rendering the actual site favicon from the source URL
- Match favicon size (20px) to the popular sources list for visual consistency
- Falls back to a `BoxIcon` when no URL is available or the image fails to load

**Before**

<img width="790" height="600" alt="CleanShot 2026-04-13 at 12 26 29" src="https://github.com/user-attachments/assets/95c802ed-4276-4678-8aca-7aba75cd526d" />

**After**

<img width="920" height="723" alt="CleanShot 2026-04-13 at 12 25 54" src="https://github.com/user-attachments/assets/6bcc5bed-8e73-454e-9f4a-d4e207a02725" />

## Test plan
- [ ] Verify connected sources with a URL show their site favicon
- [ ] Verify sources without a URL show the fallback BoxIcon
- [ ] Verify favicon size matches the popular sources list icons