### PR TITLE
Add totalSources to tools.executor.sources.list() output

### DIFF
--- a/packages/core/execution/src/description.ts
+++ b/packages/core/execution/src/description.ts
@@ -36,7 +36,7 @@ const formatDescription = (namespaces: readonly string[], sources: readonly Sour
     "",
     "- `tools.search()` returns ranked matches, best-first. Use short intent phrases like `github issues`, `repo details`, or `create calendar event`.",
     '- When you already know the namespace, narrow with `tools.search({ namespace: "github", query: "issues" })`.',
-    "- Use `tools.executor.sources.list()` to inspect configured sources and their tool counts. Returns `[{ id, toolCount, ... }]`.",
+    "- Use `tools.executor.sources.list()` to inspect configured sources and their tool counts. Returns `{ sources: [{ id, toolCount, ... }], totalSources }`.",
     "- Always use the namespace prefix when calling tools: `tools.<namespace>.<tool>(args)`. Example: `tools.home_assistant_rest_api.states.getState(...)` — not `tools.states.getState(...)`.",
     "- The `tools` object is a lazy proxy — `Object.keys(tools)` won't work. Use `tools.search()` or `tools.executor.sources.list()` instead.",
     '- Pass an object to system tools, e.g. `tools.search({ query: "..." })`, `tools.executor.sources.list()`, and `tools.describe.tool({ path })`.',

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -170,12 +170,13 @@ describe("tool discovery", () => {
         }),
       );
       expect(listed.error).toBeUndefined();
-      expect(listed.result).toEqual(
-        expect.arrayContaining([
+      expect(listed.result).toEqual({
+        sources: expect.arrayContaining([
           expect.objectContaining({ id: "github", toolCount: 3 }),
           expect.objectContaining({ id: "crm", toolCount: 2 }),
         ]),
-      );
+        totalSources: 2,
+      });
 
       const searched = yield* Effect.promise(() =>
         createExecutionEngine({ executor }).execute(

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -65,6 +65,11 @@ export type ExecutorSourceListItem = {
   readonly toolCount: number;
 };
 
+export type ExecutorSourceListResult = {
+  readonly sources: readonly ExecutorSourceListItem[];
+  readonly totalSources: number;
+};
+
 type SearchableTool = Pick<Tool, "id" | "sourceId" | "name" | "description">;
 
 type PreparedField = {
@@ -270,7 +275,7 @@ export const searchTools = (
 export const listExecutorSources = (
   executor: Executor,
   options?: { readonly query?: string; readonly limit?: number },
-): Effect.Effect<ReadonlyArray<ExecutorSourceListItem>> =>
+): Effect.Effect<ExecutorSourceListResult> =>
   Effect.gen(function* () {
     const normalizedQuery = normalizeSearchText(options?.query ?? "");
     const limit = options?.limit ?? 200;
@@ -304,9 +309,10 @@ export const listExecutorSources = (
         }) satisfies ExecutorSourceListItem,
     );
 
-    return withCounts
+    const sortedWithCounts = withCounts
       .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id))
       .slice(0, limit);
+    return { sources: sortedWithCounts, totalSources: withCounts.length };
   });
 
 /** What `tools.describe.tool()` calls inside the sandbox. */


### PR DESCRIPTION
## Why

`tools.executor.sources.list()` returns a paginated list (default 12). 

When a user has more than 12 sources, the model mistakes that first page for the full list.

I hit this myself: a source I'd just registered was at alphabetical position 13, so `sources.list()` never returned it and I spent a while debugging a "missing" source that was there the whole time.

## What

Change the return shape from `ExecutorSourceListItem[]` to `{ sources, totalSources }`. `totalSources` is the count after filtering but before the limit is applied.

Computing it is free given the full filtered+counted list is already materialized before `.slice(0, limit)`.