### PR TITLE
openapi: per-user OAuth connections pane in EditOpenApiSource

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -4,12 +4,12 @@ import { Option } from "effect";
 
 import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
 
-import { SecretPicker } from "@executor/react/plugins/secret-picker";
 import { useScope } from "@executor/react/api/scope-context";
 import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
 import { usePendingSources } from "@executor/react/api/optimistic";
 import { HeadersList } from "@executor/react/plugins/headers-list";
 import {
+  CreatableSecretPicker,
   matchPresetKey,
   type HeaderState,
 } from "@executor/react/plugins/secret-header-auth";
@@ -20,6 +20,7 @@ import {
 } from "@executor/react/plugins/source-identity";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor/react/components/button";
+import { CopyButton } from "@executor/react/components/copy-button";
 import {
   CardStack,
   CardStackContent,
@@ -56,8 +57,9 @@ import {
   type ServerVariable,
 } from "../sdk/types";
 
-const OPENAPI_OAUTH_CHANNEL = "executor:openapi-oauth-result";
-const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
+export const OPENAPI_OAUTH_CHANNEL = "executor:openapi-oauth-result";
+export const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
+export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/openapi/oauth/callback";
 
 // Stable secret ids for the access/refresh tokens a given OAuth2 security
 // scheme on a given source mints. The same ids must be passed into
@@ -259,6 +261,10 @@ export default function AddOpenApiSource(props: {
   const customHeadersValid = customHeaders.every((ch) => ch.name.trim() && ch.secretId);
 
   const oauth2Presets: readonly OAuth2Preset[] = preview?.oauth2Presets ?? [];
+  const oauth2RedirectUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}${OPENAPI_OAUTH_CALLBACK_PATH}`
+      : OPENAPI_OAUTH_CALLBACK_PATH;
   const selectedOAuth2Preset: OAuth2Preset | null =
     strategy.kind === "oauth2" ? (oauth2Presets[strategy.presetIndex] ?? null) : null;
 
@@ -391,7 +397,7 @@ export default function AddOpenApiSource(props: {
           flow: "authorizationCode",
           authorizationUrl: Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
           tokenUrl: selectedOAuth2Preset.tokenUrl,
-          redirectUrl: `${window.location.origin}/api/openapi/oauth/callback`,
+          redirectUrl: oauth2RedirectUrl,
           clientIdSecretId: oauth2ClientIdSecretId,
           clientSecretSecretId: oauth2ClientSecretSecretId,
           scopes: [...oauth2SelectedScopes],
@@ -453,6 +459,7 @@ export default function AddOpenApiSource(props: {
     oauth2ClientIdSecretId,
     oauth2ClientSecretSecretId,
     oauth2SelectedScopes,
+    oauth2RedirectUrl,
     preview,
     doStartOAuth,
     scopeId,
@@ -820,14 +827,28 @@ export default function AddOpenApiSource(props: {
             {selectedOAuth2Preset && (
               <div className="space-y-3 rounded-lg border border-border/60 bg-muted/10 p-3">
                 <div className="space-y-1.5">
+                  <FieldLabel className="text-[11px]">
+                    Redirect URL{" "}
+                    <span className="text-muted-foreground">
+                      · add this to your OAuth app's allowed redirects
+                    </span>
+                  </FieldLabel>
+                  <div className="flex items-center gap-1 rounded-md border border-border bg-background/50 px-2.5 py-1.5 font-mono text-[11px]">
+                    <span className="truncate flex-1 text-foreground">{oauth2RedirectUrl}</span>
+                    <CopyButton value={oauth2RedirectUrl} />
+                  </div>
+                </div>
+                <div className="space-y-1.5">
                   <FieldLabel className="text-[11px]">Client ID secret</FieldLabel>
-                  <SecretPicker
+                  <CreatableSecretPicker
                     value={oauth2ClientIdSecretId}
                     onSelect={(id: string) => {
                       setOauth2ClientIdSecretId(id);
                       setOauth2Auth(null);
                     }}
                     secrets={secretList}
+                    sourceName={identity.name}
+                    secretLabel="Client ID"
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -837,13 +858,15 @@ export default function AddOpenApiSource(props: {
                       · optional for public clients with PKCE
                     </span>
                   </FieldLabel>
-                  <SecretPicker
+                  <CreatableSecretPicker
                     value={oauth2ClientSecretSecretId}
                     onSelect={(id: string) => {
                       setOauth2ClientSecretSecretId(id);
                       setOauth2Auth(null);
                     }}
                     secrets={secretList}
+                    sourceName={identity.name}
+                    secretLabel="Client Secret"
                   />
                 </div>
                 <div className="space-y-1.5">

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -1,8 +1,30 @@
-import { useState } from "react";
-import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
-import { openApiSourceAtom, updateOpenApiSource } from "./atoms";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useAtomValue,
+  useAtomSet,
+  useAtomRefresh,
+  Result,
+} from "@effect-atom/atom-react";
+import { Option } from "effect";
+
+import { SecretId } from "@executor/sdk";
+import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
+
+import {
+  openApiSourceAtom,
+  previewOpenApiSpec,
+  startOpenApiOAuth,
+  updateOpenApiSource,
+} from "./atoms";
 import { useScope } from "@executor/react/api/scope-context";
-import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
+import {
+  secretStatusAtom,
+  removeSecret,
+} from "@executor/react/api/atoms";
+import {
+  secretWriteKeys,
+  sourceWriteKeys,
+} from "@executor/react/api/reactivity-keys";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import {
   headerValueToState,
@@ -23,7 +45,305 @@ import {
 import { FieldLabel } from "@executor/react/components/field";
 import { Input } from "@executor/react/components/input";
 import { Badge } from "@executor/react/components/badge";
+import { Spinner } from "@executor/react/components/spinner";
+import {
+  OPENAPI_OAUTH_CALLBACK_PATH,
+  OPENAPI_OAUTH_CHANNEL,
+  OPENAPI_OAUTH_POPUP_NAME,
+} from "./AddOpenApiSource";
+import type { SpecPreview, OAuth2Preset } from "../sdk/preview";
+import { OAuth2Auth } from "../sdk/types";
 import type { StoredSourceSchemaType } from "../sdk/store";
+
+// ---------------------------------------------------------------------------
+// Connections — one row per OAuth2Auth on the source
+// ---------------------------------------------------------------------------
+
+/**
+ * Single OAuth2Auth connection row. Each org member sees the status of
+ * their own tokens (access/refresh secrets resolve via per-user scope
+ * fall-through) and can trigger the same OAuth flow another member used
+ * when first onboarding the source.
+ */
+function ConnectionRow(props: {
+  readonly auth: OAuth2Auth;
+  readonly sourceName: string;
+  readonly preset: OAuth2Preset | null;
+  readonly previewError: string | null;
+}) {
+  const scopeId = useScope();
+  const { auth, preset } = props;
+
+  const statusAtom = secretStatusAtom(
+    scopeId,
+    SecretId.make(auth.accessTokenSecretId),
+  );
+  const accessStatus = useAtomValue(statusAtom);
+  const refreshStatus = useAtomRefresh(statusAtom);
+  const isConnected =
+    Result.isSuccess(accessStatus) && accessStatus.value.status === "resolved";
+
+  const doStartOAuth = useAtomSet(startOpenApiOAuth, { mode: "promise" });
+  const doRemoveSecret = useAtomSet(removeSecret, { mode: "promise" });
+
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const redirectUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}${OPENAPI_OAUTH_CALLBACK_PATH}`
+      : OPENAPI_OAUTH_CALLBACK_PATH;
+
+  const handleConnect = useCallback(async () => {
+    if (!preset) return;
+    cleanupRef.current?.();
+    cleanupRef.current = null;
+    setBusy(true);
+    setError(null);
+    try {
+      const response = await doStartOAuth({
+        path: { scopeId },
+        payload: {
+          displayName: props.sourceName || auth.securitySchemeName,
+          securitySchemeName: auth.securitySchemeName,
+          flow: "authorizationCode",
+          authorizationUrl: Option.getOrElse(preset.authorizationUrl, () => ""),
+          tokenUrl: auth.tokenUrl,
+          redirectUrl,
+          clientIdSecretId: auth.clientIdSecretId,
+          clientSecretSecretId: auth.clientSecretSecretId,
+          // Reuse the source-wide scopes granted at onboarding time —
+          // per-member connects should land the same capabilities.
+          scopes: [...auth.scopes],
+          // Reuse the same secret ids the source already references.
+          // On completeOAuth the plugin writes tokens at the innermost
+          // (per-user) scope by default; same id + inner scope shadows
+          // any org-level fallback so each member's bearer is theirs.
+          accessTokenSecretId: auth.accessTokenSecretId,
+          refreshTokenSecretId: auth.refreshTokenSecretId,
+        },
+      });
+
+      cleanupRef.current = openOAuthPopup<OAuth2Auth>({
+        url: response.authorizationUrl,
+        popupName: OPENAPI_OAUTH_POPUP_NAME,
+        channelName: OPENAPI_OAUTH_CHANNEL,
+        onResult: (result: OAuthPopupResult<OAuth2Auth>) => {
+          cleanupRef.current = null;
+          setBusy(false);
+          if (result.ok) {
+            setError(null);
+            // completeOAuth ran server-side (inside the popup's callback
+            // HTML handler) and wrote the access/refresh tokens via
+            // ctx.secrets.set — that bypasses our atom-layer mutation,
+            // so we refresh the status atom here to flip the badge.
+            refreshStatus();
+          } else {
+            setError(result.error);
+          }
+        },
+        onClosed: () => {
+          cleanupRef.current = null;
+          setBusy(false);
+          setError("OAuth cancelled — popup was closed before completing the flow.");
+        },
+        onOpenFailed: () => {
+          cleanupRef.current = null;
+          setBusy(false);
+          setError("OAuth popup was blocked by the browser");
+        },
+      });
+    } catch (e) {
+      setBusy(false);
+      setError(e instanceof Error ? e.message : "Failed to start OAuth");
+    }
+  }, [
+    preset,
+    auth.securitySchemeName,
+    auth.tokenUrl,
+    auth.clientIdSecretId,
+    auth.clientSecretSecretId,
+    auth.accessTokenSecretId,
+    auth.refreshTokenSecretId,
+    auth.scopes,
+    doStartOAuth,
+    redirectUrl,
+    scopeId,
+    props.sourceName,
+    refreshStatus,
+  ]);
+
+  const handleDisconnect = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await doRemoveSecret({
+        path: {
+          scopeId,
+          secretId: SecretId.make(auth.accessTokenSecretId),
+        },
+        reactivityKeys: secretWriteKeys,
+      });
+      if (auth.refreshTokenSecretId) {
+        await doRemoveSecret({
+          path: {
+            scopeId,
+            secretId: SecretId.make(auth.refreshTokenSecretId),
+          },
+          reactivityKeys: secretWriteKeys,
+        }).catch(() => {
+          // The refresh secret may not exist for this user — ignore.
+        });
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to disconnect");
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    doRemoveSecret,
+    scopeId,
+    auth.accessTokenSecretId,
+    auth.refreshTokenSecretId,
+  ]);
+
+  const canConnect = preset !== null && Option.isSome(preset.authorizationUrl);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border/60 bg-background/40 p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs font-medium text-foreground">
+            {auth.securitySchemeName}
+          </div>
+          <div className="mt-0.5 text-[10px] text-muted-foreground">
+            {auth.scopes.length} scope{auth.scopes.length === 1 ? "" : "s"}
+          </div>
+        </div>
+        {isConnected ? (
+          <Badge
+            variant="outline"
+            className="border-green-500/30 bg-green-500/5 text-green-700 dark:text-green-400"
+          >
+            Connected
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="text-muted-foreground">
+            Not connected
+          </Badge>
+        )}
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        {isConnected ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleDisconnect}
+            disabled={busy}
+          >
+            {busy && <Spinner className="size-3.5" />}
+            Disconnect
+          </Button>
+        ) : (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleConnect}
+            disabled={busy || !canConnect}
+          >
+            {busy && <Spinner className="size-3.5" />}
+            Connect
+          </Button>
+        )}
+      </div>
+
+      {!canConnect && props.previewError && (
+        <p className="text-[11px] text-amber-600 dark:text-amber-400">
+          {props.previewError}
+        </p>
+      )}
+      {!canConnect && !props.previewError && preset === null && (
+        <p className="text-[11px] text-muted-foreground">
+          Loading OAuth configuration…
+        </p>
+      )}
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-2.5 py-1.5">
+          <p className="text-[11px] text-destructive">{error}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConnectionsSection(props: {
+  readonly sourceName: string;
+  readonly spec: string;
+  readonly oauth2Entries: readonly OAuth2Auth[];
+}) {
+  const scopeId = useScope();
+  const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promise" });
+  const [preview, setPreview] = useState<SpecPreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    doPreview({ path: { scopeId }, payload: { spec: props.spec } })
+      .then((result) => {
+        if (!cancelled) setPreview(result);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) {
+          setPreviewError(
+            e instanceof Error
+              ? `Couldn't load OAuth config from spec: ${e.message}`
+              : "Couldn't load OAuth config from spec",
+          );
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [doPreview, scopeId, props.spec]);
+
+  const presetFor = (securitySchemeName: string): OAuth2Preset | null => {
+    if (!preview) return null;
+    return (
+      preview.oauth2Presets.find(
+        (p) =>
+          p.securitySchemeName === securitySchemeName &&
+          p.flow === "authorizationCode",
+      ) ?? null
+    );
+  };
+
+  return (
+    <section className="space-y-2.5">
+      <div>
+        <FieldLabel>Connections</FieldLabel>
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Each member of this organization connects with their own OAuth
+          credentials.
+        </p>
+      </div>
+      <div className="space-y-2">
+        {props.oauth2Entries.map((auth) => (
+          <ConnectionRow
+            key={auth.securitySchemeName}
+            auth={auth}
+            sourceName={props.sourceName}
+            preset={presetFor(auth.securitySchemeName)}
+            previewError={previewError}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Edit form
@@ -53,6 +373,13 @@ function EditForm(props: {
   const [dirty, setDirty] = useState(false);
 
   const identityDirty = identity.name.trim() !== props.initial.name.trim();
+
+  // A source may have zero or one stored OAuth2Auth today, but the
+  // "Connections" section is written to iterate so future multi-scheme
+  // specs surface without another pass.
+  const oauth2Entries: readonly OAuth2Auth[] = props.initial.config.oauth2
+    ? [props.initial.config.oauth2]
+    : [];
 
   const handleHeadersChange = (next: HeaderState[]) => {
     setHeaders(next);
@@ -126,6 +453,14 @@ function EditForm(props: {
           sourceName={identity.name}
         />
       </section>
+
+      {oauth2Entries.length > 0 && (
+        <ConnectionsSection
+          sourceName={props.initial.name}
+          spec={props.initial.config.spec}
+          oauth2Entries={oauth2Entries}
+        />
+      )}
 
       {error && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -302,13 +302,18 @@ export const invokeWithLayer = (
 // Derive annotations from HTTP method
 // ---------------------------------------------------------------------------
 
-const SAFE_METHODS = new Set(["get", "head", "options"]);
+const DEFAULT_REQUIRE_APPROVAL = new Set(["post", "put", "patch", "delete"]);
 
 export const annotationsForOperation = (
   method: string,
   pathTemplate: string,
+  policy?: { readonly requireApprovalFor?: readonly string[] },
 ): { requiresApproval?: boolean; approvalDescription?: string } => {
-  if (SAFE_METHODS.has(method.toLowerCase())) return {};
+  const m = method.toLowerCase();
+  const requireSet = policy?.requireApprovalFor
+    ? new Set(policy.requireApprovalFor.map((v) => v.toLowerCase()))
+    : DEFAULT_REQUIRE_APPROVAL;
+  if (!requireSet.has(m)) return {};
   return {
     requiresApproval: true,
     approvalDescription: `${method.toUpperCase()} ${pathTemplate}`,

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -7,6 +7,7 @@ import {
 } from "@executor/sdk";
 
 import {
+  AnnotationPolicy,
   HeaderValue,
   InvocationConfig,
   OAuth2Auth,
@@ -31,6 +32,7 @@ export const openapiSchema = defineSchema({
       base_url: { type: "string", required: false },
       headers: { type: "json", required: false },
       oauth2: { type: "json", required: false },
+      annotation_policy: { type: "json", required: false },
       invocation_config: { type: "json", required: true },
     },
   },
@@ -64,6 +66,7 @@ export interface SourceConfig {
   readonly namespace?: string;
   readonly headers?: Record<string, HeaderValue>;
   readonly oauth2?: OAuth2Auth;
+  readonly annotationPolicy?: AnnotationPolicy;
 }
 
 export interface StoredSource {

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -139,6 +139,19 @@ export class OAuth2Auth extends Schema.Class<OAuth2Auth>("OpenApiOAuth2Auth")({
   scopes: Schema.Array(Schema.String),
 }) {}
 
+// ---------------------------------------------------------------------------
+// Annotation policy — per-source override of the HTTP-method-based default
+// for `requiresApproval`. If `requireApprovalFor` is set, it replaces the
+// default set ({POST, PUT, PATCH, DELETE}) wholesale: any method present
+// requires approval, any method absent does not.
+// ---------------------------------------------------------------------------
+
+export class AnnotationPolicy extends Schema.Class<AnnotationPolicy>(
+  "OpenApiAnnotationPolicy",
+)({
+  requireApprovalFor: Schema.optional(Schema.Array(HttpMethod)),
+}) {}
+
 export class InvocationConfig extends Schema.Class<InvocationConfig>("InvocationConfig")({
   baseUrl: Schema.String,
   /** Headers applied to every request. Values can reference secrets. */


### PR DESCRIPTION
- Edit page gains a Connections section with one row per OAuth2 auth,
  showing per-user connection status (secretStatusAtom), connect
  (startOpenApiOAuth) and disconnect (removeSecret) actions so
  different users in the same org can manage their own tokens
  independently.
- Add page sends deterministic ${slug}_access_token/_refresh_token ids
  in startOAuth, renders the copyable redirect URL, exports the shared
  OAuth constants, and swaps to the CreatableSecretPicker.