### PR TITLE
cloud: add db:migrate:prod script

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -12,6 +12,7 @@
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
     "db:studio:prod": "op run --env-file=.env.production -- drizzle-kit studio",
+    "db:migrate:prod": "op run --env-file=.env.production -- drizzle-kit migrate",
     "build": "vite build",
     "preview": "vite preview",
     "deploy": "op run --env-file=.env.production -- bun run build && op run --env-file=.env.production -- wrangler deploy",


### PR DESCRIPTION
## Summary
- Adds `db:migrate:prod` to `apps/cloud/package.json`, mirroring the existing `db:studio:prod` pattern (`op run --env-file=.env.production -- drizzle-kit migrate`).
- Migrations are run out-of-band (Cloudflare Workers can't read the FS), and this was previously a one-off command. Scripting it keeps the flow consistent with the other `db:*` scripts.

## Test plan
- [ ] `bun run db:migrate:prod` applies `0002_fat_white_tiger.sql` (bigint expires_at) to prod Hyperdrive.