### PR TITLE
[codex] Make cloud auth portable and surface callback failures

### DIFF
--- a/apps/cloud/src/auth/context.ts
+++ b/apps/cloud/src/auth/context.ts
@@ -16,7 +16,7 @@ const makeService = (store: RawStore) => ({
   use: <A>(fn: (s: RawStore) => Promise<A>) =>
     withServiceLogging(
       "user_store",
-      () => new UserStoreError(),
+      (message) => new UserStoreError({ message }),
       tryPromiseService(() => fn(store)),
     ),
 });

--- a/apps/cloud/src/auth/errors.ts
+++ b/apps/cloud/src/auth/errors.ts
@@ -2,13 +2,17 @@ import { Data, Effect, Schema } from "effect";
 
 export class UserStoreError extends Schema.TaggedErrorClass<UserStoreError>()(
   "UserStoreError",
-  {},
+  {
+    message: Schema.String,
+  },
   { httpApiStatus: 500 },
 ) {}
 
 export class WorkOSError extends Schema.TaggedErrorClass<WorkOSError>()(
   "WorkOSError",
-  {},
+  {
+    message: Schema.String,
+  },
   { httpApiStatus: 500 },
 ) {}
 
@@ -41,11 +45,21 @@ export const tryPromiseService = <A>(fn: () => Promise<A>): Effect.Effect<A, Ser
  */
 export const withServiceLogging = <A, E, R>(
   name: string,
-  publicError: () => E,
+  publicError: (message: string) => E,
   effect: Effect.Effect<A, unknown, R>,
 ): Effect.Effect<A, E, R> =>
   effect.pipe(
     Effect.tapCause((cause) => Effect.logError(`${name} failed`, cause)),
-    Effect.mapError(publicError),
+    Effect.mapError((error) => {
+      const message =
+        error instanceof ServiceAdapterError
+          ? error.cause instanceof Error
+            ? error.cause.message
+            : String(error.cause)
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      return publicError(message);
+    }),
     Effect.withSpan(name),
   ) as Effect.Effect<A, E, R>;

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -8,7 +8,7 @@ import { SessionContext } from "./middleware";
 import { UserStoreService } from "./context";
 import { authorizeOrganization } from "./authorize-organization";
 import { env } from "cloudflare:workers";
-import { WorkOSError } from "./errors";
+import { UserStoreError, WorkOSError } from "./errors";
 import { WorkOSAuth } from "./workos";
 
 const COOKIE_OPTIONS = {
@@ -156,7 +156,40 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
             ),
             STATE_COOKIE,
           );
-        }),
+        }).pipe(
+          Effect.catchTags({
+            WorkOSError: (error) =>
+              Effect.sync(() => {
+                console.error("[auth] WorkOS callback failed:", error);
+                return HttpServerResponse.text(
+                  [
+                    "Authentication failed during the WorkOS callback.",
+                    error.message ? `WorkOS said: ${error.message}` : "",
+                    "",
+                    "Verify this exact redirect URI is allowed in WorkOS:",
+                    `${env.VITE_PUBLIC_SITE_URL}${AUTH_PATHS.callback}`,
+                    "",
+                    "You should start sign-in from this URL:",
+                    `${env.VITE_PUBLIC_SITE_URL}${AUTH_PATHS.login}`,
+                  ].join("\n"),
+                  { status: 500 },
+                );
+              }),
+            UserStoreError: (error) =>
+              Effect.sync(() => {
+                console.error("[auth] User store callback failed:", error);
+                return HttpServerResponse.text(
+                  [
+                    "Authentication succeeded with WorkOS, but local account setup failed.",
+                    error.message ? `Local error: ${error.message}` : "",
+                  ]
+                    .filter(Boolean)
+                    .join("\n"),
+                  { status: 500 },
+                );
+              }),
+          }),
+        ),
       ),
 );
 

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -27,7 +27,7 @@ const make = Effect.gen(function* () {
   const use = <A>(fn: (wos: WorkOS) => Promise<A>) =>
     withServiceLogging(
       "workos",
-      () => new WorkOSError(),
+      (message) => new WorkOSError({ message }),
       tryPromiseService(() => fn(workos)),
     );
 


### PR DESCRIPTION
## What changed

This PR makes the cloud auth flow portable across deployments and much easier to debug when WorkOS or local account setup fails.

- add `WORKOS_AUTHKIT_DOMAIN` to the cloud env shape and use it for MCP auth metadata and JWT issuer checks instead of a hardcoded AuthKit host
- return explicit callback error responses instead of silently redirecting failed auth attempts back to the marketing site
- preserve safe underlying WorkOS and user-store error messages in the callback response while still logging full internal causes server-side

## Why

The cloud auth stack still had a hardcoded AuthKit domain in its MCP surface, which made non-`executor.sh` deployments incorrect. On top of that, auth callback failures were getting swallowed by a redirect to `/`, which made real deployment issues look like broken login loops instead of exposing the underlying problem.

## Impact

- cloud auth and MCP metadata can follow the configured WorkOS AuthKit domain
- failed sign-ins now surface actionable callback errors instead of bouncing users to marketing
- WorkOS and database setup issues are easier to diagnose in deployed environments

## Validation

- deployed the cloud worker with these changes during debugging
- verified the callback page surfaced the real WorkOS failure instead of redirecting
