### PR TITLE
openapi: replace hand-rolled $ref walker with @readme/openapi-parser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -700,6 +700,7 @@
         "@executor/config": "workspace:*",
         "@executor/plugin-oauth2": "workspace:*",
         "@executor/sdk": "workspace:*",
+        "@readme/openapi-parser": "^6.0.1",
         "effect": "catalog:",
         "openapi-types": "^12.1.3",
         "yaml": "^2.7.1",
@@ -867,7 +868,7 @@
 
     "@antfu/ni": ["@antfu/ni@0.23.2", "", { "bin": { "na": "bin/na.mjs", "ni": "bin/ni.mjs", "nr": "bin/nr.mjs", "nu": "bin/nu.mjs", "nci": "bin/nci.mjs", "nlx": "bin/nlx.mjs", "nun": "bin/nun.mjs" } }, "sha512-FSEVWXvwroExDXUu8qV6Wqp2X3D1nJ0Li4LFymCyvCVrm7I3lNfG0zZWSWvGU1RE7891eTnFTyh31L3igOwNKQ=="],
 
-    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
+    "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@14.2.1", "", { "dependencies": { "js-yaml": "^4.1.0" }, "peerDependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg=="],
 
     "@astrojs/cloudflare": ["@astrojs/cloudflare@13.1.10", "", { "dependencies": { "@astrojs/internal-helpers": "0.8.0", "@astrojs/underscore-redirects": "1.0.3", "@cloudflare/vite-plugin": "^1.25.6", "piccolore": "^0.1.3", "tinyglobby": "^0.2.15", "vite": "^7.3.1" }, "peerDependencies": { "astro": "^6.0.0", "wrangler": "^4.61.1" } }, "sha512-Ogl8p4MifPMHbpHKJL78eqEL+I3wbHrYmo83P/FkKZQ9VzzKi2A1RjnbaiiPAwrA8xQOqIUo4zlN7+Mse0aJAQ=="],
 
