### PR TITLE
[codex] add daemon lifecycle management for local CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ executor call --file script.ts
 executor call 'return await tools.discover({ query: "send email" })'
 ```
 
+`executor call` and `executor resume` auto-start a local daemon if needed.
+
 If an execution pauses for auth or approval, resume it:
 
 ```bash
@@ -95,6 +97,10 @@ executor resume --execution-id exec_123
 
 ```bash
 executor web                        # start runtime + web UI
+executor daemon run                 # run persistent local daemon
+executor daemon status              # show daemon status
+executor daemon stop                # stop daemon
+executor daemon restart             # restart daemon
 executor mcp                        # start MCP endpoint
 executor call --file script.ts      # execute a file
 executor call '<code>'              # execute inline code

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Run code via the CLI:
 executor call --file script.ts
 executor call 'return await tools.discover({ query: "send email" })'
 executor tools search "send email"
-executor tools run "send email" --input '{"to":"alice@example.com","subject":"Hi"}'
 executor tools invoke gmail.send --input '{"to":"alice@example.com","subject":"Hi"}'
+executor tools run gmail send '{"to":"alice@example.com","subject":"Hi"}'
+executor call github issues create '{"owner":"octocat","repo":"Hello-World","title":"Hi"}'
 ```
 
 `executor call`, `executor resume`, and `executor tools ...` commands auto-start a local daemon if needed.
@@ -114,7 +115,8 @@ executor tools search "<query>"     # search tools by intent
 executor tools sources              # list configured sources + tool counts
 executor tools describe <path>      # show tool TypeScript/JSON schema
 executor tools invoke <path> --input '{"k":"v"}' # invoke a tool directly
-executor tools run "<query>" --input '{"k":"v"}' # search + invoke top match
+executor tools run <path...> '{"k":"v"}' # run a tool via path segments
+executor call <path...> '{"k":"v"}' # shorthand tool invocation
 ```
 
 ## Developing locally

--- a/README.md
+++ b/README.md
@@ -83,9 +83,12 @@ Run code via the CLI:
 ```bash
 executor call --file script.ts
 executor call 'return await tools.discover({ query: "send email" })'
+executor tools search "send email"
+executor tools run "send email" --input '{"to":"alice@example.com","subject":"Hi"}'
+executor tools invoke gmail.send --input '{"to":"alice@example.com","subject":"Hi"}'
 ```
 
-`executor call` and `executor resume` auto-start a local daemon if needed.
+`executor call`, `executor resume`, and `executor tools ...` commands auto-start a local daemon if needed.
 
 If an execution pauses for auth or approval, resume it:
 
@@ -106,6 +109,11 @@ executor call --file script.ts      # execute a file
 executor call '<code>'              # execute inline code
 executor call --stdin               # execute from stdin
 executor resume --execution-id <id> # resume paused execution
+executor tools search "<query>"     # search tools by intent
+executor tools sources              # list configured sources + tool counts
+executor tools describe <path>      # show tool TypeScript/JSON schema
+executor tools invoke <path> --input '{"k":"v"}' # invoke a tool directly
+executor tools run "<query>" --input '{"k":"v"}' # search + invoke top match
 ```
 
 ## Developing locally

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ Open `http://127.0.0.1:4788`, go to **Add Source**, paste a URL, and Executor wi
 ### Via the CLI
 
 ```bash
-executor call 'return await tools.executor.sources.add({
-  kind: "openapi",
-  name: "GitHub",
-  specUrl: "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json",
-  baseUrl: null,
-  auth: { kind: "none" }
-})'
+executor tools invoke openapi.addSource --input '{
+  "spec": "https://petstore3.swagger.io/api/v3/openapi.json",
+  "namespace": "petstore",
+  "baseUrl": "https://petstore3.swagger.io/api/v3"
+}'
 ```
+
+Use `baseUrl` when the OpenAPI document has relative `servers` entries (for example `"/api/v3"`).
 
 ## Use tools
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Open `http://127.0.0.1:4788`, go to **Add Source**, paste a URL, and Executor wi
 ### Via the CLI
 
 ```bash
-executor tools invoke openapi.addSource --input '{
+executor call openapi addSource '{
   "spec": "https://petstore3.swagger.io/api/v3/openapi.json",
   "namespace": "petstore",
   "baseUrl": "https://petstore3.swagger.io/api/v3"
@@ -84,8 +84,7 @@ Run code via the CLI:
 executor call --file script.ts
 executor call 'return await tools.discover({ query: "send email" })'
 executor tools search "send email"
-executor tools invoke gmail.send --input '{"to":"alice@example.com","subject":"Hi"}'
-executor tools run gmail send '{"to":"alice@example.com","subject":"Hi"}'
+executor call gmail send '{"to":"alice@example.com","subject":"Hi"}'
 executor call github issues create '{"owner":"octocat","repo":"Hello-World","title":"Hi"}'
 ```
 
@@ -114,9 +113,7 @@ executor resume --execution-id <id> # resume paused execution
 executor tools search "<query>"     # search tools by intent
 executor tools sources              # list configured sources + tool counts
 executor tools describe <path>      # show tool TypeScript/JSON schema
-executor tools invoke <path> --input '{"k":"v"}' # invoke a tool directly
-executor tools run <path...> '{"k":"v"}' # run a tool via path segments
-executor call <path...> '{"k":"v"}' # shorthand tool invocation
+executor call <path...> '{"k":"v"}' # invoke a tool by path segments
 ```
 
 ## Developing locally

--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ Use tools via the CLI:
 
 ```bash
 executor tools search "send email"
-executor call gmail send '{"to":"alice@example.com","subject":"Hi"}'
+executor call --help
+executor call github --help
+executor call github issues --help
 executor call github issues create '{"owner":"octocat","repo":"Hello-World","title":"Hi"}'
+executor call gmail send '{"to":"alice@example.com","subject":"Hi"}'
 ```
 
 `executor call`, `executor resume`, and `executor tools ...` commands auto-start a local daemon if needed.
@@ -105,6 +108,7 @@ executor daemon stop                # stop daemon
 executor daemon restart             # restart daemon
 executor mcp                        # start MCP endpoint
 executor call <path...> '{"k":"v"}' # invoke a tool by path segments
+executor call <path...> --help      # browse namespaces/resources/methods
 executor resume --execution-id <id> # resume paused execution
 executor tools search "<query>"     # search tools by intent
 executor tools sources              # list configured sources + tool counts

--- a/README.md
+++ b/README.md
@@ -78,11 +78,9 @@ const issues = await tools.github.issues.list({
 });
 ```
 
-Run code via the CLI:
+Use tools via the CLI:
 
 ```bash
-executor call --file script.ts
-executor call 'return await tools.discover({ query: "send email" })'
 executor tools search "send email"
 executor call gmail send '{"to":"alice@example.com","subject":"Hi"}'
 executor call github issues create '{"owner":"octocat","repo":"Hello-World","title":"Hi"}'
@@ -106,14 +104,11 @@ executor daemon status              # show daemon status
 executor daemon stop                # stop daemon
 executor daemon restart             # restart daemon
 executor mcp                        # start MCP endpoint
-executor call --file script.ts      # execute a file
-executor call '<code>'              # execute inline code
-executor call --stdin               # execute from stdin
+executor call <path...> '{"k":"v"}' # invoke a tool by path segments
 executor resume --execution-id <id> # resume paused execution
 executor tools search "<query>"     # search tools by intent
 executor tools sources              # list configured sources + tool counts
 executor tools describe <path>      # show tool TypeScript/JSON schema
-executor call <path...> '{"k":"v"}' # invoke a tool by path segments
 ```
 
 ## Developing locally

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ executor tools search "send email"
 executor call --help
 executor call github --help
 executor call github issues --help
+executor call cloudflare --help --match dns --limit 20
 executor call github issues create '{"owner":"octocat","repo":"Hello-World","title":"Hi"}'
 executor call gmail send '{"to":"alice@example.com","subject":"Hi"}'
 ```
@@ -109,6 +110,7 @@ executor daemon restart             # restart daemon
 executor mcp                        # start MCP endpoint
 executor call <path...> '{"k":"v"}' # invoke a tool by path segments
 executor call <path...> --help      # browse namespaces/resources/methods
+executor call <path...> --help --match "<text>" --limit <n> # narrow huge namespaces
 executor resume --execution-id <id> # resume paused execution
 executor tools search "<query>"     # search tools by intent
 executor tools sources              # list configured sources + tool counts

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ executor tools invoke gmail.send --input '{"to":"alice@example.com","subject":"H
 ```
 
 `executor call`, `executor resume`, and `executor tools ...` commands auto-start a local daemon if needed.
+If the default port is busy, the CLI will pick an available local port and track it automatically.
 
 If an execution pauses for auth or approval, resume it:
 

--- a/apps/cli/src/daemon-state.ts
+++ b/apps/cli/src/daemon-state.ts
@@ -1,0 +1,140 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DaemonRecord {
+  readonly version: 1;
+  readonly hostname: string;
+  readonly port: number;
+  readonly pid: number;
+  readonly startedAt: string;
+  readonly scopeDir: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Host normalization
+// ---------------------------------------------------------------------------
+
+const LOCAL_HOST_ALIASES = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0"]);
+
+export const canonicalDaemonHost = (hostname: string): string => {
+  const normalized = hostname.trim().toLowerCase();
+  return LOCAL_HOST_ALIASES.has(normalized) ? "localhost" : normalized;
+};
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const resolveDaemonDataDir = (): string => process.env.EXECUTOR_DATA_DIR ?? join(homedir(), ".executor");
+
+const sanitizeHostForPath = (hostname: string): string => hostname.replaceAll(/[^a-z0-9.-]+/gi, "_");
+
+const daemonRecordPath = (input: { hostname: string; port: number }): string => {
+  const host = sanitizeHostForPath(canonicalDaemonHost(input.hostname));
+  return join(resolveDaemonDataDir(), `daemon-${host}-${input.port}.json`);
+};
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+export const writeDaemonRecord = async (input: {
+  hostname: string;
+  port: number;
+  pid: number;
+  scopeDir: string | null;
+}): Promise<void> => {
+  const path = daemonRecordPath({ hostname: input.hostname, port: input.port });
+  const dir = resolveDaemonDataDir();
+  await mkdir(dir, { recursive: true });
+
+  const payload: DaemonRecord = {
+    version: 1,
+    hostname: canonicalDaemonHost(input.hostname),
+    port: input.port,
+    pid: input.pid,
+    startedAt: new Date().toISOString(),
+    scopeDir: input.scopeDir,
+  };
+
+  await writeFile(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+};
+
+const parseRecord = (raw: string): DaemonRecord | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    (parsed as { version?: unknown }).version !== 1
+  ) {
+    return null;
+  }
+
+  const r = parsed as Record<string, unknown>;
+  if (
+    typeof r.hostname !== "string" ||
+    typeof r.port !== "number" ||
+    typeof r.pid !== "number" ||
+    typeof r.startedAt !== "string" ||
+    !(typeof r.scopeDir === "string" || r.scopeDir === null)
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    hostname: canonicalDaemonHost(r.hostname),
+    port: r.port,
+    pid: r.pid,
+    startedAt: r.startedAt,
+    scopeDir: r.scopeDir,
+  };
+};
+
+export const readDaemonRecord = async (input: {
+  hostname: string;
+  port: number;
+}): Promise<DaemonRecord | null> => {
+  const path = daemonRecordPath({ hostname: input.hostname, port: input.port });
+  try {
+    const raw = await readFile(path, "utf8");
+    return parseRecord(raw);
+  } catch {
+    return null;
+  }
+};
+
+export const removeDaemonRecord = async (input: { hostname: string; port: number }): Promise<void> => {
+  const path = daemonRecordPath({ hostname: input.hostname, port: input.port });
+  await rm(path, { force: true });
+};
+
+// ---------------------------------------------------------------------------
+// Process helpers
+// ---------------------------------------------------------------------------
+
+export const isPidAlive = (pid: number): boolean => {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const terminatePid = (pid: number): void => {
+  process.kill(pid, "SIGTERM");
+};

--- a/apps/cli/src/daemon-state.ts
+++ b/apps/cli/src/daemon-state.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { FileSystem, Path } from "@effect/platform";
+import type { PlatformError } from "@effect/platform/Error";
+import * as Effect from "effect/Effect";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -30,40 +31,47 @@ export const canonicalDaemonHost = (hostname: string): string => {
 // Paths
 // ---------------------------------------------------------------------------
 
-const resolveDaemonDataDir = (): string => process.env.EXECUTOR_DATA_DIR ?? join(homedir(), ".executor");
+const resolveDaemonDataDir = (path: Path.Path): string =>
+  process.env.EXECUTOR_DATA_DIR ?? path.join(homedir(), ".executor");
 
 const sanitizeHostForPath = (hostname: string): string => hostname.replaceAll(/[^a-z0-9.-]+/gi, "_");
 
-const daemonRecordPath = (input: { hostname: string; port: number }): string => {
+const daemonRecordPath = (path: Path.Path, input: { hostname: string; port: number }): string => {
   const host = sanitizeHostForPath(canonicalDaemonHost(input.hostname));
-  return join(resolveDaemonDataDir(), `daemon-${host}-${input.port}.json`);
+  return path.join(resolveDaemonDataDir(path), `daemon-${host}-${input.port}.json`);
 };
 
 // ---------------------------------------------------------------------------
 // Persistence
 // ---------------------------------------------------------------------------
 
-export const writeDaemonRecord = async (input: {
+export const writeDaemonRecord = (input: {
   hostname: string;
   port: number;
   pid: number;
   scopeDir: string | null;
-}): Promise<void> => {
-  const path = daemonRecordPath({ hostname: input.hostname, port: input.port });
-  const dir = resolveDaemonDataDir();
-  await mkdir(dir, { recursive: true });
+}): Effect.Effect<void, PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dataDir = resolveDaemonDataDir(path);
 
-  const payload: DaemonRecord = {
-    version: 1,
-    hostname: canonicalDaemonHost(input.hostname),
-    port: input.port,
-    pid: input.pid,
-    startedAt: new Date().toISOString(),
-    scopeDir: input.scopeDir,
-  };
+    yield* fs.makeDirectory(dataDir, { recursive: true });
 
-  await writeFile(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
-};
+    const payload: DaemonRecord = {
+      version: 1,
+      hostname: canonicalDaemonHost(input.hostname),
+      port: input.port,
+      pid: input.pid,
+      startedAt: new Date().toISOString(),
+      scopeDir: input.scopeDir,
+    };
+
+    yield* fs.writeFileString(
+      daemonRecordPath(path, { hostname: input.hostname, port: input.port }),
+      `${JSON.stringify(payload, null, 2)}\n`,
+    );
+  });
 
 const parseRecord = (raw: string): DaemonRecord | null => {
   let parsed: unknown;
@@ -103,23 +111,29 @@ const parseRecord = (raw: string): DaemonRecord | null => {
   };
 };
 
-export const readDaemonRecord = async (input: {
+export const readDaemonRecord = (input: {
   hostname: string;
   port: number;
-}): Promise<DaemonRecord | null> => {
-  const path = daemonRecordPath({ hostname: input.hostname, port: input.port });
-  try {
-    const raw = await readFile(path, "utf8");
+}): Effect.Effect<DaemonRecord | null, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const raw = yield* fs.readFileString(daemonRecordPath(path, input)).pipe(
+      Effect.catchAll(() => Effect.succeed(null)),
+    );
+    if (raw === null) return null;
     return parseRecord(raw);
-  } catch {
-    return null;
-  }
-};
+  });
 
-export const removeDaemonRecord = async (input: { hostname: string; port: number }): Promise<void> => {
-  const path = daemonRecordPath({ hostname: input.hostname, port: input.port });
-  await rm(path, { force: true });
-};
+export const removeDaemonRecord = (input: {
+  hostname: string;
+  port: number;
+}): Effect.Effect<void, PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.remove(daemonRecordPath(path, input), { force: true });
+  });
 
 // ---------------------------------------------------------------------------
 // Process helpers
@@ -135,6 +149,11 @@ export const isPidAlive = (pid: number): boolean => {
   }
 };
 
-export const terminatePid = (pid: number): void => {
-  process.kill(pid, "SIGTERM");
-};
+export const terminatePid = (pid: number): Effect.Effect<void, Error> =>
+  Effect.try({
+    try: () => {
+      process.kill(pid, "SIGTERM");
+    },
+    catch: (cause) =>
+      cause instanceof Error ? cause : new Error(`Failed to terminate pid ${pid}: ${String(cause)}`),
+  });

--- a/apps/cli/src/daemon-state.ts
+++ b/apps/cli/src/daemon-state.ts
@@ -16,6 +16,23 @@ export interface DaemonRecord {
   readonly scopeDir: string | null;
 }
 
+export interface DaemonPointer {
+  readonly version: 1;
+  readonly hostname: string;
+  readonly port: number;
+  readonly pid: number;
+  readonly startedAt: string;
+  readonly scopeId: string;
+  readonly scopeDir: string | null;
+  readonly token: string;
+}
+
+export interface DaemonStartLock {
+  readonly path: string;
+  readonly hostname: string;
+  readonly scopeId: string;
+}
+
 // ---------------------------------------------------------------------------
 // Host normalization
 // ---------------------------------------------------------------------------
@@ -27,6 +44,14 @@ export const canonicalDaemonHost = (hostname: string): string => {
   return LOCAL_HOST_ALIASES.has(normalized) ? "localhost" : normalized;
 };
 
+export const currentDaemonScopeId = (): string => {
+  const explicitScope = process.env.EXECUTOR_SCOPE_DIR?.trim();
+  if (explicitScope && explicitScope.length > 0) {
+    return `scope:${explicitScope}`;
+  }
+  return `cwd:${process.cwd()}`;
+};
+
 // ---------------------------------------------------------------------------
 // Paths
 // ---------------------------------------------------------------------------
@@ -35,11 +60,21 @@ const resolveDaemonDataDir = (path: Path.Path): string =>
   process.env.EXECUTOR_DATA_DIR ?? path.join(homedir(), ".executor");
 
 const sanitizeHostForPath = (hostname: string): string => hostname.replaceAll(/[^a-z0-9.-]+/gi, "_");
+const sanitizeScopeForPath = (scopeId: string): string => scopeId.replaceAll(/[^a-z0-9.-]+/gi, "_");
 
 const daemonRecordPath = (path: Path.Path, input: { hostname: string; port: number }): string => {
   const host = sanitizeHostForPath(canonicalDaemonHost(input.hostname));
   return path.join(resolveDaemonDataDir(path), `daemon-${host}-${input.port}.json`);
 };
+
+const daemonPointerPath = (path: Path.Path, input: { hostname: string; scopeId: string }): string => {
+  const host = sanitizeHostForPath(canonicalDaemonHost(input.hostname));
+  const scope = sanitizeScopeForPath(input.scopeId);
+  return path.join(resolveDaemonDataDir(path), `daemon-active-${host}-${scope}.json`);
+};
+
+const daemonStartLockPath = (path: Path.Path, input: { hostname: string; scopeId: string }): string =>
+  `${daemonPointerPath(path, input)}.lock`;
 
 // ---------------------------------------------------------------------------
 // Persistence
@@ -111,6 +146,48 @@ const parseRecord = (raw: string): DaemonRecord | null => {
   };
 };
 
