### PR TITLE
refactor(import): sync parsers, fix copilot path, dedupe normalizers (4/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,7 @@ executor.jsonc
 # reference repos (pulled via `bun run pull:references`)
 .reference/
 
+# local source snapshots (pulled via opensrc skill)
+opensrc/
+
 .mcp.json

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -16,5 +16,5 @@
       },
     ],
   },
-  "ignorePatterns": [".astro/", "**/routeTree.gen.ts"],
+  "ignorePatterns": [".astro/", "**/routeTree.gen.ts", "opensrc/"],
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,6 +23,7 @@
     "@effect/platform": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@executor/api": "workspace:*",
+    "@executor/config": "workspace:*",
     "@executor/plugin-mcp": "workspace:*",
     "@executor/local": "workspace:*",
     "@executor/runtime-quickjs": "workspace:*",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -23,6 +23,7 @@
     "@effect/platform": "catalog:",
     "@effect/platform-bun": "catalog:",
     "@executor/api": "workspace:*",
+    "@executor/plugin-mcp": "workspace:*",
     "@executor/local": "workspace:*",
     "@executor/runtime-quickjs": "workspace:*",
     "@jitl/quickjs-wasmfile-release-sync": "catalog:",

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -4,10 +4,7 @@ import { Command, Options, Args } from "@effect/cli";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import { BunFileSystem } from "@effect/platform-bun";
-import {
-  findAndReadAgentConfig,
-  detectInstalledAgents,
-} from "@executor/plugin-mcp/agent-import";
+import { findAndReadAgentConfig, detectInstalledAgents } from "@executor/plugin-mcp/agent-import";
 import type { AgentKey, NormalizedServer } from "@executor/plugin-mcp/agent-import";
 import { addSourceToConfig } from "@executor/config";
 import type { SourceConfig } from "@executor/config";
@@ -106,8 +103,7 @@ const printLocalDryRun = (filePath: string, servers: NormalizedServer[]) => {
   console.log(`\n${filename} — ${servers.length} server(s) found (dry run, not imported):`);
   console.log(`  ${filePath}`);
   for (const s of servers) {
-    const detail =
-      s.config.transport === "stdio" ? s.config.command : s.config.endpoint;
+    const detail = s.config.transport === "stdio" ? s.config.command : s.config.endpoint;
     console.log(`  ${s.name.padEnd(24)} [${s.config.transport}]  ${detail ?? ""}`);
   }
 };
