### PR TITLE
Unify new-secret flows behind a SecretForm compound component

### DIFF
--- a/packages/react/src/components/tooltip.tsx
+++ b/packages/react/src/components/tooltip.tsx
@@ -28,11 +28,8 @@ function TooltipContent({
   className,
   sideOffset = 0,
   children,
-  hideArrow = false,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
-  hideArrow?: boolean;
-}) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -45,9 +42,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        {!hideArrow && (
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
-        )}
+        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/react/src/components/tooltip.tsx
+++ b/packages/react/src/components/tooltip.tsx
@@ -28,8 +28,11 @@ function TooltipContent({
   className,
   sideOffset = 0,
   children,
+  hideArrow = false,
   ...props
-}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+}: React.ComponentProps<typeof TooltipPrimitive.Content> & {
+  hideArrow?: boolean;
+}) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Content
@@ -42,7 +45,9 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        {!hideArrow && (
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
+        )}
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -5,6 +5,7 @@ import { secretsAtom, setSecret, removeSecret } from "../api/atoms";
 import { secretWriteKeys } from "../api/reactivity-keys";
 import { useSecretProviderPlugins } from "@executor-js/sdk/client";
 import { SecretId } from "@executor-js/sdk";
+import { useUniqueSecretIdInput } from "../plugins/secret-id";
 import { useScope } from "../hooks/use-scope";
 import {
   Dialog,
@@ -42,6 +43,7 @@ import {
   CardStackHeader,
 } from "../components/card-stack";
 import { Badge } from "../components/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../components/tooltip";
 
 type SecretStorageOption = {
   readonly label: string;
@@ -63,9 +65,9 @@ function AddSecretDialog(props: {
   onOpenChange: (v: boolean) => void;
   description: string;
   storageOptions: readonly SecretStorageOption[];
+  existingSecretIds: readonly string[];
 }) {
   const initialProvider = props.storageOptions[0]?.value ?? "auto";
-  const [id, setId] = useState("");
   const [name, setName] = useState("");
   const [value, setValue] = useState("");
   const [provider, setProvider] = useState(initialProvider);
@@ -74,9 +76,19 @@ function AddSecretDialog(props: {
 
   const scopeId = useScope();
   const doSet = useAtomSet(setSecret, { mode: "promise" });
+  const {
+    secretId: id,
+    duplicateError,
+    setSecretIdOverride,
+    resetSecretIdOverride,
+  } = useUniqueSecretIdInput({
+    baseName: name,
+    existingSecretIds: props.existingSecretIds,
+    fallbackId: "",
+  });
 
   const reset = () => {
-    setId("");
+    resetSecretIdOverride();
     setName("");
     setValue("");
     setProvider(initialProvider);
@@ -85,7 +97,7 @@ function AddSecretDialog(props: {
   };
 
   const handleSave = async () => {
-    if (!id.trim() || !name.trim() || !value.trim()) return;
+    if (!id.trim() || !name.trim() || !value.trim() || duplicateError) return;
     setSaving(true);
     setError(null);
     try {
@@ -136,9 +148,12 @@ function AddSecretDialog(props: {
                 id="secret-id"
                 placeholder="github-token"
                 value={id}
-                onChange={(e) => setId((e.target as HTMLInputElement).value)}
+                onChange={(e) => setSecretIdOverride((e.target as HTMLInputElement).value)}
                 className="font-mono text-xs h-9"
               />
+              {duplicateError && (
+                <p className="text-xs text-destructive">{duplicateError}</p>
+              )}
             </div>
             <div className="grid gap-1.5">
               <Label
@@ -215,7 +230,7 @@ function AddSecretDialog(props: {
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={!id.trim() || !name.trim() || !value.trim() || saving}
+            disabled={!id.trim() || !name.trim() || !value.trim() || !!duplicateError || saving}
           >
             {saving ? "Saving…" : "Save secret"}
           </Button>
@@ -239,8 +254,26 @@ function SecretRow(props: {
   return (
     <CardStackEntry>
       <CardStackEntryContent>
-        <CardStackEntryTitle className="flex items-center gap-2">
-          <span className="truncate">{secret.name}</span>
+        <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+          <span className="min-w-0 shrink truncate" title={secret.name}>
+            {secret.name}
+          </span>
+          <TooltipProvider delayDuration={0}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground">
+                  {secret.id}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent
+                sideOffset={6}
+                hideArrow
+                className="border border-emerald-500/60 bg-black font-mono text-foreground shadow-none"
+              >
+                {secret.id}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </CardStackEntryTitle>
       </CardStackEntryContent>
       <CardStackEntryActions>
@@ -291,6 +324,11 @@ export function SecretsPage(props: {
   const [addOpen, setAddOpen] = useState(false);
   const scopeId = useScope();
   const secrets = useAtomValue(secretsAtom(scopeId));
+  const existingSecretIds = AsyncResult.match(secrets, {
+    onInitial: () => [] as string[],
+    onFailure: () => [] as string[],
+    onSuccess: ({ value }) => value.map((secret) => secret.id),
+  });
   const doRemove = useAtomSet(removeSecret, { mode: "promise" });
 
   const handleRemove = async (secretId: string) => {
@@ -413,6 +451,7 @@ export function SecretsPage(props: {
           onOpenChange={setAddOpen}
           description={addSecretDescription}
           storageOptions={storageOptions}
+          existingSecretIds={existingSecretIds}
         />
       </div>
     </div>

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -1,11 +1,11 @@
-import { useState, Suspense } from "react";
+import { useMemo, useState, Suspense } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { secretsAtom, setSecret, removeSecret } from "../api/atoms";
+import { secretsAtom, removeSecret } from "../api/atoms";
 import { secretWriteKeys } from "../api/reactivity-keys";
 import { useSecretProviderPlugins } from "@executor-js/sdk/client";
 import { SecretId } from "@executor-js/sdk";
-import { useUniqueSecretIdInput } from "../plugins/secret-id";
+import { SecretForm } from "../plugins/secret-form";
 import { useScope } from "../hooks/use-scope";
 import {
   Dialog,
@@ -17,21 +17,12 @@ import {
   DialogClose,
 } from "../components/dialog";
 import { Button } from "../components/button";
-import { Input } from "../components/input";
-import { Label } from "../components/label";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../components/dropdown-menu";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "../components/select";
 import {
   CardStack,
   CardStackContent,
@@ -43,7 +34,6 @@ import {
   CardStackHeader,
 } from "../components/card-stack";
 import { Badge } from "../components/badge";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../components/tooltip";
 
 type SecretStorageOption = {
   readonly label: string;
@@ -58,6 +48,11 @@ const defaultStorageOptions: readonly SecretStorageOption[] = [
 
 // ---------------------------------------------------------------------------
 // Add secret dialog
+//
+// Form state, derived id, dup detection, and submit lifecycle live in
+// `<SecretForm.Provider>` and are shared with the inline create flow in
+// secret-header-auth.tsx. Dialog content remounts on each open via `key` so
+// state always starts fresh — no manual reset.
 // ---------------------------------------------------------------------------
 
 function AddSecretDialog(props: {
@@ -67,65 +62,34 @@ function AddSecretDialog(props: {
   storageOptions: readonly SecretStorageOption[];
   existingSecretIds: readonly string[];
 }) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      {props.open && (
+        <AddSecretDialogContent
+          key="open"
+          description={props.description}
+          storageOptions={props.storageOptions}
+          existingSecretIds={props.existingSecretIds}
+          onClose={() => props.onOpenChange(false)}
+        />
+      )}
+    </Dialog>
+  );
+}
+
+function AddSecretDialogContent(props: {
+  description: string;
+  storageOptions: readonly SecretStorageOption[];
+  existingSecretIds: readonly string[];
+  onClose: () => void;
+}) {
   const initialProvider = props.storageOptions[0]?.value ?? "auto";
-  const [name, setName] = useState("");
-  const [value, setValue] = useState("");
-  const [provider, setProvider] = useState(initialProvider);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const scopeId = useScope();
-  const doSet = useAtomSet(setSecret, { mode: "promise" });
-  const {
-    secretId: id,
-    duplicateError,
-    setSecretIdOverride,
-    resetSecretIdOverride,
-  } = useUniqueSecretIdInput({
-    baseName: name,
-    existingSecretIds: props.existingSecretIds,
-    fallbackId: "",
-  });
-
-  const reset = () => {
-    resetSecretIdOverride();
-    setName("");
-    setValue("");
-    setProvider(initialProvider);
-    setError(null);
-    setSaving(false);
-  };
-
-  const handleSave = async () => {
-    if (!id.trim() || !name.trim() || !value.trim() || duplicateError) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await doSet({
-        params: { scopeId },
-        payload: {
-          id: SecretId.make(id.trim()),
-          name: name.trim(),
-          value: value.trim(),
-          provider: provider === "auto" ? undefined : provider,
-        },
-        reactivityKeys: secretWriteKeys,
-      });
-      reset();
-      props.onOpenChange(false);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save secret");
-      setSaving(false);
-    }
-  };
 
   return (
-    <Dialog
-      open={props.open}
-      onOpenChange={(v) => {
-        if (!v) reset();
-        props.onOpenChange(v);
-      }}
+    <SecretForm.Provider
+      existingSecretIds={props.existingSecretIds}
+      initialProvider={initialProvider}
+      onCreated={props.onClose}
     >
       <DialogContent className="sm:max-w-[440px]">
         <DialogHeader>
@@ -137,88 +101,12 @@ function AddSecretDialog(props: {
 
         <div className="grid gap-5 py-3">
           <div className="grid grid-cols-2 gap-3">
-            <div className="grid gap-1.5">
-              <Label
-                htmlFor="secret-id"
-                className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
-              >
-                ID
-              </Label>
-              <Input
-                id="secret-id"
-                placeholder="github-token"
-                value={id}
-                onChange={(e) => setSecretIdOverride((e.target as HTMLInputElement).value)}
-                className="font-mono text-xs h-9"
-              />
-              {duplicateError && (
-                <p className="text-xs text-destructive">{duplicateError}</p>
-              )}
-            </div>
-            <div className="grid gap-1.5">
-              <Label
-                htmlFor="secret-name"
-                className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
-              >
-                Name
-              </Label>
-              <Input
-                id="secret-name"
-                placeholder="GitHub PAT"
-                value={name}
-                onChange={(e) => setName((e.target as HTMLInputElement).value)}
-                className="text-sm h-9"
-              />
-            </div>
+            <SecretForm.NameField />
+            <SecretForm.IdField />
           </div>
-
-          <div className="grid gap-1.5">
-            <Label
-              htmlFor="secret-value"
-              className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
-            >
-              Value
-            </Label>
-            <Input
-              id="secret-value"
-              type="password"
-              placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
-              value={value}
-              onChange={(e) => setValue((e.target as HTMLInputElement).value)}
-              className="font-mono text-xs h-9"
-            />
-          </div>
-
-          <div className="grid gap-3">
-            {props.storageOptions.length > 1 && (
-              <div className="grid gap-1.5">
-                <Label
-                  htmlFor="secret-provider"
-                  className="text-sm font-medium uppercase tracking-wider text-muted-foreground"
-                >
-                  Storage
-                </Label>
-                <Select value={provider} onValueChange={setProvider}>
-                  <SelectTrigger id="secret-provider" className="h-9 text-sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {props.storageOptions.map((option) => (
-                      <SelectItem key={option.value} value={option.value}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            )}
-          </div>
-
-          {error && (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-              <p className="text-sm text-destructive">{error}</p>
-            </div>
-          )}
+          <SecretForm.ValueField />
+          <SecretForm.ProviderField options={props.storageOptions} />
+          <SecretForm.ErrorBanner />
         </div>
 
         <DialogFooter>
@@ -227,16 +115,10 @@ function AddSecretDialog(props: {
               Cancel
             </Button>
           </DialogClose>
-          <Button
-            size="sm"
-            onClick={handleSave}
-            disabled={!id.trim() || !name.trim() || !value.trim() || !!duplicateError || saving}
-          >
-            {saving ? "Saving…" : "Save secret"}
-          </Button>
+          <SecretForm.SubmitButton size="sm">Save secret</SecretForm.SubmitButton>
         </DialogFooter>
       </DialogContent>
-    </Dialog>
+    </SecretForm.Provider>
   );
 }
 
@@ -258,22 +140,12 @@ function SecretRow(props: {
           <span className="min-w-0 shrink truncate" title={secret.name}>
             {secret.name}
           </span>
-          <TooltipProvider delayDuration={0}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground">
-                  {secret.id}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent
-                sideOffset={6}
-                hideArrow
-                className="border border-emerald-500/60 bg-black font-mono text-foreground shadow-none"
-              >
-                {secret.id}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <span
+            className="max-w-40 shrink truncate font-mono text-xs text-muted-foreground"
+            title={secret.id}
+          >
+            {secret.id}
+          </span>
         </CardStackEntryTitle>
       </CardStackEntryContent>
       <CardStackEntryActions>
@@ -324,11 +196,15 @@ export function SecretsPage(props: {
   const [addOpen, setAddOpen] = useState(false);
   const scopeId = useScope();
   const secrets = useAtomValue(secretsAtom(scopeId));
-  const existingSecretIds = AsyncResult.match(secrets, {
-    onInitial: () => [] as string[],
-    onFailure: () => [] as string[],
-    onSuccess: ({ value }) => value.map((secret) => secret.id),
-  });
+  const existingSecretIds = useMemo(
+    () =>
+      AsyncResult.match(secrets, {
+        onInitial: () => [] as string[],
+        onFailure: () => [] as string[],
+        onSuccess: ({ value }) => value.map((secret) => secret.id),
+      }),
+    [secrets],
+  );
   const doRemove = useAtomSet(removeSecret, { mode: "promise" });
 
   const handleRemove = async (secretId: string) => {

--- a/packages/react/src/plugins/secret-form.tsx
+++ b/packages/react/src/plugins/secret-form.tsx
@@ -1,0 +1,366 @@
+import {
+  createContext,
+  use,
+  useId,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { useAtomSet } from "@effect/atom-react";
+
+import { setSecret } from "../api/atoms";
+import { secretWriteKeys } from "../api/reactivity-keys";
+import { useScope } from "../api/scope-context";
+import { SecretId, type ScopeId } from "@executor-js/sdk";
+import { Button, type buttonVariants } from "../components/button";
+import { Field, FieldError, FieldLabel } from "../components/field";
+import { Input } from "../components/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/select";
+import type { VariantProps } from "class-variance-authority";
+
+import {
+  getUniqueSecretId,
+  isSecretIdTaken,
+} from "./secret-id";
+
+// ---------------------------------------------------------------------------
+// Context
+//
+// One generic interface — `state`, `actions`, `meta` — that both the modal
+// and inline create flows share. Surfaces compose the `SecretForm.*` parts
+// they want; provider owns state, derived values, and submit lifecycle.
+// ---------------------------------------------------------------------------
+
+type SubmitStatus =
+  | { readonly kind: "idle" }
+  | { readonly kind: "submitting" }
+  | { readonly kind: "error"; readonly message: string };
+
+interface SecretFormState {
+  readonly name: string;
+  readonly value: string;
+  readonly idOverride: string | null;
+  readonly provider: string;
+  readonly revealed: boolean;
+  readonly status: SubmitStatus;
+}
+
+interface SecretFormActions {
+  readonly setName: (v: string) => void;
+  readonly setValue: (v: string) => void;
+  readonly setIdOverride: (v: string) => void;
+  readonly setProvider: (v: string) => void;
+  readonly toggleReveal: () => void;
+  readonly submit: () => Promise<void>;
+}
+
+interface SecretFormMeta {
+  readonly id: string;
+  readonly duplicateError: string | null;
+  readonly canSubmit: boolean;
+}
+
+interface SecretFormContextValue {
+  readonly state: SecretFormState;
+  readonly actions: SecretFormActions;
+  readonly meta: SecretFormMeta;
+}
+
+const SecretFormContext = createContext<SecretFormContextValue | null>(null);
+
+function useSecretForm(): SecretFormContextValue {
+  const ctx = use(SecretFormContext);
+  if (!ctx) {
+    throw new Error("SecretForm parts must be rendered inside <SecretForm.Provider>");
+  }
+  return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface SecretFormProviderProps {
+  readonly existingSecretIds: readonly string[];
+  readonly suggestedName?: string;
+  readonly fallbackId?: string;
+  readonly initialProvider?: string;
+  readonly scopeId?: ScopeId;
+  readonly onCreated: (secretId: string) => void;
+  readonly children: ReactNode;
+}
+
+function SecretFormProvider(props: SecretFormProviderProps) {
+  const {
+    existingSecretIds,
+    suggestedName = "",
+    fallbackId = "secret",
+    initialProvider = "auto",
+    scopeId: scopeIdProp,
+    onCreated,
+    children,
+  } = props;
+
+  const defaultScope = useScope();
+  const scopeId = scopeIdProp ?? defaultScope;
+  const doSet = useAtomSet(setSecret, { mode: "promise" });
+
+  const [state, setState] = useState<SecretFormState>(() => ({
+    name: "",
+    value: "",
+    idOverride: null,
+    provider: initialProvider,
+    revealed: false,
+    status: { kind: "idle" },
+  }));
+
+  const baseName = state.name || suggestedName;
+  const autoId = useMemo(
+    () => getUniqueSecretId(baseName, existingSecretIds, fallbackId),
+    [baseName, existingSecretIds, fallbackId],
+  );
+  const id = state.idOverride ?? autoId;
+  const duplicateError =
+    state.idOverride !== null && isSecretIdTaken(state.idOverride, existingSecretIds)
+      ? "Secret ID already exists"
+      : null;
+
+  const displayName = state.name.trim() || suggestedName.trim();
+  const canSubmit =
+    id.trim() !== "" &&
+    state.value.trim() !== "" &&
+    duplicateError === null &&
+    state.status.kind !== "submitting";
+
+  const submit = async () => {
+    if (!canSubmit) return;
+    setState((s) => ({ ...s, status: { kind: "submitting" } }));
+    try {
+      await doSet({
+        params: { scopeId },
+        payload: {
+          id: SecretId.make(id.trim()),
+          name: displayName || id.trim(),
+          value: state.value.trim(),
+          provider: state.provider === "auto" ? undefined : state.provider,
+        },
+        reactivityKeys: secretWriteKeys,
+      });
+      onCreated(id.trim());
+    } catch (e) {
+      setState((s) => ({
+        ...s,
+        status: {
+          kind: "error",
+          message: e instanceof Error ? e.message : "Failed to save secret",
+        },
+      }));
+    }
+  };
+
+  const value: SecretFormContextValue = {
+    state,
+    actions: {
+      setName: (v) => setState((s) => ({ ...s, name: v })),
+      setValue: (v) => setState((s) => ({ ...s, value: v })),
+      setIdOverride: (v) => setState((s) => ({ ...s, idOverride: v })),
+      setProvider: (v) => setState((s) => ({ ...s, provider: v })),
+      toggleReveal: () => setState((s) => ({ ...s, revealed: !s.revealed })),
+      submit,
+    },
+    meta: { id, duplicateError, canSubmit },
+  };
+
+  return <SecretFormContext value={value}>{children}</SecretFormContext>;
+}
+
+// ---------------------------------------------------------------------------
+// Parts
+// ---------------------------------------------------------------------------
+
+function NameField(props: { label?: string; placeholder?: string }) {
+  const { state, actions } = useSecretForm();
+  const inputId = useId();
+  return (
+    <Field>
+      <FieldLabel htmlFor={inputId}>{props.label ?? "Name"}</FieldLabel>
+      <Input
+        id={inputId}
+        value={state.name}
+        onChange={(e) => actions.setName((e.target as HTMLInputElement).value)}
+        placeholder={props.placeholder ?? "GitHub PAT"}
+      />
+    </Field>
+  );
+}
+
+function IdField(props: { placeholder?: string }) {
+  const { actions, meta } = useSecretForm();
+  const inputId = useId();
+  return (
+    <Field>
+      <FieldLabel htmlFor={inputId}>ID</FieldLabel>
+      <Input
+        id={inputId}
+        value={meta.id}
+        onChange={(e) => actions.setIdOverride((e.target as HTMLInputElement).value)}
+        placeholder={props.placeholder ?? "github-token"}
+        className="font-mono"
+      />
+      {meta.duplicateError && <FieldError>{meta.duplicateError}</FieldError>}
+    </Field>
+  );
+}
+
+function ValueField(props: { revealable?: boolean; placeholder?: string }) {
+  const { state, actions } = useSecretForm();
+  const inputId = useId();
+  const revealable = props.revealable ?? false;
+  const errored = state.status.kind === "error";
+
+  return (
+    <Field>
+      <FieldLabel htmlFor={inputId}>Value</FieldLabel>
+      <div className="relative">
+        <Input
+          id={inputId}
+          type={revealable ? "text" : "password"}
+          value={state.value}
+          onChange={(e) => actions.setValue((e.target as HTMLInputElement).value)}
+          placeholder={props.placeholder ?? "ghp_xxxxxxxxxxxxxxxxxxxx"}
+          className={revealable ? "pr-9 font-mono" : "font-mono"}
+          style={
+            revealable && !state.revealed
+              ? ({ WebkitTextSecurity: "disc" } as CSSProperties)
+              : undefined
+          }
+        />
+        {revealable && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="absolute right-1 top-1/2 size-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            onClick={actions.toggleReveal}
+            aria-label={state.revealed ? "Hide secret value" : "Reveal secret value"}
+          >
+            <SecretVisibilityIcon revealed={state.revealed} />
+          </Button>
+        )}
+      </div>
+      {errored && <FieldError>{state.status.kind === "error" ? state.status.message : ""}</FieldError>}
+    </Field>
+  );
+}
+
+function ProviderField(props: { options: readonly { label: string; value: string }[] }) {
+  const { state, actions } = useSecretForm();
+  const inputId = useId();
+  if (props.options.length <= 1) return null;
+  return (
+    <Field>
+      <FieldLabel htmlFor={inputId}>Storage</FieldLabel>
+      <Select value={state.provider} onValueChange={actions.setProvider}>
+        <SelectTrigger id={inputId} className="h-9 text-sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {props.options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </Field>
+  );
+}
+
+function ErrorBanner() {
+  const { state } = useSecretForm();
+  if (state.status.kind !== "error") return null;
+  return (
+    <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+      <p className="text-sm text-destructive">{state.status.message}</p>
+    </div>
+  );
+}
+
+type ButtonProps = React.ComponentProps<"button"> & VariantProps<typeof buttonVariants>;
+
+function SubmitButton(props: ButtonProps & { children?: ReactNode }) {
+  const { state, meta, actions } = useSecretForm();
+  const { children, disabled, onClick, ...rest } = props;
+  const submitting = state.status.kind === "submitting";
+  return (
+    <Button
+      {...rest}
+      onClick={(e) => {
+        onClick?.(e);
+        if (!e.defaultPrevented) void actions.submit();
+      }}
+      disabled={disabled || !meta.canSubmit}
+    >
+      {submitting ? "Saving…" : children}
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Reveal-eye icon (used by ValueField when `revealable`)
+// ---------------------------------------------------------------------------
+
+function SecretVisibilityIcon(props: { revealed: boolean }) {
+  return props.revealed ? (
+    <svg
+      viewBox="0 0 16 16"
+      className="size-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M2 2l12 12" />
+      <path d="M6.5 6.5a2 2 0 0 0 3 3" />
+      <path d="M3.5 5.5C2.3 6.7 1.5 8 1.5 8s2.5 4.5 6.5 4.5c1 0 1.9-.3 2.7-.7" />
+      <path d="M10.7 10.7c2-1.4 3.3-3.2 3.8-3.7 0 0-2.5-5-6.5-5-.7 0-1.4.1-2 .4" />
+    </svg>
+  ) : (
+    <svg
+      viewBox="0 0 16 16"
+      className="size-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8s-2.5 4.5-6.5 4.5S1.5 8 1.5 8z" />
+      <circle cx="8" cy="8" r="2" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Compound export
+// ---------------------------------------------------------------------------
+
+export const SecretForm = {
+  Provider: SecretFormProvider,
+  NameField,
+  IdField,
+  ValueField,
+  ProviderField,
+  ErrorBanner,
+  SubmitButton,
+};
+
+export type { SecretFormProviderProps };

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -1,14 +1,10 @@
-import { useId, useState, type CSSProperties } from "react";
-import { useAtomSet } from "@effect/atom-react";
+import { useId, useState } from "react";
 
-import { setSecret } from "../api/atoms";
-import { secretWriteKeys } from "../api/reactivity-keys";
-import { useScope } from "../api/scope-context";
-import { SecretId, type ScopeId } from "@executor-js/sdk";
+import { type ScopeId } from "@executor-js/sdk";
 import { Button } from "../components/button";
-import { Field, FieldError, FieldGroup, FieldLabel } from "../components/field";
+import { Field, FieldGroup, FieldLabel } from "../components/field";
 import { Input } from "../components/input";
-import { slugifyForSecretId, useUniqueSecretIdInput } from "./secret-id";
+import { SecretForm } from "./secret-form";
 import { SecretPicker, type SecretPickerSecret } from "./secret-picker";
 
 export interface HeaderAuthPreset {
@@ -28,156 +24,40 @@ export const defaultHeaderAuthPresets: readonly HeaderAuthPreset[] = [
   { key: "custom", label: "Custom", name: "" },
 ];
 
-function SecretVisibilityIcon(props: { revealed: boolean }) {
-  return props.revealed ? (
-    <svg
-      viewBox="0 0 16 16"
-      className="size-3.5"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M2 2l12 12" />
-      <path d="M6.5 6.5a2 2 0 0 0 3 3" />
-      <path d="M3.5 5.5C2.3 6.7 1.5 8 1.5 8s2.5 4.5 6.5 4.5c1 0 1.9-.3 2.7-.7" />
-      <path d="M10.7 10.7c2-1.4 3.3-3.2 3.8-3.7 0 0-2.5-5-6.5-5-.7 0-1.4.1-2 .4" />
-    </svg>
-  ) : (
-    <svg
-      viewBox="0 0 16 16"
-      className="size-3.5"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.3"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M1.5 8s2.5-4.5 6.5-4.5S14.5 8 14.5 8s-2.5 4.5-6.5 4.5S1.5 8 1.5 8z" />
-      <circle cx="8" cy="8" r="2" />
-    </svg>
-  );
-}
-
 export function InlineCreateSecret(props: {
-  suggestedId: string;
   suggestedName: string;
   existingSecretIds: readonly string[];
   onCreated: (secretId: string) => void;
   onCancel: () => void;
+  fallbackId?: string;
   targetScope?: ScopeId;
   writeScope?: ScopeId;
 }) {
-  const [nameOverride, setNameOverride] = useState<string | null>(null);
-  const [secretValue, setSecretValue] = useState("");
-  const [secretRevealed, setSecretRevealed] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const defaultScope = useScope();
-  const scopeId = props.targetScope ?? props.writeScope ?? defaultScope;
-  const doSet = useAtomSet(setSecret, { mode: "promise" });
-  const secretIdInputId = useId();
-  const secretNameInputId = useId();
-  const secretValueInputId = useId();
-
-  const secretName = nameOverride ?? props.suggestedName;
-  const {
-    secretId,
-    duplicateError,
-    setSecretIdOverride,
-  } = useUniqueSecretIdInput({
-    baseName: secretName,
-    existingSecretIds: props.existingSecretIds,
-    fallbackId: props.suggestedId || "custom-header",
-  });
-
-  const handleSave = async () => {
-    if (!secretId.trim() || !secretValue.trim() || duplicateError) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await doSet({
-        params: { scopeId },
-        payload: {
-          id: SecretId.make(secretId.trim()),
-          name: secretName.trim() || secretId.trim(),
-          value: secretValue.trim(),
-        },
-        reactivityKeys: secretWriteKeys,
-      });
-      props.onCreated(secretId.trim());
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save secret");
-      setSaving(false);
-    }
-  };
-
   return (
-    <div className="bg-primary/[0.03] px-4 py-3 space-y-3">
-      <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
-      <FieldGroup className="gap-3">
-        <div className="grid grid-cols-2 gap-3">
-          <Field>
-            <FieldLabel htmlFor={secretNameInputId}>Label</FieldLabel>
-            <Input
-              id={secretNameInputId}
-              value={secretName}
-              onChange={(e) => setNameOverride((e.target as HTMLInputElement).value)}
-              placeholder="API Token"
-            />
-          </Field>
-          <Field>
-            <FieldLabel htmlFor={secretIdInputId}>ID</FieldLabel>
-            <Input
-              id={secretIdInputId}
-              value={secretId}
-              onChange={(e) => setSecretIdOverride((e.target as HTMLInputElement).value)}
-              placeholder="my-api-token"
-              className="font-mono"
-            />
-            {duplicateError && <FieldError>{duplicateError}</FieldError>}
-          </Field>
-        </div>
-        <Field>
-          <FieldLabel htmlFor={secretValueInputId}>Value</FieldLabel>
-          <div className="relative">
-            <Input
-              id={secretValueInputId}
-              type="text"
-              value={secretValue}
-              onChange={(e) => setSecretValue((e.target as HTMLInputElement).value)}
-              placeholder="paste your token or key…"
-              className="pr-9 font-mono"
-              style={secretRevealed ? undefined : ({ WebkitTextSecurity: "disc" } as CSSProperties)}
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              className="absolute right-1 top-1/2 size-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              onClick={() => setSecretRevealed((revealed) => !revealed)}
-              aria-label={secretRevealed ? "Hide secret value" : "Reveal secret value"}
-            >
-              <SecretVisibilityIcon revealed={secretRevealed} />
-            </Button>
+    <SecretForm.Provider
+      existingSecretIds={props.existingSecretIds}
+      suggestedName={props.suggestedName}
+      fallbackId={props.fallbackId ?? "custom-header"}
+      scopeId={props.targetScope ?? props.writeScope}
+      onCreated={props.onCreated}
+    >
+      <div className="bg-primary/[0.03] px-4 py-3 space-y-3">
+        <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
+        <FieldGroup className="gap-3">
+          <div className="grid grid-cols-2 gap-3">
+            <SecretForm.NameField label="Label" placeholder="API Token" />
+            <SecretForm.IdField placeholder="my-api-token" />
           </div>
-          {error && <FieldError>{error}</FieldError>}
-        </Field>
-      </FieldGroup>
-      <div className="flex justify-end gap-1.5 pt-0.5">
-        <Button variant="outline" size="xs" onClick={props.onCancel}>
-          Cancel
-        </Button>
-        <Button
-          size="xs"
-          onClick={handleSave}
-          disabled={!secretId.trim() || !secretValue.trim() || !!duplicateError || saving}
-        >
-          {saving ? "Saving…" : "Create and use"}
-        </Button>
+          <SecretForm.ValueField revealable placeholder="paste your token or key…" />
+        </FieldGroup>
+        <div className="flex justify-end gap-1.5 pt-0.5">
+          <Button variant="outline" size="xs" onClick={props.onCancel}>
+            Cancel
+          </Button>
+          <SecretForm.SubmitButton size="xs">Create and use</SecretForm.SubmitButton>
+        </div>
       </div>
-    </div>
+    </SecretForm.Provider>
   );
 }
 
@@ -290,12 +170,10 @@ export function SecretHeaderAuthRow(props: {
   const isCustom = presetKey === "custom" || presetKey === undefined;
   const headerLabel = name.trim() || "Custom Header";
   const suggestedName = [sourceName?.trim(), headerLabel].filter(Boolean).join(" ");
-  const suggestedId = slugifyForSecretId(suggestedName) || "custom-header";
 
   if (creating) {
     return (
       <InlineCreateSecret
-        suggestedId={suggestedId}
         suggestedName={suggestedName}
         existingSecretIds={existingSecrets.map((secret) => secret.id)}
         onCreated={(id) => {
@@ -409,14 +287,13 @@ export function CreatableSecretPicker(props: {
   const [creating, setCreating] = useState(false);
 
   const suggestedName = [sourceName?.trim(), secretLabel].filter(Boolean).join(" ");
-  const suggestedId = suggestedIdProp?.trim() || slugifyForSecretId(suggestedName) || "secret";
 
   if (creating) {
     return (
       <InlineCreateSecret
-        suggestedId={suggestedId}
         suggestedName={suggestedName}
         existingSecretIds={secrets.map((secret) => secret.id)}
+        fallbackId={suggestedIdProp?.trim() || "secret"}
         onCreated={(id) => {
           onSelect(id);
           setCreating(false);

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -8,6 +8,7 @@ import { SecretId, type ScopeId } from "@executor-js/sdk";
 import { Button } from "../components/button";
 import { Field, FieldError, FieldGroup, FieldLabel } from "../components/field";
 import { Input } from "../components/input";
+import { slugifyForSecretId, useUniqueSecretIdInput } from "./secret-id";
 import { SecretPicker, type SecretPickerSecret } from "./secret-picker";
 
 export interface HeaderAuthPreset {
@@ -59,24 +60,16 @@ function SecretVisibilityIcon(props: { revealed: boolean }) {
   );
 }
 
-function slugifyForSecretId(input: string): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
 export function InlineCreateSecret(props: {
   suggestedId: string;
   suggestedName: string;
+  existingSecretIds: readonly string[];
   onCreated: (secretId: string) => void;
   onCancel: () => void;
   targetScope?: ScopeId;
   writeScope?: ScopeId;
 }) {
   const [nameOverride, setNameOverride] = useState<string | null>(null);
-  const [idOverride, setIdOverride] = useState<string | null>(null);
   const [secretValue, setSecretValue] = useState("");
   const [secretRevealed, setSecretRevealed] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -89,10 +82,18 @@ export function InlineCreateSecret(props: {
   const secretValueInputId = useId();
 
   const secretName = nameOverride ?? props.suggestedName;
-  const secretId = idOverride ?? (slugifyForSecretId(secretName) || "custom-header");
+  const {
+    secretId,
+    duplicateError,
+    setSecretIdOverride,
+  } = useUniqueSecretIdInput({
+    baseName: secretName,
+    existingSecretIds: props.existingSecretIds,
+    fallbackId: props.suggestedId || "custom-header",
+  });
 
   const handleSave = async () => {
-    if (!secretId.trim() || !secretValue.trim()) return;
+    if (!secretId.trim() || !secretValue.trim() || duplicateError) return;
     setSaving(true);
     setError(null);
     try {
@@ -131,10 +132,11 @@ export function InlineCreateSecret(props: {
             <Input
               id={secretIdInputId}
               value={secretId}
-              onChange={(e) => setIdOverride((e.target as HTMLInputElement).value)}
+              onChange={(e) => setSecretIdOverride((e.target as HTMLInputElement).value)}
               placeholder="my-api-token"
               className="font-mono"
             />
+            {duplicateError && <FieldError>{duplicateError}</FieldError>}
           </Field>
         </div>
         <Field>
@@ -170,7 +172,7 @@ export function InlineCreateSecret(props: {
         <Button
           size="xs"
           onClick={handleSave}
-          disabled={!secretId.trim() || !secretValue.trim() || saving}
+          disabled={!secretId.trim() || !secretValue.trim() || !!duplicateError || saving}
         >
           {saving ? "Saving…" : "Create and use"}
         </Button>
@@ -295,6 +297,7 @@ export function SecretHeaderAuthRow(props: {
       <InlineCreateSecret
         suggestedId={suggestedId}
         suggestedName={suggestedName}
+        existingSecretIds={existingSecrets.map((secret) => secret.id)}
         onCreated={(id) => {
           onSelectSecret(id);
           setCreating(false);
@@ -413,6 +416,7 @@ export function CreatableSecretPicker(props: {
       <InlineCreateSecret
         suggestedId={suggestedId}
         suggestedName={suggestedName}
+        existingSecretIds={secrets.map((secret) => secret.id)}
         onCreated={(id) => {
           onSelect(id);
           setCreating(false);

--- a/packages/react/src/plugins/secret-id.test.ts
+++ b/packages/react/src/plugins/secret-id.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 
 import {
   getUniqueSecretId,

--- a/packages/react/src/plugins/secret-id.test.ts
+++ b/packages/react/src/plugins/secret-id.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getUniqueSecretId,
+  isSecretIdTaken,
+  slugifyForSecretId,
+} from "./secret-id";
+
+describe("secret id helpers", () => {
+  it("slugifies display names into secret ids", () => {
+    expect(slugifyForSecretId("GitHub PAT")).toBe("github-pat");
+    expect(slugifyForSecretId("  Client Secret  ")).toBe("client-secret");
+  });
+
+  it("returns the base id when it is unused", () => {
+    expect(getUniqueSecretId("GitHub PAT", ["openai-api-key"])).toBe("github-pat");
+  });
+
+  it("appends a numeric suffix when the base id already exists", () => {
+    expect(getUniqueSecretId("GitHub PAT", ["github-pat"])).toBe("github-pat-2");
+    expect(getUniqueSecretId("GitHub PAT", ["github-pat", "github-pat-2"])).toBe(
+      "github-pat-3",
+    );
+  });
+
+  it("matches existing ids exactly after trimming", () => {
+    expect(isSecretIdTaken("github-pat", [" github-pat "])).toBe(true);
+    expect(isSecretIdTaken("github-pat", ["github-pat-2"])).toBe(false);
+  });
+
+  it("allows an empty fallback for flows that should start blank", () => {
+    expect(getUniqueSecretId("", [], "")).toBe("");
+  });
+});

--- a/packages/react/src/plugins/secret-id.tsx
+++ b/packages/react/src/plugins/secret-id.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+// Pure helpers shared by `SecretForm` (compound form for new-secret flows)
+// and the reuse tests. UI state lives in `secret-form.tsx`.
 
 export function slugifyForSecretId(input: string): string {
   return input
@@ -40,32 +41,4 @@ export function getUniqueSecretId(
     suffix += 1;
   }
   return `${baseId}-${suffix}`;
-}
-
-export function useUniqueSecretIdInput(options: {
-  baseName: string;
-  existingSecretIds: readonly string[];
-  fallbackId?: string;
-}) {
-  const { baseName, existingSecretIds, fallbackId = "secret" } = options;
-  const [idOverride, setIdOverride] = useState<string | null>(null);
-
-  const suggestedId = useMemo(
-    () => getUniqueSecretId(baseName, existingSecretIds, fallbackId),
-    [baseName, existingSecretIds, fallbackId],
-  );
-  const secretId = idOverride ?? suggestedId;
-  const duplicateError = useMemo(
-    () => (isSecretIdTaken(secretId, existingSecretIds) ? "Secret ID already exists" : null),
-    [secretId, existingSecretIds],
-  );
-
-  return {
-    secretId,
-    suggestedId,
-    duplicateError,
-    hasManualOverride: idOverride !== null,
-    setSecretIdOverride: (value: string) => setIdOverride(value),
-    resetSecretIdOverride: () => setIdOverride(null),
-  };
 }

--- a/packages/react/src/plugins/secret-id.tsx
+++ b/packages/react/src/plugins/secret-id.tsx
@@ -1,0 +1,71 @@
+import { useMemo, useState } from "react";
+
+export function slugifyForSecretId(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const normalizeSecretId = (secretId: string): string => secretId.trim();
+
+export function isSecretIdTaken(
+  secretId: string,
+  existingSecretIds: Iterable<string>,
+): boolean {
+  const normalizedId = normalizeSecretId(secretId);
+  if (!normalizedId) return false;
+
+  for (const existingSecretId of existingSecretIds) {
+    if (normalizeSecretId(existingSecretId) === normalizedId) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function getUniqueSecretId(
+  baseName: string,
+  existingSecretIds: Iterable<string>,
+  fallbackId = "secret",
+): string {
+  const baseId = slugifyForSecretId(baseName) || fallbackId;
+  if (!baseId) return "";
+  if (!isSecretIdTaken(baseId, existingSecretIds)) return baseId;
+
+  let suffix = 2;
+  while (isSecretIdTaken(`${baseId}-${suffix}`, existingSecretIds)) {
+    suffix += 1;
+  }
+  return `${baseId}-${suffix}`;
+}
+
+export function useUniqueSecretIdInput(options: {
+  baseName: string;
+  existingSecretIds: readonly string[];
+  fallbackId?: string;
+}) {
+  const { baseName, existingSecretIds, fallbackId = "secret" } = options;
+  const [idOverride, setIdOverride] = useState<string | null>(null);
+
+  const suggestedId = useMemo(
+    () => getUniqueSecretId(baseName, existingSecretIds, fallbackId),
+    [baseName, existingSecretIds, fallbackId],
+  );
+  const secretId = idOverride ?? suggestedId;
+  const duplicateError = useMemo(
+    () => (isSecretIdTaken(secretId, existingSecretIds) ? "Secret ID already exists" : null),
+    [secretId, existingSecretIds],
+  );
+
+  return {
+    secretId,
+    suggestedId,
+    duplicateError,
+    hasManualOverride: idOverride !== null,
+    setSecretIdOverride: (value: string) => setIdOverride(value),
+    resetSecretIdOverride: () => setIdOverride(null),
+  };
+}

--- a/packages/react/src/plugins/secret-picker.tsx
+++ b/packages/react/src/plugins/secret-picker.tsx
@@ -35,7 +35,7 @@ export function SecretPicker(props: {
   readonly onSelect: (secretId: string) => void;
   readonly secrets: readonly SecretPickerSecret[];
   readonly placeholder?: string;
-  /** When provided, renders a "+ New secret" row at the bottom of the dropdown. */
+  /** When provided, renders a "+ New secret" row at the top of the dropdown. */
   readonly onCreateNew?: () => void;
 }) {
   const { value, onSelect, secrets, placeholder = "Search secrets…", onCreateNew } = props;
@@ -98,6 +98,25 @@ export function SecretPicker(props: {
           <Command shouldFilter={false}>
             <CommandList>
               <CommandEmpty>No secrets found</CommandEmpty>
+              {onCreateNew && (
+                <>
+                  <CommandGroup>
+                    <CommandItem
+                      value="__create_new__"
+                      onSelect={() => {
+                        onCreateNew();
+                        setOpen(false);
+                        setQuery("");
+                      }}
+                      className="text-muted-foreground data-[selected=true]:text-foreground"
+                    >
+                      <PlusIcon aria-hidden className="size-3.5" />
+                      <span>New secret</span>
+                    </CommandItem>
+                  </CommandGroup>
+                  {secrets.length > 0 && <CommandSeparator />}
+                </>
+              )}
               {groups.map(([label, items]) => {
                 const lowerQuery = query.toLowerCase();
                 const filtered = lowerQuery
@@ -126,25 +145,6 @@ export function SecretPicker(props: {
                   </CommandGroup>
                 );
               })}
-              {onCreateNew && (
-                <>
-                  {secrets.length > 0 && <CommandSeparator />}
-                  <CommandGroup>
-                    <CommandItem
-                      value="__create_new__"
-                      onSelect={() => {
-                        onCreateNew();
-                        setOpen(false);
-                        setQuery("");
-                      }}
-                      className="text-muted-foreground data-[selected=true]:text-foreground"
-                    >
-                      <PlusIcon aria-hidden className="size-3.5" />
-                      <span>New secret</span>
-                    </CommandItem>
-                  </CommandGroup>
-                </>
-              )}
             </CommandList>
           </Command>
         </PopoverContent>

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+});


### PR DESCRIPTION
## What changed

The web UI had two divergent copies of the new-secret form — the page-level dialog and the inline create flow on source headers — both reimplementing name + auto-derived id + value + scope + submit. The original PR's dup-detection only landed in one of them, and form state was scattered across five `useState`s per surface with manual `reset()` bookkeeping. This PR collapses both surfaces onto a shared compound component.

## SecretForm compound API

New `packages/react/src/plugins/secret-form.tsx` with a generic `state` / `actions` / `meta` context interface (per the React composition pattern):

```tsx
<SecretForm.Provider existingSecretIds={…} suggestedName={…} onCreated={…}>
  <SecretForm.NameField />
  <SecretForm.IdField />
  <SecretForm.ValueField revealable />
  <SecretForm.ProviderField options={…} />
  <SecretForm.ErrorBanner />
  <SecretForm.SubmitButton>Save secret</SecretForm.SubmitButton>
</SecretForm.Provider>
```

Both surfaces compose the parts they need:

- **`AddSecretDialog`** (modal) — provider field + standard placeholders.
- **`InlineCreateSecret`** (header auth flow) — `revealable` value field + custom labels.

Layout is each surface's responsibility; logic isn't. Future fixes (async validation, password strength, additional providers, etc.) land in one place.

## State-management cleanup

- 5 separate `useState`s per form → one state object inside the provider.
- `saving: boolean` + `error: string | null` → discriminated `status: idle | submitting | error`.
- Manual `reset()` bookkeeping → dialog content remounts on open via `key`, so state always starts fresh.
- `existingSecretIds` memoised in `SecretsPage` so the array reference is stable when the secrets list is unchanged (avoids re-running `getUniqueSecretId` on every parent render).
- Removed the `SecretRow` secret-id tooltip and the bespoke `hideArrow` tooltip prop introduced for it; native `title` attribute carries the same info without a custom Radix subtree.
- Removed the `useUniqueSecretIdInput` hook. Pure helpers (`slugifyForSecretId`, `isSecretIdTaken`, `getUniqueSecretId`) stay in `secret-id.tsx`; override state lives inside the form provider.

## Behaviour preserved from the original PR

- Auto-slugifies the typed name into the ID; collisions auto-suffix `-2`, `-3`, …
- Manually-typed IDs that collide with an existing secret show "Secret ID already exists" and disable Save.
- Inline create flow on source headers and the secrets-page dialog use the same dedup rules.

## Validation

- `bun run typecheck` — green
- `bun run lint` — green
- `bunx vitest run` from `packages/react` — 5/5 pass (`secret-id.test.ts`)
- Manual: `apps/local` dev server, exercised both the modal and the inline flow
