### PR TITLE
fix(openapi): use Workers-native fetch for spec URLs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -669,7 +669,6 @@
       "name": "@executor/plugin-openapi",
       "version": "0.0.1",
       "dependencies": {
-        "@apidevtools/swagger-parser": "^12.1.0",
         "@effect/platform": "catalog:",
         "@effect/platform-node": "catalog:",
         "@executor/config": "workspace:*",
@@ -840,13 +839,7 @@
 
     "@antfu/ni": ["@antfu/ni@0.23.2", "", { "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nu": "bin/nu.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs" } }, "sha512-FSEVWXvwroExDXUu8qV6Wqp2X3D1nJ0Li4LFymCyvCVrm7I3lNfG0zZWSWvGU1RE7891eTnFTyh31L3igOwNKQ=="],
 
-    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@14.0.1", "", { "dependencies": { "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw=="],
-
-    "@apidevtools/openapi-schemas": ["@apidevtools/openapi-schemas@2.1.0", "", {}, "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="],
-
-    "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
-
-    "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@12.1.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "14.0.1", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng=="],
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
 
     "@astrojs/cloudflare": ["@astrojs/cloudflare@13.1.10", "", { "dependencies": { "@astrojs/internal-helpers": "0.8.0", "@astrojs/underscore-redirects": "1.0.3", "@cloudflare/vite-plugin": "^1.25.6", "piccolore": "^0.1.3", "tinyglobby": "^0.2.15", "vite": "^7.3.1" }, "peerDependencies": { "astro": "^6.0.0", "wrangler": "^4.61.1" } }, "sha512-Ogl8p4MifPMHbpHKJL78eqEL+I3wbHrYmo83P/FkKZQ9VzzKi2A1RjnbaiiPAwrA8xQOqIUo4zlN7+Mse0aJAQ=="],
 
@@ -2380,8 +2373,6 @@
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
-    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
-
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ajv-keywords": ["ajv-keywords@3.5.2", "", { "peerDependencies": { "ajv": "^6.9.1" } }, "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="],
@@ -2553,8 +2544,6 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
-
-    "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -5125,8 +5114,6 @@
     "ink-confirm-input/ink-text-input": ["ink-text-input@3.3.0", "", { "dependencies": { "chalk": "^3.0.0", "prop-types": "^15.5.10" }, "peerDependencies": { "ink": "^2.0.0", "react": "^16.5.2" } }, "sha512-gO4wrOf2ie3YuEARTIwGlw37lMjFn3Gk6CKIDrMlHb46WFMagZU7DplohjM24zynlqfnXA5UDEIfC2NBcvD8kg=="],
 
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
-
-    "json-schema-to-typescript/@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -47,7 +47,6 @@
     "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@apidevtools/swagger-parser": "^12.1.0",
     "@effect/platform": "catalog:",
     "@effect/platform-node": "catalog:",
     "@executor/config": "workspace:*",

--- a/packages/plugins/openapi/src/sdk/parse.ts
+++ b/packages/plugins/openapi/src/sdk/parse.ts
@@ -1,38 +1,80 @@
-import SwaggerParser from "@apidevtools/swagger-parser";
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
-import { Effect } from "effect";
+import { Duration, Effect } from "effect";
+import { HttpClient, HttpClientRequest } from "@effect/platform";
+import YAML from "yaml";
 
-import { OpenApiParseError } from "./errors";
+import { OpenApiExtractionError, OpenApiParseError } from "./errors";
 
 export type ParsedDocument = OpenAPIV3.Document | OpenAPIV3_1.Document;
 
