### PR TITLE
instrument executor path + nest engine spans under mcp.request

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -50,6 +50,7 @@
     "@opentelemetry/resources": "^2.6.1",
     "@opentelemetry/sdk-logs": "^0.214.0",
     "@opentelemetry/sdk-trace-base": "^2.6.1",
+    "@opentelemetry/sdk-trace-web": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
     "@sentry/cloudflare": "^10.48.0",
     "@sentry/react": "^10.48.0",

--- a/apps/cloud/src/mcp-session.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-session.e2e.node.test.ts
@@ -136,7 +136,7 @@ const openSession = (
     Effect.gen(function* () {
       const executor = yield* buildScopedExecutor(orgId, `Org ${orgId}`, options);
       const engine = createExecutionEngine({ executor, codeExecutor: makeQuickJsExecutor() });
-      const mcpServer = yield* Effect.promise(() => createExecutorMcpServer({ engine }));
+      const mcpServer = yield* createExecutorMcpServer({ engine });
       const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
       const client = new Client(
         { name: "cloud-e2e-test", version: "1.0.0" },

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -6,6 +6,7 @@ import { DurableObject, env } from "cloudflare:workers";
 import { createTraceState } from "@opentelemetry/api";
 import { Data, Effect, Layer } from "effect";
 import * as OtelTracer from "@effect/opentelemetry/Tracer";
+import type * as Tracer from "effect/Tracer";
 import * as Sentry from "@sentry/cloudflare";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WorkerTransport, type TransportState } from "agents/mcp";
@@ -182,6 +183,15 @@ export class McpSessionDO extends DurableObject {
   private lastActivityMs = 0;
   private dbHandle: DbHandle | null = null;
   private sessionMeta: SessionMeta | null = null;
+  // Updated at the start of each `handleRequest` so the host-mcp server's
+  // `parentSpan` getter — invoked by the MCP SDK's deferred tool callbacks
+  // after `transport.handleRequest()` has already returned its streaming
+  // Response — can hand back the request-scoped span. The server is
+  // session-scoped (a fresh server-per-request would lose the elicitation
+  // request → reply correlation that the SDK keeps in-memory on the
+  // `Server` instance), so we have to bridge a per-request value through
+  // a per-session reference.
+  private currentRequestSpan: Tracer.AnySpan | null = null;
 
   private makeStorage() {
     return {
@@ -233,9 +243,11 @@ export class McpSessionDO extends DurableObject {
       // `Effect.runPromise(engine.getDescription)` at its async
       // MCP-SDK boundary and orphan the sub-span.
       const description = yield* buildExecuteDescription(executor);
-      const mcpServer = yield* Effect.promise(() =>
-        createExecutorMcpServer({ engine, description }),
-      ).pipe(Effect.withSpan("McpSessionDO.createExecutorMcpServer"));
+      const mcpServer = yield* createExecutorMcpServer({
+        engine,
+        description,
+        parentSpan: () => self.currentRequestSpan ?? undefined,
+      }).pipe(Effect.withSpan("McpSessionDO.createExecutorMcpServer"));
       const transport = new WorkerTransport({
         sessionIdGenerator: () => self.ctx.id.toString(),
         storage: self.makeStorage(),
@@ -294,8 +306,16 @@ export class McpSessionDO extends DurableObject {
 
       if (!requestScopedRuntimeEnabled) {
         self.dbHandle = makeLongLivedDb();
+        // POST responses go out as JSON so `transport.handleRequest()` awaits
+        // every MCP tool callback before resolving — keeps engine spans inside
+        // the outer `handleRequest` Effect's fiber so `currentRequestSpan` is
+        // still set when the host-mcp `parentSpan` getter reads it. With SSE
+        // POSTs the callback fires after `Effect.ensuring` clears the field
+        // and engine spans orphan into new root traces. GET still streams
+        // (the GET handler doesn't consult `enableJsonResponse`).
         const runtime = yield* self.createConnectedRuntimeEffect(sessionMeta, {
           dbHandle: self.dbHandle,
+          enableJsonResponse: true,
         });
         self.mcpServer = runtime.mcpServer;
         self.transport = runtime.transport;
@@ -323,47 +343,50 @@ export class McpSessionDO extends DurableObject {
     );
   }
 
-  private async handleRequestWithRequestScopedRuntime(request: Request): Promise<Response> {
-    const sessionMeta = await this.loadSessionMeta();
-    if (!sessionMeta) {
-      return jsonRpcError(404, -32001, "Session timed out due to inactivity — please reconnect");
-    }
+  private handleRequestWithRequestScopedRuntimeEffect(request: Request) {
+    const self = this;
+    return Effect.gen(function* () {
+      const sessionMeta = yield* Effect.promise(() => self.loadSessionMeta());
+      if (!sessionMeta) {
+        return jsonRpcError(404, -32001, "Session timed out due to inactivity — please reconnect");
+      }
 
-    this.initialized = true;
-    this.lastActivityMs = Date.now();
+      self.initialized = true;
+      self.lastActivityMs = Date.now();
 
-    let dbHandle: DbHandle | null = null;
-    let mcpServer: McpServer | null = null;
-    let transport: WorkerTransport | null = null;
-
-    try {
-      dbHandle = makeRequestScopedDb();
-      const runtime = await Effect.runPromise(
-        this.createConnectedRuntimeEffect(sessionMeta, {
+      const dbHandle = makeRequestScopedDb();
+      const cleanupDb = Effect.promise(() => dbHandle.end());
+      return yield* Effect.acquireUseRelease(
+        self.createConnectedRuntimeEffect(sessionMeta, {
           dbHandle,
           enableJsonResponse: request.method !== "GET",
-        }).pipe(Effect.provide(DoTelemetryLive)),
+        }),
+        ({ transport }) =>
+          Effect.gen(function* () {
+            const response = yield* Effect.promise(() => transport.handleRequest(request)).pipe(
+              Effect.withSpan("McpSessionDO.transport.handleRequest"),
+            );
+            if (request.method === "DELETE") {
+              yield* Effect.promise(() => self.clearSessionState());
+            }
+            return response;
+          }),
+        ({ mcpServer, transport }) =>
+          Effect.gen(function* () {
+            yield* Effect.promise(() => transport.close().catch(() => undefined));
+            yield* Effect.promise(() => mcpServer.close().catch(() => undefined));
+            yield* cleanupDb;
+          }),
       );
-      mcpServer = runtime.mcpServer;
-      transport = runtime.transport;
-
-      const response = await transport.handleRequest(request);
-      if (request.method === "DELETE") {
-        await this.clearSessionState();
-      }
-      return response;
-    } catch (err) {
-      console.error(
-        "[mcp-session] request-scoped handleRequest error:",
-        err instanceof Error ? err.stack : err,
-      );
-      Sentry.captureException(err);
-      return jsonRpcError(500, -32603, "Internal error");
-    } finally {
-      await transport?.close().catch(() => undefined);
-      await mcpServer?.close().catch(() => undefined);
-      await dbHandle?.end();
-    }
+    }).pipe(
+      Effect.catchAllCause((cause) =>
+        Effect.sync(() => {
+          console.error("[mcp-session] request-scoped handleRequest error:", cause);
+          Sentry.captureException(cause);
+          return jsonRpcError(500, -32603, "Internal error");
+        }),
+      ),
+    );
   }
 
   async handleRequest(request: Request): Promise<Response> {
@@ -377,12 +400,29 @@ export class McpSessionDO extends DurableObject {
       tracestate: request.headers.get("tracestate") ?? undefined,
       baggage: request.headers.get("baggage") ?? undefined,
     } satisfies IncomingTraceHeaders;
-    const program = Effect.promise(() => this.dispatchRequest(request)).pipe(
-      Effect.tap((response) =>
-        Effect.annotateCurrentSpan({
-          "mcp.response.status_code": response.status,
-        }),
-      ),
+    const self = this;
+    const program = Effect.gen(function* () {
+      // Capture the request-entry span so the host-mcp `parentSpan` getter
+      // — fired by deferred MCP SDK callbacks after this Effect has already
+      // returned — anchors engine spans under the same trace. Cleared in a
+      // finalizer so a future request that arrives without a fresh span
+      // doesn't accidentally inherit a stale one.
+      const span = yield* Effect.currentSpan;
+      self.currentRequestSpan = span;
+
+      return yield* self.dispatchRequestEffect(request).pipe(
+        Effect.tap((response) =>
+          Effect.annotateCurrentSpan({
+            "mcp.response.status_code": response.status,
+          }),
+        ),
+        Effect.ensuring(
+          Effect.sync(() => {
+            self.currentRequestSpan = null;
+          }),
+        ),
+      );
+    }).pipe(
       Effect.withSpan("McpSessionDO.handleRequest", {
         attributes: {
           "mcp.request.method": request.method,
@@ -395,28 +435,37 @@ export class McpSessionDO extends DurableObject {
     return Effect.runPromise(program);
   }
 
-  private async dispatchRequest(request: Request): Promise<Response> {
+  private dispatchRequestEffect(request: Request): Effect.Effect<Response> {
     if (requestScopedRuntimeEnabled) {
-      return this.handleRequestWithRequestScopedRuntime(request);
+      return this.handleRequestWithRequestScopedRuntimeEffect(request);
     }
 
     if (!this.initialized || !this.transport) {
-      return jsonRpcError(404, -32001, "Session timed out due to inactivity — please reconnect");
+      return Effect.succeed(
+        jsonRpcError(404, -32001, "Session timed out due to inactivity — please reconnect"),
+      );
     }
 
     this.lastActivityMs = Date.now();
-
-    try {
-      const response = await this.transport.handleRequest(request);
+    const transport = this.transport;
+    const self = this;
+    return Effect.gen(function* () {
+      const response = yield* Effect.promise(() => transport.handleRequest(request)).pipe(
+        Effect.withSpan("McpSessionDO.transport.handleRequest"),
+      );
       if (request.method === "DELETE") {
-        await this.cleanup();
+        yield* Effect.promise(() => self.cleanup());
       }
       return response;
-    } catch (err) {
-      console.error("[mcp-session] handleRequest error:", err instanceof Error ? err.stack : err);
-      Sentry.captureException(err);
-      return jsonRpcError(500, -32603, "Internal error");
-    }
+    }).pipe(
+      Effect.catchAllCause((cause) =>
+        Effect.sync(() => {
+          console.error("[mcp-session] handleRequest error:", cause);
+          Sentry.captureException(cause);
+          return jsonRpcError(500, -32603, "Internal error");
+        }),
+      ),
+    );
   }
 
   async alarm(): Promise<void> {

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -411,7 +411,20 @@ const rpcResponseAttrs = (payload: JsonRpcErrorBody | null): Record<string, unkn
 const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
   Effect.gen(function* () {
     if (!response.body) return response;
-    const text = yield* Effect.promise(() => response.text());
+    // The DO returns a streaming SSE Response (POST responses aren't
+    // `enableJsonResponse`'d in prod), so `response.text()` blocks on the
+    // entire downstream execution — RPC into the dynamic Worker, tool
+    // invocations back to the host, result serialisation. Carving this
+    // into its own span pins "worker drain time" on the trace so you can
+    // tell worker-side waiting apart from any pre/post work on the edge.
+    const text = yield* Effect.promise(() => response.text()).pipe(
+      Effect.withSpan("mcp.peek_response", {
+        attributes: {
+          "http.response.content_type": response.headers.get("content-type") ?? "",
+          "http.response.status_code": response.status,
+        },
+      }),
+    );
     const payload = parseFirstJsonRpc(response.headers.get("content-type") ?? "", text);
     const attrs = rpcResponseAttrs(payload);
     if (Object.keys(attrs).length > 0) {

--- a/apps/cloud/src/services/telemetry.ts
+++ b/apps/cloud/src/services/telemetry.ts
@@ -8,17 +8,27 @@
 //   `@microlabs/otel-cf-workers`' `instrument(...)` installs in `server.ts`.
 //   Flushing is handled by `instrument()` via `ctx.waitUntil` at request end.
 //
-// - `DoTelemetryLive` (Durable Object path): provisions its own
-//   `WebSdk`-backed tracer via `Effect`. The DO runs in a separate isolate
-//   and we deliberately avoid `instrumentDO` (it wraps DO methods in a way
-//   that breaks `this` binding on `WorkerTransport`'s stream primitives —
-//   every MCP request 500s with "Illegal invocation"). The DO uses a
-//   `SimpleSpanProcessor` so spans export immediately; there's no
-//   `ctx.waitUntil` to rely on for batching. Gated inside a
-//   `Layer.unwrapEffect` so the `AXIOM_TOKEN` check happens at
-//   layer-provide time — `server` is now a lazy Proxy, so this is just
-//   defensive against the token genuinely being unset (dev / missing
-//   secret).
+// - `DoTelemetryLive` (Durable Object path): the DO runs in a separate
+//   isolate and we deliberately avoid `instrumentDO` (it wraps DO methods
+//   in a way that breaks `this` binding on `WorkerTransport`'s stream
+//   primitives — every MCP request 500s with "Illegal invocation").
+//
+//   We install a `WebTracerProvider` once per isolate as the global
+//   provider (lazy on first `DoTelemetryLive` provide, not at module
+//   load — `env` from `cloudflare:workers` is reliably populated at
+//   request time but we keep the lazy gate as a defensive cheap no-op).
+//   Once installed, the provider lives for the entire isolate lifetime,
+//   so deferred MCP SDK callbacks — which fire after the request Effect
+//   has resolved — still hit a live `SimpleSpanProcessor` + exporter.
+//
+//   Previously the WebSdk layer was scoped per-request: when the outer
+//   `Effect.runPromise(...)` resolved, the layer's scope closed and
+//   `processor.shutdown()` ran. Engine / runtime spans created from
+//   deferred SDK callbacks (which captured the old runtime + tracer)
+//   then silently failed to export, even though they showed up in
+//   `Effect.currentSpan` traces during execution. The DO has been
+//   missing every `executor.code.exec.*` and `executor.runtime.*` span
+//   since `DoTelemetryLive` first started shipping spans.
 // ---------------------------------------------------------------------------
 
 // Subpath imports — the barrel `@effect/opentelemetry` re-exports `NodeSdk`,
@@ -28,7 +38,7 @@
 // unused NodeSdk; vitest does not.
 import * as Resource from "@effect/opentelemetry/Resource";
 import * as OtelTracer from "@effect/opentelemetry/Tracer";
-import * as WebSdk from "@effect/opentelemetry/WebSdk";
+import { trace } from "@opentelemetry/api";
 // Force the browser platform entry — the package's conditional export would
 // otherwise resolve to the Node build, which uses `https.request` / `node:http`.
 // Under workerd + unenv's nodejs_compat, `https.request` isn't implemented
@@ -36,28 +46,66 @@ import * as WebSdk from "@effect/opentelemetry/WebSdk";
 // time) and every DO span fails to ship. The browser build uses `fetch()`,
 // which workerd does support.
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http/build/esm/platform/browser/index.js";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { WebTracerProvider } from "@opentelemetry/sdk-trace-web";
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+} from "@opentelemetry/semantic-conventions";
 import { Effect, Layer } from "effect";
 
 import { server } from "../env";
 
+const SERVICE_NAME = "executor-cloud";
+const SERVICE_VERSION = "1.0.0";
+
 export const TelemetryLive: Layer.Layer<never> = OtelTracer.layerGlobal.pipe(
-  Layer.provide(Resource.layer({ serviceName: "executor-cloud", serviceVersion: "1.0.0" })),
+  Layer.provide(Resource.layer({ serviceName: SERVICE_NAME, serviceVersion: SERVICE_VERSION })),
 );
 
+// Module-scope: one provider per DO isolate, never shut down. The provider
+// holds the SimpleSpanProcessor + OTLP exporter, so any tracer reference
+// the engine/runtime spans hold (via captured Effect runtimes) keeps
+// finding a live exporter even after the request Effect has resolved.
+let installed = false;
+const ensureGlobalTracerProvider = (): boolean => {
+  if (installed) return true;
+  if (!server.AXIOM_TOKEN) return false;
+  const provider = new WebTracerProvider({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: SERVICE_NAME,
+      [ATTR_SERVICE_VERSION]: SERVICE_VERSION,
+    }),
+    spanProcessors: [
+      new SimpleSpanProcessor(
+        new OTLPTraceExporter({
+          url: server.AXIOM_TRACES_URL,
+          headers: {
+            Authorization: `Bearer ${server.AXIOM_TOKEN}`,
+            "X-Axiom-Dataset": server.AXIOM_DATASET,
+          },
+        }),
+      ),
+    ],
+  });
+  // Skip `provider.register()` — its StackContextManager / W3C propagator
+  // setup wires the global OTel context API, but Effect's tracer goes
+  // through `OtelTracer.layerGlobal` which only needs the global provider,
+  // not the OTel context machinery.
+  trace.setGlobalTracerProvider(provider);
+  installed = true;
+  return true;
+};
+
 export const DoTelemetryLive: Layer.Layer<never> = Layer.unwrapEffect(
-  Effect.sync(() => {
-    if (!server.AXIOM_TOKEN) return Layer.empty;
-    const exporter = new OTLPTraceExporter({
-      url: server.AXIOM_TRACES_URL,
-      headers: {
-        Authorization: `Bearer ${server.AXIOM_TOKEN}`,
-        "X-Axiom-Dataset": server.AXIOM_DATASET,
-      },
-    });
-    return WebSdk.layer(() => ({
-      resource: { serviceName: "executor-cloud", serviceVersion: "1.0.0" },
-      spanProcessor: new SimpleSpanProcessor(exporter),
-    }));
-  }),
+  Effect.sync(() =>
+    ensureGlobalTracerProvider()
+      ? OtelTracer.layerGlobal.pipe(
+          Layer.provide(
+            Resource.layer({ serviceName: SERVICE_NAME, serviceVersion: SERVICE_VERSION }),
+          ),
+        )
+      : Layer.empty,
+  ),
 );

--- a/apps/local/src/server/mcp.ts
+++ b/apps/local/src/server/mcp.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -59,7 +60,7 @@ export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpReq
       };
 
       try {
-        created = await createExecutorMcpServer(config);
+        created = await Effect.runPromise(createExecutorMcpServer(config));
         await created.connect(transport);
         const response = await transport.handleRequest(request);
 
@@ -90,7 +91,7 @@ export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpReq
 // ---------------------------------------------------------------------------
 
 export const runMcpStdioServer = async (config: ExecutorMcpServerConfig): Promise<void> => {
-  const server = await createExecutorMcpServer(config);
+  const server = await Effect.runPromise(createExecutorMcpServer(config));
   const transport = new StdioServerTransport();
 
   const waitForExit = () =>

--- a/bun.lock
+++ b/bun.lock
@@ -73,6 +73,7 @@
         "@opentelemetry/resources": "^2.6.1",
         "@opentelemetry/sdk-logs": "^0.214.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/sdk-trace-web": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@sentry/cloudflare": "^10.48.0",
         "@sentry/react": "^10.48.0",

--- a/packages/hosts/mcp/src/server.test.ts
+++ b/packages/hosts/mcp/src/server.test.ts
@@ -34,7 +34,7 @@ const withClient = async (
   capabilities: ClientCapabilities,
   fn: (client: Client) => Promise<void>,
 ) => {
-  const mcpServer = await createExecutorMcpServer({ engine });
+  const mcpServer = await Effect.runPromise(createExecutorMcpServer({ engine }));
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities });
   await mcpServer.connect(serverTransport);

--- a/packages/hosts/mcp/src/server.ts
+++ b/packages/hosts/mcp/src/server.ts
@@ -1,4 +1,4 @@
-import { Effect, Match } from "effect";
+import { Effect, Match, Runtime } from "effect";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   jsonSchemaValidator,
@@ -15,6 +15,7 @@ import type {
   ElicitationRequest,
 } from "@executor/sdk";
 import type * as Cause from "effect/Cause";
+import type * as Tracer from "effect/Tracer";
 import {
   createExecutionEngine,
   formatExecuteResult,
@@ -48,13 +49,23 @@ class CfWorkerJsonSchemaValidator implements jsonSchemaValidator {
 type SharedMcpServerConfig = {
   /**
    * Pre-built `execute` tool description. When provided, the factory skips
-   * its internal `engine.getDescription()` call. Useful when the caller
+   * its internal `engine.getDescription` yield. Useful when the caller
    * wants to compute the description inside its own Effect tracer context
    * so sub-spans (`executor.sources.list`, `executor.tools.list`) nest as
-   * children of the caller's root span instead of being orphaned by the
-   * `Effect.runPromise` that `engine.getDescription()` runs internally.
+   * children of the caller's root span.
    */
   readonly description?: string;
+  /**
+   * Parent span override for engine calls. The factory captures the
+   * caller's `Runtime` at construction time, but `Runtime.runPromise`
+   * starts a fresh fiber per SDK callback — so the `currentSpan`
+   * FiberRef resets to root unless explicitly anchored.
+   *
+   * Accepts either a fixed span (per-request McpServer instances) or a
+   * getter (session-scoped instances that need to anchor each callback
+   * under whichever request triggered it; see the Cloud DO).
+   */
+  readonly parentSpan?: Tracer.AnySpan | (() => Tracer.AnySpan | undefined);
 };
 
 export type ExecutorMcpServerConfig<E extends Cause.YieldableError = Cause.YieldableError> =
@@ -162,109 +173,129 @@ const toMcpPausedResult = (formatted: ReturnType<typeof formatPausedExecution>):
   structuredContent: formatted.structured,
 });
 
+const parseJsonContent = (raw: string): Record<string, unknown> | undefined => {
+  if (raw === "{}") return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+    ? (parsed as Record<string, unknown>)
+    : undefined;
+};
+
 // ---------------------------------------------------------------------------
 // Server factory
 // ---------------------------------------------------------------------------
 
-export const createExecutorMcpServer = async <E extends Cause.YieldableError>(
+export const createExecutorMcpServer = <E extends Cause.YieldableError>(
   config: ExecutorMcpServerConfig<E>,
-): Promise<McpServer> => {
-  const engine = "engine" in config ? config.engine : createExecutionEngine(config);
-  const description = config.description ?? (await Effect.runPromise(engine.getDescription));
+): Effect.Effect<McpServer> =>
+  Effect.gen(function* () {
+    const engine = "engine" in config ? config.engine : createExecutionEngine(config);
+    const description = config.description ?? (yield* engine.getDescription);
 
-  const server = new McpServer(
-    { name: "executor", version: "1.0.0" },
-    { capabilities: { tools: {} }, jsonSchemaValidator: new CfWorkerJsonSchemaValidator() },
-  );
+    // Captured at construction time. SDK callbacks fire later (often
+    // deferred past the outer Effect's await), so we use the runtime to
+    // re-enter Effect-land at each callback edge.
+    const runtime = yield* Effect.runtime<never>();
 
-  const executeCode = async (code: string): Promise<McpToolResult> => {
-    if (supportsManagedElicitation(server)) {
-      const result = await Effect.runPromise(
-        engine.execute(code, {
-          onElicitation: makeMcpElicitationHandler(server),
-        }),
-      );
-      return toMcpResult(formatExecuteResult(result));
-    }
+    const resolveParentSpan = (): Tracer.AnySpan | undefined => {
+      const ps = config.parentSpan;
+      return typeof ps === "function" ? ps() : ps;
+    };
+    const anchor = <A, EffE>(effect: Effect.Effect<A, EffE>): Effect.Effect<A, EffE> => {
+      const parent = resolveParentSpan();
+      return parent ? Effect.withParentSpan(effect, parent) : effect;
+    };
 
-    const outcome = await Effect.runPromise(engine.executeWithPause(code));
-    return outcome.status === "completed"
-      ? toMcpResult(formatExecuteResult(outcome.result))
-      : toMcpPausedResult(formatPausedExecution(outcome.execution));
-  };
+    const server = new McpServer(
+      { name: "executor", version: "1.0.0" },
+      { capabilities: { tools: {} }, jsonSchemaValidator: new CfWorkerJsonSchemaValidator() },
+    );
 
-  const parseJsonContent = (raw: string): Record<string, unknown> | undefined => {
-    if (raw === "{}") return undefined;
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      return undefined;
-    }
-    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
-  };
+    const executeCode = (code: string): Effect.Effect<McpToolResult, E> =>
+      Effect.gen(function* () {
+        if (supportsManagedElicitation(server)) {
+          const result = yield* engine.execute(code, {
+            onElicitation: makeMcpElicitationHandler(server),
+          });
+          return toMcpResult(formatExecuteResult(result));
+        }
+        const outcome = yield* engine.executeWithPause(code);
+        return outcome.status === "completed"
+          ? toMcpResult(formatExecuteResult(outcome.result))
+          : toMcpPausedResult(formatPausedExecution(outcome.execution));
+      });
 
-  // --- tools ---
+    const resumeExecution = (
+      executionId: string,
+      action: "accept" | "decline" | "cancel",
+      content: Record<string, unknown> | undefined,
+    ): Effect.Effect<McpToolResult, E> =>
+      Effect.gen(function* () {
+        const outcome = yield* engine.resume(executionId, { action, content });
+        if (!outcome) {
+          return {
+            content: [{ type: "text", text: `No paused execution: ${executionId}` }],
+            isError: true,
+          };
+        }
+        return outcome.status === "completed"
+          ? toMcpResult(formatExecuteResult(outcome.result))
+          : toMcpPausedResult(formatPausedExecution(outcome.execution));
+      });
 
-  const executeTool = server.registerTool(
-    "execute",
-    {
-      description,
-      inputSchema: { code: z.string().trim().min(1) },
-    },
-    async ({ code }) => executeCode(code),
-  );
+    // --- tools ---
 
-  const resumeTool = server.registerTool(
-    "resume",
-    {
-      description: [
-        "Resume a paused execution using the executionId returned by execute.",
-        "Never call this without user approval unless they explicitly state otherwise.",
-      ].join("\n"),
-      inputSchema: {
-        executionId: z.string().describe("The execution ID from the paused result"),
-        action: z
-          .enum(["accept", "decline", "cancel"])
-          .describe("How to respond to the interaction"),
-        content: z
-          .string()
-          .describe("Optional JSON-encoded response content for form elicitations")
-          .default("{}"),
+    const executeTool = server.registerTool(
+      "execute",
+      {
+        description,
+        inputSchema: { code: z.string().trim().min(1) },
       },
-    },
-    async ({ executionId, action, content: rawContent }) => {
-      const content = parseJsonContent(rawContent);
-      const outcome = await Effect.runPromise(engine.resume(executionId, { action, content }));
+      ({ code }) => Runtime.runPromise(runtime)(anchor(executeCode(code))),
+    );
 
-      if (!outcome) {
-        return {
-          content: [{ type: "text", text: `No paused execution: ${executionId}` }],
-          isError: true,
-        };
+    const resumeTool = server.registerTool(
+      "resume",
+      {
+        description: [
+          "Resume a paused execution using the executionId returned by execute.",
+          "Never call this without user approval unless they explicitly state otherwise.",
+        ].join("\n"),
+        inputSchema: {
+          executionId: z.string().describe("The execution ID from the paused result"),
+          action: z
+            .enum(["accept", "decline", "cancel"])
+            .describe("How to respond to the interaction"),
+          content: z
+            .string()
+            .describe("Optional JSON-encoded response content for form elicitations")
+            .default("{}"),
+        },
+      },
+      ({ executionId, action, content: rawContent }) =>
+        Runtime.runPromise(runtime)(
+          anchor(resumeExecution(executionId, action, parseJsonContent(rawContent))),
+        ),
+    );
+
+    // --- capability-based tool visibility ---
+
+    const syncToolAvailability = () => {
+      executeTool.enable();
+      if (supportsManagedElicitation(server)) {
+        resumeTool.disable();
+      } else {
+        resumeTool.enable();
       }
+    };
 
-      return outcome.status === "completed"
-        ? toMcpResult(formatExecuteResult(outcome.result))
-        : toMcpPausedResult(formatPausedExecution(outcome.execution));
-    },
-  );
+    syncToolAvailability();
+    server.server.oninitialized = syncToolAvailability;
 
-  // --- capability-based tool visibility ---
-
-  const syncToolAvailability = () => {
-    executeTool.enable();
-    if (supportsManagedElicitation(server)) {
-      resumeTool.disable();
-    } else {
-      resumeTool.enable();
-    }
-  };
-
-  syncToolAvailability();
-  server.server.oninitialized = syncToolAvailability;
-
-  return server;
-};
+    return server;
+  });

--- a/packages/kernel/runtime-dynamic-worker/src/executor.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/executor.ts
@@ -12,6 +12,7 @@ import { RpcTarget } from "cloudflare:workers";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Runtime from "effect/Runtime";
 
 import {
   recoverExecutionBody,
@@ -227,18 +228,22 @@ export const decodeWorkerRpcResponse = (raw: string): WorkerRpcResponse =>
  * `mcp.tool.dispatch` span that `tool-invoker.ts` wraps around
  * `executor.tools.invoke`.
  */
+export type RunPromise = <A, E>(effect: Effect.Effect<A, E>) => Promise<A>;
+
 export class ToolDispatcher extends RpcTarget {
   readonly #invoker: SandboxToolInvoker;
+  readonly #runPromise: RunPromise;
 
-  constructor(invoker: SandboxToolInvoker) {
+  constructor(invoker: SandboxToolInvoker, runPromise: RunPromise) {
     super();
     this.#invoker = invoker;
+    this.#runPromise = runPromise;
   }
 
   async call(path: string, argsJson: string): Promise<string> {
     const args = argsJson ? JSON.parse(argsJson) : undefined;
 
-    return Effect.runPromise(
+    return this.#runPromise(
       this.#invoker.invoke({ path, args }).pipe(
         Effect.map(
           (value): WorkerRpcResponse => ({
@@ -322,9 +327,10 @@ const evaluate = (
   toolInvoker: SandboxToolInvoker,
 ): Effect.Effect<ExecuteResult, DynamicWorkerExecutionError> => {
   const timeoutMs = Math.max(100, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
-  const dispatcher = new ToolDispatcher(toolInvoker);
 
   return Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<never>();
+    const dispatcher = new ToolDispatcher(toolInvoker, Runtime.runPromise(runtime));
     const entrypoint = yield* startDynamicWorker(options, code, timeoutMs);
     const response = yield* Effect.tryPromise({
       try: () => entrypoint.evaluate(dispatcher),

--- a/packages/kernel/runtime-dynamic-worker/src/executor.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/executor.ts
@@ -219,6 +219,13 @@ export const decodeWorkerRpcResponse = (raw: string): WorkerRpcResponse =>
  * An `RpcTarget` passed to the dynamic Worker so that sandboxed code can
  * invoke tools on the host. The dynamic worker calls
  * `__dispatcher.call(path, argsJson)` over Workers RPC.
+ *
+ * Each call is wrapped in an `executor.tool.rpc_dispatch` span so the
+ * tool-invocation shell (Workers RPC roundtrip → local invoker →
+ * serialize result) is visible in the trace. Tool-level attributes
+ * like `mcp.tool.name` already come from the inner
+ * `mcp.tool.dispatch` span that `tool-invoker.ts` wraps around
+ * `executor.tools.invoke`.
  */
 export class ToolDispatcher extends RpcTarget {
   readonly #invoker: SandboxToolInvoker;
@@ -247,6 +254,12 @@ export class ToolDispatcher extends RpcTarget {
           }),
         ),
         Effect.map(encodeWorkerRpcResponse),
+        Effect.withSpan("executor.tool.rpc_dispatch", {
+          attributes: {
+            "mcp.tool.name": path,
+            "executor.tool.args_length": argsJson.length,
+          },
+        }),
       ),
     );
   }
@@ -256,46 +269,81 @@ export class ToolDispatcher extends RpcTarget {
 // Evaluate
 // ---------------------------------------------------------------------------
 
-const evaluate = async (
+type DynamicWorkerEntrypoint = {
+  evaluate(dispatcher: ToolDispatcher): Promise<{
+    result: unknown;
+    error?: SerializedWorkerError;
+    logs?: string[];
+  }>;
+};
+
+/**
+ * Assemble the executor module source and ask the `WorkerLoader` for an
+ * isolate. Spans the synchronous module-build + RPC-stub acquisition as
+ * `executor.runtime.startup` so the trace separates "did we wait on
+ * worker boot?" from the actual `evaluate` RPC roundtrip.
+ */
+const startDynamicWorker = (
+  options: DynamicWorkerExecutorOptions,
+  code: string,
+  timeoutMs: number,
+): Effect.Effect<DynamicWorkerEntrypoint> =>
+  Effect.sync((): DynamicWorkerEntrypoint => {
+    const recoveredBody = recoverExecutionBody(code);
+    const executorModule = buildExecutorModule(recoveredBody, timeoutMs);
+    const { [ENTRY_MODULE]: _, ...safeModules } = options.modules ?? {};
+
+    const worker = options.loader.get(`executor-${crypto.randomUUID()}`, () => ({
+      compatibilityDate: "2025-06-01",
+      compatibilityFlags: ["nodejs_compat"],
+      mainModule: ENTRY_MODULE,
+      modules: {
+        ...safeModules,
+        [ENTRY_MODULE]: executorModule,
+      },
+      globalOutbound: options.globalOutbound ?? null,
+    }));
+
+    return worker.getEntrypoint() as unknown as DynamicWorkerEntrypoint;
+  }).pipe(
+    Effect.withSpan("executor.runtime.startup", {
+      attributes: {
+        "executor.runtime": "dynamic-worker",
+        "executor.code.length": code.length,
+        "executor.timeout_ms": timeoutMs,
+        "executor.extra_modules": Object.keys(options.modules ?? {}).length,
+      },
+    }),
+  );
+
+const evaluate = (
   options: DynamicWorkerExecutorOptions,
   code: string,
   toolInvoker: SandboxToolInvoker,
-): Promise<ExecuteResult> => {
+): Effect.Effect<ExecuteResult, DynamicWorkerExecutionError> => {
   const timeoutMs = Math.max(100, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
-  const recoveredBody = recoverExecutionBody(code);
-  const executorModule = buildExecutorModule(recoveredBody, timeoutMs);
-
-  const { [ENTRY_MODULE]: _, ...safeModules } = options.modules ?? {};
-
   const dispatcher = new ToolDispatcher(toolInvoker);
 
-  const worker = options.loader.get(`executor-${crypto.randomUUID()}`, () => ({
-    compatibilityDate: "2025-06-01",
-    compatibilityFlags: ["nodejs_compat"],
-    mainModule: ENTRY_MODULE,
-    modules: {
-      ...safeModules,
-      [ENTRY_MODULE]: executorModule,
-    },
-    globalOutbound: options.globalOutbound ?? null,
-  }));
-
-  const entrypoint = worker.getEntrypoint() as unknown as {
-    evaluate(dispatcher: ToolDispatcher): Promise<{
-      result: unknown;
-      error?: SerializedWorkerError;
-      logs?: string[];
-    }>;
-  };
-
-  const response = await entrypoint.evaluate(dispatcher);
-  const error = response.error ? renderWorkerError(response.error) : undefined;
-
-  return {
-    result: error ? null : response.result,
-    error,
-    logs: response.logs,
-  };
+  return Effect.gen(function* () {
+    const entrypoint = yield* startDynamicWorker(options, code, timeoutMs);
+    const response = yield* Effect.tryPromise({
+      try: () => entrypoint.evaluate(dispatcher),
+      catch: (cause) =>
+        new DynamicWorkerExecutionError({
+          message: renderTransportMessage(serializeWorkerErrorValue(cause)),
+        }),
+    }).pipe(
+      Effect.withSpan("executor.runtime.evaluate", {
+        attributes: { "executor.runtime": "dynamic-worker" },
+      }),
+    );
+    const error = response.error ? renderWorkerError(response.error) : undefined;
+    return {
+      result: error ? null : response.result,
+      error,
+      logs: response.logs,
+    } satisfies ExecuteResult;
+  });
 };
 
 // ---------------------------------------------------------------------------
@@ -307,13 +355,7 @@ const runInDynamicWorker = (
   code: string,
   toolInvoker: SandboxToolInvoker,
 ): Effect.Effect<ExecuteResult, DynamicWorkerExecutionError> =>
-  Effect.tryPromise({
-    try: () => evaluate(options, code, toolInvoker),
-    catch: (cause) =>
-      new DynamicWorkerExecutionError({
-        message: renderTransportMessage(serializeWorkerErrorValue(cause)),
-      }),
-  }).pipe(
+  evaluate(options, code, toolInvoker).pipe(
     Effect.withSpan("executor.code.exec.dynamic_worker", {
       attributes: { "executor.runtime": "dynamic-worker" },
     }),

--- a/packages/kernel/runtime-dynamic-worker/src/invocation.test.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/invocation.test.ts
@@ -30,14 +30,14 @@ const failingInvoker = (message: string): SandboxToolInvoker => ({
 describe("ToolDispatcher", () => {
   it("returns a success envelope on successful tool call", async () => {
     const invoker = makeInvoker(({ args }) => args);
-    const dispatcher = new ToolDispatcher(invoker);
+    const dispatcher = new ToolDispatcher(invoker, Effect.runPromise);
 
     const result = await dispatcher.call("test.tool", '{"key":"value"}');
     expect(decodeWorkerRpcResponse(result)).toEqual({ ok: true, result: { key: "value" } });
   });
 
   it("serializes tagged failures into a structured error envelope", async () => {
-    const dispatcher = new ToolDispatcher(failingInvoker("tool broke"));
+    const dispatcher = new ToolDispatcher(failingInvoker("tool broke"), Effect.runPromise);
 
     const result = await dispatcher.call("broken.tool", "{}");
     expect(decodeWorkerRpcResponse(result)).toMatchObject({
@@ -54,13 +54,16 @@ describe("ToolDispatcher", () => {
   });
 
   it("serializes object-shaped tool errors without collapsing them", async () => {
-    const dispatcher = new ToolDispatcher({
-      invoke: () =>
-        Effect.fail({
-          code: "forbidden",
-          detail: "missing team access",
-        }),
-    });
+    const dispatcher = new ToolDispatcher(
+      {
+        invoke: () =>
+          Effect.fail({
+            code: "forbidden",
+            detail: "missing team access",
+          }),
+      },
+      Effect.runPromise,
+    );
 
     const result = await dispatcher.call("broken.tool", "{}");
     expect(decodeWorkerRpcResponse(result)).toEqual({
@@ -86,7 +89,7 @@ describe("ToolDispatcher", () => {
 
   it("handles undefined args", async () => {
     const invoker = makeInvoker(({ args }) => args);
-    const dispatcher = new ToolDispatcher(invoker);
+    const dispatcher = new ToolDispatcher(invoker, Effect.runPromise);
 
     const result = await dispatcher.call("test.tool", "");
     expect(decodeWorkerRpcResponse(result)).toEqual({ ok: true, result: undefined });
@@ -98,7 +101,7 @@ describe("ToolDispatcher", () => {
       capturedPath = path;
       return "ok";
     });
-    const dispatcher = new ToolDispatcher(invoker);
+    const dispatcher = new ToolDispatcher(invoker, Effect.runPromise);
 
     await dispatcher.call("my.deep.tool.path", "{}");
     expect(capturedPath).toBe("my.deep.tool.path");

--- a/packages/kernel/runtime-quickjs/src/index.ts
+++ b/packages/kernel/runtime-quickjs/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from "@executor/codemode-core";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Runtime from "effect/Runtime";
 import {
   getQuickJS,
   shouldInterruptAfterDeadline,
@@ -165,10 +166,13 @@ const createLogBridge = (context: QuickJSContext, logs: string[]): QuickJSHandle
     return context.undefined;
   });
 
+type RunPromise = <A, E>(effect: Effect.Effect<A, E>) => Promise<A>;
+
 const createToolBridge = (
   context: QuickJSContext,
   toolInvoker: SandboxToolInvoker,
   pendingDeferreds: Set<QuickJSDeferredPromise>,
+  runPromise: RunPromise,
 ): QuickJSHandle =>
   context.newFunction("__executor_invokeTool", (pathHandle, argsHandle) => {
     const path = context.getString(pathHandle);
@@ -182,7 +186,7 @@ const createToolBridge = (
       pendingDeferreds.delete(deferred);
     });
 
-    void Effect.runPromise(toolInvoker.invoke({ path, args })).then(
+    void runPromise(toolInvoker.invoke({ path, args })).then(
       (value) => {
         if (!deferred.alive) {
           return;
@@ -278,6 +282,7 @@ const evaluateInQuickJs = async (
   options: QuickJsExecutorOptions,
   code: string,
   toolInvoker: SandboxToolInvoker,
+  runPromise: RunPromise,
 ): Promise<ExecuteResult> => {
   const timeoutMs = Math.max(100, options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const deadlineMs = Date.now() + timeoutMs;
@@ -303,7 +308,7 @@ const evaluateInQuickJs = async (
       context.setProp(context.global, "__executor_log", logBridge);
       logBridge.dispose();
 
-      const toolBridge = createToolBridge(context, toolInvoker, pendingDeferreds);
+      const toolBridge = createToolBridge(context, toolInvoker, pendingDeferreds, runPromise);
       context.setProp(context.global, "__executor_invokeTool", toolBridge);
       toolBridge.dispose();
 
@@ -387,9 +392,13 @@ const runInQuickJs = (
   code: string,
   toolInvoker: SandboxToolInvoker,
 ): Effect.Effect<ExecuteResult, QuickJsExecutionError> =>
-  Effect.tryPromise({
-    try: () => evaluateInQuickJs(options, code, toolInvoker),
-    catch: (cause) => new QuickJsExecutionError({ message: String(cause) }),
+  Effect.gen(function* () {
+    const runtime = yield* Effect.runtime<never>();
+    const runPromise = Runtime.runPromise(runtime);
+    return yield* Effect.tryPromise({
+      try: () => evaluateInQuickJs(options, code, toolInvoker, runPromise),
+      catch: (cause) => new QuickJsExecutionError({ message: String(cause) }),
+    });
   }).pipe(
     Effect.withSpan("executor.code.exec.quickjs", {
       attributes: { "executor.runtime": "quickjs" },


### PR DESCRIPTION
## Summary

- Adds spans across the executor/sandbox path (`executor.runtime.startup`, `executor.runtime.evaluate`, `executor.tool.rpc_dispatch`, `mcp.peek_response`) so the time inside `mcp.request` for `tools/call execute` is no longer opaque.
- Stitches engine spans under the request's trace by giving `createExecutorMcpServer` a typed `parentSpan?: Tracer.AnySpan | (() => Tracer.AnySpan | undefined)` config field and capturing the request-entry span via `Effect.currentSpan` in the DO.
- Flips the persistent transport's `enableJsonResponse: true` so POST callbacks fire inside `transport.handleRequest()`'s await — keeps the engine work inside the outer `McpSessionDO.handleRequest` Effect's fiber, so the captured span is still in scope when the SDK callbacks read it.

## Why

In Axiom we saw `mcp.request` for `tools/call execute` running ~4.7s with `McpSessionDO.handleRequest = 0ms` — the entire wall-clock cost was in the worker draining the SSE response from an uninstrumented sandbox. Engine spans (when they existed at all) were starting fresh root traces because the MCP SDK's tool callbacks fire after the outer Effect has already returned, so Effect's fiber-local tracer context was gone.

The first attempt at trace stitching used a `run?: <A,E>(effect) => Promise<A>` injection on the SDK plus a mutable `currentRequestSpanContext` stash on the DO instance. Reverted in favor of a clean Effect model: typed `parentSpan` config + `enableJsonResponse: true` so all the work happens inside the outer fiber.

## Wire-protocol note

POST responses go from `text/event-stream` (one event wrapping the JSON-RPC payload) to plain `application/json`. Both are MCP-spec-compliant; any conformant client handles either. GET (server→client SSE channel for elicitation pushes etc.) is unchanged.

## Test plan

- [x] `bunx vitest run` in `packages/core/execution/` — 8/8 pass
- [x] `bunx vitest run` in `packages/hosts/mcp/` — 23/23 pass
- [x] `bunx vitest run --config vitest.node.config.ts` in `apps/cloud/` — 29/29 pass, including elicitation round-trips and the trace-propagation regression guards in `mcp-miniflare.e2e.node.test.ts`
- [x] `bun run typecheck` — 34/34 pass
- [ ] After deploy: confirm in Axiom that `tools/call execute` traces show child spans under `mcp.request` (executor.runtime.startup, executor.runtime.evaluate, executor.tool.rpc_dispatch) instead of opaque time inside `mcp.peek_response`