### PR TITLE
execution: add Effect.fn spans for tool-call + code-exec boundaries

### DIFF
--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -320,78 +320,102 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
    * The sandbox is forked as a daemon because paused executions can outlive the
    * caller scope that returned the first pause, such as an HTTP request handler.
    */
-  const startPausableExecution = (code: string): Effect.Effect<ExecutionResult> =>
-    Effect.gen(function* () {
-      // Ref holds the current pause signal. The elicitation handler reads
-      // it each time it fires, so resume() can swap in a fresh Deferred
-      // before unblocking the fiber.
-      const pauseSignalRef = yield* Ref.make(yield* Deferred.make<InternalPausedExecution>());
-
-      // Will be set once the fiber is forked.
-      let fiber: Fiber.Fiber<ExecuteResult, unknown>;
-
-      const elicitationHandler: ElicitationHandler = (ctx) =>
-        Effect.gen(function* () {
-          const responseDeferred = yield* Deferred.make<typeof ElicitationResponse.Type>();
-          const id = `exec_${++nextId}`;
-
-          const paused: InternalPausedExecution = {
-            id,
-            elicitationContext: ctx,
-            response: responseDeferred,
-            fiber: fiber!,
-            pauseSignalRef,
-          };
-          pausedExecutions.set(id, paused);
-
-          const currentSignal = yield* Ref.get(pauseSignalRef);
-          yield* Deferred.succeed(currentSignal, paused);
-
-          // Suspend until resume() completes responseDeferred.
-          return yield* Deferred.await(responseDeferred);
-        });
-
-      const invoker = makeFullInvoker(executor, { onElicitation: elicitationHandler });
-      fiber = yield* Effect.forkDaemon(codeExecutor.execute(code, invoker));
-
-      const initialSignal = yield* Ref.get(pauseSignalRef);
-      return yield* awaitCompletionOrPause(fiber, initialSignal);
+  const startPausableExecution = Effect.fn("mcp.execute")(function* (code: string) {
+    yield* Effect.annotateCurrentSpan({
+      "mcp.execute.mode": "pausable",
+      "mcp.execute.code_length": code.length,
     });
+
+    // Ref holds the current pause signal. The elicitation handler reads
+    // it each time it fires, so resume() can swap in a fresh Deferred
+    // before unblocking the fiber.
+    const pauseSignalRef = yield* Ref.make(yield* Deferred.make<InternalPausedExecution>());
+
+    // Will be set once the fiber is forked.
+    let fiber: Fiber.Fiber<ExecuteResult, unknown>;
+
+    const elicitationHandler: ElicitationHandler = (ctx) =>
+      Effect.gen(function* () {
+        const responseDeferred = yield* Deferred.make<typeof ElicitationResponse.Type>();
+        const id = `exec_${++nextId}`;
+
+        const paused: InternalPausedExecution = {
+          id,
+          elicitationContext: ctx,
+          response: responseDeferred,
+          fiber: fiber!,
+          pauseSignalRef,
+        };
+        pausedExecutions.set(id, paused);
+
+        const currentSignal = yield* Ref.get(pauseSignalRef);
+        yield* Deferred.succeed(currentSignal, paused);
+
+        // Suspend until resume() completes responseDeferred.
+        return yield* Deferred.await(responseDeferred);
+      });
+
+    const invoker = makeFullInvoker(executor, { onElicitation: elicitationHandler });
+    fiber = yield* Effect.forkDaemon(
+      codeExecutor.execute(code, invoker).pipe(Effect.withSpan("executor.code.exec")),
+    );
+
+    const initialSignal = yield* Ref.get(pauseSignalRef);
+    return (yield* awaitCompletionOrPause(fiber, initialSignal)) as ExecutionResult;
+  });
 
   /**
    * Resume a paused execution. Swaps in a fresh pause signal, completes
    * the response Deferred to unblock the fiber, then races completion
    * against the next pause.
    */
-  const resumeExecution = (
+  const resumeExecution = Effect.fn("mcp.execute.resume")(function* (
     executionId: string,
     response: ResumeResponse,
-  ): Effect.Effect<ExecutionResult | null> =>
-    Effect.gen(function* () {
-      const paused = pausedExecutions.get(executionId);
-      if (!paused) return null;
-      pausedExecutions.delete(executionId);
-
-      // Swap in a fresh pause signal BEFORE unblocking the fiber, so the
-      // next elicitation handler call signals this new Deferred.
-      const nextSignal = yield* Deferred.make<InternalPausedExecution>();
-      yield* Ref.set(paused.pauseSignalRef, nextSignal);
-
-      yield* Deferred.succeed(paused.response, {
-        action: response.action,
-        content: response.content,
-      });
-
-      return yield* awaitCompletionOrPause(paused.fiber, nextSignal);
+  ) {
+    yield* Effect.annotateCurrentSpan({
+      "mcp.execute.resume.action": response.action,
     });
 
+    const paused = pausedExecutions.get(executionId);
+    if (!paused) return null;
+    pausedExecutions.delete(executionId);
+
+    // Swap in a fresh pause signal BEFORE unblocking the fiber, so the
+    // next elicitation handler call signals this new Deferred.
+    const nextSignal = yield* Deferred.make<InternalPausedExecution>();
+    yield* Ref.set(paused.pauseSignalRef, nextSignal);
+
+    yield* Deferred.succeed(paused.response, {
+      action: response.action,
+      content: response.content,
+    });
+
+    return (yield* awaitCompletionOrPause(paused.fiber, nextSignal)) as ExecutionResult;
+  });
+
+  /**
+   * Inline-elicitation execute path. Wrapped so every call produces an
+   * `mcp.execute` span with the inner `executor.code.exec` as a child.
+   */
+  const runInlineExecution = Effect.fn("mcp.execute")(function* (
+    code: string,
+    options: { readonly onElicitation: ElicitationHandler },
+  ) {
+    yield* Effect.annotateCurrentSpan({
+      "mcp.execute.mode": "inline",
+      "mcp.execute.code_length": code.length,
+    });
+    const invoker = makeFullInvoker(executor, {
+      onElicitation: options.onElicitation,
+    });
+    return yield* codeExecutor
+      .execute(code, invoker)
+      .pipe(Effect.withSpan("executor.code.exec"));
+  });
+
   return {
-    execute: async (code, options) => {
-      const invoker = makeFullInvoker(executor, {
-        onElicitation: options.onElicitation,
-      });
-      return runEffect(codeExecutor.execute(code, invoker));
-    },
+    execute: (code, options) => runEffect(runInlineExecution(code, options)),
 
     executeWithPause: (code) => runEffect(startPausableExecution(code)),
 

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -11,40 +11,65 @@ import type { SandboxToolInvoker } from "@executor/codemode-core";
 import { ExecutionToolError } from "./errors";
 
 /**
+ * Extract the source namespace from a tool path. Tool paths look like
+ * "<sourceId>.<op>" or "<sourceId>.<group>.<op>" — we take the first
+ * segment as a cheap, non-lookup stand-in for the source id so the span
+ * attribute is always populated without hitting `executor.sources.list()`
+ * per call.
+ */
+const extractSourceNamespace = (path: string): string => {
+  const idx = path.indexOf(".");
+  return idx === -1 ? path : path.slice(0, idx);
+};
+
+/**
  * Bridges QuickJS `tools.someSource.someOp(args)` calls into
  * `executor.tools.invoke(toolId, args)`.
+ *
+ * Wrapped in `Effect.fn("mcp.tool.dispatch")` so every tool call becomes a
+ * span in the Effect tracer. Attributes:
+ *   - `mcp.tool.name`      — full tool path (e.g. "github.repos.get")
+ *   - `mcp.tool.source_id` — first segment of the path (namespace)
+ *
+ * `mcp.tool.kind` (openapi | mcp | graphql | code) is NOT annotated here
+ * because it would require a `sources.list()` lookup on every invocation.
+ * Callers that already know the source kind can annotate at their own span.
  */
 export const makeExecutorToolInvoker = (
   executor: Executor,
   options: { readonly invokeOptions: InvokeOptions },
 ): SandboxToolInvoker => ({
-  invoke: ({ path, args }) =>
-    Effect.gen(function* () {
-      const result = yield* executor.tools.invoke(path as ToolId, args, options.invokeOptions).pipe(
-        Effect.catchTag("ElicitationDeclinedError", (err) =>
-          Effect.fail(
-            new ExecutionToolError({
-              message: `Tool "${err.toolId}" requires approval but the request was ${err.action === "cancel" ? "cancelled" : "declined"} by the user.`,
-              cause: err,
-            }),
-          ),
+  invoke: Effect.fn("mcp.tool.dispatch")(function* ({ path, args }) {
+    yield* Effect.annotateCurrentSpan({
+      "mcp.tool.name": path,
+      "mcp.tool.source_id": extractSourceNamespace(path),
+    });
+
+    const result = yield* executor.tools.invoke(path as ToolId, args, options.invokeOptions).pipe(
+      Effect.catchTag("ElicitationDeclinedError", (err) =>
+        Effect.fail(
+          new ExecutionToolError({
+            message: `Tool "${err.toolId}" requires approval but the request was ${err.action === "cancel" ? "cancelled" : "declined"} by the user.`,
+            cause: err,
+          }),
         ),
-      );
-      const r = result as { readonly error?: unknown; readonly data?: unknown } | unknown;
-      if (
-        r !== null &&
-        typeof r === "object" &&
-        "error" in r &&
-        (r as { error?: unknown }).error !== null &&
-        (r as { error?: unknown }).error !== undefined
-      ) {
-        return yield* Effect.fail((r as { error: unknown }).error);
-      }
-      if (r !== null && typeof r === "object" && "data" in r) {
-        return (r as { data: unknown }).data;
-      }
-      return r;
-    }),
+      ),
+    );
+    const r = result as { readonly error?: unknown; readonly data?: unknown } | unknown;
+    if (
+      r !== null &&
+      typeof r === "object" &&
+      "error" in r &&
+      (r as { error?: unknown }).error !== null &&
+      (r as { error?: unknown }).error !== undefined
+    ) {
+      return yield* Effect.fail((r as { error: unknown }).error);
+    }
+    if (r !== null && typeof r === "object" && "data" in r) {
+      return (r as { data: unknown }).data;
+    }
+    return r;
+  }),
 });
 
 export type ToolDiscoveryResult = {
@@ -246,103 +271,98 @@ const scoreToolMatch = (tool: SearchableTool, query: string): ToolDiscoveryResul
 };
 
 /** What `tools.search()` calls inside the sandbox. */
-export const searchTools = (
+export const searchTools = Effect.fn("executor.tools.search")(function* (
   executor: Executor,
   query: string,
   limit = 12,
   options?: { readonly namespace?: string },
-): Effect.Effect<ReadonlyArray<ToolDiscoveryResult>> =>
-  Effect.gen(function* () {
-    if (normalizeSearchText(query).length === 0) {
-      return [];
-    }
-
-    const all = yield* executor.tools.list().pipe(Effect.orDie);
-    return all
-      .filter((tool: Tool) => matchesNamespace(tool, options?.namespace))
-      .map((tool: Tool) => scoreToolMatch(tool, query))
-      .filter((tool): tool is ToolDiscoveryResult => tool !== null)
-      .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
-      .slice(0, limit);
+) {
+  yield* Effect.annotateCurrentSpan({
+    "executor.search.query_length": query.length,
+    "executor.search.limit": limit,
+    ...(options?.namespace ? { "executor.search.namespace": options.namespace } : {}),
   });
+
+  if (normalizeSearchText(query).length === 0) {
+    return [] as ReadonlyArray<ToolDiscoveryResult>;
+  }
+
+  const all = yield* executor.tools.list().pipe(Effect.orDie);
+  return all
+    .filter((tool: Tool) => matchesNamespace(tool, options?.namespace))
+    .map((tool: Tool) => scoreToolMatch(tool, query))
+    .filter((tool): tool is ToolDiscoveryResult => tool !== null)
+    .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
+    .slice(0, limit);
+});
 
 /** What `tools.executor.sources.list()` calls inside the sandbox. */
-export const listExecutorSources = (
+export const listExecutorSources = Effect.fn("executor.sources.list")(function* (
   executor: Executor,
   options?: { readonly query?: string; readonly limit?: number },
-): Effect.Effect<ReadonlyArray<ExecutorSourceListItem>> =>
-  Effect.gen(function* () {
-    const normalizedQuery = normalizeSearchText(options?.query ?? "");
-    const limit = options?.limit ?? 200;
-    const sources = yield* executor.sources.list().pipe(Effect.orDie);
+) {
+  const normalizedQuery = normalizeSearchText(options?.query ?? "");
+  const limit = options?.limit ?? 200;
+  const sources = yield* executor.sources.list().pipe(Effect.orDie);
 
-    const filtered =
-      normalizedQuery.length === 0
-        ? sources
-        : sources.filter((source: Source) => {
-            const haystack = normalizeSearchText([source.id, source.name, source.kind].join(" "));
-            return tokenizeSearchText(normalizedQuery).every((token) => haystack.includes(token));
-          });
+  const filtered =
+    normalizedQuery.length === 0
+      ? sources
+      : sources.filter((source: Source) => {
+          const haystack = normalizeSearchText([source.id, source.name, source.kind].join(" "));
+          return tokenizeSearchText(normalizedQuery).every((token) => haystack.includes(token));
+        });
 
-    // Single query for all tools, then count per source in memory.
-    const allTools = yield* executor.tools.list().pipe(Effect.orDie);
-    const toolCountBySource = new Map<string, number>();
-    for (const tool of allTools) {
-      toolCountBySource.set(tool.sourceId, (toolCountBySource.get(tool.sourceId) ?? 0) + 1);
-    }
+  // Single query for all tools, then count per source in memory.
+  const allTools = yield* executor.tools.list().pipe(Effect.orDie);
+  const toolCountBySource = new Map<string, number>();
+  for (const tool of allTools) {
+    toolCountBySource.set(tool.sourceId, (toolCountBySource.get(tool.sourceId) ?? 0) + 1);
+  }
 
-    const withCounts = filtered.map(
-      (source: Source) =>
-        ({
-          id: source.id,
-          name: source.name,
-          kind: source.kind,
-          runtime: source.runtime,
-          canRemove: source.canRemove,
-          canRefresh: source.canRefresh,
-          toolCount: toolCountBySource.get(source.id) ?? 0,
-        }) satisfies ExecutorSourceListItem,
-    );
+  const withCounts = filtered.map(
+    (source: Source) =>
+      ({
+        id: source.id,
+        name: source.name,
+        kind: source.kind,
+        runtime: source.runtime,
+        canRemove: source.canRemove,
+        canRefresh: source.canRefresh,
+        toolCount: toolCountBySource.get(source.id) ?? 0,
+      }) satisfies ExecutorSourceListItem,
+  );
 
-    return withCounts
-      .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id))
-      .slice(0, limit);
-  });
+  return withCounts
+    .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id))
+    .slice(0, limit);
+});
 
 /** What `tools.describe.tool()` calls inside the sandbox. */
-export const describeTool = (
+export const describeTool = Effect.fn("executor.tools.describe")(function* (
   executor: Executor,
   path: string,
-): Effect.Effect<
-  {
-    path: string;
-    name: string;
-    description?: string;
-    inputTypeScript?: string;
-    outputTypeScript?: string;
-    typeScriptDefinitions?: Record<string, string>;
-  },
-  unknown
-> =>
-  Effect.gen(function* () {
-    // Single tools.schema() call — it already fetches the tool row
-    // internally. No need to also call tools.list() just for name/description.
-    const schema: ToolSchema | null = yield* executor.tools.schema(path);
+) {
+  yield* Effect.annotateCurrentSpan({ "mcp.tool.name": path });
 
-    // tools.schema() returns null if the tool doesn't exist. Fall back to
-    // a minimal stub so callers can still render something.
-    if (schema === null) {
-      return { path, name: path };
-    }
+  // Single tools.schema() call — it already fetches the tool row
+  // internally. No need to also call tools.list() just for name/description.
+  const schema: ToolSchema | null = yield* executor.tools.schema(path);
 
-    // The schema's id is the tool path; name/description come from the
-    // tool row which tools.schema() already loaded.
-    return {
-      path,
-      name: schema.name ?? path,
-      description: schema.description,
-      inputTypeScript: schema.inputTypeScript,
-      outputTypeScript: schema.outputTypeScript,
-      typeScriptDefinitions: schema.typeScriptDefinitions,
-    };
-  });
+  // tools.schema() returns null if the tool doesn't exist. Fall back to
+  // a minimal stub so callers can still render something.
+  if (schema === null) {
+    return { path, name: path };
+  }
+
+  // The schema's id is the tool path; name/description come from the
+  // tool row which tools.schema() already loaded.
+  return {
+    path,
+    name: schema.name ?? path,
+    description: schema.description,
+    inputTypeScript: schema.inputTypeScript,
+    outputTypeScript: schema.outputTypeScript,
+    typeScriptDefinitions: schema.typeScriptDefinitions,
+  };
+});

--- a/packages/kernel/runtime-dynamic-worker/src/executor.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/executor.ts
@@ -313,7 +313,11 @@ const runInDynamicWorker = (
       new DynamicWorkerExecutionError({
         message: renderTransportMessage(serializeWorkerErrorValue(cause)),
       }),
-  });
+  }).pipe(
+    Effect.withSpan("executor.code.exec.dynamic_worker", {
+      attributes: { "executor.runtime": "dynamic-worker" },
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // Public API

--- a/packages/kernel/runtime-quickjs/src/index.ts
+++ b/packages/kernel/runtime-quickjs/src/index.ts
@@ -390,7 +390,11 @@ const runInQuickJs = (
   Effect.tryPromise({
     try: () => evaluateInQuickJs(options, code, toolInvoker),
     catch: (cause) => new QuickJsExecutionError({ message: String(cause) }),
-  });
+  }).pipe(
+    Effect.withSpan("executor.code.exec.quickjs", {
+      attributes: { "executor.runtime": "quickjs" },
+    }),
+  );
 
 export const makeQuickJsExecutor = (options: QuickJsExecutorOptions = {}): CodeExecutor => ({
   execute: (code: string, toolInvoker: SandboxToolInvoker) =>


### PR DESCRIPTION
## Summary

Wire Effect tracer spans through the execution engine so Axiom can build MCP DO dashboards (tool-call volume, success rate, p95 duration, top failing tools) without any additional instrumentation at the caller side.

Previous PRs (#280, #281) routed the Effect tracer into Axiom via `@microlabs/otel-cf-workers` on the HTTP path and `@effect/opentelemetry`'s WebSdk on the MCP DO. This PR adds the span boundaries inside the engine itself.

Zero business-logic changes. `Effect.fn` and `Effect.withSpan` only — no new services, no new error handling, no param changes. The engine still uses pure `Effect` APIs (`fn` / `withSpan` / `annotateCurrentSpan`); `@effect/opentelemetry` stays at the layer level.

## Spans added

| Span | Location | Attributes |
| --- | --- | --- |
| `mcp.execute` | `packages/core/execution/src/engine.ts` — `execute()` (inline) and `executeWithPause()` entry points | `mcp.execute.mode` (`inline` \| `pausable`), `mcp.execute.code_length` |
| `mcp.execute.resume` | same file — `resume()` | `mcp.execute.resume.action` (`accept` \| `decline` \| `cancel`) |
| `executor.code.exec` | engine — wraps `codeExecutor.execute(...)` call inside both execute paths | (engine doesn't know the runtime kind; the runtime-side span annotates it) |
| `executor.code.exec.dynamic_worker` | `packages/kernel/runtime-dynamic-worker/src/executor.ts` | `executor.runtime` = `dynamic-worker` |
| `executor.code.exec.quickjs` | `packages/kernel/runtime-quickjs/src/index.ts` | `executor.runtime` = `quickjs` |
| `mcp.tool.dispatch` | `packages/core/execution/src/tool-invoker.ts` — every tool call flowing through `SandboxToolInvoker.invoke` | `mcp.tool.name`, `mcp.tool.source_id` |
| `executor.tools.search` | tool-invoker — `tools.search()` from inside the sandbox | `executor.search.query_length`, `executor.search.limit`, optional `executor.search.namespace` |
| `executor.tools.describe` | tool-invoker — `describe.tool()` from inside the sandbox | `mcp.tool.name` |
| `executor.sources.list` | tool-invoker — `executor.sources.list()` from inside the sandbox | (none; invocation itself is the signal) |

## Naming convention

Single pattern so future spans match:

- **Outermost MCP boundary** (tool-call entry from the outside world): `mcp.execute`, `mcp.execute.resume`, `mcp.tool.dispatch`.
- **Engine-internal / sandbox intrinsics**: `executor.<thing>.<action>` — e.g. `executor.code.exec`, `executor.tools.search`, `executor.sources.list`.
- **Runtime-specific code execution**: `executor.code.exec.<runtime>` (annotates `executor.runtime`).
- Attribute keys namespace with dots: `mcp.tool.name`, `mcp.execute.mode`, `executor.runtime`, etc.

Converted a handful of `Effect.gen` generators to `Effect.fn(name)(function*)` to get the three-location stack traces for free (definition / call / raise-site) without any change at call sites.

## Tension with the "don't plumb new services" constraint

- **`mcp.tool.kind`** (`openapi` \| `mcp` \| `graphql` \| `code`) is NOT annotated on `mcp.tool.dispatch`. Resolving it from a tool path requires `executor.sources.list()` per invocation, which would add a DB hit to every tool call purely for telemetry. Left unannotated; documented in code. For Axiom panels, the practical substitute is `mcp.tool.source_id` (first segment of the tool path, e.g. `github` in `github.repos.get`), which is cheap and always populated. If we really want `kind`, a better place is the plugin-level invoke implementations (they already know their kind) — that's a follow-up.
- **`org.id`** is NOT annotated inside the engine. The engine is shared code and shouldn't know about WorkOS organizations. Annotate at the caller (`apps/cloud`) on a parent span; child engine spans inherit via the Effect context.

## Example APL — tool success rate

```kusto
['executor']
| where ['attributes.otel.name'] == 'mcp.tool.dispatch'
| extend tool = tostring(['attributes.custom.mcp.tool.name'])
| summarize
    total = count(),
    errors = countif(['attributes.otel.status_code'] == 'ERROR')
  by tool
| extend success_rate = round(100.0 * (total - errors) / total, 2)
| order by total desc
```

Same shape works for `executor.code.exec.*` (overall execution success rate) and can be faceted by `attributes.custom.executor.runtime` to split `dynamic-worker` vs `quickjs`.

## Test plan

- [x] `bun run typecheck` at repo root (34/34 packages)
- [x] `bun run test` in `packages/core/execution` (8/8)
- [x] `bun run test` in `apps/cloud` (workerd + node configs — 27 + 23)
- [x] `bun run test` in `packages/hosts/mcp` (23/23)
- [x] `bun run test` in `packages/kernel/runtime-dynamic-worker` (26/26) and `runtime-quickjs` (8/8)
- [ ] Deploy (user) — verify `mcp.execute` / `mcp.tool.dispatch` / `executor.code.exec.dynamic_worker` spans land in Axiom with the documented attributes