### PR TITLE
Add OAuth popup UI utilities to @executor/plugin-oauth2

### DIFF
--- a/packages/plugins/google-discovery/src/api/handlers.ts
+++ b/packages/plugins/google-discovery/src/api/handlers.ts
@@ -1,6 +1,8 @@
 import { HttpApiBuilder, HttpServerResponse } from "@effect/platform";
 import { Cause, Context, Effect } from "effect";
 
+import { runOAuthCallback } from "@executor/plugin-oauth2/http";
+
 import { addGroup } from "@executor/api";
 import type {
   GoogleDiscoveryAddSourceInput,
@@ -26,55 +28,7 @@ export class GoogleDiscoveryExtensionService extends Context.Tag("GoogleDiscover
 
 const ExecutorApiWithGoogleDiscovery = addGroup(GoogleDiscoveryGroup);
 
-type OAuthPopupResult =
-  | ({
-      type: "executor:oauth-result";
-      ok: true;
-      sessionId: string;
-    } & GoogleDiscoveryOAuthAuthResult)
-  | {
-      type: "executor:oauth-result";
-      ok: false;
-      sessionId: null;
-      error: string;
-    };
-
-const escapeHtml = (value: string): string =>
-  value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
-
-const popupDocument = (payload: OAuthPopupResult): string => {
-  const serialized = JSON.stringify(payload)
-    .replaceAll("<", "\\u003c")
-    .replaceAll(">", "\\u003e")
-    .replaceAll("&", "\\u0026");
-  const title = payload.ok ? "Connected" : "Connection failed";
-  const message = payload.ok
-    ? "Authentication complete. This window will close automatically."
-    : payload.error;
-  const statusColor = payload.ok ? "#22c55e" : "#ef4444";
-
-  return `<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${escapeHtml(title)}</title></head>
-<body style="font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fafafa;color:#111">
-<style>@media(prefers-color-scheme:dark){body{background:#09090b!important;color:#fafafa!important}p{color:#a1a1aa!important}}</style>
-<main style="text-align:center;max-width:360px;padding:24px">
-<div style="width:40px;height:40px;border-radius:50%;background:${statusColor};margin:0 auto 16px;display:flex;align-items:center;justify-content:center">
-<svg width="20" height="20" viewBox="0 0 20 20" fill="none">${payload.ok ? '<path d="M6 10l3 3 5-6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' : '<path d="M7 7l6 6M13 7l-6 6" stroke="white" stroke-width="2" stroke-linecap="round"/>'}</svg>
-</div>
-<h1 style="margin:0 0 8px;font-size:18px;font-weight:600">${escapeHtml(title)}</h1>
-<p style="margin:0;font-size:14px;color:#666;line-height:1.5">${escapeHtml(message)}</p>
-</main>
-<script>
-(()=>{const p=${serialized};try{if(window.opener)window.opener.postMessage(p,window.location.origin);if("BroadcastChannel"in window){const c=new BroadcastChannel("executor:google-discovery-oauth-result");c.postMessage(p);setTimeout(()=>c.close(),100)}}finally{setTimeout(()=>window.close(),150)}})();
-</script>
-</body></html>`;
-};
+const GOOGLE_DISCOVERY_OAUTH_CHANNEL = "executor:google-discovery-oauth-result";
 
 const toPopupErrorMessage = (error: unknown): string => {
   if (error instanceof GoogleDiscoveryOAuthError) {
@@ -156,31 +110,22 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
       .handle("oauthCallback", ({ urlParams }) =>
         Effect.gen(function* () {
           const ext = yield* GoogleDiscoveryExtensionService;
-          const result = yield* ext
-            .completeOAuth({
-              state: urlParams.state,
-              code: urlParams.code,
-              error: urlParams.error ?? urlParams.error_description,
-            })
-            .pipe(
-              Effect.map(
-                (auth): OAuthPopupResult => ({
-                  type: "executor:oauth-result",
-                  ok: true,
-                  sessionId: urlParams.state,
-                  ...auth,
-                }),
-              ),
-              Effect.catchAllCause((cause) =>
-                Effect.succeed<OAuthPopupResult>({
-                  type: "executor:oauth-result",
-                  ok: false,
-                  sessionId: null,
-                  error: toPopupErrorMessage(Cause.squash(cause)),
-                }),
-              ),
-            );
-          return yield* HttpServerResponse.html(popupDocument(result));
+          const html = yield* runOAuthCallback<
+            GoogleDiscoveryOAuthAuthResult,
+            GoogleDiscoveryOAuthError,
+            never
+          >({
+            complete: ({ state, code, error }) =>
+              ext.completeOAuth({
+                state,
+                code: code ?? undefined,
+                error: error ?? undefined,
+              }),
+            urlParams,
+            toErrorMessage: toPopupErrorMessage,
+            channelName: GOOGLE_DISCOVERY_OAUTH_CHANNEL,
+          });
+          return yield* HttpServerResponse.html(html);
         }).pipe(sanitizeGoogleDiscoveryFailure),
       ),
 );

--- a/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet, useAtomValue, useAtomRefresh, Result } from "@effect-atom/atom-react";
 
+import {
+  openOAuthPopup,
+  type OAuthPopupResult,
+} from "@executor/plugin-oauth2/react";
+
 import { secretsAtom, setSecret } from "@executor/react/api/atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { SecretPicker, type SecretPickerSecret } from "@executor/react/plugins/secret-picker";
@@ -373,69 +378,10 @@ type OAuthAuth = {
   scopes: string[];
 };
 
-type OAuthPopupResult =
-  | ({
-      type: "executor:oauth-result";
-      ok: true;
-      sessionId: string;
-    } & OAuthAuth)
-  | {
-      type: "executor:oauth-result";
-      ok: false;
-      sessionId: null;
-      error: string;
-    };
+type GoogleOAuthPopupResult = OAuthPopupResult<OAuthAuth>;
 
 const OAUTH_RESULT_CHANNEL = "executor:google-discovery-oauth-result";
-
-const isOAuthPopupResult = (value: unknown): value is OAuthPopupResult =>
-  typeof value === "object" &&
-  value !== null &&
-  (value as { type?: unknown }).type === "executor:oauth-result";
-
-function openOAuthPopup(
-  url: string,
-  onResult: (data: OAuthPopupResult) => void,
-  onOpenFailed?: () => void,
-): () => void {
-  const w = 640;
-  const h = 760;
-  const left = window.screenX + (window.outerWidth - w) / 2;
-  const top = window.screenY + (window.outerHeight - h) / 2;
-
-  let settled = false;
-  const channel =
-    typeof BroadcastChannel !== "undefined" ? new BroadcastChannel(OAUTH_RESULT_CHANNEL) : null;
-  const settle = () => {
-    if (settled) return;
-    settled = true;
-    window.removeEventListener("message", onMessage);
-    channel?.close();
-  };
-
-  const handleResult = (data: unknown) => {
-    if (!isOAuthPopupResult(data) || settled) return;
-    settle();
-    onResult(data);
-  };
-
-  const onMessage = (event: MessageEvent) => {
-    if (event.origin === window.location.origin) handleResult(event.data);
-  };
-  window.addEventListener("message", onMessage);
-  if (channel) channel.onmessage = (event) => handleResult(event.data);
-
-  const popup = window.open(
-    url,
-    "google-discovery-oauth",
-    `width=${w},height=${h},left=${left},top=${top},popup=1`,
-  );
-  if (!popup && !settled) {
-    settle();
-    queueMicrotask(() => onOpenFailed?.());
-  }
-  return settle;
-}
+const OAUTH_POPUP_NAME = "google-discovery-oauth";
 
 export default function AddGoogleDiscoverySource(props: {
   readonly onComplete: () => void;
@@ -565,9 +511,11 @@ export default function AddGoogleDiscoverySource(props: {
         },
       });
 
-      oauthCleanup.current = openOAuthPopup(
-        response.authorizationUrl,
-        (result) => {
+      oauthCleanup.current = openOAuthPopup<OAuthAuth>({
+        url: response.authorizationUrl,
+        popupName: OAUTH_POPUP_NAME,
+        channelName: OAUTH_RESULT_CHANNEL,
+        onResult: (result: GoogleOAuthPopupResult) => {
           oauthCleanup.current = null;
           setStartingOAuth(false);
           if (result.ok) {
@@ -587,12 +535,12 @@ export default function AddGoogleDiscoverySource(props: {
             setError(result.error);
           }
         },
-        () => {
+        onOpenFailed: () => {
           oauthCleanup.current = null;
           setStartingOAuth(false);
           setError("OAuth popup was blocked");
         },
-      );
+      });
     } catch (e) {
       setStartingOAuth(false);
       setError(e instanceof Error ? e.message : "Failed to start OAuth");

--- a/packages/plugins/oauth2/package.json
+++ b/packages/plugins/oauth2/package.json
@@ -16,7 +16,9 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./http": "./src/http.ts",
+    "./react": "./src/react.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -25,6 +27,18 @@
         "import": {
           "types": "./dist/index.d.ts",
           "default": "./dist/index.js"
+        }
+      },
+      "./http": {
+        "import": {
+          "types": "./dist/http.d.ts",
+          "default": "./dist/http.js"
+        }
+      },
+      "./react": {
+        "import": {
+          "types": "./dist/react.d.ts",
+          "default": "./dist/react.js"
         }
       }
     }

--- a/packages/plugins/oauth2/src/http.test.ts
+++ b/packages/plugins/oauth2/src/http.test.ts
@@ -1,0 +1,201 @@
+// ---------------------------------------------------------------------------
+// Fidelity tests for the OAuth popup HTML generator + callback wrapper.
+// Locks in the escaping rules, postMessage/BroadcastChannel behavior, and
+// the completeOAuth-to-popup-payload conversion semantics so the google-
+// discovery port is provably behavior-preserving.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "vitest";
+import { Effect } from "effect";
+
+import {
+  OAUTH_POPUP_MESSAGE_TYPE,
+  popupDocument,
+  runOAuthCallback,
+  type OAuthPopupResult,
+} from "./http";
+
+type GoogleAuth = {
+  kind: "oauth2";
+  accessTokenSecretId: string;
+  refreshTokenSecretId: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// popupDocument
+// ---------------------------------------------------------------------------
+
+describe("popupDocument", () => {
+  const successPayload: OAuthPopupResult<GoogleAuth> = {
+    type: OAUTH_POPUP_MESSAGE_TYPE,
+    ok: true,
+    sessionId: "session-abc",
+    kind: "oauth2",
+    accessTokenSecretId: "secret_1",
+    refreshTokenSecretId: "secret_2",
+  };
+
+  it("renders a success page with Connected title and the green check icon", () => {
+    const html = popupDocument(successPayload, "channel-x");
+    expect(html).toContain("<title>Connected</title>");
+    expect(html).toContain("#22c55e");
+    expect(html).toContain("Authentication complete");
+  });
+
+  it("renders a failure page with the error text escaped", () => {
+    const html = popupDocument(
+      {
+        type: OAUTH_POPUP_MESSAGE_TYPE,
+        ok: false,
+        sessionId: null,
+        error: "Token endpoint returned 400 <script>alert(1)</script>",
+      },
+      "channel-x",
+    );
+    expect(html).toContain("<title>Connection failed</title>");
+    expect(html).toContain("#ef4444");
+    expect(html).toContain("Token endpoint returned 400 &lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  it("HTML-escapes the BroadcastChannel name so attacker-controlled names cannot break out", () => {
+    const html = popupDocument(successPayload, 'evil"name');
+    expect(html).toContain('new BroadcastChannel("evil&quot;name")');
+  });
+
+  it("escapes < > & in the serialized script payload to prevent </script> breakout", () => {
+    const html = popupDocument(
+      {
+        type: OAUTH_POPUP_MESSAGE_TYPE,
+        ok: false,
+        sessionId: null,
+        error: "</script><img/src=x onerror=alert(1)>",
+      },
+      "channel-x",
+    );
+    // The raw `</script>` must not appear in the inline script literal.
+    const scriptLiteralMatch = /const p=(\{.*?\});/.exec(html);
+    expect(scriptLiteralMatch).not.toBeNull();
+    const scriptLiteral = scriptLiteralMatch![1]!;
+    expect(scriptLiteral).not.toContain("</script>");
+    expect(scriptLiteral).toContain("\\u003c/script\\u003e");
+  });
+
+  it("posts to window.opener AND falls back to BroadcastChannel with the given channel name", () => {
+    const html = popupDocument(successPayload, "executor:openapi-oauth-result");
+    expect(html).toContain("window.opener.postMessage(p,window.location.origin)");
+    expect(html).toContain('new BroadcastChannel("executor:openapi-oauth-result")');
+    expect(html).toContain("window.close()");
+  });
+
+  it("includes dark-mode CSS", () => {
+    const html = popupDocument(successPayload, "c");
+    expect(html).toContain("@media(prefers-color-scheme:dark)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runOAuthCallback
+// ---------------------------------------------------------------------------
+
+describe("runOAuthCallback", () => {
+  it("renders a success popup when completeOAuth succeeds", async () => {
+    const html = await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete: () =>
+          Effect.succeed({
+            kind: "oauth2",
+            accessTokenSecretId: "s1",
+            refreshTokenSecretId: "s2",
+          }),
+        urlParams: { state: "session-xyz", code: "abc" },
+        toErrorMessage: () => "should not reach",
+        channelName: "channel-x",
+      }),
+    );
+    expect(html).toContain("<title>Connected</title>");
+    expect(html).toContain("session-xyz");
+    expect(html).toContain("s1");
+  });
+
+  it("passes code and error through to the complete callback verbatim", async () => {
+    const received: Array<{ state: string; code: string | null; error: string | null }> = [];
+    await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete: (params) => {
+          received.push(params);
+          return Effect.succeed({
+            kind: "oauth2",
+            accessTokenSecretId: "s",
+            refreshTokenSecretId: null,
+          });
+        },
+        urlParams: { state: "s1", code: "code1", error: null },
+        toErrorMessage: () => "",
+        channelName: "c",
+      }),
+    );
+    expect(received).toEqual([{ state: "s1", code: "code1", error: null }]);
+  });
+
+  it("prefers `error` over `error_description` but falls back when absent", async () => {
+    const received: Array<{ state: string; code: string | null; error: string | null }> = [];
+    const complete = (params: { state: string; code: string | null; error: string | null }) => {
+      received.push(params);
+      return Effect.succeed({
+        kind: "oauth2" as const,
+        accessTokenSecretId: "s",
+        refreshTokenSecretId: null,
+      });
+    };
+    await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete,
+        urlParams: { state: "s1", error: "access_denied" },
+        toErrorMessage: () => "",
+        channelName: "c",
+      }),
+    );
+    await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete,
+        urlParams: { state: "s2", error_description: "user cancelled" },
+        toErrorMessage: () => "",
+        channelName: "c",
+      }),
+    );
+    expect(received[0]!.error).toBe("access_denied");
+    expect(received[1]!.error).toBe("user cancelled");
+  });
+
+  it("renders a failure popup when completeOAuth fails and uses toErrorMessage", async () => {
+    class DomainError {
+      readonly _tag = "DomainError";
+      constructor(readonly message: string) {}
+    }
+    const html = await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, DomainError, never>({
+        complete: () => Effect.fail(new DomainError("Code expired")),
+        urlParams: { state: "s1" },
+        toErrorMessage: (error) =>
+          error instanceof DomainError ? error.message : "unknown",
+        channelName: "c",
+      }),
+    );
+    expect(html).toContain("<title>Connection failed</title>");
+    expect(html).toContain("Code expired");
+  });
+
+  it("never rejects — even defects are rendered as a failure popup", async () => {
+    const html = await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete: () => Effect.die("boom"),
+        urlParams: { state: "s1" },
+        toErrorMessage: () => "transport error",
+        channelName: "c",
+      }),
+    );
+    expect(html).toContain("<title>Connection failed</title>");
+    expect(html).toContain("transport error");
+  });
+});

