### PR TITLE
feat(mcp): add agent-import SDK module (1/4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -516,6 +516,8 @@
         "@executor/sdk": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "effect": "catalog:",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.7.1",
       },
       "devDependencies": {
         "@effect-atom/atom-react": "^0.5.0",

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -20,7 +20,8 @@
     "./promise": "./src/promise.ts",
     "./api": "./src/api/index.ts",
     "./react": "./src/react/index.ts",
-    "./presets": "./src/sdk/presets.ts"
+    "./presets": "./src/sdk/presets.ts",
+    "./agent-import": "./src/sdk/agent-import/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -52,7 +53,9 @@
     "@executor/config": "workspace:*",
     "@executor/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "smol-toml": "^1.6.1",
+    "yaml": "^2.7.1"
   },
   "devDependencies": {
     "@effect-atom/atom-react": "^0.5.0",

--- a/packages/plugins/mcp/src/sdk/agent-import/agent-import.test.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/agent-import.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeAgentConfig } from "./normalize";
+import { detectAgentFromFilename, detectAgentFromContent, parseAgentConfigContent } from "./reader";
+import type { AgentKey } from "./types";
+
+// ---------------------------------------------------------------------------
+// normalizeAgentConfig
+// ---------------------------------------------------------------------------
+
+describe("normalizeAgentConfig — standard agents (mcpServers)", () => {
+  const stdioConfig = {
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        env: { DEBUG: "1" },
+      },
+    },
+  };
+
+  const remoteConfig = {
+    mcpServers: {
+      context7: {
+        url: "https://mcp.context7.com/mcp",
+        type: "http",
+        headers: { Authorization: "Bearer tok" },
+      },
+    },
+  };
+
+  for (const agent of [
+    "claude-code",
+    "claude-desktop",
+    "amp",
+    "cursor",
+    "cline",
+    "cline-cli",
+    "gemini-cli",
+    "copilot",
+    "antigravity",
+  ] as AgentKey[]) {
+    it(`${agent} — normalizes stdio server`, () => {
+      const result = normalizeAgentConfig(agent, stdioConfig);
+      expect(result).toHaveLength(1);
+      const s = result[0]!;
+      expect(s.name).toBe("filesystem");
+      expect(s.config.transport).toBe("stdio");
+      if (s.config.transport === "stdio") {
+        expect(s.config.command).toBe("npx");
+        expect(s.config.args).toEqual(["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]);
+        expect(s.config.env).toEqual({ DEBUG: "1" });
+      }
+    });
+
+    it(`${agent} — normalizes remote server`, () => {
+      const result = normalizeAgentConfig(agent, remoteConfig);
+      expect(result).toHaveLength(1);
+      const s = result[0]!;
+      expect(s.name).toBe("context7");
+      expect(s.config.transport).toBe("remote");
+      if (s.config.transport === "remote") {
+        expect(s.config.endpoint).toBe("https://mcp.context7.com/mcp");
+        expect(s.config.headers).toEqual({ Authorization: "Bearer tok" });
+        expect(s.config.remoteTransport).toBe("streamable-http");
+      }
+    });
+  }
+});
+
+describe("normalizeAgentConfig — opencode", () => {
+  it("normalizes remote server", () => {
+    const config = {
+      mcp: {
+        context7: { type: "remote", url: "https://mcp.context7.com/mcp", enabled: true },
+      },
+    };
+    const result = normalizeAgentConfig("opencode", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    expect(s.config.transport).toBe("remote");
+    if (s.config.transport === "remote") {
+      expect(s.config.endpoint).toBe("https://mcp.context7.com/mcp");
+    }
+  });
+
+  it("normalizes stdio server with array command", () => {
+    const config = {
+      mcp: {
+        filesystem: {
+          type: "local",
+          command: ["node", "/path/to/server.js"],
+          enabled: true,
+          environment: { HOME: "/home/user" },
+        },
+      },
+    };
+    const result = normalizeAgentConfig("opencode", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    expect(s.config.transport).toBe("stdio");
+    if (s.config.transport === "stdio") {
+      expect(s.config.command).toBe("node");
+      expect(s.config.args).toEqual(["/path/to/server.js"]);
+      expect(s.config.env).toEqual({ HOME: "/home/user" });
+    }
+  });
+
+  it("normalizes stdio server with string command", () => {
+    const config = {
+      mcp: {
+        myserver: { type: "local", command: "python", args: ["server.py"] },
+      },
+    };
+    const result = normalizeAgentConfig("opencode", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    if (s.config.transport === "stdio") {
+      expect(s.config.command).toBe("python");
+      expect(s.config.args).toEqual(["server.py"]);
+    }
+  });
+});
+
+describe("normalizeAgentConfig — vscode", () => {
+  it("uses servers key", () => {
+    const config = {
+      servers: {
+        myserver: { type: "http", url: "https://example.com/mcp" },
+      },
+    };
+    const result = normalizeAgentConfig("vscode", config);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("remote");
+  });
+});
+
+describe("normalizeAgentConfig — zed", () => {
+  it("uses context_servers key", () => {
+    const config = {
+      context_servers: {
+        myserver: { source: "custom", url: "https://example.com/mcp" },
+      },
+    };
+    const result = normalizeAgentConfig("zed", config);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("remote");
+  });
+
+  it("normalizes stdio", () => {
+    const config = {
+      context_servers: {
+        local: { source: "custom", command: "node", args: ["server.js"] },
+      },
+    };
+    const result = normalizeAgentConfig("zed", config);
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "stdio") {
+      expect(result[0]!.config.command).toBe("node");
+    }
+  });
+});
+
+describe("normalizeAgentConfig — goose", () => {
+  it("normalizes remote (streamable_http)", () => {
+    const config = {
+      extensions: {
+        context7: {
+          type: "streamable_http",
+          uri: "https://mcp.context7.com/mcp",
+          enabled: true,
+        },
+      },
+    };
+    const result = normalizeAgentConfig("goose", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    expect(s.config.transport).toBe("remote");
+    if (s.config.transport === "remote") {
+      expect(s.config.endpoint).toBe("https://mcp.context7.com/mcp");
+      expect(s.config.remoteTransport).toBe("streamable-http");
+    }
+  });
+
+  it("normalizes stdio (cmd key)", () => {
+    const config = {
+      extensions: {
+        myserver: {
+          type: "stdio",
+          cmd: "npx",
+          args: ["-y", "some-pkg"],
+          envs: { KEY: "val" },
+        },
+      },
+    };
+    const result = normalizeAgentConfig("goose", config);
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "stdio") {
+      expect(result[0]!.config.command).toBe("npx");
+      expect(result[0]!.config.env).toEqual({ KEY: "val" });
+    }
+  });
+});
+
+describe("normalizeAgentConfig — codex", () => {
+  it("normalizes remote with http_headers", () => {
+    const config = {
+      mcp_servers: {
+        myapi: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+          http_headers: { "X-Key": "secret" },
+        },
+      },
+    };
+    const result = normalizeAgentConfig("codex", config);
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "remote") {
+      expect(result[0]!.config.headers).toEqual({ "X-Key": "secret" });
+    }
+  });
+});
+
+describe("normalizeAgentConfig — edge cases", () => {
+  it("returns empty array for empty config", () => {
+    expect(normalizeAgentConfig("claude-code", {})).toEqual([]);
+  });
+
+  it("returns empty array when servers key missing", () => {
+    expect(normalizeAgentConfig("claude-code", { other: {} })).toEqual([]);
+  });
+
+  it("skips entries with no command or url", () => {
+    const config = { mcpServers: { broken: { unknown: "field" } } };
+    expect(normalizeAgentConfig("claude-code", config)).toEqual([]);
+  });
+
+  it("handles multiple servers", () => {
+    const config = {
+      mcpServers: {
+        a: { command: "npx", args: ["-y", "pkg-a"] },
+        b: { url: "https://b.example.com/mcp" },
+        c: { command: "python", args: ["c.py"] },
+      },
+    };
+    const result = normalizeAgentConfig("claude-code", config);
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("derives namespace from server name", () => {
+    const config = { mcpServers: { "My Server": { command: "myserver" } } };
+    const result = normalizeAgentConfig("claude-code", config);
+    expect(result[0]!.suggestedNamespace).toBe("my_server");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSONC comment stripping
+// ---------------------------------------------------------------------------
+
+describe("JSONC comment stripping", () => {
+  it("strips line comments", () => {
+    const jsonc = `{
+  // This is a comment
+  "key": "value"
+}`;
+    // We test indirectly via parseAgentConfigContent
+    const result = parseAgentConfigContent(jsonc, "test.json", "claude-code");
+    expect(result).resolves.toHaveLength(0); // no mcpServers key
+  });
+
+  it("strips block comments", () => {
+    const jsonc = `{
+  /* block comment */
+  "mcpServers": {
+    "fs": { "command": "node" }
+  }
+}`;
+    return expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).resolves.toHaveLength(
+      1,
+    );
+  });
+
+  it("strips trailing commas", () => {
+    const jsonc = `{
+  "mcpServers": {
+    "fs": { "command": "node", },
+  }
+}`;
+    return expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).resolves.toHaveLength(
+      1,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAgentFromFilename
+// ---------------------------------------------------------------------------
+
+describe("detectAgentFromFilename", () => {
+  it.each([
+    ["opencode.json", "opencode"],
+    ["opencode.jsonc", "opencode"],
+    [".mcp.json", "claude-code"],
+    ["mcp.json", "claude-code"],
+    ["claude_desktop_config.json", "claude-desktop"],
+    ["cline_mcp_settings.json", "cline"],
+    ["config.toml", "codex"],
+    ["config.yaml", "goose"],
+    ["mcp-config.json", "copilot"],
+    ["mcp_config.json", "antigravity"],
+    ["mcporter.json", "mcporter"],
+    ["mcporter.jsonc", "mcporter"],
+    [".claude.json", "claude-code"],
+    ["unknown.json", null],
+  ])("filename %s → %s", (filename, expected) => {
+    expect(detectAgentFromFilename(filename)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAgentFromContent
+// ---------------------------------------------------------------------------
+
+describe("detectAgentFromContent", () => {
+  it.each([
+    [{ mcp: {} }, "opencode"],
+    [{ context_servers: {} }, "zed"],
+    [{ extensions: {} }, "goose"],
+    [{ mcp_servers: {} }, "codex"],
+    [{ servers: {} }, "vscode"],
+    [{ mcpServers: {} }, "claude-code"],
+    [{}, null],
+    [null, null],
+    ["string", null],
+  ])("content %j → %s", (content, expected) => {
+    expect(detectAgentFromContent(content)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAgentConfigContent — format detection
+// ---------------------------------------------------------------------------
+
+describe("parseAgentConfigContent", () => {
+  it("parses opencode.json", async () => {
+    const content = JSON.stringify({
+      mcp: {
+        context7: { type: "remote", url: "https://mcp.context7.com/mcp" },
+      },
+    });
+    const result = await parseAgentConfigContent(content, "opencode.json");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("remote");
+  });
+
+  it("parses .mcp.json as claude-code", async () => {
+    const content = JSON.stringify({
+      mcpServers: { fs: { command: "npx", args: ["-y", "fs"] } },
+    });
+    const result = await parseAgentConfigContent(content, ".mcp.json");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("stdio");
+  });
+
+  it("auto-detects agent from content when filename unknown", async () => {
+    const content = JSON.stringify({
+      context_servers: {
+        local: { command: "node", args: ["server.js"] },
+      },
+    });
+    const result = await parseAgentConfigContent(content, "unknown.json");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("stdio");
+  });
+
+  it("returns empty array for empty content", async () => {
+    const result = await parseAgentConfigContent("{}", "mcp.json", "claude-code");
+    expect(result).toHaveLength(0);
+  });
+
+  it("throws AgentImportError on invalid JSON", async () => {
+    await expect(
+      parseAgentConfigContent("not valid json", "mcp.json", "claude-code"),
+    ).rejects.toThrow("Failed to parse config file");
+  });
+
+  it("parses goose YAML config", async () => {
+    const yaml = `
+extensions:
+  context7:
+    type: streamable_http
+    uri: https://mcp.context7.com/mcp
+    enabled: true
+`;
+    const result = await parseAgentConfigContent(yaml, "config.yaml", "goose");
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "remote") {
+      expect(result[0]!.config.endpoint).toBe("https://mcp.context7.com/mcp");
+    }
+  });
+
+  it("parses codex TOML config", async () => {
+    const toml = `
+[mcp_servers.myserver]
+command = "npx"
+args = ["-y", "some-pkg"]
+`;
+    const result = await parseAgentConfigContent(toml, "config.toml", "codex");
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "stdio") {
+      expect(result[0]!.config.command).toBe("npx");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Remote transport normalization
+// ---------------------------------------------------------------------------
+
+describe("remote transport normalization", () => {
+  it.each([
+    ["sse", "sse"],
+    ["streamableHttp", "streamable-http"],
+    ["streamable-http", "streamable-http"],
+    ["http", "streamable-http"],
+    [undefined, "auto"],
+    ["unknown", "auto"],
+  ] as [string | undefined, string][])("type=%s → remoteTransport=%s", (type, expected) => {
+    const config = {
+      mcpServers: {
+        server: type
+          ? { url: "https://example.com/mcp", type }
+          : { url: "https://example.com/mcp" },
+      },
+    };
+    const result = normalizeAgentConfig("claude-code", config);
+    expect(result[0]!.config.transport).toBe("remote");
+    if (result[0]!.config.transport === "remote") {
+      expect(result[0]!.config.remoteTransport).toBe(expected);
+    }
+  });
+});

--- a/packages/plugins/mcp/src/sdk/agent-import/index.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/index.ts
@@ -1,0 +1,19 @@
+export type { AgentKey, ConfigFormat, NormalizedServer, NormalizedServerConfig } from "./types";
+export { AgentImportError } from "./types";
+export { normalizeAgentConfig, configKeyByAgent } from "./normalize";
+export {
+  getCurrentPlatformEnv,
+  getGlobalConfigPaths,
+  getLocalConfigPaths,
+  detectFormat,
+  detectAgentFromFilename,
+  detectAgentFromContent,
+  parseContent,
+  readAgentConfigFile,
+  parseAgentConfigContent,
+  findAndReadAgentConfig,
+  detectInstalledAgents,
+  type PlatformEnv,
+  type ResolvedAgentConfig,
+  type DetectedAgent,
+} from "./reader";

--- a/packages/plugins/mcp/src/sdk/agent-import/normalize.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/normalize.ts
@@ -1,0 +1,351 @@
+// ---------------------------------------------------------------------------
+// Agent config normalization — maps agent-specific shapes → NormalizedServer
+// ---------------------------------------------------------------------------
+
+import { deriveMcpNamespace } from "../manifest";
+import type { AgentKey, NormalizedServer, NormalizedServerConfig } from "./types";
+
+// ---------------------------------------------------------------------------
+// Raw server shapes (loosely typed — we handle unknown agent configs)
+// ---------------------------------------------------------------------------
+
+type RawServer = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length > 0 ? v : undefined;
+
+const strRecord = (v: unknown): Record<string, string> | undefined => {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, val] of Object.entries(v)) {
+    if (typeof val === "string") out[k] = val;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+
+const strArray = (v: unknown): string[] | undefined => {
+  if (!Array.isArray(v)) return undefined;
+  const out = v.filter((x): x is string => typeof x === "string");
+  return out.length > 0 ? out : undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Standard mcpServers format (Claude Code, Cursor, Cline, Gemini CLI, etc.)
+// {command, args, env} or {url, type, headers}
+// ---------------------------------------------------------------------------
+
+const normalizeStandard = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url) ?? str(raw.serverUrl) ?? str(raw.uri);
+  if (url) {
+    const transport = normalizeRemoteTransport(str(raw.type));
+    const config: NormalizedServerConfig = {
+      transport: "remote",
+      endpoint: url,
+      headers: strRecord(raw.headers),
+      remoteTransport: transport,
+    };
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config,
+    };
+  }
+
+  const command = str(raw.command);
+  if (command) {
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, command }),
+      config: {
+        transport: "stdio",
+        command,
+        args: strArray(raw.args),
+        env: strRecord(raw.env),
+        cwd: str(raw.cwd),
+      },
+    };
+  }
+
+  return null;
+};
+
+const normalizeRemoteTransport = (t: string | undefined): "streamable-http" | "sse" | "auto" => {
+  if (t === "sse") return "sse";
+  if (t === "streamableHttp" || t === "streamable-http" || t === "http") return "streamable-http";
+  return "auto";
+};
+
+// ---------------------------------------------------------------------------
+// OpenCode: {mcp: {name: {type:"remote"|"local", url?, command:[...], environment:{}}}}
+// ---------------------------------------------------------------------------
+
+const normalizeOpenCode = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url || str(raw.type) === "remote") {
+    if (!url) return null;
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers: strRecord(raw.headers),
+        remoteTransport: "auto",
+      },
+    };
+  }
+
+  // command is array in opencode: ["node", "server.js"] or string
+  let command: string | undefined;
+  let args: string[] | undefined;
+
+  if (Array.isArray(raw.command)) {
+    const parts = raw.command.filter((x): x is string => typeof x === "string");
+    command = parts[0];
+    args = parts.slice(1);
+  } else {
+    command = str(raw.command);
+    args = strArray(raw.args);
+  }
+
+  if (!command) return null;
+
+  const env = strRecord(raw.environment) ?? strRecord(raw.env);
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: { transport: "stdio", command, args, env },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Goose: {extensions: {name: {type:"streamable_http"|"sse"|"stdio", uri?, cmd?, args?, envs:{}}}}
+// ---------------------------------------------------------------------------
+
+const normalizeGoose = (name: string, raw: RawServer): NormalizedServer | null => {
+  const uri = str(raw.uri);
+  if (uri) {
+    const t = str(raw.type);
+    const transport = t === "sse" ? "sse" : "streamable-http";
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: uri }),
+      config: {
+        transport: "remote",
+        endpoint: uri,
+        headers: strRecord(raw.headers),
+        remoteTransport: transport,
+      },
+    };
+  }
+
+  const cmd = str(raw.cmd) ?? str(raw.command);
+  if (!cmd) return null;
+
+  const env = strRecord(raw.envs) ?? strRecord(raw.env);
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command: cmd }),
+    config: {
+      transport: "stdio",
+      command: cmd,
+      args: strArray(raw.args),
+      env,
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Codex: {mcp_servers: {name: {type:"http"|"sse", url?} or {command, args, env}}}
+// http_headers used instead of headers in codex
+// ---------------------------------------------------------------------------
+
+const normalizeCodex = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url) {
+    const headers = strRecord(raw.http_headers) ?? strRecord(raw.headers);
+    const t = str(raw.type);
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers,
+        remoteTransport: normalizeRemoteTransport(t),
+      },
+    };
+  }
+
+  const command = str(raw.command);
+  if (!command) return null;
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: {
+      transport: "stdio",
+      command,
+      args: strArray(raw.args),
+      env: strRecord(raw.env),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Zed: {context_servers: {name: {source:"custom", type?, url?, command?, args?, env}}}
+// ---------------------------------------------------------------------------
+
+const normalizeZed = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url) {
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers: strRecord(raw.headers),
+        remoteTransport: normalizeRemoteTransport(str(raw.type)),
+      },
+    };
+  }
+
+  const command = str(raw.command);
+  if (!command) return null;
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: {
+      transport: "stdio",
+      command,
+      args: strArray(raw.args),
+      env: strRecord(raw.env),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// VS Code: {servers: {name: {type:"http"|"stdio", url?, command?, args}}}
+// ---------------------------------------------------------------------------
+
+const normalizeVSCode = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url) {
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers: strRecord(raw.headers),
+        remoteTransport: normalizeRemoteTransport(str(raw.type)),
+      },
+    };
+  }
+
+  const command = str(raw.command);
+  if (!command) return null;
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: {
+      transport: "stdio",
+      command,
+      args: strArray(raw.args),
+      env: strRecord(raw.env),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Dispatch by agent key
+// ---------------------------------------------------------------------------
+
+type NormalizeFn = (name: string, raw: RawServer) => NormalizedServer | null;
+
+const normalizersByAgent: Record<AgentKey, NormalizeFn> = {
+  opencode: normalizeOpenCode,
+  "claude-code": normalizeStandard,
+  "claude-desktop": normalizeStandard,
+  amp: normalizeStandard,
+  cursor: normalizeStandard,
+  vscode: normalizeVSCode,
+  cline: normalizeStandard,
+  "cline-cli": normalizeStandard,
+  zed: normalizeZed,
+  goose: normalizeGoose,
+  codex: normalizeCodex,
+  "gemini-cli": normalizeStandard,
+  copilot: normalizeStandard,
+  antigravity: normalizeStandard,
+  mcporter: normalizeStandard,
+};
+
+// ---------------------------------------------------------------------------
+// Config key by agent — where in the parsed object the servers live
+// ---------------------------------------------------------------------------
+
+export const configKeyByAgent: Record<AgentKey, string> = {
+  opencode: "mcp",
+  "claude-code": "mcpServers",
+  "claude-desktop": "mcpServers",
+  amp: "mcpServers",
+  cursor: "mcpServers",
+  vscode: "servers",
+  cline: "mcpServers",
+  "cline-cli": "mcpServers",
+  zed: "context_servers",
+  goose: "extensions",
+  codex: "mcp_servers",
+  "gemini-cli": "mcpServers",
+  copilot: "mcpServers",
+  antigravity: "mcpServers",
+  mcporter: "mcpServers",
+};
+
+// ---------------------------------------------------------------------------
+// Extract servers object from parsed config using dot-notation key
+// ---------------------------------------------------------------------------
+
+const getNestedValue = (obj: unknown, key: string): unknown => {
+  const parts = key.split(".");
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (!cur || typeof cur !== "object" || Array.isArray(cur)) return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur;
+};
+
+// ---------------------------------------------------------------------------
+// Public: normalize all servers from a parsed config object
+// ---------------------------------------------------------------------------
+
+export const normalizeAgentConfig = (agent: AgentKey, parsed: unknown): NormalizedServer[] => {
+  const configKey = configKeyByAgent[agent];
+  const serversObj = getNestedValue(parsed, configKey);
+
+  if (!serversObj || typeof serversObj !== "object" || Array.isArray(serversObj)) {
+    return [];
+  }
+
+  const normalize = normalizersByAgent[agent];
+  const results: NormalizedServer[] = [];
+
+  for (const [name, raw] of Object.entries(serversObj as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const normalized = normalize(name, raw as RawServer);
+    if (normalized) results.push(normalized);
+  }
+
+  return results;
+};

--- a/packages/plugins/mcp/src/sdk/agent-import/reader.test.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/reader.test.ts
@@ -1,0 +1,474 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readAgentConfigFile,
+  parseAgentConfigContent,
+  findAndReadAgentConfig,
+  detectInstalledAgents,
+} from "./reader";
+
+// ---------------------------------------------------------------------------
+// Temp directory management
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "executor-agent-import-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const write = (rel: string, content: string): string => {
+  const full = join(tmpDir, rel);
+  mkdirSync(join(tmpDir, rel.split("/").slice(0, -1).join("/")), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+  return full;
+};
+
+// ---------------------------------------------------------------------------
+// readAgentConfigFile — real file I/O
+// ---------------------------------------------------------------------------
+
+describe("readAgentConfigFile", () => {
+  it("reads and normalizes a claude-code config", async () => {
+    const filePath = write(
+      "claude.json",
+      JSON.stringify({
+        mcpServers: {
+          filesystem: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            env: { DEBUG: "1" },
+          },
+        },
+      }),
+    );
+
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("filesystem");
+    expect(servers[0]!.config.transport).toBe("stdio");
+    if (servers[0]!.config.transport === "stdio") {
+      expect(servers[0]!.config.command).toBe("npx");
+      expect(servers[0]!.config.args).toEqual([
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp",
+      ]);
+      expect(servers[0]!.config.env).toEqual({ DEBUG: "1" });
+    }
+  });
+
+  it("reads and normalizes an opencode JSONC config with comments", async () => {
+    const filePath = write(
+      "opencode.jsonc",
+      `{
+  // opencode config with comments
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      /* the remote URL */
+      "url": "https://mcp.context7.com/mcp",
+    },
+  }
+}`,
+    );
+
+    const servers = await readAgentConfigFile(filePath, "opencode");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("context7");
+    expect(servers[0]!.config.transport).toBe("remote");
+    if (servers[0]!.config.transport === "remote") {
+      expect(servers[0]!.config.endpoint).toBe("https://mcp.context7.com/mcp");
+    }
+  });
+
+  it("reads a vscode mcp.json config", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({
+        servers: {
+          myapi: { type: "http", url: "https://api.example.com/mcp" },
+        },
+      }),
+    );
+
+    const servers = await readAgentConfigFile(filePath, "vscode");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("remote");
+  });
+
+  it("reads a goose YAML config", async () => {
+    const filePath = write(
+      "config.yaml",
+      `extensions:
+  context7:
+    type: streamable_http
+    uri: https://mcp.context7.com/mcp
+    enabled: true
+  localserver:
+    type: stdio
+    cmd: npx
+    args:
+      - -y
+      - some-package
+    envs:
+      KEY: value
+`,
+    );
+
+    const servers = await readAgentConfigFile(filePath, "goose");
+    expect(servers).toHaveLength(2);
+    const remote = servers.find((s) => s.name === "context7")!;
+    const local = servers.find((s) => s.name === "localserver")!;
+    expect(remote.config.transport).toBe("remote");
+    expect(local.config.transport).toBe("stdio");
+    if (remote.config.transport === "remote") {
+      expect(remote.config.endpoint).toBe("https://mcp.context7.com/mcp");
+      expect(remote.config.remoteTransport).toBe("streamable-http");
+    }
+    if (local.config.transport === "stdio") {
+      expect(local.config.command).toBe("npx");
+      expect(local.config.env).toEqual({ KEY: "value" });
+    }
+  });
+
+  it("reads a codex TOML config", async () => {
+    const filePath = write(
+      "config.toml",
+      `[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem"]
+
+[mcp_servers.myapi]
+type = "http"
+url = "https://api.example.com/mcp"
+`,
+    );
+
+    const servers = await readAgentConfigFile(filePath, "codex");
+    expect(servers).toHaveLength(2);
+    const local = servers.find((s) => s.name === "filesystem")!;
+    const remote = servers.find((s) => s.name === "myapi")!;
+    expect(local.config.transport).toBe("stdio");
+    expect(remote.config.transport).toBe("remote");
+  });
+
+  it("returns empty array for config with no servers", async () => {
+    const filePath = write("empty.json", JSON.stringify({ mcpServers: {} }));
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers).toHaveLength(0);
+  });
+
+  it("throws AgentImportError when file does not exist", async () => {
+    await expect(
+      readAgentConfigFile(join(tmpDir, "nonexistent.json"), "claude-code"),
+    ).rejects.toThrow("Config file not found");
+  });
+
+  it("throws AgentImportError on malformed JSON", async () => {
+    const filePath = write("bad.json", "{ not valid json }");
+    await expect(readAgentConfigFile(filePath, "claude-code")).rejects.toThrow(
+      "Failed to parse config file",
+    );
+  });
+
+  it("reads multiple servers and preserves order", async () => {
+    const filePath = write(
+      "multi.json",
+      JSON.stringify({
+        mcpServers: {
+          alpha: { command: "alpha" },
+          beta: { url: "https://beta.example.com/mcp" },
+          gamma: { command: "gamma", args: ["-v"] },
+        },
+      }),
+    );
+
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers).toHaveLength(3);
+    expect(servers.map((s) => s.name)).toEqual(["alpha", "beta", "gamma"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAgentConfigContent — raw string input
+// ---------------------------------------------------------------------------
+
+describe("parseAgentConfigContent", () => {
+  it("parses JSON content with explicit agent", async () => {
+    const content = JSON.stringify({
+      mcp: { context7: { type: "remote", url: "https://mcp.context7.com/mcp" } },
+    });
+    const servers = await parseAgentConfigContent(content, "opencode.json", "opencode");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("remote");
+  });
+
+  it("auto-detects opencode from filename", async () => {
+    const content = JSON.stringify({
+      mcp: { myserver: { type: "local", command: "node", args: ["server.js"] } },
+    });
+    const servers = await parseAgentConfigContent(content, "opencode.json");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("stdio");
+  });
+
+  it("auto-detects claude-code from .mcp.json filename", async () => {
+    const content = JSON.stringify({
+      mcpServers: { fs: { command: "npx", args: ["-y", "fs"] } },
+    });
+    const servers = await parseAgentConfigContent(content, ".mcp.json");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("stdio");
+  });
+
+  it("auto-detects goose from config.yaml filename", async () => {
+    const yaml = `extensions:\n  srv:\n    type: stdio\n    cmd: node\n    args: []\n`;
+    const servers = await parseAgentConfigContent(yaml, "config.yaml");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("srv");
+  });
+
+  it("auto-detects agent from content when filename is unknown", async () => {
+    const content = JSON.stringify({
+      context_servers: { local: { command: "node", args: ["server.js"] } },
+    });
+    const servers = await parseAgentConfigContent(content, "some-unknown-file.json");
+    // auto-detected as zed
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("stdio");
+  });
+
+  it("strips JSONC comments and trailing commas", async () => {
+    const jsonc = `{
+  // comment
+  "mcpServers": {
+    /* block */
+    "server": {
+      "command": "node",
+      "args": ["server.js"], /* trailing comma below */
+    },
+  }
+}`;
+    const servers = await parseAgentConfigContent(jsonc, "mcp.json", "claude-code");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("server");
+  });
+
+  it("throws on completely invalid JSON", async () => {
+    await expect(
+      parseAgentConfigContent("not json at all", "mcp.json", "claude-code"),
+    ).rejects.toThrow("Failed to parse config file");
+  });
+
+  it("returns empty array for empty mcpServers object", async () => {
+    const content = JSON.stringify({ mcpServers: {} });
+    const servers = await parseAgentConfigContent(content, "mcp.json", "claude-code");
+    expect(servers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAndReadAgentConfig — real filesystem
+// ---------------------------------------------------------------------------
+
+describe("findAndReadAgentConfig", () => {
+  it("finds local config file in cwd", async () => {
+    const content = JSON.stringify({
+      mcpServers: { fs: { command: "npx", args: ["-y", "fs-server"] } },
+    });
+    write("opencode.json", content);
+
+    // Use a different agent key since we want to find opencode.json locally
+    const configContent = JSON.stringify({
+      mcp: { myserver: { type: "local", command: "node", args: ["s.js"] } },
+    });
+    write("opencode.json", configContent);
+
+    const result = await findAndReadAgentConfig("opencode", { cwd: tmpDir });
+    expect(result.agent).toBe("opencode");
+    expect(result.filePath).toContain("opencode.json");
+    expect(result.servers).toHaveLength(1);
+  });
+
+  it("finds .mcp.json for claude-code", async () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        context7: { url: "https://mcp.context7.com/mcp" },
+      },
+    });
+    write(".mcp.json", content);
+
+    const result = await findAndReadAgentConfig("claude-code", { cwd: tmpDir });
+    expect(result.filePath).toContain(".mcp.json");
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]!.name).toBe("context7");
+  });
+
+  it("throws AgentImportError when no config found", async () => {
+    // Use mcporter — its global path (~/.mcporter/mcporter.json) is
+    // extremely unlikely to exist on any dev/CI machine, and its only
+    // local path (config/mcporter.json) is not present in tmpDir.
+    await expect(findAndReadAgentConfig("mcporter", { cwd: tmpDir })).rejects.toThrow(
+      "No config file found for agent",
+    );
+  });
+
+  it("local config takes priority over global config path", async () => {
+    // Write a local config with 1 server
+    write(".mcp.json", JSON.stringify({ mcpServers: { local: { command: "local-server" } } }));
+
+    const result = await findAndReadAgentConfig("claude-code", { cwd: tmpDir });
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]!.name).toBe("local");
+  });
+
+  it("reads vscode local config from .vscode/mcp.json", async () => {
+    write(
+      ".vscode/mcp.json",
+      JSON.stringify({ servers: { myapi: { url: "https://api.example.com/mcp" } } }),
+    );
+
+    const result = await findAndReadAgentConfig("vscode", { cwd: tmpDir });
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]!.config.transport).toBe("remote");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectInstalledAgents — real filesystem
+// ---------------------------------------------------------------------------
+
+describe("detectInstalledAgents", () => {
+  it("detects opencode config in cwd", async () => {
+    write(
+      "opencode.json",
+      JSON.stringify({
+        mcp: { context7: { type: "remote", url: "https://mcp.context7.com/mcp" } },
+      }),
+    );
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const opencode = agents.find((a) => a.agent === "opencode");
+    expect(opencode).toBeDefined();
+    expect(opencode!.serverCount).toBe(1);
+  });
+
+  it("detects multiple agents", async () => {
+    write(
+      "opencode.json",
+      JSON.stringify({
+        mcp: { srv1: { type: "local", command: "node", args: [] } },
+      }),
+    );
+    write(
+      ".mcp.json",
+      JSON.stringify({
+        mcpServers: { srv2: { command: "npx", args: ["-y", "pkg"] } },
+      }),
+    );
+    write(
+      ".vscode/mcp.json",
+      JSON.stringify({
+        servers: { srv3: { url: "https://srv3.example.com/mcp" } },
+      }),
+    );
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const keys = agents.map((a) => a.agent);
+    expect(keys).toContain("opencode");
+    expect(keys).toContain("claude-code");
+    expect(keys).toContain("vscode");
+  });
+
+  it("returns empty array when no configs found", async () => {
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    // Only checking local paths from tmpDir — global paths may or may not exist
+    const localAgents = agents.filter((a) => a.filePath.startsWith(tmpDir));
+    expect(localAgents).toHaveLength(0);
+  });
+
+  it("skips configs that have no servers", async () => {
+    write("opencode.json", JSON.stringify({ mcp: {} }));
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const local = agents.filter((a) => a.filePath.startsWith(tmpDir));
+    const opencode = local.find((a) => a.agent === "opencode");
+    // Should not be included since serverCount is 0
+    expect(opencode).toBeUndefined();
+  });
+
+  it("reports correct serverCount", async () => {
+    write(
+      "opencode.json",
+      JSON.stringify({
+        mcp: {
+          srv1: { type: "remote", url: "https://srv1.example.com/mcp" },
+          srv2: { type: "local", command: "node", args: [] },
+          srv3: { type: "local", command: "python", args: ["s.py"] },
+        },
+      }),
+    );
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const opencode = agents.find((a) => a.agent === "opencode" && a.filePath.startsWith(tmpDir));
+    expect(opencode).toBeDefined();
+    expect(opencode!.serverCount).toBe(3);
+  });
+
+  it("does not deduplicate across agent types with different keys", async () => {
+    // claude-code and amp both read .mcp.json but are different agents
+    write(".mcp.json", JSON.stringify({ mcpServers: { fs: { command: "node" } } }));
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const local = agents.filter((a) => a.filePath.startsWith(tmpDir));
+    // At least claude-code should appear; amp uses same path but might be deduplicated
+    expect(local.some((a) => a.agent === "claude-code")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Namespace derivation in normalized servers
+// ---------------------------------------------------------------------------
+
+describe("suggestedNamespace derivation", () => {
+  it("derives namespace from server name", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({ mcpServers: { "My Cool Server": { command: "server" } } }),
+    );
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers[0]!.suggestedNamespace).toBe("my_cool_server");
+  });
+
+  it("derives namespace from endpoint hostname for remote servers", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({
+        mcpServers: { context7: { url: "https://mcp.context7.com/mcp" } },
+      }),
+    );
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    // name takes priority over endpoint in deriveMcpNamespace
+    expect(servers[0]!.suggestedNamespace).toBe("context7");
+  });
+
+  it("falls through to command for whitespace-only server names", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({
+        mcpServers: { "   ": { command: "my-server" } },
+      }),
+    );
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    // whitespace-only name → deriveMcpNamespace skips name branch, uses command
+    expect(servers[0]!.suggestedNamespace).toBe("my_server");
+  });
+});

--- a/packages/plugins/mcp/src/sdk/agent-import/reader.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/reader.ts
@@ -1,0 +1,504 @@
+// ---------------------------------------------------------------------------
+// Agent config reader — resolve paths + parse files
+// ---------------------------------------------------------------------------
+
+import { homedir } from "node:os";
+import { parse as yamlParse } from "yaml";
+import { parse as tomlParse } from "smol-toml";
+import { join, dirname } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import type { AgentKey, ConfigFormat, NormalizedServer } from "./types";
+import { AgentImportError } from "./types";
+import { normalizeAgentConfig } from "./normalize";
+
+// ---------------------------------------------------------------------------
+// Platform environment
+// ---------------------------------------------------------------------------
+
+export interface PlatformEnv {
+  readonly platform: NodeJS.Platform;
+  readonly home: string;
+  readonly appData: string; // Windows %APPDATA% or fallback
+  readonly xdgConfig: string; // XDG_CONFIG_HOME or fallback
+}
+
+export const getCurrentPlatformEnv = (): PlatformEnv => {
+  const home = homedir();
+  const platform = process.platform;
+  const appData =
+    platform === "win32"
+      ? (process.env.APPDATA ?? join(home, "AppData", "Roaming"))
+      : join(home, "Library", "Application Support");
+  const xdgConfig = process.env.XDG_CONFIG_HOME ?? join(home, ".config");
+  return { platform, home, appData, xdgConfig };
+};
+
+// ---------------------------------------------------------------------------
+// Global config paths per agent
+// ---------------------------------------------------------------------------
+
+export const getGlobalConfigPaths = (agent: AgentKey, env: PlatformEnv): string[] => {
+  const { platform, home, appData, xdgConfig } = env;
+
+  switch (agent) {
+    case "opencode":
+      return [join(xdgConfig, "opencode", "opencode.json")];
+
+    case "claude-code":
+      return [join(home, ".claude.json")];
+
+    case "claude-desktop": {
+      if (platform === "win32") return [join(appData, "Claude", "claude_desktop_config.json")];
+      if (platform === "darwin")
+        return [
+          join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"),
+        ];
+      return [join(xdgConfig, "Claude", "claude_desktop_config.json")];
+    }
+
+    case "amp":
+      // Claude AMP uses same location as claude-code
+      return [join(home, ".claude.json")];
+
+    case "cursor":
+      return [join(home, ".cursor", "mcp.json")];
+
+    case "vscode": {
+      if (platform === "win32") return [join(appData, "Code", "User", "mcp.json")];
+      if (platform === "darwin")
+        return [join(home, "Library", "Application Support", "Code", "User", "mcp.json")];
+      return [join(xdgConfig, "Code", "User", "mcp.json")];
+    }
+
+    case "cline": {
+      if (platform === "win32")
+        return [
+          join(
+            appData,
+            "Code",
+            "User",
+            "globalStorage",
+            "saoudrizwan.claude-dev",
+            "settings",
+            "cline_mcp_settings.json",
+          ),
+        ];
+      if (platform === "darwin")
+        return [
+          join(
+            home,
+            "Library",
+            "Application Support",
+            "Code",
+            "User",
+            "globalStorage",
+            "saoudrizwan.claude-dev",
+            "settings",
+            "cline_mcp_settings.json",
+          ),
+        ];
+      return [
+        join(
+          xdgConfig,
+          "Code",
+          "User",
+          "globalStorage",
+          "saoudrizwan.claude-dev",
+          "settings",
+          "cline_mcp_settings.json",
+        ),
+      ];
+    }
+
+    case "cline-cli": {
+      const clineDir = process.env.CLINE_DIR ?? join(home, ".cline");
+      return [join(clineDir, "data", "settings", "cline_mcp_settings.json")];
+    }
+
+    case "zed": {
+      if (platform === "darwin")
+        return [join(home, "Library", "Application Support", "Zed", "settings.json")];
+      if (platform === "win32") return [join(appData, "Zed", "settings.json")];
+      return [join(xdgConfig, "zed", "settings.json")];
+    }
+
+    case "goose": {
+      if (platform === "win32") return [join(appData, "Block", "goose", "config", "config.yaml")];
+      return [join(xdgConfig, "goose", "config.yaml")];
+    }
+
+    case "codex": {
+      const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
+      return [join(codexHome, "config.toml")];
+    }
+
+    case "gemini-cli":
+      return [join(home, ".gemini", "settings.json")];
+
+    case "copilot": {
+      const copilotDir = process.env.XDG_CONFIG_HOME
+        ? join(process.env.XDG_CONFIG_HOME)
+        : join(home, ".copilot");
+      return [join(copilotDir, "mcp-config.json")];
+    }
+
+    case "antigravity":
+      return [join(home, ".gemini", "antigravity", "mcp_config.json")];
+
+    case "mcporter": {
+      const base = join(home, ".mcporter");
+      return [join(base, "mcporter.json"), join(base, "mcporter.jsonc")];
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Local config paths per agent (relative to cwd)
+// ---------------------------------------------------------------------------
+
+export const getLocalConfigPaths = (agent: AgentKey): string[] => {
+  switch (agent) {
+    case "opencode":
+      return ["opencode.json", "opencode.jsonc"];
+    case "claude-code":
+    case "amp":
+      return [".mcp.json"];
+    case "cursor":
+      return [".cursor/mcp.json"];
+    case "vscode":
+    case "copilot":
+      return [".vscode/mcp.json"];
+    case "cline":
+    case "cline-cli":
+      return [];
+    case "zed":
+      return [".zed/settings.json"];
+    case "codex":
+      return [".codex/config.toml"];
+    case "gemini-cli":
+      return [".gemini/settings.json"];
+    case "mcporter":
+      return ["config/mcporter.json", "config/mcporter.jsonc"];
+    default:
+      return [];
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Format detection
+// ---------------------------------------------------------------------------
+
+export const detectFormat = (filePath: string, agent: AgentKey): ConfigFormat => {
+  // Filename extension takes priority — allows drag-dropping non-default formats
+  if (filePath.endsWith(".yaml") || filePath.endsWith(".yml")) return "yaml";
+  if (filePath.endsWith(".toml")) return "toml";
+  if (filePath.endsWith(".json") || filePath.endsWith(".jsonc")) return "json";
+  // Fall back to agent-specific defaults
+  if (agent === "goose") return "yaml";
+  if (agent === "codex") return "toml";
+  return "json";
+};
+
+// ---------------------------------------------------------------------------
+// JSONC parser — two-pass: strip comments, then strip trailing commas
+// ---------------------------------------------------------------------------
+
+const stripComments = (text: string): string => {
+  let result = "";
+  let i = 0;
+  const len = text.length;
+
+  while (i < len) {
+    // String literal — pass through verbatim (don't treat // or /* inside as comments)
+    if (text[i] === '"') {
+      result += text[i++];
+      while (i < len) {
+        if (text[i] === "\\") {
+          result += text[i++];
+          if (i < len) result += text[i++];
+        } else if (text[i] === '"') {
+          result += text[i++];
+          break;
+        } else {
+          result += text[i++];
+        }
+      }
+      continue;
+    }
+
+    // Line comment — replace with newline to preserve line numbers
+    if (text[i] === "/" && text[i + 1] === "/") {
+      while (i < len && text[i] !== "\n") i++;
+      continue;
+    }
+
+    // Block comment — replace with a space
+    if (text[i] === "/" && text[i + 1] === "*") {
+      i += 2;
+      result += " ";
+      while (i < len && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+
+    result += text[i++];
+  }
+
+  return result;
+};
+
+const stripTrailingCommas = (text: string): string => {
+  let result = "";
+  let i = 0;
+  const len = text.length;
+
+  while (i < len) {
+    // String literal — pass through verbatim
+    if (text[i] === '"') {
+      result += text[i++];
+      while (i < len) {
+        if (text[i] === "\\") {
+          result += text[i++];
+          if (i < len) result += text[i++];
+        } else if (text[i] === '"') {
+          result += text[i++];
+          break;
+        } else {
+          result += text[i++];
+        }
+      }
+      continue;
+    }
+
+    // Trailing comma — look ahead through whitespace for } or ]
+    if (text[i] === ",") {
+      let j = i + 1;
+      while (j < len && /\s/.test(text[j])) j++;
+      if (j < len && (text[j] === "}" || text[j] === "]")) {
+        i++;
+        continue;
+      }
+    }
+
+    result += text[i++];
+  }
+
+  return result;
+};
+
+const stripJsoncComments = (text: string): string => stripTrailingCommas(stripComments(text));
+
+// ---------------------------------------------------------------------------
+// Parse raw content by format
+// ---------------------------------------------------------------------------
+
+const parseJson = (content: string): unknown => {
+  return JSON.parse(stripJsoncComments(content));
+};
+
+const parseYamlContent = (content: string): unknown => yamlParse(content);
+
+const parseTomlContent = (content: string): unknown => tomlParse(content);
+
+export const parseContent = async (content: string, format: ConfigFormat): Promise<unknown> => {
+  switch (format) {
+    case "json":
+      return parseJson(content);
+    case "yaml":
+      return parseYamlContent(content);
+    case "toml":
+      return parseTomlContent(content);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Detect agent from filename heuristics
+// ---------------------------------------------------------------------------
+
+export const detectAgentFromFilename = (filename: string): AgentKey | null => {
+  const lower = filename.toLowerCase();
+  if (lower === "opencode.json" || lower === "opencode.jsonc") return "opencode";
+  if (lower === ".mcp.json" || lower === "mcp.json") return "claude-code";
+  if (lower === "claude_desktop_config.json") return "claude-desktop";
+  if (lower === "cline_mcp_settings.json") return "cline";
+  if (lower === "config.toml") return "codex";
+  if (lower === "config.yaml" || lower === "config.yml") return "goose";
+  if (lower === "mcp-config.json") return "copilot";
+  if (lower === "mcp_config.json") return "antigravity";
+  if (lower === "mcporter.json" || lower === "mcporter.jsonc") return "mcporter";
+  if (lower === ".claude.json") return "claude-code";
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Detect agent from parsed content heuristics
+// ---------------------------------------------------------------------------
+
+export const detectAgentFromContent = (parsed: unknown): AgentKey | null => {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  if ("mcp" in obj && obj.mcp && typeof obj.mcp === "object") return "opencode";
+  if ("context_servers" in obj) return "zed";
+  if ("extensions" in obj) return "goose";
+  if ("mcp_servers" in obj) return "codex";
+  if ("servers" in obj) return "vscode";
+  if ("mcpServers" in obj) return "claude-code"; // default for mcpServers
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Read from file path
+// ---------------------------------------------------------------------------
+
+export const readAgentConfigFile = async (
+  filePath: string,
+  agent: AgentKey,
+): Promise<NormalizedServer[]> => {
+  if (!existsSync(filePath)) {
+    throw new AgentImportError(`Config file not found: ${filePath}`);
+  }
+
+  const content = readFileSync(filePath, "utf-8");
+  return parseAgentConfigContent(content, filePath, agent);
+};
+
+// ---------------------------------------------------------------------------
+// Parse from raw content (used by web drag-drop and tests)
+// ---------------------------------------------------------------------------
+
+export const parseAgentConfigContent = async (
+  content: string,
+  filenameHint: string,
+  agentHint?: AgentKey,
+): Promise<NormalizedServer[]> => {
+  let agent = agentHint;
+
+  // Detect format from filename hint
+  const format = detectFormat(filenameHint, agent ?? "claude-code");
+
+  let parsed: unknown;
+  try {
+    parsed = await parseContent(content, format);
+  } catch (err) {
+    throw new AgentImportError(
+      `Failed to parse config file: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  }
+
+  if (!agent) {
+    const base = filenameHint.split(/[\\/]/).pop() ?? filenameHint;
+    agent = detectAgentFromFilename(base) ?? detectAgentFromContent(parsed) ?? "claude-code";
+  }
+
+  return normalizeAgentConfig(agent, parsed);
+};
+
+// ---------------------------------------------------------------------------
+// Resolve and read from agent global or local path
+// ---------------------------------------------------------------------------
+
+export interface ResolvedAgentConfig {
+  readonly filePath: string;
+  readonly agent: AgentKey;
+  readonly servers: NormalizedServer[];
+}
+
+export const findAndReadAgentConfig = async (
+  agent: AgentKey,
+  options?: { cwd?: string },
+): Promise<ResolvedAgentConfig> => {
+  const env = getCurrentPlatformEnv();
+  const cwd = options?.cwd ?? process.cwd();
+
+  // Check local paths first
+  for (const rel of getLocalConfigPaths(agent)) {
+    const full = join(cwd, rel);
+    if (existsSync(full)) {
+      const servers = await readAgentConfigFile(full, agent);
+      return { filePath: full, agent, servers };
+    }
+  }
+
+  // Then global paths
+  for (const full of getGlobalConfigPaths(agent, env)) {
+    if (existsSync(full)) {
+      const servers = await readAgentConfigFile(full, agent);
+      return { filePath: full, agent, servers };
+    }
+  }
+
+  const tried = [
+    ...getLocalConfigPaths(agent).map((p) => join(cwd, p)),
+    ...getGlobalConfigPaths(agent, env),
+  ].join(", ");
+
+  throw new AgentImportError(`No config file found for agent "${agent}". Tried: ${tried}`);
+};
+
+// ---------------------------------------------------------------------------
+// Detect all agents with an existing config file
+// ---------------------------------------------------------------------------
+
+export interface DetectedAgent {
+  readonly agent: AgentKey;
+  readonly filePath: string;
+  readonly serverCount: number;
+}
+
+const ALL_AGENTS: AgentKey[] = [
+  "opencode",
+  "claude-code",
+  "claude-desktop",
+  "amp",
+  "cursor",
+  "vscode",
+  "cline",
+  "cline-cli",
+  "zed",
+  "goose",
+  "codex",
+  "gemini-cli",
+  "copilot",
+  "antigravity",
+  "mcporter",
+];
+
+export const detectInstalledAgents = async (options?: {
+  cwd?: string;
+}): Promise<DetectedAgent[]> => {
+  const env = getCurrentPlatformEnv();
+  const cwd = options?.cwd ?? process.cwd();
+  const results: DetectedAgent[] = [];
+  const seen = new Set<string>();
+
+  for (const agent of ALL_AGENTS) {
+    const paths = [
+      ...getLocalConfigPaths(agent).map((p) => join(cwd, p)),
+      ...getGlobalConfigPaths(agent, env),
+    ];
+
+    for (const filePath of paths) {
+      if (seen.has(filePath)) continue;
+      if (!existsSync(filePath)) continue;
+      seen.add(filePath);
+      try {
+        const servers = await readAgentConfigFile(filePath, agent);
+        if (servers.length > 0) {
+          results.push({ agent, filePath, serverCount: servers.length });
+        }
+      } catch {
+        // skip unreadable files
+      }
+      break; // only first found path per agent
+    }
+  }
+
+  return results;
+};
+
+// ---------------------------------------------------------------------------
+// Re-export dirname for consumers that need it
+// ---------------------------------------------------------------------------
+export { dirname };

--- a/packages/plugins/mcp/src/sdk/agent-import/types.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/types.ts
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------
+// Agent import — shared types
+// ---------------------------------------------------------------------------
+
+export type AgentKey =
+  | "opencode"
+  | "claude-code"
+  | "claude-desktop"
+  | "amp"
+  | "cursor"
+  | "vscode"
+  | "cline"
+  | "cline-cli"
+  | "zed"
+  | "goose"
+  | "codex"
+  | "gemini-cli"
+  | "copilot"
+  | "antigravity"
+  | "mcporter";
+
+export type ConfigFormat = "json" | "yaml" | "toml";
+
+// ---------------------------------------------------------------------------
+// Normalized server — canonical intermediate representation
+// ---------------------------------------------------------------------------
+
+export type NormalizedServerConfig =
+  | {
+      readonly transport: "stdio";
+      readonly command: string;
+      readonly args?: string[];
+      readonly env?: Record<string, string>;
+      readonly cwd?: string;
+    }
+  | {
+      readonly transport: "remote";
+      readonly endpoint: string;
+      readonly headers?: Record<string, string>;
+      readonly remoteTransport?: "streamable-http" | "sse" | "auto";
+    };
+
+export interface NormalizedServer {
+  readonly suggestedNamespace: string;
+  readonly name: string;
+  readonly config: NormalizedServerConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Import errors
+// ---------------------------------------------------------------------------
+
+export class AgentImportError extends Error {
+  constructor(
+    message: string,
+    override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentImportError";
+  }
+}


### PR DESCRIPTION
Part of a stack implementing `executor import` for migrating MCP servers from other AI tools.

## This PR
SDK core layer — no API or CLI changes, just the parsing/normalization logic.

- `types.ts`: `NormalizedServer`, `AgentConfig`, `DetectedAgent` types
- `reader.ts`: per-agent config file readers, JSONC/YAML/TOML parsers, OS-aware path resolution (Windows/macOS/Linux)
- `normalize.ts`: per-agent normalizers mapping tool-specific formats to `NormalizedServer`
- Supports 15 agents: OpenCode, Claude Code, Claude Desktop, Amp, Cursor, VS Code, Cline, Zed, Goose, Codex, Gemini CLI, Copilot, Antigravity, MCPorter
- 104 unit tests using real file I/O (no mocks)

## Stack
1. **feat(mcp): SDK module** ← this PR
2. feat(mcp): API endpoints
3. feat(mcp): CLI command + offline import
4. refactor(import): cleanup