### PR TITLE
perf(execution): drop executor.tools.list from buildExecuteDescription in favor of sources list

### DIFF
--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -210,11 +210,11 @@ export class McpSessionDO extends DurableObject {
         sessionMeta.organizationId,
         sessionMeta.organizationName,
       );
-      // Build the description here so the two postgres queries it runs
-      // (`executor.sources.list` + `executor.tools.list`) land as
-      // children of `McpSessionDO.createRuntime`. host-mcp would
-      // otherwise call `Effect.runPromise(engine.getDescription)` at
-      // its async MCP-SDK boundary and orphan those sub-spans.
+      // Build the description here so the postgres query it runs
+      // (`executor.sources.list`) lands as a child of
+      // `McpSessionDO.createRuntime`. host-mcp would otherwise call
+      // `Effect.runPromise(engine.getDescription)` at its async
+      // MCP-SDK boundary and orphan the sub-span.
       const description = yield* buildExecuteDescription(executor);
       const mcpServer = yield* Effect.promise(() =>
         createExecutorMcpServer({ engine, description }),

--- a/packages/core/execution/src/description.test.ts
+++ b/packages/core/execution/src/description.test.ts
@@ -1,68 +1,109 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
-import type { Executor, Source } from "@executor/sdk";
+import { createExecutor, definePlugin, makeTestConfig } from "@executor/sdk";
 
 import { buildExecuteDescription } from "./description";
 
-const makeSource = (overrides: Partial<Source> & Pick<Source, "id" | "name">): Source => ({
-  kind: "in-memory",
-  pluginId: "test-plugin",
-  canRemove: false,
-  canRefresh: false,
-  canEdit: false,
-  runtime: false,
-  ...overrides,
-});
+const EmptyInputSchema = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+} as const;
 
