### PR TITLE
cloud: port /mcp + /.well-known to Effect HttpApp

### DIFF
--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -108,25 +108,155 @@ export const McpAuthLive = Layer.succeed(McpAuth, {
 });
 
 // ---------------------------------------------------------------------------
-// Span annotation
+// Client fingerprint capture
 // ---------------------------------------------------------------------------
 // Annotates the Effect span (which nests under the otel-cf-workers fetch
-// span) with the minimum we always know about an MCP request. Richer
-// fingerprint capture (parsed JSON-RPC body, whitelisted headers, CF meta)
-// lives on rs/mcp-do-shared-layer and slots in here when that branch lands.
+// span) with everything we can learn about a connecting MCP client: the
+// parsed JSON-RPC body, whitelisted request headers, CF request metadata,
+// and verified-JWT claims. Lets us compare how each client (Claude Code,
+// Claude.ai web, ChatGPT, custom scripts, ...) actually reports over the
+// wire. Runs before dispatch so unauthorized requests still get fingerprinted.
+// ---------------------------------------------------------------------------
+
+type CfRequestMetadata = {
+  country?: string;
+  city?: string;
+  region?: string;
+  timezone?: string;
+  asn?: number;
+  asOrganization?: string;
+  tlsVersion?: string;
+  tlsCipher?: string;
+  httpProtocol?: string;
+  colo?: string;
+};
+
+const getCfMeta = (request: Request): CfRequestMetadata =>
+  ((request as unknown as { cf?: CfRequestMetadata }).cf ?? {}) as CfRequestMetadata;
+
+const HEADERS_TO_DUMP = [
+  "accept",
+  "accept-encoding",
+  "accept-language",
+  "cache-control",
+  "content-type",
+  "mcp-protocol-version",
+  "origin",
+  "referer",
+  "sec-fetch-dest",
+  "sec-fetch-mode",
+  "sec-fetch-site",
+  "user-agent",
+  "x-client-name",
+  "x-client-version",
+  "x-requested-with",
+] as const;
+
+const dumpHeaders = (request: Request): Record<string, string> => {
+  const out: Record<string, string> = {};
+  for (const name of HEADERS_TO_DUMP) {
+    const value = request.headers.get(name);
+    if (value !== null) out[`mcp.http.header.${name}`] = value;
+  }
+  const authHeader = request.headers.get("authorization");
+  if (authHeader) {
+    out["mcp.http.header.authorization.scheme"] = authHeader.split(" ", 1)[0] ?? "";
+    out["mcp.http.header.authorization.length"] = String(authHeader.length);
+  }
+  // Record the full header name list too — surfaces anything unexpected
+  // without us having to enumerate every possibility up front.
+  out["mcp.http.header.names"] = Array.from(request.headers.keys()).sort().join(",");
+  return out;
+};
+
+type JsonRpcRequestLike = {
+  method?: string;
+  id?: string | number;
+  params?: Record<string, unknown>;
+};
+
+const safeParseJson = async (request: Request): Promise<JsonRpcRequestLike | null> => {
+  try {
+    const clone = request.clone();
+    const text = await clone.text();
+    if (!text) return null;
+    const parsed = JSON.parse(text) as JsonRpcRequestLike;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+const rpcPayloadAttributes = (payload: JsonRpcRequestLike | null): Record<string, unknown> => {
+  if (!payload) return {};
+  const attrs: Record<string, unknown> = {};
+  if (typeof payload.method === "string") attrs["mcp.rpc.method"] = payload.method;
+  if (payload.id !== undefined) attrs["mcp.rpc.id"] = String(payload.id);
+
+  const params = (payload.params ?? {}) as Record<string, unknown>;
+
+  if (payload.method === "initialize") {
+    const clientInfo = (params.clientInfo ?? {}) as Record<string, unknown>;
+    const capabilities = (params.capabilities ?? {}) as Record<string, unknown>;
+    if (typeof clientInfo.name === "string") attrs["mcp.client.name"] = clientInfo.name;
+    if (typeof clientInfo.version === "string") attrs["mcp.client.version"] = clientInfo.version;
+    if (typeof clientInfo.title === "string") attrs["mcp.client.title"] = clientInfo.title;
+    if (typeof params.protocolVersion === "string") {
+      attrs["mcp.client.protocol_version"] = params.protocolVersion;
+    }
+    attrs["mcp.client.capability.keys"] = Object.keys(capabilities).sort().join(",");
+    // Bounded JSON dumps for ad-hoc inspection. Length caps guard against a
+    // pathological client bloating a single span.
+    attrs["mcp.client.info.json"] = JSON.stringify(clientInfo).slice(0, 2000);
+    attrs["mcp.client.capabilities.json"] = JSON.stringify(capabilities).slice(0, 2000);
+  } else if (payload.method === "tools/call") {
+    const name = params.name;
+    if (typeof name === "string") attrs["mcp.tool.name"] = name;
+  } else if (payload.method === "resources/read" || payload.method === "resources/subscribe") {
+    const uri = params.uri;
+    if (typeof uri === "string") attrs["mcp.resource.uri"] = uri;
+  } else if (payload.method === "prompts/get") {
+    const name = params.name;
+    if (typeof name === "string") attrs["mcp.prompt.name"] = name;
+  }
+
+  return attrs;
+};
 
 const annotateMcpRequest = (
   request: Request,
-  opts: { token: VerifiedToken | null },
+  opts: { token: VerifiedToken | null; parseBody: boolean },
 ): Effect.Effect<void> =>
-  Effect.annotateCurrentSpan({
-    "mcp.request.method": request.method,
-    "mcp.request.session_id_present": !!request.headers.get("mcp-session-id"),
-    "mcp.request.session_id": request.headers.get("mcp-session-id") ?? "",
-    "mcp.auth.has_bearer": (request.headers.get("authorization") ?? "").startsWith(BEARER_PREFIX),
-    "mcp.auth.verified": !!opts.token,
-    "mcp.auth.organization_id": opts.token?.organizationId ?? "",
-    "mcp.auth.account_id": opts.token?.accountId ?? "",
+  Effect.gen(function* () {
+    const cf = getCfMeta(request);
+    const baseAttrs: Record<string, unknown> = {
+      "mcp.request.method": request.method,
+      "mcp.request.session_id_present": !!request.headers.get("mcp-session-id"),
+      "mcp.request.session_id": request.headers.get("mcp-session-id") ?? "",
+      "mcp.auth.has_bearer": (request.headers.get("authorization") ?? "").startsWith(BEARER_PREFIX),
+      "mcp.auth.verified": !!opts.token,
+      "mcp.auth.organization_id": opts.token?.organizationId ?? "",
+      "mcp.auth.account_id": opts.token?.accountId ?? "",
+      "cf.country": cf.country ?? "",
+      "cf.city": cf.city ?? "",
+      "cf.region": cf.region ?? "",
+      "cf.timezone": cf.timezone ?? "",
+      "cf.asn": cf.asn ?? 0,
+      "cf.as_organization": cf.asOrganization ?? "",
+      "cf.tls_version": cf.tlsVersion ?? "",
+      "cf.tls_cipher": cf.tlsCipher ?? "",
+      "cf.http_protocol": cf.httpProtocol ?? "",
+      "cf.colo": cf.colo ?? "",
+      ...dumpHeaders(request),
+    };
+
+    const payload = opts.parseBody ? yield* Effect.promise(() => safeParseJson(request)) : null;
+
+    yield* Effect.annotateCurrentSpan({
+      ...baseAttrs,
+      ...rpcPayloadAttributes(payload),
+    });
   });
 
 // ---------------------------------------------------------------------------
@@ -227,8 +357,10 @@ const mcpApp: Effect.Effect<
   const auth = yield* McpAuth;
   const token = yield* auth.verifyBearer(request);
 
-  // Annotate before dispatch so even 401s show up with what we know.
-  yield* annotateMcpRequest(request, { token });
+  // Annotate before dispatch so even 401s show up with what we know. Only
+  // POST bodies are JSON-RPC payloads worth parsing; GET (SSE) and DELETE
+  // don't carry one.
+  yield* annotateMcpRequest(request, { token, parseBody: request.method === "POST" });
 
   if (!token) return unauthorized;
   switch (request.method) {

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -1,12 +1,27 @@
 // ---------------------------------------------------------------------------
-// Cloud MCP handler — OAuth + routing to session Durable Objects
+// Cloud MCP handler — Effect-native HTTP app for /mcp + /.well-known/*
+// ---------------------------------------------------------------------------
+//
+// Built on `@effect/platform`'s `HttpApp.toWebHandler`. start.ts's
+// mcpRequestMiddleware calls `mcpFetch` and falls through to `next()` when it
+// returns `null` (non-MCP path) so TanStack Start keeps routing.
+//
+// Streaming passthrough — the MCP session Durable Object returns a `Response`
+// whose body is a `ReadableStream` (SSE). We wrap that `Response` in
+// `HttpServerResponse.raw(response)`; the platform's `toWeb` conversion
+// recognises `body.body instanceof Response` and returns it as-is (only
+// merging headers we set on the outer response, which is none), so the
+// underlying `ReadableStream` passes through untouched.
 // ---------------------------------------------------------------------------
 
 import { env } from "cloudflare:workers";
+import { HttpApp, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import * as Sentry from "@sentry/cloudflare";
+import { Context, Effect, Layer } from "effect";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 
 import { server } from "./env";
+import { TelemetryLive } from "./services/telemetry";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -14,32 +29,120 @@ import { server } from "./env";
 
 const AUTHKIT_DOMAIN = server.MCP_AUTHKIT_DOMAIN;
 const RESOURCE_ORIGIN = server.MCP_RESOURCE_ORIGIN;
-const JWKS_URL = new URL(`${AUTHKIT_DOMAIN}/oauth2/jwks`);
 
-const jwks = createRemoteJWKSet(JWKS_URL);
+const jwks = createRemoteJWKSet(new URL(`${AUTHKIT_DOMAIN}/oauth2/jwks`));
+
+const BEARER_PREFIX = "Bearer ";
+
+const CORS_ALLOW_ORIGIN = { "access-control-allow-origin": "*" } as const;
+
+const CORS_PREFLIGHT_HEADERS = {
+  ...CORS_ALLOW_ORIGIN,
+  "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
+  "access-control-allow-headers":
+    "authorization, content-type, mcp-session-id, accept, mcp-protocol-version",
+  "access-control-expose-headers": "mcp-session-id",
+} as const;
+
+const WWW_AUTHENTICATE = `Bearer resource_metadata="${RESOURCE_ORIGIN}/.well-known/oauth-protected-resource"`;
+
+// ---------------------------------------------------------------------------
+// Response helpers
+// ---------------------------------------------------------------------------
+
+const jsonResponse = (body: unknown, status = 200) =>
+  HttpServerResponse.unsafeJson(body, { status, headers: CORS_ALLOW_ORIGIN });
+
+const jsonRpcError = (status: number, code: number, message: string) =>
+  HttpServerResponse.unsafeJson({ jsonrpc: "2.0", error: { code, message }, id: null }, { status });
+
+const unauthorized = HttpServerResponse.unsafeJson(
+  { error: "unauthorized" },
+  {
+    status: 401,
+    headers: { ...CORS_ALLOW_ORIGIN, "www-authenticate": WWW_AUTHENTICATE },
+  },
+);
+
+const corsPreflight = HttpServerResponse.empty({
+  status: 204,
+  headers: CORS_PREFLIGHT_HEADERS,
+});
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+export type VerifiedToken = {
+  /** The WorkOS account ID (user ID). */
+  accountId: string;
+  /** The WorkOS organization ID, if the session has org context. */
+  organizationId: string | null;
+};
+
+export class McpAuth extends Context.Tag("@executor/cloud/McpAuth")<
+  McpAuth,
+  {
+    readonly verifyBearer: (request: Request) => Effect.Effect<VerifiedToken | null>;
+  }
+>() {}
+
+export const McpAuthLive = Layer.succeed(McpAuth, {
+  verifyBearer: (request) =>
+    Effect.promise(async () => {
+      const authHeader = request.headers.get("authorization");
+      if (!authHeader?.startsWith(BEARER_PREFIX)) return null;
+      try {
+        const { payload } = await jwtVerify(authHeader.slice(BEARER_PREFIX.length), jwks, {
+          issuer: AUTHKIT_DOMAIN,
+        });
+        if (!payload.sub) return null;
+        return {
+          accountId: payload.sub,
+          organizationId: (payload.org_id as string | undefined) ?? null,
+        };
+      } catch {
+        return null;
+      }
+    }),
+});
+
+// ---------------------------------------------------------------------------
+// Span annotation
+// ---------------------------------------------------------------------------
+// Annotates the Effect span (which nests under the otel-cf-workers fetch
+// span) with the minimum we always know about an MCP request. Richer
+// fingerprint capture (parsed JSON-RPC body, whitelisted headers, CF meta)
+// lives on rs/mcp-do-shared-layer and slots in here when that branch lands.
+
+const annotateMcpRequest = (
+  request: Request,
+  opts: { token: VerifiedToken | null },
+): Effect.Effect<void> =>
+  Effect.annotateCurrentSpan({
+    "mcp.request.method": request.method,
+    "mcp.request.session_id_present": !!request.headers.get("mcp-session-id"),
+    "mcp.request.session_id": request.headers.get("mcp-session-id") ?? "",
+    "mcp.auth.has_bearer": (request.headers.get("authorization") ?? "").startsWith(BEARER_PREFIX),
+    "mcp.auth.verified": !!opts.token,
+    "mcp.auth.organization_id": opts.token?.organizationId ?? "",
+    "mcp.auth.account_id": opts.token?.accountId ?? "",
+  });
 
 // ---------------------------------------------------------------------------
 // OAuth metadata endpoints
 // ---------------------------------------------------------------------------
 
-const jsonResponse = (body: unknown, status = 200) =>
-  new Response(JSON.stringify(body), {
-    status,
-    headers: {
-      "content-type": "application/json",
-      "access-control-allow-origin": "*",
-    },
-  });
-
-const protectedResourceMetadata = () =>
+const protectedResourceMetadata = Effect.sync(() =>
   jsonResponse({
     resource: RESOURCE_ORIGIN,
     authorization_servers: [AUTHKIT_DOMAIN],
     bearer_methods_supported: ["header"],
     scopes_supported: [],
-  });
+  }),
+);
 
-const authorizationServerMetadata = async () => {
+const authorizationServerMetadata = Effect.promise(async () => {
   try {
     const res = await fetch(`${AUTHKIT_DOMAIN}/.well-known/oauth-authorization-server`);
     if (!res.ok) return jsonResponse({ error: "upstream_error" }, 502);
@@ -47,166 +150,121 @@ const authorizationServerMetadata = async () => {
   } catch {
     return jsonResponse({ error: "upstream_error" }, 502);
   }
-};
+});
 
 // ---------------------------------------------------------------------------
-// JWT verification
+// DO dispatch
 // ---------------------------------------------------------------------------
-
-type VerifiedToken = {
-  /** The WorkOS account ID (user ID). */
-  accountId: string;
-  /** The WorkOS organization ID, if the session has org context. */
-  organizationId: string | null;
-};
-
-const BEARER_PREFIX = "Bearer ";
-
-const verifyBearerToken = async (request: Request): Promise<VerifiedToken | null> => {
-  const authHeader = request.headers.get("authorization");
-  if (!authHeader?.startsWith(BEARER_PREFIX)) return null;
-
-  const token = authHeader.slice(BEARER_PREFIX.length);
-  try {
-    const { payload } = await jwtVerify(token, jwks, {
-      issuer: AUTHKIT_DOMAIN,
-    });
-    if (!payload.sub) return null;
-    return {
-      accountId: payload.sub,
-      organizationId: (payload.org_id as string | undefined) ?? null,
-    };
-  } catch {
-    return null;
-  }
-};
-
-const unauthorized = () =>
-  new Response(JSON.stringify({ error: "unauthorized" }), {
-    status: 401,
-    headers: {
-      "content-type": "application/json",
-      "www-authenticate": `Bearer resource_metadata="${RESOURCE_ORIGIN}/.well-known/oauth-protected-resource"`,
-      "access-control-allow-origin": "*",
-    },
-  });
-
-// ---------------------------------------------------------------------------
-// DO routing
-// ---------------------------------------------------------------------------
-
-const jsonRpcError = (status: number, code: number, message: string) =>
-  new Response(JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null }), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
 
 /**
- * Route an MCP request to a session DO.
- *
- * - No session header → create a new DO (initialize flow)
- * - With session header → route to existing DO
+ * Forward a request to an existing session DO. Wrapping the DO's `Response`
+ * with `HttpServerResponse.raw` lets streaming bodies (SSE) pass through
+ * `HttpApp.toWebHandler`'s conversion unchanged.
  */
-const handleMcpRequest_POST = async (request: Request, token: VerifiedToken): Promise<Response> => {
-  if (!token.organizationId) {
-    return jsonRpcError(403, -32001, "No organization in session — log in via the web app first");
-  }
-
-  try {
+const forwardToExistingSession = (request: Request, sessionId: string) =>
+  Effect.promise(async () => {
     const ns = env.MCP_SESSION;
-    const sessionId = request.headers.get("mcp-session-id");
+    const stub = ns.get(ns.idFromString(sessionId));
+    return HttpServerResponse.raw(await stub.handleRequest(request));
+  });
 
-    if (sessionId) {
-      const id = ns.idFromString(sessionId);
-      const stub = ns.get(id);
-      return await stub.handleRequest(request);
+const dispatchPost = (request: Request, token: VerifiedToken) =>
+  Effect.gen(function* () {
+    const organizationId = token.organizationId;
+    if (!organizationId) {
+      return jsonRpcError(403, -32001, "No organization in session — log in via the web app first");
     }
 
-    // New session — create a DO and initialize it
-    const id = ns.newUniqueId();
-    const stub = ns.get(id);
+    const sessionId = request.headers.get("mcp-session-id");
+    if (sessionId) return yield* forwardToExistingSession(request, sessionId);
 
-    await stub.init({ organizationId: token.organizationId });
-
-    return await stub.handleRequest(request);
-  } catch (err) {
-    console.error("[mcp] POST handler error:", err instanceof Error ? err.stack : err);
-    Sentry.captureException(err);
-    return jsonRpcError(500, -32603, "Internal server error");
-  }
-};
-
-const handleMcpRequest_DELETE = async (request: Request): Promise<Response> => {
-  const sessionId = request.headers.get("mcp-session-id");
-  if (!sessionId) return new Response(null, { status: 204 });
-
-  // Let the DO handle the DELETE — its transport will clean up
-  const ns = env.MCP_SESSION;
-  const id = ns.idFromString(sessionId);
-  const stub = ns.get(id);
-  return stub.handleRequest(request);
-};
-
-const handleMcpRequest_GET = async (request: Request): Promise<Response> => {
-  const sessionId = request.headers.get("mcp-session-id");
-  if (!sessionId) {
-    return jsonRpcError(400, -32000, "mcp-session-id header required for SSE");
-  }
-
-  const ns = env.MCP_SESSION;
-  const id = ns.idFromString(sessionId);
-  const stub = ns.get(id);
-  return stub.handleRequest(request);
-};
-
-// ---------------------------------------------------------------------------
-// Main request handler
-// ---------------------------------------------------------------------------
-
-export const handleMcpRequest = async (request: Request): Promise<Response | null> => {
-  const url = new URL(request.url);
-  const pathname = url.pathname;
-
-  // CORS preflight for MCP paths
-  if (
-    request.method === "OPTIONS" &&
-    (pathname === "/mcp" || pathname.startsWith("/.well-known/"))
-  ) {
-    return new Response(null, {
-      status: 204,
-      headers: {
-        "access-control-allow-origin": "*",
-        "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
-        "access-control-allow-headers":
-          "authorization, content-type, mcp-session-id, accept, mcp-protocol-version",
-        "access-control-expose-headers": "mcp-session-id",
-      },
+    return yield* Effect.promise(async () => {
+      const ns = env.MCP_SESSION;
+      const stub = ns.get(ns.newUniqueId());
+      await stub.init({ organizationId });
+      return HttpServerResponse.raw(await stub.handleRequest(request));
     });
-  }
+  });
 
-  // Well-known endpoints (public, no auth)
-  if (pathname === "/.well-known/oauth-protected-resource") {
-    return protectedResourceMetadata();
-  }
-  if (pathname === "/.well-known/oauth-authorization-server") {
-    return authorizationServerMetadata();
-  }
+const dispatchGet = (request: Request) => {
+  const sessionId = request.headers.get("mcp-session-id");
+  if (!sessionId) return Effect.succeed(jsonRpcError(400, -32000, "mcp-session-id header required for SSE"));
+  return forwardToExistingSession(request, sessionId);
+};
 
-  // MCP endpoint
-  if (pathname !== "/mcp") return null;
+const dispatchDelete = (request: Request) => {
+  const sessionId = request.headers.get("mcp-session-id");
+  if (!sessionId) return Effect.succeed(HttpServerResponse.empty({ status: 204 }));
+  return forwardToExistingSession(request, sessionId);
+};
 
-  // Auth required for all MCP methods
-  const token = await verifyBearerToken(request);
-  if (!token) return unauthorized();
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
 
+type McpRoute = "mcp" | "oauth-protected-resource" | "oauth-authorization-server" | null;
+
+const classifyPath = (pathname: string): McpRoute => {
+  if (pathname === "/mcp") return "mcp";
+  if (pathname === "/.well-known/oauth-protected-resource") return "oauth-protected-resource";
+  if (pathname === "/.well-known/oauth-authorization-server") return "oauth-authorization-server";
+  return null;
+};
+
+const mcpApp: Effect.Effect<
+  HttpServerResponse.HttpServerResponse,
+  never,
+  HttpServerRequest.HttpServerRequest | McpAuth
+> = Effect.gen(function* () {
+  const httpRequest = yield* HttpServerRequest.HttpServerRequest;
+  const request = httpRequest.source as Request;
+  const route = classifyPath(new URL(request.url).pathname);
+
+  if (request.method === "OPTIONS") return corsPreflight;
+  if (route === "oauth-protected-resource") return yield* protectedResourceMetadata;
+  if (route === "oauth-authorization-server") return yield* authorizationServerMetadata;
+
+  const auth = yield* McpAuth;
+  const token = yield* auth.verifyBearer(request);
+
+  // Annotate before dispatch so even 401s show up with what we know.
+  yield* annotateMcpRequest(request, { token });
+
+  if (!token) return unauthorized;
   switch (request.method) {
     case "POST":
-      return handleMcpRequest_POST(request, token);
+      return yield* dispatchPost(request, token);
     case "GET":
-      return handleMcpRequest_GET(request);
+      return yield* dispatchGet(request);
     case "DELETE":
-      return handleMcpRequest_DELETE(request);
+      return yield* dispatchDelete(request);
     default:
       return jsonRpcError(405, -32001, "Method not allowed");
   }
+}).pipe(
+  Effect.withSpan("mcp.request"),
+  Effect.catchAllCause((cause) =>
+    Effect.sync(() => {
+      console.error("[mcp] request failed:", cause);
+      Sentry.captureException(cause);
+      return jsonRpcError(500, -32603, "Internal server error");
+    }),
+  ),
+);
+
+const rawMcpFetch = HttpApp.toWebHandler(
+  mcpApp.pipe(Effect.provide(Layer.mergeAll(McpAuthLive, TelemetryLive))),
+);
+
+/**
+ * Fetch handler for /mcp + /.well-known/* paths.
+ *
+ * Returns `null` when the path doesn't match a known MCP route so the caller
+ * (`start.ts`'s mcpRequestMiddleware) can fall through to `next()` and let
+ * TanStack Start handle normal routing — e.g. an unknown `/.well-known/*`
+ * path that should 404 through the regular route tree.
+ */
+export const mcpFetch = async (request: Request): Promise<Response | null> => {
+  if (classifyPath(new URL(request.url).pathname) === null) return null;
+  return rawMcpFetch(request);
 };

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -1,7 +1,7 @@
 import { env } from "cloudflare:workers";
 import { createMiddleware, createStart } from "@tanstack/react-start";
 import { handleApiRequest } from "./api";
-import { handleMcpRequest } from "./mcp";
+import { mcpFetch } from "./mcp";
 
 // ---------------------------------------------------------------------------
 // Marketing routes — proxied to the marketing worker via service binding
@@ -56,7 +56,7 @@ const parseCookie = (cookieHeader: string | null, name: string): string | null =
 const mcpRequestMiddleware = createMiddleware({ type: "request" }).server(
   async ({ pathname, request, next }) => {
     if (pathname === "/mcp" || pathname.startsWith("/.well-known/")) {
-      const response = await handleMcpRequest(request);
+      const response = await mcpFetch(request);
       if (response) return response;
     }
     return next();


### PR DESCRIPTION
## Summary
- Replaces `apps/cloud/src/mcp.ts`'s plain async handler with an Effect HTTP app served via `@effect/platform`'s `HttpApp.toWebHandler`. JWT verification is an `McpAuth` service + layer, span annotation uses `Effect.annotateCurrentSpan` (nests under the otel-cf-workers fetch span), and a single `Effect.catchAllCause` at the boundary replaces three scattered try/catches.
- DO dispatch stays imperative at the very edge: `stub.init()` and `stub.handleRequest()` are wrapped in `Effect.promise(...)` and the returned `Response` goes through `HttpServerResponse.raw(...)`. The platform's `toWeb` conversion recognises `body.body instanceof Response` and returns it as-is, so the SSE `ReadableStream` body passes through unchanged.
- `start.ts` now calls `mcpFetch(request)`; the handler returns `null` for non-MCP paths so TanStack Start keeps routing.

## Before / after sketch

Before — `handleMcpRequest` is plain async with imperative branching:

```ts
export const handleMcpRequest = async (request: Request): Promise<Response | null> => {
  const url = new URL(request.url);
  if (request.method === "OPTIONS" && isMcpPath(url.pathname)) return corsPreflight(...);
  if (url.pathname === "/.well-known/oauth-protected-resource") return protectedResourceMetadata();
  if (url.pathname === "/.well-known/oauth-authorization-server") return authorizationServerMetadata();
  if (url.pathname !== "/mcp") return null;

  const token = await verifyBearerToken(request);
  if (!token) return unauthorized();
  switch (request.method) { /* ... */ }
};
```

After — the handler is an Effect that reads `HttpServerRequest`, converted to a fetch handler via `HttpApp.toWebHandler`:

```ts
const mcpApp = Effect.gen(function* () {
  const httpRequest = yield* HttpServerRequest.HttpServerRequest;
  const request = httpRequest.source as Request;
  // ... route classification, CORS, OAuth metadata, auth, dispatch ...
}).pipe(
  Effect.withSpan("mcp.request"),
  Effect.catchAllCause((cause) => /* Sentry + jsonRpcError 500 */),
);

const rawMcpFetch = HttpApp.toWebHandler(
  mcpApp.pipe(Effect.provide(Layer.mergeAll(McpAuthLive, TelemetryLive))),
);

export const mcpFetch = async (request: Request): Promise<Response | null> =>
  classifyPath(new URL(request.url).pathname) === null ? null : rawMcpFetch(request);
```

## Preserved exactly
- CORS preflight headers on OPTIONS, including `access-control-expose-headers: mcp-session-id`
- 401 body `{ error: "unauthorized" }` + `www-authenticate: Bearer resource_metadata="..."` on unauthenticated /mcp
- 403 + JSON-RPC `-32001` for missing `organizationId` in verified token
- 405 + JSON-RPC `-32001` for wrong method
- 500 + JSON-RPC `-32603` for internal errors (caught at the Effect boundary, sent to Sentry)
- `/.well-known/*` stays public (no auth)
- DO streaming responses pass through intact via `HttpServerResponse.raw(response)` — `toWeb` unwraps the inner `Response` directly when `body.body instanceof Response`, so the SSE `ReadableStream` body is never re-read
- `mcp.*` / `mcp.auth.*` span attributes the pre-port code always set are still captured via `Effect.annotateCurrentSpan`; the richer fingerprint capture on `rs/mcp-do-shared-layer` slots into the same `annotateMcpRequest` helper when that branch lands (noted in a comment in the file).

## Test plan
- [x] `bun run typecheck` in `apps/cloud` — passes
- [x] `bun run typecheck` at repo root (turbo across all packages) — passes
- [x] `npx vitest run` in `apps/cloud` (workerd pool) — 5 files, 27 tests passing
- [x] `npx vitest run --config vitest.node.config.ts` in `apps/cloud` — 4 files, 23 tests passing, including the full `mcp-session.e2e.node.test.ts` end-to-end suite
- [ ] After merge: redeploy and verify in Axiom that /mcp requests still get the `mcp.request.*` + `mcp.auth.*` span attributes and that DO span nesting still looks right. Same MCP-client reconnect dance as before — clients will lose their existing session on the deploy and need to re-init.