### PR TITLE
cloud: restore McpSessionDO init/handleRequest span coverage + real-flow telemetry test

### DIFF
--- a/apps/cloud/src/env.ts
+++ b/apps/cloud/src/env.ts
@@ -22,6 +22,7 @@ const serverShape = {
   SENTRY_DSN: Env.stringOr("SENTRY_DSN", ""),
   AXIOM_TOKEN: Env.stringOr("AXIOM_TOKEN", ""),
   AXIOM_DATASET: Env.stringOr("AXIOM_DATASET", "executor-cloud"),
+  AXIOM_TRACES_URL: Env.stringOr("AXIOM_TRACES_URL", "https://api.axiom.co/v1/traces"),
 };
 
 type SharedEnv = Readonly<{
@@ -42,6 +43,7 @@ type ServerEnv = SharedEnv &
     SENTRY_DSN: string;
     AXIOM_TOKEN: string;
     AXIOM_DATASET: string;
+    AXIOM_TRACES_URL: string;
   }>;
 
 type WebEnv = Readonly<Record<string, never>>;

--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -22,6 +22,7 @@
 import { expect, layer } from "@effect/vitest";
 import { resolve } from "node:path";
 import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 
 import {
   HttpApi,
@@ -90,6 +91,23 @@ class Worker extends Context.Tag("MiniflareE2E/Worker")<
   }
 >() {}
 
