### PR TITLE
Scope cloud routes under /:org/:path

### DIFF
--- a/apps/cloud/drizzle/0001_bent_the_initiative.sql
+++ b/apps/cloud/drizzle/0001_bent_the_initiative.sql
@@ -1,0 +1,19 @@
+-- Add slug column to organizations (URL-safe identifier for routing).
+-- For existing rows, derive a deterministic slug from (name, id) that matches
+-- the application-level `makeOrganizationSlug` helper: slugified name +
+-- `-` + first 6 alphanumeric chars of the id after the `org_` prefix.
+ALTER TABLE "organizations" ADD COLUMN "slug" text;--> statement-breakpoint
+UPDATE "organizations"
+SET "slug" =
+  COALESCE(
+    NULLIF(regexp_replace(lower("name"), '[^a-z0-9]+', '-', 'g'), ''),
+    'org'
+  )
+  || '-'
+  || substring(
+    regexp_replace(lower(regexp_replace("id", '^org_', '')), '[^a-z0-9]', '', 'g')
+    from 1 for 6
+  )
+WHERE "slug" IS NULL;--> statement-breakpoint
+ALTER TABLE "organizations" ALTER COLUMN "slug" SET NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "organizations_slug_idx" ON "organizations" USING btree ("slug");

--- a/apps/cloud/drizzle/meta/0001_snapshot.json
+++ b/apps/cloud/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,525 @@
+{
+  "id": "d8f470b7-76db-4bab-a9c1-24696806bd0a",
+  "prevId": "1a3473eb-f8df-44f3-aaa4-16b1574e4a65",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_account_id_accounts_id_fk": {
+          "name": "memberships_account_id_accounts_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_account_id_organization_id_pk": {
+          "name": "memberships_account_id_organization_id_pk",
+          "columns": [
+            "account_id",
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_slug_idx": {
+          "name": "organizations_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_kv": {
+      "name": "plugin_kv",
+      "schema": "",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_kv_organization_id_namespace_key_pk": {
+          "name": "plugin_kv_organization_id_namespace_key_pk",
+          "columns": [
+            "organization_id",
+            "namespace",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.policies": {
+      "name": "policies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_tool_pattern": {
+          "name": "match_tool_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_source_id": {
+          "name": "match_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "policies_id_organization_id_pk": {
+          "name": "policies_id_organization_id_pk",
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.secrets": {
+      "name": "secrets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "iv": {
+          "name": "iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "secrets_id_organization_id_pk": {
+          "name": "secrets_id_organization_id_pk",
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sources": {
+      "name": "sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sources_id_organization_id_pk": {
+          "name": "sources_id_organization_id_pk",
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_definitions": {
+      "name": "tool_definitions",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tool_definitions_name_organization_id_pk": {
+          "name": "tool_definitions_name_organization_id_pk",
+          "columns": [
+            "name",
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tools": {
+      "name": "tools",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_key": {
+          "name": "plugin_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "may_elicit": {
+          "name": "may_elicit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "tools_id_organization_id_pk": {
+          "name": "tools_id_organization_id_pk",
+          "columns": [
+            "id",
+            "organization_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775764846378,
       "tag": "0000_redundant_night_nurse",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776190441873,
+      "tag": "0001_bent_the_initiative",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cloud/src/auth/api.ts
+++ b/apps/cloud/src/auth/api.ts
@@ -12,6 +12,7 @@ const AuthUser = Schema.Struct({
 
 const AuthOrganization = Schema.Struct({
   id: Schema.String,
+  slug: Schema.String,
   name: Schema.String,
 });
 
@@ -22,6 +23,7 @@ const AuthMeResponse = Schema.Struct({
 
 const AuthOrganizationSummary = Schema.Struct({
   id: Schema.String,
+  slug: Schema.String,
   name: Schema.String,
 });
 
@@ -40,6 +42,7 @@ const CreateOrganizationBody = Schema.Struct({
 
 const CreateOrganizationResponse = Schema.Struct({
   id: Schema.String,
+  slug: Schema.String,
   name: Schema.String,
 });
 

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -6,6 +6,7 @@ import { AUTH_PATHS, CloudAuthApi, CloudAuthPublicApi } from "./api";
 import { SessionContext } from "./middleware";
 import { UserStoreService } from "./context";
 import { authorizeOrganization } from "./authorize-organization";
+import { resolveOrganization } from "./resolve-organization";
 import { WorkOSError } from "./errors";
 import { WorkOSAuth } from "./workos";
 import { server } from "../env";
@@ -62,6 +63,7 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
           // memberships at all, leave the session org-less — the frontend
           // AuthGate will render the onboarding flow. We never auto-create
           // organizations on login.
+          let activeOrgId = result.organizationId ?? null;
           if (!result.organizationId && sealedSession) {
             const memberships = yield* workos.listUserMemberships(result.user.id);
             const existing = memberships.data[0];
@@ -70,7 +72,10 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
                 sealedSession,
                 existing.organizationId,
               );
-              if (refreshed) sealedSession = refreshed;
+              if (refreshed) {
+                sealedSession = refreshed;
+                activeOrgId = existing.organizationId;
+              }
             }
           }
 
@@ -79,7 +84,17 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
           }
 
           setCookie("wos-session", sealedSession, COOKIE_OPTIONS);
-          return HttpServerResponse.redirect("/", { status: 302 });
+          // Land the user directly on their active org's scoped URL. If we
+          // can't resolve a slug (no active org yet), fall back to root —
+          // the frontend AuthGate will render the onboarding flow from
+          // there and redirect out once an org exists.
+          const target = activeOrgId
+            ? yield* resolveOrganization(activeOrgId).pipe(
+                Effect.map((org) => `/${org.slug}/`),
+                Effect.orElseSucceed(() => "/"),
+              )
+            : "/";
+          return HttpServerResponse.redirect(target, { status: 302 });
         }),
       ),
 );
@@ -107,7 +122,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
               name: session.name,
               avatarUrl: session.avatarUrl,
             },
-            organization: org ? { id: org.id, name: org.name } : null,
+            organization: org ? { id: org.id, slug: org.slug, name: org.name } : null,
           };
         }),
       )
@@ -123,8 +138,8 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           const memberships = yield* workos.listUserMemberships(session.accountId);
           const organizations = yield* Effect.all(
             memberships.data.map((m) =>
-              workos.getOrganization(m.organizationId).pipe(
-                Effect.map((org) => ({ id: org.id, name: org.name })),
+              resolveOrganization(m.organizationId).pipe(
+                Effect.map((org) => ({ id: org.id, slug: org.slug, name: org.name })),
                 Effect.orElseSucceed(() => null),
               ),
             ),
@@ -160,7 +175,9 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           const name = payload.name.trim();
           const org = yield* workos.createOrganization(name);
           yield* workos.createMembership(org.id, session.accountId, "admin");
-          yield* users.use((s) => s.upsertOrganization({ id: org.id, name: org.name }));
+          const stored = yield* users.use((s) =>
+            s.upsertOrganization({ id: org.id, name: org.name }),
+          );
 
           // Try to attach the new org to the current session. This can fail
           // (or silently return a session still scoped to the old org) when
@@ -189,7 +206,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           }
 
           setCookie("wos-session", refreshed, COOKIE_OPTIONS);
-          return { id: org.id, name: org.name };
+          return { id: stored.id, slug: stored.slug, name: stored.name };
         }),
       ),
 );

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -9,33 +9,20 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ToolsRouteImport } from './routes/tools'
-import { Route as SecretsRouteImport } from './routes/secrets'
-import { Route as OrgRouteImport } from './routes/org'
-import { Route as BillingRouteImport } from './routes/billing'
+import { Route as OrgRouteImport } from './routes/$org'
 import { Route as IndexRouteImport } from './routes/index'
