### PR TITLE
Remove google-discovery plugin from cloud app

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -28,7 +28,6 @@
     "@executor/env": "workspace:*",
     "@executor/execution": "workspace:*",
     "@executor/host-mcp": "workspace:*",
-    "@executor/plugin-google-discovery": "workspace:*",
     "@executor/plugin-graphql": "workspace:*",
     "@executor/plugin-mcp": "workspace:*",
     "@executor/plugin-openapi": "workspace:*",

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -5,10 +5,6 @@ import { CoreExecutorApi } from "@executor/api";
 import { CoreHandlers } from "@executor/api/server";
 import { OpenApiGroup, OpenApiHandlers } from "@executor/plugin-openapi/api";
 import { McpGroup, McpHandlers } from "@executor/plugin-mcp/api";
-import {
-  GoogleDiscoveryGroup,
-  GoogleDiscoveryHandlers,
-} from "@executor/plugin-google-discovery/api";
 import { GraphqlGroup, GraphqlHandlers } from "@executor/plugin-graphql/api";
 
 import { OrgAuth } from "../auth/middleware";
@@ -27,7 +23,6 @@ import { OrgHandlers } from "../org/handlers";
 
 const ProtectedCloudApi = CoreExecutorApi.add(OpenApiGroup)
   .add(McpGroup)
-  .add(GoogleDiscoveryGroup)
   .add(GraphqlGroup)
   .middleware(OrgAuth);
 
@@ -50,7 +45,6 @@ export const ProtectedCloudApiLive = HttpApiBuilder.api(ProtectedCloudApi).pipe(
       CoreHandlers,
       OpenApiHandlers,
       McpHandlers,
-      GoogleDiscoveryHandlers,
       GraphqlHandlers,
       OrgAuthLive,
     ),

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -7,7 +7,6 @@ import { createExecutionEngine } from "@executor/execution";
 import { makeDynamicWorkerExecutor } from "@executor/runtime-dynamic-worker";
 import { OpenApiExtensionService } from "@executor/plugin-openapi/api";
 import { McpExtensionService } from "@executor/plugin-mcp/api";
-import { GoogleDiscoveryExtensionService } from "@executor/plugin-google-discovery/api";
 import { GraphqlExtensionService } from "@executor/plugin-graphql/api";
 
 import { authorizeOrganization } from "../auth/authorize-organization";
@@ -53,7 +52,6 @@ const createProtectedApp = (organizationId: string, organizationName: string) =>
       Layer.succeed(ExecutionEngineService, engine),
       Layer.succeed(OpenApiExtensionService, executor.openapi),
       Layer.succeed(McpExtensionService, executor.mcp),
-      Layer.succeed(GoogleDiscoveryExtensionService, executor.googleDiscovery),
       Layer.succeed(GraphqlExtensionService, executor.graphql),
     );
 

--- a/apps/cloud/src/routes/index.tsx
+++ b/apps/cloud/src/routes/index.tsx
@@ -2,15 +2,9 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SourcesPage } from "@executor/react/pages/sources";
 import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
 import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
 import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
 
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
+const sourcePlugins = [openApiSourcePlugin, mcpSourcePlugin, graphqlSourcePlugin];
 
 export const Route = createFileRoute("/")({
   component: () => <SourcesPage sourcePlugins={sourcePlugins} />,

--- a/apps/cloud/src/routes/sources.$namespace.tsx
+++ b/apps/cloud/src/routes/sources.$namespace.tsx
@@ -2,15 +2,9 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SourceDetailPage } from "@executor/react/pages/source-detail";
 import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
 import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
 import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
 
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
+const sourcePlugins = [openApiSourcePlugin, mcpSourcePlugin, graphqlSourcePlugin];
 
 export const Route = createFileRoute("/sources/$namespace")({
   component: () => {

--- a/apps/cloud/src/routes/sources.add.$pluginKey.tsx
+++ b/apps/cloud/src/routes/sources.add.$pluginKey.tsx
@@ -3,15 +3,9 @@ import { createFileRoute } from "@tanstack/react-router";
 import { SourcesAddPage } from "@executor/react/pages/sources-add";
 import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
 import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
 import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
 
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
+const sourcePlugins = [openApiSourcePlugin, mcpSourcePlugin, graphqlSourcePlugin];
 
 const SearchParams = Schema.standardSchemaV1(
   Schema.Struct({

--- a/apps/cloud/src/services/executor.ts
+++ b/apps/cloud/src/services/executor.ts
@@ -9,10 +9,6 @@ import { makePgKv, makePgPolicyEngine, makePgToolRegistry } from "@executor/stor
 import { openApiPlugin, makeKvOperationStore } from "@executor/plugin-openapi";
 import { mcpPlugin, makeKvBindingStore } from "@executor/plugin-mcp";
 import {
-  googleDiscoveryPlugin,
-  makeKvBindingStore as makeKvGoogleDiscoveryBindingStore,
-} from "@executor/plugin-google-discovery";
-import {
   graphqlPlugin,
   makeKvOperationStore as makeKvGraphqlOperationStore,
 } from "@executor/plugin-graphql";
@@ -59,9 +55,6 @@ export const createOrgExecutor = (
         }),
         mcpPlugin({
           bindingStore: makeKvBindingStore(kv, "mcp"),
-        }),
-        googleDiscoveryPlugin({
-          bindingStore: makeKvGoogleDiscoveryBindingStore(kv, "google-discovery"),
         }),
         graphqlPlugin({
           operationStore: makeKvGraphqlOperationStore(kv, "graphql"),

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -29,7 +29,6 @@ import { SourceFavicon } from "@executor/react/components/source-favicon";
 import { CommandPalette } from "@executor/react/components/command-palette";
 import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
 import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
 import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
 import { AUTH_PATHS } from "../auth/api";
 import { organizationsAtom, switchOrganization, useAuth } from "./auth";
@@ -41,7 +40,6 @@ import {
 const sourcePlugins = [
   openApiSourcePlugin,
   mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
   graphqlSourcePlugin,
 ];
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,6 @@
         "@executor/env": "workspace:*",
         "@executor/execution": "workspace:*",
         "@executor/host-mcp": "workspace:*",
-        "@executor/plugin-google-discovery": "workspace:*",
         "@executor/plugin-graphql": "workspace:*",
         "@executor/plugin-mcp": "workspace:*",
         "@executor/plugin-openapi": "workspace:*",


### PR DESCRIPTION
## Summary
- Drop `@executor/plugin-google-discovery` from `apps/cloud`: package dep, executor wiring, API layers/handlers, protected request services, and all source-plugin route/shell references.

## Test plan
- [x] `bun run typecheck` in `apps/cloud`