-const makeFakeExecutor = (sources: readonly Source[]): Executor =>
-  ({
-    sources: {
-      list: () => Effect.succeed(sources),
+// Two plugins registering static sources whose ids are distinct from their
+// pluginIds/names. If `buildExecuteDescription` ever renders the wrong field
+// (e.g. pluginId, an internal UUID, or the source name), these assertions
+// fail — which is the class of bug a hand-rolled fake `Executor` would miss.
+const githubPlugin = definePlugin(() => ({
+  id: "github-plugin" as const,
+  storage: () => ({}),
+  staticSources: () => [
+    {
+      id: "github",
+      kind: "in-memory",
+      name: "GitHub",
+      tools: [
+        {
+          name: "noop",
+          description: "noop",
+          inputSchema: EmptyInputSchema,
+          handler: () => Effect.succeed(null),
+        },
+      ],
     },
-  }) as unknown as Executor;
+  ],
+}));
+
+const slackPlugin = definePlugin(() => ({
+  id: "slack-plugin" as const,
+  storage: () => ({}),
+  staticSources: () => [
+    {
+      id: "slack",
+      kind: "in-memory",
+      name: "Slack Workspace",
+      tools: [
+        {
+          name: "noop",
+          description: "noop",
+          inputSchema: EmptyInputSchema,
+          handler: () => Effect.succeed(null),
+        },
+      ],
+    },
+  ],
+}));
 
 describe("buildExecuteDescription", () => {
-  it.effect("includes the workflow preamble and lists sources sorted by id", () =>
-    Effect.gen(function* () {
-      const sources: readonly Source[] = [
-        // Intentionally out of order — the formatter is expected to sort.
-        makeSource({ id: "slack", name: "Slack Workspace" }),
-        makeSource({ id: "github", name: "GitHub" }),
-      ];
-      const executor = makeFakeExecutor(sources);
+  it.effect(
+    "renders real source ids as namespaces (sorted) through the real executor flow",
+    () =>
+      Effect.gen(function* () {
+        // Intentionally register in non-alphabetical order — the formatter
+        // is expected to sort by source id.
+        const executor = yield* createExecutor(
+          makeTestConfig({ plugins: [slackPlugin(), githubPlugin()] as const }),
+        );
 
-      const description = yield* buildExecuteDescription(executor);
+        const description = yield* buildExecuteDescription(executor);
 
-      // Stable anchor from the workflow preamble.
-      expect(description).toContain(
-        "Execute TypeScript in a sandboxed runtime",
-      );
-      // The namespaces section header.
-      expect(description).toContain("## Available namespaces");
-      // Both sources rendered with backticks + label-suffix rule.
-      expect(description).toContain("`github` — GitHub");
-      expect(description).toContain("`slack` — Slack Workspace");
+        // Stable anchor from the workflow preamble.
+        expect(description).toContain(
+          "Execute TypeScript in a sandboxed runtime",
+        );
+        // The namespaces section header.
+        expect(description).toContain("## Available namespaces");
+        // Each source renders with its ACTUAL id (not pluginId / name / UUID).
+        expect(description).toContain("`github` — GitHub");
+        expect(description).toContain("`slack` — Slack Workspace");
+        // And the plugin ids must NOT leak into the namespace list.
+        expect(description).not.toContain("`github-plugin`");
+        expect(description).not.toContain("`slack-plugin`");
 
-      // Sort order: `github` appears before `slack`.
-      const githubIdx = description.indexOf("`github`");
-      const slackIdx = description.indexOf("`slack`");
-      expect(githubIdx).toBeGreaterThan(-1);
-      expect(slackIdx).toBeGreaterThan(-1);
-      expect(githubIdx).toBeLessThan(slackIdx);
-    }),
+        // Sort order: `github` before `slack`.
+        const githubIdx = description.indexOf("`github`");
+        const slackIdx = description.indexOf("`slack`");
+        expect(githubIdx).toBeGreaterThan(-1);
+        expect(slackIdx).toBeGreaterThan(-1);
+        expect(githubIdx).toBeLessThan(slackIdx);
+      }),
   );
 
-  it.effect("omits the Available namespaces section when there are no sources", () =>
-    Effect.gen(function* () {
-      const executor = makeFakeExecutor([]);
+  it.effect(
+    "omits the Available namespaces section when no plugins register sources",
+    () =>
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(
+          makeTestConfig({ plugins: [] as const }),
+        );
 
-      const description = yield* buildExecuteDescription(executor);
+        const description = yield* buildExecuteDescription(executor);
 
-      expect(description).toContain(
-        "Execute TypeScript in a sandboxed runtime",
-      );
-      expect(description).not.toContain("## Available namespaces");
-    }),
+        expect(description).toContain(
+          "Execute TypeScript in a sandboxed runtime",
+        );
+        expect(description).not.toContain("## Available namespaces");
+      }),
   );
 });

--- a/packages/core/execution/src/description.test.ts
+++ b/packages/core/execution/src/description.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import type { Executor, Source } from "@executor/sdk";
+
+import { buildExecuteDescription } from "./description";
+
+const makeSource = (overrides: Partial<Source> & Pick<Source, "id" | "name">): Source => ({
+  kind: "in-memory",
+  pluginId: "test-plugin",
+  canRemove: false,
+  canRefresh: false,
+  canEdit: false,
+  runtime: false,
+  ...overrides,
+});
+
+const makeFakeExecutor = (sources: readonly Source[]): Executor =>
+  ({
+    sources: {
+      list: () => Effect.succeed(sources),
+    },
+  }) as unknown as Executor;
+
+describe("buildExecuteDescription", () => {
+  it.effect("includes the workflow preamble and lists sources sorted by id", () =>
+    Effect.gen(function* () {
+      const sources: readonly Source[] = [
+        // Intentionally out of order — the formatter is expected to sort.
+        makeSource({ id: "slack", name: "Slack Workspace" }),
+        makeSource({ id: "github", name: "GitHub" }),
+      ];
+      const executor = makeFakeExecutor(sources);
+
+      const description = yield* buildExecuteDescription(executor);
+
+      // Stable anchor from the workflow preamble.
+      expect(description).toContain(
+        "Execute TypeScript in a sandboxed runtime",
+      );
+      // The namespaces section header.
+      expect(description).toContain("## Available namespaces");
+      // Both sources rendered with backticks + label-suffix rule.
+      expect(description).toContain("`github` — GitHub");
+      expect(description).toContain("`slack` — Slack Workspace");
+
+      // Sort order: `github` appears before `slack`.
+      const githubIdx = description.indexOf("`github`");
+      const slackIdx = description.indexOf("`slack`");
+      expect(githubIdx).toBeGreaterThan(-1);
+      expect(slackIdx).toBeGreaterThan(-1);
+      expect(githubIdx).toBeLessThan(slackIdx);
+    }),
+  );
+
+  it.effect("omits the Available namespaces section when there are no sources", () =>
+    Effect.gen(function* () {
+      const executor = makeFakeExecutor([]);
+
+      const description = yield* buildExecuteDescription(executor);
+
+      expect(description).toContain(
+        "Execute TypeScript in a sandboxed runtime",
+      );
+      expect(description).not.toContain("## Available namespaces");
+    }),
+  );
+});

--- a/packages/core/execution/src/description.ts
+++ b/packages/core/execution/src/description.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import type { Executor, Tool, Source } from "@executor/sdk";
+import type { Executor, Source } from "@executor/sdk";
 
 /**
  * Builds a tool description dynamically.
@@ -13,17 +13,11 @@ export const buildExecuteDescription = (executor: Executor): Effect.Effect<strin
     const sources: readonly Source[] = yield* executor.sources
       .list()
       .pipe(Effect.orDie, Effect.withSpan("executor.sources.list"));
-    const tools: readonly Tool[] = yield* executor.tools
-      .list()
-      .pipe(Effect.orDie, Effect.withSpan("executor.tools.list"));
 
-    const namespaces = new Set<string>();
-    for (const tool of tools) namespaces.add(tool.sourceId);
-
-    return formatDescription([...namespaces], sources);
+    return formatDescription(sources);
   }).pipe(Effect.withSpan("buildExecuteDescription"));
 
-const formatDescription = (namespaces: readonly string[], sources: readonly Source[]): string => {
+const formatDescription = (sources: readonly Source[]): string => {
   const lines: string[] = [
     "Execute TypeScript in a sandboxed runtime with access to configured API tools.",
     "",
@@ -50,15 +44,14 @@ const formatDescription = (namespaces: readonly string[], sources: readonly Sour
     "- If execution pauses for interaction, resume it with the returned `resumePayload`.",
   ];
 
-  if (namespaces.length > 0) {
+  if (sources.length > 0) {
     lines.push("");
     lines.push("## Available namespaces");
     lines.push("");
-    const sorted = [...namespaces].sort();
-    for (const ns of sorted) {
-      const source = sources.find((s) => s.id === ns);
-      const label = source?.name ?? ns;
-      lines.push(`- \`${ns}\`${label !== ns ? ` — ${label}` : ""}`);
+    const sorted = [...sources].sort((a, b) => a.id.localeCompare(b.id));
+    for (const source of sorted) {
+      const label = source.name;
+      lines.push(`- \`${source.id}\`${label !== source.id ? ` — ${label}` : ""}`);
     }
   }
 


### PR DESCRIPTION
## What

Drop the `executor.tools.list()` call from `buildExecuteDescription` and derive the "Available namespaces" section of the system prompt directly from `sources`.

## Why

In production Axiom, `executor.tools.list` was running ~1.9s p50 during every MCP session init. The call inside `buildExecuteDescription` was only used to extract a set of unique `tool.sourceId` values for the namespace list at the bottom of the description — we already have the same information (plus the source name) from `sources.list`. Loading the full tool rows (including the JSONB `input_schema` / `output_schema` blobs) just to build a set of strings is wasteful.

With this change, `buildExecuteDescription` runs a single `executor.sources.list` query and the tools table is no longer touched on session init.

## Behavior change

The description now lists every configured source as a namespace, not just sources that have at least one tool. Confirmed acceptable — sources without tools are rare and showing them as namespaces is fine.

## Test plan

- [x] `bunx vitest run` in `packages/core/execution` — 8/8 passing
- [x] `bun run typecheck` — execution package types cleanly; the only failures (`@executor/host-mcp`, `@executor/api`) reproduce on `main` and are unrelated to this change
- [x] Grepped all callers of `buildExecuteDescription` (`apps/cloud/src/mcp-session.ts`, `packages/core/execution/src/engine.ts`, `packages/core/execution/src/promise.ts`) — none relied on `tools.list` being called as a side effect. Updated the tracing comment in `mcp-session.ts` to reflect that only `executor.sources.list` runs now.