### PR TITLE
Replace loading text with skeletons in cloud shell

### DIFF
--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/react";
 import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router";
 import { AutumnProvider } from "autumn-js/react";
 import { ExecutorProvider } from "@executor/react/api/provider";
+import { Skeleton } from "@executor/react/components/skeleton";
 import { Toaster } from "@executor/react/components/sonner";
 import { AuthProvider, useAuth } from "../web/auth";
 import { LoginPage } from "../web/pages/login";
@@ -68,15 +69,72 @@ function RootComponent() {
   );
 }
 
+function ShellSkeleton() {
+  return (
+    <div className="flex h-screen overflow-hidden">
+      {/* Desktop sidebar skeleton */}
+      <aside className="hidden w-52 shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col lg:w-56">
+        <div className="flex h-12 shrink-0 items-center border-b border-sidebar-border px-4">
+          <Skeleton className="h-4 w-20" />
+        </div>
+        <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-2">
+          <Skeleton className="h-7 w-full rounded-md" />
+          <Skeleton className="h-7 w-full rounded-md" />
+          <Skeleton className="h-7 w-full rounded-md" />
+          <Skeleton className="h-7 w-full rounded-md" />
+          <div className="mt-5 mb-2 px-2.5">
+            <Skeleton className="h-3 w-14" />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-7 w-11/12 rounded-md" />
+            <Skeleton className="h-7 w-10/12 rounded-md" />
+            <Skeleton className="h-7 w-9/12 rounded-md" />
+          </div>
+        </nav>
+        <div className="shrink-0 border-t border-sidebar-border px-3 py-2.5">
+          <div className="flex items-center gap-2.5">
+            <Skeleton className="size-7 rounded-full" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      {/* Main content skeleton */}
+      <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {/* Mobile top bar */}
+        <div className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:hidden">
+          <Skeleton className="size-7 rounded-md" />
+          <Skeleton className="h-4 w-20" />
+          <div className="w-7 shrink-0" />
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-6 px-6 py-8">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-2">
+              <Skeleton className="h-6 w-40" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+            <Skeleton className="h-8 w-28 rounded-md" />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-lg" />
+            ))}
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}
+
 function AuthGate() {
   const auth = useAuth();
 
   if (auth.status === "loading") {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-background">
-        <p className="text-sm text-muted-foreground">Loading...</p>
-      </div>
-    );
+    return <ShellSkeleton />;
   }
 
   if (auth.status === "unauthenticated") {
@@ -89,7 +147,7 @@ function AuthGate() {
 
   return (
     <AutumnProvider pathPrefix="/api/autumn">
-      <ExecutorProvider>
+      <ExecutorProvider fallback={<ShellSkeleton />}>
         <Shell />
         <Toaster />
       </ExecutorProvider>

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -4,6 +4,7 @@ import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
 import { sourcesAtom } from "@executor/react/api/atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import { Skeleton } from "@executor/react/components/skeleton";
 import {
   Dialog,
   DialogClose,
@@ -71,7 +72,14 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
 
   return Result.match(sources, {
     onInitial: () => (
-      <div className="px-2.5 py-2 text-xs text-muted-foreground">Loading…</div>
+      <div className="flex flex-col gap-1 px-2.5 py-1">
+        {[80, 65, 72, 58, 68].map((w, i) => (
+          <div key={i} className="flex items-center gap-2 rounded-md py-1.5">
+            <Skeleton className="size-3.5 shrink-0 rounded" />
+            <Skeleton className="h-3" style={{ width: `${w}%` }} />
+          </div>
+        ))}
+      </div>
     ),
     onFailure: () => (
       <div className="px-2.5 py-2 text-xs text-muted-foreground">No sources yet</div>

--- a/packages/react/src/api/provider.tsx
+++ b/packages/react/src/api/provider.tsx
@@ -2,8 +2,10 @@ import { RegistryProvider } from "@effect-atom/atom-react";
 import * as React from "react";
 import { ScopeProvider } from "./scope-context";
 
-export const ExecutorProvider = (props: React.PropsWithChildren) => (
+export const ExecutorProvider = (
+  props: React.PropsWithChildren<{ fallback?: React.ReactNode }>,
+) => (
   <RegistryProvider>
-    <ScopeProvider>{props.children}</ScopeProvider>
+    <ScopeProvider fallback={props.fallback}>{props.children}</ScopeProvider>
   </RegistryProvider>
 );

--- a/packages/react/src/api/scope-context.tsx
+++ b/packages/react/src/api/scope-context.tsx
@@ -14,17 +14,18 @@ const ScopeContext = React.createContext<ScopeInfo | null>(null);
 
 /**
  * Provides the server scope to all children.
- * Renders nothing until the scope is fetched.
+ * Renders the optional `fallback` until the scope is fetched.
  */
-export function ScopeProvider(props: React.PropsWithChildren) {
+export function ScopeProvider(
+  props: React.PropsWithChildren<{ fallback?: React.ReactNode }>,
+) {
   const result = useAtomValue(scopeAtom);
 
   if (Result.isSuccess(result)) {
     return <ScopeContext.Provider value={result.value}>{props.children}</ScopeContext.Provider>;
   }
 
-  // Loading or error — don't render children
-  return null;
+  return <>{props.fallback ?? null}</>;
 }
 
 /**

--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -15,6 +15,7 @@ import { useScope } from "../hooks/use-scope";
 import type { SourcePlugin } from "../plugins/source-plugin";
 import { Button } from "../components/button";
 import { Badge } from "../components/badge";
+import { Skeleton } from "../components/skeleton";
 
 export function SourceDetailPage(props: {
   namespace: string;
@@ -190,9 +191,7 @@ export function SourceDetailPage(props: {
       {editing && editPlugin ? (
         <div className="min-h-0 flex-1 overflow-y-auto">
           <div className="mx-auto max-w-2xl px-6 py-8">
-            <Suspense
-              fallback={<div className="p-6 text-sm text-muted-foreground">Loading...</div>}
-            >
+            <Suspense fallback={<EditFormSkeleton />}>
               <editPlugin.edit sourceId={namespace} onSave={handleEditSave} />
             </Suspense>
           </div>
@@ -200,7 +199,7 @@ export function SourceDetailPage(props: {
       ) : (
         /* Content -- split pane */
         Result.match(tools, {
-          onInitial: () => <div className="p-6 text-sm text-muted-foreground">Loading...</div>,
+          onInitial: () => <SourceDetailSkeleton />,
           onFailure: () => <div className="p-6 text-sm text-destructive">Failed to load tools</div>,
           onSuccess: () => (
             <div className="flex min-h-0 flex-1 overflow-hidden">
@@ -230,6 +229,65 @@ export function SourceDetailPage(props: {
           ),
         })
       )}
+    </div>
+  );
+}
+
+function SourceDetailSkeleton() {
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden">
+      {/* Left: tool tree skeleton */}
+      <div className="flex w-72 shrink-0 flex-col gap-1 border-r border-border/60 p-3 lg:w-80 xl:w-[22rem]">
+        <Skeleton className="mb-2 h-8 w-full rounded-md" />
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+            <Skeleton className="size-4 shrink-0 rounded" />
+            <Skeleton
+              className="h-3.5"
+              style={{ width: `${55 + ((i * 13) % 35)}%` }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Right: tool detail skeleton */}
+      <div className="flex min-w-0 flex-1 flex-col gap-6 overflow-hidden p-6">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-80" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-20 w-full rounded-md" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-20 w-full rounded-md" />
+        </div>
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+function EditFormSkeleton() {
+  return (
+    <div className="flex flex-col gap-5 p-6">
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-9 w-full rounded-md" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-9 w-full rounded-md" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-24 w-full rounded-md" />
+      </div>
+      <div className="flex justify-end gap-2 pt-2">
+        <Skeleton className="h-9 w-20 rounded-md" />
+        <Skeleton className="h-9 w-24 rounded-md" />
+      </div>
     </div>
   );
 }

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -21,6 +21,7 @@ import {
   CardStackEntryActions,
 } from "../components/card-stack";
 import { SourceFavicon } from "../components/source-favicon";
+import { Skeleton } from "../components/skeleton";
 
 const KIND_TO_PLUGIN_KEY: Record<string, string> = {
   openapi: "openapi",
@@ -144,7 +145,7 @@ export function SourcesPage(props: { sourcePlugins: readonly SourcePlugin[] }) {
         </div>
 
         {Result.match(sources, {
-          onInitial: () => <p className="text-sm text-muted-foreground">Loading…</p>,
+          onInitial: () => <SourcesGridSkeleton />,
           onFailure: () => <p className="text-sm text-destructive">Failed to load sources</p>,
           onSuccess: ({ value }) => {
             const connectedSources = value.filter((source) => !source.runtime);
@@ -292,6 +293,29 @@ function SourceGrid(props: {
               </CardStackEntryActions>
             </Link>
           </CardStackEntry>
+        ))}
+      </CardStackContent>
+    </CardStack>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton
+// ---------------------------------------------------------------------------
+
+function SourcesGridSkeleton() {
+  return (
+    <CardStack>
+      <CardStackContent>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-4 py-3">
+            <Skeleton className="size-8 shrink-0 rounded-md" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <Skeleton className="h-4" style={{ width: `${40 + ((i * 11) % 30)}%` }} />
+              <Skeleton className="h-3" style={{ width: `${25 + ((i * 7) % 20)}%` }} />
+            </div>
+            <Skeleton className="h-5 w-16 rounded-full" />
+          </div>
         ))}
       </CardStackContent>
     </CardStack>


### PR DESCRIPTION
## Summary
- Renders a full shell skeleton (sidebar nav, source list, user footer, main content) while auth is loading, instead of a centered "Loading..." text.
- Adds section-level skeletons for the sidebar `SourceList`, the sources page grid, and the source detail split-pane + plugin edit form.
- `ScopeProvider` / `ExecutorProvider` now accept a `fallback` so the shell skeleton stays visible through scope loading — previously rendered `null`, causing a blank flash between auth-gate skeleton and the real shell.

## Test plan
- [ ] Hard reload the cloud app while signed out → skeleton renders immediately, no text flash.
- [ ] Hard reload while signed in → skeleton persists through auth + scope load, then pops to real content without a blank intermediate frame.
- [ ] Navigate to a source detail page → tool tree + detail pane skeleton shows before tools resolve.
- [ ] Open a source's Edit view → form skeleton shows in the Suspense fallback.