### PR TITLE
[codex] add additional headers workflows to OpenAPI and GraphQL

### DIFF
--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -4,6 +4,12 @@ import { useAtomSet } from "@effect-atom/atom-react";
 import { useScope } from "@executor/react/api/scope-context";
 import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
 import { usePendingSources } from "@executor/react/api/optimistic";
+import {
+  AdditionalHeadersSection,
+  mergeHeaders,
+  validateHeaderConfiguration,
+  type PlainHeader,
+} from "@executor/react/plugins/additional-headers";
 import { HeadersList } from "@executor/react/plugins/headers-list";
 import { type HeaderState } from "@executor/react/plugins/secret-header-auth";
 import {
@@ -43,6 +49,7 @@ export default function AddGraphqlSource(props: {
     fallbackName: displayNameFromUrl(endpoint) ?? "",
   });
   const [headers, setHeaders] = useState<HeaderState[]>([initialHeader()]);
+  const [additionalHeaders, setAdditionalHeaders] = useState<PlainHeader[]>([]);
   const [adding, setAdding] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
 
@@ -52,21 +59,19 @@ export default function AddGraphqlSource(props: {
   const secretList = useSecretPickerSecrets();
 
   const headersValid = headers.every((header) => header.name.trim() && header.secretId);
-  const canAdd = endpoint.trim().length > 0 && (headers.length === 0 || headersValid);
+  const headerError = validateHeaderConfiguration({
+    authHeaders: headers,
+    additionalHeaders,
+  });
+  const canAdd =
+    endpoint.trim().length > 0 &&
+    (headers.length === 0 || headersValid) &&
+    headerError === null;
 
   const handleAdd = async () => {
     setAdding(true);
     setAddError(null);
-    const headerMap: Record<string, HeaderValue> = {};
-    for (const header of headers) {
-      const name = header.name.trim();
-      if (name && header.secretId) {
-        headerMap[name] = {
-          secretId: header.secretId,
-          ...(header.prefix ? { prefix: header.prefix } : {}),
-        };
-      }
-    }
+    const headerMap = mergeHeaders(headers, additionalHeaders) as Record<string, HeaderValue>;
 
     const trimmedEndpoint = endpoint.trim();
     const namespace =
@@ -127,7 +132,7 @@ export default function AddGraphqlSource(props: {
       />
 
       <section className="space-y-2.5">
-        <FieldLabel>Headers</FieldLabel>
+        <FieldLabel>Authentication</FieldLabel>
         <HeadersList
           headers={headers}
           onHeadersChange={setHeaders}
@@ -135,6 +140,12 @@ export default function AddGraphqlSource(props: {
           sourceName={identity.name}
         />
       </section>
+
+      <AdditionalHeadersSection
+        headers={additionalHeaders}
+        onHeadersChange={setAdditionalHeaders}
+        error={headerError}
+      />
 
       {/* Error */}
       {addError && (

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -3,10 +3,15 @@ import { useAtomValue, useAtomSet, Result } from "@effect-atom/atom-react";
 import { graphqlSourceAtom, updateGraphqlSource } from "./atoms";
 import { useScope } from "@executor/react/api/scope-context";
 import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
+import {
+  AdditionalHeadersSection,
+  mergeHeaders,
+  partitionHeaders,
+  validateHeaderConfiguration,
+  type PlainHeader,
+} from "@executor/react/plugins/additional-headers";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import {
-  headerValueToState,
-  headersFromState,
   type HeaderState,
 } from "@executor/react/plugins/secret-header-auth";
 import { HeadersList } from "@executor/react/plugins/headers-list";
@@ -47,19 +52,28 @@ function EditForm(props: {
     fallbackNamespace: props.initial.namespace,
   });
   const [endpoint, setEndpoint] = useState(props.initial.endpoint);
-  const [headers, setHeaders] = useState<HeaderState[]>(() =>
-    Object.entries(props.initial.headers ?? {}).map(([name, value]) =>
-      headerValueToState(name, value),
-    ),
+  const initialHeaders = partitionHeaders(props.initial.headers);
+  const [headers, setHeaders] = useState<HeaderState[]>(() => initialHeaders.authHeaders);
+  const [additionalHeaders, setAdditionalHeaders] = useState<PlainHeader[]>(
+    () => initialHeaders.additionalHeaders,
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
 
   const identityDirty = identity.name.trim() !== props.initial.name.trim();
+  const headerError = validateHeaderConfiguration({
+    authHeaders: headers,
+    additionalHeaders,
+  });
 
   const handleHeadersChange = (next: HeaderState[]) => {
     setHeaders(next);
+    setDirty(true);
+  };
+
+  const handleAdditionalHeadersChange = (next: PlainHeader[]) => {
+    setAdditionalHeaders(next);
     setDirty(true);
   };
 
@@ -72,7 +86,7 @@ function EditForm(props: {
         payload: {
           name: identity.name.trim() || undefined,
           endpoint: endpoint.trim() || undefined,
-          headers: headersFromState(headers),
+          headers: mergeHeaders(headers, additionalHeaders),
         },
         reactivityKeys: sourceWriteKeys,
       });
@@ -90,7 +104,7 @@ function EditForm(props: {
       <div>
         <h1 className="text-xl font-semibold text-foreground">Edit GraphQL Source</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Update the endpoint and authentication headers for this source.
+          Update the endpoint, authentication, and additional headers for this source.
         </p>
       </div>
 
@@ -122,7 +136,7 @@ function EditForm(props: {
       </CardStack>
 
       <section className="space-y-2.5">
-        <FieldLabel>Headers</FieldLabel>
+        <FieldLabel>Authentication</FieldLabel>
         <HeadersList
           headers={headers}
           onHeadersChange={handleHeadersChange}
@@ -130,6 +144,12 @@ function EditForm(props: {
           sourceName={identity.name}
         />
       </section>
+
+      <AdditionalHeadersSection
+        headers={additionalHeaders}
+        onHeadersChange={handleAdditionalHeadersChange}
+        error={headerError}
+      />
 
       {error && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
@@ -141,7 +161,10 @@ function EditForm(props: {
         <Button variant="ghost" onClick={props.onSave}>
           Cancel
         </Button>
-        <Button onClick={handleSave} disabled={(!dirty && !identityDirty) || saving}>
+        <Button
+          onClick={handleSave}
+          disabled={(!dirty && !identityDirty) || saving || headerError !== null}
+        >
           {saving ? "Saving…" : "Save changes"}
         </Button>
       </div>

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -222,12 +222,18 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.updateSource("patched", TEST_SCOPE, {
         endpoint: "http://localhost:5000/graphql",
-        headers: { "x-custom": "abc" },
+        headers: {
+          Authorization: { secretId: "graphql-token", prefix: "Bearer " },
+          "x-custom": "abc",
+        },
       });
 
       const source = yield* executor.graphql.getSource("patched", TEST_SCOPE);
       expect(source?.endpoint).toBe("http://localhost:5000/graphql");
-      expect(source?.headers).toEqual({ "x-custom": "abc" });
+      expect(source?.headers).toEqual({
+        Authorization: { secretId: "graphql-token", prefix: "Bearer " },
+        "x-custom": "abc",
+      });
 
       // Tools still present (no re-register happened, but they were
       // already there from addSource and haven't been removed).

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useReducer, useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 
 import { useScope } from "@executor/react/api/scope-context";
@@ -18,12 +18,15 @@ import { FieldError, FieldLabel } from "@executor/react/components/field";
 import { FilterTabs } from "@executor/react/components/filter-tabs";
 import { FloatActions } from "@executor/react/components/float-actions";
 import { Input } from "@executor/react/components/input";
-import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
 import { Skeleton } from "@executor/react/components/skeleton";
 import { SourceFavicon } from "@executor/react/components/source-favicon";
 import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
 import { Textarea } from "@executor/react/components/textarea";
+import {
+  AdditionalHeadersSection,
+  type PlainHeader,
+} from "@executor/react/plugins/additional-headers";
 import { HeadersList } from "@executor/react/plugins/headers-list";
 import { type HeaderState } from "@executor/react/plugins/secret-header-auth";
 import {
@@ -90,11 +93,6 @@ type ProbeResult = {
   namespace: string;
   toolCount: number | null;
   serverName: string | null;
-};
-
-type PlainHeader = {
-  name: string;
-  value: string;
 };
 
 type State =
@@ -855,104 +853,7 @@ export default function AddMcpSource(props: {
 
           {/* Additional headers */}
           {probe && (
-            <section className="space-y-2.5">
-              <div>
-                <Label>Additional headers</Label>
-                <p className="mt-1 text-[12px] text-muted-foreground">
-                  Plaintext headers sent with every request. Use authentication for secret-backed
-                  auth headers.
-                </p>
-              </div>
-
-              <CardStack>
-                <CardStackContent>
-                  {remoteHeaders.length === 0 ? (
-                    <AddPlainHeaderRow
-                      leading={<span>No headers</span>}
-                      onClick={() =>
-                        setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
-                      }
-                    />
-                  ) : (
-                    <>
-                      {remoteHeaders.map((header, index) => (
-                        <CardStackEntry key={index} className="flex-col items-stretch gap-2">
-                          <div className="flex items-center justify-between">
-                            <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                              Header
-                            </Label>
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="xs"
-                              className="text-muted-foreground hover:text-destructive"
-                              onClick={() =>
-                                setRemoteHeaders((headers) =>
-                                  headers.filter((_, headerIndex) => headerIndex !== index),
-                                )
-                              }
-                            >
-                              Remove
-                            </Button>
-                          </div>
-                          <div className="grid grid-cols-2 gap-2">
-                            <div className="space-y-1">
-                              <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                                Name
-                              </Label>
-                              <Input
-                                value={header.name}
-                                onChange={(event) =>
-                                  setRemoteHeaders((headers) =>
-                                    headers.map((current, headerIndex) =>
-                                      headerIndex === index
-                                        ? {
-                                            ...current,
-                                            name: (event.target as HTMLInputElement).value,
-                                          }
-                                        : current,
-                                    ),
-                                  )
-                                }
-                                placeholder="X-Organization-Id"
-                                className="h-8 text-xs font-mono"
-                              />
-                            </div>
-                            <div className="space-y-1">
-                              <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                                Value
-                              </Label>
-                              <Input
-                                value={header.value}
-                                onChange={(event) =>
-                                  setRemoteHeaders((headers) =>
-                                    headers.map((current, headerIndex) =>
-                                      headerIndex === index
-                                        ? {
-                                            ...current,
-                                            value: (event.target as HTMLInputElement).value,
-                                          }
-                                        : current,
-                                    ),
-                                  )
-                                }
-                                placeholder="workspace-id"
-                                className="h-8 text-xs font-mono"
-                              />
-                            </div>
-                          </div>
-                        </CardStackEntry>
-                      ))}
-                      <AddPlainHeaderRow
-                        onClick={() =>
-                          setRemoteHeaders((headers) => [...headers, { name: "", value: "" }])
-                        }
-                      />
-                    </>
-                  )}
-                </CardStackContent>
-              </CardStack>
-            </section>
+            <AdditionalHeadersSection headers={remoteHeaders} onHeadersChange={setRemoteHeaders} />
           )}
 
           {/* Error (OAuth / add source). Probe errors show inline on the field. */}
@@ -1063,31 +964,5 @@ export default function AddMcpSource(props: {
         </>
       )}
     </div>
-  );
-}
-
-function AddPlainHeaderRow({
-  onClick,
-  leading,
-}: {
-  readonly onClick: () => void;
-  readonly leading?: ReactNode;
-}) {
-  return (
-    // oxlint-disable-next-line react/forbid-elements
-    <button
-      type="button"
-      onClick={(event) => {
-        event.stopPropagation();
-        onClick();
-      }}
-      aria-label="Add header"
-      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
-    >
-      <span className="min-w-0 flex-1 text-left">{leading}</span>
-      <svg aria-hidden viewBox="0 0 16 16" fill="none" className="size-4 shrink-0">
-        <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-      </svg>
-    </button>
   );
 }

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
-import { createExecutor, makeTestConfig, Scope, ScopeId } from "@executor/sdk";
+import {
+  createExecutor,
+  makeTestConfig,
+  Scope,
+  ScopeId,
+  StorageError,
+  type DBAdapter,
+} from "@executor/sdk";
 
 import { mcpPlugin } from "./plugin";
 import {
@@ -9,6 +16,7 @@ import {
   deriveMcpNamespace,
   joinToolPath,
 } from "./manifest";
+import { McpOAuthError } from "./errors";
 
 // ---------------------------------------------------------------------------
 // Manifest extraction
@@ -129,6 +137,22 @@ describe("joinToolPath", () => {
 // ---------------------------------------------------------------------------
 
 describe("mcpPlugin", () => {
+  const makeMcpSessionLookupFailingAdapter = (): DBAdapter => {
+    const inner = makeTestConfig({ plugins: [mcpPlugin()] as const }).adapter;
+    const failure = new StorageError({
+      message: "session store unavailable",
+      cause: new Error("db down"),
+    });
+
+    return {
+      ...inner,
+      findOne: ((input) =>
+        input.model === "mcp_oauth_session"
+          ? Effect.fail(failure)
+          : inner.findOne(input)) as DBAdapter["findOne"],
+    };
+  };
+
   it.effect("creates executor with mcp plugin", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
@@ -144,6 +168,33 @@ describe("mcpPlugin", () => {
       expect(executor.mcp.probeEndpoint).toBeTypeOf("function");
       expect(executor.mcp.startOAuth).toBeTypeOf("function");
       expect(executor.mcp.completeOAuth).toBeTypeOf("function");
+    }),
+  );
+
+  it.effect("maps oauth session lookup storage failures to McpOAuthError", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor({
+        scopes: [
+          new Scope({
+            id: ScopeId.make("test-scope"),
+            name: "test",
+            createdAt: new Date(),
+          }),
+        ],
+        adapter: makeMcpSessionLookupFailingAdapter(),
+        blobs: makeTestConfig().blobs,
+        plugins: [mcpPlugin()] as const,
+      });
+
+      const result = yield* executor.mcp
+        .completeOAuth({
+          state: "mcp_oauth_test",
+          code: "code",
+        })
+        .pipe(Effect.flip);
+
+      expect(result).toBeInstanceOf(McpOAuthError);
+      expect(result.message).toContain("session store unavailable");
     }),
   );
 

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -286,6 +286,9 @@ const remoteConnectionError = (message: string) =>
 
 const mcpOAuthError = (message: string) => new McpOAuthError({ message });
 
+const toMcpErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
 const mcpDiscoveryError = (message: string) =>
   new McpToolDiscoveryError({ stage: "list_tools", message });
 
@@ -892,7 +895,10 @@ export const mcpPlugin = definePlugin(
                 accessTokenSecretId: input.accessTokenSecretId,
                 refreshTokenSecretId: input.refreshTokenSecretId ?? null,
               })
-              .pipe(Effect.withSpan("mcp.plugin.oauth.persist_session"));
+              .pipe(
+                Effect.mapError((err) => mcpOAuthError(toMcpErrorMessage(err))),
+                Effect.withSpan("mcp.plugin.oauth.persist_session"),
+              );
 
             return {
               sessionId,
@@ -913,7 +919,13 @@ export const mcpPlugin = definePlugin(
               );
             }
 
-            const session = yield* ctx.storage.getOAuthSession(input.state);
+            const session = yield* ctx.storage
+              .getOAuthSession(input.state)
+              .pipe(
+                Effect.mapError((err) =>
+                  mcpOAuthError(toMcpErrorMessage(err)),
+                ),
+              );
             if (!session) {
               return yield* Effect.fail(
                 mcpOAuthError(`OAuth session not found: ${input.state}`),
@@ -975,7 +987,13 @@ export const mcpPlugin = definePlugin(
               refreshTokenSecretId = refreshId;
             }
 
-            yield* ctx.storage.deleteOAuthSession(input.state);
+            yield* ctx.storage
+              .deleteOAuthSession(input.state)
+              .pipe(
+                Effect.mapError((err) =>
+                  mcpOAuthError(toMcpErrorMessage(err)),
+                ),
+              );
 
             const expiresAt =
               typeof exchanged.tokens.expires_in === "number"

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -7,6 +7,12 @@ import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/r
 import { useScope } from "@executor/react/api/scope-context";
 import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
 import { usePendingSources } from "@executor/react/api/optimistic";
+import {
+  AdditionalHeadersSection,
+  mergeHeaders,
+  validateHeaderConfiguration,
+  type PlainHeader,
+} from "@executor/react/plugins/additional-headers";
 import { HeadersList } from "@executor/react/plugins/headers-list";
 import {
   CreatableSecretPicker,
@@ -175,7 +181,8 @@ export default function AddOpenApiSource(props: {
 
   // Auth
   const [strategy, setStrategy] = useState<StrategySelection>({ kind: "none" });
-  const [customHeaders, setCustomHeaders] = useState<HeaderState[]>([]);
+  const [authHeaders, setAuthHeaders] = useState<HeaderState[]>([]);
+  const [additionalHeaders, setAdditionalHeaders] = useState<PlainHeader[]>([]);
 
   // OAuth2 state (only populated while an oauth2 preset is selected)
   const [oauth2ClientIdSecretId, setOauth2ClientIdSecretId] = useState<string | null>(null);
@@ -247,18 +254,15 @@ export default function AddOpenApiSource(props: {
     return out;
   };
 
-  const allHeaders: Record<string, HeaderValue> = {};
-  for (const ch of customHeaders) {
-    if (ch.name.trim() && ch.secretId) {
-      allHeaders[ch.name.trim()] = {
-        secretId: ch.secretId,
-        ...(ch.prefix ? { prefix: ch.prefix } : {}),
-      };
-    }
-  }
+  const allHeaders = mergeHeaders(authHeaders, additionalHeaders) as Record<string, HeaderValue>;
   const hasHeaders = Object.keys(allHeaders).length > 0;
 
-  const customHeadersValid = customHeaders.every((ch) => ch.name.trim() && ch.secretId);
+  const customHeadersValid = authHeaders.every((ch) => ch.name.trim() && ch.secretId);
+  const headerError = validateHeaderConfiguration({
+    authHeaders,
+    additionalHeaders,
+    reserveAuthorization: strategy.kind === "oauth2",
+  });
 
   const oauth2Presets: readonly OAuth2Preset[] = preview?.oauth2Presets ?? [];
   const oauth2RedirectUrl =
@@ -274,8 +278,9 @@ export default function AddOpenApiSource(props: {
   const canAdd =
     preview !== null &&
     resolvedBaseUrl.length > 0 &&
-    (customHeaders.length === 0 || customHeadersValid) &&
-    oauth2Ready;
+    (authHeaders.length === 0 || customHeadersValid) &&
+    oauth2Ready &&
+    headerError === null;
 
   // ---- Handlers ----
 
@@ -304,10 +309,10 @@ export default function AddOpenApiSource(props: {
       const firstPreset = result.headerPresets[0];
       if (firstPreset) {
         setStrategy({ kind: "header", presetIndex: 0 });
-        setCustomHeaders(entriesFromSpecPreset(firstPreset));
+        setAuthHeaders(entriesFromSpecPreset(firstPreset));
       } else {
         setStrategy({ kind: "none" });
-        setCustomHeaders([]);
+        setAuthHeaders([]);
       }
     } catch (e) {
       setAnalyzeError(e instanceof Error ? e.message : "Failed to parse spec");
@@ -327,22 +332,22 @@ export default function AddOpenApiSource(props: {
     }
     switch (next.kind) {
       case "none":
-        setCustomHeaders([]);
+        setAuthHeaders([]);
         return;
       case "custom": {
-        const userHeaders = customHeaders.filter((h) => !h.fromPreset);
-        setCustomHeaders(userHeaders.length > 0 ? userHeaders : []);
+        const userHeaders = authHeaders.filter((h) => !h.fromPreset);
+        setAuthHeaders(userHeaders.length > 0 ? userHeaders : []);
         return;
       }
       case "header": {
         const preset = preview?.headerPresets[next.presetIndex];
         if (!preset) return;
-        const userHeaders = customHeaders.filter((h) => !h.fromPreset);
-        setCustomHeaders([...entriesFromSpecPreset(preset), ...userHeaders]);
+        const userHeaders = authHeaders.filter((h) => !h.fromPreset);
+        setAuthHeaders([...entriesFromSpecPreset(preset), ...userHeaders]);
         return;
       }
       case "oauth2": {
-        setCustomHeaders([]);
+        setAuthHeaders([]);
         const preset = preview?.oauth2Presets[next.presetIndex];
         if (preset) {
           setOauth2SelectedScopes(new Set(Object.keys(preset.scopes)));
@@ -353,7 +358,7 @@ export default function AddOpenApiSource(props: {
   };
 
   const handleHeadersChange = (next: HeaderState[]) => {
-    setCustomHeaders(next);
+    setAuthHeaders(next);
     if (strategy.kind === "header" && next.every((h) => !h.fromPreset)) {
       setStrategy(next.length === 0 ? { kind: "none" } : { kind: "custom" });
     }
@@ -574,7 +579,8 @@ export default function AddOpenApiSource(props: {
                     setSelectedServerIndex(-1);
                     setCustomBaseUrl("");
                     setVariableSelections({});
-                    setCustomHeaders([]);
+                    setAuthHeaders([]);
+                    setAdditionalHeaders([]);
                     setStrategy({ kind: "none" });
                     setOauth2Auth(null);
                     setOauth2Error(null);
@@ -854,7 +860,7 @@ export default function AddOpenApiSource(props: {
             {/* Header-based auth input */}
             {strategy.kind !== "none" && strategy.kind !== "oauth2" && (
               <HeadersList
-                headers={customHeaders}
+                headers={authHeaders}
                 onHeadersChange={handleHeadersChange}
                 existingSecrets={secretList}
                 sourceName={identity.name}
@@ -984,6 +990,12 @@ export default function AddOpenApiSource(props: {
               </div>
             )}
           </section>
+
+          <AdditionalHeadersSection
+            headers={additionalHeaders}
+            onHeadersChange={setAdditionalHeaders}
+            error={headerError}
+          />
 
           {/* Add error */}
           {addError && (

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -25,10 +25,15 @@ import {
   secretWriteKeys,
   sourceWriteKeys,
 } from "@executor/react/api/reactivity-keys";
+import {
+  AdditionalHeadersSection,
+  mergeHeaders,
+  partitionHeaders,
+  validateHeaderConfiguration,
+  type PlainHeader,
+} from "@executor/react/plugins/additional-headers";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import {
-  headerValueToState,
-  headersFromState,
   type HeaderState,
 } from "@executor/react/plugins/secret-header-auth";
 import { HeadersList } from "@executor/react/plugins/headers-list";
@@ -400,10 +405,10 @@ function EditForm(props: {
     fallbackNamespace: props.initial.namespace,
   });
   const [baseUrl, setBaseUrl] = useState(props.initial.config.baseUrl ?? "");
-  const [headers, setHeaders] = useState<HeaderState[]>(() =>
-    Object.entries(props.initial.config.headers ?? {}).map(([name, value]) =>
-      headerValueToState(name, value),
-    ),
+  const initialHeaders = partitionHeaders(props.initial.config.headers);
+  const [headers, setHeaders] = useState<HeaderState[]>(() => initialHeaders.authHeaders);
+  const [additionalHeaders, setAdditionalHeaders] = useState<PlainHeader[]>(
+    () => initialHeaders.additionalHeaders,
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -417,9 +422,19 @@ function EditForm(props: {
   const oauth2Entries: readonly OAuth2Auth[] = props.initial.config.oauth2
     ? [props.initial.config.oauth2]
     : [];
+  const headerError = validateHeaderConfiguration({
+    authHeaders: headers,
+    additionalHeaders,
+    reserveAuthorization: oauth2Entries.length > 0,
+  });
 
   const handleHeadersChange = (next: HeaderState[]) => {
     setHeaders(next);
+    setDirty(true);
+  };
+
+  const handleAdditionalHeadersChange = (next: PlainHeader[]) => {
+    setAdditionalHeaders(next);
     setDirty(true);
   };
 
@@ -432,7 +447,7 @@ function EditForm(props: {
         payload: {
           name: identity.name.trim() || undefined,
           baseUrl: baseUrl.trim() || undefined,
-          headers: headersFromState(headers),
+          headers: mergeHeaders(headers, additionalHeaders),
         },
         reactivityKeys: sourceWriteKeys,
       });
@@ -450,7 +465,7 @@ function EditForm(props: {
       <div>
         <h1 className="text-xl font-semibold text-foreground">Edit OpenAPI Source</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Update the base URL and authentication headers for this source.
+          Update the base URL, authentication, and additional headers for this source.
         </p>
       </div>
 
@@ -482,7 +497,7 @@ function EditForm(props: {
       </CardStack>
 
       <section className="space-y-2.5">
-        <FieldLabel>Headers</FieldLabel>
+        <FieldLabel>Authentication</FieldLabel>
         <HeadersList
           headers={headers}
           onHeadersChange={handleHeadersChange}
@@ -490,6 +505,12 @@ function EditForm(props: {
           sourceName={identity.name}
         />
       </section>
+
+      <AdditionalHeadersSection
+        headers={additionalHeaders}
+        onHeadersChange={handleAdditionalHeadersChange}
+        error={headerError}
+      />
 
       {oauth2Entries.length > 0 && (
         <ConnectionsSection
@@ -509,7 +530,10 @@ function EditForm(props: {
         <Button variant="ghost" onClick={props.onSave}>
           Cancel
         </Button>
-        <Button onClick={handleSave} disabled={(!dirty && !identityDirty) || saving}>
+        <Button
+          onClick={handleSave}
+          disabled={(!dirty && !identityDirty) || saving || headerError !== null}
+        >
           {saving ? "Saving…" : "Save changes"}
         </Button>
       </div>

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -300,6 +300,48 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
     }),
   );
 
+  it.effect("stores mixed plaintext and secret-backed headers on the source", () =>
+    Effect.gen(function* () {
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [
+            openApiPlugin({ httpClientLayer: clientLayer }),
+            memorySecretsPlugin(),
+          ] as const,
+        }),
+      );
+
+      yield* executor.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("test-api-token"),
+          scope: ScopeId.make(TEST_SCOPE),
+          name: "Test API Token",
+          value: "secret-value-123",
+        }),
+      );
+
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: TEST_SCOPE,
+        namespace: "mixed",
+        baseUrl: "",
+        headers: {
+          Authorization: { secretId: "test-api-token", prefix: "Bearer " },
+          "X-Static": "hello",
+        },
+      });
+
+      const source = yield* executor.openapi.getSource("mixed", TEST_SCOPE);
+      expect(source?.config.headers).toEqual({
+        Authorization: { secretId: "test-api-token", prefix: "Bearer " },
+        "X-Static": "hello",
+      });
+    }),
+  );
+
   it.effect("fails clearly when a secret is missing", () =>
     Effect.gen(function* () {
       const httpClient = yield* HttpClient.HttpClient;

--- a/packages/react/src/plugins/additional-headers.test.ts
+++ b/packages/react/src/plugins/additional-headers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import type { HeaderState } from "./secret-header-auth";
+import {
+  mergeHeaders,
+  partitionHeaders,
+  validateHeaderConfiguration,
+  type PlainHeader,
+} from "./additional-headers";
+
+describe("additional-headers helpers", () => {
+  it("partitions mixed header values into auth and additional headers", () => {
+    const result = partitionHeaders({
+      Authorization: { secretId: "token", prefix: "Bearer " },
+      "X-Workspace": "team-123",
+    });
+
+    expect(result.authHeaders).toEqual([
+      {
+        name: "Authorization",
+        secretId: "token",
+        prefix: "Bearer ",
+        presetKey: "bearer",
+      },
+    ]);
+    expect(result.additionalHeaders).toEqual([{ name: "X-Workspace", value: "team-123" }]);
+  });
+
+  it("merges auth and additional headers back into one payload", () => {
+    const authHeaders: HeaderState[] = [
+      {
+        name: "Authorization",
+        secretId: "token",
+        prefix: "Bearer ",
+        presetKey: "bearer",
+      },
+    ];
+    const additionalHeaders: PlainHeader[] = [{ name: "X-Workspace", value: "team-123" }];
+
+    expect(mergeHeaders(authHeaders, additionalHeaders)).toEqual({
+      Authorization: { secretId: "token", prefix: "Bearer " },
+      "X-Workspace": "team-123",
+    });
+  });
+
+  it("rejects duplicate header names case-insensitively", () => {
+    const error = validateHeaderConfiguration({
+      authHeaders: [{ name: "Authorization", secretId: "token" }],
+      additionalHeaders: [{ name: " authorization ", value: "shadow" }],
+    });
+
+    expect(error).toBe("Header names must be unique across authentication and additional headers.");
+  });
+
+  it("rejects manual authorization headers when OAuth manages auth", () => {
+    const error = validateHeaderConfiguration({
+      authHeaders: [],
+      additionalHeaders: [{ name: "Authorization", value: "Bearer shadow" }],
+      reserveAuthorization: true,
+    });
+
+    expect(error).toBe("Authorization header is managed by OAuth and can't be set manually.");
+  });
+});

--- a/packages/react/src/plugins/additional-headers.tsx
+++ b/packages/react/src/plugins/additional-headers.tsx
@@ -1,0 +1,233 @@
+import type { ReactNode } from "react";
+
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntry,
+} from "../components/card-stack";
+import { Label } from "../components/label";
+import { Button } from "../components/button";
+import { Input } from "../components/input";
+import {
+  headerValueToState,
+  headersFromState,
+  type HeaderState,
+} from "./secret-header-auth";
+
+export type PlainHeader = {
+  readonly name: string;
+  readonly value: string;
+};
+
+type SharedHeaderValue = string | { readonly secretId: string; readonly prefix?: string };
+
+export function partitionHeaders(
+  headers: Record<string, SharedHeaderValue> | undefined,
+): {
+  readonly authHeaders: HeaderState[];
+  readonly additionalHeaders: PlainHeader[];
+} {
+  const authHeaders: HeaderState[] = [];
+  const additionalHeaders: PlainHeader[] = [];
+
+  for (const [name, value] of Object.entries(headers ?? {})) {
+    if (typeof value === "string") {
+      additionalHeaders.push({ name, value });
+      continue;
+    }
+    authHeaders.push(headerValueToState(name, value));
+  }
+
+  return { authHeaders, additionalHeaders };
+}
+
+export function mergeHeaders(
+  authHeaders: readonly HeaderState[],
+  additionalHeaders: readonly PlainHeader[],
+): Record<string, SharedHeaderValue> {
+  const merged: Record<string, SharedHeaderValue> = {
+    ...headersFromState(authHeaders),
+  };
+
+  for (const header of additionalHeaders) {
+    const name = header.name.trim();
+    const value = header.value.trim();
+    if (!name || !value) continue;
+    merged[name] = value;
+  }
+
+  return merged;
+}
+
+export function validateHeaderConfiguration(args: {
+  readonly authHeaders: readonly HeaderState[];
+  readonly additionalHeaders: readonly PlainHeader[];
+  readonly reserveAuthorization?: boolean;
+}): string | null {
+  const names = new Map<string, string>();
+
+  const noteName = (rawName: string) => {
+    const trimmed = rawName.trim();
+    if (!trimmed) return null;
+    const normalized = trimmed.toLowerCase();
+    if (args.reserveAuthorization && normalized === "authorization") {
+      return "Authorization header is managed by OAuth and can't be set manually.";
+    }
+    const existing = names.get(normalized);
+    if (existing) {
+      return "Header names must be unique across authentication and additional headers.";
+    }
+    names.set(normalized, trimmed);
+    return null;
+  };
+
+  for (const header of args.authHeaders) {
+    const error = noteName(header.name);
+    if (error) return error;
+  }
+
+  for (const header of args.additionalHeaders) {
+    if (!header.name.trim() || !header.value.trim()) {
+      return "Additional headers require both a name and value.";
+    }
+    const error = noteName(header.name);
+    if (error) return error;
+  }
+
+  return null;
+}
+
+export function AdditionalHeadersSection(props: {
+  readonly headers: readonly PlainHeader[];
+  readonly onHeadersChange: (headers: PlainHeader[]) => void;
+  readonly error?: string | null;
+  readonly label?: string;
+  readonly description?: ReactNode;
+  readonly emptyLabel?: ReactNode;
+}) {
+  const {
+    headers,
+    onHeadersChange,
+    error = null,
+    label = "Additional headers",
+    description = (
+      <>
+        Plaintext headers sent with every request. Use authentication for secret-backed auth
+        headers.
+      </>
+    ),
+    emptyLabel = "No headers",
+  } = props;
+
+  const updateHeader = (index: number, update: Partial<PlainHeader>) => {
+    onHeadersChange(headers.map((entry, i) => (i === index ? { ...entry, ...update } : entry)));
+  };
+
+  const removeHeader = (index: number) => {
+    onHeadersChange(headers.filter((_, i) => i !== index));
+  };
+
+  const addHeader = () => {
+    onHeadersChange([...headers, { name: "", value: "" }]);
+  };
+
+  return (
+    <section className="space-y-2.5">
+      <div>
+        <Label>{label}</Label>
+        <p className="mt-1 text-[12px] text-muted-foreground">{description}</p>
+      </div>
+
+      <CardStack>
+        <CardStackContent>
+          {headers.length === 0 ? (
+            <AddPlainHeaderRow leading={<span>{emptyLabel}</span>} onClick={addHeader} />
+          ) : (
+            <>
+              {headers.map((header, index) => (
+                <CardStackEntry key={index} className="flex-col items-stretch gap-2">
+                  <div className="flex items-center justify-between">
+                    <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                      Header
+                    </Label>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="xs"
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => removeHeader(index)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                  <div className="grid grid-cols-2 gap-2">
+                    <div className="space-y-1">
+                      <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                        Name
+                      </Label>
+                      <Input
+                        value={header.name}
+                        onChange={(event) =>
+                          updateHeader(index, {
+                            name: (event.target as HTMLInputElement).value,
+                          })
+                        }
+                        placeholder="X-Organization-Id"
+                        className="h-8 text-xs font-mono"
+                      />
+                    </div>
+                    <div className="space-y-1">
+                      <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                        Value
+                      </Label>
+                      <Input
+                        value={header.value}
+                        onChange={(event) =>
+                          updateHeader(index, {
+                            value: (event.target as HTMLInputElement).value,
+                          })
+                        }
+                        placeholder="workspace-id"
+                        className="h-8 text-xs font-mono"
+                      />
+                    </div>
+                  </div>
+                </CardStackEntry>
+              ))}
+              <AddPlainHeaderRow onClick={addHeader} />
+            </>
+          )}
+        </CardStackContent>
+      </CardStack>
+
+      {error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+          <p className="text-[12px] text-destructive">{error}</p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function AddPlainHeaderRow(props: {
+  readonly onClick: () => void;
+  readonly leading?: ReactNode;
+}) {
+  return (
+    // oxlint-disable-next-line react/forbid-elements
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        props.onClick();
+      }}
+      aria-label="Add header"
+      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
+    >
+      <span className="min-w-0 flex-1 text-left">{props.leading}</span>
+      <svg aria-hidden viewBox="0 0 16 16" fill="none" className="size-4 shrink-0">
+        <path d="M8 3.5v9M3.5 8h9" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- add the shared MCP-style plaintext Additional headers UI for OpenAPI and GraphQL
- partition secret-backed auth headers from plaintext additional headers and merge them back into the existing persisted `headers` payload
- add validation for blank additional headers, duplicate header names, and OAuth-managed `Authorization` conflicts

## Why

OpenAPI and GraphQL previously lacked the separate plaintext additional-headers workflow that MCP already exposed, which made the header UX inconsistent and mixed plaintext headers into authentication flows.

## Validation

- `bunx vitest run packages/react/src/plugins/additional-headers.test.ts`
- `bunx vitest run packages/plugins/graphql/src/sdk/plugin.test.ts`
- `bunx vitest run packages/plugins/openapi/src/sdk/plugin.test.ts`
- manual verification in Helium against the local dev server for GraphQL and OpenAPI source edit flows