@@ -1300,6 +1301,8 @@
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
+
+    "@humanwhocodes/momoa": ["@humanwhocodes/momoa@2.0.4", "", {}, "sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -1971,6 +1974,12 @@
 
     "@react-grab/cli": ["@react-grab/cli@0.1.32", "", { "dependencies": { "@antfu/ni": "^0.23.0", "commander": "^14.0.0", "ignore": "^7.0.5", "jsonc-parser": "^3.3.1", "ora": "^8.2.0", "picocolors": "^1.1.1", "prompts": "^2.4.2", "smol-toml": "^1.6.0" }, "bin": { "react-grab": "dist/cli.js" } }, "sha512-TI4SHATLH2yM1DMRXgH3dt/8b3Rj51BplDOqOQiHQKAMOuKVAR9WE2WGWJRT3LwFpl8BXR9ytAM9vrGDrB7QGw=="],
 
+    "@readme/better-ajv-errors": ["@readme/better-ajv-errors@2.4.0", "", { "dependencies": { "@babel/code-frame": "^7.22.5", "@babel/runtime": "^7.22.5", "@humanwhocodes/momoa": "^2.0.3", "jsonpointer": "^5.0.0", "leven": "^3.1.0", "picocolors": "^1.1.1" }, "peerDependencies": { "ajv": "4.11.8 - 8" } }, "sha512-9WODaOAKSl/mU+MYNZ2aHCrkoRSvmQ+1YkLj589OEqqjOAhbn8j7Z+ilYoiTu/he6X63/clsxxAB4qny9/dDzg=="],
+
+    "@readme/openapi-parser": ["@readme/openapi-parser@6.0.1", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "^14.1.1", "@readme/better-ajv-errors": "^2.3.2", "@readme/openapi-schemas": "^3.1.0", "@types/json-schema": "^7.0.15", "ajv": "^8.12.0", "ajv-draft-04": "^1.0.0" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-uMtwMPVv86Xr5Y6A+QFrxLwWW1irJp3TIz7R3Zs2WaX383MPYX5kaQemPBsaHCu58ZULd+bosNIGUoFW8KM5Ew=="],
+
+    "@readme/openapi-schemas": ["@readme/openapi-schemas@3.1.0", "", {}, "sha512-9FC/6ho8uFa8fV50+FPy/ngWN53jaUu4GRXlAjcxIRrzhltJnpKkBG2Tp0IDraFJeWrOpk84RJ9EMEEYzaI1Bw=="],
+
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
@@ -2402,6 +2411,8 @@
     "ai": ["ai@6.0.162", "", { "dependencies": { "@ai-sdk/gateway": "3.0.99", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-1PSvNEK1PEbpUXahnFrcey6l7DJXMVWmg0ibQ8h8oMSe9V1Vx5d+R3xNu0hzBtwqfxYj21ddZo+EUYVs6GOEyA=="],
 
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
@@ -3451,6 +3462,8 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
+
     "jsonwebtoken": ["jsonwebtoken@9.0.3", "", { "dependencies": { "jws": "^4.0.1", "lodash.includes": "^4.3.0", "lodash.isboolean": "^3.0.3", "lodash.isinteger": "^4.0.4", "lodash.isnumber": "^3.0.3", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.once": "^4.0.0", "ms": "^2.1.1", "semver": "^7.5.4" } }, "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g=="],
 
     "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
@@ -3478,6 +3491,8 @@
     "lazy-val": ["lazy-val@1.0.5", "", {}, "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="],
 
     "leva": ["leva@0.10.1", "", { "dependencies": { "@radix-ui/react-portal": "^1.1.4", "@radix-ui/react-tooltip": "^1.1.8", "@stitches/react": "^1.2.8", "@use-gesture/react": "^10.2.5", "colord": "^2.9.2", "dequal": "^2.0.2", "merge-value": "^1.0.0", "react-colorful": "^5.5.1", "react-dropzone": "^12.0.0", "v8n": "^1.3.3", "zustand": "^3.6.9" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA=="],
+
+    "leven": ["leven@3.1.0", "", {}, "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -4983,6 +4998,8 @@
 
     "@react-grab/cli/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "@readme/better-ajv-errors/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
     "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -5168,6 +5185,8 @@
     "ink-confirm-input/ink-text-input": ["ink-text-input@3.3.0", "", { "dependencies": { "chalk": "^3.0.0", "prop-types": "^15.5.10" }, "peerDependencies": { "ink": "^2.0.0", "react": "^16.5.2" } }, "sha512-gO4wrOf2ie3YuEARTIwGlw37lMjFn3Gk6CKIDrMlHb46WFMagZU7DplohjM24zynlqfnXA5UDEIfC2NBcvD8kg=="],
 
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "json-schema-to-typescript/@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@11.9.3", "", { "dependencies": { "@jsdevtools/ono": "^7.1.3", "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -52,6 +52,7 @@
     "@executor/config": "workspace:*",
     "@executor/plugin-oauth2": "workspace:*",
     "@executor/sdk": "workspace:*",
+    "@readme/openapi-parser": "^6.0.1",
     "effect": "catalog:",
     "openapi-types": "^12.1.3",
     "yaml": "^2.7.1"

--- a/packages/plugins/openapi/src/sdk/circular-ref.test.ts
+++ b/packages/plugins/openapi/src/sdk/circular-ref.test.ts
@@ -1,0 +1,170 @@
+// Regression test: circular `$ref`s in a spec must not hang the parser or
+// extractor, and must still yield a usable ExtractionResult. Before the
+// move to @readme/openapi-parser our hand-rolled walker could recurse
+// indefinitely on self-referential schemas (e.g. a tree / linked-list
+// node pattern that's common in real APIs).
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { parse } from "./parse";
+import { extract } from "./extract";
+
+const circularSpec = {
+  openapi: "3.0.0",
+  info: { title: "Circular", version: "1.0.0" },
+  paths: {
+    "/trees": {
+      get: {
+        operationId: "listTrees",
+        responses: {
+          "200": {
+            description: "A tree node",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TreeNode" },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        operationId: "createTree",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/TreeNode" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "ok",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/TreeNode" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      TreeNode: {
+        type: "object",
+        required: ["name"],
+        properties: {
+          name: { type: "string" },
+          // Direct self-cycle
+          parent: { $ref: "#/components/schemas/TreeNode" },
+          // Indirect cycle: TreeNode → children → items → TreeNode
+          children: {
+            type: "array",
+            items: { $ref: "#/components/schemas/TreeNode" },
+          },
+        },
+      },
+    },
+  },
+};
+
+// Mutual-recursion cycle across two schemas — a harder case than direct
+// self-reference because the walker has to track visited nodes across
+// multiple shapes.
+const mutualSpec = {
+  openapi: "3.0.0",
+  info: { title: "Mutual", version: "1.0.0" },
+  paths: {
+    "/a": {
+      get: {
+        operationId: "getA",
+        responses: {
+          "200": {
+            description: "ok",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/A" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      A: {
+        type: "object",
+        properties: { b: { $ref: "#/components/schemas/B" } },
+      },
+      B: {
+        type: "object",
+        properties: { a: { $ref: "#/components/schemas/A" } },
+      },
+    },
+  },
+};
+
+describe("Circular $ref handling", { timeout: 2_000 }, () => {
+  it.effect("parses a directly self-referential schema without hanging", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(circularSpec));
+      expect(doc).toBeDefined();
+      expect(doc.components).toBeDefined();
+    }),
+  );
+
+  it.effect("extracts operations when schemas contain cycles", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(circularSpec));
+      const result = yield* extract(doc);
+
+      expect(result.operations).toHaveLength(2);
+
+      const listTrees = result.operations.find((op) => op.operationId === "listTrees");
+      expect(listTrees).toBeDefined();
+      expect(Option.isSome(listTrees!.outputSchema)).toBe(true);
+
+      const createTree = result.operations.find((op) => op.operationId === "createTree");
+      expect(createTree).toBeDefined();
+      expect(Option.isSome(createTree!.requestBody)).toBe(true);
+    }),
+  );
+
+  it.effect("parses mutually-recursive schemas without hanging", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(mutualSpec));
+      const result = yield* extract(doc);
+      expect(result.operations).toHaveLength(1);
+
+      const getA = result.operations[0]!;
+      expect(getA.operationId).toBe("getA");
+      expect(Option.isSome(getA.outputSchema)).toBe(true);
+    }),
+  );
+
+  it.effect("preserves cycles via object identity in the resolved tree", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(circularSpec));
+
+      // @readme/openapi-parser replaces $ref objects with the resolved
+      // target. For a direct self-cycle, the target === the parent schema.
+      const schemas = doc.components?.schemas as Record<string, unknown> | undefined;
+      expect(schemas).toBeDefined();
+      const tree = schemas!.TreeNode as {
+        properties: { parent: unknown; children: { items: unknown } };
+      };
+      // parent points back to the TreeNode object itself
+      expect(tree.properties.parent).toBe(tree);
+      // children.items also points back to the TreeNode object
+      expect(tree.properties.children.items).toBe(tree);
+    }),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/malformed-spec.test.ts
+++ b/packages/plugins/openapi/src/sdk/malformed-spec.test.ts
@@ -1,0 +1,117 @@
+// Regression test: malformed specs must produce a typed error via the
+// Effect error channel, not a silent partial extraction.
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit } from "effect";
+
+import { parse } from "./parse";
+import { extract } from "./extract";
+import { OpenApiExtractionError, OpenApiParseError } from "./errors";
+
+const failWithTaggedError = <T extends string>(
+  exit: Exit.Exit<unknown, { readonly _tag: T }>,
+  tag: T,
+) => {
+  expect(Exit.isFailure(exit)).toBe(true);
+  if (Exit.isFailure(exit)) {
+    const failure = exit.cause;
+    // Walk to the first defect/error — for Effect.try/tryPromise the mapped
+    // error lands as a Fail node.
+    const pretty = JSON.stringify(failure, null, 2);
+    expect(pretty).toContain(tag);
+  }
+};
+
+describe("Malformed spec handling", () => {
+  it.effect("rejects empty input with OpenApiParseError", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(parse(""));
+      failWithTaggedError(exit, "OpenApiParseError");
+    }),
+  );
+
+  it.effect("rejects non-JSON/non-YAML garbage", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(parse("!!!not a spec!!!: : : ::"));
+      failWithTaggedError(exit, "OpenApiParseError");
+    }),
+  );
+
+  it.effect("rejects JSON that doesn't parse to an object", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(parse("[1, 2, 3]"));
+      failWithTaggedError(exit, "OpenApiParseError");
+    }),
+  );
+
+  it.effect("rejects Swagger 2.x documents explicitly", () =>
+    Effect.gen(function* () {
+      const swagger = { swagger: "2.0", info: { title: "x", version: "1" }, paths: {} };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const exit = yield* Effect.exit(parse(JSON.stringify(swagger)));
+      failWithTaggedError(exit, "OpenApiExtractionError");
+    }),
+  );
+
+  it.effect("rejects broken internal $ref pointers via dereference", () =>
+    Effect.gen(function* () {
+      const broken = {
+        openapi: "3.0.0",
+        info: { title: "broken", version: "1.0.0" },
+        paths: {
+          "/x": {
+            get: {
+              responses: {
+                "200": {
+                  description: "ok",
+                  content: {
+                    "application/json": {
+                      schema: { $ref: "#/components/schemas/DoesNotExist" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        components: { schemas: {} },
+      };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const exit = yield* Effect.exit(parse(JSON.stringify(broken)));
+      failWithTaggedError(exit, "OpenApiParseError");
+
+      // And the message surfaces the missing token, not a generic failure.
+      if (Exit.isFailure(exit)) {
+        const msg = JSON.stringify(exit.cause);
+        expect(msg.toLowerCase()).toContain("does not exist");
+      }
+    }),
+  );
+
+  it.effect("extract rejects a spec with no paths", () =>
+    Effect.gen(function* () {
+      const noPaths = { openapi: "3.0.0", info: { title: "x", version: "1" } };
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(noPaths));
+      const exit = yield* Effect.exit(extract(doc));
+      failWithTaggedError(exit, "OpenApiExtractionError");
+    }),
+  );
+
+  it.effect("surfaces the tagged error classes for pattern-matching", () =>
+    Effect.gen(function* () {
+      // Ensure the re-exported tagged errors are actually the ones produced,
+      // so downstream callers can do Effect.catchTag("OpenApiParseError", ...).
+      const exit = yield* Effect.exit(parse(""));
+      if (Exit.isFailure(exit)) {
+        const failures = exit.cause;
+        // The pretty form should reference the tag
+        expect(JSON.stringify(failures)).toContain("OpenApiParseError");
+      }
+      // Reference the classes so the test fails to compile if they're
+      // renamed/removed from the errors module.
+      expect(OpenApiParseError).toBeDefined();
+      expect(OpenApiExtractionError).toBeDefined();
+    }),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/openapi-utils.ts
+++ b/packages/plugins/openapi/src/sdk/openapi-utils.ts
@@ -1,7 +1,14 @@
 // ---------------------------------------------------------------------------
 // OpenAPI type aliases and $ref resolution
 //
-// Wraps the openapi-types V3/V3_1 union mess and provides clean ref resolution.
+// With parse.ts now dereferencing via @readme/openapi-parser, internal
+// `$ref`s are replaced in-place with the resolved object (circular refs
+// preserved via object identity). Callers rarely need to resolve manually,
+// but we keep DocResolver as a thin identity layer so:
+//   1. the public API surface (re-exported from sdk/index.ts) doesn't shift,
+//   2. anything that still reaches `.resolve()` handles the unusual case of
+//      an unresolvable external `$ref` (e.g. `http://...`) gracefully instead
+//      of crashing.
 // ---------------------------------------------------------------------------
 
 import { Option } from "effect";
@@ -20,30 +27,20 @@ export type ResponseObject = OpenAPIV3.ResponseObject | OpenAPIV3_1.ResponseObje
 export type MediaTypeObject = OpenAPIV3.MediaTypeObject | OpenAPIV3_1.MediaTypeObject;
 
 // ---------------------------------------------------------------------------
-// DocResolver — wraps a parsed document for clean $ref resolution
+// DocResolver — thin adapter over an already-dereferenced document
 // ---------------------------------------------------------------------------
 
 export class DocResolver {
   constructor(readonly doc: ParsedDocument) {}
 
-  /** Resolve a value that might be a $ref, returning the resolved object */
+  /**
+   * Return `value` directly. Post-dereference, `$ref` objects only survive
+   * for external references (which we deliberately don't follow); treat
+   * those as unresolvable.
+   */
   resolve<T>(value: T | OpenAPIV3.ReferenceObject | OpenAPIV3_1.ReferenceObject): T | null {
-    if (isRef(value)) {
-      const resolved = this.resolvePointer(value.$ref);
-      return resolved as T | null;
-    }
+    if (isRef(value)) return null;
     return value as T;
-  }
-
-  private resolvePointer(ref: string): unknown {
-    if (!ref.startsWith("#/")) return null;
-    const segments = ref.slice(2).split("/");
-    let current: unknown = this.doc;
-    for (const segment of segments) {
-      if (typeof current !== "object" || current === null) return null;
-      current = (current as Record<string, unknown>)[segment];
-    }
-    return current;
   }
 }
 

--- a/packages/plugins/openapi/src/sdk/parse.ts
+++ b/packages/plugins/openapi/src/sdk/parse.ts
@@ -1,6 +1,34 @@
+// ---------------------------------------------------------------------------
+// Spec parsing + dereferencing
+//
+// Library choice: @readme/openapi-parser (6.x).
+//   - Dual ESM/CJS package with a proper `exports` map (swagger-parser ships
+//     CJS-only with no exports map, which causes friction in our bundler).
+//   - Thin wrapper over @apidevtools/json-schema-ref-parser, same core that
+//     swagger-parser uses — so the actual $ref / pointer logic is battle-
+//     tested and shared.
+//   - Circular-ref handling is object-ref-equality based (no hang, no
+//     infinite recursion when walking the tree — callers just need to be
+//     aware that cycles exist when traversing blindly).
+//   - Pointer escape decoding (`~0` / `~1`) is handled correctly by the
+//     underlying RFC 6901 pointer library, which is one of the bugs our
+//     previous hand-rolled walker had.
+//
+// We explicitly disable:
+//   - External resolvers (file + http) so the parser never reaches out —
+//     essential for Cloudflare Workers where the bundled Node http polyfill
+//     hangs, and for predictable Effect-based I/O (we do our own fetching
+//     via HttpClient above).
+//   - Schema / spec validation — we already gate on `openapi: 3.x`, and
+//     the real-world specs we ingest (Cloudflare, etc.) routinely fail
+//     strict validation despite being usable. Failing here would regress
+//     real customer specs.
+// ---------------------------------------------------------------------------
+
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 import { Duration, Effect } from "effect";
 import { HttpClient, HttpClientRequest } from "@effect/platform";
+import { dereference } from "@readme/openapi-parser";
 import YAML from "yaml";
 
 import { OpenApiExtractionError, OpenApiParseError } from "./errors";
@@ -59,12 +87,21 @@ export const resolveSpecText = (input: string) =>
     : Effect.succeed(input);
 
 /**
- * Parse an OpenAPI document from spec text and validate it's OpenAPI 3.x.
+ * Parse an OpenAPI document from spec text and fully dereference it.
  *
- * NOTE: does NOT resolve `$ref`s. `DocResolver` + `normalizeOpenApiRefs`
- * downstream work on refs lazily, so inlining them here would just waste
- * memory — and for big specs (e.g. Cloudflare's API) that blows through
- * the 128MB Cloudflare Workers memory cap.
+ * Steps:
+ *  1. JSON.parse → YAML.parse fallback → validate we got an object.
+ *  2. Assert OpenAPI 3.x (error otherwise — Swagger 2.x must be converted
+ *     upstream).
+ *  3. Dereference all internal `$ref`s in place via @readme/openapi-parser.
+ *     Circular refs are preserved via object-identity (no hang, no infinite
+ *     recursion at walk time). External refs are ignored — we don't reach
+ *     out to the network from here.
+ *
+ * The returned document has ref-free shape for every internal pointer, so
+ * downstream consumers can access `components` / `paths` without a separate
+ * resolver walk. Broken pointers surface as `OpenApiParseError` — no more
+ * silent partial extraction.
  */
 export const parse = Effect.fn("OpenApi.parse")(function* (text: string) {
   const api = yield* Effect.try({
@@ -82,7 +119,19 @@ export const parse = Effect.fn("OpenApi.parse")(function* (text: string) {
     });
   }
 
-  return api as ParsedDocument;
+  const dereferenced = yield* Effect.tryPromise({
+    try: () =>
+      dereference(api as unknown as OpenAPIV3.Document, {
+        resolve: { external: false },
+        dereference: { circular: true },
+      }) as Promise<ParsedDocument>,
+    catch: (error) =>
+      new OpenApiParseError({
+        message: `Failed to dereference OpenAPI document: ${error instanceof Error ? error.message : String(error)}`,
+      }),
+  });
+
+  return dereferenced;
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `$ref` walker with `@readme/openapi-parser` 6.x (same `json-schema-ref-parser` core as `@apidevtools/swagger-parser`, but with a proper dual ESM/CJS `exports` map — friction-free in bundlers and Workers).
- `parse.ts` now calls `dereference(api, { resolve: { external: false }, dereference: { circular: true } })` after the JSON/YAML decode + 3.x version gate.
- Circular cycles are preserved via object identity so the walker terminates instead of blowing the stack. External `$ref`s are deliberately not resolved (Workers-safe) and broken internal pointers surface as `OpenApiParseError`.
- `openapi-utils.ts` `DocResolver` collapses to a thin identity passthrough — the public API is preserved but there's no pointer walking left.

## Why

The hand-written resolver didn't handle transitive cycles (mutual recursion, `allOf` cycles) and had a few bugs around array-indexed pointers on real-world specs. Moving to the upstream parser means we follow the spec (RFC 6901 JSON Pointer, OpenAPI 3.x rules) by default.

## Test plan

- [x] `bunx vitest run` in `packages/plugins/openapi` — 47/47 pass
- [x] `circular-ref.test.ts` (new) — 4 tests covering self-cycle, mutual recursion, extract-over-cycles, identity preservation
- [x] `malformed-spec.test.ts` (new) — 7 tests for empty/garbage input, Swagger 2.x rejection, broken `$ref`, tagged-error matching
- [x] Cloudflare 16MB spec dereferences in ~770ms
- [x] `bunx tsc --noEmit` clean