### PR TITLE
Extract @executor/plugin-oauth2 shared helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -427,6 +427,7 @@
       "dependencies": {
         "@effect/platform": "catalog:",
         "@executor/api": "workspace:*",
+        "@executor/plugin-oauth2": "workspace:*",
         "@executor/sdk": "workspace:*",
         "effect": "catalog:",
       },
@@ -544,6 +545,19 @@
         "@tanstack/react-router",
         "react",
       ],
+    },
+    "packages/plugins/oauth2": {
+      "name": "@executor/plugin-oauth2",
+      "version": "0.0.1",
+      "dependencies": {
+        "effect": "catalog:",
+      },
+      "devDependencies": {
+        "@types/node": "catalog:",
+        "bun-types": "catalog:",
+        "tsup": "catalog:",
+        "vitest": "catalog:",
+      },
     },
     "packages/plugins/onepassword": {
       "name": "@executor/plugin-onepassword",
@@ -1129,6 +1143,8 @@
     "@executor/plugin-keychain": ["@executor/plugin-keychain@workspace:packages/plugins/keychain"],
 
     "@executor/plugin-mcp": ["@executor/plugin-mcp@workspace:packages/plugins/mcp"],
+
+    "@executor/plugin-oauth2": ["@executor/plugin-oauth2@workspace:packages/plugins/oauth2"],
 
     "@executor/plugin-onepassword": ["@executor/plugin-onepassword@workspace:packages/plugins/onepassword"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -553,6 +553,7 @@
         "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
         "tsup": "catalog:",

--- a/packages/plugins/google-discovery/package.json
+++ b/packages/plugins/google-discovery/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "@effect/platform": "catalog:",
     "@executor/api": "workspace:*",
+    "@executor/plugin-oauth2": "workspace:*",
     "@executor/sdk": "workspace:*",
     "effect": "catalog:"
   },

--- a/packages/plugins/google-discovery/src/sdk/invoke.ts
+++ b/packages/plugins/google-discovery/src/sdk/invoke.ts
@@ -1,6 +1,8 @@
 import { Effect, Layer, Option } from "effect";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "@effect/platform";
 
+import { shouldRefreshToken } from "@executor/plugin-oauth2";
+
 import {
   type ScopeId,
   type SecretId,
@@ -18,8 +20,6 @@ import {
   type GoogleDiscoveryParameter,
 } from "./types";
 import { refreshAccessToken } from "./oauth";
-
-const OAUTH_REFRESH_SKEW_MS = 60_000;
 
 const SAFE_METHODS = new Set(["get", "head", "options"]);
 
@@ -91,11 +91,9 @@ const resolveOAuthAccessToken = (input: {
     }
 
     const auth = input.source.auth;
-    const now = Date.now();
     const needsRefresh =
       auth.refreshTokenSecretId !== null &&
-      auth.expiresAt !== null &&
-      auth.expiresAt <= now + OAUTH_REFRESH_SKEW_MS;
+      shouldRefreshToken({ expiresAt: auth.expiresAt });
 
     if (!needsRefresh) {
       return yield* input.secrets.resolve(auth.accessTokenSecretId as SecretId, input.scopeId).pipe(

--- a/packages/plugins/google-discovery/src/sdk/oauth.ts
+++ b/packages/plugins/google-discovery/src/sdk/oauth.ts
@@ -1,24 +1,38 @@
-import { createHash, randomBytes } from "node:crypto";
+// ---------------------------------------------------------------------------
+// Google-specific thin wrapper over @executor/plugin-oauth2.
+//
+// All standards-compliant OAuth 2.0 logic lives in the shared package. This
+// file only carries the bits Google needs that are NOT in the spec:
+//   - Hardcoded authorization URL (accounts.google.com/o/oauth2/v2/auth)
+//   - access_type=offline                — required to receive a refresh_token
+//   - prompt=consent                     — forces re-consent so refresh_token is reissued
+//   - include_granted_scopes=true        — Google's incremental authorization
+// ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
 
+import {
+  buildAuthorizationUrl,
+  createPkceCodeVerifier as sharedCreatePkceCodeVerifier,
+  exchangeAuthorizationCode as sharedExchangeAuthorizationCode,
+  refreshAccessToken as sharedRefreshAccessToken,
+  type OAuth2TokenResponse,
+} from "@executor/plugin-oauth2";
+
 import { GoogleDiscoveryOAuthError } from "./errors";
 
-export type OAuth2TokenResponse = {
-  readonly access_token: string;
-  readonly token_type?: string;
-  readonly refresh_token?: string;
-  readonly expires_in?: number;
-  readonly scope?: string;
-};
+const GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 
-const encodeBase64Url = (input: Buffer): string =>
-  input.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+const GOOGLE_EXTRA_AUTHORIZATION_PARAMS = {
+  access_type: "offline",
+  include_granted_scopes: "true",
+  prompt: "consent",
+} as const;
 
-export const createPkceCodeVerifier = (): string => encodeBase64Url(randomBytes(48));
+export type { OAuth2TokenResponse as OAuth2TokenResponse };
 
-const createPkceCodeChallenge = (verifier: string): string =>
-  encodeBase64Url(createHash("sha256").update(verifier).digest());
+export const createPkceCodeVerifier = sharedCreatePkceCodeVerifier;
 
 export const buildGoogleAuthorizationUrl = (input: {
   readonly clientId: string;
@@ -26,87 +40,21 @@ export const buildGoogleAuthorizationUrl = (input: {
   readonly scopes: readonly string[];
   readonly state: string;
   readonly codeVerifier: string;
-}): string => {
-  const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
-  url.searchParams.set("client_id", input.clientId);
-  url.searchParams.set("redirect_uri", input.redirectUrl);
-  url.searchParams.set("response_type", "code");
-  url.searchParams.set("scope", input.scopes.join(" "));
-  url.searchParams.set("state", input.state);
-  url.searchParams.set("code_challenge_method", "S256");
-  url.searchParams.set("code_challenge", createPkceCodeChallenge(input.codeVerifier));
-  url.searchParams.set("access_type", "offline");
-  url.searchParams.set("include_granted_scopes", "true");
-  url.searchParams.set("prompt", "consent");
-  return url.toString();
-};
-
-const decodeTokenResponse = async (response: Response): Promise<OAuth2TokenResponse> => {
-  const rawText = await response.text();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawText);
-  } catch {
-    throw new Error(`OAuth token endpoint returned non-JSON response (${response.status})`);
-  }
-
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`OAuth token endpoint returned invalid JSON payload (${response.status})`);
-  }
-
-  const record = parsed as Record<string, unknown>;
-  const accessToken =
-    typeof record.access_token === "string" && record.access_token.length > 0
-      ? record.access_token
-      : null;
-
-  if (!response.ok) {
-    const description =
-      typeof record.error_description === "string"
-        ? record.error_description
-        : typeof record.error === "string"
-          ? record.error
-          : `status ${response.status}`;
-    throw new Error(`OAuth token exchange failed: ${description}`);
-  }
-
-  if (accessToken === null) {
-    throw new Error("OAuth token endpoint did not return an access_token");
-  }
-
-  return {
-    access_token: accessToken,
-    token_type: typeof record.token_type === "string" ? record.token_type : undefined,
-    refresh_token: typeof record.refresh_token === "string" ? record.refresh_token : undefined,
-    expires_in:
-      typeof record.expires_in === "number"
-        ? record.expires_in
-        : typeof record.expires_in === "string"
-          ? Number(record.expires_in)
-          : undefined,
-    scope: typeof record.scope === "string" ? record.scope : undefined,
-  };
-};
-
-const postToTokenEndpoint = (body: URLSearchParams) =>
-  Effect.tryPromise({
-    try: async () => {
-      const response = await fetch("https://oauth2.googleapis.com/token", {
-        method: "POST",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          accept: "application/json",
-        },
-        body,
-        signal: AbortSignal.timeout(20_000),
-      });
-      return decodeTokenResponse(response);
-    },
-    catch: (cause) =>
-      new GoogleDiscoveryOAuthError({
-        message: cause instanceof Error ? cause.message : String(cause),
-      }),
+}): string =>
+  buildAuthorizationUrl({
+    authorizationUrl: GOOGLE_AUTHORIZATION_URL,
+    clientId: input.clientId,
+    redirectUrl: input.redirectUrl,
+    scopes: input.scopes,
+    state: input.state,
+    codeVerifier: input.codeVerifier,
+    extraParams: GOOGLE_EXTRA_AUTHORIZATION_PARAMS,
   });
+
+const wrapError = <A>(
+  effect: Effect.Effect<A, { readonly message: string }>,
+): Effect.Effect<A, GoogleDiscoveryOAuthError> =>
+  Effect.mapError(effect, (error) => new GoogleDiscoveryOAuthError({ message: error.message }));
 
 export const exchangeAuthorizationCode = (input: {
   readonly clientId: string;
@@ -115,19 +63,16 @@ export const exchangeAuthorizationCode = (input: {
   readonly codeVerifier: string;
   readonly code: string;
 }): Effect.Effect<OAuth2TokenResponse, GoogleDiscoveryOAuthError> =>
-  Effect.gen(function* () {
-    const body = new URLSearchParams({
-      grant_type: "authorization_code",
-      client_id: input.clientId,
-      redirect_uri: input.redirectUrl,
-      code_verifier: input.codeVerifier,
+  wrapError(
+    sharedExchangeAuthorizationCode({
+      tokenUrl: GOOGLE_TOKEN_URL,
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      redirectUrl: input.redirectUrl,
+      codeVerifier: input.codeVerifier,
       code: input.code,
-    });
-    if (input.clientSecret) {
-      body.set("client_secret", input.clientSecret);
-    }
-    return yield* postToTokenEndpoint(body);
-  });
+    }),
+  );
 
 export const refreshAccessToken = (input: {
   readonly clientId: string;
@@ -135,17 +80,12 @@ export const refreshAccessToken = (input: {
   readonly refreshToken: string;
   readonly scopes?: readonly string[];
 }): Effect.Effect<OAuth2TokenResponse, GoogleDiscoveryOAuthError> =>
-  Effect.gen(function* () {
-    const body = new URLSearchParams({
-      grant_type: "refresh_token",
-      client_id: input.clientId,
-      refresh_token: input.refreshToken,
-    });
-    if (input.clientSecret) {
-      body.set("client_secret", input.clientSecret);
-    }
-    if (input.scopes && input.scopes.length > 0) {
-      body.set("scope", input.scopes.join(" "));
-    }
-    return yield* postToTokenEndpoint(body);
-  });
+  wrapError(
+    sharedRefreshAccessToken({
+      tokenUrl: GOOGLE_TOKEN_URL,
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      refreshToken: input.refreshToken,
+      scopes: input.scopes,
+    }),
+  );

--- a/packages/plugins/oauth2/package.json
+++ b/packages/plugins/oauth2/package.json
@@ -40,6 +40,7 @@
     "effect": "catalog:"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
     "tsup": "catalog:",

--- a/packages/plugins/oauth2/package.json
+++ b/packages/plugins/oauth2/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@executor/plugin-oauth2",
+  "version": "0.0.1",
+  "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/oauth2",
+  "bugs": {
+    "url": "https://github.com/RhysSullivan/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RhysSullivan/executor.git",
+    "directory": "packages/plugins/oauth2"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "import": {
+          "types": "./dist/index.d.ts",
+          "default": "./dist/index.js"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "effect": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "bun-types": "catalog:",
+    "tsup": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugins/oauth2/src/index.test.ts
+++ b/packages/plugins/oauth2/src/index.test.ts
@@ -1,0 +1,483 @@
+// ---------------------------------------------------------------------------
+// Fidelity suite — locks in every edge case the prior hand-rolled
+// google-discovery oauth.ts handled, so future "simplifications" of the
+// shared helpers fail loudly instead of silently breaking refresh / parsing /
+// provider-specific quirks.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Effect, Exit } from "effect";
+
+import {
+  OAUTH2_DEFAULT_TIMEOUT_MS,
+  OAUTH2_REFRESH_SKEW_MS,
+  OAuth2Error,
+  buildAuthorizationUrl,
+  createPkceCodeChallenge,
+  createPkceCodeVerifier,
+  decodeTokenResponse,
+  exchangeAuthorizationCode,
+  refreshAccessToken,
+  shouldRefreshToken,
+} from "./index";
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const textResponse = (status: number, body: string): Response =>
+  new Response(body, { status, headers: { "content-type": "text/html" } });
+
+// ---------------------------------------------------------------------------
+// PKCE
+// ---------------------------------------------------------------------------
+
+describe("PKCE", () => {
+  it("createPkceCodeVerifier returns a base64url string in the RFC 7636 length range", () => {
+    for (let i = 0; i < 25; i++) {
+      const verifier = createPkceCodeVerifier();
+      expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(verifier.length).toBeGreaterThanOrEqual(43);
+      expect(verifier.length).toBeLessThanOrEqual(128);
+    }
+  });
+
+  it("createPkceCodeChallenge matches the RFC 7636 Appendix A test vector", () => {
+    // RFC 7636 §4.2 test vector
+    const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+    expect(createPkceCodeChallenge(verifier)).toBe(expected);
+  });
+
+  it("createPkceCodeVerifier produces unique values", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 50; i++) seen.add(createPkceCodeVerifier());
+    expect(seen.size).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAuthorizationUrl
+// ---------------------------------------------------------------------------
+
+describe("buildAuthorizationUrl", () => {
+  const baseInput = {
+    authorizationUrl: "https://example.com/authorize",
+    clientId: "client-123",
+    redirectUrl: "https://app.example.com/callback",
+    scopes: ["read", "write"] as const,
+    state: "state-abc",
+    codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+  };
+
+  it("emits all RFC 6749 + PKCE params", () => {
+    const url = new URL(buildAuthorizationUrl(baseInput));
+    expect(url.origin + url.pathname).toBe("https://example.com/authorize");
+    expect(url.searchParams.get("client_id")).toBe("client-123");
+    expect(url.searchParams.get("redirect_uri")).toBe("https://app.example.com/callback");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("scope")).toBe("read write");
+    expect(url.searchParams.get("state")).toBe("state-abc");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBe(
+      "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+    );
+  });
+
+  it("supports a custom scope separator (e.g. comma for legacy providers)", () => {
+    const url = new URL(buildAuthorizationUrl({ ...baseInput, scopeSeparator: "," }));
+    expect(url.searchParams.get("scope")).toBe("read,write");
+  });
+
+  it("merges Google-style extra params without dropping them", () => {
+    const url = new URL(
+      buildAuthorizationUrl({
+        ...baseInput,
+        extraParams: {
+          access_type: "offline",
+          prompt: "consent",
+          include_granted_scopes: "true",
+        },
+      }),
+    );
+    expect(url.searchParams.get("access_type")).toBe("offline");
+    expect(url.searchParams.get("prompt")).toBe("consent");
+    expect(url.searchParams.get("include_granted_scopes")).toBe("true");
+    // Standard params are still present.
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  it("preserves pre-existing query params on the authorization URL", () => {
+    const url = new URL(
+      buildAuthorizationUrl({ ...baseInput, authorizationUrl: "https://example.com/auth?tenant=acme" }),
+    );
+    expect(url.searchParams.get("tenant")).toBe("acme");
+    expect(url.searchParams.get("client_id")).toBe("client-123");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decodeTokenResponse
+// ---------------------------------------------------------------------------
+
+describe("decodeTokenResponse", () => {
+  it("parses a minimal successful response", async () => {
+    const result = await decodeTokenResponse(jsonResponse(200, { access_token: "tok" }));
+    expect(result.access_token).toBe("tok");
+    expect(result.token_type).toBeUndefined();
+    expect(result.expires_in).toBeUndefined();
+  });
+
+  it("parses a fully populated successful response", async () => {
+    const result = await decodeTokenResponse(
+      jsonResponse(200, {
+        access_token: "tok",
+        token_type: "Bearer",
+        refresh_token: "rtok",
+        expires_in: 3600,
+        scope: "read write",
+      }),
+    );
+    expect(result).toEqual({
+      access_token: "tok",
+      token_type: "Bearer",
+      refresh_token: "rtok",
+      expires_in: 3600,
+      scope: "read write",
+    });
+  });
+
+  it("accepts expires_in as a string (Azure / older providers)", async () => {
+    const result = await decodeTokenResponse(
+      jsonResponse(200, { access_token: "tok", expires_in: "3600" }),
+    );
+    expect(result.expires_in).toBe(3600);
+  });
+
+  it("rejects non-JSON bodies (HTML error pages from proxies / 5xx)", async () => {
+    await expect(decodeTokenResponse(textResponse(502, "<html>bad gateway</html>"))).rejects.toThrow(
+      /non-JSON response \(502\)/,
+    );
+  });
+
+  it("rejects JSON arrays / non-object payloads", async () => {
+    await expect(
+      decodeTokenResponse(jsonResponse(200, ["not", "an", "object"])),
+    ).rejects.toThrow(/invalid JSON payload \(200\)/);
+  });
+
+  it("uses error_description from RFC 6749 error responses", async () => {
+    await expect(
+      decodeTokenResponse(
+        jsonResponse(400, {
+          error: "invalid_grant",
+          error_description: "The provided authorization grant is invalid",
+        }),
+      ),
+    ).rejects.toThrow("OAuth token exchange failed: The provided authorization grant is invalid");
+  });
+
+  it("falls back to error code when error_description is absent", async () => {
+    await expect(
+      decodeTokenResponse(jsonResponse(400, { error: "invalid_grant" })),
+    ).rejects.toThrow("OAuth token exchange failed: invalid_grant");
+  });
+
+  it("falls back to status N when no error fields are present", async () => {
+    await expect(decodeTokenResponse(jsonResponse(500, {}))).rejects.toThrow(
+      "OAuth token exchange failed: status 500",
+    );
+  });
+
+  it("rejects 200 responses with an empty access_token", async () => {
+    await expect(
+      decodeTokenResponse(jsonResponse(200, { access_token: "" })),
+    ).rejects.toThrow(/did not return an access_token/);
+  });
+
+  it("rejects 200 responses with no access_token field", async () => {
+    await expect(decodeTokenResponse(jsonResponse(200, { token_type: "Bearer" }))).rejects.toThrow(
+      /did not return an access_token/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exchangeAuthorizationCode / refreshAccessToken — request shape
+// ---------------------------------------------------------------------------
+
+type FetchArgs = { url: string; init: RequestInit };
+
+const captureFetch = (response: Response): { calls: FetchArgs[] } => {
+  const calls: FetchArgs[] = [];
+  globalThis.fetch = vi
+    .fn()
+    .mockImplementation(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return response;
+    }) as unknown as typeof fetch;
+  return { calls };
+};
+
+const originalFetch = globalThis.fetch;
+
+describe("exchangeAuthorizationCode", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const validBody = {
+    access_token: "tok",
+    token_type: "Bearer",
+    refresh_token: "rtok",
+    expires_in: 3600,
+    scope: "read",
+  };
+
+  it("posts form-urlencoded body with grant_type=authorization_code and PKCE verifier", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    const result = await Effect.runPromise(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        clientSecret: "csecret",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+      }),
+    );
+    expect(result.access_token).toBe("tok");
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.url).toBe("https://example.com/token");
+    expect(call.init.method).toBe("POST");
+    const headers = call.init.headers as Record<string, string>;
+    expect(headers["content-type"]).toBe("application/x-www-form-urlencoded");
+    expect(headers["accept"]).toBe("application/json");
+    const body = call.init.body as URLSearchParams;
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("client_id")).toBe("cid");
+    expect(body.get("client_secret")).toBe("csecret");
+    expect(body.get("redirect_uri")).toBe("https://app.example.com/cb");
+    expect(body.get("code_verifier")).toBe("verifier");
+    expect(body.get("code")).toBe("abc");
+  });
+
+  it("omits client_secret when none is provided (public clients with PKCE)", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.get("client_id")).toBe("cid");
+    expect(body.has("client_secret")).toBe(false);
+  });
+
+  it("uses HTTP Basic auth when clientAuth=basic (Stripe-style)", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        clientSecret: "csecret",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+        clientAuth: "basic",
+      }),
+    );
+    const headers = calls[0]!.init.headers as Record<string, string>;
+    const expected = `Basic ${Buffer.from("cid:csecret").toString("base64")}`;
+    expect(headers["authorization"]).toBe(expected);
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.has("client_id")).toBe(false);
+    expect(body.has("client_secret")).toBe(false);
+  });
+
+  it("sets a 20-second AbortSignal timeout by default", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://cb",
+        codeVerifier: "v",
+        code: "c",
+      }),
+    );
+    expect(OAUTH2_DEFAULT_TIMEOUT_MS).toBe(20_000);
+    expect(calls[0]!.init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("returns a typed OAuth2Error on transport failure", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("boom")) as unknown as typeof fetch;
+    const exit = await Effect.runPromiseExit(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://cb",
+        codeVerifier: "v",
+        code: "c",
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const err = exit.cause;
+      const failure = JSON.stringify(err);
+      expect(failure).toContain("OAuth2Error");
+      expect(failure).toContain("boom");
+    }
+  });
+
+  it("propagates RFC 6749 error_description text in the OAuth2Error", async () => {
+    captureFetch(
+      jsonResponse(400, {
+        error: "invalid_grant",
+        error_description: "Code expired",
+      }),
+    );
+    const exit = await Effect.runPromiseExit(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://cb",
+        codeVerifier: "v",
+        code: "c",
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(JSON.stringify(exit.cause)).toContain("Code expired");
+    }
+  });
+});
+
+describe("refreshAccessToken", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const validBody = { access_token: "tok2", token_type: "Bearer", expires_in: 3600 };
+
+  it("posts grant_type=refresh_token with the refresh token", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      refreshAccessToken({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        clientSecret: "csecret",
+        refreshToken: "old",
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("old");
+    expect(body.get("client_id")).toBe("cid");
+    expect(body.get("client_secret")).toBe("csecret");
+  });
+
+  it("includes scope when scopes are provided", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      refreshAccessToken({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        refreshToken: "old",
+        scopes: ["a", "b"],
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.get("scope")).toBe("a b");
+  });
+
+  it("omits scope when scopes is empty", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      refreshAccessToken({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        refreshToken: "old",
+        scopes: [],
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.has("scope")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldRefreshToken
+// ---------------------------------------------------------------------------
+
+describe("shouldRefreshToken", () => {
+  it("never refreshes when expiresAt is null", () => {
+    expect(shouldRefreshToken({ expiresAt: null })).toBe(false);
+  });
+
+  it("returns true when within the skew window", () => {
+    const now = 1_000_000;
+    expect(shouldRefreshToken({ expiresAt: now + 30_000, now })).toBe(true);
+  });
+
+  it("returns false when comfortably in the future", () => {
+    const now = 1_000_000;
+    expect(shouldRefreshToken({ expiresAt: now + 5 * 60_000, now })).toBe(false);
+  });
+
+  it("uses the documented 60s default skew", () => {
+    expect(OAUTH2_REFRESH_SKEW_MS).toBe(60_000);
+    const now = 1_000_000;
+    expect(shouldRefreshToken({ expiresAt: now + 59_000, now })).toBe(true);
+    expect(shouldRefreshToken({ expiresAt: now + 61_000, now })).toBe(false);
+  });
+
+  it("respects a custom skew", () => {
+    const now = 1_000_000;
+    expect(shouldRefreshToken({ expiresAt: now + 30_000, now, skewMs: 10_000 })).toBe(false);
+    expect(shouldRefreshToken({ expiresAt: now + 5_000, now, skewMs: 10_000 })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error type plumbing — make sure Effect propagates the tagged error
+// ---------------------------------------------------------------------------
+
+describe("OAuth2Error tagging", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down")) as unknown as typeof fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("Effect failure channel carries OAuth2Error", async () => {
+    const exit = await Effect.runPromiseExit(
+      refreshAccessToken({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        refreshToken: "old",
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      // Walk the cause to find the failure
+      const failures = JSON.stringify(exit.cause);
+      expect(failures).toContain("OAuth2Error");
+    }
+  });
+
+  it("OAuth2Error is constructable directly with message and cause", () => {
+    const err = new OAuth2Error({ message: "test", cause: { foo: 1 } });
+    expect(err._tag).toBe("OAuth2Error");
+    expect(err.message).toBe("test");
+    expect(err.cause).toEqual({ foo: 1 });
+  });
+});

--- a/packages/plugins/oauth2/src/index.test.ts
+++ b/packages/plugins/oauth2/src/index.test.ts
@@ -5,8 +5,8 @@
 // provider-specific quirks.
 // ---------------------------------------------------------------------------
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { Effect, Exit } from "effect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "@effect/vitest";
+import { Cause, Chunk, Effect, Exit } from "effect";
 
 import {
   OAUTH2_DEFAULT_TIMEOUT_MS,
@@ -123,85 +123,133 @@ describe("buildAuthorizationUrl", () => {
 // ---------------------------------------------------------------------------
 
 describe("decodeTokenResponse", () => {
-  it("parses a minimal successful response", async () => {
-    const result = await decodeTokenResponse(jsonResponse(200, { access_token: "tok" }));
-    expect(result.access_token).toBe("tok");
-    expect(result.token_type).toBeUndefined();
-    expect(result.expires_in).toBeUndefined();
-  });
+  /** Assert the decode effect fails with an OAuth2Error whose message matches `pattern`. */
+  const expectOAuth2ErrorMatching = (
+    exit: Exit.Exit<unknown, OAuth2Error>,
+    pattern: RegExp | string,
+  ) => {
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const failures = Chunk.toReadonlyArray(Cause.failures(exit.cause));
+    expect(failures.length).toBeGreaterThan(0);
+    const error = failures[0]!;
+    expect(error).toBeInstanceOf(OAuth2Error);
+    if (typeof pattern === "string") {
+      expect(error.message).toContain(pattern);
+    } else {
+      expect(error.message).toMatch(pattern);
+    }
+  };
 
-  it("parses a fully populated successful response", async () => {
-    const result = await decodeTokenResponse(
-      jsonResponse(200, {
+  it.effect("parses a minimal successful response", () =>
+    Effect.gen(function* () {
+      const result = yield* decodeTokenResponse(
+        jsonResponse(200, { access_token: "tok" }),
+      );
+      expect(result.access_token).toBe("tok");
+      expect(result.token_type).toBeUndefined();
+      expect(result.expires_in).toBeUndefined();
+    }),
+  );
+
+  it.effect("parses a fully populated successful response", () =>
+    Effect.gen(function* () {
+      const result = yield* decodeTokenResponse(
+        jsonResponse(200, {
+          access_token: "tok",
+          token_type: "Bearer",
+          refresh_token: "rtok",
+          expires_in: 3600,
+          scope: "read write",
+        }),
+      );
+      expect(result).toEqual({
         access_token: "tok",
         token_type: "Bearer",
         refresh_token: "rtok",
         expires_in: 3600,
         scope: "read write",
-      }),
-    );
-    expect(result).toEqual({
-      access_token: "tok",
-      token_type: "Bearer",
-      refresh_token: "rtok",
-      expires_in: 3600,
-      scope: "read write",
-    });
-  });
+      });
+    }),
+  );
 
-  it("accepts expires_in as a string (Azure / older providers)", async () => {
-    const result = await decodeTokenResponse(
-      jsonResponse(200, { access_token: "tok", expires_in: "3600" }),
-    );
-    expect(result.expires_in).toBe(3600);
-  });
+  it.effect("accepts expires_in as a string (Azure / older providers)", () =>
+    Effect.gen(function* () {
+      const result = yield* decodeTokenResponse(
+        jsonResponse(200, { access_token: "tok", expires_in: "3600" }),
+      );
+      expect(result.expires_in).toBe(3600);
+    }),
+  );
 
-  it("rejects non-JSON bodies (HTML error pages from proxies / 5xx)", async () => {
-    await expect(decodeTokenResponse(textResponse(502, "<html>bad gateway</html>"))).rejects.toThrow(
-      /non-JSON response \(502\)/,
-    );
-  });
+  it.effect("fails with OAuth2Error on non-JSON bodies (HTML error pages from proxies / 5xx)", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeTokenResponse(textResponse(502, "<html>bad gateway</html>")),
+      );
+      expectOAuth2ErrorMatching(exit, /non-JSON response \(502\)/);
+    }),
+  );
 
-  it("rejects JSON arrays / non-object payloads", async () => {
-    await expect(
-      decodeTokenResponse(jsonResponse(200, ["not", "an", "object"])),
-    ).rejects.toThrow(/invalid JSON payload \(200\)/);
-  });
+  it.effect("fails with OAuth2Error on JSON arrays / non-object payloads", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeTokenResponse(jsonResponse(200, ["not", "an", "object"])),
+      );
+      expectOAuth2ErrorMatching(exit, /invalid JSON payload \(200\)/);
+    }),
+  );
 
-  it("uses error_description from RFC 6749 error responses", async () => {
-    await expect(
-      decodeTokenResponse(
-        jsonResponse(400, {
-          error: "invalid_grant",
-          error_description: "The provided authorization grant is invalid",
-        }),
-      ),
-    ).rejects.toThrow("OAuth token exchange failed: The provided authorization grant is invalid");
-  });
+  it.effect("uses error_description from RFC 6749 error responses", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeTokenResponse(
+          jsonResponse(400, {
+            error: "invalid_grant",
+            error_description: "The provided authorization grant is invalid",
+          }),
+        ),
+      );
+      expectOAuth2ErrorMatching(
+        exit,
+        "OAuth token exchange failed: The provided authorization grant is invalid",
+      );
+    }),
+  );
 
-  it("falls back to error code when error_description is absent", async () => {
-    await expect(
-      decodeTokenResponse(jsonResponse(400, { error: "invalid_grant" })),
-    ).rejects.toThrow("OAuth token exchange failed: invalid_grant");
-  });
+  it.effect("falls back to error code when error_description is absent", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeTokenResponse(jsonResponse(400, { error: "invalid_grant" })),
+      );
+      expectOAuth2ErrorMatching(exit, "OAuth token exchange failed: invalid_grant");
+    }),
+  );
 
-  it("falls back to status N when no error fields are present", async () => {
-    await expect(decodeTokenResponse(jsonResponse(500, {}))).rejects.toThrow(
-      "OAuth token exchange failed: status 500",
-    );
-  });
+  it.effect("falls back to status N when no error fields are present", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(decodeTokenResponse(jsonResponse(500, {})));
+      expectOAuth2ErrorMatching(exit, "OAuth token exchange failed: status 500");
+    }),
+  );
 
-  it("rejects 200 responses with an empty access_token", async () => {
-    await expect(
-      decodeTokenResponse(jsonResponse(200, { access_token: "" })),
-    ).rejects.toThrow(/did not return an access_token/);
-  });
+  it.effect("fails with OAuth2Error on 200 responses with an empty access_token", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeTokenResponse(jsonResponse(200, { access_token: "" })),
+      );
+      expectOAuth2ErrorMatching(exit, /did not return an access_token/);
+    }),
+  );
 
-  it("rejects 200 responses with no access_token field", async () => {
-    await expect(decodeTokenResponse(jsonResponse(200, { token_type: "Bearer" }))).rejects.toThrow(
-      /did not return an access_token/,
-    );
-  });
+  it.effect("fails with OAuth2Error on 200 responses with no access_token field", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        decodeTokenResponse(jsonResponse(200, { token_type: "Bearer" })),
+      );
+      expectOAuth2ErrorMatching(exit, /did not return an access_token/);
+    }),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/oauth2/src/index.ts
+++ b/packages/plugins/oauth2/src/index.ts
@@ -1,0 +1,307 @@
+// ---------------------------------------------------------------------------
+// @executor/plugin-oauth2 — generic OAuth 2.0 helpers
+//
+// Pure helpers for building authorization URLs, exchanging codes, and
+// refreshing tokens against a standards-compliant OAuth 2.0 token endpoint.
+// Plugins (google-discovery, openapi, ...) wrap these with their own
+// session storage, secret management, and onboarding UI.
+//
+// Every public helper is intentionally provider-agnostic. Provider-specific
+// query parameters (Google's `access_type=offline`, `prompt=consent`, etc.)
+// are passed via the `extraParams` escape hatch so callers don't lose
+// fidelity when switching from a hand-rolled implementation.
+// ---------------------------------------------------------------------------
+
+import { createHash, randomBytes } from "node:crypto";
+
+import { Data, Effect } from "effect";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class OAuth2Error extends Data.TaggedError("OAuth2Error")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+// ---------------------------------------------------------------------------
+// Token response shape (RFC 6749 §5.1)
+// ---------------------------------------------------------------------------
+
+export type OAuth2TokenResponse = {
+  readonly access_token: string;
+  readonly token_type?: string;
+  readonly refresh_token?: string;
+  readonly expires_in?: number;
+  readonly scope?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Refresh tokens this many ms before expiry to avoid mid-request expiration. */
+export const OAUTH2_REFRESH_SKEW_MS = 60_000;
+
+/** Default token-endpoint timeout. */
+export const OAUTH2_DEFAULT_TIMEOUT_MS = 20_000;
+
+// ---------------------------------------------------------------------------
+// PKCE (RFC 7636)
+// ---------------------------------------------------------------------------
+
+const encodeBase64Url = (input: Buffer): string =>
+  input.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+
+/** Generate a 48-byte (64-char base64url) PKCE code verifier. */
+export const createPkceCodeVerifier = (): string => encodeBase64Url(randomBytes(48));
+
+/** Compute the S256 code challenge for a given verifier. */
+export const createPkceCodeChallenge = (verifier: string): string =>
+  encodeBase64Url(createHash("sha256").update(verifier).digest());
+
+// ---------------------------------------------------------------------------
+// Authorization URL builder
+// ---------------------------------------------------------------------------
+
+export type BuildAuthorizationUrlInput = {
+  readonly authorizationUrl: string;
+  readonly clientId: string;
+  readonly redirectUrl: string;
+  readonly scopes: readonly string[];
+  readonly state: string;
+  readonly codeVerifier: string;
+  /** Separator between scopes. RFC 6749 says space; some providers use comma. */
+  readonly scopeSeparator?: string;
+  /**
+   * Provider-specific extra params (e.g. Google's `access_type=offline`,
+   * `prompt=consent`, `include_granted_scopes=true`). Merged AFTER the
+   * standard params so callers can override if absolutely necessary.
+   */
+  readonly extraParams?: Readonly<Record<string, string>>;
+};
+
+export const buildAuthorizationUrl = (input: BuildAuthorizationUrlInput): string => {
+  const url = new URL(input.authorizationUrl);
+  const separator = input.scopeSeparator ?? " ";
+  url.searchParams.set("client_id", input.clientId);
+  url.searchParams.set("redirect_uri", input.redirectUrl);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", input.scopes.join(separator));
+  url.searchParams.set("state", input.state);
+  url.searchParams.set("code_challenge_method", "S256");
+  url.searchParams.set("code_challenge", createPkceCodeChallenge(input.codeVerifier));
+  if (input.extraParams) {
+    for (const [k, v] of Object.entries(input.extraParams)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return url.toString();
+};
+
+// ---------------------------------------------------------------------------
+// Token endpoint response parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Response from a token endpoint into an `OAuth2TokenResponse`.
+ *
+ * Handles, in order, the failure modes we have seen in the wild:
+ *   1. Non-JSON bodies (HTML error pages from misconfigured proxies / 5xx)
+ *   2. JSON arrays / primitives instead of an object
+ *   3. RFC 6749 error responses (`error_description` → `error` → `status N`)
+ *   4. 200 responses with empty / missing `access_token`
+ *   5. `expires_in` returned as a string instead of a number (Azure et al.)
+ */
+export const decodeTokenResponse = async (response: Response): Promise<OAuth2TokenResponse> => {
+  const rawText = await response.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    throw new Error(`OAuth token endpoint returned non-JSON response (${response.status})`);
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`OAuth token endpoint returned invalid JSON payload (${response.status})`);
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const accessToken =
+    typeof record.access_token === "string" && record.access_token.length > 0
+      ? record.access_token
+      : null;
+
+  if (!response.ok) {
+    const description =
+      typeof record.error_description === "string"
+        ? record.error_description
+        : typeof record.error === "string"
+          ? record.error
+          : `status ${response.status}`;
+    throw new Error(`OAuth token exchange failed: ${description}`);
+  }
+
+  if (accessToken === null) {
+    throw new Error("OAuth token endpoint did not return an access_token");
+  }
+
+  return {
+    access_token: accessToken,
+    token_type: typeof record.token_type === "string" ? record.token_type : undefined,
+    refresh_token: typeof record.refresh_token === "string" ? record.refresh_token : undefined,
+    expires_in:
+      typeof record.expires_in === "number"
+        ? record.expires_in
+        : typeof record.expires_in === "string"
+          ? Number(record.expires_in)
+          : undefined,
+    scope: typeof record.scope === "string" ? record.scope : undefined,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Token endpoint POST
+// ---------------------------------------------------------------------------
+
+export type ClientAuthMethod = "body" | "basic";
+
+const buildClientAuthHeaders = (
+  clientId: string,
+  clientSecret: string | null | undefined,
+  method: ClientAuthMethod,
+): Record<string, string> => {
+  if (method !== "basic" || !clientSecret) return {};
+  const encoded = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+  return { authorization: `Basic ${encoded}` };
+};
+
+const applyClientAuthBody = (
+  body: URLSearchParams,
+  clientId: string,
+  clientSecret: string | null | undefined,
+  method: ClientAuthMethod,
+): void => {
+  if (method === "basic") return;
+  body.set("client_id", clientId);
+  if (clientSecret) body.set("client_secret", clientSecret);
+};
+
+const postToTokenEndpoint = (input: {
+  readonly tokenUrl: string;
+  readonly body: URLSearchParams;
+  readonly extraHeaders: Record<string, string>;
+  readonly timeoutMs: number;
+}): Effect.Effect<OAuth2TokenResponse, OAuth2Error> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(input.tokenUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          accept: "application/json",
+          ...input.extraHeaders,
+        },
+        body: input.body,
+        signal: AbortSignal.timeout(input.timeoutMs),
+      });
+      return decodeTokenResponse(response);
+    },
+    catch: (cause) =>
+      new OAuth2Error({
+        message: cause instanceof Error ? cause.message : String(cause),
+        cause,
+      }),
+  });
+
+// ---------------------------------------------------------------------------
+// Exchange authorization code → tokens
+// ---------------------------------------------------------------------------
+
+export type ExchangeAuthorizationCodeInput = {
+  readonly tokenUrl: string;
+  readonly clientId: string;
+  readonly clientSecret?: string | null;
+  readonly redirectUrl: string;
+  readonly codeVerifier: string;
+  readonly code: string;
+  /** "body" (default) sends client creds in the form body; "basic" uses HTTP Basic. */
+  readonly clientAuth?: ClientAuthMethod;
+  readonly timeoutMs?: number;
+};
+
+export const exchangeAuthorizationCode = (
+  input: ExchangeAuthorizationCodeInput,
+): Effect.Effect<OAuth2TokenResponse, OAuth2Error> => {
+  const clientAuth = input.clientAuth ?? "body";
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    redirect_uri: input.redirectUrl,
+    code_verifier: input.codeVerifier,
+    code: input.code,
+  });
+  applyClientAuthBody(body, input.clientId, input.clientSecret, clientAuth);
+  return postToTokenEndpoint({
+    tokenUrl: input.tokenUrl,
+    body,
+    extraHeaders: buildClientAuthHeaders(input.clientId, input.clientSecret, clientAuth),
+    timeoutMs: input.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Refresh access token
+// ---------------------------------------------------------------------------
+
+export type RefreshAccessTokenInput = {
+  readonly tokenUrl: string;
+  readonly clientId: string;
+  readonly clientSecret?: string | null;
+  readonly refreshToken: string;
+  readonly scopes?: readonly string[];
+  readonly scopeSeparator?: string;
+  readonly clientAuth?: ClientAuthMethod;
+  readonly timeoutMs?: number;
+};
+
+export const refreshAccessToken = (
+  input: RefreshAccessTokenInput,
+): Effect.Effect<OAuth2TokenResponse, OAuth2Error> => {
+  const clientAuth = input.clientAuth ?? "body";
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: input.refreshToken,
+  });
+  applyClientAuthBody(body, input.clientId, input.clientSecret, clientAuth);
+  if (input.scopes && input.scopes.length > 0) {
+    body.set("scope", input.scopes.join(input.scopeSeparator ?? " "));
+  }
+  return postToTokenEndpoint({
+    tokenUrl: input.tokenUrl,
+    body,
+    extraHeaders: buildClientAuthHeaders(input.clientId, input.clientSecret, clientAuth),
+    timeoutMs: input.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Refresh-needed predicate
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns true iff the current time is within `OAUTH2_REFRESH_SKEW_MS` of
+ * `expiresAt`. A null `expiresAt` (server didn't return `expires_in`) means
+ * we cannot proactively refresh — callers should fall back to reactive
+ * refresh on 401 responses.
+ */
+export const shouldRefreshToken = (input: {
+  readonly expiresAt: number | null;
+  readonly now?: number;
+  readonly skewMs?: number;
+}): boolean => {
+  if (input.expiresAt === null) return false;
+  const now = input.now ?? Date.now();
+  const skew = input.skewMs ?? OAUTH2_REFRESH_SKEW_MS;
+  return input.expiresAt <= now + skew;
+};

--- a/packages/plugins/oauth2/src/index.ts
+++ b/packages/plugins/oauth2/src/index.ts
@@ -14,7 +14,7 @@
 
 import { createHash, randomBytes } from "node:crypto";
 
-import { Data, Effect } from "effect";
+import { Data, Effect, ParseResult, Schema } from "effect";
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -104,8 +104,82 @@ export const buildAuthorizationUrl = (input: BuildAuthorizationUrlInput): string
 // Token endpoint response parsing
 // ---------------------------------------------------------------------------
 
+const oauth2Error = (message: string, cause?: unknown): OAuth2Error =>
+  new OAuth2Error({ message, cause });
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
 /**
- * Parse a Response from a token endpoint into an `OAuth2TokenResponse`.
+ * `expires_in` per RFC 6749 is a number of seconds, but some providers
+ * (Azure, older OAuth servers) return it as a string. Accept either and
+ * coerce to number.
+ */
+const TokenExpirySeconds = Schema.transformOrFail(
+  Schema.Union(Schema.Number, Schema.String),
+  Schema.Number,
+  {
+    strict: true,
+    decode: (input, _options, ast) => {
+      if (typeof input === "number") return ParseResult.succeed(input);
+      const parsed = Number(input);
+      return Number.isFinite(parsed)
+        ? ParseResult.succeed(parsed)
+        : ParseResult.fail(
+            new ParseResult.Type(ast, input, `expires_in "${input}" is not a number`),
+          );
+    },
+    encode: (value) => ParseResult.succeed(value),
+  },
+);
+
+const OAuth2TokenSuccessSchema = Schema.Struct({
+  /** RFC 6749 §5.1 requires a non-empty access_token on success. */
+  access_token: Schema.String.pipe(Schema.minLength(1)),
+  token_type: Schema.optional(Schema.String),
+  refresh_token: Schema.optional(Schema.String),
+  expires_in: Schema.optional(TokenExpirySeconds),
+  scope: Schema.optional(Schema.String),
+});
+
+/** RFC 6749 §5.2 error response envelope — all fields optional; we probe them. */
+const OAuth2ErrorEnvelopeSchema = Schema.Struct({
+  error: Schema.optional(Schema.String),
+  error_description: Schema.optional(Schema.String),
+});
+
+const decodeSuccessBody = Schema.decodeUnknown(OAuth2TokenSuccessSchema);
+const decodeErrorBody = Schema.decodeUnknown(OAuth2ErrorEnvelopeSchema);
+
+/**
+ * Parse the body of a token endpoint Response as JSON and ensure it's a
+ * plain object. Fails with `OAuth2Error` whose message matches the
+ * historical wording (`non-JSON response (${status})` /
+ * `invalid JSON payload (${status})`) so callers keep their fidelity
+ * guarantees.
+ */
+const parseJsonObject = (
+  rawText: string,
+  status: number,
+): Effect.Effect<Record<string, unknown>, OAuth2Error> =>
+  Effect.try({
+    try: () => JSON.parse(rawText) as unknown,
+    catch: () => oauth2Error(`OAuth token endpoint returned non-JSON response (${status})`),
+  }).pipe(
+    Effect.flatMap((parsed) =>
+      parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+        ? Effect.succeed(parsed as Record<string, unknown>)
+        : Effect.fail(
+            oauth2Error(`OAuth token endpoint returned invalid JSON payload (${status})`),
+          ),
+    ),
+  );
+
+/**
+ * Parse a `Response` from an OAuth 2.0 token endpoint into an
+ * `OAuth2TokenResponse`. Failures surface through the Effect failure
+ * channel as `OAuth2Error`.
  *
  * Handles, in order, the failure modes we have seen in the wild:
  *   1. Non-JSON bodies (HTML error pages from misconfigured proxies / 5xx)
@@ -114,52 +188,45 @@ export const buildAuthorizationUrl = (input: BuildAuthorizationUrlInput): string
  *   4. 200 responses with empty / missing `access_token`
  *   5. `expires_in` returned as a string instead of a number (Azure et al.)
  */
-export const decodeTokenResponse = async (response: Response): Promise<OAuth2TokenResponse> => {
-  const rawText = await response.text();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(rawText);
-  } catch {
-    throw new Error(`OAuth token endpoint returned non-JSON response (${response.status})`);
-  }
+export const decodeTokenResponse = (
+  response: Response,
+): Effect.Effect<OAuth2TokenResponse, OAuth2Error> =>
+  Effect.gen(function* () {
+    const rawText = yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: (cause) =>
+        oauth2Error(
+          `Failed to read OAuth token endpoint body: ${cause instanceof Error ? cause.message : String(cause)}`,
+          cause,
+        ),
+    });
 
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error(`OAuth token endpoint returned invalid JSON payload (${response.status})`);
-  }
+    const record = yield* parseJsonObject(rawText, response.status);
 
-  const record = parsed as Record<string, unknown>;
-  const accessToken =
-    typeof record.access_token === "string" && record.access_token.length > 0
-      ? record.access_token
-      : null;
+    if (!response.ok) {
+      // Probe the error envelope. A body that doesn't match the envelope
+      // (e.g. completely empty) is not itself a failure — we just fall
+      // back to `status N`. This mirrors the tolerant behavior of the
+      // prior hand-rolled parser.
+      const envelope = yield* decodeErrorBody(record).pipe(
+        Effect.catchAll(() => Effect.succeed({} as { error?: string; error_description?: string })),
+      );
+      const description =
+        envelope.error_description ?? envelope.error ?? `status ${response.status}`;
+      return yield* Effect.fail(oauth2Error(`OAuth token exchange failed: ${description}`));
+    }
 
-  if (!response.ok) {
-    const description =
-      typeof record.error_description === "string"
-        ? record.error_description
-        : typeof record.error === "string"
-          ? record.error
-          : `status ${response.status}`;
-    throw new Error(`OAuth token exchange failed: ${description}`);
-  }
-
-  if (accessToken === null) {
-    throw new Error("OAuth token endpoint did not return an access_token");
-  }
-
-  return {
-    access_token: accessToken,
-    token_type: typeof record.token_type === "string" ? record.token_type : undefined,
-    refresh_token: typeof record.refresh_token === "string" ? record.refresh_token : undefined,
-    expires_in:
-      typeof record.expires_in === "number"
-        ? record.expires_in
-        : typeof record.expires_in === "string"
-          ? Number(record.expires_in)
-          : undefined,
-    scope: typeof record.scope === "string" ? record.scope : undefined,
-  };
-};
+    return yield* decodeSuccessBody(record).pipe(
+      Effect.mapError(() =>
+        // The only schema constraint that can fail on a 2xx is "access_token
+        // is a non-empty string". Any other shape mismatch (wrong type on an
+        // optional field, malformed expires_in) also surfaces as the same
+        // message — we deliberately fold them together: the user needs an
+        // access token, and they didn't get one.
+        oauth2Error("OAuth token endpoint did not return an access_token"),
+      ),
+    );
+  });
 
 // ---------------------------------------------------------------------------
 // Token endpoint POST