+const parsePointer = (raw: string): DaemonPointer | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    (parsed as { version?: unknown }).version !== 1
+  ) {
+    return null;
+  }
+
+  const r = parsed as Record<string, unknown>;
+  if (
+    typeof r.hostname !== "string" ||
+    typeof r.port !== "number" ||
+    typeof r.pid !== "number" ||
+    typeof r.startedAt !== "string" ||
+    typeof r.scopeId !== "string" ||
+    !(typeof r.scopeDir === "string" || r.scopeDir === null) ||
+    typeof r.token !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    hostname: canonicalDaemonHost(r.hostname),
+    port: r.port,
+    pid: r.pid,
+    startedAt: r.startedAt,
+    scopeId: r.scopeId,
+    scopeDir: r.scopeDir,
+    token: r.token,
+  };
+};
+
 export const readDaemonRecord = (input: {
   hostname: string;
   port: number;
@@ -133,6 +210,148 @@ export const removeDaemonRecord = (input: {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
     yield* fs.remove(daemonRecordPath(path, input), { force: true });
+  });
+
+export const writeDaemonPointer = (input: {
+  hostname: string;
+  port: number;
+  pid: number;
+  scopeId: string;
+  scopeDir: string | null;
+  token: string;
+}): Effect.Effect<void, PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dataDir = resolveDaemonDataDir(path);
+    yield* fs.makeDirectory(dataDir, { recursive: true });
+
+    const payload: DaemonPointer = {
+      version: 1,
+      hostname: canonicalDaemonHost(input.hostname),
+      port: input.port,
+      pid: input.pid,
+      startedAt: new Date().toISOString(),
+      scopeId: input.scopeId,
+      scopeDir: input.scopeDir,
+      token: input.token,
+    };
+
+    yield* fs.writeFileString(
+      daemonPointerPath(path, { hostname: input.hostname, scopeId: input.scopeId }),
+      `${JSON.stringify(payload, null, 2)}\n`,
+    );
+  });
+
+export const readDaemonPointer = (input: {
+  hostname: string;
+  scopeId: string;
+}): Effect.Effect<DaemonPointer | null, never, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const raw = yield* fs
+      .readFileString(daemonPointerPath(path, input))
+      .pipe(Effect.catchAll(() => Effect.succeed(null)));
+    if (raw === null) return null;
+    return parsePointer(raw);
+  });
+
+export const removeDaemonPointer = (input: {
+  hostname: string;
+  scopeId: string;
+}): Effect.Effect<void, PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.remove(daemonPointerPath(path, input), { force: true });
+  });
+
+const parseLockPid = (raw: string): number | null => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as Record<string, unknown>).pid !== "number"
+  ) {
+    return null;
+  }
+
+  return (parsed as Record<string, number>).pid;
+};
+
+export const acquireDaemonStartLock = (input: {
+  hostname: string;
+  scopeId: string;
+}): Effect.Effect<DaemonStartLock, Error, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dataDir = resolveDaemonDataDir(path);
+    yield* fs.makeDirectory(dataDir, { recursive: true });
+
+    const lockPath = daemonStartLockPath(path, input);
+    const lockPayload = JSON.stringify(
+      {
+        pid: process.pid,
+        hostname: canonicalDaemonHost(input.hostname),
+        scopeId: input.scopeId,
+        startedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    );
+
+    const tryAcquire = () =>
+      fs.writeFileString(lockPath, `${lockPayload}\n`, { flag: "wx" }).pipe(
+        Effect.as(true),
+        Effect.catchAll(() => Effect.succeed(false)),
+      );
+
+    if (yield* tryAcquire()) {
+      return {
+        path: lockPath,
+        hostname: canonicalDaemonHost(input.hostname),
+        scopeId: input.scopeId,
+      };
+    }
+
+    const existingRaw = yield* fs.readFileString(lockPath).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    if (existingRaw !== null) {
+      const existingPid = parseLockPid(existingRaw);
+      if (existingPid !== null && !isPidAlive(existingPid)) {
+        yield* fs.remove(lockPath, { force: true });
+        if (yield* tryAcquire()) {
+          return {
+            path: lockPath,
+            hostname: canonicalDaemonHost(input.hostname),
+            scopeId: input.scopeId,
+          };
+        }
+      }
+    }
+
+    return yield* Effect.fail(
+      new Error(
+        `Another daemon startup is already in progress for ${canonicalDaemonHost(input.hostname)} (${input.scopeId}).`,
+      ),
+    );
+  });
+
+export const releaseDaemonStartLock = (input: DaemonStartLock): Effect.Effect<
+  void,
+  PlatformError,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    yield* fs.remove(input.path, { force: true });
   });
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/daemon.ts
+++ b/apps/cli/src/daemon.ts
@@ -1,0 +1,118 @@
+import { spawn } from "node:child_process";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ParsedDaemonBaseUrl {
+  readonly hostname: string;
+  readonly port: number;
+}
+
+export interface DaemonSpawnSpec {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Base URL parsing
+// ---------------------------------------------------------------------------
+
+export const parseDaemonBaseUrl = (baseUrl: string, defaultPort: number): ParsedDaemonBaseUrl => {
+  const parsed = new URL(baseUrl);
+
+  if (parsed.protocol !== "http:") {
+    throw new Error(`Only http:// base URLs are supported for daemon auto-start: ${baseUrl}`);
+  }
+
+  const port = Number(parsed.port) || defaultPort;
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid daemon port in base URL: ${baseUrl}`);
+  }
+
+  return {
+    hostname: parsed.hostname || "localhost",
+    port,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Local-host checks
+// ---------------------------------------------------------------------------
+
+const LOCAL_DAEMON_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0"]);
+
+export const canAutoStartLocalDaemonForHost = (hostname: string): boolean =>
+  LOCAL_DAEMON_HOSTNAMES.has(hostname.toLowerCase());
+
+// ---------------------------------------------------------------------------
+// Process spec
+// ---------------------------------------------------------------------------
+
+export const buildDaemonSpawnSpec = (input: {
+  readonly port: number;
+  readonly hostname: string;
+  readonly isDevMode: boolean;
+  readonly scriptPath: string | undefined;
+  readonly executablePath: string;
+}): DaemonSpawnSpec => {
+  const daemonArgs = ["daemon", "run", "--port", String(input.port), "--hostname", input.hostname];
+
+  if (input.isDevMode) {
+    if (!input.scriptPath) {
+      throw new Error("Cannot auto-start daemon in dev mode without a CLI script path");
+    }
+    return {
+      command: "bun",
+      args: ["run", input.scriptPath, ...daemonArgs],
+    };
+  }
+
+  return {
+    command: input.executablePath,
+    args: daemonArgs,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Spawn + wait
+// ---------------------------------------------------------------------------
+
+export const spawnDetached = (input: {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+  readonly env: Record<string, string | undefined>;
+}): void => {
+  const child = spawn(input.command, [...input.args], {
+    detached: true,
+    stdio: "ignore",
+    env: input.env,
+  });
+  child.unref();
+};
+
+export const waitForReachable = async (input: {
+  readonly check: () => Promise<boolean>;
+  readonly timeoutMs: number;
+  readonly intervalMs: number;
+}): Promise<boolean> => {
+  const deadline = Date.now() + input.timeoutMs;
+  while (Date.now() < deadline) {
+    if (await input.check()) return true;
+    await new Promise((resolve) => setTimeout(resolve, input.intervalMs));
+  }
+  return false;
+};
+
+export const waitForUnreachable = async (input: {
+  readonly check: () => Promise<boolean>;
+  readonly timeoutMs: number;
+  readonly intervalMs: number;
+}): Promise<boolean> => {
+  const deadline = Date.now() + input.timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await input.check())) return true;
+    await new Promise((resolve) => setTimeout(resolve, input.intervalMs));
+  }
+  return false;
+};

--- a/apps/cli/src/daemon.ts
+++ b/apps/cli/src/daemon.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createServer } from "node:net";
 import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 
@@ -141,4 +142,83 @@ export const waitForUnreachable = <E, R>(input: {
     expected: false,
     timeoutMs: input.timeoutMs,
     intervalMs: input.intervalMs,
+  });
+
+const toProbeHost = (hostname: string): string => {
+  const normalized = hostname.trim().toLowerCase();
+  if (normalized === "localhost" || normalized === "0.0.0.0") {
+    return "127.0.0.1";
+  }
+  return hostname;
+};
+
+const isPortAvailable = (input: { hostname: string; port: number }): Effect.Effect<boolean, Error> =>
+  Effect.tryPromise({
+    try: () =>
+      new Promise<boolean>((resolve) => {
+        const server = createServer() as any;
+        const cleanup = () => {
+          if (typeof server.removeAllListeners === "function") {
+            server.removeAllListeners();
+          }
+        };
+
+        server.once("error", () => {
+          cleanup();
+          resolve(false);
+        });
+
+        server.once("listening", () => {
+          cleanup();
+          server.close(() => resolve(true));
+        });
+
+        server.listen({ port: input.port, host: toProbeHost(input.hostname) });
+      }),
+    catch: (cause) =>
+      cause instanceof Error
+        ? cause
+        : new Error(`Failed probing port availability: ${String(cause)}`),
+  });
+
+const pickEphemeralPort = (hostname: string): Effect.Effect<number, Error> =>
+  Effect.tryPromise({
+    try: () =>
+      new Promise<number>((resolve, reject) => {
+        const server = createServer() as any;
+
+        server.once("error", (error: unknown) => {
+          reject(error);
+        });
+
+        server.once("listening", () => {
+          const address = server.address();
+          const port = typeof address === "object" && address !== null ? address.port : 0;
+          server.close(() => resolve(port));
+        });
+
+        server.listen({ port: 0, host: toProbeHost(hostname) });
+      }),
+    catch: (cause) =>
+      cause instanceof Error ? cause : new Error(`Failed selecting ephemeral port: ${String(cause)}`),
+  });
+
+export const chooseDaemonPort = (input: {
+  preferredPort: number;
+  hostname: string;
+}): Effect.Effect<number, Error> =>
+  Effect.gen(function* () {
+    const preferredAvailable = yield* isPortAvailable({
+      hostname: input.hostname,
+      port: input.preferredPort,
+    });
+    if (preferredAvailable) return input.preferredPort;
+
+    const fallbackPort = yield* pickEphemeralPort(input.hostname);
+    if (!Number.isFinite(fallbackPort) || fallbackPort <= 0 || fallbackPort > 65535) {
+      return yield* Effect.fail(
+        new Error(`Could not find an available daemon port for host ${input.hostname}`),
+      );
+    }
+    return fallbackPort;
   });

--- a/apps/cli/src/daemon.ts
+++ b/apps/cli/src/daemon.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -82,37 +84,61 @@ export const spawnDetached = (input: {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
   readonly env: Record<string, string | undefined>;
-}): void => {
-  const child = spawn(input.command, [...input.args], {
-    detached: true,
-    stdio: "ignore",
-    env: input.env,
+}): Effect.Effect<void, Error> =>
+  Effect.try({
+    try: () => {
+      const child = spawn(input.command, [...input.args], {
+        detached: true,
+        stdio: "ignore",
+        env: input.env,
+      });
+      child.unref();
+    },
+    catch: (cause) =>
+      cause instanceof Error
+        ? cause
+        : new Error(`Failed to spawn daemon process: ${String(cause)}`),
   });
-  child.unref();
-};
 
-export const waitForReachable = async (input: {
-  readonly check: () => Promise<boolean>;
+const waitForCondition = <E, R>(input: {
+  readonly check: Effect.Effect<boolean, E, R>;
+  readonly expected: boolean;
   readonly timeoutMs: number;
   readonly intervalMs: number;
-}): Promise<boolean> => {
-  const deadline = Date.now() + input.timeoutMs;
-  while (Date.now() < deadline) {
-    if (await input.check()) return true;
-    await new Promise((resolve) => setTimeout(resolve, input.intervalMs));
-  }
-  return false;
-};
+}): Effect.Effect<boolean, E, R> =>
+  Effect.gen(function* () {
+    const startedAt = yield* Clock.currentTimeMillis;
+    while (true) {
+      const reachable = yield* input.check;
+      if (reachable === input.expected) return true;
 
-export const waitForUnreachable = async (input: {
-  readonly check: () => Promise<boolean>;
+      const now = yield* Clock.currentTimeMillis;
+      if (now - startedAt >= input.timeoutMs) return false;
+
+      yield* Effect.sleep(input.intervalMs);
+    }
+  });
+
+export const waitForReachable = <E, R>(input: {
+  readonly check: Effect.Effect<boolean, E, R>;
   readonly timeoutMs: number;
   readonly intervalMs: number;
-}): Promise<boolean> => {
-  const deadline = Date.now() + input.timeoutMs;
-  while (Date.now() < deadline) {
-    if (!(await input.check())) return true;
-    await new Promise((resolve) => setTimeout(resolve, input.intervalMs));
-  }
-  return false;
-};
+}): Effect.Effect<boolean, E, R> =>
+  waitForCondition({
+    check: input.check,
+    expected: true,
+    timeoutMs: input.timeoutMs,
+    intervalMs: input.intervalMs,
+  });
+
+export const waitForUnreachable = <E, R>(input: {
+  readonly check: Effect.Effect<boolean, E, R>;
+  readonly timeoutMs: number;
+  readonly intervalMs: number;
+}): Effect.Effect<boolean, E, R> =>
+  waitForCondition({
+    check: input.check,
+    expected: false,
+    timeoutMs: input.timeoutMs,
+    intervalMs: input.intervalMs,
+  });

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -66,13 +66,14 @@ import {
   writeDaemonRecord,
 } from "./daemon-state";
 import {
+  buildToolPath,
   buildDescribeToolCode,
   buildInvokeToolCode,
   buildListSourcesCode,
-  buildRunToolQueryCode,
   buildSearchToolsCode,
   extractExecutionId,
   extractExecutionResult,
+  isLikelyToolPathToken,
   parseJsonObjectInput,
 } from "./tooling";
 
@@ -578,6 +579,36 @@ const applyScope = (s: Option.Option<string>) => {
   if (dir) process.env.EXECUTOR_SCOPE_DIR = resolve(dir);
 };
 
+const resolveToolInvocation = (input: {
+  rawPathParts: ReadonlyArray<string>;
+  rawInput: string | undefined;
+}): Effect.Effect<{ path: string; args: Record<string, unknown> }, Error> =>
+  Effect.gen(function* () {
+    const explicitInput = input.rawInput?.trim();
+    if (explicitInput && explicitInput.length > 0) {
+      const args = yield* parseJsonObjectInput(explicitInput);
+      const path = yield* Effect.try({
+        try: () => buildToolPath(input.rawPathParts),
+        catch: (cause) =>
+          cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
+      });
+      return { path, args };
+    }
+
+    const maybeJsonArg = input.rawPathParts.at(-1)?.trim();
+    const hasInlineJsonArg = maybeJsonArg !== undefined && maybeJsonArg.startsWith("{");
+    const pathParts = hasInlineJsonArg ? input.rawPathParts.slice(0, -1) : input.rawPathParts;
+    const args = hasInlineJsonArg ? yield* parseJsonObjectInput(maybeJsonArg) : {};
+
+    const path = yield* Effect.try({
+      try: () => buildToolPath(pathParts),
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
+    });
+
+    return { path, args };
+  });
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -585,16 +616,46 @@ const applyScope = (s: Option.Option<string>) => {
 const callCommand = Command.make(
   "call",
   {
-    code: Args.text({ name: "code" }).pipe(Args.optional),
+    codeOrTool: Args.text({ name: "code-or-tool" }).pipe(Args.repeated),
+    input: Options.text("input")
+      .pipe(Options.optional)
+      .pipe(Options.withDescription("JSON object arguments when invoking a tool path")),
     file: Options.text("file").pipe(Options.optional),
     stdin: Options.boolean("stdin").pipe(Options.withDefault(false)),
     baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
     scope,
   },
-  ({ code, file, stdin, baseUrl, scope }) =>
+  ({ codeOrTool, input, file, stdin, baseUrl, scope }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      const resolvedCode = yield* readCode({ code, file, stdin });
+      const rawInput = Option.getOrUndefined(input);
+      const hasRawInput = rawInput !== undefined && rawInput.trim().length > 0;
+      const singleArg = codeOrTool.length === 1 ? codeOrTool[0] : undefined;
+      const singleArgLooksLikeToolPath =
+        singleArg !== undefined && singleArg.includes(".") && isLikelyToolPathToken(singleArg);
+      const isToolInvocation =
+        !stdin &&
+        Option.isNone(file) &&
+        (codeOrTool.length > 1 || hasRawInput || singleArgLooksLikeToolPath);
+
+      if (isToolInvocation) {
+        const { path, args } = yield* resolveToolInvocation({
+          rawPathParts: codeOrTool,
+          rawInput,
+        });
+        const code = yield* Effect.try({
+          try: () => buildInvokeToolCode(path, args),
+          catch: (cause) =>
+            cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
+        });
+
+        const outcome = yield* executeCode({ baseUrl, code });
+        yield* printExecutionOutcome({ baseUrl, outcome });
+        return;
+      }
+
+      const inlineCode = singleArg !== undefined ? Option.some(singleArg) : Option.none<string>();
+      const resolvedCode = yield* readCode({ code: inlineCode, file, stdin });
       const daemonUrl = yield* ensureDaemon(baseUrl);
 
       const client = yield* makeApiClient(daemonUrl);
@@ -619,7 +680,11 @@ const callCommand = Command.make(
         process.exit(0);
       }
     }),
-).pipe(Command.withDescription("Execute code against the local executor"));
+).pipe(
+  Command.withDescription(
+    "Execute JavaScript or invoke a tool path (e.g. `executor call github issues create '{\"title\":\"Hi\"}'`)",
+  ),
+);
 
 const resumeCommand = Command.make(
   "resume",
@@ -742,24 +807,24 @@ const toolsInvokeCommand = Command.make(
 const toolsRunCommand = Command.make(
   "run",
   {
-    query: Args.text({ name: "query" }),
-    namespace: Options.text("namespace").pipe(Options.optional),
-    limit: Options.integer("limit").pipe(Options.withDefault(12)),
+    pathParts: Args.text({ name: "tool-path-segment" }).pipe(Args.repeated),
     input: Options.text("input")
       .pipe(Options.optional)
-      .pipe(Options.withDescription("JSON object arguments for the selected tool")),
+      .pipe(Options.withDescription("JSON object arguments for the tool")),
     baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
     scope,
   },
-  ({ query, namespace, limit, input, baseUrl, scope }) =>
+  ({ pathParts, input, baseUrl, scope }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      const args = yield* parseJsonObjectInput(Option.getOrUndefined(input));
-      const code = buildRunToolQueryCode({
-        query,
-        namespace: Option.getOrUndefined(namespace),
-        args,
-        limit,
+      const { path, args } = yield* resolveToolInvocation({
+        rawPathParts: pathParts,
+        rawInput: Option.getOrUndefined(input),
+      });
+      const code = yield* Effect.try({
+        try: () => buildInvokeToolCode(path, args),
+        catch: (cause) =>
+          cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
       });
 
       const outcome = yield* executeCode({ baseUrl, code });
@@ -767,7 +832,7 @@ const toolsRunCommand = Command.make(
     }),
 ).pipe(
   Command.withDescription(
-    "Search by query, pick the best tool match, and invoke it with JSON input",
+    "Run a tool by path segments (e.g. `executor tools run github issues list '{\"owner\":\"octo\"}'`)",
   ),
 );
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,5 +1,5 @@
 // Ensure binaries next to the executor (e.g. secure-exec-v8) are on $PATH
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 const execDir = dirname(process.execPath);
 if (process.env.PATH && !process.env.PATH.includes(execDir)) {
   process.env.PATH = `${execDir}:${process.env.PATH}`;
@@ -31,7 +31,6 @@ if (typeof Bun !== "undefined" && (await Bun.file(wasmOnDisk).exists())) {
   setQuickJSModule(mod);
 }
 
-import { resolve } from "node:path";
 import { Command, Options, Args } from "@effect/cli";
 import { BunRuntime } from "@effect/platform-bun";
 import { FetchHttpClient, HttpApiClient } from "@effect/platform";
@@ -42,6 +41,22 @@ import * as Cause from "effect/Cause";
 import { ExecutorApi } from "@executor/api";
 import { startServer, runMcpStdioServer, getExecutor } from "@executor/local";
 import { makeQuickJsExecutor } from "@executor/runtime-quickjs";
+import {
+  buildDaemonSpawnSpec,
+  canAutoStartLocalDaemonForHost,
+  parseDaemonBaseUrl,
+  spawnDetached,
+  waitForReachable,
+  waitForUnreachable,
+} from "./daemon";
+import {
+  canonicalDaemonHost,
+  isPidAlive,
+  readDaemonRecord,
+  removeDaemonRecord,
+  terminatePid,
+  writeDaemonRecord,
+} from "./daemon-state";
 
 // Embedded web UI — baked into compiled binaries via `with { type: "file" }`
 import embeddedWebUI from "./embedded-web-ui.gen";
@@ -54,6 +69,9 @@ const CLI_NAME = "executor";
 const { version: CLI_VERSION } = await import("../package.json");
 const DEFAULT_PORT = 4788;
 const DEFAULT_BASE_URL = `http://localhost:${DEFAULT_PORT}`;
+const DAEMON_BOOT_TIMEOUT_MS = 15_000;
+const DAEMON_BOOT_POLL_MS = 150;
+const DAEMON_STOP_TIMEOUT_MS = 10_000;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -87,16 +105,143 @@ const script = process.argv[1];
 const isDevMode = script?.endsWith(".ts") || script?.endsWith(".js");
 const cliPrefix = isDevMode ? `bun run ${script}` : "executor";
 
-const ensureServer = (baseUrl: string) =>
+const ensureDaemon = (baseUrl: string) =>
   Effect.gen(function* () {
     if (yield* Effect.promise(() => isServerReachable(baseUrl))) return;
 
-    // Start server in-process instead of spawning a background child.
-    // This is more reliable across environments (containers, sandboxes, etc.)
-    const url = new URL(baseUrl);
-    const port = Number(url.port) || DEFAULT_PORT;
-    console.error(`Starting server on port ${port}...`);
-    yield* Effect.promise(() => startServer({ port, embeddedWebUI }));
+    const parsed = yield* Effect.try({
+      try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(`Invalid base URL: ${String(cause)}`),
+    });
+
+    if (!canAutoStartLocalDaemonForHost(parsed.hostname)) {
+      return yield* Effect.fail(
+        new Error(
+          [
+            `Executor daemon is not reachable at ${baseUrl}.`,
+            "Auto-start is only supported for local hosts.",
+            `Start it manually: ${cliPrefix} daemon run --port ${parsed.port} --hostname ${parsed.hostname}`,
+          ].join("\n"),
+        ),
+      );
+    }
+
+    const spec = yield* Effect.try({
+      try: () =>
+        buildDaemonSpawnSpec({
+          port: parsed.port,
+          hostname: parsed.hostname,
+          isDevMode,
+          scriptPath: script,
+          executablePath: process.execPath,
+        }),
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(`Failed to build daemon command: ${String(cause)}`),
+    });
+
+    console.error(`Starting daemon on ${parsed.hostname}:${parsed.port}...`);
+    spawnDetached({
+      command: spec.command,
+      args: spec.args,
+      env: process.env,
+    });
+
+    const ready = yield* Effect.promise(() =>
+      waitForReachable({
+        check: () => isServerReachable(baseUrl),
+        timeoutMs: DAEMON_BOOT_TIMEOUT_MS,
+        intervalMs: DAEMON_BOOT_POLL_MS,
+      }),
+    );
+
+    if (!ready) {
+      return yield* Effect.fail(
+        new Error(
+          [
+            `Daemon did not become reachable at ${baseUrl} within ${DAEMON_BOOT_TIMEOUT_MS}ms.`,
+            `Run in foreground to inspect logs: ${cliPrefix} daemon run --port ${parsed.port} --hostname ${parsed.hostname}`,
+          ].join("\n"),
+        ),
+      );
+    }
+  });
+
+const stopDaemon = (baseUrl: string) =>
+  Effect.gen(function* () {
+    const parsed = yield* Effect.try({
+      try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(`Invalid base URL: ${String(cause)}`),
+    });
+
+    const host = canonicalDaemonHost(parsed.hostname);
+    const record = yield* Effect.promise(() => readDaemonRecord({ hostname: host, port: parsed.port }));
+    const reachable = yield* Effect.promise(() => isServerReachable(baseUrl));
+
+    if (!record) {
+      if (reachable) {
+        return yield* Effect.fail(
+          new Error(
+            [
+              `Executor is reachable at ${baseUrl} but no daemon record exists.`,
+              "It may not be managed by this CLI process.",
+              "Stop it from the terminal/session where it was started.",
+            ].join("\n"),
+          ),
+        );
+      }
+      console.log(`No daemon running at ${baseUrl}.`);
+      return;
+    }
+
+    if (!isPidAlive(record.pid)) {
+      yield* Effect.promise(() => removeDaemonRecord({ hostname: host, port: parsed.port }));
+      if (reachable) {
+        return yield* Effect.fail(
+          new Error(
+            [
+              `Daemon record for ${baseUrl} points to dead pid ${record.pid}, but endpoint is still reachable.`,
+              "Refusing to stop an unknown process without ownership metadata.",
+            ].join("\n"),
+          ),
+        );
+      }
+      console.log(`No daemon running at ${baseUrl} (removed stale record for pid ${record.pid}).`);
+      return;
+    }
+
+    console.log(`Stopping daemon at ${baseUrl} (pid ${record.pid})...`);
+
+    yield* Effect.try({
+      try: () => terminatePid(record.pid),
+      catch: (cause) =>
+        cause instanceof Error
+          ? cause
+          : new Error(`Failed sending SIGTERM to pid ${record.pid}: ${String(cause)}`),
+    });
+
+    const stopped = yield* Effect.promise(() =>
+      waitForUnreachable({
+        check: () => isServerReachable(baseUrl),
+        timeoutMs: DAEMON_STOP_TIMEOUT_MS,
+        intervalMs: DAEMON_BOOT_POLL_MS,
+      }),
+    );
+
+    if (!stopped) {
+      return yield* Effect.fail(
+        new Error(
+          [
+            `Daemon at ${baseUrl} did not stop within ${DAEMON_STOP_TIMEOUT_MS}ms.`,
+            "Try terminating the process manually.",
+          ].join("\n"),
+        ),
+      );
+    }
+
+    yield* Effect.promise(() => removeDaemonRecord({ hostname: host, port: parsed.port }));
+    console.log(`Daemon stopped at ${baseUrl}.`);
   });
 
 // ---------------------------------------------------------------------------
@@ -146,6 +291,43 @@ const runForegroundSession = (input: {
 
     yield* waitForShutdownSignal();
     yield* Effect.promise(() => server.stop());
+  });
+
+const runDaemonSession = (input: {
+  port: number;
+  hostname: string;
+  allowedHosts: ReadonlyArray<string>;
+}) =>
+  Effect.gen(function* () {
+    const server = yield* Effect.promise(() =>
+      startServer({
+        port: input.port,
+        hostname: input.hostname,
+        allowedHosts: input.allowedHosts,
+        embeddedWebUI,
+      }),
+    );
+
+    const daemonHost = canonicalDaemonHost(input.hostname);
+    const daemonPort = server.port;
+
+    yield* Effect.promise(() =>
+      writeDaemonRecord({
+        hostname: daemonHost,
+        port: daemonPort,
+        pid: process.pid,
+        scopeDir: process.env.EXECUTOR_SCOPE_DIR ?? null,
+      }),
+    );
+
+    console.log(`Daemon ready on http://${daemonHost}:${daemonPort}`);
+
+    try {
+      yield* waitForShutdownSignal();
+    } finally {
+      yield* Effect.promise(() => server.stop());
+      yield* Effect.promise(() => removeDaemonRecord({ hostname: daemonHost, port: daemonPort }));
+    }
   });
 
 // ---------------------------------------------------------------------------
@@ -200,6 +382,16 @@ const readCode = (input: {
     );
   });
 
+const scope = Options.text("scope").pipe(
+  Options.optional,
+  Options.withDescription("Path to workspace directory containing executor.jsonc"),
+);
+
+const applyScope = (s: Option.Option<string>) => {
+  const dir = Option.getOrUndefined(s);
+  if (dir) process.env.EXECUTOR_SCOPE_DIR = resolve(dir);
+};
+
 // ---------------------------------------------------------------------------
 // Commands
 // ---------------------------------------------------------------------------
@@ -211,11 +403,13 @@ const callCommand = Command.make(
     file: Options.text("file").pipe(Options.optional),
     stdin: Options.boolean("stdin").pipe(Options.withDefault(false)),
     baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
   },
-  ({ code, file, stdin, baseUrl }) =>
+  ({ code, file, stdin, baseUrl, scope }) =>
     Effect.gen(function* () {
+      applyScope(scope);
       const resolvedCode = yield* readCode({ code, file, stdin });
-      yield* ensureServer(baseUrl);
+      yield* ensureDaemon(baseUrl);
 
       const client = yield* makeApiClient(baseUrl);
       const result = yield* client.executions.execute({ payload: { code: resolvedCode } });
@@ -248,10 +442,12 @@ const resumeCommand = Command.make(
     action: Options.text("action").pipe(Options.withDefault("accept")),
     content: Options.text("content").pipe(Options.optional),
     baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
   },
-  ({ executionId, action, content, baseUrl }) =>
+  ({ executionId, action, content, baseUrl, scope }) =>
     Effect.gen(function* () {
-      yield* ensureServer(baseUrl);
+      applyScope(scope);
+      yield* ensureDaemon(baseUrl);
 
       const parsedContent = Option.getOrUndefined(content);
       const contentObj = parsedContent ? JSON.parse(parsedContent) : undefined;
@@ -271,16 +467,6 @@ const resumeCommand = Command.make(
       }
     }),
 ).pipe(Command.withDescription("Resume a paused execution"));
-
-const scope = Options.text("scope").pipe(
-  Options.optional,
-  Options.withDescription("Path to workspace directory containing executor.jsonc"),
-);
-
-const applyScope = (s: Option.Option<string>) => {
-  const dir = Option.getOrUndefined(s);
-  if (dir) process.env.EXECUTOR_SCOPE_DIR = resolve(dir);
-};
 
 const webCommand = Command.make(
   "web",
@@ -305,6 +491,107 @@ const webCommand = Command.make(
     }),
 ).pipe(Command.withDescription("Start a foreground web session"));
 
+const daemonRunCommand = Command.make(
+  "run",
+  {
+    port: Options.integer("port").pipe(Options.withDefault(DEFAULT_PORT)),
+    hostname: Options.text("hostname")
+      .pipe(Options.withDefault("127.0.0.1"))
+      .pipe(Options.withDescription("Bind address. Keep this local unless you trust the network.")),
+    allowedHost: Options.text("allowed-host")
+      .pipe(Options.repeated)
+      .pipe(
+        Options.withDescription(
+          "Additional hostname permitted in the Host header (repeatable). localhost/127.0.0.1 are always allowed.",
+        ),
+      ),
+    scope,
+  },
+  ({ port, scope, hostname, allowedHost }) =>
+    Effect.gen(function* () {
+      applyScope(scope);
+      yield* runDaemonSession({ port, hostname, allowedHosts: allowedHost });
+    }),
+).pipe(Command.withDescription("Run the local executor daemon"));
+
+const daemonStatusCommand = Command.make(
+  "status",
+  {
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+  },
+  ({ baseUrl }) =>
+    Effect.gen(function* () {
+      const parsed = yield* Effect.try({
+        try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
+        catch: (cause) =>
+          cause instanceof Error ? cause : new Error(`Invalid base URL: ${String(cause)}`),
+      });
+      const host = canonicalDaemonHost(parsed.hostname);
+
+      const [record, reachable] = yield* Effect.all([
+        Effect.promise(() => readDaemonRecord({ hostname: host, port: parsed.port })),
+        Effect.promise(() => isServerReachable(baseUrl)),
+      ]);
+
+      if (!record) {
+        if (reachable) {
+          console.log(`Daemon reachable at ${baseUrl} (no local ownership record).`);
+        } else {
+          console.log(`Daemon not running at ${baseUrl}.`);
+        }
+        return;
+      }
+
+      if (!isPidAlive(record.pid)) {
+        if (!reachable) {
+          yield* Effect.promise(() => removeDaemonRecord({ hostname: host, port: parsed.port }));
+          console.log(`Daemon not running at ${baseUrl} (removed stale record for pid ${record.pid}).`);
+          return;
+        }
+        console.log(
+          `Daemon reachable at ${baseUrl}, but recorded pid ${record.pid} is not alive (ownership mismatch).`,
+        );
+        return;
+      }
+
+      const state = reachable ? "running" : "unreachable";
+      console.log(`Daemon ${state} at ${baseUrl} (pid ${record.pid}).`);
+      if (record.scopeDir) {
+        console.log(`Scope: ${record.scopeDir}`);
+      }
+    }),
+).pipe(Command.withDescription("Show daemon status"));
+
+const daemonStopCommand = Command.make(
+  "stop",
+  {
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+  },
+  ({ baseUrl }) => stopDaemon(baseUrl),
+).pipe(Command.withDescription("Stop the local daemon"));
+
+const daemonRestartCommand = Command.make(
+  "restart",
+  {
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
+  },
+  ({ baseUrl, scope }) =>
+    Effect.gen(function* () {
+      applyScope(scope);
+      yield* stopDaemon(baseUrl);
+      yield* ensureDaemon(baseUrl);
+      console.log(`Daemon restarted at ${baseUrl}.`);
+    }),
+).pipe(Command.withDescription("Restart the local daemon"));
+
+const daemonCommand = Command.make("daemon").pipe(
+  Command.withSubcommands(
+    [daemonRunCommand, daemonStatusCommand, daemonStopCommand, daemonRestartCommand] as const,
+  ),
+  Command.withDescription("Manage the local daemon"),
+);
+
 const mcpCommand = Command.make("mcp", { scope }, ({ scope }) =>
   Effect.gen(function* () {
     applyScope(scope);
@@ -317,7 +604,7 @@ const mcpCommand = Command.make("mcp", { scope }, ({ scope }) =>
 // ---------------------------------------------------------------------------
 
 const root = Command.make("executor").pipe(
-  Command.withSubcommands([callCommand, resumeCommand, webCommand, mcpCommand] as const),
+  Command.withSubcommands([callCommand, resumeCommand, webCommand, daemonCommand, mcpCommand] as const),
   Command.withDescription("Executor local CLI"),
 );
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -57,6 +57,16 @@ import {
   terminatePid,
   writeDaemonRecord,
 } from "./daemon-state";
+import {
+  buildDescribeToolCode,
+  buildInvokeToolCode,
+  buildListSourcesCode,
+  buildRunToolQueryCode,
+  buildSearchToolsCode,
+  extractExecutionId,
+  extractExecutionResult,
+  parseJsonObjectInput,
+} from "./tooling";
 
 // Embedded web UI — baked into compiled binaries via `with { type: "file" }`
 import embeddedWebUI from "./embedded-web-ui.gen";
@@ -229,6 +239,71 @@ const stopDaemon = (baseUrl: string) =>
 
     yield* removeDaemonRecord({ hostname: host, port: parsed.port });
     console.log(`Daemon stopped at ${baseUrl}.`);
+  });
+
+type ExecuteCodeOutcome =
+  | {
+      readonly status: "completed";
+      readonly result: unknown;
+    }
+  | {
+      readonly status: "paused";
+      readonly text: string;
+      readonly executionId: string | undefined;
+    };
+
+const toError = (cause: unknown): Error =>
+  cause instanceof Error ? cause : new Error(String(cause));
+
+const executeCode = (input: {
+  baseUrl: string;
+  code: string;
+}): Effect.Effect<ExecuteCodeOutcome, Error> =>
+  Effect.gen(function* () {
+    yield* ensureDaemon(input.baseUrl);
+    const client = yield* makeApiClient(input.baseUrl);
+    const response = yield* client.executions.execute({
+      payload: {
+        code: input.code,
+      },
+    });
+
+    if (response.status === "paused") {
+      return {
+        status: "paused" as const,
+        text: response.text,
+        executionId: extractExecutionId(response.structured),
+      };
+    }
+
+    if (response.isError) {
+      return yield* Effect.fail(new Error(response.text));
+    }
+
+    return {
+      status: "completed" as const,
+      result: extractExecutionResult(response.structured),
+    };
+  }).pipe(Effect.mapError(toError));
+
+const printExecutionOutcome = (input: { baseUrl: string; outcome: ExecuteCodeOutcome }) =>
+  Effect.sync(() => {
+    if (input.outcome.status === "paused") {
+      console.log(input.outcome.text);
+      if (input.outcome.executionId) {
+        console.log(
+          `\nTo resume:\n  ${cliPrefix} resume --execution-id ${input.outcome.executionId} --action accept --base-url ${input.baseUrl}`,
+        );
+      }
+      return;
+    }
+
+    if (typeof input.outcome.result === "string") {
+      console.log(input.outcome.result);
+      return;
+    }
+
+    console.log(JSON.stringify(input.outcome.result, null, 2));
   });
 
 // ---------------------------------------------------------------------------
@@ -453,6 +528,136 @@ const resumeCommand = Command.make(
     }),
 ).pipe(Command.withDescription("Resume a paused execution"));
 
+const toolsSearchCommand = Command.make(
+  "search",
+  {
+    query: Args.text({ name: "query" }),
+    namespace: Options.text("namespace").pipe(Options.optional),
+    limit: Options.integer("limit").pipe(Options.withDefault(12)),
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
+  },
+  ({ query, namespace, limit, baseUrl, scope }) =>
+    Effect.gen(function* () {
+      applyScope(scope);
+      const code = buildSearchToolsCode({
+        query,
+        namespace: Option.getOrUndefined(namespace),
+        limit,
+      });
+
+      const outcome = yield* executeCode({ baseUrl, code });
+      yield* printExecutionOutcome({ baseUrl, outcome });
+    }),
+).pipe(Command.withDescription("Search tools by natural-language query"));
+
+const toolsSourcesCommand = Command.make(
+  "sources",
+  {
+    query: Options.text("query").pipe(Options.optional),
+    limit: Options.integer("limit").pipe(Options.withDefault(50)),
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
+  },
+  ({ query, limit, baseUrl, scope }) =>
+    Effect.gen(function* () {
+      applyScope(scope);
+      const code = buildListSourcesCode({
+        query: Option.getOrUndefined(query),
+        limit,
+      });
+
+      const outcome = yield* executeCode({ baseUrl, code });
+      yield* printExecutionOutcome({ baseUrl, outcome });
+    }),
+).pipe(Command.withDescription("List configured sources and tool counts"));
+
+const toolsDescribeCommand = Command.make(
+  "describe",
+  {
+    path: Args.text({ name: "path" }),
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
+  },
+  ({ path, baseUrl, scope }) =>
+    Effect.gen(function* () {
+      applyScope(scope);
+      const code = buildDescribeToolCode(path);
+      const outcome = yield* executeCode({ baseUrl, code });
+      yield* printExecutionOutcome({ baseUrl, outcome });
+    }),
+).pipe(Command.withDescription("Describe a tool's TypeScript and JSON schema"));
+
+const toolsInvokeCommand = Command.make(
+  "invoke",
+  {
+    path: Args.text({ name: "path" }),
+    input: Options.text("input")
+      .pipe(Options.optional)
+      .pipe(Options.withDescription("JSON object arguments for the tool")),
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
+  },
+  ({ path, input, baseUrl, scope }) =>
+    Effect.gen(function* () {
+      applyScope(scope);
+      const args = yield* parseJsonObjectInput(Option.getOrUndefined(input));
+      const code = yield* Effect.try({
+        try: () => buildInvokeToolCode(path, args),
+        catch: (cause) =>
+          cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
+      });
+
+      const outcome = yield* executeCode({ baseUrl, code });
+      yield* printExecutionOutcome({ baseUrl, outcome });
+    }),
+).pipe(Command.withDescription("Invoke a tool by path (e.g. github.listIssues)"));
+
+const toolsRunCommand = Command.make(
+  "run",
+  {
+    query: Args.text({ name: "query" }),
+    namespace: Options.text("namespace").pipe(Options.optional),
+    limit: Options.integer("limit").pipe(Options.withDefault(12)),
+    input: Options.text("input")
+      .pipe(Options.optional)
+      .pipe(Options.withDescription("JSON object arguments for the selected tool")),
+    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
+    scope,
+  },
+  ({ query, namespace, limit, input, baseUrl, scope }) =>
+    Effect.gen(function* () {
+      applyScope(scope);
+      const args = yield* parseJsonObjectInput(Option.getOrUndefined(input));
+      const code = buildRunToolQueryCode({
+        query,
+        namespace: Option.getOrUndefined(namespace),
+        args,
+        limit,
+      });
+
+      const outcome = yield* executeCode({ baseUrl, code });
+      yield* printExecutionOutcome({ baseUrl, outcome });
+    }),
+).pipe(
+  Command.withDescription(
+    "Search by query, pick the best tool match, and invoke it with JSON input",
+  ),
+);
+
+const toolsCommand = Command.make("tools").pipe(
+  Command.withSubcommands(
+    [
+      toolsSearchCommand,
+      toolsSourcesCommand,
+      toolsDescribeCommand,
+      toolsInvokeCommand,
+      toolsRunCommand,
+    ] as const,
+  ),
+  Command.withDescription("Discover and invoke tools without writing JavaScript"),
+);
+
 const webCommand = Command.make(
   "web",
   {
@@ -589,7 +794,9 @@ const mcpCommand = Command.make("mcp", { scope }, ({ scope }) =>
 // ---------------------------------------------------------------------------
 
 const root = Command.make("executor").pipe(
-  Command.withSubcommands([callCommand, resumeCommand, webCommand, daemonCommand, mcpCommand] as const),
+  Command.withSubcommands(
+    [callCommand, resumeCommand, toolsCommand, webCommand, daemonCommand, mcpCommand] as const,
+  ),
   Command.withDescription("Executor local CLI"),
 );
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -66,12 +66,15 @@ import {
   writeDaemonRecord,
 } from "./daemon-state";
 import {
+  buildResumeContentTemplate,
   buildToolPath,
   buildDescribeToolCode,
+  filterToolPathChildren,
   buildInvokeToolCode,
   buildListSourcesCode,
   buildSearchToolsCode,
   extractExecutionId,
+  extractPausedInteraction,
   extractExecutionResult,
   inspectToolPath,
   parseJsonObjectInput,
@@ -351,6 +354,14 @@ type ExecuteCodeOutcome =
       readonly status: "paused";
       readonly text: string;
       readonly executionId: string | undefined;
+      readonly interaction:
+        | {
+            readonly kind: "url" | "form";
+            readonly message: string;
+            readonly url?: string;
+            readonly requestedSchema?: Record<string, unknown>;
+          }
+        | undefined;
     };
 
 const executeCode = (input: {
@@ -371,6 +382,7 @@ const executeCode = (input: {
         status: "paused" as const,
         text: response.text,
         executionId: extractExecutionId(response.structured),
+        interaction: extractPausedInteraction(response.structured),
       };
     }
 
@@ -389,9 +401,23 @@ const printExecutionOutcome = (input: { baseUrl: string; outcome: ExecuteCodeOut
     if (input.outcome.status === "paused") {
       console.log(input.outcome.text);
       if (input.outcome.executionId) {
-        console.log(
-          `\nTo resume:\n  ${cliPrefix} resume --execution-id ${input.outcome.executionId} --action accept --base-url ${input.baseUrl}`,
-        );
+        const commandPrefix = `${cliPrefix} resume --execution-id ${input.outcome.executionId} --base-url ${input.baseUrl}`;
+        if (input.outcome.interaction?.kind === "form") {
+          const requestedSchema = input.outcome.interaction.requestedSchema;
+          if (requestedSchema && Object.keys(requestedSchema).length > 0) {
+            console.log(`\nRequested schema:\n${JSON.stringify(requestedSchema, null, 2)}`);
+          }
+          const template = buildResumeContentTemplate(requestedSchema);
+          console.log("\nResume commands:");
+          console.log(
+            `  ${commandPrefix} --action accept --content '${JSON.stringify(template)}'`,
+          );
+          console.log(`  ${commandPrefix} --action decline`);
+          console.log(`  ${commandPrefix} --action cancel`);
+        } else {
+          console.log("\nResume command:");
+          console.log(`  ${commandPrefix} --action accept`);
+        }
       }
       return;
     }
@@ -539,10 +565,33 @@ const applyScope = (s: Option.Option<string>) => {
   if (dir) process.env.EXECUTOR_SCOPE_DIR = resolve(dir);
 };
 
+const parseOptionalJsonObject = (raw: string | undefined): Effect.Effect<
+  Record<string, unknown> | undefined,
+  Error
+> =>
+  raw === undefined
+    ? Effect.succeed(undefined)
+    : parseJsonObjectInput(raw).pipe(
+        Effect.mapError((error) => new Error(`Invalid --content JSON: ${error.message}`)),
+      );
+
+const parsePositiveIntegerOption = (name: string, raw: string): number => {
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Invalid --${name} value: ${raw}`);
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`Invalid --${name} value: ${raw}`);
+  }
+  return parsed;
+};
+
 interface ParsedCallHelpArgs {
   readonly pathParts: ReadonlyArray<string>;
   readonly baseUrl: string;
   readonly scopeDir: string | undefined;
+  readonly match: string | undefined;
+  readonly limit: number | undefined;
 }
 
 const HELP_FLAGS = new Set(["--help", "-h"]);
@@ -552,6 +601,8 @@ const isHelpFlag = (value: string): boolean => HELP_FLAGS.has(value);
 const parseCallHelpArgs = (args: ReadonlyArray<string>): ParsedCallHelpArgs => {
   let baseUrl = DEFAULT_BASE_URL;
   let scopeDir: string | undefined = undefined;
+  let match: string | undefined = undefined;
+  let limit: number | undefined = undefined;
   const pathParts: Array<string> = [];
 
   for (let index = 0; index < args.length; index += 1) {
@@ -582,6 +633,31 @@ const parseCallHelpArgs = (args: ReadonlyArray<string>): ParsedCallHelpArgs => {
       continue;
     }
 
+    if (token === "--match") {
+      const value = args[index + 1];
+      if (!value) throw new Error("Missing value for --match");
+      match = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--match=")) {
+      match = token.slice("--match=".length);
+      continue;
+    }
+
+    if (token === "--limit") {
+      const value = args[index + 1];
+      if (!value) throw new Error("Missing value for --limit");
+      limit = parsePositiveIntegerOption("limit", value);
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--limit=")) {
+      const raw = token.slice("--limit=".length);
+      limit = parsePositiveIntegerOption("limit", raw);
+      continue;
+    }
+
     if (token.startsWith("-")) {
       throw new Error(`Unknown option for call help: ${token}`);
     }
@@ -594,7 +670,7 @@ const parseCallHelpArgs = (args: ReadonlyArray<string>): ParsedCallHelpArgs => {
     pathParts.pop();
   }
 
-  return { pathParts, baseUrl, scopeDir };
+  return { pathParts, baseUrl, scopeDir, match, limit };
 };
 
 const printCallBrowseHelp = (input: {
@@ -605,6 +681,9 @@ const printCallBrowseHelp = (input: {
     readonly hasChildren: boolean;
     readonly toolCount: number;
   }>;
+  readonly totalChildren: number;
+  readonly query: string | undefined;
+  readonly limit: number | undefined;
   readonly exactTool:
     | {
         readonly id: string;
@@ -620,6 +699,7 @@ const printCallBrowseHelp = (input: {
       "Usage:",
       `  ${commandPrefix} ${nextPlaceholder} [<subcommand> ...] ['{"k":"v"}']`,
       `  ${commandPrefix} --help`,
+      `  ${commandPrefix} --help [--match text] [--limit integer]`,
     ];
 
     if (input.exactTool) {
@@ -638,6 +718,14 @@ const printCallBrowseHelp = (input: {
     if (input.children.length === 0) {
       console.log("\nNo subcommands at this level.");
       return;
+    }
+
+    if (input.query && input.query.trim().length > 0) {
+      console.log(`\nFiltered by: ${input.query}`);
+    }
+    if (input.children.length < input.totalChildren || input.limit) {
+      const suffix = input.limit ? ` (limit ${input.limit})` : "";
+      console.log(`Showing ${input.children.length} of ${input.totalChildren} subcommands${suffix}.`);
     }
 
     const rows = input.children.map((child) => {
@@ -684,6 +772,32 @@ const printCallLeafHelp = (input: {
     }
   });
 
+const applyCallHelpChildFilters = (input: {
+  readonly children: ReadonlyArray<{
+    readonly segment: string;
+    readonly invokable: boolean;
+    readonly hasChildren: boolean;
+    readonly toolCount: number;
+  }>;
+  readonly args: ParsedCallHelpArgs;
+  readonly fallbackQuery: string | undefined;
+}) => {
+  const query = [input.fallbackQuery, input.args.match]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .trim();
+  const filtered = filterToolPathChildren(input.children, query.length > 0 ? query : undefined);
+  const children =
+    input.args.limit && input.args.limit > 0 ? filtered.slice(0, input.args.limit) : filtered;
+
+  return {
+    query: query.length > 0 ? query : undefined,
+    filteredCount: filtered.length,
+    totalCount: input.children.length,
+    children,
+  };
+};
+
 const runCallHelp = (args: ParsedCallHelpArgs): Effect.Effect<void, Error, FileSystem.FileSystem | PlatformPath.Path> =>
   Effect.gen(function* () {
     if (args.scopeDir) process.env.EXECUTOR_SCOPE_DIR = resolve(args.scopeDir);
@@ -728,20 +842,29 @@ const runCallHelp = (args: ParsedCallHelpArgs): Effect.Effect<void, Error, FileS
         }
       }
 
-      const token = mismatchToken?.toLowerCase();
-      const filteredChildren =
-        token && token.length > 0
-          ? fallback.children.filter((child) => child.segment.toLowerCase().includes(token))
-          : fallback.children;
-      const children = filteredChildren.length > 0 ? filteredChildren : fallback.children;
+      const filtered = applyCallHelpChildFilters({
+        children: fallback.children,
+        args,
+        fallbackQuery: mismatchToken,
+      });
+      const children = filtered.children.length > 0 ? filtered.children : fallback.children;
       const fallbackPrefix = fallback.prefixSegments.join(".");
-      if (mismatchToken && fallbackPrefix.length > 0 && filteredChildren.length > 0) {
+      if (
+        mismatchToken &&
+        fallbackPrefix.length > 0 &&
+        filtered.query &&
+        filtered.filteredCount > 0
+      ) {
         console.error(`Showing subcommands under "${fallbackPrefix}" matching "${mismatchToken}".`);
       }
 
       yield* printCallBrowseHelp({
         prefixSegments: fallback.prefixSegments,
         children,
+        totalChildren:
+          filtered.children.length > 0 ? filtered.totalCount : fallback.children.length,
+        query: filtered.children.length > 0 ? filtered.query : undefined,
+        limit: filtered.children.length > 0 ? args.limit : undefined,
         exactTool: undefined,
       });
       process.exitCode = 1;
@@ -778,9 +901,18 @@ const runCallHelp = (args: ParsedCallHelpArgs): Effect.Effect<void, Error, FileS
       return;
     }
 
+    const filtered = applyCallHelpChildFilters({
+      children: inspection.children,
+      args,
+      fallbackQuery: undefined,
+    });
+
     yield* printCallBrowseHelp({
       prefixSegments: inspection.prefixSegments,
-      children: inspection.children,
+      children: filtered.children,
+      totalChildren: filtered.totalCount,
+      query: filtered.query,
+      limit: args.limit,
       exactTool: exactTool
         ? {
             id: exactTool.id,
@@ -842,16 +974,24 @@ const callCommand = Command.make(
     }),
 ).pipe(
   Command.withDescription(
-    "Invoke a tool path (e.g. `executor call github issues create '{\"title\":\"Hi\"}'`). Use `--help` to browse by namespace/path.",
+    "Invoke a tool path (e.g. `executor call github issues create '{\"title\":\"Hi\"}'`). Use `--help` to browse by namespace/path (`--match`, `--limit`).",
   ),
 );
 
 const resumeCommand = Command.make(
   "resume",
   {
-    executionId: Options.text("execution-id"),
-    action: Options.text("action").pipe(Options.withDefault("accept")),
-    content: Options.text("content").pipe(Options.optional),
+    executionId: Options.text("execution-id").pipe(
+      Options.withDescription("Execution ID returned by a paused call"),
+    ),
+    action: Options.choice("action", ["accept", "decline", "cancel"] as const).pipe(
+      Options.withDefault("accept"),
+      Options.withDescription("Interaction response action"),
+    ),
+    content: Options.text("content").pipe(
+      Options.optional,
+      Options.withDescription("JSON object to send when action=accept"),
+    ),
     baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
     scope,
   },
@@ -860,13 +1000,12 @@ const resumeCommand = Command.make(
       applyScope(scope);
       const daemonUrl = yield* ensureDaemon(baseUrl);
 
-      const parsedContent = Option.getOrUndefined(content);
-      const contentObj = parsedContent ? JSON.parse(parsedContent) : undefined;
+      const contentObj = yield* parseOptionalJsonObject(Option.getOrUndefined(content));
 
       const client = yield* makeApiClient(daemonUrl);
       const result = yield* client.executions.resume({
         path: { executionId },
-        payload: { action: action as "accept" | "decline" | "cancel", content: contentObj },
+        payload: { action, content: contentObj },
       });
 
       if (result.isError) {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -32,8 +32,8 @@ if (typeof Bun !== "undefined" && (await Bun.file(wasmOnDisk).exists())) {
 }
 
 import { Command, Options, Args } from "@effect/cli";
-import { BunRuntime } from "@effect/platform-bun";
-import { FetchHttpClient, HttpApiClient } from "@effect/platform";
+import { BunContext, BunRuntime } from "@effect/platform-bun";
+import { FetchHttpClient, FileSystem, HttpApiClient } from "@effect/platform";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Cause from "effect/Cause";
@@ -92,14 +92,11 @@ const waitForShutdownSignal = () =>
 // Background server management
 // ---------------------------------------------------------------------------
 
-const isServerReachable = async (baseUrl: string): Promise<boolean> => {
-  try {
-    const res = await fetch(`${baseUrl}/api/scope`, { signal: AbortSignal.timeout(2000) });
-    return res.ok;
-  } catch {
-    return false;
-  }
-};
+const isServerReachable = (baseUrl: string): Effect.Effect<boolean> =>
+  Effect.tryPromise(() => fetch(`${baseUrl}/api/scope`, { signal: AbortSignal.timeout(2000) })).pipe(
+    Effect.map((res) => res.ok),
+    Effect.catchAll(() => Effect.succeed(false)),
+  );
 
 const script = process.argv[1];
 const isDevMode = script?.endsWith(".ts") || script?.endsWith(".js");
@@ -107,7 +104,7 @@ const cliPrefix = isDevMode ? `bun run ${script}` : "executor";
 
 const ensureDaemon = (baseUrl: string) =>
   Effect.gen(function* () {
-    if (yield* Effect.promise(() => isServerReachable(baseUrl))) return;
+    if (yield* isServerReachable(baseUrl)) return;
 
     const parsed = yield* Effect.try({
       try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
@@ -141,19 +138,17 @@ const ensureDaemon = (baseUrl: string) =>
     });
 
     console.error(`Starting daemon on ${parsed.hostname}:${parsed.port}...`);
-    spawnDetached({
+    yield* spawnDetached({
       command: spec.command,
       args: spec.args,
       env: process.env,
     });
 
-    const ready = yield* Effect.promise(() =>
-      waitForReachable({
-        check: () => isServerReachable(baseUrl),
-        timeoutMs: DAEMON_BOOT_TIMEOUT_MS,
-        intervalMs: DAEMON_BOOT_POLL_MS,
-      }),
-    );
+    const ready = yield* waitForReachable({
+      check: isServerReachable(baseUrl),
+      timeoutMs: DAEMON_BOOT_TIMEOUT_MS,
+      intervalMs: DAEMON_BOOT_POLL_MS,
+    });
 
     if (!ready) {
       return yield* Effect.fail(
@@ -176,8 +171,8 @@ const stopDaemon = (baseUrl: string) =>
     });
 
     const host = canonicalDaemonHost(parsed.hostname);
-    const record = yield* Effect.promise(() => readDaemonRecord({ hostname: host, port: parsed.port }));
-    const reachable = yield* Effect.promise(() => isServerReachable(baseUrl));
+    const record = yield* readDaemonRecord({ hostname: host, port: parsed.port });
+    const reachable = yield* isServerReachable(baseUrl);
 
     if (!record) {
       if (reachable) {
@@ -196,7 +191,7 @@ const stopDaemon = (baseUrl: string) =>
     }
 
     if (!isPidAlive(record.pid)) {
-      yield* Effect.promise(() => removeDaemonRecord({ hostname: host, port: parsed.port }));
+      yield* removeDaemonRecord({ hostname: host, port: parsed.port });
       if (reachable) {
         return yield* Effect.fail(
           new Error(
@@ -213,21 +208,13 @@ const stopDaemon = (baseUrl: string) =>
 
     console.log(`Stopping daemon at ${baseUrl} (pid ${record.pid})...`);
 
-    yield* Effect.try({
-      try: () => terminatePid(record.pid),
-      catch: (cause) =>
-        cause instanceof Error
-          ? cause
-          : new Error(`Failed sending SIGTERM to pid ${record.pid}: ${String(cause)}`),
-    });
+    yield* terminatePid(record.pid);
 
-    const stopped = yield* Effect.promise(() =>
-      waitForUnreachable({
-        check: () => isServerReachable(baseUrl),
-        timeoutMs: DAEMON_STOP_TIMEOUT_MS,
-        intervalMs: DAEMON_BOOT_POLL_MS,
-      }),
-    );
+    const stopped = yield* waitForUnreachable({
+      check: isServerReachable(baseUrl),
+      timeoutMs: DAEMON_STOP_TIMEOUT_MS,
+      intervalMs: DAEMON_BOOT_POLL_MS,
+    });
 
     if (!stopped) {
       return yield* Effect.fail(
@@ -240,7 +227,7 @@ const stopDaemon = (baseUrl: string) =>
       );
     }
 
-    yield* Effect.promise(() => removeDaemonRecord({ hostname: host, port: parsed.port }));
+    yield* removeDaemonRecord({ hostname: host, port: parsed.port });
     console.log(`Daemon stopped at ${baseUrl}.`);
   });
 
@@ -311,14 +298,12 @@ const runDaemonSession = (input: {
     const daemonHost = canonicalDaemonHost(input.hostname);
     const daemonPort = server.port;
 
-    yield* Effect.promise(() =>
-      writeDaemonRecord({
-        hostname: daemonHost,
-        port: daemonPort,
-        pid: process.pid,
-        scopeDir: process.env.EXECUTOR_SCOPE_DIR ?? null,
-      }),
-    );
+    yield* writeDaemonRecord({
+      hostname: daemonHost,
+      port: daemonPort,
+      pid: process.pid,
+      scopeDir: process.env.EXECUTOR_SCOPE_DIR ?? null,
+    });
 
     console.log(`Daemon ready on http://${daemonHost}:${daemonPort}`);
 
@@ -326,7 +311,7 @@ const runDaemonSession = (input: {
       yield* waitForShutdownSignal();
     } finally {
       yield* Effect.promise(() => server.stop());
-      yield* Effect.promise(() => removeDaemonRecord({ hostname: daemonHost, port: daemonPort }));
+      yield* removeDaemonRecord({ hostname: daemonHost, port: daemonPort });
     }
   });
 
@@ -350,17 +335,17 @@ const readCode = (input: {
   code: Option.Option<string>;
   file: Option.Option<string>;
   stdin: boolean;
-}): Effect.Effect<string, Error> =>
+}): Effect.Effect<string, Error, FileSystem.FileSystem> =>
   Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
     const code = Option.getOrUndefined(input.code);
     if (code && code.trim().length > 0) return code;
 
     const file = Option.getOrUndefined(input.file);
     if (file && file.trim().length > 0) {
-      const contents = yield* Effect.tryPromise({
-        try: () => Bun.file(file).text(),
-        catch: (e) => new Error(`Failed to read file: ${e}`),
-      });
+      const contents = yield* fs.readFileString(file).pipe(
+        Effect.mapError((cause) => new Error(`Failed to read file: ${String(cause)}`)),
+      );
       if (contents.trim().length > 0) return contents;
     }
 
@@ -529,8 +514,8 @@ const daemonStatusCommand = Command.make(
       const host = canonicalDaemonHost(parsed.hostname);
 
       const [record, reachable] = yield* Effect.all([
-        Effect.promise(() => readDaemonRecord({ hostname: host, port: parsed.port })),
-        Effect.promise(() => isServerReachable(baseUrl)),
+        readDaemonRecord({ hostname: host, port: parsed.port }),
+        isServerReachable(baseUrl),
       ]);
 
       if (!record) {
@@ -544,7 +529,7 @@ const daemonStatusCommand = Command.make(
 
       if (!isPidAlive(record.pid)) {
         if (!reachable) {
-          yield* Effect.promise(() => removeDaemonRecord({ hostname: host, port: parsed.port }));
+          yield* removeDaemonRecord({ hostname: host, port: parsed.port });
           console.log(`Daemon not running at ${baseUrl} (removed stale record for pid ${record.pid}).`);
           return;
         }
@@ -624,6 +609,7 @@ if (process.argv.includes("-v")) {
 }
 
 const program = runCli(process.argv).pipe(
+  Effect.provide(BunContext.layer),
   Effect.catchAllCause((cause) =>
     Effect.sync(() => {
       console.error(Cause.pretty(cause));

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,4 +1,5 @@
 // Ensure binaries next to the executor (e.g. secure-exec-v8) are on $PATH
+import { randomUUID } from "node:crypto";
 import { dirname, join, resolve } from "node:path";
 const execDir = dirname(process.execPath);
 if (process.env.PATH && !process.env.PATH.includes(execDir)) {
@@ -33,7 +34,7 @@ if (typeof Bun !== "undefined" && (await Bun.file(wasmOnDisk).exists())) {
 
 import { Command, Options, Args } from "@effect/cli";
 import { BunContext, BunRuntime } from "@effect/platform-bun";
-import { FetchHttpClient, FileSystem, HttpApiClient } from "@effect/platform";
+import { FetchHttpClient, FileSystem, HttpApiClient, Path as PlatformPath } from "@effect/platform";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Cause from "effect/Cause";
@@ -43,6 +44,7 @@ import { startServer, runMcpStdioServer, getExecutor } from "@executor/local";
 import { makeQuickJsExecutor } from "@executor/runtime-quickjs";
 import {
   buildDaemonSpawnSpec,
+  chooseDaemonPort,
   canAutoStartLocalDaemonForHost,
   parseDaemonBaseUrl,
   spawnDetached,
@@ -50,11 +52,17 @@ import {
   waitForUnreachable,
 } from "./daemon";
 import {
+  acquireDaemonStartLock,
   canonicalDaemonHost,
+  currentDaemonScopeId,
   isPidAlive,
+  readDaemonPointer,
   readDaemonRecord,
+  releaseDaemonStartLock,
+  removeDaemonPointer,
   removeDaemonRecord,
   terminatePid,
+  writeDaemonPointer,
   writeDaemonRecord,
 } from "./daemon-state";
 import {
@@ -102,9 +110,25 @@ const waitForShutdownSignal = () =>
 // Background server management
 // ---------------------------------------------------------------------------
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const isServerReachable = (baseUrl: string): Effect.Effect<boolean> =>
   Effect.tryPromise(() => fetch(`${baseUrl}/api/scope`, { signal: AbortSignal.timeout(2000) })).pipe(
-    Effect.map((res) => res.ok),
+    Effect.flatMap((res) => {
+      if (!res.ok) return Effect.succeed(false);
+      return Effect.tryPromise(() => res.json()).pipe(
+        Effect.map((payload) => {
+          if (!isRecord(payload)) return false;
+          return (
+            typeof payload.id === "string" &&
+            typeof payload.name === "string" &&
+            typeof payload.dir === "string"
+          );
+        }),
+        Effect.catchAll(() => Effect.succeed(false)),
+      );
+    }),
     Effect.catchAll(() => Effect.succeed(false)),
   );
 
@@ -112,116 +136,191 @@ const script = process.argv[1];
 const isDevMode = script?.endsWith(".ts") || script?.endsWith(".js");
 const cliPrefix = isDevMode ? `bun run ${script}` : "executor";
 
-const ensureDaemon = (baseUrl: string) =>
+const toError = (cause: unknown): Error =>
+  cause instanceof Error ? cause : new Error(String(cause));
+
+const parseDaemonUrl = (baseUrl: string) =>
+  Effect.try({
+    try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
+    catch: (cause) =>
+      cause instanceof Error ? cause : new Error(`Invalid base URL: ${String(cause)}`),
+  });
+
+const daemonBaseUrl = (hostname: string, port: number): string =>
+  `http://${canonicalDaemonHost(hostname)}:${port}`;
+
+const cleanupPointer = (input: { hostname: string; scopeId: string; port: number }) =>
   Effect.gen(function* () {
-    if (yield* isServerReachable(baseUrl)) return;
+    yield* removeDaemonPointer({ hostname: input.hostname, scopeId: input.scopeId }).pipe(Effect.ignore);
+    yield* removeDaemonRecord({ hostname: input.hostname, port: input.port }).pipe(Effect.ignore);
+  });
 
-    const parsed = yield* Effect.try({
-      try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
-      catch: (cause) =>
-        cause instanceof Error ? cause : new Error(`Invalid base URL: ${String(cause)}`),
-    });
+const resolveDaemonTarget = (baseUrl: string) =>
+  Effect.gen(function* () {
+    const parsed = yield* parseDaemonUrl(baseUrl);
+    const host = canonicalDaemonHost(parsed.hostname);
+    const scopeId = currentDaemonScopeId();
+    const pointer = yield* readDaemonPointer({ hostname: host, scopeId });
 
-    if (!canAutoStartLocalDaemonForHost(parsed.hostname)) {
+    if (pointer) {
+      const pointerUrl = daemonBaseUrl(pointer.hostname, pointer.port);
+      if (isPidAlive(pointer.pid) && (yield* isServerReachable(pointerUrl))) {
+        return {
+          baseUrl: pointerUrl,
+          hostname: pointer.hostname,
+          port: pointer.port,
+          scopeId,
+        };
+      }
+
+      yield* cleanupPointer({ hostname: pointer.hostname, scopeId, port: pointer.port });
+    }
+
+    return {
+      baseUrl: daemonBaseUrl(host, parsed.port),
+      hostname: host,
+      port: parsed.port,
+      scopeId,
+    };
+  });
+
+const ensureDaemon = (
+  baseUrl: string,
+): Effect.Effect<string, Error, FileSystem.FileSystem | PlatformPath.Path> =>
+  Effect.gen(function* () {
+    const resolvedTarget = yield* resolveDaemonTarget(baseUrl);
+    if (yield* isServerReachable(resolvedTarget.baseUrl)) {
+      return resolvedTarget.baseUrl;
+    }
+
+    const parsed = yield* parseDaemonUrl(baseUrl);
+    const scopeId = currentDaemonScopeId();
+    const host = canonicalDaemonHost(parsed.hostname);
+
+    if (!canAutoStartLocalDaemonForHost(host)) {
       return yield* Effect.fail(
         new Error(
           [
             `Executor daemon is not reachable at ${baseUrl}.`,
             "Auto-start is only supported for local hosts.",
-            `Start it manually: ${cliPrefix} daemon run --port ${parsed.port} --hostname ${parsed.hostname}`,
+            `Start it manually: ${cliPrefix} daemon run --port ${parsed.port} --hostname ${host}`,
           ].join("\n"),
         ),
       );
     }
 
-    const spec = yield* Effect.try({
-      try: () =>
-        buildDaemonSpawnSpec({
-          port: parsed.port,
-          hostname: parsed.hostname,
-          isDevMode,
-          scriptPath: script,
-          executablePath: process.execPath,
-        }),
-      catch: (cause) =>
-        cause instanceof Error ? cause : new Error(`Failed to build daemon command: ${String(cause)}`),
-    });
+    const lock = yield* acquireDaemonStartLock({ hostname: host, scopeId });
 
-    console.error(`Starting daemon on ${parsed.hostname}:${parsed.port}...`);
-    yield* spawnDetached({
-      command: spec.command,
-      args: spec.args,
-      env: process.env,
-    });
+    try {
+      const existing = yield* resolveDaemonTarget(baseUrl);
+      if (yield* isServerReachable(existing.baseUrl)) {
+        return existing.baseUrl;
+      }
 
-    const ready = yield* waitForReachable({
-      check: isServerReachable(baseUrl),
-      timeoutMs: DAEMON_BOOT_TIMEOUT_MS,
-      intervalMs: DAEMON_BOOT_POLL_MS,
-    });
+      const selectedPort = yield* chooseDaemonPort({
+        preferredPort: parsed.port,
+        hostname: host,
+      });
 
-    if (!ready) {
-      return yield* Effect.fail(
-        new Error(
-          [
-            `Daemon did not become reachable at ${baseUrl} within ${DAEMON_BOOT_TIMEOUT_MS}ms.`,
-            `Run in foreground to inspect logs: ${cliPrefix} daemon run --port ${parsed.port} --hostname ${parsed.hostname}`,
-          ].join("\n"),
-        ),
-      );
+      if (selectedPort !== parsed.port) {
+        console.error(
+          `Port ${parsed.port} is in use. Starting daemon on available port ${selectedPort} instead.`,
+        );
+      }
+
+      const spec = yield* Effect.try({
+        try: () =>
+          buildDaemonSpawnSpec({
+            port: selectedPort,
+            hostname: host,
+            isDevMode,
+            scriptPath: script,
+            executablePath: process.execPath,
+          }),
+        catch: (cause) =>
+          cause instanceof Error ? cause : new Error(`Failed to build daemon command: ${String(cause)}`),
+      });
+
+      const startBaseUrl = daemonBaseUrl(host, selectedPort);
+      console.error(`Starting daemon on ${host}:${selectedPort}...`);
+      yield* spawnDetached({
+        command: spec.command,
+        args: spec.args,
+        env: process.env,
+      });
+
+      const ready = yield* waitForReachable({
+        check: isServerReachable(startBaseUrl),
+        timeoutMs: DAEMON_BOOT_TIMEOUT_MS,
+        intervalMs: DAEMON_BOOT_POLL_MS,
+      });
+
+      if (!ready) {
+        return yield* Effect.fail(
+          new Error(
+            [
+              `Daemon did not become reachable at ${startBaseUrl} within ${DAEMON_BOOT_TIMEOUT_MS}ms.`,
+              `Run in foreground to inspect logs: ${cliPrefix} daemon run --port ${selectedPort} --hostname ${host}`,
+            ].join("\n"),
+          ),
+        );
+      }
+
+      return startBaseUrl;
+    } finally {
+      yield* releaseDaemonStartLock(lock).pipe(Effect.ignore);
     }
-  });
+  }).pipe(Effect.mapError(toError));
 
-const stopDaemon = (baseUrl: string) =>
+const stopDaemon = (
+  baseUrl: string,
+): Effect.Effect<void, Error, FileSystem.FileSystem | PlatformPath.Path> =>
   Effect.gen(function* () {
-    const parsed = yield* Effect.try({
-      try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
-      catch: (cause) =>
-        cause instanceof Error ? cause : new Error(`Invalid base URL: ${String(cause)}`),
-    });
-
-    const host = canonicalDaemonHost(parsed.hostname);
-    const record = yield* readDaemonRecord({ hostname: host, port: parsed.port });
-    const reachable = yield* isServerReachable(baseUrl);
+    const target = yield* resolveDaemonTarget(baseUrl);
+    const host = canonicalDaemonHost(target.hostname);
+    const scopeId = target.scopeId;
+    const record = yield* readDaemonRecord({ hostname: host, port: target.port });
+    const reachable = yield* isServerReachable(target.baseUrl);
 
     if (!record) {
       if (reachable) {
         return yield* Effect.fail(
           new Error(
             [
-              `Executor is reachable at ${baseUrl} but no daemon record exists.`,
+              `Executor is reachable at ${target.baseUrl} but no daemon record exists.`,
               "It may not be managed by this CLI process.",
               "Stop it from the terminal/session where it was started.",
             ].join("\n"),
           ),
         );
       }
-      console.log(`No daemon running at ${baseUrl}.`);
+      console.log(`No daemon running at ${target.baseUrl}.`);
       return;
     }
 
     if (!isPidAlive(record.pid)) {
-      yield* removeDaemonRecord({ hostname: host, port: parsed.port });
+      yield* removeDaemonRecord({ hostname: host, port: target.port });
+      yield* removeDaemonPointer({ hostname: host, scopeId }).pipe(Effect.ignore);
       if (reachable) {
         return yield* Effect.fail(
           new Error(
             [
-              `Daemon record for ${baseUrl} points to dead pid ${record.pid}, but endpoint is still reachable.`,
+              `Daemon record for ${target.baseUrl} points to dead pid ${record.pid}, but endpoint is still reachable.`,
               "Refusing to stop an unknown process without ownership metadata.",
             ].join("\n"),
           ),
         );
       }
-      console.log(`No daemon running at ${baseUrl} (removed stale record for pid ${record.pid}).`);
+      console.log(`No daemon running at ${target.baseUrl} (removed stale record for pid ${record.pid}).`);
       return;
     }
 
-    console.log(`Stopping daemon at ${baseUrl} (pid ${record.pid})...`);
+    console.log(`Stopping daemon at ${target.baseUrl} (pid ${record.pid})...`);
 
     yield* terminatePid(record.pid);
 
     const stopped = yield* waitForUnreachable({
-      check: isServerReachable(baseUrl),
+      check: isServerReachable(target.baseUrl),
       timeoutMs: DAEMON_STOP_TIMEOUT_MS,
       intervalMs: DAEMON_BOOT_POLL_MS,
     });
@@ -230,16 +329,17 @@ const stopDaemon = (baseUrl: string) =>
       return yield* Effect.fail(
         new Error(
           [
-            `Daemon at ${baseUrl} did not stop within ${DAEMON_STOP_TIMEOUT_MS}ms.`,
+            `Daemon at ${target.baseUrl} did not stop within ${DAEMON_STOP_TIMEOUT_MS}ms.`,
             "Try terminating the process manually.",
           ].join("\n"),
         ),
       );
     }
 
-    yield* removeDaemonRecord({ hostname: host, port: parsed.port });
-    console.log(`Daemon stopped at ${baseUrl}.`);
-  });
+    yield* removeDaemonRecord({ hostname: host, port: target.port });
+    yield* removeDaemonPointer({ hostname: host, scopeId }).pipe(Effect.ignore);
+    console.log(`Daemon stopped at ${target.baseUrl}.`);
+  }).pipe(Effect.mapError(toError));
 
 type ExecuteCodeOutcome =
   | {
@@ -252,16 +352,13 @@ type ExecuteCodeOutcome =
       readonly executionId: string | undefined;
     };
 
-const toError = (cause: unknown): Error =>
-  cause instanceof Error ? cause : new Error(String(cause));
-
 const executeCode = (input: {
   baseUrl: string;
   code: string;
-}): Effect.Effect<ExecuteCodeOutcome, Error> =>
+}): Effect.Effect<ExecuteCodeOutcome, Error, FileSystem.FileSystem | PlatformPath.Path> =>
   Effect.gen(function* () {
-    yield* ensureDaemon(input.baseUrl);
-    const client = yield* makeApiClient(input.baseUrl);
+    const daemonUrl = yield* ensureDaemon(input.baseUrl);
+    const client = yield* makeApiClient(daemonUrl);
     const response = yield* client.executions.execute({
       payload: {
         code: input.code,
@@ -361,6 +458,26 @@ const runDaemonSession = (input: {
   allowedHosts: ReadonlyArray<string>;
 }) =>
   Effect.gen(function* () {
+    const daemonHost = canonicalDaemonHost(input.hostname);
+    const scopeId = currentDaemonScopeId();
+    const existing = yield* readDaemonPointer({ hostname: daemonHost, scopeId });
+
+    if (existing) {
+      const existingUrl = daemonBaseUrl(existing.hostname, existing.port);
+      if (isPidAlive(existing.pid) && (yield* isServerReachable(existingUrl))) {
+        return yield* Effect.fail(
+          new Error(
+            [
+              `A daemon is already running for scope ${scopeId} on ${daemonHost}.`,
+              `Existing daemon: ${existingUrl} (pid ${existing.pid}).`,
+              `Stop it first: ${cliPrefix} daemon stop`,
+            ].join("\n"),
+          ),
+        );
+      }
+      yield* cleanupPointer({ hostname: existing.hostname, scopeId, port: existing.port });
+    }
+
     const server = yield* Effect.promise(() =>
       startServer({
         port: input.port,
@@ -370,14 +487,22 @@ const runDaemonSession = (input: {
       }),
     );
 
-    const daemonHost = canonicalDaemonHost(input.hostname);
     const daemonPort = server.port;
+    const token = randomUUID();
 
     yield* writeDaemonRecord({
       hostname: daemonHost,
       port: daemonPort,
       pid: process.pid,
       scopeDir: process.env.EXECUTOR_SCOPE_DIR ?? null,
+    });
+    yield* writeDaemonPointer({
+      hostname: daemonHost,
+      port: daemonPort,
+      pid: process.pid,
+      scopeId,
+      scopeDir: process.env.EXECUTOR_SCOPE_DIR ?? null,
+      token,
     });
 
     console.log(`Daemon ready on http://${daemonHost}:${daemonPort}`);
@@ -387,6 +512,7 @@ const runDaemonSession = (input: {
     } finally {
       yield* Effect.promise(() => server.stop());
       yield* removeDaemonRecord({ hostname: daemonHost, port: daemonPort });
+      yield* removeDaemonPointer({ hostname: daemonHost, scopeId }).pipe(Effect.ignore);
     }
   });
 
@@ -469,9 +595,9 @@ const callCommand = Command.make(
     Effect.gen(function* () {
       applyScope(scope);
       const resolvedCode = yield* readCode({ code, file, stdin });
-      yield* ensureDaemon(baseUrl);
+      const daemonUrl = yield* ensureDaemon(baseUrl);
 
-      const client = yield* makeApiClient(baseUrl);
+      const client = yield* makeApiClient(daemonUrl);
       const result = yield* client.executions.execute({ payload: { code: resolvedCode } });
 
       if (result.status === "completed") {
@@ -507,12 +633,12 @@ const resumeCommand = Command.make(
   ({ executionId, action, content, baseUrl, scope }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      yield* ensureDaemon(baseUrl);
+      const daemonUrl = yield* ensureDaemon(baseUrl);
 
       const parsedContent = Option.getOrUndefined(content);
       const contentObj = parsedContent ? JSON.parse(parsedContent) : undefined;
 
-      const client = yield* makeApiClient(baseUrl);
+      const client = yield* makeApiClient(daemonUrl);
       const result = yield* client.executions.resume({
         path: { executionId },
         payload: { action: action as "accept" | "decline" | "cancel", content: contentObj },
@@ -711,41 +837,43 @@ const daemonStatusCommand = Command.make(
   },
   ({ baseUrl }) =>
     Effect.gen(function* () {
-      const parsed = yield* Effect.try({
-        try: () => parseDaemonBaseUrl(baseUrl, DEFAULT_PORT),
-        catch: (cause) =>
-          cause instanceof Error ? cause : new Error(`Invalid base URL: ${String(cause)}`),
-      });
-      const host = canonicalDaemonHost(parsed.hostname);
+      const target = yield* resolveDaemonTarget(baseUrl);
+      const host = canonicalDaemonHost(target.hostname);
 
       const [record, reachable] = yield* Effect.all([
-        readDaemonRecord({ hostname: host, port: parsed.port }),
-        isServerReachable(baseUrl),
+        readDaemonRecord({ hostname: host, port: target.port }),
+        isServerReachable(target.baseUrl),
       ]);
 
       if (!record) {
         if (reachable) {
-          console.log(`Daemon reachable at ${baseUrl} (no local ownership record).`);
+          console.log(`Daemon reachable at ${target.baseUrl} (no local ownership record).`);
         } else {
-          console.log(`Daemon not running at ${baseUrl}.`);
+          console.log(`Daemon not running at ${target.baseUrl}.`);
         }
         return;
       }
 
       if (!isPidAlive(record.pid)) {
         if (!reachable) {
-          yield* removeDaemonRecord({ hostname: host, port: parsed.port });
-          console.log(`Daemon not running at ${baseUrl} (removed stale record for pid ${record.pid}).`);
+          yield* removeDaemonRecord({ hostname: host, port: target.port });
+          yield* removeDaemonPointer({ hostname: host, scopeId: target.scopeId }).pipe(Effect.ignore);
+          console.log(
+            `Daemon not running at ${target.baseUrl} (removed stale record for pid ${record.pid}).`,
+          );
           return;
         }
         console.log(
-          `Daemon reachable at ${baseUrl}, but recorded pid ${record.pid} is not alive (ownership mismatch).`,
+          `Daemon reachable at ${target.baseUrl}, but recorded pid ${record.pid} is not alive (ownership mismatch).`,
         );
         return;
       }
 
       const state = reachable ? "running" : "unreachable";
-      console.log(`Daemon ${state} at ${baseUrl} (pid ${record.pid}).`);
+      console.log(`Daemon ${state} at ${target.baseUrl} (pid ${record.pid}).`);
+      if (target.baseUrl !== baseUrl) {
+        console.log(`Requested: ${baseUrl}`);
+      }
       if (record.scopeDir) {
         console.log(`Scope: ${record.scopeDir}`);
       }
@@ -770,8 +898,8 @@ const daemonRestartCommand = Command.make(
     Effect.gen(function* () {
       applyScope(scope);
       yield* stopDaemon(baseUrl);
-      yield* ensureDaemon(baseUrl);
-      console.log(`Daemon restarted at ${baseUrl}.`);
+      const daemonUrl = yield* ensureDaemon(baseUrl);
+      console.log(`Daemon restarted at ${daemonUrl}.`);
     }),
 ).pipe(Command.withDescription("Restart the local daemon"));
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -73,6 +73,7 @@ import {
   buildSearchToolsCode,
   extractExecutionId,
   extractExecutionResult,
+  inspectToolPath,
   parseJsonObjectInput,
 } from "./tooling";
 
@@ -538,6 +539,257 @@ const applyScope = (s: Option.Option<string>) => {
   if (dir) process.env.EXECUTOR_SCOPE_DIR = resolve(dir);
 };
 
+interface ParsedCallHelpArgs {
+  readonly pathParts: ReadonlyArray<string>;
+  readonly baseUrl: string;
+  readonly scopeDir: string | undefined;
+}
+
+const HELP_FLAGS = new Set(["--help", "-h"]);
+
+const isHelpFlag = (value: string): boolean => HELP_FLAGS.has(value);
+
+const parseCallHelpArgs = (args: ReadonlyArray<string>): ParsedCallHelpArgs => {
+  let baseUrl = DEFAULT_BASE_URL;
+  let scopeDir: string | undefined = undefined;
+  const pathParts: Array<string> = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (!token || isHelpFlag(token)) continue;
+
+    if (token === "--base-url") {
+      const value = args[index + 1];
+      if (!value) throw new Error("Missing value for --base-url");
+      baseUrl = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--base-url=")) {
+      baseUrl = token.slice("--base-url=".length);
+      continue;
+    }
+
+    if (token === "--scope") {
+      const value = args[index + 1];
+      if (!value) throw new Error("Missing value for --scope");
+      scopeDir = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--scope=")) {
+      scopeDir = token.slice("--scope=".length);
+      continue;
+    }
+
+    if (token.startsWith("-")) {
+      throw new Error(`Unknown option for call help: ${token}`);
+    }
+
+    pathParts.push(token);
+  }
+
+  const maybeJsonArg = pathParts.at(-1)?.trim();
+  if (maybeJsonArg && maybeJsonArg.startsWith("{")) {
+    pathParts.pop();
+  }
+
+  return { pathParts, baseUrl, scopeDir };
+};
+
+const printCallBrowseHelp = (input: {
+  readonly prefixSegments: ReadonlyArray<string>;
+  readonly children: ReadonlyArray<{
+    readonly segment: string;
+    readonly invokable: boolean;
+    readonly hasChildren: boolean;
+    readonly toolCount: number;
+  }>;
+  readonly exactTool:
+    | {
+        readonly id: string;
+        readonly description?: string;
+      }
+    | undefined;
+}) =>
+  Effect.sync(() => {
+    const prefixText = input.prefixSegments.join(" ");
+    const commandPrefix = `${cliPrefix} call${prefixText.length > 0 ? ` ${prefixText}` : ""}`;
+    const nextPlaceholder = input.prefixSegments.length === 0 ? "<namespace>" : "<subcommand>";
+    const usageLines = [
+      "Usage:",
+      `  ${commandPrefix} ${nextPlaceholder} [<subcommand> ...] ['{"k":"v"}']`,
+      `  ${commandPrefix} --help`,
+    ];
+
+    if (input.exactTool) {
+      usageLines.push(`  ${commandPrefix} ['{"k":"v"}']`);
+    }
+
+    console.log(usageLines.join("\n"));
+
+    if (input.exactTool) {
+      console.log(`\nCallable path: ${input.exactTool.id}`);
+      if (input.exactTool.description) {
+        console.log(input.exactTool.description);
+      }
+    }
+
+    if (input.children.length === 0) {
+      console.log("\nNo subcommands at this level.");
+      return;
+    }
+
+    const rows = input.children.map((child) => {
+      const kind =
+        child.invokable && child.hasChildren ? "tool+group" : child.invokable ? "tool" : "group";
+      return { name: child.segment, meta: `${kind}, ${child.toolCount} path${child.toolCount === 1 ? "" : "s"}` };
+    });
+
+    const width = rows.reduce((max, row) => Math.max(max, row.name.length), 0);
+    console.log("\nSubcommands:");
+    for (const row of rows) {
+      console.log(`  ${row.name.padEnd(width)}  ${row.meta}`);
+    }
+
+    console.log(`\nDrill down: ${commandPrefix} ${nextPlaceholder} --help`);
+  });
+
+const printCallLeafHelp = (input: {
+  readonly tool: {
+    readonly id: string;
+    readonly description?: string;
+  };
+  readonly schema:
+    | {
+        readonly inputTypeScript?: string;
+        readonly outputTypeScript?: string;
+      }
+    | undefined;
+}) =>
+  Effect.sync(() => {
+    const segments = input.tool.id.split(".");
+    const callPath = `${cliPrefix} call ${segments.join(" ")}`;
+
+    console.log(`Usage:\n  ${callPath}\n  ${callPath} '{"k":"v"}'`);
+    console.log(`\nTool: ${input.tool.id}`);
+    if (input.tool.description) {
+      console.log(input.tool.description);
+    }
+    if (input.schema?.inputTypeScript) {
+      console.log(`\nInput:\n${input.schema.inputTypeScript}`);
+    }
+    if (input.schema?.outputTypeScript) {
+      console.log(`\nOutput:\n${input.schema.outputTypeScript}`);
+    }
+  });
+
+const runCallHelp = (args: ParsedCallHelpArgs): Effect.Effect<void, Error, FileSystem.FileSystem | PlatformPath.Path> =>
+  Effect.gen(function* () {
+    if (args.scopeDir) process.env.EXECUTOR_SCOPE_DIR = resolve(args.scopeDir);
+
+    const daemonUrl = yield* ensureDaemon(args.baseUrl);
+    const client = yield* makeApiClient(daemonUrl);
+    const scopeInfo = yield* client.scope.info();
+    const tools = yield* client.tools.list({ path: { scopeId: scopeInfo.id } });
+    const toolPaths = tools.map((tool) => tool.id);
+
+    const inspection = yield* Effect.try({
+      try: () =>
+        inspectToolPath({
+          toolPaths,
+          rawPrefixParts: args.pathParts,
+        }),
+      catch: (cause) =>
+        cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
+    });
+
+    if (inspection.matchingToolCount === 0) {
+      const typed = inspection.prefixSegments.join(".");
+      console.error(
+        typed.length > 0
+          ? `No tool path starts with "${typed}".`
+          : "No tools are currently registered in this scope.",
+      );
+
+      let fallback = inspectToolPath({ toolPaths, rawPrefixParts: [] });
+      let mismatchToken: string | undefined = undefined;
+
+      for (let depth = inspection.prefixSegments.length - 1; depth >= 0; depth -= 1) {
+        const candidatePrefix = inspection.prefixSegments.slice(0, depth);
+        const candidate = inspectToolPath({
+          toolPaths,
+          rawPrefixParts: candidatePrefix,
+        });
+        if (candidate.matchingToolCount > 0) {
+          fallback = candidate;
+          mismatchToken = inspection.prefixSegments[depth];
+          break;
+        }
+      }
+
+      const token = mismatchToken?.toLowerCase();
+      const filteredChildren =
+        token && token.length > 0
+          ? fallback.children.filter((child) => child.segment.toLowerCase().includes(token))
+          : fallback.children;
+      const children = filteredChildren.length > 0 ? filteredChildren : fallback.children;
+      const fallbackPrefix = fallback.prefixSegments.join(".");
+      if (mismatchToken && fallbackPrefix.length > 0 && filteredChildren.length > 0) {
+        console.error(`Showing subcommands under "${fallbackPrefix}" matching "${mismatchToken}".`);
+      }
+
+      yield* printCallBrowseHelp({
+        prefixSegments: fallback.prefixSegments,
+        children,
+        exactTool: undefined,
+      });
+      process.exitCode = 1;
+      return;
+    }
+
+    const exactTool = inspection.exactPath
+      ? tools.find((tool) => tool.id === inspection.exactPath)
+      : undefined;
+
+    if (exactTool && inspection.children.length === 0) {
+      const schema = yield* client.tools
+        .schema({
+          path: {
+            scopeId: scopeInfo.id,
+            toolId: exactTool.id,
+          },
+        })
+        .pipe(
+          Effect.map((result) => ({
+            inputTypeScript: result.inputTypeScript,
+            outputTypeScript: result.outputTypeScript,
+          })),
+          Effect.catchAll(() => Effect.succeed(undefined)),
+        );
+
+      yield* printCallLeafHelp({
+        tool: {
+          id: exactTool.id,
+          description: exactTool.description,
+        },
+        schema,
+      });
+      return;
+    }
+
+    yield* printCallBrowseHelp({
+      prefixSegments: inspection.prefixSegments,
+      children: inspection.children,
+      exactTool: exactTool
+        ? {
+            id: exactTool.id,
+            description: exactTool.description,
+          }
+        : undefined,
+    });
+  }).pipe(Effect.mapError(toError));
+
 const resolveToolInvocation = (input: {
   rawPathParts: ReadonlyArray<string>;
 }): Effect.Effect<{ path: string; args: Record<string, unknown> }, Error> =>
@@ -590,7 +842,7 @@ const callCommand = Command.make(
     }),
 ).pipe(
   Command.withDescription(
-    "Invoke a tool path (e.g. `executor call github issues create '{\"title\":\"Hi\"}'`)",
+    "Invoke a tool path (e.g. `executor call github issues create '{\"title\":\"Hi\"}'`). Use `--help` to browse by namespace/path.",
   ),
 );
 
@@ -853,7 +1105,19 @@ if (process.argv.includes("-v")) {
   process.exit(0);
 }
 
-const program = runCli(process.argv).pipe(
+const isCallHelpInvocation =
+  process.argv[2] === "call" && process.argv.slice(3).some((arg) => isHelpFlag(arg));
+
+const program = (isCallHelpInvocation
+  ? Effect.gen(function* () {
+      const args = yield* Effect.try({
+        try: () => parseCallHelpArgs(process.argv.slice(3)),
+        catch: (cause) => (cause instanceof Error ? cause : new Error(String(cause))),
+      });
+      yield* runCallHelp(args);
+    })
+  : runCli(process.argv)
+).pipe(
   Effect.provide(BunContext.layer),
   Effect.catchAllCause((cause) =>
     Effect.sync(() => {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -77,6 +77,7 @@ import {
   extractPausedInteraction,
   extractExecutionResult,
   inspectToolPath,
+  normalizeCliErrorText,
   parseJsonObjectInput,
 } from "./tooling";
 
@@ -575,6 +576,46 @@ const parseOptionalJsonObject = (raw: string | undefined): Effect.Effect<
         Effect.mapError((error) => new Error(`Invalid --content JSON: ${error.message}`)),
       );
 
+const formatUnknownMessage = (cause: unknown): string => {
+  if (cause instanceof Error) return cause.message;
+  if (typeof cause === "string") return cause;
+  if (typeof cause === "object" && cause !== null && "message" in cause) {
+    const message = cause.message;
+    if (typeof message === "string") return message;
+  }
+  return String(cause);
+};
+
+const readCliLogLevel = (argv: ReadonlyArray<string>): string | undefined => {
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token) continue;
+    if (token === "--log-level") {
+      return argv[index + 1];
+    }
+    if (token.startsWith("--log-level=")) {
+      return token.slice("--log-level=".length);
+    }
+  }
+  return undefined;
+};
+
+const shouldPrintVerboseErrors = (argv: ReadonlyArray<string>): boolean => {
+  const level = readCliLogLevel(argv)?.trim().toLowerCase();
+  return level === "all" || level === "trace" || level === "debug";
+};
+
+const renderCliError = (cause: Cause.Cause<unknown>): string => {
+  const squashed = Cause.squash(cause);
+  const raw = formatUnknownMessage(squashed);
+  const normalized = normalizeCliErrorText(raw);
+  if (normalized.length === 0) return "Unknown error";
+  if (normalized !== raw.trim()) {
+    return `${normalized}\n(run with --log-level debug for full details)`;
+  }
+  return normalized;
+};
+
 const parsePositiveIntegerOption = (name: string, raw: string): number => {
   if (!/^\d+$/.test(raw)) {
     throw new Error(`Invalid --${name} value: ${raw}`);
@@ -630,6 +671,16 @@ const parseCallHelpArgs = (args: ReadonlyArray<string>): ParsedCallHelpArgs => {
     }
     if (token.startsWith("--scope=")) {
       scopeDir = token.slice("--scope=".length);
+      continue;
+    }
+
+    if (token === "--log-level") {
+      const value = args[index + 1];
+      if (!value) throw new Error("Missing value for --log-level");
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("--log-level=")) {
       continue;
     }
 
@@ -1009,7 +1060,16 @@ const resumeCommand = Command.make(
       });
 
       if (result.isError) {
-        console.error(result.text);
+        if (shouldPrintVerboseErrors(process.argv)) {
+          console.error(result.text);
+        } else {
+          const normalized = normalizeCliErrorText(result.text);
+          console.error(
+            normalized.length > 0
+              ? normalized
+              : "Resume failed (run with --log-level debug for full details).",
+          );
+        }
         process.exit(1);
       } else {
         console.log(result.text);
@@ -1260,7 +1320,11 @@ const program = (isCallHelpInvocation
   Effect.provide(BunContext.layer),
   Effect.catchAllCause((cause) =>
     Effect.sync(() => {
-      console.error(Cause.pretty(cause));
+      if (shouldPrintVerboseErrors(process.argv)) {
+        console.error(Cause.pretty(cause));
+      } else {
+        console.error(renderCliError(cause));
+      }
       process.exitCode = 1;
     }),
   ),

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -73,7 +73,6 @@ import {
   buildSearchToolsCode,
   extractExecutionId,
   extractExecutionResult,
-  isLikelyToolPathToken,
   parseJsonObjectInput,
 } from "./tooling";
 
@@ -529,46 +528,6 @@ const runStdioMcpSession = () =>
     );
   });
 
-// ---------------------------------------------------------------------------
-// Code resolution — positional arg > --file > stdin
-// ---------------------------------------------------------------------------
-
-const readCode = (input: {
-  code: Option.Option<string>;
-  file: Option.Option<string>;
-  stdin: boolean;
-}): Effect.Effect<string, Error, FileSystem.FileSystem> =>
-  Effect.gen(function* () {
-    const fs = yield* FileSystem.FileSystem;
-    const code = Option.getOrUndefined(input.code);
-    if (code && code.trim().length > 0) return code;
-
-    const file = Option.getOrUndefined(input.file);
-    if (file && file.trim().length > 0) {
-      const contents = yield* fs.readFileString(file).pipe(
-        Effect.mapError((cause) => new Error(`Failed to read file: ${String(cause)}`)),
-      );
-      if (contents.trim().length > 0) return contents;
-    }
-
-    if (input.stdin || !process.stdin.isTTY) {
-      const chunks: string[] = [];
-      process.stdin.setEncoding("utf8");
-      const contents = yield* Effect.tryPromise({
-        try: async () => {
-          for await (const chunk of process.stdin) chunks.push(chunk as string);
-          return chunks.join("");
-        },
-        catch: (e) => new Error(`Failed to read stdin: ${e}`),
-      });
-      if (contents.trim().length > 0) return contents;
-    }
-
-    return yield* Effect.fail(
-      new Error("No code provided. Pass code as an argument, --file, or pipe to stdin."),
-    );
-  });
-
 const scope = Options.text("scope").pipe(
   Options.optional,
   Options.withDescription("Path to workspace directory containing executor.jsonc"),
@@ -610,67 +569,28 @@ const resolveToolInvocation = (input: {
 const callCommand = Command.make(
   "call",
   {
-    codeOrTool: Args.text({ name: "code-or-tool" }).pipe(Args.repeated),
-    file: Options.text("file").pipe(Options.optional),
-    stdin: Options.boolean("stdin").pipe(Options.withDefault(false)),
+    pathParts: Args.text({ name: "tool-path-segment" }).pipe(Args.repeated),
     baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
     scope,
   },
-  ({ codeOrTool, file, stdin, baseUrl, scope }) =>
+  ({ pathParts, baseUrl, scope }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      const singleArg = codeOrTool.length === 1 ? codeOrTool[0] : undefined;
-      const singleArgLooksLikeToolPath =
-        singleArg !== undefined && singleArg.includes(".") && isLikelyToolPathToken(singleArg);
-      const isToolInvocation =
-        !stdin &&
-        Option.isNone(file) &&
-        (codeOrTool.length > 1 || singleArgLooksLikeToolPath);
+      const { path, args } = yield* resolveToolInvocation({
+        rawPathParts: pathParts,
+      });
+      const code = yield* Effect.try({
+        try: () => buildInvokeToolCode(path, args),
+        catch: (cause) =>
+          cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
+      });
 
-      if (isToolInvocation) {
-        const { path, args } = yield* resolveToolInvocation({
-          rawPathParts: codeOrTool,
-        });
-        const code = yield* Effect.try({
-          try: () => buildInvokeToolCode(path, args),
-          catch: (cause) =>
-            cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
-        });
-
-        const outcome = yield* executeCode({ baseUrl, code });
-        yield* printExecutionOutcome({ baseUrl, outcome });
-        return;
-      }
-
-      const inlineCode = singleArg !== undefined ? Option.some(singleArg) : Option.none<string>();
-      const resolvedCode = yield* readCode({ code: inlineCode, file, stdin });
-      const daemonUrl = yield* ensureDaemon(baseUrl);
-
-      const client = yield* makeApiClient(daemonUrl);
-      const result = yield* client.executions.execute({ payload: { code: resolvedCode } });
-
-      if (result.status === "completed") {
-        if (result.isError) {
-          console.error(result.text);
-          process.exit(1);
-        } else {
-          console.log(result.text);
-          process.exit(0);
-        }
-      } else {
-        console.log(result.text);
-        const executionId = (result.structured as Record<string, unknown> | undefined)?.executionId;
-        if (executionId) {
-          console.log(
-            `\nTo resume:\n  ${cliPrefix} resume --execution-id ${executionId} --action accept`,
-          );
-        }
-        process.exit(0);
-      }
+      const outcome = yield* executeCode({ baseUrl, code });
+      yield* printExecutionOutcome({ baseUrl, outcome });
     }),
 ).pipe(
   Command.withDescription(
-    "Execute JavaScript or invoke a tool path (e.g. `executor call github issues create '{\"title\":\"Hi\"}'`)",
+    "Invoke a tool path (e.g. `executor call github issues create '{\"title\":\"Hi\"}'`)",
   ),
 );
 

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -581,24 +581,18 @@ const applyScope = (s: Option.Option<string>) => {
 
 const resolveToolInvocation = (input: {
   rawPathParts: ReadonlyArray<string>;
-  rawInput: string | undefined;
 }): Effect.Effect<{ path: string; args: Record<string, unknown> }, Error> =>
   Effect.gen(function* () {
-    const explicitInput = input.rawInput?.trim();
-    if (explicitInput && explicitInput.length > 0) {
-      const args = yield* parseJsonObjectInput(explicitInput);
-      const path = yield* Effect.try({
-        try: () => buildToolPath(input.rawPathParts),
-        catch: (cause) =>
-          cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
-      });
-      return { path, args };
-    }
-
     const maybeJsonArg = input.rawPathParts.at(-1)?.trim();
     const hasInlineJsonArg = maybeJsonArg !== undefined && maybeJsonArg.startsWith("{");
     const pathParts = hasInlineJsonArg ? input.rawPathParts.slice(0, -1) : input.rawPathParts;
     const args = hasInlineJsonArg ? yield* parseJsonObjectInput(maybeJsonArg) : {};
+
+    if (pathParts.some((part) => part.trim().startsWith("-"))) {
+      return yield* Effect.fail(
+        new Error("Tool invocation no longer accepts flags. Use: executor call <path...> '{...json...}'"),
+      );
+    }
 
     const path = yield* Effect.try({
       try: () => buildToolPath(pathParts),
@@ -617,31 +611,25 @@ const callCommand = Command.make(
   "call",
   {
     codeOrTool: Args.text({ name: "code-or-tool" }).pipe(Args.repeated),
-    input: Options.text("input")
-      .pipe(Options.optional)
-      .pipe(Options.withDescription("JSON object arguments when invoking a tool path")),
     file: Options.text("file").pipe(Options.optional),
     stdin: Options.boolean("stdin").pipe(Options.withDefault(false)),
     baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
     scope,
   },
-  ({ codeOrTool, input, file, stdin, baseUrl, scope }) =>
+  ({ codeOrTool, file, stdin, baseUrl, scope }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      const rawInput = Option.getOrUndefined(input);
-      const hasRawInput = rawInput !== undefined && rawInput.trim().length > 0;
       const singleArg = codeOrTool.length === 1 ? codeOrTool[0] : undefined;
       const singleArgLooksLikeToolPath =
         singleArg !== undefined && singleArg.includes(".") && isLikelyToolPathToken(singleArg);
       const isToolInvocation =
         !stdin &&
         Option.isNone(file) &&
-        (codeOrTool.length > 1 || hasRawInput || singleArgLooksLikeToolPath);
+        (codeOrTool.length > 1 || singleArgLooksLikeToolPath);
 
       if (isToolInvocation) {
         const { path, args } = yield* resolveToolInvocation({
           rawPathParts: codeOrTool,
-          rawInput,
         });
         const code = yield* Effect.try({
           try: () => buildInvokeToolCode(path, args),
@@ -779,74 +767,11 @@ const toolsDescribeCommand = Command.make(
     }),
 ).pipe(Command.withDescription("Describe a tool's TypeScript and JSON schema"));
 
-const toolsInvokeCommand = Command.make(
-  "invoke",
-  {
-    path: Args.text({ name: "path" }),
-    input: Options.text("input")
-      .pipe(Options.optional)
-      .pipe(Options.withDescription("JSON object arguments for the tool")),
-    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
-    scope,
-  },
-  ({ path, input, baseUrl, scope }) =>
-    Effect.gen(function* () {
-      applyScope(scope);
-      const args = yield* parseJsonObjectInput(Option.getOrUndefined(input));
-      const code = yield* Effect.try({
-        try: () => buildInvokeToolCode(path, args),
-        catch: (cause) =>
-          cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
-      });
-
-      const outcome = yield* executeCode({ baseUrl, code });
-      yield* printExecutionOutcome({ baseUrl, outcome });
-    }),
-).pipe(Command.withDescription("Invoke a tool by path (e.g. github.listIssues)"));
-
-const toolsRunCommand = Command.make(
-  "run",
-  {
-    pathParts: Args.text({ name: "tool-path-segment" }).pipe(Args.repeated),
-    input: Options.text("input")
-      .pipe(Options.optional)
-      .pipe(Options.withDescription("JSON object arguments for the tool")),
-    baseUrl: Options.text("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
-    scope,
-  },
-  ({ pathParts, input, baseUrl, scope }) =>
-    Effect.gen(function* () {
-      applyScope(scope);
-      const { path, args } = yield* resolveToolInvocation({
-        rawPathParts: pathParts,
-        rawInput: Option.getOrUndefined(input),
-      });
-      const code = yield* Effect.try({
-        try: () => buildInvokeToolCode(path, args),
-        catch: (cause) =>
-          cause instanceof Error ? cause : new Error(`Invalid tool path: ${String(cause)}`),
-      });
-
-      const outcome = yield* executeCode({ baseUrl, code });
-      yield* printExecutionOutcome({ baseUrl, outcome });
-    }),
-).pipe(
-  Command.withDescription(
-    "Run a tool by path segments (e.g. `executor tools run github issues list '{\"owner\":\"octo\"}'`)",
-  ),
-);
-
 const toolsCommand = Command.make("tools").pipe(
   Command.withSubcommands(
-    [
-      toolsSearchCommand,
-      toolsSourcesCommand,
-      toolsDescribeCommand,
-      toolsInvokeCommand,
-      toolsRunCommand,
-    ] as const,
+    [toolsSearchCommand, toolsSourcesCommand, toolsDescribeCommand] as const,
   ),
-  Command.withDescription("Discover and invoke tools without writing JavaScript"),
+  Command.withDescription("Discover available tools and sources"),
 );
 
 const webCommand = Command.make(

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -3,14 +3,29 @@ import * as Effect from "effect/Effect";
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const toToolPathSegments = (toolPath: string): ReadonlyArray<string> =>
-  toolPath
-    .split(".")
+const TOOL_PATH_TOKEN = /^[A-Za-z0-9._-]+$/;
+
+const toToolPathSegments = (parts: ReadonlyArray<string>): ReadonlyArray<string> =>
+  parts
+    .flatMap((part) => part.split("."))
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0);
 
+export const buildToolPath = (parts: ReadonlyArray<string>): string => {
+  const segments = toToolPathSegments(parts);
+  if (segments.length === 0) {
+    throw new Error("Tool path must include at least one segment");
+  }
+  return segments.join(".");
+};
+
+export const isLikelyToolPathToken = (raw: string): boolean => {
+  const value = raw.trim();
+  return value.length > 0 && TOOL_PATH_TOKEN.test(value);
+};
+
 const buildToolAccessExpression = (toolPath: string): string => {
-  const segments = toToolPathSegments(toolPath);
+  const segments = toToolPathSegments([toolPath]);
   if (segments.length === 0) {
     throw new Error("Tool path must include at least one segment");
   }
@@ -92,42 +107,5 @@ export const buildInvokeToolCode = (toolPath: string, args: Record<string, unkno
     "  throw new Error(`Tool not found: ${__toolPath}`);",
     "}",
     "return await __target(__args);",
-  ].join("\n");
-};
-
-export const buildRunToolQueryCode = (input: {
-  query: string;
-  namespace?: string;
-  args: Record<string, unknown>;
-  limit: number;
-}): string => {
-  const payload: Record<string, unknown> = {
-    query: input.query,
-    limit: input.limit,
-  };
-  if (input.namespace && input.namespace.trim().length > 0) {
-    payload.namespace = input.namespace;
-  }
-
-  return [
-    `const __matches = await tools.search(${JSON.stringify(payload)});`,
-    "if (!Array.isArray(__matches) || __matches.length === 0) {",
-    `  throw new Error(${JSON.stringify(`No tool matches query: ${input.query}`)});`,
-    "}",
-    "const __path = __matches[0]?.path;",
-    'if (typeof __path !== "string" || __path.trim().length === 0) {',
-    '  throw new Error("Top search result did not include a tool path");',
-    "}",
-    "let __target = tools;",
-    "for (const __segment of __path.split('.')) {",
-    "  if (!__segment) continue;",
-    "  __target = __target?.[__segment];",
-    "}",
-    'if (typeof __target !== "function") {',
-    "  throw new Error(`Tool not found: ${__path}`);",
-    "}",
-    `const __args = ${JSON.stringify(input.args, null, 2)};`,
-    "const __result = await __target(__args);",
-    "return { path: __path, result: __result };",
   ].join("\n");
 };

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -1,0 +1,133 @@
+import * as Effect from "effect/Effect";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const toToolPathSegments = (toolPath: string): ReadonlyArray<string> =>
+  toolPath
+    .split(".")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+
+const buildToolAccessExpression = (toolPath: string): string => {
+  const segments = toToolPathSegments(toolPath);
+  if (segments.length === 0) {
+    throw new Error("Tool path must include at least one segment");
+  }
+  return segments.map((segment) => `[${JSON.stringify(segment)}]`).join("");
+};
+
+export const parseJsonObjectInput = (
+  raw: string | undefined,
+): Effect.Effect<Record<string, unknown>, Error> =>
+  Effect.gen(function* () {
+    if (raw === undefined || raw.trim().length === 0) {
+      return {};
+    }
+
+    const parsed = yield* Effect.try({
+      try: () => JSON.parse(raw) as unknown,
+      catch: (cause) =>
+        cause instanceof Error
+          ? new Error(`Invalid --input JSON: ${cause.message}`)
+          : new Error(`Invalid --input JSON: ${String(cause)}`),
+    });
+
+    if (!isRecord(parsed)) {
+      return yield* Effect.fail(new Error("--input must decode to a JSON object"));
+    }
+
+    return parsed;
+  });
+
+export const extractExecutionResult = (structured: unknown): unknown => {
+  if (!isRecord(structured) || !("result" in structured)) {
+    return null;
+  }
+  return structured.result;
+};
+
+export const extractExecutionId = (structured: unknown): string | undefined => {
+  if (!isRecord(structured) || typeof structured.executionId !== "string") {
+    return undefined;
+  }
+  return structured.executionId;
+};
+
+export const buildSearchToolsCode = (input: {
+  query: string;
+  namespace?: string;
+  limit: number;
+}): string => {
+  const payload: Record<string, unknown> = {
+    query: input.query,
+    limit: input.limit,
+  };
+  if (input.namespace && input.namespace.trim().length > 0) {
+    payload.namespace = input.namespace;
+  }
+  return `return await tools.search(${JSON.stringify(payload)});`;
+};
+
+export const buildListSourcesCode = (input: { query?: string; limit: number }): string => {
+  const payload: Record<string, unknown> = {
+    limit: input.limit,
+  };
+  if (input.query && input.query.trim().length > 0) {
+    payload.query = input.query;
+  }
+  return `return await tools.executor.sources.list(${JSON.stringify(payload)});`;
+};
+
+export const buildDescribeToolCode = (toolPath: string): string =>
+  `return await tools.describe.tool({ path: ${JSON.stringify(toolPath)} });`;
+
+export const buildInvokeToolCode = (toolPath: string, args: Record<string, unknown>): string => {
+  const access = buildToolAccessExpression(toolPath);
+  return [
+    `const __toolPath = ${JSON.stringify(toolPath)};`,
+    `const __args = ${JSON.stringify(args, null, 2)};`,
+    `const __target = tools${access};`,
+    `if (typeof __target !== "function") {`,
+    "  throw new Error(`Tool not found: ${__toolPath}`);",
+    "}",
+    "return await __target(__args);",
+  ].join("\n");
+};
+
+export const buildRunToolQueryCode = (input: {
+  query: string;
+  namespace?: string;
+  args: Record<string, unknown>;
+  limit: number;
+}): string => {
+  const payload: Record<string, unknown> = {
+    query: input.query,
+    limit: input.limit,
+  };
+  if (input.namespace && input.namespace.trim().length > 0) {
+    payload.namespace = input.namespace;
+  }
+
+  return [
+    `const __matches = await tools.search(${JSON.stringify(payload)});`,
+    "if (!Array.isArray(__matches) || __matches.length === 0) {",
+    `  throw new Error(${JSON.stringify(`No tool matches query: ${input.query}`)});`,
+    "}",
+    "const __path = __matches[0]?.path;",
+    'if (typeof __path !== "string" || __path.trim().length === 0) {',
+    '  throw new Error("Top search result did not include a tool path");',
+    "}",
+    "let __target = tools;",
+    "for (const __segment of __path.split('.')) {",
+    "  if (!__segment) continue;",
+    "  __target = __target?.[__segment];",
+    "}",
+    'if (typeof __target !== "function") {',
+    "  throw new Error(`Tool not found: ${__path}`);",
+    "}",
+    `const __args = ${JSON.stringify(input.args, null, 2)};`,
+    "const __result = await __target(__args);",
+    "return { path: __path, result: __result };",
+  ].join("\n");
+};

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -44,12 +44,12 @@ export const parseJsonObjectInput = (
       try: () => JSON.parse(raw) as unknown,
       catch: (cause) =>
         cause instanceof Error
-          ? new Error(`Invalid --input JSON: ${cause.message}`)
-          : new Error(`Invalid --input JSON: ${String(cause)}`),
+          ? new Error(`Invalid JSON arguments: ${cause.message}`)
+          : new Error(`Invalid JSON arguments: ${String(cause)}`),
     });
 
     if (!isRecord(parsed)) {
-      return yield* Effect.fail(new Error("--input must decode to a JSON object"));
+      return yield* Effect.fail(new Error("Tool arguments must decode to a JSON object"));
     }
 
     return parsed;

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -16,12 +16,12 @@ export const buildToolPath = (parts: ReadonlyArray<string>): string => {
   if (segments.length === 0) {
     throw new Error("Tool path must include at least one segment");
   }
+  if (segments.some((segment) => !TOOL_PATH_TOKEN.test(segment))) {
+    throw new Error(
+      "Tool path segments must contain only letters, numbers, '.', '_' or '-'",
+    );
+  }
   return segments.join(".");
-};
-
-export const isLikelyToolPathToken = (raw: string): boolean => {
-  const value = raw.trim();
-  return value.length > 0 && TOOL_PATH_TOKEN.test(value);
 };
 
 const buildToolAccessExpression = (toolPath: string): string => {

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -3,6 +3,14 @@ import * as Effect from "effect/Effect";
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const stripRepeatedErrorPrefix = (input: string): string => {
+  let output = input.trim();
+  while (output.toLowerCase().startsWith("error:")) {
+    output = output.slice("error:".length).trimStart();
+  }
+  return output;
+};
+
 const TOOL_PATH_TOKEN = /^[A-Za-z0-9._-]+$/;
 
 const toToolPathSegments = (parts: ReadonlyArray<string>): ReadonlyArray<string> =>
@@ -139,6 +147,36 @@ export const extractExecutionId = (structured: unknown): string | undefined => {
     return undefined;
   }
   return structured.executionId;
+};
+
+export const normalizeCliErrorText = (raw: string): string => {
+  const lines = raw.split(/\r?\n/);
+  const compacted: Array<string> = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      if (compacted.length > 0 && compacted[compacted.length - 1] !== "") {
+        compacted.push("");
+      }
+      continue;
+    }
+    if (/^at\s+/.test(trimmed)) continue;
+    if (/^From previous event/.test(trimmed)) continue;
+    compacted.push(trimmed);
+  }
+
+  if (compacted.length === 0) {
+    return stripRepeatedErrorPrefix(raw);
+  }
+
+  compacted[0] = stripRepeatedErrorPrefix(compacted[0] ?? "");
+  while (compacted.length > 0 && compacted[0]?.length === 0) {
+    compacted.shift();
+  }
+
+  const limited = compacted.slice(0, 24);
+  return limited.join("\n").trim();
 };
 
 export interface PausedInteraction {

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -141,6 +141,147 @@ export const extractExecutionId = (structured: unknown): string | undefined => {
   return structured.executionId;
 };
 
+export interface PausedInteraction {
+  readonly kind: "url" | "form";
+  readonly message: string;
+  readonly url?: string;
+  readonly requestedSchema?: Record<string, unknown>;
+}
+
+export const extractPausedInteraction = (
+  structured: unknown,
+): PausedInteraction | undefined => {
+  if (!isRecord(structured) || !isRecord(structured.interaction)) {
+    return undefined;
+  }
+
+  const interaction = structured.interaction;
+  if (
+    (interaction.kind !== "url" && interaction.kind !== "form") ||
+    typeof interaction.message !== "string"
+  ) {
+    return undefined;
+  }
+
+  const base: PausedInteraction = {
+    kind: interaction.kind,
+    message: interaction.message,
+  };
+
+  if (interaction.kind === "url" && typeof interaction.url === "string") {
+    return { ...base, url: interaction.url };
+  }
+
+  if (interaction.kind === "form" && isRecord(interaction.requestedSchema)) {
+    return { ...base, requestedSchema: interaction.requestedSchema };
+  }
+
+  return base;
+};
+
+const schemaExample = (schema: unknown, depth = 0): unknown => {
+  if (!isRecord(schema) || depth > 4) return {};
+
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum[0];
+  }
+
+  const candidate = Array.isArray(schema.oneOf)
+    ? schema.oneOf[0]
+    : Array.isArray(schema.anyOf)
+      ? schema.anyOf[0]
+      : Array.isArray(schema.allOf)
+        ? schema.allOf[0]
+        : undefined;
+
+  if (candidate !== undefined) {
+    return schemaExample(candidate, depth + 1);
+  }
+
+  if (schema.type === "string") return "<string>";
+  if (schema.type === "number" || schema.type === "integer") return 0;
+  if (schema.type === "boolean") return false;
+  if (schema.type === "array") return [];
+
+  const properties = isRecord(schema.properties) ? schema.properties : undefined;
+  if (schema.type === "object" || properties) {
+    const required = Array.isArray(schema.required)
+      ? schema.required.filter((key): key is string => typeof key === "string")
+      : undefined;
+    const keys = Object.keys(properties ?? {});
+    const selectedKeys = required && required.length > 0 ? required : keys;
+    const result: Record<string, unknown> = {};
+    for (const key of selectedKeys) {
+      const value = properties?.[key];
+      result[key] = schemaExample(value, depth + 1);
+    }
+    return result;
+  }
+
+  return {};
+};
+
+export const buildResumeContentTemplate = (
+  requestedSchema: Record<string, unknown> | undefined,
+): Record<string, unknown> => schemaExample(requestedSchema ?? {}) as Record<string, unknown>;
+
+const tokenizeSegment = (input: string): ReadonlyArray<string> =>
+  input
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[._-]+/g, " ")
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+
+const tokenVariants = (input: string): ReadonlyArray<string> => {
+  const token = input.toLowerCase();
+  const variants = new Set<string>([token]);
+
+  if (token.endsWith("ies") && token.length > 3) {
+    variants.add(`${token.slice(0, -3)}y`);
+  } else if (token.endsWith("s") && token.length > 1) {
+    variants.add(token.slice(0, -1));
+  } else {
+    variants.add(`${token}s`);
+    if (token.endsWith("y") && token.length > 1) {
+      variants.add(`${token.slice(0, -1)}ies`);
+    }
+  }
+
+  return [...variants];
+};
+
+const segmentMatchesToken = (segment: string, queryToken: string): boolean => {
+  const normalizedSegment = segment.toLowerCase();
+  const segmentTokens = tokenizeSegment(segment);
+  const variants = tokenVariants(queryToken);
+  return variants.some((variant) => {
+    if (normalizedSegment.includes(variant)) return true;
+    return segmentTokens.some((token) => token === variant || token.startsWith(variant));
+  });
+};
+
+export const filterToolPathChildren = (
+  children: ReadonlyArray<ToolPathChildEntry>,
+  query: string | undefined,
+): ReadonlyArray<ToolPathChildEntry> => {
+  if (!query || query.trim().length === 0) {
+    return children;
+  }
+  const tokens = query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+  if (tokens.length === 0) {
+    return children;
+  }
+  return children.filter((child) =>
+    tokens.every((token) => segmentMatchesToken(child.segment, token)),
+  );
+};
+
 export const buildSearchToolsCode = (input: {
   query: string;
   namespace?: string;

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -11,6 +11,78 @@ const toToolPathSegments = (parts: ReadonlyArray<string>): ReadonlyArray<string>
     .map((segment) => segment.trim())
     .filter((segment) => segment.length > 0);
 
+const isPrefixOf = (prefix: ReadonlyArray<string>, path: ReadonlyArray<string>): boolean =>
+  prefix.every((segment, index) => path[index] === segment);
+
+export interface ToolPathChildEntry {
+  readonly segment: string;
+  readonly invokable: boolean;
+  readonly hasChildren: boolean;
+  readonly toolCount: number;
+}
+
+export interface ToolPathInspection {
+  readonly prefixSegments: ReadonlyArray<string>;
+  readonly exactPath: string | undefined;
+  readonly matchingToolCount: number;
+  readonly children: ReadonlyArray<ToolPathChildEntry>;
+}
+
+export const inspectToolPath = (input: {
+  toolPaths: ReadonlyArray<string>;
+  rawPrefixParts: ReadonlyArray<string>;
+}): ToolPathInspection => {
+  const prefixSegments =
+    input.rawPrefixParts.length === 0 ? [] : buildToolPath(input.rawPrefixParts).split(".");
+  const children = new Map<string, { invokable: boolean; hasChildren: boolean; toolCount: number }>();
+  let exactPath: string | undefined = undefined;
+  let matchingToolCount = 0;
+
+  for (const path of input.toolPaths) {
+    const segments = toToolPathSegments([path]);
+    if (segments.length === 0 || !isPrefixOf(prefixSegments, segments)) {
+      continue;
+    }
+
+    matchingToolCount += 1;
+
+    if (segments.length === prefixSegments.length) {
+      exactPath = exactPath ?? segments.join(".");
+      continue;
+    }
+
+    const childSegment = segments[prefixSegments.length];
+    if (!childSegment) continue;
+
+    const existing = children.get(childSegment) ?? {
+      invokable: false,
+      hasChildren: false,
+      toolCount: 0,
+    };
+    children.set(childSegment, {
+      invokable: existing.invokable || segments.length === prefixSegments.length + 1,
+      hasChildren: existing.hasChildren || segments.length > prefixSegments.length + 1,
+      toolCount: existing.toolCount + 1,
+    });
+  }
+
+  const sortedChildren: ReadonlyArray<ToolPathChildEntry> = [...children.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([segment, value]) => ({
+      segment,
+      invokable: value.invokable,
+      hasChildren: value.hasChildren,
+      toolCount: value.toolCount,
+    }));
+
+  return {
+    prefixSegments,
+    exactPath,
+    matchingToolCount,
+    children: sortedChildren,
+  };
+};
+
 export const buildToolPath = (parts: ReadonlyArray<string>): string => {
   const segments = toToolPathSegments(parts);
   if (segments.length === 0) {

--- a/apps/local/src/serve.test.ts
+++ b/apps/local/src/serve.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+vi.mock("./server/main", () => ({
+  getServerHandlers: async () => ({
+    api: {
+      handler: async () => new Response("ok"),
+      dispose: async () => {},
+    },
+    mcp: {
+      handleRequest: async () => new Response("ok"),
+      close: async () => {},
+    },
+  }),
+}));
+
+import { startServer, type ServerInstance } from "./serve";
+
+let clientDir: string;
+let server: ServerInstance | null = null;
+
+const startTestServer = async (): Promise<string> => {
+  server = await startServer({
+    port: 0,
+    hostname: "127.0.0.1",
+    clientDir,
+  });
+  return `http://127.0.0.1:${server.port}`;
+};
+
+beforeEach(() => {
+  clientDir = mkdtempSync(join(tmpdir(), "exec-local-serve-"));
+  mkdirSync(join(clientDir, "assets"), { recursive: true });
+  writeFileSync(join(clientDir, "index.html"), "<!doctype html><html><body>index-shell</body></html>");
+  writeFileSync(join(clientDir, "assets", "app.js"), "console.log('ok')");
+});
+
+afterEach(async () => {
+  if (server) {
+    await server.stop();
+    server = null;
+  }
+  rmSync(clientDir, { recursive: true, force: true });
+});
+
+describe("startServer static/SPA routing", () => {
+  it("returns 404 for missing asset-like paths", async () => {
+    const baseUrl = await startTestServer();
+    const response = await fetch(`${baseUrl}/assets/missing.js`);
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("Not Found");
+  });
+
+  it("falls back to index.html for extension-less SPA routes", async () => {
+    const baseUrl = await startTestServer();
+    const response = await fetch(`${baseUrl}/sources/add`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/html");
+    expect(await response.text()).toContain("index-shell");
+  });
+});

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -30,6 +30,11 @@ const makeIsAllowedHost = (allowed: ReadonlySet<string>) => (request: Request): 
 
 type StaticHandler = () => Response | Promise<Response>;
 
+const hasFileExtension = (pathname: string): boolean => {
+  const lastSegment = pathname.split("/").at(-1) ?? "";
+  return lastSegment.includes(".");
+};
+
 function collectStaticRoutes(dir: string, prefix = ""): Record<string, StaticHandler> {
   const routes: Record<string, StaticHandler> = {};
   try {
@@ -131,6 +136,13 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
       if (url.pathname.startsWith("/api/") || url.pathname === "/api") {
         url.pathname = url.pathname.slice("/api".length) || "/";
         return handlers.api.handler(new Request(url, req));
+      }
+
+      // If a path looks like a static asset (has a file extension), do not
+      // fall back to SPA HTML. Returning index.html here causes browser module
+      // MIME errors when hashed chunks are stale/missing.
+      if (hasFileExtension(url.pathname)) {
+        return new Response("Not Found", { status: 404 });
       }
 
       // SPA fallback

--- a/tests/daemon-bootstrap.test.ts
+++ b/tests/daemon-bootstrap.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDaemonSpawnSpec,
+  canAutoStartLocalDaemonForHost,
+  parseDaemonBaseUrl,
+} from "../apps/cli/src/daemon";
+
+describe("daemon bootstrap helpers", () => {
+  it("parses default port when none is provided", () => {
+    const parsed = parseDaemonBaseUrl("http://localhost", 4788);
+    expect(parsed).toEqual({ hostname: "localhost", port: 4788 });
+  });
+
+  it("parses explicit port from base url", () => {
+    const parsed = parseDaemonBaseUrl("http://127.0.0.1:9001", 4788);
+    expect(parsed).toEqual({ hostname: "127.0.0.1", port: 9001 });
+  });
+
+  it("rejects non-http schemes for auto-start", () => {
+    expect(() => parseDaemonBaseUrl("https://localhost:4788", 4788)).toThrow(
+      "Only http:// base URLs are supported",
+    );
+  });
+
+  it("only auto-starts for local hosts", () => {
+    expect(canAutoStartLocalDaemonForHost("localhost")).toBe(true);
+    expect(canAutoStartLocalDaemonForHost("127.0.0.1")).toBe(true);
+    expect(canAutoStartLocalDaemonForHost("::1")).toBe(true);
+    expect(canAutoStartLocalDaemonForHost("api.example.com")).toBe(false);
+  });
+
+  it("builds bun-run spec in dev mode", () => {
+    const spec = buildDaemonSpawnSpec({
+      port: 4788,
+      hostname: "localhost",
+      isDevMode: true,
+      scriptPath: "/repo/apps/cli/src/main.ts",
+      executablePath: "/ignored",
+    });
+
+    expect(spec.command).toBe("bun");
+    expect(spec.args).toEqual([
+      "run",
+      "/repo/apps/cli/src/main.ts",
+      "daemon",
+      "run",
+      "--port",
+      "4788",
+      "--hostname",
+      "localhost",
+    ]);
+  });
+
+  it("builds executable spec outside dev mode", () => {
+    const spec = buildDaemonSpawnSpec({
+      port: 5000,
+      hostname: "127.0.0.1",
+      isDevMode: false,
+      scriptPath: undefined,
+      executablePath: "/usr/local/bin/executor",
+    });
+
+    expect(spec.command).toBe("/usr/local/bin/executor");
+    expect(spec.args).toEqual([
+      "daemon",
+      "run",
+      "--port",
+      "5000",
+      "--hostname",
+      "127.0.0.1",
+    ]);
+  });
+
+  it("fails in dev mode when script path is missing", () => {
+    expect(() =>
+      buildDaemonSpawnSpec({
+        port: 4788,
+        hostname: "localhost",
+        isDevMode: true,
+        scriptPath: undefined,
+        executablePath: "/usr/local/bin/executor",
+      }),
+    ).toThrow("Cannot auto-start daemon in dev mode");
+  });
+});

--- a/tests/daemon-bootstrap.test.ts
+++ b/tests/daemon-bootstrap.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { createServer } from "node:net";
+import * as Effect from "effect/Effect";
 
 import {
   buildDaemonSpawnSpec,
   canAutoStartLocalDaemonForHost,
+  chooseDaemonPort,
   parseDaemonBaseUrl,
 } from "../apps/cli/src/daemon";
 
@@ -82,5 +85,30 @@ describe("daemon bootstrap helpers", () => {
         executablePath: "/usr/local/bin/executor",
       }),
     ).toThrow("Cannot auto-start daemon in dev mode");
+  });
+
+  it("falls back when preferred daemon port is occupied", async () => {
+    const blocker = createServer();
+    await new Promise<void>((resolve, reject) => {
+      blocker.once("error", reject);
+      blocker.listen({ port: 0, host: "127.0.0.1" }, () => resolve());
+    });
+
+    const occupied = (() => {
+      const address = blocker.address();
+      return typeof address === "object" && address !== null ? address.port : 0;
+    })();
+
+    try {
+      const picked = await Effect.runPromise(
+        chooseDaemonPort({
+          preferredPort: occupied,
+          hostname: "127.0.0.1",
+        }),
+      );
+      expect(picked).not.toBe(occupied);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
   });
 });

--- a/tests/daemon-state.test.ts
+++ b/tests/daemon-state.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalDaemonHost,
+  isPidAlive,
+  readDaemonRecord,
+  removeDaemonRecord,
+  writeDaemonRecord,
+} from "../apps/cli/src/daemon-state";
+
+describe("daemon state", () => {
+  it("normalizes local host aliases", () => {
+    expect(canonicalDaemonHost("localhost")).toBe("localhost");
+    expect(canonicalDaemonHost("127.0.0.1")).toBe("localhost");
+    expect(canonicalDaemonHost("::1")).toBe("localhost");
+    expect(canonicalDaemonHost("0.0.0.0")).toBe("localhost");
+    expect(canonicalDaemonHost("api.example.com")).toBe("api.example.com");
+  });
+
+  it("writes, reads, and removes daemon records", async () => {
+    const prev = process.env.EXECUTOR_DATA_DIR;
+    const dir = mkdtempSync(join(tmpdir(), "executor-daemon-state-test-"));
+    process.env.EXECUTOR_DATA_DIR = dir;
+
+    try {
+      await writeDaemonRecord({
+        hostname: "127.0.0.1",
+        port: 4788,
+        pid: 12345,
+        scopeDir: "/tmp/scope",
+      });
+
+      const stored = await readDaemonRecord({ hostname: "localhost", port: 4788 });
+      expect(stored).toEqual({
+        version: 1,
+        hostname: "localhost",
+        port: 4788,
+        pid: 12345,
+        startedAt: expect.any(String),
+        scopeDir: "/tmp/scope",
+      });
+
+      await removeDaemonRecord({ hostname: "localhost", port: 4788 });
+      const after = await readDaemonRecord({ hostname: "localhost", port: 4788 });
+      expect(after).toBeNull();
+    } finally {
+      if (prev === undefined) {
+        delete process.env.EXECUTOR_DATA_DIR;
+      } else {
+        process.env.EXECUTOR_DATA_DIR = prev;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("detects live and invalid pids", () => {
+    expect(isPidAlive(process.pid)).toBe(true);
+    expect(isPidAlive(-1)).toBe(false);
+  });
+});

--- a/tests/daemon-state.test.ts
+++ b/tests/daemon-state.test.ts
@@ -9,10 +9,16 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
 
 import {
+  acquireDaemonStartLock,
   canonicalDaemonHost,
+  currentDaemonScopeId,
   isPidAlive,
+  readDaemonPointer,
   readDaemonRecord,
+  releaseDaemonStartLock,
+  removeDaemonPointer,
   removeDaemonRecord,
+  writeDaemonPointer,
   writeDaemonRecord,
 } from "../apps/cli/src/daemon-state";
 
@@ -31,9 +37,9 @@ const fileSystemLayer = FileSystem.layerNoop({
       try: () => mkdir(path, { recursive: options?.recursive, mode: options?.mode }),
       catch: (cause) => fileSystemError("makeDirectory", cause),
     }),
-  writeFileString: (path, data, _options) =>
+  writeFileString: (path, data, options) =>
     Effect.tryPromise({
-      try: () => writeFile(path, data, "utf8"),
+      try: () => writeFile(path, data, { encoding: "utf8", flag: options?.flag }),
       catch: (cause) => fileSystemError("writeFileString", cause),
     }),
   readFileString: (path, encoding = "utf8") =>
@@ -103,6 +109,86 @@ describe("daemon state", () => {
       }),
     ),
   );
+
+  it.effect("writes, reads, and removes daemon pointers", () =>
+    withDaemonDataDir(
+      Effect.gen(function* () {
+        yield* writeDaemonPointer({
+          hostname: "127.0.0.1",
+          port: 5799,
+          pid: 24680,
+          scopeId: "scope:/tmp/project",
+          scopeDir: "/tmp/project",
+          token: "tok_123",
+        });
+
+        const stored = yield* readDaemonPointer({
+          hostname: "localhost",
+          scopeId: "scope:/tmp/project",
+        });
+        expect(stored).toEqual({
+          version: 1,
+          hostname: "localhost",
+          port: 5799,
+          pid: 24680,
+          startedAt: expect.any(String),
+          scopeId: "scope:/tmp/project",
+          scopeDir: "/tmp/project",
+          token: "tok_123",
+        });
+
+        yield* removeDaemonPointer({
+          hostname: "localhost",
+          scopeId: "scope:/tmp/project",
+        });
+        const after = yield* readDaemonPointer({
+          hostname: "localhost",
+          scopeId: "scope:/tmp/project",
+        });
+        expect(after).toBeNull();
+      }),
+    ),
+  );
+
+  it.effect("serializes daemon startup with lock files", () =>
+    withDaemonDataDir(
+      Effect.gen(function* () {
+        const lock = yield* acquireDaemonStartLock({
+          hostname: "localhost",
+          scopeId: "scope:/tmp/project",
+        });
+
+        const second = yield* acquireDaemonStartLock({
+          hostname: "localhost",
+          scopeId: "scope:/tmp/project",
+        }).pipe(Effect.flip);
+
+        expect(second.message).toContain("already in progress");
+
+        yield* releaseDaemonStartLock(lock);
+
+        const third = yield* acquireDaemonStartLock({
+          hostname: "localhost",
+          scopeId: "scope:/tmp/project",
+        });
+        yield* releaseDaemonStartLock(third);
+      }),
+    ),
+  );
+
+  it("derives scope id from EXECUTOR_SCOPE_DIR or cwd", () => {
+    const prev = process.env.EXECUTOR_SCOPE_DIR;
+    process.env.EXECUTOR_SCOPE_DIR = "/tmp/explicit-scope";
+    expect(currentDaemonScopeId()).toBe("scope:/tmp/explicit-scope");
+
+    if (prev === undefined) {
+      delete process.env.EXECUTOR_SCOPE_DIR;
+    } else {
+      process.env.EXECUTOR_SCOPE_DIR = prev;
+    }
+
+    expect(currentDaemonScopeId()).toContain("cwd:");
+  });
 
   it("detects live and invalid pids", () => {
     expect(isPidAlive(process.pid)).toBe(true);

--- a/tests/daemon-state.test.ts
+++ b/tests/daemon-state.test.ts
@@ -1,7 +1,12 @@
 import { mkdtempSync, rmSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { FileSystem } from "@effect/platform";
+import * as PlatformError from "@effect/platform/Error";
+import * as PlatformPath from "@effect/platform/Path";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
 
 import {
   canonicalDaemonHost,
@@ -10,6 +15,58 @@ import {
   removeDaemonRecord,
   writeDaemonRecord,
 } from "../apps/cli/src/daemon-state";
+
+const fileSystemError = (method: string, cause: unknown) =>
+  new PlatformError.SystemError({
+    module: "FileSystem",
+    method,
+    reason: "Unknown",
+    description: cause instanceof Error ? cause.message : String(cause),
+    cause,
+  });
+
+const fileSystemLayer = FileSystem.layerNoop({
+  makeDirectory: (path, options) =>
+    Effect.tryPromise({
+      try: () => mkdir(path, { recursive: options?.recursive, mode: options?.mode }),
+      catch: (cause) => fileSystemError("makeDirectory", cause),
+    }),
+  writeFileString: (path, data, _options) =>
+    Effect.tryPromise({
+      try: () => writeFile(path, data, "utf8"),
+      catch: (cause) => fileSystemError("writeFileString", cause),
+    }),
+  readFileString: (path, encoding = "utf8") =>
+    Effect.tryPromise({
+      try: () => readFile(path, { encoding: encoding as BufferEncoding }),
+      catch: (cause) => fileSystemError("readFileString", cause),
+    }),
+  remove: (path, options) =>
+    Effect.tryPromise({
+      try: () => rm(path, { recursive: options?.recursive ?? false, force: options?.force ?? false }),
+      catch: (cause) => fileSystemError("remove", cause),
+    }),
+});
+
+const daemonStateLayer = Layer.merge(fileSystemLayer, PlatformPath.layer);
+
+const withDaemonDataDir = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | PlatformPath.Path>) =>
+  Effect.gen(function* () {
+    const prev = process.env.EXECUTOR_DATA_DIR;
+    const dir = mkdtempSync(join(tmpdir(), "executor-daemon-state-test-"));
+    process.env.EXECUTOR_DATA_DIR = dir;
+
+    try {
+      return yield* effect;
+    } finally {
+      if (prev === undefined) {
+        delete process.env.EXECUTOR_DATA_DIR;
+      } else {
+        process.env.EXECUTOR_DATA_DIR = prev;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }).pipe(Effect.provide(daemonStateLayer));
 
 describe("daemon state", () => {
   it("normalizes local host aliases", () => {
@@ -20,41 +77,32 @@ describe("daemon state", () => {
     expect(canonicalDaemonHost("api.example.com")).toBe("api.example.com");
   });
 
-  it("writes, reads, and removes daemon records", async () => {
-    const prev = process.env.EXECUTOR_DATA_DIR;
-    const dir = mkdtempSync(join(tmpdir(), "executor-daemon-state-test-"));
-    process.env.EXECUTOR_DATA_DIR = dir;
+  it.effect("writes, reads, and removes daemon records", () =>
+    withDaemonDataDir(
+      Effect.gen(function* () {
+        yield* writeDaemonRecord({
+          hostname: "127.0.0.1",
+          port: 4788,
+          pid: 12345,
+          scopeDir: "/tmp/scope",
+        });
 
-    try {
-      await writeDaemonRecord({
-        hostname: "127.0.0.1",
-        port: 4788,
-        pid: 12345,
-        scopeDir: "/tmp/scope",
-      });
+        const stored = yield* readDaemonRecord({ hostname: "localhost", port: 4788 });
+        expect(stored).toEqual({
+          version: 1,
+          hostname: "localhost",
+          port: 4788,
+          pid: 12345,
+          startedAt: expect.any(String),
+          scopeDir: "/tmp/scope",
+        });
 
-      const stored = await readDaemonRecord({ hostname: "localhost", port: 4788 });
-      expect(stored).toEqual({
-        version: 1,
-        hostname: "localhost",
-        port: 4788,
-        pid: 12345,
-        startedAt: expect.any(String),
-        scopeDir: "/tmp/scope",
-      });
-
-      await removeDaemonRecord({ hostname: "localhost", port: 4788 });
-      const after = await readDaemonRecord({ hostname: "localhost", port: 4788 });
-      expect(after).toBeNull();
-    } finally {
-      if (prev === undefined) {
-        delete process.env.EXECUTOR_DATA_DIR;
-      } else {
-        process.env.EXECUTOR_DATA_DIR = prev;
-      }
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
+        yield* removeDaemonRecord({ hostname: "localhost", port: 4788 });
+        const after = yield* readDaemonRecord({ hostname: "localhost", port: 4788 });
+        expect(after).toBeNull();
+      }),
+    ),
+  );
 
   it("detects live and invalid pids", () => {
     expect(isPidAlive(process.pid)).toBe(true);

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import {
+  buildToolPath,
   buildInvokeToolCode,
   buildListSourcesCode,
-  buildRunToolQueryCode,
   buildSearchToolsCode,
   extractExecutionId,
   extractExecutionResult,
+  isLikelyToolPathToken,
   parseJsonObjectInput,
 } from "../apps/cli/src/tooling";
 
@@ -39,6 +40,16 @@ describe("CLI tooling helpers", () => {
     expect(code).toContain('const __args = {');
   });
 
+  it("builds tool paths from dot or segmented forms", () => {
+    expect(buildToolPath(["github", "issues", "create"])).toBe("github.issues.create");
+    expect(buildToolPath(["github.issues", "create"])).toBe("github.issues.create");
+  });
+
+  it("detects likely tool path tokens", () => {
+    expect(isLikelyToolPathToken("github.issues.create")).toBe(true);
+    expect(isLikelyToolPathToken("return await tools.search({})")).toBe(false);
+  });
+
   it("builds search and sources code snippets", () => {
     const searchCode = buildSearchToolsCode({
       query: "google calendar events",
@@ -51,19 +62,6 @@ describe("CLI tooling helpers", () => {
       'return await tools.search({"query":"google calendar events","limit":5,"namespace":"google"});',
     );
     expect(sourcesCode).toBe('return await tools.executor.sources.list({"limit":20,"query":"google"});');
-  });
-
-  it("builds query-run code that selects and invokes the top search result", () => {
-    const code = buildRunToolQueryCode({
-      query: "google calendar list events",
-      namespace: "google",
-      args: { calendarId: "primary" },
-      limit: 3,
-    });
-
-    expect(code).toContain('const __matches = await tools.search({"query":"google calendar list events","limit":3,"namespace":"google"});');
-    expect(code).toContain("const __result = await __target(__args);");
-    expect(code).toContain("return { path: __path, result: __result };");
   });
 
   it("extracts completed result payload and pause execution id", () => {

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import {
+  buildInvokeToolCode,
+  buildListSourcesCode,
+  buildRunToolQueryCode,
+  buildSearchToolsCode,
+  extractExecutionId,
+  extractExecutionResult,
+  parseJsonObjectInput,
+} from "../apps/cli/src/tooling";
+
+describe("CLI tooling helpers", () => {
+  it.effect("parses empty input as an empty args object", () =>
+    Effect.gen(function* () {
+      const args = yield* parseJsonObjectInput(undefined);
+      expect(args).toEqual({});
+    }),
+  );
+
+  it.effect("parses JSON object input", () =>
+    Effect.gen(function* () {
+      const args = yield* parseJsonObjectInput('{"calendarId":"primary"}');
+      expect(args).toEqual({ calendarId: "primary" });
+    }),
+  );
+
+  it.effect("rejects non-object JSON input", () =>
+    Effect.gen(function* () {
+      const error = yield* parseJsonObjectInput('[1,2,3]').pipe(Effect.flip);
+      expect(error.message).toContain("must decode to a JSON object");
+    }),
+  );
+
+  it("builds bracket-safe invocation code for dynamic tool paths", () => {
+    const code = buildInvokeToolCode("google-drive.files.list", { pageSize: 10 });
+    expect(code).toContain('const __target = tools["google-drive"]["files"]["list"]');
+    expect(code).toContain('const __args = {');
+  });
+
+  it("builds search and sources code snippets", () => {
+    const searchCode = buildSearchToolsCode({
+      query: "google calendar events",
+      namespace: "google",
+      limit: 5,
+    });
+    const sourcesCode = buildListSourcesCode({ query: "google", limit: 20 });
+
+    expect(searchCode).toBe(
+      'return await tools.search({"query":"google calendar events","limit":5,"namespace":"google"});',
+    );
+    expect(sourcesCode).toBe('return await tools.executor.sources.list({"limit":20,"query":"google"});');
+  });
+
+  it("builds query-run code that selects and invokes the top search result", () => {
+    const code = buildRunToolQueryCode({
+      query: "google calendar list events",
+      namespace: "google",
+      args: { calendarId: "primary" },
+      limit: 3,
+    });
+
+    expect(code).toContain('const __matches = await tools.search({"query":"google calendar list events","limit":3,"namespace":"google"});');
+    expect(code).toContain("const __result = await __target(__args);");
+    expect(code).toContain("return { path: __path, result: __result };");
+  });
+
+  it("extracts completed result payload and pause execution id", () => {
+    expect(extractExecutionResult({ status: "completed", result: { ok: true }, logs: [] })).toEqual({
+      ok: true,
+    });
+    expect(extractExecutionResult({ status: "completed" })).toBeNull();
+
+    expect(extractExecutionId({ executionId: "exec_123" })).toBe("exec_123");
+    expect(extractExecutionId({ executionId: 123 })).toBeUndefined();
+  });
+});

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -8,7 +8,6 @@ import {
   buildSearchToolsCode,
   extractExecutionId,
   extractExecutionResult,
-  isLikelyToolPathToken,
   parseJsonObjectInput,
 } from "../apps/cli/src/tooling";
 
@@ -45,9 +44,8 @@ describe("CLI tooling helpers", () => {
     expect(buildToolPath(["github.issues", "create"])).toBe("github.issues.create");
   });
 
-  it("detects likely tool path tokens", () => {
-    expect(isLikelyToolPathToken("github.issues.create")).toBe(true);
-    expect(isLikelyToolPathToken("return await tools.search({})")).toBe(false);
+  it("rejects invalid tool-path segments", () => {
+    expect(() => buildToolPath(["github", "issues", "create now"])).toThrow();
   });
 
   it("builds search and sources code snippets", () => {

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -12,6 +12,7 @@ import {
   extractExecutionId,
   extractExecutionResult,
   inspectToolPath,
+  normalizeCliErrorText,
   parseJsonObjectInput,
 } from "../apps/cli/src/tooling";
 
@@ -165,5 +166,15 @@ describe("CLI tooling helpers", () => {
     expect(filterToolPathChildren(children, "worker").map((entry) => entry.segment)).toEqual([
       "workersAi",
     ]);
+  });
+
+  it("normalizes stack-heavy CLI error text", () => {
+    const normalized = normalizeCliErrorText(`Error: Error: TypeError: bad
+      at fn1 (/tmp/a.ts:1:1)
+      at fn2 (/tmp/b.ts:2:2)
+From previous event:
+      at fn3 (/tmp/c.ts:3:3)`);
+
+    expect(normalized).toBe("TypeError: bad");
   });
 });

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -8,6 +8,7 @@ import {
   buildSearchToolsCode,
   extractExecutionId,
   extractExecutionResult,
+  inspectToolPath,
   parseJsonObjectInput,
 } from "../apps/cli/src/tooling";
 
@@ -70,5 +71,37 @@ describe("CLI tooling helpers", () => {
 
     expect(extractExecutionId({ executionId: "exec_123" })).toBe("exec_123");
     expect(extractExecutionId({ executionId: 123 })).toBeUndefined();
+  });
+
+  it("inspects hierarchical tool path prefixes for call help", () => {
+    const view = inspectToolPath({
+      toolPaths: [
+        "cloudflare.dns.records.list",
+        "cloudflare.dns.records.create",
+        "cloudflare.dns.analytics",
+        "cloudflare.zones.list",
+      ],
+      rawPrefixParts: ["cloudflare", "dns"],
+    });
+
+    expect(view.prefixSegments).toEqual(["cloudflare", "dns"]);
+    expect(view.exactPath).toBeUndefined();
+    expect(view.matchingToolCount).toBe(3);
+    expect(view.children).toEqual([
+      { segment: "analytics", invokable: true, hasChildren: false, toolCount: 1 },
+      { segment: "records", invokable: false, hasChildren: true, toolCount: 2 },
+    ]);
+  });
+
+  it("reports exact matches for leaf tool paths", () => {
+    const view = inspectToolPath({
+      toolPaths: ["github.issues.create", "github.issues.list"],
+      rawPrefixParts: ["github", "issues", "create"],
+    });
+
+    expect(view.prefixSegments).toEqual(["github", "issues", "create"]);
+    expect(view.exactPath).toBe("github.issues.create");
+    expect(view.matchingToolCount).toBe(1);
+    expect(view.children).toEqual([]);
   });
 });

--- a/tests/tools-cli.test.ts
+++ b/tests/tools-cli.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import {
+  buildResumeContentTemplate,
   buildToolPath,
+  filterToolPathChildren,
   buildInvokeToolCode,
   buildListSourcesCode,
   buildSearchToolsCode,
+  extractPausedInteraction,
   extractExecutionId,
   extractExecutionResult,
   inspectToolPath,
@@ -103,5 +106,64 @@ describe("CLI tooling helpers", () => {
     expect(view.exactPath).toBe("github.issues.create");
     expect(view.matchingToolCount).toBe(1);
     expect(view.children).toEqual([]);
+  });
+
+  it("extracts paused form interaction payload", () => {
+    const interaction = extractPausedInteraction({
+      status: "waiting_for_interaction",
+      executionId: "exec_1",
+      interaction: {
+        kind: "form",
+        message: "Need approval",
+        requestedSchema: {
+          type: "object",
+          properties: {
+            approved: { type: "boolean" },
+          },
+          required: ["approved"],
+        },
+      },
+    });
+
+    expect(interaction).toEqual({
+      kind: "form",
+      message: "Need approval",
+      requestedSchema: {
+        type: "object",
+        properties: {
+          approved: { type: "boolean" },
+        },
+        required: ["approved"],
+      },
+    });
+  });
+
+  it("builds resume content template from requested schema", () => {
+    const template = buildResumeContentTemplate({
+      type: "object",
+      properties: {
+        approved: { type: "boolean" },
+        note: { type: "string" },
+      },
+      required: ["approved"],
+    });
+
+    expect(template).toEqual({ approved: false });
+  });
+
+  it("filters child segments with singular/plural matching", () => {
+    const children = [
+      { segment: "zoneRulesets", invokable: false, hasChildren: true, toolCount: 10 },
+      { segment: "dnsRecordsForAZone", invokable: false, hasChildren: true, toolCount: 14 },
+      { segment: "workersAi", invokable: false, hasChildren: true, toolCount: 8 },
+    ] as const;
+
+    expect(filterToolPathChildren(children, "zones").map((entry) => entry.segment)).toEqual([
+      "zoneRulesets",
+      "dnsRecordsForAZone",
+    ]);
+    expect(filterToolPathChildren(children, "worker").map((entry) => entry.segment)).toEqual([
+      "workersAi",
+    ]);
   });
 });


### PR DESCRIPTION
## What changed

- switched `executor call` and `executor resume` from in-process startup to daemon-first behavior via `ensureDaemon(...)`
- added a dedicated `daemon` helper module for spawn specs, URL parsing, and startup/shutdown polling
- added daemon process record persistence (`apps/cli/src/daemon-state.ts`) with pid/scope metadata under `EXECUTOR_DATA_DIR` (or `~/.executor`)
- added new CLI lifecycle commands:
  - `executor daemon status`
  - `executor daemon stop`
  - `executor daemon restart`
- made `executor daemon run` write/remove daemon ownership records
- documented the daemon commands in `README.md`
- added tests for daemon bootstrap + daemon record state

## Why this changed

Paused executions currently depend on an in-memory execution engine. If `executor call` starts the runtime in-process and exits, there is no live process left to resume from. This change makes CLI commands daemon-backed by default, so pause/resume flows can continue across command invocations.

## User and developer impact

- agents and users can run `executor call` and `executor resume` without manually booting `executor web`
- daemon lifecycle is now scriptable via status/stop/restart commands
- local ownership metadata enables safer stop/restart behavior instead of killing arbitrary reachable processes

## Root cause (fix context)

The root issue was process lifetime mismatch: short-lived CLI commands were responsible for starting execution state that must outlive those commands. Moving command execution to a persistent daemon process fixes that mismatch for local workflows.

## Validation

- `bun run --cwd apps/cli typecheck:slow`
- `bun x vitest run tests/daemon-bootstrap.test.ts tests/daemon-state.test.ts`
- manual checks:
  - `executor call --base-url http://localhost:4901 'return 41+1'` auto-started daemon and returned result
  - `executor daemon status --base-url http://localhost:4901`
  - `executor daemon restart --base-url http://localhost:4901`
  - `executor daemon stop --base-url http://localhost:4901`
