### PR TITLE
Polish secret creation UX in header-auth flow

### DIFF
--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -132,6 +132,7 @@ export default function AddGraphqlSource(props: {
           headers={headers}
           onHeadersChange={setHeaders}
           existingSecrets={secretList}
+          sourceName={identity.name}
         />
       </section>
 

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -123,6 +123,7 @@ function EditForm(props: {
           headers={headers}
           onHeadersChange={handleHeadersChange}
           existingSecrets={secretList}
+          sourceName={identity.name}
         />
       </section>
 

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -758,6 +758,7 @@ export default function AddMcpSource(props: {
                   onHeadersChange={setRemoteAuthHeaders}
                   existingSecrets={secretList}
                   singleHeader
+                  sourceName={remoteIdentity.name}
                 />
               )}
 

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 import { Option } from "effect";
 
@@ -39,6 +39,7 @@ import {
 } from "@executor/react/components/native-select";
 import { Textarea } from "@executor/react/components/textarea";
 import { Checkbox } from "@executor/react/components/checkbox";
+import { SourceFavicon } from "@executor/react/components/source-favicon";
 import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
 import { Skeleton } from "@executor/react/components/skeleton";
 import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
@@ -223,26 +224,6 @@ export default function AddOpenApiSource(props: {
     for (const [name, v] of Object.entries(vars)) out[name] = v.default;
     return out;
   };
-
-  // Derive a favicon URL from the spec URL (if the user entered one — raw
-  // JSON/YAML content will fail URL parsing and yield null). Uses Google's
-  // favicon service so we don't depend on the domain serving /favicon.ico.
-  const faviconUrl = useMemo(() => {
-    try {
-      const trimmed = specUrl.trim();
-      if (!trimmed) return null;
-      const u = new URL(trimmed);
-      if (u.protocol !== "http:" && u.protocol !== "https:") return null;
-      return `https://www.google.com/s2/favicons?domain=${u.hostname}&sz=64`;
-    } catch {
-      return null;
-    }
-  }, [specUrl]);
-
-  const [faviconFailed, setFaviconFailed] = useState(false);
-  useEffect(() => {
-    setFaviconFailed(false);
-  }, [faviconUrl]);
 
   const allHeaders: Record<string, HeaderValue> = {};
   for (const ch of customHeaders) {
@@ -542,14 +523,7 @@ export default function AddOpenApiSource(props: {
         <CardStack>
           <CardStackContent className="border-t-0">
             <CardStackEntry>
-              {faviconUrl && !faviconFailed && (
-                <img
-                  src={faviconUrl}
-                  alt=""
-                  className="size-4 shrink-0 object-contain"
-                  onError={() => setFaviconFailed(true)}
-                />
-              )}
+              {resolvedBaseUrl && <SourceFavicon url={resolvedBaseUrl} size={16} />}
               <CardStackEntryContent>
                 <CardStackEntryTitle>
                   {Option.getOrElse(preview.title, () => "API")}
@@ -806,6 +780,7 @@ export default function AddOpenApiSource(props: {
                 headers={customHeaders}
                 onHeadersChange={handleHeadersChange}
                 existingSecrets={secretList}
+                sourceName={identity.name}
               />
             )}
 

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -123,6 +123,7 @@ function EditForm(props: {
           headers={headers}
           onHeadersChange={handleHeadersChange}
           existingSecrets={secretList}
+          sourceName={identity.name}
         />
       </section>
 

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -359,9 +359,15 @@ export const previewSpec = Effect.fn("OpenApi.previewSpec")(function* (input: st
   );
 
   const rawSecurity = (doc.security ?? []) as Array<Record<string, unknown>>;
-  const authStrategies = rawSecurity.map(
+  const declaredStrategies = rawSecurity.map(
     (entry) => new AuthStrategy({ schemes: Object.keys(entry) }),
   );
+  // Fall back to one strategy per scheme when the spec only declares schemes
+  // under components (e.g. Sentry) so the user still sees auth options.
+  const authStrategies =
+    declaredStrategies.length > 0
+      ? declaredStrategies
+      : securitySchemes.map((scheme) => new AuthStrategy({ schemes: [scheme.name] }));
 
   return new SpecPreview({
     title: result.title,

--- a/packages/react/src/plugins/headers-list.tsx
+++ b/packages/react/src/plugins/headers-list.tsx
@@ -26,6 +26,11 @@ export interface HeadersListProps {
   readonly singleHeader?: boolean;
   /** Text shown in the empty state. */
   readonly emptyLabel?: ReactNode;
+  /**
+   * Display name of the source that owns these headers (e.g. "Axiom"). Used
+   * to derive unique default secret labels/IDs like `axiom-authorization`.
+   */
+  readonly sourceName?: string;
 }
 
 export function HeadersList({
@@ -35,6 +40,7 @@ export function HeadersList({
   presets = defaultHeaderAuthPresets,
   singleHeader = false,
   emptyLabel = "No headers",
+  sourceName,
 }: HeadersListProps) {
   const [picking, setPicking] = useState(false);
   const canAddMore = !singleHeader || headers.length === 0;
@@ -100,6 +106,7 @@ export function HeadersList({
                 onSelectSecret={(secretId) => updateHeader(index, { secretId })}
                 onRemove={singleHeader ? undefined : () => removeHeader(index)}
                 existingSecrets={existingSecrets}
+                sourceName={sourceName}
               />
             ))}
             {canAddMore && <AddHeaderRow onClick={() => setPicking(true)} />}

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useId, useState, type CSSProperties } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 
 import { setSecret, resolveSecret } from "../api/atoms";
@@ -60,14 +60,22 @@ function SecretVisibilityIcon(props: { revealed: boolean }) {
   );
 }
 
+function slugifyForSecretId(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
 function InlineCreateSecret(props: {
-  headerName: string;
   suggestedId: string;
+  suggestedName: string;
   onCreated: (secretId: string) => void;
   onCancel: () => void;
 }) {
-  const [secretId, setSecretId] = useState(props.suggestedId);
-  const [secretName, setSecretName] = useState(props.headerName);
+  const [nameOverride, setNameOverride] = useState<string | null>(null);
+  const [idOverride, setIdOverride] = useState<string | null>(null);
   const [secretValue, setSecretValue] = useState("");
   const [secretRevealed, setSecretRevealed] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -78,6 +86,9 @@ function InlineCreateSecret(props: {
   const secretNameInputId = useId();
   const secretValueInputId = useId();
 
+  const secretName = nameOverride ?? props.suggestedName;
+  const secretId = idOverride ?? (slugifyForSecretId(secretName) || "custom-header");
+
   const handleSave = async () => {
     if (!secretId.trim() || !secretValue.trim()) return;
     setSaving(true);
@@ -87,7 +98,7 @@ function InlineCreateSecret(props: {
         path: { scopeId },
         payload: {
           id: SecretId.make(secretId.trim()),
-          name: `${secretName.trim() || secretId.trim()} (Auth header: ${props.headerName})`,
+          name: secretName.trim() || secretId.trim(),
           value: secretValue.trim(),
         },
         reactivityKeys: secretWriteKeys,
@@ -100,27 +111,27 @@ function InlineCreateSecret(props: {
   };
 
   return (
-    <div className="rounded-lg border border-primary/20 bg-primary/[0.02] p-3 space-y-3">
+    <div className="bg-primary/[0.03] px-4 py-3 space-y-3">
       <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
       <FieldGroup className="gap-3">
         <div className="grid grid-cols-2 gap-3">
-          <Field>
-            <FieldLabel htmlFor={secretIdInputId}>ID</FieldLabel>
-            <Input
-              id={secretIdInputId}
-              value={secretId}
-              onChange={(e) => setSecretId((e.target as HTMLInputElement).value)}
-              placeholder="my-api-token"
-              className="font-mono"
-            />
-          </Field>
           <Field>
             <FieldLabel htmlFor={secretNameInputId}>Label</FieldLabel>
             <Input
               id={secretNameInputId}
               value={secretName}
-              onChange={(e) => setSecretName((e.target as HTMLInputElement).value)}
+              onChange={(e) => setNameOverride((e.target as HTMLInputElement).value)}
               placeholder="API Token"
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor={secretIdInputId}>ID</FieldLabel>
+            <Input
+              id={secretIdInputId}
+              value={secretId}
+              onChange={(e) => setIdOverride((e.target as HTMLInputElement).value)}
+              placeholder="my-api-token"
+              className="font-mono"
             />
           </Field>
         </div>
@@ -129,11 +140,14 @@ function InlineCreateSecret(props: {
           <div className="relative">
             <Input
               id={secretValueInputId}
-              type={secretRevealed ? "text" : "password"}
+              type="text"
               value={secretValue}
               onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
               placeholder="paste your token or key…"
               className="pr-9 font-mono"
+              style={
+                secretRevealed ? undefined : ({ WebkitTextSecurity: "disc" } as CSSProperties)
+              }
             />
             <Button
               type="button"
@@ -293,6 +307,12 @@ export function SecretHeaderAuthRow(props: {
   onRemove?: () => void;
   removeLabel?: string;
   label?: string;
+  /**
+   * Display name of the source this header belongs to (e.g. "Axiom"). Used
+   * to prefix the suggested secret label and ID so tokens from different
+   * sources don't collide on ids like `authorization`.
+   */
+  sourceName?: string;
 }) {
   const [creating, setCreating] = useState(false);
   const nameInputId = useId();
@@ -308,24 +328,25 @@ export function SecretHeaderAuthRow(props: {
     onRemove,
     removeLabel = "Remove",
     label = "Header",
+    sourceName,
   } = props;
 
   const isCustom = presetKey === "custom" || presetKey === undefined;
-  const suggestedId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-") || "custom-header";
+  const headerLabel = name.trim() || "Custom Header";
+  const suggestedName = [sourceName?.trim(), headerLabel].filter(Boolean).join(" ");
+  const suggestedId = slugifyForSecretId(suggestedName) || "custom-header";
 
   if (creating) {
     return (
-      <div className="px-4 py-3">
-        <InlineCreateSecret
-          headerName={name || "Custom Header"}
-          suggestedId={suggestedId}
-          onCreated={(id) => {
-            onSelectSecret(id);
-            setCreating(false);
-          }}
-          onCancel={() => setCreating(false)}
-        />
-      </div>
+      <InlineCreateSecret
+        suggestedId={suggestedId}
+        suggestedName={suggestedName}
+        onCreated={(id) => {
+          onSelectSecret(id);
+          setCreating(false);
+        }}
+        onCancel={() => setCreating(false)}
+      />
     );
   }
 
@@ -382,19 +403,12 @@ export function SecretHeaderAuthRow(props: {
         </Field>
       </FieldGroup>
 
-      <div className="flex items-center gap-1.5">
-        <div className="flex-1 min-w-0">
-          <SecretPicker value={secretId} onSelect={onSelectSecret} secrets={existingSecrets} />
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="shrink-0"
-          onClick={() => setCreating(true)}
-        >
-          + New
-        </Button>
-      </div>
+      <SecretPicker
+        value={secretId}
+        onSelect={onSelectSecret}
+        secrets={existingSecrets}
+        onCreateNew={() => setCreating(true)}
+      />
 
       {secretId && name.trim() && (
         <HeaderValuePreview headerName={name.trim()} secretId={secretId} prefix={prefix} />

--- a/packages/react/src/plugins/secret-picker.tsx
+++ b/packages/react/src/plugins/secret-picker.tsx
@@ -1,4 +1,5 @@
 import { useState, type ChangeEvent, type FocusEvent } from "react";
+import { PlusIcon } from "lucide-react";
 
 import { Input } from "../components/input";
 import {
@@ -7,6 +8,7 @@ import {
   CommandGroup,
   CommandItem,
   CommandList,
+  CommandSeparator,
 } from "../components/command";
 import { Popover, PopoverAnchor, PopoverContent } from "../components/popover";
 
@@ -33,8 +35,10 @@ export function SecretPicker(props: {
   readonly onSelect: (secretId: string) => void;
   readonly secrets: readonly SecretPickerSecret[];
   readonly placeholder?: string;
+  /** When provided, renders a "+ New secret" row at the bottom of the dropdown. */
+  readonly onCreateNew?: () => void;
 }) {
-  const { value, onSelect, secrets, placeholder = "Search secrets…" } = props;
+  const { value, onSelect, secrets, placeholder = "Search secrets…", onCreateNew } = props;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -122,6 +126,25 @@ export function SecretPicker(props: {
                   </CommandGroup>
                 );
               })}
+              {onCreateNew && (
+                <>
+                  {secrets.length > 0 && <CommandSeparator />}
+                  <CommandGroup>
+                    <CommandItem
+                      value="__create_new__"
+                      onSelect={() => {
+                        onCreateNew();
+                        setOpen(false);
+                        setQuery("");
+                      }}
+                      className="text-muted-foreground data-[selected=true]:text-foreground"
+                    >
+                      <PlusIcon aria-hidden className="size-3.5" />
+                      <span>New secret</span>
+                    </CommandItem>
+                  </CommandGroup>
+                </>
+              )}
             </CommandList>
           </Command>
         </PopoverContent>


### PR DESCRIPTION
## Summary
- Secret-creation form inside `SecretHeaderAuthRow` now renders as a full-width CardStack row — the wrapping `px-4 py-3` div that squeezed inputs is gone, and the nested double-border card is flattened into a subtle tinted row.
- Suggested secret label + ID derive from the source name (`"Axiom Authorization"` / `"axiom-authorization"`), so multiple sources no longer collide on a shared `authorization` id. Threaded `sourceName` through `HeadersList` → `SecretHeaderAuthRow` from every Add/Edit source form (MCP, GraphQL, OpenAPI).
- Label ↔ ID are now an override-or-derive pair mirroring `useSourceIdentity`: ID auto-slugs from label until the user edits ID, then they decouple.
- Secret value input switched from `type="password"` to `type="text"` with CSS `-webkit-text-security: disc` masking — password-manager extensions key off `type="password"` and were swallowing Cmd+V.
- `+ New secret` moved inside the `SecretPicker` dropdown (new `onCreateNew` prop), replacing the external button.
- OpenAPI: specs that only declare schemes under `components.securitySchemes` (e.g. Sentry) now surface Authentication presets — fall back to one `AuthStrategy` per scheme when root `security` is missing.
- OpenAPI: title-card favicon uses the resolved base URL's apex domain (via `tldts` through `SourceFavicon`) instead of the spec URL's host.

## Test plan
- [ ] Add a GraphQL / OpenAPI / MCP source, open "+ New secret" in the header-auth dropdown, confirm the form spans the full card width and suggests a source-prefixed label/ID.
- [ ] Edit the label → ID updates. Edit the ID → label/ID decouple.
- [ ] Paste a value with 1Password / LastPass / Bitwarden installed.
- [ ] Add the Sentry OpenAPI spec (`https://raw.githubusercontent.com/getsentry/sentry-api-schema/main/openapi-derefed.json`): Authentication shows Bearer/DSN presets, title card shows the Sentry favicon.