### PR TITLE
sdk: layered ScopeStack with shadow-ranked secret resolver

### DIFF
--- a/notes/per-user-scopes.md
+++ b/notes/per-user-scopes.md
@@ -1,0 +1,133 @@
+# Per-user scopes
+
+Concrete plan for per-user OAuth, per-user bearer tokens, and per-user
+source preferences. Builds on `scopes.md` (layered scopes) — this is
+the first real use of the layering primitive.
+
+## The shape
+
+The user scope is just another layer in the existing scope stack.
+Read chain per request: `[userScope, orgScope]`, innermost wins.
+Writes target exactly one scope — caller picks personal vs shared.
+
+No new `account_id` column on anything. No `Principal` concept in the
+SDK. The scope id string IS the association.
+
+## Scope id derivation
+
+User scope id is deterministic, derived from the verified JWT:
+
+```
+${orgScopeId}:user:${accountId}
+```
+
+Namespaced under the org so the same WorkOS account in two
+organizations gets two disjoint personal scopes — Alice's vercel
+credential in Acme does not leak into her BigCo view.
+
+No `account_scope` mapping table. No request-time lookup. The host
+reconstructs the id from the authenticated principal every request.
+
+Authz is enforced at the host boundary: the cloud app derives the
+user-scope id from the JWT's `sub`, never from a client-supplied field.
+A malicious caller can't claim another user's scope because the server
+is the one constructing the chain.
+
+## Materialization
+
+Scope rows (the `scope` table) materialize lazily on first write. The
+`scopeAdapter.stampScope` already writes `scope_id` into every row — we
+just need an upsert into the `scope` table on first use of a new user
+scope id, or an eager "on org-membership add" hook. Either works;
+lazy is simpler.
+
+Org scopes continue to materialize on org creation as today.
+
+## Resolver (personal → shared)
+
+This is already the behaviour `scopes.md` specifies for layered scopes:
+
+- `findOne` / `findMany` get `WHERE scope_id IN (readChain)`.
+- On id collision across scopes, the innermost wins (shadowing pass on
+  top of `findMany` results).
+- Secret `get` naturally returns the user-scope value if one exists,
+  else falls back to the org-scope value.
+
+No `account_id`-aware resolver code. The `secretsGet` / `secretsList` /
+`secretsStatus` changes reduce to the general layered-scope shadowing
+pass, not a per-feature walk.
+
+## What this unlocks beyond secrets
+
+Anything that lives on a `scope_id`-aware table becomes user-overridable
+for free — no per-feature plumbing:
+
+- Per-user tool approval preferences (policy rows at user scope shadow
+  org defaults).
+- Per-user "auto-run this source" / "never prompt on this tool" flags.
+- Per-user default args, per-user elicitation behaviour.
+
+Org admin sets defaults at org scope. User shadows them at user scope.
+Same primitive.
+
+## Write-target selection
+
+The `ScopeContext.write` field (already in `scoped-adapter.ts`) picks
+the target. UI affordance on the kickoff page / secrets page sends a
+`scope: "personal" | "shared"` field, and the cloud handler maps:
+
+- `"personal"` → `write = userScopeId`
+- `"shared"`   → `write = orgScopeId`
+
+Host-side authz gate: writing to org scope requires the writer to hold
+an org-admin role. RBAC check lives at the API boundary, not in the
+SDK. Deferred initially — every authed user can write to either scope
+until RBAC lands.
+
+## Sources and tools: a consequence
+
+User-scope writes of sources and tools make them user-visible only.
+Alice's personal Vercel source (registered with `write = userScope`) is
+invisible to Bob. This is exactly the per-user OAuth story — it falls
+out of the scope layering, not out of a new dimension.
+
+Shared sources stay at org scope; everyone in the org sees them.
+
+## Cloud glue (the concrete diff)
+
+- `AuthContext` already carries `accountId`. No change.
+- `createScopedExecutor(scopeId, scopeName)` grows into taking a scope
+  stack: `createScopedExecutor({ read: [user, org], write: "user" | "org" })`.
+  Default `write` depends on the endpoint — secret writes pick up a
+  request field; passive reads don't care.
+- `McpSessionInit` gains `accountId` so the DO can reconstruct the
+  user-scope id on every request into the session.
+- `makeExecutionStack` threads the scope stack down to `createExecutor`.
+
+## What we're NOT doing
+
+- No `account_id` column on `secret`, `workos_vault_metadata`, or any
+  other table.
+- No `Principal` type in `@executor/sdk`.
+- No `SecretOwner` union in public API. "Personal" vs "shared" is a
+  host-side UI concept; the SDK sees only a scope stack and a write
+  target.
+- No per-feature "account-aware" resolver code. The layered-scope
+  shadowing pass is the mechanism.
+
+## Migration
+
+For existing secrets: nothing to migrate. Every existing row keeps its
+`scope_id = orgScope` and becomes an org-shared credential by default.
+Users who want a personal override write a new row at their user scope
+after the layering lands.
+
+Personal `scope` rows get inserted lazily on first use.
+
+## Related
+
+- `notes/scopes.md` — the general layering plan this specializes.
+- `packages/core/sdk/src/scoped-adapter.ts` — already list-shaped,
+  nothing to change in the wrapper itself.
+- `packages/core/sdk/src/executor.ts` — needs the layered-scope
+  shadowing pass on `findMany` / secret `get` / secret `list`.

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -36,7 +36,7 @@ import {
   ToolInvocationError,
   ToolNotFoundError,
 } from "./errors";
