### PR TITLE
feat(otel): instrument tool dispatch, plugins, storage, schema, transport

### DIFF
--- a/apps/cloud/src/api/autumn.ts
+++ b/apps/cloud/src/api/autumn.ts
@@ -7,7 +7,7 @@ import { server } from "../env";
 import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
 import { SharedServices } from "./layers";
 
-const handleAutumnRequestEffect = Effect.gen(function* () {
+export const AutumnApiApp = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
   const webRequest = yield* Effect.mapError(
     HttpServerRequest.toWeb(request),
@@ -86,5 +86,3 @@ const handleAutumnRequestEffect = Effect.gen(function* () {
     return Effect.succeed(toErrorServerResponse(err));
   }),
 );
-
-export const AutumnApiApp = handleAutumnRequestEffect;

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -56,7 +56,7 @@ const createProtectedApp = (organizationId: string, organizationName: string) =>
     );
   });
 
-const handleProtectedRequestEffect = Effect.gen(function* () {
+export const ProtectedApiApp = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
   const org = yield* lookupOrgForRequest(request);
   if (!org) {
@@ -80,5 +80,3 @@ const handleProtectedRequestEffect = Effect.gen(function* () {
     return Effect.succeed(toErrorServerResponse(err));
   }),
 );
-
-export const ProtectedApiApp = handleProtectedRequestEffect;

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -211,6 +211,12 @@ export class McpSessionDO extends DurableObject {
     return this.sessionMeta;
   }
 
+  private loadSessionMetaEffect(): Effect.Effect<SessionMeta | null> {
+    return Effect.promise(() => this.loadSessionMeta()).pipe(
+      Effect.withSpan("mcp.session.load_meta"),
+    );
+  }
+
   private async saveSessionMeta(sessionMeta: SessionMeta): Promise<void> {
     this.sessionMeta = sessionMeta;
     await this.ctx.storage.put(SESSION_META_KEY, sessionMeta);
@@ -225,6 +231,12 @@ export class McpSessionDO extends DurableObject {
       this.ctx.storage.delete(TRANSPORT_STATE_KEY).catch(() => false),
       this.ctx.storage.delete(SESSION_META_KEY).catch(() => false),
     ]);
+  }
+
+  private clearSessionStateEffect(): Effect.Effect<void> {
+    return Effect.promise(() => this.clearSessionState()).pipe(
+      Effect.withSpan("mcp.session.clear_state"),
+    );
   }
 
   private createConnectedRuntimeEffect(
@@ -271,12 +283,14 @@ export class McpSessionDO extends DurableObject {
         const sessionMeta = yield* resolveSessionMeta(token.organizationId).pipe(
           Effect.provide(makeResolveOrganizationServices(dbHandle)),
         );
-        yield* Effect.promise(() => self.saveSessionMeta(sessionMeta));
+        yield* Effect.promise(() => self.saveSessionMeta(sessionMeta)).pipe(
+          Effect.withSpan("mcp.session.save_meta"),
+        );
         return sessionMeta;
       } finally {
         yield* Effect.promise(() => dbHandle.end());
       }
-    });
+    }).pipe(Effect.withSpan("mcp.session.resolve_and_store_meta"));
   }
 
   async init(token: McpSessionInit, incoming?: IncomingTraceHeaders): Promise<void> {
@@ -346,7 +360,7 @@ export class McpSessionDO extends DurableObject {
   private handleRequestWithRequestScopedRuntimeEffect(request: Request) {
     const self = this;
     return Effect.gen(function* () {
-      const sessionMeta = yield* Effect.promise(() => self.loadSessionMeta());
+      const sessionMeta = yield* self.loadSessionMetaEffect();
       if (!sessionMeta) {
         return jsonRpcError(404, -32001, "Session timed out due to inactivity — please reconnect");
       }
@@ -355,7 +369,9 @@ export class McpSessionDO extends DurableObject {
       self.lastActivityMs = Date.now();
 
       const dbHandle = makeRequestScopedDb();
-      const cleanupDb = Effect.promise(() => dbHandle.end());
+      const cleanupDb = Effect.promise(() => dbHandle.end()).pipe(
+        Effect.withSpan("mcp.session.db.close"),
+      );
       return yield* Effect.acquireUseRelease(
         self.createConnectedRuntimeEffect(sessionMeta, {
           dbHandle,
@@ -364,21 +380,37 @@ export class McpSessionDO extends DurableObject {
         ({ transport }) =>
           Effect.gen(function* () {
             const response = yield* Effect.promise(() => transport.handleRequest(request)).pipe(
-              Effect.withSpan("McpSessionDO.transport.handleRequest"),
+              Effect.withSpan("McpSessionDO.transport.handleRequest", {
+                attributes: {
+                  "mcp.request.method": request.method,
+                  "mcp.request.content_type":
+                    request.headers.get("content-type") ?? "",
+                  "mcp.request.content_length":
+                    request.headers.get("content-length") ?? "",
+                },
+              }),
             );
+            yield* Effect.annotateCurrentSpan({
+              "mcp.response.status_code": response.status,
+            });
             if (request.method === "DELETE") {
-              yield* Effect.promise(() => self.clearSessionState());
+              yield* self.clearSessionStateEffect();
             }
             return response;
           }),
         ({ mcpServer, transport }) =>
           Effect.gen(function* () {
-            yield* Effect.promise(() => transport.close().catch(() => undefined));
-            yield* Effect.promise(() => mcpServer.close().catch(() => undefined));
+            yield* Effect.promise(() => transport.close().catch(() => undefined)).pipe(
+              Effect.withSpan("mcp.session.transport.close"),
+            );
+            yield* Effect.promise(() => mcpServer.close().catch(() => undefined)).pipe(
+              Effect.withSpan("mcp.session.server.close"),
+            );
             yield* cleanupDb;
-          }),
+          }).pipe(Effect.withSpan("mcp.session.runtime.release")),
       );
     }).pipe(
+      Effect.withSpan("mcp.session.request_scoped_runtime"),
       Effect.catchAllCause((cause) =>
         Effect.sync(() => {
           console.error("[mcp-session] request-scoped handleRequest error:", cause);
@@ -451,10 +483,23 @@ export class McpSessionDO extends DurableObject {
     const self = this;
     return Effect.gen(function* () {
       const response = yield* Effect.promise(() => transport.handleRequest(request)).pipe(
-        Effect.withSpan("McpSessionDO.transport.handleRequest"),
+        Effect.withSpan("McpSessionDO.transport.handleRequest", {
+          attributes: {
+            "mcp.request.method": request.method,
+            "mcp.request.content_type":
+              request.headers.get("content-type") ?? "",
+            "mcp.request.content_length":
+              request.headers.get("content-length") ?? "",
+          },
+        }),
       );
+      yield* Effect.annotateCurrentSpan({
+        "mcp.response.status_code": response.status,
+      });
       if (request.method === "DELETE") {
-        yield* Effect.promise(() => self.cleanup());
+        yield* Effect.promise(() => self.cleanup()).pipe(
+          Effect.withSpan("mcp.session.cleanup"),
+        );
       }
       return response;
     }).pipe(

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -204,17 +204,13 @@ export class McpSessionDO extends DurableObject {
     };
   }
 
-  private async loadSessionMeta(): Promise<SessionMeta | null> {
-    if (this.sessionMeta) return this.sessionMeta;
-    const stored = await this.ctx.storage.get<SessionMeta>(SESSION_META_KEY);
-    this.sessionMeta = stored ?? null;
-    return this.sessionMeta;
-  }
-
-  private loadSessionMetaEffect(): Effect.Effect<SessionMeta | null> {
-    return Effect.promise(() => this.loadSessionMeta()).pipe(
-      Effect.withSpan("mcp.session.load_meta"),
-    );
+  private loadSessionMeta(): Effect.Effect<SessionMeta | null> {
+    return Effect.promise(async () => {
+      if (this.sessionMeta) return this.sessionMeta;
+      const stored = await this.ctx.storage.get<SessionMeta>(SESSION_META_KEY);
+      this.sessionMeta = stored ?? null;
+      return this.sessionMeta;
+    }).pipe(Effect.withSpan("mcp.session.load_meta"));
   }
 
   private async saveSessionMeta(sessionMeta: SessionMeta): Promise<void> {
@@ -222,24 +218,20 @@ export class McpSessionDO extends DurableObject {
     await this.ctx.storage.put(SESSION_META_KEY, sessionMeta);
   }
 
-  private async clearSessionState(): Promise<void> {
-    this.sessionMeta = null;
-    this.initialized = false;
-    this.lastActivityMs = 0;
+  private clearSessionState(): Effect.Effect<void> {
+    return Effect.promise(async () => {
+      this.sessionMeta = null;
+      this.initialized = false;
+      this.lastActivityMs = 0;
 
-    await Promise.all([
-      this.ctx.storage.delete(TRANSPORT_STATE_KEY).catch(() => false),
-      this.ctx.storage.delete(SESSION_META_KEY).catch(() => false),
-    ]);
+      await Promise.all([
+        this.ctx.storage.delete(TRANSPORT_STATE_KEY).catch(() => false),
+        this.ctx.storage.delete(SESSION_META_KEY).catch(() => false),
+      ]);
+    }).pipe(Effect.withSpan("mcp.session.clear_state"));
   }
 
-  private clearSessionStateEffect(): Effect.Effect<void> {
-    return Effect.promise(() => this.clearSessionState()).pipe(
-      Effect.withSpan("mcp.session.clear_state"),
-    );
-  }
-
-  private createConnectedRuntimeEffect(
+  private createConnectedRuntime(
     sessionMeta: SessionMeta,
     options: { readonly dbHandle: DbHandle; readonly enableJsonResponse?: boolean },
   ) {
@@ -275,7 +267,7 @@ export class McpSessionDO extends DurableObject {
     );
   }
 
-  private resolveAndStoreSessionMetaEffect(token: McpSessionInit) {
+  private resolveAndStoreSessionMeta(token: McpSessionInit) {
     const self = this;
     return Effect.gen(function* () {
       const dbHandle = makeRequestScopedDb();
@@ -296,7 +288,7 @@ export class McpSessionDO extends DurableObject {
   async init(token: McpSessionInit, incoming?: IncomingTraceHeaders): Promise<void> {
     if (this.initialized) return;
     return Effect.runPromise(
-      this.doInitEffect(token).pipe(
+      this.doInit(token).pipe(
         Effect.withSpan("McpSessionDO.init", {
           attributes: { "mcp.auth.organization_id": token.organizationId },
         }),
@@ -306,7 +298,7 @@ export class McpSessionDO extends DurableObject {
     );
   }
 
-  private doInitEffect(token: McpSessionInit) {
+  private doInit(token: McpSessionInit) {
     const self = this;
     // Single Effect chain so every sub-span (resolveSessionMeta,
     // createRuntime, createScopedExecutor, createExecutorMcpServer,
@@ -316,7 +308,7 @@ export class McpSessionDO extends DurableObject {
     // each sub-span into its own root trace and made init opaque —
     // dashboard saw one 2.77s span with nothing under it.
     return Effect.gen(function* () {
-      const sessionMeta = yield* self.resolveAndStoreSessionMetaEffect(token);
+      const sessionMeta = yield* self.resolveAndStoreSessionMeta(token);
 
       if (!requestScopedRuntimeEnabled) {
         self.dbHandle = makeLongLivedDb();
@@ -327,7 +319,7 @@ export class McpSessionDO extends DurableObject {
         // POSTs the callback fires after `Effect.ensuring` clears the field
         // and engine spans orphan into new root traces. GET still streams
         // (the GET handler doesn't consult `enableJsonResponse`).
-        const runtime = yield* self.createConnectedRuntimeEffect(sessionMeta, {
+        const runtime = yield* self.createConnectedRuntime(sessionMeta, {
           dbHandle: self.dbHandle,
           enableJsonResponse: true,
         });
@@ -357,10 +349,10 @@ export class McpSessionDO extends DurableObject {
     );
   }
 
-  private handleRequestWithRequestScopedRuntimeEffect(request: Request) {
+  private handleRequestWithRequestScopedRuntime(request: Request) {
     const self = this;
     return Effect.gen(function* () {
-      const sessionMeta = yield* self.loadSessionMetaEffect();
+      const sessionMeta = yield* self.loadSessionMeta();
       if (!sessionMeta) {
         return jsonRpcError(404, -32001, "Session timed out due to inactivity — please reconnect");
       }
@@ -373,7 +365,7 @@ export class McpSessionDO extends DurableObject {
         Effect.withSpan("mcp.session.db.close"),
       );
       return yield* Effect.acquireUseRelease(
-        self.createConnectedRuntimeEffect(sessionMeta, {
+        self.createConnectedRuntime(sessionMeta, {
           dbHandle,
           enableJsonResponse: request.method !== "GET",
         }),
@@ -394,7 +386,7 @@ export class McpSessionDO extends DurableObject {
               "mcp.response.status_code": response.status,
             });
             if (request.method === "DELETE") {
-              yield* self.clearSessionStateEffect();
+              yield* self.clearSessionState();
             }
             return response;
           }),
@@ -442,7 +434,7 @@ export class McpSessionDO extends DurableObject {
       const span = yield* Effect.currentSpan;
       self.currentRequestSpan = span;
 
-      return yield* self.dispatchRequestEffect(request).pipe(
+      return yield* self.dispatchRequest(request).pipe(
         Effect.tap((response) =>
           Effect.annotateCurrentSpan({
             "mcp.response.status_code": response.status,
@@ -467,9 +459,9 @@ export class McpSessionDO extends DurableObject {
     return Effect.runPromise(program);
   }
 
-  private dispatchRequestEffect(request: Request): Effect.Effect<Response> {
+  private dispatchRequest(request: Request): Effect.Effect<Response> {
     if (requestScopedRuntimeEnabled) {
-      return this.handleRequestWithRequestScopedRuntimeEffect(request);
+      return this.handleRequestWithRequestScopedRuntime(request);
     }
 
     if (!this.initialized || !this.transport) {
@@ -543,6 +535,6 @@ export class McpSessionDO extends DurableObject {
       await this.dbHandle.end();
       this.dbHandle = null;
     }
-    await this.clearSessionState();
+    await Effect.runPromise(this.clearSessionState());
   }
 }

--- a/packages/core/execution/src/description.ts
+++ b/packages/core/execution/src/description.ts
@@ -14,8 +14,19 @@ export const buildExecuteDescription = (executor: Executor): Effect.Effect<strin
       .list()
       .pipe(Effect.orDie, Effect.withSpan("executor.sources.list"));
 
-    return formatDescription(sources);
-  }).pipe(Effect.withSpan("buildExecuteDescription"));
+    const description = yield* Effect.sync(() => formatDescription(sources)).pipe(
+      Effect.withSpan("schema.compile.description", {
+        attributes: { "executor.source_count": sources.length },
+      }),
+    );
+
+    yield* Effect.annotateCurrentSpan({
+      "executor.source_count": sources.length,
+      "schema.kind": "execute",
+    });
+
+    return description;
+  }).pipe(Effect.withSpan("schema.describe.execute"));
 
 const formatDescription = (sources: readonly Source[]): string => {
   const lines: string[] = [

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -194,7 +194,11 @@ const makeFullInvoker = (executor: Executor, invokeOptions: InvokeOptions): Sand
 
         return searchTools(executor, args.query ?? "", limit, {
           namespace: args.namespace,
-        });
+        }).pipe(
+          Effect.withSpan("mcp.tool.dispatch", {
+            attributes: { "mcp.tool.name": path, "executor.tool.builtin": true },
+          }),
+        );
       }
       if (path === "executor.sources.list") {
         if (args !== undefined && !isRecord(args)) {
@@ -225,7 +229,11 @@ const makeFullInvoker = (executor: Executor, invokeOptions: InvokeOptions): Sand
         return listExecutorSources(executor, {
           query: isRecord(args) && typeof args.query === "string" ? args.query : undefined,
           limit,
-        });
+        }).pipe(
+          Effect.withSpan("mcp.tool.dispatch", {
+            attributes: { "mcp.tool.name": path, "executor.tool.builtin": true },
+          }),
+        );
       }
       if (path === "describe.tool") {
         if (!isRecord(args)) {
@@ -248,7 +256,15 @@ const makeFullInvoker = (executor: Executor, invokeOptions: InvokeOptions): Sand
           );
         }
 
-        return describeTool(executor, args.path);
+        return describeTool(executor, args.path).pipe(
+          Effect.withSpan("mcp.tool.dispatch", {
+            attributes: {
+              "mcp.tool.name": path,
+              "executor.tool.builtin": true,
+              "executor.tool.target_path": args.path,
+            },
+          }),
+        );
       }
       return base.invoke({ path, args });
     },

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -288,12 +288,18 @@ export const searchTools = Effect.fn("executor.tools.search")(function* (
   }
 
   const all = yield* executor.tools.list().pipe(Effect.orDie);
-  return all
+  const results = all
     .filter((tool: Tool) => matchesNamespace(tool, options?.namespace))
     .map((tool: Tool) => scoreToolMatch(tool, query))
     .filter((tool): tool is ToolDiscoveryResult => tool !== null)
     .sort((left, right) => right.score - left.score || left.path.localeCompare(right.path))
     .slice(0, limit);
+
+  yield* Effect.annotateCurrentSpan({
+    "executor.search.candidate_count": all.length,
+    "executor.search.result_count": results.length,
+  });
+  return results;
 });
 
 /** What `tools.executor.sources.list()` calls inside the sandbox. */
@@ -333,9 +339,15 @@ export const listExecutorSources = Effect.fn("executor.sources.list")(function* 
       }) satisfies ExecutorSourceListItem,
   );
 
-  return withCounts
+  const results = withCounts
     .sort((left, right) => left.name.localeCompare(right.name) || left.id.localeCompare(right.id))
     .slice(0, limit);
+
+  yield* Effect.annotateCurrentSpan({
+    "executor.sources.candidate_count": sources.length,
+    "executor.sources.result_count": results.length,
+  });
+  return results;
 });
 
 /** What `tools.describe.tool()` calls inside the sandbox. */

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -892,8 +892,13 @@ export const createExecutor = <
         for (const { source, pluginId } of staticSources.values()) {
           staticList.push(staticDeclToSource(source, pluginId));
         }
-        return [...staticList, ...dynamic.map(rowToSource)];
-      });
+        const merged = [...staticList, ...dynamic.map(rowToSource)];
+        yield* Effect.annotateCurrentSpan({
+          "executor.sources.static_count": staticList.length,
+          "executor.sources.dynamic_count": dynamic.length,
+        });
+        return merged;
+      }).pipe(Effect.withSpan("executor.sources.list"));
 
     // Bulk-resolve annotations across a set of dynamic tool rows by
     // grouping them under their owning plugin's resolveAnnotations
@@ -936,7 +941,9 @@ export const createExecutor = <
     const listTools = (filter?: ToolListFilter) =>
       Effect.gen(function* () {
         const dynamic = yield* core.findMany({ model: "tool" });
-        const annotations = yield* resolveAnnotationsFor(dynamic);
+        const annotations = yield* resolveAnnotationsFor(dynamic).pipe(
+          Effect.withSpan("executor.tools.list.annotations"),
+        );
 
         const out: Tool[] = [];
         // Static tools — annotations from the declaration, not a resolver.
@@ -946,9 +953,14 @@ export const createExecutor = <
         for (const row of dynamic) {
           out.push(rowToTool(row, annotations.get(row.id)));
         }
-        if (!filter) return out;
-        return out.filter((t) => toolMatchesFilter(t, filter));
-      });
+        const result = filter ? out.filter((t) => toolMatchesFilter(t, filter)) : out;
+        yield* Effect.annotateCurrentSpan({
+          "executor.tools.static_count": staticTools.size,
+          "executor.tools.dynamic_count": dynamic.length,
+          "executor.tools.result_count": result.length,
+        });
+        return result;
+      }).pipe(Effect.withSpan("executor.tools.list"));
 
     // Load all definitions for a single source as a plain map.
     const loadDefinitionsForSource = (sourceId: string) =>
@@ -975,7 +987,9 @@ export const createExecutor = <
     }) =>
       Effect.gen(function* () {
         const defs: Record<string, unknown> = opts.sourceId
-          ? yield* loadDefinitionsForSource(opts.sourceId)
+          ? yield* loadDefinitionsForSource(opts.sourceId).pipe(
+              Effect.withSpan("executor.tool.schema.load_defs"),
+            )
           : {};
 
         const attachDefs = (schema: unknown): unknown => {
@@ -988,11 +1002,18 @@ export const createExecutor = <
         const outputSchema = attachDefs(opts.rawOutput);
 
         const defsMap = new Map<string, unknown>(Object.entries(defs));
-        const preview = buildToolTypeScriptPreview({
-          inputSchema,
-          outputSchema,
-          defs: defsMap,
-        });
+        const preview = yield* Effect.sync(() =>
+          buildToolTypeScriptPreview({ inputSchema, outputSchema, defs: defsMap }),
+        ).pipe(
+          Effect.withSpan("schema.compile.preview", {
+            attributes: {
+              "schema.kind": "tool.preview",
+              "schema.has_input": inputSchema !== undefined,
+              "schema.has_output": outputSchema !== undefined,
+              "schema.def_count": defsMap.size,
+            },
+          }),
+        );
 
         return new ToolSchema({
           id: ToolId.make(opts.toolId),
@@ -1012,6 +1033,11 @@ export const createExecutor = <
         // no `$defs` attach; just wrap the declared schemas.
         const staticEntry = staticTools.get(toolId);
         if (staticEntry) {
+          yield* Effect.annotateCurrentSpan({
+            "executor.tool.dispatch_path": "static",
+            "executor.source_id": staticEntry.source.id,
+            "executor.source_kind": staticEntry.source.kind,
+          });
           return yield* buildToolSchemaView({
             toolId,
             name: staticEntry.tool.name,
@@ -1021,11 +1047,18 @@ export const createExecutor = <
             rawOutput: staticEntry.tool.outputSchema,
           });
         }
-        const row = yield* core.findOne({
-          model: "tool",
-          where: [{ field: "id", value: toolId }],
-        });
+        const row = yield* core
+          .findOne({
+            model: "tool",
+            where: [{ field: "id", value: toolId }],
+          })
+          .pipe(Effect.withSpan("executor.tool.resolve"));
         if (!row) return null;
+        yield* Effect.annotateCurrentSpan({
+          "executor.tool.dispatch_path": "dynamic",
+          "executor.source_id": row.source_id,
+          "executor.plugin_id": row.plugin_id,
+        });
         return yield* buildToolSchemaView({
           toolId,
           name: row.name,
@@ -1034,7 +1067,11 @@ export const createExecutor = <
           rawInput: decodeJsonColumn(row.input_schema),
           rawOutput: decodeJsonColumn(row.output_schema),
         });
-      });
+      }).pipe(
+        Effect.withSpan("executor.tool.schema", {
+          attributes: { "mcp.tool.name": toolId },
+        }),
+      );
 
     // Bulk definitions accessor — every source's $defs, grouped by
     // source id. One query against the definition table, plus an
@@ -1121,31 +1158,44 @@ export const createExecutor = <
         // Static path — O(1) map lookup, no DB hit.
         const staticEntry = staticTools.get(toolId);
         if (staticEntry) {
+          yield* Effect.annotateCurrentSpan({
+            "executor.tool.dispatch_path": "static",
+            "executor.source_id": staticEntry.source.id,
+            "executor.source_kind": staticEntry.source.kind,
+            "executor.plugin_id": staticEntry.pluginId,
+          });
           yield* enforceApproval(
             staticEntry.tool.annotations,
             toolId,
             args,
             options,
-          );
+          ).pipe(Effect.withSpan("executor.tool.enforce_approval"));
           return yield* wrapInvocationError(
             staticEntry.tool.handler({
               ctx: staticEntry.ctx,
               args,
               elicit: buildElicit(toolId, args, options),
             }),
-          );
+          ).pipe(Effect.withSpan("executor.tool.handler"));
         }
 
         // Dynamic path — DB lookup + delegate to owning plugin.
-        const row = yield* core.findOne({
-          model: "tool",
-          where: [{ field: "id", value: toolId }],
-        });
+        const row = yield* core
+          .findOne({
+            model: "tool",
+            where: [{ field: "id", value: toolId }],
+          })
+          .pipe(Effect.withSpan("executor.tool.resolve"));
         if (!row) {
           return yield* new ToolNotFoundError({
             toolId: ToolId.make(toolId),
           });
         }
+        yield* Effect.annotateCurrentSpan({
+          "executor.tool.dispatch_path": "dynamic",
+          "executor.source_id": row.source_id,
+          "executor.plugin_id": row.plugin_id,
+        });
         const runtime = runtimes.get(row.plugin_id);
         if (!runtime) {
           return yield* new PluginNotLoadedError({
@@ -1167,14 +1217,18 @@ export const createExecutor = <
         // around a single storage read.
         let annotations: ToolAnnotations | undefined;
         if (runtime.plugin.resolveAnnotations) {
-          const map = yield* runtime.plugin.resolveAnnotations({
-            ctx: runtime.ctx,
-            sourceId: row.source_id,
-            toolRows: [row],
-          });
+          const map = yield* runtime.plugin
+            .resolveAnnotations({
+              ctx: runtime.ctx,
+              sourceId: row.source_id,
+              toolRows: [row],
+            })
+            .pipe(Effect.withSpan("executor.tool.resolve_annotations"));
           annotations = map[toolId];
         }
-        yield* enforceApproval(annotations, toolId, args, options);
+        yield* enforceApproval(annotations, toolId, args, options).pipe(
+          Effect.withSpan("executor.tool.enforce_approval"),
+        );
 
         return yield* wrapInvocationError(
           runtime.plugin.invokeTool({
@@ -1183,8 +1237,14 @@ export const createExecutor = <
             args,
             elicit: buildElicit(toolId, args, options),
           }),
-        );
-      });
+        ).pipe(Effect.withSpan("executor.tool.handler"));
+      }).pipe(
+        Effect.withSpan("executor.tool.invoke", {
+          attributes: {
+            "mcp.tool.name": toolId,
+          },
+        }),
+      );
 
     const removeSource = (sourceId: string) =>
       Effect.gen(function* () {

--- a/packages/core/sdk/src/schema-types.ts
+++ b/packages/core/sdk/src/schema-types.ts
@@ -364,16 +364,18 @@ export const schemaToTypeScriptPreviewWithDefs = (
   };
 };
 
+export type ToolTypeScriptPreview = {
+  inputTypeScript?: string;
+  outputTypeScript?: string;
+  typeScriptDefinitions?: Record<string, string>;
+};
+
 export const buildToolTypeScriptPreview = (input: {
   inputSchema?: unknown;
   outputSchema?: unknown;
   defs: ReadonlyMap<string, unknown>;
   options?: TypeScriptRenderOptions;
-}): {
-  inputTypeScript?: string;
-  outputTypeScript?: string;
-  typeScriptDefinitions?: Record<string, string>;
-} => {
+}): ToolTypeScriptPreview => {
   const inputPreview =
     input.inputSchema !== undefined
       ? schemaToTypeScriptPreviewWithDefs(input.inputSchema, input.defs, input.options)
@@ -396,3 +398,4 @@ export const buildToolTypeScriptPreview = (input: {
       : {}),
   };
 };
+

--- a/packages/core/storage-core/src/factory.ts
+++ b/packages/core/storage-core/src/factory.ts
@@ -638,7 +638,14 @@ export const createAdapter = (
           data.select,
         );
         return out as unknown as R;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.create", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     createMany: <T extends Record<string, unknown>, R = T>(data: {
       model: string;
@@ -678,7 +685,15 @@ export const createAdapter = (
           );
         }
         return out as unknown as readonly R[];
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.create_many", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+            "executor.storage.row_count": data.data.length,
+          },
+        }),
+      ),
 
     findOne: <T>(data: {
       model: string;
@@ -698,7 +713,14 @@ export const createAdapter = (
         const out = yield* maybeTransformOutput(data.model, res, data.select);
         const merged = yield* attachJoinedRows(out, res, data.join);
         return merged as unknown as T | null;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.find_one", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     findMany: <T>(data: {
       model: string;
@@ -734,7 +756,14 @@ export const createAdapter = (
           out.push(merged);
         }
         return out as readonly T[];
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.find_many", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     count: (data: { model: string; where?: Where[] | undefined }) =>
       Effect.gen(function* () {
@@ -743,7 +772,14 @@ export const createAdapter = (
           model: getModelName(data.model),
           where,
         });
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.count", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     update: <T>(data: {
       model: string;
@@ -765,7 +801,14 @@ export const createAdapter = (
         });
         const out = yield* maybeTransformOutput(data.model, res);
         return out as unknown as T | null;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.update", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     updateMany: (data: {
       model: string;
@@ -785,7 +828,14 @@ export const createAdapter = (
           where,
           update,
         });
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.update_many", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     delete: (data: { model: string; where: Where[] }) =>
       Effect.gen(function* () {
@@ -794,7 +844,14 @@ export const createAdapter = (
           model: getModelName(data.model),
           where,
         });
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.delete", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     deleteMany: (data: { model: string; where: Where[] }) =>
       Effect.gen(function* () {
@@ -803,17 +860,28 @@ export const createAdapter = (
           model: getModelName(data.model),
           where,
         });
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.delete_many", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.table": data.model,
+          },
+        }),
+      ),
 
     transaction: <R, E>(
       callback: (trx: DBTransactionAdapter) => Effect.Effect<R, E>,
     ) => {
       const txFn = config.transaction;
-      if (!txFn) {
-        // No real transaction support — just run the callback against self.
-        return callback(self);
-      }
-      return txFn(callback);
+      const ran = !txFn ? callback(self) : txFn(callback);
+      return ran.pipe(
+        Effect.withSpan("executor.storage.transaction", {
+          attributes: {
+            "executor.storage.adapter_id": config.adapterId,
+            "executor.storage.transaction.native": txFn !== undefined,
+          },
+        }),
+      );
     },
 
     // Forward the backend's createSchema verbatim. Upstream better-auth

--- a/packages/core/storage-drizzle/src/adapter.ts
+++ b/packages/core/storage-drizzle/src/adapter.ts
@@ -361,6 +361,12 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     return t;
   };
 
+  const backendAttrs = (model: string) => ({
+    "executor.storage.backend": "drizzle" as const,
+    "executor.storage.drizzle.provider": provider,
+    "executor.storage.table": model,
+  });
+
   const custom: CustomAdapter = {
     create: ({ model, data }) =>
       Effect.gen(function* () {
@@ -375,7 +381,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           model,
         );
         return row as never;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.create", {
+          attributes: backendAttrs(model),
+        }),
+      ),
 
     // Real multi-row INSERT in fixed-size chunks. One statement per
     // chunk, not one per row — per-row loops blow the Hyperdrive
@@ -401,7 +411,14 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           for (const row of rows) all.push(row);
         }
         return all as never;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.create_many", {
+          attributes: {
+            ...backendAttrs(model),
+            "executor.storage.row_count": data.length,
+          },
+        }),
+      ),
 
     findOne: ({ model, where, join }) =>
       Effect.gen(function* () {
@@ -430,7 +447,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           model,
         )) as Record<string, unknown>[];
         return (rows[0] ?? null) as never;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.find_one", {
+          attributes: backendAttrs(model),
+        }),
+      ),
 
     findMany: ({ model, where, limit, sortBy, offset, join }) =>
       Effect.gen(function* () {
@@ -477,7 +498,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           model,
         )) as Record<string, unknown>[];
         return rows as never[];
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.find_many", {
+          attributes: backendAttrs(model),
+        }),
+      ),
 
     count: ({ model, where }) =>
       Effect.gen(function* () {
@@ -492,7 +517,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
         )) as { c: number | string | bigint }[];
         const raw = rows[0]?.c ?? 0;
         return typeof raw === "number" ? raw : Number(raw);
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.count", {
+          attributes: backendAttrs(model),
+        }),
+      ),
 
     update: ({ model, where, update }) =>
       Effect.gen(function* () {
@@ -529,7 +558,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           model,
         )) as Record<string, unknown>[];
         return (reread[0] ?? null) as never;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.update", {
