### PR TITLE
openapi: support oauth2 client_credentials flow end-to-end

### DIFF
--- a/packages/plugins/oauth2/src/index.ts
+++ b/packages/plugins/oauth2/src/index.ts
@@ -312,6 +312,38 @@ export const exchangeAuthorizationCode = (
 };
 
 // ---------------------------------------------------------------------------
+// Exchange client credentials → tokens (RFC 6749 §4.4)
+// ---------------------------------------------------------------------------
+
+export type ExchangeClientCredentialsInput = {
+  readonly tokenUrl: string;
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly scopes?: readonly string[];
+  readonly scopeSeparator?: string;
+  /** "body" (default) sends client creds in the form body; "basic" uses HTTP Basic. */
+  readonly clientAuth?: ClientAuthMethod;
+  readonly timeoutMs?: number;
+};
+
+export const exchangeClientCredentials = (
+  input: ExchangeClientCredentialsInput,
+): Effect.Effect<OAuth2TokenResponse, OAuth2Error> => {
+  const clientAuth = input.clientAuth ?? "body";
+  const body = new URLSearchParams({ grant_type: "client_credentials" });
+  if (input.scopes && input.scopes.length > 0) {
+    body.set("scope", input.scopes.join(input.scopeSeparator ?? " "));
+  }
+  applyClientAuthBody(body, input.clientId, input.clientSecret, clientAuth);
+  return postToTokenEndpoint({
+    tokenUrl: input.tokenUrl,
+    body,
+    extraHeaders: buildClientAuthHeaders(input.clientId, input.clientSecret, clientAuth),
+    timeoutMs: input.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS,
+  });
+};
+
+// ---------------------------------------------------------------------------
 // Refresh access token
 // ---------------------------------------------------------------------------
 

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -59,31 +59,54 @@ const AddSpecResponse = Schema.Struct({
 // OAuth payloads / responses
 // ---------------------------------------------------------------------------
 
-const StartOAuthPayload = Schema.Struct({
+// Shared identity fields for both OAuth2 flows. `tokenScope` names which
+// executor scope will own the minted tokens (typically the per-user scope).
+// The token secret ids are pre-decided so the source's stored `OAuth2Auth`
+// can reference the same ids across every user — per-user values shadow
+// org-level fallbacks via secret fall-through on read.
+const StartOAuthIdentityFields = {
   displayName: Schema.String,
   securitySchemeName: Schema.String,
-  flow: Schema.Literal("authorizationCode"),
-  authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
-  redirectUrl: Schema.String,
   clientIdSecretId: Schema.String,
-  clientSecretSecretId: Schema.optional(Schema.NullOr(Schema.String)),
   scopes: Schema.Array(Schema.String),
-  // Caller-owned token identity. `tokenScope` names which executor scope
-  // will own the minted tokens (typically the per-user scope). The two
-  // token secret ids are pre-decided so the source's stored `OAuth2Auth`
-  // can reference the same ids across every user — per-user values
-  // shadow org-level fallbacks via secret fall-through on read.
   tokenScope: Schema.optional(ScopeId),
   accessTokenSecretId: Schema.String,
-  refreshTokenSecretId: Schema.optional(Schema.NullOr(Schema.String)),
-});
+} as const;
 
-const StartOAuthResponse = Schema.Struct({
-  sessionId: Schema.String,
-  authorizationUrl: Schema.String,
-  scopes: Schema.Array(Schema.String),
-});
+const StartOAuthPayload = Schema.Union(
+  Schema.Struct({
+    ...StartOAuthIdentityFields,
+    flow: Schema.Literal("authorizationCode"),
+    authorizationUrl: Schema.String,
+    redirectUrl: Schema.String,
+    clientSecretSecretId: Schema.optional(Schema.NullOr(Schema.String)),
+    refreshTokenSecretId: Schema.optional(Schema.NullOr(Schema.String)),
+  }),
+  // RFC 6749 §4.4 — no user-interactive step, no session, no popup. The
+  // plugin exchanges tokens inline and returns a completed auth. The
+  // client_secret is required (the grant is client authentication + token
+  // request) and no refresh token is issued (§4.4.3).
+  Schema.Struct({
+    ...StartOAuthIdentityFields,
+    flow: Schema.Literal("clientCredentials"),
+    clientSecretSecretId: Schema.String,
+  }),
+);
+
+const StartOAuthResponse = Schema.Union(
+  Schema.Struct({
+    flow: Schema.Literal("authorizationCode"),
+    sessionId: Schema.String,
+    authorizationUrl: Schema.String,
+    scopes: Schema.Array(Schema.String),
+  }),
+  Schema.Struct({
+    flow: Schema.Literal("clientCredentials"),
+    auth: OAuth2Auth,
+    scopes: Schema.Array(Schema.String),
+  }),
+);
 
 const CompleteOAuthPayload = Schema.Struct({
   state: Schema.String,

--- a/packages/plugins/openapi/src/api/handlers.ts
+++ b/packages/plugins/openapi/src/api/handlers.ts
@@ -98,20 +98,34 @@ export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "ope
     .handle("startOAuth", ({ payload }) =>
       capture(Effect.gen(function* () {
         const ext = yield* OpenApiExtensionService;
+        // No tokenScope → plugin defaults to ctx.scopes[0].id (innermost).
+        // Single-scope executors: only scope in stack.
+        // Stacked executors: per-user scope, so tokens shadow by id.
+        const tokenScope = payload.tokenScope as string | undefined;
+        if (payload.flow === "clientCredentials") {
+          return yield* ext.startOAuth({
+            flow: "clientCredentials",
+            displayName: payload.displayName,
+            securitySchemeName: payload.securitySchemeName,
+            tokenUrl: payload.tokenUrl,
+            clientIdSecretId: payload.clientIdSecretId,
+            clientSecretSecretId: payload.clientSecretSecretId,
+            scopes: [...payload.scopes],
+            tokenScope,
+            accessTokenSecretId: payload.accessTokenSecretId,
+          });
+        }
         return yield* ext.startOAuth({
+          flow: "authorizationCode",
           displayName: payload.displayName,
           securitySchemeName: payload.securitySchemeName,
-          flow: payload.flow,
           authorizationUrl: payload.authorizationUrl,
           tokenUrl: payload.tokenUrl,
           redirectUrl: payload.redirectUrl,
           clientIdSecretId: payload.clientIdSecretId,
           clientSecretSecretId: payload.clientSecretSecretId ?? null,
           scopes: [...payload.scopes],
-          // No tokenScope → plugin defaults to ctx.scopes[0].id (innermost).
-          // Single-scope executors: only scope in stack.
-          // Stacked executors: per-user scope, so tokens shadow by id.
-          tokenScope: payload.tokenScope as string | undefined,
+          tokenScope,
           accessTokenSecretId: payload.accessTokenSecretId,
           refreshTokenSecretId: payload.refreshTokenSecretId ?? null,
         });

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -389,6 +389,38 @@ export default function AddOpenApiSource(props: {
         selectedOAuth2Preset.securitySchemeName,
       );
 
+      if (selectedOAuth2Preset.flow === "clientCredentials") {
+        // RFC 6749 §4.4: no user-interactive consent step. The client_secret
+        // is mandatory; the backend exchanges tokens inline and returns a
+        // completed OAuth2Auth we can attach to the source directly.
+        if (!oauth2ClientSecretSecretId) {
+          setStartingOAuth(false);
+          setOauth2Error("client_credentials requires a client secret");
+          return;
+        }
+        const response = await doStartOAuth({
+          path: { scopeId },
+          payload: {
+            displayName,
+            securitySchemeName: selectedOAuth2Preset.securitySchemeName,
+            flow: "clientCredentials",
+            tokenUrl: selectedOAuth2Preset.tokenUrl,
+            clientIdSecretId: oauth2ClientIdSecretId,
+            clientSecretSecretId: oauth2ClientSecretSecretId,
+            scopes: [...oauth2SelectedScopes],
+            accessTokenSecretId: tokenIds.accessTokenSecretId,
+          },
+        });
+        setStartingOAuth(false);
+        if (response.flow !== "clientCredentials") {
+          setOauth2Error("Unexpected response flow from server");
+          return;
+        }
+        setOauth2Auth(response.auth);
+        setOauth2Error(null);
+        return;
+      }
+
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
@@ -405,6 +437,12 @@ export default function AddOpenApiSource(props: {
           refreshTokenSecretId: tokenIds.refreshTokenSecretId,
         },
       });
+
+      if (response.flow !== "authorizationCode") {
+        setStartingOAuth(false);
+        setOauth2Error("Unexpected response flow from server");
+        return;
+      }
 
       oauthCleanup.current = openOAuthPopup<OAuth2Auth>({
         url: response.authorizationUrl,

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -104,6 +104,36 @@ function ConnectionRow(props: {
     setBusy(true);
     setError(null);
     try {
+      if (auth.flow === "clientCredentials") {
+        // No popup, no session — the backend exchanges tokens inline.
+        if (!auth.clientSecretSecretId) {
+          setBusy(false);
+          setError("client_credentials requires a client secret");
+          return;
+        }
+        const response = await doStartOAuth({
+          path: { scopeId },
+          payload: {
+            displayName: props.sourceName || auth.securitySchemeName,
+            securitySchemeName: auth.securitySchemeName,
+            flow: "clientCredentials",
+            tokenUrl: auth.tokenUrl,
+            clientIdSecretId: auth.clientIdSecretId,
+            clientSecretSecretId: auth.clientSecretSecretId,
+            scopes: [...auth.scopes],
+            accessTokenSecretId: auth.accessTokenSecretId,
+          },
+        });
+        setBusy(false);
+        if (response.flow !== "clientCredentials") {
+          setError("Unexpected response flow from server");
+          return;
+        }
+        setError(null);
+        refreshStatus();
+        return;
+      }
+
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
@@ -126,6 +156,12 @@ function ConnectionRow(props: {
           refreshTokenSecretId: auth.refreshTokenSecretId,
         },
       });
+
+      if (response.flow !== "authorizationCode") {
+        setBusy(false);
+        setError("Unexpected response flow from server");
+        return;
+      }
 
       cleanupRef.current = openOAuthPopup<OAuth2Auth>({
         url: response.authorizationUrl,
@@ -162,6 +198,7 @@ function ConnectionRow(props: {
     }
   }, [
     preset,
+    auth.flow,
     auth.securitySchemeName,
     auth.tokenUrl,
     auth.clientIdSecretId,

--- a/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
@@ -1,0 +1,320 @@
+// ---------------------------------------------------------------------------
+// End-to-end test for the OAuth2 `client_credentials` grant on the OpenAPI
+// plugin — the DealCloud-style scenario where a spec declares ONLY a
+// `clientCredentials` flow (no authorizationCode, no user-interactive
+// popup, no PKCE).
+//
+// Regression: production 500s at `/api/scopes/:scope/openapi/oauth/start`
+// for a DealCloud spec. The UI sent `flow: "authorizationCode"` with an
+// empty `authorizationUrl` because the spec had no such flow — `new
+// URL("")` inside `buildAuthorizationUrl` threw `TypeError: Invalid URL`,
+// escaped as an Effect defect, returned 500.
+//
+// The fix: support `flow: "clientCredentials"` end-to-end. `startOAuth`
+// does the token exchange inline (there is no user consent step), writes
+// the access token to the caller-named secret at the caller-pinned
+// scope, and returns a completed `OAuth2Auth`. No session row, no
+// `completeOAuth` round-trip, no popup.
+// ---------------------------------------------------------------------------
+
+import { afterEach } from "vitest";
+import { expect, layer } from "@effect/vitest";
+import { Effect, Layer, Schema } from "effect";
+import {
+  HttpApi,
+  HttpApiBuilder,
+  HttpApiEndpoint,
+  HttpApiGroup,
+  HttpClient,
+  HttpServerRequest,
+  OpenApi,
+} from "@effect/platform";
+import { NodeHttpServer } from "@effect/platform-node";
+
+import {
+  collectSchemas,
+  createExecutor,
+  definePlugin,
+  makeInMemoryBlobStore,
+  Scope,
+  ScopeId,
+  SecretId,
+  SetSecretInput,
+  type InvokeOptions,
+  type SecretProvider,
+} from "@executor/sdk";
+import { makeMemoryAdapter } from "@executor/storage-core/testing/memory";
+
+import { OAuth2Auth } from "./types";
+import { openApiPlugin } from "./plugin";
+
+const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
+
+// ---------------------------------------------------------------------------
+// Test API — single endpoint that echoes the Authorization header.
+// ---------------------------------------------------------------------------
+
+class EchoHeaders extends Schema.Class<EchoHeaders>("EchoHeaders")({
+  authorization: Schema.optional(Schema.String),
+}) {}
+
+const ItemsGroup = HttpApiGroup.make("items").add(
+  HttpApiEndpoint.get("echoHeaders", "/echo-headers").addSuccess(EchoHeaders),
+);
+
+const TestApi = HttpApi.make("testApi").add(ItemsGroup);
+const specJson = JSON.stringify(OpenApi.fromApi(TestApi));
+
+const ItemsGroupLive = HttpApiBuilder.group(TestApi, "items", (handlers) =>
+  handlers.handle("echoHeaders", () =>
+    Effect.gen(function* () {
+      const req = yield* HttpServerRequest.HttpServerRequest;
+      return new EchoHeaders({
+        authorization: req.headers["authorization"],
+      });
+    }),
+  ),
+);
+
+const ApiLive = HttpApiBuilder.api(TestApi).pipe(Layer.provide(ItemsGroupLive));
+
+const TestLayer = HttpApiBuilder.serve().pipe(
+  Layer.provide(ApiLive),
+  Layer.provideMerge(NodeHttpServer.layerTest),
+);
+
+// ---------------------------------------------------------------------------
+// Fetch override — records the POST body the plugin sends to the token
+// endpoint so the test can assert it's a spec-compliant client_credentials
+// request, and returns a distinct access_token each call so the test can
+// tell a re-exchange apart from a cached value.
+// ---------------------------------------------------------------------------
+
+const originalFetch = globalThis.fetch;
+
+type TokenCall = {
+  readonly grantType: string | null;
+  readonly clientId: string | null;
+  readonly clientSecret: string | null;
+  readonly scope: string | null;
+};
+
+const mockClientCredentialsFetch = (args: {
+  readonly calls: TokenCall[];
+  readonly accessTokens: readonly string[];
+  readonly expiresIn?: number;
+}) => {
+  let callIndex = 0;
+  globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    const bodyText =
+      init?.body instanceof URLSearchParams
+        ? init.body.toString()
+        : typeof init?.body === "string"
+          ? init.body
+          : "";
+    const params = new URLSearchParams(bodyText);
+    args.calls.push({
+      grantType: params.get("grant_type"),
+      clientId: params.get("client_id"),
+      clientSecret: params.get("client_secret"),
+      scope: params.get("scope"),
+    });
+    const token =
+      args.accessTokens[Math.min(callIndex, args.accessTokens.length - 1)] ??
+      "unknown";
+    callIndex += 1;
+    const body: Record<string, unknown> = {
+      access_token: token,
+      token_type: "Bearer",
+    };
+    if (typeof args.expiresIn === "number") body.expires_in = args.expiresIn;
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
+  it.effect(
+    "startOAuth exchanges tokens inline and makes them usable at invoke time",
+    () =>
+      Effect.gen(function* () {
+        // Flat in-memory secret provider — no list() so the scope-walk
+        // is the only resolver. Matches multi-scope-oauth.test.ts.
+        const secretStore = new Map<string, string>();
+        const key = (scope: string, id: string) => `${scope}\u0000${id}`;
+        const memoryProvider: SecretProvider = {
+          key: "memory",
+          writable: true,
+          get: (id, scope) =>
+            Effect.sync(() => secretStore.get(key(scope, id)) ?? null),
+          set: (id, value, scope) =>
+            Effect.sync(() => {
+              secretStore.set(key(scope, id), value);
+            }),
+          delete: (id, scope) =>
+            Effect.sync(() => secretStore.delete(key(scope, id))),
+        };
+        const memorySecretsPlugin = definePlugin(() => ({
+          id: "memory-secrets" as const,
+          storage: () => ({}),
+          secretProviders: [memoryProvider],
+        }));
+
+        const httpClient = yield* HttpClient.HttpClient;
+        const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+        const plugins = [
+          openApiPlugin({ httpClientLayer: clientLayer }),
+          memorySecretsPlugin(),
+        ] as const;
+
+        const schema = collectSchemas(plugins);
+        const adapter = makeMemoryAdapter({ schema });
+        const blobs = makeInMemoryBlobStore();
+
+        const now = new Date();
+        const orgScope = new Scope({
+          id: ScopeId.make("org"),
+          name: "acme-org",
+          createdAt: now,
+        });
+        const userScope = new Scope({
+          id: ScopeId.make("user-alice"),
+          name: "alice",
+          createdAt: now,
+        });
+
+        const adminExec = yield* createExecutor({
+          scopes: [orgScope],
+          adapter,
+          blobs,
+          plugins,
+        });
+        const userExec = yield* createExecutor({
+          scopes: [userScope, orgScope],
+          adapter,
+          blobs,
+          plugins,
+        });
+
+        // Admin seeds the shared client_id + client_secret at the org.
+        yield* adminExec.secrets.set(
+          new SetSecretInput({
+            id: SecretId.make("dealcloud_client_id"),
+            scope: orgScope.id,
+            name: "DealCloud Client ID",
+            value: "client-abc",
+          }),
+        );
+        yield* adminExec.secrets.set(
+          new SetSecretInput({
+            id: SecretId.make("dealcloud_client_secret"),
+            scope: orgScope.id,
+            name: "DealCloud Client Secret",
+            value: "secret-xyz",
+          }),
+        );
+
+        // Pre-seed the source row with an OAuth2Auth the completed flow
+        // will fill in. Using `flow: "clientCredentials"` and a null
+        // refreshTokenSecretId — DealCloud doesn't issue refresh tokens.
+        yield* userExec.openapi.addSpec({
+          spec: specJson,
+          scope: userScope.id as string,
+          namespace: "dealcloud",
+          baseUrl: "",
+          oauth2: new OAuth2Auth({
+            kind: "oauth2",
+            securitySchemeName: "oauth2",
+            flow: "clientCredentials",
+            tokenUrl: "https://token.example.com/token",
+            clientIdSecretId: "dealcloud_client_id",
+            clientSecretSecretId: "dealcloud_client_secret",
+            accessTokenSecretId: "dealcloud_access_token_alice",
+            refreshTokenSecretId: null,
+            tokenType: "Bearer",
+            expiresAt: null,
+            scope: null,
+            scopes: ["data"],
+          }),
+        });
+
+        const calls: TokenCall[] = [];
+        mockClientCredentialsFetch({
+          calls,
+          accessTokens: ["alice-token-1"],
+        });
+
+        // -------------------------------------------------------------
+        // startOAuth for clientCredentials: no authorizationUrl, no
+        // popup, no completeOAuth. The plugin exchanges tokens inline
+        // and returns the completed auth.
+        // -------------------------------------------------------------
+        const started = yield* userExec.openapi.startOAuth({
+          displayName: "DealCloud",
+          securitySchemeName: "oauth2",
+          flow: "clientCredentials",
+          tokenUrl: "https://token.example.com/token",
+          clientIdSecretId: "dealcloud_client_id",
+          clientSecretSecretId: "dealcloud_client_secret",
+          scopes: ["data"],
+          tokenScope: userScope.id as unknown as string,
+          accessTokenSecretId: "dealcloud_access_token_alice",
+        });
+
+        // The response is a completed OAuth2Auth — no authorizationUrl,
+        // no sessionId, no subsequent completeOAuth step.
+        if (started.flow !== "clientCredentials") {
+          throw new Error("expected clientCredentials flow");
+        }
+        expect(started.auth.accessTokenSecretId).toBe(
+          "dealcloud_access_token_alice",
+        );
+        expect(started.auth.refreshTokenSecretId).toBeNull();
+
+        // The token endpoint call is RFC 6749 §4.4 compliant.
+        expect(calls).toHaveLength(1);
+        expect(calls[0]!.grantType).toBe("client_credentials");
+        expect(calls[0]!.clientId).toBe("client-abc");
+        expect(calls[0]!.clientSecret).toBe("secret-xyz");
+        expect(calls[0]!.scope).toBe("data");
+
+        // Invoking the tool through the user executor injects the
+        // freshly-minted bearer.
+        const result = (yield* userExec.tools.invoke(
+          "dealcloud.items.echoHeaders",
+          {},
+          autoApprove,
+        )) as {
+          data: { authorization?: string } | null;
+          error: unknown;
+        };
+        expect(result.error).toBeNull();
+        expect(result.data?.authorization).toBe("Bearer alice-token-1");
+
+        // The access token is pinned to alice's scope, not the org.
+        const userRows = yield* userExec.secrets.list();
+        const accessRow = userRows.find(
+          (r) => (r.id as unknown as string) === "dealcloud_access_token_alice",
+        );
+        expect(accessRow?.scopeId as unknown as string).toBe("user-alice");
+
+        // Admin scope does not see alice's access token.
+        const adminIds = new Set(
+          (yield* adminExec.secrets.list()).map(
+            (s) => s.id as unknown as string,
+          ),
+        );
+        expect(adminIds).not.toContain("dealcloud_access_token_alice");
+      }),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
@@ -312,6 +312,12 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         const bobStart = yield* bobExec.openapi.startOAuth(
           startInputFor("bob", bobScope.id),
         );
+        if (aliceStart.flow !== "authorizationCode") {
+          throw new Error("expected authorizationCode flow for alice");
+        }
+        if (bobStart.flow !== "authorizationCode") {
+          throw new Error("expected authorizationCode flow for bob");
+        }
 
         yield* aliceExec.openapi.completeOAuth({
           state: aliceStart.sessionId,

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -8,6 +8,8 @@ import {
   buildAuthorizationUrl,
   createPkceCodeVerifier,
   exchangeAuthorizationCode,
+  exchangeClientCredentials,
+  shouldRefreshToken,
   withRefreshedAccessToken,
   type OAuth2TokenResponse,
 } from "@executor/plugin-oauth2";
@@ -94,40 +96,68 @@ export interface OpenApiUpdateSourceInput {
 // OAuth2 onboarding inputs / outputs
 // ---------------------------------------------------------------------------
 
-export interface OpenApiStartOAuthInput {
+/**
+ * Shared caller-owned token-identity knobs. `tokenScope` names which
+ * executor scope will own the minted tokens (typically the per-user
+ * scope, defaulting to `ctx.scopes[0].id`). The token secret ids are
+ * pre-decided so the source's stored `OAuth2Auth` can reference the
+ * same ids across every user — per-user values shadow org-level
+ * fallbacks via secret fall-through on read.
+ */
+interface StartOAuthIdentity {
   readonly displayName: string;
   readonly securitySchemeName: string;
+  readonly clientIdSecretId: string;
+  readonly scopes: readonly string[];
+  readonly tokenScope?: string;
+  readonly accessTokenSecretId: string;
+}
+
+export interface StartAuthorizationCodeOAuthInput extends StartOAuthIdentity {
   readonly flow: "authorizationCode";
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
   readonly redirectUrl: string;
-  readonly clientIdSecretId: string;
   readonly clientSecretSecretId?: string | null;
-  readonly scopes: readonly string[];
-  /**
-   * Executor scope id where the minted access/refresh tokens will land
-   * on completeOAuth. Defaults to `ctx.scopes[0].id` (the innermost
-   * scope) — which for a single-scope executor is the only scope, and
-   * for a stacked executor pins tokens to the per-user scope so
-   * org-level shadowing works by id.
-   */
-  readonly tokenScope?: string;
-  /**
-   * Pre-decided secret ids for the minted access + refresh tokens. Use
-   * deterministic ids (e.g. `${namespace}_access_token`) so the source's
-   * stored `OAuth2Auth` can reference them and `ctx.secrets.get` resolves
-   * via scope fall-through — per-user tokens shadow org-level fallbacks
-   * on the same source.
-   */
-  readonly accessTokenSecretId: string;
   readonly refreshTokenSecretId?: string | null;
 }
 
-export interface OpenApiStartOAuthResponse {
+/**
+ * RFC 6749 §4.4 has no user-interactive step. `startOAuth` exchanges
+ * tokens inline and writes the access token at
+ * `accessTokenSecretId` + `tokenScope`, returning a completed
+ * `OAuth2Auth`. No `authorizationUrl`, no session row, no
+ * `completeOAuth`. Re-exchange happens at invoke time when the token
+ * is near expiry.
+ */
+export interface StartClientCredentialsOAuthInput extends StartOAuthIdentity {
+  readonly flow: "clientCredentials";
+  readonly tokenUrl: string;
+  /** RFC 6749 §2.3.1 — client_credentials is unusable without the secret. */
+  readonly clientSecretSecretId: string;
+}
+
+export type OpenApiStartOAuthInput =
+  | StartAuthorizationCodeOAuthInput
+  | StartClientCredentialsOAuthInput;
+
+export interface StartAuthorizationCodeOAuthResponse {
+  readonly flow: "authorizationCode";
   readonly sessionId: string;
   readonly authorizationUrl: string;
   readonly scopes: readonly string[];
 }
+
+export interface StartClientCredentialsOAuthResponse {
+  readonly flow: "clientCredentials";
+  /** Completed auth ready to attach to the source's `OAuth2Auth`. */
+  readonly auth: OAuth2Auth;
+  readonly scopes: readonly string[];
+}
+
+export type OpenApiStartOAuthResponse =
+  | StartAuthorizationCodeOAuthResponse
+  | StartClientCredentialsOAuthResponse;
 
 export interface OpenApiCompleteOAuthInput {
   readonly state: string;
@@ -248,6 +278,91 @@ const descriptionFor = (def: ToolDefinition): string => {
     Option.getOrElse(op.summary, () => `${op.method.toUpperCase()} ${op.pathTemplate}`),
   );
 };
+
+// ---------------------------------------------------------------------------
+// clientCredentials access-token resolver.
+//
+// RFC 6749 §4.4.3 forbids refresh tokens for this grant, so the only way to
+// recover from an expired access token is a fresh client_credentials
+// exchange. We re-exchange proactively (when `shouldRefreshToken` fires
+// within skew) and persist the new token at the same id+scope the source's
+// OAuth2Auth already references, keeping per-user shadowing intact.
+// ---------------------------------------------------------------------------
+
+type ResolveClientCredentialsArgs = {
+  readonly auth: OAuth2Auth;
+  readonly source: StoredSource;
+  readonly scopeId: string;
+  readonly secretsGet: (id: string) => Effect.Effect<string | null, Error>;
+  readonly secretsSet: (args: {
+    readonly id: string;
+    readonly scope: string;
+    readonly name: string;
+    readonly value: string;
+  }) => Effect.Effect<void, Error>;
+  readonly updateSourceMeta: (oauth2: OAuth2Auth) => Effect.Effect<void, Error>;
+};
+
+const resolveClientCredentialsAccessToken = (args: ResolveClientCredentialsArgs) =>
+  Effect.gen(function* () {
+    const { auth } = args;
+    const needsRefresh = shouldRefreshToken({ expiresAt: auth.expiresAt });
+
+    if (!needsRefresh) {
+      const current = yield* args.secretsGet(auth.accessTokenSecretId);
+      if (current !== null) return current;
+      // Secret was deleted out from under us — fall through to re-exchange.
+    }
+
+    if (auth.clientSecretSecretId === null) {
+      return yield* Effect.fail(
+        new Error("client_credentials flow requires clientSecretSecretId"),
+      );
+    }
+
+    const clientId = yield* args.secretsGet(auth.clientIdSecretId);
+    if (clientId === null) {
+      return yield* Effect.fail(
+        new Error(`Missing client ID secret: ${auth.clientIdSecretId}`),
+      );
+    }
+    const clientSecret = yield* args.secretsGet(auth.clientSecretSecretId);
+    if (clientSecret === null) {
+      return yield* Effect.fail(
+        new Error(`Missing client secret: ${auth.clientSecretSecretId}`),
+      );
+    }
+
+    const tokenResponse = yield* exchangeClientCredentials({
+      tokenUrl: auth.tokenUrl,
+      clientId,
+      clientSecret,
+      scopes: auth.scopes,
+    }).pipe(Effect.mapError((err) => new Error(err.message)));
+
+    yield* args.secretsSet({
+      id: auth.accessTokenSecretId,
+      scope: args.scopeId,
+      name: `${args.source.name} Access Token`,
+      value: tokenResponse.access_token,
+    });
+
+    const expiresAt =
+      typeof tokenResponse.expires_in === "number"
+        ? Date.now() + tokenResponse.expires_in * 1000
+        : null;
+
+    yield* args.updateSourceMeta(
+      new OAuth2Auth({
+        ...auth,
+        tokenType: tokenResponse.token_type ?? auth.tokenType,
+        expiresAt,
+        scope: tokenResponse.scope ?? auth.scope,
+      }),
+    );
+
+    return tokenResponse.access_token;
+  });
 
 // ---------------------------------------------------------------------------
 // Plugin factory
@@ -508,10 +623,88 @@ export const openApiPlugin = definePlugin(
 
           startOAuth: (input) =>
             Effect.gen(function* () {
-              const sessionId = randomUUID();
-              const codeVerifier = createPkceCodeVerifier();
               const scopesArray = [...input.scopes];
               const tokenScope = input.tokenScope ?? (ctx.scopes[0]!.id as string);
+
+              const clientId = yield* ctx.secrets.get(input.clientIdSecretId).pipe(
+                Effect.mapError((err) => new OpenApiOAuthError({ message: err.message })),
+              );
+              if (clientId === null) {
+                return yield* new OpenApiOAuthError({
+                  message: `Missing client ID secret: ${input.clientIdSecretId}`,
+                });
+              }
+
+              if (input.flow === "clientCredentials") {
+                // RFC 6749 §4.4: no user consent, no session, no PKCE. The
+                // client_secret is mandatory — the spec defines the grant
+                // as client authentication + a token request.
+                const clientSecret = yield* ctx.secrets
+                  .get(input.clientSecretSecretId)
+                  .pipe(
+                    Effect.mapError(
+                      (err) => new OpenApiOAuthError({ message: err.message }),
+                    ),
+                  );
+                if (clientSecret === null) {
+                  return yield* new OpenApiOAuthError({
+                    message: `Missing client secret: ${input.clientSecretSecretId}`,
+                  });
+                }
+
+                const tokenResponse = yield* exchangeClientCredentials({
+                  tokenUrl: input.tokenUrl,
+                  clientId,
+                  clientSecret,
+                  scopes: scopesArray,
+                }).pipe(
+                  Effect.mapError(
+                    (err) => new OpenApiOAuthError({ message: err.message }),
+                  ),
+                );
+
+                const accessRef = yield* writeOAuthSecret({
+                  id: input.accessTokenSecretId,
+                  scope: tokenScope,
+                  name: `${input.displayName} Access Token`,
+                  value: tokenResponse.access_token,
+                }).pipe(
+                  Effect.mapError(
+                    (err) => new OpenApiOAuthError({ message: err.message }),
+                  ),
+                );
+
+                const expiresAt =
+                  typeof tokenResponse.expires_in === "number"
+                    ? Date.now() + tokenResponse.expires_in * 1000
+                    : null;
+
+                const auth = new OAuth2Auth({
+                  kind: "oauth2",
+                  securitySchemeName: input.securitySchemeName,
+                  flow: "clientCredentials",
+                  tokenUrl: input.tokenUrl,
+                  clientIdSecretId: input.clientIdSecretId,
+                  clientSecretSecretId: input.clientSecretSecretId,
+                  accessTokenSecretId: accessRef.id,
+                  // RFC 6749 §4.4.3: refresh tokens SHOULD NOT be issued.
+                  refreshTokenSecretId: null,
+                  tokenType: tokenResponse.token_type ?? "Bearer",
+                  expiresAt,
+                  scope: tokenResponse.scope ?? null,
+                  scopes: scopesArray,
+                });
+
+                return {
+                  flow: "clientCredentials" as const,
+                  auth,
+                  scopes: scopesArray,
+                };
+              }
+
+              // authorizationCode path.
+              const sessionId = randomUUID();
+              const codeVerifier = createPkceCodeVerifier();
 
               yield* ctx.storage
                 .putOAuthSession(
@@ -535,15 +728,6 @@ export const openApiPlugin = definePlugin(
                   Effect.mapError((err) => new OpenApiOAuthError({ message: err.message })),
                 );
 
-              const clientId = yield* ctx.secrets.get(input.clientIdSecretId).pipe(
-                Effect.mapError((err) => new OpenApiOAuthError({ message: err.message })),
-              );
-              if (clientId === null) {
-                return yield* new OpenApiOAuthError({
-                  message: `Missing client ID secret: ${input.clientIdSecretId}`,
-                });
-              }
-
               const authorizationUrl = buildAuthorizationUrl({
                 authorizationUrl: input.authorizationUrl,
                 clientId,
@@ -554,6 +738,7 @@ export const openApiPlugin = definePlugin(
               });
 
               return {
+                flow: "authorizationCode" as const,
                 sessionId,
                 authorizationUrl,
                 scopes: scopesArray,
@@ -765,7 +950,38 @@ export const openApiPlugin = definePlugin(
           // inject Authorization header (wins over a manually-set one).
           if (Option.isSome(config.oauth2)) {
             const auth = config.oauth2.value;
-            const accessToken = yield* withRefreshedAccessToken({
+            const accessToken =
+              auth.flow === "clientCredentials"
+                ? yield* resolveClientCredentialsAccessToken({
+                    auth,
+                    source,
+                    scopeId: ctx.scopes[0]!.id as string,
+                    secretsGet: (id) =>
+                      ctx.secrets
+                        .get(id)
+                        .pipe(Effect.mapError((err) => new Error(err.message))),
+                    secretsSet: (args) =>
+                      ctx.secrets
+                        .set(
+                          new SetSecretInput({
+                            id: SecretId.make(args.id),
+                            scope: ScopeId.make(args.scope),
+                            name: args.name,
+                            value: args.value,
+                          }),
+                        )
+                        .pipe(
+                          Effect.asVoid,
+                          Effect.mapError((err) => new Error(err.message)),
+                        ),
+                    updateSourceMeta: (oauth2) =>
+                      ctx.storage
+                        .updateSourceMeta(source.namespace, source.scope, {
+                          oauth2,
+                        })
+                        .pipe(Effect.mapError((err) => new Error(err.message))),
+                  })
+                : yield* withRefreshedAccessToken({
               auth: {
                 clientIdSecretId: auth.clientIdSecretId,
                 clientSecretSecretId: auth.clientSecretSecretId,

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -122,9 +122,13 @@ export class OAuth2Auth extends Schema.Class<OAuth2Auth>("OpenApiOAuth2Auth")({
   kind: Schema.Literal("oauth2"),
   /** Key into `components.securitySchemes` this auth came from. */
   securitySchemeName: Schema.String,
-  /** Which flow produced this auth. Only authorizationCode is supported end-to-end today. */
-  flow: Schema.Literal("authorizationCode"),
-  /** Token endpoint (from the flow) — used for refresh. */
+  /**
+   * Which flow produced this auth. `clientCredentials` sources have no
+   * refresh token — the invoker re-exchanges via client_credentials when
+   * the access token is near expiry.
+   */
+  flow: Schema.Literal("authorizationCode", "clientCredentials"),
+  /** Token endpoint (from the flow) — used for refresh / re-exchange. */
   tokenUrl: Schema.String,
   clientIdSecretId: Schema.String,
   clientSecretSecretId: Schema.NullOr(Schema.String),


### PR DESCRIPTION
## Summary
- DealCloud-style specs that only declare a `clientCredentials` OAuth2 flow were 500'ing at `/api/scopes/:scope/openapi/oauth/start` — the UI sent `flow: "authorizationCode"` with an empty `authorizationUrl`, and `new URL("")` inside `buildAuthorizationUrl` threw as a defect.
- `startOAuth` now branches on flow: `clientCredentials` exchanges tokens inline (RFC 6749 §4.4) and returns a completed `OAuth2Auth` — no session, no popup, no `completeOAuth`. `invokeTool` re-exchanges via `resolveClientCredentialsAccessToken` when the token nears expiry (no refresh token per §4.4.3).
- Start payload/response are now discriminated unions on `flow`. Add/Edit UIs branch on the preset/auth flow and skip the popup for `clientCredentials`.

## Test plan
- [x] New `client-credentials-oauth.test.ts` replicates the DealCloud scenario: spec with only `clientCredentials`, inline token exchange, per-user scope pinning, RFC 6749 §4.4 request body.
- [x] `vitest run` in `packages/plugins/openapi` — 36 tests pass.
- [x] `vitest run` in `packages/plugins/oauth2` — 69 tests pass.
- [x] `tsc --noEmit` clean in both plugin packages and `apps/cloud`.
- [ ] Manual: add a DealCloud source in the UI, verify the access token is minted and a subsequent tool call carries `Authorization: Bearer <token>`.