-/** Parse, validate, and bundle an OpenAPI document from text or URL */
-export const parse = Effect.fn("OpenApi.parse")(function* (input: string) {
-  const api: OpenAPI.Document = yield* Effect.tryPromise({
-    try: async () => {
-      const source =
-        input.startsWith("http://") || input.startsWith("https://")
-          ? input
-          : parseTextToObject(input);
+// ExtractionError subclass raised from parse() for non-3.x specs
+class OpenApiExtractionErrorFromParse extends OpenApiExtractionError {}
 
-      // Try full bundle first (resolves $refs cleanly)
-      try {
-        return await SwaggerParser.bundle(source);
-      } catch {
-        // Bundle failed (broken $refs) — parse without ref resolution,
-        // then manually resolve valid refs and strip broken ones
-        const parsed = (await SwaggerParser.parse(source)) as OpenAPI.Document;
-        resolveRefsInPlace(parsed);
-        return parsed;
-      }
-    },
+/**
+ * Fetch an OpenAPI spec URL and return its body text. Uses the Effect
+ * HttpClient so the caller chooses the transport via layer — in Cloudflare
+ * Workers, `FetchHttpClient.layer` binds to the Workers-native `fetch` and
+ * avoids json-schema-ref-parser's Node-polyfill http resolver, which hangs
+ * in production. Bounded by a 20s timeout.
+ */
+export const fetchSpecText = Effect.fn("OpenApi.fetchSpecText")(function* (url: string) {
+  const client = yield* HttpClient.HttpClient;
+  const response = yield* client
+    .execute(
+      HttpClientRequest.get(url).pipe(
+        HttpClientRequest.setHeader("Accept", "application/json, application/yaml, text/yaml, */*"),
+      ),
+    )
+    .pipe(
+      Effect.timeout(Duration.seconds(20)),
+      Effect.mapError(
+        (cause) =>
+          new OpenApiParseError({
+            message: `Failed to fetch OpenAPI document: ${cause instanceof Error ? cause.message : String(cause)}`,
+          }),
+      ),
+    );
+  if (response.status < 200 || response.status >= 300) {
+    return yield* new OpenApiParseError({
+      message: `Failed to fetch OpenAPI document: HTTP ${response.status}`,
+    });
+  }
+  return yield* response.text.pipe(
+    Effect.mapError(
+      (cause) =>
+        new OpenApiParseError({
+          message: `Failed to read OpenAPI document body: ${cause instanceof Error ? cause.message : String(cause)}`,
+        }),
+    ),
+  );
+});
+
+/**
+ * Resolve an input string to spec text — if it's a URL, fetch it via
+ * HttpClient; otherwise return it as-is.
+ */
+export const resolveSpecText = (input: string) =>
+  input.startsWith("http://") || input.startsWith("https://")
+    ? fetchSpecText(input)
+    : Effect.succeed(input);
+
+/**
+ * Parse an OpenAPI document from spec text and validate it's OpenAPI 3.x.
+ *
+ * NOTE: does NOT resolve `$ref`s. `DocResolver` + `normalizeOpenApiRefs`
+ * downstream work on refs lazily, so inlining them here would just waste
+ * memory — and for big specs (e.g. Cloudflare's API) that blows through
+ * the 128MB Cloudflare Workers memory cap.
+ */
+export const parse = Effect.fn("OpenApi.parse")(function* (text: string) {
+  const api = yield* Effect.try({
+    try: () => parseTextToObject(text),
     catch: (error) =>
       new OpenApiParseError({
         message: `Failed to parse OpenAPI document: ${error instanceof Error ? error.message : String(error)}`,
       }),
   });
 
-  // Ensure it's OpenAPI 3.x (not Swagger 2)
   if (!isOpenApi3(api)) {
     return yield* new OpenApiExtractionErrorFromParse({
       message:
@@ -46,12 +88,6 @@ export const parse = Effect.fn("OpenApi.parse")(function* (input: string) {
 // ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
-
-import YAML from "yaml";
-import { OpenApiExtractionError } from "./errors";
-
-// swagger-parser's dereference needs a tagged error for this path
-class OpenApiExtractionErrorFromParse extends OpenApiExtractionError {}
 
 const isOpenApi3 = (doc: OpenAPI.Document): doc is OpenAPIV3.Document | OpenAPIV3_1.Document =>
   "openapi" in doc && typeof doc.openapi === "string" && doc.openapi.startsWith("3.");
@@ -73,89 +109,3 @@ const parseTextToObject = (text: string): OpenAPI.Document => {
 
   return parsed as OpenAPI.Document;
 };
-
-// ---------------------------------------------------------------------------
-// Manual $ref resolver — resolves valid refs in-place, strips broken ones
-// ---------------------------------------------------------------------------
-
-/**
- * Walk the document tree and resolve `$ref` pointers that point to
- * `#/components/...` paths. Valid refs are inlined (deep-cloned to
- * avoid shared references). Broken refs are replaced with a
- * placeholder. Circular `$ref`s (a schema referencing itself) are
- * left as-is to avoid creating circular object graphs.
- */
-const resolveRefsInPlace = (doc: OpenAPI.Document): void => {
-  const lookup = (pointer: string): unknown | undefined => {
-    if (!pointer.startsWith("#/")) return undefined;
-    const parts = pointer.slice(2).split("/");
-    let current: unknown = doc;
-    for (const part of parts) {
-      if (typeof current !== "object" || current === null) return undefined;
-      current = (current as Record<string, unknown>)[part];
-    }
-    return current;
-  };
-
-  // Track which $ref pointers are currently being resolved to detect cycles
-  const resolving = new Set<string>();
-
-  const resolveRef = (pointer: string): unknown | undefined => {
-    if (resolving.has(pointer)) return undefined; // circular — leave as $ref
-    const target = lookup(pointer);
-    if (!target) return undefined;
-    resolving.add(pointer);
-    const cloned = deepClone(target);
-    walk(cloned);
-    resolving.delete(pointer);
-    return cloned;
-  };
-
-  const deepClone = (obj: unknown): unknown => {
-    if (!obj || typeof obj !== "object") return obj;
-    if (Array.isArray(obj)) return obj.map(deepClone);
-    const result: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-      result[k] = deepClone(v);
-    }
-    return result;
-  };
-
-  const walk = (obj: unknown): void => {
-    if (!obj || typeof obj !== "object") return;
-
-    if (Array.isArray(obj)) {
-      for (let i = 0; i < obj.length; i++) {
-        const item = obj[i];
-        if (isRef(item)) {
-          const resolved = resolveRef(item.$ref);
-          if (resolved) obj[i] = resolved;
-          else obj[i] = { description: `Unresolved: ${item.$ref}` };
-        } else {
-          walk(item);
-        }
-      }
-      return;
-    }
-
-    const record = obj as Record<string, unknown>;
-    for (const [k, v] of Object.entries(record)) {
-      if (k === "$ref") continue;
-      if (isRef(v)) {
-        const resolved = resolveRef(v.$ref);
-        if (resolved) record[k] = resolved;
-        else record[k] = { description: `Unresolved: ${v.$ref}` };
-      } else {
-        walk(v);
-      }
-    }
-  };
-
-  walk(doc);
-};
-
-const isRef = (v: unknown): v is { $ref: string } =>
-  typeof v === "object" &&
-  v !== null &&
-  "$ref" in v &&
-  typeof (v as Record<string, unknown>).$ref === "string";

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -29,7 +29,7 @@ import {
 } from "@executor/config";
 
 import { OpenApiOAuthError } from "./errors";
-import { parse } from "./parse";
+import { parse, resolveSpecText } from "./parse";
 import { extract } from "./extract";
 import { compileToolDefinitions, type ToolDefinition } from "./definitions";
 import {
@@ -242,94 +242,103 @@ export const openApiPlugin = definePlugin(
             .pipe(Effect.map((ref) => ({ id: ref.id as string })));
 
         const addSpecInternal = (config: OpenApiSpecConfig) =>
-          ctx.transaction(
-            Effect.gen(function* () {
-              const doc = yield* parse(config.spec);
-              const result = yield* extract(doc);
+          Effect.gen(function* () {
+            // Resolve URL → text and parse BEFORE opening a transaction.
+            // Holding `BEGIN` on the pool=1 Postgres connection across a
+            // network fetch is the Hyperdrive deadlock path in production.
+            const specText = yield* resolveSpecText(config.spec).pipe(
+              Effect.provide(httpClientLayer),
+            );
+            const doc = yield* parse(specText);
+            const result = yield* extract(doc);
 
-              const namespace =
-                config.namespace ??
-                Option.getOrElse(result.title, () => "api")
-                  .toLowerCase()
-                  .replace(/[^a-z0-9]+/g, "_");
+            const namespace =
+              config.namespace ??
+              Option.getOrElse(result.title, () => "api")
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, "_");
 
-              const hoistedDefs: Record<string, unknown> = {};
-              if (doc.components?.schemas) {
-                for (const [k, v] of Object.entries(doc.components.schemas)) {
-                  hoistedDefs[k] = normalizeOpenApiRefs(v);
-                }
+            const hoistedDefs: Record<string, unknown> = {};
+            if (doc.components?.schemas) {
+              for (const [k, v] of Object.entries(doc.components.schemas)) {
+                hoistedDefs[k] = normalizeOpenApiRefs(v);
               }
+            }
 
-              const baseUrl = config.baseUrl ?? resolveBaseUrl(result.servers);
-              const oauth2 = config.oauth2 ?? undefined;
-              const invocationConfig = new InvocationConfig({
-                baseUrl,
-                headers: config.headers ?? {},
-                oauth2: oauth2 ? Option.some(oauth2) : Option.none(),
-              });
+            const baseUrl = config.baseUrl ?? resolveBaseUrl(result.servers);
+            const oauth2 = config.oauth2 ?? undefined;
+            const invocationConfig = new InvocationConfig({
+              baseUrl,
+              headers: config.headers ?? {},
+              oauth2: oauth2 ? Option.some(oauth2) : Option.none(),
+            });
 
-              const definitions = compileToolDefinitions(result.operations);
-              const sourceName =
-                config.name ?? Option.getOrElse(result.title, () => namespace);
+            const definitions = compileToolDefinitions(result.operations);
+            const sourceName =
+              config.name ?? Option.getOrElse(result.title, () => namespace);
 
-              const sourceConfig: SourceConfig = {
-                spec: config.spec,
-                baseUrl: config.baseUrl,
-                namespace: config.namespace,
-                headers: config.headers,
-                oauth2,
-              };
+            const sourceConfig: SourceConfig = {
+              spec: config.spec,
+              baseUrl: config.baseUrl,
+              namespace: config.namespace,
+              headers: config.headers,
+              oauth2,
+            };
 
-              const storedSource: StoredSource = {
-                namespace,
-                name: sourceName,
-                config: sourceConfig,
-                invocationConfig,
-              };
+            const storedSource: StoredSource = {
+              namespace,
+              name: sourceName,
+              config: sourceConfig,
+              invocationConfig,
+            };
 
-              const storedOps: StoredOperation[] = definitions.map((def) => ({
-                toolId: `${namespace}.${def.toolPath}`,
-                sourceId: namespace,
-                binding: toBinding(def),
-              }));
+            const storedOps: StoredOperation[] = definitions.map((def) => ({
+              toolId: `${namespace}.${def.toolPath}`,
+              sourceId: namespace,
+              binding: toBinding(def),
+            }));
 
-              yield* ctx.storage.upsertSource(storedSource, storedOps);
+            yield* ctx.transaction(
+              Effect.gen(function* () {
+                yield* ctx.storage.upsertSource(storedSource, storedOps);
 
-              yield* ctx.core.sources.register({
-                id: namespace,
-                kind: "openapi",
-                name: sourceName,
-                url: baseUrl || undefined,
-                canRemove: true,
-                canRefresh: false,
-                canEdit: true,
-                tools: definitions.map((def) => ({
-                  name: def.toolPath,
-                  description: descriptionFor(def),
-                  inputSchema: normalizeOpenApiRefs(
-                    Option.getOrUndefined(def.operation.inputSchema),
-                  ),
-                  outputSchema: normalizeOpenApiRefs(
-                    Option.getOrUndefined(def.operation.outputSchema),
-                  ),
-                })),
-              });
-
-              if (Object.keys(hoistedDefs).length > 0) {
-                yield* ctx.core.definitions.register({
-                  sourceId: namespace,
-                  definitions: hoistedDefs,
+                yield* ctx.core.sources.register({
+                  id: namespace,
+                  kind: "openapi",
+                  name: sourceName,
+                  url: baseUrl || undefined,
+                  canRemove: true,
+                  canRefresh: false,
+                  canEdit: true,
+                  tools: definitions.map((def) => ({
+                    name: def.toolPath,
+                    description: descriptionFor(def),
+                    inputSchema: normalizeOpenApiRefs(
+                      Option.getOrUndefined(def.operation.inputSchema),
+                    ),
+                    outputSchema: normalizeOpenApiRefs(
+                      Option.getOrUndefined(def.operation.outputSchema),
+                    ),
+                  })),
                 });
-              }
 
-              return { sourceId: namespace, toolCount: definitions.length };
-            }),
-          );
+                if (Object.keys(hoistedDefs).length > 0) {
+                  yield* ctx.core.definitions.register({
+                    sourceId: namespace,
+                    definitions: hoistedDefs,
+                  });
+                }
+              }),
+            );
+
+            return { sourceId: namespace, toolCount: definitions.length };
+          });
 
         const configFile = options?.configFile;
 
         return {
-          previewSpec: (specText) => previewSpec(specText),
+          previewSpec: (specText) =>
+            previewSpec(specText).pipe(Effect.provide(httpClientLayer)),
 
           addSpec: (config) =>
             Effect.gen(function* () {
@@ -680,7 +689,12 @@ export const openApiPlugin = definePlugin(
             Effect.option,
           );
           if (parsed._tag === "None") return null;
-          const doc = yield* parse(trimmed).pipe(
+          const specText = yield* resolveSpecText(trimmed).pipe(
+            Effect.provide(httpClientLayer),
+            Effect.catchAll(() => Effect.succeed(null)),
+          );
+          if (specText === null) return null;
+          const doc = yield* parse(specText).pipe(
             Effect.catchAll(() => Effect.succeed(null)),
           );
           if (!doc) return null;

--- a/packages/plugins/openapi/src/sdk/preview-oauth2.test.ts
+++ b/packages/plugins/openapi/src/sdk/preview-oauth2.test.ts
@@ -9,8 +9,12 @@
 
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
+import { FetchHttpClient } from "@effect/platform";
 
-import { previewSpec } from "./preview";
+import { previewSpec as previewSpecRaw } from "./preview";
+
+const previewSpec = (input: string) =>
+  previewSpecRaw(input).pipe(Effect.provide(FetchHttpClient.layer));
 
 const minimalSpec = (
   securitySchemes: Record<string, unknown>,

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -1,7 +1,7 @@
 import { Effect, Option } from "effect";
 import { Schema } from "effect";
 
-import { parse, type ParsedDocument } from "./parse";
+import { parse, resolveSpecText, type ParsedDocument } from "./parse";
 import { extract } from "./extract";
 import { DocResolver } from "./openapi-utils";
 import { HttpMethod, ServerInfo, type ExtractionResult } from "./types";
@@ -346,8 +346,9 @@ const collectTags = (result: ExtractionResult): string[] => {
 // ---------------------------------------------------------------------------
 
 /** Preview an OpenAPI spec — extract metadata without registering anything.
- *  Reuses parse() + extract() for the heavy lifting. */
-export const previewSpec = Effect.fn("OpenApi.previewSpec")(function* (specText: string) {
+ *  Accepts either a URL or raw JSON/YAML text. */
+export const previewSpec = Effect.fn("OpenApi.previewSpec")(function* (input: string) {
+  const specText = yield* resolveSpecText(input);
   const doc: ParsedDocument = yield* parse(specText);
   const result = yield* extract(doc);
 

--- a/packages/plugins/openapi/src/sdk/real-specs.test.ts
+++ b/packages/plugins/openapi/src/sdk/real-specs.test.ts
@@ -1,15 +1,24 @@
+// Parse / extract / preview coverage against a big real-world spec.
+// DB-touching behaviour (addSpec, removeSpec, tool registration) moved
+// to apps/cloud/src/services/sources-api.node.test.ts — those run
+// through the real postgres + drizzle adapter so adapter regressions
+// (e.g. a per-row createMany fallback) surface automatically instead
+// of needing a dedicated budget assertion.
+
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Option } from "effect";
+import { FetchHttpClient } from "@effect/platform";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import type { ParsedDocument } from "./parse";
 import { parse } from "./parse";
 import { extract } from "./extract";
-import { previewSpec } from "./preview";
+import { previewSpec as previewSpecRaw } from "./preview";
 import type { ExtractionResult } from "./types";
-import { createExecutor, makeTestConfig } from "@executor/sdk";
-import { openApiPlugin } from "./plugin";
+
+const previewSpec = (input: string) =>
+  previewSpecRaw(input).pipe(Effect.provide(FetchHttpClient.layer));
 
 // ---------------------------------------------------------------------------
 // Load + parse once, share across tests
@@ -97,65 +106,6 @@ describe("Real specs: Cloudflare API", { timeout: 60_000 }, () => {
     }),
   );
 
-  it.effect("registers all operations as tools via the plugin", () =>
-    Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({
-          plugins: [openApiPlugin()] as const,
-        }),
-      );
-
-      const result = yield* executor.openapi.addSpec({
-        spec: specText,
-        namespace: "cloudflare",
-      });
-
-      expect(result.toolCount).toBeGreaterThan(1000);
-
-      const tools = yield* executor.tools.list();
-      // + 2 static control tools (previewSpec, addSource)
-      expect(tools.length).toBe(result.toolCount + 2);
-
-      const cloudflareTools = tools.filter((tool) => tool.sourceId === "cloudflare");
-      expect(cloudflareTools.length).toBe(result.toolCount);
-
-      const zoneTools = yield* executor.tools.list({ query: "zone" });
-      expect(zoneTools.length).toBeGreaterThan(0);
-    }),
-  );
-
-  it.effect("schema deduplication: $defs registered via core.definitions.register", () =>
-    Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [openApiPlugin()] as const }),
-      );
-
-      yield* executor.openapi.addSpec({
-        spec: specText,
-        namespace: "cloudflare",
-      });
-
-      // Pick a tool and ensure the schema read path attached $defs.
-      const tools = yield* executor.tools.list({ query: "dns" });
-      expect(tools.length).toBeGreaterThan(0);
-
-      const schema = yield* executor.tools.schema(tools[0]!.id);
-      expect(schema).not.toBeNull();
-
-      // At least one of input/output should carry a $defs object via the
-      // read-time attachment path.
-      const hasDefs = (s: unknown): boolean =>
-        !!s &&
-        typeof s === "object" &&
-        "$defs" in (s as Record<string, unknown>) &&
-        Object.keys((s as { $defs: Record<string, unknown> }).$defs).length > 0;
-
-      expect(
-        hasDefs(schema!.inputSchema) || hasDefs(schema!.outputSchema),
-      ).toBe(true);
-    }),
-  );
-
   it.effect("previewSpec returns security schemes and header presets", () =>
     Effect.gen(function* () {
       const preview = yield* previewSpec(specText);
@@ -181,32 +131,6 @@ describe("Real specs: Cloudflare API", { timeout: 60_000 }, () => {
       expect(keyEmailPreset).toBeDefined();
       expect(keyEmailPreset!.headers["X-Auth-Email"]).toBeNull();
       expect(keyEmailPreset!.headers["X-Auth-Key"]).toBeNull();
-    }),
-  );
-
-  it.effect("removeSpec cleans up all Cloudflare tools", () =>
-    Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({
-          plugins: [openApiPlugin()] as const,
-        }),
-      );
-
-      yield* executor.openapi.addSpec({
-        spec: specText,
-        namespace: "cloudflare",
-      });
-
-      expect((yield* executor.tools.list()).length).toBeGreaterThan(2);
-
-      yield* executor.openapi.removeSpec("cloudflare");
-
-      const remaining = yield* executor.tools.list();
-      const ids = remaining.map((t) => t.id).sort();
-      expect(ids).toEqual([
-        "openapi.addSource",
-        "openapi.previewSpec",
-      ]);
     }),
   );
 });


### PR DESCRIPTION
Adding an OpenAPI source via URL hangs on production Cloudflare Workers.
Two compounding causes:

1. @apidevtools/swagger-parser fetches URLs via @apidevtools/json-schema-ref-parser's
   HTTP resolver, which goes through Node's http/https under nodejs_compat and
   stalls indefinitely on prod workerd. It also inlines every $ref on bundle(),
   deep-cloning shared schemas — a 16MB spec balloons to hundreds of MB and
   trips the 128MB Worker cap before it can finish.

2. addSpec wrapped parse + extract inside ctx.transaction, so the pool=1
   Hyperdrive Postgres connection held BEGIN open across the network fetch.

Changes:

- parse.ts: drop @apidevtools/swagger-parser entirely. Add fetchSpecText(url)
  that uses @effect/platform's HttpClient with a 20s Effect.timeout — pluggable
  via FetchHttpClient.layer (Workers-native) or a test-injected fetch. parse()
  is now JSON.parse + YAML fallback + 3.x validation; no ref resolution, because
  DocResolver (openapi-utils.ts) already resolves $refs lazily and
  normalizeOpenApiRefs preserves them through to the $defs table. Removed the
  manual resolveRefsInPlace walker — same deep-clone memory problem.

- plugin.ts: resolveSpecText(config.spec) runs with httpClientLayer provided;
  parse + extract run BEFORE ctx.transaction. Only the three storage writes
  (upsertSource, sources.register, definitions.register) stay inside the tx,
  so Hyperdrive's single connection isn't held during network I/O. detect() +
  previewSpec() get the same treatment.

- preview.ts / preview-oauth2.test.ts / real-specs.test.ts: wrap previewSpec
  with FetchHttpClient.layer where tests call it directly. real-specs.test.ts
  also strips the three in-memory-adapter addSpec tests — equivalent coverage
  lives in the cloud-app integration suite after this stack lands.

- package.json / bun.lock: drop @apidevtools/swagger-parser.

openapi test suite: 30/30 pass, 2.4s (was 12.4s with swagger-parser).