+          attributes: backendAttrs(model),
+        }),
+      ),
 
     updateMany: ({ model, where, update }) =>
       Effect.gen(function* () {
@@ -554,7 +587,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           model,
         );
         return n;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.update_many", {
+          attributes: backendAttrs(model),
+        }),
+      ),
 
     delete: ({ model, where }) =>
       Effect.gen(function* () {
@@ -575,7 +612,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           () => Promise.resolve(db.delete(table).where(eq(table.id, first.id))),
           model,
         );
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.delete", {
+          attributes: backendAttrs(model),
+        }),
+      ),
 
     deleteMany: ({ model, where }) =>
       Effect.gen(function* () {
@@ -598,7 +639,11 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
           model,
         );
         return n;
-      }),
+      }).pipe(
+        Effect.withSpan("executor.storage.backend.delete_many", {
+          attributes: backendAttrs(model),
+        }),
+      ),
   };
 
   // Transaction strategy differs by dialect:
@@ -659,6 +704,13 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
               if (e instanceof TxFailure) return e.inner;
               return classifyError("pg transaction", undefined, e);
             }),
+            Effect.withSpan("executor.storage.backend.transaction", {
+              attributes: {
+                "executor.storage.backend": "drizzle",
+                "executor.storage.drizzle.provider": provider,
+                "executor.storage.transaction.strategy": "drizzle_native",
+              },
+            }),
           ) as Effect.Effect<R, E | StorageFailure>;
         }
 