@@ -195,8 +262,8 @@ const postToTokenEndpoint = (input: {
   readonly timeoutMs: number;
 }): Effect.Effect<OAuth2TokenResponse, OAuth2Error> =>
   Effect.tryPromise({
-    try: async () => {
-      const response = await fetch(input.tokenUrl, {
+    try: () =>
+      fetch(input.tokenUrl, {
         method: "POST",
         headers: {
           "content-type": "application/x-www-form-urlencoded",
@@ -205,15 +272,9 @@ const postToTokenEndpoint = (input: {
         },
         body: input.body,
         signal: AbortSignal.timeout(input.timeoutMs),
-      });
-      return decodeTokenResponse(response);
-    },
-    catch: (cause) =>
-      new OAuth2Error({
-        message: cause instanceof Error ? cause.message : String(cause),
-        cause,
       }),
-  });
+    catch: (cause) => oauth2Error(cause instanceof Error ? cause.message : String(cause), cause),
+  }).pipe(Effect.flatMap(decodeTokenResponse));
 
 // ---------------------------------------------------------------------------
 // Exchange authorization code → tokens

--- a/packages/plugins/oauth2/tsconfig.json
+++ b/packages/plugins/oauth2/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "lib": ["ES2022"],
+    "types": ["bun-types", "node"],
+    "noUnusedLocals": true,
+    "noImplicitOverride": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnosticSeverity": {
+          "preferSchemaOverJson": "off"
+        }
+      }
+    ]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugins/oauth2/tsconfig.json
+++ b/packages/plugins/oauth2/tsconfig.json
@@ -12,9 +12,7 @@
     "plugins": [
       {
         "name": "@effect/language-service",
-        "diagnosticSeverity": {
-          "preferSchemaOverJson": "off"
-        }
+        "diagnosticSeverity": {}
       }
     ]
   },

