### PR TITLE
[codex] simplify cloud org switching

### DIFF
--- a/apps/cloud/src/auth/api.ts
+++ b/apps/cloud/src/auth/api.ts
@@ -20,6 +20,29 @@ const AuthMeResponse = Schema.Struct({
   organization: Schema.NullOr(AuthOrganization),
 });
 
+const AuthOrganizationSummary = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+});
+
+const AuthOrganizationsResponse = Schema.Struct({
+  organizations: Schema.Array(AuthOrganizationSummary),
+  activeOrganizationId: Schema.NullOr(Schema.String),
+});
+
+const SwitchOrganizationBody = Schema.Struct({
+  organizationId: Schema.String,
+});
+
+const CreateOrganizationBody = Schema.Struct({
+  name: Schema.String,
+});
+
+const CreateOrganizationResponse = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+});
+
 const AuthCallbackSearch = Schema.Struct({
   code: Schema.String,
 });
@@ -28,6 +51,7 @@ export const AUTH_PATHS = {
   login: "/api/auth/login",
   logout: "/api/auth/logout",
   callback: "/api/auth/callback",
+  switchOrganization: "/api/auth/switch-organization",
 } as const;
 
 /** Public auth endpoints — no authentication required */
@@ -44,4 +68,21 @@ export class CloudAuthPublicApi extends HttpApiGroup.make("cloudAuthPublic")
 export class CloudAuthApi extends HttpApiGroup.make("cloudAuth")
   .add(HttpApiEndpoint.get("me")`/auth/me`.addSuccess(AuthMeResponse).addError(UserStoreError))
   .add(HttpApiEndpoint.post("logout")`/auth/logout`)
+  .add(
+    HttpApiEndpoint.get("organizations")`/auth/organizations`
+      .addSuccess(AuthOrganizationsResponse)
+      .addError(WorkOSError),
+  )
+  .add(
+    HttpApiEndpoint.post("switchOrganization")`/auth/switch-organization`
+      .setPayload(SwitchOrganizationBody)
+      .addError(WorkOSError),
+  )
+  .add(
+    HttpApiEndpoint.post("createOrganization")`/auth/create-organization`
+      .setPayload(CreateOrganizationBody)
+      .addSuccess(CreateOrganizationResponse)
+      .addError(UserStoreError)
+      .addError(WorkOSError),
+  )
   .middleware(SessionAuth) {}

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -133,12 +133,10 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           };
         }),
       )