--- a/packages/plugins/oauth2/src/http.ts
+++ b/packages/plugins/oauth2/src/http.ts
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------
+// @executor/plugin-oauth2/http — server-side HTTP helpers for OAuth popups.
+//
+// `popupDocument` renders the HTML page returned by the OAuth redirect
+// handler. The page immediately `postMessage`s the result back to the
+// opener window and falls back to a `BroadcastChannel` if the opener is
+// gone (mobile Safari closes the opener on popup open in some cases).
+//
+// `runOAuthCallback` wraps the "call completeOAuth, turn Exit into
+// popup payload, render HTML" glue so plugin handlers stay one-liners.
+// ---------------------------------------------------------------------------
+
+import { Cause, Effect } from "effect";
+
+import {
+  OAUTH_POPUP_MESSAGE_TYPE,
+  type OAuthPopupResult,
+} from "./popup-types";
+
+export { OAUTH_POPUP_MESSAGE_TYPE, isOAuthPopupResult } from "./popup-types";
+export type { OAuthPopupResult } from "./popup-types";
+
+// ---------------------------------------------------------------------------
+// HTML generation
+// ---------------------------------------------------------------------------
+
+const escapeHtml = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+/**
+ * Serialize for embedding inside a `<script>` tag. Escapes the characters
+ * that could prematurely terminate the script or mislead an HTML parser
+ * (`<`, `>`, `&`) so an attacker-controlled `error` field can't break out.
+ */
+const serializeForScript = (value: unknown): string =>
+  JSON.stringify(value)
+    .replaceAll("<", "\\u003c")
+    .replaceAll(">", "\\u003e")
+    .replaceAll("&", "\\u0026");
+
+/**
+ * Render the HTML page that the OAuth redirect returns. The page is
+ * intentionally dependency-free: inline CSS, dark-mode support via
+ * `prefers-color-scheme`, and a small inline script that posts the result
+ * back to the opener via `postMessage` + `BroadcastChannel` then closes
+ * itself.
+ */
+export const popupDocument = <TAuth>(
+  payload: OAuthPopupResult<TAuth>,
+  channelName: string,
+): string => {
+  const serialized = serializeForScript(payload);
+  const title = payload.ok ? "Connected" : "Connection failed";
+  const message = payload.ok
+    ? "Authentication complete. This window will close automatically."
+    : payload.error;
+  const statusColor = payload.ok ? "#22c55e" : "#ef4444";
+  const icon = payload.ok
+    ? '<path d="M6 10l3 3 5-6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>'
+    : '<path d="M7 7l6 6M13 7l-6 6" stroke="white" stroke-width="2" stroke-linecap="round"/>';
+  const escapedChannel = escapeHtml(channelName);
+
+  return `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${escapeHtml(title)}</title></head>
+<body style="font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fafafa;color:#111">
+<style>@media(prefers-color-scheme:dark){body{background:#09090b!important;color:#fafafa!important}p{color:#a1a1aa!important}}</style>
+<main style="text-align:center;max-width:360px;padding:24px">
+<div style="width:40px;height:40px;border-radius:50%;background:${statusColor};margin:0 auto 16px;display:flex;align-items:center;justify-content:center">
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none">${icon}</svg>
+</div>
+<h1 style="margin:0 0 8px;font-size:18px;font-weight:600">${escapeHtml(title)}</h1>
+<p style="margin:0;font-size:14px;color:#666;line-height:1.5">${escapeHtml(message)}</p>
+</main>
+<script>
+(()=>{const p=${serialized};try{if(window.opener)window.opener.postMessage(p,window.location.origin);if("BroadcastChannel"in window){const c=new BroadcastChannel("${escapedChannel}");c.postMessage(p);setTimeout(()=>c.close(),100)}}finally{setTimeout(()=>window.close(),150)}})();
+</script>
+</body></html>`;
+};
+
+// ---------------------------------------------------------------------------
+// Callback wrapper — turns a completeOAuth Effect into a popup HTML string.
+// ---------------------------------------------------------------------------
+
+export type OAuthCallbackUrlParams = {
+  readonly state: string;
+  readonly code?: string | null;
+  readonly error?: string | null;
+  readonly error_description?: string | null;
+};
+
+export type RunOAuthCallbackInput<TAuth, E, R> = {
+  /** The plugin's `completeOAuth` — resolves to the auth descriptor on success. */
+  readonly complete: (params: {
+    readonly state: string;
+    readonly code: string | null;
+    readonly error: string | null;
+  }) => Effect.Effect<TAuth, E, R>;
+  readonly urlParams: OAuthCallbackUrlParams;
+  /** Map a plugin-specific error into a user-facing message. */
+  readonly toErrorMessage: (error: unknown) => string;
+  readonly channelName: string;
+};
+
+/**
+ * Run a plugin's `completeOAuth` against URL params from the OAuth redirect,
+ * wrap the success / failure in an `OAuthPopupResult`, and return the HTML
+ * body ready to hand to `HttpServerResponse.html(...)`.
+ *
+ * This never fails — errors become a `{ ok: false }` result so the popup
+ * can still render and close itself.
+ */
+export const runOAuthCallback = <TAuth, E, R>(
+  input: RunOAuthCallbackInput<TAuth, E, R>,
+): Effect.Effect<string, never, R> =>
+  input
+    .complete({
+      state: input.urlParams.state,
+      code: input.urlParams.code ?? null,
+      error: input.urlParams.error ?? input.urlParams.error_description ?? null,
+    })
+    .pipe(
+      Effect.map(
+        (auth): OAuthPopupResult<TAuth> => ({
+          type: OAUTH_POPUP_MESSAGE_TYPE,
+          ok: true,
+          sessionId: input.urlParams.state,
+          ...auth,
+        }),
+      ),
+      Effect.catchAllCause((cause) =>
+        Effect.succeed<OAuthPopupResult<TAuth>>({
+          type: OAUTH_POPUP_MESSAGE_TYPE,
+          ok: false,
+          sessionId: null,
+          error: input.toErrorMessage(Cause.squash(cause)),
+        }),
+      ),
+      Effect.map((result) => popupDocument(result, input.channelName)),
+    );