@@ -711,7 +763,15 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
             });
           }
           return result;
-        });
+        }).pipe(
+          Effect.withSpan("executor.storage.backend.transaction", {
+            attributes: {
+              "executor.storage.backend": "drizzle",
+              "executor.storage.drizzle.provider": provider,
+              "executor.storage.transaction.strategy": "raw_begin_commit",
+            },
+          }),
+        );
       }
     : undefined;
 

--- a/packages/hosts/mcp/src/server.ts
+++ b/packages/hosts/mcp/src/server.ts
@@ -195,7 +195,11 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
 ): Effect.Effect<McpServer> =>
   Effect.gen(function* () {
     const engine = "engine" in config ? config.engine : createExecutionEngine(config);
-    const description = config.description ?? (yield* engine.getDescription);
+    const description =
+      config.description ??
+      (yield* engine.getDescription.pipe(
+        Effect.withSpan("mcp.host.get_description"),
+      ));
 
     // Captured at construction time. SDK callbacks fire later (often
     // deferred past the outer Effect's await), so we use the runtime to
@@ -211,10 +215,16 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       return parent ? Effect.withParentSpan(effect, parent) : effect;
     };
 
-    const server = new McpServer(
-      { name: "executor", version: "1.0.0" },
-      { capabilities: { tools: {} }, jsonSchemaValidator: new CfWorkerJsonSchemaValidator() },
-    );
+    const server = yield* Effect.sync(
+      () =>
+        new McpServer(
+          { name: "executor", version: "1.0.0" },
+          {
+            capabilities: { tools: {} },
+            jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+          },
+        ),
+    ).pipe(Effect.withSpan("mcp.host.create_server"));
 
     const executeCode = (code: string): Effect.Effect<McpToolResult, E> =>
       Effect.gen(function* () {
@@ -228,7 +238,14 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         return outcome.status === "completed"
           ? toMcpResult(formatExecuteResult(outcome.result))
           : toMcpPausedResult(formatPausedExecution(outcome.execution));
-      });
+      }).pipe(
+        Effect.withSpan("mcp.host.tool.execute", {
+          attributes: {
+            "mcp.tool.name": "execute",
+            "mcp.execute.code_length": code.length,
+          },
+        }),
+      );
 
     const resumeExecution = (
       executionId: string,
@@ -239,48 +256,70 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         const outcome = yield* engine.resume(executionId, { action, content });
         if (!outcome) {
           return {
-            content: [{ type: "text", text: `No paused execution: ${executionId}` }],
+            content: [
+              { type: "text" as const, text: `No paused execution: ${executionId}` },
+            ],
             isError: true,
-          };
+          } satisfies McpToolResult;
         }
         return outcome.status === "completed"
           ? toMcpResult(formatExecuteResult(outcome.result))
           : toMcpPausedResult(formatPausedExecution(outcome.execution));
