### PR TITLE
fix(cloud): propagate OTEL trace context across worker→DO boundary

### DIFF
--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -93,6 +93,9 @@ class Worker extends Context.Tag("MiniflareE2E/Worker")<
 
 type CapturedSpan = {
   readonly name: string;
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly parentSpanId: string | null;
   readonly attributes: Record<string, unknown>;
 };
 
@@ -142,7 +145,13 @@ type OtlpAttributeValue = {
   readonly boolValue?: boolean;
 };
 type OtlpAttribute = { readonly key: string; readonly value?: OtlpAttributeValue };
-type OtlpSpan = { readonly name: string; readonly attributes?: ReadonlyArray<OtlpAttribute> };
+type OtlpSpan = {
+  readonly name: string;
+  readonly traceId?: string;
+  readonly spanId?: string;
+  readonly parentSpanId?: string;
+  readonly attributes?: ReadonlyArray<OtlpAttribute>;
+};
 type OtlpPayload = {
   readonly resourceSpans?: ReadonlyArray<{
     readonly scopeSpans?: ReadonlyArray<{ readonly spans?: ReadonlyArray<OtlpSpan> }>;
@@ -189,7 +198,13 @@ const TelemetryReceiverLive = Layer.scoped(
                   for (const a of sp.attributes ?? []) {
                     attrs[a.key] = unwrapAttrValue(a.value);
                   }
-                  store.push({ name: sp.name, attributes: attrs });
+                  store.push({
+                    name: sp.name,
+                    traceId: sp.traceId ?? "",
+                    spanId: sp.spanId ?? "",
+                    parentSpanId: sp.parentSpanId ? sp.parentSpanId : null,
+                    attributes: attrs,
+                  });
                 }
               }
             }
@@ -436,6 +451,74 @@ layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it)
       yield* Effect.promise(() =>
         receiver.waitForSpan((s) => s.name === "McpSessionDO.init"),
       );
+    }), 30_000,
+  );
+
+  // ---------------------------------------------------------------------------
+  // Worker→DO trace propagation.
+  //
+  // Worker and DO run in separate isolates with independent WebSdk tracer
+  // providers. The worker's `mcp.request` span's SpanContext is ferried to
+  // the DO as a W3C `traceparent` header (and a second arg to `init()`), and
+  // the DO anchors its root span under it via `OtelTracer.withSpanContext`.
+  // Regression guard: `mcp.request` and `McpSessionDO.init` must share a
+  // trace_id, and the init span's parent_span_id must match the mcp.request
+  // span_id.
+  // ---------------------------------------------------------------------------
+  it.effect("propagates trace context from worker mcp.request into DO init", () =>
+    Effect.gen(function* () {
+      const { baseUrl, seedOrg } = yield* Worker;
+      const receiver = yield* TelemetryReceiver;
+      const orgId = nextOrgId();
+      yield* Effect.promise(() => seedOrg(orgId, "Trace Propagation Org"));
+
+      const client = yield* Effect.promise(() =>
+        connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
+      );
+      // Drive a second request through handleRequest so we can assert the
+      // header-borne propagation path too, not just init's out-of-band arg.
+      yield* Effect.promise(() => client.listTools());
+      yield* Effect.promise(() => client.close());
+
+      // `initialize` is the first POST and is the one that triggers `init()`
+      // on a freshly minted DO stub — so mcp.request + MCPSessionDO.init
+      // should be in the same trace for that request.
+      const mcpRequestInitialize = yield* Effect.promise(() =>
+        receiver.waitForSpan(
+          (s) =>
+            s.name === "mcp.request" &&
+            s.attributes["mcp.rpc.method"] === "initialize",
+        ),
+      );
+      const doInit = yield* Effect.promise(() =>
+        receiver.waitForSpan((s) => s.name === "McpSessionDO.init"),
+      );
+
+      expect(mcpRequestInitialize.traceId).not.toBe("");
+      expect(doInit.traceId).not.toBe("");
+      expect(doInit.traceId).toBe(mcpRequestInitialize.traceId);
+      expect(doInit.parentSpanId).toBe(mcpRequestInitialize.spanId);
+
+      // A subsequent POST (e.g. tools/list) traverses handleRequest, which
+      // reads the `traceparent` header off the forwarded Request.
+      const mcpRequestToolsList = yield* Effect.promise(() =>
+        receiver.waitForSpan(
+          (s) =>
+            s.name === "mcp.request" &&
+            s.attributes["mcp.rpc.method"] === "tools/list",
+        ),
+      );
+      // Correlate by parent — several handleRequest spans land per session
+      // (initialize, notifications/initialized, SSE GET, ...). We want the
+      // one that actually corresponds to this tools/list mcp.request.
+      const doHandle = yield* Effect.promise(() =>
+        receiver.waitForSpan(
+          (s) =>
+            s.name === "McpSessionDO.handleRequest" &&
+            s.parentSpanId === mcpRequestToolsList.spanId,
+        ),
+      );
+      expect(doHandle.traceId).toBe(mcpRequestToolsList.traceId);
     }), 30_000,
   );
 });

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -4,6 +4,7 @@
 
 import { DurableObject, env } from "cloudflare:workers";
 import { Data, Effect, Layer } from "effect";