+type CapturedSpan = {
+  readonly name: string;
+  readonly attributes: Record<string, unknown>;
+};
+
+class TelemetryReceiver extends Context.Tag("MiniflareE2E/TelemetryReceiver")<
+  TelemetryReceiver,
+  {
+    readonly tracesUrl: string;
+    readonly spans: () => ReadonlyArray<CapturedSpan>;
+    readonly waitForSpan: (
+      predicate: (span: CapturedSpan) => boolean,
+      timeoutMs?: number,
+    ) => Promise<CapturedSpan>;
+  }
+>() {}
+
 const UpstreamLive = Layer.effect(
   Upstream,
   Effect.gen(function* () {
@@ -107,36 +125,160 @@ const UpstreamLive = Layer.effect(
   }),
 ).pipe(Layer.provide(UpstreamServeLayer));
 
-const WorkerLive = Layer.scoped(
-  Worker,
+// ---------------------------------------------------------------------------
+// Telemetry receiver — a node HTTP server on a random port that speaks
+// OTLP/JSON. The Effect OTLPTraceExporter in `services/telemetry.ts`
+// posts JSON bodies to it (confirmed via
+// `@opentelemetry/exporter-trace-otlp-http` — `Content-Type:
+// application/json` + `JsonTraceSerializer`). We parse resourceSpans →
+// scopeSpans → spans → attributes so tests can assert the DO actually
+// reported the expected spans, not just that the exporter was called.
+// ---------------------------------------------------------------------------
+
+type OtlpAttributeValue = {
+  readonly stringValue?: string;
+  readonly intValue?: string | number;
+  readonly doubleValue?: number;
+  readonly boolValue?: boolean;
+};
+type OtlpAttribute = { readonly key: string; readonly value?: OtlpAttributeValue };
+type OtlpSpan = { readonly name: string; readonly attributes?: ReadonlyArray<OtlpAttribute> };
+type OtlpPayload = {
+  readonly resourceSpans?: ReadonlyArray<{
+    readonly scopeSpans?: ReadonlyArray<{ readonly spans?: ReadonlyArray<OtlpSpan> }>;
+  }>;
+};
+
+const unwrapAttrValue = (v?: OtlpAttributeValue): unknown => {
+  if (!v) return undefined;
+  if (v.stringValue !== undefined) return v.stringValue;
+  if (v.intValue !== undefined) return Number(v.intValue);
+  if (v.doubleValue !== undefined) return v.doubleValue;
+  if (v.boolValue !== undefined) return v.boolValue;
+  return undefined;
+};
+
+const TelemetryReceiverLive = Layer.scoped(
+  TelemetryReceiver,
   Effect.acquireRelease(
-    Effect.promise(() =>
-      unstable_dev(resolve(__dirname, "./test-worker.ts"), {
-        config: resolve(__dirname, "../wrangler.miniflare.jsonc"),
-        experimental: { disableExperimentalWarning: true },
-        ip: "127.0.0.1",
-        logLevel: "info",
-      }),
-    ),
-    (w) => Effect.promise(() => w.stop()),
-  ).pipe(
-    Effect.map((w: Unstable_DevWorker) => ({
-      baseUrl: new URL(`http://${w.address}:${w.port}`),
-      seedOrg: async (id: string, name: string) => {
-        const res = await w.fetch("/__test__/seed-org", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ id, name }),
+    Effect.async<
+      {
+        readonly tracesUrl: string;
+        readonly spans: ReadonlyArray<CapturedSpan>;
+        readonly store: Array<CapturedSpan>;
+        readonly close: () => Promise<void>;
+      },
+      never
+    >((resume) => {
+      const store: Array<CapturedSpan> = [];
+      const server = createServer((req, res) => {
+        if (req.method !== "POST" || !req.url?.endsWith("/v1/traces")) {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+        let body = "";
+        req.on("data", (chunk) => { body += chunk; });
+        req.on("end", () => {
+          try {
+            const payload = JSON.parse(body) as OtlpPayload;
+            for (const rs of payload.resourceSpans ?? []) {
+              for (const ss of rs.scopeSpans ?? []) {
+                for (const sp of ss.spans ?? []) {
+                  const attrs: Record<string, unknown> = {};
+                  for (const a of sp.attributes ?? []) {
+                    attrs[a.key] = unwrapAttrValue(a.value);
+                  }
+                  store.push({ name: sp.name, attributes: attrs });
+                }
+              }
+            }
+          } catch {
+            // ignore malformed payloads
+          }
+          res.writeHead(200, { "content-type": "application/json" });
+          res.end("{}");
         });
-        if (res.status !== 204) {
-          throw new Error(`seed-org failed: ${res.status} ${await res.text()}`);
+      });
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address() as AddressInfo;
+        resume(
+          Effect.succeed({
+            tracesUrl: `http://127.0.0.1:${addr.port}/v1/traces`,
+            spans: store,
+            store,
+            close: () => new Promise<void>((r) => server.close(() => r())),
+          }),
+        );
+      });
+    }),
+    (t) => Effect.promise(() => t.close()),
+  ).pipe(
+    Effect.map((t) => ({
+      tracesUrl: t.tracesUrl,
+      spans: () => [...t.store],
+      waitForSpan: async (
+        predicate: (s: CapturedSpan) => boolean,
+        timeoutMs = 5_000,
+      ) => {
+        const deadline = Date.now() + timeoutMs;
+        for (;;) {
+          const hit = t.store.find(predicate);
+          if (hit) return hit;
+          if (Date.now() > deadline) {
+            throw new Error(
+              `Timed out waiting for span. Captured ${t.store.length}: ${t.store.map((s) => s.name).join(", ") || "<none>"}`,
+            );
+          }
+          await new Promise((r) => setTimeout(r, 50));
         }
       },
     })),
   ),
 );
 
-const TestEnv = Layer.mergeAll(UpstreamLive, WorkerLive);
+const WorkerLive = Layer.scoped(
+  Worker,
+  Effect.gen(function* () {
+    const receiver = yield* TelemetryReceiver;
+    // AXIOM_TOKEN activates DoTelemetryLive inside the worker; AXIOM_TRACES_URL
+    // redirects the exporter at our in-process OTLP/JSON receiver so spans
+    // become observable in the test process.
+    return yield* Effect.acquireRelease(
+      Effect.promise(() =>
+        unstable_dev(resolve(__dirname, "./test-worker.ts"), {
+          config: resolve(__dirname, "../wrangler.miniflare.jsonc"),
+          experimental: { disableExperimentalWarning: true },
+          ip: "127.0.0.1",
+          logLevel: "info",
+          vars: {
+            AXIOM_TOKEN: "test-token",
+            AXIOM_TRACES_URL: receiver.tracesUrl,
+          },
+        }),
+      ),
+      (w) => Effect.promise(() => w.stop()),
+    ).pipe(
+      Effect.map((w: Unstable_DevWorker) => ({
+        baseUrl: new URL(`http://${w.address}:${w.port}`),
+        seedOrg: async (id: string, name: string) => {
+          const res = await w.fetch("/__test__/seed-org", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id, name }),
+          });
+          if (res.status !== 204) {
+            throw new Error(`seed-org failed: ${res.status} ${await res.text()}`);
+          }
+        },
+      })),
+    );
+  }),
+);
+
+const TestEnv = Layer.mergeAll(UpstreamLive, WorkerLive).pipe(
+  Layer.provideMerge(TelemetryReceiverLive),
+);
 
 // ---------------------------------------------------------------------------
 // Client helpers
@@ -256,6 +398,44 @@ layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it)
       expect(text).toContain("approved");
 
       yield* Effect.promise(() => client.close());
+    }), 30_000,
+  );
+
+  it.effect("reports the McpSessionDO.handleRequest span via the OTLP exporter", () =>
+    Effect.gen(function* () {
+      const { baseUrl, seedOrg } = yield* Worker;
+      const receiver = yield* TelemetryReceiver;
+      const orgId = nextOrgId();
+      yield* Effect.promise(() => seedOrg(orgId, "Telemetry Org"));
+      const client = yield* Effect.promise(() =>
+        connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
+      );
+      // Trigger the DO through a multi-step flow so we can assert that
+      // handleRequest spans are reported for every DO hit, not just init.
+      yield* Effect.promise(() => client.listTools());
+      yield* Effect.promise(() =>
+        client.callTool({ name: "execute", arguments: { code: "return 1 + 2" } }),
+      );
+      yield* Effect.promise(() => client.close());
+
+      // The initialize POST carries no session-id; subsequent requests do.
+      // Assert on one of the session-id'd handleRequest spans so we verify
+      // attribute propagation beyond the degenerate init case.
+      const handleSpan = yield* Effect.promise(() =>
+        receiver.waitForSpan(
+          (s) =>
+            s.name === "McpSessionDO.handleRequest" &&
+            s.attributes["mcp.request.session_id_present"] === true,
+        ),
+      );
+      expect(handleSpan.attributes["mcp.request.method"]).toBeDefined();
+      // 200 for normal POSTs, 202 for notifications/initialized.
+      expect([200, 202]).toContain(handleSpan.attributes["mcp.response.status_code"]);
+
+      // init runs once per new session and should appear on the initialize POST.
+      yield* Effect.promise(() =>
+        receiver.waitForSpan((s) => s.name === "McpSessionDO.init"),
+      );
     }), 30_000,
   );
 });

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -207,7 +207,23 @@ export class McpSessionDO extends DurableObject {
 
   async init(token: McpSessionInit): Promise<void> {
     if (this.initialized) return;
+    // Outer `McpSessionDO.init` span wraps the full session-bootstrap cost
+    // (resolveSessionMeta + createRuntime + alarm setup) so the MCP DO
+    // dashboard's "new sessions" / "init p95" panels have one uniform span
+    // to filter on, regardless of whether the DO is running the long-lived
+    // or request-scoped variant.
+    const program = Effect.promise(() => this.doInit(token)).pipe(
+      Effect.withSpan("McpSessionDO.init", {
+        attributes: {
+          "mcp.auth.organization_id": token.organizationId,
+        },
+      }),
+      Effect.provide(DoTelemetryLive),
+    );
+    return Effect.runPromise(program);
+  }
 
+  private async doInit(token: McpSessionInit): Promise<void> {
     try {
       const sessionMeta = await this.resolveAndStoreSessionMeta(token);
 
@@ -274,6 +290,29 @@ export class McpSessionDO extends DurableObject {
   }
 
   async handleRequest(request: Request): Promise<Response> {
+    // Wrap the dispatch in an Effect span so every DO request — not just
+    // the rare new-session `init()` — shows up in Axiom. Basic attributes
+    // only (method, session-id presence, response status); rich client
+    // fingerprint stays on the edge `mcp.request` span, which shares a
+    // trace_id with this one.
+    const program = Effect.promise(() => this.dispatchRequest(request)).pipe(
+      Effect.tap((response) =>
+        Effect.annotateCurrentSpan({
+          "mcp.response.status_code": response.status,
+        }),
+      ),
+      Effect.withSpan("McpSessionDO.handleRequest", {
+        attributes: {
+          "mcp.request.method": request.method,
+          "mcp.request.session_id_present": !!request.headers.get("mcp-session-id"),
+        },
+      }),
+      Effect.provide(DoTelemetryLive),
+    );
+    return Effect.runPromise(program);
+  }
+
+  private async dispatchRequest(request: Request): Promise<Response> {
     if (requestScopedRuntimeEnabled) {
       return this.handleRequestWithRequestScopedRuntime(request);
     }
@@ -297,6 +336,14 @@ export class McpSessionDO extends DurableObject {
   }
 
   async alarm(): Promise<void> {
+    const program = Effect.promise(() => this.runAlarm()).pipe(
+      Effect.withSpan("McpSessionDO.alarm"),
+      Effect.provide(DoTelemetryLive),
+    );
+    return Effect.runPromise(program);
+  }
+
+  private async runAlarm(): Promise<void> {
     const idleMs = Date.now() - this.lastActivityMs;
     if (idleMs >= SESSION_TIMEOUT_MS) {
       await this.cleanup();

--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -18,7 +18,7 @@ import { server } from "./env";
 const otelConfig: TraceConfig = {
   service: { name: "executor-cloud", version: "1.0.0" },
   exporter: {
-    url: "https://api.axiom.co/v1/traces",
+    url: server.AXIOM_TRACES_URL,
     headers: {
       Authorization: `Bearer ${server.AXIOM_TOKEN}`,
       "X-Axiom-Dataset": server.AXIOM_DATASET,

--- a/apps/cloud/src/services/telemetry.ts
+++ b/apps/cloud/src/services/telemetry.ts
@@ -37,7 +37,7 @@ export const TelemetryLive: Layer.Layer<never> = OtelTracer.layerGlobal.pipe(
 
 const makeDoOtelExporter = () =>
   new OTLPTraceExporter({
-    url: "https://api.axiom.co/v1/traces",
+    url: server.AXIOM_TRACES_URL,
     headers: {
       Authorization: `Bearer ${server.AXIOM_TOKEN}`,
       "X-Axiom-Dataset": server.AXIOM_DATASET,


### PR DESCRIPTION
Follow-up to #289. Two o11y regressions caught by audit against live Axiom data:

1. **`McpSessionDO.handleRequest` was never a span.** The method was plain async, so ~95% of MCP traffic (every session-reuse request) was invisible at the DO layer. Only `McpSessionDO.init` ever fired, and init runs once per new session.
2. **`McpSessionDO.init` disappeared during the request-scoped refactor.** The body got split into `resolveSessionMeta` + `createRuntime` spans and lost the outer aggregate the MCP DO dashboard filters on. Axiom showed 3 init spans over 24h vs ~20+ actual sessions.

Fix: re-add `Effect.withSpan` wrappers on both the outer `init` body and every `handleRequest` dispatch. Exports through the existing `DoTelemetryLive`. Span attrs kept minimal; the edge `mcp.request` span in `mcp.ts` still carries the full client fingerprint and correlates by trace id.

- `McpSessionDO.init`: `mcp.auth.organization_id`
- `McpSessionDO.handleRequest`: `mcp.request.method`, `mcp.request.session_id_present`, `mcp.response.status_code`
- `McpSessionDO.alarm`: span only, no attrs

## Real-flow telemetry test

`mcp-miniflare.e2e.node.test.ts` now:

- Stands up an OTLP/JSON receiver on a random port (a tiny `node:http.createServer` that parses `resourceSpans → scopeSpans → spans`).
- Sets `AXIOM_TRACES_URL` (new env var, defaults to Axiom) on `unstable_dev` vars so the worker's exporter posts to the in-process receiver.
- Sets a dummy `AXIOM_TOKEN` so `DoTelemetryLive` activates.
- Drives initialize → notifications/initialized → tools/list → tools/call through the real MCP SDK.
- Asserts the receiver saw both a `McpSessionDO.handleRequest` span with `session_id_present=true` + 2xx status, and a `McpSessionDO.init` span. If either wrapper gets dropped in future refactors, the test fails.

The `AXIOM_TRACES_URL` indirection is the cleanest way to keep the "real flow" property (full OTLP export path, actual worker emitting spans) without hitting production Axiom from CI.

## Test plan

- [x] `apps/cloud` typecheck — green
- [x] Workerd-pool `mcp-flow.test.ts` — 9/9
- [x] Node `mcp-miniflare.e2e.node.test.ts` — 5/5 (adds 1 new telemetry test)
- [x] Lint — green
- [ ] After merge: confirm `McpSessionDO.init` + `McpSessionDO.handleRequest` spans start landing in Axiom. Update the MCP DO dashboard's `table-do-rpcs` query (currently filters on bare `init` / `handleRequest` names) to use `name startswith 'McpSessionDO'`.