### PR TITLE
plugins: adopt layered scope API + workos-vault KEK colon fix

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -708,6 +708,7 @@
         "@effect/vitest": "catalog:",
         "@executor/api": "workspace:*",
         "@executor/react": "workspace:*",
+        "@executor/storage-core": "workspace:*",
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",

--- a/packages/plugins/file-secrets/src/index.ts
+++ b/packages/plugins/file-secrets/src/index.ts
@@ -123,36 +123,49 @@ const toStorageError = (cause: unknown) =>
     cause,
   });
 
-const makeScopedProvider = (filePath: string, scopeId: string): SecretProvider => ({
+// Scope arg is honored at every call: the auth.json is partitioned by
+// scope id, so read/write/delete route to `file[scope][secretId]`. The
+// provider is a singleton per executor; scope routing happens via the
+// arg passed from the executor's secrets facade.
+//
+// `list` enumerates the innermost scope the provider was configured
+// for — the executor's fallback/list path passes scope separately but
+// the SecretProvider.list signature is scope-agnostic. That's fine for
+// the current use: `list` feeds `secrets.list()` which already walks
+// the stack at the caller layer. Innermost-first is the display default.
+const makeScopedProvider = (
+  filePath: string,
+  listScope: string,
+): SecretProvider => ({
   key: "file",
   writable: true,
 
-  get: (secretId) =>
+  get: (secretId, scope) =>
     Effect.try({
       try: () => {
-        const data = readScopeSecrets(filePath, scopeId);
+        const data = readScopeSecrets(filePath, scope);
         return data[secretId] ?? null;
       },
       catch: toStorageError,
     }),
 
-  set: (secretId, value) =>
+  set: (secretId, value, scope) =>
     Effect.try({
       try: () => {
-        const data = readScopeSecrets(filePath, scopeId);
+        const data = readScopeSecrets(filePath, scope);
         data[secretId] = value;
-        writeScopeSecrets(filePath, scopeId, data);
+        writeScopeSecrets(filePath, scope, data);
       },
       catch: toStorageError,
     }),
 
-  delete: (secretId) =>
+  delete: (secretId, scope) =>
     Effect.try({
       try: () => {
-        const data = readScopeSecrets(filePath, scopeId);
+        const data = readScopeSecrets(filePath, scope);
         const had = secretId in data;
         delete data[secretId];
-        if (had) writeScopeSecrets(filePath, scopeId, data);
+        if (had) writeScopeSecrets(filePath, scope, data);
         return had;
       },
       catch: toStorageError,
@@ -161,7 +174,7 @@ const makeScopedProvider = (filePath: string, scopeId: string): SecretProvider =
   list: () =>
     Effect.try({
       try: () => {
-        const data = readScopeSecrets(filePath, scopeId);
+        const data = readScopeSecrets(filePath, listScope);
         return Object.keys(data).map((k) => ({ id: k, name: k }));
       },
       catch: toStorageError,
@@ -189,7 +202,9 @@ export const fileSecretsPlugin = definePlugin(
     }),
 
     secretProviders: (ctx: PluginCtx<unknown>) => [
-      makeScopedProvider(resolveFilePath(options), ctx.scope.id),
+      // list() falls back to the innermost scope for display; per-call
+      // get/set/delete honor the scope arg threaded from the secrets facade.
+      makeScopedProvider(resolveFilePath(options), ctx.scopes[0]!.id as string),
     ],
   }),
 );

--- a/packages/plugins/google-discovery/src/api/handlers.ts
+++ b/packages/plugins/google-discovery/src/api/handlers.ts
@@ -65,10 +65,13 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
           return yield* ext.probeDiscovery(payload.discoveryUrl);
         })),
       )