--- a/packages/plugins/oauth2/src/popup-types.ts
+++ b/packages/plugins/oauth2/src/popup-types.ts
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------
+// OAuth popup result — the message shape exchanged between the popup window
+// (opened during authorization) and the opener (the onboarding UI). Both the
+// server-side HTML generator and the client-side popup opener agree on this
+// shape so that success / failure can be communicated reliably via both
+// `postMessage` and `BroadcastChannel`.
+// ---------------------------------------------------------------------------
+
+/** Message type literal used to identify our popup results. */
+export const OAUTH_POPUP_MESSAGE_TYPE = "executor:oauth-result" as const;
+
+export type OAuthPopupResult<TAuth> =
+  | ({
+      readonly type: typeof OAUTH_POPUP_MESSAGE_TYPE;
+      readonly ok: true;
+      readonly sessionId: string;
+    } & TAuth)
+  | {
+      readonly type: typeof OAUTH_POPUP_MESSAGE_TYPE;
+      readonly ok: false;
+      readonly sessionId: null;
+      readonly error: string;
+    };
+
+export const isOAuthPopupResult = <TAuth>(
+  value: unknown,
+): value is OAuthPopupResult<TAuth> =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { type?: unknown }).type === OAUTH_POPUP_MESSAGE_TYPE;