-      });
+      }).pipe(
+        Effect.withSpan("mcp.host.tool.resume", {
+          attributes: {
+            "mcp.tool.name": "resume",
+            "mcp.execute.resume.action": action,
+            "mcp.execute.execution_id": executionId,
+          },
+        }),
+      );
 
     // --- tools ---
 
-    const executeTool = server.registerTool(
-      "execute",
-      {
-        description,
-        inputSchema: { code: z.string().trim().min(1) },
-      },
-      ({ code }) => Runtime.runPromise(runtime)(anchor(executeCode(code))),
+    const executeTool = yield* Effect.sync(() =>
+      server.registerTool(
+        "execute",
+        {
+          description,
+          inputSchema: { code: z.string().trim().min(1) },
+        },
+        ({ code }) => Runtime.runPromise(runtime)(anchor(executeCode(code))),
+      ),
+    ).pipe(
+      Effect.withSpan("mcp.host.register_tool", {
+        attributes: { "mcp.tool.name": "execute" },
+      }),
     );
 
-    const resumeTool = server.registerTool(
-      "resume",
-      {
-        description: [
-          "Resume a paused execution using the executionId returned by execute.",
-          "Never call this without user approval unless they explicitly state otherwise.",
-        ].join("\n"),
-        inputSchema: {
-          executionId: z.string().describe("The execution ID from the paused result"),
-          action: z
-            .enum(["accept", "decline", "cancel"])
-            .describe("How to respond to the interaction"),
-          content: z
-            .string()
-            .describe("Optional JSON-encoded response content for form elicitations")
-            .default("{}"),
+    const resumeTool = yield* Effect.sync(() =>
+      server.registerTool(
+        "resume",
+        {
+          description: [
+            "Resume a paused execution using the executionId returned by execute.",
+            "Never call this without user approval unless they explicitly state otherwise.",
+          ].join("\n"),
+          inputSchema: {
+            executionId: z.string().describe("The execution ID from the paused result"),
+            action: z
+              .enum(["accept", "decline", "cancel"])
+              .describe("How to respond to the interaction"),
+            content: z
+              .string()
+              .describe("Optional JSON-encoded response content for form elicitations")
+              .default("{}"),
+          },
         },
-      },
-      ({ executionId, action, content: rawContent }) =>
-        Runtime.runPromise(runtime)(
-          anchor(resumeExecution(executionId, action, parseJsonContent(rawContent))),
-        ),
+        ({ executionId, action, content: rawContent }) =>
+          Runtime.runPromise(runtime)(
+            anchor(resumeExecution(executionId, action, parseJsonContent(rawContent))),
+          ),
+      ),
+    ).pipe(
+      Effect.withSpan("mcp.host.register_tool", {
+        attributes: { "mcp.tool.name": "resume" },
+      }),
     );
 
     // --- capability-based tool visibility ---
@@ -294,8 +333,10 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       }
     };
 
-    syncToolAvailability();
-    server.server.oninitialized = syncToolAvailability;
+    yield* Effect.sync(() => {
+      syncToolAvailability();
+      server.server.oninitialized = syncToolAvailability;
+    }).pipe(Effect.withSpan("mcp.host.sync_tool_availability"));
 
     return server;
-  });
+  }).pipe(Effect.withSpan("mcp.host.create_executor_server"));

