### PR TITLE
fix(local): replay MCP auth during config sync

### DIFF
--- a/apps/local/src/server/config-sync.test.ts
+++ b/apps/local/src/server/config-sync.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Effect } from "effect";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import type { ExecutorFileConfig } from "@executor/config";
+import { syncFromConfig, type ConfigSyncExecutor } from "./config-sync";
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "exec-config-sync-"));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+const writeConfig = (config: ExecutorFileConfig): string => {
+  const configPath = join(workDir, "executor.jsonc");
+  writeFileSync(configPath, JSON.stringify(config, null, 2));
+  return configPath;
+};
+
+const makeExecutorSpy = (): {
+  calls: Array<unknown>;
+  executor: ConfigSyncExecutor;
+} => {
+  const calls: Array<unknown> = [];
+  return {
+    calls,
+    executor: {
+      scopes: [{ id: "scope_test" }],
+      openapi: {
+        addSpec: () => Effect.void,
+      },
+      graphql: {
+        addSource: () => Effect.void,
+      },
+      mcp: {
+        addSource: (input: Record<string, unknown>) =>
+          Effect.sync(() => {
+            calls.push(input);
+          }),
+      },
+    },
+  };
+};
+
+describe("syncFromConfig", () => {
+  it("replays remote MCP header auth from executor.jsonc into addSource", async () => {
+    const configPath = writeConfig({
+      sources: [
+        {
+          kind: "mcp",
+          transport: "remote",
+          name: "PostHog",
+          endpoint: "https://mcp.posthog.com/mcp",
+          namespace: "posthog",
+          auth: {
+            kind: "header",
+            headerName: "Authorization",
+            secret: "secret-public-ref:posthog-api-key",
+            prefix: "Bearer ",
+          },
+        },
+      ],
+    });
+    const { calls, executor } = makeExecutorSpy();
+
+    await Effect.runPromise(syncFromConfig(executor, configPath));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      transport: "remote",
+      scope: "scope_test",
+      name: "PostHog",
+      endpoint: "https://mcp.posthog.com/mcp",
+      namespace: "posthog",
+      auth: {
+        kind: "header",
+        headerName: "Authorization",
+        secretId: "posthog-api-key",
+        prefix: "Bearer ",
+      },
+    });
+  });
+
+  it("replays remote MCP oauth token refs from executor.jsonc into addSource", async () => {
+    const configPath = writeConfig({
+      sources: [
+        {
+          kind: "mcp",
+          transport: "remote",
+          name: "Example",
+          endpoint: "https://example.com/mcp",
+          namespace: "example",
+          auth: {
+            kind: "oauth2",
+            accessTokenSecret: "secret-public-ref:mcp-oauth-access-example",
+            refreshTokenSecret: "secret-public-ref:mcp-oauth-refresh-example",
+            tokenType: "Bearer",
+          },
+        },
+      ],
+    });
+    const { calls, executor } = makeExecutorSpy();
+
+    await Effect.runPromise(syncFromConfig(executor, configPath));
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      transport: "remote",
+      scope: "scope_test",
+      name: "Example",
+      endpoint: "https://example.com/mcp",
+      namespace: "example",
+      auth: {
+        kind: "oauth2",
+        accessTokenSecretId: "mcp-oauth-access-example",
+        refreshTokenSecretId: "mcp-oauth-refresh-example",
+        tokenType: "Bearer",
+        expiresAt: null,
+        scope: null,
+      },
+    });
+  });
+});

--- a/apps/local/src/server/config-sync.ts
+++ b/apps/local/src/server/config-sync.ts
@@ -14,10 +14,9 @@ import type {
   SourceConfig,
   ExecutorFileConfig,
   ConfigHeaderValue,
+  McpAuthConfig,
 } from "@executor/config";
 import { SECRET_REF_PREFIX } from "@executor/config";
-
-import type { LocalExecutor } from "./executor";
 
 // ---------------------------------------------------------------------------
 // Header translation: config format → plugin format
@@ -53,6 +52,99 @@ const translateHeaders = (
   return out;
 };
 
