### PR TITLE
[codex] surface MCP auth failures as user-facing errors

### DIFF
--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
-import { createExecutor, makeTestConfig, Scope, ScopeId } from "@executor/sdk";
+import {
+  createExecutor,
+  makeTestConfig,
+  Scope,
+  ScopeId,
+  StorageError,
+  type DBAdapter,
+} from "@executor/sdk";
 
 import { mcpPlugin } from "./plugin";
 import {
@@ -9,6 +16,7 @@ import {
   deriveMcpNamespace,
   joinToolPath,
 } from "./manifest";
+import { McpOAuthError } from "./errors";
 
 // ---------------------------------------------------------------------------
 // Manifest extraction
@@ -129,6 +137,22 @@ describe("joinToolPath", () => {
 // ---------------------------------------------------------------------------
 
 describe("mcpPlugin", () => {
+  const makeMcpSessionLookupFailingAdapter = (): DBAdapter => {
+    const inner = makeTestConfig({ plugins: [mcpPlugin()] as const }).adapter;
+    const failure = new StorageError({
+      message: "session store unavailable",
+      cause: new Error("db down"),
+    });
+
+    return {
+      ...inner,
+      findOne: ((input) =>
+        input.model === "mcp_oauth_session"
+          ? Effect.fail(failure)
+          : inner.findOne(input)) as DBAdapter["findOne"],
+    };
+  };
+
   it.effect("creates executor with mcp plugin", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
@@ -144,6 +168,33 @@ describe("mcpPlugin", () => {
       expect(executor.mcp.probeEndpoint).toBeTypeOf("function");
       expect(executor.mcp.startOAuth).toBeTypeOf("function");
       expect(executor.mcp.completeOAuth).toBeTypeOf("function");
+    }),
+  );
+
+  it.effect("maps oauth session lookup storage failures to McpOAuthError", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor({
+        scopes: [
+          new Scope({
+            id: ScopeId.make("test-scope"),
+            name: "test",
+            createdAt: new Date(),
+          }),
+        ],
+        adapter: makeMcpSessionLookupFailingAdapter(),
+        blobs: makeTestConfig().blobs,
+        plugins: [mcpPlugin()] as const,
+      });
+
+      const result = yield* executor.mcp
+        .completeOAuth({
+          state: "mcp_oauth_test",
+          code: "code",
+        })
+        .pipe(Effect.flip);
+
+      expect(result).toBeInstanceOf(McpOAuthError);
+      expect(result.message).toContain("session store unavailable");
     }),
   );
 

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -286,6 +286,9 @@ const remoteConnectionError = (message: string) =>
 
 const mcpOAuthError = (message: string) => new McpOAuthError({ message });
 
+const toMcpErrorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
 const mcpDiscoveryError = (message: string) =>
   new McpToolDiscoveryError({ stage: "list_tools", message });
 
@@ -892,7 +895,10 @@ export const mcpPlugin = definePlugin(
                 accessTokenSecretId: input.accessTokenSecretId,
                 refreshTokenSecretId: input.refreshTokenSecretId ?? null,
               })
-              .pipe(Effect.withSpan("mcp.plugin.oauth.persist_session"));
+              .pipe(
+                Effect.mapError((err) => mcpOAuthError(toMcpErrorMessage(err))),
+                Effect.withSpan("mcp.plugin.oauth.persist_session"),
+              );
 
             return {
               sessionId,
@@ -913,7 +919,13 @@ export const mcpPlugin = definePlugin(
               );
             }
 
-            const session = yield* ctx.storage.getOAuthSession(input.state);
+            const session = yield* ctx.storage
+              .getOAuthSession(input.state)
+              .pipe(
+                Effect.mapError((err) =>
+                  mcpOAuthError(toMcpErrorMessage(err)),
+                ),
+              );
             if (!session) {
               return yield* Effect.fail(
                 mcpOAuthError(`OAuth session not found: ${input.state}`),
@@ -975,7 +987,13 @@ export const mcpPlugin = definePlugin(
               refreshTokenSecretId = refreshId;
             }
 
-            yield* ctx.storage.deleteOAuthSession(input.state);
+            yield* ctx.storage
+              .deleteOAuthSession(input.state)
+              .pipe(
+                Effect.mapError((err) =>
+                  mcpOAuthError(toMcpErrorMessage(err)),
+                ),
+              );
 
             const expiresAt =
               typeof exchanged.tokens.expires_in === "number"


### PR DESCRIPTION
## What changed
- map MCP OAuth session persistence, lookup, and cleanup storage failures into `McpOAuthError`
- keep failed MCP auth flows user-readable instead of surfacing only an opaque trace id
- add a regression test for failed OAuth session lookup

## Root cause
The MCP OAuth flow already converted protocol and token-storage failures into `McpOAuthError`, but it left OAuth session store operations as raw `StorageError`. At the HTTP edge those raw storage failures are intentionally translated into `InternalError({ traceId })`, so the user only saw a trace id instead of an auth error message.

## Impact
Failed MCP auth flows now return a string error that explains what went wrong, matching the behavior of the other OAuth-backed plugins.

## Validation
- `bunx vitest run src/sdk/plugin.test.ts`
