### PR TITLE
[codex] Allow underscores while editing source namespaces

### DIFF
--- a/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
@@ -14,6 +14,7 @@ import {
 } from "@executor/react/components/card-stack";
 import {
   SourceIdentityFields,
+  slugifyNamespace,
   useSourceIdentity,
 } from "@executor/react/plugins/source-identity";
 import {
@@ -614,7 +615,7 @@ export default function AddGoogleDiscoverySource(props: {
         payload: {
           name: identity.name.trim() || probe.name,
           discoveryUrl: discoveryUrl.trim(),
-          namespace: identity.namespace.trim() || undefined,
+          namespace: slugifyNamespace(identity.namespace) || undefined,
           auth:
             authKind === "oauth2"
               ? (oauthAuth ?? { kind: "none" as const })

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -6,6 +6,7 @@ import { HeadersList } from "@executor/react/plugins/headers-list";
 import { type HeaderState } from "@executor/react/plugins/secret-header-auth";
 import {
   displayNameFromUrl,
+  slugifyNamespace,
   SourceIdentityFields,
   useSourceIdentity,
 } from "@executor/react/plugins/source-identity";
@@ -70,7 +71,7 @@ export default function AddGraphqlSource(props: {
         payload: {
           endpoint: endpoint.trim(),
           name: identity.name.trim() || undefined,
-          namespace: identity.namespace.trim() || undefined,
+          namespace: slugifyNamespace(identity.namespace) || undefined,
           ...(Object.keys(headerMap).length > 0 ? { headers: headerMap } : {}),
         },
       });

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -28,6 +28,7 @@ import { HeadersList } from "@executor/react/plugins/headers-list";
 import { type HeaderState } from "@executor/react/plugins/secret-header-auth";
 import {
   displayNameFromUrl,
+  slugifyNamespace,
   SourceIdentityFields,
   useSourceIdentity,
 } from "@executor/react/plugins/source-identity";
@@ -486,7 +487,7 @@ export default function AddMcpSource(props: {
         payload: {
           transport: "remote" as const,
           name: remoteIdentity.name.trim() || probe.serverName || probe.name,
-          namespace: remoteIdentity.namespace.trim() || undefined,
+          namespace: slugifyNamespace(remoteIdentity.namespace) || undefined,
           endpoint: state.url.trim(),
           auth,
           ...(Object.keys(headers).length > 0 ? { headers } : {}),
@@ -548,7 +549,7 @@ export default function AddMcpSource(props: {
         payload: {
           transport: "stdio" as const,
           name: stdioIdentity.name.trim() || cmd,
-          namespace: stdioIdentity.namespace.trim() || undefined,
+          namespace: slugifyNamespace(stdioIdentity.namespace) || undefined,
           command: cmd,
           args: parseStdioArgs(stdioArgs),
           env: parseStdioEnv(stdioEnv),

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -9,6 +9,7 @@ import {
   type HeaderState,
 } from "@executor/react/plugins/secret-header-auth";
 import {
+  slugifyNamespace,
   SourceIdentityFields,
   useSourceIdentity,
 } from "@executor/react/plugins/source-identity";
@@ -226,7 +227,7 @@ export default function AddOpenApiSource(props: {
         payload: {
           spec: specUrl,
           name: identity.name.trim() || undefined,
-          namespace: identity.namespace.trim() || undefined,
+          namespace: slugifyNamespace(identity.namespace) || undefined,
           baseUrl: baseUrl.trim() || undefined,
           ...(hasHeaders ? { headers: allHeaders } : {}),
         },

--- a/packages/react/src/plugins/namespace.ts
+++ b/packages/react/src/plugins/namespace.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalizes a display name into a valid namespace identifier: lowercase
+ * snake_case, only `[a-z0-9_]`, no leading/trailing underscores. Produces
+ * strings that are safe to use as TypeScript/tool-name prefixes.
+ */
+export function slugifyNamespace(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+/**
+ * Sanitizes namespace input as the user types without removing intentional
+ * underscores that are still in-progress at the field boundaries.
+ */
+export function normalizeNamespaceInput(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, "_");
+}

--- a/packages/react/src/plugins/source-identity.tsx
+++ b/packages/react/src/plugins/source-identity.tsx
@@ -7,23 +7,8 @@ import {
   CardStackEntryField,
 } from "../components/card-stack";
 import { Input } from "../components/input";
-
-// ---------------------------------------------------------------------------
-// Slug helper
-// ---------------------------------------------------------------------------
-
-/**
- * Normalizes a display name into a valid namespace identifier: lowercase
- * snake_case, only `[a-z0-9_]`, no leading/trailing underscores. Produces
- * strings that are safe to use as TypeScript/tool-name prefixes.
- */
-export function slugifyNamespace(input: string): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
-}
+import { normalizeNamespaceInput, slugifyNamespace } from "./namespace";
+export { normalizeNamespaceInput, slugifyNamespace } from "./namespace";
 
 /**
  * Derives a display-name candidate from a URL by extracting its apex domain
@@ -86,7 +71,7 @@ export function useSourceIdentity(options?: UseSourceIdentityOptions): SourceIde
   }, []);
 
   const setNamespace = useCallback((next: string) => {
-    setNamespaceOverride(slugifyNamespace(next));
+    setNamespaceOverride(normalizeNamespaceInput(next));
   }, []);
 
   const reset = useCallback(() => {

--- a/tests/source-identity.test.ts
+++ b/tests/source-identity.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeNamespaceInput,
+  slugifyNamespace,
+} from "../packages/react/src/plugins/namespace";
+
+describe("source identity namespace helpers", () => {
+  it("preserves underscores while the user is typing", () => {
+    expect(normalizeNamespaceInput("archil_useast1")).toBe("archil_useast1");
+    expect(normalizeNamespaceInput("archil_")).toBe("archil_");
+    expect(normalizeNamespaceInput("_archil")).toBe("_archil");
+  });
+
+  it("canonicalizes the saved namespace", () => {
+    expect(slugifyNamespace("archil_")).toBe("archil");
+    expect(slugifyNamespace("_archil")).toBe("archil");
+    expect(slugifyNamespace("Archil USEast1")).toBe("archil_useast1");
+  });
+});


### PR DESCRIPTION
## What changed
This updates the shared source identity namespace handling so manual namespace edits preserve underscores while the user is typing.

It also canonicalizes the submitted namespace in the add-source flows for OpenAPI, GraphQL, MCP, and Google Discovery, and extracts the pure namespace helper logic into a small shared module.

## Before
![CleanShot 2026-04-13 at 12 38 22](https://github.com/user-attachments/assets/bbbeea09-beea-46dd-add8-653525980689)

## After
![CleanShot 2026-04-13 at 12 39 26](https://github.com/user-attachments/assets/86016997-662f-4508-9929-073c7f4260a5)


## Why
The namespace field in Executor Cloud was re-slugifying every keystroke. That caused `_` to disappear at input boundaries, so users could not reliably type namespace values containing underscores.

## Impact
Users can now type namespace values like `archil_useast1` without the field fighting their input, while saved namespaces still normalize to the expected canonical format.

## Root cause
The UI used the final slugification logic during editing instead of a typing-friendly normalization path.

## Validation
- `bun x vitest run tests/source-identity.test.ts`