+import * as OtelTracer from "@effect/opentelemetry/Tracer";
 import * as Sentry from "@sentry/cloudflare";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WorkerTransport, type TransportState } from "agents/mcp";
@@ -57,6 +58,34 @@ const jsonRpcError = (status: number, code: number, message: string) =>
     status,
     headers: { "content-type": "application/json" },
   });
+
+// W3C traceparent propagation across the worker→DO boundary. mcp.ts injects
+// the worker-side `mcp.request` SpanContext as a `traceparent` header on
+// forwarded requests (and as a second arg to `init()`). We parse it here and
+// use `OtelTracer.withSpanContext` to stitch the DO's root span under the
+// worker span so the entire logical request lives in one Axiom trace.
+const TRACEPARENT_PATTERN = /^([0-9a-f]{2})-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+type IncomingSpanContext = {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly traceFlags: number;
+};
+
+const parseTraceparent = (value: string | null | undefined): IncomingSpanContext | null => {
+  if (!value) return null;
+  const match = TRACEPARENT_PATTERN.exec(value);
+  if (!match) return null;
+  return { traceId: match[2]!, spanId: match[3]!, traceFlags: parseInt(match[4]!, 16) };
+};
+
+const withIncomingParent = <A, E, R>(
+  traceparent: string | null | undefined,
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> => {
+  const parsed = parseTraceparent(traceparent);
+  return parsed ? OtelTracer.withSpanContext(effect, parsed) : effect;
+};
 
 type DbHandle = DbServiceShape & { end: () => Promise<void> };
 type SessionMeta = {
@@ -221,13 +250,14 @@ export class McpSessionDO extends DurableObject {
     });
   }
 
