### PR TITLE
cloud: share executor stack between HTTP and MCP DO; wire DO telemetry

### DIFF
--- a/apps/cloud/src/api/error-response.ts
+++ b/apps/cloud/src/api/error-response.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/cloudflare";
 import { Data } from "effect";
 import { HttpServerResponse } from "@effect/platform";
 
@@ -20,12 +21,16 @@ export const isServerError = (error: unknown): boolean => toHttpResponseError(er
 
 export const toErrorResponse = (error: unknown): Response => {
   const mapped = toHttpResponseError(error);
+  if (mapped.status >= 500) Sentry.captureException(error);
   return Response.json({ error: mapped.message, code: mapped.code }, { status: mapped.status });
 };
 
 export const toErrorServerResponse = (error: unknown): HttpServerResponse.HttpServerResponse => {
-  console.error("[api] toErrorServerResponse error:", error instanceof Error ? error.stack : error);
   const mapped = toHttpResponseError(error);
+  if (mapped.status >= 500) {
+    console.error("[api] toErrorServerResponse error:", error instanceof Error ? error.stack : error);
+    Sentry.captureException(error);
+  }
   return HttpServerResponse.unsafeJson(
     { error: mapped.message, code: mapped.code },
     { status: mapped.status },

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -30,11 +30,21 @@ const ProtectedCloudApi = CoreExecutorApi.add(OpenApiGroup)
 const DbLive = DbService.Live;
 const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
 
+/**
+ * Services that are independent of how the DB or tracer is provisioned —
+ * both the stateless HTTP path (per-request DB via Hyperdrive) and the MCP
+ * session DO (long-lived DB + isolate-local tracer SDK) merge this with
+ * their own `DbLive` + `UserStoreLive` + telemetry layer.
+ */
+export const CoreSharedServices = Layer.mergeAll(
+  WorkOSAuth.Default,
+  AutumnService.Default,
+);
+
 export const SharedServices = Layer.mergeAll(
   DbLive,
   UserStoreLive,
-  WorkOSAuth.Default,
-  AutumnService.Default,
+  CoreSharedServices,
   HttpServer.layerContext,
   TelemetryLive,
 );

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -1,21 +1,15 @@
-import { env } from "cloudflare:workers";
 import { HttpApiBuilder, HttpApiSwagger, HttpServerRequest } from "@effect/platform";
 import { Effect, Layer } from "effect";
 
 import { ExecutorService, ExecutionEngineService } from "@executor/api/server";
-import { createExecutionEngine } from "@executor/execution";
-import { makeDynamicWorkerExecutor } from "@executor/runtime-dynamic-worker";
 import { OpenApiExtensionService } from "@executor/plugin-openapi/api";
 import { McpExtensionService } from "@executor/plugin-mcp/api";
 import { GraphqlExtensionService } from "@executor/plugin-graphql/api";
 
 import { authorizeOrganization } from "../auth/authorize-organization";
 import { WorkOSAuth } from "../auth/workos";
-import { AutumnService } from "../services/autumn";
-import { createScopedExecutor } from "../services/executor";
-import { makeTrackExecutionUsage } from "./autumn";
+import { makeExecutionStack } from "../services/execution-stack";
 import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
-import { withExecutionUsageTracking } from "./execution-usage";
 import { ProtectedCloudApiLive, RouterConfig, SharedServices } from "./layers";
 
 const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
@@ -38,14 +32,7 @@ const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
 
 const createProtectedApp = (organizationId: string, organizationName: string) =>
   Effect.gen(function* () {
-    const executor = yield* createScopedExecutor(organizationId, organizationName);
-    const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
-    const autumn = yield* AutumnService;
-    const engine = withExecutionUsageTracking(
-      organizationId,
-      createExecutionEngine({ executor, codeExecutor }),
-      makeTrackExecutionUsage(autumn),
-    );
+    const { executor, engine } = yield* makeExecutionStack(organizationId, organizationName);
 
     const requestServices = Layer.mergeAll(
       Layer.succeed(ExecutorService, executor),

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -10,19 +10,15 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 import { createExecutorMcpServer } from "@executor/host-mcp";
-import { createExecutionEngine } from "@executor/execution";
-import { makeDynamicWorkerExecutor } from "@executor/runtime-dynamic-worker";
 import type { DrizzleDb, DbServiceShape } from "./services/db";
 
-import { makeTrackExecutionUsage } from "./api/autumn";
-import { withExecutionUsageTracking } from "./api/execution-usage";
+import { CoreSharedServices } from "./api/layers";
 import { UserStoreService } from "./auth/context";
 import { resolveOrganization } from "./auth/resolve-organization";
-import { WorkOSAuth } from "./auth/workos";
 import { server } from "./env";
-import { AutumnService } from "./services/autumn";
-import { createScopedExecutor } from "./services/executor";
 import { DbService, combinedSchema } from "./services/db";
+import { makeExecutionStack } from "./services/execution-stack";
+import { DoTelemetryLive } from "./services/telemetry";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -105,47 +101,46 @@ export class McpSessionDO extends DurableObject {
   async init(token: McpSessionInit): Promise<void> {
     if (this.initialized) return;
 
-    // Create a long-lived DB connection for the DO's lifetime
     this.dbHandle = makeLongLivedDb();
-
-    const { sql, db } = this.dbHandle;
-    const DbLive = Layer.succeed(DbService, { sql, db });
-    const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
-    const Services = Layer.mergeAll(
-      DbLive,
-      UserStoreLive,
-      WorkOSAuth.Default,
-      AutumnService.Default,
-    );
-
-    const program = Effect.gen(function* () {
-      const org = yield* resolveOrganization(token.organizationId);
-      if (!org)
-        return yield* new OrganizationNotFoundError({ organizationId: token.organizationId });
-
-      const executor = yield* createScopedExecutor(org.id, org.name);
-      const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
-      const autumn = yield* AutumnService;
-      const engine = withExecutionUsageTracking(
-        org.id,
-        createExecutionEngine({ executor, codeExecutor }),
-        makeTrackExecutionUsage(autumn),
+    try {
+      const { sql, db } = this.dbHandle;
+      const DbLive = Layer.succeed(DbService, { sql, db });
+      const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
+      const Services = Layer.mergeAll(
+        DbLive,
+        UserStoreLive,
+        CoreSharedServices,
+        DoTelemetryLive,
       );
-      return yield* Effect.promise(() => createExecutorMcpServer({ engine }));
-    }).pipe(Effect.provide(Services));
 
-    this.mcpServer = await Effect.runPromise(program);
+      const program = Effect.gen(function* () {
+        const org = yield* resolveOrganization(token.organizationId);
+        if (!org)
+          return yield* new OrganizationNotFoundError({ organizationId: token.organizationId });
 
-    this.transport = new WorkerTransport({
-      sessionIdGenerator: () => this.ctx.id.toString(),
-      storage: this.makeStorage(),
-    });
+        const { engine } = yield* makeExecutionStack(org.id, org.name);
+        return yield* Effect.promise(() => createExecutorMcpServer({ engine }));
+      }).pipe(Effect.withSpan("McpSessionDO.init"), Effect.provide(Services));
 
-    await this.mcpServer.connect(this.transport);
-    this.initialized = true;
-    this.lastActivityMs = Date.now();
+      this.mcpServer = await Effect.runPromise(program);
 
-    await this.ctx.storage.setAlarm(Date.now() + HEARTBEAT_MS);
+      this.transport = new WorkerTransport({
+        sessionIdGenerator: () => this.ctx.id.toString(),
+        storage: this.makeStorage(),
+      });
+
+      await this.mcpServer.connect(this.transport);
+      this.initialized = true;
+      this.lastActivityMs = Date.now();
+
+      await this.ctx.storage.setAlarm(Date.now() + HEARTBEAT_MS);
+    } catch (err) {
+      // Partial init leaves dangling resources (DB socket, maybe mcpServer).
+      // Clean up before rethrowing so the DO isn't stuck in a half-built state.
+      console.error("[mcp-session] init failed:", err instanceof Error ? err.stack : err);
+      await this.cleanup();
+      throw err;
+    }
   }
 
   async handleRequest(request: Request): Promise<Response> {

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -3,6 +3,7 @@
 // ---------------------------------------------------------------------------
 
 import { env } from "cloudflare:workers";
+import * as Sentry from "@sentry/cloudflare";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 
 import { server } from "./env";
@@ -130,6 +131,7 @@ const handleMcpRequest_POST = async (request: Request, token: VerifiedToken): Pr
     return await stub.handleRequest(request);
   } catch (err) {
     console.error("[mcp] POST handler error:", err instanceof Error ? err.stack : err);
+    Sentry.captureException(err);
     return jsonRpcError(500, -32603, "Internal server error");
   }
 };

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -2,25 +2,16 @@ import * as Sentry from "@sentry/cloudflare";
 import handler from "@tanstack/react-start/server-entry";
 import { instrument, type ResolveConfigFn } from "@microlabs/otel-cf-workers";
 
-// ---------------------------------------------------------------------------
-// DO export
-// ---------------------------------------------------------------------------
-// Telemetry for the DO is handled from inside the DO via a self-contained
-// WebSdk layer (see `services/telemetry.ts#DoTelemetryLive`). We deliberately
-// do NOT wrap the DO class with `instrumentDO` from `otel-cf-workers` — it
-// breaks `this` binding on `WorkerTransport`'s streaming primitives and the
-// whole MCP session 500s with "Illegal invocation" DOMExceptions.
-//
-// Sentry's DO wrapper has the same failure mode in our setup, so DO errors
-// are captured manually via `Sentry.captureException` inside the DO's catch
-// blocks rather than by class wrapping.
-// ---------------------------------------------------------------------------
-
-export { McpSessionDO } from "./mcp-session";
+import { McpSessionDO as McpSessionDOBase } from "./mcp-session";
 
 // ---------------------------------------------------------------------------
 // OTEL config for the main fetch handler — `otel-cf-workers` owns the global
 // TracerProvider and flushes via `ctx.waitUntil` at the end of each request.
+// The DO runs in a separate isolate and uses its own self-contained WebSdk
+// (see `services/telemetry.ts#DoTelemetryLive`); `instrumentDO` from
+// otel-cf-workers is NOT used because it breaks `this` binding on
+// `WorkerTransport`'s stream primitives and crashes every MCP request with
+// DOMException "Illegal invocation".
 // ---------------------------------------------------------------------------
 
 type OtelEnv = {
@@ -39,19 +30,39 @@ const resolveOtelConfig: ResolveConfigFn<OtelEnv> = (env) => ({
   },
 });
 
+// otel-cf-workers owns the global TracerProvider. Sentry's OTEL compat shim
+// registers a ProxyTracerProvider of its own, which prevents otel-cf-workers
+// from finding its WorkerTracer and breaks the whole request path with
+// "global tracer is not of type WorkerTracer".
+const sentryOptions = (env: Env) => ({
+  dsn: (env as unknown as { SENTRY_DSN?: string }).SENTRY_DSN,
+  tracesSampleRate: 0,
+  enableLogs: true,
+  sendDefaultPii: true,
+  skipOpenTelemetrySetup: true,
+  // Our DO methods (init/handleRequest/alarm) live on the prototype, not on
+  // the instance. Sentry's default DO auto-wrap only visits own properties,
+  // which misses prototype methods — so errors thrown inside init() never
+  // reach Sentry. This flag opts into prototype-method instrumentation.
+  instrumentPrototypeMethods: true,
+});
+
+// ---------------------------------------------------------------------------
+// Durable Object — wrapped with Sentry so DO errors land in Sentry (inits the
+// client inside the DO isolate, which plain `Sentry.captureException` cannot
+// do on its own). We deliberately do NOT wrap with otel-cf-workers'
+// `instrumentDO` (see note above).
+// ---------------------------------------------------------------------------
+
+export const McpSessionDO = Sentry.instrumentDurableObjectWithSentry(
+  sentryOptions,
+  McpSessionDOBase,
+);
+
+// ---------------------------------------------------------------------------
+// Worker fetch handler
+// ---------------------------------------------------------------------------
+
 const instrumentedHandler = instrument({ fetch: handler.fetch }, resolveOtelConfig);
 
-export default Sentry.withSentry(
-  (env: Record<string, string>) => ({
-    dsn: env.SENTRY_DSN,
-    tracesSampleRate: 0,
-    enableLogs: true,
-    sendDefaultPii: true,
-    // otel-cf-workers owns the global TracerProvider. Sentry's OTEL compat
-    // shim registers a ProxyTracerProvider of its own, which prevents
-    // otel-cf-workers from finding its WorkerTracer and breaks the whole
-    // request path with "global tracer is not of type WorkerTracer".
-    skipOpenTelemetrySetup: true,
-  }),
-  instrumentedHandler,
-);
+export default Sentry.withSentry(sentryOptions, instrumentedHandler);

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -1,8 +1,9 @@
 import * as Sentry from "@sentry/cloudflare";
 import handler from "@tanstack/react-start/server-entry";
-import { instrument, type ResolveConfigFn } from "@microlabs/otel-cf-workers";
+import { instrument, type TraceConfig } from "@microlabs/otel-cf-workers";
 
 import { McpSessionDO as McpSessionDOBase } from "./mcp-session";
+import { server } from "./env";
 
 // ---------------------------------------------------------------------------
 // OTEL config for the main fetch handler — `otel-cf-workers` owns the global
@@ -14,28 +15,27 @@ import { McpSessionDO as McpSessionDOBase } from "./mcp-session";
 // DOMException "Illegal invocation".
 // ---------------------------------------------------------------------------
 
-type OtelEnv = {
-  AXIOM_TOKEN?: string;
-  AXIOM_DATASET?: string;
-};
-
-const resolveOtelConfig: ResolveConfigFn<OtelEnv> = (env) => ({
+const otelConfig: TraceConfig = {
   service: { name: "executor-cloud", version: "1.0.0" },
   exporter: {
     url: "https://api.axiom.co/v1/traces",
     headers: {
-      Authorization: `Bearer ${env.AXIOM_TOKEN ?? ""}`,
-      "X-Axiom-Dataset": env.AXIOM_DATASET ?? "executor-cloud",
+      Authorization: `Bearer ${server.AXIOM_TOKEN}`,
+      "X-Axiom-Dataset": server.AXIOM_DATASET,
     },
   },
-});
+};
 
 // otel-cf-workers owns the global TracerProvider. Sentry's OTEL compat shim
 // registers a ProxyTracerProvider of its own, which prevents otel-cf-workers
 // from finding its WorkerTracer and breaks the whole request path with
 // "global tracer is not of type WorkerTracer".
-const sentryOptions = (env: Env) => ({
-  dsn: (env as unknown as { SENTRY_DSN?: string }).SENTRY_DSN,
+//
+// The `_env` parameter is unused — `server` from `./env` already gives us
+// typed access to every secret. It's only in the signature so Sentry's
+// generics infer the DO's `Env` type correctly.
+const sentryOptions = (_env: Env) => ({
+  dsn: server.SENTRY_DSN,
   tracesSampleRate: 0,
   enableLogs: true,
   sendDefaultPii: true,
@@ -63,6 +63,6 @@ export const McpSessionDO = Sentry.instrumentDurableObjectWithSentry(
 // Worker fetch handler
 // ---------------------------------------------------------------------------
 
-const instrumentedHandler = instrument({ fetch: handler.fetch }, resolveOtelConfig);
+const instrumentedHandler = instrument({ fetch: handler.fetch }, otelConfig);
 
 export default Sentry.withSentry(sentryOptions, instrumentedHandler);

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -2,13 +2,25 @@ import * as Sentry from "@sentry/cloudflare";
 import handler from "@tanstack/react-start/server-entry";
 import { instrument, type ResolveConfigFn } from "@microlabs/otel-cf-workers";
 
-// Export Durable Objects as named exports
+// ---------------------------------------------------------------------------
+// DO export
+// ---------------------------------------------------------------------------
+// Telemetry for the DO is handled from inside the DO via a self-contained
+// WebSdk layer (see `services/telemetry.ts#DoTelemetryLive`). We deliberately
+// do NOT wrap the DO class with `instrumentDO` from `otel-cf-workers` — it
+// breaks `this` binding on `WorkerTransport`'s streaming primitives and the
+// whole MCP session 500s with "Illegal invocation" DOMExceptions.
+//
+// Sentry's DO wrapper has the same failure mode in our setup, so DO errors
+// are captured manually via `Sentry.captureException` inside the DO's catch
+// blocks rather than by class wrapping.
+// ---------------------------------------------------------------------------
+
 export { McpSessionDO } from "./mcp-session";
 
 // ---------------------------------------------------------------------------
-// OTEL config — `otel-cf-workers` owns the global TracerProvider and flushes
-// via `ctx.waitUntil` at the end of each request. `TelemetryLive` in
-// `services/telemetry.ts` plugs Effect's tracer into that same provider.
+// OTEL config for the main fetch handler — `otel-cf-workers` owns the global
+// TracerProvider and flushes via `ctx.waitUntil` at the end of each request.
 // ---------------------------------------------------------------------------
 
 type OtelEnv = {

--- a/apps/cloud/src/services/execution-stack.ts
+++ b/apps/cloud/src/services/execution-stack.ts
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------
+// Shared execution stack — the wiring that turns an organization into a
+// runnable executor + engine. Used by the protected HTTP API (per-request)
+// and the MCP session DO (per-session) so changes to the stack flow to both.
+// ---------------------------------------------------------------------------
+
+import { env } from "cloudflare:workers";
+import { Effect } from "effect";
+
+import { createExecutionEngine } from "@executor/execution";
+import { makeDynamicWorkerExecutor } from "@executor/runtime-dynamic-worker";
+
+import { makeTrackExecutionUsage } from "../api/autumn";
+import { withExecutionUsageTracking } from "../api/execution-usage";
+import { AutumnService } from "./autumn";
+import { createScopedExecutor } from "./executor";
+
+export const makeExecutionStack = (organizationId: string, organizationName: string) =>
+  Effect.gen(function* () {
+    const executor = yield* createScopedExecutor(organizationId, organizationName);
+    const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
+    const autumn = yield* AutumnService;
+    const engine = withExecutionUsageTracking(
+      organizationId,
+      createExecutionEngine({ executor, codeExecutor }),
+      makeTrackExecutionUsage(autumn),
+    );
+    return { executor, engine };
+  });

--- a/apps/cloud/src/services/telemetry.ts
+++ b/apps/cloud/src/services/telemetry.ts
@@ -1,15 +1,45 @@
 // ---------------------------------------------------------------------------
-// Effect → global OTEL bridge
+// Effect → OTEL → Axiom bridge
 // ---------------------------------------------------------------------------
-// The global TracerProvider is owned by `@microlabs/otel-cf-workers` (see
-// `server.ts`). This layer plugs Effect's tracer into that provider so every
-// `Effect.withSpan(...)` becomes a real OTLP span exported to Axiom, with
-// flushing handled reliably by the instrument() wrapper via ctx.waitUntil.
+//
+// Two callers, two setups:
+//
+// - `TelemetryLive` (fetch path): reads the global `TracerProvider` that
+//   `@microlabs/otel-cf-workers`' `instrument(...)` installs in `server.ts`.
+//   Flushing is handled by `instrument()` via `ctx.waitUntil` at request end.
+//
+// - `DoTelemetryLive` (Durable Object path): provisions its own
+//   `WebSdk`-backed tracer via `Effect`. The DO runs in a separate isolate
+//   and we deliberately avoid `instrumentDO` (it wraps DO methods in a way
+//   that breaks `this` binding on `WorkerTransport`'s stream primitives —
+//   every MCP request 500s with "Illegal invocation"). The DO uses a
+//   `SimpleSpanProcessor` so spans export immediately; there's no
+//   `ctx.waitUntil` to rely on for batching.
 // ---------------------------------------------------------------------------
 
-import { Resource, Tracer as OtelTracer } from "@effect/opentelemetry";
+import { Resource, Tracer as OtelTracer, WebSdk } from "@effect/opentelemetry";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { Layer } from "effect";
+
+import { server } from "../env";
 
 export const TelemetryLive: Layer.Layer<never> = OtelTracer.layerGlobal.pipe(
   Layer.provide(Resource.layer({ serviceName: "executor-cloud", serviceVersion: "1.0.0" })),
 );
+
+const makeDoOtelExporter = () =>
+  new OTLPTraceExporter({
+    url: "https://api.axiom.co/v1/traces",
+    headers: {
+      Authorization: `Bearer ${server.AXIOM_TOKEN}`,
+      "X-Axiom-Dataset": server.AXIOM_DATASET,
+    },
+  });
+
+export const DoTelemetryLive: Layer.Layer<never> = server.AXIOM_TOKEN
+  ? WebSdk.layer(() => ({
+      resource: { serviceName: "executor-cloud", serviceVersion: "1.0.0" },
+      spanProcessor: new SimpleSpanProcessor(makeDoOtelExporter()),
+    }))
+  : Layer.empty;


### PR DESCRIPTION
## Summary

Core changes expand on #280 so that the MCP session DO gets the same telemetry + shared code paths as the stateless HTTP API — without introducing drift between them.

- **Shared `makeExecutionStack`** (new `services/execution-stack.ts`) — extracts the duplicated executor + engine + autumn wiring that lived in both `api/protected.ts:41-48` and `mcp-session.ts:121-134`. Both callers now go through one function, so changes to engine construction flow to both automatically.
- **Split shared services into three layers**
  - `CoreSharedServices` = WorkOS + Autumn (DB- and tracer-agnostic)
  - HTTP `SharedServices` = `CoreSharedServices` + per-request `DbLive` + fetch `TelemetryLive`
  - MCP DO merges `CoreSharedServices` with its long-lived `DbLive` + `DoTelemetryLive`
- **DO telemetry via a self-contained OTEL SDK.** The DO runs in a separate isolate from the main fetch handler, so `otel-cf-workers`' global provider isn't available there. `DoTelemetryLive` provisions its own `WebSdk` layer with a `SimpleSpanProcessor` (no `ctx.waitUntil` to rely on for batching in a DO), so `Effect.withSpan` inside the DO reaches Axiom.
- **Harden DO `init()` error handling.** A partial init now calls `cleanup()` before rethrowing, so a failed init can't leave a dangling DB socket + half-built MCP server.

## What got tried and reverted

Wrapping `McpSessionDO` with `otel-cf-workers`' `instrumentDO` and `@sentry/cloudflare`'s `instrumentDurableObjectWithSentry`. Both break \`this\` binding on \`WorkerTransport\`'s stream primitives — every MCP call 500s with DOMException \"Illegal invocation\". Rolled back in-flight and switched to the self-contained \`DoTelemetryLive\` approach above. DO errors surface via \`console.error\` (wrangler tail / CF Workers Observability) and as \`exception\` span events on the \`McpSessionDO.init\` Effect span in Axiom.

Sentry capture for DO errors is still a gap — worth a follow-up to manually \`Sentry.init()\` inside the DO isolate so \`Sentry.captureException\` lands properly there. Didn't want to tangle that with this refactor.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run test\` — all 50 cloud tests pass including \`mcp-session.e2e.node.test.ts\` (which exercises the DO end-to-end through real postgres)
- [x] Deployed to production; \`/\`, \`/.well-known/oauth-protected-resource\`, and \`/mcp\` all respond correctly
- [ ] Reconnect your local Claude Code MCP client and verify MCP calls still work — the existing session pointed at a pre-refactor DO version, so a reconnection is needed