--- a/packages/plugins/graphql/src/sdk/invoke.ts
+++ b/packages/plugins/graphql/src/sdk/invoke.ts
@@ -15,9 +15,13 @@ import {
 export const resolveHeaders = (
   headers: Record<string, HeaderValue>,
   secrets: { readonly get: (id: string) => Effect.Effect<string | null, unknown> },
-): Effect.Effect<Record<string, string>> =>
-  Effect.gen(function* () {
-    const entries = Object.entries(headers);
+): Effect.Effect<Record<string, string>> => {
+  const entries = Object.entries(headers);
+  const secretCount = entries.reduce(
+    (acc, [, value]) => (typeof value === "string" ? acc : acc + 1),
+    0,
+  );
+  return Effect.gen(function* () {
     // Resolve secret-backed headers in parallel. Missing / failing
     // lookups drop the header rather than fail the invocation, same
     // as the serial version.
@@ -48,7 +52,15 @@ export const resolveHeaders = (
       if (value !== null) resolved[name] = value;
     }
     return resolved;
-  });
+  }).pipe(
+    Effect.withSpan("plugin.graphql.secret.resolve", {
+      attributes: {
+        "plugin.graphql.headers.total": entries.length,
+        "plugin.graphql.headers.secret_count": secretCount,
+      },
+    }),
+  );
+};
 
 // ---------------------------------------------------------------------------
 // Response helpers
