### PR TITLE
sdk: layered scope stack + explicit per-write scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ executor.jsonc
 .reference/
 
 .mcp.json
+.codex/

--- a/packages/core/sdk/src/blob.test.ts
+++ b/packages/core/sdk/src/blob.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { makeInMemoryBlobStore, pluginBlobStore } from "./blob";
+
+describe("pluginBlobStore", () => {
+  it.effect("get returns innermost scope's value when both scopes have one", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      yield* store.put("inner/my-plugin", "k", "inner-value");
+      yield* store.put("outer/my-plugin", "k", "outer-value");
+
+      const plugin = pluginBlobStore(store, ["inner", "outer"], "my-plugin");
+      const value = yield* plugin.get("k");
+      expect(value).toBe("inner-value");
+    }),
+  );
+
+  it.effect("get falls through to outer scope when inner is empty", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      yield* store.put("outer/my-plugin", "k", "outer-value");
+
+      const plugin = pluginBlobStore(store, ["inner", "outer"], "my-plugin");
+      const value = yield* plugin.get("k");
+      expect(value).toBe("outer-value");
+    }),
+  );
+
+  it.effect("get returns null when no scope has the key", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      const plugin = pluginBlobStore(store, ["inner", "outer"], "my-plugin");
+      const value = yield* plugin.get("k");
+      expect(value).toBeNull();
+    }),
+  );
+
+  it.effect("has returns true when any scope has the key", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      yield* store.put("outer/my-plugin", "k", "v");
+
+      const plugin = pluginBlobStore(store, ["inner", "outer"], "my-plugin");
+      const found = yield* plugin.has("k");
+      expect(found).toBe(true);
+    }),
+  );
+
+  it.effect("has returns false when no scope has the key", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      const plugin = pluginBlobStore(store, ["inner", "outer"], "my-plugin");
+      const found = yield* plugin.has("k");
+      expect(found).toBe(false);
+    }),
+  );
+
+  it.effect("namespaces are keyed by scope/pluginId — different plugins don't collide", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      yield* store.put("inner/plugin-a", "k", "a-value");
+      yield* store.put("inner/plugin-b", "k", "b-value");
+
+      const pluginA = pluginBlobStore(store, ["inner"], "plugin-a");
+      const pluginB = pluginBlobStore(store, ["inner"], "plugin-b");
+      expect(yield* pluginA.get("k")).toBe("a-value");
+      expect(yield* pluginB.get("k")).toBe("b-value");
+    }),
+  );
+});
+
+describe("BlobStore.getMany", () => {
+  it.effect("returns hits keyed by namespace", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      yield* store.put("ns-a", "k", "a");
+      yield* store.put("ns-c", "k", "c");
+
+      const hits = yield* store.getMany(["ns-a", "ns-b", "ns-c"], "k");
+      expect(hits.size).toBe(2);
+      expect(hits.get("ns-a")).toBe("a");
+      expect(hits.get("ns-b")).toBeUndefined();
+      expect(hits.get("ns-c")).toBe("c");
+    }),
+  );
+
+  it.effect("empty namespaces returns empty map", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      const hits = yield* store.getMany([], "k");
+      expect(hits.size).toBe(0);
+    }),
+  );
+});

--- a/packages/core/sdk/src/blob.test.ts
+++ b/packages/core/sdk/src/blob.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
+
+import { StorageError } from "@executor/storage-core";
 
 import { makeInMemoryBlobStore, pluginBlobStore } from "./blob";
 
@@ -66,6 +68,35 @@ describe("pluginBlobStore", () => {
       const pluginB = pluginBlobStore(store, ["inner"], "plugin-b");
       expect(yield* pluginA.get("k")).toBe("a-value");
       expect(yield* pluginB.get("k")).toBe("b-value");
+    }),
+  );
+
+  it.effect("put rejects scope outside the stack", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      const plugin = pluginBlobStore(store, ["inner", "outer"], "my-plugin");
+      const result = yield* Effect.exit(
+        plugin.put("k", "v", { scope: "not-in-stack" }),
+      );
+      expect(Exit.isFailure(result)).toBe(true);
+      if (Exit.isFailure(result)) {
+        const err = result.cause._tag === "Fail" ? result.cause.error : null;
+        expect(err).toBeInstanceOf(StorageError);
+        expect((err as StorageError).message).toContain("not in the");
+      }
+      // Write must not have reached the store.
+      expect(yield* store.get("not-in-stack/my-plugin", "k")).toBeNull();
+    }),
+  );
+
+  it.effect("delete rejects scope outside the stack", () =>
+    Effect.gen(function* () {
+      const store = makeInMemoryBlobStore();
+      const plugin = pluginBlobStore(store, ["inner"], "my-plugin");
+      const result = yield* Effect.exit(
+        plugin.delete("k", { scope: "not-in-stack" }),
+      );
+      expect(Exit.isFailure(result)).toBe(true);
     }),
   );
 });

--- a/packages/core/sdk/src/blob.ts
+++ b/packages/core/sdk/src/blob.ts
@@ -25,6 +25,15 @@ export interface BlobStore {
     namespace: string,
     key: string,
   ) => Effect.Effect<string | null, StorageError>;
