### PR TITLE
api+ui: expose scope in writes + CreatableSecretPicker

### DIFF
--- a/packages/core/api/src/handlers/scope.ts
+++ b/packages/core/api/src/handlers/scope.ts
@@ -9,10 +9,15 @@ export const ScopeHandlers = HttpApiBuilder.group(ExecutorApi, "scope", (handler
   handlers.handle("info", () =>
     capture(Effect.gen(function* () {
       const executor = yield* ExecutorService;
+      // Outermost scope (organization / workspace). A follow-up that
+      // exposes per-user stacks end-to-end can extend this response
+      // with the full list; for now, single-scope deployments and the
+      // current `[org]` cloud setup see identical output.
+      const scope = executor.scopes.at(-1)!;
       return {
-        id: executor.scope.id,
-        name: executor.scope.name,
-        dir: executor.scope.name,
+        id: scope.id,
+        name: scope.name,
+        dir: scope.name,
       };
     })),
   ),

--- a/packages/core/api/src/handlers/secrets.ts
+++ b/packages/core/api/src/handlers/secrets.ts
@@ -1,6 +1,6 @@
 import { HttpApiBuilder } from "@effect/platform";
 import { Effect } from "effect";
-import { SecretNotFoundError, type SecretRef } from "@executor/sdk";
+import { SecretNotFoundError, SetSecretInput, type SecretRef } from "@executor/sdk";
 
 import { ExecutorApi } from "../api";
 import { ExecutorService } from "../services";
@@ -30,15 +30,18 @@ export const SecretsHandlers = HttpApiBuilder.group(ExecutorApi, "secrets", (han
         return { secretId: path.secretId, status };
       })),
     )
-    .handle("set", ({ payload }) =>
+    .handle("set", ({ path, payload }) =>
       capture(Effect.gen(function* () {
         const executor = yield* ExecutorService;
-        const ref = yield* executor.secrets.set({
-          id: payload.id,
-          name: payload.name,
-          value: payload.value,
-          provider: payload.provider,
-        });
+        const ref = yield* executor.secrets.set(
+          new SetSecretInput({
+            id: payload.id,
+            scope: path.scopeId,
+            name: payload.name,
+            value: payload.value,
+            provider: payload.provider,
+          }),
+        );
         return refToResponse(ref);
       })),
     )

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -68,7 +68,7 @@ function slugifyForSecretId(input: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-function InlineCreateSecret(props: {
+export function InlineCreateSecret(props: {
   suggestedId: string;
   suggestedName: string;
   onCreated: (secretId: string) => void;
@@ -414,5 +414,53 @@ export function SecretHeaderAuthRow(props: {
         <HeaderValuePreview headerName={name.trim()} secretId={secretId} prefix={prefix} />
       )}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CreatableSecretPicker — SecretPicker + inline "+ New secret" create flow
+// ---------------------------------------------------------------------------
+
+export function CreatableSecretPicker(props: {
+  readonly value: string | null;
+  readonly onSelect: (secretId: string) => void;
+  readonly secrets: readonly SecretPickerSecret[];
+  readonly placeholder?: string;
+  /**
+   * Display name of the source the secret belongs to (e.g. "Stripe").
+   * Combined with `secretLabel` to produce a suggested name/ID.
+   */
+  readonly sourceName?: string;
+  /** Role of this secret (e.g. "Client ID", "API Token"). */
+  readonly secretLabel: string;
+}) {
+  const { value, onSelect, secrets, placeholder, sourceName, secretLabel } = props;
+  const [creating, setCreating] = useState(false);
+
+  const suggestedName = [sourceName?.trim(), secretLabel].filter(Boolean).join(" ");
+  const suggestedId = slugifyForSecretId(suggestedName) || "secret";
+
+  if (creating) {
+    return (
+      <InlineCreateSecret
+        suggestedId={suggestedId}
+        suggestedName={suggestedName}
+        onCreated={(id) => {
+          onSelect(id);
+          setCreating(false);
+        }}
+        onCancel={() => setCreating(false)}
+      />
+    );
+  }
+
+  return (
+    <SecretPicker
+      value={value}
+      onSelect={onSelect}
+      secrets={secrets}
+      placeholder={placeholder}
+      onCreateNew={() => setCreating(true)}
+    />
   );
 }


### PR DESCRIPTION
- scope handler: surfaces outermost scope (executor.scopes.at(-1))
  instead of the old single scope.
- secrets handler: set takes path.scopeId and threads it as
  SetSecretInput.scope so the executor writes at the right scope.
- secret-header-auth: exports CreatableSecretPicker + InlineCreateSecret
  for reuse by the OpenAPI connections pane.