### PR TITLE
[codex] mcp: name oauth secrets after source display name

### DIFF
--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -105,6 +105,7 @@ const NamespacePayload = Schema.Struct({
 });
 
 const StartOAuthPayload = Schema.Struct({
+  name: Schema.String,
   endpoint: Schema.String,
   redirectUrl: Schema.String,
   queryParams: Schema.optional(Schema.NullOr(StringMap)),

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -201,6 +201,7 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
       capture(Effect.gen(function* () {
         const ext = yield* McpExtensionService;
         return yield* ext.startOAuth({
+          name: payload.name,
           endpoint: payload.endpoint,
           redirectUrl: payload.redirectUrl,
           queryParams: payload.queryParams,

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -418,10 +418,11 @@ export default function AddMcpSource(props: {
     oauthCleanup.current = null;
     dispatch({ type: "oauth-start" });
     try {
+      const displayName = remoteIdentity.name.trim() || probe?.serverName || probe?.name || "";
       const redirectUrl = `${window.location.origin}/api/mcp/oauth/callback`;
       const result = await doStartOAuth({
         path: { scopeId },
-        payload: { endpoint: state.url.trim(), redirectUrl },
+        payload: { name: displayName, endpoint: state.url.trim(), redirectUrl },
       });
       dispatch({ type: "oauth-waiting", sessionId: result.sessionId });
       oauthCleanup.current = openOAuthPopup(
@@ -454,7 +455,7 @@ export default function AddMcpSource(props: {
         error: e instanceof Error ? e.message : "Failed to start OAuth",
       });
     }
-  }, [state.url, scopeId, doStartOAuth]);
+  }, [probe, remoteIdentity.name, state.url, scopeId, doStartOAuth]);
 
   const handleCancelOAuth = useCallback(() => {
     oauthCleanup.current?.();

--- a/packages/plugins/mcp/src/sdk/oauth.ts
+++ b/packages/plugins/mcp/src/sdk/oauth.ts
@@ -34,6 +34,7 @@ export type McpOAuthDiscoveryState = typeof McpOAuthDiscoveryState.Type;
 /** Pending OAuth session persisted between startOAuth and completeOAuth */
 export const McpOAuthSession = Schema.Struct({
   ...McpOAuthDiscoveryState.fields,
+  name: Schema.String,
   endpoint: Schema.String,
   redirectUrl: Schema.String,
   codeVerifier: Schema.String,

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 
 import { createExecutor, makeTestConfig, Scope, ScopeId } from "@executor/sdk";
 
-import { mcpPlugin } from "./plugin";
+import { mcpPlugin, oauthTokenSecretName } from "./plugin";
 import {
   extractManifestFromListToolsResult,
   deriveMcpNamespace,
@@ -129,6 +129,13 @@ describe("joinToolPath", () => {
 // ---------------------------------------------------------------------------
 
 describe("mcpPlugin", () => {
+  it.effect("derives OAuth secret labels from the MCP source display name", () =>
+    Effect.sync(() => {
+      expect(oauthTokenSecretName("Linear", "access")).toBe("Linear Access Token");
+      expect(oauthTokenSecretName("Linear", "refresh")).toBe("Linear Refresh Token");
+    }),
+  );
+
   it.effect("creates executor with mcp plugin", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -86,6 +86,7 @@ export type McpSourceConfig = McpRemoteSourceConfig | McpStdioSourceConfig;
 // ---------------------------------------------------------------------------
 
 export interface McpOAuthStartInput {
+  readonly name: string;
   readonly endpoint: string;
   readonly redirectUrl: string;
   readonly queryParams?: Record<string, string> | null;
@@ -211,6 +212,11 @@ const mcpOAuthError = (message: string) => new McpOAuthError({ message });
 
 const mcpDiscoveryError = (message: string) =>
   new McpToolDiscoveryError({ stage: "list_tools", message });
+
+const oauthTokenSecretName = (
+  displayName: string,
+  kind: "access" | "refresh",
+): string => `${displayName} ${kind === "access" ? "Access" : "Refresh"} Token`;
 
 // ---------------------------------------------------------------------------
 // Shared connector resolution — reads secrets, builds stdio/remote input
@@ -749,6 +755,7 @@ export const mcpPlugin = definePlugin(
 
             yield* ctx.storage
               .putOAuthSession(sessionId, ctx.scopes[0]!.id as string, {
+                name: input.name,
                 endpoint: fullEndpoint,
                 redirectUrl: input.redirectUrl,
                 codeVerifier: started.codeVerifier,
@@ -808,7 +815,7 @@ export const mcpPlugin = definePlugin(
                 new SetSecretInput({
                   id: SecretId.make(accessSecretId),
                   scope: tokenScope,
-                  name: "MCP OAuth Access Token",
+                  name: oauthTokenSecretName(session.name, "access"),
                   value: exchanged.tokens.access_token,
                 }),
               )
@@ -826,7 +833,7 @@ export const mcpPlugin = definePlugin(
                   new SetSecretInput({
                     id: SecretId.make(refreshId),
                     scope: tokenScope,
-                    name: "MCP OAuth Refresh Token",
+                    name: oauthTokenSecretName(session.name, "refresh"),
                     value: exchanged.tokens.refresh_token,
                   }),
                 )
@@ -1130,3 +1137,5 @@ export interface McpPluginExtension {
     input: McpUpdateSourceInput,
   ) => Effect.Effect<void, McpExtensionFailure>;
 }
+
+export { oauthTokenSecretName };


### PR DESCRIPTION
## What changed
MCP OAuth token secrets now use the source/session display name instead of fixed generic labels.

## Why
The MCP flow was storing secrets as `MCP OAuth Access Token` and `MCP OAuth Refresh Token`, which made multiple MCP connections hard to distinguish in the secrets UI.

### Before 
<img width="614" height="236" alt="CleanShot 2026-04-20 at 10 21 26@2x" src="https://github.com/user-attachments/assets/f1e51502-c360-4e2f-a8e7-ee41914aafad" />

### After
<img width="1670" height="406" alt="CleanShot 2026-04-20 at 10 25 27@2x" src="https://github.com/user-attachments/assets/ba6dd40d-837d-4b99-8e88-617223962bb9" />


## Root cause
The MCP start/complete OAuth flow did not carry the source display name through the persisted OAuth session, so token writes had no source-specific label available and fell back to hardcoded names.

## Validation
- `bunx vitest run src/sdk/plugin.test.ts`
- `bun run typecheck`
