### PR TITLE
openapi: encode non-JSON request bodies correctly

### DIFF
--- a/packages/plugins/openapi/src/sdk/form-urlencoded-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/form-urlencoded-body.test.ts
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------------
+// Regression test for non-JSON request-body serialization.
+//
+// Before the fix, the invoke path only had two branches — JSON, or
+// `String(bodyValue)` with whatever content-type the spec declared. For an
+// object body that meant shipping the literal string `[object Object]`
+// with `Content-Type: application/x-www-form-urlencoded`, which servers
+// reject or hold open waiting for valid framing.
+//
+// Now we dispatch on content-type: form-urlencoded → bodyUrlParams,
+// multipart → bodyFormDataRecord, string passthrough for pre-serialized
+// bodies, JSON.stringify as a last-resort fallback (never `[object Object]`).
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { FetchHttpClient } from "@effect/platform";
+import { createServer, type AddressInfo } from "node:http";
+
+import {
+  createExecutor,
+  definePlugin,
+  makeTestConfig,
+  type InvokeOptions,
+  type SecretProvider,
+} from "@executor/sdk";
+
+import { openApiPlugin } from "./plugin";
+
+const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
+const TEST_SCOPE = "test-scope";
+
+const memoryProvider: SecretProvider = (() => {
+  const store = new Map<string, string>();
+  return {
+    key: "memory",
+    writable: true,
+    get: (id, scope) =>
+      Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
+    set: (id, value, scope) =>
+      Effect.sync(() => {
+        store.set(`${scope}\u0000${id}`, value);
+      }),
+    delete: (id, scope) =>
+      Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
+    list: () => Effect.sync(() => []),
+  };
+})();
+
+const memorySecretsPlugin = definePlugin(() => ({
+  id: "memory-secrets" as const,
+  storage: () => ({}),
+  secretProviders: [memoryProvider],
+}));
+
+type Captured = {
+  contentType: string;
+  body: string;
+};
+
+const startEchoServer = () =>
+  Effect.acquireRelease(
+    Effect.async<{ baseUrl: string; captured: Captured; close: () => void }>(
+      (resume) => {
+        const captured: Captured = { contentType: "", body: "" };
+        const server = createServer((req, res) => {
+          const chunks: Buffer[] = [];
+          req.on("data", (c: Buffer) => chunks.push(c));
+          req.on("end", () => {
+            captured.contentType = req.headers["content-type"] ?? "";
+            captured.body = Buffer.concat(chunks).toString("utf8");
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+          });
+        });
+        server.listen(0, "127.0.0.1", () => {
+          const port = (server.address() as AddressInfo).port;
+          resume(
+            Effect.succeed({
+              baseUrl: `http://127.0.0.1:${port}`,
+              captured,
+              close: () => server.close(),
+            }),
+          );
+        });
+      },
+    ),
+    (s) => Effect.sync(() => s.close()),
+  );
+
+const formSpec = JSON.stringify({
+  openapi: "3.0.0",
+  info: { title: "FormTest", version: "1.0.0" },
+  paths: {
+    "/submit": {
+      post: {
+        operationId: "submit",
+        tags: ["forms"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/x-www-form-urlencoded": {
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  email: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "ok",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { ok: { type: "boolean" } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+describe("OpenAPI non-JSON request body serialization", () => {
+  it.scoped(
+    "form-urlencoded object body is properly encoded (no '[object Object]')",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, captured } = yield* startEchoServer();
+
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              openApiPlugin({ httpClientLayer: FetchHttpClient.layer }),
+              memorySecretsPlugin(),
+            ] as const,
+          }),
+        );
+
+        yield* executor.openapi.addSpec({
+          spec: formSpec,
+          scope: TEST_SCOPE,
+          namespace: "form",
+          baseUrl,
+        });
+
+        yield* executor.tools.invoke(
+          "form.forms.submit",
+          { body: { name: "Acme", email: "a@b.com" } },
+          autoApprove,
+        );
+
+        expect(captured.contentType).toBe("application/x-www-form-urlencoded");
+        expect(captured.body).not.toBe("[object Object]");
+
+        const parsed = new URLSearchParams(captured.body);
+        expect(parsed.get("name")).toBe("Acme");
+        expect(parsed.get("email")).toBe("a@b.com");
+      }),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/form-urlencoded-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/form-urlencoded-body.test.ts
@@ -15,7 +15,8 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 import { FetchHttpClient } from "@effect/platform";
-import { createServer, type AddressInfo } from "node:http";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 
 import {
   createExecutor,

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -158,13 +158,22 @@ const applyHeaders = (
 // Response helpers
 // ---------------------------------------------------------------------------
 
+const normalizeContentType = (ct: string | null | undefined): string =>
+  ct?.split(";")[0]?.trim().toLowerCase() ?? "";
+
 const isJsonContentType = (ct: string | null | undefined): boolean => {
-  if (!ct) return false;
-  const normalized = ct.split(";")[0]?.trim().toLowerCase() ?? "";
+  const normalized = normalizeContentType(ct);
+  if (!normalized) return false;
   return (
     normalized === "application/json" || normalized.includes("+json") || normalized.includes("json")
   );
 };
+
+const isFormUrlEncoded = (ct: string | null | undefined): boolean =>
+  normalizeContentType(ct) === "application/x-www-form-urlencoded";
+
+const isMultipartFormData = (ct: string | null | undefined): boolean =>
+  normalizeContentType(ct).startsWith("multipart/form-data");
 
 // ---------------------------------------------------------------------------
 // Public API — invoke a single operation
@@ -211,8 +220,20 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
     if (bodyValue !== undefined) {
       if (isJsonContentType(rb.contentType)) {
         request = HttpClientRequest.bodyUnsafeJson(request, bodyValue);
+      } else if (typeof bodyValue === "string") {
+        request = HttpClientRequest.bodyText(request, bodyValue, rb.contentType);
+      } else if (isFormUrlEncoded(rb.contentType)) {
+        request = HttpClientRequest.bodyUrlParams(
+          request,
+          bodyValue as Parameters<typeof HttpClientRequest.bodyUrlParams>[1],
+        );
+      } else if (isMultipartFormData(rb.contentType)) {
+        request = HttpClientRequest.bodyFormDataRecord(
+          request,
+          bodyValue as Parameters<typeof HttpClientRequest.bodyFormDataRecord>[1],
+        );
       } else {
-        request = HttpClientRequest.bodyText(request, String(bodyValue), rb.contentType);
+        request = HttpClientRequest.bodyText(request, JSON.stringify(bodyValue), rb.contentType);
       }
     }
   }


### PR DESCRIPTION
## Summary
- The invoke path had only two body branches — JSON, or `String(bodyValue)` with the spec's content-type. For an object body + a non-JSON content-type we shipped the literal string `[object Object]` on the wire, which servers reject or hold open waiting for valid framing (the "hung request" reports from Affinity).
- Dispatch on declared content-type: `application/x-www-form-urlencoded` → `bodyUrlParams`, `multipart/form-data` → `bodyFormDataRecord` (Effect picks the boundary), pre-serialized strings pass through unchanged, unknown non-JSON content-types fall back to `JSON.stringify` instead of `[object Object]`.
- New test `form-urlencoded-body.test.ts` stands up a raw node http echo server, registers a hand-authored spec with a form-urlencoded POST, invokes it with an object body, and asserts the bytes on the wire are properly URL-encoded.

## Test plan
- [x] `bunx vitest run src/sdk/form-urlencoded-body.test.ts` — passes
- [x] Full openapi plugin suite — 37/37 green