### PR TITLE
marketing: wrap Astro Worker with otel-cf-workers + Sentry

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -4,9 +4,9 @@
   "type": "module",
   "scripts": {
     "dev": "portless run --no-tls --name executor-marketing astro dev",
-    "build": "astro build",
+    "build": "astro build && bun run scripts/wrap-worker.ts",
     "preview": "astro preview",
-    "deploy": "astro build && npx wrangler deploy --config dist/server/wrangler.json",
+    "deploy": "astro build && bun run scripts/wrap-worker.ts && npx wrangler deploy --config dist/server/wrangler.json",
     "astro": "astro",
     "typecheck": "tsgo --noEmit",
     "typecheck:slow": "tsc --noEmit"
@@ -17,6 +17,9 @@
     "@executor/plugin-graphql": "workspace:*",
     "@executor/plugin-openapi": "workspace:*",
     "@executor/sdk": "workspace:*",
+    "@microlabs/otel-cf-workers": "^1.0.0-rc.52",
+    "@opentelemetry/api": "~1.9.0",
+    "@sentry/cloudflare": "^10.49.0",
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.3",
     "effect": "^3.14.16",

--- a/apps/marketing/scripts/wrap-worker.ts
+++ b/apps/marketing/scripts/wrap-worker.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+/**
+ * Post-build step: wraps the Astro Cloudflare adapter output with
+ * otel-cf-workers + Sentry Cloudflare instrumentation.
+ *
+ * The Astro adapter emits dist/server/entry.mjs as the worker entry (per
+ * dist/server/wrangler.json -> "main"). There is no Astro hook to substitute
+ * that entry, so we:
+ *
+ *   1. Rename dist/server/entry.mjs -> dist/server/astro-entry.mjs
+ *   2. Write a shim source file that imports ./astro-entry.mjs and wraps its
+ *      default export with `instrument()` + `Sentry.withSentry()` (mirroring
+ *      apps/cloud/src/server.ts).
+ *   3. Bundle the shim back to dist/server/entry.mjs with @microlabs/otel-cf-workers
+ *      and @sentry/cloudflare inlined (Astro's Vite pass is done, so anything
+ *      we add here has to ship as a self-contained bundle).
+ *   4. Patch dist/server/wrangler.json to ensure `nodejs_compat` is set.
+ *
+ * We deliberately do NOT use `instrumentDO` / `instrumentDurableObjectWithSentry`
+ * because marketing has no Durable Objects and those wrappers have known
+ * this-binding issues on WorkerTransport anyway.
+ */
+
+import { existsSync } from "node:fs";
+import { readFile, rename, rm, writeFile } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const marketingRoot = resolve(__dirname, "..");
+const serverDir = resolve(marketingRoot, "dist", "server");
+const entryPath = join(serverDir, "entry.mjs");
+const astroEntryPath = join(serverDir, "astro-entry.mjs");
+const wranglerJsonPath = join(serverDir, "wrangler.json");
+
+// The shim lives under apps/marketing/ (not dist/server/) so npm resolution
+// finds node_modules when Bun bundles. We relocate the bundled output into
+// dist/server/entry.mjs afterward.
+const shimSourcePath = join(marketingRoot, "__otel-shim__.mjs");
+// Relative path from the shim source to the renamed Astro entry. After the
+// bundle lands in dist/server/ this will be rewritten to "./astro-entry.mjs".
+const astroEntryImportSpec = "./" + relative(marketingRoot, astroEntryPath).replace(/\\/g, "/");
+
+if (!existsSync(entryPath)) {
+  throw new Error(
+    `Expected Astro adapter output at ${entryPath}. Run \`astro build\` first.`,
+  );
+}
+
+// 1. Rename Astro's entry so the shim can import it by relative path.
+if (existsSync(astroEntryPath)) {
+  await rm(astroEntryPath);
+}
+await rename(entryPath, astroEntryPath);
+
+// 2. Write the shim source. It reads config from process.env at request time
+//    (Cloudflare surfaces secrets there when nodejs_compat is on). We mirror
+//    apps/cloud/src/server.ts's sentryOptions shape verbatim.
+const shimSource = /* js */ `import * as Sentry from "@sentry/cloudflare";
+import { instrument } from "@microlabs/otel-cf-workers";
+import astroHandler from ${JSON.stringify(astroEntryImportSpec)};
+
+const readEnv = (key) => {
+  const value = globalThis.process?.env?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+// otel-cf-workers owns the global TracerProvider. Sentry's OTEL compat shim
+// registers a ProxyTracerProvider of its own, which prevents otel-cf-workers
+// from finding its WorkerTracer and breaks the whole request path with
+// "global tracer is not of type WorkerTracer". Hence \`skipOpenTelemetrySetup\`.
+const sentryOptions = (_env) => ({
+  dsn: readEnv("SENTRY_DSN"),
+  tracesSampleRate: 0,
+  enableLogs: true,
+  sendDefaultPii: true,
+  skipOpenTelemetrySetup: true,
+});
+
+const otelConfig = {
+  service: { name: "executor-marketing" },
+  exporter: {
+    url: "https://api.axiom.co/v1/traces",
+    headers: {
+      Authorization: \`Bearer \${readEnv("AXIOM_TOKEN") ?? ""}\`,
+      "X-Axiom-Dataset": readEnv("AXIOM_DATASET") ?? "executor-cloud",
+    },
+  },
+};
+
+const baseHandler = astroHandler ?? {};
+if (typeof baseHandler.fetch !== "function") {
+  throw new Error(
+    "Astro adapter default export is missing a fetch handler; the adapter layout changed?",
+  );
+}
+
+// Preserve every top-level handler Astro emitted (fetch, scheduled, queue, etc.)
+// but route fetch through otel-cf-workers' \`instrument()\`.
+const instrumentedFetch = instrument(
+  { fetch: baseHandler.fetch.bind(baseHandler) },
+  otelConfig,
+).fetch;
+
+const wrapped = {
+  ...baseHandler,
+  fetch: instrumentedFetch,
+};
+
+export default Sentry.withSentry(sentryOptions, wrapped);
+`;
+
+await writeFile(shimSourcePath, shimSource, "utf8");
+
+// 3. Bundle the shim. The renamed Astro entry stays external (kept as a
+//    relative import) so its own relative chunks and `cloudflare:workers`
+//    imports resolve the way Astro emitted them. Everything else (Sentry,
+//    otel-cf-workers, their transitive deps) gets inlined because we're
+//    running AFTER Astro's Vite pass.
+//
+//    We bundle from apps/marketing/ (not from dist/server/) so npm resolution
+//    finds node_modules. The output then gets moved into dist/server/ and the
+//    astro-entry import path gets rewritten to a server-dir-relative one.
+let bundled: string;
+try {
+  const result = await Bun.build({
+    entrypoints: [shimSourcePath],
+    target: "browser",
+    format: "esm",
+    conditions: ["workerd", "worker", "browser"],
+    minify: false,
+    external: ["cloudflare:*", "node:*", astroEntryImportSpec],
+  });
+
+  if (!result.success) {
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    throw new Error("Failed to bundle OTEL/Sentry shim");
+  }
+  if (result.outputs.length === 0) {
+    throw new Error("Bun.build produced no outputs");
+  }
+  bundled = await result.outputs[0]!.text();
+} finally {
+  // Always clean up the shim source regardless of build success so it doesn't
+  // clutter the marketing app root.
+  await rm(shimSourcePath, { force: true });
+}
+
+// Rewrite the import path from the shim-relative spec to a
+// server-dir-relative one so Cloudflare can resolve it once the bundle moves
+// into dist/server/.
+const rewritten = bundled.replaceAll(
+  JSON.stringify(astroEntryImportSpec),
+  JSON.stringify("./astro-entry.mjs"),
+);
+if (!rewritten.includes("./astro-entry.mjs")) {
+  throw new Error(
+    "Bundled shim does not reference astro-entry.mjs — bundler may have inlined it unexpectedly.",
+  );
+}
+
+await writeFile(entryPath, rewritten, "utf8");
+
+// 4. Patch wrangler.json — ensure nodejs_compat is present (defensively; the
+//    Astro adapter already sets it at the time of writing, but that's not
+//    guaranteed across versions).
+const wranglerRaw = await readFile(wranglerJsonPath, "utf8");
+const wrangler = JSON.parse(wranglerRaw) as {
+  compatibility_flags?: string[];
+  [key: string]: unknown;
+};
+const flags = new Set<string>(wrangler.compatibility_flags ?? []);
+flags.add("nodejs_compat");
+wrangler.compatibility_flags = Array.from(flags);
+await writeFile(wranglerJsonPath, JSON.stringify(wrangler), "utf8");
+
+console.log(
+  `[wrap-worker] wrapped ${entryPath} with otel-cf-workers + Sentry; compatibility_flags=${wrangler.compatibility_flags.join(",")}`,
+);

--- a/apps/marketing/tsconfig.json
+++ b/apps/marketing/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "astro/tsconfigs/strict",
   "include": [".astro/types.d.ts", "**/*"],
-  "exclude": ["dist", "astro.config.mjs"]
+  "exclude": ["dist", "astro.config.mjs", "scripts"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -177,6 +177,9 @@
         "@executor/plugin-graphql": "workspace:*",
         "@executor/plugin-openapi": "workspace:*",
         "@executor/sdk": "workspace:*",
+        "@microlabs/otel-cf-workers": "^1.0.0-rc.52",
+        "@opentelemetry/api": "~1.9.0",
+        "@sentry/cloudflare": "^10.49.0",
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.3",
         "effect": "^3.14.16",
@@ -4807,6 +4810,8 @@
 
     "@executor/example-promise-sdk/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
+    "@executor/marketing/@sentry/cloudflare": ["@sentry/cloudflare@10.49.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@sentry/core": "10.49.0" }, "peerDependencies": { "@cloudflare/workers-types": "^4.x" }, "optionalPeers": ["@cloudflare/workers-types"] }, "sha512-kHNIwJ6SX39R5TRoW/Bf25rgrBwXBbD44fEK9+hkJ3IdGBLktXG2+T7mNGjpvR98TWxQDhcvs8WLfFw/SsDGrA=="],
+
     "@executor/storage-postgres/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
