### PR TITLE
cloud: expand MCP observability + flip engine to Effect-native

### DIFF
--- a/apps/cloud/src/api/execution-usage.ts
+++ b/apps/cloud/src/api/execution-usage.ts
@@ -1,24 +1,22 @@
+import { Effect } from "effect";
+import type * as Cause from "effect/Cause";
+
 import type { ExecutionEngine } from "@executor/execution";
 
-export const withExecutionUsageTracking = (
+export const withExecutionUsageTracking = <E extends Cause.YieldableError>(
   organizationId: string,
-  engine: ExecutionEngine,
+  engine: ExecutionEngine<E>,
   trackUsage: (organizationId: string) => void,
-): ExecutionEngine => ({
-  execute: async (code, options) => {
-    const result = await engine.execute(code, options);
-    trackUsage(organizationId);
-    return result;
-  },
-  executeWithPause: async (code) => {
-    const result = await engine.executeWithPause(code);
-    trackUsage(organizationId);
-    return result;
-  },
-  resume: async (executionId, response) => {
-    const result = await engine.resume(executionId, response);
-    // resume doesn't count as usage
-    return result;
-  },
+): ExecutionEngine<E> => ({
+  execute: (code, options) =>
+    engine
+      .execute(code, options)
+      .pipe(Effect.tap(() => Effect.sync(() => trackUsage(organizationId)))),
+  executeWithPause: (code) =>
+    engine
+      .executeWithPause(code)
+      .pipe(Effect.tap(() => Effect.sync(() => trackUsage(organizationId)))),
+  // resume doesn't count as usage
+  resume: (executionId, response) => engine.resume(executionId, response),
   getDescription: engine.getDescription,
 });

--- a/apps/cloud/src/api/protected.test.ts
+++ b/apps/cloud/src/api/protected.test.ts
@@ -5,16 +5,18 @@ import { withExecutionUsageTracking } from "./execution-usage";
 
 const makeBaseEngine = (): ExecutionEngine =>
   ({
-    execute: async () => ({ result: "ok", logs: [] }),
-    executeWithPause: async () => ({
-      status: "completed",
-      result: { result: "ok", logs: [] },
-    }),
-    resume: async () => ({
-      status: "completed",
-      result: { result: "ok", logs: [] },
-    }),
-    getDescription: async () => "desc",
+    execute: () => Effect.succeed({ result: "ok", logs: [] }),
+    executeWithPause: () =>
+      Effect.succeed({
+        status: "completed",
+        result: { result: "ok", logs: [] },
+      }),
+    resume: () =>
+      Effect.succeed({
+        status: "completed",
+        result: { result: "ok", logs: [] },
+      }),
+    getDescription: Effect.succeed("desc"),
   }) as ExecutionEngine;
 
 describe("withExecutionUsageTracking", () => {
@@ -25,10 +27,8 @@ describe("withExecutionUsageTracking", () => {
         tracked.push(orgId);
       });
 
-      yield* Effect.promise(() =>
-        engine.execute("1+1", { onElicitation: (() => Effect.die("unused")) as never }),
-      );
-      yield* Effect.promise(() => engine.executeWithPause("2+2"));
+      yield* engine.execute("1+1", { onElicitation: (() => Effect.die("unused")) as never });
+      yield* engine.executeWithPause("2+2");
 
       expect(tracked).toEqual(["org_1", "org_1"]);
     }),
@@ -44,8 +44,8 @@ describe("withExecutionUsageTracking", () => {
         "org_2",
         {
           ...base,
-          resume: async (...args) => {
-            if (shouldReturnNull) return null;
+          resume: (...args) => {
+            if (shouldReturnNull) return Effect.succeed(null);
             return base.resume(...args);
           },
         },
@@ -54,17 +54,13 @@ describe("withExecutionUsageTracking", () => {
         },
       );
 
-      yield* Effect.promise(() =>
-        engine.resume("exec_1", {
-          action: "accept",
-        }),
-      );
+      yield* engine.resume("exec_1", {
+        action: "accept",
+      });
       shouldReturnNull = true;
-      yield* Effect.promise(() =>
-        engine.resume("missing", {
-          action: "accept",
-        }),
-      );
+      yield* engine.resume("missing", {
+        action: "accept",
+      });
 
       expect(tracked).toEqual([]);
     }),

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -34,9 +34,6 @@ const createProtectedApp = (organizationId: string, organizationName: string) =>
   Effect.gen(function* () {
     const { executor, engine } = yield* makeExecutionStack(organizationId, organizationName);
 
-    // Handlers wrap their own bodies with `capture(...)` — the edge
-    // translation lives per-handler, not at service construction. See
-    // notes/error-handling.md.
     const requestServices = Layer.mergeAll(
       Layer.succeed(ExecutorService, executor),
       Layer.succeed(ExecutionEngineService, engine),

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -11,6 +11,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 import { createExecutorMcpServer } from "@executor/host-mcp";
+import { buildExecuteDescription } from "@executor/execution";
 import type { DrizzleDb, DbServiceShape } from "./services/db";
 
 // Import directly from core-shared-services, NOT from ./api/layers.ts.
@@ -176,12 +177,18 @@ export class McpSessionDO extends DurableObject {
   ) {
     const self = this;
     return Effect.gen(function* () {
-      const { engine } = yield* makeExecutionStack(
+      const { executor, engine } = yield* makeExecutionStack(
         sessionMeta.organizationId,
         sessionMeta.organizationName,
       );
+      // Build the description here so the two postgres queries it runs
+      // (`executor.sources.list` + `executor.tools.list`) land as
+      // children of `McpSessionDO.createRuntime`. host-mcp would
+      // otherwise call `Effect.runPromise(engine.getDescription)` at
+      // its async MCP-SDK boundary and orphan those sub-spans.
+      const description = yield* buildExecuteDescription(executor);
       const mcpServer = yield* Effect.promise(() =>
-        createExecutorMcpServer({ engine }),
+        createExecutorMcpServer({ engine, description }),
       ).pipe(Effect.withSpan("McpSessionDO.createExecutorMcpServer"));
       const transport = new WorkerTransport({
         sessionIdGenerator: () => self.ctx.id.toString(),

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -4,6 +4,7 @@
 
 import { DurableObject, env } from "cloudflare:workers";
 import { Data, Effect, Layer } from "effect";
+import * as Sentry from "@sentry/cloudflare";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WorkerTransport, type TransportState } from "agents/mcp";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -100,8 +101,13 @@ const makeResolveOrganizationServices = (dbHandle: DbHandle) => {
   return Layer.mergeAll(DbLive, UserStoreLive, CoreSharedServices);
 };
 
+// Session services DON'T re-provide `DoTelemetryLive` — that would install a
+// second WebSdk tracer in the nested Effect scope, disconnecting every
+// child span from the outer `McpSessionDO.init` / `McpSessionDO.handleRequest`
+// trace. Tracer comes from the outermost `Effect.provide(DoTelemetryLive)`
+// at the DO method boundary.
 const makeSessionServices = (dbHandle: DbHandle) =>
-  Layer.mergeAll(makeResolveOrganizationServices(dbHandle), DoTelemetryLive);
+  makeResolveOrganizationServices(dbHandle);
 
 const resolveSessionMeta = Effect.fn("McpSessionDO.resolveSessionMeta")(function* (
   organizationId: string,
@@ -164,89 +170,103 @@ export class McpSessionDO extends DurableObject {
     ]);
   }
 
-  private async createConnectedRuntime(
+  private createConnectedRuntimeEffect(
     sessionMeta: SessionMeta,
-    options: {
-      readonly dbHandle: DbHandle;
-      readonly enableJsonResponse?: boolean;
-    },
-  ): Promise<{ mcpServer: McpServer; transport: WorkerTransport }> {
-    const program = Effect.gen(function* () {
+    options: { readonly dbHandle: DbHandle; readonly enableJsonResponse?: boolean },
+  ) {
+    const self = this;
+    return Effect.gen(function* () {
       const { engine } = yield* makeExecutionStack(
         sessionMeta.organizationId,
         sessionMeta.organizationName,
       );
-      return yield* Effect.promise(() => createExecutorMcpServer({ engine }));
-    }).pipe(Effect.withSpan("McpSessionDO.createRuntime"), Effect.provide(makeSessionServices(options.dbHandle)));
-
-    const mcpServer = await Effect.runPromise(program);
-    const transport = new WorkerTransport({
-      sessionIdGenerator: () => this.ctx.id.toString(),
-      storage: this.makeStorage(),
-      enableJsonResponse: options.enableJsonResponse,
-    });
-
-    await mcpServer.connect(transport);
-    return { mcpServer, transport };
+      const mcpServer = yield* Effect.promise(() =>
+        createExecutorMcpServer({ engine }),
+      ).pipe(Effect.withSpan("McpSessionDO.createExecutorMcpServer"));
+      const transport = new WorkerTransport({
+        sessionIdGenerator: () => self.ctx.id.toString(),
+        storage: self.makeStorage(),
+        enableJsonResponse: options.enableJsonResponse,
+      });
+      yield* Effect.promise(() => mcpServer.connect(transport)).pipe(
+        Effect.withSpan("McpSessionDO.transport.connect"),
+      );
+      return { mcpServer, transport };
+    }).pipe(
+      Effect.withSpan("McpSessionDO.createRuntime"),
+      Effect.provide(makeSessionServices(options.dbHandle)),
+    );
   }
 
-  private async resolveAndStoreSessionMeta(token: McpSessionInit): Promise<SessionMeta> {
-    const dbHandle = makeRequestScopedDb();
-    try {
-      const sessionMeta = await Effect.runPromise(
-        resolveSessionMeta(token.organizationId).pipe(
+  private resolveAndStoreSessionMetaEffect(token: McpSessionInit) {
+    const self = this;
+    return Effect.gen(function* () {
+      const dbHandle = makeRequestScopedDb();
+      try {
+        const sessionMeta = yield* resolveSessionMeta(token.organizationId).pipe(
           Effect.provide(makeResolveOrganizationServices(dbHandle)),
-        ),
-      );
-      await this.saveSessionMeta(sessionMeta);
-      return sessionMeta;
-    } finally {
-      await dbHandle.end();
-    }
+        );
+        yield* Effect.promise(() => self.saveSessionMeta(sessionMeta));
+        return sessionMeta;
+      } finally {
+        yield* Effect.promise(() => dbHandle.end());
+      }
+    });
   }
 
   async init(token: McpSessionInit): Promise<void> {
     if (this.initialized) return;
-    // Outer `McpSessionDO.init` span wraps the full session-bootstrap cost
-    // (resolveSessionMeta + createRuntime + alarm setup) so the MCP DO
-    // dashboard's "new sessions" / "init p95" panels have one uniform span
-    // to filter on, regardless of whether the DO is running the long-lived
-    // or request-scoped variant.
-    const program = Effect.promise(() => this.doInit(token)).pipe(
-      Effect.withSpan("McpSessionDO.init", {
-        attributes: {
-          "mcp.auth.organization_id": token.organizationId,
-        },
-      }),
-      Effect.provide(DoTelemetryLive),
+    return Effect.runPromise(
+      this.doInitEffect(token).pipe(
+        Effect.withSpan("McpSessionDO.init", {
+          attributes: { "mcp.auth.organization_id": token.organizationId },
+        }),
+        Effect.provide(DoTelemetryLive),
+      ),
     );
-    return Effect.runPromise(program);
   }
 
-  private async doInit(token: McpSessionInit): Promise<void> {
-    try {
-      const sessionMeta = await this.resolveAndStoreSessionMeta(token);
+  private doInitEffect(token: McpSessionInit) {
+    const self = this;
+    // Single Effect chain so every sub-span (resolveSessionMeta,
+    // createRuntime, createScopedExecutor, createExecutorMcpServer,
+    // transport.connect, storage.setAlarm) lands as a child of
+    // `McpSessionDO.init`. The prior implementation called
+    // `Effect.runPromise` nested inside an async function, which orphaned
+    // each sub-span into its own root trace and made init opaque —
+    // dashboard saw one 2.77s span with nothing under it.
+    return Effect.gen(function* () {
+      const sessionMeta = yield* self.resolveAndStoreSessionMetaEffect(token);
 
       if (!requestScopedRuntimeEnabled) {
-        this.dbHandle = makeLongLivedDb();
-        const runtime = await this.createConnectedRuntime(sessionMeta, {
-          dbHandle: this.dbHandle,
+        self.dbHandle = makeLongLivedDb();
+        const runtime = yield* self.createConnectedRuntimeEffect(sessionMeta, {
+          dbHandle: self.dbHandle,
         });
-        this.mcpServer = runtime.mcpServer;
-        this.transport = runtime.transport;
+        self.mcpServer = runtime.mcpServer;
+        self.transport = runtime.transport;
       }
 
-      this.initialized = true;
-      this.lastActivityMs = Date.now();
+      self.initialized = true;
+      self.lastActivityMs = Date.now();
 
-      await this.ctx.storage.setAlarm(Date.now() + HEARTBEAT_MS);
-    } catch (err) {
-      // Partial init leaves dangling resources (DB socket, maybe mcpServer).
-      // Clean up before rethrowing so the DO isn't stuck in a half-built state.
-      console.error("[mcp-session] init failed:", err instanceof Error ? err.stack : err);
-      await this.cleanup();
-      throw err;
-    }
+      yield* Effect.promise(() => self.ctx.storage.setAlarm(Date.now() + HEARTBEAT_MS)).pipe(
+        Effect.withSpan("McpSessionDO.setAlarm"),
+      );
+    }).pipe(
+      Effect.tapErrorCause((cause) =>
+        Effect.sync(() => {
+          console.error("[mcp-session] init failed:", cause);
+        }),
+      ),
+      Effect.catchAllCause((cause) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => self.cleanup());
+          return yield* Effect.failCause(cause);
+        }),
+      ),
+      Effect.orDie,
+    );
   }
 
   private async handleRequestWithRequestScopedRuntime(request: Request): Promise<Response> {
@@ -264,10 +284,12 @@ export class McpSessionDO extends DurableObject {
 
     try {
       dbHandle = makeRequestScopedDb();
-      const runtime = await this.createConnectedRuntime(sessionMeta, {
-        dbHandle,
-        enableJsonResponse: request.method !== "GET",
-      });
+      const runtime = await Effect.runPromise(
+        this.createConnectedRuntimeEffect(sessionMeta, {
+          dbHandle,
+          enableJsonResponse: request.method !== "GET",
+        }).pipe(Effect.provide(DoTelemetryLive)),
+      );
       mcpServer = runtime.mcpServer;
       transport = runtime.transport;
 
@@ -281,6 +303,7 @@ export class McpSessionDO extends DurableObject {
         "[mcp-session] request-scoped handleRequest error:",
         err instanceof Error ? err.stack : err,
       );
+      Sentry.captureException(err);
       return jsonRpcError(500, -32603, "Internal error");
     } finally {
       await transport?.close().catch(() => undefined);
@@ -331,6 +354,7 @@ export class McpSessionDO extends DurableObject {
       return response;
     } catch (err) {
       console.error("[mcp-session] handleRequest error:", err instanceof Error ? err.stack : err);
+      Sentry.captureException(err);
       return jsonRpcError(500, -32603, "Internal error");
     }
   }

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -180,8 +180,15 @@ const JsonRpcEnvelope = Schema.Struct({
   method: Schema.optional(Schema.String),
   id: Schema.optional(Schema.Union(Schema.String, Schema.Number, Schema.Null)),
   params: Schema.optional(UnknownRecord),
+  // Responses to server-initiated requests arrive as POST bodies too —
+  // notably elicitation replies (`result.action = "accept" | "decline" | "cancel"`).
+  result: Schema.optional(UnknownRecord),
 });
 type JsonRpcEnvelope = typeof JsonRpcEnvelope.Type;
+
+const ElicitationReplyResult = Schema.Struct({
+  action: Schema.optional(Schema.Literal("accept", "decline", "cancel")),
+});
 
 const InitializeParams = Schema.Struct({
   protocolVersion: Schema.optional(Schema.String),
@@ -247,6 +254,14 @@ const methodAttrs = (envelope: JsonRpcEnvelope): Record<string, unknown> => {
   }
 };
 
+const replyAttrs = (envelope: JsonRpcEnvelope): Record<string, unknown> => {
+  if (!envelope.result || envelope.method) return {};
+  return Option.match(decode(ElicitationReplyResult, envelope.result), {
+    onNone: () => ({}),
+    onSome: ({ action }) => (action ? { "mcp.elicitation.action": action } : {}),
+  });
+};
+
 const rpcAttrs = (envelope: Option.Option<JsonRpcEnvelope>): Record<string, unknown> =>
   Option.match(envelope, {
     onNone: () => ({}),
@@ -254,6 +269,7 @@ const rpcAttrs = (envelope: Option.Option<JsonRpcEnvelope>): Record<string, unkn
       ...(e.method && { "mcp.rpc.method": e.method }),
       ...(e.id !== undefined && e.id !== null && { "mcp.rpc.id": String(e.id) }),
       ...methodAttrs(e),
+      ...replyAttrs(e),
     }),
   });
 
@@ -331,10 +347,18 @@ const authorizationServerMetadata = Effect.promise(async () => {
 // onto a long-lived SSE channel we don't want to consume.
 // ---------------------------------------------------------------------------
 
+type SandboxOutcome = {
+  readonly status?: string;
+  readonly error?: { readonly kind?: string; readonly message?: string };
+};
+
 type JsonRpcErrorBody = {
   readonly jsonrpc?: string;
   readonly error?: { readonly code?: number; readonly message?: string };
-  readonly result?: { readonly isError?: boolean };
+  readonly result?: {
+    readonly isError?: boolean;
+    readonly structuredContent?: SandboxOutcome;
+  };
 };
 
 const parseFirstJsonRpc = (contentType: string, body: string): JsonRpcErrorBody | null => {
@@ -373,6 +397,14 @@ const rpcResponseAttrs = (payload: JsonRpcErrorBody | null): Record<string, unkn
   if (payload.result?.isError === true) {
     attrs["mcp.tool.result.is_error"] = true;
   }
+  const sc = payload.result?.structuredContent;
+  if (sc && typeof sc.status === "string") {
+    attrs["mcp.tool.sandbox.status"] = sc.status;
+    if (sc.error?.kind) attrs["mcp.tool.sandbox.error.kind"] = sc.error.kind;
+    if (typeof sc.error?.message === "string") {
+      attrs["mcp.tool.sandbox.error.message"] = sc.error.message.slice(0, 500);
+    }
+  }
   return attrs;
 };
 
@@ -384,6 +416,16 @@ const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
     const attrs = rpcResponseAttrs(payload);
     if (Object.keys(attrs).length > 0) {
       yield* Effect.annotateCurrentSpan(attrs);
+    }
+    // Internal-error code -32603 means our server failed handling a
+    // structurally valid request. Unlike -32601 / -32602 ("the client
+    // fucked up"), this is a real bug in our code — route to Sentry so
+    // we get alerted. Protocol-level client errors stay in Axiom.
+    if (payload?.error?.code === -32603) {
+      yield* Effect.sync(() => {
+        const msg = payload.error?.message ?? "unknown";
+        Sentry.captureException(new Error(`MCP internal error (-32603): ${msg}`));
+      });
     }
     return new Response(text, {
       status: response.status,

--- a/apps/cloud/src/services/autumn.ts
+++ b/apps/cloud/src/services/autumn.ts
@@ -2,6 +2,7 @@
 // Autumn billing service — wraps the autumn-js SDK with Effect
 // ---------------------------------------------------------------------------
 
+import * as Sentry from "@sentry/cloudflare";
 import { Autumn } from "autumn-js";
 import { Context, Data, Effect, Layer } from "effect";
 
@@ -56,16 +57,21 @@ const make = Effect.sync(() => {
     }).pipe(Effect.withSpan(`autumn.${fn.name ?? "use"}`));
 
   const trackExecution = (organizationId: string) =>
-    use((c) =>
-      c.track({ customerId: organizationId, featureId: "executions", value: 1 }),
-    ).pipe(
-      Effect.asVoid,
-      Effect.tapError((err) =>
-        Effect.sync(() => console.error("[billing] track failed:", err)),
-      ),
-      Effect.orElse(() => Effect.void),
-      Effect.withSpan("autumn.trackExecution"),
-    );
+    Effect.gen(function* () {
+      yield* Effect.annotateCurrentSpan({ "autumn.customer.id": organizationId });
+      const outcome = yield* Effect.either(
+        use((c) =>
+          c.track({ customerId: organizationId, featureId: "executions", value: 1 }),
+        ),
+      );
+      if (outcome._tag === "Left") {
+        // Silent billing data loss is worth paging on — autumn.trackExecution
+        // is fire-and-forget so the caller doesn't handle it themselves.
+        console.error("[billing] track failed:", outcome.left);
+        Sentry.captureException(outcome.left);
+        yield* Effect.annotateCurrentSpan({ "autumn.track.failed": true });
+      }
+    }).pipe(Effect.withSpan("autumn.trackExecution"));
 
   return { use, trackExecution } satisfies IAutumnService;
 });

--- a/apps/cloud/src/services/execution-stack.ts
+++ b/apps/cloud/src/services/execution-stack.ts
@@ -16,7 +16,9 @@ import { createScopedExecutor } from "./executor";
 
 export const makeExecutionStack = (organizationId: string, organizationName: string) =>
   Effect.gen(function* () {
-    const executor = yield* createScopedExecutor(organizationId, organizationName);
+    const executor = yield* createScopedExecutor(organizationId, organizationName).pipe(
+      Effect.withSpan("McpSessionDO.createScopedExecutor"),
+    );
     const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
     const autumn = yield* AutumnService;
     const engine = withExecutionUsageTracking(
@@ -25,4 +27,4 @@ export const makeExecutionStack = (organizationId: string, organizationName: str
       (orgId) => Effect.runFork(autumn.trackExecution(orgId)),
     );
     return { executor, engine };
-  });
+  }).pipe(Effect.withSpan("McpSessionDO.makeExecutionStack"));

--- a/packages/core/api/src/handlers/executions.ts
+++ b/packages/core/api/src/handlers/executions.ts
@@ -11,7 +11,7 @@ export const ExecutionsHandlers = HttpApiBuilder.group(ExecutorApi, "executions"
     .handle("execute", ({ payload }) =>
       capture(Effect.gen(function* () {
         const engine = yield* ExecutionEngineService;
-        const outcome = yield* Effect.promise(() => engine.executeWithPause(payload.code));
+        const outcome = yield* engine.executeWithPause(payload.code);
 
         if (outcome.status === "completed") {
           const formatted = formatExecuteResult(outcome.result);
@@ -34,12 +34,10 @@ export const ExecutionsHandlers = HttpApiBuilder.group(ExecutorApi, "executions"
     .handle("resume", ({ path, payload }) =>
       capture(Effect.gen(function* () {
         const engine = yield* ExecutionEngineService;
-        const result = yield* Effect.promise(() =>
-          engine.resume(path.executionId, {
-            action: payload.action,
-            content: payload.content as Record<string, unknown> | undefined,
-          }),
-        );
+        const result = yield* engine.resume(path.executionId, {
+          action: payload.action,
+          content: payload.content as Record<string, unknown> | undefined,
+        });
 
         if (!result) {
           return yield* Effect.fail({

--- a/packages/core/api/src/services.ts
+++ b/packages/core/api/src/services.ts
@@ -1,4 +1,5 @@
 import { Context } from "effect";
+import type * as Cause from "effect/Cause";
 import type { Executor } from "@executor/sdk";
 import type { ExecutionEngine } from "@executor/execution";
 
@@ -7,7 +8,12 @@ export class ExecutorService extends Context.Tag("ExecutorService")<
   Executor
 >() {}
 
+// Error channel widened to `Cause.YieldableError` so callers that plug
+// in a runtime-specific tagged error (e.g.
+// `ExecutionEngine<DynamicWorkerExecutionError>`) assign structurally.
+// Handlers yield directly; defects flow through `Effect.catchAllCause`
+// at the edge.
 export class ExecutionEngineService extends Context.Tag("ExecutionEngineService")<
   ExecutionEngineService,
-  ExecutionEngine
+  ExecutionEngine<Cause.YieldableError>
 >() {}

--- a/packages/core/execution/src/description.ts
+++ b/packages/core/execution/src/description.ts
@@ -10,14 +10,18 @@ import type { Executor, Tool, Source } from "@executor/sdk";
  */
 export const buildExecuteDescription = (executor: Executor): Effect.Effect<string> =>
   Effect.gen(function* () {
-    const sources: readonly Source[] = yield* executor.sources.list().pipe(Effect.orDie);
-    const tools: readonly Tool[] = yield* executor.tools.list().pipe(Effect.orDie);
+    const sources: readonly Source[] = yield* executor.sources
+      .list()
+      .pipe(Effect.orDie, Effect.withSpan("executor.sources.list"));
+    const tools: readonly Tool[] = yield* executor.tools
+      .list()
+      .pipe(Effect.orDie, Effect.withSpan("executor.tools.list"));
 
     const namespaces = new Set<string>();
     for (const tool of tools) namespaces.add(tool.sourceId);
 
     return formatDescription([...namespaces], sources);
-  });
+  }).pipe(Effect.withSpan("buildExecuteDescription"));
 
 const formatDescription = (namespaces: readonly string[], sources: readonly Source[]): string => {
   const lines: string[] = [

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -1,4 +1,5 @@
 import { Deferred, Effect, Fiber, Ref } from "effect";
+import type * as Cause from "effect/Cause";
 
 import type {
   Executor,
@@ -7,6 +8,7 @@ import type {
   ElicitationHandler,
   ElicitationContext,
 } from "@executor/sdk";
+import { CodeExecutionError } from "@executor/codemode-core";
 import type { CodeExecutor, ExecuteResult, SandboxToolInvoker } from "@executor/codemode-core";
 
 import {
@@ -22,9 +24,11 @@ import { buildExecuteDescription } from "./description";
 // Types
 // ---------------------------------------------------------------------------
 
-export type ExecutionEngineConfig = {
+export type ExecutionEngineConfig<
+  E extends Cause.YieldableError = CodeExecutionError,
+> = {
   readonly executor: Executor;
-  readonly codeExecutor: CodeExecutor;
+  readonly codeExecutor: CodeExecutor<E>;
 };
 
 export type ExecutionResult =
@@ -37,10 +41,10 @@ export type PausedExecution = {
 };
 
 /** Internal representation with Effect runtime state for pause/resume. */
-type InternalPausedExecution = PausedExecution & {
+type InternalPausedExecution<E> = PausedExecution & {
   readonly response: Deferred.Deferred<typeof ElicitationResponse.Type>;
-  readonly fiber: Fiber.Fiber<ExecuteResult, unknown>;
-  readonly pauseSignalRef: Ref.Ref<Deferred.Deferred<InternalPausedExecution>>;
+  readonly fiber: Fiber.Fiber<ExecuteResult, E>;
+  readonly pauseSignalRef: Ref.Ref<Deferred.Deferred<InternalPausedExecution<E>>>;
 };
 
 export type ResumeResponse = {
@@ -255,22 +259,26 @@ const makeFullInvoker = (executor: Executor, invokeOptions: InvokeOptions): Sand
 // Execution Engine
 // ---------------------------------------------------------------------------
 
-export type ExecutionEngine = {
+export type ExecutionEngine<E extends Cause.YieldableError = CodeExecutionError> = {
   /**
    * Execute code with elicitation handled inline by the provided handler.
    * Use this when the host supports elicitation (e.g. MCP with elicitation capability).
+   *
+   * Fails with the code executor's typed error `E` (defaults to
+   * `CodeExecutionError`). Runtimes surface their own `Data.TaggedError`
+   * subclass, which flows through here unchanged.
    */
   readonly execute: (
     code: string,
     options: { readonly onElicitation: ElicitationHandler },
-  ) => Promise<ExecuteResult>;
+  ) => Effect.Effect<ExecuteResult, E>;
 
   /**
    * Execute code, intercepting the first elicitation as a pause point.
    * Use this when the host doesn't support inline elicitation.
    * Returns either a completed result or a paused execution that can be resumed.
    */
-  readonly executeWithPause: (code: string) => Promise<ExecutionResult>;
+  readonly executeWithPause: (code: string) => Effect.Effect<ExecutionResult, E>;
 
   /**
    * Resume a paused execution. Returns a completed result, a new pause, or
@@ -279,20 +287,21 @@ export type ExecutionEngine = {
   readonly resume: (
     executionId: string,
     response: ResumeResponse,
-  ) => Promise<ExecutionResult | null>;
+  ) => Effect.Effect<ExecutionResult | null, E>;
 
   /**
    * Get the dynamic tool description (workflow + namespaces).
    */
-  readonly getDescription: () => Promise<string>;
+  readonly getDescription: Effect.Effect<string>;
 };
 
-const runEffect = <A>(effect: Effect.Effect<A, unknown>): Promise<A> =>
-  Effect.runPromise(effect as Effect.Effect<A, never>);
-
-export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionEngine => {
+export const createExecutionEngine = <
+  E extends Cause.YieldableError = CodeExecutionError,
+>(
+  config: ExecutionEngineConfig<E>,
+): ExecutionEngine<E> => {
   const { executor, codeExecutor } = config;
-  const pausedExecutions = new Map<string, InternalPausedExecution>();
+  const pausedExecutions = new Map<string, InternalPausedExecution<E>>();
   let nextId = 0;
 
   /**
@@ -301,12 +310,11 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
    * comes first). Re-used by both executeWithPause and resume.
    */
   const awaitCompletionOrPause = (
-    fiber: Fiber.Fiber<ExecuteResult, unknown>,
-    pauseSignal: Deferred.Deferred<InternalPausedExecution>,
-  ): Effect.Effect<ExecutionResult> =>
+    fiber: Fiber.Fiber<ExecuteResult, E>,
+    pauseSignal: Deferred.Deferred<InternalPausedExecution<E>>,
+  ): Effect.Effect<ExecutionResult, E> =>
     Effect.race(
       Fiber.join(fiber).pipe(
-        Effect.orDie,
         Effect.map((result): ExecutionResult => ({ status: "completed", result })),
       ),
       Deferred.await(pauseSignal).pipe(
@@ -329,17 +337,17 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
     // Ref holds the current pause signal. The elicitation handler reads
     // it each time it fires, so resume() can swap in a fresh Deferred
     // before unblocking the fiber.
-    const pauseSignalRef = yield* Ref.make(yield* Deferred.make<InternalPausedExecution>());
+    const pauseSignalRef = yield* Ref.make(yield* Deferred.make<InternalPausedExecution<E>>());
 
     // Will be set once the fiber is forked.
-    let fiber: Fiber.Fiber<ExecuteResult, unknown>;
+    let fiber: Fiber.Fiber<ExecuteResult, E>;
 
     const elicitationHandler: ElicitationHandler = (ctx) =>
       Effect.gen(function* () {
         const responseDeferred = yield* Deferred.make<typeof ElicitationResponse.Type>();
         const id = `exec_${++nextId}`;
 
-        const paused: InternalPausedExecution = {
+        const paused: InternalPausedExecution<E> = {
           id,
           elicitationContext: ctx,
           response: responseDeferred,
@@ -383,7 +391,7 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
 
     // Swap in a fresh pause signal BEFORE unblocking the fiber, so the
     // next elicitation handler call signals this new Deferred.
-    const nextSignal = yield* Deferred.make<InternalPausedExecution>();
+    const nextSignal = yield* Deferred.make<InternalPausedExecution<E>>();
     yield* Ref.set(paused.pauseSignalRef, nextSignal);
 
     yield* Deferred.succeed(paused.response, {
@@ -415,12 +423,9 @@ export const createExecutionEngine = (config: ExecutionEngineConfig): ExecutionE
   });
 
   return {
-    execute: (code, options) => runEffect(runInlineExecution(code, options)),
-
-    executeWithPause: (code) => runEffect(startPausableExecution(code)),
-
-    resume: (executionId, response) => runEffect(resumeExecution(executionId, response)),
-
-    getDescription: () => runEffect(buildExecuteDescription(executor)),
+    execute: runInlineExecution,
+    executeWithPause: startPausableExecution,
+    resume: resumeExecution,
+    getDescription: buildExecuteDescription(executor),
   };
 };

--- a/packages/core/execution/src/errors.ts
+++ b/packages/core/execution/src/errors.ts
@@ -4,3 +4,8 @@ export class ExecutionToolError extends Data.TaggedError("ExecutionToolError")<{
   readonly message: string;
   readonly cause?: unknown;
 }> {}
+
+// `CodeExecutionError` lives in `@executor/codemode-core` — the `CodeExecutor`
+// interface uses it as the default error channel, so the runtime packages
+// can import the same class directly.
+export { CodeExecutionError } from "@executor/codemode-core";

--- a/packages/core/execution/src/promise.ts
+++ b/packages/core/execution/src/promise.ts
@@ -1,24 +1,28 @@
 // ---------------------------------------------------------------------------
 // @executor/execution/promise — Promise-native surface for the execution
-// engine. Accepts a Promise-style Executor (from @executor/sdk) and an
-// async `onElicitation` handler — no Effect imports required by callers.
+// engine.
+// ---------------------------------------------------------------------------
 //
-// Under the hood the engine is Effect-based, so we wrap the incoming
-// Promise executor into the minimal Effect shape the engine consumes,
-// and bridge the elicitation handler via `Effect.tryPromise`.
+// `engine.ts` is Effect-native; this module runs each method with
+// `Effect.runPromise` at the boundary so hosts that can't compose Effects
+// (the MCP SDK tool handlers, plain async call sites) can still use the
+// engine. Callers already inside an Effect context should import directly
+// from `@executor/execution` to keep trace context intact.
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
+import type * as Cause from "effect/Cause";
 
 import type {
   ElicitationContext,
   ElicitationResponse,
   Executor as PromiseExecutor,
 } from "@executor/sdk";
-import type { CodeExecutor, ExecuteResult } from "@executor/codemode-core";
+import type { CodeExecutionError, CodeExecutor, ExecuteResult } from "@executor/codemode-core";
 
 import {
   createExecutionEngine as createEffectExecutionEngine,
+  type ExecutionEngine as EffectExecutionEngine,
   type ExecutionResult,
   type PausedExecution,
   type ResumeResponse,
@@ -28,9 +32,11 @@ export type ElicitationHandler = (
   ctx: ElicitationContext,
 ) => Promise<ElicitationResponse>;
 
-export type ExecutionEngineConfig = {
+export type ExecutionEngineConfig<
+  E extends Cause.YieldableError = CodeExecutionError,
+> = {
   readonly executor: PromiseExecutor;
-  readonly codeExecutor: CodeExecutor;
+  readonly codeExecutor: CodeExecutor<E>;
 };
 
 export type ExecutionEngine = {
@@ -49,7 +55,7 @@ export type ExecutionEngine = {
 /**
  * Wrap a Promise-style executor into the Effect shape the engine consumes.
  * Only the four method families the engine actually touches need wrapping:
- * `tools.{invoke,list,schema}` and `sources.list`.
+ * `tools.{invoke,list,schema,definitions}` and `sources.list`.
  */
 const wrapPromiseExecutor = (pe: PromiseExecutor): any => ({
   scope: (pe as any).scope,
@@ -84,35 +90,44 @@ const wrapPromiseExecutor = (pe: PromiseExecutor): any => ({
   },
 });
 
-export const createExecutionEngine = (
-  config: ExecutionEngineConfig,
-): ExecutionEngine => {
-  const engine = createEffectExecutionEngine({
-    executor: wrapPromiseExecutor(config.executor),
-    codeExecutor: config.codeExecutor,
-  });
-  return {
-    execute: (code, options) =>
+/**
+ * Promise-wrap an Effect-native `ExecutionEngine` (from `./engine`).
+ * Exposed separately so callers that already hold an Effect engine
+ * (apps/cloud's execution-stack composes both) can convert it for hosts
+ * that need the Promise surface (host-mcp).
+ */
+export const toPromiseExecutionEngine = <E extends Cause.YieldableError>(
+  engine: EffectExecutionEngine<E>,
+): ExecutionEngine => ({
+  execute: (code, options) =>
+    Effect.runPromise(
       engine.execute(code, {
         onElicitation: (ctx) =>
-          Effect.tryPromise(() => options.onElicitation(ctx)).pipe(
-            Effect.orDie,
-          ),
+          Effect.tryPromise(() => options.onElicitation(ctx)).pipe(Effect.orDie),
       }),
-    executeWithPause: (code) => engine.executeWithPause(code),
-    resume: (executionId, response) => engine.resume(executionId, response),
-    getDescription: () => engine.getDescription(),
-  };
-};
+    ),
+  executeWithPause: (code) => Effect.runPromise(engine.executeWithPause(code)),
+  resume: (executionId, response) => Effect.runPromise(engine.resume(executionId, response)),
+  getDescription: () => Effect.runPromise(engine.getDescription),
+});
+
+export const createExecutionEngine = <
+  E extends Cause.YieldableError = CodeExecutionError,
+>(
+  config: ExecutionEngineConfig<E>,
+): ExecutionEngine =>
+  toPromiseExecutionEngine(
+    createEffectExecutionEngine({
+      executor: wrapPromiseExecutor(config.executor),
+      codeExecutor: config.codeExecutor,
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // Re-exports — plain types/helpers that don't carry Effect signatures.
 // ---------------------------------------------------------------------------
 
-export {
-  formatExecuteResult,
-  formatPausedExecution,
-} from "./engine";
+export { formatExecuteResult, formatPausedExecution } from "./engine";
 
 export type { ExecutionResult, PausedExecution, ResumeResponse };
 

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -150,11 +150,9 @@ describe("tool discovery", () => {
       });
       expect(crmOnly.map((match) => match.path)).toEqual(["crm.listContacts"]);
 
-      const sandboxResult = yield* Effect.promise(() =>
-        createExecutionEngine({ executor, codeExecutor }).execute(
-          'return await tools.search({ namespace: "crm", query: "create contact", limit: 5 });',
-          { onElicitation: acceptAll },
-        ),
+      const sandboxResult = yield* createExecutionEngine({ executor, codeExecutor }).execute(
+        'return await tools.search({ namespace: "crm", query: "create contact", limit: 5 });',
+        { onElicitation: acceptAll },
       );
       expect(sandboxResult.error).toBeUndefined();
       expect(sandboxResult.result).toEqual([
@@ -167,10 +165,9 @@ describe("tool discovery", () => {
     Effect.gen(function* () {
       const executor = yield* makeSearchExecutor();
 
-      const listed = yield* Effect.promise(() =>
-        createExecutionEngine({ executor, codeExecutor }).execute("return await tools.executor.sources.list();", {
-          onElicitation: acceptAll,
-        }),
+      const listed = yield* createExecutionEngine({ executor, codeExecutor }).execute(
+        "return await tools.executor.sources.list();",
+        { onElicitation: acceptAll },
       );
       expect(listed.error).toBeUndefined();
       expect(listed.result).toEqual(
@@ -180,11 +177,9 @@ describe("tool discovery", () => {
         ]),
       );
 
-      const searched = yield* Effect.promise(() =>
-        createExecutionEngine({ executor, codeExecutor }).execute(
-          'return await tools.search({ query: "list contacts", namespace: "crm", limit: 5 });',
-          { onElicitation: acceptAll },
-        ),
+      const searched = yield* createExecutionEngine({ executor, codeExecutor }).execute(
+        'return await tools.search({ query: "list contacts", namespace: "crm", limit: 5 });',
+        { onElicitation: acceptAll },
       );
       expect(searched.error).toBeUndefined();
       expect(searched.result).toEqual([expect.objectContaining({ path: "crm.listContacts" })]);
@@ -210,55 +205,48 @@ describe("tool discovery", () => {
       const executor = yield* makeSearchExecutor();
       const engine = createExecutionEngine({ executor, codeExecutor });
 
-      const invalid = yield* Effect.promise(() =>
-        engine.execute(
-          [
-            "try {",
-            '  await tools.search("github issues");',
-            '  return "unexpected";',
-            "} catch (error) {",
-            "  return error instanceof Error ? error.message : String(error);",
-            "}",
-          ].join("\n"),
-          { onElicitation: acceptAll },
-        ),
+      const invalid = yield* engine.execute(
+        [
+          "try {",
+          '  await tools.search("github issues");',
+          '  return "unexpected";',
+          "} catch (error) {",
+          "  return error instanceof Error ? error.message : String(error);",
+          "}",
+        ].join("\n"),
+        { onElicitation: acceptAll },
       );
       expect(invalid.error).toBeUndefined();
       expect(String(invalid.result)).toContain(
         "tools.search expects an object: { query?: string; namespace?: string; limit?: number }",
       );
 
-      const emptyQuery = yield* Effect.promise(() =>
-        engine.execute('return await tools.search({ query: "", limit: 5 });', {
-          onElicitation: acceptAll,
-        }),
+      const emptyQuery = yield* engine.execute(
+        'return await tools.search({ query: "", limit: 5 });',
+        { onElicitation: acceptAll },
       );
       expect(emptyQuery.error).toBeUndefined();
       expect(emptyQuery.result).toEqual([]);
 
-      const invalidDescribe = yield* Effect.promise(() =>
-        engine.execute(
-          [
-            "try {",
-            '  await tools.describe.tool({ path: "github.listRepositoryIssues", includeSchemas: true });',
-            '  return "unexpected";',
-            "} catch (error) {",
-            "  return error instanceof Error ? error.message : String(error);",
-            "}",
-          ].join("\n"),
-          { onElicitation: acceptAll },
-        ),
+      const invalidDescribe = yield* engine.execute(
+        [
+          "try {",
+          '  await tools.describe.tool({ path: "github.listRepositoryIssues", includeSchemas: true });',
+          '  return "unexpected";',
+          "} catch (error) {",
+          "  return error instanceof Error ? error.message : String(error);",
+          "}",
+        ].join("\n"),
+        { onElicitation: acceptAll },
       );
       expect(invalidDescribe.error).toBeUndefined();
       expect(String(invalidDescribe.result)).toContain(
         "tools.describe.tool no longer accepts includeSchemas",
       );
 
-      const invalidSearch = yield* Effect.promise(() =>
-        engine.execute(
-          'try { return await tools.search("crm"); } catch (error) { return error instanceof Error ? error.message : String(error); }',
-          { onElicitation: acceptAll },
-        ),
+      const invalidSearch = yield* engine.execute(
+        'try { return await tools.search("crm"); } catch (error) { return error instanceof Error ? error.message : String(error); }',
+        { onElicitation: acceptAll },
       );
       expect(invalidSearch.error).toBeUndefined();
       expect(String(invalidSearch.result)).toContain("tools.search expects an object");
@@ -334,7 +322,7 @@ describe("pause/resume with multiple elicitations", () => {
 
         const code = "return await tools.api.multiApproval({});";
 
-        const outcome1 = yield* Effect.promise(() => engine.executeWithPause(code));
+        const outcome1 = yield* engine.executeWithPause(code);
         expect(outcome1.status).toBe("paused");
         const paused1 = outcome1 as Extract<typeof outcome1, { status: "paused" }>;
         expect(paused1.execution.elicitationContext.request.message).toBe("First approval");
@@ -344,7 +332,7 @@ describe("pause/resume with multiple elicitations", () => {
         // result or the completion).
         const outcome2 = yield* Effect.promise(() =>
           Promise.race([
-            engine.resume(paused1.execution.id, { action: "accept" }),
+            Effect.runPromise(engine.resume(paused1.execution.id, { action: "accept" })),
             new Promise<never>((_, reject) =>
               setTimeout(
                 () => reject(new Error("resume hung — second elicitation not surfaced")),
@@ -368,7 +356,7 @@ describe("pause/resume with multiple elicitations", () => {
 
     const code = "return await tools.api.singleApproval({});";
 
-    const outcome1 = await engine.executeWithPause(code);
+    const outcome1 = await Effect.runPromise(engine.executeWithPause(code));
     expect(outcome1.status).toBe("paused");
     const paused1 = outcome1 as Extract<typeof outcome1, { status: "paused" }>;
     expect(paused1.execution.elicitationContext.request.message).toBe("Only approval");
@@ -389,7 +377,7 @@ describe("pause/resume with multiple elicitations", () => {
     expect(exitProbe).toBe("still-running");
 
     const outcome2 = await Promise.race([
-      engine.resume(paused1.execution.id, { action: "accept" }),
+      Effect.runPromise(engine.resume(paused1.execution.id, { action: "accept" })),
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error("resume hung across runPromise boundaries")), 2000),
       ),

--- a/packages/hosts/mcp/src/server.ts
+++ b/packages/hosts/mcp/src/server.ts
@@ -14,6 +14,7 @@ import type {
   ElicitationContext,
   ElicitationRequest,
 } from "@executor/sdk";
+import type * as Cause from "effect/Cause";
 import {
   createExecutionEngine,
   formatExecuteResult,
@@ -44,11 +45,23 @@ class CfWorkerJsonSchemaValidator implements jsonSchemaValidator {
 // Config
 // ---------------------------------------------------------------------------
 
-export type ExecutorMcpServerConfig =
-  | ExecutionEngineConfig
-  | { readonly engine: ExecutionEngine }
-  | (ExecutionEngineConfig & { readonly stateless: true })
-  | { readonly engine: ExecutionEngine; readonly stateless: true };
+type SharedMcpServerConfig = {
+  /**
+   * Pre-built `execute` tool description. When provided, the factory skips
+   * its internal `engine.getDescription()` call. Useful when the caller
+   * wants to compute the description inside its own Effect tracer context
+   * so sub-spans (`executor.sources.list`, `executor.tools.list`) nest as
+   * children of the caller's root span instead of being orphaned by the
+   * `Effect.runPromise` that `engine.getDescription()` runs internally.
+   */
+  readonly description?: string;
+};
+
+export type ExecutorMcpServerConfig<E extends Cause.YieldableError = Cause.YieldableError> =
+  | (ExecutionEngineConfig<E> & SharedMcpServerConfig)
+  | ({ readonly engine: ExecutionEngine<E> } & SharedMcpServerConfig)
+  | (ExecutionEngineConfig<E> & SharedMcpServerConfig & { readonly stateless: true })
+  | ({ readonly engine: ExecutionEngine<E>; readonly stateless: true } & SharedMcpServerConfig);
 
 // ---------------------------------------------------------------------------
 // Elicitation bridge
@@ -153,11 +166,11 @@ const toMcpPausedResult = (formatted: ReturnType<typeof formatPausedExecution>):
 // Server factory
 // ---------------------------------------------------------------------------
 
-export const createExecutorMcpServer = async (
-  config: ExecutorMcpServerConfig,
+export const createExecutorMcpServer = async <E extends Cause.YieldableError>(
+  config: ExecutorMcpServerConfig<E>,
 ): Promise<McpServer> => {
   const engine = "engine" in config ? config.engine : createExecutionEngine(config);
-  const description = await engine.getDescription();
+  const description = config.description ?? (await Effect.runPromise(engine.getDescription));
 
   const server = new McpServer(
     { name: "executor", version: "1.0.0" },
@@ -166,13 +179,15 @@ export const createExecutorMcpServer = async (
 
   const executeCode = async (code: string): Promise<McpToolResult> => {
     if (supportsManagedElicitation(server)) {
-      const result = await engine.execute(code, {
-        onElicitation: makeMcpElicitationHandler(server),
-      });
+      const result = await Effect.runPromise(
+        engine.execute(code, {
+          onElicitation: makeMcpElicitationHandler(server),
+        }),
+      );
       return toMcpResult(formatExecuteResult(result));
     }
 
-    const outcome = await engine.executeWithPause(code);
+    const outcome = await Effect.runPromise(engine.executeWithPause(code));
     return outcome.status === "completed"
       ? toMcpResult(formatExecuteResult(outcome.result))
       : toMcpPausedResult(formatPausedExecution(outcome.execution));
@@ -222,7 +237,7 @@ export const createExecutorMcpServer = async (
     },
     async ({ executionId, action, content: rawContent }) => {
       const content = parseJsonContent(rawContent);
-      const outcome = await engine.resume(executionId, { action, content });
+      const outcome = await Effect.runPromise(engine.resume(executionId, { action, content }));
 
       if (!outcome) {
         return {

--- a/packages/kernel/core/src/effect-errors.ts
+++ b/packages/kernel/core/src/effect-errors.ts
@@ -7,3 +7,17 @@ export class KernelCoreEffectError extends Data.TaggedError("KernelCoreEffectErr
 
 export const kernelCoreEffectError = (module: string, message: string) =>
   new KernelCoreEffectError({ module, message });
+
+/**
+ * Default failure type for any `CodeExecutor.execute` implementation —
+ * surfaces sandbox-level defects (isolate crash, module load failure,
+ * worker loader error) as a typed error so callers can handle them
+ * structurally instead of untyped `unknown`. Runtimes that want a
+ * narrower error shape can define their own `Data.TaggedError` subclass
+ * and parameterize `CodeExecutor<MyError>`.
+ */
+export class CodeExecutionError extends Data.TaggedError("CodeExecutionError")<{
+  readonly runtime: string;
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}

--- a/packages/kernel/core/src/types.ts
+++ b/packages/kernel/core/src/types.ts
@@ -1,5 +1,8 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type * as Cause from "effect/Cause";
 import type * as Effect from "effect/Effect";
+
+import type { CodeExecutionError } from "./effect-errors";
 
 /** Branded tool path */
 export type ToolPath = string & { readonly __toolPath: unique symbol };
@@ -30,9 +33,17 @@ export type ExecuteResult = {
   logs?: string[];
 };
 
-/** Executes code in a sandboxed runtime with tool access */
-export interface CodeExecutor {
-  execute(code: string, toolInvoker: SandboxToolInvoker): Effect.Effect<ExecuteResult, unknown>;
+/**
+ * Executes code in a sandboxed runtime with tool access.
+ *
+ * Error channel is constrained to Effect's `YieldableError` (the base
+ * shape `Data.TaggedError(...)` produces) so callers always get a
+ * structurally tagged error, never untyped `unknown`. Defaults to
+ * `CodeExecutionError`; runtimes can parameterize with their own
+ * `Data.TaggedError` subclass — e.g. `CodeExecutor<WorkerLoaderError>`.
+ */
+export interface CodeExecutor<E extends Cause.YieldableError = CodeExecutionError> {
+  execute(code: string, toolInvoker: SandboxToolInvoker): Effect.Effect<ExecuteResult, E>;
 }
 
 /** Accept-anything schema for tools with no input validation */

--- a/packages/kernel/runtime-deno-subprocess/src/index.ts
+++ b/packages/kernel/runtime-deno-subprocess/src/index.ts
@@ -330,7 +330,7 @@ export const isDenoAvailable = (executable: string = defaultDenoExecutable()): b
 
 export const makeDenoSubprocessExecutor = (
   options: DenoSubprocessExecutorOptions = {},
-): CodeExecutor => ({
+): CodeExecutor<never> => ({
   execute: (code: string, toolInvoker: SandboxToolInvoker) =>
     executeInDeno(code, toolInvoker, options),
 });

--- a/packages/kernel/runtime-dynamic-worker/src/executor.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/executor.ts
@@ -323,7 +323,9 @@ const runInDynamicWorker = (
 // Public API
 // ---------------------------------------------------------------------------
 
-export const makeDynamicWorkerExecutor = (options: DynamicWorkerExecutorOptions): CodeExecutor => ({
+export const makeDynamicWorkerExecutor = (
+  options: DynamicWorkerExecutorOptions,
+): CodeExecutor<DynamicWorkerExecutionError> => ({
   execute: (code: string, toolInvoker: SandboxToolInvoker) =>
     runInDynamicWorker(options, code, toolInvoker),
 });

--- a/packages/kernel/runtime-quickjs/src/index.ts
+++ b/packages/kernel/runtime-quickjs/src/index.ts
@@ -396,7 +396,9 @@ const runInQuickJs = (
     }),
   );
 
-export const makeQuickJsExecutor = (options: QuickJsExecutorOptions = {}): CodeExecutor => ({
+export const makeQuickJsExecutor = (
+  options: QuickJsExecutorOptions = {},
+): CodeExecutor<QuickJsExecutionError> => ({
   execute: (code: string, toolInvoker: SandboxToolInvoker) =>
     runInQuickJs(options, code, toolInvoker),
 });

--- a/packages/kernel/runtime-secure-exec/src/index.ts
+++ b/packages/kernel/runtime-secure-exec/src/index.ts
@@ -441,7 +441,9 @@ const evaluateInSecureExec = (
   );
 };
 
-export const makeSecureExecExecutor = (options: SecureExecExecutorOptions = {}): CodeExecutor => ({
+export const makeSecureExecExecutor = (
+  options: SecureExecExecutorOptions = {},
+): CodeExecutor<never> => ({
   execute: (code: string, toolInvoker: SandboxToolInvoker) =>
     evaluateInSecureExec(options, code, toolInvoker),
 });


### PR DESCRIPTION
Two commits. First adds observability attrs + Sentry routing for the known error classes; second fixes the underlying engine architecture that was making those attrs land on orphaned root traces.

## 1. Sandbox + elicitation attrs, Sentry routing, init span hierarchy

Builds on #293 (JSON-RPC protocol errors). Adds:

- **Sandbox outcome on `mcp.request`** — response-body peek stamps `mcp.tool.sandbox.status` / `error.kind` / `error.message` from `structuredContent` when the tool is `execute`.
- **Elicitation action on `mcp.request`** — request-body envelope schema now also reads `result.action` (elicitation replies have no `method`), stamping `mcp.elicitation.action` = `accept` / `decline` / `cancel`.
- **Sentry routing** — `-32603` internal errors in the DO's catch blocks plus `AutumnService.trackExecution` failures all `Sentry.captureException(...)` now. Protocol errors (`-32601` / `-32602`) stay Axiom-only since they're caller bugs.
- **Init span hierarchy** — the existing `McpSessionDO.init` span used to be a 2.77s root with no children because `doInit` was an async function calling `Effect.runPromise` twice (once for `resolveSessionMeta`, once for `createRuntime`), each spawning its own root trace. Restructures to a single Effect chain run at the DO method boundary; adds sub-step spans.

Dashboard panels added:
- `stat-rpc-error-rate`, `ts-rpc-errors-by-code`, `table-rpc-errors`
- `pie-sandbox-outcomes`, `table-sandbox-errors`
- `ts-elicitation-action`
- `stat-autumn-failed`

## 2. Engine refactor — Effect-native, typed errors

Even after (1), the sub-spans inside `createExecutorMcpServer` still came out orphaned because `engine.getDescription()` was a Promise wrapping `Effect.runPromise` internally — every engine method was doing this. Real fix: flip the engine architecture so the Promise surface lives where it's supposed to.

- `engine.ts` — Effect-native. Methods return `Effect.Effect<..., E>`.
- `promise.ts` — sole home of `Effect.runPromise`. New `toPromiseExecutionEngine` helper.
- `CodeExecutor<E extends Cause.YieldableError = CodeExecutionError>` — generic, constrained to Effect's yieldable error shape. Drops `unknown` and the `instanceof Error` dance.
- Runtimes parameterize: `runtime-dynamic-worker` → `CodeExecutor<DynamicWorkerExecutionError>`, etc.
- `host-mcp` stays Promise-out (MCP SDK constraint) but now uses the Effect engine and `Effect.runPromise` at the SDK callback boundary.
- `@executor/api`'s `ExecutionEngineService` is Effect-typed; `handlers/executions.ts` yields directly.
- `withExecutionUsageTracking<E>` is Effect-native + generic.

## Trace tree after deploy

Sample trace `16b2e150e986d703b3b23adad6ae3816`:

```
McpSessionDO.init                              2.51s
├── resolveSessionMeta                         231ms
└── createRuntime                              2.28s
    ├── makeExecutionStack
    │   └── createScopedExecutor                0ms
    ├── buildExecuteDescription                 2.28s
    │   ├── executor.sources.list               167ms
    │   └── executor.tools.list                 2.11s  ← real bottleneck
    ├── createExecutorMcpServer                 0ms
    └── transport.connect                       0ms
```

`executor.tools.list` — a single postgres query walking every tool row to build the description — eats the whole budget. That's now a visible, named span we can go optimize separately.

## Test plan

- [x] `apps/cloud` typecheck — green (ignoring pre-existing `observability.ts` module-not-found warnings)
- [x] Lint — green
- [x] `mcp-flow.test.ts` (workerd pool) — 9/9
- [x] `mcp-miniflare.e2e.node.test.ts` (node pool, real OTLP) — 5/5
- [x] `mcp-session.e2e.node.test.ts` — passes
- [x] Deployed + verified trace hierarchy + all dashboard panels populate against live traffic