@@ -73,6 +85,15 @@ export const invoke = Effect.fn("GraphQL.invoke")(function* (
   resolvedHeaders: Record<string, string>,
 ) {
   const client = yield* HttpClient.HttpClient;
+
+  yield* Effect.annotateCurrentSpan({
+    "http.method": "POST",
+    "http.url": endpoint,
+    "plugin.graphql.endpoint": endpoint,
+    "plugin.graphql.operation_kind": operation.kind,
+    "plugin.graphql.field_name": operation.fieldName,
+    "plugin.graphql.headers.resolved_count": Object.keys(resolvedHeaders).length,
+  });
 
   // Build the GraphQL request body
   const variables: Record<string, unknown> = {};
@@ -121,6 +142,12 @@ export const invoke = Effect.fn("GraphQL.invoke")(function* (
   const gqlBody = body as { data?: unknown; errors?: unknown[] } | null;
   const hasErrors = Array.isArray(gqlBody?.errors) && gqlBody.errors.length > 0;
 
+  yield* Effect.annotateCurrentSpan({
+    "http.status_code": status,
+    "plugin.graphql.has_errors": hasErrors,
+    "plugin.graphql.error_count": hasErrors ? gqlBody!.errors!.length : 0,
+  });
+
   return new InvocationResult({
     status,
     data: gqlBody?.data ?? null,
@@ -150,4 +177,11 @@ export const invokeWithLayer = (
             cause: err,
           }),
     ),
+    Effect.withSpan("plugin.graphql.invoke", {
+      attributes: {
+        "plugin.graphql.endpoint": endpoint,
+        "plugin.graphql.operation_kind": operation.kind,
+        "plugin.graphql.field_name": operation.fieldName,
+      },
+    }),
   );

--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -79,7 +79,11 @@ const connectClient = (input: {
             cause instanceof Error ? cause.message : String(cause)
           }`,
         }),
-    });
+    }).pipe(
+      Effect.withSpan("plugin.mcp.connection.handshake", {
+        attributes: { "plugin.mcp.transport": input.transport },
+      }),
+    );
 
     return connectionFromClient(client);
   });

--- a/packages/plugins/mcp/src/sdk/invoke.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.ts
@@ -136,7 +136,11 @@ const useConnection = (
             cause instanceof Error ? cause.message : String(cause)
           }`,
         }),
-    });
+    }).pipe(
+      Effect.withSpan("plugin.mcp.client.call_tool", {
+        attributes: { "mcp.tool.name": toolName },
+      }),
+    );
   });
 
 // ---------------------------------------------------------------------------
@@ -163,8 +167,12 @@ export interface InvokeMcpToolInput {
 
 export const invokeMcpTool = (
   input: InvokeMcpToolInput,
-): Effect.Effect<unknown, McpConnectionError | McpInvocationError> =>
-  Effect.gen(function* () {
+): Effect.Effect<unknown, McpConnectionError | McpInvocationError> => {
+  const transport: string =
+    input.sourceData.transport === "stdio"
+      ? "stdio"
+      : (input.sourceData.remoteTransport ?? "auto");
+  return Effect.gen(function* () {
     const cacheKey = connectionCacheKey(input.sourceData);
     const args = asRecord(input.args);
 
@@ -173,7 +181,15 @@ export const invokeMcpTool = (
     const connector = input.resolveConnector();
     input.pendingConnectors.set(cacheKey, connector);
 
-    const firstConnection = yield* input.connectionCache.get(cacheKey);
+    const firstConnection = yield* input.connectionCache.get(cacheKey).pipe(
+      Effect.withSpan("plugin.mcp.connection.acquire", {
+        attributes: {
+          "plugin.mcp.transport": transport,
+          "plugin.mcp.cache_key": cacheKey,
+          "plugin.mcp.attempt": 1,
+        },
+      }),
+    );
 
     return yield* useConnection(
       firstConnection,
@@ -194,7 +210,25 @@ export const invokeMcpTool = (
             args,
             input.elicit,
           );
-        }),
+        }).pipe(
+          Effect.withSpan("plugin.mcp.invoke.retry", {
+            attributes: {
+              "plugin.mcp.transport": transport,
+              "plugin.mcp.cache_key": cacheKey,
+              "mcp.tool.name": input.toolName,
+            },
+          }),
+        ),
       ),
     );
-  }).pipe(Effect.scoped);
+  }).pipe(
+    Effect.scoped,
+    Effect.withSpan("plugin.mcp.invoke", {
+      attributes: {
+        "mcp.tool.name": input.toolName,
+        "plugin.mcp.tool_id": input.toolId,
+        "plugin.mcp.transport": transport,
+      },
+    }),
+  );
+};

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -445,6 +445,7 @@ export const mcpPlugin = definePlugin(
               Effect.catchAll(() =>
                 Effect.succeed({ ok: false as const, manifest: null }),
               ),
+              Effect.withSpan("mcp.plugin.discover_tools"),
             );
 
             if (result.ok && result.manifest) {
@@ -465,6 +466,7 @@ export const mcpPlugin = definePlugin(
             }).pipe(
               Effect.map(() => true),
               Effect.catchAll(() => Effect.succeed(false)),
+              Effect.withSpan("mcp.plugin.probe_oauth"),
             );
 
             if (hasOAuth) {
@@ -483,7 +485,11 @@ export const mcpPlugin = definePlugin(
                 "Could not connect to MCP endpoint and no OAuth was detected",
               ),
             );
-          });
+          }).pipe(
+            Effect.withSpan("mcp.plugin.probe_endpoint", {
+              attributes: { "mcp.endpoint": endpoint },
+            }),
+          );
 
         const configFile = options?.configFile;
 
@@ -493,7 +499,14 @@ export const mcpPlugin = definePlugin(
             const sd = toStoredSourceData(config);
 
             // Resolve auth (may fail if stdio gate is off)
-            const ci = yield* resolveConnectorInput(sd, ctx, allowStdio);
+            const ci = yield* resolveConnectorInput(sd, ctx, allowStdio).pipe(
+              Effect.withSpan("mcp.plugin.resolve_connector", {
+                attributes: {
+                  "mcp.source.namespace": namespace,
+                  "mcp.source.transport": sd.transport,
+                },
+              }),
+            );
 
             const connector = createMcpConnector(ci);
             // Try discovery. If it fails (auth, network, bad spec), we still
@@ -505,6 +518,9 @@ export const mcpPlugin = definePlugin(
                 mcpDiscoveryError(`MCP discovery failed: ${err.message}`),
               ),
               Effect.either,
+              Effect.withSpan("mcp.plugin.discover_tools", {
+                attributes: { "mcp.source.namespace": namespace },
+              }),
             );
             const manifest =
               discovery._tag === "Right"