-      .handleRaw("logout", () =>
-        Effect.gen(function* () {
-          deleteCookie("wos-session", { path: "/" });
-          return HttpServerResponse.redirect("/", { status: 302 });
-        }),
-      )
+      .handleRaw("logout", () => {
+        deleteCookie("wos-session", { path: "/" });
+        return Effect.succeed(HttpServerResponse.redirect("/", { status: 302 }));
+      })
       .handle("organizations", () =>
         Effect.gen(function* () {
           const workos = yield* WorkOSAuth;

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -1,4 +1,4 @@
-import { HttpApi, HttpApiBuilder, HttpServerRequest, HttpServerResponse } from "@effect/platform";
+import { HttpApi, HttpApiBuilder, HttpServerResponse } from "@effect/platform";
 import { Effect } from "effect";
 import { setCookie, deleteCookie } from "@tanstack/react-start/server";
 
@@ -15,26 +15,6 @@ const COOKIE_OPTIONS = {
   maxAge: 60 * 60 * 24 * 7,
   secure: true,
 };
-
-const parseCookies = (cookieHeader: string | undefined | null): Record<string, string> => {
-  if (!cookieHeader) return {};
-  const out: Record<string, string> = {};
-  for (const part of cookieHeader.split(";")) {
-    const trimmed = part.trim();
-    if (!trimmed) continue;
-    const eq = trimmed.indexOf("=");
-    if (eq <= 0) continue;
-    const k = trimmed.slice(0, eq);
-    const v = trimmed.slice(eq + 1);
-    if (k && !(k in out)) out[k] = v;
-  }
-  return out;
-};
-
-const getRequestCookies = Effect.gen(function* () {
-  const req = yield* HttpServerRequest.HttpServerRequest;
-  return parseCookies(req.headers.cookie);
-});
 
 // ---------------------------------------------------------------------------
 // Single non-protected API surface — public (login/callback) + session
@@ -184,16 +164,12 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
       .handle("switchOrganization", ({ payload }) =>
         Effect.gen(function* () {
           const workos = yield* WorkOSAuth;
-          const cookies = yield* getRequestCookies;
+          const session = yield* SessionContext;
 
-          const currentSealed = cookies["wos-session"];
-          if (!currentSealed) {
-            // Middleware already validated the session, so this should be
-            // unreachable in practice.
-            return;
-          }
-
-          const refreshed = yield* workos.refreshSession(currentSealed, payload.organizationId);
+          const refreshed = yield* workos.refreshSession(
+            session.sealedSession,
+            payload.organizationId,
+          );
           if (refreshed) {
             setCookie("wos-session", refreshed, COOKIE_OPTIONS);
           }
@@ -204,19 +180,15 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           const workos = yield* WorkOSAuth;
           const users = yield* UserStoreService;
           const session = yield* SessionContext;
-          const cookies = yield* getRequestCookies;
 
           const name = payload.name.trim();
           const org = yield* workos.createOrganization(name);
           yield* workos.createMembership(org.id, session.accountId, "admin");
           yield* users.use((s) => s.upsertOrganization({ id: org.id, name: org.name }));
 
-          const currentSealed = cookies["wos-session"];
-          if (currentSealed) {
-            const refreshed = yield* workos.refreshSession(currentSealed, org.id);
-            if (refreshed) {
-              setCookie("wos-session", refreshed, COOKIE_OPTIONS);
-            }
+          const refreshed = yield* workos.refreshSession(session.sealedSession, org.id);
+          if (refreshed) {
+            setCookie("wos-session", refreshed, COOKIE_OPTIONS);
           }
 
           return { id: org.id, name: org.name };

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -1,4 +1,4 @@
-import { HttpApi, HttpApiBuilder, HttpServerResponse } from "@effect/platform";
+import { HttpApi, HttpApiBuilder, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import { Effect } from "effect";
 import { setCookie, deleteCookie } from "@tanstack/react-start/server";
 
@@ -16,9 +16,29 @@ const COOKIE_OPTIONS = {
   secure: true,
 };
 
+const parseCookies = (cookieHeader: string | undefined | null): Record<string, string> => {
+  if (!cookieHeader) return {};
+  const out: Record<string, string> = {};
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) continue;
+    const k = trimmed.slice(0, eq);
+    const v = trimmed.slice(eq + 1);
+    if (k && !(k in out)) out[k] = v;
+  }
+  return out;
+};
+
+const getRequestCookies = Effect.gen(function* () {
+  const req = yield* HttpServerRequest.HttpServerRequest;
+  return parseCookies(req.headers.cookie);
+});
+
 // ---------------------------------------------------------------------------
 // Single non-protected API surface — public (login/callback) + session
-// (me/logout). The session group has SessionAuth on it.
+// (me/logout/organizations/switch-organization). The session group has SessionAuth on it.
 // ---------------------------------------------------------------------------
 
 export const NonProtectedApi = HttpApi.make("cloudWeb").add(CloudAuthPublicApi).add(CloudAuthApi);
@@ -57,7 +77,7 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
           let organizationId = result.organizationId;
 
           // If the auth response doesn't include an org, check if the user
-          // already belongs to one. Only create a new workspace if they truly
+          // already belongs to one. Only create a new organization if they truly
           // have no memberships — this prevents duplicate orgs on re-login.
           if (!organizationId) {
             const memberships = yield* workos.listUserMemberships(result.user.id);
@@ -134,9 +154,72 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
         }),
       )
       .handleRaw("logout", () =>
-        Effect.sync(() => {
+        Effect.gen(function* () {
           deleteCookie("wos-session", { path: "/" });
           return HttpServerResponse.redirect("/", { status: 302 });
+        }),
+      )
+      .handle("organizations", () =>
+        Effect.gen(function* () {
+          const workos = yield* WorkOSAuth;
+          const session = yield* SessionContext;
+
+          const memberships = yield* workos.listUserMemberships(session.accountId);
+          const organizations = yield* Effect.all(
+            memberships.data.map((m) =>
+              workos.getOrganization(m.organizationId).pipe(
+                Effect.map((org) => ({ id: org.id, name: org.name })),
+                Effect.orElseSucceed(() => null),
+              ),
+            ),
+            { concurrency: "unbounded" },
+          );
+
+          return {
+            organizations: organizations.filter((org): org is NonNullable<typeof org> => org !== null),
+            activeOrganizationId: session.organizationId,
+          };
+        }),
+      )
+      .handle("switchOrganization", ({ payload }) =>
+        Effect.gen(function* () {
+          const workos = yield* WorkOSAuth;
+          const cookies = yield* getRequestCookies;
+
+          const currentSealed = cookies["wos-session"];
+          if (!currentSealed) {
+            // Middleware already validated the session, so this should be
+            // unreachable in practice.
+            return;
+          }
+
+          const refreshed = yield* workos.refreshSession(currentSealed, payload.organizationId);
+          if (refreshed) {
+            setCookie("wos-session", refreshed, COOKIE_OPTIONS);
+          }
+        }),
+      )
+      .handle("createOrganization", ({ payload }) =>
+        Effect.gen(function* () {
+          const workos = yield* WorkOSAuth;
+          const users = yield* UserStoreService;
+          const session = yield* SessionContext;
+          const cookies = yield* getRequestCookies;
+
+          const name = payload.name.trim();
+          const org = yield* workos.createOrganization(name);
+          yield* workos.createMembership(org.id, session.accountId, "admin");
+          yield* users.use((s) => s.upsertOrganization({ id: org.id, name: org.name }));
+
+          const currentSealed = cookies["wos-session"];
+          if (currentSealed) {
+            const refreshed = yield* workos.refreshSession(currentSealed, org.id);
+            if (refreshed) {
+              setCookie("wos-session", refreshed, COOKIE_OPTIONS);
+            }
+          }
+
+          return { id: org.id, name: org.name };
         }),
       ),
 );

--- a/apps/cloud/src/auth/middleware-live.ts
+++ b/apps/cloud/src/auth/middleware-live.ts
@@ -29,6 +29,7 @@ export const SessionAuthLive = Layer.effect(
             name: `${result.firstName ?? ""} ${result.lastName ?? ""}`.trim() || null,
             avatarUrl: result.avatarUrl ?? null,
             organizationId: result.organizationId ?? null,
+            sealedSession: result.refreshedSession ?? Redacted.value(sealedSession),
             refreshedSession: result.refreshedSession ?? null,
           };
         }),

--- a/apps/cloud/src/auth/middleware.ts
+++ b/apps/cloud/src/auth/middleware.ts
@@ -19,6 +19,7 @@ export type Session = {
   readonly avatarUrl: string | null;
   /** May be null if the user hasn't joined an organization yet. */
   readonly organizationId: string | null;
+  readonly sealedSession: string;
   readonly refreshedSession: string | null;
 };
 

--- a/apps/cloud/src/routes/secrets.tsx
+++ b/apps/cloud/src/routes/secrets.tsx
@@ -5,7 +5,7 @@ export const Route = createFileRoute("/secrets")({
   component: () => (
     <SecretsPage
       secretProviderPlugins={[]}
-      addSecretDescription="Store a credential or API key for this workspace."
+      addSecretDescription="Store a credential or API key for this organization."
       showProviderInfo={false}
       storageOptions={[{ value: "workos-vault", label: "WorkOS Vault" }]}
     />

--- a/apps/cloud/src/web/auth.tsx
+++ b/apps/cloud/src/web/auth.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext } from "react";
+import { Atom } from "@effect-atom/atom";
 import { useAtomValue, Result } from "@effect-atom/atom-react";
 
 import { CloudApiClient } from "./client";
@@ -26,6 +27,13 @@ type AuthOrganization = {
 export const authAtom = CloudApiClient.query("cloudAuth", "me", {
   timeToLive: "5 minutes",
 });
+
+export const organizationsAtom = Atom.refreshOnWindowFocus(
+  CloudApiClient.query("cloudAuth", "organizations", { timeToLive: "1 minute" }),
+);
+
+export const switchOrganization = CloudApiClient.mutation("cloudAuth", "switchOrganization");
+export const createOrganization = CloudApiClient.mutation("cloudAuth", "createOrganization");
 
 // ---------------------------------------------------------------------------
 // Provider + hook

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -1,9 +1,31 @@
 import { Link, Outlet, useLocation } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
-import { useAtomValue, Result } from "@effect-atom/atom-react";
+import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
 import { sourcesAtom } from "@executor/react/api/atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@executor/react/components/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@executor/react/components/dropdown-menu";
+import { Input } from "@executor/react/components/input";
+import { Label } from "@executor/react/components/label";
 import { SourceFavicon } from "@executor/react/components/source-favicon";
 import { CommandPalette } from "@executor/react/components/command-palette";
 import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
@@ -11,7 +33,13 @@ import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
 import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
 import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
 import { AUTH_PATHS } from "../auth/api";
-import { useAuth } from "./auth";
+import {
+  authAtom,
+  createOrganization,
+  organizationsAtom,
+  switchOrganization,
+  useAuth,
+} from "./auth";
 
 const sourcePlugins = [
   openApiSourcePlugin,
@@ -91,57 +119,277 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
 
 // ── UserFooter ──────────────────────────────────────────────────────────
 
+function initialsFor(name: string | null, email: string) {
+  if (name) {
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }
+  return email[0]!.toUpperCase();
+}
+
+function Avatar(props: { url: string | null; name: string | null; email: string; size?: "sm" | "md" }) {
+  const size = props.size === "md" ? "size-8" : "size-7";
+  const text = props.size === "md" ? "text-sm" : "text-xs";
+  if (props.url) {
+    return <img src={props.url} alt="" className={`${size} shrink-0 rounded-full`} />;
+  }
+  return (
+    <div
+      className={`flex ${size} shrink-0 items-center justify-center rounded-full bg-primary/10 ${text} font-semibold text-primary`}
+    >
+      {initialsFor(props.name, props.email)}
+    </div>
+  );
+}
+
+function OrganizationSwitcherItems(props: { activeOrganizationId: string | null }) {
+  const organizations = useAtomValue(organizationsAtom);
+  const doSwitchOrganization = useAtomSet(switchOrganization, { mode: "promiseExit" });
+
+  const handleSwitch = async (organizationId: string) => {
+    if (organizationId === props.activeOrganizationId) return;
+    const exit = await doSwitchOrganization({ payload: { organizationId } });
+    if (exit._tag === "Success") window.location.reload();
+  };
+
+  return Result.match(organizations, {
+    onInitial: () => <DropdownMenuItem disabled>Loading…</DropdownMenuItem>,
+    onFailure: () => <DropdownMenuItem disabled>Failed to load organizations</DropdownMenuItem>,
+    onSuccess: ({ value }) =>
+      value.organizations.length === 0 ? (
+        <DropdownMenuItem disabled>No organizations</DropdownMenuItem>
+      ) : (
+        <>
+          {value.organizations.map((organization) => {
+            const isActive = organization.id === props.activeOrganizationId;
+            return (
+              <DropdownMenuItem
+                key={organization.id}
+                disabled={isActive}
+                onClick={() => handleSwitch(organization.id)}
+                className="text-xs"
+              >
+                <span className="min-w-0 flex-1 truncate">{organization.name}</span>
+                {isActive && <CheckIcon />}
+              </DropdownMenuItem>
+            );
+          })}
+        </>
+      ),
+  });
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" className="ml-auto size-3 text-muted-foreground">
+      <path
+        d="M3.5 8.5L6.5 11.5L12.5 5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 function UserFooter() {
   const auth = useAuth();
+  const doCreateOrganization = useAtomSet(createOrganization, { mode: "promiseExit" });
+  const [createOrganizationOpen, setCreateOrganizationOpen] = useState(false);
+  const [organizationName, setOrganizationName] = useState("");
+  const [createOrganizationError, setCreateOrganizationError] = useState<string | null>(null);
+  const [creatingOrganization, setCreatingOrganization] = useState(false);
   if (auth.status !== "authenticated") return null;
 
-  const initials = auth.user.name
-    ? auth.user.name
-        .split(" ")
-        .map((n) => n[0])
-        .join("")
-        .slice(0, 2)
-        .toUpperCase()
-    : auth.user.email[0]!.toUpperCase();
+  const suggestedOrganizationName =
+    auth.user.name?.trim() !== "" && auth.user.name != null
+      ? `${auth.user.name}'s Organization`
+      : "New Organization";
+
+  const openCreateOrganization = () => {
+    setOrganizationName(suggestedOrganizationName);
+    setCreateOrganizationError(null);
+    setCreateOrganizationOpen(true);
+  };
+
+  const handleCreateOrganization = async () => {
+    const name = organizationName.trim();
+    if (!name) {
+      setCreateOrganizationError("Organization name is required.");
+      return;
+    }
+
+    setCreatingOrganization(true);
+    setCreateOrganizationError(null);
+    const exit = await doCreateOrganization({ payload: { name } });
+    if (exit._tag === "Success") {
+      window.location.reload();
+    } else {
+      setCreateOrganizationError("Failed to create organization.");
+    }
+
+    setCreatingOrganization(false);
+  };
 
   return (
     <div className="shrink-0 border-t border-sidebar-border px-3 py-2.5">
-      <div className="flex items-center gap-2.5">
-        {auth.user.avatarUrl ? (
-          <img src={auth.user.avatarUrl} alt="" className="size-7 shrink-0 rounded-full" />
-        ) : (
-          <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
-            {initials}
-          </div>
-        )}
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-xs font-medium text-foreground">
-            {auth.user.name ?? auth.user.email}
-          </p>
-          {auth.organization && (
-            <p className="truncate text-xs text-muted-foreground">{auth.organization.name}</p>
-          )}
-        </div>
-        <form action={AUTH_PATHS.logout} method="post">
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            type="submit"
-            className="shrink-0 text-muted-foreground hover:bg-sidebar-active hover:text-foreground"
-            title="Sign out"
-          >
-            <svg viewBox="0 0 16 16" fill="none" className="size-3.5">
-              <path
-                d="M6 2H3.5A1.5 1.5 0 002 3.5v9A1.5 1.5 0 003.5 14H6M10.5 11.5L14 8l-3.5-3.5M14 8H6"
-                stroke="currentColor"
-                strokeWidth="1.2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
+      <Dialog
+        open={createOrganizationOpen}
+        onOpenChange={(open) => {
+          setCreateOrganizationOpen(open);
+          if (!open) {
+            setOrganizationName(suggestedOrganizationName);
+            setCreateOrganizationError(null);
+            setCreatingOrganization(false);
+          }
+        }}
+      >
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              className="flex h-auto w-full items-center justify-start gap-2.5 rounded-md px-1 py-1 text-left hover:bg-sidebar-active/60"
+            >
+              <Avatar
+                url={auth.user.avatarUrl}
+                name={auth.user.name}
+                email={auth.user.email}
               />
-            </svg>
-          </Button>
-        </form>
-      </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-xs font-medium text-foreground">
+                  {auth.user.name ?? auth.user.email}
+                </p>
+                {auth.organization && (
+                  <p className="truncate text-xs text-muted-foreground">{auth.organization.name}</p>
+                )}
+              </div>
+              <svg
+                viewBox="0 0 16 16"
+                fill="none"
+                className="size-3.5 shrink-0 text-muted-foreground"
+              >
+                <path
+                  d="M4 6l4 4 4-4"
+                  stroke="currentColor"
+                  strokeWidth="1.3"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" side="top" className="w-64">
+            <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+              Organization
+            </DropdownMenuLabel>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="text-xs">
+                <span className="min-w-0 flex-1 truncate">
+                  {auth.organization?.name ?? "No organization"}
+                </span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="w-56">
+                <OrganizationSwitcherItems activeOrganizationId={auth.organization?.id ?? null} />
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  className="text-xs"
+                  onSelect={(event) => {
+                    event.preventDefault();
+                    openCreateOrganization();
+                  }}
+                >
+                  Create organization
+                </DropdownMenuItem>
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+              Signed in as
+            </DropdownMenuLabel>
+            <DropdownMenuItem disabled className="gap-2 text-xs opacity-100">
+              <Avatar url={auth.user.avatarUrl} name={auth.user.name} email={auth.user.email} />
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-medium text-foreground">
+                  {auth.user.name ?? auth.user.email}
+                </p>
+                {auth.user.name && (
+                  <p className="truncate text-muted-foreground">{auth.user.email}</p>
+                )}
+              </div>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-xs text-destructive focus:text-destructive"
+              onClick={async () => {
+                await fetch(AUTH_PATHS.logout, { method: "POST" });
+                window.location.href = "/";
+              }}
+            >
+              Sign out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+
+        <DialogContent className="sm:max-w-[420px]">
+          <DialogHeader>
+            <DialogTitle className="font-display text-xl">Create organization</DialogTitle>
+            <DialogDescription className="text-sm leading-relaxed">
+              Add another organization under your current account and switch into it immediately.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-3">
+            <div className="grid gap-1.5">
+              <Label
+                htmlFor="organization-name"
+                className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
+              >
+                Organization name
+              </Label>
+              <Input
+                id="organization-name"
+                value={organizationName}
+                placeholder="Northwind Labs"
+                autoFocus
+                onChange={(event) => {
+                  setOrganizationName((event.target as HTMLInputElement).value);
+                  if (createOrganizationError) setCreateOrganizationError(null);
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") void handleCreateOrganization();
+                }}
+                className="h-9 text-sm"
+              />
+            </div>
+
+            {createOrganizationError && (
+              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+                <p className="text-sm text-destructive">{createOrganizationError}</p>
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost" size="sm" disabled={creatingOrganization}>
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              size="sm"
+              onClick={() => void handleCreateOrganization()}
+              disabled={!organizationName.trim() || creatingOrganization}
+            >
+              {creatingOrganization ? "Creating…" : "Create organization"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -1,6 +1,6 @@
 import { Link, Outlet, useLocation } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
-import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
 import { sourcesAtom } from "@executor/react/api/atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
@@ -34,7 +34,6 @@ import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/r
 import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
 import { AUTH_PATHS } from "../auth/api";
 import {
-  authAtom,
   createOrganization,
   organizationsAtom,
   switchOrganization,


### PR DESCRIPTION
## What changed
- simplify cloud auth down to a single WorkOS account with organization switching
- replace the browser `prompt()` flow with an in-app create-organization dialog in the shell menu
- rename the remaining auth-side workspace terminology to organization terminology

## Why
The previous add-account flow was fighting WorkOS/AuthKit session reuse and added a lot of cookie/UI complexity for a use case we do not actually need. The real requirement is switching organizations under the same user account.

## Impact
- users can switch organizations from the account menu and the app reloads to pick up the new scope cleanly
- users can create a new organization from the same menu and switch into it immediately
- the cloud auth/UI surface now consistently talks about organizations instead of workspaces

## Validation
- `./node_modules/.bin/vitest run --root apps/cloud --config vitest.unit.config.ts`
- `./node_modules/.bin/tsc --noEmit -p apps/cloud/tsconfig.json` (still reports pre-existing unrelated diagnostics in `apps/cloud/src/api/*` and `packages/plugins/workos-vault/*`)
