### PR TITLE
scope api + secrets UI: expose read chain, add personal/shared picker

### DIFF
--- a/packages/core/api/src/handlers/scope.ts
+++ b/packages/core/api/src/handlers/scope.ts
@@ -13,6 +13,7 @@ export const ScopeHandlers = HttpApiBuilder.group(ExecutorApi, "scope", (handler
         id: executor.scope.id,
         name: executor.scope.name,
         dir: executor.scope.name,
+        chain: executor.scopeStack.read.map((s) => ({ id: s.id, name: s.name })),
       };
     })),
   ),

--- a/packages/core/api/src/scope/api.ts
+++ b/packages/core/api/src/scope/api.ts
@@ -8,10 +8,22 @@ import { InternalError } from "../observability";
 // Response schemas
 // ---------------------------------------------------------------------------
 
+const ScopeChainEntry = Schema.Struct({
+  id: ScopeId,
+  name: Schema.String,
+});
+
+// `id` / `name` / `dir` describe the request's write-target scope —
+// kept as loose top-level fields for existing callers that just want
+// "the active scope". `chain` is the full read chain innermost-first;
+// single-element for CLI/local hosts, `[user, org]` (or longer in the
+// future) for cloud hosts so the UI can offer a scope selector and
+// render a scope badge on layered rows.
 const ScopeInfoResponse = Schema.Struct({
   id: ScopeId,
   name: Schema.String,
   dir: Schema.String,
+  chain: Schema.Array(ScopeChainEntry),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/api/scope-context.tsx
+++ b/packages/react/src/api/scope-context.tsx
@@ -4,10 +4,20 @@ import { useAtomValue, Result } from "@effect-atom/atom-react";
 import type { ScopeId } from "@executor/sdk";
 import { scopeAtom } from "./atoms";
 
+export interface ScopeChainEntry {
+  readonly id: ScopeId;
+  readonly name: string;
+}
+
 export interface ScopeInfo {
   readonly id: ScopeId;
   readonly name: string;
   readonly dir: string;
+  /** Full read chain innermost-first. Single-element for CLI/local
+   *  hosts; `[user, org]` for cloud hosts that layer per-user over
+   *  per-org scopes. Consumers that need to offer a scope picker or
+   *  label rows by scope read this. */
+  readonly chain: readonly ScopeChainEntry[];
 }
 
 const ScopeContext = React.createContext<ScopeInfo | null>(null);
@@ -50,4 +60,18 @@ export function useScopeInfo(): ScopeInfo {
     throw new Error("useScopeInfo must be used inside a ScopeProvider");
   }
   return scope;
+}
+
+/**
+ * Returns the caller's full read chain (innermost-first). Multi-scope
+ * hosts (cloud) expose `[user, org]`; single-scope hosts return a
+ * one-element array. UI surfaces that want to offer "personal vs
+ * shared" can key off `chain.length > 1`.
+ */
+export function useScopeChain(): readonly ScopeChainEntry[] {
+  const scope = React.useContext(ScopeContext);
+  if (scope === null) {
+    throw new Error("useScopeChain must be used inside a ScopeProvider");
+  }
+  return scope.chain;
 }

--- a/packages/react/src/hooks/use-scope.ts
+++ b/packages/react/src/hooks/use-scope.ts
@@ -1,1 +1,2 @@
-export { useScope } from "../api/scope-context";
+export { useScope, useScopeInfo, useScopeChain } from "../api/scope-context";
+export type { ScopeChainEntry, ScopeInfo } from "../api/scope-context";

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -3,8 +3,8 @@ import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
 import { secretsAtom, setSecret, removeSecret } from "../api/atoms";
 import { secretWriteKeys } from "../api/reactivity-keys";
 import type { SecretProviderPlugin } from "../plugins/secret-provider-plugin";
-import { SecretId } from "@executor/sdk";
-import { useScope } from "../hooks/use-scope";
+import { SecretId, type ScopeId } from "@executor/sdk";
+import { useScope, useScopeChain } from "../hooks/use-scope";
 import {
   Dialog,
   DialogContent,
@@ -64,14 +64,16 @@ function AddSecretDialog(props: {
   storageOptions: readonly SecretStorageOption[];
 }) {
   const initialProvider = props.storageOptions[0]?.value ?? "auto";
+  const defaultScopeId = useScope();
+  const chain = useScopeChain();
   const [id, setId] = useState("");
   const [name, setName] = useState("");
   const [value, setValue] = useState("");
   const [provider, setProvider] = useState(initialProvider);
+  const [targetScopeId, setTargetScopeId] = useState<ScopeId>(defaultScopeId);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const scopeId = useScope();
   const doSet = useAtomSet(setSecret, { mode: "promise" });
 
   const reset = () => {
@@ -79,6 +81,7 @@ function AddSecretDialog(props: {
     setName("");
     setValue("");
     setProvider(initialProvider);
+    setTargetScopeId(defaultScopeId);
     setError(null);
     setSaving(false);
   };
@@ -89,7 +92,7 @@ function AddSecretDialog(props: {
     setError(null);
     try {
       await doSet({
-        path: { scopeId },
+        path: { scopeId: targetScopeId },
         payload: {
           id: SecretId.make(id.trim()),
           name: name.trim(),
@@ -174,6 +177,36 @@ function AddSecretDialog(props: {
           </div>
 
           <div className="grid gap-3">
+            {chain.length > 1 && (
+              <div className="grid gap-1.5">
+                <Label
+                  htmlFor="secret-scope"
+                  className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
+                >
+                  Visibility
+                </Label>
+                <Select
+                  value={targetScopeId}
+                  onValueChange={(v) => setTargetScopeId(v as ScopeId)}
+                >
+                  <SelectTrigger id="secret-scope" className="h-9 text-sm">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {chain.map((s, i) => (
+                      <SelectItem key={s.id} value={s.id}>
+                        {i === 0 ? `Personal (${s.name})` : `Shared (${s.name})`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {targetScopeId === chain[0]?.id
+                    ? "Only you can read this secret."
+                    : "Everyone in the organization can read this secret."}
+                </p>
+              </div>
+            )}
             {props.storageOptions.length > 1 && (
               <div className="grid gap-1.5">
                 <Label
@@ -230,10 +263,11 @@ function AddSecretDialog(props: {
 
 function SecretRow(props: {
   showProvider: boolean;
-  secret: { id: string; name: string; provider?: string };
+  secret: { id: string; name: string; provider?: string; scopeId: string };
+  scopeLabel: { text: string; tone: "personal" | "shared" } | null;
   onRemove: () => void;
 }) {
-  const { secret, showProvider } = props;
+  const { secret, showProvider, scopeLabel } = props;
 
   return (
     <CardStackEntry>
@@ -243,6 +277,11 @@ function SecretRow(props: {
         </CardStackEntryTitle>
       </CardStackEntryContent>
       <CardStackEntryActions>
+        {scopeLabel && (
+          <Badge variant={scopeLabel.tone === "personal" ? "secondary" : "outline"}>
+            {scopeLabel.text}
+          </Badge>
+        )}
         {showProvider && secret.provider && <Badge variant="outline">{secret.provider}</Badge>}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -290,8 +329,22 @@ export function SecretsPage(props: {
   const { secretProviderPlugins } = props;
   const [addOpen, setAddOpen] = useState(false);
   const scopeId = useScope();
+  const chain = useScopeChain();
   const secrets = useAtomValue(secretsAtom(scopeId));
   const doRemove = useAtomSet(removeSecret, { mode: "promise" });
+
+  // Only label rows when the caller actually has more than one scope.
+  // In a single-scope world (CLI/local) the badge would be noise.
+  const labelForScope = (
+    secretScopeId: string,
+  ): { text: string; tone: "personal" | "shared" } | null => {
+    if (chain.length <= 1) return null;
+    const idx = chain.findIndex((s) => s.id === secretScopeId);
+    if (idx === -1) return null;
+    return idx === 0
+      ? { text: "Personal", tone: "personal" }
+      : { text: "Shared", tone: "shared" };
+  };
 
   const handleRemove = async (secretId: string) => {
     try {
@@ -386,13 +439,15 @@ export function SecretsPage(props: {
                 ) : (
                   value.map((s) => (
                     <SecretRow
-                      key={s.id}
+                      key={`${s.scopeId}::${s.id}`}
                       showProvider={showProviderInfo}
                       secret={{
                         id: s.id,
                         name: s.name,
                         provider: s.provider ? String(s.provider) : undefined,
+                        scopeId: s.scopeId,
                       }}
+                      scopeLabel={labelForScope(s.scopeId)}
                       onRemove={() => handleRemove(s.id)}
                     />
                   ))


### PR DESCRIPTION
Surfaces the ScopeStack read chain through the scope-info API so UI
clients can distinguish personal vs shared scopes and let users pick
a write target.

- `ScopeInfoResponse` gains `chain: ScopeChainEntry[]` (innermost-first).
  Single-scope hosts send a one-element chain; cloud sends
  `[user, org]`. The existing `id` / `name` / `dir` fields still
  describe the default write target for back-compat.
- React `ScopeProvider` exposes the chain via a new `useScopeChain()`
  hook. UI can key off `chain.length > 1` to offer a visibility
  toggle.
- Secrets page: add-dialog shows a "Visibility" select with
  Personal (user scope) / Shared (org scope) options when the chain
  has more than one entry, and threads the chosen `targetScopeId`
  into the POST path. Rows render a Personal/Shared badge derived
  from each row's `scopeId`. Row key becomes `${scopeId}::${id}` so
  same-name secrets at different scopes don't collide in the list.