### PR TITLE
Track MCP tool executions in Autumn billing

### DIFF
--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -10,14 +10,18 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 import { createExecutorMcpServer } from "@executor/host-mcp";
+import { createExecutionEngine } from "@executor/execution";
 import { makeDynamicWorkerExecutor } from "@executor/runtime-dynamic-worker";
 import type { DrizzleDb } from "@executor/storage-postgres";
 import * as sharedSchema from "@executor/storage-postgres/schema";
 
+import { makeTrackExecutionUsage } from "./api/autumn";
+import { withExecutionUsageTracking } from "./api/execution-usage";
 import { UserStoreService } from "./auth/context";
 import { resolveOrganization } from "./auth/resolve-organization";
 import { WorkOSAuth } from "./auth/workos";
 import { server } from "./env";
+import { AutumnService } from "./services/autumn";
 import { createOrgExecutor } from "./services/executor";
 import { DbService } from "./services/db";
 import * as cloudSchema from "./services/schema";
@@ -107,7 +111,12 @@ export class McpSessionDO extends DurableObject {
 
     const DbLive = Layer.succeed(DbService, this.dbHandle.db);
     const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
-    const Services = Layer.mergeAll(DbLive, UserStoreLive, WorkOSAuth.Default);
+    const Services = Layer.mergeAll(
+      DbLive,
+      UserStoreLive,
+      WorkOSAuth.Default,
+      AutumnService.Default,
+    );
 
     const program = Effect.gen(function* () {
       const org = yield* resolveOrganization(token.organizationId);
@@ -116,7 +125,13 @@ export class McpSessionDO extends DurableObject {
 
       const executor = yield* createOrgExecutor(org.id, org.name);
       const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
-      return yield* Effect.promise(() => createExecutorMcpServer({ executor, codeExecutor }));
+      const autumn = yield* AutumnService;
+      const engine = withExecutionUsageTracking(
+        org.id,
+        createExecutionEngine({ executor, codeExecutor }),
+        makeTrackExecutionUsage(autumn),
+      );
+      return yield* Effect.promise(() => createExecutorMcpServer({ engine }));
     }).pipe(Effect.provide(Services));
 
     this.mcpServer = await Effect.runPromise(program);

--- a/bun.lock
+++ b/bun.lock
@@ -324,6 +324,7 @@
       "name": "@executor/codemode-core",
       "version": "1.4.3",
       "dependencies": {
+        "@babel/parser": "^7.29.2",
         "@standard-schema/spec": "^1.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",


### PR DESCRIPTION
## Summary
- MCP tool executions were not incrementing the Autumn `executions` feature because the session DO passed `{ executor, codeExecutor }` directly to `createExecutorMcpServer`, which builds a raw engine internally — bypassing the `withExecutionUsageTracking` wrapper that the HTTP API path in `api/protected.ts` uses.
- Build the engine explicitly in `McpSessionDO.init`, wrap it with `withExecutionUsageTracking(makeTrackExecutionUsage(autumn))`, and pass `{ engine }` to `createExecutorMcpServer`.
- Add `AutumnService.Default` to the DO's service layer so the tracker has a client.

## Test plan
- [ ] Connect via the cloud MCP endpoint and call the `execute` tool; confirm the Autumn customer's `executions` usage increments.
- [ ] Confirm HTTP API execution tracking still works (unchanged path).
- [ ] `resume` tool calls should not increment usage (matches existing `withExecutionUsageTracking` behavior).