### PR TITLE
openapi: resolve relative OAuth2 URLs against source baseUrl

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -89,6 +89,28 @@ const substituteUrlVariables = (url: string, values: Record<string, string>): st
   return out;
 };
 
+/**
+ * OpenAPI 3.x requires OAuth2 tokenUrl/authorizationUrl to be absolute,
+ * but some specs ship relative paths like `/api/rest/v1/oauth/token`.
+ * Resolve them against the source's chosen baseUrl so the backend can
+ * fetch them directly and the absolute URL is what gets persisted on
+ * OAuth2Auth.
+ */
+export function resolveOAuthUrl(url: string, baseUrl: string): string {
+  if (!url) return url;
+  try {
+    new URL(url);
+    return url;
+  } catch {
+    if (!baseUrl) return url;
+    try {
+      return new URL(url, baseUrl).toString();
+    } catch {
+      return url;
+    }
+  }
+}
+
 type StrategySelection =
   | { readonly kind: "none" }
   | { readonly kind: "custom" }
@@ -389,6 +411,11 @@ export default function AddOpenApiSource(props: {
         selectedOAuth2Preset.securitySchemeName,
       );
 
+      const tokenUrl = resolveOAuthUrl(
+        selectedOAuth2Preset.tokenUrl,
+        resolvedBaseUrl,
+      );
+
       if (selectedOAuth2Preset.flow === "clientCredentials") {
         // RFC 6749 §4.4: no user-interactive consent step. The client_secret
         // is mandatory; the backend exchanges tokens inline and returns a
@@ -404,7 +431,7 @@ export default function AddOpenApiSource(props: {
             displayName,
             securitySchemeName: selectedOAuth2Preset.securitySchemeName,
             flow: "clientCredentials",
-            tokenUrl: selectedOAuth2Preset.tokenUrl,
+            tokenUrl,
             clientIdSecretId: oauth2ClientIdSecretId,
             clientSecretSecretId: oauth2ClientSecretSecretId,
             scopes: [...oauth2SelectedScopes],
@@ -421,14 +448,19 @@ export default function AddOpenApiSource(props: {
         return;
       }
 
+      const authorizationUrl = resolveOAuthUrl(
+        Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
+        resolvedBaseUrl,
+      );
+
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
           displayName,
           securitySchemeName: selectedOAuth2Preset.securitySchemeName,
           flow: "authorizationCode",
-          authorizationUrl: Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
-          tokenUrl: selectedOAuth2Preset.tokenUrl,
+          authorizationUrl,
+          tokenUrl,
           redirectUrl: oauth2RedirectUrl,
           clientIdSecretId: oauth2ClientIdSecretId,
           clientSecretSecretId: oauth2ClientSecretSecretId,
@@ -498,6 +530,7 @@ export default function AddOpenApiSource(props: {
     oauth2ClientSecretSecretId,
     oauth2SelectedScopes,
     oauth2RedirectUrl,
+    resolvedBaseUrl,
     preview,
     doStartOAuth,
     scopeId,

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -50,6 +50,7 @@ import {
   OPENAPI_OAUTH_CALLBACK_PATH,
   OPENAPI_OAUTH_CHANNEL,
   OPENAPI_OAUTH_POPUP_NAME,
+  resolveOAuthUrl,
 } from "./AddOpenApiSource";
 import type { SpecPreview, OAuth2Preset } from "../sdk/preview";
 import { OAuth2Auth } from "../sdk/types";
@@ -68,6 +69,7 @@ import type { StoredSourceSchemaType } from "../sdk/store";
 function ConnectionRow(props: {
   readonly auth: OAuth2Auth;
   readonly sourceName: string;
+  readonly sourceBaseUrl: string;
   readonly preset: OAuth2Preset | null;
   readonly previewError: string | null;
 }) {
@@ -104,6 +106,8 @@ function ConnectionRow(props: {
     setBusy(true);
     setError(null);
     try {
+      const tokenUrl = resolveOAuthUrl(auth.tokenUrl, props.sourceBaseUrl);
+
       if (auth.flow === "clientCredentials") {
         // No popup, no session — the backend exchanges tokens inline.
         if (!auth.clientSecretSecretId) {
@@ -117,7 +121,7 @@ function ConnectionRow(props: {
             displayName: props.sourceName || auth.securitySchemeName,
             securitySchemeName: auth.securitySchemeName,
             flow: "clientCredentials",
-            tokenUrl: auth.tokenUrl,
+            tokenUrl,
             clientIdSecretId: auth.clientIdSecretId,
             clientSecretSecretId: auth.clientSecretSecretId,
             scopes: [...auth.scopes],
@@ -134,14 +138,19 @@ function ConnectionRow(props: {
         return;
       }
 
+      const authorizationUrl = resolveOAuthUrl(
+        Option.getOrElse(preset.authorizationUrl, () => ""),
+        props.sourceBaseUrl,
+      );
+
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
           displayName: props.sourceName || auth.securitySchemeName,
           securitySchemeName: auth.securitySchemeName,
           flow: "authorizationCode",
-          authorizationUrl: Option.getOrElse(preset.authorizationUrl, () => ""),
-          tokenUrl: auth.tokenUrl,
+          authorizationUrl,
+          tokenUrl,
           redirectUrl,
           clientIdSecretId: auth.clientIdSecretId,
           clientSecretSecretId: auth.clientSecretSecretId,
@@ -210,6 +219,7 @@ function ConnectionRow(props: {
     redirectUrl,
     scopeId,
     props.sourceName,
+    props.sourceBaseUrl,
     refreshStatus,
   ]);
 
@@ -319,6 +329,7 @@ function ConnectionRow(props: {
 
 function ConnectionsSection(props: {
   readonly sourceName: string;
+  readonly sourceBaseUrl: string;
   readonly spec: string;
   readonly oauth2Entries: readonly OAuth2Auth[];
 }) {
@@ -373,6 +384,7 @@ function ConnectionsSection(props: {
             key={auth.securitySchemeName}
             auth={auth}
             sourceName={props.sourceName}
+            sourceBaseUrl={props.sourceBaseUrl}
             preset={presetFor(auth.securitySchemeName)}
             previewError={previewError}
           />
@@ -494,6 +506,7 @@ function EditForm(props: {
       {oauth2Entries.length > 0 && (
         <ConnectionsSection
           sourceName={props.initial.name}
+          sourceBaseUrl={baseUrl.trim() || props.initial.config.baseUrl || ""}
           spec={props.initial.config.spec}
           oauth2Entries={oauth2Entries}
         />


### PR DESCRIPTION
## Summary
- OpenAPI 3.x technically requires OAuth2 `tokenUrl` and `authorizationUrl` to be absolute, but some specs ship them as relative paths like `/api/rest/v1/oauth/token`. The UI was forwarding those through `startOAuth` unchanged, which then failed at fetch time (or opened a broken popup URL).
- `AddOpenApiSource` now resolves both URLs against the user-chosen `baseUrl` before calling `startOAuth`, so the absolute URL is what ends up persisted on `OAuth2Auth` and used for later re-exchange / refresh.
- `EditOpenApiSource` reuses the same helper for the per-user re-connect path, threading `sourceBaseUrl` through `ConnectionsSection` → `ConnectionRow`.
- Absolute URLs pass through unchanged, so specs that already comply are unaffected.

## Test plan
- [x] `vitest run` in `packages/plugins/openapi` — 36 tests pass.
- [x] `tsc --noEmit` clean in `packages/plugins/openapi`.
- [ ] Manual: add a source whose spec declares a relative `tokenUrl`, connect OAuth, confirm the token endpoint is hit at the absolute URL and a subsequent tool call injects a valid bearer.