### PR TITLE
mcp: add Notion as a featured preset source

### DIFF
--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -88,6 +88,14 @@ export const mcpPresets: readonly McpPreset[] = [
     featured: true,
   },
   {
+    id: "notion",
+    name: "Notion",
+    summary: "Databases, pages, blocks, and search via MCP.",
+    url: "https://mcp.notion.com/mcp",
+    icon: "https://www.notion.so/favicon.ico",
+    featured: true,
+  },
+  {
     id: "sentry",
     name: "Sentry",
     summary: "Error monitoring, issues, and performance data.",


### PR DESCRIPTION
Adds Notion (`https://mcp.notion.com/mcp`) to `mcpPresets` as a featured source.