### PR TITLE
cloud: thread per-user ScopeStack through HTTP + MCP

### DIFF
--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -7,10 +7,25 @@ import { McpExtensionService } from "@executor/plugin-mcp/api";
 import { GraphqlExtensionService } from "@executor/plugin-graphql/api";
 
 import { authorizeOrganization } from "../auth/authorize-organization";
+import { deriveUserScopeId } from "../auth/middleware-live";
 import { WorkOSAuth } from "../auth/workos";
 import { makeExecutionStack } from "../services/execution-stack";
 import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
 import { ProtectedCloudApiLive, RouterConfig, SharedServices } from "./layers";
+
+// `/scopes/<scopeId>/...` — the URL's scope segment selects the write
+// target for the request. Anything outside that pattern (unscoped
+// routes) uses the default write target (innermost = user scope).
+const SCOPE_PATH_REGEX = /\/scopes\/([^/]+)/;
+const extractUrlScopeId = (url: string): string | null => {
+  try {
+    const pathname = new URL(url, "http://x").pathname;
+    const match = pathname.match(SCOPE_PATH_REGEX);
+    return match?.[1] ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+};
 
 const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
   Effect.gen(function* () {
@@ -27,12 +42,28 @@ const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
     const session = yield* workos.authenticateRequest(webRequest);
     if (!session || !session.organizationId) return null;
 
-    return yield* authorizeOrganization(session.userId, session.organizationId);
+    const org = yield* authorizeOrganization(session.userId, session.organizationId);
+    return org ? { ...org, userId: session.userId, userName: session.firstName ?? null } : null;
   });
 
-const createProtectedApp = (organizationId: string, organizationName: string) =>
+interface ProtectedAppOptions {
+  readonly organizationId: string;
+  readonly organizationName: string;
+  readonly userScopeId: string;
+  readonly userName: string;
+  readonly writeScopeId: string;
+}
+
+const createProtectedApp = (options: ProtectedAppOptions) =>
   Effect.gen(function* () {
-    const { executor, engine } = yield* makeExecutionStack(organizationId, organizationName);
+    const { executor, engine } = yield* makeExecutionStack({
+      organizationId: options.organizationId,
+      read: [
+        { id: options.userScopeId, name: options.userName },
+        { id: options.organizationId, name: options.organizationName },
+      ],
+      writeScopeId: options.writeScopeId,
+    });
 
     const requestServices = Layer.mergeAll(
       Layer.succeed(ExecutorService, executor),
@@ -69,7 +100,22 @@ export const ProtectedApiApp = Effect.gen(function* () {
     );
   }
 
-  const app = yield* createProtectedApp(org.id, org.name);
+  const userScopeId = deriveUserScopeId(org.userId);
+  const urlScopeId = extractUrlScopeId(request.url);
+  // Only accept an explicit write-target when the URL names a scope
+  // the caller actually has in their read chain. Anything else would
+  // be a cross-tenant write.
+  const writeScopeId =
+    urlScopeId === org.id || urlScopeId === userScopeId
+      ? urlScopeId
+      : userScopeId;
+  const app = yield* createProtectedApp({
+    organizationId: org.id,
+    organizationName: org.name,
+    userScopeId,
+    userName: org.userName ?? org.userId,
+    writeScopeId,
+  });
   return yield* app;
 }).pipe(
   Effect.provide(SharedServices),

--- a/apps/cloud/src/auth/middleware-live.ts
+++ b/apps/cloud/src/auth/middleware-live.ts
@@ -58,6 +58,7 @@ export const OrgAuthLive = Layer.effect(
 
           return {
             accountId: result.userId,
+            userScopeId: deriveUserScopeId(result.userId),
             organizationId: result.organizationId,
             email: result.email,
             name: `${result.firstName ?? ""} ${result.lastName ?? ""}`.trim() || null,
@@ -67,3 +68,9 @@ export const OrgAuthLive = Layer.effect(
     });
   }),
 );
+
+/** Stable user-scope id derivation. Prefixed so it can never collide
+ *  with a WorkOS org id (which uses `org_…`). Used as the innermost
+ *  scope in the executor's read chain for HTTP + MCP requests. */
+export const deriveUserScopeId = (accountId: string): string =>
+  `user_${accountId}`;

--- a/apps/cloud/src/auth/middleware.ts
+++ b/apps/cloud/src/auth/middleware.ts
@@ -64,6 +64,11 @@ export class AuthContext extends Context.Tag("@executor/cloud/AuthContext")<
   AuthContext,
   {
     readonly accountId: string;
+    /** Per-user scope id — stable derivation from `accountId` so user-
+     *  scoped rows (personal OAuth tokens, personal overrides) can be
+     *  written without materializing a dedicated `scopes` table. The
+     *  executor's read chain is `[userScopeId, organizationId]`. */
+    readonly userScopeId: string;
     readonly organizationId: string;
     readonly email: string;
     readonly name: string | null;

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -237,10 +237,19 @@ export class McpSessionDO extends DurableObject {
   ) {
     const self = this;
     return Effect.gen(function* () {
-      const { executor, engine } = yield* makeExecutionStack(
-        sessionMeta.organizationId,
-        sessionMeta.organizationName,
-      );
+      // MCP sessions are per-org, not per-user (today the MCP client
+      // init token only carries `organizationId`). Until we thread the
+      // user through MCP's OAuth-init path, org is both the only scope
+      // and the write target for this session.
+      const { executor, engine } = yield* makeExecutionStack({
+        organizationId: sessionMeta.organizationId,
+        read: [
+          {
+            id: sessionMeta.organizationId,
+            name: sessionMeta.organizationName,
+          },
+        ],
+      });
       // Build the description here so the postgres query it runs
       // (`executor.sources.list`) lands as a child of
       // `McpSessionDO.createRuntime`. host-mcp would otherwise call

--- a/apps/cloud/src/org/handlers.test.ts
+++ b/apps/cloud/src/org/handlers.test.ts
@@ -40,6 +40,7 @@ const stubWorkOS = (overrides: StubOverrides = {}) =>
 
 const adminAuth = {
   accountId: "user_admin",
+  userScopeId: "user_user_admin",
   organizationId: "org_1",
   email: "admin@test.com",
   name: "Admin",
@@ -48,6 +49,7 @@ const adminAuth = {
 
 const memberAuth = {
   accountId: "user_member",
+  userScopeId: "user_user_member",
   organizationId: "org_1",
   email: "member@test.com",
   name: "Member",

--- a/apps/cloud/src/services/__test-harness__/api-harness.ts
+++ b/apps/cloud/src/services/__test-harness__/api-harness.ts
@@ -35,6 +35,7 @@ import { makeQuickJsExecutor } from "@executor/runtime-quickjs";
 import {
   Scope,
   ScopeId,
+  ScopeStack,
   collectSchemas,
   createExecutor,
 } from "@executor/sdk";
@@ -66,6 +67,22 @@ import { DbService } from "../db";
 
 export const TEST_BASE_URL = "http://test.local";
 export const TEST_ORG_HEADER = "x-test-org-id";
+export const TEST_USER_HEADER = "x-test-user-id";
+// `/scopes/<scopeId>/...` — the URL's scope segment selects the write
+// target for the request, mirroring the prod `protected.ts` plumbing.
+// When the URL scopeId is in the caller's read chain it becomes the
+// write target; otherwise the innermost scope (user) is used.
+const SCOPE_PATH_REGEX = /\/scopes\/([^/]+)/;
+const extractUrlScopeId = (url: string): string | null => {
+  try {
+    const pathname = new URL(url, "http://x").pathname;
+    const match = pathname.match(SCOPE_PATH_REGEX);
+    return match?.[1] ? decodeURIComponent(match[1]) : null;
+  } catch {
+    return null;
+  }
+};
+const deriveUserScopeId = (accountId: string): string => `user_${accountId}`;
 
 // ---------------------------------------------------------------------------
 // Fake WorkOS Vault client — in-memory map keyed by name.
@@ -164,7 +181,12 @@ export const makeFakeVaultClient = (): WorkOSVaultClient => {
 
 const fakeVault = makeFakeVaultClient();
 
-const createTestScopedExecutor = (scopeId: string, scopeName: string) =>
+interface TestExecutorOptions {
+  readonly read: readonly { readonly id: string; readonly name: string }[];
+  readonly writeScopeId?: string;
+}
+
+const createTestScopedExecutor = (options: TestExecutorOptions) =>
   Effect.gen(function* () {
     const { db } = yield* DbService;
     const plugins = [
@@ -176,11 +198,24 @@ const createTestScopedExecutor = (scopeId: string, scopeName: string) =>
     const schema = collectSchemas(plugins);
     const adapter = makePostgresAdapter({ db, schema });
     const blobs = makePostgresBlobStore({ db });
-    const scope = new Scope({
-      id: ScopeId.make(scopeId),
-      name: scopeName,
-      createdAt: new Date(),
-    });
+
+    const read = options.read.map(
+      (s) =>
+        new Scope({
+          id: ScopeId.make(s.id),
+          name: s.name,
+          createdAt: new Date(),
+        }),
+    );
+    const write = options.writeScopeId
+      ? read.find((s) => s.id === options.writeScopeId)
+      : read[0];
+    if (!write) {
+      return yield* Effect.die(
+        new Error(`writeScopeId ${options.writeScopeId} not in read chain`),
+      );
+    }
+    const scope = new ScopeStack({ read, write });
     return yield* createExecutor({ scope, adapter, blobs, plugins });
   });
 
@@ -198,8 +233,17 @@ const FakeOrgAuthLive = Layer.succeed(
         if (!orgId || typeof orgId !== "string") {
           return yield* Effect.die(new Error("missing x-test-org-id"));
         }
+        const userHeader = request.headers[TEST_USER_HEADER];
+        // Default account id = `acct_<orgId>` so tests that don't set
+        // `x-test-user-id` still get a stable, per-org identity (the
+        // single-user-per-org world the cloud stack used to model).
+        const accountId =
+          typeof userHeader === "string" && userHeader.length > 0
+            ? userHeader
+            : `acct_${orgId}`;
         return AuthContext.of({
-          accountId: `acct_${orgId}`,
+          accountId,
+          userScopeId: deriveUserScopeId(accountId),
           organizationId: orgId,
           email: "test@example.com",
           name: "Test User",
@@ -213,9 +257,23 @@ const TestApiLive = HttpApiBuilder.api(ProtectedCloudApi).pipe(
   Layer.provide(Layer.merge(ProtectedCloudApiHandlers, FakeOrgAuthLive)),
 );
 
-const buildAppForScope = (scopeId: string, scopeName: string) =>
+interface BuildAppOptions {
+  readonly organizationId: string;
+  readonly organizationName: string;
+  readonly userScopeId: string;
+  readonly userName: string;
+  readonly writeScopeId: string;
+}
+
+const buildAppForScope = (options: BuildAppOptions) =>
   Effect.gen(function* () {
-    const executor = yield* createTestScopedExecutor(scopeId, scopeName);
+    const executor = yield* createTestScopedExecutor({
+      read: [
+        { id: options.userScopeId, name: options.userName },
+        { id: options.organizationId, name: options.organizationName },
+      ],
+      writeScopeId: options.writeScopeId,
+    });
     const engine = createExecutionEngine({ executor, codeExecutor: makeQuickJsExecutor() });
     const services = Layer.mergeAll(
       Layer.succeed(ExecutorService, executor),
@@ -245,7 +303,26 @@ const RouterApp = Effect.gen(function* () {
   if (!orgId || typeof orgId !== "string") {
     return yield* Effect.die(new Error("missing x-test-org-id"));
   }
-  return yield* yield* buildAppForScope(orgId, `Org ${orgId}`);
+  const userHeader = request.headers[TEST_USER_HEADER];
+  const accountId =
+    typeof userHeader === "string" && userHeader.length > 0
+      ? userHeader
+      : `acct_${orgId}`;
+  const userScopeId = deriveUserScopeId(accountId);
+  const urlScopeId = extractUrlScopeId(request.url);
+  // URL scope only becomes write target if the caller can actually
+  // reach it — otherwise fall back to the innermost (user) scope.
+  const writeScopeId =
+    urlScopeId === orgId || urlScopeId === userScopeId
+      ? urlScopeId
+      : userScopeId;
+  return yield* yield* buildAppForScope({
+    organizationId: orgId,
+    organizationName: `Org ${orgId}`,
+    userScopeId,
+    userName: accountId,
+    writeScopeId,
+  });
 });
 
 const handler = HttpApp.toWebHandler(
@@ -255,18 +332,21 @@ const handler = HttpApp.toWebHandler(
   ),
 );
 
-export const fetchForOrg = (orgId: string): typeof globalThis.fetch =>
+export const fetchForOrg = (orgId: string, userId?: string): typeof globalThis.fetch =>
   ((input: RequestInfo | URL, init?: RequestInit) => {
     const base = input instanceof Request ? input : new Request(input, init);
-    const req = new Request(base, {
-      headers: { ...Object.fromEntries(base.headers), [TEST_ORG_HEADER]: orgId },
-    });
+    const headers: Record<string, string> = {
+      ...Object.fromEntries(base.headers),
+      [TEST_ORG_HEADER]: orgId,
+    };
+    if (userId) headers[TEST_USER_HEADER] = userId;
+    const req = new Request(base, { headers });
     return handler(req);
   }) as typeof globalThis.fetch;
 
-export const clientLayerForOrg = (orgId: string) =>
+export const clientLayerForOrg = (orgId: string, userId?: string) =>
   FetchHttpClient.layer.pipe(
-    Layer.provide(Layer.succeed(FetchHttpClient.Fetch, fetchForOrg(orgId))),
+    Layer.provide(Layer.succeed(FetchHttpClient.Fetch, fetchForOrg(orgId, userId))),
   );
 
 // Constructs an HttpApiClient bound to the given org, hands it to `body`,
@@ -289,6 +369,20 @@ export const asOrg = <A, E>(
     const client = yield* HttpApiClient.make(ProtectedCloudApi, { baseUrl: TEST_BASE_URL });
     return yield* body(client);
   }).pipe(Effect.provide(clientLayerForOrg(orgId))) as Effect.Effect<A, E>;
+
+// Scope helper for per-user tests. `userId` is the synthetic account id
+// (test chooses); `userScopeId` is what it maps to in the read chain.
+export const userScopeIdFor = (userId: string): string => deriveUserScopeId(userId);
+
+export const asUser = <A, E>(
+  orgId: string,
+  userId: string,
+  body: (client: ApiShape) => Effect.Effect<A, E>,
+): Effect.Effect<A, E> =>
+  Effect.gen(function* () {
+    const client = yield* HttpApiClient.make(ProtectedCloudApi, { baseUrl: TEST_BASE_URL });
+    return yield* body(client);
+  }).pipe(Effect.provide(clientLayerForOrg(orgId, userId))) as Effect.Effect<A, E>;
 
 // Re-exports so call sites don't need a second import.
 export { ProtectedCloudApi };

--- a/apps/cloud/src/services/execution-stack.ts
+++ b/apps/cloud/src/services/execution-stack.ts
@@ -12,17 +12,23 @@ import { makeDynamicWorkerExecutor } from "@executor/runtime-dynamic-worker";
 
 import { withExecutionUsageTracking } from "../api/execution-usage";
 import { AutumnService } from "./autumn";
-import { createScopedExecutor } from "./executor";
+import { createScopedExecutor, type ScopedExecutorOptions } from "./executor";
 
-export const makeExecutionStack = (organizationId: string, organizationName: string) =>
+// Usage tracking is always attributed to the org (not the user). The
+// user may be the write-target, but billing + quota are per-org.
+export interface ExecutionStackOptions extends ScopedExecutorOptions {
+  readonly organizationId: string;
+}
+
+export const makeExecutionStack = (options: ExecutionStackOptions) =>
   Effect.gen(function* () {
-    const executor = yield* createScopedExecutor(organizationId, organizationName).pipe(
+    const executor = yield* createScopedExecutor(options).pipe(
       Effect.withSpan("McpSessionDO.createScopedExecutor"),
     );
     const codeExecutor = makeDynamicWorkerExecutor({ loader: env.LOADER });
     const autumn = yield* AutumnService;
     const engine = withExecutionUsageTracking(
-      organizationId,
+      options.organizationId,
       createExecutionEngine({ executor, codeExecutor }),
       (orgId) => Effect.runFork(autumn.trackExecution(orgId)),
     );

--- a/apps/cloud/src/services/executor.ts
+++ b/apps/cloud/src/services/executor.ts
@@ -13,6 +13,7 @@ import { Effect } from "effect";
 import {
   Scope,
   ScopeId,
+  ScopeStack,
   collectSchemas,
   createExecutor,
 } from "@executor/sdk";
@@ -52,18 +53,27 @@ const createOrgPlugins = () =>
   ] as const;
 
 // ---------------------------------------------------------------------------
-// Create a fresh executor for a scope (stateless, per-request).
+// ScopedExecutorOptions — read chain + explicit write target.
 //
-// Today "scope" is the WorkOS organization — orgs are the only scope
-// level the cloud app exposes. When workspace / user scopes land, this
-// function grows to accept a `ScopeStack` instead of a single scope id,
-// and nothing downstream (executor, plugins, storage) has to change.
+// `read` is innermost-first: `[user, org]` means per-user rows shadow
+// per-org rows on id collision. `writeScopeId`, when set, routes writes
+// to a specific scope in the chain. When omitted the innermost scope
+// is the write target (the natural default — users "own" their own
+// writes). The cloud HTTP edge uses the URL's `:scopeId` path param to
+// select the write target so `POST /scopes/<orgId>/secrets` writes at
+// the org scope while `POST /scopes/<userId>/secrets` writes at the
+// user scope.
 // ---------------------------------------------------------------------------
 
-export const createScopedExecutor = (
-  scopeId: string,
-  scopeName: string,
-) =>
+export interface ScopedExecutorOptions {
+  readonly read: readonly {
+    readonly id: string;
+    readonly name: string;
+  }[];
+  readonly writeScopeId?: string;
+}
+
+export const createScopedExecutor = (options: ScopedExecutorOptions) =>
   Effect.gen(function* () {
     const { db } = yield* DbService;
 
@@ -72,11 +82,34 @@ export const createScopedExecutor = (
     const adapter = makePostgresAdapter({ db, schema });
     const blobs = makePostgresBlobStore({ db });
 
-    const scope = new Scope({
-      id: ScopeId.make(scopeId),
-      name: scopeName,
-      createdAt: new Date(),
-    });
+    if (options.read.length === 0) {
+      return yield* Effect.die(
+        new Error("createScopedExecutor requires at least one scope in `read`"),
+      );
+    }
+
+    const read = options.read.map(
+      (s) =>
+        new Scope({
+          id: ScopeId.make(s.id),
+          name: s.name,
+          createdAt: new Date(),
+        }),
+    );
+    // Default write = innermost (first) scope. When the caller specifies
+    // a write target it must appear in the read chain — writing at a
+    // scope the caller can't read is a wiring bug.
+    const write = options.writeScopeId
+      ? read.find((s) => s.id === options.writeScopeId)
+      : read[0];
+    if (!write) {
+      return yield* Effect.die(
+        new Error(
+          `writeScopeId ${options.writeScopeId} is not in the read chain`,
+        ),
+      );
+    }
+    const scope = new ScopeStack({ read, write });
 
     // The executor surface returns raw `StorageFailure`; translation to
     // the opaque `InternalError({ traceId })` happens at the HTTP edge

--- a/apps/cloud/src/services/layered-oauth.node.test.ts
+++ b/apps/cloud/src/services/layered-oauth.node.test.ts
@@ -1,0 +1,318 @@
+// Layered-scope OAuth2 integration test — cloud HTTP edition.
+//
+// Mirrors packages/plugins/openapi/src/sdk/layered-oauth.test.ts but
+// drives the real cloud HTTP stack: the admin POSTs to
+// /scopes/<orgId>/secrets via asOrg(); a member POSTs to
+// /scopes/<userScopeId>/openapi/oauth/start via asUser(), reading the
+// org-seeded client credentials through ScopeStack layering and landing
+// the resulting access / refresh tokens at the user scope.
+//
+// Token endpoint is stubbed via `vi.stubGlobal("fetch", ...)` — the
+// oauth2 helper uses global fetch directly (see
+// packages/plugins/oauth2/src/index.ts). The harness's own client fetch
+// goes through FetchHttpClient.Fetch (injected), not global fetch, so
+// stubbing globalThis.fetch only intercepts the token endpoint call.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { ScopeId, SecretId } from "@executor/sdk";
+
+import { asOrg, asUser, userScopeIdFor } from "./__test-harness__/api-harness";
+
+const TOKEN_URL = "https://idp.example.com/oauth/token";
+const AUTH_URL = "https://idp.example.com/oauth/authorize";
+const REDIRECT_URL = "https://app.example.com/oauth/callback";
+
+type TokenCall = {
+  readonly code: string;
+  readonly clientId: string;
+  readonly clientSecret: string | null;
+};
+
+const installMockTokenEndpoint = (options: {
+  readonly issueToken: (call: TokenCall) => {
+    readonly access_token: string;
+    readonly refresh_token?: string;
+    readonly expires_in?: number;
+    readonly scope?: string;
+  };
+}) => {
+  const calls: TokenCall[] = [];
+  vi.stubGlobal(
+    "fetch",
+    async (url: string | URL | Request, init?: RequestInit) => {
+      const u =
+        typeof url === "string"
+          ? url
+          : url instanceof URL
+            ? url.toString()
+            : url.url;
+      if (u !== TOKEN_URL) {
+        throw new Error(`unexpected fetch target: ${u}`);
+      }
+      const body = init?.body;
+      const form =
+        body instanceof URLSearchParams
+          ? body
+          : new URLSearchParams(typeof body === "string" ? body : "");
+      const call: TokenCall = {
+        code: form.get("code") ?? "",
+        clientId: form.get("client_id") ?? "",
+        clientSecret: form.get("client_secret"),
+      };
+      calls.push(call);
+      const payload = options.issueToken(call);
+      return new Response(
+        JSON.stringify({ token_type: "Bearer", ...payload }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    },
+  );
+  return { calls };
+};
+
+describe("cloud layered OAuth (HTTP)", () => {
+  let stubbed = false;
+  beforeEach(() => {
+    stubbed = false;
+  });
+  afterEach(() => {
+    if (stubbed) vi.unstubAllGlobals();
+  });
+
+  it.effect(
+    "org admin seeds client creds; member OAuths with them and lands tokens at user scope",
+    () =>
+      Effect.gen(function* () {
+        const org = `org_${crypto.randomUUID()}`;
+        const aliceId = `user-alice-${crypto.randomUUID().slice(0, 8)}`;
+        const aliceScope = userScopeIdFor(aliceId);
+
+        // Admin seeds shared client credentials at org scope.
+        yield* asOrg(org, (client) =>
+          Effect.gen(function* () {
+            yield* client.secrets.set({
+              path: { scopeId: ScopeId.make(org) },
+              payload: {
+                id: SecretId.make("shared-github-client-id"),
+                name: "GitHub App Client ID",
+                value: "client-id-abc",
+              },
+            });
+            yield* client.secrets.set({
+              path: { scopeId: ScopeId.make(org) },
+              payload: {
+                id: SecretId.make("shared-github-client-secret"),
+                name: "GitHub App Client Secret",
+                value: "client-secret-xyz",
+              },
+            });
+          }),
+        );
+
+        // Member should already see those via layering (read chain
+        // [user, org]) before we install the fetch stub.
+        const aliceSanity = yield* asUser(org, aliceId, (client) =>
+          client.secrets.resolve({
+            path: {
+              scopeId: ScopeId.make(aliceScope),
+              secretId: SecretId.make("shared-github-client-id"),
+            },
+          }),
+        );
+        expect(aliceSanity.value).toBe("client-id-abc");
+
+        const mock = installMockTokenEndpoint({
+          issueToken: (call) => ({
+            access_token: `access-for-${call.code}`,
+            refresh_token: `refresh-for-${call.code}`,
+            expires_in: 3600,
+            scope: "repo read:user",
+          }),
+        });
+        stubbed = true;
+
+        // Member kicks off the OAuth flow against her user scope —
+        // startOAuth reads the org's client_id via layering.
+        const started = yield* asUser(org, aliceId, (client) =>
+          client.openapi.startOAuth({
+            path: { scopeId: ScopeId.make(aliceScope) },
+            payload: {
+              displayName: "GitHub",
+              securitySchemeName: "githubOAuth",
+              flow: "authorizationCode",
+              authorizationUrl: AUTH_URL,
+              tokenUrl: TOKEN_URL,
+              redirectUrl: REDIRECT_URL,
+              clientIdSecretId: "shared-github-client-id",
+              clientSecretSecretId: "shared-github-client-secret",
+              scopes: ["repo", "read:user"],
+            },
+          }),
+        );
+
+        const authUrl = new URL(started.authorizationUrl);
+        expect(authUrl.searchParams.get("client_id")).toBe("client-id-abc");
+        expect(authUrl.searchParams.get("state")).toBe(started.sessionId);
+
+        // Exchange the auth code — token endpoint hit via stubbed fetch,
+        // tokens land in alice's user scope.
+        const auth = yield* asUser(org, aliceId, (client) =>
+          client.openapi.completeOAuth({
+            path: { scopeId: ScopeId.make(aliceScope) },
+            payload: { state: started.sessionId, code: "alice-auth-code" },
+          }),
+        );
+        expect(mock.calls).toHaveLength(1);
+        expect(mock.calls[0]!.clientId).toBe("client-id-abc");
+        expect(mock.calls[0]!.clientSecret).toBe("client-secret-xyz");
+        expect(mock.calls[0]!.code).toBe("alice-auth-code");
+
+        // Alice's view lists both the org-seeded creds (scopeId=org) and
+        // her own newly-stored access/refresh tokens (scopeId=aliceScope).
+        const aliceList = yield* asUser(org, aliceId, (client) =>
+          client.secrets.list({ path: { scopeId: ScopeId.make(aliceScope) } }),
+        );
+        const aliceById = new Map(aliceList.map((s) => [String(s.id), s]));
+        expect(aliceById.get("shared-github-client-id")?.scopeId).toBe(org);
+        expect(aliceById.get("shared-github-client-secret")?.scopeId).toBe(org);
+        expect(aliceById.get(auth.accessTokenSecretId)?.scopeId).toBe(aliceScope);
+        if (auth.refreshTokenSecretId) {
+          expect(aliceById.get(auth.refreshTokenSecretId)?.scopeId).toBe(aliceScope);
+        }
+
+        // Admin's org-scope list must not leak alice's user-scoped tokens.
+        const adminList = yield* asOrg(org, (client) =>
+          client.secrets.list({ path: { scopeId: ScopeId.make(org) } }),
+        );
+        const adminScopes = new Set(adminList.map((s) => s.scopeId));
+        expect(adminScopes).not.toContain(aliceScope);
+        expect(
+          adminList.find((s) => s.id === auth.accessTokenSecretId),
+        ).toBeUndefined();
+      }),
+  );
+
+  it.effect(
+    "two members of the same org get independent sessions against a shared client",
+    () =>
+      Effect.gen(function* () {
+        const org = `org_${crypto.randomUUID()}`;
+        const aliceId = `user-alice-${crypto.randomUUID().slice(0, 8)}`;
+        const bobId = `user-bob-${crypto.randomUUID().slice(0, 8)}`;
+        const aliceScope = userScopeIdFor(aliceId);
+        const bobScope = userScopeIdFor(bobId);
+
+        // Org admin seeds shared client id (no secret — public client).
+        yield* asOrg(org, (client) =>
+          client.secrets.set({
+            path: { scopeId: ScopeId.make(org) },
+            payload: {
+              id: SecretId.make("shared-github-client-id"),
+              name: "Client ID",
+              value: "shared-cid",
+            },
+          }),
+        );
+
+        const mock = installMockTokenEndpoint({
+          issueToken: (call) => ({
+            access_token: `token-${call.code}`,
+            refresh_token: `refresh-${call.code}`,
+            expires_in: 3600,
+          }),
+        });
+        stubbed = true;
+
+        // Both members start their own flows — separate sessions rooted
+        // at their own user scope.
+        const aliceStart = yield* asUser(org, aliceId, (client) =>
+          client.openapi.startOAuth({
+            path: { scopeId: ScopeId.make(aliceScope) },
+            payload: {
+              displayName: "GitHub",
+              securitySchemeName: "githubOAuth",
+              flow: "authorizationCode",
+              authorizationUrl: AUTH_URL,
+              tokenUrl: TOKEN_URL,
+              redirectUrl: REDIRECT_URL,
+              clientIdSecretId: "shared-github-client-id",
+              scopes: ["repo"],
+            },
+          }),
+        );
+        const bobStart = yield* asUser(org, bobId, (client) =>
+          client.openapi.startOAuth({
+            path: { scopeId: ScopeId.make(bobScope) },
+            payload: {
+              displayName: "GitHub",
+              securitySchemeName: "githubOAuth",
+              flow: "authorizationCode",
+              authorizationUrl: AUTH_URL,
+              tokenUrl: TOKEN_URL,
+              redirectUrl: REDIRECT_URL,
+              clientIdSecretId: "shared-github-client-id",
+              scopes: ["repo"],
+            },
+          }),
+        );
+
+        // Alice trying to complete Bob's session against her own executor
+        // must fail — her read chain is [alice, org] and doesn't include
+        // bob's scope, so the session row is invisible to her.
+        const aliceStealing = yield* asUser(org, aliceId, (client) =>
+          client.openapi
+            .completeOAuth({
+              path: { scopeId: ScopeId.make(aliceScope) },
+              payload: { state: bobStart.sessionId, code: "stolen" },
+            })
+            .pipe(Effect.either),
+        );
+        expect(aliceStealing._tag).toBe("Left");
+
+        const aliceAuth = yield* asUser(org, aliceId, (client) =>
+          client.openapi.completeOAuth({
+            path: { scopeId: ScopeId.make(aliceScope) },
+            payload: { state: aliceStart.sessionId, code: "alice-code" },
+          }),
+        );
+        const bobAuth = yield* asUser(org, bobId, (client) =>
+          client.openapi.completeOAuth({
+            path: { scopeId: ScopeId.make(bobScope) },
+            payload: { state: bobStart.sessionId, code: "bob-code" },
+          }),
+        );
+
+        // Only the two real completions hit the token endpoint; the
+        // stolen attempt fails before the exchange.
+        const realCalls = mock.calls.filter(
+          (c) => c.code === "alice-code" || c.code === "bob-code",
+        );
+        expect(realCalls).toHaveLength(2);
+
+        // Each member sees their own tokens but not the other's.
+        const aliceList = yield* asUser(org, aliceId, (client) =>
+          client.secrets.list({ path: { scopeId: ScopeId.make(aliceScope) } }),
+        );
+        const aliceIds = new Set(aliceList.map((s) => String(s.id)));
+        expect(aliceIds.has(aliceAuth.accessTokenSecretId)).toBe(true);
+        expect(aliceIds.has(bobAuth.accessTokenSecretId)).toBe(false);
+
+        const bobList = yield* asUser(org, bobId, (client) =>
+          client.secrets.list({ path: { scopeId: ScopeId.make(bobScope) } }),
+        );
+        const bobIds = new Set(bobList.map((s) => String(s.id)));
+        expect(bobIds.has(bobAuth.accessTokenSecretId)).toBe(true);
+        expect(bobIds.has(aliceAuth.accessTokenSecretId)).toBe(false);
+
+        // And the shared client id is visible to both (scopeId=org).
+        expect(
+          aliceList.find((s) => s.id === "shared-github-client-id")?.scopeId,
+        ).toBe(org);
+        expect(
+          bobList.find((s) => s.id === "shared-github-client-id")?.scopeId,
+        ).toBe(org);
+      }),
+  );
+});


### PR DESCRIPTION
Wires the SDK's layered ScopeStack into the cloud request pipeline so
members of an org get a read chain of `[userScope, orgScope]`
innermost-first, with writes landing at whichever scope the URL
names (falling back to the user scope).

- AuthContext gains `userScopeId`, derived at middleware time as
  `user_<accountId>`. No physical scope table — it's a plain string
  namespace, lazy by construction.
- `createScopedExecutor` takes a `{ read, writeScopeId? }` options
  object, builds Scope[] from the chain, and validates the write
  target against the chain (writing to a scope the caller can't read
  is a wiring bug).
- `makeExecutionStack` threads the read chain through; per-request
  usage tracking stays attributed to the org.
- The protected HTTP entrypoint parses `/scopes/<scopeId>/...` and
  selects the write target from it when present, falling back to the
  user scope when the URL names an unreachable scope (cross-tenant
  write prevention).
- MCP sessions remain single-scope for now — the session token only
  carries org identity; threading user identity through MCP init is
  a follow-up.
- Test harness matches prod: `x-test-user-id` header, `asUser` /
  `userScopeIdFor` helpers, URL-scope → write-target selection.
  Adds a cloud-level layered-oauth integration test: admin seeds
  org-scope creds, member OAuths with them, tokens land at user
  scope, admin's org-scope view doesn't leak user tokens.