### PR TITLE
Pin cloud API requests to /api/o/:slug/*

### DIFF
--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -11,6 +11,7 @@ import { GoogleDiscoveryExtensionService } from "@executor/plugin-google-discove
 import { GraphqlExtensionService } from "@executor/plugin-graphql/api";
 
 import { authorizeOrganization } from "../auth/authorize-organization";
+import { UserStoreService } from "../auth/context";
 import { WorkOSAuth } from "../auth/workos";
 import { AutumnService } from "../services/autumn";
 import { createOrgExecutor } from "../services/executor";
@@ -18,6 +19,20 @@ import { makeTrackExecutionUsage } from "./autumn";
 import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
 import { withExecutionUsageTracking } from "./execution-usage";
 import { ProtectedCloudApiLive, RouterConfig, SharedServices } from "./layers";
+
+// ---------------------------------------------------------------------------
+// Org resolution for protected requests.
+//
+// The URL is the source of truth for which org a request targets. The
+// `x-executor-org-slug` header is set by `apiRequestMiddleware` (start.ts)
+// when it peels `/api/o/:slug/` off the incoming path. We resolve the slug
+// to an orgId and then verify live membership against WorkOS — the session
+// cookie is used for *user identity only*, no longer for org selection.
+//
+// If the header is absent (legacy calls that haven't been rewritten) we
+// fall back to the session-cookie organizationId so existing flows keep
+// working while clients migrate.
+// ---------------------------------------------------------------------------
 
 const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
   Effect.gen(function* () {
@@ -32,8 +47,17 @@ const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
     );
     const workos = yield* WorkOSAuth;
     const session = yield* workos.authenticateRequest(webRequest);
-    if (!session || !session.organizationId) return null;
+    if (!session) return null;
 
+    const slug = request.headers["x-executor-org-slug"] ?? null;
+    if (slug) {
+      const users = yield* UserStoreService;
+      const stored = yield* users.use((s) => s.getOrganizationBySlug(slug));
+      if (!stored) return null;
+      return yield* authorizeOrganization(session.userId, stored.id);
+    }
+
+    if (!session.organizationId) return null;
     return yield* authorizeOrganization(session.userId, session.organizationId);
   });
 

--- a/apps/cloud/src/routes/$org.tsx
+++ b/apps/cloud/src/routes/$org.tsx
@@ -1,18 +1,23 @@
 import { useEffect } from "react";
 import { Outlet, createFileRoute } from "@tanstack/react-router";
 import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
+import { setOrgSlug } from "@executor/react/api/base-url";
 
 import { organizationsAtom, switchOrganization, useAuth } from "../web/auth";
 
 // ---------------------------------------------------------------------------
 // /$org layout — scopes everything under an organization slug.
 //
-// The session cookie is the server-side source of truth for which org is
-// active. The slug in the URL is the *client-side* source of truth. When
-// they disagree we reconcile by calling switchOrganization (which mutates
-// the cookie) and reloading. Keeping the URL authoritative means links,
-// bookmarks and copy-pasted addresses all work without the user having to
-// manually flip orgs.
+// The slug in the URL is the source of truth: `setOrgSlug` tells the API
+// client to pin every request to `/api/o/:slug/*` and the server resolves
+// the org from that path independent of the session cookie. Bookmarks,
+// copy-pasted links and cross-tab navigation all work without first having
+// to flip the cookie.
+//
+// We still call `switchOrganization` as a best-effort side-channel so that
+// flows which read the cookie directly (the WorkOS user portal, Autumn
+// billing redirects) see the same active org. That reconcile is no longer
+// a render-gate though — children mount immediately.
 // ---------------------------------------------------------------------------
 
 export const Route = createFileRoute("/$org")({
@@ -25,8 +30,14 @@ function OrgLayout() {
   const organizationsResult = useAtomValue(organizationsAtom);
   const doSwitch = useAtomSet(switchOrganization, { mode: "promiseExit" });
 
+  // Pin API requests to this slug before any child atoms fetch. Writing to
+  // a module-level ref during render is safe (idempotent) and avoids a
+  // first-render window where the client would otherwise hit `/api/*`
+  // unscoped and get authorized against the cookie instead.
+  setOrgSlug(slug);
+
   const activeSlug = auth.status === "authenticated" ? auth.organization?.slug ?? null : null;
-  const slugMatches = activeSlug === slug;
+  const cookieMatches = activeSlug === slug;
 
   const targetOrg = Result.match(organizationsResult, {
     onInitial: () => null,
@@ -34,36 +45,31 @@ function OrgLayout() {
     onSuccess: ({ value }) => value.organizations.find((o) => o.slug === slug) ?? null,
   });
 
+  // Best-effort cookie reconcile — no longer a render gate. If the switch
+  // fails or is slow, the API still works because requests are URL-pinned.
   useEffect(() => {
-    if (slugMatches) return;
+    if (cookieMatches) return;
     if (!targetOrg) return;
     let cancelled = false;
-    void doSwitch({ payload: { organizationId: targetOrg.id } }).then((exit) => {
+    void doSwitch({ payload: { organizationId: targetOrg.id } }).then(() => {
       if (cancelled) return;
-      if (exit._tag === "Success") window.location.reload();
     });
     return () => {
       cancelled = true;
     };
-  }, [slugMatches, targetOrg, doSwitch]);
+  }, [cookieMatches, targetOrg, doSwitch]);
 
-  if (slugMatches) {
-    return <Outlet />;
-  }
-
-  // Mid-switch or looking up whether the user is a member of :org.
-  const lookupPending = Result.match(organizationsResult, {
-    onInitial: () => true,
-    onFailure: () => false,
-    onSuccess: () => false,
+  // We still need to know whether the user is actually a member of this
+  // slug: if the org list has resolved and the slug isn't in it, show the
+  // not-found card instead of mounting children that'll 403.
+  const orgKnown = Result.match(organizationsResult, {
+    onInitial: () => true, // still loading — optimistically mount
+    onFailure: () => true, // org list failed — let children try
+    onSuccess: () => targetOrg !== null || cookieMatches,
   });
 
-  if (lookupPending || targetOrg) {
-    return (
-      <div className="flex flex-1 items-center justify-center">
-        <p className="text-sm text-muted-foreground">Loading organization…</p>
-      </div>
-    );
+  if (orgKnown) {
+    return <Outlet />;
   }
 
   return (

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -65,16 +65,47 @@ const mcpRequestMiddleware = createMiddleware({ type: "request" }).server(
 
 // ---------------------------------------------------------------------------
 // API middleware — routes /api/* to the Effect HTTP layer
+//
+// `/api/o/:orgSlug/*` is the org-scoped namespace for the protected API
+// (tools, sources, secrets, executions). We peel the slug off the front of
+// the path and stash it on an internal `x-executor-org-slug` header, then
+// forward the inner path to the Effect router. `lookupOrgForRequest` reads
+// the header when authorizing — falling back to the session cookie when no
+// header is present (auth endpoints, Autumn, OrgApi).
+//
+// We deliberately use `/o/` (not `/org/`) to avoid colliding with the
+// existing OrgApi mount at `/api/org/*`.
 // ---------------------------------------------------------------------------
+
+const ORG_SCOPED_PATH = /^\/o\/([^/]+)(\/.*)?$/;
 
 const apiRequestMiddleware = createMiddleware({ type: "request" }).server(
   ({ pathname, request, next }) => {
-    if (pathname === "/api" || pathname.startsWith("/api/")) {
-      const url = new URL(request.url);
-      url.pathname = url.pathname.replace(/^\/api/, "");
-      return handleApiRequest(new Request(url, request));
+    if (pathname !== "/api" && !pathname.startsWith("/api/")) return next();
+
+    const url = new URL(request.url);
+    let innerPath = url.pathname.replace(/^\/api/, "") || "/";
+
+    const headers = new Headers(request.headers);
+    const scoped = innerPath.match(ORG_SCOPED_PATH);
+    if (scoped) {
+      const [, orgSlug, rest] = scoped;
+      headers.set("x-executor-org-slug", orgSlug);
+      innerPath = rest ?? "/";
     }
-    return next();
+
+    url.pathname = innerPath;
+    return handleApiRequest(
+      new Request(url, {
+        method: request.method,
+        headers,
+        body: request.body,
+        redirect: request.redirect,
+        // Cloudflare Workers requires `duplex: "half"` when forwarding a
+        // streaming body; tolerate runtimes that don't know the option.
+        ...(request.body ? { duplex: "half" } : {}),
+      } as RequestInit),
+    );
   },
 );
 

--- a/packages/react/src/api/base-url.tsx
+++ b/packages/react/src/api/base-url.tsx
@@ -1,12 +1,47 @@
+// ---------------------------------------------------------------------------
+// Executor API base URL
+// ---------------------------------------------------------------------------
+//
+// The base URL points at the executor HTTP API. For cloud, the shell calls
+// `setOrgSlug(slug)` during render once auth resolves. The ExecutorApiClient
+// reads the current slug per-request via `transformClient` and rewrites the
+// URL from `/api/...` to `/api/o/${slug}/...` so every request is URL-pinned
+// to a specific org. The server's api middleware peels the slug back off
+// and uses it instead of the session cookie for authorization — this makes
+// cross-tab fetches independent and removes the need for a
+// `switchOrganization` round-trip when a bookmarked URL doesn't match the
+// active session cookie.
+//
+// For local there is no org, so `setOrgSlug` is never called and requests
+// go to `${origin}/api`.
+
 const DEFAULT_BASE_URL = "http://127.0.0.1:4000";
 
-let baseUrl =
+const rootBase =
   typeof window !== "undefined" && typeof window.location?.origin === "string"
     ? `${window.location.origin}/api`
     : `${DEFAULT_BASE_URL}/api`;
+
+let baseUrl = rootBase;
 
 export const getBaseUrl = (): string => baseUrl;
 
 export const setBaseUrl = (url: string): void => {
   baseUrl = url;
+};
+
+// Current org slug, read per-request by the api client's transformClient.
+// We can't bake the slug into `baseUrl` because AtomHttpApi captures baseUrl
+// once at class construction time; instead we keep it in a mutable ref that
+// the transform reads on each request.
+let currentOrgSlug: string | null = null;
+
+export const getCurrentOrgSlug = (): string | null => currentOrgSlug;
+
+/**
+ * Pin subsequent API requests to an org slug. Pass `null` to return to the
+ * unscoped root (e.g., during logout).
+ */
+export const setOrgSlug = (slug: string | null): void => {
+  currentOrgSlug = slug;
 };