@@ -270,7 +266,7 @@ export const importCommand = Command.make(
 
       // ---- agent name provided ----
       if (agentKey) {
-        const resolved = yield* Effect.tryPromise({
+        const resolved = yield* Effect.try({
           try: () => findAndReadAgentConfig(agentKey as AgentKey),
           catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
         });
@@ -289,7 +285,7 @@ export const importCommand = Command.make(
       // ---- auto-detect all agents ----
       console.log("Scanning for agent configs...\n");
 
-      const detectedLocally = yield* Effect.tryPromise({
+      const detectedLocally = yield* Effect.try({
         try: () => detectInstalledAgents(),
         catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
       });
@@ -312,12 +308,7 @@ export const importCommand = Command.make(
 
       console.log("\nImporting all...");
       for (const d of detectedLocally) {
-        if (!existsSync(d.filePath)) continue;
-        const agentServers = yield* Effect.tryPromise({
-          try: () => findAndReadAgentConfig(d.agent),
-          catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
-        });
-        yield* importServersWithFallback(agentServers.servers, d.filePath, d.agent, baseUrl);
+        yield* importServersWithFallback(d.servers, d.filePath, d.agent, baseUrl);
       }
     }),
 ).pipe(

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -1,0 +1,262 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Command, Options, Args } from "@effect/cli";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+const agentArg = Args.text({ name: "agent" }).pipe(Args.optional);
+
+const fileOption = Options.text("file").pipe(
+  Options.withDescription("Path to a config file to import"),
+  Options.optional,
+);
+
+const dryRunOption = Options.boolean("dry-run").pipe(
+  Options.withDescription("Preview servers without importing"),
+  Options.withDefault(false),
+);
+
+const baseUrlOption = Options.text("base-url").pipe(Options.withDefault("http://localhost:4788"));
+
+// ---------------------------------------------------------------------------
+// API helpers (raw fetch — avoids typed client dep for new endpoints)
+// ---------------------------------------------------------------------------
+
+interface DetectedAgent {
+  agent: string;
+  filePath: string;
+  serverCount: number;
+}
+
+interface ImportedServer {
+  namespace: string;
+  name: string;
+  toolCount: number;
+}
+
+interface SkippedServer {
+  name: string;
+  reason: string;
+}
+
+interface ImportResult {
+  imported: ImportedServer[];
+  skipped: SkippedServer[];
+  dryRunParsed?: unknown[];
+}
+
+interface NormalizedServerPreview {
+  name: string;
+  suggestedNamespace: string;
+  config: { transport: string; command?: string; endpoint?: string };
+}
+
+const apiGet = async <T>(url: string): Promise<T> => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json() as Promise<T>;
+};
+
+const apiPost = async <T>(url: string, body: unknown): Promise<T> => {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
+  return res.json() as Promise<T>;
+};
+
+const getScopeId = async (baseUrl: string): Promise<string> => {
+  const data = await apiGet<{ id?: string }>(`${baseUrl}/api/scope`);
+  return data.id ?? "default";
+};
+
+// ---------------------------------------------------------------------------
+// Print helpers
+// ---------------------------------------------------------------------------
+
+const printResult = (filename: string, result: ImportResult) => {
+  console.log(`\n${filename}:`);
+  for (const s of result.imported) {
+    console.log(`  ✓ ${s.name.padEnd(24)} →  ${s.namespace}  (${s.toolCount} tools)`);
+  }
+  for (const s of result.skipped) {
+    console.log(`  ✗ ${s.name.padEnd(24)} skipped: ${s.reason}`);
+  }
+  console.log(`  ${result.imported.length} imported, ${result.skipped.length} skipped`);
+};
+
+const printDryRun = (filename: string, servers: NormalizedServerPreview[]) => {
+  console.log(`\n${filename} — ${servers.length} server(s) found (dry run, not imported):`);
+  for (const s of servers) {
+    const detail = s.config.transport === "stdio" ? s.config.command : s.config.endpoint;
+    console.log(`  ${s.name.padEnd(24)} [${s.config.transport}]  ${detail ?? ""}`);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Import a single file via API
+// ---------------------------------------------------------------------------
+
+const importFile = (
+  content: string,
+  filename: string,
+  agentHint: string | undefined,
+  baseUrl: string,
+  dryRun: boolean,
+) =>
+  Effect.gen(function* () {
+    const scopeId = yield* Effect.tryPromise({
+      try: () => getScopeId(baseUrl),
+      catch: (e) =>
+        new Error(
+          `Cannot reach executor at ${baseUrl}: ${e instanceof Error ? e.message : String(e)}`,
+        ),
+    });
+
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        apiPost<ImportResult>(`${baseUrl}/api/scopes/${scopeId}/mcp/import`, {
+          content,
+          filename,
+          agentHint,
+          dryRun,
+        }),
+      catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
+    });
+
+    if (dryRun && result.dryRunParsed) {
+      printDryRun(filename, result.dryRunParsed as NormalizedServerPreview[]);
+    } else {
+      printResult(filename, result);
+    }
+  });
+
+// ---------------------------------------------------------------------------
+// Command
+// ---------------------------------------------------------------------------
+
+export const importCommand = Command.make(
+  "import",
+  {
+    agent: agentArg,
+    file: fileOption,
+    dryRun: dryRunOption,
+    baseUrl: baseUrlOption,
+  },
+  ({ agent, file, dryRun, baseUrl }) =>
+    Effect.gen(function* () {
+      const agentKey = Option.getOrUndefined(agent);
+      const filePath = Option.getOrUndefined(file);
+
+      // ---- --file path provided ----
+      if (filePath) {
+        const abs = resolve(filePath);
+        if (!existsSync(abs)) {
+          console.error(`File not found: ${abs}`);
+          process.exitCode = 1;
+          return;
+        }
+        const content = readFileSync(abs, "utf-8");
+        const filename = abs.split(/[\\/]/).pop() ?? filePath;
+        yield* importFile(content, filename, agentKey, baseUrl, dryRun);
+        return;
+      }
+
+      // ---- agent name provided ----
+      if (agentKey) {
+        // Ask the server to detect the agent's config path
+        const scopeId = yield* Effect.tryPromise({
+          try: () => getScopeId(baseUrl),
+          catch: (e) =>
+            new Error(
+              `Cannot reach executor at ${baseUrl}: ${e instanceof Error ? e.message : String(e)}`,
+            ),
+        });
+
+        const detected = yield* Effect.tryPromise({
+          try: () =>
+            apiGet<{ agents: DetectedAgent[] }>(
+              `${baseUrl}/api/scopes/${scopeId}/mcp/detect-agents`,
+            ),
+          catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
+        });
+
+        const match = detected.agents.find((a) => a.agent === agentKey);
+        if (!match) {
+          console.error(`No config found for agent: ${agentKey}`);
+          process.exitCode = 1;
+          return;
+        }
+
+        console.log(`Found: ${match.filePath}  (${match.serverCount} servers)`);
+        if (!existsSync(match.filePath)) {
+          console.error(`Config file not accessible from this machine: ${match.filePath}`);
+          process.exitCode = 1;
+          return;
+        }
+
+        const content = readFileSync(match.filePath, "utf-8");
+        const filename = match.filePath.split(/[\\/]/).pop() ?? match.filePath;
+        yield* importFile(content, filename, agentKey, baseUrl, dryRun);
+        return;
+      }
+
+      // ---- auto-detect all agents ----
+      console.log("Scanning for agent configs...\n");
+
+      const scopeId = yield* Effect.tryPromise({
+        try: () => getScopeId(baseUrl),
+        catch: (e) =>
+          new Error(
+            `Cannot reach executor at ${baseUrl}: ${e instanceof Error ? e.message : String(e)}`,
+          ),
+      });
+
+      const detected = yield* Effect.tryPromise({
+        try: () =>
+          apiGet<{ agents: DetectedAgent[] }>(`${baseUrl}/api/scopes/${scopeId}/mcp/detect-agents`),
+        catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
+      });
+
+      if (detected.agents.length === 0) {
+        console.log("No agent configs found.");
+        return;
+      }
+
+      console.log("Found:");
+      for (let i = 0; i < detected.agents.length; i++) {
+        const d = detected.agents[i]!;
+        console.log(`  [${i + 1}] ${d.agent.padEnd(16)} ${d.filePath}  (${d.serverCount} servers)`);
+      }
+
+      if (dryRun) {
+        console.log("\n(dry run — use without --dry-run to import)");
+        return;
+      }
+
+      console.log("\nImporting all...");
+      for (const d of detected.agents) {
+        if (!existsSync(d.filePath)) continue;
+        const content = readFileSync(d.filePath, "utf-8");
+        const filename = d.filePath.split(/[\\/]/).pop() ?? d.filePath;
+        yield* importFile(content, filename, d.agent, baseUrl, false);
+      }
+    }),
+).pipe(
+  Command.withDescription(
+    "Import MCP servers from an AI agent config file.\n" +
+      "Agents: opencode, claude-code, claude-desktop, amp, cursor, vscode, cline, cline-cli,\n" +
+      "        zed, goose, codex, gemini-cli, copilot, antigravity, mcporter\n\n" +
+      "Examples:\n" +
+      "  executor import opencode\n" +
+      "  executor import cursor --dry-run\n" +
+      "  executor import --file ./opencode.json\n" +
+      "  executor import  (auto-detect all)",
+  ),
+);

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -1,13 +1,16 @@
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { join, resolve } from "node:path";
 import { Command, Options, Args } from "@effect/cli";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import { BunFileSystem } from "@effect/platform-bun";
 import {
   findAndReadAgentConfig,
   detectInstalledAgents,
 } from "@executor/plugin-mcp/agent-import";
 import type { AgentKey, NormalizedServer } from "@executor/plugin-mcp/agent-import";
+import { addSourceToConfig } from "@executor/config";
+import type { SourceConfig } from "@executor/config";
 
 // ---------------------------------------------------------------------------
 // Options
@@ -110,6 +113,93 @@ const printLocalDryRun = (filePath: string, servers: NormalizedServer[]) => {
 };
 
 // ---------------------------------------------------------------------------
+// Offline write — direct executor.jsonc update, no server required
+// ---------------------------------------------------------------------------
+
+const resolveConfigPath = (): string =>
+  join(process.env.EXECUTOR_SCOPE_DIR ?? process.cwd(), "executor.jsonc");
+
+const normalizedServerToSourceConfig = (server: NormalizedServer): SourceConfig => {
+  if (server.config.transport === "stdio") {
+    return {
+      kind: "mcp",
+      transport: "stdio",
+      name: server.name,
+      command: server.config.command,
+      args: server.config.args ? [...server.config.args] : undefined,
+      env: server.config.env,
+      cwd: server.config.cwd,
+      namespace: server.suggestedNamespace,
+    };
+  }
+  return {
+    kind: "mcp",
+    transport: "remote",
+    name: server.name,
+    endpoint: server.config.endpoint,
+    remoteTransport: server.config.remoteTransport,
+    headers: server.config.headers,
+    namespace: server.suggestedNamespace,
+  };
+};
+
+const writeServersToConfigFile = (servers: NormalizedServer[]) =>
+  Effect.gen(function* () {
+    const configPath = resolveConfigPath();
+    let written = 0;
+    for (const server of servers) {
+      const source = normalizedServerToSourceConfig(server);
+      yield* addSourceToConfig(configPath, source).pipe(Effect.provide(BunFileSystem.layer));
+      written++;
+    }
+    return { written, configPath };
+  });
+
+// Try server; if unreachable fall back to writing executor.jsonc directly
+const importServersWithFallback = (
+  servers: NormalizedServer[],
+  filePath: string,
+  agentKey: string | undefined,
+  baseUrl: string,
+) =>
+  Effect.gen(function* () {
+    const content = readFileSync(filePath, "utf-8");
+    const filename = filePath.split(/[\\/]/).pop() ?? filePath;
+
+    // Try server path
+    const serverResult = yield* Effect.tryPromise({
+      try: () => getScopeId(baseUrl),
+      catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
+    }).pipe(
+      Effect.flatMap((scopeId) =>
+        Effect.tryPromise({
+          try: () =>
+            apiPost<ImportResult>(`${baseUrl}/api/scopes/${scopeId}/mcp/import`, {
+              content,
+              filename,
+              agentHint: agentKey,
+              dryRun: false,
+            }),
+          catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
+        }),
+      ),
+      Effect.map((r) => ({ ok: true as const, result: r })),
+      Effect.catchAll(() => Effect.succeed({ ok: false as const })),
+    );
+
+    if (serverResult.ok) {
+      printResult(filename, serverResult.result);
+      return;
+    }
+
+    // Server not reachable — write to executor.jsonc offline
+    const { written, configPath } = yield* writeServersToConfigFile(servers);
+    console.log(`\n${filename}:`);
+    console.log(`  ${written} server(s) written to ${configPath}`);
+    console.log(`  (server offline — will load on next start)`);
+  });
+
+// ---------------------------------------------------------------------------
 // Import a single file via API
 // ---------------------------------------------------------------------------
 
@@ -192,9 +282,7 @@ export const importCommand = Command.make(
           return;
         }
 
-        const content = readFileSync(resolved.filePath, "utf-8");
-        const filename = resolved.filePath.split(/[\\/]/).pop() ?? resolved.filePath;
-        yield* importFile(content, filename, agentKey, baseUrl, false);
+        yield* importServersWithFallback(resolved.servers, resolved.filePath, agentKey, baseUrl);
         return;
       }
 
@@ -225,9 +313,11 @@ export const importCommand = Command.make(
       console.log("\nImporting all...");
       for (const d of detectedLocally) {
         if (!existsSync(d.filePath)) continue;
-        const content = readFileSync(d.filePath, "utf-8");
-        const filename = d.filePath.split(/[\\/]/).pop() ?? d.filePath;
-        yield* importFile(content, filename, d.agent, baseUrl, false);
+        const agentServers = yield* Effect.tryPromise({
+          try: () => findAndReadAgentConfig(d.agent),
+          catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
+        });
+        yield* importServersWithFallback(agentServers.servers, d.filePath, d.agent, baseUrl);
       }
     }),
 ).pipe(

--- a/apps/cli/src/commands/import.ts
+++ b/apps/cli/src/commands/import.ts
@@ -3,6 +3,11 @@ import { resolve } from "node:path";
 import { Command, Options, Args } from "@effect/cli";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import {
+  findAndReadAgentConfig,
+  detectInstalledAgents,
+} from "@executor/plugin-mcp/agent-import";
+import type { AgentKey, NormalizedServer } from "@executor/plugin-mcp/agent-import";
 
 // ---------------------------------------------------------------------------
 // Options
@@ -25,12 +30,6 @@ const baseUrlOption = Options.text("base-url").pipe(Options.withDefault("http://
 // ---------------------------------------------------------------------------
 // API helpers (raw fetch — avoids typed client dep for new endpoints)
 // ---------------------------------------------------------------------------
-
-interface DetectedAgent {
-  agent: string;
-  filePath: string;
-  serverCount: number;
-}
 
 interface ImportedServer {
   namespace: string;
@@ -95,6 +94,17 @@ const printDryRun = (filename: string, servers: NormalizedServerPreview[]) => {
   console.log(`\n${filename} — ${servers.length} server(s) found (dry run, not imported):`);
   for (const s of servers) {
     const detail = s.config.transport === "stdio" ? s.config.command : s.config.endpoint;
+    console.log(`  ${s.name.padEnd(24)} [${s.config.transport}]  ${detail ?? ""}`);
+  }
+};
+
+const printLocalDryRun = (filePath: string, servers: NormalizedServer[]) => {
+  const filename = filePath.split(/[\\/]/).pop() ?? filePath;
+  console.log(`\n${filename} — ${servers.length} server(s) found (dry run, not imported):`);
+  console.log(`  ${filePath}`);
+  for (const s of servers) {
+    const detail =
+      s.config.transport === "stdio" ? s.config.command : s.config.endpoint;
     console.log(`  ${s.name.padEnd(24)} [${s.config.transport}]  ${detail ?? ""}`);
   }
 };
@@ -170,68 +180,40 @@ export const importCommand = Command.make(
 
       // ---- agent name provided ----
       if (agentKey) {
-        // Ask the server to detect the agent's config path
-        const scopeId = yield* Effect.tryPromise({
-          try: () => getScopeId(baseUrl),
-          catch: (e) =>
-            new Error(
-              `Cannot reach executor at ${baseUrl}: ${e instanceof Error ? e.message : String(e)}`,
-            ),
-        });
-
-        const detected = yield* Effect.tryPromise({
-          try: () =>
-            apiGet<{ agents: DetectedAgent[] }>(
-              `${baseUrl}/api/scopes/${scopeId}/mcp/detect-agents`,
-            ),
+        const resolved = yield* Effect.tryPromise({
+          try: () => findAndReadAgentConfig(agentKey as AgentKey),
           catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
         });
 
-        const match = detected.agents.find((a) => a.agent === agentKey);
-        if (!match) {
-          console.error(`No config found for agent: ${agentKey}`);
-          process.exitCode = 1;
+        console.log(`Found: ${resolved.filePath}  (${resolved.servers.length} servers)`);
+
+        if (dryRun) {
+          printLocalDryRun(resolved.filePath, resolved.servers);
           return;
         }
 
-        console.log(`Found: ${match.filePath}  (${match.serverCount} servers)`);
-        if (!existsSync(match.filePath)) {
-          console.error(`Config file not accessible from this machine: ${match.filePath}`);
-          process.exitCode = 1;
-          return;
-        }
-
-        const content = readFileSync(match.filePath, "utf-8");
-        const filename = match.filePath.split(/[\\/]/).pop() ?? match.filePath;
-        yield* importFile(content, filename, agentKey, baseUrl, dryRun);
+        const content = readFileSync(resolved.filePath, "utf-8");
+        const filename = resolved.filePath.split(/[\\/]/).pop() ?? resolved.filePath;
+        yield* importFile(content, filename, agentKey, baseUrl, false);
         return;
       }
 
       // ---- auto-detect all agents ----
       console.log("Scanning for agent configs...\n");
 
-      const scopeId = yield* Effect.tryPromise({
-        try: () => getScopeId(baseUrl),
-        catch: (e) =>
-          new Error(
-            `Cannot reach executor at ${baseUrl}: ${e instanceof Error ? e.message : String(e)}`,
-          ),
-      });
-
-      const detected = yield* Effect.tryPromise({
-        try: () =>
-          apiGet<{ agents: DetectedAgent[] }>(`${baseUrl}/api/scopes/${scopeId}/mcp/detect-agents`),
+      const detectedLocally = yield* Effect.tryPromise({
+        try: () => detectInstalledAgents(),
         catch: (e) => new Error(e instanceof Error ? e.message : String(e)),
       });
 
-      if (detected.agents.length === 0) {
+      if (detectedLocally.length === 0) {
         console.log("No agent configs found.");
         return;
       }
 
       console.log("Found:");
-      for (let i = 0; i < detected.agents.length; i++) {
-        const d = detected.agents[i]!;
+      for (let i = 0; i < detectedLocally.length; i++) {
+        const d = detectedLocally[i]!;
         console.log(`  [${i + 1}] ${d.agent.padEnd(16)} ${d.filePath}  (${d.serverCount} servers)`);
       }
 
@@ -241,7 +223,7 @@ export const importCommand = Command.make(
       }
 
       console.log("\nImporting all...");
-      for (const d of detected.agents) {
+      for (const d of detectedLocally) {
         if (!existsSync(d.filePath)) continue;
         const content = readFileSync(d.filePath, "utf-8");
         const filename = d.filePath.split(/[\\/]/).pop() ?? d.filePath;

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -41,6 +41,7 @@ import * as Cause from "effect/Cause";
 
 import { ExecutorApi } from "@executor/api";
 import { startServer, runMcpStdioServer, getExecutor } from "@executor/local";
+import { importCommand } from "./commands/import";
 
 // Embedded web UI — baked into compiled binaries via `with { type: "file" }`
 import embeddedWebUI from "./embedded-web-ui.gen";
@@ -283,7 +284,13 @@ const mcpCommand = Command.make("mcp", { scope }, ({ scope }) =>
 // ---------------------------------------------------------------------------
 
 const root = Command.make("executor").pipe(
-  Command.withSubcommands([callCommand, resumeCommand, webCommand, mcpCommand] as const),
+  Command.withSubcommands([
+    callCommand,
+    resumeCommand,
+    webCommand,
+    mcpCommand,
+    importCommand,
+  ] as const),
   Command.withDescription("Executor local CLI"),
 );
 

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -17,7 +17,9 @@ import {
   mcpPlugin,
   makeKvBindingStore,
   withConfigFile as withMcpConfigFile,
+  type McpSourceConfig,
 } from "@executor/plugin-mcp";
+import { loadConfig } from "@executor/config";
 import {
   googleDiscoveryPlugin,
   makeKvBindingStore as makeKvGoogleDiscoveryBindingStore,
@@ -49,6 +51,7 @@ const createLocalPlugins = (
   scopedKv: ReturnType<typeof makeScopedKv>,
   configPath: string,
   fsLayer: typeof NodeFileSystem.layer,
+  mcpBindingStore?: ReturnType<typeof makeKvBindingStore>,
 ) =>
   [
     openApiPlugin({
@@ -59,8 +62,11 @@ const createLocalPlugins = (
       ),
     }),
     mcpPlugin({
-      bindingStore: withMcpConfigFile(makeKvBindingStore(scopedKv, "mcp"), configPath, fsLayer),
-      dangerouslyAllowStdioMCP: true,
+      bindingStore: withMcpConfigFile(
+        mcpBindingStore ?? makeKvBindingStore(scopedKv, "mcp"),
+        configPath,
+        fsLayer,
+      ),
     }),
     googleDiscoveryPlugin({
       bindingStore: makeKvGoogleDiscoveryBindingStore(scopedKv, "google-discovery"),
@@ -111,10 +117,58 @@ const createLocalExecutorLayer = () => {
       const configPath = join(cwd, "executor.jsonc");
       const fsLayer = NodeFileSystem.layer;
 
-      return yield* createExecutor({
+      // Keep raw binding store reference so we can check what's already registered
+      const rawBindingStore = makeKvBindingStore(scopedKv, "mcp");
+      const executor = yield* createExecutor({
         ...config,
-        plugins: createLocalPlugins(scopedKv, configPath, fsLayer),
+        plugins: createLocalPlugins(scopedKv, configPath, fsLayer, rawBindingStore),
       });
+
+      // Sync executor.jsonc → KV for MCP sources written offline (not yet in KV)
+      const fileConfig = yield* loadConfig(configPath).pipe(
+        Effect.provide(fsLayer),
+        Effect.catchAll(() => Effect.succeed(null)),
+      );
+      const mcpSources = (fileConfig?.sources ?? []).filter((s) => s.kind === "mcp");
+      if (mcpSources.length > 0) {
+        const existingSources = yield* rawBindingStore.listSources();
+        const existingNamespaces = new Set(existingSources.map((s) => s.namespace));
+        for (const source of mcpSources) {
+          const ns = source.namespace ?? source.name;
+          if (existingNamespaces.has(ns)) continue;
+          // Strip config-file-only fields (kind, auth) — auth in file format uses
+          // public secret refs, not secretIds; agent-imported sources have no auth anyway
+          const mcpConfig: McpSourceConfig =
+            source.transport === "stdio"
+              ? {
+                  transport: "stdio",
+                  name: source.name,
+                  command: source.command,
+                  args: source.args ? [...source.args] : undefined,
+                  env: source.env,
+                  cwd: source.cwd,
+                  namespace: source.namespace,
+                }
+              : {
+                  transport: "remote",
+                  name: source.name,
+                  endpoint: source.endpoint,
+                  remoteTransport: source.remoteTransport,
+                  queryParams: source.queryParams,
+                  headers: source.headers,
+                  namespace: source.namespace,
+                };
+          yield* executor.mcp.addSource(mcpConfig).pipe(
+            Effect.catchAll((e) =>
+              Effect.sync(() =>
+                console.warn(`[startup] MCP source "${source.name}": ${e.message}`),
+              ),
+            ),
+          );
+        }
+      }
+
+      return executor;
     }),
   ).pipe(Layer.provide(SqliteClient.layer({ filename: dbPath })));
 };

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@effect/platform-bun": "catalog:",
         "@executor/api": "workspace:*",
         "@executor/local": "workspace:*",
+        "@executor/plugin-mcp": "workspace:*",
         "@executor/runtime-quickjs": "workspace:*",
         "@jitl/quickjs-wasmfile-release-sync": "catalog:",
         "effect": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -516,6 +516,8 @@
         "@executor/sdk": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "effect": "catalog:",
+        "smol-toml": "^1.6.1",
+        "yaml": "^2.7.1",
       },
       "devDependencies": {
         "@effect-atom/atom-react": "^0.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@effect/platform": "catalog:",
         "@effect/platform-bun": "catalog:",
         "@executor/api": "workspace:*",
+        "@executor/config": "workspace:*",
         "@executor/local": "workspace:*",
         "@executor/plugin-mcp": "workspace:*",
         "@executor/runtime-quickjs": "workspace:*",

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -20,7 +20,8 @@
     "./promise": "./src/promise.ts",
     "./api": "./src/api/index.ts",
     "./react": "./src/react/index.ts",
-    "./presets": "./src/sdk/presets.ts"
+    "./presets": "./src/sdk/presets.ts",
+    "./agent-import": "./src/sdk/agent-import/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -52,7 +53,9 @@
     "@executor/config": "workspace:*",
     "@executor/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "smol-toml": "^1.6.1",
+    "yaml": "^2.7.1"
   },
   "devDependencies": {
     "@effect-atom/atom-react": "^0.5.0",

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -150,6 +150,44 @@ const CompleteOAuthResponse = Schema.Struct({
 });
 
 // ---------------------------------------------------------------------------
+// Import from agent config
+// ---------------------------------------------------------------------------
+
+const ImportFromAgentPayload = Schema.Struct({
+  content: Schema.String,
+  filename: Schema.optionalWith(Schema.String, { default: () => "mcp.json" }),
+  agentHint: Schema.optional(Schema.String),
+  dryRun: Schema.optionalWith(Schema.Boolean, { default: () => false }),
+});
+
+const ImportedServer = Schema.Struct({
+  namespace: Schema.String,
+  name: Schema.String,
+  toolCount: Schema.Number,
+});
+
+const SkippedServer = Schema.Struct({
+  name: Schema.String,
+  reason: Schema.String,
+});
+
+const ImportFromAgentResponse = Schema.Struct({
+  imported: Schema.Array(ImportedServer),
+  skipped: Schema.Array(SkippedServer),
+  dryRunParsed: Schema.optional(Schema.Array(Schema.Unknown)),
+});
+
+const DetectedAgentInfo = Schema.Struct({
+  agent: Schema.String,
+  filePath: Schema.String,
+  serverCount: Schema.Number,
+});
+
+const DetectAgentsResponse = Schema.Struct({
+  agents: Schema.Array(DetectedAgentInfo),
+});
+
+// ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
 
@@ -233,6 +271,19 @@ export class McpGroup extends HttpApiGroup.make("mcp")
     HttpApiEndpoint.patch("updateSource")`/scopes/${scopeIdParam}/mcp/sources/${namespaceParam}`
       .setPayload(UpdateSourcePayload)
       .addSuccess(UpdateSourceResponse)
+      .addError(McpApiError)
+      .addError(McpInternalError),
+  )
+  .add(
+    HttpApiEndpoint.post("importFromAgent")`/scopes/${scopeIdParam}/mcp/import`
+      .setPayload(ImportFromAgentPayload)
+      .addSuccess(ImportFromAgentResponse)
+      .addError(McpApiError)
+      .addError(McpInternalError),
+  )
+  .add(
+    HttpApiEndpoint.get("detectAgents")`/scopes/${scopeIdParam}/mcp/detect-agents`
+      .addSuccess(DetectAgentsResponse)
       .addError(McpApiError)
       .addError(McpInternalError),
   ) {}

--- a/packages/plugins/mcp/src/api/handlers-import.test.ts
+++ b/packages/plugins/mcp/src/api/handlers-import.test.ts
@@ -1,0 +1,553 @@
+import { HttpApiBuilder, HttpServer } from "@effect/platform";
+import { describe, expect, it } from "vitest";
+import { Effect, Layer } from "effect";
+
+import { addGroup } from "@executor/api";
+import { CoreHandlers, ExecutionEngineService, ExecutorService } from "@executor/api/server";
+import type { McpPluginExtension, McpSourceConfig } from "../sdk/plugin";
+import { McpExtensionService, McpHandlers } from "./handlers";
+import { McpGroup } from "./group";
+
+// ---------------------------------------------------------------------------
+// Test extension — records addSource calls, returns canned results
+// ---------------------------------------------------------------------------
+
+interface RecordedCall {
+  config: McpSourceConfig;
+}
+
+const makeCapturingExtension = (
+  opts: {
+    addSourceResult?: (
+      config: McpSourceConfig,
+    ) => Effect.Effect<{ toolCount: number; namespace: string }, Error>;
+  } = {},
+): { extension: McpPluginExtension; calls: RecordedCall[] } => {
+  const calls: RecordedCall[] = [];
+
+  const extension: McpPluginExtension = {
+    probeEndpoint: () => Effect.die(new Error("unused")),
+    addSource: (config) => {
+      calls.push({ config });
+      if (opts.addSourceResult) return opts.addSourceResult(config);
+      const namespace = config.namespace ?? config.name.toLowerCase().replace(/\s+/g, "_");
+      return Effect.succeed({ toolCount: 3, namespace });
+    },
+    removeSource: () => Effect.die(new Error("unused")),
+    refreshSource: () => Effect.die(new Error("unused")),
+    startOAuth: () => Effect.die(new Error("unused")),
+    completeOAuth: () => Effect.die(new Error("unused")),
+    getSource: () => Effect.succeed(null),
+    updateSource: () => Effect.die(new Error("unused")),
+  };
+
+  return { extension, calls };
+};
+
+// ---------------------------------------------------------------------------
+// Handler setup
+// ---------------------------------------------------------------------------
+
+const Api = addGroup(McpGroup);
+const fakeExecutor = {} as never;
+const fakeExecutionEngine = {} as never;
+
+const createHandler = (extension: McpPluginExtension) =>
+  HttpApiBuilder.toWebHandler(
+    HttpApiBuilder.api(Api).pipe(
+      Layer.provide(CoreHandlers),
+      Layer.provide(McpHandlers),
+      Layer.provide(Layer.succeed(ExecutorService, fakeExecutor)),
+      Layer.provide(Layer.succeed(ExecutionEngineService, fakeExecutionEngine)),
+      Layer.provide(Layer.succeed(McpExtensionService, extension)),
+      Layer.provideMerge(HttpServer.layerContext),
+      Layer.provideMerge(HttpApiBuilder.Router.Live),
+      Layer.provideMerge(HttpApiBuilder.Middleware.layer),
+    ),
+  );
+
+const post = async (
+  handler: ReturnType<typeof createHandler>["handler"],
+  path: string,
+  body: unknown,
+) =>
+  handler(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+
+const get = async (handler: ReturnType<typeof createHandler>["handler"], path: string) =>
+  handler(new Request(`http://localhost${path}`));
+
+// ---------------------------------------------------------------------------
+// importFromAgent — dry run (no addSource calls)
+// ---------------------------------------------------------------------------
+
+describe("POST /scopes/:scopeId/mcp/import — dry run", () => {
+  it("returns parsed servers without importing when dryRun=true", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcpServers: {
+          filesystem: { command: "npx", args: ["-y", "fs"] },
+          context7: { url: "https://mcp.context7.com/mcp" },
+        },
+      });
+
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "mcp.json",
+        agentHint: "claude-code",
+        dryRun: true,
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        imported: unknown[];
+        skipped: unknown[];
+        dryRunParsed: unknown[];
+      };
+
+      expect(body.imported).toHaveLength(0);
+      expect(body.skipped).toHaveLength(0);
+      expect(body.dryRunParsed).toHaveLength(2);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("dry run returns nothing for empty config", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content: JSON.stringify({ mcpServers: {} }),
+        filename: "mcp.json",
+        agentHint: "claude-code",
+        dryRun: true,
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { dryRunParsed: unknown[] };
+      expect(body.dryRunParsed).toHaveLength(0);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("dry run auto-detects agent from opencode filename", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcp: {
+          context7: { type: "remote", url: "https://mcp.context7.com/mcp" },
+        },
+      });
+
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "opencode.json",
+        dryRun: true,
+        // no agentHint — should auto-detect from filename
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { dryRunParsed: unknown[] };
+      expect(body.dryRunParsed).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importFromAgent — real import (addSource called)
+// ---------------------------------------------------------------------------
+
+describe("POST /scopes/:scopeId/mcp/import — real import", () => {
+  it("imports stdio server and returns namespace + toolCount", async () => {
+    const { extension, calls } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcpServers: {
+          filesystem: { command: "npx", args: ["-y", "fs"], env: { HOME: "/tmp" } },
+        },
+      });
+
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "mcp.json",
+        agentHint: "claude-code",
+        dryRun: false,
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        imported: { namespace: string; name: string; toolCount: number }[];
+        skipped: unknown[];
+      };
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.config.transport).toBe("stdio");
+      if (calls[0]!.config.transport === "stdio") {
+        expect(calls[0]!.config.command).toBe("npx");
+        expect(calls[0]!.config.args).toEqual(["-y", "fs"]);
+        expect(calls[0]!.config.env).toEqual({ HOME: "/tmp" });
+      }
+
+      expect(body.imported).toHaveLength(1);
+      expect(body.imported[0]!.name).toBe("filesystem");
+      expect(body.imported[0]!.toolCount).toBe(3);
+      expect(body.skipped).toHaveLength(0);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("imports remote server and preserves headers", async () => {
+    const { extension, calls } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcpServers: {
+          context7: {
+            url: "https://mcp.context7.com/mcp",
+            type: "http",
+            headers: { "X-Api-Key": "secret" },
+          },
+        },
+      });
+
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "mcp.json",
+        agentHint: "claude-code",
+        dryRun: false,
+      });
+
+      expect(res.status).toBe(200);
+      expect(calls).toHaveLength(1);
+      if (calls[0]!.config.transport === "remote") {
+        expect(calls[0]!.config.endpoint).toBe("https://mcp.context7.com/mcp");
+        expect(calls[0]!.config.headers).toEqual({ "X-Api-Key": "secret" });
+      }
+
+      const body = (await res.json()) as { imported: unknown[] };
+      expect(body.imported).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("imports multiple servers in one request", async () => {
+    const { extension, calls } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcpServers: {
+          alpha: { command: "alpha-server" },
+          beta: { url: "https://beta.example.com/mcp" },
+          gamma: { command: "gamma-server", args: ["--port", "9000"] },
+        },
+      });
+
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "mcp.json",
+        agentHint: "claude-code",
+        dryRun: false,
+      });
+
+      expect(res.status).toBe(200);
+      expect(calls).toHaveLength(3);
+      const body = (await res.json()) as { imported: unknown[]; skipped: unknown[] };
+      expect(body.imported).toHaveLength(3);
+      expect(body.skipped).toHaveLength(0);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("skips servers where addSource fails and continues with the rest", async () => {
+    const { extension, calls } = makeCapturingExtension({
+      addSourceResult: (config) => {
+        if (config.name === "broken") {
+          return Effect.fail(new Error("Connection refused"));
+        }
+        return Effect.succeed({ toolCount: 2, namespace: config.name });
+      },
+    });
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcpServers: {
+          working: { command: "good-server" },
+          broken: { command: "bad-server" },
+          alsogood: { command: "another-server" },
+        },
+      });
+
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "mcp.json",
+        agentHint: "claude-code",
+        dryRun: false,
+      });
+
+      expect(res.status).toBe(200);
+      expect(calls).toHaveLength(3);
+      const body = (await res.json()) as {
+        imported: { name: string }[];
+        skipped: { name: string; reason: string }[];
+      };
+
+      expect(body.imported.map((s) => s.name)).toEqual(["working", "alsogood"]);
+      expect(body.skipped).toHaveLength(1);
+      expect(body.skipped[0]!.name).toBe("broken");
+      expect(body.skipped[0]!.reason).toContain("Connection refused");
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("imports opencode config with array command", async () => {
+    const { extension, calls } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcp: {
+          myserver: {
+            type: "local",
+            command: ["node", "/path/to/server.js", "--debug"],
+            enabled: true,
+            environment: { NODE_ENV: "production" },
+          },
+        },
+      });
+
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "opencode.json",
+        agentHint: "opencode",
+        dryRun: false,
+      });
+
+      expect(res.status).toBe(200);
+      expect(calls).toHaveLength(1);
+      if (calls[0]!.config.transport === "stdio") {
+        expect(calls[0]!.config.command).toBe("node");
+        expect(calls[0]!.config.args).toEqual(["/path/to/server.js", "--debug"]);
+        expect(calls[0]!.config.env).toEqual({ NODE_ENV: "production" });
+      }
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("returns 400 for malformed JSON content", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const res = await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content: "{ not valid json !!!",
+        filename: "mcp.json",
+        dryRun: false,
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { message: string };
+      expect(body.message).toContain("Failed to parse config file");
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("uses suggestedNamespace from normalized server", async () => {
+    const { extension, calls } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const content = JSON.stringify({
+        mcpServers: {
+          "My Server": { command: "my-server" },
+        },
+      });
+
+      await post(web.handler, "/scopes/scope_1/mcp/import", {
+        content,
+        filename: "mcp.json",
+        agentHint: "claude-code",
+        dryRun: false,
+      });
+
+      expect(calls[0]!.config.namespace).toBe("my_server");
+    } finally {
+      await web.dispose();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importFromAgent — agent-specific format handling
+// ---------------------------------------------------------------------------
+
+describe("POST /scopes/:scopeId/mcp/import — per-agent formats", () => {
+  const importContent = async (
+    handler: ReturnType<typeof createHandler>["handler"],
+    agentHint: string,
+    filename: string,
+    content: string,
+  ) => {
+    const res = await post(handler, "/scopes/scope_1/mcp/import", {
+      content,
+      filename,
+      agentHint,
+      dryRun: true,
+    });
+    expect(res.status).toBe(200);
+    return ((await res.json()) as { dryRunParsed: unknown[] }).dryRunParsed;
+  };
+
+  it("handles vscode servers key", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+    try {
+      const content = JSON.stringify({
+        servers: { myapi: { url: "https://api.example.com/mcp" } },
+      });
+      const parsed = await importContent(web.handler, "vscode", "mcp.json", content);
+      expect(parsed).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("handles zed context_servers key", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+    try {
+      const content = JSON.stringify({
+        context_servers: { myserver: { command: "node", args: [] } },
+      });
+      const parsed = await importContent(web.handler, "zed", "settings.json", content);
+      expect(parsed).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("handles goose YAML", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+    try {
+      const content = `extensions:\n  srv:\n    type: streamable_http\n    uri: https://mcp.example.com/mcp\n`;
+      const parsed = await importContent(web.handler, "goose", "config.yaml", content);
+      expect(parsed).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("handles codex TOML", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+    try {
+      const content = `[mcp_servers.myserver]\ncommand = "npx"\nargs = ["-y", "pkg"]\n`;
+      const parsed = await importContent(web.handler, "codex", "config.toml", content);
+      expect(parsed).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("handles antigravity serverUrl key", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+    try {
+      const content = JSON.stringify({
+        mcpServers: { myserver: { serverUrl: "https://api.example.com/mcp" } },
+      });
+      const parsed = await importContent(web.handler, "antigravity", "mcp_config.json", content);
+      expect(parsed).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("handles codex http_headers via dry run", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+    try {
+      // Codex uses JSON key mcp_servers (TOML structure parsed same way)
+      const content = JSON.stringify({
+        mcp_servers: {
+          myapi: {
+            type: "http",
+            url: "https://api.example.com/mcp",
+            http_headers: { "X-Key": "val" },
+          },
+        },
+      });
+      const parsed = await importContent(web.handler, "codex", "config.json", content);
+      expect(parsed).toHaveLength(1);
+    } finally {
+      await web.dispose();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAgents endpoint
+// ---------------------------------------------------------------------------
+
+describe("GET /scopes/:scopeId/mcp/detect-agents", () => {
+  it("returns an agents array", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const res = await get(web.handler, "/scopes/scope_1/mcp/detect-agents");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { agents: unknown[] };
+      expect(Array.isArray(body.agents)).toBe(true);
+    } finally {
+      await web.dispose();
+    }
+  });
+
+  it("each detected agent has required fields", async () => {
+    const { extension } = makeCapturingExtension();
+    const web = createHandler(extension);
+
+    try {
+      const res = await get(web.handler, "/scopes/scope_1/mcp/detect-agents");
+      const body = (await res.json()) as {
+        agents: { agent: string; filePath: string; serverCount: number }[];
+      };
+
+      for (const agent of body.agents) {
+        expect(typeof agent.agent).toBe("string");
+        expect(typeof agent.filePath).toBe("string");
+        expect(typeof agent.serverCount).toBe("number");
+        expect(agent.serverCount).toBeGreaterThan(0);
+      }
+    } finally {
+      await web.dispose();
+    }
+  });
+});

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -282,17 +282,14 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
     )
     .handle("importFromAgent", ({ payload }) =>
       Effect.gen(function* () {
-        const servers = yield* Effect.tryPromise({
+        const servers = yield* Effect.try({
           try: () =>
             parseAgentConfigContent(
               payload.content,
               payload.filename,
               payload.agentHint as AgentKey | undefined,
             ),
-          catch: (e) =>
-            new McpApiError({
-              message: e instanceof Error ? e.message : String(e),
-            }),
+          catch: (e) => new McpApiError({ message: e instanceof Error ? e.message : String(e) }),
         });
 
         if (payload.dryRun) {
@@ -304,10 +301,10 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
         const skipped: { name: string; reason: string }[] = [];
 
         for (const server of servers) {
-          const config: McpSourceConfig =
-            server.config.transport === "stdio"
+          const config = toSourceConfig({
+            ...(server.config.transport === "stdio"
               ? {
-                  transport: "stdio",
+                  transport: "stdio" as const,
                   name: server.name,
                   command: server.config.command,
                   args: server.config.args,
@@ -315,13 +312,14 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
                   namespace: server.suggestedNamespace,
                 }
               : {
-                  transport: "remote",
+                  transport: "remote" as const,
                   name: server.name,
                   endpoint: server.config.endpoint,
                   headers: server.config.headers,
                   remoteTransport: server.config.remoteTransport,
                   namespace: server.suggestedNamespace,
-                };
+                }),
+          });
 
           const result = yield* ext.addSource(config).pipe(
             Effect.map((r) => ({ ok: true as const, ...r })),
@@ -349,8 +347,13 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
     )
     .handle("detectAgents", () =>
       Effect.gen(function* () {
-        const agents = yield* Effect.tryPromise({
-          try: () => detectInstalledAgents(),
+        const agents = yield* Effect.try({
+          try: () =>
+            detectInstalledAgents().map(({ agent, filePath, serverCount }) => ({
+              agent,
+              filePath,
+              serverCount,
+            })),
           catch: (e) =>
             new McpInternalError({
               message: e instanceof Error ? e.message : String(e),

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -3,6 +3,7 @@ import { Cause, Context, Effect } from "effect";
 
 import { addGroup } from "@executor/api";
 import type { McpPluginExtension, McpSourceConfig, McpUpdateSourceInput } from "../sdk/plugin";
+import { parseAgentConfigContent, detectInstalledAgents, type AgentKey } from "../sdk/agent-import";
 import {
   McpConnectionError,
   McpInvocationError,
@@ -277,6 +278,85 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
             ),
           );
         return yield* HttpServerResponse.html(popupDocument(result));
+      }).pipe(sanitizeMcpFailure),
+    )
+    .handle("importFromAgent", ({ payload }) =>
+      Effect.gen(function* () {
+        const servers = yield* Effect.tryPromise({
+          try: () =>
+            parseAgentConfigContent(
+              payload.content,
+              payload.filename,
+              payload.agentHint as AgentKey | undefined,
+            ),
+          catch: (e) =>
+            new McpApiError({
+              message: e instanceof Error ? e.message : String(e),
+            }),
+        });
+
+        if (payload.dryRun) {
+          return { imported: [], skipped: [], dryRunParsed: servers as unknown[] };
+        }
+
+        const ext = yield* McpExtensionService;
+        const imported: { namespace: string; name: string; toolCount: number }[] = [];
+        const skipped: { name: string; reason: string }[] = [];
+
+        for (const server of servers) {
+          const config: McpSourceConfig =
+            server.config.transport === "stdio"
+              ? {
+                  transport: "stdio",
+                  name: server.name,
+                  command: server.config.command,
+                  args: server.config.args,
+                  env: server.config.env,
+                  namespace: server.suggestedNamespace,
+                }
+              : {
+                  transport: "remote",
+                  name: server.name,
+                  endpoint: server.config.endpoint,
+                  headers: server.config.headers,
+                  remoteTransport: server.config.remoteTransport,
+                  namespace: server.suggestedNamespace,
+                };
+
+          const result = yield* ext.addSource(config).pipe(
+            Effect.map((r) => ({ ok: true as const, ...r })),
+            Effect.catchAll((e) =>
+              Effect.succeed({
+                ok: false as const,
+                reason: e instanceof Error ? e.message : String(e),
+              }),
+            ),
+          );
+
+          if (result.ok) {
+            imported.push({
+              namespace: result.namespace,
+              name: server.name,
+              toolCount: result.toolCount,
+            });
+          } else {
+            skipped.push({ name: server.name, reason: result.reason });
+          }
+        }
+
+        return { imported, skipped };
+      }).pipe(sanitizeMcpFailure),
+    )
+    .handle("detectAgents", () =>
+      Effect.gen(function* () {
+        const agents = yield* Effect.tryPromise({
+          try: () => detectInstalledAgents(),
+          catch: (e) =>
+            new McpInternalError({
+              message: e instanceof Error ? e.message : String(e),
+            }),
+        });
+        return { agents };
       }).pipe(sanitizeMcpFailure),
     ),
 );

--- a/packages/plugins/mcp/src/sdk/agent-import/agent-import.test.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/agent-import.test.ts
@@ -267,7 +267,7 @@ describe("JSONC comment stripping", () => {
 }`;
     // We test indirectly via parseAgentConfigContent
     const result = parseAgentConfigContent(jsonc, "test.json", "claude-code");
-    expect(result).resolves.toHaveLength(0); // no mcpServers key
+    expect(result).toHaveLength(0); // no mcpServers key
   });
 
   it("strips block comments", () => {
@@ -277,9 +277,7 @@ describe("JSONC comment stripping", () => {
     "fs": { "command": "node" }
   }
 }`;
-    return expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).resolves.toHaveLength(
-      1,
-    );
+    expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).toHaveLength(1);
   });
 
   it("strips trailing commas", () => {
@@ -288,9 +286,7 @@ describe("JSONC comment stripping", () => {
     "fs": { "command": "node", },
   }
 }`;
-    return expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).resolves.toHaveLength(
-      1,
-    );
+    expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).toHaveLength(1);
   });
 });
 
@@ -380,10 +376,10 @@ describe("parseAgentConfigContent", () => {
     expect(result).toHaveLength(0);
   });
 
-  it("throws AgentImportError on invalid JSON", async () => {
-    await expect(
-      parseAgentConfigContent("not valid json", "mcp.json", "claude-code"),
-    ).rejects.toThrow("Failed to parse config file");
+  it("throws AgentImportError on invalid JSON", () => {
+    expect(() => parseAgentConfigContent("not valid json", "mcp.json", "claude-code")).toThrow(
+      "Failed to parse config file",
+    );
   });
 
   it("parses goose YAML config", async () => {

--- a/packages/plugins/mcp/src/sdk/agent-import/agent-import.test.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/agent-import.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeAgentConfig } from "./normalize";
+import { detectAgentFromFilename, detectAgentFromContent, parseAgentConfigContent } from "./reader";
+import type { AgentKey } from "./types";
+
+// ---------------------------------------------------------------------------
+// normalizeAgentConfig
+// ---------------------------------------------------------------------------
+
+describe("normalizeAgentConfig — standard agents (mcpServers)", () => {
+  const stdioConfig = {
+    mcpServers: {
+      filesystem: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+        env: { DEBUG: "1" },
+      },
+    },
+  };
+
+  const remoteConfig = {
+    mcpServers: {
+      context7: {
+        url: "https://mcp.context7.com/mcp",
+        type: "http",
+        headers: { Authorization: "Bearer tok" },
+      },
+    },
+  };
+
+  for (const agent of [
+    "claude-code",
+    "claude-desktop",
+    "amp",
+    "cursor",
+    "cline",
+    "cline-cli",
+    "gemini-cli",
+    "copilot",
+    "antigravity",
+  ] as AgentKey[]) {
+    it(`${agent} — normalizes stdio server`, () => {
+      const result = normalizeAgentConfig(agent, stdioConfig);
+      expect(result).toHaveLength(1);
+      const s = result[0]!;
+      expect(s.name).toBe("filesystem");
+      expect(s.config.transport).toBe("stdio");
+      if (s.config.transport === "stdio") {
+        expect(s.config.command).toBe("npx");
+        expect(s.config.args).toEqual(["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]);
+        expect(s.config.env).toEqual({ DEBUG: "1" });
+      }
+    });
+
+    it(`${agent} — normalizes remote server`, () => {
+      const result = normalizeAgentConfig(agent, remoteConfig);
+      expect(result).toHaveLength(1);
+      const s = result[0]!;
+      expect(s.name).toBe("context7");
+      expect(s.config.transport).toBe("remote");
+      if (s.config.transport === "remote") {
+        expect(s.config.endpoint).toBe("https://mcp.context7.com/mcp");
+        expect(s.config.headers).toEqual({ Authorization: "Bearer tok" });
+        expect(s.config.remoteTransport).toBe("streamable-http");
+      }
+    });
+  }
+});
+
+describe("normalizeAgentConfig — opencode", () => {
+  it("normalizes remote server", () => {
+    const config = {
+      mcp: {
+        context7: { type: "remote", url: "https://mcp.context7.com/mcp", enabled: true },
+      },
+    };
+    const result = normalizeAgentConfig("opencode", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    expect(s.config.transport).toBe("remote");
+    if (s.config.transport === "remote") {
+      expect(s.config.endpoint).toBe("https://mcp.context7.com/mcp");
+    }
+  });
+
+  it("normalizes stdio server with array command", () => {
+    const config = {
+      mcp: {
+        filesystem: {
+          type: "local",
+          command: ["node", "/path/to/server.js"],
+          enabled: true,
+          environment: { HOME: "/home/user" },
+        },
+      },
+    };
+    const result = normalizeAgentConfig("opencode", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    expect(s.config.transport).toBe("stdio");
+    if (s.config.transport === "stdio") {
+      expect(s.config.command).toBe("node");
+      expect(s.config.args).toEqual(["/path/to/server.js"]);
+      expect(s.config.env).toEqual({ HOME: "/home/user" });
+    }
+  });
+
+  it("normalizes stdio server with string command", () => {
+    const config = {
+      mcp: {
+        myserver: { type: "local", command: "python", args: ["server.py"] },
+      },
+    };
+    const result = normalizeAgentConfig("opencode", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    if (s.config.transport === "stdio") {
+      expect(s.config.command).toBe("python");
+      expect(s.config.args).toEqual(["server.py"]);
+    }
+  });
+});
+
+describe("normalizeAgentConfig — vscode", () => {
+  it("uses servers key", () => {
+    const config = {
+      servers: {
+        myserver: { type: "http", url: "https://example.com/mcp" },
+      },
+    };
+    const result = normalizeAgentConfig("vscode", config);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("remote");
+  });
+});
+
+describe("normalizeAgentConfig — zed", () => {
+  it("uses context_servers key", () => {
+    const config = {
+      context_servers: {
+        myserver: { source: "custom", url: "https://example.com/mcp" },
+      },
+    };
+    const result = normalizeAgentConfig("zed", config);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("remote");
+  });
+
+  it("normalizes stdio", () => {
+    const config = {
+      context_servers: {
+        local: { source: "custom", command: "node", args: ["server.js"] },
+      },
+    };
+    const result = normalizeAgentConfig("zed", config);
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "stdio") {
+      expect(result[0]!.config.command).toBe("node");
+    }
+  });
+});
+
+describe("normalizeAgentConfig — goose", () => {
+  it("normalizes remote (streamable_http)", () => {
+    const config = {
+      extensions: {
+        context7: {
+          type: "streamable_http",
+          uri: "https://mcp.context7.com/mcp",
+          enabled: true,
+        },
+      },
+    };
+    const result = normalizeAgentConfig("goose", config);
+    expect(result).toHaveLength(1);
+    const s = result[0]!;
+    expect(s.config.transport).toBe("remote");
+    if (s.config.transport === "remote") {
+      expect(s.config.endpoint).toBe("https://mcp.context7.com/mcp");
+      expect(s.config.remoteTransport).toBe("streamable-http");
+    }
+  });
+
+  it("normalizes stdio (cmd key)", () => {
+    const config = {
+      extensions: {
+        myserver: {
+          type: "stdio",
+          cmd: "npx",
+          args: ["-y", "some-pkg"],
+          envs: { KEY: "val" },
+        },
+      },
+    };
+    const result = normalizeAgentConfig("goose", config);
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "stdio") {
+      expect(result[0]!.config.command).toBe("npx");
+      expect(result[0]!.config.env).toEqual({ KEY: "val" });
+    }
+  });
+});
+
+describe("normalizeAgentConfig — codex", () => {
+  it("normalizes remote with http_headers", () => {
+    const config = {
+      mcp_servers: {
+        myapi: {
+          type: "http",
+          url: "https://api.example.com/mcp",
+          http_headers: { "X-Key": "secret" },
+        },
+      },
+    };
+    const result = normalizeAgentConfig("codex", config);
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "remote") {
+      expect(result[0]!.config.headers).toEqual({ "X-Key": "secret" });
+    }
+  });
+});
+
+describe("normalizeAgentConfig — edge cases", () => {
+  it("returns empty array for empty config", () => {
+    expect(normalizeAgentConfig("claude-code", {})).toEqual([]);
+  });
+
+  it("returns empty array when servers key missing", () => {
+    expect(normalizeAgentConfig("claude-code", { other: {} })).toEqual([]);
+  });
+
+  it("skips entries with no command or url", () => {
+    const config = { mcpServers: { broken: { unknown: "field" } } };
+    expect(normalizeAgentConfig("claude-code", config)).toEqual([]);
+  });
+
+  it("handles multiple servers", () => {
+    const config = {
+      mcpServers: {
+        a: { command: "npx", args: ["-y", "pkg-a"] },
+        b: { url: "https://b.example.com/mcp" },
+        c: { command: "python", args: ["c.py"] },
+      },
+    };
+    const result = normalizeAgentConfig("claude-code", config);
+    expect(result).toHaveLength(3);
+    expect(result.map((s) => s.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("derives namespace from server name", () => {
+    const config = { mcpServers: { "My Server": { command: "myserver" } } };
+    const result = normalizeAgentConfig("claude-code", config);
+    expect(result[0]!.suggestedNamespace).toBe("my_server");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSONC comment stripping
+// ---------------------------------------------------------------------------
+
+describe("JSONC comment stripping", () => {
+  it("strips line comments", () => {
+    const jsonc = `{
+  // This is a comment
+  "key": "value"
+}`;
+    // We test indirectly via parseAgentConfigContent
+    const result = parseAgentConfigContent(jsonc, "test.json", "claude-code");
+    expect(result).resolves.toHaveLength(0); // no mcpServers key
+  });
+
+  it("strips block comments", () => {
+    const jsonc = `{
+  /* block comment */
+  "mcpServers": {
+    "fs": { "command": "node" }
+  }
+}`;
+    return expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).resolves.toHaveLength(
+      1,
+    );
+  });
+
+  it("strips trailing commas", () => {
+    const jsonc = `{
+  "mcpServers": {
+    "fs": { "command": "node", },
+  }
+}`;
+    return expect(parseAgentConfigContent(jsonc, "test.json", "claude-code")).resolves.toHaveLength(
+      1,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAgentFromFilename
+// ---------------------------------------------------------------------------
+
+describe("detectAgentFromFilename", () => {
+  it.each([
+    ["opencode.json", "opencode"],
+    ["opencode.jsonc", "opencode"],
+    [".mcp.json", "claude-code"],
+    ["mcp.json", "claude-code"],
+    ["claude_desktop_config.json", "claude-desktop"],
+    ["cline_mcp_settings.json", "cline"],
+    ["config.toml", "codex"],
+    ["config.yaml", "goose"],
+    ["mcp-config.json", "copilot"],
+    ["mcp_config.json", "antigravity"],
+    ["mcporter.json", "mcporter"],
+    ["mcporter.jsonc", "mcporter"],
+    [".claude.json", "claude-code"],
+    ["unknown.json", null],
+  ])("filename %s → %s", (filename, expected) => {
+    expect(detectAgentFromFilename(filename)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectAgentFromContent
+// ---------------------------------------------------------------------------
+
+describe("detectAgentFromContent", () => {
+  it.each([
+    [{ mcp: {} }, "opencode"],
+    [{ context_servers: {} }, "zed"],
+    [{ extensions: {} }, "goose"],
+    [{ mcp_servers: {} }, "codex"],
+    [{ servers: {} }, "vscode"],
+    [{ mcpServers: {} }, "claude-code"],
+    [{}, null],
+    [null, null],
+    ["string", null],
+  ])("content %j → %s", (content, expected) => {
+    expect(detectAgentFromContent(content)).toBe(expected);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAgentConfigContent — format detection
+// ---------------------------------------------------------------------------
+
+describe("parseAgentConfigContent", () => {
+  it("parses opencode.json", async () => {
+    const content = JSON.stringify({
+      mcp: {
+        context7: { type: "remote", url: "https://mcp.context7.com/mcp" },
+      },
+    });
+    const result = await parseAgentConfigContent(content, "opencode.json");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("remote");
+  });
+
+  it("parses .mcp.json as claude-code", async () => {
+    const content = JSON.stringify({
+      mcpServers: { fs: { command: "npx", args: ["-y", "fs"] } },
+    });
+    const result = await parseAgentConfigContent(content, ".mcp.json");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("stdio");
+  });
+
+  it("auto-detects agent from content when filename unknown", async () => {
+    const content = JSON.stringify({
+      context_servers: {
+        local: { command: "node", args: ["server.js"] },
+      },
+    });
+    const result = await parseAgentConfigContent(content, "unknown.json");
+    expect(result).toHaveLength(1);
+    expect(result[0]!.config.transport).toBe("stdio");
+  });
+
+  it("returns empty array for empty content", async () => {
+    const result = await parseAgentConfigContent("{}", "mcp.json", "claude-code");
+    expect(result).toHaveLength(0);
+  });
+
+  it("throws AgentImportError on invalid JSON", async () => {
+    await expect(
+      parseAgentConfigContent("not valid json", "mcp.json", "claude-code"),
+    ).rejects.toThrow("Failed to parse config file");
+  });
+
+  it("parses goose YAML config", async () => {
+    const yaml = `
+extensions:
+  context7:
+    type: streamable_http
+    uri: https://mcp.context7.com/mcp
+    enabled: true
+`;
+    const result = await parseAgentConfigContent(yaml, "config.yaml", "goose");
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "remote") {
+      expect(result[0]!.config.endpoint).toBe("https://mcp.context7.com/mcp");
+    }
+  });
+
+  it("parses codex TOML config", async () => {
+    const toml = `
+[mcp_servers.myserver]
+command = "npx"
+args = ["-y", "some-pkg"]
+`;
+    const result = await parseAgentConfigContent(toml, "config.toml", "codex");
+    expect(result).toHaveLength(1);
+    if (result[0]!.config.transport === "stdio") {
+      expect(result[0]!.config.command).toBe("npx");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Remote transport normalization
+// ---------------------------------------------------------------------------
+
+describe("remote transport normalization", () => {
+  it.each([
+    ["sse", "sse"],
+    ["streamableHttp", "streamable-http"],
+    ["streamable-http", "streamable-http"],
+    ["http", "streamable-http"],
+    [undefined, "auto"],
+    ["unknown", "auto"],
+  ] as [string | undefined, string][])("type=%s → remoteTransport=%s", (type, expected) => {
+    const config = {
+      mcpServers: {
+        server: type
+          ? { url: "https://example.com/mcp", type }
+          : { url: "https://example.com/mcp" },
+      },
+    };
+    const result = normalizeAgentConfig("claude-code", config);
+    expect(result[0]!.config.transport).toBe("remote");
+    if (result[0]!.config.transport === "remote") {
+      expect(result[0]!.config.remoteTransport).toBe(expected);
+    }
+  });
+});

--- a/packages/plugins/mcp/src/sdk/agent-import/index.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/index.ts
@@ -1,0 +1,19 @@
+export type { AgentKey, ConfigFormat, NormalizedServer, NormalizedServerConfig } from "./types";
+export { AgentImportError } from "./types";
+export { normalizeAgentConfig, configKeyByAgent } from "./normalize";
+export {
+  getCurrentPlatformEnv,
+  getGlobalConfigPaths,
+  getLocalConfigPaths,
+  detectFormat,
+  detectAgentFromFilename,
+  detectAgentFromContent,
+  parseContent,
+  readAgentConfigFile,
+  parseAgentConfigContent,
+  findAndReadAgentConfig,
+  detectInstalledAgents,
+  type PlatformEnv,
+  type ResolvedAgentConfig,
+  type DetectedAgent,
+} from "./reader";

--- a/packages/plugins/mcp/src/sdk/agent-import/normalize.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/normalize.ts
@@ -199,74 +199,6 @@ const normalizeCodex = (name: string, raw: RawServer): NormalizedServer | null =
 };
 
 // ---------------------------------------------------------------------------
-// Zed: {context_servers: {name: {source:"custom", type?, url?, command?, args?, env}}}
-// ---------------------------------------------------------------------------
-
-const normalizeZed = (name: string, raw: RawServer): NormalizedServer | null => {
-  const url = str(raw.url);
-  if (url) {
-    return {
-      name,
-      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
-      config: {
-        transport: "remote",
-        endpoint: url,
-        headers: strRecord(raw.headers),
-        remoteTransport: normalizeRemoteTransport(str(raw.type)),
-      },
-    };
-  }
-
-  const command = str(raw.command);
-  if (!command) return null;
-
-  return {
-    name,
-    suggestedNamespace: deriveMcpNamespace({ name, command }),
-    config: {
-      transport: "stdio",
-      command,
-      args: strArray(raw.args),
-      env: strRecord(raw.env),
-    },
-  };
-};
-
-// ---------------------------------------------------------------------------
-// VS Code: {servers: {name: {type:"http"|"stdio", url?, command?, args}}}
-// ---------------------------------------------------------------------------
-
-const normalizeVSCode = (name: string, raw: RawServer): NormalizedServer | null => {
-  const url = str(raw.url);
-  if (url) {
-    return {
-      name,
-      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
-      config: {
-        transport: "remote",
-        endpoint: url,
-        headers: strRecord(raw.headers),
-        remoteTransport: normalizeRemoteTransport(str(raw.type)),
-      },
-    };
-  }
-
-  const command = str(raw.command);
-  if (!command) return null;
-
-  return {
-    name,
-    suggestedNamespace: deriveMcpNamespace({ name, command }),
-    config: {
-      transport: "stdio",
-      command,
-      args: strArray(raw.args),
-      env: strRecord(raw.env),
-    },
-  };
-};
-
-// ---------------------------------------------------------------------------
 // Dispatch by agent key
 // ---------------------------------------------------------------------------
 
@@ -278,10 +210,10 @@ const normalizersByAgent: Record<AgentKey, NormalizeFn> = {
   "claude-desktop": normalizeStandard,
   amp: normalizeStandard,
   cursor: normalizeStandard,
-  vscode: normalizeVSCode,
+  vscode: normalizeStandard,
   cline: normalizeStandard,
   "cline-cli": normalizeStandard,
-  zed: normalizeZed,
+  zed: normalizeStandard,
   goose: normalizeGoose,
   codex: normalizeCodex,
   "gemini-cli": normalizeStandard,

--- a/packages/plugins/mcp/src/sdk/agent-import/normalize.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/normalize.ts
@@ -1,0 +1,351 @@
+// ---------------------------------------------------------------------------
+// Agent config normalization — maps agent-specific shapes → NormalizedServer
+// ---------------------------------------------------------------------------
+
+import { deriveMcpNamespace } from "../manifest";
+import type { AgentKey, NormalizedServer, NormalizedServerConfig } from "./types";
+
+// ---------------------------------------------------------------------------
+// Raw server shapes (loosely typed — we handle unknown agent configs)
+// ---------------------------------------------------------------------------
+
+type RawServer = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length > 0 ? v : undefined;
+
+const strRecord = (v: unknown): Record<string, string> | undefined => {
+  if (!v || typeof v !== "object" || Array.isArray(v)) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, val] of Object.entries(v)) {
+    if (typeof val === "string") out[k] = val;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+
+const strArray = (v: unknown): string[] | undefined => {
+  if (!Array.isArray(v)) return undefined;
+  const out = v.filter((x): x is string => typeof x === "string");
+  return out.length > 0 ? out : undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Standard mcpServers format (Claude Code, Cursor, Cline, Gemini CLI, etc.)
+// {command, args, env} or {url, type, headers}
+// ---------------------------------------------------------------------------
+
+const normalizeStandard = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url) ?? str(raw.serverUrl) ?? str(raw.uri);
+  if (url) {
+    const transport = normalizeRemoteTransport(str(raw.type));
+    const config: NormalizedServerConfig = {
+      transport: "remote",
+      endpoint: url,
+      headers: strRecord(raw.headers),
+      remoteTransport: transport,
+    };
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config,
+    };
+  }
+
+  const command = str(raw.command);
+  if (command) {
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, command }),
+      config: {
+        transport: "stdio",
+        command,
+        args: strArray(raw.args),
+        env: strRecord(raw.env),
+        cwd: str(raw.cwd),
+      },
+    };
+  }
+
+  return null;
+};
+
+const normalizeRemoteTransport = (t: string | undefined): "streamable-http" | "sse" | "auto" => {
+  if (t === "sse") return "sse";
+  if (t === "streamableHttp" || t === "streamable-http" || t === "http") return "streamable-http";
+  return "auto";
+};
+
+// ---------------------------------------------------------------------------
+// OpenCode: {mcp: {name: {type:"remote"|"local", url?, command:[...], environment:{}}}}
+// ---------------------------------------------------------------------------
+
+const normalizeOpenCode = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url || str(raw.type) === "remote") {
+    if (!url) return null;
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers: strRecord(raw.headers),
+        remoteTransport: "auto",
+      },
+    };
+  }
+
+  // command is array in opencode: ["node", "server.js"] or string
+  let command: string | undefined;
+  let args: string[] | undefined;
+
+  if (Array.isArray(raw.command)) {
+    const parts = raw.command.filter((x): x is string => typeof x === "string");
+    command = parts[0];
+    args = parts.slice(1);
+  } else {
+    command = str(raw.command);
+    args = strArray(raw.args);
+  }
+
+  if (!command) return null;
+
+  const env = strRecord(raw.environment) ?? strRecord(raw.env);
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: { transport: "stdio", command, args, env },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Goose: {extensions: {name: {type:"streamable_http"|"sse"|"stdio", uri?, cmd?, args?, envs:{}}}}
+// ---------------------------------------------------------------------------
+
+const normalizeGoose = (name: string, raw: RawServer): NormalizedServer | null => {
+  const uri = str(raw.uri);
+  if (uri) {
+    const t = str(raw.type);
+    const transport = t === "sse" ? "sse" : "streamable-http";
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: uri }),
+      config: {
+        transport: "remote",
+        endpoint: uri,
+        headers: strRecord(raw.headers),
+        remoteTransport: transport,
+      },
+    };
+  }
+
+  const cmd = str(raw.cmd) ?? str(raw.command);
+  if (!cmd) return null;
+
+  const env = strRecord(raw.envs) ?? strRecord(raw.env);
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command: cmd }),
+    config: {
+      transport: "stdio",
+      command: cmd,
+      args: strArray(raw.args),
+      env,
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Codex: {mcp_servers: {name: {type:"http"|"sse", url?} or {command, args, env}}}
+// http_headers used instead of headers in codex
+// ---------------------------------------------------------------------------
+
+const normalizeCodex = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url) {
+    const headers = strRecord(raw.http_headers) ?? strRecord(raw.headers);
+    const t = str(raw.type);
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers,
+        remoteTransport: normalizeRemoteTransport(t),
+      },
+    };
+  }
+
+  const command = str(raw.command);
+  if (!command) return null;
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: {
+      transport: "stdio",
+      command,
+      args: strArray(raw.args),
+      env: strRecord(raw.env),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Zed: {context_servers: {name: {source:"custom", type?, url?, command?, args?, env}}}
+// ---------------------------------------------------------------------------
+
+const normalizeZed = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url) {
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers: strRecord(raw.headers),
+        remoteTransport: normalizeRemoteTransport(str(raw.type)),
+      },
+    };
+  }
+
+  const command = str(raw.command);
+  if (!command) return null;
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: {
+      transport: "stdio",
+      command,
+      args: strArray(raw.args),
+      env: strRecord(raw.env),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// VS Code: {servers: {name: {type:"http"|"stdio", url?, command?, args}}}
+// ---------------------------------------------------------------------------
+
+const normalizeVSCode = (name: string, raw: RawServer): NormalizedServer | null => {
+  const url = str(raw.url);
+  if (url) {
+    return {
+      name,
+      suggestedNamespace: deriveMcpNamespace({ name, endpoint: url }),
+      config: {
+        transport: "remote",
+        endpoint: url,
+        headers: strRecord(raw.headers),
+        remoteTransport: normalizeRemoteTransport(str(raw.type)),
+      },
+    };
+  }
+
+  const command = str(raw.command);
+  if (!command) return null;
+
+  return {
+    name,
+    suggestedNamespace: deriveMcpNamespace({ name, command }),
+    config: {
+      transport: "stdio",
+      command,
+      args: strArray(raw.args),
+      env: strRecord(raw.env),
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Dispatch by agent key
+// ---------------------------------------------------------------------------
+
+type NormalizeFn = (name: string, raw: RawServer) => NormalizedServer | null;
+
+const normalizersByAgent: Record<AgentKey, NormalizeFn> = {
+  opencode: normalizeOpenCode,
+  "claude-code": normalizeStandard,
+  "claude-desktop": normalizeStandard,
+  amp: normalizeStandard,
+  cursor: normalizeStandard,
+  vscode: normalizeVSCode,
+  cline: normalizeStandard,
+  "cline-cli": normalizeStandard,
+  zed: normalizeZed,
+  goose: normalizeGoose,
+  codex: normalizeCodex,
+  "gemini-cli": normalizeStandard,
+  copilot: normalizeStandard,
+  antigravity: normalizeStandard,
+  mcporter: normalizeStandard,
+};
+
+// ---------------------------------------------------------------------------
+// Config key by agent — where in the parsed object the servers live
+// ---------------------------------------------------------------------------
+
+export const configKeyByAgent: Record<AgentKey, string> = {
+  opencode: "mcp",
+  "claude-code": "mcpServers",
+  "claude-desktop": "mcpServers",
+  amp: "mcpServers",
+  cursor: "mcpServers",
+  vscode: "servers",
+  cline: "mcpServers",
+  "cline-cli": "mcpServers",
+  zed: "context_servers",
+  goose: "extensions",
+  codex: "mcp_servers",
+  "gemini-cli": "mcpServers",
+  copilot: "mcpServers",
+  antigravity: "mcpServers",
+  mcporter: "mcpServers",
+};
+
+// ---------------------------------------------------------------------------
+// Extract servers object from parsed config using dot-notation key
+// ---------------------------------------------------------------------------
+
+const getNestedValue = (obj: unknown, key: string): unknown => {
+  const parts = key.split(".");
+  let cur: unknown = obj;
+  for (const part of parts) {
+    if (!cur || typeof cur !== "object" || Array.isArray(cur)) return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur;
+};
+
+// ---------------------------------------------------------------------------
+// Public: normalize all servers from a parsed config object
+// ---------------------------------------------------------------------------
+
+export const normalizeAgentConfig = (agent: AgentKey, parsed: unknown): NormalizedServer[] => {
+  const configKey = configKeyByAgent[agent];
+  const serversObj = getNestedValue(parsed, configKey);
+
+  if (!serversObj || typeof serversObj !== "object" || Array.isArray(serversObj)) {
+    return [];
+  }
+
+  const normalize = normalizersByAgent[agent];
+  const results: NormalizedServer[] = [];
+
+  for (const [name, raw] of Object.entries(serversObj as Record<string, unknown>)) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) continue;
+    const normalized = normalize(name, raw as RawServer);
+    if (normalized) results.push(normalized);
+  }
+
+  return results;
+};

--- a/packages/plugins/mcp/src/sdk/agent-import/reader.test.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/reader.test.ts
@@ -166,15 +166,15 @@ url = "https://api.example.com/mcp"
     expect(servers).toHaveLength(0);
   });
 
-  it("throws AgentImportError when file does not exist", async () => {
-    await expect(
-      readAgentConfigFile(join(tmpDir, "nonexistent.json"), "claude-code"),
-    ).rejects.toThrow("Config file not found");
+  it("throws AgentImportError when file does not exist", () => {
+    expect(() => readAgentConfigFile(join(tmpDir, "nonexistent.json"), "claude-code")).toThrow(
+      "Config file not found",
+    );
   });
 
-  it("throws AgentImportError on malformed JSON", async () => {
+  it("throws AgentImportError on malformed JSON", () => {
     const filePath = write("bad.json", "{ not valid json }");
-    await expect(readAgentConfigFile(filePath, "claude-code")).rejects.toThrow(
+    expect(() => readAgentConfigFile(filePath, "claude-code")).toThrow(
       "Failed to parse config file",
     );
   });
@@ -262,10 +262,10 @@ describe("parseAgentConfigContent", () => {
     expect(servers[0]!.name).toBe("server");
   });
 
-  it("throws on completely invalid JSON", async () => {
-    await expect(
-      parseAgentConfigContent("not json at all", "mcp.json", "claude-code"),
-    ).rejects.toThrow("Failed to parse config file");
+  it("throws on completely invalid JSON", () => {
+    expect(() => parseAgentConfigContent("not json at all", "mcp.json", "claude-code")).toThrow(
+      "Failed to parse config file",
+    );
   });
 
   it("returns empty array for empty mcpServers object", async () => {
@@ -312,11 +312,11 @@ describe("findAndReadAgentConfig", () => {
     expect(result.servers[0]!.name).toBe("context7");
   });
 
-  it("throws AgentImportError when no config found", async () => {
+  it("throws AgentImportError when no config found", () => {
     // Use mcporter — its global path (~/.mcporter/mcporter.json) is
     // extremely unlikely to exist on any dev/CI machine, and its only
     // local path (config/mcporter.json) is not present in tmpDir.
-    await expect(findAndReadAgentConfig("mcporter", { cwd: tmpDir })).rejects.toThrow(
+    expect(() => findAndReadAgentConfig("mcporter", { cwd: tmpDir })).toThrow(
       "No config file found for agent",
     );
   });

--- a/packages/plugins/mcp/src/sdk/agent-import/reader.test.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/reader.test.ts
@@ -1,0 +1,474 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readAgentConfigFile,
+  parseAgentConfigContent,
+  findAndReadAgentConfig,
+  detectInstalledAgents,
+} from "./reader";
+
+// ---------------------------------------------------------------------------
+// Temp directory management
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "executor-agent-import-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const write = (rel: string, content: string): string => {
+  const full = join(tmpDir, rel);
+  mkdirSync(join(tmpDir, rel.split("/").slice(0, -1).join("/")), { recursive: true });
+  writeFileSync(full, content, "utf-8");
+  return full;
+};
+
+// ---------------------------------------------------------------------------
+// readAgentConfigFile — real file I/O
+// ---------------------------------------------------------------------------
+
+describe("readAgentConfigFile", () => {
+  it("reads and normalizes a claude-code config", async () => {
+    const filePath = write(
+      "claude.json",
+      JSON.stringify({
+        mcpServers: {
+          filesystem: {
+            command: "npx",
+            args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+            env: { DEBUG: "1" },
+          },
+        },
+      }),
+    );
+
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("filesystem");
+    expect(servers[0]!.config.transport).toBe("stdio");
+    if (servers[0]!.config.transport === "stdio") {
+      expect(servers[0]!.config.command).toBe("npx");
+      expect(servers[0]!.config.args).toEqual([
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/tmp",
+      ]);
+      expect(servers[0]!.config.env).toEqual({ DEBUG: "1" });
+    }
+  });
+
+  it("reads and normalizes an opencode JSONC config with comments", async () => {
+    const filePath = write(
+      "opencode.jsonc",
+      `{
+  // opencode config with comments
+  "mcp": {
+    "context7": {
+      "type": "remote",
+      /* the remote URL */
+      "url": "https://mcp.context7.com/mcp",
+    },
+  }
+}`,
+    );
+
+    const servers = await readAgentConfigFile(filePath, "opencode");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("context7");
+    expect(servers[0]!.config.transport).toBe("remote");
+    if (servers[0]!.config.transport === "remote") {
+      expect(servers[0]!.config.endpoint).toBe("https://mcp.context7.com/mcp");
+    }
+  });
+
+  it("reads a vscode mcp.json config", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({
+        servers: {
+          myapi: { type: "http", url: "https://api.example.com/mcp" },
+        },
+      }),
+    );
+
+    const servers = await readAgentConfigFile(filePath, "vscode");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("remote");
+  });
+
+  it("reads a goose YAML config", async () => {
+    const filePath = write(
+      "config.yaml",
+      `extensions:
+  context7:
+    type: streamable_http
+    uri: https://mcp.context7.com/mcp
+    enabled: true
+  localserver:
+    type: stdio
+    cmd: npx
+    args:
+      - -y
+      - some-package
+    envs:
+      KEY: value
+`,
+    );
+
+    const servers = await readAgentConfigFile(filePath, "goose");
+    expect(servers).toHaveLength(2);
+    const remote = servers.find((s) => s.name === "context7")!;
+    const local = servers.find((s) => s.name === "localserver")!;
+    expect(remote.config.transport).toBe("remote");
+    expect(local.config.transport).toBe("stdio");
+    if (remote.config.transport === "remote") {
+      expect(remote.config.endpoint).toBe("https://mcp.context7.com/mcp");
+      expect(remote.config.remoteTransport).toBe("streamable-http");
+    }
+    if (local.config.transport === "stdio") {
+      expect(local.config.command).toBe("npx");
+      expect(local.config.env).toEqual({ KEY: "value" });
+    }
+  });
+
+  it("reads a codex TOML config", async () => {
+    const filePath = write(
+      "config.toml",
+      `[mcp_servers.filesystem]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-filesystem"]
+
+[mcp_servers.myapi]
+type = "http"
+url = "https://api.example.com/mcp"
+`,
+    );
+
+    const servers = await readAgentConfigFile(filePath, "codex");
+    expect(servers).toHaveLength(2);
+    const local = servers.find((s) => s.name === "filesystem")!;
+    const remote = servers.find((s) => s.name === "myapi")!;
+    expect(local.config.transport).toBe("stdio");
+    expect(remote.config.transport).toBe("remote");
+  });
+
+  it("returns empty array for config with no servers", async () => {
+    const filePath = write("empty.json", JSON.stringify({ mcpServers: {} }));
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers).toHaveLength(0);
+  });
+
+  it("throws AgentImportError when file does not exist", async () => {
+    await expect(
+      readAgentConfigFile(join(tmpDir, "nonexistent.json"), "claude-code"),
+    ).rejects.toThrow("Config file not found");
+  });
+
+  it("throws AgentImportError on malformed JSON", async () => {
+    const filePath = write("bad.json", "{ not valid json }");
+    await expect(readAgentConfigFile(filePath, "claude-code")).rejects.toThrow(
+      "Failed to parse config file",
+    );
+  });
+
+  it("reads multiple servers and preserves order", async () => {
+    const filePath = write(
+      "multi.json",
+      JSON.stringify({
+        mcpServers: {
+          alpha: { command: "alpha" },
+          beta: { url: "https://beta.example.com/mcp" },
+          gamma: { command: "gamma", args: ["-v"] },
+        },
+      }),
+    );
+
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers).toHaveLength(3);
+    expect(servers.map((s) => s.name)).toEqual(["alpha", "beta", "gamma"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAgentConfigContent — raw string input
+// ---------------------------------------------------------------------------
+
+describe("parseAgentConfigContent", () => {
+  it("parses JSON content with explicit agent", async () => {
+    const content = JSON.stringify({
+      mcp: { context7: { type: "remote", url: "https://mcp.context7.com/mcp" } },
+    });
+    const servers = await parseAgentConfigContent(content, "opencode.json", "opencode");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("remote");
+  });
+
+  it("auto-detects opencode from filename", async () => {
+    const content = JSON.stringify({
+      mcp: { myserver: { type: "local", command: "node", args: ["server.js"] } },
+    });
+    const servers = await parseAgentConfigContent(content, "opencode.json");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("stdio");
+  });
+
+  it("auto-detects claude-code from .mcp.json filename", async () => {
+    const content = JSON.stringify({
+      mcpServers: { fs: { command: "npx", args: ["-y", "fs"] } },
+    });
+    const servers = await parseAgentConfigContent(content, ".mcp.json");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("stdio");
+  });
+
+  it("auto-detects goose from config.yaml filename", async () => {
+    const yaml = `extensions:\n  srv:\n    type: stdio\n    cmd: node\n    args: []\n`;
+    const servers = await parseAgentConfigContent(yaml, "config.yaml");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("srv");
+  });
+
+  it("auto-detects agent from content when filename is unknown", async () => {
+    const content = JSON.stringify({
+      context_servers: { local: { command: "node", args: ["server.js"] } },
+    });
+    const servers = await parseAgentConfigContent(content, "some-unknown-file.json");
+    // auto-detected as zed
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.config.transport).toBe("stdio");
+  });
+
+  it("strips JSONC comments and trailing commas", async () => {
+    const jsonc = `{
+  // comment
+  "mcpServers": {
+    /* block */
+    "server": {
+      "command": "node",
+      "args": ["server.js"], /* trailing comma below */
+    },
+  }
+}`;
+    const servers = await parseAgentConfigContent(jsonc, "mcp.json", "claude-code");
+    expect(servers).toHaveLength(1);
+    expect(servers[0]!.name).toBe("server");
+  });
+
+  it("throws on completely invalid JSON", async () => {
+    await expect(
+      parseAgentConfigContent("not json at all", "mcp.json", "claude-code"),
+    ).rejects.toThrow("Failed to parse config file");
+  });
+
+  it("returns empty array for empty mcpServers object", async () => {
+    const content = JSON.stringify({ mcpServers: {} });
+    const servers = await parseAgentConfigContent(content, "mcp.json", "claude-code");
+    expect(servers).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAndReadAgentConfig — real filesystem
+// ---------------------------------------------------------------------------
+
+describe("findAndReadAgentConfig", () => {
+  it("finds local config file in cwd", async () => {
+    const content = JSON.stringify({
+      mcpServers: { fs: { command: "npx", args: ["-y", "fs-server"] } },
+    });
+    write("opencode.json", content);
+
+    // Use a different agent key since we want to find opencode.json locally
+    const configContent = JSON.stringify({
+      mcp: { myserver: { type: "local", command: "node", args: ["s.js"] } },
+    });
+    write("opencode.json", configContent);
+
+    const result = await findAndReadAgentConfig("opencode", { cwd: tmpDir });
+    expect(result.agent).toBe("opencode");
+    expect(result.filePath).toContain("opencode.json");
+    expect(result.servers).toHaveLength(1);
+  });
+
+  it("finds .mcp.json for claude-code", async () => {
+    const content = JSON.stringify({
+      mcpServers: {
+        context7: { url: "https://mcp.context7.com/mcp" },
+      },
+    });
+    write(".mcp.json", content);
+
+    const result = await findAndReadAgentConfig("claude-code", { cwd: tmpDir });
+    expect(result.filePath).toContain(".mcp.json");
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]!.name).toBe("context7");
+  });
+
+  it("throws AgentImportError when no config found", async () => {
+    // Use mcporter — its global path (~/.mcporter/mcporter.json) is
+    // extremely unlikely to exist on any dev/CI machine, and its only
+    // local path (config/mcporter.json) is not present in tmpDir.
+    await expect(findAndReadAgentConfig("mcporter", { cwd: tmpDir })).rejects.toThrow(
+      "No config file found for agent",
+    );
+  });
+
+  it("local config takes priority over global config path", async () => {
+    // Write a local config with 1 server
+    write(".mcp.json", JSON.stringify({ mcpServers: { local: { command: "local-server" } } }));
+
+    const result = await findAndReadAgentConfig("claude-code", { cwd: tmpDir });
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]!.name).toBe("local");
+  });
+
+  it("reads vscode local config from .vscode/mcp.json", async () => {
+    write(
+      ".vscode/mcp.json",
+      JSON.stringify({ servers: { myapi: { url: "https://api.example.com/mcp" } } }),
+    );
+
+    const result = await findAndReadAgentConfig("vscode", { cwd: tmpDir });
+    expect(result.servers).toHaveLength(1);
+    expect(result.servers[0]!.config.transport).toBe("remote");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectInstalledAgents — real filesystem
+// ---------------------------------------------------------------------------
+
+describe("detectInstalledAgents", () => {
+  it("detects opencode config in cwd", async () => {
+    write(
+      "opencode.json",
+      JSON.stringify({
+        mcp: { context7: { type: "remote", url: "https://mcp.context7.com/mcp" } },
+      }),
+    );
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const opencode = agents.find((a) => a.agent === "opencode");
+    expect(opencode).toBeDefined();
+    expect(opencode!.serverCount).toBe(1);
+  });
+
+  it("detects multiple agents", async () => {
+    write(
+      "opencode.json",
+      JSON.stringify({
+        mcp: { srv1: { type: "local", command: "node", args: [] } },
+      }),
+    );
+    write(
+      ".mcp.json",
+      JSON.stringify({
+        mcpServers: { srv2: { command: "npx", args: ["-y", "pkg"] } },
+      }),
+    );
+    write(
+      ".vscode/mcp.json",
+      JSON.stringify({
+        servers: { srv3: { url: "https://srv3.example.com/mcp" } },
+      }),
+    );
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const keys = agents.map((a) => a.agent);
+    expect(keys).toContain("opencode");
+    expect(keys).toContain("claude-code");
+    expect(keys).toContain("vscode");
+  });
+
+  it("returns empty array when no configs found", async () => {
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    // Only checking local paths from tmpDir — global paths may or may not exist
+    const localAgents = agents.filter((a) => a.filePath.startsWith(tmpDir));
+    expect(localAgents).toHaveLength(0);
+  });
+
+  it("skips configs that have no servers", async () => {
+    write("opencode.json", JSON.stringify({ mcp: {} }));
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const local = agents.filter((a) => a.filePath.startsWith(tmpDir));
+    const opencode = local.find((a) => a.agent === "opencode");
+    // Should not be included since serverCount is 0
+    expect(opencode).toBeUndefined();
+  });
+
+  it("reports correct serverCount", async () => {
+    write(
+      "opencode.json",
+      JSON.stringify({
+        mcp: {
+          srv1: { type: "remote", url: "https://srv1.example.com/mcp" },
+          srv2: { type: "local", command: "node", args: [] },
+          srv3: { type: "local", command: "python", args: ["s.py"] },
+        },
+      }),
+    );
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const opencode = agents.find((a) => a.agent === "opencode" && a.filePath.startsWith(tmpDir));
+    expect(opencode).toBeDefined();
+    expect(opencode!.serverCount).toBe(3);
+  });
+
+  it("does not deduplicate across agent types with different keys", async () => {
+    // claude-code and amp both read .mcp.json but are different agents
+    write(".mcp.json", JSON.stringify({ mcpServers: { fs: { command: "node" } } }));
+
+    const agents = await detectInstalledAgents({ cwd: tmpDir });
+    const local = agents.filter((a) => a.filePath.startsWith(tmpDir));
+    // At least claude-code should appear; amp uses same path but might be deduplicated
+    expect(local.some((a) => a.agent === "claude-code")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Namespace derivation in normalized servers
+// ---------------------------------------------------------------------------
+
+describe("suggestedNamespace derivation", () => {
+  it("derives namespace from server name", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({ mcpServers: { "My Cool Server": { command: "server" } } }),
+    );
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    expect(servers[0]!.suggestedNamespace).toBe("my_cool_server");
+  });
+
+  it("derives namespace from endpoint hostname for remote servers", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({
+        mcpServers: { context7: { url: "https://mcp.context7.com/mcp" } },
+      }),
+    );
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    // name takes priority over endpoint in deriveMcpNamespace
+    expect(servers[0]!.suggestedNamespace).toBe("context7");
+  });
+
+  it("falls through to command for whitespace-only server names", async () => {
+    const filePath = write(
+      "mcp.json",
+      JSON.stringify({
+        mcpServers: { "   ": { command: "my-server" } },
+      }),
+    );
+    const servers = await readAgentConfigFile(filePath, "claude-code");
+    // whitespace-only name → deriveMcpNamespace skips name branch, uses command
+    expect(servers[0]!.suggestedNamespace).toBe("my_server");
+  });
+});

--- a/packages/plugins/mcp/src/sdk/agent-import/reader.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/reader.ts
@@ -139,10 +139,10 @@ export const getGlobalConfigPaths = (agent: AgentKey, env: PlatformEnv): string[
       return [join(home, ".gemini", "settings.json")];
 
     case "copilot": {
-      const copilotDir = process.env.XDG_CONFIG_HOME
-        ? join(process.env.XDG_CONFIG_HOME)
-        : join(home, ".copilot");
-      return [join(copilotDir, "mcp-config.json")];
+      if (platform === "win32") return [join(appData, "copilot", "mcp-config.json")];
+      if (platform === "darwin")
+        return [join(home, "Library", "Application Support", "copilot", "mcp-config.json")];
+      return [join(xdgConfig, "copilot", "mcp-config.json")];
     }
 
     case "antigravity":
@@ -303,7 +303,7 @@ const parseYamlContent = (content: string): unknown => yamlParse(content);
 
 const parseTomlContent = (content: string): unknown => tomlParse(content);
 
-export const parseContent = async (content: string, format: ConfigFormat): Promise<unknown> => {
+export const parseContent = (content: string, format: ConfigFormat): unknown => {
   switch (format) {
     case "json":
       return parseJson(content);
@@ -354,10 +354,7 @@ export const detectAgentFromContent = (parsed: unknown): AgentKey | null => {
 // Read from file path
 // ---------------------------------------------------------------------------
 
-export const readAgentConfigFile = async (
-  filePath: string,
-  agent: AgentKey,
-): Promise<NormalizedServer[]> => {
+export const readAgentConfigFile = (filePath: string, agent: AgentKey): NormalizedServer[] => {
   if (!existsSync(filePath)) {
     throw new AgentImportError(`Config file not found: ${filePath}`);
   }
@@ -370,19 +367,18 @@ export const readAgentConfigFile = async (
 // Parse from raw content (used by web drag-drop and tests)
 // ---------------------------------------------------------------------------
 
-export const parseAgentConfigContent = async (
+export const parseAgentConfigContent = (
   content: string,
   filenameHint: string,
   agentHint?: AgentKey,
-): Promise<NormalizedServer[]> => {
+): NormalizedServer[] => {
   let agent = agentHint;
 
-  // Detect format from filename hint
   const format = detectFormat(filenameHint, agent ?? "claude-code");
 
   let parsed: unknown;
   try {
-    parsed = await parseContent(content, format);
+    parsed = parseContent(content, format);
   } catch (err) {
     throw new AgentImportError(
       `Failed to parse config file: ${err instanceof Error ? err.message : String(err)}`,
@@ -408,10 +404,10 @@ export interface ResolvedAgentConfig {
   readonly servers: NormalizedServer[];
 }
 
-export const findAndReadAgentConfig = async (
+export const findAndReadAgentConfig = (
   agent: AgentKey,
   options?: { cwd?: string },
-): Promise<ResolvedAgentConfig> => {
+): ResolvedAgentConfig => {
   const env = getCurrentPlatformEnv();
   const cwd = options?.cwd ?? process.cwd();
 
@@ -419,7 +415,7 @@ export const findAndReadAgentConfig = async (
   for (const rel of getLocalConfigPaths(agent)) {
     const full = join(cwd, rel);
     if (existsSync(full)) {
-      const servers = await readAgentConfigFile(full, agent);
+      const servers = readAgentConfigFile(full, agent);
       return { filePath: full, agent, servers };
     }
   }
@@ -427,7 +423,7 @@ export const findAndReadAgentConfig = async (
   // Then global paths
   for (const full of getGlobalConfigPaths(agent, env)) {
     if (existsSync(full)) {
-      const servers = await readAgentConfigFile(full, agent);
+      const servers = readAgentConfigFile(full, agent);
       return { filePath: full, agent, servers };
     }
   }
@@ -447,6 +443,7 @@ export const findAndReadAgentConfig = async (
 export interface DetectedAgent {
   readonly agent: AgentKey;
   readonly filePath: string;
+  readonly servers: NormalizedServer[];
   readonly serverCount: number;
 }
 
@@ -468,9 +465,7 @@ const ALL_AGENTS: AgentKey[] = [
   "mcporter",
 ];
 
-export const detectInstalledAgents = async (options?: {
-  cwd?: string;
-}): Promise<DetectedAgent[]> => {
+export const detectInstalledAgents = (options?: { cwd?: string }): DetectedAgent[] => {
   const env = getCurrentPlatformEnv();
   const cwd = options?.cwd ?? process.cwd();
   const results: DetectedAgent[] = [];
@@ -487,9 +482,9 @@ export const detectInstalledAgents = async (options?: {
       if (!existsSync(filePath)) continue;
       seen.add(filePath);
       try {
-        const servers = await readAgentConfigFile(filePath, agent);
+        const servers = readAgentConfigFile(filePath, agent);
         if (servers.length > 0) {
-          results.push({ agent, filePath, serverCount: servers.length });
+          results.push({ agent, filePath, servers, serverCount: servers.length });
         }
       } catch {
         // skip unreadable files

--- a/packages/plugins/mcp/src/sdk/agent-import/reader.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/reader.ts
@@ -42,7 +42,10 @@ export const getGlobalConfigPaths = (agent: AgentKey, env: PlatformEnv): string[
 
   switch (agent) {
     case "opencode":
-      return [join(xdgConfig, "opencode", "opencode.json")];
+      return [
+        join(xdgConfig, "opencode", "opencode.json"),
+        join(xdgConfig, "opencode", "opencode.jsonc"),
+      ];
 
     case "claude-code":
       return [join(home, ".claude.json")];

--- a/packages/plugins/mcp/src/sdk/agent-import/reader.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/reader.ts
@@ -1,0 +1,504 @@
+// ---------------------------------------------------------------------------
+// Agent config reader — resolve paths + parse files
+// ---------------------------------------------------------------------------
+
+import { homedir } from "node:os";
+import { parse as yamlParse } from "yaml";
+import { parse as tomlParse } from "smol-toml";
+import { join, dirname } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import type { AgentKey, ConfigFormat, NormalizedServer } from "./types";
+import { AgentImportError } from "./types";
+import { normalizeAgentConfig } from "./normalize";
+
+// ---------------------------------------------------------------------------
+// Platform environment
+// ---------------------------------------------------------------------------
+
+export interface PlatformEnv {
+  readonly platform: NodeJS.Platform;
+  readonly home: string;
+  readonly appData: string; // Windows %APPDATA% or fallback
+  readonly xdgConfig: string; // XDG_CONFIG_HOME or fallback
+}
+
+export const getCurrentPlatformEnv = (): PlatformEnv => {
+  const home = homedir();
+  const platform = process.platform;
+  const appData =
+    platform === "win32"
+      ? (process.env.APPDATA ?? join(home, "AppData", "Roaming"))
+      : join(home, "Library", "Application Support");
+  const xdgConfig = process.env.XDG_CONFIG_HOME ?? join(home, ".config");
+  return { platform, home, appData, xdgConfig };
+};
+
+// ---------------------------------------------------------------------------
+// Global config paths per agent
+// ---------------------------------------------------------------------------
+
+export const getGlobalConfigPaths = (agent: AgentKey, env: PlatformEnv): string[] => {
+  const { platform, home, appData, xdgConfig } = env;
+
+  switch (agent) {
+    case "opencode":
+      return [join(xdgConfig, "opencode", "opencode.json")];
+
+    case "claude-code":
+      return [join(home, ".claude.json")];
+
+    case "claude-desktop": {
+      if (platform === "win32") return [join(appData, "Claude", "claude_desktop_config.json")];
+      if (platform === "darwin")
+        return [
+          join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"),
+        ];
+      return [join(xdgConfig, "Claude", "claude_desktop_config.json")];
+    }
+
+    case "amp":
+      // Claude AMP uses same location as claude-code
+      return [join(home, ".claude.json")];
+
+    case "cursor":
+      return [join(home, ".cursor", "mcp.json")];
+
+    case "vscode": {
+      if (platform === "win32") return [join(appData, "Code", "User", "mcp.json")];
+      if (platform === "darwin")
+        return [join(home, "Library", "Application Support", "Code", "User", "mcp.json")];
+      return [join(xdgConfig, "Code", "User", "mcp.json")];
+    }
+
+    case "cline": {
+      if (platform === "win32")
+        return [
+          join(
+            appData,
+            "Code",
+            "User",
+            "globalStorage",
+            "saoudrizwan.claude-dev",
+            "settings",
+            "cline_mcp_settings.json",
+          ),
+        ];
+      if (platform === "darwin")
+        return [
+          join(
+            home,
+            "Library",
+            "Application Support",
+            "Code",
+            "User",
+            "globalStorage",
+            "saoudrizwan.claude-dev",
+            "settings",
+            "cline_mcp_settings.json",
+          ),
+        ];
+      return [
+        join(
+          xdgConfig,
+          "Code",
+          "User",
+          "globalStorage",
+          "saoudrizwan.claude-dev",
+          "settings",
+          "cline_mcp_settings.json",
+        ),
+      ];
+    }
+
+    case "cline-cli": {
+      const clineDir = process.env.CLINE_DIR ?? join(home, ".cline");
+      return [join(clineDir, "data", "settings", "cline_mcp_settings.json")];
+    }
+
+    case "zed": {
+      if (platform === "darwin")
+        return [join(home, "Library", "Application Support", "Zed", "settings.json")];
+      if (platform === "win32") return [join(appData, "Zed", "settings.json")];
+      return [join(xdgConfig, "zed", "settings.json")];
+    }
+
+    case "goose": {
+      if (platform === "win32") return [join(appData, "Block", "goose", "config", "config.yaml")];
+      return [join(xdgConfig, "goose", "config.yaml")];
+    }
+
+    case "codex": {
+      const codexHome = process.env.CODEX_HOME ?? join(home, ".codex");
+      return [join(codexHome, "config.toml")];
+    }
+
+    case "gemini-cli":
+      return [join(home, ".gemini", "settings.json")];
+
+    case "copilot": {
+      const copilotDir = process.env.XDG_CONFIG_HOME
+        ? join(process.env.XDG_CONFIG_HOME)
+        : join(home, ".copilot");
+      return [join(copilotDir, "mcp-config.json")];
+    }
+
+    case "antigravity":
+      return [join(home, ".gemini", "antigravity", "mcp_config.json")];
+
+    case "mcporter": {
+      const base = join(home, ".mcporter");
+      return [join(base, "mcporter.json"), join(base, "mcporter.jsonc")];
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Local config paths per agent (relative to cwd)
+// ---------------------------------------------------------------------------
+
+export const getLocalConfigPaths = (agent: AgentKey): string[] => {
+  switch (agent) {
+    case "opencode":
+      return ["opencode.json", "opencode.jsonc"];
+    case "claude-code":
+    case "amp":
+      return [".mcp.json"];
+    case "cursor":
+      return [".cursor/mcp.json"];
+    case "vscode":
+    case "copilot":
+      return [".vscode/mcp.json"];
+    case "cline":
+    case "cline-cli":
+      return [];
+    case "zed":
+      return [".zed/settings.json"];
+    case "codex":
+      return [".codex/config.toml"];
+    case "gemini-cli":
+      return [".gemini/settings.json"];
+    case "mcporter":
+      return ["config/mcporter.json", "config/mcporter.jsonc"];
+    default:
+      return [];
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Format detection
+// ---------------------------------------------------------------------------
+
+export const detectFormat = (filePath: string, agent: AgentKey): ConfigFormat => {
+  // Filename extension takes priority — allows drag-dropping non-default formats
+  if (filePath.endsWith(".yaml") || filePath.endsWith(".yml")) return "yaml";
+  if (filePath.endsWith(".toml")) return "toml";
+  if (filePath.endsWith(".json") || filePath.endsWith(".jsonc")) return "json";
+  // Fall back to agent-specific defaults
+  if (agent === "goose") return "yaml";
+  if (agent === "codex") return "toml";
+  return "json";
+};
+
+// ---------------------------------------------------------------------------
+// JSONC parser — two-pass: strip comments, then strip trailing commas
+// ---------------------------------------------------------------------------
+
+const stripComments = (text: string): string => {
+  let result = "";
+  let i = 0;
+  const len = text.length;
+
+  while (i < len) {
+    // String literal — pass through verbatim (don't treat // or /* inside as comments)
+    if (text[i] === '"') {
+      result += text[i++];
+      while (i < len) {
+        if (text[i] === "\\") {
+          result += text[i++];
+          if (i < len) result += text[i++];
+        } else if (text[i] === '"') {
+          result += text[i++];
+          break;
+        } else {
+          result += text[i++];
+        }
+      }
+      continue;
+    }
+
+    // Line comment — replace with newline to preserve line numbers
+    if (text[i] === "/" && text[i + 1] === "/") {
+      while (i < len && text[i] !== "\n") i++;
+      continue;
+    }
+
+    // Block comment — replace with a space
+    if (text[i] === "/" && text[i + 1] === "*") {
+      i += 2;
+      result += " ";
+      while (i < len && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i += 2;
+      continue;
+    }
+
+    result += text[i++];
+  }
+
+  return result;
+};
+
+const stripTrailingCommas = (text: string): string => {
+  let result = "";
+  let i = 0;
+  const len = text.length;
+
+  while (i < len) {
+    // String literal — pass through verbatim
+    if (text[i] === '"') {
+      result += text[i++];
+      while (i < len) {
+        if (text[i] === "\\") {
+          result += text[i++];
+          if (i < len) result += text[i++];
+        } else if (text[i] === '"') {
+          result += text[i++];
+          break;
+        } else {
+          result += text[i++];
+        }
+      }
+      continue;
+    }
+
+    // Trailing comma — look ahead through whitespace for } or ]
+    if (text[i] === ",") {
+      let j = i + 1;
+      while (j < len && /\s/.test(text[j])) j++;
+      if (j < len && (text[j] === "}" || text[j] === "]")) {
+        i++;
+        continue;
+      }
+    }
+
+    result += text[i++];
+  }
+
+  return result;
+};
+
+const stripJsoncComments = (text: string): string => stripTrailingCommas(stripComments(text));
+
+// ---------------------------------------------------------------------------
+// Parse raw content by format
+// ---------------------------------------------------------------------------
+
+const parseJson = (content: string): unknown => {
+  return JSON.parse(stripJsoncComments(content));
+};
+
+const parseYamlContent = (content: string): unknown => yamlParse(content);
+
+const parseTomlContent = (content: string): unknown => tomlParse(content);
+
+export const parseContent = async (content: string, format: ConfigFormat): Promise<unknown> => {
+  switch (format) {
+    case "json":
+      return parseJson(content);
+    case "yaml":
+      return parseYamlContent(content);
+    case "toml":
+      return parseTomlContent(content);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Detect agent from filename heuristics
+// ---------------------------------------------------------------------------
+
+export const detectAgentFromFilename = (filename: string): AgentKey | null => {
+  const lower = filename.toLowerCase();
+  if (lower === "opencode.json" || lower === "opencode.jsonc") return "opencode";
+  if (lower === ".mcp.json" || lower === "mcp.json") return "claude-code";
+  if (lower === "claude_desktop_config.json") return "claude-desktop";
+  if (lower === "cline_mcp_settings.json") return "cline";
+  if (lower === "config.toml") return "codex";
+  if (lower === "config.yaml" || lower === "config.yml") return "goose";
+  if (lower === "mcp-config.json") return "copilot";
+  if (lower === "mcp_config.json") return "antigravity";
+  if (lower === "mcporter.json" || lower === "mcporter.jsonc") return "mcporter";
+  if (lower === ".claude.json") return "claude-code";
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Detect agent from parsed content heuristics
+// ---------------------------------------------------------------------------
+
+export const detectAgentFromContent = (parsed: unknown): AgentKey | null => {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const obj = parsed as Record<string, unknown>;
+
+  if ("mcp" in obj && obj.mcp && typeof obj.mcp === "object") return "opencode";
+  if ("context_servers" in obj) return "zed";
+  if ("extensions" in obj) return "goose";
+  if ("mcp_servers" in obj) return "codex";
+  if ("servers" in obj) return "vscode";
+  if ("mcpServers" in obj) return "claude-code"; // default for mcpServers
+  return null;
+};
+
+// ---------------------------------------------------------------------------
+// Read from file path
+// ---------------------------------------------------------------------------
+
+export const readAgentConfigFile = async (
+  filePath: string,
+  agent: AgentKey,
+): Promise<NormalizedServer[]> => {
+  if (!existsSync(filePath)) {
+    throw new AgentImportError(`Config file not found: ${filePath}`);
+  }
+
+  const content = readFileSync(filePath, "utf-8");
+  return parseAgentConfigContent(content, filePath, agent);
+};
+
+// ---------------------------------------------------------------------------
+// Parse from raw content (used by web drag-drop and tests)
+// ---------------------------------------------------------------------------
+
+export const parseAgentConfigContent = async (
+  content: string,
+  filenameHint: string,
+  agentHint?: AgentKey,
+): Promise<NormalizedServer[]> => {
+  let agent = agentHint;
+
+  // Detect format from filename hint
+  const format = detectFormat(filenameHint, agent ?? "claude-code");
+
+  let parsed: unknown;
+  try {
+    parsed = await parseContent(content, format);
+  } catch (err) {
+    throw new AgentImportError(
+      `Failed to parse config file: ${err instanceof Error ? err.message : String(err)}`,
+      err,
+    );
+  }
+
+  if (!agent) {
+    const base = filenameHint.split(/[\\/]/).pop() ?? filenameHint;
+    agent = detectAgentFromFilename(base) ?? detectAgentFromContent(parsed) ?? "claude-code";
+  }
+
+  return normalizeAgentConfig(agent, parsed);
+};
+
+// ---------------------------------------------------------------------------
+// Resolve and read from agent global or local path
+// ---------------------------------------------------------------------------
+
+export interface ResolvedAgentConfig {
+  readonly filePath: string;
+  readonly agent: AgentKey;
+  readonly servers: NormalizedServer[];
+}
+
+export const findAndReadAgentConfig = async (
+  agent: AgentKey,
+  options?: { cwd?: string },
+): Promise<ResolvedAgentConfig> => {
+  const env = getCurrentPlatformEnv();
+  const cwd = options?.cwd ?? process.cwd();
+
+  // Check local paths first
+  for (const rel of getLocalConfigPaths(agent)) {
+    const full = join(cwd, rel);
+    if (existsSync(full)) {
+      const servers = await readAgentConfigFile(full, agent);
+      return { filePath: full, agent, servers };
+    }
+  }
+
+  // Then global paths
+  for (const full of getGlobalConfigPaths(agent, env)) {
+    if (existsSync(full)) {
+      const servers = await readAgentConfigFile(full, agent);
+      return { filePath: full, agent, servers };
+    }
+  }
+
+  const tried = [
+    ...getLocalConfigPaths(agent).map((p) => join(cwd, p)),
+    ...getGlobalConfigPaths(agent, env),
+  ].join(", ");
+
+  throw new AgentImportError(`No config file found for agent "${agent}". Tried: ${tried}`);
+};
+
+// ---------------------------------------------------------------------------
+// Detect all agents with an existing config file
+// ---------------------------------------------------------------------------
+
+export interface DetectedAgent {
+  readonly agent: AgentKey;
+  readonly filePath: string;
+  readonly serverCount: number;
+}
+
+const ALL_AGENTS: AgentKey[] = [
+  "opencode",
+  "claude-code",
+  "claude-desktop",
+  "amp",
+  "cursor",
+  "vscode",
+  "cline",
+  "cline-cli",
+  "zed",
+  "goose",
+  "codex",
+  "gemini-cli",
+  "copilot",
+  "antigravity",
+  "mcporter",
+];
+
+export const detectInstalledAgents = async (options?: {
+  cwd?: string;
+}): Promise<DetectedAgent[]> => {
+  const env = getCurrentPlatformEnv();
+  const cwd = options?.cwd ?? process.cwd();
+  const results: DetectedAgent[] = [];
+  const seen = new Set<string>();
+
+  for (const agent of ALL_AGENTS) {
+    const paths = [
+      ...getLocalConfigPaths(agent).map((p) => join(cwd, p)),
+      ...getGlobalConfigPaths(agent, env),
+    ];
+
+    for (const filePath of paths) {
+      if (seen.has(filePath)) continue;
+      if (!existsSync(filePath)) continue;
+      seen.add(filePath);
+      try {
+        const servers = await readAgentConfigFile(filePath, agent);
+        if (servers.length > 0) {
+          results.push({ agent, filePath, serverCount: servers.length });
+        }
+      } catch {
+        // skip unreadable files
+      }
+      break; // only first found path per agent
+    }
+  }
+
+  return results;
+};
+
+// ---------------------------------------------------------------------------
+// Re-export dirname for consumers that need it
+// ---------------------------------------------------------------------------
+export { dirname };

--- a/packages/plugins/mcp/src/sdk/agent-import/types.ts
+++ b/packages/plugins/mcp/src/sdk/agent-import/types.ts
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------
+// Agent import — shared types
+// ---------------------------------------------------------------------------
+
+export type AgentKey =
+  | "opencode"
+  | "claude-code"
+  | "claude-desktop"
+  | "amp"
+  | "cursor"
+  | "vscode"
+  | "cline"
+  | "cline-cli"
+  | "zed"
+  | "goose"
+  | "codex"
+  | "gemini-cli"
+  | "copilot"
+  | "antigravity"
+  | "mcporter";
+
+export type ConfigFormat = "json" | "yaml" | "toml";
+
+// ---------------------------------------------------------------------------
+// Normalized server — canonical intermediate representation
+// ---------------------------------------------------------------------------
+
+export type NormalizedServerConfig =
+  | {
+      readonly transport: "stdio";
+      readonly command: string;
+      readonly args?: string[];
+      readonly env?: Record<string, string>;
+      readonly cwd?: string;
+    }
+  | {
+      readonly transport: "remote";
+      readonly endpoint: string;
+      readonly headers?: Record<string, string>;
+      readonly remoteTransport?: "streamable-http" | "sse" | "auto";
+    };
+
+export interface NormalizedServer {
+  readonly suggestedNamespace: string;
+  readonly name: string;
+  readonly config: NormalizedServerConfig;
+}
+
+// ---------------------------------------------------------------------------
+// Import errors
+// ---------------------------------------------------------------------------
+
+export class AgentImportError extends Error {
+  constructor(
+    message: string,
+    override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentImportError";
+  }
+}

--- a/packages/plugins/mcp/src/sdk/index.ts
+++ b/packages/plugins/mcp/src/sdk/index.ts
@@ -1,4 +1,10 @@
-export { mcpPlugin, type McpPluginExtension } from "./plugin";
+export {
+  mcpPlugin,
+  type McpPluginExtension,
+  type McpSourceConfig,
+  type McpStdioSourceConfig,
+  type McpRemoteSourceConfig,
+} from "./plugin";
 
 export { makeKvBindingStore, type McpBindingStore, type McpStoredSource } from "./binding-store";
 export { withConfigFile } from "./config-file-store";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
         "name": "@effect/language-service"
       }
     ]
-  }
+  },
+  "exclude": ["opensrc"]
 }


### PR DESCRIPTION
Stacked on #256. **Merge #254, #255, #256 first, then retarget this PR.**

## This PR
Cleanup pass after the initial implementation.

- Drop fake `async` from parsers (all were sync already)
- Fix Copilot global config path bug (was ignoring platform, using raw `XDG_CONFIG_HOME`)
- Delete `normalizeZed` + `normalizeVSCode` (identical to `normalizeStandard`); map to shared fn
- Store parsed servers on `DetectedAgent`; CLI auto-detect no longer re-reads each file
- `importFromAgent` handler uses `Effect.try` + `toSourceConfig` instead of inline duplication
- Add `opensrc/` to `.gitignore`, `tsconfig` exclude, and `oxlint` ignorePatterns

## Stack
1. feat(mcp): SDK module (#254)
2. feat(mcp): API endpoints (#255)
3. feat(mcp): CLI + offline import (#256)
4. **refactor(import): cleanup** ← this PR