@@ -513,73 +529,101 @@ export const mcpPlugin = definePlugin(
 
             const sourceName = manifest.server?.name ?? config.name ?? namespace;
 
-            yield* ctx.transaction(
-              Effect.gen(function* () {
-                // Remove stale rows for this namespace (plugin-owned)
-                yield* ctx.storage.removeBindingsByNamespace(namespace);
-                yield* ctx.storage.removeSource(namespace);
+            yield* ctx
+              .transaction(
+                Effect.gen(function* () {
+                  // Remove stale rows for this namespace (plugin-owned)
+                  yield* ctx.storage.removeBindingsByNamespace(namespace);
+                  yield* ctx.storage.removeSource(namespace);
 
-                yield* ctx.storage.putSource({
-                  namespace,
-                  name: sourceName,
-                  config: sd,
-                });
+                  yield* ctx.storage.putSource({
+                    namespace,
+                    name: sourceName,
+                    config: sd,
+                  });
 
-                yield* ctx.storage.putBindings(
-                  namespace,
-                  manifest.tools.map((e) => ({
-                    toolId: `${namespace}.${e.toolId}`,
-                    binding: toBinding(e),
-                  })),
-                );
+                  yield* ctx.storage.putBindings(
+                    namespace,
+                    manifest.tools.map((e) => ({
+                      toolId: `${namespace}.${e.toolId}`,
+                      binding: toBinding(e),
+                    })),
+                  );
 
-                yield* ctx.core.sources.register({
-                  id: namespace,
-                  kind: "mcp",
-                  name: sourceName,
-                  url: sd.transport === "remote" ? sd.endpoint : undefined,
-                  canRemove: true,
-                  canRefresh: true,
-                  canEdit: sd.transport === "remote",
-                  tools: manifest.tools.map((e) => ({
-                    name: e.toolId,
-                    description: e.description ?? `MCP tool: ${e.toolName}`,
-                    inputSchema: e.inputSchema,
-                    outputSchema: e.outputSchema,
-                  })),
-                });
-              }),
-            );
+                  yield* ctx.core.sources.register({
+                    id: namespace,
+                    kind: "mcp",
+                    name: sourceName,
+                    url: sd.transport === "remote" ? sd.endpoint : undefined,
+                    canRemove: true,
+                    canRefresh: true,
+                    canEdit: sd.transport === "remote",
+                    tools: manifest.tools.map((e) => ({
+                      name: e.toolId,
+                      description: e.description ?? `MCP tool: ${e.toolName}`,
+                      inputSchema: e.inputSchema,
+                      outputSchema: e.outputSchema,
+                    })),
+                  });
+                }),
+              )
+              .pipe(
+                Effect.withSpan("mcp.plugin.persist_source", {
+                  attributes: {
+                    "mcp.source.namespace": namespace,
+                    "mcp.source.tool_count": manifest.tools.length,
+                  },
+                }),
+              );
 
             if (configFile) {
-              yield* configFile.upsertSource(
-                toMcpConfigEntry(namespace, sourceName, config),
-              );
+              yield* configFile
+                .upsertSource(toMcpConfigEntry(namespace, sourceName, config))
+                .pipe(Effect.withSpan("mcp.plugin.config_file.upsert"));
             }
 
             if (discovery._tag === "Left") {
               return yield* Effect.fail(discovery.left);
             }
             return { toolCount: manifest.tools.length, namespace };
-          });
+          }).pipe(
+            Effect.withSpan("mcp.plugin.add_source", {
+              attributes: {
+                "mcp.source.transport": config.transport,
+                "mcp.source.name": config.name,
+              },
+            }),
+          );
 
         const removeSource = (namespace: string) =>
           Effect.gen(function* () {
-            yield* ctx.transaction(
-              Effect.gen(function* () {
-                yield* ctx.storage.removeBindingsByNamespace(namespace);
-                yield* ctx.storage.removeSource(namespace);
-                yield* ctx.core.sources.unregister(namespace);
-              }),
-            );
+            yield* ctx
+              .transaction(
+                Effect.gen(function* () {
+                  yield* ctx.storage.removeBindingsByNamespace(namespace);
+                  yield* ctx.storage.removeSource(namespace);
+                  yield* ctx.core.sources.unregister(namespace);
+                }),
+              )
+              .pipe(Effect.withSpan("mcp.plugin.persist_remove"));
             if (configFile) {
-              yield* configFile.removeSource(namespace);
+              yield* configFile
+                .removeSource(namespace)
+                .pipe(Effect.withSpan("mcp.plugin.config_file.remove"));
             }
-          });
+          }).pipe(
+            Effect.withSpan("mcp.plugin.remove_source", {
+              attributes: { "mcp.source.namespace": namespace },
+            }),
+          );
 
         const refreshSource = (namespace: string) =>
           Effect.gen(function* () {
-            const sd = yield* ctx.storage.getSourceConfig(namespace);
+            const sd = yield* ctx.storage.getSourceConfig(namespace).pipe(
+              Effect.withSpan("mcp.plugin.load_source_config", {
+                attributes: { "mcp.source.namespace": namespace },
+              }),
+            );
             if (!sd) {
               return yield* Effect.fail(
                 remoteConnectionError(
@@ -588,49 +632,72 @@ export const mcpPlugin = definePlugin(
               );
             }
 
-            const ci = yield* resolveConnectorInput(sd, ctx, allowStdio);
+            const ci = yield* resolveConnectorInput(sd, ctx, allowStdio).pipe(
+              Effect.withSpan("mcp.plugin.resolve_connector", {
+                attributes: {
+                  "mcp.source.namespace": namespace,
+                  "mcp.source.transport": sd.transport,
+                },
+              }),
+            );
             const manifest = yield* discoverTools(createMcpConnector(ci)).pipe(
               Effect.mapError((err) =>
                 mcpDiscoveryError(`MCP refresh failed: ${err.message}`),
               ),
+              Effect.withSpan("mcp.plugin.discover_tools", {
+                attributes: { "mcp.source.namespace": namespace },
+              }),
             );
 
             const existing = yield* ctx.storage.getSource(namespace);
             const sourceName =
               manifest.server?.name ?? existing?.name ?? namespace;
 
-            yield* ctx.transaction(
-              Effect.gen(function* () {
-                yield* ctx.storage.removeBindingsByNamespace(namespace);
-                yield* ctx.core.sources.unregister(namespace);
+            yield* ctx
+              .transaction(
+                Effect.gen(function* () {
+                  yield* ctx.storage.removeBindingsByNamespace(namespace);
+                  yield* ctx.core.sources.unregister(namespace);
 
-                yield* ctx.storage.putBindings(
-                  namespace,
-                  manifest.tools.map((e) => ({
-                    toolId: `${namespace}.${e.toolId}`,
-                    binding: toBinding(e),
-                  })),
-                );
-                yield* ctx.core.sources.register({
-                  id: namespace,
-                  kind: "mcp",
-                  name: sourceName,
-                  url: sd.transport === "remote" ? sd.endpoint : undefined,
-                  canRemove: true,
-                  canRefresh: true,
-                  canEdit: sd.transport === "remote",
-                  tools: manifest.tools.map((e) => ({
-                    name: e.toolId,
-                    description: e.description ?? `MCP tool: ${e.toolName}`,
-                    inputSchema: e.inputSchema,
-                    outputSchema: e.outputSchema,
-                  })),
-                });
-              }),
-            );
+                  yield* ctx.storage.putBindings(
+                    namespace,
+                    manifest.tools.map((e) => ({
+                      toolId: `${namespace}.${e.toolId}`,
+                      binding: toBinding(e),
+                    })),
+                  );
+                  yield* ctx.core.sources.register({
+                    id: namespace,
+                    kind: "mcp",
+                    name: sourceName,
+                    url: sd.transport === "remote" ? sd.endpoint : undefined,
+                    canRemove: true,
+                    canRefresh: true,
+                    canEdit: sd.transport === "remote",
+                    tools: manifest.tools.map((e) => ({
+                      name: e.toolId,
+                      description: e.description ?? `MCP tool: ${e.toolName}`,
+                      inputSchema: e.inputSchema,
+                      outputSchema: e.outputSchema,
+                    })),
+                  });
+                }),
+              )
+              .pipe(
+                Effect.withSpan("mcp.plugin.persist_source", {
+                  attributes: {
+                    "mcp.source.namespace": namespace,
+                    "mcp.source.tool_count": manifest.tools.length,
+                  },
+                }),
+              );
 
             return { toolCount: manifest.tools.length };
-          });
+          }).pipe(
+            Effect.withSpan("mcp.plugin.refresh_source", {
+              attributes: { "mcp.source.namespace": namespace },
+            }),
+          );
 
         const startOAuth = (input: McpOAuthStartInput) =>
           Effect.gen(function* () {
@@ -659,24 +726,27 @@ export const mcpPlugin = definePlugin(
               Effect.mapError((e) =>
                 mcpOAuthError(`OAuth start failed: ${e.message}`),
               ),
+              Effect.withSpan("mcp.plugin.oauth.start_authorization"),
             );
 
-            yield* ctx.storage.putOAuthSession(sessionId, {
-              endpoint: fullEndpoint,
-              redirectUrl: input.redirectUrl,
-              codeVerifier: started.codeVerifier,
-              resourceMetadataUrl: started.resourceMetadataUrl,
-              authorizationServerUrl: started.authorizationServerUrl,
-              resourceMetadata: started.resourceMetadata,
-              authorizationServerMetadata: started.authorizationServerMetadata,
-              clientInformation: started.clientInformation,
-            });
+            yield* ctx.storage
+              .putOAuthSession(sessionId, {
+                endpoint: fullEndpoint,
+                redirectUrl: input.redirectUrl,
+                codeVerifier: started.codeVerifier,
+                resourceMetadataUrl: started.resourceMetadataUrl,
+                authorizationServerUrl: started.authorizationServerUrl,
+                resourceMetadata: started.resourceMetadata,
+                authorizationServerMetadata: started.authorizationServerMetadata,
+                clientInformation: started.clientInformation,
+              })
+              .pipe(Effect.withSpan("mcp.plugin.oauth.persist_session"));
 
             return {
               sessionId,
               authorizationUrl: started.authorizationUrl,
             };
-          });
+          }).pipe(Effect.withSpan("mcp.plugin.start_oauth"));
 
         const completeOAuth = (input: McpOAuthCompleteInput) =>
           Effect.gen(function* () {
@@ -705,6 +775,7 @@ export const mcpPlugin = definePlugin(
               Effect.mapError((e) =>
                 mcpOAuthError(`OAuth exchange failed: ${e.message}`),
               ),
+              Effect.withSpan("mcp.plugin.oauth.exchange_code"),
             );
 
             const accessSecretId = `mcp-oauth-access-${input.state}`;
@@ -757,7 +828,7 @@ export const mcpPlugin = definePlugin(
               expiresAt,
               scope: exchanged.tokens.scope ?? null,
             };
-          });
+          }).pipe(Effect.withSpan("mcp.plugin.complete_oauth"));
 
         const updateSource = (
           namespace: string,
@@ -783,10 +854,18 @@ export const mcpPlugin = definePlugin(
               name: input.name?.trim() || existing.name,
               config: updatedConfig,
             });
-          });
+          }).pipe(
+            Effect.withSpan("mcp.plugin.update_source", {
+              attributes: { "mcp.source.namespace": namespace },
+            }),
+          );
 
         const getSource = (namespace: string) =>
