### PR TITLE
Fix OpenAI and Sentry icons in popular OpenAPI presets

### DIFF
--- a/apps/cloud/src/mcp-session.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-session.e2e.node.test.ts
@@ -124,8 +124,6 @@ const buildScopedExecutor = (
     return yield* createExecutor({ scope, adapter, blobs, plugins });
   });
 
-type McpSession = { readonly client: Client };
-
 // Builds a scope, wires a real execution engine + MCP server, and yields
 // them connected to an in-memory MCP client. Shaped as an acquireRelease so
 // the transport teardown is guaranteed when the test scope closes.

--- a/packages/plugins/openapi/src/sdk/presets.ts
+++ b/packages/plugins/openapi/src/sdk/presets.ts
@@ -53,6 +53,7 @@ export const openApiPresets: readonly OpenApiPreset[] = [
     name: "OpenAI",
     summary: "Models, files, responses, and fine-tuning.",
     url: "https://app.stainless.com/api/spec/documented/openai/openapi.documented.yml",
+    icon: "https://openai.com/favicon.ico",
     featured: true,
   },
   {
@@ -60,7 +61,7 @@ export const openApiPresets: readonly OpenApiPreset[] = [
     name: "Sentry",
     summary: "Error tracking, performance monitoring, and releases.",
     url: "https://raw.githubusercontent.com/getsentry/sentry-api-schema/main/openapi-derefed.json",
-    icon: "https://sentry.io/favicon.ico",
+    icon: "https://sentry-brand.storage.googleapis.com/sentry-glyph-black.png",
     featured: true,
   },
   {


### PR DESCRIPTION
## Summary
- Add missing favicon for OpenAI preset
- Swap Sentry icon from `sentry.io/favicon.ico` to the official brand glyph (the favicon was rendering poorly)