+  /** Multi-namespace lookup for a single key. Backends issue one query
+   *  (`WHERE namespace IN (...) AND key = ?`) and return the hits keyed
+   *  by namespace — the caller applies its own precedence. Lets
+   *  `pluginBlobStore` walk the scope stack in O(1) round-trips instead
+   *  of one per scope. */
+  readonly getMany: (
+    namespaces: readonly string[],
+    key: string,
+  ) => Effect.Effect<ReadonlyMap<string, string>, StorageError>;
   readonly put: (
     namespace: string,
     key: string,
@@ -90,9 +99,12 @@ export const pluginBlobStore = (
 ): PluginBlobStore => ({
   get: (key) =>
     Effect.gen(function* () {
-      for (const scope of scopes) {
-        const value = yield* store.get(nsFor(scope, pluginId), key);
-        if (value !== null) return value;
+      const namespaces = scopes.map((s) => nsFor(s, pluginId));
+      const hits = yield* store.getMany(namespaces, key);
+      if (hits.size === 0) return null;
+      for (const ns of namespaces) {
+        const v = hits.get(ns);
+        if (v !== undefined) return v;
       }
       return null;
     }),
@@ -105,13 +117,12 @@ export const pluginBlobStore = (
       store.delete(nsFor(options.scope, pluginId), key),
     ),
   has: (key) =>
-    Effect.gen(function* () {
-      for (const scope of scopes) {
-        const found = yield* store.has(nsFor(scope, pluginId), key);
-        if (found) return true;
-      }
-      return false;
-    }),
+    store
+      .getMany(
+        scopes.map((s) => nsFor(s, pluginId)),
+        key,
+      )
+      .pipe(Effect.map((hits) => hits.size > 0)),
 });
 
 /**
@@ -128,6 +139,15 @@ export const makeInMemoryBlobStore = (): BlobStore => {
   const k = (ns: string, key: string) => `${ns}::${key}`;
   return {
     get: (ns, key) => Effect.sync(() => store.get(k(ns, key)) ?? null),
+    getMany: (namespaces, key) =>
+      Effect.sync(() => {
+        const hits = new Map<string, string>();
+        for (const ns of namespaces) {
+          const v = store.get(k(ns, key));
+          if (v !== undefined) hits.set(ns, v);
+        }
+        return hits;
+      }),
     put: (ns, key, value) =>
       Effect.sync(() => {
         store.set(k(ns, key), value);

--- a/packages/core/sdk/src/blob.ts
+++ b/packages/core/sdk/src/blob.ts
@@ -4,8 +4,12 @@
 // durability, and placement (think S3/R2 in cloud, flat files locally)
 // than the metadata that indexes them.
 //
-// Plugins see a `ScopedBlobStore` that's already namespaced to the plugin
-// id, so key collisions across plugins are structurally impossible.
+// Plugins see a `PluginBlobStore` that's already namespaced to the
+// plugin id and bound to the executor's scope stack. Reads fall through
+// the stack in order (innermost first, first hit wins); writes and
+// deletes require an explicit scope id naming where the operation
+// should land. That mirrors the secrets API — shadowing by key on
+// read, explicit target on write.
 //
 // Error channel is `StorageError` — blobs only do read/write/delete, so
 // they never produce `UniqueViolationError`. The HTTP edge translates
@@ -36,24 +40,78 @@ export interface BlobStore {
   ) => Effect.Effect<boolean, StorageError>;
 }
 
-export interface ScopedBlobStore {
+export interface PluginBlobStore {
+  /** Walk the scope stack (innermost first) and return the first
+   *  non-null value for `key`. */
   readonly get: (key: string) => Effect.Effect<string | null, StorageError>;
+  /** Write `value` under `key` at the named scope. Scope must be one
+   *  of the executor's configured scopes. */
   readonly put: (
     key: string,
     value: string,
+    options: { readonly scope: string },
   ) => Effect.Effect<void, StorageError>;
-  readonly delete: (key: string) => Effect.Effect<void, StorageError>;
+  /** Delete `key` at the named scope. */
+  readonly delete: (
+    key: string,
+    options: { readonly scope: string },
+  ) => Effect.Effect<void, StorageError>;
+  /** Walk the scope stack and return true if any scope has a value for `key`. */
   readonly has: (key: string) => Effect.Effect<boolean, StorageError>;
 }
 
-export const scopeBlobStore = (
+const assertScope = (
+  scope: string,
+  scopes: readonly string[],
+): Effect.Effect<void, StorageError> =>
+  scopes.includes(scope)
+    ? Effect.void
+    : Effect.fail(
+        new StorageError({
+          message:
+            `Blob write targets scope "${scope}" which is not in the ` +
+            `executor's scope stack [${scopes.join(", ")}].`,
+          cause: undefined,
+        }),
+      );
+
+const nsFor = (scope: string, pluginId: string) => `${scope}/${pluginId}`;
+
+/**
+ * Bind a `BlobStore` to a specific scope stack and plugin id. Reads
+ * fall through the stack; writes require an explicit scope. Used by
+ * the executor to build the `blobs` field handed to each plugin's
+ * `storage` factory.
+ */
+export const pluginBlobStore = (
   store: BlobStore,
-  namespace: string,
-): ScopedBlobStore => ({
-  get: (key) => store.get(namespace, key),
-  put: (key, value) => store.put(namespace, key, value),
-  delete: (key) => store.delete(namespace, key),
-  has: (key) => store.has(namespace, key),
+  scopes: readonly string[],
+  pluginId: string,
+): PluginBlobStore => ({
+  get: (key) =>
+    Effect.gen(function* () {
+      for (const scope of scopes) {
+        const value = yield* store.get(nsFor(scope, pluginId), key);
+        if (value !== null) return value;
+      }
+      return null;
+    }),
+  put: (key, value, options) =>
+    Effect.flatMap(assertScope(options.scope, scopes), () =>
+      store.put(nsFor(options.scope, pluginId), key, value),
+    ),
+  delete: (key, options) =>
+    Effect.flatMap(assertScope(options.scope, scopes), () =>
+      store.delete(nsFor(options.scope, pluginId), key),
+    ),
+  has: (key) =>
+    Effect.gen(function* () {
+      for (const scope of scopes) {
+        const found = yield* store.has(nsFor(scope, pluginId), key);
+        if (found) return true;
+      }
+      return false;
+    }),
 });
 
 /**

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -161,6 +161,10 @@ export interface SourceInputTool {
 
 export interface SourceInput {
   readonly id: string;
+  /** Scope id this source belongs to. Must be one of the executor's
+   *  configured scopes. Callers (plugins) pick the target scope
+   *  explicitly — typically the scope the source was authored against. */
+  readonly scope: string;
   readonly kind: string;
   readonly name: string;
   readonly url?: string;
@@ -179,5 +183,8 @@ export interface SourceInput {
 
 export interface DefinitionsInput {
   readonly sourceId: string;
+  /** Scope id these definitions belong to — should match the scope of
+   *  the source they're registered under. */
+  readonly scope: string;
   readonly definitions: Record<string, unknown>;
 }

--- a/packages/core/sdk/src/error-handling.test.ts
+++ b/packages/core/sdk/src/error-handling.test.ts
@@ -70,7 +70,7 @@ const testScope = new Scope({
 });
 
 const baseConfig = (adapter: DBAdapter) => ({
-  scope: testScope,
+  scopes: [testScope],
   adapter,
   blobs: makeInMemoryBlobStore(),
 });

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -68,6 +68,7 @@ const testPlugin = definePlugin(() => ({
           yield* ctx.storage.writeThing(id, value);
           yield* ctx.core.sources.register({
             id,
+            scope: ctx.scopes[0]!.id,
             kind: "test",
             name: id,
             canRemove: true,
@@ -135,17 +136,23 @@ const testPlugin = definePlugin(() => ({
 
 const memoryProvider: SecretProvider = (() => {
   const store = new Map<string, string>();
+  const key = (scope: string, id: string) => `${scope}\u0000${id}`;
   return {
     key: "memory",
     writable: true,
-    get: (id) => Effect.sync(() => store.get(id) ?? null),
-    set: (id, value) =>
+    get: (id, scope) => Effect.sync(() => store.get(key(scope, id)) ?? null),
+    set: (id, value, scope) =>
       Effect.sync(() => {
-        store.set(id, value);
+        store.set(key(scope, id), value);
       }),
-    delete: (id) => Effect.sync(() => store.delete(id)),
+    delete: (id, scope) => Effect.sync(() => store.delete(key(scope, id))),
     list: () =>
-      Effect.sync(() => Array.from(store.keys()).map((id) => ({ id, name: id }))),
+      Effect.sync(() =>
+        Array.from(store.keys()).map((k) => {
+          const name = k.split("\u0000", 2)[1] ?? k;
+          return { id: name, name };
+        }),
+      ),
   };
 })();
 
@@ -286,6 +293,7 @@ describe("createExecutor", () => {
           register: () =>
             ctx.core.sources.register({
               id: "cloudflare",
+              scope: ctx.scopes[0]!.id,
               kind: "nested",
               name: "cloudflare",
               canRemove: true,
@@ -341,6 +349,7 @@ describe("createExecutor", () => {
           tryRegister: () =>
             ctx.core.sources.register({
               id: "test.control", // collides with testPlugin's static source
+              scope: ctx.scopes[0]!.id,
               kind: "x",
               name: "x",
               tools: [],
@@ -409,6 +418,7 @@ describe("createExecutor", () => {
                 yield* ctx.storage.writeThing("x1", "v1");
                 yield* ctx.core.sources.register({
                   id: "rb-source",
+                  scope: ctx.scopes[0]!.id,
                   kind: "rb",
                   name: "rb",
                   canRemove: true,
@@ -451,6 +461,7 @@ describe("createExecutor", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("api-token"),
+          scope: ScopeId.make("test-scope"),
           name: "API Token",
           value: "sk-abc",
         }),
@@ -715,6 +726,7 @@ describe("createExecutor", () => {
               yield* ctx.secrets.set(
                 new SetSecretInput({
                   id: SecretId.make(id),
+                  scope: ctx.scopes[0]!.id,
                   name: id,
                   value: newValue,
                 }),
@@ -733,6 +745,7 @@ describe("createExecutor", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("DB_PASSWORD"),
+          scope: ScopeId.make("test-scope"),
           name: "DB_PASSWORD",
           value: "hunter2",
         }),
@@ -767,17 +780,23 @@ describe("createExecutor", () => {
 // independent of the core.secret routing table isolation we're testing.
 const makeScopedMemoryProvider = (): SecretProvider => {
   const store = new Map<string, string>();
+  const key = (scope: string, id: string) => `${scope}\u0000${id}`;
   return {
     key: "scoped-memory",
     writable: true,
-    get: (id) => Effect.sync(() => store.get(id) ?? null),
-    set: (id, value) =>
+    get: (id, scope) => Effect.sync(() => store.get(key(scope, id)) ?? null),
+    set: (id, value, scope) =>
       Effect.sync(() => {
-        store.set(id, value);
+        store.set(key(scope, id), value);
       }),
-    delete: (id) => Effect.sync(() => store.delete(id)),
+    delete: (id, scope) => Effect.sync(() => store.delete(key(scope, id))),
     list: () =>
-      Effect.sync(() => Array.from(store.keys()).map((id) => ({ id, name: id }))),
+      Effect.sync(() =>
+        Array.from(store.keys()).map((k) => {
+          const name = k.split("\u0000", 2)[1] ?? k;
+          return { id: name, name };
+        }),
+      ),
   };
 };
 
@@ -806,6 +825,7 @@ const tenantPlugin = definePlugin(() => ({
         Effect.gen(function* () {
           yield* ctx.core.sources.register({
             id,
+            scope: ctx.scopes[0]!.id,
             kind: "tenant",
             name: id,
             canRemove: true,
@@ -825,11 +845,13 @@ const makeSharedTenantExecutors = () =>
 
     const makeOne = (id: string) =>
       createExecutor({
-        scope: new Scope({
-          id: ScopeId.make(id),
-          name: id,
-          createdAt: new Date(),
-        }),
+        scopes: [
+          new Scope({
+            id: ScopeId.make(id),
+            name: id,
+            createdAt: new Date(),
+          }),
+        ],
         adapter,
         blobs,
         plugins,
@@ -867,6 +889,7 @@ describe("tenant isolation (SDK)", () => {
       yield* execA.secrets.set(
         new SetSecretInput({
           id: SecretId.make("shared-id"),
+          scope: ScopeId.make("scope-a"),
           name: "A only",
           value: "a-value",
         }),
@@ -883,6 +906,7 @@ describe("tenant isolation (SDK)", () => {
       yield* execA.secrets.set(
         new SetSecretInput({
           id: SecretId.make("shared-id"),
+          scope: ScopeId.make("scope-a"),
           name: "A only",
           value: "a-value",
         }),
@@ -899,6 +923,7 @@ describe("tenant isolation (SDK)", () => {
       yield* execA.secrets.set(
         new SetSecretInput({
           id: SecretId.make("shared-id"),
+          scope: ScopeId.make("scope-a"),
           name: "A only",
           value: "a-value",
         }),

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -933,4 +933,46 @@ describe("tenant isolation (SDK)", () => {
       expect(value).toBeNull();
     }),
   );
+
+  it.effect("secrets.get — innermost scope shadows outer on same id", () =>
+    Effect.gen(function* () {
+      const plugins = [tenantPlugin()] as const;
+      const schema = collectSchemas(plugins);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+
+      const innerScope = ScopeId.make("user-org:u1:o1");
+      const outerScope = ScopeId.make("o1");
+
+      const exec = yield* createExecutor({
+        scopes: [
+          new Scope({ id: innerScope, name: "inner", createdAt: new Date() }),
+          new Scope({ id: outerScope, name: "outer", createdAt: new Date() }),
+        ],
+        adapter,
+        blobs,
+        plugins,
+      });
+
+      yield* exec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("token"),
+          scope: outerScope,
+          name: "org token",
+          value: "org-value",
+        }),
+      );
+      yield* exec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("token"),
+          scope: innerScope,
+          name: "user token",
+          value: "user-value",
+        }),
+      );
+
+      const value = yield* exec.secrets.get("token");
+      expect(value).toBe("user-value");
+    }),
+  );
 });

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -934,6 +934,23 @@ describe("tenant isolation (SDK)", () => {
     }),
   );
 
+  it.effect("secrets.set rejects scope outside the executor's stack", () =>
+    Effect.gen(function* () {
+      const { execA } = yield* makeSharedTenantExecutors();
+      const result = yield* Effect.exit(
+        execA.secrets.set(
+          new SetSecretInput({
+            id: SecretId.make("x"),
+            scope: ScopeId.make("not-in-stack"),
+            name: "x",
+            value: "v",
+          }),
+        ),
+      );
+      expect(result._tag).toBe("Failure");
+    }),
+  );
+
   it.effect("secrets.get — innermost scope shadows outer on same id", () =>
     Effect.gen(function* () {
       const plugins = [tenantPlugin()] as const;

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -10,7 +10,7 @@ import {
 } from "@executor/storage-core";
 
 import {
-  scopeBlobStore,
+  pluginBlobStore,
   type BlobStore,
 } from "./blob";
 import {
@@ -36,7 +36,7 @@ import {
   ToolInvocationError,
   ToolNotFoundError,
 } from "./errors";
-import { SecretId, ToolId } from "./ids";
+import { ScopeId, SecretId, ToolId } from "./ids";
 import type {
   AnyPlugin,
   Elicit,
@@ -95,7 +95,14 @@ const resolveElicitationHandler = (
 // ---------------------------------------------------------------------------
 
 export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
-  readonly scope: Scope;
+  /**
+   * Precedence-ordered scope stack this executor was configured with.
+   * Innermost first. Consumers that need "the display scope" typically
+   * pick `scopes.at(-1)` (outermost, e.g. the organization) or
+   * `scopes[0]` (innermost, e.g. the current user-in-org) depending on
+   * what they're rendering.
+   */
+  readonly scopes: readonly Scope[];
 
   readonly tools: {
     readonly list: (
@@ -172,7 +179,14 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
 export interface ExecutorConfig<
   TPlugins extends readonly AnyPlugin[] = [],
 > {
-  readonly scope: Scope;
+  /**
+   * Precedence-ordered scope stack. Innermost first; typical shape is
+   * `[userInOrgScope, orgScope]`. Reads on scoped tables walk the
+   * stack (first hit wins for shadow-by-id consumers like secrets and
+   * blobs); writes require callers to name an explicit target scope.
+   * Must be non-empty.
+   */
+  readonly scopes: readonly Scope[];
   readonly adapter: DBAdapter;
   readonly blobs: BlobStore;
   readonly plugins?: TPlugins;
@@ -296,6 +310,7 @@ const writeSourceInput = (
       model: "source",
       data: {
         id: input.id,
+        scope_id: input.scope,
         plugin_id: pluginId,
         kind: input.kind,
         name: input.name,
@@ -314,6 +329,7 @@ const writeSourceInput = (
         model: "tool",
         data: input.tools.map((tool) => ({
           id: `${input.id}.${tool.name}`,
+          scope_id: input.scope,
           source_id: input.id,
           plugin_id: pluginId,
           name: tool.name,
@@ -364,6 +380,7 @@ const writeDefinitions = (
       model: "definition",
       data: entries.map(([name, schema]) => ({
         id: `${input.sourceId}.${name}`,
+        scope_id: input.scope,
         source_id: input.sourceId,
         plugin_id: pluginId,
         name,
@@ -471,22 +488,30 @@ export const createExecutor = <
 ): Effect.Effect<Executor<TPlugins>, Error> =>
   Effect.gen(function* () {
     const {
-      scope,
+      scopes,
       adapter: rootAdapter,
       blobs,
       plugins = [] as unknown as TPlugins,
     } = config;
 
-    // Scope-wrap the root adapter so every read on a tenant-scoped table
-    // filters by the current scope stack and every write stamps the
-    // write target. Today the stack has one element; the adapter's
-    // `ScopeContext` shape already accepts an ordered list so layering
-    // (org → workspace → user) can land later without changing plugin
-    // code. Only tables whose schema declares `scope_id` are scoped.
+    if (scopes.length === 0) {
+      return yield* Effect.fail(
+        new Error("createExecutor requires a non-empty scopes array"),
+      );
+    }
+
+    // Scope-wrap the root adapter so every read on a tenant-scoped
+    // table filters by `scope_id IN (scopes)` and every write's
+    // `scope_id` payload is validated to be in the stack. Reads walk
+    // the scope array in order at the consumer layer (secrets,
+    // blobs) — the adapter itself just bounds the set of rows
+    // visible. Only tables whose schema declares `scope_id` are
+    // scoped.
     const schema = collectSchemas(plugins);
+    const scopeIds = scopes.map((s) => s.id as string);
     const scopedRoot = scopeAdapter(
       rootAdapter,
-      { read: [scope.id], write: scope.id },
+      { scopes: scopeIds },
       schema,
     );
     const adapter = buildAdapterRouter(scopedRoot);
@@ -511,31 +536,50 @@ export const createExecutor = <
     // without a list() implementation (keychain) never hit the fallback
     // walk because their secrets must be registered through set() to
     // be known at all.
+    //
+    // Multi-scope behavior: the routing-table lookup walks the scope
+    // stack explicitly, innermost first, so that a secret registered
+    // in a deeper scope shadows one with the same id at a shallower
+    // scope (e.g. a user's personal OAuth token wins over an org-wide
+    // one). The provider-enumeration fallback is scope-agnostic —
+    // providers like env or 1password don't partition their inventory
+    // by executor scope.
     const secretsGet = (
       id: string,
     ): Effect.Effect<string | null, StorageFailure> =>
       Effect.gen(function* () {
-        // Fast path: routing table
-        const row = yield* core.findOne({
-          model: "secret",
-          where: [{ field: "id", value: id }],
-        });
-        if (row) {
-          const provider = secretProviders.get(row.provider);
-          if (!provider) return null;
-          return yield* provider.get(id);
+        for (const scopeId of scopeIds) {
+          const row = yield* core.findOne({
+            model: "secret",
+            where: [
+              { field: "id", value: id },
+              { field: "scope_id", value: scopeId },
+            ],
+          });
+          if (row) {
+            const provider = secretProviders.get(row.provider);
+            if (!provider) continue;
+            const value = yield* provider.get(id, scopeId);
+            if (value !== null) return value;
+          }
         }
 
         // Fallback: ask every enumerating provider in parallel. First
         // non-null in registration order wins. Providers that throw
         // are treated as "don't have it" so one flaky provider can't
-        // block resolution via others.
+        // block resolution via others. Scope-partitioning providers
+        // get asked at the innermost scope as a display default — the
+        // enumeration fallback doesn't know which scope the value
+        // lives in; flat providers ignore the arg.
+        const fallbackScope = scopeIds[0]!;
         const candidates = [...secretProviders.values()].filter(
           (p) => p.list,
         );
         const values = yield* Effect.all(
           candidates.map((p) =>
-            p.get(id).pipe(Effect.catchAll(() => Effect.succeed(null))),
+            p
+              .get(id, fallbackScope)
+              .pipe(Effect.catchAll(() => Effect.succeed(null))),
           ),
           { concurrency: "unbounded" },
         );
@@ -547,6 +591,20 @@ export const createExecutor = <
       input: SetSecretInput,
     ): Effect.Effect<SecretRef, StorageFailure> =>
       Effect.gen(function* () {
+        // Validate the write target up front. The adapter would reject
+        // an out-of-stack scope too, but catching it here gives a
+        // clearer error before we touch the provider.
+        if (!scopeIds.includes(input.scope as string)) {
+          return yield* Effect.fail(
+            new StorageError({
+              message:
+                `secrets.set targets scope "${input.scope}" which is not ` +
+                `in the executor's scope stack [${scopeIds.join(", ")}].`,
+              cause: undefined,
+            }),
+          );
+        }
+
         // Pick provider: explicit or first-writable. Misconfiguration
         // (unknown provider, no writable provider, read-only provider)
         // is a host setup bug — surface as `StorageError` so it lands
@@ -587,9 +645,14 @@ export const createExecutor = <
           );
         }
 
-        yield* target.set(input.id, input.value);
+        yield* target.set(input.id, input.value, input.scope as string);
 
-        // Upsert metadata row in the core `secret` table.
+        // Upsert metadata row in the core `secret` table at the
+        // caller-named scope. Delete is scoped via the adapter's
+        // IN-clause filter to the full stack, which removes any
+        // previously-registered row for this id anywhere in the stack
+        // (avoids leftover shadow rows from a different scope); then
+        // we create fresh at the target scope.
         const now = new Date();
         yield* core.delete({
           model: "secret",
@@ -599,6 +662,7 @@ export const createExecutor = <
           model: "secret",
           data: {
             id: input.id,
+            scope_id: input.scope,
             name: input.name,
             provider: target.key,
             created_at: now,
@@ -608,7 +672,7 @@ export const createExecutor = <
 
         return new SecretRef({
           id: input.id,
-          scopeId: scope.id,
+          scopeId: input.scope,
           name: input.name,
           provider: target.key,
           createdAt: now,
@@ -618,16 +682,19 @@ export const createExecutor = <
     const secretsRemove = (id: string): Effect.Effect<void, StorageFailure> =>
       Effect.gen(function* () {
         // Providers don't coordinate on which of them own the id — they
-        // each get asked. Most calls are no-ops; fan them out so one
-        // slow provider doesn't serialize the rest.
+        // each get asked, across every scope in the stack. Flat
+        // providers see the same delete call repeated and no-op on
+        // the second hit; scope-partitioned providers use the scope
+        // arg to pick the right partition. Fan out so one slow
+        // provider doesn't serialize the rest.
         const deleters = [...secretProviders.values()].filter(
           (p): p is typeof p & { delete: NonNullable<typeof p.delete> } =>
             !!(p.writable && p.delete),
         );
-        yield* Effect.all(
-          deleters.map((p) => p.delete(id)),
-          { concurrency: "unbounded" },
+        const tasks = deleters.flatMap((p) =>
+          scopeIds.map((scopeId) => p.delete(id, scopeId)),
         );
+        yield* Effect.all(tasks, { concurrency: "unbounded" });
         yield* core.delete({
           model: "secret",
           where: [{ field: "id", value: id }],
@@ -649,18 +716,36 @@ export const createExecutor = <
     // so that routing information in the core table is authoritative.
     // Providers without a list() method (e.g. keychain) contribute
     // only via the core table path.
+    //
+    // Multi-scope: core rows from any scope in the stack show up
+    // (adapter filters by `scope_id IN`), each tagged with its own
+    // `scope_id`. When the same id appears in multiple scopes, the
+    // innermost wins — same rule as `secretsGet`. Provider-enumerated
+    // entries don't know what scope they belong to and are attributed
+    // to the innermost scope as a display default.
     const secretsList = (): Effect.Effect<readonly SecretRef[], StorageFailure> =>
       Effect.gen(function* () {
         const byId = new Map<string, SecretRef>();
 
-        // Core routing rows first
+        // Core routing rows first. Adapter returns rows from every
+        // scope in the stack; resolve collisions using the caller's
+        // precedence order (innermost first).
         const rows = yield* core.findMany({ model: "secret" });
-        for (const row of rows) {
+        const precedence = new Map<string, number>();
+        scopeIds.forEach((id, index) => precedence.set(id, index));
+        const pick = (row: typeof rows[number]) => {
+          const existing = byId.get(row.id);
+          const incomingScope = row.scope_id as string;
+          const incomingRank = precedence.get(incomingScope) ?? Number.MAX_SAFE_INTEGER;
+          if (existing) {
+            const existingRank = precedence.get(existing.scopeId as string) ?? Number.MAX_SAFE_INTEGER;
+            if (existingRank <= incomingRank) return;
+          }
           byId.set(
             row.id,
             new SecretRef({
               id: SecretId.make(row.id),
-              scopeId: scope.id,
+              scopeId: ScopeId.make(incomingScope),
               name: row.name,
               provider: row.provider,
               createdAt:
@@ -669,13 +754,15 @@ export const createExecutor = <
                   : new Date(row.created_at as string),
             }),
           );
-        }
+        };
+        for (const row of rows) pick(row);
 
         // Then every provider that can enumerate itself, in parallel.
         // If a provider fails to list (unlocked vault, network error),
         // swallow the failure so one flaky provider can't block the
         // whole list. Merge in registration order afterwards so the
         // "first provider wins" precedence stays deterministic.
+        const attribution = scopes[0]!.id;
         const listers = [...secretProviders.entries()].filter(
           ([, p]) => p.list,
         );
@@ -697,7 +784,7 @@ export const createExecutor = <
               entry.id,
               new SecretRef({
                 id: SecretId.make(entry.id),
-                scopeId: scope.id,
+                scopeId: attribution,
                 name: entry.name,
                 provider: key,
                 createdAt: new Date(),
@@ -740,17 +827,19 @@ export const createExecutor = <
       // `StorageError` that still escapes into the opaque InternalError.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const storageDeps: StorageDeps<any> = {
-        scope,
+        scopes,
         adapter: typedAdapter(adapter) as never,
         // Blob keys are namespaced by `<scope>/<plugin>` so two tenants
-        // sharing a backing BlobStore can't collide or leak on the same
-        // `(plugin, key)` pair. Mirrors the adapter's scope-stamping.
-        blobs: scopeBlobStore(blobs, `${scope.id}/${plugin.id}`),
+        // sharing a backing BlobStore can't collide or leak on the
+        // same `(plugin, key)` pair. The store's `get`/`has` walk the
+        // scope stack (innermost first); `put`/`delete` require the
+        // plugin to name a target scope explicitly.
+        blobs: pluginBlobStore(blobs, scopeIds, plugin.id),
       };
       const storage = plugin.storage(storageDeps);
 
       const ctx: PluginCtx<unknown> = {
-        scope,
+        scopes,
         storage,
         core: {
           sources: {
@@ -1358,7 +1447,7 @@ export const createExecutor = <
     // translate `StorageError` → `InternalError({ traceId })`; non-HTTP
     // consumers (CLI, Promise SDK, tests) see the raw typed channel.
     const base = {
-      scope,
+      scopes,
       tools: {
         list: listTools,
         schema: toolSchema,

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -537,31 +537,40 @@ export const createExecutor = <
     // walk because their secrets must be registered through set() to
     // be known at all.
     //
-    // Multi-scope behavior: the routing-table lookup walks the scope
-    // stack explicitly, innermost first, so that a secret registered
-    // in a deeper scope shadows one with the same id at a shallower
-    // scope (e.g. a user's personal OAuth token wins over an org-wide
-    // one). The provider-enumeration fallback is scope-agnostic —
-    // providers like env or 1password don't partition their inventory
-    // by executor scope.
+    // Multi-scope behavior: the routing-table lookup pulls every row
+    // for this id across the scope stack in a single `IN (...)` query,
+    // then sorts innermost-first so a secret registered in a deeper
+    // scope shadows one with the same id at a shallower scope (e.g. a
+    // user's personal OAuth token wins over an org-wide one). Provider
+    // calls stay sequential — scope-partitioning providers (workos-vault,
+    // 1password-per-vault) have to be asked per scope because the object
+    // name includes the scope — but they're bounded by the number of
+    // registered rows for this id, not by scope-stack depth. The
+    // provider-enumeration fallback is scope-agnostic: providers like
+    // env or 1password don't partition their inventory by executor scope.
+    const scopePrecedence = new Map<string, number>();
+    scopeIds.forEach((s, i) => scopePrecedence.set(s, i));
+
     const secretsGet = (
       id: string,
     ): Effect.Effect<string | null, StorageFailure> =>
       Effect.gen(function* () {
-        for (const scopeId of scopeIds) {
-          const row = yield* core.findOne({
-            model: "secret",
-            where: [
-              { field: "id", value: id },
-              { field: "scope_id", value: scopeId },
-            ],
-          });
-          if (row) {
-            const provider = secretProviders.get(row.provider);
-            if (!provider) continue;
-            const value = yield* provider.get(id, scopeId);
-            if (value !== null) return value;
-          }
+        // The scope-wrapped adapter injects `scope_id IN (scopeIds)`
+        // automatically, so we only filter by id here.
+        const rows = yield* core.findMany({
+          model: "secret",
+          where: [{ field: "id", value: id }],
+        });
+        const ordered = [...rows].sort(
+          (a, b) =>
+            (scopePrecedence.get(a.scope_id as string) ?? Infinity) -
+            (scopePrecedence.get(b.scope_id as string) ?? Infinity),
+        );
+        for (const row of ordered) {
+          const provider = secretProviders.get(row.provider as string);
+          if (!provider) continue;
+          const value = yield* provider.get(id, row.scope_id as string);
+          if (value !== null) return value;
         }
 
         // Fallback: ask every enumerating provider in parallel. First

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -86,8 +86,8 @@ export {
 // Blob store
 export {
   type BlobStore,
-  type ScopedBlobStore,
-  scopeBlobStore,
+  type PluginBlobStore,
+  pluginBlobStore,
   makeInMemoryBlobStore,
 } from "./blob";
 

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -6,7 +6,7 @@ import type {
   TypedAdapter,
 } from "@executor/storage-core";
 
-import type { ScopedBlobStore } from "./blob";
+import type { PluginBlobStore } from "./blob";
 import type {
   DefinitionsInput,
   SourceInput,
@@ -36,7 +36,13 @@ import type { SecretProvider, SecretRef, SetSecretInput } from "./secrets";
 // ---------------------------------------------------------------------------
 
 export interface StorageDeps<TSchema extends DBSchema | undefined = undefined> {
-  readonly scope: Scope;
+  /**
+   * Precedence-ordered scope stack visible to this executor. Innermost
+   * first. Reads on scoped tables walk every scope; writes require the
+   * plugin to name a target scope explicitly (via `scope_id` on the
+   * adapter payload, via `options.scope` on the blob store).
+   */
+  readonly scopes: readonly Scope[];
   /**
    * Plugin-facing typed adapter. Failures surface as raw `StorageFailure`
    * (`StorageError` | `UniqueViolationError`). Plugins can
@@ -48,7 +54,7 @@ export interface StorageDeps<TSchema extends DBSchema | undefined = undefined> {
   readonly adapter: TSchema extends DBSchema
     ? TypedAdapter<TSchema, StorageFailure>
     : DBAdapter;
-  readonly blobs: ScopedBlobStore;
+  readonly blobs: PluginBlobStore;
 }
 
 // ---------------------------------------------------------------------------
@@ -78,7 +84,13 @@ export type Elicit = (
 // ---------------------------------------------------------------------------
 
 export interface PluginCtx<TStore = unknown> {
-  readonly scope: Scope;
+  /**
+   * Precedence-ordered scope stack visible to this executor. Innermost
+   * first. Plugins that write scoped rows must pick an element of
+   * `scopes` as the `scope`/`scope_id` they stamp; reads through the
+   * adapter or `ctx.secrets` automatically fall through the stack.
+   */
+  readonly scopes: readonly Scope[];
   readonly storage: TStore;
 
   readonly core: {

--- a/packages/core/sdk/src/promise-executor.ts
+++ b/packages/core/sdk/src/promise-executor.ts
@@ -45,7 +45,12 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = Promisified<
 >;
 
 export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = []> {
-  readonly scope?: { readonly id?: string; readonly name?: string };
+  /**
+   * Precedence-ordered scope stack (innermost first). Optional — defaults
+   * to a single-element stack with id "default-scope". Pass an array of
+   * `{ id, name }` partials to build a multi-scope executor.
+   */
+  readonly scopes?: readonly { readonly id?: string; readonly name?: string }[];
   readonly plugins?: TPlugins;
 }
 
@@ -112,14 +117,26 @@ export const createExecutor = async <
   const plugins = (config?.plugins ?? []) as unknown as TPlugins;
   const schema = collectSchemas(plugins);
 
-  const scope = new Scope({
-    id: ScopeId.make(config?.scope?.id ?? "default-scope"),
-    name: config?.scope?.name ?? "default",
-    createdAt: new Date(),
-  });
+  const scopes =
+    config?.scopes && config.scopes.length > 0
+      ? config.scopes.map(
+          (s, i) =>
+            new Scope({
+              id: ScopeId.make(s.id ?? (i === 0 ? "default-scope" : `scope-${i}`)),
+              name: s.name ?? (i === 0 ? "default" : `scope-${i}`),
+              createdAt: new Date(),
+            }),
+        )
+      : [
+          new Scope({
+            id: ScopeId.make("default-scope"),
+            name: "default",
+            createdAt: new Date(),
+          }),
+        ];
 
   const effectConfig = {
-    scope,
+    scopes,
     adapter: makeMemoryAdapter({ schema }),
     blobs: makeInMemoryBlobStore(),
     plugins,

--- a/packages/core/sdk/src/scoped-adapter.test.ts
+++ b/packages/core/sdk/src/scoped-adapter.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+
+import { makeMemoryAdapter } from "@executor/storage-core/testing/memory";
+import { StorageError, typedAdapter } from "@executor/storage-core";
+
+import { defineSchema } from "./plugin";
+import { scopeAdapter } from "./scoped-adapter";
+
+const schema = defineSchema({
+  thing: {
+    fields: {
+      id: { type: "string", required: true },
+      scope_id: { type: "string", required: true, index: true },
+      value: { type: "string", required: true },
+    },
+  },
+  shared: {
+    fields: {
+      id: { type: "string", required: true },
+      label: { type: "string", required: true },
+    },
+  },
+});
+
+const setup = (scopes: readonly string[]) => {
+  const inner = makeMemoryAdapter({ schema });
+  const wrapped = scopeAdapter(inner, { scopes }, schema);
+  return typedAdapter<typeof schema>(wrapped);
+};
+
+describe("scopeAdapter — write rejection on scoped tables", () => {
+  it.effect("rejects create with scope_id outside the stack", () =>
+    Effect.gen(function* () {
+      const db = setup(["a", "b"]);
+      const result = yield* Effect.exit(
+        db.create({
+          model: "thing",
+          data: { id: "t1", scope_id: "c", value: "v" },
+          forceAllowId: true,
+        }),
+      );
+      expect(Exit.isFailure(result)).toBe(true);
+      if (Exit.isFailure(result)) {
+        const err = result.cause._tag === "Fail" ? result.cause.error : null;
+        expect(err).toBeInstanceOf(StorageError);
+        expect((err as StorageError).message).toContain("not in the executor");
+      }
+    }),
+  );
+
+  it.effect("rejects create with missing scope_id", () =>
+    Effect.gen(function* () {
+      const db = setup(["a"]);
+      const result = yield* Effect.exit(
+        db.create({
+          // Cast because the schema typing requires scope_id — we're
+          // testing the runtime guard against programmatic omission.
+          model: "thing",
+          data: { id: "t1", value: "v" } as unknown as {
+            id: string;
+            scope_id: string;
+            value: string;
+          },
+          forceAllowId: true,
+        }),
+      );
+      expect(Exit.isFailure(result)).toBe(true);
+      if (Exit.isFailure(result)) {
+        const err = result.cause._tag === "Fail" ? result.cause.error : null;
+        expect(err).toBeInstanceOf(StorageError);
+        expect((err as StorageError).message).toContain("missing required");
+      }
+    }),
+  );
+
+  it.effect("accepts create with scope_id in the stack", () =>
+    Effect.gen(function* () {
+      const db = setup(["a", "b"]);
+      yield* db.create({
+        model: "thing",
+        data: { id: "t1", scope_id: "b", value: "v" },
+        forceAllowId: true,
+      });
+      const row = yield* db.findOne({
+        model: "thing",
+        where: [{ field: "id", value: "t1" }],
+      });
+      expect(row?.value).toBe("v");
+    }),
+  );
+
+  it.effect("createMany rejects if any row targets an out-of-stack scope", () =>
+    Effect.gen(function* () {
+      const db = setup(["a"]);
+      const result = yield* Effect.exit(
+        db.createMany({
+          model: "thing",
+          data: [
+            { id: "t1", scope_id: "a", value: "v1" },
+            { id: "t2", scope_id: "b", value: "v2" },
+          ],
+          forceAllowId: true,
+        }),
+      );
+      expect(Exit.isFailure(result)).toBe(true);
+    }),
+  );
+
+  it.effect("update with out-of-stack scope_id in payload is rejected", () =>
+    Effect.gen(function* () {
+      const db = setup(["a"]);
+      yield* db.create({
+        model: "thing",
+        data: { id: "t1", scope_id: "a", value: "v" },
+        forceAllowId: true,
+      });
+      const result = yield* Effect.exit(
+        db.update({
+          model: "thing",
+          where: [{ field: "id", value: "t1" }],
+          update: { scope_id: "b", value: "v2" },
+        }),
+      );
+      expect(Exit.isFailure(result)).toBe(true);
+    }),
+  );
+});
+
+describe("scopeAdapter — read isolation", () => {
+  it.effect("findMany returns rows from every scope in the stack", () =>
+    Effect.gen(function* () {
+      const db = setup(["a", "b"]);
+      yield* db.create({
+        model: "thing",
+        data: { id: "t1", scope_id: "a", value: "a-v" },
+        forceAllowId: true,
+      });
+      yield* db.create({
+        model: "thing",
+        data: { id: "t2", scope_id: "b", value: "b-v" },
+        forceAllowId: true,
+      });
+
+      const rows = yield* db.findMany({ model: "thing" });
+      const ids = rows.map((r) => r.id).sort();
+      expect(ids).toEqual(["t1", "t2"]);
+    }),
+  );
+
+  it.effect("findMany hides rows from out-of-stack scopes", () =>
+    Effect.gen(function* () {
+      // Write to scope "c" via an adapter that sees "c", then read via
+      // an adapter that only sees ["a", "b"]. "c" must not appear.
+      const inner = makeMemoryAdapter({ schema });
+      const writerCtx = scopeAdapter(inner, { scopes: ["c"] }, schema);
+      const writer = typedAdapter<typeof schema>(writerCtx);
+      yield* writer.create({
+        model: "thing",
+        data: { id: "t-hidden", scope_id: "c", value: "leak?" },
+        forceAllowId: true,
+      });
+
+      const readerCtx = scopeAdapter(inner, { scopes: ["a", "b"] }, schema);
+      const reader = typedAdapter<typeof schema>(readerCtx);
+      const rows = yield* reader.findMany({ model: "thing" });
+      expect(rows.map((r) => r.id)).not.toContain("t-hidden");
+    }),
+  );
+
+  it.effect("caller-supplied scope_id filter is stripped (can't bypass isolation)", () =>
+    Effect.gen(function* () {
+      const inner = makeMemoryAdapter({ schema });
+      yield* typedAdapter<typeof schema>(
+        scopeAdapter(inner, { scopes: ["c"] }, schema),
+      ).create({
+        model: "thing",
+        data: { id: "t-hidden", scope_id: "c", value: "secret" },
+      });
+
+      const reader = typedAdapter<typeof schema>(
+        scopeAdapter(inner, { scopes: ["a"] }, schema),
+      );
+      // Attempt to bypass by explicitly filtering for scope_id "c".
+      const rows = yield* reader.findMany({
+        model: "thing",
+        where: [{ field: "scope_id", value: "c" }],
+      });
+      expect(rows).toHaveLength(0);
+    }),
+  );
+
+  it.effect("unscoped tables pass through untouched (no scope filter, no guard)", () =>
+    Effect.gen(function* () {
+      const db = setup(["a"]);
+      yield* db.create({
+        model: "shared",
+        data: { id: "s1", label: "hello" },
+        forceAllowId: true,
+      });
+      const row = yield* db.findOne({
+        model: "shared",
+        where: [{ field: "id", value: "s1" }],
+      });
+      expect(row?.label).toBe("hello");
+    }),
+  );
+});

--- a/packages/core/sdk/src/scoped-adapter.ts
+++ b/packages/core/sdk/src/scoped-adapter.ts
@@ -1,42 +1,44 @@
 // Scoped adapter — wraps a DBAdapter so every read on a tenant-scoped
-// table filters by `scope_id IN (read scopes)` and every write stamps
-// `scope_id = writeTarget` into the row payload. Tables the schema
-// doesn't declare a `scope_id` field on pass through untouched — the
-// wrapper doesn't invent columns that aren't there.
+// table filters by `scope_id IN (scopes)` and every write validates that
+// its `scope_id` payload is one of the allowed scopes. Tables the
+// schema doesn't declare a `scope_id` field on pass through untouched —
+// the wrapper doesn't invent columns that aren't there.
 //
-// The `scopes` argument is an ordered-list primitive even though the
-// SDK today always passes a single-element read list. The shape lets us
-// layer scopes later (org → workspace → user, innermost wins on
-// shadowing) without changing the wrapper signature or any plugin code.
-// `read` and `write` are independent: a caller can read across an
-// entire stack while writes always land in exactly one scope.
+// Writes are explicit: the caller must include `scope_id` in every
+// create/update payload for scoped tables. The adapter does not pick a
+// default. A missing `scope_id` on a scoped write, or a value outside
+// the allowed `scopes` array, is a `StorageError`.
 //
-// The SDK's `createExecutor` wraps the root adapter (and every tx handle
-// passed back into transaction callbacks) with this before handing it to
-// the core table writers or to plugin storage via `typedAdapter(...)`.
-// Plugins see a stable DBAdapter; they don't know or care about scope.
+// The SDK's `createExecutor` wraps the root adapter (and every tx
+// handle passed back into transaction callbacks) with this before
+// handing it to the core table writers or to plugin storage via
+// `typedAdapter(...)`. Plugins see a stable DBAdapter; they learn their
+// scope from `ctx.scopes` and stamp it explicitly on every write.
 //
 // Contract: every multi-tenant table's schema must include
 // `scope_id: { type: "string", required: true, index: true }`. Tables
 // without it are shared across scopes by construction.
 
-import type {
-  DBAdapter,
-  DBSchema,
-  DBTransactionAdapter,
-  Where,
+import { Effect } from "effect";
+
+import {
+  StorageError,
+  type DBAdapter,
+  type DBSchema,
+  type DBTransactionAdapter,
+  type Where,
 } from "@executor/storage-core";
 
 const SCOPE_FIELD = "scope_id";
 
 export interface ScopeContext {
   /**
-   * Precedence-ordered list of scope ids visible to reads. Innermost
-   * first when layering is used. Today always one element.
+   * Precedence-ordered list of scope ids the wrapper accepts on reads
+   * and writes. Innermost first. Reads walk every scope in the list
+   * (via `scope_id IN (...)`); writes must name one of them explicitly
+   * via `scope_id` in the payload.
    */
-  readonly read: readonly string[];
-  /** The single scope id written rows get stamped with. */
-  readonly write: string;
+  readonly scopes: readonly string[];
 }
 
 const collectScopedModels = (schema: DBSchema): Set<string> => {
@@ -49,7 +51,7 @@ const collectScopedModels = (schema: DBSchema): Set<string> => {
 
 const withScopeRead = (
   where: readonly Where[] | undefined,
-  scopes: ScopeContext,
+  ctx: ScopeContext,
 ): Where[] => {
   // Strip any caller-provided scope filter so they can't override
   // isolation, then AND ours in. For a single-scope stack we use `eq`
@@ -57,25 +59,47 @@ const withScopeRead = (
   // scopes we emit `in (...)`.
   const base = (where ?? []).filter((w) => w.field !== SCOPE_FIELD);
   const scope: Where =
-    scopes.read.length === 1
-      ? { field: SCOPE_FIELD, value: scopes.read[0]! }
-      : { field: SCOPE_FIELD, value: [...scopes.read], operator: "in" };
+    ctx.scopes.length === 1
+      ? { field: SCOPE_FIELD, value: ctx.scopes[0]! }
+      : { field: SCOPE_FIELD, value: [...ctx.scopes], operator: "in" };
   return [...base, scope];
 };
 
-const stampScope = (
+const assertScopedWrite = (
+  model: string,
   data: Record<string, unknown>,
-  writeScope: string,
-): Record<string, unknown> => ({
-  ...data,
-  [SCOPE_FIELD]: writeScope,
-});
+  ctx: ScopeContext,
+): Effect.Effect<void, StorageError> => {
+  const value = data[SCOPE_FIELD];
+  if (typeof value !== "string" || value.length === 0) {
+    return Effect.fail(
+      new StorageError({
+        message:
+          `Write to scoped table "${model}" missing required \`scope_id\`. ` +
+          `Callers must name the target scope explicitly.`,
+        cause: undefined,
+      }),
+    );
+  }
+  if (!ctx.scopes.includes(value)) {
+    return Effect.fail(
+      new StorageError({
+        message:
+          `Write to scoped table "${model}" targets scope "${value}" ` +
+          `which is not in the executor's scope stack ` +
+          `[${ctx.scopes.join(", ")}].`,
+        cause: undefined,
+      }),
+    );
+  }
+  return Effect.void;
+};
 
 type TxMethods = Omit<DBAdapter, "transaction" | "createSchema" | "options">;
 
 const wrapTxMethods = (
   inner: TxMethods,
-  scopes: ScopeContext,
+  ctx: ScopeContext,
   scopedModels: Set<string>,
 ): TxMethods => {
   const isScoped = (model: string) => scopedModels.has(model);
@@ -84,76 +108,107 @@ const wrapTxMethods = (
     id: inner.id,
     create: (data) =>
       isScoped(data.model)
-        ? inner.create({
-            ...data,
-            data: stampScope(data.data as Record<string, unknown>, scopes.write),
-          })
+        ? Effect.flatMap(
+            assertScopedWrite(
+              data.model,
+              data.data as Record<string, unknown>,
+              ctx,
+            ),
+            () => inner.create(data),
+          )
         : inner.create(data),
     createMany: (data) =>
       isScoped(data.model)
-        ? inner.createMany({
-            ...data,
-            data: data.data.map((row) =>
-              stampScope(row as Record<string, unknown>, scopes.write),
-            ) as typeof data.data,
-          })
+        ? Effect.flatMap(
+            Effect.all(
+              data.data.map((row) =>
+                assertScopedWrite(
+                  data.model,
+                  row as Record<string, unknown>,
+                  ctx,
+                ),
+              ),
+            ),
+            () => inner.createMany(data),
+          )
         : inner.createMany(data),
     findOne: (data) =>
       isScoped(data.model)
-        ? inner.findOne({ ...data, where: withScopeRead(data.where, scopes) })
+        ? inner.findOne({ ...data, where: withScopeRead(data.where, ctx) })
         : inner.findOne(data),
     findMany: (data) =>
       isScoped(data.model)
-        ? inner.findMany({ ...data, where: withScopeRead(data.where, scopes) })
+        ? inner.findMany({ ...data, where: withScopeRead(data.where, ctx) })
         : inner.findMany(data),
     count: (data) =>
       isScoped(data.model)
-        ? inner.count({ ...data, where: withScopeRead(data.where, scopes) })
+        ? inner.count({ ...data, where: withScopeRead(data.where, ctx) })
         : inner.count(data),
     update: (data) =>
       isScoped(data.model)
-        ? inner.update({
-            ...data,
-            where: withScopeRead(data.where, scopes),
-            // Force-overwrite any caller-supplied `scope_id` so an update
-            // can't transfer a row to a different scope. Symmetric with
-            // `create`'s `stampScope(data.data)`.
-            update: stampScope(data.update, scopes.write),
-          })
+        ? Effect.flatMap(
+            // If the caller sets `scope_id` in the update payload, it
+            // must be one of the allowed scopes. If they don't, we leave
+            // the row's existing scope_id in place — updates are scoped
+            // by the where filter's IN clause, so you can only mutate
+            // rows you can read. That's sufficient for isolation; we
+            // don't need to force-stamp on update.
+            (data.update as Record<string, unknown>)[SCOPE_FIELD] !== undefined
+              ? assertScopedWrite(
+                  data.model,
+                  data.update as Record<string, unknown>,
+                  ctx,
+                )
+              : Effect.void,
+            () =>
+              inner.update({
+                ...data,
+                where: withScopeRead(data.where, ctx),
+              }),
+          )
         : inner.update(data),
     updateMany: (data) =>
       isScoped(data.model)
-        ? inner.updateMany({
-            ...data,
-            where: withScopeRead(data.where, scopes),
-            update: stampScope(data.update, scopes.write),
-          })
+        ? Effect.flatMap(
+            (data.update as Record<string, unknown>)[SCOPE_FIELD] !== undefined
+              ? assertScopedWrite(
+                  data.model,
+                  data.update as Record<string, unknown>,
+                  ctx,
+                )
+              : Effect.void,
+            () =>
+              inner.updateMany({
+                ...data,
+                where: withScopeRead(data.where, ctx),
+              }),
+          )
         : inner.updateMany(data),
     delete: (data) =>
       isScoped(data.model)
-        ? inner.delete({ ...data, where: withScopeRead(data.where, scopes) })
+        ? inner.delete({ ...data, where: withScopeRead(data.where, ctx) })
         : inner.delete(data),
     deleteMany: (data) =>
       isScoped(data.model)
-        ? inner.deleteMany({ ...data, where: withScopeRead(data.where, scopes) })
+        ? inner.deleteMany({ ...data, where: withScopeRead(data.where, ctx) })
         : inner.deleteMany(data),
   };
 };
 
 export const scopeAdapter = (
   inner: DBAdapter,
-  scopes: ScopeContext,
+  ctx: ScopeContext,
   schema: DBSchema,
 ): DBAdapter => {
   const scopedModels = collectScopedModels(schema);
-  const tx = wrapTxMethods(inner, scopes, scopedModels);
+  const tx = wrapTxMethods(inner, ctx, scopedModels);
   return {
     ...tx,
     transaction: (callback) =>
       inner.transaction((rawTrx) => {
         const scopedTrx: DBTransactionAdapter = wrapTxMethods(
           rawTrx,
-          scopes,
+          ctx,
           scopedModels,
         );
         return callback(scopedTrx);

--- a/packages/core/sdk/src/secrets.ts
+++ b/packages/core/sdk/src/secrets.ts
@@ -11,7 +11,7 @@ import { SecretId, ScopeId } from "./ids";
 // at startup; there's no runtime registration.
 //
 // The `key` field is the provider's identifier in the secret table's
-// `provider` column and in `executor.secrets.set(id, value, provider?)`.
+// `provider` column and in `executor.secrets.set({ provider, ... })`.
 // Unique per executor.
 // ---------------------------------------------------------------------------
 
@@ -22,20 +22,32 @@ export interface SecretProvider {
    *  honours this before routing writes — trying to write to a
    *  read-only provider is an error, not a silent drop. */
   readonly writable: boolean;
-  /** Get a secret value by id. Returns null if not found. Failures
-   *  (provider unreachable, decryption failed, etc.) surface as
-   *  `StorageFailure` — the executor treats a provider call the same
-   *  as a DB call; `StorageError` is captured at the HTTP edge to
-   *  `InternalError`, `UniqueViolationError` dies. */
-  readonly get: (id: string) => Effect.Effect<string | null, StorageFailure>;
-  /** Set a secret value. Only called on writable providers. */
+  /** Get a secret value. `scope` is the executor scope the lookup is
+   *  being made on behalf of — providers that partition their storage
+   *  by scope (memory, keychain via service name, per-vault in
+   *  1password) use it; providers without tenancy ignore it and fall
+   *  back to a flat lookup. Failures (provider unreachable, decryption
+   *  failed, etc.) surface as `StorageFailure` — the executor treats
+   *  a provider call the same as a DB call; `StorageError` is captured
+   *  at the HTTP edge to `InternalError`, `UniqueViolationError` dies. */
+  readonly get: (
+    id: string,
+    scope: string,
+  ) => Effect.Effect<string | null, StorageFailure>;
+  /** Set a secret value at a named scope. Only called on writable
+   *  providers. Providers that partition by scope use this arg to
+   *  decide where to write; flat providers ignore it. */
   readonly set?: (
     id: string,
     value: string,
+    scope: string,
   ) => Effect.Effect<void, StorageFailure>;
-  /** Delete a secret. Only called on writable providers. Returns true
-   *  if something was deleted. */
-  readonly delete?: (id: string) => Effect.Effect<boolean, StorageFailure>;
+  /** Delete a secret at a named scope. Only called on writable providers.
+   *  Returns true if something was deleted. */
+  readonly delete?: (
+    id: string,
+    scope: string,
+  ) => Effect.Effect<boolean, StorageFailure>;
   /** Enumerate known secret entries. Optional — not all backends can
    *  enumerate (env-backed providers, for example). */
   readonly list?: () => Effect.Effect<
@@ -64,12 +76,20 @@ export class SecretRef extends Schema.Class<SecretRef>("SecretRef")({
 // SetSecretInput — all the metadata to write a secret in one call.
 // `executor.secrets.set(input)` takes this and writes both the
 // value (to the provider) and the ref (to the `secret` table).
+//
+// `scope` is required — there's no default write target. Callers name
+// which scope in the executor's stack should own the secret. Typical
+// pattern: UI wiring up org-level API keys writes to the org scope;
+// OAuth token exchange writes to the innermost per-user scope.
 // ---------------------------------------------------------------------------
 
 export class SetSecretInput extends Schema.Class<SetSecretInput>(
   "SetSecretInput",
 )({
   id: SecretId,
+  /** Scope id to own this secret. Must be one of the executor's
+   *  configured scopes. */
+  scope: ScopeId,
   /** Display name shown in secret-list UI. */
   name: Schema.String,
   /** The secret value itself — never persisted outside the provider. */

--- a/packages/core/sdk/src/testing.ts
+++ b/packages/core/sdk/src/testing.ts
@@ -11,24 +11,31 @@ import { Scope } from "./scope";
 // makeTestConfig — build an ExecutorConfig backed by in-memory adapter +
 // blob store. For unit tests, plugin authors validating their plugin,
 // REPL experimentation. No persistence.
+//
+// Defaults to a single-element scope stack ("test-scope") — tests that
+// need multi-scope behavior can pass `scopes` explicitly.
 // ---------------------------------------------------------------------------
 
 export const makeTestConfig = <
   const TPlugins extends readonly AnyPlugin[] = [],
 >(options?: {
   readonly scopeName?: string;
+  readonly scopes?: readonly Scope[];
   readonly plugins?: TPlugins;
 }): ExecutorConfig<TPlugins> => {
-  const scope = new Scope({
-    id: ScopeId.make("test-scope"),
-    name: options?.scopeName ?? "test",
-    createdAt: new Date(),
-  });
+  const scopes =
+    options?.scopes ?? [
+      new Scope({
+        id: ScopeId.make("test-scope"),
+        name: options?.scopeName ?? "test",
+        createdAt: new Date(),
+      }),
+    ];
 
   const schema = collectSchemas(options?.plugins ?? []);
 
   return {
-    scope,
+    scopes,
     adapter: makeMemoryAdapter({ schema }),
     blobs: makeInMemoryBlobStore(),
     plugins: options?.plugins,

--- a/packages/core/storage-file/src/blob-store.ts
+++ b/packages/core/storage-file/src/blob-store.ts
@@ -9,7 +9,7 @@
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
-import { and, eq, sql as drizzleSql } from "drizzle-orm";
+import { and, eq, inArray, sql as drizzleSql } from "drizzle-orm";
 import { primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 import type { BlobStore } from "@executor/sdk";
@@ -62,6 +62,33 @@ export const makeSqliteBlobStore = (
           .all() as ReadonlyArray<{ value: string }>,
       catch: wrapErr("get"),
     }).pipe(Effect.map((rows) => rows[0]?.value ?? null)),
+
+  getMany: (namespaces, key) =>
+    namespaces.length === 0
+      ? Effect.succeed(new Map<string, string>())
+      : Effect.try({
+          try: () =>
+            options.db
+              .select({
+                namespace: blobTable.namespace,
+                value: blobTable.value,
+              })
+              .from(blobTable)
+              .where(
+                and(
+                  inArray(blobTable.namespace, [...namespaces]),
+                  eq(blobTable.key, key),
+                ),
+              )
+              .all() as ReadonlyArray<{ namespace: string; value: string }>,
+          catch: wrapErr("getMany"),
+        }).pipe(
+          Effect.map((rows) => {
+            const out = new Map<string, string>();
+            for (const row of rows) out.set(row.namespace, row.value);
+            return out;
+          }),
+        ),
 
   put: (namespace, key, value) =>
     Effect.try({

--- a/packages/core/storage-postgres/src/blob-store.ts
+++ b/packages/core/storage-postgres/src/blob-store.ts
@@ -10,7 +10,7 @@
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import type { PgDatabase } from "drizzle-orm/pg-core";
 import { pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 
@@ -64,6 +64,29 @@ export const makePostgresBlobStore = (
       },
       catch: wrapErr("get"),
     }),
+  getMany: (namespaces, key) =>
+    namespaces.length === 0
+      ? Effect.succeed(new Map<string, string>())
+      : Effect.tryPromise({
+          try: async () => {
+            const rows = await options.db
+              .select({
+                namespace: blobTable.namespace,
+                value: blobTable.value,
+              })
+              .from(blobTable)
+              .where(
+                and(
+                  inArray(blobTable.namespace, [...namespaces]),
+                  eq(blobTable.key, key),
+                ),
+              );
+            const out = new Map<string, string>();
+            for (const row of rows) out.set(row.namespace, row.value);
+            return out as ReadonlyMap<string, string>;
+          },
+          catch: wrapErr("getMany"),
+        }),
   put: (namespace, key, value) =>
     Effect.tryPromise({
       try: async () => {


### PR DESCRIPTION
Replaces single-scope executor API with a read chain (innermost-first) and
explicit scope on every scoped write.

- Executor exposes scopes: readonly Scope[] instead of scope: Scope.
- Scoped reads use scope_id IN (scopes); writes take an explicit scope
  argument and refuse rows stamped outside the allowed set (no more
  implicit stamping).
- SecretProvider.get/set/delete accept a scope; SetSecretInput gains
  scope. Blob store splits into pluginBlobStore with explicit { scope }
  on writes/deletes and stack-walking reads (ScopedBlobStore renamed to
  PluginBlobStore).
- SourceInput/DefinitionsInput gain scope. promise-executor accepts
  scopes?: readonly {id?,name?}[] and defaults to a single scope.
- Test harness updated to scopes: [scope].