### PR TITLE
Support OpenAPI server variables during onboarding

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -28,13 +28,25 @@ import { FieldLabel } from "@executor/react/components/field";
 import { FloatActions } from "@executor/react/components/float-actions";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
+import {
+  NativeSelect,
+  NativeSelectOption,
+} from "@executor/react/components/native-select";
 import { Textarea } from "@executor/react/components/textarea";
 import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
 import { Skeleton } from "@executor/react/components/skeleton";
 import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
 import { previewOpenApiSpec, addOpenApiSpec } from "./atoms";
 import type { SpecPreview, HeaderPreset } from "../sdk/preview";
-import type { HeaderValue } from "../sdk/types";
+import type { HeaderValue, ServerInfo, ServerVariable } from "../sdk/types";
+
+const substituteUrlVariables = (url: string, values: Record<string, string>): string => {
+  let out = url;
+  for (const [name, value] of Object.entries(values)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -79,7 +91,11 @@ export default function AddOpenApiSource(props: {
 
   // After analysis
   const [preview, setPreview] = useState<SpecPreview | null>(null);
-  const [baseUrl, setBaseUrl] = useState("");
+  // -1 means the user is entering a fully custom base URL (no server selected).
+  const [selectedServerIndex, setSelectedServerIndex] = useState<number>(-1);
+  const [customBaseUrl, setCustomBaseUrl] = useState("");
+  // Variable selections for the currently selected server, keyed by variable name.
+  const [variableSelections, setVariableSelections] = useState<Record<string, string>>({});
   const identity = useSourceIdentity({
     fallbackName: preview ? Option.getOrElse(preview.title, () => "") : "",
     fallbackNamespace: props.initialNamespace,
@@ -118,7 +134,35 @@ export default function AddOpenApiSource(props: {
 
   // ---- Derived state ----
 
-  const servers = (preview?.servers ?? []) as Array<{ url?: string }>;
+  const servers: readonly ServerInfo[] = preview?.servers ?? [];
+  const selectedServer: ServerInfo | null =
+    selectedServerIndex >= 0 ? (servers[selectedServerIndex] ?? null) : null;
+
+  const serverVariables: Record<string, ServerVariable> = selectedServer
+    ? Option.getOrElse(
+        selectedServer.variables,
+        () => ({}) as Record<string, ServerVariable>,
+      )
+    : {};
+  const serverVariableEntries: Array<[string, ServerVariable]> =
+    Object.entries(serverVariables);
+
+  const resolvedBaseUrl =
+    selectedServer !== null
+      ? substituteUrlVariables(selectedServer.url, variableSelections)
+      : customBaseUrl.trim();
+
+  // Helper used by analyze + server selection: build a default selection map
+  // from a server's variable defaults.
+  const defaultSelectionsFor = (server: ServerInfo): Record<string, string> => {
+    const vars: Record<string, ServerVariable> = Option.getOrElse(
+      server.variables,
+      () => ({}) as Record<string, ServerVariable>,
+    );
+    const out: Record<string, string> = {};
+    for (const [name, v] of Object.entries(vars)) out[name] = v.default;
+    return out;
+  };
 
   // Derive a favicon URL from the spec URL (if the user entered one — raw
   // JSON/YAML content will fail URL parsing and yield null). Uses Google's
@@ -155,7 +199,7 @@ export default function AddOpenApiSource(props: {
 
   const canAdd =
     preview !== null &&
-    baseUrl.trim().length > 0 &&
+    resolvedBaseUrl.length > 0 &&
     (customHeaders.length === 0 || customHeadersValid);
 
   // ---- Handlers ----
@@ -171,8 +215,16 @@ export default function AddOpenApiSource(props: {
       });
       setPreview(result);
 
-      const firstUrl = (result.servers as Array<{ url?: string }>)?.[0]?.url;
-      if (firstUrl) setBaseUrl(firstUrl);
+      const firstServer = result.servers[0];
+      if (firstServer) {
+        setSelectedServerIndex(0);
+        setVariableSelections(defaultSelectionsFor(firstServer));
+        setCustomBaseUrl("");
+      } else {
+        setSelectedServerIndex(-1);
+        setVariableSelections({});
+        setCustomBaseUrl("");
+      }
 
       const firstPreset = result.headerPresets[0];
       if (firstPreset) {
@@ -228,7 +280,7 @@ export default function AddOpenApiSource(props: {
           spec: specUrl,
           name: identity.name.trim() || undefined,
           namespace: slugifyNamespace(identity.namespace) || undefined,
-          baseUrl: baseUrl.trim() || undefined,
+          baseUrl: resolvedBaseUrl || undefined,
           ...(hasHeaders ? { headers: allHeaders } : {}),
         },
       });
@@ -259,7 +311,9 @@ export default function AddOpenApiSource(props: {
                   setSpecUrl((e.target as HTMLTextAreaElement).value);
                   if (preview) {
                     setPreview(null);
-                    setBaseUrl("");
+                    setSelectedServerIndex(-1);
+                    setCustomBaseUrl("");
+                    setVariableSelections({});
                     setCustomHeaders([]);
                     setSelectedStrategy(-1);
                   }
@@ -337,45 +391,125 @@ export default function AddOpenApiSource(props: {
           <CardStack>
             <CardStackContent className="border-t-0">
               <CardStackEntryField label="Base URL">
-                {servers.length > 1 ? (
-                  <div className="space-y-2">
-                    <RadioGroup value={baseUrl} onValueChange={setBaseUrl} className="gap-1.5">
-                      {servers.map((s, i) => {
-                        const url = s.url ?? "";
-                        return (
-                          <Label
-                            key={i}
-                            className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
-                              baseUrl === url
-                                ? "border-primary/50 bg-primary/[0.03]"
-                                : "border-border hover:bg-accent/50"
-                            }`}
-                          >
-                            <RadioGroupItem value={url} />
-                            <span className="font-mono text-xs text-foreground truncate">
-                              {url}
-                            </span>
-                          </Label>
-                        );
-                      })}
-                    </RadioGroup>
-                    <Input
-                      value={baseUrl}
-                      onChange={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
-                      placeholder="Or enter a custom URL…"
-                      className="font-mono text-sm"
-                    />
+                {servers.length >= 1 && (
+                  <RadioGroup
+                    value={String(selectedServerIndex)}
+                    onValueChange={(value) => {
+                      const idx = Number(value);
+                      setSelectedServerIndex(idx);
+                      if (idx >= 0) {
+                        const s = servers[idx];
+                        if (s) setVariableSelections(defaultSelectionsFor(s));
+                      } else {
+                        setVariableSelections({});
+                      }
+                    }}
+                    className="gap-1.5"
+                  >
+                    {servers.map((s, i) => (
+                      <Label
+                        key={i}
+                        className={`flex items-start gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
+                          selectedServerIndex === i
+                            ? "border-primary/50 bg-primary/[0.03]"
+                            : "border-border hover:bg-accent/50"
+                        }`}
+                      >
+                        <RadioGroupItem value={String(i)} className="mt-0.5" />
+                        <div className="min-w-0 flex-1">
+                          <div className="font-mono text-xs text-foreground truncate">
+                            {s.url}
+                          </div>
+                          {Option.isSome(s.description) && (
+                            <div className="mt-0.5 text-[10px] text-muted-foreground">
+                              {s.description.value}
+                            </div>
+                          )}
+                        </div>
+                      </Label>
+                    ))}
+                    <Label
+                      className={`flex items-center gap-2.5 rounded-lg border px-3 py-2 cursor-pointer transition-colors ${
+                        selectedServerIndex === -1
+                          ? "border-primary/50 bg-primary/[0.03]"
+                          : "border-border hover:bg-accent/50"
+                      }`}
+                    >
+                      <RadioGroupItem value="-1" />
+                      <span className="text-xs font-medium text-foreground">Custom</span>
+                    </Label>
+                  </RadioGroup>
+                )}
+
+                {/* Per-variable pickers for the selected server */}
+                {selectedServer && serverVariableEntries.length > 0 && (
+                  <div className="mt-2 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-2.5">
+                    {serverVariableEntries.map(([name, variable]) => {
+                      const enumValues: readonly string[] = Option.getOrElse(
+                        variable.enum,
+                        () => [] as readonly string[],
+                      );
+                      const current = variableSelections[name] ?? variable.default;
+                      return (
+                        <div key={name} className="space-y-1">
+                          <div className="flex items-baseline justify-between gap-2">
+                            <Label className="font-mono text-[11px] text-foreground">
+                              {`{${name}}`}
+                            </Label>
+                            {Option.isSome(variable.description) && (
+                              <span className="text-[10px] text-muted-foreground truncate">
+                                {variable.description.value}
+                              </span>
+                            )}
+                          </div>
+                          {enumValues.length > 0 ? (
+                            <NativeSelect
+                              value={current}
+                              onChange={(e) =>
+                                setVariableSelections((prev) => ({
+                                  ...prev,
+                                  [name]: (e.target as HTMLSelectElement).value,
+                                }))
+                              }
+                            >
+                              {enumValues.map((v) => (
+                                <NativeSelectOption key={v} value={v}>
+                                  {v}
+                                </NativeSelectOption>
+                              ))}
+                            </NativeSelect>
+                          ) : (
+                            <Input
+                              value={current}
+                              onChange={(e) =>
+                                setVariableSelections((prev) => ({
+                                  ...prev,
+                                  [name]: (e.target as HTMLInputElement).value,
+                                }))
+                              }
+                              className="font-mono text-xs"
+                            />
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
-                ) : (
+                )}
+
+                {selectedServerIndex === -1 ? (
                   <Input
-                    value={baseUrl}
-                    onChange={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
+                    value={customBaseUrl}
+                    onChange={(e) => setCustomBaseUrl((e.target as HTMLInputElement).value)}
                     placeholder="https://api.example.com"
                     className="font-mono text-sm"
                   />
+                ) : (
+                  <div className="rounded-md bg-muted/30 px-2.5 py-1.5 font-mono text-[11px] text-muted-foreground">
+                    {resolvedBaseUrl || "\u00A0"}
+                  </div>
                 )}
 
-                {!baseUrl.trim() && (
+                {!resolvedBaseUrl && (
                   <p className="text-[11px] text-amber-600 dark:text-amber-400">
                     A base URL is required to make requests.
                   </p>

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -20,6 +20,7 @@ import {
   OperationRequestBody,
   type ParameterLocation,
   ServerInfo,
+  ServerVariable,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -177,14 +178,31 @@ const extractServers = (doc: ParsedDocument): ServerInfo[] =>
     if (!server.url) return [];
     const vars = server.variables
       ? Object.fromEntries(
-          Object.entries(server.variables).flatMap(([name, v]) =>
-            v.default ? [[name, v.default]] : [],
-          ),
+          Object.entries(server.variables).flatMap(([name, v]) => {
+            if (v.default === undefined || v.default === null) return [];
+            const enumValues = Array.isArray(v.enum)
+              ? v.enum.filter((x): x is string => typeof x === "string")
+              : undefined;
+            return [
+              [
+                name,
+                new ServerVariable({
+                  default: String(v.default),
+                  enum:
+                    enumValues && enumValues.length > 0
+                      ? Option.some(enumValues)
+                      : Option.none(),
+                  description: Option.fromNullable(v.description),
+                }),
+              ],
+            ];
+          }),
         )
       : undefined;
     return [
       new ServerInfo({
         url: server.url,
+        description: Option.fromNullable(server.description),
         variables: vars && Object.keys(vars).length > 0 ? Option.some(vars) : Option.none(),
       }),
     ];

--- a/packages/plugins/openapi/src/sdk/index.test.ts
+++ b/packages/plugins/openapi/src/sdk/index.test.ts
@@ -160,4 +160,98 @@ describe("OpenAPI plugin", () => {
       expect(paths).toContain("pets.getPet");
     }),
   );
+
+  it.effect("extracts server variables with enum and description", () =>
+    Effect.gen(function* () {
+      const specWithServerVars = {
+        openapi: "3.0.0",
+        info: { title: "Sentry", version: "1.0.0" },
+        servers: [
+          {
+            url: "https://{region}.sentry.io",
+            description: "Regional endpoint",
+            variables: {
+              region: {
+                default: "us",
+                description: "The data-storage-location for an organization",
+                enum: ["us", "de"],
+              },
+            },
+          },
+        ],
+        paths: {
+          "/ping": { get: { responses: { "200": { description: "ok" } } } },
+        },
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(specWithServerVars));
+      const result = yield* extract(doc);
+
+      expect(result.servers).toHaveLength(1);
+      const server = result.servers[0]!;
+      expect(server.url).toBe("https://{region}.sentry.io");
+      expect(Option.getOrElse(server.description, () => "")).toBe("Regional endpoint");
+
+      const vars = Option.getOrThrow(server.variables);
+      expect(vars.region!.default).toBe("us");
+      expect(
+        Option.getOrElse(vars.region!.enum, () => [] as readonly string[]),
+      ).toEqual(["us", "de"]);
+      expect(Option.getOrElse(vars.region!.description, () => "")).toBe(
+        "The data-storage-location for an organization",
+      );
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Server variable extraction
+// ---------------------------------------------------------------------------
+
+describe("extract — server variables", () => {
+  const specWithServerVars = {
+    openapi: "3.0.0",
+    info: { title: "Test", version: "1.0.0" },
+    servers: [
+      {
+        url: "https://{region}.example.com/{basePath}",
+        description: "Regional endpoint",
+        variables: {
+          region: {
+            default: "us",
+            enum: ["us", "eu", "ap"],
+            description: "Data region",
+          },
+          basePath: { default: "v1" },
+        },
+      },
+    ],
+    paths: {
+      "/ping": { get: { responses: { "200": { description: "ok" } } } },
+    },
+  };
+
+  it.effect("preserves enum, default, and description for server variables", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(specWithServerVars));
+      const result = yield* extract(doc);
+
+      expect(result.servers).toHaveLength(1);
+      const server = result.servers[0]!;
+      expect(server.url).toBe("https://{region}.example.com/{basePath}");
+      expect(Option.getOrNull(server.description)).toBe("Regional endpoint");
+
+      const vars = Option.getOrNull(server.variables);
+      expect(vars).not.toBeNull();
+      const region = vars!.region!;
+      expect(region.default).toBe("us");
+      expect(Option.getOrNull(region.enum)).toEqual(["us", "eu", "ap"]);
+      expect(Option.getOrNull(region.description)).toBe("Data region");
+
+      const basePath = vars!.basePath!;
+      expect(basePath.default).toBe("v1");
+      expect(Option.isNone(basePath.enum)).toBe(true);
+    }),
+  );
 });

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -18,7 +18,12 @@ export {
   PreviewOperation,
   SpecPreview,
 } from "./preview";
-export { DocResolver, resolveBaseUrl, preferredContent } from "./openapi-utils";
+export {
+  DocResolver,
+  resolveBaseUrl,
+  substituteUrlVariables,
+  preferredContent,
+} from "./openapi-utils";
 
 export { OpenApiParseError, OpenApiExtractionError, OpenApiInvocationError } from "./errors";
 
@@ -31,6 +36,7 @@ export {
   OperationParameter,
   OperationRequestBody,
   ServerInfo,
+  ServerVariable,
   OperationId,
   HttpMethod,
   ParameterLocation,

--- a/packages/plugins/openapi/src/sdk/openapi-utils.ts
+++ b/packages/plugins/openapi/src/sdk/openapi-utils.ts
@@ -54,22 +54,36 @@ const isRef = (value: unknown): value is { $ref: string } =>
 // Server URL resolution
 // ---------------------------------------------------------------------------
 
-export const resolveBaseUrl = (
-  servers: readonly {
-    url: string;
-    variables: import("effect/Option").Option<Record<string, string>>;
-  }[],
+/** Substitute `{var}` placeholders in a templated URL using a plain map. */
+export const substituteUrlVariables = (
+  url: string,
+  values: Record<string, string>,
 ): string => {
+  let out = url;
+  for (const [name, value] of Object.entries(values)) {
+    out = out.replaceAll(`{${name}}`, value);
+  }
+  return out;
+};
+
+type ServerLike = {
+  url: string;
+  variables: import("effect/Option").Option<
+    Record<string, { default: string } | string>
+  >;
+};
+
+export const resolveBaseUrl = (servers: readonly ServerLike[]): string => {
   const server = servers[0];
   if (!server) return "";
 
-  let url = server.url;
-  if (Option.isSome(server.variables)) {
-    for (const [name, value] of Object.entries(server.variables.value)) {
-      url = url.replaceAll(`{${name}}`, value);
-    }
+  if (!Option.isSome(server.variables)) return server.url;
+
+  const values: Record<string, string> = {};
+  for (const [name, v] of Object.entries(server.variables.value)) {
+    values[name] = typeof v === "string" ? v : v.default;
   }
-  return url;
+  return substituteUrlVariables(server.url, values);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -3,7 +3,7 @@ import { Schema } from "effect";
 
 import { parse } from "./parse";
 import { extract } from "./extract";
-import { HttpMethod, type ExtractionResult } from "./types";
+import { HttpMethod, ServerInfo, type ExtractionResult } from "./types";
 
 // ---------------------------------------------------------------------------
 // Security scheme — what the spec declares it needs
@@ -66,7 +66,7 @@ export class SpecPreview extends Schema.Class<SpecPreview>("SpecPreview")({
   title: Schema.optionalWith(Schema.String, { as: "Option" }),
   version: Schema.optionalWith(Schema.String, { as: "Option" }),
   /** Reuses ServerInfo from extraction */
-  servers: Schema.Array(Schema.Unknown),
+  servers: Schema.Array(ServerInfo),
   operationCount: Schema.Number,
   /** Lightweight operation list for the add-source UI */
   operations: Schema.Array(PreviewOperation),
@@ -185,7 +185,7 @@ export const previewSpec = Effect.fn("OpenApi.previewSpec")(function* (specText:
   return new SpecPreview({
     title: result.title,
     version: result.version,
-    servers: result.servers as unknown as readonly unknown[],
+    servers: result.servers,
     operationCount: result.operations.length,
     operations: result.operations.map(
       (op) =>

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -63,9 +63,16 @@ export class ExtractedOperation extends Schema.Class<ExtractedOperation>("Extrac
   deprecated: Schema.optionalWith(Schema.Boolean, { default: () => false }),
 }) {}
 
+export class ServerVariable extends Schema.Class<ServerVariable>("ServerVariable")({
+  default: Schema.String,
+  enum: Schema.optionalWith(Schema.Array(Schema.String), { as: "Option" }),
+  description: Schema.optionalWith(Schema.String, { as: "Option" }),
+}) {}
+
 export class ServerInfo extends Schema.Class<ServerInfo>("ServerInfo")({
   url: Schema.String,
-  variables: Schema.optionalWith(Schema.Record({ key: Schema.String, value: Schema.String }), {
+  description: Schema.optionalWith(Schema.String, { as: "Option" }),
+  variables: Schema.optionalWith(Schema.Record({ key: Schema.String, value: ServerVariable }), {
     as: "Option",
   }),
 }) {}


### PR DESCRIPTION
## Summary
- Preserve `enum` and `description` on server variables through extraction + preview (previously we flattened to just the `default`).
- Rework the Add OpenAPI Source UI to render per-variable pickers (enum → select, free-form → input) and submit a **resolved** base URL instead of a templated one like `https://{region}.sentry.io`.
- Tighten `SpecPreview.servers` from `Schema.Array(Schema.Unknown)` to `Schema.Array(ServerInfo)` and export `ServerVariable` + `substituteUrlVariables` from the SDK.

## Why
Specs like Sentry's declare server variables with enums:

```yaml
servers:
  - url: https://{region}.sentry.io
    variables:
      region:
        default: us
        enum: [us, de]
```

Previously the UI stored the literal `https://{region}.sentry.io` as the base URL, which broke requests. Users also had no way to pick `de` over `us`.

## Test plan
- [x] `bunx vitest run` in `packages/plugins/openapi` (27 passing, incl. new extraction test for Sentry-style `{region}` with enum + description)
- [x] `bunx turbo run typecheck` across all 28 packages
- [ ] Manual: onboard a Sentry-style spec, verify the region picker appears and the resolved base URL is stored