-      .handle("addSource", ({ payload }) =>
+      .handle("addSource", ({ path, payload }) =>
         capture(Effect.gen(function* () {
           const ext = yield* GoogleDiscoveryExtensionService;
-          return yield* ext.addSource(payload as GoogleDiscoveryAddSourceInput);
+          return yield* ext.addSource({
+            ...(payload as Omit<GoogleDiscoveryAddSourceInput, "scope">),
+            scope: path.scopeId,
+          });
         })),
       )
       .handle("startOAuth", ({ payload }) =>

--- a/packages/plugins/google-discovery/src/sdk/binding-store.ts
+++ b/packages/plugins/google-discovery/src/sdk/binding-store.ts
@@ -74,6 +74,10 @@ export type GoogleDiscoverySchema = typeof googleDiscoverySchema;
 
 export interface GoogleDiscoveryStoredSource {
   readonly namespace: string;
+  /** Executor scope id this source row lives in. Writes stamp this on
+   *  `scope_id`; reads return whichever scope's row the adapter's
+   *  fall-through walk surfaced first. */
+  readonly scope: string;
   readonly name: string;
   readonly config: GoogleDiscoveryStoredSourceData;
 }
@@ -117,6 +121,7 @@ export interface GoogleDiscoveryStore {
   readonly putBinding: (
     toolId: string,
     sourceId: string,
+    scope: string,
     binding: GoogleDiscoveryMethodBinding,
   ) => Effect.Effect<void, StorageFailure>;
   readonly removeBindingsBySource: (
@@ -142,6 +147,7 @@ export interface GoogleDiscoveryStore {
 
   readonly putOAuthSession: (
     sessionId: string,
+    scope: string,
     session: GoogleDiscoveryOAuthSession,
   ) => Effect.Effect<void, StorageFailure>;
   readonly getOAuthSession: (
@@ -171,7 +177,7 @@ export const makeGoogleDiscoveryStore = (
         return { namespace: row.source_id as string, binding: decoded };
       }),
 
-    putBinding: (toolId, sourceId, binding) =>
+    putBinding: (toolId, sourceId, scope, binding) =>
       Effect.gen(function* () {
         // Upsert: delete + insert. The in-memory adapter accepts
         // overwriting via create; real SQL backends would fail without
@@ -184,6 +190,7 @@ export const makeGoogleDiscoveryStore = (
           model: "google_discovery_binding",
           data: {
             id: toolId,
+            scope_id: scope,
             source_id: sourceId,
             binding: encodeBinding(binding) as unknown as Record<string, unknown>,
             created_at: new Date(),
@@ -230,6 +237,7 @@ export const makeGoogleDiscoveryStore = (
           model: "google_discovery_source",
           data: {
             id: source.namespace,
+            scope_id: source.scope,
             name: source.name,
             config: encodeStoredSourceData(source.config) as unknown as Record<string, unknown>,
             created_at: now,
@@ -256,6 +264,7 @@ export const makeGoogleDiscoveryStore = (
         if (!row) return null;
         return {
           namespace: row.id as string,
+          scope: row.scope_id as string,
           name: row.name as string,
           config: decodeStoredSourceData(decodeJson(row.config)),
         };
@@ -271,7 +280,7 @@ export const makeGoogleDiscoveryStore = (
         return decodeStoredSourceData(decodeJson(row.config));
       }),
 
-    putOAuthSession: (sessionId, session) =>
+    putOAuthSession: (sessionId, scope, session) =>
       Effect.gen(function* () {
         yield* db.delete({
           model: "google_discovery_oauth_session",
@@ -281,6 +290,7 @@ export const makeGoogleDiscoveryStore = (
           model: "google_discovery_oauth_session",
           data: {
             id: sessionId,
+            scope_id: scope,
             session: encodeSession(session) as unknown as Record<string, unknown>,
             expires_at: new Date(Date.now() + GOOGLE_DISCOVERY_OAUTH_SESSION_TTL_MS),
           },

--- a/packages/plugins/google-discovery/src/sdk/invoke.ts
+++ b/packages/plugins/google-discovery/src/sdk/invoke.ts
@@ -55,6 +55,9 @@ const makeSecretsIO = (ctx: PluginCtx<GoogleDiscoveryStore>): OAuth2SecretsIO =>
       .set(
         new SetSecretInput({
           id: secretId as SetSecretInput["id"],
+          // Refresh writes land at the innermost (user) scope — same
+          // partition as the original mint.
+          scope: ctx.scopes[0]!.id,
           name,
           value,
         }),
@@ -117,6 +120,7 @@ const isJsonContentType = (contentType: string | null | undefined): boolean => {
 const resolveOAuthAccessToken = (input: {
   ctx: PluginCtx<GoogleDiscoveryStore>;
   sourceId: string;
+  sourceScope: string;
   source: GoogleDiscoveryStoredSourceData;
 }): Effect.Effect<string, GoogleDiscoveryOAuthError> =>
   Effect.gen(function* () {
@@ -156,6 +160,7 @@ const resolveOAuthAccessToken = (input: {
           });
           yield* input.ctx.storage.putSource({
             namespace: input.sourceId,
+            scope: input.sourceScope,
             name: input.source.name,
             config: updated,
           });
@@ -293,8 +298,8 @@ export const invokeGoogleDiscoveryTool = (input: {
         }),
       );
     }
-    const source = yield* input.ctx.storage.getSourceConfig(entry.namespace);
-    if (!source) {
+    const stored = yield* input.ctx.storage.getSource(entry.namespace);
+    if (!stored) {
       return yield* Effect.fail(
         new GoogleDiscoveryInvocationError({
           message: `No Google Discovery source found for "${entry.namespace}"`,
@@ -302,12 +307,14 @@ export const invokeGoogleDiscoveryTool = (input: {
         }),
       );
     }
+    const source = stored.config;
 
     const accessToken =
       source.auth.kind === "oauth2"
         ? yield* resolveOAuthAccessToken({
             ctx: input.ctx,
             sourceId: entry.namespace,
+            sourceScope: stored.scope,
             source,
           })
         : "";

--- a/packages/plugins/google-discovery/src/sdk/plugin.test.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.test.ts
@@ -114,14 +114,21 @@ const makeMemorySecretsPlugin = () => {
   const provider: SecretProvider = {
     key: "memory",
     writable: true,
-    get: (id) => Effect.sync(() => store.get(id) ?? null),
-    set: (id, value) =>
+    get: (id, scope) =>
+      Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
+    set: (id, value, scope) =>
       Effect.sync(() => {
-        store.set(id, value);
+        store.set(`${scope}\u0000${id}`, value);
       }),
-    delete: (id) => Effect.sync(() => store.delete(id)),
+    delete: (id, scope) =>
+      Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
     list: () =>
-      Effect.sync(() => Array.from(store.keys()).map((id) => ({ id, name: id }))),
+      Effect.sync(() =>
+        Array.from(store.keys()).map((k) => {
+          const name = k.split("\u0000", 2)[1] ?? k;
+          return { id: name, name };
+        }),
+      ),
   };
   return definePlugin(() => ({
     id: "memory-secrets" as const,
@@ -194,6 +201,7 @@ describe("Google Discovery plugin", () => {
         yield* executor.secrets.set(
           new SetSecretInput({
             id: SecretId.make("google-client-id"),
+            scope: "test-scope" as SetSecretInput["scope"],
             name: "Google Client ID",
             value: "client-123",
           }),
@@ -232,6 +240,7 @@ describe("Google Discovery plugin", () => {
         yield* executor.secrets.set(
           new SetSecretInput({
             id: SecretId.make("google-client-id"),
+            scope: "test-scope" as SetSecretInput["scope"],
             name: "Google Client ID",
             value: "client-123",
           }),
@@ -239,6 +248,7 @@ describe("Google Discovery plugin", () => {
         yield* executor.secrets.set(
           new SetSecretInput({
             id: SecretId.make("google-client-secret"),
+            scope: "test-scope" as SetSecretInput["scope"],
             name: "Google Client Secret",
             value: "client-secret-value",
           }),
@@ -319,6 +329,7 @@ describe("Google Discovery plugin", () => {
           yield* executor.secrets.set(
             new SetSecretInput({
               id: SecretId.make("drive-access-token"),
+              scope: "test-scope" as SetSecretInput["scope"],
               name: "Drive Access Token",
               value: "secret-token",
             }),
@@ -326,6 +337,7 @@ describe("Google Discovery plugin", () => {
           yield* executor.secrets.set(
             new SetSecretInput({
               id: SecretId.make("drive-client-id"),
+              scope: "test-scope" as SetSecretInput["scope"],
               name: "Drive Client ID",
               value: "client-123",
             }),
@@ -333,6 +345,7 @@ describe("Google Discovery plugin", () => {
 
           const result = yield* executor.googleDiscovery.addSource({
             name: "Google Drive",
+            scope: "test-scope",
             discoveryUrl: handle.discoveryUrl,
             namespace: "drive",
             auth: {

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -62,6 +62,7 @@ export interface GoogleDiscoveryProbeResult {
 
 export interface GoogleDiscoveryAddSourceInput {
   readonly name: string;
+  readonly scope: string;
   readonly discoveryUrl: string;
   readonly namespace?: string;
   readonly auth: GoogleDiscoveryAuth;
@@ -224,6 +225,7 @@ const deriveNamespace = (input: { name: string; service: string; version: string
 const registerManifest = (
   ctx: PluginCtx<GoogleDiscoveryStore>,
   namespace: string,
+  scope: string,
   manifest: GoogleDiscoveryManifest,
   sourceData: GoogleDiscoveryStoredSourceData,
 ) =>
@@ -235,6 +237,7 @@ const registerManifest = (
     // 2. Register the source + tool rows in core.
     yield* ctx.core.sources.register({
       id: namespace,
+      scope,
       kind: "googleDiscovery",
       name: sourceData.name,
       url: sourceData.rootUrl,
@@ -253,6 +256,7 @@ const registerManifest = (
     if (Object.keys(manifest.schemaDefinitions).length > 0) {
       yield* ctx.core.definitions.register({
         sourceId: namespace,
+        scope,
         definitions: manifest.schemaDefinitions,
       });
     }
@@ -265,6 +269,7 @@ const registerManifest = (
         ctx.storage.putBinding(
           `${namespace}.${method.toolPath}`,
           namespace,
+          scope,
           method.binding,
         ),
       { discard: true },
@@ -273,6 +278,7 @@ const registerManifest = (
     // 5. Write the source config blob.
     yield* ctx.storage.putSource({
       namespace,
+      scope,
       name: sourceData.name,
       config: sourceData,
     });
@@ -297,6 +303,9 @@ const createSecretForOAuth = (
     .set(
       new SetSecretInput({
         id: `${input.idPrefix}_${randomUUID().slice(0, 8)}` as SetSecretInput["id"],
+        // OAuth tokens are per-user: pin to the innermost scope so Alice
+        // and Bob don't overwrite each other's tokens.
+        scope: ctx.scopes[0]!.id,
         name: input.name,
         value: input.value,
       }),
@@ -361,7 +370,13 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
             servicePath: manifest.servicePath,
             auth: input.auth,
           });
-          const toolCount = yield* registerManifest(ctx, namespace, manifest, sourceData);
+          const toolCount = yield* registerManifest(
+            ctx,
+            namespace,
+            input.scope,
+            manifest,
+            sourceData,
+          );
           return { toolCount, namespace };
         }),
       ),
@@ -398,7 +413,7 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
         }
         const sessionId = randomUUID();
         const codeVerifier = createPkceCodeVerifier();
-        yield* ctx.storage.putOAuthSession(sessionId, {
+        yield* ctx.storage.putOAuthSession(sessionId, ctx.scopes[0]!.id as string, {
           discoveryUrl: normalizeDiscoveryUrl(input.discoveryUrl),
           name: input.name,
           clientIdSecretId: input.clientIdSecretId,
@@ -567,17 +582,18 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
   refreshSource: ({ ctx, sourceId }) =>
     Effect.gen(function* () {
       const typedCtx = ctx as PluginCtx<GoogleDiscoveryStore>;
-      const source = yield* typedCtx.storage.getSourceConfig(sourceId);
-      if (!source) return;
-      const text = yield* fetchDiscoveryDocument(source.discoveryUrl);
+      const existing = yield* typedCtx.storage.getSource(sourceId);
+      if (!existing) return;
+      const refreshScope = existing.scope ?? (typedCtx.scopes.at(-1)!.id as string);
+      const text = yield* fetchDiscoveryDocument(existing.config.discoveryUrl);
       const manifest = yield* extractGoogleDiscoveryManifest(text);
       const next = new GoogleDiscoveryStoredSourceDataSchema({
-        ...source,
+        ...existing.config,
         service: manifest.service,
         version: manifest.version,
         rootUrl: manifest.rootUrl,
         servicePath: manifest.servicePath,
       });
-      yield* registerManifest(typedCtx, sourceId, manifest, next);
+      yield* registerManifest(typedCtx, sourceId, refreshScope, manifest, next);
     }).pipe(Effect.mapError((err) => (err instanceof Error ? err : new Error(String(err))))),
 }));

--- a/packages/plugins/graphql/src/api/handlers.ts
+++ b/packages/plugins/graphql/src/api/handlers.ts
@@ -43,11 +43,12 @@ const ExecutorApiWithGraphql = addGroup(GraphqlGroup);
 
 export const GraphqlHandlers = HttpApiBuilder.group(ExecutorApiWithGraphql, "graphql", (handlers) =>
   handlers
-    .handle("addSource", ({ payload }) =>
+    .handle("addSource", ({ path, payload }) =>
       capture(Effect.gen(function* () {
         const ext = yield* GraphqlExtensionService;
         const result = yield* ext.addSource({
           endpoint: payload.endpoint,
+          scope: path.scopeId,
           name: payload.name,
           introspectionJson: payload.introspectionJson,
           namespace: payload.namespace,

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -25,13 +25,17 @@ import { Input } from "@executor/react/components/input";
 import { Badge } from "@executor/react/components/badge";
 import type { StoredGraphqlSource } from "../sdk/store";
 
+// UI only needs the fields the API exposes; `scope` on the SDK interface
+// isn't part of the HTTP response.
+type EditableSource = Omit<StoredGraphqlSource, "scope">;
+
 // ---------------------------------------------------------------------------
 // Edit form
 // ---------------------------------------------------------------------------
 
 function EditForm(props: {
   sourceId: string;
-  initial: StoredGraphqlSource;
+  initial: EditableSource;
   onSave: () => void;
 }) {
   const scopeId = useScope();

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -86,6 +86,7 @@ describe("graphqlPlugin", () => {
 
       const result = yield* executor.graphql.addSource({
         endpoint: "http://localhost:4000/graphql",
+        scope: "test-scope",
         introspectionJson,
         namespace: "test_api",
       });
@@ -116,6 +117,7 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://localhost:4000/graphql",
+        scope: "test-scope",
         introspectionJson,
         namespace: "removable",
       });
@@ -145,6 +147,7 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://localhost:4000/graphql",
+        scope: "test-scope",
         introspectionJson,
         namespace: "my_gql",
       });
@@ -171,6 +174,7 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://localhost:4000/graphql",
+        scope: "test-scope",
         introspectionJson,
         namespace: "approval_test",
       });
@@ -201,6 +205,7 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://localhost:4000/graphql",
+        scope: "test-scope",
         introspectionJson,
         namespace: "patched",
       });

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -50,6 +50,13 @@ export type HeaderValue = HeaderValueValue;
 export interface GraphqlSourceConfig {
   /** The GraphQL endpoint URL */
   readonly endpoint: string;
+  /**
+   * Executor scope id that owns this source row. Must be one of the
+   * executor's configured scopes. Typical shape: an admin adds the
+   * source at the outermost (organization) scope so it's visible to
+   * every inner (per-user) scope via fall-through reads.
+   */
+  readonly scope: string;
   /** Display name for the source. Falls back to namespace if not provided. */
   readonly name?: string;
   /** Optional: introspection JSON text (if endpoint doesn't support introspection) */
@@ -341,6 +348,7 @@ export const graphqlPlugin = definePlugin(
               // subsequent core-source register collision rolls back both.
               const storedSource: StoredGraphqlSource = {
                 namespace,
+                scope: config.scope,
                 name: displayName,
                 endpoint: config.endpoint,
                 headers: config.headers ?? {},
@@ -356,6 +364,7 @@ export const graphqlPlugin = definePlugin(
 
               yield* ctx.core.sources.register({
                 id: namespace,
+                scope: config.scope,
                 kind: "graphql",
                 name: displayName,
                 url: config.endpoint,
@@ -372,6 +381,7 @@ export const graphqlPlugin = definePlugin(
               if (Object.keys(definitions).length > 0) {
                 yield* ctx.core.definitions.register({
                   sourceId: namespace,
+                  scope: config.scope,
                   definitions,
                 });
               }
@@ -447,8 +457,16 @@ export const graphqlPlugin = definePlugin(
                 },
                 required: ["toolCount"],
               },
-              handler: ({ args }) =>
-                self.addSource(args as GraphqlSourceConfig),
+              // Static-tool callers don't name a scope. Default to the
+              // outermost scope in the executor's stack — for a single-
+              // scope executor that's the only scope; for a per-user
+              // stack `[user, org]` it writes at `org` so the source is
+              // visible across every user.
+              handler: ({ ctx, args }) =>
+                self.addSource({
+                  ...(args as Omit<GraphqlSourceConfig, "scope">),
+                  scope: ctx.scopes.at(-1)!.id as string,
+                }),
             },
           ],
         },

--- a/packages/plugins/graphql/src/sdk/store.ts
+++ b/packages/plugins/graphql/src/sdk/store.ts
@@ -38,6 +38,10 @@ export type GraphqlSchema = typeof graphqlSchema;
 
 export interface StoredGraphqlSource {
   readonly namespace: string;
+  /** Executor scope id this source row lives in. Writes stamp this on
+   *  `scope_id`; reads return whichever scope's row the adapter's
+   *  fall-through walk surfaced first. */
+  readonly scope: string;
   readonly name: string;
   readonly endpoint: string;
   readonly headers: Record<string, HeaderValue>;
@@ -122,6 +126,7 @@ export const makeDefaultGraphqlStore = ({
 }: StorageDeps<GraphqlSchema>): GraphqlStore => {
   const rowToSource = (row: Record<string, unknown>): StoredGraphqlSource => ({
     namespace: row.id as string,
+    scope: row.scope_id as string,
     name: row.name as string,
     endpoint: row.endpoint as string,
     headers: decodeHeaders(row.headers),
@@ -153,6 +158,7 @@ export const makeDefaultGraphqlStore = ({
           model: "graphql_source",
           data: {
             id: input.namespace,
+            scope_id: input.scope,
             name: input.name,
             endpoint: input.endpoint,
             headers: input.headers as unknown as Record<string, unknown>,
@@ -164,6 +170,7 @@ export const makeDefaultGraphqlStore = ({
             model: "graphql_operation",
             data: operations.map((op) => ({
               id: op.toolId,
+              scope_id: input.scope,
               source_id: op.sourceId,
               binding: encodeBinding(op.binding) as unknown as Record<string, unknown>,
             })),

--- a/packages/plugins/keychain/src/index.test.ts
+++ b/packages/plugins/keychain/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "@effect/vitest";
 import { Effect } from "effect";
 import {
+  ScopeId,
   SecretId,
   SetSecretInput,
   createExecutor,
@@ -42,6 +43,7 @@ describe("keychain plugin", () => {
         yield* executor.secrets.set(
           new SetSecretInput({
             id: testId,
+            scope: ScopeId.make("test-scope"),
             name: "Test Secret",
             value: "keychain-test-value",
             provider: "keychain",

--- a/packages/plugins/keychain/src/index.ts
+++ b/packages/plugins/keychain/src/index.ts
@@ -65,7 +65,7 @@ const scopedServiceName = (
   ctx: PluginCtx<unknown>,
   options: KeychainPluginConfig | undefined,
 ): string =>
-  `${resolveServiceName(options?.serviceName)}/${ctx.scope.id}`;
+  `${resolveServiceName(options?.serviceName)}/${ctx.scopes[0]!.id as string}`;
 
 export const keychainPlugin = definePlugin(
   (options?: KeychainPluginConfig) => ({

--- a/packages/plugins/keychain/src/provider.ts
+++ b/packages/plugins/keychain/src/provider.ts
@@ -21,14 +21,18 @@ import { getPassword, setPassword, deletePassword } from "./keyring";
 const toStorageError = (cause: { readonly message: string; readonly cause?: unknown }) =>
   new StorageError({ message: cause.message, cause: cause.cause ?? cause });
 
+// Scope arg is ignored — keychain partitions by `serviceName`, which the
+// host fixes per executor at construction time. A future refactor could
+// fold `scope` into the service name, but today a keychain provider
+// instance is already one-scope.
 export const makeKeychainProvider = (serviceName: string): SecretProvider => ({
   key: "keychain",
   writable: true,
-  get: (secretId) =>
+  get: (secretId, _scope) =>
     getPassword(serviceName, secretId).pipe(Effect.mapError(toStorageError)),
-  set: (secretId, value) =>
+  set: (secretId, value, _scope) =>
     setPassword(serviceName, secretId, value).pipe(Effect.mapError(toStorageError)),
-  delete: (secretId) =>
+  delete: (secretId, _scope) =>
     deletePassword(serviceName, secretId).pipe(Effect.mapError(toStorageError)),
   // Keychain doesn't support enumerating — you need to know the account name
   list: undefined,

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -95,6 +95,7 @@ const toPopupErrorMessage = (cause: Cause.Cause<unknown>): string => {
 
 const toSourceConfig = (
   payload: { transport: "remote" | "stdio" } & Record<string, unknown>,
+  scope: string,
 ): McpSourceConfig => {
   if (payload.transport === "stdio") {
     const p = payload as {
@@ -108,6 +109,7 @@ const toSourceConfig = (
     };
     return {
       transport: "stdio",
+      scope,
       name: p.name,
       command: p.command,
       args: p.args ? [...p.args] : undefined,
@@ -139,6 +141,7 @@ const toSourceConfig = (
 
   return {
     transport: "remote",
+    scope,
     name: p.name,
     endpoint: p.endpoint,
     remoteTransport: p.remoteTransport,
@@ -170,11 +173,14 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
         return yield* ext.probeEndpoint(payload.endpoint);
       })),
     )
-    .handle("addSource", ({ payload }) =>
+    .handle("addSource", ({ path, payload }) =>
       capture(Effect.gen(function* () {
         const ext = yield* McpExtensionService;
         return yield* ext.addSource(
-          toSourceConfig(payload as Parameters<typeof toSourceConfig>[0]),
+          toSourceConfig(
+            payload as Parameters<typeof toSourceConfig>[0],
+            path.scopeId,
+          ),
         );
       })),
     )

--- a/packages/plugins/mcp/src/sdk/binding-store.ts
+++ b/packages/plugins/mcp/src/sdk/binding-store.ts
@@ -87,6 +87,10 @@ const coerceJson = (value: unknown): unknown => {
 
 export interface McpStoredSource {
   readonly namespace: string;
+  /** Executor scope id this source row lives in. Writes stamp this on
+   *  `scope_id`; reads return whichever scope's row the adapter's
+   *  fall-through walk surfaced first. */
+  readonly scope: string;
   readonly name: string;
   readonly config: McpStoredSourceData;
 }
@@ -109,6 +113,7 @@ export interface McpBindingStore {
 
   readonly putBindings: (
     namespace: string,
+    scope: string,
     entries: ReadonlyArray<{ readonly toolId: string; readonly binding: McpToolBinding }>,
   ) => Effect.Effect<void, StorageFailure>;
 
@@ -128,6 +133,7 @@ export interface McpBindingStore {
 
   readonly putOAuthSession: (
     sessionId: string,
+    scope: string,
     session: McpOAuthSession,
   ) => Effect.Effect<void, StorageFailure>;
   readonly getOAuthSession: (
@@ -155,7 +161,7 @@ export const makeMcpStore = ({
         return { binding, namespace: row.source_id };
       }),
 
-    putBindings: (namespace, entries) =>
+    putBindings: (namespace, scope, entries) =>
       Effect.gen(function* () {
         if (entries.length === 0) return;
         const now = new Date();
@@ -163,6 +169,7 @@ export const makeMcpStore = ({
           model: "mcp_binding",
           data: entries.map((e) => ({
             id: e.toolId,
+            scope_id: scope,
             source_id: namespace,
             binding: encodeBinding(e.binding),
             created_at: now,
@@ -184,6 +191,7 @@ export const makeMcpStore = ({
         const rows = yield* db.findMany({ model: "mcp_source" });
         return rows.map((row) => ({
           namespace: row.id,
+          scope: row.scope_id,
           name: row.name,
           config: decodeSourceData(coerceJson(row.config)),
         }));
@@ -198,6 +206,7 @@ export const makeMcpStore = ({
         if (!row) return null;
         return {
           namespace: row.id,
+          scope: row.scope_id,
           name: row.name,
           config: decodeSourceData(coerceJson(row.config)),
         };
@@ -224,6 +233,7 @@ export const makeMcpStore = ({
           model: "mcp_source",
           data: {
             id: source.namespace,
+            scope_id: source.scope,
             name: source.name,
             config: encodeSourceData(source.config),
             created_at: now,
@@ -244,7 +254,7 @@ export const makeMcpStore = ({
         });
       }),
 
-    putOAuthSession: (sessionId, session) =>
+    putOAuthSession: (sessionId, scope, session) =>
       Effect.gen(function* () {
         const now = new Date();
         yield* db.delete({
@@ -255,6 +265,7 @@ export const makeMcpStore = ({
           model: "mcp_oauth_session",
           data: {
             id: sessionId,
+            scope_id: scope,
             session: encodeSession(session),
             expires_at: Date.now() + MCP_OAUTH_SESSION_TTL_MS,
             created_at: now,

--- a/packages/plugins/mcp/src/sdk/elicitation.test.ts
+++ b/packages/plugins/mcp/src/sdk/elicitation.test.ts
@@ -142,6 +142,7 @@ const makeTestExecutor = (serverUrl: string) =>
     Effect.tap((executor) =>
       executor.mcp.addSource({
         transport: "remote",
+        scope: "test-scope",
         name: "test-mcp",
         endpoint: serverUrl,
       }),

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -180,6 +180,7 @@ describe("mcpPlugin", () => {
       const result = yield* executor.mcp
         .addSource({
           transport: "remote",
+          scope: "test-scope",
           name: "broken",
           // Port 1 is reserved — will connection-refused immediately,
           // giving us a deterministic discovery failure without any

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -50,7 +50,15 @@ import {
 // Plugin config — discriminated union on transport
 // ---------------------------------------------------------------------------
 
-export interface McpRemoteSourceConfig {
+/**
+ * Executor scope id that owns a newly-added MCP source row. Must be one
+ * of the executor's configured scopes. Admins adding a shared server at
+ * org scope pin here; per-user stdio sources can pin at the inner
+ * scope.
+ */
+type McpSourceScopeField = { readonly scope: string };
+
+export interface McpRemoteSourceConfig extends McpSourceScopeField {
   readonly transport: "remote";
   readonly name: string;
   readonly endpoint: string;
@@ -61,7 +69,7 @@ export interface McpRemoteSourceConfig {
   readonly auth?: McpConnectionAuth;
 }
 
-export interface McpStdioSourceConfig {
+export interface McpStdioSourceConfig extends McpSourceScopeField {
   readonly transport: "stdio";
   readonly name: string;
   readonly command: string;
@@ -538,12 +546,14 @@ export const mcpPlugin = definePlugin(
 
                   yield* ctx.storage.putSource({
                     namespace,
+                    scope: config.scope,
                     name: sourceName,
                     config: sd,
                   });
 
                   yield* ctx.storage.putBindings(
                     namespace,
+                    config.scope,
                     manifest.tools.map((e) => ({
                       toolId: `${namespace}.${e.toolId}`,
                       binding: toBinding(e),
@@ -552,6 +562,7 @@ export const mcpPlugin = definePlugin(
 
                   yield* ctx.core.sources.register({
                     id: namespace,
+                    scope: config.scope,
                     kind: "mcp",
                     name: sourceName,
                     url: sd.transport === "remote" ? sd.endpoint : undefined,
@@ -652,6 +663,12 @@ export const mcpPlugin = definePlugin(
             const existing = yield* ctx.storage.getSource(namespace);
             const sourceName =
               manifest.server?.name ?? existing?.name ?? namespace;
+            // Refresh preserves the scope the source was originally
+            // added at. If the source row was lost (manual delete?)
+            // fall back to the outermost (org) scope so the catalog
+            // entry still lands somewhere visible.
+            const refreshScope =
+              existing?.scope ?? (ctx.scopes.at(-1)!.id as string);
 
             yield* ctx
               .transaction(
@@ -661,6 +678,7 @@ export const mcpPlugin = definePlugin(
 
                   yield* ctx.storage.putBindings(
                     namespace,
+                    refreshScope,
                     manifest.tools.map((e) => ({
                       toolId: `${namespace}.${e.toolId}`,
                       binding: toBinding(e),
@@ -668,6 +686,7 @@ export const mcpPlugin = definePlugin(
                   );
                   yield* ctx.core.sources.register({
                     id: namespace,
+                    scope: refreshScope,
                     kind: "mcp",
                     name: sourceName,
                     url: sd.transport === "remote" ? sd.endpoint : undefined,
@@ -730,7 +749,7 @@ export const mcpPlugin = definePlugin(
             );
 
             yield* ctx.storage
-              .putOAuthSession(sessionId, {
+              .putOAuthSession(sessionId, ctx.scopes[0]!.id as string, {
                 endpoint: fullEndpoint,
                 redirectUrl: input.redirectUrl,
                 codeVerifier: started.codeVerifier,
@@ -778,11 +797,18 @@ export const mcpPlugin = definePlugin(
               Effect.withSpan("mcp.plugin.oauth.exchange_code"),
             );
 
+            // MCP OAuth tokens are user-specific, so they land at the
+            // innermost scope. On a single-scope executor that's the
+            // only scope; on a per-user stack `[user, org]` it's the
+            // user scope — so tokens shadow org-level fallbacks for
+            // the caller's own invocations.
+            const tokenScope = ctx.scopes[0]!.id;
             const accessSecretId = `mcp-oauth-access-${input.state}`;
             yield* ctx.secrets
               .set(
                 new SetSecretInput({
                   id: SecretId.make(accessSecretId),
+                  scope: tokenScope,
                   name: "MCP OAuth Access Token",
                   value: exchanged.tokens.access_token,
                 }),
@@ -800,6 +826,7 @@ export const mcpPlugin = definePlugin(
                 .set(
                   new SetSecretInput({
                     id: SecretId.make(refreshId),
+                    scope: tokenScope,
                     name: "MCP OAuth Refresh Token",
                     value: exchanged.tokens.refresh_token,
                   }),
@@ -851,6 +878,7 @@ export const mcpPlugin = definePlugin(
 
             yield* ctx.storage.putSource({
               namespace,
+              scope: existing.scope,
               name: input.name?.trim() || existing.name,
               config: updatedConfig,
             });

--- a/packages/plugins/onepassword/src/sdk/plugin.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.ts
@@ -4,7 +4,7 @@ import {
   definePlugin,
   StorageError,
   type PluginCtx,
-  type ScopedBlobStore,
+  type PluginBlobStore,
   type SecretProvider,
   type StorageFailure,
 } from "@executor/sdk";
@@ -106,7 +106,11 @@ const blobStorageError = (operation: string) =>
     });
 
 export const makeOnePasswordStore = (
-  blobs: ScopedBlobStore,
+  blobs: PluginBlobStore,
+  /** Scope id that owns the single 1Password config blob. Default is the
+   *  outermost scope (org/workspace) so the config is visible across
+   *  every per-user scope via the blob store's fall-through read. */
+  writeScope: string,
 ): OnePasswordStore => ({
   getConfig: () =>
     blobs.get(CONFIG_KEY).pipe(
@@ -133,11 +137,14 @@ export const makeOnePasswordStore = (
           vaultId: config.vaultId,
           name: config.name,
         }),
+        { scope: writeScope },
       )
       .pipe(Effect.mapError(blobStorageError("write"))),
 
   deleteConfig: () =>
-    blobs.delete(CONFIG_KEY).pipe(Effect.mapError(blobStorageError("delete"))),
+    blobs
+      .delete(CONFIG_KEY, { scope: writeScope })
+      .pipe(Effect.mapError(blobStorageError("delete"))),
 });
 
 // ---------------------------------------------------------------------------
@@ -196,7 +203,10 @@ const makeProvider = (
   key: "onepassword",
   writable: false,
 
-  get: (secretId) =>
+  // 1Password vaults are named in the stored config; the executor-scope
+  // arg isn't used for routing here. A future refactor could let the
+  // plugin store per-scope vault bindings and pick based on `scope`.
+  get: (secretId, _scope) =>
     ctx.storage.getConfig().pipe(
       Effect.flatMap((config) => {
         if (!config) return Effect.succeed(null as string | null);
@@ -253,7 +263,8 @@ export const onepasswordPlugin = definePlugin(
 
     return {
       id: "onepassword" as const,
-      storage: ({ blobs }) => makeOnePasswordStore(blobs),
+      storage: ({ blobs, scopes }) =>
+        makeOnePasswordStore(blobs, scopes.at(-1)!.id as string),
 
       extension: (ctx) => {
         return {

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -61,6 +61,7 @@
     "@effect/vitest": "catalog:",
     "@executor/api": "workspace:*",
     "@executor/react": "workspace:*",
+    "@executor/storage-core": "workspace:*",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -69,6 +69,14 @@ const StartOAuthPayload = Schema.Struct({
   clientIdSecretId: Schema.String,
   clientSecretSecretId: Schema.optional(Schema.NullOr(Schema.String)),
   scopes: Schema.Array(Schema.String),
+  // Caller-owned token identity. `tokenScope` names which executor scope
+  // will own the minted tokens (typically the per-user scope). The two
+  // token secret ids are pre-decided so the source's stored `OAuth2Auth`
+  // can reference the same ids across every user — per-user values
+  // shadow org-level fallbacks via secret fall-through on read.
+  tokenScope: Schema.optional(ScopeId),
+  accessTokenSecretId: Schema.String,
+  refreshTokenSecretId: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 const StartOAuthResponse = Schema.Struct({

--- a/packages/plugins/openapi/src/api/handlers.ts
+++ b/packages/plugins/openapi/src/api/handlers.ts
@@ -60,11 +60,12 @@ export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "ope
         return yield* ext.previewSpec(payload.spec);
       })),
     )
-    .handle("addSpec", ({ payload }) =>
+    .handle("addSpec", ({ path, payload }) =>
       capture(Effect.gen(function* () {
         const ext = yield* OpenApiExtensionService;
         const result = yield* ext.addSpec({
           spec: payload.spec,
+          scope: path.scopeId,
           name: payload.name,
           baseUrl: payload.baseUrl,
           namespace: payload.namespace,
@@ -107,6 +108,12 @@ export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "ope
           clientIdSecretId: payload.clientIdSecretId,
           clientSecretSecretId: payload.clientSecretSecretId ?? null,
           scopes: [...payload.scopes],
+          // No tokenScope → plugin defaults to ctx.scopes[0].id (innermost).
+          // Single-scope executors: only scope in stack.
+          // Stacked executors: per-user scope, so tokens shadow by id.
+          tokenScope: payload.tokenScope as string | undefined,
+          accessTokenSecretId: payload.accessTokenSecretId,
+          refreshTokenSecretId: payload.refreshTokenSecretId ?? null,
         });
       })),
     )

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -95,14 +95,9 @@ const resolvePath = Effect.fn("OpenApi.resolvePath")(function* (
 export const resolveHeaders = (
   headers: Record<string, HeaderValue>,
   secrets: {
-    readonly get: (
-      id: string,
-    ) => Effect.Effect<string | null, StorageFailure>;
+    readonly get: (id: string) => Effect.Effect<string | null, StorageFailure>;
   },
-): Effect.Effect<
-  Record<string, string>,
-  OpenApiInvocationError | StorageFailure
-> => {
+): Effect.Effect<Record<string, string>, OpenApiInvocationError | StorageFailure> => {
   const entries = Object.entries(headers);
   const secretCount = entries.reduce(
     (acc, [, value]) => (typeof value === "string" ? acc : acc + 1),

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -15,11 +15,14 @@ import {
   createExecutor,
   definePlugin,
   makeTestConfig,
+  ScopeId,
   SecretId,
   SetSecretInput,
   type InvokeOptions,
   type SecretProvider,
 } from "@executor/sdk";
+
+const TEST_SCOPE = "test-scope";
 import { openApiPlugin } from "./plugin";
 
 const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
@@ -34,15 +37,20 @@ const memoryProvider: SecretProvider = (() => {
   return {
     key: "memory",
     writable: true,
-    get: (id) => Effect.sync(() => store.get(id) ?? null),
-    set: (id, value) =>
+    get: (id, scope) =>
+      Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
+    set: (id, value, scope) =>
       Effect.sync(() => {
-        store.set(id, value);
+        store.set(`${scope}\u0000${id}`, value);
       }),
-    delete: (id) => Effect.sync(() => store.delete(id)),
+    delete: (id, scope) =>
+      Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
     list: () =>
       Effect.sync(() =>
-        Array.from(store.keys()).map((id) => ({ id, name: id })),
+        Array.from(store.keys()).map((k) => {
+          const name = k.split("\u0000", 2)[1] ?? k;
+          return { id: name, name };
+        }),
       ),
   };
 })();
@@ -261,6 +269,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("test-api-token"),
+          scope: ScopeId.make(TEST_SCOPE),
           name: "Test API Token",
           value: "secret-value-123",
         }),
@@ -268,6 +277,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       yield* executor.openapi.addSpec({
         spec: specJson,
+        scope: TEST_SCOPE,
         namespace: "authed",
         baseUrl: "",
         headers: {
@@ -305,6 +315,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       yield* executor.openapi.addSpec({
         spec: specJson,
+        scope: TEST_SCOPE,
         namespace: "noauth",
         baseUrl: "",
         headers: {
@@ -337,6 +348,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       const result = yield* executor.openapi.addSpec({
         spec: specJson,
+        scope: TEST_SCOPE,
         namespace: "test",
         baseUrl: "",
       });
@@ -366,6 +378,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       yield* executor.openapi.addSpec({
         spec: specJson,
+        scope: TEST_SCOPE,
         namespace: "test",
         baseUrl: "",
       });
@@ -396,6 +409,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       yield* executor.openapi.addSpec({
         spec: specJson,
+        scope: TEST_SCOPE,
         namespace: "test",
         baseUrl: "",
       });
@@ -426,6 +440,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       yield* executor.openapi.addSpec({
         spec: specJson,
+        scope: TEST_SCOPE,
         namespace: "removable",
         baseUrl: "",
       });

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -8,12 +8,12 @@ import {
   buildAuthorizationUrl,
   createPkceCodeVerifier,
   exchangeAuthorizationCode,
-  storeOAuthTokens,
   withRefreshedAccessToken,
   type OAuth2TokenResponse,
 } from "@executor/plugin-oauth2";
 
 import {
+  ScopeId,
   SecretId,
   SetSecretInput,
   SourceDetectionResult,
@@ -69,6 +69,13 @@ export type HeaderValue = HeaderValueValue;
 
 export interface OpenApiSpecConfig {
   readonly spec: string;
+  /**
+   * Executor scope id that owns this source row. Must be one of the
+   * executor's configured scopes. Typical shape: an admin adds the
+   * source at the outermost (organization) scope so it's visible to
+   * every inner (per-user) scope via fall-through reads.
+   */
+  readonly scope: string;
   readonly name?: string;
   readonly baseUrl?: string;
   readonly namespace?: string;
@@ -96,6 +103,23 @@ export interface OpenApiStartOAuthInput {
   readonly clientIdSecretId: string;
   readonly clientSecretSecretId?: string | null;
   readonly scopes: readonly string[];
+  /**
+   * Executor scope id where the minted access/refresh tokens will land
+   * on completeOAuth. Defaults to `ctx.scopes[0].id` (the innermost
+   * scope) — which for a single-scope executor is the only scope, and
+   * for a stacked executor pins tokens to the per-user scope so
+   * org-level shadowing works by id.
+   */
+  readonly tokenScope?: string;
+  /**
+   * Pre-decided secret ids for the minted access + refresh tokens. Use
+   * deterministic ids (e.g. `${namespace}_access_token`) so the source's
+   * stored `OAuth2Auth` can reference them and `ctx.secrets.get` resolves
+   * via scope fall-through — per-user tokens shadow org-level fallbacks
+   * on the same source.
+   */
+  readonly accessTokenSecretId: string;
+  readonly refreshTokenSecretId?: string | null;
 }
 
 export interface OpenApiStartOAuthResponse {
@@ -251,18 +275,22 @@ export const openApiPlugin = definePlugin(
       storage: (deps): OpenapiStore => makeDefaultOpenapiStore(deps),
 
       extension: (ctx) => {
-        // Wraps ctx.secrets.set for the oauth2 helper so createSecret
-        // returns the freshly-minted id.
-        const createOAuthSecret = (args: {
-          readonly idPrefix: string;
+        // Write a token secret at a caller-pinned id and scope. The
+        // session persisted by `startOAuth` names both, so the plugin
+        // never picks them itself — that keeps shadowing by id
+        // deterministic (user scope overrides org scope for the same
+        // secret id) instead of minting random suffixes per completion.
+        const writeOAuthSecret = (args: {
+          readonly id: string;
+          readonly scope: string;
           readonly name: string;
           readonly value: string;
-          readonly purpose: string;
         }) =>
           ctx.secrets
             .set(
               new SetSecretInput({
-                id: SecretId.make(`${args.idPrefix}_${randomUUID().slice(0, 8)}`),
+                id: SecretId.make(args.id),
+                scope: ScopeId.make(args.scope),
                 name: args.name,
                 value: args.value,
               }),
@@ -315,6 +343,7 @@ export const openApiPlugin = definePlugin(
 
             const storedSource: StoredSource = {
               namespace,
+              scope: config.scope,
               name: sourceName,
               config: sourceConfig,
               invocationConfig,
@@ -332,6 +361,7 @@ export const openApiPlugin = definePlugin(
 
                 yield* ctx.core.sources.register({
                   id: namespace,
+                  scope: config.scope,
                   kind: "openapi",
                   name: sourceName,
                   url: baseUrl || undefined,
@@ -353,6 +383,7 @@ export const openApiPlugin = definePlugin(
                 if (Object.keys(hoistedDefs).length > 0) {
                   yield* ctx.core.definitions.register({
                     sourceId: namespace,
+                    scope: config.scope,
                     definitions: hoistedDefs,
                   });
                 }
@@ -406,6 +437,7 @@ export const openApiPlugin = definePlugin(
               const sessionId = randomUUID();
               const codeVerifier = createPkceCodeVerifier();
               const scopesArray = [...input.scopes];
+              const tokenScope = input.tokenScope ?? (ctx.scopes[0]!.id as string);
 
               yield* ctx.storage
                 .putOAuthSession(
@@ -418,6 +450,9 @@ export const openApiPlugin = definePlugin(
                     redirectUrl: input.redirectUrl,
                     clientIdSecretId: input.clientIdSecretId,
                     clientSecretSecretId: input.clientSecretSecretId ?? null,
+                    tokenScope,
+                    accessTokenSecretId: input.accessTokenSecretId,
+                    refreshTokenSecretId: input.refreshTokenSecretId ?? null,
                     scopes: scopesArray,
                     codeVerifier,
                   }),
@@ -506,28 +541,44 @@ export const openApiPlugin = definePlugin(
                     ),
                   );
 
-                const slug = session.displayName
-                  .toLowerCase()
-                  .replace(/[^a-z0-9]+/g, "_");
-
-                const stored = yield* storeOAuthTokens({
-                  tokens: tokenResponse,
-                  slug: `${slug}_openapi`,
-                  displayName: session.displayName,
-                  accessTokenPurpose: "openapi_oauth_access_token",
-                  refreshTokenPurpose: "openapi_oauth_refresh_token",
-                  createSecret: (args) =>
-                    createOAuthSecret(args).pipe(
-                      Effect.mapError(
-                        (err) =>
-                          new OpenApiOAuthError({ message: err.message }),
-                      ),
-                    ),
+                // Write tokens at the exact id + scope named by the
+                // session. Shadowing by id (per-user scope wins over
+                // org fall-through) is what makes a single stored
+                // `OAuth2Auth` on the source resolve to per-user
+                // values at invoke time.
+                const accessRef = yield* writeOAuthSecret({
+                  id: session.accessTokenSecretId,
+                  scope: session.tokenScope,
+                  name: `${session.displayName} Access Token`,
+                  value: tokenResponse.access_token,
                 }).pipe(
                   Effect.mapError(
                     (err) => new OpenApiOAuthError({ message: err.message }),
                   ),
                 );
+
+                let refreshSecretId: string | null = null;
+                if (
+                  tokenResponse.refresh_token &&
+                  session.refreshTokenSecretId
+                ) {
+                  const refreshRef = yield* writeOAuthSecret({
+                    id: session.refreshTokenSecretId,
+                    scope: session.tokenScope,
+                    name: `${session.displayName} Refresh Token`,
+                    value: tokenResponse.refresh_token,
+                  }).pipe(
+                    Effect.mapError(
+                      (err) => new OpenApiOAuthError({ message: err.message }),
+                    ),
+                  );
+                  refreshSecretId = refreshRef.id;
+                }
+
+                const expiresAt =
+                  typeof tokenResponse.expires_in === "number"
+                    ? Date.now() + tokenResponse.expires_in * 1000
+                    : null;
 
                 return new OAuth2Auth({
                   kind: "oauth2",
@@ -536,11 +587,11 @@ export const openApiPlugin = definePlugin(
                   tokenUrl: session.tokenUrl,
                   clientIdSecretId: session.clientIdSecretId,
                   clientSecretSecretId: session.clientSecretSecretId,
-                  accessTokenSecretId: stored.accessTokenSecretId,
-                  refreshTokenSecretId: stored.refreshTokenSecretId,
-                  tokenType: stored.tokenType,
-                  expiresAt: stored.expiresAt,
-                  scope: stored.scope,
+                  accessTokenSecretId: accessRef.id,
+                  refreshTokenSecretId: refreshSecretId,
+                  tokenType: tokenResponse.token_type ?? "Bearer",
+                  expiresAt,
+                  scope: tokenResponse.scope ?? null,
                   scopes: [...session.scopes],
                 });
               }),
@@ -594,8 +645,16 @@ export const openApiPlugin = definePlugin(
                 },
                 required: ["sourceId", "toolCount"],
               },
-              handler: ({ args }) =>
-                self.addSpec(args as AddSourceInput),
+              // Static-tool callers don't name a scope. Default to the
+              // outermost scope in the executor's stack — for a single-
+              // scope executor that's the only scope; for a per-user
+              // stack `[user, org]` it writes at `org` so the source is
+              // visible across every user.
+              handler: ({ ctx, args }) =>
+                self.addSpec({
+                  ...(args as AddSourceInput),
+                  scope: ctx.scopes.at(-1)!.id as string,
+                }),
             },
           ],
         },
@@ -647,10 +706,15 @@ export const openApiPlugin = definePlugin(
                     ),
                   ),
                 setValue: ({ secretId, value, name }) =>
+                  // Refresh writes land at the innermost scope of the
+                  // executor that invoked the tool. When a per-user
+                  // stack calls, that's the user scope — their token
+                  // shadows the org fall-through on the same id.
                   ctx.secrets
                     .set(
                       new SetSecretInput({
                         id: SecretId.make(secretId),
+                        scope: ctx.scopes[0]!.id,
                         name,
                         value,
                       }),

--- a/packages/plugins/openapi/src/sdk/presets.ts
+++ b/packages/plugins/openapi/src/sdk/presets.ts
@@ -129,4 +129,11 @@ export const openApiPresets: readonly OpenApiPreset[] = [
     url: "https://raw.githubusercontent.com/resend/resend-openapi/main/resend.yaml",
     icon: "https://resend.com/static/favicons/favicon.ico",
   },
+  {
+    id: "spotify",
+    name: "Spotify",
+    summary: "Tracks, albums, playlists, library, and playback.",
+    url: "https://raw.githubusercontent.com/sonallux/spotify-web-api/refs/heads/main/official-spotify-open-api.yml",
+    icon: "https://spotify.com/favicon.ico",
+  },
 ];

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -68,6 +68,10 @@ export interface SourceConfig {
 
 export interface StoredSource {
   readonly namespace: string;
+  /** Executor scope id this source row lives in. Writes stamp this on
+   *  `scope_id`; reads return whichever scope's row the adapter's
+   *  fall-through filter sees first. */
+  readonly scope: string;
   readonly name: string;
   readonly config: SourceConfig;
   readonly invocationConfig: InvocationConfig;
@@ -90,6 +94,10 @@ export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>(
     headers: Schema.optional(
       Schema.Record({ key: Schema.String, value: HeaderValue }),
     ),
+    // Exposed so the UI can render a per-user "Connections" pane for
+    // sources onboarded with an OAuth2 preset — one OAuth2Auth per
+    // securitySchemeName, with the secret ids that back its tokens.
+    oauth2: Schema.optional(OAuth2Auth),
   }),
   // TODO(migration): make required once all rows have been migrated to
   // carry invocationConfig. Left optional for decode compat with rows
@@ -205,6 +213,7 @@ export const makeDefaultOpenapiStore = ({
     );
     return {
       namespace: row.id as string,
+      scope: row.scope_id as string,
       name: row.name as string,
       config: {
         spec: row.spec as string,
@@ -244,6 +253,7 @@ export const makeDefaultOpenapiStore = ({
           model: "openapi_source",
           data: {
             id: input.namespace,
+            scope_id: input.scope,
             name: input.name,
             spec: input.config.spec,
             base_url: input.config.baseUrl ?? undefined,
@@ -262,6 +272,7 @@ export const makeDefaultOpenapiStore = ({
             model: "openapi_operation",
             data: operations.map((op) => ({
               id: op.toolId,
+              scope_id: input.scope,
               source_id: op.sourceId,
               binding: encodeBinding(op.binding) as unknown as Record<string, unknown>,
             })),
@@ -351,6 +362,11 @@ export const makeDefaultOpenapiStore = ({
           model: "openapi_oauth_session",
           data: {
             id: sessionId,
+            // Session row lives at the same scope the completed tokens
+            // will land in — keeps in-flight sessions visible only to
+            // the executor that started them (user stacks can see
+            // their own sessions but not another user's).
+            scope_id: session.tokenScope,
             session: encodeOAuthSession(session) as unknown as Record<string, unknown>,
             created_at: new Date(),
           },

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -169,6 +169,23 @@ export class OpenApiOAuthSession extends Schema.Class<OpenApiOAuthSession>(
   redirectUrl: Schema.String,
   clientIdSecretId: Schema.String,
   clientSecretSecretId: Schema.NullOr(Schema.String),
+  /**
+   * Executor scope id where the minted access/refresh token secrets will
+   * land when `completeOAuth` runs. Typically the innermost (per-user)
+   * scope. Persisted in the session so the callback that completes the
+   * flow writes tokens to the same tenancy the caller intended at
+   * `startOAuth` time.
+   */
+  tokenScope: Schema.String,
+  /**
+   * Pre-decided secret ids for the minted access + refresh tokens. The
+   * caller names these so the source's `OAuth2Auth` can reference the
+   * same ids regardless of which scope actually owns the value —
+   * `ctx.secrets.get` resolves them via fallthrough (innermost first),
+   * so per-user tokens shadow org-level fallbacks on the same source.
+   */
+  accessTokenSecretId: Schema.String,
+  refreshTokenSecretId: Schema.NullOr(Schema.String),
   scopes: Schema.Array(Schema.String),
   codeVerifier: Schema.String,
 }) {}

--- a/packages/plugins/workos-vault/src/sdk/plugin.ts
+++ b/packages/plugins/workos-vault/src/sdk/plugin.ts
@@ -33,7 +33,8 @@ export interface WorkOSVaultExtension {
 
 // The plugin's typed store is just its metadata-store wrapper. The
 // secret provider closes over this store plus the resolved WorkOS
-// client + scope id at `secretProviders` time.
+// client; the scope id is threaded in per-call by the executor's
+// secrets facade.
 type WorkosVaultPluginStore = WorkosVaultStore;
 
 const buildClient = (
@@ -70,7 +71,6 @@ export const workosVaultPlugin = definePlugin(
         makeWorkOSVaultSecretProvider({
           client,
           store: ctx.storage,
-          scopeId: ctx.scope.id,
           objectPrefix: options?.objectPrefix,
         }),
       ];

--- a/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect";
 import {
   createExecutor,
   makeTestConfig,
+  ScopeId,
   SecretId,
   SetSecretInput,
 } from "@executor/sdk";
@@ -175,6 +176,7 @@ describe("WorkOS Vault secret provider", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("github-token"),
+          scope: ScopeId.make("test-scope"),
           name: "GitHub Token",
           value: "ghp_secret",
         }),
@@ -197,6 +199,7 @@ describe("WorkOS Vault secret provider", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("api-key"),
+          scope: ScopeId.make("test-scope"),
           name: "Initial",
           value: "v1",
         }),
@@ -205,6 +208,7 @@ describe("WorkOS Vault secret provider", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("api-key"),
+          scope: ScopeId.make("test-scope"),
           name: "Updated",
           value: "v2",
         }),
@@ -225,6 +229,7 @@ describe("WorkOS Vault secret provider", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("remove-me"),
+          scope: ScopeId.make("test-scope"),
           name: "Remove Me",
           value: "gone soon",
         }),
@@ -252,6 +257,7 @@ describe("WorkOS Vault secret provider", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("conflict"),
+          scope: ScopeId.make("test-scope"),
           name: "Conflict",
           value: "initial",
         }),
@@ -260,6 +266,7 @@ describe("WorkOS Vault secret provider", () => {
       yield* executor.secrets.set(
         new SetSecretInput({
           id: SecretId.make("conflict"),
+          scope: ScopeId.make("test-scope"),
           name: "Conflict",
           value: "retry-me",
         }),

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -19,6 +19,13 @@ export const WORKOS_VAULT_PROVIDER_KEY = "workos-vault";
 
 const DEFAULT_OBJECT_PREFIX = "executor";
 const MAX_WRITE_ATTEMPTS = 3;
+// WorkOS creates a per-context KEK just-in-time on first write; a create
+// call immediately after that provisioning step can race with the KEK
+// becoming usable and return a transient error whose message ends in
+// "KEK was created but is not yet ready. This request can be retried."
+// We back off and retry the whole attempt (read + create) a few times.
+const MAX_KEK_NOT_READY_ATTEMPTS = 20;
+const KEK_NOT_READY_BACKOFF_MS = 1000;
 
 // ---------------------------------------------------------------------------
 // Metadata schema — the plugin owns its own table for secret metadata
@@ -42,6 +49,7 @@ export type WorkosVaultSchema = typeof workosVaultSchema;
 
 interface MetadataRow {
   readonly id: string;
+  readonly scope_id: string;
   readonly name: string;
   readonly purpose?: string | null;
   readonly created_at: Date;
@@ -92,6 +100,7 @@ export const makeWorkosVaultStore = (
           model: "workos_vault_metadata",
           data: {
             id: row.id,
+            scope_id: row.scope_id,
             name: row.name,
             purpose: row.purpose ?? null,
             created_at: row.created_at,
@@ -141,11 +150,37 @@ const isStatusError = (error: unknown, status: number): boolean => {
   );
 };
 
-const objectContext = (scopeId: string): Record<string, string> => ({
-  app: "executor",
-  organization_id: scopeId,
-  scope_id: scopeId,
-});
+const isKekNotReadyError = (error: unknown): boolean => {
+  const cause = unwrapVaultError(error);
+  const message =
+    cause instanceof Error
+      ? cause.message
+      : typeof cause === "string"
+        ? cause
+        : typeof cause === "object" && cause !== null && "message" in cause
+          ? String((cause as { message: unknown }).message)
+          : "";
+  return message.includes("KEK was created but is not yet ready");
+};
+
+// WorkOS's KEK provisioning hangs indefinitely when a context value
+// contains `:` (reproduced against the live vault API: colon-free
+// values provision in ~1s, any value with a colon stalls on the
+// "KEK was created but is not yet ready" response forever).
+// Our compound per-user scope ids look like
+// `user-org:<userId>:<orgId>`, so we substitute `:` with `__` when
+// stuffing scope values into vault context keys. Object names still
+// carry the original scope id verbatim (those aren't partition keys).
+const sanitizeCtxValue = (value: string): string => value.replace(/:/g, "__");
+
+const objectContext = (scopeId: string): Record<string, string> => {
+  const safe = sanitizeCtxValue(scopeId);
+  return {
+    app: "executor",
+    organization_id: safe,
+    scope_id: safe,
+  };
+};
 
 const secretObjectName = (
   prefix: string,
@@ -173,7 +208,8 @@ const upsertSecretValue = (
   value: string,
 ): Effect.Effect<void, WorkOSVaultClientError, never> => {
   const attemptWrite = (
-    remainingAttempts: number,
+    remainingConflictAttempts: number,
+    remainingKekAttempts: number,
   ): Effect.Effect<void, WorkOSVaultClientError, never> =>
     Effect.gen(function* () {
       const existing = yield* loadSecretObject(client, prefix, scopeId, secretId);
@@ -194,14 +230,32 @@ const upsertSecretValue = (
       });
     }).pipe(
       Effect.catchAll((error) => {
-        if (remainingAttempts > 1 && isStatusError(error, 409)) {
-          return attemptWrite(remainingAttempts - 1);
+        if (remainingConflictAttempts > 1 && isStatusError(error, 409)) {
+          return attemptWrite(remainingConflictAttempts - 1, remainingKekAttempts);
+        }
+        if (remainingKekAttempts > 1 && isKekNotReadyError(error)) {
+          console.warn(
+            `[workos-vault] KEK not ready for scope=${scopeId} secret=${secretId} — ` +
+              `retrying in ${KEK_NOT_READY_BACKOFF_MS}ms ` +
+              `(${MAX_KEK_NOT_READY_ATTEMPTS - remainingKekAttempts + 1}/${MAX_KEK_NOT_READY_ATTEMPTS})`,
+          );
+          return Effect.sleep(KEK_NOT_READY_BACKOFF_MS).pipe(
+            Effect.flatMap(() =>
+              attemptWrite(remainingConflictAttempts, remainingKekAttempts - 1),
+            ),
+          );
+        }
+        if (isKekNotReadyError(error)) {
+          console.error(
+            `[workos-vault] KEK still not ready after ${MAX_KEK_NOT_READY_ATTEMPTS} attempts ` +
+              `for scope=${scopeId} secret=${secretId}; giving up.`,
+          );
         }
         return Effect.fail(error);
       }),
     );
 
-  return attemptWrite(MAX_WRITE_ATTEMPTS);
+  return attemptWrite(MAX_WRITE_ATTEMPTS, MAX_KEK_NOT_READY_ATTEMPTS);
 };
 
 const deleteSecretValue = (
@@ -232,7 +286,6 @@ const formatVaultError = (error: unknown): StorageError => {
 export interface WorkOSVaultSecretProviderOptions {
   readonly client: WorkOSVaultClient;
   readonly store: WorkosVaultStore;
-  readonly scopeId: string;
   readonly objectPrefix?: string;
 }
 
@@ -240,42 +293,43 @@ export const makeWorkOSVaultSecretProvider = (
   options: WorkOSVaultSecretProviderOptions,
 ): SecretProvider => {
   const prefix = options.objectPrefix ?? DEFAULT_OBJECT_PREFIX;
-  const { client, store, scopeId } = options;
+  const { client, store } = options;
 
   return {
     key: WORKOS_VAULT_PROVIDER_KEY,
     writable: true,
 
-    get: (id) =>
+    get: (id, scope) =>
       Effect.gen(function* () {
         const meta = yield* store.get(id);
         if (!meta) return null;
-        const object = yield* loadSecretObject(client, prefix, scopeId, id).pipe(
+        const object = yield* loadSecretObject(client, prefix, scope, id).pipe(
           Effect.mapError(formatVaultError),
         );
         if (!object || !object.value) return null;
         return object.value;
       }),
 
-    set: (id, value) =>
+    set: (id, value, scope) =>
       Effect.gen(function* () {
         const existing = yield* store.get(id);
-        yield* upsertSecretValue(client, prefix, scopeId, id, value).pipe(
+        yield* upsertSecretValue(client, prefix, scope, id, value).pipe(
           Effect.mapError(formatVaultError),
         );
         yield* store.upsert({
           id,
+          scope_id: existing?.scope_id ?? scope,
           name: existing?.name ?? id,
           purpose: existing?.purpose ?? null,
           created_at: existing?.created_at ?? new Date(),
         });
       }),
 
-    delete: (id) =>
+    delete: (id, scope) =>
       Effect.gen(function* () {
         const meta = yield* store.get(id);
         if (!meta) return false;
-        yield* deleteSecretValue(client, prefix, scopeId, id).pipe(
+        yield* deleteSecretValue(client, prefix, scope, id).pipe(
           Effect.mapError(formatVaultError),
         );
         yield* store.remove(id);


### PR DESCRIPTION
Threads the new SDK scope API through every plugin:

- Provider methods (get/set/delete) accept a scope argument. Static-tool
  fallbacks default to ctx.scopes.at(-1) (outermost); OAuth token writes
  default to ctx.scopes[0] (innermost, per-user).
- Source configs gain a scope field; plugin stores stamp scope_id on
  rows and return the stored scope so invocation paths can refresh
  tokens against the correct scope.
- Renames ScopedBlobStore -> PluginBlobStore at usage sites.
- OpenAPI: StoredSourceSchema exposes OAuth2Auth with
  tokenScope/accessTokenSecretId/refreshTokenSecretId so the UI can
  check per-user token status. Adds Spotify preset (small ride-along).

Also rides along: WorkOS Vault KEK colon sanitization fix — context
values with `:` hang WorkOS KEK provisioning indefinitely, so we
replace colons with `__` in objectContext() and retry up to 20 times
on the rare "KEK not ready" transient.