--- a/packages/react/src/api/client.tsx
+++ b/packages/react/src/api/client.tsx
@@ -1,17 +1,33 @@
 import { AtomHttpApi } from "@effect-atom/atom-react";
-import { FetchHttpClient } from "@effect/platform";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "@effect/platform";
 import { ExecutorApi } from "@executor/api";
 
-import { getBaseUrl } from "./base-url";
+import { getBaseUrl, getCurrentOrgSlug } from "./base-url";
 
 // ---------------------------------------------------------------------------
 // Core API client — tools + secrets
 // ---------------------------------------------------------------------------
+//
+// `baseUrl` is captured once at class construction, so we can't bake the
+// org slug into it. Instead we read the current slug per-request via
+// `transformClient` and rewrite `/api/...` to `/api/o/${slug}/...`. The
+// server's api middleware peels the slug off and uses it for authorization
+// independent of the session cookie. See `base-url.tsx` for why this lives
+// in a mutable module-level ref.
+
+const injectOrgSlug = (url: string): string => {
+  const slug = getCurrentOrgSlug();
+  if (!slug) return url;
+  // `/api` may be followed by `/`, `?`, `#`, or end-of-string — match all.
+  return url.replace(/\/api(?=\/|$|\?|#)/, `/api/o/${slug}`);
+};
 
 class ExecutorApiClient extends AtomHttpApi.Tag<ExecutorApiClient>()("ExecutorApiClient", {
   api: ExecutorApi,
   httpClient: FetchHttpClient.layer,
   baseUrl: getBaseUrl(),
+  transformClient: (client) =>
+    HttpClient.mapRequest(client, HttpClientRequest.updateUrl(injectOrgSlug)),
 }) {}
 
 export { ExecutorApiClient };


### PR DESCRIPTION
## Summary
- Server: `apiRequestMiddleware` in `start.ts` peels `/api/o/:slug/*` off incoming requests, stashes the slug on an internal `x-executor-org-slug` header, and forwards the inner path to the Effect router. `lookupOrgForRequest` in `api/protected.ts` prefers the header-derived slug (resolving it via `getOrganizationBySlug` + live WorkOS membership check) and falls back to `session.organizationId` for legacy/unpinned calls (auth endpoints, Autumn, OrgApi).
- Client: `@executor/react` base-url now keeps the org slug in a module-level ref, and the `ExecutorApiClient` uses `transformClient` + `HttpClient.mapRequest` to rewrite each request URL from `/api/...` to `/api/o/\${slug}/...` at send time — necessary because `AtomHttpApi` captures `baseUrl` statically at class construction. The cloud `\$org.tsx` layout calls `setOrgSlug(slug)` during render, before any child atoms can fetch.
- `\$org.tsx` no longer render-gates on slug/cookie match; children mount immediately and `switchOrganization` runs in the background as a best-effort reconcile for flows that still read the cookie (WorkOS user portal, Autumn billing redirects).

## Why
Stacked on #242. That PR made the web routes org-scoped (`/:orgSlug/*`), but the API still resolved the active org from the session cookie — meaning a bookmarked or cross-tab URL couldn't take effect until `switchOrganization` had flipped the cookie and reloaded. Pinning API requests to the same URL-derived slug makes cross-tab navigation independent and removes the reconcile round-trip.

We use `/api/o/:slug/*` (not `/api/org/*`) to avoid colliding with the existing OrgApi mount at `/api/org/*`.

## Test plan
- [x] Monorepo typecheck clean (28/28 packages)
- [ ] Manual: load `/acme/` — API requests should go to `/api/o/acme/scopes/...`
- [ ] Manual: open a second tab at `/other/` while first tab is `/acme/` — both should work independently without needing to switch orgs
- [ ] Manual: bookmarked URL for an org the cookie isn't currently pinned to should load without the old "Loading organization…" gate
- [ ] Manual: logout from one org and log back into another — verify `setOrgSlug` refreshes correctly
- [ ] `bun x vitest run` blocked by pre-existing `@vitest/expect` / miniflare version mismatch (unrelated to this branch)