### PR TITLE
Allow "Remote"-ing to Executor Web Dashboard

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -111,11 +111,12 @@ const makeApiClient = (baseUrl: string) =>
 // Foreground session
 // ---------------------------------------------------------------------------
 
-const runForegroundSession = (input: { port: number; hostname: string; noCors: boolean }) =>
+const runForegroundSession = (input: { port: number; hostname: string; exposed: boolean }) =>
   Effect.gen(function* () {
-    const server = yield* Effect.promise(() => startServer({ port: input.port, hostname: input.hostname, disableHostCheck: input.noCors, embeddedWebUI }));
+    const hostname = input.exposed ? "0.0.0.0" : input.hostname;
+    const server = yield* Effect.promise(() => startServer({ port: input.port, hostname, disableHostCheck: input.exposed, embeddedWebUI }));
 
-    const baseUrl = `http://${input.hostname}:${server.port}`;
+    const baseUrl = `http://${hostname}:${server.port}`;
     console.log(`Executor is ready.`);
     console.log(`Web:     ${baseUrl}`);
     console.log(`MCP:     ${baseUrl}/mcp`);
@@ -263,13 +264,13 @@ const webCommand = Command.make(
   {
     port: Options.integer("port").pipe(Options.withDefault(DEFAULT_PORT)),
     hostname: Options.text("hostname").pipe(Options.withDefault("127.0.0.1")),
-    noCors: Options.boolean("no-cors").pipe(Options.withDefault(false)),
+    exposed: Options.boolean("exposed").pipe(Options.withDefault(false)),
     scope,
   },
-  ({ port, scope, hostname, noCors }) =>
+  ({ port, scope, hostname, exposed }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      yield* runForegroundSession({ port, hostname, noCors });
+      yield* runForegroundSession({ port, hostname, exposed });
     }),
 ).pipe(Command.withDescription("Start a foreground web session"));
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -111,11 +111,11 @@ const makeApiClient = (baseUrl: string) =>
 // Foreground session
 // ---------------------------------------------------------------------------
 
-const runForegroundSession = (input: { port: number }) =>
+const runForegroundSession = (input: { port: number; hostname: string; noCors: boolean }) =>
   Effect.gen(function* () {
-    const server = yield* Effect.promise(() => startServer({ port: input.port, embeddedWebUI }));
+    const server = yield* Effect.promise(() => startServer({ port: input.port, hostname: input.hostname, disableHostCheck: input.noCors, embeddedWebUI }));
 
-    const baseUrl = `http://localhost:${server.port}`;
+    const baseUrl = `http://${input.hostname}:${server.port}`;
     console.log(`Executor is ready.`);
     console.log(`Web:     ${baseUrl}`);
     console.log(`MCP:     ${baseUrl}/mcp`);
@@ -262,12 +262,14 @@ const webCommand = Command.make(
   "web",
   {
     port: Options.integer("port").pipe(Options.withDefault(DEFAULT_PORT)),
+    hostname: Options.text("hostname").pipe(Options.withDefault("127.0.0.1")),
+    noCors: Options.boolean("no-cors").pipe(Options.withDefault(false)),
     scope,
   },
-  ({ port, scope }) =>
+  ({ port, scope, hostname, noCors }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      yield* runForegroundSession({ port });
+      yield* runForegroundSession({ port, hostname, noCors });
     }),
 ).pipe(Command.withDescription("Start a foreground web session"));
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -111,16 +111,36 @@ const makeApiClient = (baseUrl: string) =>
 // Foreground session
 // ---------------------------------------------------------------------------
 
-const runForegroundSession = (input: { port: number; hostname: string; exposed: boolean }) =>
+const runForegroundSession = (input: {
+  port: number;
+  hostname: string;
+  allowedHosts: ReadonlyArray<string>;
+}) =>
   Effect.gen(function* () {
-    const hostname = input.exposed ? "0.0.0.0" : input.hostname;
-    const server = yield* Effect.promise(() => startServer({ port: input.port, hostname, disableHostCheck: input.exposed, embeddedWebUI }));
+    const server = yield* Effect.promise(() =>
+      startServer({
+        port: input.port,
+        hostname: input.hostname,
+        allowedHosts: input.allowedHosts,
+        embeddedWebUI,
+      }),
+    );
 
-    const baseUrl = `http://${hostname}:${server.port}`;
+    const displayHost =
+      input.hostname === "0.0.0.0" || input.hostname === "::" ? "localhost" : input.hostname;
+    const baseUrl = `http://${displayHost}:${server.port}`;
     console.log(`Executor is ready.`);
     console.log(`Web:     ${baseUrl}`);
     console.log(`MCP:     ${baseUrl}/mcp`);
     console.log(`OpenAPI: ${baseUrl}/api/docs`);
+    if (input.hostname !== "127.0.0.1" && input.hostname !== "localhost") {
+      console.log(
+        `\n⚠  Listening on ${input.hostname}. Executor runs arbitrary commands — only expose on trusted networks.`,
+      );
+      if (input.allowedHosts.length > 0) {
+        console.log(`   Extra allowed Host headers: ${input.allowedHosts.join(", ")}`);
+      }
+    }
     console.log(`\nPress Ctrl+C to stop.`);
 
     yield* waitForShutdownSignal();
@@ -263,14 +283,22 @@ const webCommand = Command.make(
   "web",
   {
     port: Options.integer("port").pipe(Options.withDefault(DEFAULT_PORT)),
-    hostname: Options.text("hostname").pipe(Options.withDefault("127.0.0.1")),
-    exposed: Options.boolean("exposed").pipe(Options.withDefault(false)),
+    hostname: Options.text("hostname")
+      .pipe(Options.withDefault("127.0.0.1"))
+      .pipe(Options.withDescription("Bind address. Use 0.0.0.0 to listen on all interfaces.")),
+    allowedHost: Options.text("allowed-host")
+      .pipe(Options.repeated)
+      .pipe(
+        Options.withDescription(
+          "Additional hostname permitted in the Host header (repeatable). localhost/127.0.0.1 are always allowed.",
+        ),
+      ),
     scope,
   },
-  ({ port, scope, hostname, exposed }) =>
+  ({ port, scope, hostname, allowedHost }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      yield* runForegroundSession({ port, hostname, exposed });
+      yield* runForegroundSession({ port, hostname, allowedHosts: allowedHost });
     }),
 ).pipe(Command.withDescription("Start a foreground web session"));
 

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -76,6 +76,8 @@ export interface StartServerOptions {
   clientDir?: string;
   /** Embedded web UI map from compiled binary (path → bunfs path). Overrides clientDir. */
   embeddedWebUI?: Record<string, string> | null;
+  hostname?: string;
+  disableHostCheck?: boolean;
 }
 
 export interface ServerInstance {
@@ -85,6 +87,7 @@ export interface ServerInstance {
 
 export async function startServer(opts: StartServerOptions = {}): Promise<ServerInstance> {
   const port = opts.port ?? parseInt(process.env.PORT ?? "4788", 10);
+  const hostname = opts.hostname ?? "127.0.0.1";
   const clientDir = opts.clientDir ?? resolve(import.meta.dirname, "../dist");
 
   const handlers = await getServerHandlers();
@@ -105,13 +108,13 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
 
   const server = Bun.serve({
     port,
-    hostname: "127.0.0.1",
+    hostname,
     // Disable Bun's default 10s idle timeout. MCP elicitation and pause/resume
     // can idle longer during human approval; `0` disables the socket timeout.
     idleTimeout: 0,
     routes: { ...staticRoutes },
     async fetch(req) {
-      if (!isAllowedHost(req)) {
+      if (!opts.disableHostCheck && !isAllowedHost(req)) {
         return new Response("Forbidden", { status: 403 });
       }
 

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -15,13 +15,13 @@ import { getServerHandlers } from "./server/main";
 // Host allowlist
 // ---------------------------------------------------------------------------
 
-const ALLOWED_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+const DEFAULT_ALLOWED_HOSTS = ["localhost", "127.0.0.1", "[::1]", "::1"];
 
-const isAllowedHost = (request: Request): boolean => {
+const makeIsAllowedHost = (allowed: ReadonlySet<string>) => (request: Request): boolean => {
   const host = request.headers.get("host");
   if (!host) return true;
   const hostname = host.replace(/:\d+$/, "");
-  return ALLOWED_HOSTS.has(hostname);
+  return allowed.has(hostname);
 };
 
 // ---------------------------------------------------------------------------
@@ -76,8 +76,10 @@ export interface StartServerOptions {
   clientDir?: string;
   /** Embedded web UI map from compiled binary (path → bunfs path). Overrides clientDir. */
   embeddedWebUI?: Record<string, string> | null;
+  /** Bind address. Defaults to 127.0.0.1. Use 0.0.0.0 to listen on all interfaces. */
   hostname?: string;
-  disableHostCheck?: boolean;
+  /** Extra hostnames permitted in the Host header, on top of localhost/127.0.0.1. */
+  allowedHosts?: ReadonlyArray<string>;
 }
 
 export interface ServerInstance {
@@ -88,6 +90,8 @@ export interface ServerInstance {
 export async function startServer(opts: StartServerOptions = {}): Promise<ServerInstance> {
   const port = opts.port ?? parseInt(process.env.PORT ?? "4788", 10);
   const hostname = opts.hostname ?? "127.0.0.1";
+  const allowedHostSet = new Set<string>([...DEFAULT_ALLOWED_HOSTS, ...(opts.allowedHosts ?? [])]);
+  const isAllowedHost = makeIsAllowedHost(allowedHostSet);
   const clientDir = opts.clientDir ?? resolve(import.meta.dirname, "../dist");
 
   const handlers = await getServerHandlers();
@@ -114,7 +118,7 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
     idleTimeout: 0,
     routes: { ...staticRoutes },
     async fetch(req) {
-      if (!opts.disableHostCheck && !isAllowedHost(req)) {
+      if (!isAllowedHost(req)) {
         return new Response("Forbidden", { status: 403 });
       }
 


### PR DESCRIPTION
## What Changed

Added `--hostname` and `--exposed` CLI flags to `executor web`:

- `--hostname <addr>` changes the `Bun.serve` bind address (default: `127.0.0.1`)
- `--exposed` binds to `0.0.0.0` and disables the host allowlist check, allowing remote access from non localhost clients

## Why

When running `executor web` in Docker or on a remote machine (ex. trying to access over Tailscale), the server needs to bind to `0.0.0.0` instead of `127.0.0.1`, and the `isAllowedHost` check must be bypassed since non localhost `Host` headers get rejected with `403`.

## Impact

Two files changed:

- `apps/local/src/serve.ts`
  - Added `hostname` and `disableHostCheck` to `StartServerOptions`
  - Used in `Bun.serve()` and host check logic

- `apps/cli/src/main.ts`
  - Added `--hostname` and `--exposed` flags to the `web` command
  - Wired through to `startServer()`

Default behavior unchanged: `executor web` with no flags behaves identically to upstream.

## Validation

- `bun vitest run`
  - 141/143 tests passing
  - 2 pre existing failures in preset icon tests (unrelated)

- `bun run apps/cli/src/main.ts web --help`
  - Shows `--hostname` and `--exposed`

- `executor web --exposed`
  - Binds to `0.0.0.0`
  - Non localhost `Host` headers return `200`

- `executor web`
  - Binds to `127.0.0.1`
  - Non localhost `Host` headers return `403`
  
  
## Notes
This PR was vibe-coded with with Opencode + Oh-my-Openagent + GLM-5.1 / GLM-5-Turbo.

The `--hostname` flag might not be necessary. If you are going to host this on a custom domain / IP, you could instead use the `--exposed` flag, then containerize + reverse proxy, etc., instead of putting that burden on this repo / maintainers moving forward. 

I am not that familiar with networking stuff so correct me if I am wrong here...

Feel free to checkout the branch and push changes accordingly.