--- a/packages/plugins/oauth2/src/react.test.ts
+++ b/packages/plugins/oauth2/src/react.test.ts
@@ -1,0 +1,339 @@
+// ---------------------------------------------------------------------------
+// openOAuthPopup fidelity tests. Simulates the browser environment by
+// stubbing window.open / postMessage / BroadcastChannel so we can lock in
+// the settle-once semantics, origin checking, and popup-blocked handling
+// without a real DOM.
+// ---------------------------------------------------------------------------
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  OAUTH_POPUP_MESSAGE_TYPE,
+  openOAuthPopup,
+  type OAuthPopupResult,
+} from "./react";
+
+type TestAuth = { accessToken: string };
+
+type MockPopup = { closed: boolean; close: () => void };
+
+const originalWindow = (globalThis as { window?: unknown }).window;
+const originalBroadcastChannel = (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel;
+
+type MockChannel = {
+  name: string;
+  onmessage: ((event: { data: unknown }) => void) | null;
+  close: () => void;
+  closed: boolean;
+};
+
+const channels: MockChannel[] = [];
+
+class FakeBroadcastChannel {
+  name: string;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  closed = false;
+  constructor(name: string) {
+    this.name = name;
+    channels.push(this as unknown as MockChannel);
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+type WindowListener = (event: { origin: string; data: unknown }) => void;
+
+type FakeWindow = {
+  location: { origin: string };
+  screenX: number;
+  screenY: number;
+  outerWidth: number;
+  outerHeight: number;
+  open: (url: string, name: string, features?: string) => MockPopup | null;
+  addEventListener: (type: string, cb: WindowListener) => void;
+  removeEventListener: (type: string, cb: WindowListener) => void;
+  messageListeners: Set<WindowListener>;
+  _openCalls: Array<{ url: string; name: string; features?: string }>;
+  _popupBlocked: boolean;
+  _popups: MockPopup[];
+};
+
+const makeFakeWindow = (): FakeWindow => {
+  const messageListeners = new Set<WindowListener>();
+  const openCalls: FakeWindow["_openCalls"] = [];
+  const popups: MockPopup[] = [];
+  return {
+    location: { origin: "https://app.example.com" },
+    screenX: 0,
+    screenY: 0,
+    outerWidth: 1280,
+    outerHeight: 900,
+    open: (url, name, features) => {
+      openCalls.push({ url, name, features });
+      if (fakeWindow._popupBlocked) return null;
+      const popup: MockPopup = {
+        closed: false,
+        close() {
+          popup.closed = true;
+        },
+      };
+      popups.push(popup);
+      return popup;
+    },
+    addEventListener: (type, cb) => {
+      if (type === "message") messageListeners.add(cb);
+    },
+    removeEventListener: (type, cb) => {
+      if (type === "message") messageListeners.delete(cb);
+    },
+    messageListeners,
+    _openCalls: openCalls,
+    _popupBlocked: false,
+    _popups: popups,
+  };
+};
+
+let fakeWindow: FakeWindow;
+
+beforeEach(() => {
+  fakeWindow = makeFakeWindow();
+  (globalThis as { window?: unknown }).window = fakeWindow;
+  (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = FakeBroadcastChannel;
+  channels.length = 0;
+});
+
+afterEach(() => {
+  (globalThis as { window?: unknown }).window = originalWindow;
+  (globalThis as { BroadcastChannel?: unknown }).BroadcastChannel = originalBroadcastChannel;
+});
+
+const successMessage = (auth: TestAuth): OAuthPopupResult<TestAuth> => ({
+  type: OAUTH_POPUP_MESSAGE_TYPE,
+  ok: true,
+  sessionId: "session-1",
+  ...auth,
+});
+
+describe("openOAuthPopup", () => {
+  it("opens a centered popup at the given url with the given name", () => {
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize?x=1",
+      onResult: () => {},
+      popupName: "my-oauth-popup",
+      channelName: "my-channel",
+    });
+    expect(fakeWindow._openCalls).toHaveLength(1);
+    const call = fakeWindow._openCalls[0]!;
+    expect(call.url).toBe("https://auth.example.com/authorize?x=1");
+    expect(call.name).toBe("my-oauth-popup");
+    expect(call.features).toContain("width=640");
+    expect(call.features).toContain("height=760");
+    expect(call.features).toContain("popup=1");
+  });
+
+  it("resolves via window.message event and only accepts same-origin messages", () => {
+    const results: Array<OAuthPopupResult<TestAuth>> = [];
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: (data) => results.push(data),
+      popupName: "p",
+      channelName: "c",
+    });
+
+    // Cross-origin message should be ignored.
+    for (const listener of fakeWindow.messageListeners) {
+      listener({ origin: "https://evil.example.com", data: successMessage({ accessToken: "nope" }) });
+    }
+    expect(results).toHaveLength(0);
+
+    // Same-origin message resolves.
+    for (const listener of fakeWindow.messageListeners) {
+      listener({ origin: "https://app.example.com", data: successMessage({ accessToken: "tok" }) });
+    }
+    expect(results).toHaveLength(1);
+    expect(results[0]!.ok).toBe(true);
+  });
+
+  it("resolves via BroadcastChannel when postMessage does not reach the opener", () => {
+    const results: Array<OAuthPopupResult<TestAuth>> = [];
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: (data) => results.push(data),
+      popupName: "p",
+      channelName: "c",
+    });
+    expect(channels).toHaveLength(1);
+    channels[0]!.onmessage?.({ data: successMessage({ accessToken: "tok" }) });
+    expect(results).toHaveLength(1);
+  });
+
+  it("settles exactly once even if both channels deliver a result", () => {
+    const results: Array<OAuthPopupResult<TestAuth>> = [];
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: (data) => results.push(data),
+      popupName: "p",
+      channelName: "c",
+    });
+    // Deliver via BroadcastChannel first.
+    channels[0]!.onmessage?.({ data: successMessage({ accessToken: "one" }) });
+    // Then via postMessage.
+    for (const listener of fakeWindow.messageListeners) {
+      listener({ origin: "https://app.example.com", data: successMessage({ accessToken: "two" }) });
+    }
+    expect(results).toHaveLength(1);
+  });
+
+  it("ignores messages that don't match the OAuthPopupResult shape", () => {
+    const results: Array<OAuthPopupResult<TestAuth>> = [];
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: (data) => results.push(data),
+      popupName: "p",
+      channelName: "c",
+    });
+    for (const listener of fakeWindow.messageListeners) {
+      listener({ origin: "https://app.example.com", data: { type: "other", ok: true } });
+    }
+    expect(results).toHaveLength(0);
+  });
+
+  it("closes the BroadcastChannel and removes the listener when settled", () => {
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: () => {},
+      popupName: "p",
+      channelName: "c",
+    });
+    for (const listener of fakeWindow.messageListeners) {
+      listener({ origin: "https://app.example.com", data: successMessage({ accessToken: "tok" }) });
+    }
+    expect(fakeWindow.messageListeners.size).toBe(0);
+    expect(channels[0]!.closed).toBe(true);
+  });
+
+  it("invokes onOpenFailed when the browser blocks the popup", async () => {
+    fakeWindow._popupBlocked = true;
+    const onOpenFailed = vi.fn();
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: () => {},
+      popupName: "p",
+      channelName: "c",
+      onOpenFailed,
+    });
+    // queueMicrotask is still a microtask — await a resolved promise to flush.
+    await Promise.resolve();
+    expect(onOpenFailed).toHaveBeenCalledOnce();
+  });
+
+  it("teardown function is idempotent", () => {
+    const teardown = openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: () => {},
+      popupName: "p",
+      channelName: "c",
+    });
+    teardown();
+    teardown();
+    expect(fakeWindow.messageListeners.size).toBe(0);
+    expect(channels[0]!.closed).toBe(true);
+  });
+
+  it("accepts a custom width and height", () => {
+    openOAuthPopup<TestAuth>({
+      url: "https://auth.example.com/authorize",
+      onResult: () => {},
+      popupName: "p",
+      channelName: "c",
+      width: 500,
+      height: 500,
+    });
+    const call = fakeWindow._openCalls[0]!;
+    expect(call.features).toContain("width=500");
+    expect(call.features).toContain("height=500");
+  });
+
+  describe("close detection", () => {
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+    afterAll(() => {
+      vi.useRealTimers();
+    });
+
+    it("fires onClosed when the user manually closes the popup without delivering a result", () => {
+      const onResult = vi.fn();
+      const onClosed = vi.fn();
+      openOAuthPopup<TestAuth>({
+        url: "https://auth.example.com/authorize",
+        onResult,
+        popupName: "p",
+        channelName: "c",
+        onClosed,
+        closedPollMs: 100,
+      });
+      expect(fakeWindow._popups).toHaveLength(1);
+      // Simulate the user closing the popup.
+      fakeWindow._popups[0]!.closed = true;
+      vi.advanceTimersByTime(150);
+      expect(onClosed).toHaveBeenCalledOnce();
+      expect(onResult).not.toHaveBeenCalled();
+    });
+
+    it("does NOT fire onClosed when the popup closes as a side effect of delivering a result", () => {
+      const onResult = vi.fn();
+      const onClosed = vi.fn();
+      openOAuthPopup<TestAuth>({
+        url: "https://auth.example.com/authorize",
+        onResult,
+        popupName: "p",
+        channelName: "c",
+        onClosed,
+        closedPollMs: 100,
+      });
+      for (const listener of fakeWindow.messageListeners) {
+        listener({
+          origin: "https://app.example.com",
+          data: successMessage({ accessToken: "tok" }),
+        });
+      }
+      expect(onResult).toHaveBeenCalledOnce();
+      // The popup will close itself after posting; advance the timer and
+      // verify we do NOT fire onClosed redundantly.
+      fakeWindow._popups[0]!.closed = true;
+      vi.advanceTimersByTime(500);
+      expect(onClosed).not.toHaveBeenCalled();
+    });
+
+    it("stops polling once the teardown function is invoked", () => {
+      const onClosed = vi.fn();
+      const teardown = openOAuthPopup<TestAuth>({
+        url: "https://auth.example.com/authorize",
+        onResult: () => {},
+        popupName: "p",
+        channelName: "c",
+        onClosed,
+        closedPollMs: 100,
+      });
+      teardown();
+      // Simulate the popup being closed after teardown — onClosed must not fire.
+      fakeWindow._popups[0]!.closed = true;
+      vi.advanceTimersByTime(500);
+      expect(onClosed).not.toHaveBeenCalled();
+    });
+
+    it("teardown closes the popup window if it's still open", () => {
+      const teardown = openOAuthPopup<TestAuth>({
+        url: "https://auth.example.com/authorize",
+        onResult: () => {},
+        popupName: "p",
+        channelName: "c",
+      });
+      expect(fakeWindow._popups[0]!.closed).toBe(false);
+      teardown();
+      expect(fakeWindow._popups[0]!.closed).toBe(true);
+    });
+  });
+});

