### PR TITLE
ci(pkg-pr-new): skip preview binary build for fork PRs

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -9,6 +9,10 @@ jobs:
   # needs to know which platforms made it this far.
   build-preview-binary:
     name: Build preview binary (${{ matrix.target }})
+    # Fork PRs don't receive repo secrets, so the R2 upload step can't
+    # authenticate. Skip the whole preview pipeline (publish `needs:` this
+    # job and cascades to skipped) rather than failing the check.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What this fixes

Fork PRs currently fail the **Build preview binary** check in the `Publish (pkg.pr.new)` workflow:

```
curl: (6) Could not resolve host: .r2.cloudflarestorage.com
```

GitHub's `pull_request` trigger does not expose repository secrets to workflows running on PRs from forks. That means `secrets.CLOUDFLARE_ACCOUNT_ID` (and the R2 access keys) are empty, so the `R2_ENDPOINT` URL resolves to `https://.r2.cloudflarestorage.com` and the upload fails.

This PR adds `if: github.event.pull_request.head.repo.full_name == github.repository` to the `build-preview-binary` job so it only runs for same-repo PRs. The `publish` job skips automatically via its `needs:` dependency.

## Blocked PR

[#268](https://github.com/RhysSullivan/executor/pull/268) is currently red solely because of this CI issue — its actual changes only touch `apps/*/src/web/shell.tsx` and a screenshot.

## Test plan
- [ ] Same-repo PR still runs the preview binary build + publish
- [ ] Fork PR (e.g. #268 after rebase) shows `build-preview-binary` / `publish` as skipped rather than failed