-import { SecretId, ToolId } from "./ids";
+import { ScopeId, SecretId, ToolId } from "./ids";
 import type {
   AnyPlugin,
   Elicit,
@@ -46,7 +46,12 @@ import type {
   StaticToolDecl,
   StorageDeps,
 } from "./plugin";
-import type { Scope } from "./scope";
+import {
+  normalizeScopeStack,
+  type Scope,
+  type ScopeInput,
+  type ScopeStack,
+} from "./scope";
 import {
   SecretRef,
   SetSecretInput,
@@ -95,7 +100,12 @@ const resolveElicitationHandler = (
 // ---------------------------------------------------------------------------
 
 export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
+  /** The write-target scope. Matches `ctx.scope` inside plugins. */
   readonly scope: Scope;
+  /** Full request-time scope composition. Single-element for CLI/local
+   *  hosts; multi-element for cloud hosts that layer per-user over
+   *  per-org scopes. */
+  readonly scopeStack: ScopeStack;
 
   readonly tools: {
     readonly list: (
@@ -172,7 +182,11 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
 export interface ExecutorConfig<
   TPlugins extends readonly AnyPlugin[] = [],
 > {
-  readonly scope: Scope;
+  /** Either a single Scope (single-scope hosts: CLI, local) or a full
+   *  ScopeStack (layered hosts: cloud, where per-user scopes stack on
+   *  top of per-org scopes). Single-scope input is normalized to a
+   *  1-element stack internally. */
+  readonly scope: ScopeInput;
   readonly adapter: DBAdapter;
   readonly blobs: BlobStore;
   readonly plugins?: TPlugins;
@@ -471,11 +485,25 @@ export const createExecutor = <
 ): Effect.Effect<Executor<TPlugins>, Error> =>
   Effect.gen(function* () {
     const {
-      scope,
+      scope: scopeInput,
       adapter: rootAdapter,
       blobs,
       plugins = [] as unknown as TPlugins,
     } = config;
+    const scopeStack = normalizeScopeStack(scopeInput);
+    // `scope` is the write-target throughout the executor. Plugin code
+    // that uses `ctx.scope.id` for per-scope namespacing (keychain
+    // service names, file paths) continues to work unchanged.
+    const scope = scopeStack.write;
+    const readScopeIds = scopeStack.read.map((s) => s.id);
+    // Where-in-chain index: 0 = innermost, N-1 = outermost. Used by
+    // shadowing passes to pick the innermost row on id collision.
+    const scopeRank = new Map<string, number>();
+    scopeStack.read.forEach((s, idx) => {
+      if (!scopeRank.has(s.id)) scopeRank.set(s.id, idx);
+    });
+    const rankOf = (scopeId: string): number =>
+      scopeRank.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
 
     // Scope-wrap the root adapter so every read on a tenant-scoped table
     // filters by the current scope stack and every write stamps the
@@ -486,7 +514,7 @@ export const createExecutor = <
     const schema = collectSchemas(plugins);
     const scopedRoot = scopeAdapter(
       rootAdapter,
-      { read: [scope.id], write: scope.id },
+      { read: readScopeIds, write: scope.id },
       schema,
     );
     const adapter = buildAdapterRouter(scopedRoot);
@@ -511,25 +539,80 @@ export const createExecutor = <
     // without a list() implementation (keychain) never hit the fallback
     // walk because their secrets must be registered through set() to
     // be known at all.
+    //
+    // Layered-scope shadowing: when the read chain has more than one
+    // scope, the scope adapter filters `WHERE scope_id IN (chain)` but
+    // can return rows from any matching scope. We pick the innermost
+    // match on id collision so per-user overrides beat org defaults.
+
+    // Generic shadowing helper: given rows from a scope-aware table,
+    // pick the innermost-scope row for each unique key. Used for
+    // secrets (key = id), sources (key = id), tools (key = id).
+    const shadowByKey = <T extends { readonly scope_id: string }>(
+      rows: readonly T[],
+      key: (row: T) => string,
+    ): T[] => {
+      const best = new Map<string, T>();
+      for (const row of rows) {
+        const k = key(row);
+        const existing = best.get(k);
+        if (!existing || rankOf(row.scope_id) < rankOf(existing.scope_id)) {
+          best.set(k, row);
+        }
+      }
+      return Array.from(best.values());
+    };
+
+    // Scope-aware "find exactly one" for a table that carries scope_id.
+    // `findOne` with a non-scope where clause would return any row in
+    // the chain; we want the innermost match so per-user rows beat
+    // per-org rows on collision. Cheaper than findOne-per-scope: one
+    // findMany + O(chain-length) scan in memory.
+    const pickInnermost = <T extends { readonly scope_id: string }>(
+      rows: readonly T[],
+    ): T | null => {
+      let best: T | null = null;
+      for (const row of rows) {
+        if (!best || rankOf(row.scope_id) < rankOf(best.scope_id)) {
+          best = row;
+        }
+      }
+      return best;
+    };
+
     const secretsGet = (
       id: string,
     ): Effect.Effect<string | null, StorageFailure> =>
       Effect.gen(function* () {
-        // Fast path: routing table
-        const row = yield* core.findOne({
+        // Fast path: routing table with shadowing. `findOne` would pick
+        // any row in the chain; we need the innermost. One findMany
+        // and an O(n) scan (n ≤ chain length) is cheaper than one
+        // findOne-per-scope.
+        const rows = yield* core.findMany({
           model: "secret",
           where: [{ field: "id", value: id }],
         });
-        if (row) {
-          const provider = secretProviders.get(row.provider);
+        const winner = shadowByKey(
+          rows as readonly { scope_id: string; id: string; provider: string }[],
+          (r) => r.id,
+        )[0];
+        if (winner) {
+          const provider = secretProviders.get(winner.provider);
           if (!provider) return null;
-          return yield* provider.get(id);
+          // Pass the winner's scope so scope-aware backends
+          // (workos-vault) read from the right keyspace even when
+          // the executor's write target is a different scope.
+          return yield* provider.get(id, winner.scope_id);
         }
 
         // Fallback: ask every enumerating provider in parallel. First
         // non-null in registration order wins. Providers that throw
         // are treated as "don't have it" so one flaky provider can't
-        // block resolution via others.
+        // block resolution via others. Enumerating providers are
+        // already scope-bound at construction time (each plugin
+        // contributes one provider per executor, ctx.scope identifies
+        // the write target) so they resolve within a single scope's
+        // view — shadowing across scopes is a core-table concern.
         const candidates = [...secretProviders.values()].filter(
           (p) => p.list,
         );
@@ -587,7 +670,9 @@ export const createExecutor = <
           );
         }
 
-        yield* target.set(input.id, input.value);
+        // Pass the write-target scope so scope-aware providers land
+        // the value in the right keyspace.
+        yield* target.set(input.id, input.value, scope.id);
 
         // Upsert metadata row in the core `secret` table.
         const now = new Date();
@@ -624,8 +709,21 @@ export const createExecutor = <
           (p): p is typeof p & { delete: NonNullable<typeof p.delete> } =>
             !!(p.writable && p.delete),
         );
+        // Find which scope currently owns this id (innermost wins) so
+        // we only delete that scope's row and value. Without this a
+        // user-first executor asked to `remove("foo")` would wipe the
+        // org's shared row too once the scoped adapter allowed it.
+        const ownerRows = yield* core.findMany({
+          model: "secret",
+          where: [{ field: "id", value: id }],
+        });
+        const ownerWinner = shadowByKey(
+          ownerRows as readonly { scope_id: string; id: string }[],
+          (r) => r.id,
+        )[0];
+        const ownerScope = ownerWinner?.scope_id ?? scope.id;
         yield* Effect.all(
-          deleters.map((p) => p.delete(id)),
+          deleters.map((p) => p.delete(id, ownerScope)),
           { concurrency: "unbounded" },
         );
         yield* core.delete({
@@ -649,18 +747,34 @@ export const createExecutor = <
     // so that routing information in the core table is authoritative.
     // Providers without a list() method (e.g. keychain) contribute
     // only via the core table path.
+    //
+    // Shadowing: when the read chain has multiple scopes, we collapse
+    // to one entry per id and pick the innermost-scope row. The
+    // returned `SecretRef.scopeId` reflects which scope the winning
+    // row actually lives at so UIs can distinguish "your override"
+    // vs "org default".
     const secretsList = (): Effect.Effect<readonly SecretRef[], StorageFailure> =>
       Effect.gen(function* () {
         const byId = new Map<string, SecretRef>();
 
-        // Core routing rows first
-        const rows = yield* core.findMany({ model: "secret" });
-        for (const row of rows) {
+        // Core routing rows first, with shadowing.
+        const rawRows = yield* core.findMany({ model: "secret" });
+        const shadowed = shadowByKey(
+          rawRows as readonly {
+            scope_id: string;
+            id: string;
+            name: string;
+            provider: string;
+            created_at: Date | string;
+          }[],
+          (r) => r.id,
+        );
+        for (const row of shadowed) {
           byId.set(
             row.id,
             new SecretRef({
               id: SecretId.make(row.id),
-              scopeId: scope.id,
+              scopeId: ScopeId.make(row.scope_id),
               name: row.name,
               provider: row.provider,
               createdAt:
@@ -676,34 +790,58 @@ export const createExecutor = <
         // swallow the failure so one flaky provider can't block the
         // whole list. Merge in registration order afterwards so the
         // "first provider wins" precedence stays deterministic.
+        //
+        // Each provider is asked once per scope in the read chain so
+        // scope-aware backends (workos-vault) surface entries that
+        // belong to outer scopes (e.g. org-level shared secrets)
+        // alongside the write target's own entries. Innermost-scope
+        // wins on id collision.
         const listers = [...secretProviders.entries()].filter(
           ([, p]) => p.list,
         );
         const lists = yield* Effect.all(
-          listers.map(([key, p]) =>
-            p
-              .list!()
-              .pipe(
-                Effect.catchAll(() => Effect.succeed([] as const)),
-                Effect.map((entries) => ({ key, entries })),
-              ),
+          listers.flatMap(([key, p]) =>
+            scopeStack.read.map((s) =>
+              p
+                .list!(s.id)
+                .pipe(
+                  Effect.catchAll(() => Effect.succeed([] as const)),
+                  Effect.map((entries) => ({ key, scopeId: s.id, entries })),
+                ),
+            ),
           ),
           { concurrency: "unbounded" },
         );
-        for (const { key, entries } of lists) {
-          for (const entry of entries) {
-            if (byId.has(entry.id)) continue; // core row wins
-            byId.set(
-              entry.id,
-              new SecretRef({
-                id: SecretId.make(entry.id),
-                scopeId: scope.id,
-                name: entry.name,
-                provider: key,
-                createdAt: new Date(),
-              }),
-            );
+        // Rank provider-enumerated rows by scope so inner scopes shadow
+        // outer ones when the same id shows up in both.
+        const providerEntries = new Map<
+          string,
+          {
+            readonly key: string;
+            readonly scopeId: string;
+            readonly name: string;
           }
+        >();
+        for (const { key, scopeId: s, entries } of lists) {
+          for (const entry of entries) {
+            const existing = providerEntries.get(entry.id);
+            if (!existing || rankOf(s) < rankOf(existing.scopeId)) {
+              providerEntries.set(entry.id, { key, scopeId: s, name: entry.name });
+            }
+          }
+        }
+        for (const [id, entry] of providerEntries) {
+          if (byId.has(id)) continue; // core row wins
+          byId.set(
+            id,
+            new SecretRef({
+              id: SecretId.make(id),
+              scopeId: ScopeId.make(entry.scopeId),
+              name: entry.name,
+              provider: entry.key,
+              createdAt: new Date(),
+            }),
+          );
         }
 
         return Array.from(byId.values());
@@ -741,6 +879,7 @@ export const createExecutor = <
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const storageDeps: StorageDeps<any> = {
         scope,
+        scopeStack,
         adapter: typedAdapter(adapter) as never,
         // Blob keys are namespaced by `<scope>/<plugin>` so two tenants
         // sharing a backing BlobStore can't collide or leak on the same
@@ -751,6 +890,7 @@ export const createExecutor = <
 
       const ctx: PluginCtx<unknown> = {
         scope,
+        scopeStack,
         storage,
         core: {
           sources: {
@@ -888,7 +1028,12 @@ export const createExecutor = <
     // ------------------------------------------------------------------
     const listSources = () =>
       Effect.gen(function* () {
-        const dynamic = yield* core.findMany({ model: "source" });
+        // Dynamic rows come back across the whole read chain; shadow
+        // collisions so per-user overrides replace org defaults in the
+        // listing. Static sources live outside the scope table entirely
+        // and never participate in shadowing.
+        const raw = yield* core.findMany({ model: "source" });
+        const dynamic = shadowByKey(raw, (r) => r.id);
         const staticList: Source[] = [];
         for (const { source, pluginId } of staticSources.values()) {
           staticList.push(staticDeclToSource(source, pluginId));
@@ -941,7 +1086,12 @@ export const createExecutor = <
 
     const listTools = (filter?: ToolListFilter) =>
       Effect.gen(function* () {
-        const dynamic = yield* core.findMany({ model: "tool" });
+        // Same shadowing story as sources.list: the scope adapter hands
+        // back every tool row across the read chain; we keep the
+        // innermost per tool id so user-scope overrides replace
+        // org-scope rows.
+        const rawRows = yield* core.findMany({ model: "tool" });
+        const dynamic = shadowByKey(rawRows, (r) => r.id);
         const annotations = yield* resolveAnnotationsFor(dynamic).pipe(
           Effect.withSpan("executor.tools.list.annotations"),
         );
@@ -1048,12 +1198,13 @@ export const createExecutor = <
             rawOutput: staticEntry.tool.outputSchema,
           });
         }
-        const row = yield* core
-          .findOne({
+        const rows = yield* core
+          .findMany({
             model: "tool",
             where: [{ field: "id", value: toolId }],
           })
           .pipe(Effect.withSpan("executor.tool.resolve"));
+        const row = pickInnermost(rows);
         if (!row) return null;
         yield* Effect.annotateCurrentSpan({
           "executor.tool.dispatch_path": "dynamic",
@@ -1180,13 +1331,17 @@ export const createExecutor = <
           ).pipe(Effect.withSpan("executor.tool.handler"));
         }
 
-        // Dynamic path — DB lookup + delegate to owning plugin.
-        const row = yield* core
-          .findOne({
+        // Dynamic path — DB lookup + delegate to owning plugin. The
+        // scope adapter returns rows across the whole read chain;
+        // `pickInnermost` narrows to the user-scoped override if one
+        // exists, falling through to org otherwise.
+        const rows = yield* core
+          .findMany({
             model: "tool",
             where: [{ field: "id", value: toolId }],
           })
           .pipe(Effect.withSpan("executor.tool.resolve"));
+        const row = pickInnermost(rows);
         if (!row) {
           return yield* new ToolNotFoundError({
             toolId: ToolId.make(toolId),
@@ -1253,10 +1408,11 @@ export const createExecutor = <
         if (staticSources.has(sourceId)) {
           return yield* new SourceRemovalNotAllowedError({ sourceId });
         }
-        const sourceRow = yield* core.findOne({
+        const sourceRows = yield* core.findMany({
           model: "source",
           where: [{ field: "id", value: sourceId }],
         });
+        const sourceRow = pickInnermost(sourceRows);
         if (!sourceRow) return;
         if (!sourceRow.can_remove) {
           return yield* new SourceRemovalNotAllowedError({ sourceId });
@@ -1282,10 +1438,11 @@ export const createExecutor = <
     const refreshSource = (sourceId: string) =>
       Effect.gen(function* () {
         if (staticSources.has(sourceId)) return;
-        const sourceRow = yield* core.findOne({
+        const sourceRows = yield* core.findMany({
           model: "source",
           where: [{ field: "id", value: sourceId }],
         });
+        const sourceRow = pickInnermost(sourceRows);
         if (!sourceRow) return;
         const runtime = runtimes.get(sourceRow.plugin_id);
         if (runtime?.plugin.refreshSource) {
@@ -1359,6 +1516,7 @@ export const createExecutor = <
     // consumers (CLI, Promise SDK, tests) see the raw typed channel.
     const base = {
       scope,
+      scopeStack,
       tools: {
         list: listTools,
         schema: toolSchema,

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -26,7 +26,12 @@ export { StorageError, UniqueViolationError } from "@executor/storage-core";
 export { ScopeId, ToolId, SecretId, PolicyId } from "./ids";
 
 // Scope
-export { Scope } from "./scope";
+export {
+  Scope,
+  ScopeStack,
+  normalizeScopeStack,
+  type ScopeInput,
+} from "./scope";
 
 // Errors (tagged)
 export {
@@ -127,8 +132,12 @@ export {
   type ExecutorDialect,
 } from "./config";
 
-// Test helper
-export { makeTestConfig } from "./testing";
+// Test helpers
+export {
+  makeTestConfig,
+  makeLayeredTestConfig,
+  makeTestScope,
+} from "./testing";
 
 // JSON schema $ref helpers (used by openapi for $defs handling)
 export {

--- a/packages/core/sdk/src/layered-scope.test.ts
+++ b/packages/core/sdk/src/layered-scope.test.ts
@@ -1,0 +1,474 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { makeMemoryAdapter } from "@executor/storage-core/testing/memory";
+
+import { makeInMemoryBlobStore } from "./blob";
+import { collectSchemas, createExecutor } from "./executor";
+import { SecretId } from "./ids";
+import { definePlugin } from "./plugin";
+import { SetSecretInput } from "./secrets";
+import type { SecretProvider } from "./secrets";
+import { ScopeStack } from "./scope";
+import { makeLayeredTestConfig, makeTestScope } from "./testing";
+
+// ---------------------------------------------------------------------------
+// Shared in-memory provider. All executors under test share one backing
+// Map. Concretely this is what a single-tenant vault (one shared backend
+// across scopes) looks like. Per-scope isolation in these tests comes
+// from the core `secret` routing table carrying `scope_id`, not from
+// provider keyspaces — that's a provider-design concern layered on top
+// and not what the executor's shadowing logic is trying to own.
+// ---------------------------------------------------------------------------
+
+const makeSharedProvider = (store: Map<string, string>): SecretProvider => ({
+  key: "memory",
+  writable: true,
+  get: (id) => Effect.sync(() => store.get(id) ?? null),
+  set: (id, value) =>
+    Effect.sync(() => {
+      store.set(id, value);
+    }),
+  delete: (id) => Effect.sync(() => store.delete(id)),
+  list: () =>
+    Effect.sync(() =>
+      Array.from(store.keys()).map((id) => ({ id, name: id })),
+    ),
+});
+
+const sharedSecretsPlugin = (store: Map<string, string>) =>
+  definePlugin(() => ({
+    id: "memory-secrets" as const,
+    storage: () => ({}),
+    secretProviders: [makeSharedProvider(store)],
+  }));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("layered scope: secrets metadata shadowing", () => {
+  it.effect("single-scope read falls back to org default via shared routing", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A", "Alice");
+      const org = makeTestScope("org-1", "Acme");
+
+      const schema = collectSchemas([sharedSecretsPlugin(new Map())()]);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const store = new Map<string, string>();
+      const backing = { adapter, blobs };
+
+      // Org writes the shared default first.
+      const orgExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* orgExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("api-token"),
+          name: "API Token (org)",
+          value: "org-value",
+        }),
+      );
+
+      // User-first chain. No user row → shadowByKey picks the org row →
+      // provider returns the shared value.
+      const userExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+
+      expect(yield* userExec.secrets.get("api-token")).toBe("org-value");
+    }),
+  );
+
+  it.effect("write target lands in stack.write, not the innermost read scope", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+      const store = new Map<string, string>();
+
+      // writeIndex = 1 (org) while reading [user, org]. Mirrors the
+      // "save for the whole team" toggle on the add-secret form.
+      const exec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          writeIndex: 1,
+          plugins: [sharedSecretsPlugin(store)()] as const,
+        }),
+      );
+
+      const ref = yield* exec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("shared-token"),
+          name: "Shared",
+          value: "v",
+        }),
+      );
+      expect(ref.scopeId).toBe(org.id);
+    }),
+  );
+
+  it.effect("rows outside the read chain are invisible", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+      const other = makeTestScope("org-2", "Other Org");
+
+      const schema = collectSchemas([sharedSecretsPlugin(new Map())()]);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const store = new Map<string, string>();
+      const backing = { adapter, blobs };
+
+      // A tenant in a completely different org writes a secret with the
+      // same id — cross-tenant isolation must keep this invisible.
+      const otherExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [other],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* otherExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("api-token"),
+          name: "Other tenant",
+          value: "other-value",
+        }),
+      );
+
+      const userExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+
+      const list = yield* userExec.secrets.list();
+      // The backing Map is shared so provider.list() still enumerates
+      // `api-token`. The test asserts core-table isolation: no entry in
+      // the list should be stamped with `other.id`. Provider-only
+      // enumeration falls back to the write target, never surfaces
+      // rows from non-chain scopes.
+      const stampedWithOther = list.find((s) => s.scopeId === other.id);
+      expect(stampedWithOther).toBeUndefined();
+    }),
+  );
+
+  it.effect("list reports each row's actual scope_id (including org rows)", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+
+      const schema = collectSchemas([sharedSecretsPlugin(new Map())()]);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const store = new Map<string, string>();
+      const backing = { adapter, blobs };
+
+      const orgExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* orgExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("shared-only"),
+          name: "Shared",
+          value: "s",
+        }),
+      );
+
+      const userExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* userExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("user-only"),
+          name: "User only",
+          value: "u",
+        }),
+      );
+
+      const list = yield* userExec.secrets.list();
+      const byId = new Map(list.map((s) => [String(s.id), s]));
+
+      expect(byId.get("shared-only")?.scopeId).toBe(org.id);
+      expect(byId.get("user-only")?.scopeId).toBe(user.id);
+    }),
+  );
+
+  it.effect("list shadows duplicates to the innermost row", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+
+      const schema = collectSchemas([sharedSecretsPlugin(new Map())()]);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const store = new Map<string, string>();
+      const backing = { adapter, blobs };
+
+      const orgExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* orgExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("dup"),
+          name: "Org",
+          value: "org",
+        }),
+      );
+
+      const userExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* userExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("dup"),
+          name: "User",
+          value: "user",
+        }),
+      );
+
+      const list = yield* userExec.secrets.list();
+      const dups = list.filter((s) => s.id === "dup");
+      expect(dups).toHaveLength(1);
+      // Innermost (user) wins shadowing.
+      expect(dups[0]!.scopeId).toBe(user.id);
+      expect(dups[0]!.name).toBe("User");
+    }),
+  );
+
+  it.effect("scopeStack is exposed on the executor", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+
+      const exec = yield* createExecutor(
+        makeLayeredTestConfig({ read: [user, org] }),
+      );
+
+      expect(exec.scopeStack).toBeInstanceOf(ScopeStack);
+      expect(exec.scopeStack.read.map((s) => s.id)).toEqual([user.id, org.id]);
+      expect(exec.scopeStack.write.id).toBe(user.id);
+      // `executor.scope` is a shortcut for `scopeStack.write`.
+      expect(exec.scope.id).toBe(user.id);
+    }),
+  );
+
+  it.effect("single-scope config stays equivalent to a 1-element stack", () =>
+    Effect.gen(function* () {
+      const org = makeTestScope("org-1");
+      const store = new Map<string, string>();
+
+      const exec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [org],
+          plugins: [sharedSecretsPlugin(store)()] as const,
+        }),
+      );
+
+      yield* exec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("t"),
+          name: "T",
+          value: "v",
+        }),
+      );
+      expect(yield* exec.secrets.get("t")).toBe("v");
+      expect(exec.scopeStack.read).toHaveLength(1);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Sources + tools shadowing. A plugin that registers a source with the
+// same id at two scopes must surface the innermost row through
+// sources.list / tools.list / tools.invoke / tools.schema.
+// ---------------------------------------------------------------------------
+
+const registrarPlugin = definePlugin(() => ({
+  id: "reg" as const,
+  storage: () => ({}),
+  extension: (ctx) => ({
+    register: (opts: {
+      readonly sourceId: string;
+      readonly sourceName: string;
+      readonly toolName: string;
+      readonly toolDescription: string;
+    }) =>
+      ctx.core.sources.register({
+        id: opts.sourceId,
+        kind: "reg",
+        name: opts.sourceName,
+        canRemove: true,
+        tools: [{ name: opts.toolName, description: opts.toolDescription }],
+      }),
+  }),
+  invokeTool: ({ toolRow }) =>
+    Effect.succeed({
+      description: toolRow.description,
+      name: toolRow.name,
+    }),
+}));
+
+describe("layered scope: sources + tools shadowing", () => {
+  it.effect("sources.list collapses duplicate ids to the innermost scope", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+      const schema = collectSchemas([registrarPlugin()]);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const backing = { adapter, blobs };
+
+      const orgExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [org],
+          plugins: [registrarPlugin()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* orgExec.reg.register({
+        sourceId: "shared",
+        sourceName: "Org default",
+        toolName: "run",
+        toolDescription: "org-run",
+      });
+
+      const userExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          plugins: [registrarPlugin()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* userExec.reg.register({
+        sourceId: "shared",
+        sourceName: "User override",
+        toolName: "run",
+        toolDescription: "user-run",
+      });
+
+      const sources = yield* userExec.sources.list();
+      const shared = sources.filter((s) => s.id === "shared");
+      expect(shared).toHaveLength(1);
+      expect(shared[0]!.name).toBe("User override");
+    }),
+  );
+
+  it.effect("tools.list shadows collisions to the innermost row", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+      const schema = collectSchemas([registrarPlugin()]);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const backing = { adapter, blobs };
+
+      const orgExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [org],
+          plugins: [registrarPlugin()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* orgExec.reg.register({
+        sourceId: "shared",
+        sourceName: "Org",
+        toolName: "run",
+        toolDescription: "org-run",
+      });
+
+      const userExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          plugins: [registrarPlugin()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* userExec.reg.register({
+        sourceId: "shared",
+        sourceName: "User",
+        toolName: "run",
+        toolDescription: "user-run",
+      });
+
+      const tools = yield* userExec.tools.list();
+      const matches = tools.filter((t) => t.id === "shared.run");
+      expect(matches).toHaveLength(1);
+      expect(matches[0]!.description).toBe("user-run");
+    }),
+  );
+
+  it.effect("tools.invoke dispatches to the innermost row's plugin state", () =>
+    Effect.gen(function* () {
+      const user = makeTestScope("user-A");
+      const org = makeTestScope("org-1");
+      const schema = collectSchemas([registrarPlugin()]);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const backing = { adapter, blobs };
+
+      const orgExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [org],
+          plugins: [registrarPlugin()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* orgExec.reg.register({
+        sourceId: "shared",
+        sourceName: "Org",
+        toolName: "run",
+        toolDescription: "org-run",
+      });
+
+      const userExec = yield* createExecutor(
+        makeLayeredTestConfig({
+          read: [user, org],
+          plugins: [registrarPlugin()] as const,
+          sharedBacking: backing,
+        }),
+      );
+      yield* userExec.reg.register({
+        sourceId: "shared",
+        sourceName: "User",
+        toolName: "run",
+        toolDescription: "user-run",
+      });
+
+      // invokeTool receives the chosen row; confirm it's the user-scope
+      // copy.
+      const result = (yield* userExec.tools.invoke("shared.run", {})) as {
+        description: string;
+        name: string;
+      };
+      expect(result.description).toBe("user-run");
+    }),
+  );
+});

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -20,7 +20,7 @@ import type {
   ElicitationRequest,
   ElicitationResponse,
 } from "./elicitation";
-import type { Scope } from "./scope";
+import type { Scope, ScopeStack } from "./scope";
 import type { SecretProvider, SecretRef, SetSecretInput } from "./secrets";
 
 // ---------------------------------------------------------------------------
@@ -36,7 +36,12 @@ import type { SecretProvider, SecretRef, SetSecretInput } from "./secrets";
 // ---------------------------------------------------------------------------
 
 export interface StorageDeps<TSchema extends DBSchema | undefined = undefined> {
+  /** Write-target scope (same as `ctx.scope`). Stable identity across
+   *  requests for single-scope hosts; per-request for layered hosts —
+   *  don't cache provider instances keyed by this when the host runs
+   *  per-request executors. */
   readonly scope: Scope;
+  readonly scopeStack: ScopeStack;
   /**
    * Plugin-facing typed adapter. Failures surface as raw `StorageFailure`
    * (`StorageError` | `UniqueViolationError`). Plugins can
@@ -78,7 +83,19 @@ export type Elicit = (
 // ---------------------------------------------------------------------------
 
 export interface PluginCtx<TStore = unknown> {
+  /** The write-target scope. Unchanged shape from single-scope days:
+   *  plugin code that uses `ctx.scope.id` to derive per-scope namespaces
+   *  (keychain service names, file-secrets paths, vault object
+   *  prefixes) keeps working unmodified. When a layered stack is in
+   *  use, this is `scopeStack.write`. */
   readonly scope: Scope;
+  /** Full request-time scope composition. Always present; for
+   *  single-scope callers, `{ read: [scope], write: scope }`. Plugins
+   *  typically don't need this — the executor does its own shadowing
+   *  over the chain and exposes it via the secret/source/tool facades.
+   *  Plugins that own scope-aware tables and want the same shadowing
+   *  semantics on their own data read this to build layered queries. */
+  readonly scopeStack: ScopeStack;
   readonly storage: TStore;
 
   readonly core: {

--- a/packages/core/sdk/src/scope.ts
+++ b/packages/core/sdk/src/scope.ts
@@ -7,3 +7,37 @@ export class Scope extends Schema.Class<Scope>("Scope")({
   name: Schema.String,
   createdAt: Schema.DateFromNumber,
 }) {}
+
+// ---------------------------------------------------------------------------
+// ScopeStack — request-time composition of scopes. `read` is an
+// precedence-ordered list (innermost first); on id collision across
+// scopes the innermost wins. `write` is the single scope every write
+// lands in — must be an element of `read`.
+//
+// One-element stacks are the common case for single-user hosts (CLI,
+// local) and drop back to today's behaviour. Multi-element stacks
+// unlock per-user overrides of org-shared rows: cloud hosts build
+// `[userScope, orgScope]` per request from the authenticated JWT, and
+// scope-aware tables (secret, source, tool, future `policy`) get
+// layered resolution for free.
+//
+// See notes/scopes.md and notes/per-user-scopes.md for the full
+// motivation.
+// ---------------------------------------------------------------------------
+
+export class ScopeStack extends Schema.Class<ScopeStack>("ScopeStack")({
+  read: Schema.Array(Scope),
+  write: Scope,
+}) {
+  static fromScope = (scope: Scope): ScopeStack =>
+    new ScopeStack({ read: [scope], write: scope });
+}
+
+/** Caller input: a bare Scope (single-scope convenience) or a full
+ *  stack. Normalized to `ScopeStack` via {@link normalizeScopeStack}. */
+export type ScopeInput = Scope | ScopeStack;
+
+export const normalizeScopeStack = (input: ScopeInput): ScopeStack => {
+  if (input instanceof ScopeStack) return input;
+  return ScopeStack.fromScope(input);
+};

--- a/packages/core/sdk/src/secrets.ts
+++ b/packages/core/sdk/src/secrets.ts
@@ -26,19 +26,41 @@ export interface SecretProvider {
    *  (provider unreachable, decryption failed, etc.) surface as
    *  `StorageFailure` — the executor treats a provider call the same
    *  as a DB call; `StorageError` is captured at the HTTP edge to
-   *  `InternalError`, `UniqueViolationError` dies. */
-  readonly get: (id: string) => Effect.Effect<string | null, StorageFailure>;
-  /** Set a secret value. Only called on writable providers. */
+   *  `InternalError`, `UniqueViolationError` dies.
+   *
+   *  `scopeId` is the scope the caller wants to read at — the
+   *  executor passes the winning scope from its core-table shadow
+   *  pass so scope-aware backends (WorkOS Vault) can look in the
+   *  right keyspace even when the executor's *write target* is a
+   *  different scope. Providers that aren't scope-aware (keychain,
+   *  env) ignore it. When unset, providers fall back to their
+   *  construction-time scope (the write target). */
+  readonly get: (
+    id: string,
+    scopeId?: string,
+  ) => Effect.Effect<string | null, StorageFailure>;
+  /** Set a secret value. Only called on writable providers.
+   *  `scopeId`, when set, routes the write to a specific scope in
+   *  the chain (the executor's current write target by default). */
   readonly set?: (
     id: string,
     value: string,
+    scopeId?: string,
   ) => Effect.Effect<void, StorageFailure>;
   /** Delete a secret. Only called on writable providers. Returns true
-   *  if something was deleted. */
-  readonly delete?: (id: string) => Effect.Effect<boolean, StorageFailure>;
+   *  if something was deleted. `scopeId` routes the delete to a
+   *  specific scope; defaults to the write target. */
+  readonly delete?: (
+    id: string,
+    scopeId?: string,
+  ) => Effect.Effect<boolean, StorageFailure>;
   /** Enumerate known secret entries. Optional — not all backends can
-   *  enumerate (env-backed providers, for example). */
-  readonly list?: () => Effect.Effect<
+   *  enumerate (env-backed providers, for example). `scopeId` scopes
+   *  the enumeration to one scope; when unset, the provider enumerates
+   *  everything visible to the caller (its read chain). */
+  readonly list?: (
+    scopeId?: string,
+  ) => Effect.Effect<
     readonly { readonly id: string; readonly name: string }[],
     StorageFailure
   >;

--- a/packages/core/sdk/src/testing.ts
+++ b/packages/core/sdk/src/testing.ts
@@ -5,7 +5,7 @@ import type { ExecutorConfig } from "./executor";
 import { collectSchemas } from "./executor";
 import { ScopeId } from "./ids";
 import type { AnyPlugin } from "./plugin";
-import { Scope } from "./scope";
+import { Scope, ScopeStack } from "./scope";
 
 // ---------------------------------------------------------------------------
 // makeTestConfig — build an ExecutorConfig backed by in-memory adapter +
@@ -32,5 +32,54 @@ export const makeTestConfig = <
     adapter: makeMemoryAdapter({ schema }),
     blobs: makeInMemoryBlobStore(),
     plugins: options?.plugins,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// makeTestScope / makeLayeredTestConfig — layered-scope fixtures. Let a
+// test write "given user + org + a shared secret, the user sees it" in
+// three lines without constructing Scope objects by hand.
+// ---------------------------------------------------------------------------
+
+export const makeTestScope = (id: string, name?: string): Scope =>
+  new Scope({
+    id: ScopeId.make(id),
+    name: name ?? id,
+    createdAt: new Date(),
+  });
+
+/** Build a multi-scope ExecutorConfig. The read chain is the list of
+ *  scopes in precedence order (innermost first). The write target is
+ *  either `read[0]` (default) or an explicit index.
+ *
+ *  Both test configs share one in-memory adapter + blob store so
+ *  caller A can write at the org scope and caller B can observe the
+ *  layering via its user-first chain against the same adapter. Pass
+ *  `sharedBacking` to opt into this pattern. */
+export const makeLayeredTestConfig = <
+  const TPlugins extends readonly AnyPlugin[] = [],
+>(options: {
+  readonly read: readonly Scope[];
+  readonly writeIndex?: number;
+  readonly plugins?: TPlugins;
+  readonly sharedBacking?: {
+    readonly adapter: ReturnType<typeof makeMemoryAdapter>;
+    readonly blobs: ReturnType<typeof makeInMemoryBlobStore>;
+  };
+}): ExecutorConfig<TPlugins> => {
+  const read = options.read;
+  if (read.length === 0) throw new Error("read chain must be non-empty");
+  const write = read[options.writeIndex ?? 0]!;
+  const scopeStack = new ScopeStack({ read, write });
+
+  const schema = collectSchemas(options.plugins ?? []);
+  const adapter = options.sharedBacking?.adapter ?? makeMemoryAdapter({ schema });
+  const blobs = options.sharedBacking?.blobs ?? makeInMemoryBlobStore();
+
+  return {
+    scope: scopeStack,
+    adapter,
+    blobs,
+    plugins: options.plugins,
   };
 };

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -42,6 +42,10 @@ export type WorkosVaultSchema = typeof workosVaultSchema;
 
 interface MetadataRow {
   readonly id: string;
+  /** Populated on rows read from the adapter (which stamps scope_id);
+   *  absent on upsert inputs since the adapter fills it from the
+   *  executor's write target. */
+  readonly scope_id?: string;
   readonly name: string;
   readonly purpose?: string | null;
   readonly created_at: Date;
@@ -240,27 +244,37 @@ export const makeWorkOSVaultSecretProvider = (
   options: WorkOSVaultSecretProviderOptions,
 ): SecretProvider => {
   const prefix = options.objectPrefix ?? DEFAULT_OBJECT_PREFIX;
-  const { client, store, scopeId } = options;
+  const { client, store } = options;
+  // Default scope — used when the executor doesn't pass one (fallback
+  // providers, legacy single-scope hosts). The executor passes the
+  // winning scope on every layered call so `get`/`delete`/`set` hit
+  // the right vault keyspace.
+  const defaultScope = options.scopeId;
 
   return {
     key: WORKOS_VAULT_PROVIDER_KEY,
     writable: true,
 
-    get: (id) =>
+    get: (id, scopeOverride) =>
       Effect.gen(function* () {
+        const targetScope = scopeOverride ?? defaultScope;
         const meta = yield* store.get(id);
         if (!meta) return null;
-        const object = yield* loadSecretObject(client, prefix, scopeId, id).pipe(
-          Effect.mapError(formatVaultError),
-        );
+        const object = yield* loadSecretObject(
+          client,
+          prefix,
+          targetScope,
+          id,
+        ).pipe(Effect.mapError(formatVaultError));
         if (!object || !object.value) return null;
         return object.value;
       }),
 
-    set: (id, value) =>
+    set: (id, value, scopeOverride) =>
       Effect.gen(function* () {
+        const targetScope = scopeOverride ?? defaultScope;
         const existing = yield* store.get(id);
-        yield* upsertSecretValue(client, prefix, scopeId, id, value).pipe(
+        yield* upsertSecretValue(client, prefix, targetScope, id, value).pipe(
           Effect.mapError(formatVaultError),
         );
         yield* store.upsert({
@@ -271,20 +285,33 @@ export const makeWorkOSVaultSecretProvider = (
         });
       }),
 
-    delete: (id) =>
+    delete: (id, scopeOverride) =>
       Effect.gen(function* () {
+        const targetScope = scopeOverride ?? defaultScope;
         const meta = yield* store.get(id);
         if (!meta) return false;
-        yield* deleteSecretValue(client, prefix, scopeId, id).pipe(
+        yield* deleteSecretValue(client, prefix, targetScope, id).pipe(
           Effect.mapError(formatVaultError),
         );
         yield* store.remove(id);
         return true;
       }),
 
-    list: () =>
+    list: (scopeOverride) =>
+      // The metadata store is already adapter-scoped so it will
+      // enumerate whatever's visible in the executor's read chain.
+      // When `scopeOverride` is passed, filter to just that scope so
+      // the executor's per-scope walk produces scope-stamped entries.
       store
         .list()
-        .pipe(Effect.map((rows) => rows.map((r) => ({ id: r.id, name: r.name })))),
+        .pipe(
+          Effect.map((rows) =>
+            rows
+              .filter((r) =>
+                scopeOverride ? r.scope_id === scopeOverride : true,
+              )
+              .map((r) => ({ id: r.id, name: r.name })),
+          ),
+        ),
   };
 };


### PR DESCRIPTION
- Generalize the SDK scope model from a single `Scope` to a
  `ScopeStack` ({ read, write }) so request-time contexts can layer
  per-user over per-org rows. Single-scope hosts pass a plain Scope
  and get back-compat behaviour via `ScopeStack.fromScope`.
- Shadow-rank secret resolution: `executor.secrets.get / list /
  remove` walk the read chain innermost-first, dedupe by id, and
  preserve `scopeId` on each row so callers see where it came from.
- Extend `SecretProvider` with optional per-call scope override
  (`get / set / delete / list`) so providers bound to a physical
  backend (WorkOS Vault, keychain) can target any scope in the chain
  instead of being pinned to one. WorkOS Vault uses the override to
  namespace object names per scope.
- New `makeLayeredTestConfig` helper + `layered-scope` SDK test
  covering innermost-wins reads, per-scope writes, and delete
  affecting only the owning scope.
- Plugin ctx / StorageDeps gain `scopeStack`; `ctx.scope` remains the
  write-target scope for existing per-scope namespace code.