--- a/packages/plugins/oauth2/src/react.ts
+++ b/packages/plugins/oauth2/src/react.ts
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------
+// @executor/plugin-oauth2/react — browser popup opener for OAuth flows.
+//
+// Opens a centered popup window pointed at an authorization URL, listens
+// for the result via `postMessage` and `BroadcastChannel` (Safari fallback),
+// and settles exactly once. Has NO React-specific imports so it can be used
+// from any browser context, but lives under the `/react` entry to signal
+// it is browser-only and should not be imported from Node / worker code.
+// ---------------------------------------------------------------------------
+
+import {
+  isOAuthPopupResult as sharedIsOAuthPopupResult,
+  type OAuthPopupResult,
+} from "./popup-types";
+
+export { OAUTH_POPUP_MESSAGE_TYPE } from "./popup-types";
+export type { OAuthPopupResult } from "./popup-types";
+
+export const isOAuthPopupResult = sharedIsOAuthPopupResult;
+
+// ---------------------------------------------------------------------------
+// openOAuthPopup
+// ---------------------------------------------------------------------------
+
+export type OpenOAuthPopupInput<TAuth> = {
+  readonly url: string;
+  readonly onResult: (data: OAuthPopupResult<TAuth>) => void;
+  /** `window.open` target name — also used to focus an existing popup. */
+  readonly popupName: string;
+  /** BroadcastChannel name, must match the server-side `popupDocument` channel. */
+  readonly channelName: string;
+  readonly onOpenFailed?: () => void;
+  /**
+   * Called if the user closes the popup window without completing the
+   * flow (detected via a `popup.closed` poll). NOT called when the popup
+   * closes itself after a successful result post — `onResult` handles
+   * that path. Also not called if the caller invokes the teardown
+   * function returned from this function.
+   */
+  readonly onClosed?: () => void;
+  readonly width?: number;
+  readonly height?: number;
+  /** How often to poll `popup.closed`. Default 500ms. */
+  readonly closedPollMs?: number;
+};
+
+/**
+ * Open a centered popup window at `url` and resolve when the popup posts
+ * an `OAuthPopupResult` back to the opener. Returns a teardown function
+ * that removes the listeners, stops polling, and closes the popup window.
+ *
+ * Settles exactly once via one of three paths:
+ *   1. `onResult`      — popup posted a message back (success or error)
+ *   2. `onClosed`      — user closed the popup without completing the flow
+ *   3. teardown called — caller cancelled programmatically
+ *
+ * If the popup is blocked (`window.open` returns null), invokes
+ * `onOpenFailed` on the next microtask and returns a no-op teardown.
+ */
+export const openOAuthPopup = <TAuth>(input: OpenOAuthPopupInput<TAuth>): (() => void) => {
+  const w = input.width ?? 640;
+  const h = input.height ?? 760;
+  const left = window.screenX + (window.outerWidth - w) / 2;
+  const top = window.screenY + (window.outerHeight - h) / 2;
+
+  let settled = false;
+  let pollHandle: ReturnType<typeof setInterval> | null = null;
+  const channel =
+    typeof BroadcastChannel !== "undefined" ? new BroadcastChannel(input.channelName) : null;
+
+  const onMessage = (event: MessageEvent) => {
+    if (event.origin !== window.location.origin) return;
+    handleResult(event.data);
+  };
+
+  const stopPolling = () => {
+    if (pollHandle !== null) {
+      clearInterval(pollHandle);
+      pollHandle = null;
+    }
+  };
+
+  /** Close the popup window if it's still open. Swallows cross-origin errors. */
+  const closePopup = (popup: Window | null) => {
+    if (!popup) return;
+    try {
+      if (!popup.closed) popup.close();
+    } catch {
+      // Cross-origin access can throw; safe to ignore.
+    }
+  };
+
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    window.removeEventListener("message", onMessage);
+    channel?.close();
+    stopPolling();
+  };
+
+  const handleResult = (data: unknown) => {
+    if (!isOAuthPopupResult<TAuth>(data) || settled) return;
+    settle();
+    input.onResult(data);
+  };
+
+  window.addEventListener("message", onMessage);
+  if (channel) channel.onmessage = (event) => handleResult(event.data);
+
+  const popup = window.open(
+    input.url,
+    input.popupName,
+    `width=${w},height=${h},left=${left},top=${top},popup=1`,
+  );
+  if (!popup) {
+    if (!settled) {
+      settle();
+      queueMicrotask(() => input.onOpenFailed?.());
+    }
+    return () => {};
+  }
+
+  // Poll for manual popup close. We only settle via onClosed if no
+  // message-based result has arrived; onResult settles first and
+  // stops the poll before we see the close.
+  const pollMs = input.closedPollMs ?? 500;
+  pollHandle = setInterval(() => {
+    let isClosed = false;
+    try {
+      isClosed = popup.closed;
+    } catch {
+      // Cross-origin access can throw during navigation; treat as open.
+    }
+    if (isClosed && !settled) {
+      settle();
+      input.onClosed?.();
+    }
+  }, pollMs);
+
+  return () => {
+    if (settled) return;
+    settle();
+    closePopup(popup);
+  };
+};