@@ -5440,6 +5445,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@executor/marketing/@sentry/cloudflare/@sentry/core": ["@sentry/core@10.49.0", "", {}, "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g=="],
 
     "@executor/storage-postgres/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 


### PR DESCRIPTION
## Summary

Mirror `apps/cloud`'s observability wiring on the marketing Worker: traces go to Axiom via `@microlabs/otel-cf-workers`, errors to Sentry via `@sentry/cloudflare`. Both workers write to the same Axiom dataset (`executor-cloud`) and are distinguished by `service.name` (`executor-marketing` vs `executor-cloud`).

## Approach

The Astro Cloudflare adapter emits `dist/server/entry.mjs` as the Worker entry and there is no hook to substitute that entry, so we added a **post-build shim** step (`apps/marketing/scripts/wrap-worker.ts`):

1. Rename `dist/server/entry.mjs` -> `dist/server/astro-entry.mjs`.
2. Write a small ESM shim that imports `./astro-entry.mjs` and wraps its default export with `Sentry.withSentry(sentryOptions, instrument({ fetch: astroHandler.fetch }, otelConfig))` (other top-level handlers like `scheduled`/`queue` are preserved via spread).
3. Bundle the shim with `Bun.build` (Sentry + otel-cf-workers inlined — Vite has already run, so anything new here needs to ship self-contained). The renamed Astro entry stays as an external relative import so its own chunk graph keeps working under wrangler's `no_bundle: true` rule.
4. Defensively ensure `compatibility_flags` in `dist/server/wrangler.json` includes `nodejs_compat`.