-import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
-import { Route as BillingPlansRouteImport } from './routes/billing_.plans'
-import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$pluginKey'
+import { Route as OrgIndexRouteImport } from './routes/$org/index'
+import { Route as OrgToolsRouteImport } from './routes/$org/tools'
+import { Route as OrgSettingsRouteImport } from './routes/$org/settings'
+import { Route as OrgSecretsRouteImport } from './routes/$org/secrets'
+import { Route as OrgBillingRouteImport } from './routes/$org/billing'
+import { Route as OrgSourcesNamespaceRouteImport } from './routes/$org/sources.$namespace'
+import { Route as OrgBillingPlansRouteImport } from './routes/$org/billing_.plans'
+import { Route as OrgSourcesAddPluginKeyRouteImport } from './routes/$org/sources.add.$pluginKey'
 
-const ToolsRoute = ToolsRouteImport.update({
-  id: '/tools',
-  path: '/tools',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SecretsRoute = SecretsRouteImport.update({
-  id: '/secrets',
-  path: '/secrets',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const OrgRoute = OrgRouteImport.update({
-  id: '/org',
-  path: '/org',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const BillingRoute = BillingRouteImport.update({
-  id: '/billing',
-  path: '/billing',
+  id: '/$org',
+  path: '/$org',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -43,125 +30,133 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
-const SourcesNamespaceRoute = SourcesNamespaceRouteImport.update({
+const OrgIndexRoute = OrgIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => OrgRoute,
+} as any)
+const OrgToolsRoute = OrgToolsRouteImport.update({
+  id: '/tools',
+  path: '/tools',
+  getParentRoute: () => OrgRoute,
+} as any)
+const OrgSettingsRoute = OrgSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => OrgRoute,
+} as any)
+const OrgSecretsRoute = OrgSecretsRouteImport.update({
+  id: '/secrets',
+  path: '/secrets',
+  getParentRoute: () => OrgRoute,
+} as any)
+const OrgBillingRoute = OrgBillingRouteImport.update({
+  id: '/billing',
+  path: '/billing',
+  getParentRoute: () => OrgRoute,
+} as any)
+const OrgSourcesNamespaceRoute = OrgSourcesNamespaceRouteImport.update({
   id: '/sources/$namespace',
   path: '/sources/$namespace',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => OrgRoute,
 } as any)
-const BillingPlansRoute = BillingPlansRouteImport.update({
+const OrgBillingPlansRoute = OrgBillingPlansRouteImport.update({
   id: '/billing_/plans',
   path: '/billing/plans',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => OrgRoute,
 } as any)
-const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
+const OrgSourcesAddPluginKeyRoute = OrgSourcesAddPluginKeyRouteImport.update({
   id: '/sources/add/$pluginKey',
   path: '/sources/add/$pluginKey',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => OrgRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/billing': typeof BillingRoute
-  '/org': typeof OrgRoute
-  '/secrets': typeof SecretsRoute
-  '/tools': typeof ToolsRoute
-  '/billing/plans': typeof BillingPlansRoute
-  '/sources/$namespace': typeof SourcesNamespaceRoute
-  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
+  '/$org': typeof OrgRouteWithChildren
+  '/$org/billing': typeof OrgBillingRoute
+  '/$org/secrets': typeof OrgSecretsRoute
+  '/$org/settings': typeof OrgSettingsRoute
+  '/$org/tools': typeof OrgToolsRoute
+  '/$org/': typeof OrgIndexRoute
+  '/$org/billing/plans': typeof OrgBillingPlansRoute
+  '/$org/sources/$namespace': typeof OrgSourcesNamespaceRoute
+  '/$org/sources/add/$pluginKey': typeof OrgSourcesAddPluginKeyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/billing': typeof BillingRoute
-  '/org': typeof OrgRoute
-  '/secrets': typeof SecretsRoute
-  '/tools': typeof ToolsRoute
-  '/billing/plans': typeof BillingPlansRoute
-  '/sources/$namespace': typeof SourcesNamespaceRoute
-  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
+  '/$org/billing': typeof OrgBillingRoute
+  '/$org/secrets': typeof OrgSecretsRoute
+  '/$org/settings': typeof OrgSettingsRoute
+  '/$org/tools': typeof OrgToolsRoute
+  '/$org': typeof OrgIndexRoute
+  '/$org/billing/plans': typeof OrgBillingPlansRoute
+  '/$org/sources/$namespace': typeof OrgSourcesNamespaceRoute
+  '/$org/sources/add/$pluginKey': typeof OrgSourcesAddPluginKeyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/billing': typeof BillingRoute
-  '/org': typeof OrgRoute
-  '/secrets': typeof SecretsRoute
-  '/tools': typeof ToolsRoute
-  '/billing_/plans': typeof BillingPlansRoute
-  '/sources/$namespace': typeof SourcesNamespaceRoute
-  '/sources/add/$pluginKey': typeof SourcesAddPluginKeyRoute
+  '/$org': typeof OrgRouteWithChildren
+  '/$org/billing': typeof OrgBillingRoute
+  '/$org/secrets': typeof OrgSecretsRoute
+  '/$org/settings': typeof OrgSettingsRoute
+  '/$org/tools': typeof OrgToolsRoute
+  '/$org/': typeof OrgIndexRoute
+  '/$org/billing_/plans': typeof OrgBillingPlansRoute
+  '/$org/sources/$namespace': typeof OrgSourcesNamespaceRoute
+  '/$org/sources/add/$pluginKey': typeof OrgSourcesAddPluginKeyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/billing'
-    | '/org'
-    | '/secrets'
-    | '/tools'
-    | '/billing/plans'
-    | '/sources/$namespace'
-    | '/sources/add/$pluginKey'
+    | '/$org'
+    | '/$org/billing'
+    | '/$org/secrets'
+    | '/$org/settings'
+    | '/$org/tools'
+    | '/$org/'
+    | '/$org/billing/plans'
+    | '/$org/sources/$namespace'
+    | '/$org/sources/add/$pluginKey'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
-    | '/billing'
-    | '/org'
-    | '/secrets'
-    | '/tools'
-    | '/billing/plans'
-    | '/sources/$namespace'
-    | '/sources/add/$pluginKey'
+    | '/$org/billing'
+    | '/$org/secrets'
+    | '/$org/settings'
+    | '/$org/tools'
+    | '/$org'
+    | '/$org/billing/plans'
+    | '/$org/sources/$namespace'
+    | '/$org/sources/add/$pluginKey'
   id:
     | '__root__'
     | '/'
-    | '/billing'
-    | '/org'
-    | '/secrets'
-    | '/tools'
-    | '/billing_/plans'
-    | '/sources/$namespace'
-    | '/sources/add/$pluginKey'
+    | '/$org'
+    | '/$org/billing'
+    | '/$org/secrets'
+    | '/$org/settings'
+    | '/$org/tools'
+    | '/$org/'
+    | '/$org/billing_/plans'
+    | '/$org/sources/$namespace'
+    | '/$org/sources/add/$pluginKey'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  BillingRoute: typeof BillingRoute
-  OrgRoute: typeof OrgRoute
-  SecretsRoute: typeof SecretsRoute
-  ToolsRoute: typeof ToolsRoute
-  BillingPlansRoute: typeof BillingPlansRoute
-  SourcesNamespaceRoute: typeof SourcesNamespaceRoute
-  SourcesAddPluginKeyRoute: typeof SourcesAddPluginKeyRoute
+  OrgRoute: typeof OrgRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/tools': {
-      id: '/tools'
-      path: '/tools'
-      fullPath: '/tools'
-      preLoaderRoute: typeof ToolsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/secrets': {
-      id: '/secrets'
-      path: '/secrets'
-      fullPath: '/secrets'
-      preLoaderRoute: typeof SecretsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/org': {
-      id: '/org'
-      path: '/org'
-      fullPath: '/org'
+    '/$org': {
+      id: '/$org'
+      path: '/$org'
+      fullPath: '/$org'
       preLoaderRoute: typeof OrgRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/billing': {
-      id: '/billing'
-      path: '/billing'
-      fullPath: '/billing'
-      preLoaderRoute: typeof BillingRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -171,39 +166,92 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/sources/$namespace': {
-      id: '/sources/$namespace'
+    '/$org/': {
+      id: '/$org/'
+      path: '/'
+      fullPath: '/$org/'
+      preLoaderRoute: typeof OrgIndexRouteImport
+      parentRoute: typeof OrgRoute
+    }
+    '/$org/tools': {
+      id: '/$org/tools'
+      path: '/tools'
+      fullPath: '/$org/tools'
+      preLoaderRoute: typeof OrgToolsRouteImport
+      parentRoute: typeof OrgRoute
+    }
+    '/$org/settings': {
+      id: '/$org/settings'
+      path: '/settings'
+      fullPath: '/$org/settings'
+      preLoaderRoute: typeof OrgSettingsRouteImport
+      parentRoute: typeof OrgRoute
+    }
+    '/$org/secrets': {
+      id: '/$org/secrets'
+      path: '/secrets'
+      fullPath: '/$org/secrets'
+      preLoaderRoute: typeof OrgSecretsRouteImport
+      parentRoute: typeof OrgRoute
+    }
+    '/$org/billing': {
+      id: '/$org/billing'
+      path: '/billing'
+      fullPath: '/$org/billing'
+      preLoaderRoute: typeof OrgBillingRouteImport
+      parentRoute: typeof OrgRoute
+    }
+    '/$org/sources/$namespace': {
+      id: '/$org/sources/$namespace'
       path: '/sources/$namespace'
-      fullPath: '/sources/$namespace'
-      preLoaderRoute: typeof SourcesNamespaceRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: '/$org/sources/$namespace'
+      preLoaderRoute: typeof OrgSourcesNamespaceRouteImport
+      parentRoute: typeof OrgRoute
     }
-    '/billing_/plans': {
-      id: '/billing_/plans'
+    '/$org/billing_/plans': {
+      id: '/$org/billing_/plans'
       path: '/billing/plans'
-      fullPath: '/billing/plans'
-      preLoaderRoute: typeof BillingPlansRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: '/$org/billing/plans'
+      preLoaderRoute: typeof OrgBillingPlansRouteImport
+      parentRoute: typeof OrgRoute
     }
-    '/sources/add/$pluginKey': {
-      id: '/sources/add/$pluginKey'
+    '/$org/sources/add/$pluginKey': {
+      id: '/$org/sources/add/$pluginKey'
       path: '/sources/add/$pluginKey'
-      fullPath: '/sources/add/$pluginKey'
-      preLoaderRoute: typeof SourcesAddPluginKeyRouteImport
-      parentRoute: typeof rootRouteImport
+      fullPath: '/$org/sources/add/$pluginKey'
+      preLoaderRoute: typeof OrgSourcesAddPluginKeyRouteImport
+      parentRoute: typeof OrgRoute
     }
   }
 }
 
+interface OrgRouteChildren {
+  OrgBillingRoute: typeof OrgBillingRoute
+  OrgSecretsRoute: typeof OrgSecretsRoute
+  OrgSettingsRoute: typeof OrgSettingsRoute
+  OrgToolsRoute: typeof OrgToolsRoute
+  OrgIndexRoute: typeof OrgIndexRoute
+  OrgBillingPlansRoute: typeof OrgBillingPlansRoute
+  OrgSourcesNamespaceRoute: typeof OrgSourcesNamespaceRoute
+  OrgSourcesAddPluginKeyRoute: typeof OrgSourcesAddPluginKeyRoute
+}
+
+const OrgRouteChildren: OrgRouteChildren = {
+  OrgBillingRoute: OrgBillingRoute,
+  OrgSecretsRoute: OrgSecretsRoute,
+  OrgSettingsRoute: OrgSettingsRoute,
+  OrgToolsRoute: OrgToolsRoute,
+  OrgIndexRoute: OrgIndexRoute,
+  OrgBillingPlansRoute: OrgBillingPlansRoute,
+  OrgSourcesNamespaceRoute: OrgSourcesNamespaceRoute,
+  OrgSourcesAddPluginKeyRoute: OrgSourcesAddPluginKeyRoute,
+}
+
+const OrgRouteWithChildren = OrgRoute._addFileChildren(OrgRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  BillingRoute: BillingRoute,
-  OrgRoute: OrgRoute,
-  SecretsRoute: SecretsRoute,
-  ToolsRoute: ToolsRoute,
-  BillingPlansRoute: BillingPlansRoute,
-  SourcesNamespaceRoute: SourcesNamespaceRoute,
-  SourcesAddPluginKeyRoute: SourcesAddPluginKeyRoute,
+  OrgRoute: OrgRouteWithChildren,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/cloud/src/routes/$org.tsx
+++ b/apps/cloud/src/routes/$org.tsx
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+import { Outlet, createFileRoute } from "@tanstack/react-router";
+import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
+
+import { organizationsAtom, switchOrganization, useAuth } from "../web/auth";
+
+// ---------------------------------------------------------------------------
+// /$org layout — scopes everything under an organization slug.
+//
+// The session cookie is the server-side source of truth for which org is
+// active. The slug in the URL is the *client-side* source of truth. When
+// they disagree we reconcile by calling switchOrganization (which mutates
+// the cookie) and reloading. Keeping the URL authoritative means links,
+// bookmarks and copy-pasted addresses all work without the user having to
+// manually flip orgs.
+// ---------------------------------------------------------------------------
+
+export const Route = createFileRoute("/$org")({
+  component: OrgLayout,
+});
+
+function OrgLayout() {
+  const { org: slug } = Route.useParams();
+  const auth = useAuth();
+  const organizationsResult = useAtomValue(organizationsAtom);
+  const doSwitch = useAtomSet(switchOrganization, { mode: "promiseExit" });
+
+  const activeSlug = auth.status === "authenticated" ? auth.organization?.slug ?? null : null;
+  const slugMatches = activeSlug === slug;
+
+  const targetOrg = Result.match(organizationsResult, {
+    onInitial: () => null,
+    onFailure: () => null,
+    onSuccess: ({ value }) => value.organizations.find((o) => o.slug === slug) ?? null,
+  });
+
+  useEffect(() => {
+    if (slugMatches) return;
+    if (!targetOrg) return;
+    let cancelled = false;
+    void doSwitch({ payload: { organizationId: targetOrg.id } }).then((exit) => {
+      if (cancelled) return;
+      if (exit._tag === "Success") window.location.reload();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [slugMatches, targetOrg, doSwitch]);
+
+  if (slugMatches) {
+    return <Outlet />;
+  }
+
+  // Mid-switch or looking up whether the user is a member of :org.
+  const lookupPending = Result.match(organizationsResult, {
+    onInitial: () => true,
+    onFailure: () => false,
+    onSuccess: () => false,
+  });
+
+  if (lookupPending || targetOrg) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-sm text-muted-foreground">Loading organization…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="max-w-sm text-center">
+        <p className="font-display text-2xl text-foreground">Organization not found</p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          You don't have access to <code className="font-mono">{slug}</code>, or it doesn't
+          exist.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/cloud/src/routes/$org/billing.tsx
+++ b/apps/cloud/src/routes/$org/billing.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@executor/react/components/badge";
 
 type Plan = NonNullable<ReturnType<typeof useListPlans>["data"]>[number];
 
-export const Route = createFileRoute("/billing")({
+export const Route = createFileRoute("/$org/billing")({
   component: BillingPage,
 });
 
@@ -16,6 +16,7 @@ const PLAN_TAGLINES: Record<string, string> = {
 };
 
 function BillingPage() {
+  const { org } = Route.useParams();
   const { data: customer, openCustomerPortal, isLoading: customerLoading } = useCustomer();
   const { data: plans, isLoading: plansLoading } = useListPlans();
 
@@ -101,7 +102,8 @@ function BillingPage() {
               </Button>
             )}
             <Link
-              to="/billing/plans"
+              to="/$org/billing/plans"
+              params={{ org }}
               className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
               Manage

--- a/apps/cloud/src/routes/$org/billing_.plans.tsx
+++ b/apps/cloud/src/routes/$org/billing_.plans.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@executor/react/components/badge";
 
 type Plan = NonNullable<ReturnType<typeof useListPlans>["data"]>[number];
 
-export const Route = createFileRoute("/billing_/plans")({
+export const Route = createFileRoute("/$org/billing_/plans")({
   component: PlansPage,
 });
 
@@ -68,6 +68,7 @@ const ENTERPRISE_MAILTO = `mailto:rhys@executor.sh?subject=${encodeURIComponent(
 )}`;
 
 function PlansPage() {
+  const { org } = Route.useParams();
   const { attach, openCustomerPortal, isLoading: customerLoading } = useCustomer();
   const { data: plans, isLoading: plansLoading, isFetching } = useListPlans();
   const [loadingPlan, setLoadingPlan] = useState<string | null>(null);
@@ -83,7 +84,8 @@ function PlansPage() {
       <div className="mx-auto max-w-5xl px-6 py-10 lg:px-10 lg:py-14">
         <div className="mb-8">
           <Link
-            to="/billing"
+            to="/$org/billing"
+            params={{ org }}
             className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors mb-4"
           >
             <svg viewBox="0 0 16 16" fill="none" className="size-3.5">

--- a/apps/cloud/src/routes/$org/index.tsx
+++ b/apps/cloud/src/routes/$org/index.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SourcesPage } from "@executor/react/pages/sources";
+import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
+import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
+import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
+import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
+
+const sourcePlugins = [
+  openApiSourcePlugin,
+  mcpSourcePlugin,
+  googleDiscoverySourcePlugin,
+  graphqlSourcePlugin,
+];
+
+export const Route = createFileRoute("/$org/")({
+  component: () => <SourcesPage sourcePlugins={sourcePlugins} />,
+});

--- a/apps/cloud/src/routes/$org/secrets.tsx
+++ b/apps/cloud/src/routes/$org/secrets.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { SecretsPage } from "@executor/react/pages/secrets";
 
-export const Route = createFileRoute("/secrets")({
+export const Route = createFileRoute("/$org/secrets")({
   component: () => (
     <SecretsPage
       secretProviderPlugins={[]}

--- a/apps/cloud/src/routes/$org/settings.tsx
+++ b/apps/cloud/src/routes/$org/settings.tsx
@@ -45,10 +45,10 @@ import {
   getDomainVerificationLink,
   deleteDomain,
   updateOrgName,
-} from "../web/org-atoms";
-import { authAtom, useAuth } from "../web/auth";
+} from "../../web/org-atoms";
+import { authAtom, useAuth } from "../../web/auth";
 
-export const Route = createFileRoute("/org")({
+export const Route = createFileRoute("/$org/settings")({
   component: OrgPage,
 });
 
@@ -103,6 +103,7 @@ function formatLastActive(lastActiveAt: string | null): string {
 }
 
 function OrgPage() {
+  const { org } = Route.useParams();
   const auth = useAuth();
   const orgName =
     auth.status === "authenticated" ? (auth.organization?.name ?? "Organization") : "Organization";
@@ -250,7 +251,7 @@ function OrgPage() {
               <p className="text-sm text-muted-foreground">
                 Domain verification is available on the Professional plan.
               </p>
-              <Link to="/billing/plans">
+              <Link to="/$org/billing/plans" params={{ org }}>
                 <Button size="sm" variant="outline">
                   Upgrade
                 </Button>
@@ -697,4 +698,3 @@ function InviteDialog(props: {
     </Dialog>
   );
 }
-

--- a/apps/cloud/src/routes/$org/sources.$namespace.tsx
+++ b/apps/cloud/src/routes/$org/sources.$namespace.tsx
@@ -12,7 +12,7 @@ const sourcePlugins = [
   graphqlSourcePlugin,
 ];
 
-export const Route = createFileRoute("/sources/$namespace")({
+export const Route = createFileRoute("/$org/sources/$namespace")({
   component: () => {
     const { namespace } = Route.useParams();
     return <SourceDetailPage namespace={namespace} sourcePlugins={sourcePlugins} />;

--- a/apps/cloud/src/routes/$org/sources.add.$pluginKey.tsx
+++ b/apps/cloud/src/routes/$org/sources.add.$pluginKey.tsx
@@ -21,7 +21,7 @@ const SearchParams = Schema.standardSchemaV1(
   }),
 );
 
-export const Route = createFileRoute("/sources/add/$pluginKey")({
+export const Route = createFileRoute("/$org/sources/add/$pluginKey")({
   validateSearch: SearchParams,
   component: () => {
     const { pluginKey } = Route.useParams();

--- a/apps/cloud/src/routes/$org/tools.tsx
+++ b/apps/cloud/src/routes/$org/tools.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ToolsPage } from "@executor/react/pages/tools";
 
-export const Route = createFileRoute("/tools")({
+export const Route = createFileRoute("/$org/tools")({
   component: ToolsPage,
 });

--- a/apps/cloud/src/routes/index.tsx
+++ b/apps/cloud/src/routes/index.tsx
@@ -1,17 +1,32 @@
-import { createFileRoute } from "@tanstack/react-router";
-import { SourcesPage } from "@executor/react/pages/sources";
-import { openApiSourcePlugin } from "@executor/plugin-openapi/react";
-import { mcpSourcePlugin } from "@executor/plugin-mcp/react";
-import { googleDiscoverySourcePlugin } from "@executor/plugin-google-discovery/react";
-import { graphqlSourcePlugin } from "@executor/plugin-graphql/react";
+import { useEffect } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 
-const sourcePlugins = [
-  openApiSourcePlugin,
-  mcpSourcePlugin,
-  googleDiscoverySourcePlugin,
-  graphqlSourcePlugin,
-];
+import { useAuth } from "../web/auth";
+
+// ---------------------------------------------------------------------------
+// `/` — lands the user on their active organization's scoped URL.
+//
+// AuthGate in __root already guarantees we only mount this when the user is
+// authenticated and has an org, so we can assume `auth.organization` is set.
+// ---------------------------------------------------------------------------
 
 export const Route = createFileRoute("/")({
-  component: () => <SourcesPage sourcePlugins={sourcePlugins} />,
+  component: IndexRedirect,
 });
+
+function IndexRedirect() {
+  const auth = useAuth();
+  const navigate = useNavigate();
+  const slug = auth.status === "authenticated" ? auth.organization?.slug ?? null : null;
+
+  useEffect(() => {
+    if (!slug) return;
+    void navigate({ to: "/$org", params: { org: slug }, replace: true });
+  }, [slug, navigate]);
+
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <p className="text-sm text-muted-foreground">Loading…</p>
+    </div>
+  );
+}

--- a/apps/cloud/src/services/db.test.ts
+++ b/apps/cloud/src/services/db.test.ts
@@ -110,8 +110,8 @@ describe("DbService", () => {
             const db = yield* DbService;
             return yield* Effect.promise(() => makeUserStore(db).getOrganization(orgId));
           }).pipe(Effect.provide(DbService.Live)),
-        ) as Effect.Effect<{ id: string; name: string } | null, never, never>;
-      }) as Effect.Effect<{ id: string; name: string } | null, never, never>,
+        ) as Effect.Effect<{ id: string; slug: string; name: string } | null, never, never>;
+      }) as Effect.Effect<{ id: string; slug: string; name: string } | null, never, never>,
     );
 
     expect(result?.id).toBe(orgId);

--- a/apps/cloud/src/services/schema.ts
+++ b/apps/cloud/src/services/schema.ts
@@ -11,7 +11,7 @@
 // We do NOT mirror invitations or user profile data — those stay in WorkOS
 // and are queried via API when needed.
 
-import { pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, primaryKey, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
 
 /** Login identity. The `id` is the WorkOS user ID. */
 export const accounts = pgTable("accounts", {
@@ -19,12 +19,25 @@ export const accounts = pgTable("accounts", {
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
-/** Organization (billing entity, scoping root). The `id` is the WorkOS organization ID. */
-export const organizations = pgTable("organizations", {
-  id: text("id").primaryKey(),
-  name: text("name").notNull(),
-  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
-});
+/**
+ * Organization (billing entity, scoping root). The `id` is the WorkOS
+ * organization ID; the `slug` is a URL-safe identifier used for routing
+ * (e.g. `/acme/secrets`). Slugs are generated from `name` at upsert time
+ * and disambiguated with a short hash of the org id, so they are stable
+ * across renames.
+ */
+export const organizations = pgTable(
+  "organizations",
+  {
+    id: text("id").primaryKey(),
+    slug: text("slug").notNull(),
+    name: text("name").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    slugIdx: uniqueIndex("organizations_slug_idx").on(t.slug),
+  }),
+);
 
 /**
  * Account ↔ organization link. Lets us answer "which workspaces does this

--- a/apps/cloud/src/services/slug.ts
+++ b/apps/cloud/src/services/slug.ts
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// Organization slug generation
+// ---------------------------------------------------------------------------
+//
+// Slugs are derived from the organization's display name and disambiguated
+// with a short, deterministic suffix sourced from the WorkOS organization
+// ID. This means two orgs with identical names still get different slugs,
+// and the slug stays stable across renames (suffix is tied to id, not name).
+//
+// The slug shape is `<slugified-name>-<suffix>`. Suffix is the first 6
+// alphanumeric characters of the id after the `org_` prefix, lowercased.
+// Example: id="org_01HABC...XYZ", name="Acme Inc" → slug="acme-inc-01habc".
+
+const slugifyName = (name: string): string => {
+  const normalized = name
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized === "" ? "org" : normalized;
+};
+
+const idSuffix = (id: string): string => {
+  const stripped = id.replace(/^org_/, "").toLowerCase();
+  const alnum = stripped.replace(/[^a-z0-9]/g, "");
+  const candidate = alnum.slice(0, 6);
+  return candidate === "" ? "x" : candidate;
+};
+
+export const makeOrganizationSlug = (args: { id: string; name: string }): string =>
+  `${slugifyName(args.name)}-${idSuffix(args.id)}`;

--- a/apps/cloud/src/services/user-store.ts
+++ b/apps/cloud/src/services/user-store.ts
@@ -10,6 +10,7 @@
 import { eq } from "drizzle-orm";
 
 import { accounts, organizations } from "./schema";
+import { makeOrganizationSlug } from "./slug";
 import type { DrizzleDb } from "@executor/storage-postgres";
 
 export type Account = typeof accounts.$inferSelect;
@@ -31,9 +32,14 @@ export const makeUserStore = (db: DrizzleDb) => ({
   // --- Organizations ---
 
   upsertOrganization: async (org: { id: string; name: string }) => {
+    const slug = makeOrganizationSlug(org);
+    // We intentionally do NOT update `slug` on conflict — it is derived
+    // from (id, name) but must remain stable for bookmarked URLs even if
+    // the org is renamed. New orgs get a fresh slug on insert; existing
+    // orgs keep whatever slug they already had.
     const [result] = await db
       .insert(organizations)
-      .values(org)
+      .values({ ...org, slug })
       .onConflictDoUpdate({
         target: organizations.id,
         set: { name: org.name },
@@ -44,6 +50,11 @@ export const makeUserStore = (db: DrizzleDb) => ({
 
   getOrganization: async (id: string) => {
     const rows = await db.select().from(organizations).where(eq(organizations.id, id));
+    return rows[0] ?? null;
+  },
+
+  getOrganizationBySlug: async (slug: string) => {
+    const rows = await db.select().from(organizations).where(eq(organizations.slug, slug));
     return rows[0] ?? null;
   },
 });

--- a/apps/cloud/src/web/auth.tsx
+++ b/apps/cloud/src/web/auth.tsx
@@ -17,6 +17,7 @@ type AuthUser = {
 
 type AuthOrganization = {
   id: string;
+  slug: string;
   name: string;
 };
 

--- a/apps/cloud/src/web/components/create-organization-form.tsx
+++ b/apps/cloud/src/web/components/create-organization-form.tsx
@@ -5,7 +5,7 @@ import { Label } from "@executor/react/components/label";
 
 import { createOrganization } from "../auth";
 
-type CreatedOrganization = { id: string; name: string };
+type CreatedOrganization = { id: string; slug: string; name: string };
 
 export function useCreateOrganizationForm(options: {
   defaultName?: string;

--- a/apps/cloud/src/web/pages/onboarding.tsx
+++ b/apps/cloud/src/web/pages/onboarding.tsx
@@ -21,12 +21,14 @@ export const OnboardingPage = () => {
 
   const form = useCreateOrganizationForm({
     defaultName: suggestedName,
-    // On success: the server set a new cookie with the new org; refetch /me
-    // so AuthGate routes into Shell.
-    // On failure: the server may have cleared the cookie because the current
-    // session was too stale to attach the new org. Refetch /me regardless so
-    // AuthGate can route to LoginPage if that's the case.
-    onSuccess: () => refreshAuth(),
+    // On success: the server set a new cookie with the new org. Hard-
+    // navigate to the new org's scoped URL so we land directly on the
+    // `/${slug}/` route rather than bouncing through `/` and an extra
+    // AuthGate cycle.
+    // On failure: the server may have cleared the cookie because the
+    // current session was too stale to attach the new org. Refetch /me
+    // so AuthGate can route to LoginPage if that's the case.
+    onSuccess: (org) => window.location.assign(`/${org.slug}/`),
     onFailure: () => refreshAuth(),
   });
 

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -1,7 +1,8 @@
 import { Link, Outlet, useLocation } from "@tanstack/react-router";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
 import { sourcesAtom } from "@executor/react/api/atoms";
+import { RoutesProvider, type AppRoutes } from "@executor/react/api/routes-context";
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
 import {
@@ -45,27 +46,78 @@ const sourcePlugins = [
 ];
 
 // ── NavItem ──────────────────────────────────────────────────────────────
+//
+// The cloud sidebar only links to the top-level `/$org/*` routes. TanStack's
+// Link is typed against the generated route tree, so rather than trying to
+// thread a generic `to` through we bind directly here. The caller passes a
+// `kind` discriminator and we render the matching Link.
 
-function NavItem(props: { to: string; label: string; active: boolean; onNavigate?: () => void }) {
-  return (
-    <Link
-      to={props.to}
-      onClick={props.onNavigate}
-      className={[
-        "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
-        props.active
-          ? "bg-sidebar-active text-foreground font-medium"
-          : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
-      ].join(" ")}
-    >
-      {props.label}
-    </Link>
-  );
+type NavItemKind = "home" | "secrets" | "settings" | "billing";
+
+type NavItemProps = {
+  kind: NavItemKind;
+  params: { org: string };
+  label: string;
+  active: boolean;
+  onNavigate?: () => void;
+};
+
+function NavItem(props: NavItemProps) {
+  const className = [
+    "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
+    props.active
+      ? "bg-sidebar-active text-foreground font-medium"
+      : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
+  ].join(" ");
+
+  const label = props.label;
+
+  switch (props.kind) {
+    case "home":
+      return (
+        <Link to="/$org" params={props.params} onClick={props.onNavigate} className={className}>
+          {label}
+        </Link>
+      );
+    case "secrets":
+      return (
+        <Link
+          to="/$org/secrets"
+          params={props.params}
+          onClick={props.onNavigate}
+          className={className}
+        >
+          {label}
+        </Link>
+      );
+    case "settings":
+      return (
+        <Link
+          to="/$org/settings"
+          params={props.params}
+          onClick={props.onNavigate}
+          className={className}
+        >
+          {label}
+        </Link>
+      );
+    case "billing":
+      return (
+        <Link
+          to="/$org/billing"
+          params={props.params}
+          onClick={props.onNavigate}
+          className={className}
+        >
+          {label}
+        </Link>
+      );
+  }
 }
 
 // ── SourceList ───────────────────────────────────────────────────────────
 
-function SourceList(props: { pathname: string; onNavigate?: () => void }) {
+function SourceList(props: { pathname: string; orgSlug: string; onNavigate?: () => void }) {
   const scopeId = useScope();
   const sources = useAtomValue(sourcesAtom(scopeId));
 
@@ -84,14 +136,14 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
       ) : (
         <div className="flex flex-col gap-px">
           {value.map((s) => {
-            const detailPath = `/sources/${s.id}`;
+            const detailPath = `/${props.orgSlug}/sources/${s.id}`;
             const active =
               props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
             return (
               <Link
                 key={s.id}
-                to="/sources/$namespace"
-                params={{ namespace: s.id }}
+                to="/$org/sources/$namespace"
+                params={{ org: props.orgSlug, namespace: s.id }}
                 onClick={props.onNavigate}
                 className={[
                   "group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors",
@@ -146,10 +198,14 @@ function OrganizationSwitcherItems(props: { activeOrganizationId: string | null 
   const organizations = useAtomValue(organizationsAtom);
   const doSwitchOrganization = useAtomSet(switchOrganization, { mode: "promiseExit" });
 
-  const handleSwitch = async (organizationId: string) => {
+  const handleSwitch = async (organizationId: string, slug: string) => {
     if (organizationId === props.activeOrganizationId) return;
     const exit = await doSwitchOrganization({ payload: { organizationId } });
-    if (exit._tag === "Success") window.location.reload();
+    // Hard-navigate to the new org's scoped URL. A plain reload would
+    // keep us on the current `/:oldSlug/...` path and immediately trip
+    // the slug-mismatch reconcile in the $org layout, causing a second
+    // round-trip; jumping straight to the new slug is one hop.
+    if (exit._tag === "Success") window.location.assign(`/${slug}/`);
   };
 
   return Result.match(organizations, {
@@ -166,7 +222,7 @@ function OrganizationSwitcherItems(props: { activeOrganizationId: string | null 
               <DropdownMenuItem
                 key={organization.id}
                 disabled={isActive}
-                onClick={() => handleSwitch(organization.id)}
+                onClick={() => handleSwitch(organization.id, organization.slug)}
                 className="text-xs"
               >
                 <span className="min-w-0 flex-1 truncate">{organization.name}</span>
@@ -206,7 +262,7 @@ function UserFooter() {
 
   const form = useCreateOrganizationForm({
     defaultName: suggestedOrganizationName,
-    onSuccess: () => window.location.reload(),
+    onSuccess: (org) => window.location.assign(`/${org.slug}/`),
   });
 
   if (auth.status !== "authenticated") return null;
@@ -351,33 +407,69 @@ function UserFooter() {
 
 // ── SidebarContent ───────────────────────────────────────────────────────
 
-function SidebarContent(props: { pathname: string; onNavigate?: () => void; showBrand?: boolean }) {
-  const isHome = props.pathname === "/";
-  const isSecrets = props.pathname === "/secrets";
-  const isBilling = props.pathname === "/billing" || props.pathname.startsWith("/billing/");
-  const isOrg = props.pathname === "/org";
+function SidebarContent(props: {
+  pathname: string;
+  orgSlug: string;
+  onNavigate?: () => void;
+  showBrand?: boolean;
+}) {
+  const base = `/${props.orgSlug}`;
+  const isHome = props.pathname === base || props.pathname === `${base}/`;
+  const isSecrets = props.pathname === `${base}/secrets`;
+  const isBilling =
+    props.pathname === `${base}/billing` || props.pathname.startsWith(`${base}/billing/`);
+  const isSettings = props.pathname === `${base}/settings`;
+  const params = { org: props.orgSlug };
 
   return (
     <>
       {props.showBrand !== false && (
         <div className="flex h-12 shrink-0 items-center border-b border-sidebar-border px-4">
-          <Link to="/" className="flex items-center gap-1.5">
+          <Link to="/$org" params={params} className="flex items-center gap-1.5">
             <span className="font-display text-base tracking-tight text-foreground">executor</span>
           </Link>
         </div>
       )}
 
       <nav className="flex flex-1 flex-col overflow-y-auto p-2">
-        <NavItem to="/" label="Sources" active={isHome} onNavigate={props.onNavigate} />
-        <NavItem to="/secrets" label="Secrets" active={isSecrets} onNavigate={props.onNavigate} />
-        <NavItem to="/org" label="Organization" active={isOrg} onNavigate={props.onNavigate} />
-        <NavItem to="/billing" label="Billing" active={isBilling} onNavigate={props.onNavigate} />
+        <NavItem
+          kind="home"
+          params={params}
+          label="Sources"
+          active={isHome}
+          onNavigate={props.onNavigate}
+        />
+        <NavItem
+          kind="secrets"
+          params={params}
+          label="Secrets"
+          active={isSecrets}
+          onNavigate={props.onNavigate}
+        />
+        <NavItem
+          kind="settings"
+          params={params}
+          label="Organization"
+          active={isSettings}
+          onNavigate={props.onNavigate}
+        />
+        <NavItem
+          kind="billing"
+          params={params}
+          label="Billing"
+          active={isBilling}
+          onNavigate={props.onNavigate}
+        />
 
         <div className="mt-5 mb-1 px-2.5 text-xs font-medium uppercase tracking-widest text-muted-foreground">
           <span>Sources</span>
         </div>
 
-        <SourceList pathname={props.pathname} onNavigate={props.onNavigate} />
+        <SourceList
+          pathname={props.pathname}
+          orgSlug={props.orgSlug}
+          onNavigate={props.onNavigate}
+        />
       </nav>
 
       <UserFooter />
@@ -390,6 +482,27 @@ function SidebarContent(props: { pathname: string; onNavigate?: () => void; show
 export function Shell() {
   const location = useLocation();
   const pathname = location.pathname;
+  const auth = useAuth();
+  // AuthGate only mounts Shell once we have an authenticated user with an
+  // active org, so the slug is guaranteed present. We fall back to an empty
+  // string to keep types happy — if it's missing we render nothing below.
+  const orgSlug =
+    auth.status === "authenticated" && auth.organization ? auth.organization.slug : "";
+  const cloudRoutes = useMemo<AppRoutes>(
+    () => ({
+      home: { to: "/$org", params: { org: orgSlug } },
+      sourceDetail: (sourceId) => ({
+        to: "/$org/sources/$namespace",
+        params: { org: orgSlug, namespace: sourceId },
+      }),
+      sourcesAdd: (pluginKey, search) => ({
+        to: "/$org/sources/add/$pluginKey",
+        params: { org: orgSlug, pluginKey },
+        search,
+      }),
+    }),
+    [orgSlug],
+  );
   const lastPathname = useRef(pathname);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   if (lastPathname.current !== pathname) {
@@ -408,11 +521,12 @@ export function Shell() {
   }, [mobileSidebarOpen]);
 
   return (
-    <div className="flex h-screen overflow-hidden">
-      <CommandPalette sourcePlugins={sourcePlugins} />
+    <RoutesProvider value={cloudRoutes}>
+      <div className="flex h-screen overflow-hidden">
+        <CommandPalette sourcePlugins={sourcePlugins} />
       {/* Desktop sidebar */}
       <aside className="hidden w-52 shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col lg:w-56">
-        <SidebarContent pathname={pathname} />
+        <SidebarContent pathname={pathname} orgSlug={orgSlug} />
       </aside>
 
       {/* Mobile sidebar overlay */}
@@ -427,7 +541,7 @@ export function Shell() {
           />
           <div className="relative flex h-full w-[84vw] max-w-xs flex-col border-r border-sidebar-border bg-sidebar shadow-2xl">
             <div className="flex h-12 shrink-0 items-center justify-between border-b border-sidebar-border px-4">
-              <Link to="/" className="flex items-center gap-1.5">
+              <Link to="/$org" params={{ org: orgSlug }} className="flex items-center gap-1.5">
                 <span className="font-display text-base tracking-tight text-foreground">
                   executor
                 </span>
@@ -452,6 +566,7 @@ export function Shell() {
             </div>
             <SidebarContent
               pathname={pathname}
+              orgSlug={orgSlug}
               onNavigate={() => setMobileSidebarOpen(false)}
               showBrand={false}
             />
@@ -480,14 +595,15 @@ export function Shell() {
               />
             </svg>
           </Button>
-          <Link to="/" className="flex items-center gap-1.5">
+          <Link to="/$org" params={{ org: orgSlug }} className="flex items-center gap-1.5">
             <span className="font-display text-base tracking-tight text-foreground">executor</span>
           </Link>
           <div className="w-8 shrink-0" />
         </div>
 
         <Outlet />
-      </main>
-    </div>
+        </main>
+      </div>
+    </RoutesProvider>
   );
 }

--- a/apps/local/src/routes/__root.tsx
+++ b/apps/local/src/routes/__root.tsx
@@ -1,16 +1,35 @@
 import React from "react";
 import { createRootRoute } from "@tanstack/react-router";
 import { ExecutorProvider } from "@executor/react/api/provider";
+import { RoutesProvider, type AppRoutes } from "@executor/react/api/routes-context";
 import { Shell } from "../web/shell";
 
 export const Route = createRootRoute({
   component: RootComponent,
 });
 
+// Local app still lives at the root — no workspace slug yet. When we add
+// multi-workspace support this is where the workspace param gets threaded
+// through the AppRoutes builder.
+const localRoutes: AppRoutes = {
+  home: { to: "/" },
+  sourceDetail: (sourceId) => ({
+    to: "/sources/$namespace",
+    params: { namespace: sourceId },
+  }),
+  sourcesAdd: (pluginKey, search) => ({
+    to: "/sources/add/$pluginKey",
+    params: { pluginKey },
+    search,
+  }),
+};
+
 function RootComponent() {
   return (
     <ExecutorProvider>
-      <Shell />
+      <RoutesProvider value={localRoutes}>
+        <Shell />
+      </RoutesProvider>
     </ExecutorProvider>
   );
 }

--- a/packages/react/src/api/routes-context.tsx
+++ b/packages/react/src/api/routes-context.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+import { Link, useNavigate } from "@tanstack/react-router";
+
+// ---------------------------------------------------------------------------
+// Routes context
+// ---------------------------------------------------------------------------
+//
+// Shared pages (sources, source-detail, sources-add) and shared components
+// (command-palette) need to navigate to app-specific routes. Cloud mounts
+// these under `/$org/*` (org-scoped) while local mounts them at the root.
+// Instead of hardcoding route literals inside the shared package, each host
+// app provides an `AppRoutes` object that returns concrete TanStack Router
+// `to`/`params`/`search` triples. Shared components consume it via
+// `useRoutes()` and render links via `<RouteLink>`.
+// ---------------------------------------------------------------------------
+
+export type RouteTarget = {
+  to: string;
+  params?: Record<string, string>;
+  search?: Record<string, unknown>;
+  replace?: boolean;
+};
+
+export interface AppRoutes {
+  home: RouteTarget;
+  sourceDetail: (sourceId: string) => RouteTarget;
+  sourcesAdd: (pluginKey: string, search?: Record<string, unknown>) => RouteTarget;
+}
+
+const RoutesContext = React.createContext<AppRoutes | null>(null);
+
+export function RoutesProvider(props: { value: AppRoutes; children: React.ReactNode }) {
+  return <RoutesContext.Provider value={props.value}>{props.children}</RoutesContext.Provider>;
+}
+
+export function useRoutes(): AppRoutes {
+  const ctx = React.useContext(RoutesContext);
+  if (ctx === null) {
+    throw new Error("useRoutes must be used inside a RoutesProvider");
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// RouteLink — spreads a RouteTarget onto TanStack `<Link>`.
+//
+// TanStack Router's Link types are derived from the generated route tree,
+// which is per-app. Shared package can't know that tree, so we cast here —
+// host apps are responsible for returning valid targets from their
+// AppRoutes implementation.
+// ---------------------------------------------------------------------------
+
+type LinkOwnProps = Omit<
+  React.ComponentProps<"a">,
+  "href" | "onClick" | "onFocus" | "onMouseEnter" | "onTouchStart"
+>;
+
+export function RouteLink(
+  props: LinkOwnProps & {
+    route: RouteTarget;
+    children?: React.ReactNode;
+  },
+) {
+  const { route, children, ...rest } = props;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const LinkAny = Link as any;
+  return (
+    <LinkAny {...(route as Record<string, unknown>)} {...rest}>
+      {children}
+    </LinkAny>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// useAppNavigate — a typed-loose wrapper around useNavigate.
+// ---------------------------------------------------------------------------
+
+export function useAppNavigate(): (target: RouteTarget) => void {
+  const navigate = useNavigate();
+  return React.useCallback(
+    (target: RouteTarget) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      void (navigate as any)(target);
+    },
+    [navigate],
+  );
+}

--- a/packages/react/src/components/command-palette.tsx
+++ b/packages/react/src/components/command-palette.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { useAtomValue, Result } from "@effect-atom/atom-react";
 import { PlusIcon } from "lucide-react";
 import { SourceFavicon } from "./source-favicon";
 import { sourcesAtom } from "../api/atoms";
+import { useRoutes, useAppNavigate } from "../api/routes-context";
 import { useScope } from "../hooks/use-scope";
 import type { SourcePlugin } from "../plugins/source-plugin";
 import {
@@ -29,7 +29,8 @@ import {
 export function CommandPalette(props: { sourcePlugins: readonly SourcePlugin[] }) {
   const { sourcePlugins } = props;
   const [open, setOpen] = useState(false);
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
+  const routes = useRoutes();
   const scopeId = useScope();
   const sourcesResult = useAtomValue(sourcesAtom(scopeId));
 
@@ -100,20 +101,17 @@ export function CommandPalette(props: { sourcePlugins: readonly SourcePlugin[] }
   const goToSource = useCallback(
     (id: string) => {
       close();
-      void navigate({ to: "/sources/$namespace", params: { namespace: id } });
+      navigate(routes.sourceDetail(id));
     },
-    [close, navigate],
+    [close, navigate, routes],
   );
 
   const goToAdd = useCallback(
     (pluginKey: string) => {
       close();
-      void navigate({
-        to: "/sources/add/$pluginKey",
-        params: { pluginKey },
-      });
+      navigate(routes.sourcesAdd(pluginKey));
     },
-    [close, navigate],
+    [close, navigate, routes],
   );
 
   const goToPreset = useCallback(
@@ -121,13 +119,9 @@ export function CommandPalette(props: { sourcePlugins: readonly SourcePlugin[] }
       close();
       const search: Record<string, string> = { preset: presetId };
       if (presetUrl) search.url = presetUrl;
-      void navigate({
-        to: "/sources/add/$pluginKey",
-        params: { pluginKey },
-        search,
-      });
+      navigate(routes.sourcesAdd(pluginKey, search));
     },
-    [close, navigate],
+    [close, navigate, routes],
   );
 
   return (

--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useEffect, useMemo, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
 import { useAtomValue, useAtomSet, useAtomRefresh, Result } from "@effect-atom/atom-react";
+import { useRoutes, useAppNavigate } from "../api/routes-context";
 import {
   sourceToolsAtom,
   sourcesAtom,
@@ -28,7 +28,8 @@ export function SourceDetailPage(props: {
   const refreshTools = useAtomRefresh(sourceToolsAtom(namespace, scopeId));
   const doRemove = useAtomSet(removeSource, { mode: "promise" });
   const doRefresh = useAtomSet(refreshSource, { mode: "promise" });
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
+  const routes = useRoutes();
 
   // HMR: refresh source tools when the backend is hot-reloaded
   useEffect(() => {
@@ -82,7 +83,7 @@ export function SourceDetailPage(props: {
         path: { scopeId, sourceId: namespace },
       });
       refreshSources();
-      void navigate({ to: "/" });
+      navigate(routes.home);
     } catch {
       setDeleting(false);
       setConfirmDelete(false);

--- a/packages/react/src/pages/sources-add.tsx
+++ b/packages/react/src/pages/sources-add.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
 import type { SourcePlugin } from "../plugins/source-plugin";
 import { useAtomRefresh } from "@effect-atom/atom-react";
 import { sourcesAtom } from "../api/atoms";
+import { RouteLink, useRoutes, useAppNavigate } from "../api/routes-context";
 import { useScope } from "../hooks/use-scope";
 
 // ---------------------------------------------------------------------------
@@ -19,7 +19,8 @@ export function SourcesAddPage(props: {
   const { pluginKey, url, preset, namespace, sourcePlugins } = props;
   const scopeId = useScope();
   const refreshSources = useAtomRefresh(sourcesAtom(scopeId));
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
+  const routes = useRoutes();
 
   const plugin = sourcePlugins.find((p) => p.key === pluginKey);
 
@@ -34,12 +35,12 @@ export function SourcesAddPage(props: {
             <p className="text-xs text-muted-foreground mb-5">
               This source plugin is not registered.
             </p>
-            <Link
-              to="/"
+            <RouteLink
+              route={routes.home}
               className="inline-flex items-center gap-1.5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
               Back to sources
-            </Link>
+            </RouteLink>
           </div>
         </div>
       </div>
@@ -58,10 +59,10 @@ export function SourcesAddPage(props: {
             initialNamespace={namespace}
             onComplete={() => {
               refreshSources();
-              void navigate({ to: "/" });
+              navigate(routes.home);
             }}
             onCancel={() => {
-              void navigate({ to: "/" });
+              navigate(routes.home);
             }}
           />
         </Suspense>

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
 import { Result, useAtomValue, useAtomSet } from "@effect-atom/atom-react";
 import { sourcesAtom, detectSource } from "../api/atoms";
+import { RouteLink, useRoutes, useAppNavigate } from "../api/routes-context";
 import { useScope } from "../hooks/use-scope";
 import type { SourcePlugin, SourcePreset } from "../plugins/source-plugin";
 import { McpInstallCard } from "../components/mcp-install-card";
@@ -42,7 +42,8 @@ export function SourcesPage(props: { sourcePlugins: readonly SourcePlugin[] }) {
   const scopeId = useScope();
   const sources = useAtomValue(sourcesAtom(scopeId));
   const doDetect = useAtomSet(detectSource, { mode: "promise" });
-  const navigate = useNavigate();
+  const navigate = useAppNavigate();
+  const routes = useRoutes();
 
   const handleDetect = useCallback(async () => {
     const trimmed = url.trim();
@@ -61,11 +62,9 @@ export function SourcesPage(props: { sourcePlugins: readonly SourcePlugin[] }) {
       }
       const pluginKey = KIND_TO_PLUGIN_KEY[results[0].kind];
       if (pluginKey) {
-        void navigate({
-          to: "/sources/add/$pluginKey",
-          params: { pluginKey },
-          search: { url: trimmed, namespace: results[0].namespace },
-        });
+        navigate(
+          routes.sourcesAdd(pluginKey, { url: trimmed, namespace: results[0].namespace }),
+        );
       } else {
         setError(`Detected source type "${results[0].kind}" but no plugin is available for it.`);
       }
@@ -74,7 +73,7 @@ export function SourcesPage(props: { sourcePlugins: readonly SourcePlugin[] }) {
     } finally {
       setDetecting(false);
     }
-  }, [url, doDetect, navigate, scopeId]);
+  }, [url, doDetect, navigate, routes, scopeId]);
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
@@ -123,14 +122,13 @@ export function SourcesPage(props: { sourcePlugins: readonly SourcePlugin[] }) {
                   <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                     Or add manually:{" "}
                     {sourcePlugins.map((p) => (
-                      <Link
+                      <RouteLink
                         key={p.key}
-                        to="/sources/add/$pluginKey"
-                        params={{ pluginKey: p.key }}
+                        route={routes.sourcesAdd(p.key)}
                         className="rounded-md border border-border px-2 py-1 text-xs font-medium transition-colors hover:bg-muted"
                       >
                         {p.label}
-                      </Link>
+                      </RouteLink>
                     ))}
                   </div>
                 </CardStackEntryField>
@@ -197,6 +195,7 @@ type PresetEntry = {
 };
 
 function PresetGrid(props: { plugins: readonly SourcePlugin[] }) {
+  const routes = useRoutes();
   const allPresets = useMemo(() => {
     const entries: PresetEntry[] = [];
     for (const plugin of props.plugins) {
@@ -227,7 +226,7 @@ function PresetGrid(props: { plugins: readonly SourcePlugin[] }) {
                 asChild
                 searchText={`${preset.name} ${preset.summary ?? ""} ${pluginLabel}`}
               >
-                <Link to="/sources/add/$pluginKey" params={{ pluginKey }} search={search}>
+                <RouteLink route={routes.sourcesAdd(pluginKey, search)}>
                   <CardStackEntryMedia>
                     {preset.icon ? (
                       <img
@@ -249,7 +248,7 @@ function PresetGrid(props: { plugins: readonly SourcePlugin[] }) {
                   <CardStackEntryActions>
                     <Badge variant="secondary">{pluginLabel}</Badge>
                   </CardStackEntryActions>
-                </Link>
+                </RouteLink>
               </CardStackEntry>
             );
           })}
@@ -272,13 +271,14 @@ function SourceGrid(props: {
     runtime?: boolean;
   }[];
 }) {
+  const routes = useRoutes();
   return (
     <CardStack searchable>
       <CardStackHeader>Connected</CardStackHeader>
       <CardStackContent>
         {props.sources.map((s) => (
           <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
-            <Link to="/sources/$namespace" params={{ namespace: s.id }}>
+            <RouteLink route={routes.sourceDetail(s.id)}>
               <CardStackEntryMedia>
                 <SourceFavicon url={s.url} size={32} />
               </CardStackEntryMedia>
@@ -290,7 +290,7 @@ function SourceGrid(props: {
                 {s.runtime && <Badge className="bg-muted text-muted-foreground">built-in</Badge>}
                 <Badge variant="secondary">{s.kind}</Badge>
               </CardStackEntryActions>
-            </Link>
+            </RouteLink>
           </CardStackEntry>
         ))}
       </CardStackContent>


### PR DESCRIPTION
## Summary

- Move the cloud app from flat `/` routing to org-slug-scoped URLs (`/$org/sources`, `/$org/secrets`, etc.) so bookmarks and shared links pin to a specific organization instead of whichever one the session cookie happened to point at. A new `$org.tsx` layout reconciles URL slug vs session cookie on mismatch (calls `switchOrganization` then reloads).
- Add a `slug` column to `organizations` with a deterministic `<slugified-name>-<id6>` generator that stays stable across renames. Manual migration (`0001_bent_the_initiative.sql`) backfills existing rows using the same shape in SQL, then flips the column to NOT NULL and adds the unique index. `/me`, `/organizations`, and the create-org response now include the slug.
- Extract an `AppRoutes` abstraction (`RoutesProvider`, `RouteLink`, `useAppNavigate`) into `@executor/react` so shared pages (`sources`, `source-detail`, `sources-add`, `command-palette`) no longer hardcode TanStack route literals. Cloud provides `/$org/*` targets via the Shell; local provides unscoped targets via `__root.tsx`. Makes a future `/$workspace/*` restructure on local a localized change.

## Test plan

- [ ] `bun run typecheck` (28/28 ✅ locally)
- [ ] Log in, land on `/$slug/` — sources list loads
- [ ] Hard-refresh on `/$slug/secrets`, `/$slug/settings`, `/$slug/billing` — no flash, no redirect to `/`
- [ ] Switch organizations from the user menu — lands directly on `/$newSlug/` without an intermediate slug-mismatch bounce
- [ ] Create a new org from the footer — redirects straight to the new slug
- [ ] Onboarding flow (no org): create org → lands on new slug
- [ ] Paste a bookmarked `/:oldSlug/...` URL while session is on a different org — `$org.tsx` layout swaps the cookie and reloads into the bookmarked org
- [ ] Try `/:nonexistent-slug/` — renders the "Organization not found" state rather than 500
- [ ] Open `⌘K` palette: jump-to-source and add-source entries navigate under `/$slug/...`
- [ ] Source add → redirect back to `/$slug/` home
- [ ] Source delete → redirect back to `/$slug/` home
- [ ] Existing rows in `organizations` receive a slug via the backfill migration on first deploy
- [ ] Local app smoke test — routes still unscoped, sources add/detail/delete still navigate via `/`