### PR TITLE
[codex] Avoid duplicate built-in source badge

### DIFF
--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -149,7 +149,7 @@ export function SourceDetailPage(props: { namespace: string }) {
           <h2 className="truncate text-sm font-semibold text-foreground">
             {sourceData?.name ?? namespace}
           </h2>
-          {sourceData?.runtime && (
+          {sourceData?.runtime && sourceData?.kind !== "built-in" && (
             <Badge className="bg-muted text-muted-foreground">built-in</Badge>
           )}
           <Badge variant="secondary">{sourceData?.kind ?? "source"}</Badge>

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -434,7 +434,9 @@ function SourceGrid(props: {
                       <SummaryComponent sourceId={s.id} />
                     </Suspense>
                   )}
-                  {s.runtime && <Badge className="bg-muted text-muted-foreground">built-in</Badge>}
+                  {s.runtime && s.kind !== "built-in" && (
+                    <Badge className="bg-muted text-muted-foreground">built-in</Badge>
+                  )}
                   <Badge variant="secondary">{s.kind}</Badge>
                 </CardStackEntryActions>
               </Link>


### PR DESCRIPTION
## What changed
- removed the duplicate `built-in` badge from the sources list row when the source kind already renders `built-in`
- removed the duplicate `built-in` badge from the source detail header for the same case

### After

<img width="307" height="100" alt="image" src="https://github.com/user-attachments/assets/13fa6521-9e25-4f7e-8935-b46874a4145f" />

### Before
<img width="868" height="216" alt="CleanShot 2026-04-15 at 08 23 59@2x" src="https://github.com/user-attachments/assets/df157d2d-94cd-4d25-8484-aa02a0e47ff4" />


## Why
The UI was rendering two adjacent `built-in` chips for built-in sources because it showed:
- a runtime badge when `runtime === true`
- a kind badge when `kind === "built-in"`

This PR keeps the runtime badge behavior for non-built-in runtime sources, but suppresses the extra chip when the kind already conveys the same label.

## Impact
Built-in sources now show a single `built-in` badge in the header and source list entry instead of a duplicated chip.

## Validation
- `bun run --cwd packages/react typecheck` in the main workspace
- verified locally with the `playwriter` CLI against `apps/local` at `http://127.0.0.1:4113/sources/built-in`
