### PR TITLE
Sort source list by name to stop optimistic-add jump

### DIFF
--- a/packages/react/src/api/optimistic.tsx
+++ b/packages/react/src/api/optimistic.tsx
@@ -93,16 +93,17 @@ export interface PendingSource {
 
 /**
  * Sidebar/list helper. Reads `sourcesAtom(scopeId)` and merges any pending
- * placeholder rows on top so the UI updates instantly when an add form pushes
- * a placeholder.
+ * placeholder rows in, sorting the combined list by name so the placeholder
+ * lands in the same position the canonical row will occupy — no visual jump
+ * when the server confirms.
  */
 export const useSourcesWithPending = (scopeId: ScopeId) => {
   const result = useAtomValue(sourcesAtom(scopeId));
   const { pending } = usePendingResource<PendingSource>(PendingResource.sources);
   return React.useMemo(
     () =>
-      Result.map(result, (sources) =>
-        mergePending(
+      Result.map(result, (sources) => {
+        const merged = mergePending(
           pending,
           sources,
           (s) => s.id,
@@ -117,8 +118,9 @@ export const useSourcesWithPending = (scopeId: ScopeId) => {
             canRefresh: false,
             canEdit: false,
           }),
-        ),
-      ),
+        );
+        return [...merged].sort((a, b) => a.name.localeCompare(b.name));
+      }),
     [result, pending],
   );
 };


### PR DESCRIPTION
## Summary
Adding a source visibly jumped: the pending placeholder landed at the top (via `mergePending`'s prepend), but when the server confirmed, the canonical row slotted in at the bottom of the dynamic section (server returns DB insertion order).

Fix: sort the merged list by `name` inside `useSourcesWithPending`. The placeholder lands in the same position its canonical row will occupy, so the confirmation is visually silent, and the list is alphabetically stable.

## Test plan
- [ ] Add a source (OpenAPI, GraphQL, or MCP) with a name that sorts somewhere in the middle of your existing list; confirm it appears in the correct alphabetical spot immediately and doesn't shift when the server confirms.
- [ ] Existing sources list renders in alphabetical order.