-          ctx.storage.getSource(namespace);
+          ctx.storage.getSource(namespace).pipe(
+            Effect.withSpan("mcp.plugin.get_source", {
+              attributes: { "mcp.source.namespace": namespace },
+            }),
+          );
 
         return {
           probeEndpoint,
@@ -804,14 +883,22 @@ export const mcpPlugin = definePlugin(
         Effect.gen(function* () {
           const runtime = yield* ensureRuntime();
 
-          const entry = yield* ctx.storage.getBinding(toolRow.id);
+          const entry = yield* ctx.storage.getBinding(toolRow.id).pipe(
+            Effect.withSpan("mcp.plugin.load_binding", {
+              attributes: { "mcp.tool.name": toolRow.id },
+            }),
+          );
           if (!entry) {
             return yield* Effect.fail(
               new Error(`No MCP binding found for tool "${toolRow.id}"`),
             );
           }
 
-          const sd = yield* ctx.storage.getSourceConfig(entry.namespace);
+          const sd = yield* ctx.storage.getSourceConfig(entry.namespace).pipe(
+            Effect.withSpan("mcp.plugin.load_source_config", {
+              attributes: { "mcp.source.namespace": entry.namespace },
+            }),
+          );
           if (!sd) {
             return yield* Effect.fail(
               new Error(
@@ -837,12 +924,25 @@ export const mcpPlugin = definePlugin(
                           err instanceof Error ? err.message : String(err),
                       }),
                 ),
+                Effect.withSpan("mcp.plugin.resolve_connector", {
+                  attributes: {
+                    "mcp.source.namespace": entry.namespace,
+                    "mcp.source.transport": sd.transport,
+                  },
+                }),
               ),
             connectionCache: runtime.connectionCache,
             pendingConnectors: runtime.pendingConnectors,
             elicit,
           });
-        }),
+        }).pipe(
+          Effect.withSpan("mcp.plugin.invoke_tool", {
+            attributes: {
+              "mcp.tool.name": toolRow.id,
+              "mcp.tool.source_id": toolRow.source_id,
+            },
+          }),
+        ),
 
       detect: ({ url }) =>
         Effect.gen(function* () {
@@ -865,6 +965,7 @@ export const mcpPlugin = definePlugin(
           const connected = yield* discoverTools(connector).pipe(
             Effect.map(() => true),
             Effect.catchAll(() => Effect.succeed(false)),
+            Effect.withSpan("mcp.plugin.discover_tools"),
           );
 
           if (connected) {
@@ -885,6 +986,7 @@ export const mcpPlugin = definePlugin(
           }).pipe(
             Effect.map(() => true),
             Effect.catchAll(() => Effect.succeed(false)),
+            Effect.withSpan("mcp.plugin.probe_oauth"),
           );
 
           if (hasOAuth) {
@@ -898,7 +1000,12 @@ export const mcpPlugin = definePlugin(
           }
 
           return null;
-        }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+        }).pipe(
+          Effect.catchAll(() => Effect.succeed(null)),
+          Effect.withSpan("mcp.plugin.detect", {
+            attributes: { "mcp.endpoint": url },
+          }),
+        ),
 
       // MCP tools never require approval at the tool level — elicitation is
       // handled mid-invocation by the server via the elicit capability.
@@ -928,7 +1035,7 @@ export const mcpPlugin = definePlugin(
             yield* Scope.close(runtime.cacheScope, Exit.void);
             runtimeRef.current = null;
           }
-        }),
+        }).pipe(Effect.withSpan("mcp.plugin.close")),
     };
   },
 );

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -102,9 +102,13 @@ export const resolveHeaders = (
 ): Effect.Effect<
   Record<string, string>,
   OpenApiInvocationError | StorageFailure
-> =>
-  Effect.gen(function* () {
-    const entries = Object.entries(headers);
+> => {
+  const entries = Object.entries(headers);
+  const secretCount = entries.reduce(
+    (acc, [, value]) => (typeof value === "string" ? acc : acc + 1),
+    0,
+  );
+  return Effect.gen(function* () {
     // Fan out secret lookups: on every invocation, one or two headers
     // typically each hit the secret store. Resolving them in parallel
     // is a free wall-clock win — preserved order is only needed for
@@ -134,7 +138,15 @@ export const resolveHeaders = (
     const resolved: Record<string, string> = {};
     for (const { name, value } of values) resolved[name] = value;
     return resolved;
-  });
+  }).pipe(
+    Effect.withSpan("plugin.openapi.secret.resolve", {
+      attributes: {
+        "plugin.openapi.headers.total": entries.length,
+        "plugin.openapi.headers.secret_count": secretCount,
+      },
+    }),
+  );
+};
 
 const applyHeaders = (
   request: HttpClientRequest.HttpClientRequest,
@@ -169,6 +181,14 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
   resolvedHeaders: Record<string, string>,
 ) {
   const client = yield* HttpClient.HttpClient;
+
+  yield* Effect.annotateCurrentSpan({
+    "http.method": operation.method.toUpperCase(),
+    "http.route": operation.pathTemplate,
+    "plugin.openapi.method": operation.method.toUpperCase(),
+    "plugin.openapi.path_template": operation.pathTemplate,
+    "plugin.openapi.headers.resolved_count": Object.keys(resolvedHeaders).length,
+  });
 
   const resolvedPath = yield* resolvePath(operation.pathTemplate, args, operation.parameters);
 
@@ -216,6 +236,9 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
   );
 
   const status = response.status;
+  yield* Effect.annotateCurrentSpan({
+    "http.status_code": status,
+  });
   const responseHeaders: Record<string, string> = { ...response.headers };
 
   const contentType = response.headers["content-type"] ?? null;
@@ -268,7 +291,16 @@ export const invokeWithLayer = (
       ).pipe(Layer.provide(httpClientLayer))
     : httpClientLayer;
 
-  return invoke(operation, args, resolvedHeaders).pipe(Effect.provide(clientWithBaseUrl));
+  return invoke(operation, args, resolvedHeaders).pipe(
+    Effect.provide(clientWithBaseUrl),
+    Effect.withSpan("plugin.openapi.invoke", {
+      attributes: {
+        "plugin.openapi.method": operation.method.toUpperCase(),
+        "plugin.openapi.path_template": operation.pathTemplate,
+        "plugin.openapi.base_url": baseUrl,
+      },
+    }),
+  );
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #324. After end-to-end span nesting was verified, the trace showed an 817ms host-side gap between `executor.tool.rpc_dispatch` and the first vault read — fully unattributed. This PR instruments the rest of the dispatch path so we can see where time actually goes.

Five buckets, fanned out across the instrumentation surface:

- **A — Engine + tool invoker** (`packages/core/execution/{engine,tool-invoker}.ts`): `executor.tools.invoke`, `mcp.tool.dispatch`
- **B — Plugin SDK invokers** (`packages/plugins/{openapi,graphql,mcp}/src/sdk/invoke.ts`, `mcp/src/sdk/connection.ts`): `plugin.openapi.invoke`, `plugin.graphql.invoke`, `plugin.mcp.invoke`, `plugin.mcp.connect`
- **C — Storage** (`packages/core/storage-core/src/factory.ts`, `packages/core/storage-drizzle/src/adapter.ts`): `executor.storage.find_one`, `executor.storage.find_many`, plus drizzle-level `db.query.*` spans
- **D — Schema compile/describe** (`packages/core/sdk/src/{executor,schema-types}.ts`, `packages/core/execution/src/description.ts`): `schema.compile.preview`, `schema.describe.execute`
- **E — Transport / session** (`apps/cloud/src/mcp-session.ts`, `packages/hosts/mcp/src/server.ts`, `packages/plugins/mcp/src/sdk/plugin.ts`): `mcp.request`, `mcp.session.handle`, `executor.sources.load`

Naming convention: `mcp.* / executor.* / executor.tool.* / executor.sources.* / executor.storage.* / plugin.{openapi,graphql,mcp}.* / vault.* / schema.*`

Verified live in Axiom on the deployed worker — every expected span name fires, parent_span_id chains are correct, the 817ms gap is now broken into named child spans (4 sequential storage reads + secret resolution).

## Follow-ups identified from the new traces (not in this PR)

1. \`openapi_operation\` is read twice per call (305ms findMany + 200ms findOne) — dedupe.
2. The 4 sequential reads in the handler are independent — parallelize for ~400ms savings.
3. No per-session cache on source/operation/secret rows.

## Test plan
- [x] Deployed and verified span tree in Axiom (\`executor-cloud\` dataset)
- [x] All bucket span families present with correct parent chains
- [ ] Watch p50/p95 trace export overhead post-merge