### PR TITLE
cloud: fix DO telemetry export + rebuild env as lazy Proxy

### DIFF
--- a/apps/cloud/src/env.ts
+++ b/apps/cloud/src/env.ts
@@ -1,29 +1,21 @@
-import { createEnv, Env } from "@executor/env";
+// ---------------------------------------------------------------------------
+// Env accessors for apps/cloud.
+// ---------------------------------------------------------------------------
+//
+// `server` / `shared` are lazy Proxies over `cloudflare:workers` `env`, with
+// a `process.env` fallback for the node-pool tests (which stub
+// `cloudflare:workers` to an empty `env` and rely on vitest to populate
+// `process.env`). Reads happen at the call site, not at module load, so
+// secrets land correctly in both the edge isolate and the Durable Object
+// isolate — the latter previously captured empty strings at env.ts
+// module-load time and silently broke `DoTelemetryLive`, `AutumnService`
+// billing writes, and likely other DO-reachable secret readers.
+//
+// Types below mirror the prior `createEnv(...)`-derived shapes so every
+// caller (`server.X`) keeps the same typed surface.
+// ---------------------------------------------------------------------------
 
-const sharedShape = {
-  NODE_ENV: Env.literalOr("NODE_ENV", "development", "development", "test", "production"),
-};
-
-const serverShape = {
-  DATABASE_URL: Env.stringOr("DATABASE_URL", ""),
-  MCP_SESSION_REQUEST_SCOPED_RUNTIME: Env.literalOr(
-    "MCP_SESSION_REQUEST_SCOPED_RUNTIME",
-    "false",
-    "false",
-    "true",
-  ),
-  WORKOS_API_KEY: Env.string("WORKOS_API_KEY"),
-  WORKOS_CLIENT_ID: Env.string("WORKOS_CLIENT_ID"),
-  WORKOS_COOKIE_PASSWORD: Env.string("WORKOS_COOKIE_PASSWORD"),
-  VITE_PUBLIC_SITE_URL: Env.stringOr("VITE_PUBLIC_SITE_URL", ""),
-  MCP_AUTHKIT_DOMAIN: Env.stringOr("MCP_AUTHKIT_DOMAIN", "https://signin.executor.sh"),
-  MCP_RESOURCE_ORIGIN: Env.stringOr("MCP_RESOURCE_ORIGIN", "https://executor.sh"),
-  AUTUMN_SECRET_KEY: Env.stringOr("AUTUMN_SECRET_KEY", ""),
-  SENTRY_DSN: Env.stringOr("SENTRY_DSN", ""),
-  AXIOM_TOKEN: Env.stringOr("AXIOM_TOKEN", ""),
-  AXIOM_DATASET: Env.stringOr("AXIOM_DATASET", "executor-cloud"),
-  AXIOM_TRACES_URL: Env.stringOr("AXIOM_TRACES_URL", "https://api.axiom.co/v1/traces"),
-};
+import { env } from "cloudflare:workers";
 
 type SharedEnv = Readonly<{
   NODE_ENV: "development" | "test" | "production";
@@ -48,22 +40,50 @@ type ServerEnv = SharedEnv &
 
 type WebEnv = Readonly<Record<string, never>>;
 
-export const shared = createEnv(sharedShape, {
-  runtimeEnv: process.env,
-  emptyStringAsUndefined: true,
-}) as SharedEnv;
+const SERVER_DEFAULTS: Record<keyof ServerEnv, string> = {
+  NODE_ENV: "development",
+  DATABASE_URL: "",
+  MCP_SESSION_REQUEST_SCOPED_RUNTIME: "false",
+  WORKOS_API_KEY: "",
+  WORKOS_CLIENT_ID: "",
+  WORKOS_COOKIE_PASSWORD: "",
+  VITE_PUBLIC_SITE_URL: "",
+  MCP_AUTHKIT_DOMAIN: "https://signin.executor.sh",
+  MCP_RESOURCE_ORIGIN: "https://executor.sh",
+  AUTUMN_SECRET_KEY: "",
+  SENTRY_DSN: "",
+  AXIOM_TOKEN: "",
+  AXIOM_DATASET: "executor-cloud",
+  AXIOM_TRACES_URL: "https://api.axiom.co/v1/traces",
+};
 
-export const web = createEnv(
-  {},
-  {
-    prefix: "PUBLIC_",
-    runtimeEnv: process.env,
-    emptyStringAsUndefined: true,
-  },
-) as WebEnv;
+const SHARED_DEFAULTS: Record<keyof SharedEnv, string> = {
+  NODE_ENV: "development",
+};
 
-export const server = createEnv(serverShape, {
-  extends: [shared],
-  runtimeEnv: process.env,
-  emptyStringAsUndefined: true,
-}) as ServerEnv;
+const readFromWorkerEnv = (key: string): string | undefined => {
+  const bag = env as unknown as Record<string, unknown>;
+  const v = bag[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+};
+
+const readFromProcessEnv = (key: string): string | undefined => {
+  if (typeof process === "undefined" || !process.env) return undefined;
+  const v = process.env[key];
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+};
+
+const read = (key: string): string | undefined =>
+  readFromWorkerEnv(key) ?? readFromProcessEnv(key);
+
+const makeEnvProxy = <T extends object>(defaults: Record<string, string>): T =>
+  new Proxy({} as T, {
+    get: (_target, key) => {
+      if (typeof key !== "string") return undefined;
+      return read(key) ?? defaults[key] ?? "";
+    },
+  });
+
+export const shared: SharedEnv = makeEnvProxy<SharedEnv>(SHARED_DEFAULTS);
+export const server: ServerEnv = makeEnvProxy<ServerEnv>(SERVER_DEFAULTS);
+export const web: WebEnv = {} as WebEnv;

--- a/apps/cloud/src/services/telemetry.ts
+++ b/apps/cloud/src/services/telemetry.ts
@@ -15,6 +15,14 @@
 //   every MCP request 500s with "Illegal invocation"). The DO uses a
 //   `SimpleSpanProcessor` so spans export immediately; there's no
 //   `ctx.waitUntil` to rely on for batching.
+//
+//   Reads the Axiom token/URL from `cloudflare:workers` `env` rather than
+//   `process.env` (via `./env`). Under nodejs_compat, `process.env` is
+//   populated for the edge fetch isolate at module load but can land
+//   empty in the DO isolate when the module evaluates before the first
+//   request — which silently demotes this layer to `Layer.empty` and
+//   drops every DO span. `env` from `cloudflare:workers` is always
+//   populated for the current isolate's bindings.
 // ---------------------------------------------------------------------------
 
 // Subpath imports — the barrel `@effect/opentelemetry` re-exports `NodeSdk`,
@@ -22,31 +30,49 @@
 // `context-async-hooks` dep. Under vitest-pool-workers that crashes module
 // load (no `async_hooks` in workerd). Production bundles tree-shake the
 // unused NodeSdk; vitest does not.
+import { env } from "cloudflare:workers";
 import * as Resource from "@effect/opentelemetry/Resource";
 import * as OtelTracer from "@effect/opentelemetry/Tracer";
 import * as WebSdk from "@effect/opentelemetry/WebSdk";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+// Force the browser platform entry — the package's conditional export would
+// otherwise resolve to the Node build, which uses `https.request` / `node:http`.
+// Under workerd + unenv's nodejs_compat, `https.request` isn't implemented
+// (surfaces as `[unenv] https.request is not implemented yet!` at export
+// time) and every DO span fails to ship. The browser build uses `fetch()`,
+// which workerd does support.
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http/build/esm/platform/browser/index.js";
 import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { Layer } from "effect";
-
-import { server } from "../env";
+import { Effect, Layer } from "effect";
 
 export const TelemetryLive: Layer.Layer<never> = OtelTracer.layerGlobal.pipe(
   Layer.provide(Resource.layer({ serviceName: "executor-cloud", serviceVersion: "1.0.0" })),
 );
 
-const makeDoOtelExporter = () =>
-  new OTLPTraceExporter({
-    url: server.AXIOM_TRACES_URL,
-    headers: {
-      Authorization: `Bearer ${server.AXIOM_TOKEN}`,
-      "X-Axiom-Dataset": server.AXIOM_DATASET,
-    },
-  });
+type AxiomEnv = {
+  readonly AXIOM_TOKEN?: string;
+  readonly AXIOM_DATASET?: string;
+  readonly AXIOM_TRACES_URL?: string;
+};
 
-export const DoTelemetryLive: Layer.Layer<never> = server.AXIOM_TOKEN
-  ? WebSdk.layer(() => ({
+// Lazy: `env.AXIOM_TOKEN` is read at layer-build time (when `Effect.provide`
+// kicks off a handleRequest/alarm/init), not at module load. Reading at
+// module load in the DO isolate landed empty in prod even when the secret
+// was configured, which silently demoted DoTelemetryLive to Layer.empty
+// and dropped every DO span.
+export const DoTelemetryLive: Layer.Layer<never> = Layer.unwrapEffect(
+  Effect.sync(() => {
+    const axiomEnv = env as AxiomEnv;
+    if (!axiomEnv.AXIOM_TOKEN) return Layer.empty;
+    const exporter = new OTLPTraceExporter({
+      url: axiomEnv.AXIOM_TRACES_URL ?? "https://api.axiom.co/v1/traces",
+      headers: {
+        Authorization: `Bearer ${axiomEnv.AXIOM_TOKEN}`,
+        "X-Axiom-Dataset": axiomEnv.AXIOM_DATASET ?? "executor-cloud",
+      },
+    });
+    return WebSdk.layer(() => ({
       resource: { serviceName: "executor-cloud", serviceVersion: "1.0.0" },
-      spanProcessor: new SimpleSpanProcessor(makeDoOtelExporter()),
-    }))
-  : Layer.empty;
+      spanProcessor: new SimpleSpanProcessor(exporter),
+    }));
+  }),
+);

--- a/apps/cloud/src/services/telemetry.ts
+++ b/apps/cloud/src/services/telemetry.ts
@@ -14,15 +14,11 @@
 //   that breaks `this` binding on `WorkerTransport`'s stream primitives —
 //   every MCP request 500s with "Illegal invocation"). The DO uses a
 //   `SimpleSpanProcessor` so spans export immediately; there's no
-//   `ctx.waitUntil` to rely on for batching.
-//
-//   Reads the Axiom token/URL from `cloudflare:workers` `env` rather than
-//   `process.env` (via `./env`). Under nodejs_compat, `process.env` is
-//   populated for the edge fetch isolate at module load but can land
-//   empty in the DO isolate when the module evaluates before the first
-//   request — which silently demotes this layer to `Layer.empty` and
-//   drops every DO span. `env` from `cloudflare:workers` is always
-//   populated for the current isolate's bindings.
+//   `ctx.waitUntil` to rely on for batching. Gated inside a
+//   `Layer.unwrapEffect` so the `AXIOM_TOKEN` check happens at
+//   layer-provide time — `server` is now a lazy Proxy, so this is just
+//   defensive against the token genuinely being unset (dev / missing
+//   secret).
 // ---------------------------------------------------------------------------
 
 // Subpath imports — the barrel `@effect/opentelemetry` re-exports `NodeSdk`,
@@ -30,7 +26,6 @@
 // `context-async-hooks` dep. Under vitest-pool-workers that crashes module
 // load (no `async_hooks` in workerd). Production bundles tree-shake the
 // unused NodeSdk; vitest does not.
-import { env } from "cloudflare:workers";
 import * as Resource from "@effect/opentelemetry/Resource";
 import * as OtelTracer from "@effect/opentelemetry/Tracer";
 import * as WebSdk from "@effect/opentelemetry/WebSdk";
@@ -44,30 +39,20 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http/build
 import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
 import { Effect, Layer } from "effect";
 
+import { server } from "../env";
+
 export const TelemetryLive: Layer.Layer<never> = OtelTracer.layerGlobal.pipe(
   Layer.provide(Resource.layer({ serviceName: "executor-cloud", serviceVersion: "1.0.0" })),
 );
 
-type AxiomEnv = {
-  readonly AXIOM_TOKEN?: string;
-  readonly AXIOM_DATASET?: string;
-  readonly AXIOM_TRACES_URL?: string;
-};
-
-// Lazy: `env.AXIOM_TOKEN` is read at layer-build time (when `Effect.provide`
-// kicks off a handleRequest/alarm/init), not at module load. Reading at
-// module load in the DO isolate landed empty in prod even when the secret
-// was configured, which silently demoted DoTelemetryLive to Layer.empty
-// and dropped every DO span.
 export const DoTelemetryLive: Layer.Layer<never> = Layer.unwrapEffect(
   Effect.sync(() => {
-    const axiomEnv = env as AxiomEnv;
-    if (!axiomEnv.AXIOM_TOKEN) return Layer.empty;
+    if (!server.AXIOM_TOKEN) return Layer.empty;
     const exporter = new OTLPTraceExporter({
-      url: axiomEnv.AXIOM_TRACES_URL ?? "https://api.axiom.co/v1/traces",
+      url: server.AXIOM_TRACES_URL,
       headers: {
-        Authorization: `Bearer ${axiomEnv.AXIOM_TOKEN}`,
-        "X-Axiom-Dataset": axiomEnv.AXIOM_DATASET ?? "executor-cloud",
+        Authorization: `Bearer ${server.AXIOM_TOKEN}`,
+        "X-Axiom-Dataset": server.AXIOM_DATASET,
       },
     });
     return WebSdk.layer(() => ({


### PR DESCRIPTION
Follow-up to #290. While auditing whether DO spans actually landed in Axiom after the span-wrap PR shipped, two deeper bugs surfaced — both silently dropping data in prod.

## 1. DO exporter was throwing on every flush

Instrumented the exporter and saw:

```
[unenv] https.request is not implemented yet!
  at HttpExporterTransport.send
  at RetryingTransport.send
```

`@opentelemetry/exporter-trace-otlp-http` resolved to its Node platform entry (`node:https`). Workerd's `nodejs_compat` (unenv) doesn't polyfill `https.request`, so every export failed before a single span reached Axiom. Wrangler's bundler picked the Node entry despite the package's `browser` field.

Fix: pin the import to the package's browser build (`.../platform/browser/index.js`) — that one uses `fetch()`, which workerd does support.

## 2. `server` env captured empty strings in the DO isolate

`apps/cloud/src/env.ts` called `createEnv({ runtimeEnv: process.env })` at module load. In the DO isolate that landed empty strings for every secret — `process.env` wasn't populated yet at the module's first evaluation — and the captured empties persisted for the isolate's lifetime.

Affected code paths:
- `DoTelemetryLive` → `AXIOM_TOKEN` empty → `Layer.empty` → every DO span dropped.
- `AutumnService.trackExecution` → `AUTUMN_SECRET_KEY` empty → `Effect.void` fallback → billing writes from the DO silently no-op.
- `workosVaultPlugin` config in `services/executor.ts` → empty WorkOS creds → Vault reads fail when exercised.
- Any future DO-reachable `server.X` secret read would hit the same class of bug.

Fix: `server` / `shared` are now `Proxy` objects that:
1. Read from `cloudflare:workers` `env` at call time (DO + edge isolates both have bindings populated for the current request).
2. Fall back to `process.env` so node-pool tests keep working — the `cloudflare:workers` stub in `test-stubs/` exports an empty `env` and vitest sets `process.env`.
3. Fall back to a typed defaults table (mirrors the prior `Env.stringOr(...)` defaults).

Every `server.X` call site keeps working; typed surface is identical. Drops `@executor/env`'s `createEnv` from this app since the workerd isolate timing makes its module-load capture model unsound for DO-reachable code.

## Verified live

After deploying both fixes to prod:

- `McpSessionDO.{init,handleRequest,alarm,createRuntime}` spans land in Axiom within seconds of each request.
- Attributes propagate correctly (`mcp.request.method`, `mcp.request.session_id_present`, `mcp.response.status_code`, `mcp.auth.organization_id`).
- MCP DO dashboard's `table-do-rpcs` panel populated for the first time (was empty for weeks because `McpSessionDO.handleRequest` never emitted a span AND the exporter couldn't ship one anyway).

## Test plan

- [x] Typecheck green
- [x] Lint green
- [x] `vitest run` (workerd pool) — 9/9 on `mcp-flow.test.ts`
- [x] `vitest run --config vitest.node.config.ts` — 5/5 on `mcp-miniflare.e2e.node.test.ts` (including the OTLP-exporter real-flow test)
- [x] Deployed + confirmed DO spans flowing in Axiom