### PR TITLE
sources: per-source connection status badge

### DIFF
--- a/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
@@ -1,3 +1,55 @@
+import { Result, useAtomValue } from "@effect-atom/atom-react";
+
+import { SecretId } from "@executor/sdk";
+import { useScope } from "@executor/react/api/scope-context";
+import { secretStatusAtom } from "@executor/react/api/atoms";
+import { Badge } from "@executor/react/components/badge";
+import { Skeleton } from "@executor/react/components/skeleton";
+
+import { openApiSourceAtom } from "./atoms";
+
+function ConnectedBadge(props: { accessTokenSecretId: string }) {
+  const scopeId = useScope();
+  const status = useAtomValue(
+    secretStatusAtom(scopeId, SecretId.make(props.accessTokenSecretId)),
+  );
+
+  return Result.match(status, {
+    onInitial: () => <Skeleton className="h-5 w-20 rounded-full" />,
+    onFailure: () => (
+      <Badge variant="outline" className="text-[10px] text-muted-foreground">
+        Not connected
+      </Badge>
+    ),
+    onSuccess: ({ value }) =>
+      value.status === "resolved" ? (
+        <Badge
+          variant="outline"
+          className="border-green-500/30 bg-green-500/5 text-[10px] text-green-700 dark:text-green-400"
+        >
+          Connected
+        </Badge>
+      ) : (
+        <Badge variant="outline" className="text-[10px] text-muted-foreground">
+          Not connected
+        </Badge>
+      ),
+  });
+}
+
+// The entry row already renders name + id + kind, so this summary
+// component only contributes extras — specifically, an OAuth status
+// badge when the source has OAuth2 configured. Non-OAuth sources
+// render nothing.
 export default function OpenApiSourceSummary(props: { sourceId: string }) {
-  return <span>OpenAPI · {props.sourceId}</span>;
+  const scopeId = useScope();
+  const sourceResult = useAtomValue(openApiSourceAtom(scopeId, props.sourceId));
+
+  const oauth2 =
+    Result.isSuccess(sourceResult) && sourceResult.value
+      ? sourceResult.value.config.oauth2
+      : undefined;
+
+  if (!oauth2) return null;
+  return <ConnectedBadge accessTokenSecretId={oauth2.accessTokenSecretId} />;
 }

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { Suspense, useState, useCallback, useMemo } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { Result, useAtomSet } from "@effect-atom/atom-react";
 import { detectSource } from "../api/atoms";
@@ -172,7 +172,10 @@ export function SourcesPage(props: { sourcePlugins: readonly SourcePlugin[] }) {
               <div className="mb-8 space-y-8">
                 {connectedSources.length > 0 && (
                   <section className="space-y-3">
-                    <SourceGrid sources={connectedSources} />
+                    <SourceGrid
+                      sources={connectedSources}
+                      sourcePlugins={sourcePlugins}
+                    />
                   </section>
                 )}
               </div>
@@ -273,28 +276,45 @@ function SourceGrid(props: {
     url?: string;
     runtime?: boolean;
   }[];
+  sourcePlugins: readonly SourcePlugin[];
 }) {
+  const pluginByKind = useMemo(() => {
+    const out = new Map<string, SourcePlugin>();
+    for (const p of props.sourcePlugins) out.set(p.key, p);
+    return out;
+  }, [props.sourcePlugins]);
+
   return (
     <CardStack searchable>
       <CardStackHeader>Connected</CardStackHeader>
       <CardStackContent>
-        {props.sources.map((s) => (
-          <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
-            <Link to="/sources/$namespace" params={{ namespace: s.id }}>
-              <CardStackEntryMedia>
-                <SourceFavicon url={s.url} size={32} />
-              </CardStackEntryMedia>
-              <CardStackEntryContent>
-                <CardStackEntryTitle>{s.name}</CardStackEntryTitle>
-                <CardStackEntryDescription>{s.id}</CardStackEntryDescription>
-              </CardStackEntryContent>
-              <CardStackEntryActions>
-                {s.runtime && <Badge className="bg-muted text-muted-foreground">built-in</Badge>}
-                <Badge variant="secondary">{s.kind}</Badge>
-              </CardStackEntryActions>
-            </Link>
-          </CardStackEntry>
-        ))}
+        {props.sources.map((s) => {
+          const pluginKey = KIND_TO_PLUGIN_KEY[s.kind] ?? s.kind;
+          const plugin = pluginByKind.get(pluginKey);
+          const SummaryComponent = plugin?.summary;
+          return (
+            <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
+              <Link to="/sources/$namespace" params={{ namespace: s.id }}>
+                <CardStackEntryMedia>
+                  <SourceFavicon url={s.url} size={32} />
+                </CardStackEntryMedia>
+                <CardStackEntryContent>
+                  <CardStackEntryTitle>{s.name}</CardStackEntryTitle>
+                  <CardStackEntryDescription>{s.id}</CardStackEntryDescription>
+                </CardStackEntryContent>
+                <CardStackEntryActions>
+                  {SummaryComponent && (
+                    <Suspense fallback={null}>
+                      <SummaryComponent sourceId={s.id} />
+                    </Suspense>
+                  )}
+                  {s.runtime && <Badge className="bg-muted text-muted-foreground">built-in</Badge>}
+                  <Badge variant="secondary">{s.kind}</Badge>
+                </CardStackEntryActions>
+              </Link>
+            </CardStackEntry>
+          );
+        })}
       </CardStackContent>
     </CardStack>
   );


### PR DESCRIPTION
- sources page SourceGrid now renders each plugin's summary component
  with Suspense, passing sourceId. Threads sourcePlugins into the grid.
- OpenApiSourceSummary turns into a real ConnectedBadge: reads
  secretStatusAtom for the configured access token and shows
  Connected / Not connected / skeleton (initial). Renders nothing for
  non-OAuth sources so bearer and header-auth sources stay clean.