-  async init(token: McpSessionInit): Promise<void> {
+  async init(token: McpSessionInit, traceparent?: string): Promise<void> {
     if (this.initialized) return;
     return Effect.runPromise(
       this.doInitEffect(token).pipe(
         Effect.withSpan("McpSessionDO.init", {
           attributes: { "mcp.auth.organization_id": token.organizationId },
         }),
+        (eff) => withIncomingParent(traceparent, eff),
         Effect.provide(DoTelemetryLive),
       ),
     );
@@ -325,6 +355,7 @@ export class McpSessionDO extends DurableObject {
     // only (method, session-id presence, response status); rich client
     // fingerprint stays on the edge `mcp.request` span, which shares a
     // trace_id with this one.
+    const traceparent = request.headers.get("traceparent");
     const program = Effect.promise(() => this.dispatchRequest(request)).pipe(
       Effect.tap((response) =>
         Effect.annotateCurrentSpan({
@@ -337,6 +368,7 @@ export class McpSessionDO extends DurableObject {
           "mcp.request.session_id_present": !!request.headers.get("mcp-session-id"),
         },
       }),
+      (eff) => withIncomingParent(traceparent, eff),
       Effect.provide(DoTelemetryLive),
     );
     return Effect.runPromise(program);

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -438,6 +438,26 @@ const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
 // DO dispatch
 // ---------------------------------------------------------------------------
 
+// Worker and DO run in separate isolates with independent WebSdk tracer
+// providers. Neither one can see the other's OTEL context, so the DO used
+// to emit a brand-new root trace on every stub call. Ferry the current
+// `mcp.request` span's SpanContext across as a W3C `traceparent` string —
+// the DO parses it and anchors its own spans under the same trace via
+// `OtelTracer.withSpanContext`.
+const currentTraceparent = Effect.map(Effect.currentSpan, (span) => {
+  if (!span || !span.traceId || !span.spanId) return undefined;
+  const flags = span.sampled ? "01" : "00";
+  return `00-${span.traceId}-${span.spanId}-${flags}`;
+}).pipe(Effect.orElseSucceed(() => undefined));
+
+const withTraceparentHeader = (request: Request) =>
+  Effect.map(currentTraceparent, (traceparent) => {
+    if (!traceparent) return request;
+    const headers = new Headers(request.headers);
+    headers.set("traceparent", traceparent);
+    return new Request(request, { headers });
+  });
+
 /**
  * Forward a request to an existing session DO. Wrapping the DO's `Response`
  * with `HttpServerResponse.raw` lets streaming bodies (SSE) pass through
@@ -447,7 +467,10 @@ const forwardToExistingSession = (request: Request, sessionId: string, peek: boo
   Effect.gen(function* () {
     const ns = env.MCP_SESSION;
     const stub = ns.get(ns.idFromString(sessionId));
-    const raw = yield* Effect.promise(() => stub.handleRequest(request) as Promise<Response>);
+    const propagated = yield* withTraceparentHeader(request);
+    const raw = yield* Effect.promise(
+      () => stub.handleRequest(propagated) as Promise<Response>,
+    );
     const annotated = peek ? yield* peekAndAnnotate(raw) : raw;
     return HttpServerResponse.raw(annotated);
   });
@@ -464,8 +487,12 @@ const dispatchPost = (request: Request, token: VerifiedToken) =>
 
     const ns = env.MCP_SESSION;
     const stub = ns.get(ns.newUniqueId());
-    yield* Effect.promise(() => stub.init({ organizationId }));
-    const raw = yield* Effect.promise(() => stub.handleRequest(request) as Promise<Response>);
+    const traceparent = yield* currentTraceparent;
+    yield* Effect.promise(() => stub.init({ organizationId }, traceparent));
+    const propagated = yield* withTraceparentHeader(request);
+    const raw = yield* Effect.promise(
+      () => stub.handleRequest(propagated) as Promise<Response>,
+    );
     const annotated = yield* peekAndAnnotate(raw);
     return HttpServerResponse.raw(annotated);
   });

--- a/apps/cloud/src/test-worker.ts
+++ b/apps/cloud/src/test-worker.ts
@@ -21,6 +21,7 @@ import postgres, { type Sql } from "postgres";
 import { McpAuth, classifyMcpPath, mcpApp } from "./mcp";
 import { organizations } from "./services/schema";
 import { parseTestBearer } from "./test-bearer";
+import { DoTelemetryLive } from "./services/telemetry";
 
 export { McpSessionDO } from "./mcp-session";
 
@@ -79,7 +80,14 @@ const handleSeedOrg = async (
   return new Response(null, { status: 204 });
 };
 
-const testMcpFetch = HttpApp.toWebHandler(mcpApp.pipe(Effect.provide(TestMcpAuthLive)));
+// Provide a WebSdk-backed tracer on the worker side so the `mcp.request` span
+// gets reported to the OTLP receiver. Prod uses the global TracerProvider
+// installed by `otel-cf-workers.instrument()`; the test worker has no such
+// instrumentation, so we reuse DoTelemetryLive (it's a plain WebSdk +
+// OTLPTraceExporter — not Durable-Object-specific) to stand in.
+const testMcpFetch = HttpApp.toWebHandler(
+  mcpApp.pipe(Effect.provide(Layer.mergeAll(TestMcpAuthLive, DoTelemetryLive))),
+);
 
 export default {
   async fetch(request: Request, envArg: Record<string, unknown>): Promise<Response> {


### PR DESCRIPTION
## Summary
- Axiom showed `mcp.request` (worker) and `McpSessionDO.*` (DO) in separate traces — the worker's WebSdk and the DO's WebSdk live in different isolates and nothing carried OTEL context across the `stub.init()` / `stub.handleRequest()` RPC, so the DO emitted a brand-new root trace per call.
- Worker now builds a W3C `traceparent` from `Effect.currentSpan` and ferries it to the DO (header on `handleRequest`, second arg on `init`). DO parses it and anchors its root span via `OtelTracer.withSpanContext`.
- Added a miniflare e2e regression guard: `McpSessionDO.init` / `handleRequest` must share `trace_id` with the corresponding `mcp.request` and point to it via `parent_span_id`.

## Test plan
- [x] `bun run vitest run --config vitest.node.config.ts` (cloud): 29/29 pass, including the new propagation assertion.
- [ ] Deploy to staging and confirm Axiom stitches `mcp.request` + `McpSessionDO.*` into a single trace.