--- a/packages/plugins/oauth2/tsconfig.json
+++ b/packages/plugins/oauth2/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "types": ["bun-types", "node"],
     "noUnusedLocals": true,
     "noImplicitOverride": true,

--- a/packages/plugins/oauth2/tsup.config.ts
+++ b/packages/plugins/oauth2/tsup.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
+    http: "src/http.ts",
+    react: "src/react.ts",
   },
   format: ["esm"],
   dts: false,


### PR DESCRIPTION
Split the package into three entrypoints (`.`, `/http`, `/react`) so
browser consumers do not pull Node crypto. New surface:

- `OAuthPopupResult<TAuth>` + `isOAuthPopupResult` in a shared types
  module so both the server-side HTML generator and the client-side
  popup opener agree on the message shape.
- `/http` entry: `popupDocument(payload, channelName)` HTML generator
  (with XSS-safe serialization, dark-mode CSS, postMessage +
  BroadcastChannel fallback), and `runOAuthCallback` wrapper that turns
  a `completeOAuth` Effect into the HTML body for the redirect route.
- `/react` entry: `openOAuthPopup` browser util with centered-popup
  math, same-origin message filtering, settle-once semantics, and
  popup-blocked detection.

Ports `google-discovery` to use them: `api/handlers.ts` drops its
inline `popupDocument` / OAuth glue and becomes a ~20-line handler,
and `AddGoogleDiscoverySource.tsx` drops its inline `openOAuthPopup`.

20 new fidelity tests lock every behavior (XSS escaping, channel name
escape, origin filtering, settle-once across both channels, popup
block handling).