### PR TITLE
Add storeOAuthTokens + withRefreshedAccessToken refresh wrapper

### DIFF
--- a/packages/plugins/google-discovery/src/sdk/index.ts
+++ b/packages/plugins/google-discovery/src/sdk/index.ts
@@ -16,7 +16,6 @@ export {
   buildGoogleAuthorizationUrl,
   createPkceCodeVerifier,
   exchangeAuthorizationCode,
-  refreshAccessToken,
 } from "./oauth";
 export {
   GoogleDiscoveryAuth,

--- a/packages/plugins/google-discovery/src/sdk/invoke.ts
+++ b/packages/plugins/google-discovery/src/sdk/invoke.ts
@@ -1,7 +1,9 @@
 import { Effect, Layer, Option } from "effect";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "@effect/platform";
 
-import { shouldRefreshToken } from "@executor/plugin-oauth2";
+import { withRefreshedAccessToken } from "@executor/plugin-oauth2";
+
+import { GOOGLE_TOKEN_URL } from "./oauth";
 
 import {
   type ScopeId,
@@ -19,7 +21,6 @@ import {
   GoogleDiscoveryStoredSourceData,
   type GoogleDiscoveryParameter,
 } from "./types";
-import { refreshAccessToken } from "./oauth";
 
 const SAFE_METHODS = new Set(["get", "head", "options"]);
 
@@ -91,68 +92,57 @@ const resolveOAuthAccessToken = (input: {
     }
 
     const auth = input.source.auth;
-    const needsRefresh =
-      auth.refreshTokenSecretId !== null &&
-      shouldRefreshToken({ expiresAt: auth.expiresAt });
+    const scopeId = input.scopeId;
 
-    if (!needsRefresh) {
-      return yield* input.secrets.resolve(auth.accessTokenSecretId as SecretId, input.scopeId).pipe(
-        Effect.mapError(
-          () =>
-            new ToolInvocationError({
-              toolId: "" as ToolId,
-              message: "Failed to resolve Google OAuth access token",
-              cause: undefined,
-            }),
-        ),
-      );
-    }
-
-    const refreshToken = yield* input.secrets
-      .resolve(auth.refreshTokenSecretId as SecretId, input.scopeId)
-      .pipe(
-        Effect.mapError(
-          () =>
-            new ToolInvocationError({
-              toolId: "" as ToolId,
-              message: "Failed to resolve Google OAuth refresh token",
-              cause: undefined,
-            }),
-        ),
-      );
-
-    const clientSecret =
-      auth.clientSecretSecretId === null
-        ? null
-        : yield* input.secrets.resolve(auth.clientSecretSecretId as SecretId, input.scopeId).pipe(
-            Effect.mapError(
-              () =>
-                new ToolInvocationError({
-                  toolId: "" as ToolId,
-                  message: "Failed to resolve Google OAuth client secret",
-                  cause: undefined,
-                }),
-            ),
-          );
-
-    const clientId = yield* input.secrets
-      .resolve(auth.clientIdSecretId as SecretId, input.scopeId)
-      .pipe(
-        Effect.mapError(
-          () =>
-            new ToolInvocationError({
-              toolId: "" as ToolId,
-              message: "Failed to resolve Google OAuth client ID",
-              cause: undefined,
-            }),
-        ),
-      );
-
-    const refreshed = yield* refreshAccessToken({
-      clientId,
-      clientSecret,
-      refreshToken,
-      scopes: auth.scopes,
+    return yield* withRefreshedAccessToken({
+      auth: {
+        clientIdSecretId: auth.clientIdSecretId,
+        clientSecretSecretId: auth.clientSecretSecretId,
+        accessTokenSecretId: auth.accessTokenSecretId,
+        refreshTokenSecretId: auth.refreshTokenSecretId,
+        tokenType: auth.tokenType,
+        expiresAt: auth.expiresAt,
+        scopes: auth.scopes,
+      },
+      tokenUrl: GOOGLE_TOKEN_URL,
+      secrets: {
+        resolve: (id) => input.secrets.resolve(id as SecretId, scopeId),
+        setValue: ({ secretId, value, name, purpose }) =>
+          input.secrets
+            .set({
+              id: secretId as SecretId,
+              scopeId,
+              name,
+              value,
+              purpose,
+            })
+            .pipe(Effect.asVoid),
+      },
+      displayName: input.source.name,
+      accessTokenPurpose: "google_oauth_access_token",
+      refreshTokenPurpose: "google_oauth_refresh_token",
+      persistAuth: (snapshot) =>
+        Effect.gen(function* () {
+          const updatedSource = new GoogleDiscoveryStoredSourceData({
+            ...input.source,
+            auth: {
+              kind: "oauth2",
+              clientIdSecretId: auth.clientIdSecretId,
+              clientSecretSecretId: auth.clientSecretSecretId,
+              accessTokenSecretId: auth.accessTokenSecretId,
+              refreshTokenSecretId: auth.refreshTokenSecretId,
+              tokenType: snapshot.tokenType,
+              expiresAt: snapshot.expiresAt,
+              scope: snapshot.scope ?? auth.scope,
+              scopes: auth.scopes,
+            },
+          });
+          yield* input.bindingStore.putSource({
+            namespace: input.sourceId,
+            name: input.source.name,
+            config: updatedSource,
+          });
+        }),
     }).pipe(
       Effect.mapError(
         (error) =>
@@ -163,73 +153,6 @@ const resolveOAuthAccessToken = (input: {
           }),
       ),
     );
-
-    yield* input.secrets
-      .set({
-        id: auth.accessTokenSecretId as SecretId,
-        scopeId: input.scopeId,
-        name: `${input.source.name} Access Token`,
-        value: refreshed.access_token,
-        purpose: "google_oauth_access_token",
-      })
-      .pipe(
-        Effect.mapError(
-          () =>
-            new ToolInvocationError({
-              toolId: "" as ToolId,
-              message: "Failed to persist refreshed Google OAuth access token",
-              cause: undefined,
-            }),
-        ),
-      );
-
-    let refreshTokenSecretId = auth.refreshTokenSecretId;
-    if (refreshed.refresh_token && auth.refreshTokenSecretId) {
-      yield* input.secrets
-        .set({
-          id: auth.refreshTokenSecretId as SecretId,
-          scopeId: input.scopeId,
-          name: `${input.source.name} Refresh Token`,
-          value: refreshed.refresh_token,
-          purpose: "google_oauth_refresh_token",
-        })
-        .pipe(
-          Effect.mapError(
-            () =>
-              new ToolInvocationError({
-                toolId: "" as ToolId,
-                message: "Failed to persist refreshed Google OAuth refresh token",
-                cause: undefined,
-              }),
-          ),
-        );
-      refreshTokenSecretId = auth.refreshTokenSecretId;
-    }
-
-    const updatedSource = new GoogleDiscoveryStoredSourceData({
-      ...input.source,
-      auth: {
-        kind: "oauth2",
-        clientIdSecretId: auth.clientIdSecretId,
-        clientSecretSecretId: auth.clientSecretSecretId,
-        accessTokenSecretId: auth.accessTokenSecretId,
-        refreshTokenSecretId,
-        tokenType: refreshed.token_type ?? auth.tokenType,
-        expiresAt:
-          typeof refreshed.expires_in === "number"
-            ? Date.now() + refreshed.expires_in * 1000
-            : auth.expiresAt,
-        scope: refreshed.scope ?? auth.scope,
-        scopes: auth.scopes,
-      },
-    });
-    yield* input.bindingStore.putSource({
-      namespace: input.sourceId,
-      name: input.source.name,
-      config: updatedSource,
-    });
-
-    return refreshed.access_token;
   });
 
 export const annotationsForOperation = (

--- a/packages/plugins/google-discovery/src/sdk/oauth.ts
+++ b/packages/plugins/google-discovery/src/sdk/oauth.ts
@@ -15,14 +15,13 @@ import {
   buildAuthorizationUrl,
   createPkceCodeVerifier as sharedCreatePkceCodeVerifier,
   exchangeAuthorizationCode as sharedExchangeAuthorizationCode,
-  refreshAccessToken as sharedRefreshAccessToken,
   type OAuth2TokenResponse,
 } from "@executor/plugin-oauth2";
 
 import { GoogleDiscoveryOAuthError } from "./errors";
 
 const GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
-const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+export const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 
 const GOOGLE_EXTRA_AUTHORIZATION_PARAMS = {
   access_type: "offline",
@@ -74,18 +73,3 @@ export const exchangeAuthorizationCode = (input: {
     }),
   );
 
-export const refreshAccessToken = (input: {
-  readonly clientId: string;
-  readonly clientSecret?: string | null;
-  readonly refreshToken: string;
-  readonly scopes?: readonly string[];
-}): Effect.Effect<OAuth2TokenResponse, GoogleDiscoveryOAuthError> =>
-  wrapError(
-    sharedRefreshAccessToken({
-      tokenUrl: GOOGLE_TOKEN_URL,
-      clientId: input.clientId,
-      clientSecret: input.clientSecret,
-      refreshToken: input.refreshToken,
-      scopes: input.scopes,
-    }),
-  );

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -2,6 +2,8 @@ import { randomUUID } from "node:crypto";
 
 import { Effect, Option } from "effect";
 
+import { storeOAuthTokens } from "@executor/plugin-oauth2";
+
 import {
   Source,
   SourceDetectionResult,
@@ -535,32 +537,29 @@ export const googleDiscoveryPlugin = (options?: {
                 code: input.code,
               });
 
-              const accessTokenRef = yield* storeSecret(ctx, {
-                idPrefix: `${normalizeSlug(session.name)}_google_access_token`,
-                name: `${session.name} Access Token`,
-                value: tokenResponse.access_token,
-                purpose: "google_oauth_access_token",
-              });
-              const refreshTokenRef = tokenResponse.refresh_token
-                ? yield* storeSecret(ctx, {
-                    idPrefix: `${normalizeSlug(session.name)}_google_refresh_token`,
-                    name: `${session.name} Refresh Token`,
-                    value: tokenResponse.refresh_token,
-                    purpose: "google_oauth_refresh_token",
-                  })
-                : null;
+              const stored = yield* storeOAuthTokens({
+                tokens: tokenResponse,
+                slug: `${normalizeSlug(session.name)}_google`,
+                displayName: session.name,
+                accessTokenPurpose: "google_oauth_access_token",
+                refreshTokenPurpose: "google_oauth_refresh_token",
+                createSecret: (args) =>
+                  storeSecret(ctx, args).pipe(Effect.map((ref) => ({ id: ref.id as string }))),
+              }).pipe(
+                Effect.mapError(
+                  (error) => new GoogleDiscoveryOAuthError({ message: error.message }),
+                ),
+              );
+
               return {
                 kind: "oauth2" as const,
                 clientIdSecretId: session.clientIdSecretId,
                 clientSecretSecretId: session.clientSecretSecretId,
-                accessTokenSecretId: accessTokenRef.id,
-                refreshTokenSecretId: refreshTokenRef?.id ?? null,
-                tokenType: tokenResponse.token_type ?? "Bearer",
-                expiresAt:
-                  typeof tokenResponse.expires_in === "number"
-                    ? Date.now() + tokenResponse.expires_in * 1000
-                    : null,
-                scope: tokenResponse.scope ?? null,
+                accessTokenSecretId: stored.accessTokenSecretId,
+                refreshTokenSecretId: stored.refreshTokenSecretId,
+                tokenType: stored.tokenType,
+                expiresAt: stored.expiresAt,
+                scope: stored.scope,
                 scopes: [...session.scopes],
               };
             }),

--- a/packages/plugins/oauth2/src/index.ts
+++ b/packages/plugins/oauth2/src/index.ts
@@ -366,3 +366,18 @@ export const shouldRefreshToken = (input: {
   const skew = input.skewMs ?? OAUTH2_REFRESH_SKEW_MS;
   return input.expiresAt <= now + skew;
 };
+
+// ---------------------------------------------------------------------------
+// Re-exports from sibling modules
+// ---------------------------------------------------------------------------
+
+export {
+  type OAuth2AuthRefs,
+  type OAuth2SecretsIO,
+  type RefreshedAuthSnapshot,
+  type StoreOAuthTokensInput,
+  type StoredOAuthTokens,
+  type WithRefreshedAccessTokenInput,
+  storeOAuthTokens,
+  withRefreshedAccessToken,
+} from "./refresh";

--- a/packages/plugins/oauth2/src/refresh.test.ts
+++ b/packages/plugins/oauth2/src/refresh.test.ts
@@ -1,0 +1,396 @@
+// ---------------------------------------------------------------------------
+// Fidelity tests for storeOAuthTokens + withRefreshedAccessToken.
+// Uses an in-memory secrets adapter so we can assert exactly which calls
+// happen in which order across the "no refresh needed", "refresh needed",
+// "refresh rotates the refresh_token", and "secret resolution fails" paths.
+// ---------------------------------------------------------------------------
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Effect, Exit } from "effect";
+
+import {
+  OAUTH2_REFRESH_SKEW_MS,
+  storeOAuthTokens,
+  withRefreshedAccessToken,
+  type OAuth2AuthRefs,
+  type OAuth2SecretsIO,
+  type RefreshedAuthSnapshot,
+} from "./index";
+
+// ---------------------------------------------------------------------------
+// In-memory secrets adapter
+// ---------------------------------------------------------------------------
+
+const makeSecrets = (initial: Record<string, string>): {
+  io: OAuth2SecretsIO;
+  state: Map<string, { value: string; name: string; purpose: string }>;
+  missing: Set<string>;
+} => {
+  const state = new Map<string, { value: string; name: string; purpose: string }>();
+  for (const [id, v] of Object.entries(initial))
+    state.set(id, { value: v, name: "", purpose: "" });
+  const missing = new Set<string>();
+  const io: OAuth2SecretsIO = {
+    resolve: (secretId) =>
+      Effect.gen(function* () {
+        if (missing.has(secretId))
+          return yield* Effect.fail(new Error(`secret ${secretId} not found`));
+        const entry = state.get(secretId);
+        if (!entry)
+          return yield* Effect.fail(new Error(`secret ${secretId} not found`));
+        return entry.value;
+      }),
+    setValue: ({ secretId, value, name, purpose }) =>
+      Effect.sync(() => {
+        state.set(secretId, { value, name, purpose });
+      }),
+  };
+  return { io, state, missing };
+};
+
+// ---------------------------------------------------------------------------
+// fetch capture for refresh path
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+const captureFetch = (
+  response: Response | (() => Response),
+): { calls: Array<{ url: string; init: RequestInit }> } => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  globalThis.fetch = vi
+    .fn()
+    .mockImplementation(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return typeof response === "function" ? response() : response;
+    }) as unknown as typeof fetch;
+  return { calls };
+};
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// storeOAuthTokens
+// ---------------------------------------------------------------------------
+
+describe("storeOAuthTokens", () => {
+  const baseInput = {
+    slug: "acme_api",
+    displayName: "Acme API",
+    accessTokenPurpose: "acme_oauth_access_token",
+    refreshTokenPurpose: "acme_oauth_refresh_token",
+  };
+
+  it("stores both access and refresh tokens as new secrets", async () => {
+    const calls: Array<{ idPrefix: string; name: string; purpose: string; value: string }> = [];
+    const result = await Effect.runPromise(
+      storeOAuthTokens({
+        ...baseInput,
+        tokens: {
+          access_token: "tok",
+          refresh_token: "rtok",
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "read write",
+        },
+        createSecret: (input) => {
+          calls.push(input);
+          return Effect.succeed({ id: `id_${calls.length}` });
+        },
+      }),
+    );
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.idPrefix).toBe("acme_api_access_token");
+    expect(calls[0]!.name).toBe("Acme API Access Token");
+    expect(calls[0]!.purpose).toBe("acme_oauth_access_token");
+    expect(calls[0]!.value).toBe("tok");
+    expect(calls[1]!.idPrefix).toBe("acme_api_refresh_token");
+    expect(calls[1]!.value).toBe("rtok");
+    expect(result.accessTokenSecretId).toBe("id_1");
+    expect(result.refreshTokenSecretId).toBe("id_2");
+    expect(result.tokenType).toBe("Bearer");
+    expect(result.scope).toBe("read write");
+    expect(result.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("omits the refresh-token secret when the response did not return one", async () => {
+    let calls = 0;
+    const result = await Effect.runPromise(
+      storeOAuthTokens({
+        ...baseInput,
+        tokens: { access_token: "tok" },
+        createSecret: () => {
+          calls++;
+          return Effect.succeed({ id: `id_${calls}` });
+        },
+      }),
+    );
+    expect(calls).toBe(1);
+    expect(result.refreshTokenSecretId).toBeNull();
+    expect(result.tokenType).toBe("Bearer");
+    expect(result.expiresAt).toBeNull();
+    expect(result.scope).toBeNull();
+  });
+
+  it("wraps createSecret failure in an OAuth2Error with a descriptive message", async () => {
+    const exit = await Effect.runPromiseExit(
+      storeOAuthTokens({
+        ...baseInput,
+        tokens: { access_token: "tok", refresh_token: "rtok" },
+        createSecret: () => Effect.fail(new Error("kv write failed")),
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const json = JSON.stringify(exit.cause);
+      expect(json).toContain("OAuth2Error");
+      expect(json).toContain("Failed to store access token");
+      expect(json).toContain("kv write failed");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withRefreshedAccessToken
+// ---------------------------------------------------------------------------
+
+describe("withRefreshedAccessToken", () => {
+  const makeAuth = (overrides: Partial<OAuth2AuthRefs> = {}): OAuth2AuthRefs => ({
+    clientIdSecretId: "cid-secret",
+    clientSecretSecretId: "csecret-secret",
+    accessTokenSecretId: "atok-secret",
+    refreshTokenSecretId: "rtok-secret",
+    tokenType: "Bearer",
+    expiresAt: null,
+    scopes: ["read", "write"],
+    ...overrides,
+  });
+
+  const baseInput = {
+    tokenUrl: "https://api.example.com/oauth/token",
+    displayName: "Acme",
+    accessTokenPurpose: "acme_access",
+    refreshTokenPurpose: "acme_refresh",
+  };
+
+  it("returns the current access token without refreshing when expiresAt is null", async () => {
+    const { io } = makeSecrets({
+      "atok-secret": "current-access-token",
+      "rtok-secret": "stored-refresh",
+      "cid-secret": "cid",
+      "csecret-secret": "csecret",
+    });
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const persistAuth = vi.fn(() => Effect.void);
+
+    const result = await Effect.runPromise(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({ expiresAt: null }),
+        secrets: io,
+        persistAuth,
+      }),
+    );
+    expect(result).toBe("current-access-token");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(persistAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns the current access token when expiresAt is comfortably in the future", async () => {
+    const { io } = makeSecrets({
+      "atok-secret": "current",
+      "rtok-secret": "r",
+      "cid-secret": "c",
+      "csecret-secret": "s",
+    });
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await Effect.runPromise(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({ expiresAt: Date.now() + 10 * 60_000 }),
+        secrets: io,
+        persistAuth: () => Effect.void,
+      }),
+    );
+    expect(result).toBe("current");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("refreshes when expiresAt is within the skew window, persists new token, calls persistAuth", async () => {
+    const { io, state } = makeSecrets({
+      "atok-secret": "old-access",
+      "rtok-secret": "stored-refresh",
+      "cid-secret": "client-1",
+      "csecret-secret": "secret-1",
+    });
+    const { calls } = captureFetch(
+      jsonResponse(200, {
+        access_token: "new-access",
+        token_type: "Bearer",
+        expires_in: 3600,
+      }),
+    );
+    const persistedSnapshots: RefreshedAuthSnapshot[] = [];
+    const persistAuth = (snapshot: RefreshedAuthSnapshot) =>
+      Effect.sync(() => {
+        persistedSnapshots.push(snapshot);
+      });
+
+    const result = await Effect.runPromise(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({ expiresAt: Date.now() + 30_000 }),
+        secrets: io,
+        persistAuth,
+      }),
+    );
+
+    expect(result).toBe("new-access");
+    expect(calls).toHaveLength(1);
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("stored-refresh");
+    expect(body.get("client_id")).toBe("client-1");
+    expect(body.get("client_secret")).toBe("secret-1");
+    expect(body.get("scope")).toBe("read write");
+
+    // Access-token secret was updated in place with the new value.
+    expect(state.get("atok-secret")!.value).toBe("new-access");
+    // persistAuth called with updated snapshot.
+    expect(persistedSnapshots).toHaveLength(1);
+    expect(persistedSnapshots[0]!.tokenType).toBe("Bearer");
+    expect(persistedSnapshots[0]!.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it("rotates the refresh_token secret when the server returns a new one", async () => {
+    const { io, state } = makeSecrets({
+      "atok-secret": "old",
+      "rtok-secret": "old-refresh",
+      "cid-secret": "c",
+      "csecret-secret": "s",
+    });
+    captureFetch(
+      jsonResponse(200, {
+        access_token: "new",
+        refresh_token: "new-refresh",
+        expires_in: 3600,
+      }),
+    );
+    await Effect.runPromise(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({ expiresAt: Date.now() + 30_000 }),
+        secrets: io,
+        persistAuth: () => Effect.void,
+      }),
+    );
+    expect(state.get("rtok-secret")!.value).toBe("new-refresh");
+  });
+
+  it("does NOT touch the refresh_token secret when the server omits it", async () => {
+    const { io, state } = makeSecrets({
+      "atok-secret": "old",
+      "rtok-secret": "old-refresh",
+      "cid-secret": "c",
+      "csecret-secret": "s",
+    });
+    captureFetch(jsonResponse(200, { access_token: "new", expires_in: 3600 }));
+    await Effect.runPromise(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({ expiresAt: Date.now() + 30_000 }),
+        secrets: io,
+        persistAuth: () => Effect.void,
+      }),
+    );
+    expect(state.get("rtok-secret")!.value).toBe("old-refresh");
+  });
+
+  it("skips the refresh path entirely when refreshTokenSecretId is null, even if expired", async () => {
+    const { io } = makeSecrets({
+      "atok-secret": "only-access",
+      "cid-secret": "c",
+      "csecret-secret": "s",
+    });
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const result = await Effect.runPromise(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({
+          refreshTokenSecretId: null,
+          expiresAt: Date.now() - 10_000,
+        }),
+        secrets: io,
+        persistAuth: () => Effect.void,
+      }),
+    );
+    expect(result).toBe("only-access");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("omits client_secret from the refresh call when clientSecretSecretId is null", async () => {
+    const { io } = makeSecrets({
+      "atok-secret": "old",
+      "rtok-secret": "rtok",
+      "cid-secret": "public-client",
+    });
+    const { calls } = captureFetch(
+      jsonResponse(200, { access_token: "new", expires_in: 3600 }),
+    );
+    await Effect.runPromise(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({
+          clientSecretSecretId: null,
+          expiresAt: Date.now() + 30_000,
+        }),
+        secrets: io,
+        persistAuth: () => Effect.void,
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.get("client_id")).toBe("public-client");
+    expect(body.has("client_secret")).toBe(false);
+  });
+
+  it("wraps secret-resolve failures in OAuth2Error with descriptive messages", async () => {
+    const { io, missing } = makeSecrets({
+      "atok-secret": "old",
+      "rtok-secret": "rtok",
+      "cid-secret": "c",
+      "csecret-secret": "s",
+    });
+    missing.add("rtok-secret");
+    captureFetch(jsonResponse(200, { access_token: "new" }));
+    const exit = await Effect.runPromiseExit(
+      withRefreshedAccessToken({
+        ...baseInput,
+        auth: makeAuth({ expiresAt: Date.now() + 30_000 }),
+        secrets: io,
+        persistAuth: () => Effect.void,
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const json = JSON.stringify(exit.cause);
+      expect(json).toContain("OAuth2Error");
+      expect(json).toContain("Failed to resolve OAuth refresh token");
+    }
+  });
+
+  it("uses the default 60s refresh skew window", () => {
+    expect(OAUTH2_REFRESH_SKEW_MS).toBe(60_000);
+  });
+});

--- a/packages/plugins/oauth2/src/refresh.ts
+++ b/packages/plugins/oauth2/src/refresh.ts
@@ -1,0 +1,238 @@
+// ---------------------------------------------------------------------------
+// Generic helpers for storing OAuth token secrets and transparently
+// refreshing access tokens before a request.
+//
+// Plugins (google-discovery, openapi) supply an adapter for their secrets
+// API and a `persistAuth` callback so this module stays decoupled from any
+// specific plugin SDK or store shape.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+
+import { OAuth2Error, type OAuth2TokenResponse } from "./index";
+import {
+  OAUTH2_DEFAULT_TIMEOUT_MS,
+  refreshAccessToken,
+  shouldRefreshToken,
+  type ClientAuthMethod,
+} from "./index";
+
+// ---------------------------------------------------------------------------
+// Secrets I/O adapter — plain string IDs, no plugin types.
+// ---------------------------------------------------------------------------
+
+export type OAuth2SecretsIO = {
+  readonly resolve: (secretId: string) => Effect.Effect<string, unknown>;
+  readonly setValue: (input: {
+    readonly secretId: string;
+    readonly value: string;
+    readonly name: string;
+    readonly purpose: string;
+  }) => Effect.Effect<void, unknown>;
+};
+
+const wrapSecretError =
+  (operation: string) =>
+  (cause: unknown): OAuth2Error =>
+    new OAuth2Error({
+      message: `${operation}: ${cause instanceof Error ? cause.message : String(cause)}`,
+      cause,
+    });
+
+// ---------------------------------------------------------------------------
+// storeOAuthTokens — freshly store access + refresh tokens as new secrets.
+// ---------------------------------------------------------------------------
+
+/** Shape of a newly persisted OAuth2 auth descriptor. */
+export type StoredOAuthTokens = {
+  readonly accessTokenSecretId: string;
+  readonly refreshTokenSecretId: string | null;
+  readonly tokenType: string;
+  readonly expiresAt: number | null;
+  readonly scope: string | null;
+};
+
+export type StoreOAuthTokensInput = {
+  readonly tokens: OAuth2TokenResponse;
+  /** Slug used as prefix for new secret IDs, e.g. `acme_api`. */
+  readonly slug: string;
+  /** Human-readable name for the source, used in secret labels. */
+  readonly displayName: string;
+  /** `purpose` label stored on the access-token secret. */
+  readonly accessTokenPurpose: string;
+  /** `purpose` label stored on the refresh-token secret. */
+  readonly refreshTokenPurpose: string;
+  /** Adapter that creates a new secret and returns its freshly-minted ID. */
+  readonly createSecret: (input: {
+    readonly idPrefix: string;
+    readonly name: string;
+    readonly value: string;
+    readonly purpose: string;
+  }) => Effect.Effect<{ readonly id: string }, unknown>;
+};
+
+/**
+ * Persist access + refresh tokens from an OAuth2 token response as new
+ * secrets and return a `StoredOAuthTokens` descriptor ready to write to a
+ * source config.
+ */
+export const storeOAuthTokens = (
+  input: StoreOAuthTokensInput,
+): Effect.Effect<StoredOAuthTokens, OAuth2Error> =>
+  Effect.gen(function* () {
+    const accessRef = yield* input
+      .createSecret({
+        idPrefix: `${input.slug}_access_token`,
+        name: `${input.displayName} Access Token`,
+        value: input.tokens.access_token,
+        purpose: input.accessTokenPurpose,
+      })
+      .pipe(Effect.mapError(wrapSecretError("Failed to store access token")));
+
+    const refreshRef = input.tokens.refresh_token
+      ? yield* input
+          .createSecret({
+            idPrefix: `${input.slug}_refresh_token`,
+            name: `${input.displayName} Refresh Token`,
+            value: input.tokens.refresh_token,
+            purpose: input.refreshTokenPurpose,
+          })
+          .pipe(Effect.mapError(wrapSecretError("Failed to store refresh token")))
+      : null;
+
+    return {
+      accessTokenSecretId: accessRef.id,
+      refreshTokenSecretId: refreshRef?.id ?? null,
+      tokenType: input.tokens.token_type ?? "Bearer",
+      expiresAt:
+        typeof input.tokens.expires_in === "number"
+          ? Date.now() + input.tokens.expires_in * 1000
+          : null,
+      scope: input.tokens.scope ?? null,
+    };
+  });
+
+// ---------------------------------------------------------------------------
+// withRefreshedAccessToken — return the current access token, refreshing
+// first if it's within the skew window.
+// ---------------------------------------------------------------------------
+
+/** The subset of a stored OAuth2 auth descriptor this helper needs. */
+export type OAuth2AuthRefs = {
+  readonly clientIdSecretId: string;
+  readonly clientSecretSecretId: string | null;
+  readonly accessTokenSecretId: string;
+  readonly refreshTokenSecretId: string | null;
+  readonly tokenType: string;
+  readonly expiresAt: number | null;
+  readonly scopes: readonly string[];
+};
+
+/** Snapshot of auth values written back after a successful refresh. */
+export type RefreshedAuthSnapshot = {
+  readonly tokenType: string;
+  readonly expiresAt: number | null;
+  readonly scope: string | null;
+};
+
+export type WithRefreshedAccessTokenInput = {
+  readonly auth: OAuth2AuthRefs;
+  readonly tokenUrl: string;
+  readonly secrets: OAuth2SecretsIO;
+  /** Display name used when re-setting the access-token secret after refresh. */
+  readonly displayName: string;
+  readonly accessTokenPurpose: string;
+  readonly refreshTokenPurpose: string;
+  readonly clientAuth?: ClientAuthMethod;
+  readonly timeoutMs?: number;
+  /**
+   * Called after a successful refresh with the new expiry / tokenType /
+   * scope so the plugin can write the updated auth back to its source
+   * config. The accessTokenSecretId does NOT change — the value behind
+   * it is overwritten in place.
+   */
+  readonly persistAuth: (
+    snapshot: RefreshedAuthSnapshot,
+  ) => Effect.Effect<void, unknown>;
+};
+
+/**
+ * Resolve the current access token for a source — if it's within the
+ * refresh-skew window, first exchange the refresh token for a new access
+ * token, persist it, and write the updated expiry back via `persistAuth`.
+ *
+ * Returns the access-token string to be used for the upcoming request.
+ */
+export const withRefreshedAccessToken = (
+  input: WithRefreshedAccessTokenInput,
+): Effect.Effect<string, OAuth2Error> =>
+  Effect.gen(function* () {
+    const { auth, secrets } = input;
+    const needsRefresh =
+      auth.refreshTokenSecretId !== null && shouldRefreshToken({ expiresAt: auth.expiresAt });
+
+    if (!needsRefresh) {
+      return yield* secrets
+        .resolve(auth.accessTokenSecretId)
+        .pipe(Effect.mapError(wrapSecretError("Failed to resolve OAuth access token")));
+    }
+
+    // Proactive refresh path.
+    const refreshToken = yield* secrets
+      .resolve(auth.refreshTokenSecretId!)
+      .pipe(Effect.mapError(wrapSecretError("Failed to resolve OAuth refresh token")));
+
+    const clientId = yield* secrets
+      .resolve(auth.clientIdSecretId)
+      .pipe(Effect.mapError(wrapSecretError("Failed to resolve OAuth client ID")));
+
+    const clientSecret =
+      auth.clientSecretSecretId === null
+        ? null
+        : yield* secrets
+            .resolve(auth.clientSecretSecretId)
+            .pipe(Effect.mapError(wrapSecretError("Failed to resolve OAuth client secret")));
+
+    const refreshed = yield* refreshAccessToken({
+      tokenUrl: input.tokenUrl,
+      clientId,
+      clientSecret,
+      refreshToken,
+      scopes: auth.scopes,
+      clientAuth: input.clientAuth,
+      timeoutMs: input.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS,
+    });
+
+    yield* secrets
+      .setValue({
+        secretId: auth.accessTokenSecretId,
+        value: refreshed.access_token,
+        name: `${input.displayName} Access Token`,
+        purpose: input.accessTokenPurpose,
+      })
+      .pipe(Effect.mapError(wrapSecretError("Failed to persist refreshed access token")));
+
+    if (refreshed.refresh_token && auth.refreshTokenSecretId) {
+      yield* secrets
+        .setValue({
+          secretId: auth.refreshTokenSecretId,
+          value: refreshed.refresh_token,
+          name: `${input.displayName} Refresh Token`,
+          purpose: input.refreshTokenPurpose,
+        })
+        .pipe(Effect.mapError(wrapSecretError("Failed to persist rotated refresh token")));
+    }
+
+    yield* input
+      .persistAuth({
+        tokenType: refreshed.token_type ?? auth.tokenType,
+        expiresAt:
+          typeof refreshed.expires_in === "number"
+            ? Date.now() + refreshed.expires_in * 1000
+            : auth.expiresAt,
+        scope: refreshed.scope ?? null,
+      })
+      .pipe(Effect.mapError(wrapSecretError("Failed to persist updated OAuth auth")));
+
+    return refreshed.access_token;
+  });


### PR DESCRIPTION
Generic helpers that take a secrets-I/O adapter and a `persistAuth`
callback so plugins can transparently refresh access tokens before a
request without re-implementing the ~150-line token-rotation dance.

- `storeOAuthTokens`: persist a fresh OAuth2TokenResponse as new access
  and (optionally) refresh-token secrets via a `createSecret` callback
  and return a `StoredOAuthTokens` descriptor ready to write to a
  source config.
- `withRefreshedAccessToken`: check `shouldRefreshToken`, resolve
  client/refresh credentials from secrets, call `refreshAccessToken`,
  overwrite the access-token secret in place, optionally rotate the
  refresh-token secret, invoke `persistAuth` with the updated snapshot,
  and return the current access token to be injected into the request.

Ports `google-discovery`:
- `completeOAuth` drops its manual `storeSecret` dance (now a ~15 line
  call to `storeOAuthTokens`).
- `invoke.ts`'s `resolveOAuthAccessToken` shrinks from ~150 lines of
  secret-resolution + refresh + persist glue to ~75 lines of adapter.
- The google-discovery-local `refreshAccessToken` wrapper is removed
  (unused after the port); the google token URL is exported so the
  invoker can pass it to the shared helper.

12 new fidelity tests lock in every branch (no refresh, refresh within
skew, rotated refresh token, preserved refresh token, null refresh ID,
public client without client_secret, secret-resolve failure wrapping).