+const translateSecretRef = (value: string): string =>
+  value.startsWith(SECRET_REF_PREFIX) ? value.slice(SECRET_REF_PREFIX.length) : value;
+
+type ConfigSyncMcpAuth =
+  | { kind: "none" }
+  | {
+      kind: "header";
+      headerName: string;
+      secretId: string;
+      prefix?: string;
+    }
+  | {
+      kind: "oauth2";
+      accessTokenSecretId: string;
+      refreshTokenSecretId: string | null;
+      tokenType: string;
+      expiresAt: number | null;
+      scope: string | null;
+    };
+
+export interface ConfigSyncExecutor {
+  readonly scopes: readonly { readonly id: string }[];
+  readonly openapi: {
+    addSpec(input: {
+      spec: string;
+      scope: string;
+      baseUrl?: string;
+      namespace?: string;
+      headers?: Record<string, string | { secretId: string; prefix?: string }>;
+    }): Effect.Effect<unknown, unknown>;
+  };
+  readonly graphql: {
+    addSource(input: {
+      endpoint: string;
+      scope: string;
+      namespace?: string;
+      headers?: Record<string, string>;
+    }): Effect.Effect<unknown, unknown>;
+  };
+  readonly mcp: {
+    addSource(input:
+      | {
+          transport: "stdio";
+          scope: string;
+          name: string;
+          command: string;
+          args?: string[];
+          env?: Record<string, string>;
+          cwd?: string;
+          namespace?: string;
+        }
+      | {
+          transport: "remote";
+          scope: string;
+          name: string;
+          endpoint: string;
+          remoteTransport?: "streamable-http" | "sse" | "auto";
+          queryParams?: Record<string, string>;
+          headers?: Record<string, string>;
+          auth?: ConfigSyncMcpAuth;
+          namespace?: string;
+        }): Effect.Effect<unknown, unknown>;
+  };
+}
+
+const translateMcpAuth = (
+  auth: McpAuthConfig | undefined,
+): ConfigSyncMcpAuth | undefined => {
+  if (!auth) return undefined;
+  switch (auth.kind) {
+    case "none":
+      return { kind: "none" };
+    case "header":
+      return {
+        kind: "header",
+        headerName: auth.headerName,
+        secretId: translateSecretRef(auth.secret),
+        prefix: auth.prefix,
+      };
+    case "oauth2":
+      return {
+        kind: "oauth2",
+        accessTokenSecretId: translateSecretRef(auth.accessTokenSecret),
+        refreshTokenSecretId: auth.refreshTokenSecret
+          ? translateSecretRef(auth.refreshTokenSecret)
+          : null,
+        tokenType: auth.tokenType ?? "Bearer",
+        expiresAt: null,
+        scope: null,
+      };
+  }
+};
+
 // ---------------------------------------------------------------------------
 // Config path resolution
 // ---------------------------------------------------------------------------
@@ -81,7 +173,7 @@ const loadConfigSync = (path: string): ExecutorFileConfig | null => {
 // ---------------------------------------------------------------------------
 
 const addSourceFromConfig = (
-  executor: LocalExecutor,
+  executor: ConfigSyncExecutor,
   source: SourceConfig,
 ): Effect.Effect<void, unknown> => {
   // `executor.jsonc` is a single-scope artifact today — the file isn't
@@ -128,6 +220,7 @@ const addSourceFromConfig = (
         remoteTransport: source.remoteTransport,
         queryParams: source.queryParams,
         headers: source.headers,
+        auth: translateMcpAuth(source.auth),
         namespace: source.namespace,
       }).pipe(Effect.asVoid);
   }
@@ -138,7 +231,7 @@ const addSourceFromConfig = (
  * Each source is added independently — if one fails, the rest still load.
  */
 export const syncFromConfig = (
-  executor: LocalExecutor,
+  executor: ConfigSyncExecutor,
   configPath: string,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {


### PR DESCRIPTION
## Summary
- replay MCP auth when boot-time config sync restores remote sources from `executor.jsonc`
- narrow the config-sync dependency to the surface it actually consumes instead of the full local executor type
- add focused regression tests for header and OAuth MCP auth replay

## Testing
- bun --cwd apps/local test src/server/config-sync.test.ts
- bun --cwd apps/local typecheck