--- a/packages/plugins/oauth2/tsup.config.ts
+++ b/packages/plugins/oauth2/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  external: [/^@executor\//, /^effect/, /^@effect\//],
+});

--- a/packages/plugins/oauth2/vitest.config.ts
+++ b/packages/plugins/oauth2/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- New `@executor/plugin-oauth2` package: generic, provider-agnostic OAuth 2.0 helpers (PKCE, authorization URL, code exchange, refresh, refresh-skew predicate, typed `OAuth2Error`).
- Ports `google-discovery` to use the shared package — its `oauth.ts` shrinks from ~150 lines to ~85, with Google-specific behavior (`access_type=offline`, `prompt=consent`, `include_granted_scopes=true`, hardcoded URLs) preserved via the `extraParams` escape hatch and a thin wrapper.
- 33-test fidelity suite encodes every real-world quirk the prior implementation handled, so future "simplifications" fail loudly.

## Why
We were about to copy this code a third time for OpenAPI L3 OAuth onboarding. Extracting it now keeps the call sites consistent and gives us one place to fix bugs. The fidelity suite is the contract — the goal of extraction was zero behavioral change in `google-discovery`, and the existing google-discovery tests verify that.

## Fidelity behaviors locked in by tests
- **PKCE**: 48-byte verifier matches `^[A-Za-z0-9_-]{43,128}$`, RFC 7636 Appendix A test vector for `S256(verifier) == challenge`, uniqueness across 50 invocations.
- **`decodeTokenResponse`**: rejects non-JSON bodies (HTML 5xx pages), rejects JSON arrays/primitives, accepts `expires_in` as **string OR number** (Azure et al.), error fallback chain (`error_description` → `error` → `status N`), rejects 200 with empty / missing `access_token`.
- **Token endpoint POST**: `application/x-www-form-urlencoded` + `accept: application/json`, `AbortSignal.timeout(20_000)`, body-based client_secret by default, optional HTTP Basic auth (`clientAuth: "basic"`) for Stripe-style providers, `OAuth2Error` propagation through the Effect failure channel.
- **`buildAuthorizationUrl`**: standard PKCE params, custom scope separator (comma for legacy providers), `extraParams` merge does not drop standard params, preserves pre-existing query params on the authorization URL.
- **`refreshAccessToken`**: `grant_type=refresh_token`, scope omitted when empty, included when provided.
- **`shouldRefreshToken`**: `null` expiry never refreshes, 60s default skew, custom skew respected.

## Test plan
- [x] `bunx vitest run` in `packages/plugins/oauth2` → 33 passed
- [x] `bunx vitest run` in `packages/plugins/google-discovery` → 6 passed (existing regression gate)
- [x] `bunx turbo run typecheck` → 29 packages clean
- [x] `bunx turbo run test` → all 23 task suites pass