### PR TITLE
fix(keychain): skip provider registration when backend unreachable

### DIFF
--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -865,10 +865,11 @@ export const createExecutor = <
       runtimes.set(plugin.id, { plugin, storage, ctx });
 
       if (plugin.secretProviders) {
-        const providers =
+        const raw =
           typeof plugin.secretProviders === "function"
             ? plugin.secretProviders(ctx)
             : plugin.secretProviders;
+        const providers = Effect.isEffect(raw) ? yield* raw : raw;
         for (const provider of providers) {
           if (secretProviders.has(provider.key)) {
             return yield* Effect.fail(

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -296,13 +296,18 @@ export interface PluginSpec<
   }) => Effect.Effect<SourceDetectionResult | null, unknown>;
 
   /** Secret providers contributed by this plugin. Either a static
-   *  array or a function of ctx (for providers that need per-instance
-   *  state like the keychain's scope-derived service name). Called
-   *  once at executor startup after `storage` and `extension` have
-   *  been built. */
+   *  array, a function of ctx (for providers that need per-instance
+   *  state like the keychain's scope-derived service name), or a
+   *  function returning an Effect so plugins can probe for backend
+   *  availability at startup and register conditionally. Called once
+   *  at executor startup after `storage` and `extension` have been
+   *  built. */
   readonly secretProviders?:
     | readonly SecretProvider[]
-    | ((ctx: PluginCtx<TStore>) => readonly SecretProvider[]);
+    | ((ctx: PluginCtx<TStore>) => readonly SecretProvider[])
+    | ((
+        ctx: PluginCtx<TStore>,
+      ) => Effect.Effect<readonly SecretProvider[]>);
 
   readonly close?: () => Effect.Effect<void, unknown>;
 }

--- a/packages/plugins/keychain/src/index.ts
+++ b/packages/plugins/keychain/src/index.ts
@@ -2,9 +2,24 @@ import { Effect } from "effect";
 
 import { definePlugin, type PluginCtx } from "@executor/sdk";
 
-import { displayName, isSupportedPlatform, resolveServiceName } from "./keyring";
-import { getPassword } from "./keyring";
+import {
+  deletePassword,
+  displayName,
+  getPassword,
+  isSupportedPlatform,
+  resolveServiceName,
+  setPassword,
+} from "./keyring";
 import { makeKeychainProvider } from "./provider";
+
+// Probe the keychain by writing and then deleting a sentinel entry. A
+// read-only probe isn't enough — on some Linux environments (WSL2,
+// headless CI) `getPassword` for a missing key returns null without
+// error, but `setPassword` fails because the secret-service backend
+// isn't actually reachable. Writing is the capability the executor
+// cares about, so test it directly.
+const PROBE_ACCOUNT = "__executor_keychain_probe__";
+const PROBE_VALUE = "probe";
 
 // ---------------------------------------------------------------------------
 // Re-exports
@@ -70,8 +85,27 @@ export const keychainPlugin = definePlugin(
       };
     },
 
-    secretProviders: (ctx) => [
-      makeKeychainProvider(scopedServiceName(ctx, options)),
-    ],
+    secretProviders: (ctx) =>
+      Effect.gen(function* () {
+        const serviceName = scopedServiceName(ctx, options);
+        const reachable = yield* setPassword(
+          serviceName,
+          PROBE_ACCOUNT,
+          PROBE_VALUE,
+        ).pipe(
+          Effect.andThen(
+            deletePassword(serviceName, PROBE_ACCOUNT).pipe(
+              Effect.catchAll(() => Effect.void),
+            ),
+          ),
+          Effect.as(true),
+          Effect.catchAll((cause) =>
+            Effect.logWarning(
+              `keychain unavailable, skipping provider registration: ${cause.message}`,
+            ).pipe(Effect.as(false)),
+          ),
+        );
+        return reachable ? [makeKeychainProvider(serviceName)] : [];
+      }),
   }),
 );


### PR DESCRIPTION
## Summary

- Keychain plugin now probes the backend with a set+delete cycle at init; if unreachable (WSL2, headless Linux, no running secret-service), logs a warning and registers no secret provider instead of fighting a broken backend at write time.
- `executor.secrets.set` then auto-picks the next writable provider the host has configured, matching the "silent fallback" pattern used by VS Code / most CLIs that wrap keyring.
- Widens `plugin.secretProviders` to accept an `Effect`-returning function alongside the existing sync forms. All other plugins (file-secrets, 1password, workos-vault, memory) keep working unchanged.

## Why a set+delete probe, not a read probe?

On WSL2 `getPassword` for a missing key returns `null` without error even when the secret-service daemon isn't reachable, so a read-only probe reports false-positive availability. Writing is the capability the executor actually cares about.

## Test plan

- [x] `vitest run` in `packages/plugins/keychain` — passes on WSL2 (3 skipped as before)
- [x] `vitest run` in `packages/core/sdk` — 35/35 passing
- [x] `tsgo --noEmit` on both packages
- [ ] Smoke test on macOS: keychain provider still registers and `executor.secrets.set` writes through it
- [ ] Smoke test on Linux CI: warning logs, provider absent, host's fallback provider gets the write