`sentryOptions` matches `apps/cloud/src/server.ts` verbatim: `skipOpenTelemetrySetup: true`, `tracesSampleRate: 0`, `enableLogs: true`, `sendDefaultPii: true`. Env reads are direct `process.env.*` since marketing has no `@executor/env` package. `skipOpenTelemetrySetup: true` is load-bearing — otel-cf-workers owns the global TracerProvider; Sentry's OTEL shim would clobber it and break every request with `global tracer is not of type WorkerTracer`.

We deliberately do NOT use `instrumentDO` or `Sentry.instrumentDurableObjectWithSentry` (marketing has no DOs, and those wrappers have known `this`-binding issues on WorkerTransport anyway).

## Why this approach vs alternatives

- **Astro integration hook**: Astro's build lifecycle has no way to replace the adapter's generated entry file — the adapter's `astro:build:setup` already owns the Rollup input. A post-build wrap is the cleanest intercept point.
- **Edit the generated entry in place**: Brittle. Astro's entry imports hashed chunks via helpers; rewriting that file would tie us to adapter internals. Isolating our changes to a new shim file and leaving Astro's output untouched is safer.
- **Import-from-source wrapping**: Would require running Astro's Vite pass through our config, not realistic.

## Testing

- [x] `bun run build` in `apps/marketing` succeeds and emits `dist/server/entry.mjs` (~390 KB bundle with Sentry + otel-cf-workers inlined) plus `dist/server/astro-entry.mjs` (unchanged Astro output, relative-imported by the shim).
- [x] `bun run typecheck` at the repo root passes (34/34 tasks green).
- [x] `bun run lint` at the repo root passes.
- [ ] **Deploy** (user): set `AXIOM_TOKEN`, optional `AXIOM_DATASET` (defaults to `executor-cloud`), and `SENTRY_DSN` as secrets on the `executor-marketing` Worker, then `bun run deploy` from `apps/marketing`.
- [ ] **Verify** (user): trigger a request, confirm a trace shows up in the Axiom `executor-cloud` dataset under `service.name = "executor-marketing"`, throw a test error and confirm it lands in the `node-cloudflare-workers` Sentry project.