### PR TITLE
[codex] Right-align inline secret creation actions

### DIFF
--- a/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
@@ -118,7 +118,7 @@ function InlineCreateSecret(props: {
         />
       </div>
       {error && <p className="text-[11px] text-destructive">{error}</p>}
-      <div className="flex gap-1.5 pt-0.5">
+      <div className="flex justify-end gap-1.5 pt-0.5">
         <Button variant="outline" size="xs" onClick={props.onCancel}>
           Cancel
         </Button>
@@ -127,7 +127,7 @@ function InlineCreateSecret(props: {
           onClick={handleSave}
           disabled={!secretId.trim() || !secretValue.trim() || saving}
         >
-          {saving ? "Saving…" : "Create & use"}
+          {saving ? "Saving…" : "Create and use"}
         </Button>
       </div>
     </div>

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -150,7 +150,7 @@ function InlineCreateSecret(props: {
           {error && <FieldError>{error}</FieldError>}
         </Field>
       </FieldGroup>
-      <div className="flex gap-1.5 pt-0.5">
+      <div className="flex justify-end gap-1.5 pt-0.5">
         <Button variant="outline" size="xs" onClick={props.onCancel}>
           Cancel
         </Button>
@@ -159,7 +159,7 @@ function InlineCreateSecret(props: {
           onClick={handleSave}
           disabled={!secretId.trim() || !secretValue.trim() || saving}
         >
-          {saving ? "Saving…" : "Create & use"}
+          {saving ? "Saving…" : "Create and use"}
         </Button>
       </div>
     </div>


### PR DESCRIPTION
## What changed
This right-aligns the action row in the inline secret creation forms and renames the primary button text from `Create & use` to `Create and use`.

The change applies to the shared secret-header auth UI and the Google Discovery inline secret creation form.

## Before
<img width="1632" height="502" alt="CleanShot 2026-04-13 at 12 34 47@2x" src="https://github.com/user-attachments/assets/895007ab-55e0-4052-a48f-12dce14943ae" />

## After
<img width="814" height="281" alt="image" src="https://github.com/user-attachments/assets/4750bc28-1c1e-4391-9e08-1c1a00a84fb4" />


## Why
The action buttons were left-aligned in the panel, which looked off relative to the rest of the form layout, and the `&` label was less consistent with the surrounding copy. 

## Impact
Inline secret creation now has trailing-edge aligned actions and more explicit primary button text.

## Root cause
The action row used a plain flex layout without end alignment, and the button label used the abbreviated copy.

## Validation
- Inspected the updated JSX in the affected components
