### PR TITLE
openapi: spec-compliant parameter serialization with url-template

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -703,6 +703,7 @@
         "@readme/openapi-parser": "^6.0.1",
         "effect": "catalog:",
         "openapi-types": "^12.1.3",
+        "url-template": "^3.1.1",
         "yaml": "^2.7.1",
       },
       "devDependencies": {
@@ -4603,6 +4604,8 @@
     "url": ["url@0.11.4", "", { "dependencies": { "punycode": "^1.4.1", "qs": "^6.12.3" } }, "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg=="],
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
+
+    "url-template": ["url-template@3.1.1", "", {}, "sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -55,6 +55,7 @@
     "@readme/openapi-parser": "^6.0.1",
     "effect": "catalog:",
     "openapi-types": "^12.1.3",
+    "url-template": "^3.1.1",
     "yaml": "^2.7.1"
   },
   "devDependencies": {

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,5 +1,24 @@
+// ---------------------------------------------------------------------------
+// Parameter serialization
+//
+// OpenAPI 3.x parameters can use a matrix of `style` + `explode` options
+// (form, simple, matrix, label, spaceDelimited, pipeDelimited, deepObject)
+// that control exactly how arrays/objects/primitives appear on the wire.
+// Rather than hand-rolling the cases, this module delegates the RFC-6570
+// covered styles (simple / label / matrix / form) to the `url-template`
+// package (a ~4KB reference implementation of RFC 6570), and implements the
+// three OpenAPI-only styles (spaceDelimited, pipeDelimited, deepObject) by
+// hand. Query strings built here are appended to the request URL directly
+// so Effect's UrlParams layer (which uses URLSearchParams and would break
+// pipe/space/deepObject framing) never runs on top of them. Required
+// parameters and request bodies are enforced up front with a clear
+// OpenApiInvocationError; cookie parameters are emitted as a single
+// Cookie: name=value; name2=value2 header as per RFC 6265.
+// ---------------------------------------------------------------------------
+
 import { Effect, Layer, Option } from "effect";
 import { HttpClient, HttpClientRequest } from "@effect/platform";
+import { parseTemplate } from "url-template";
 
 import type { StorageFailure } from "@executor/sdk";
 
@@ -38,8 +57,179 @@ const readParamValue = (args: Record<string, unknown>, param: OperationParameter
 };
 
 // ---------------------------------------------------------------------------
-// Path resolution
+// Style / explode helpers
 // ---------------------------------------------------------------------------
+
+type Style =
+  | "simple"
+  | "label"
+  | "matrix"
+  | "form"
+  | "spaceDelimited"
+  | "pipeDelimited"
+  | "deepObject";
+
+const defaultStyle = (location: OperationParameter["location"]): Style => {
+  switch (location) {
+    case "path":
+    case "header":
+      return "simple";
+    case "query":
+    case "cookie":
+      return "form";
+  }
+};
+
+const styleFor = (param: OperationParameter): Style => {
+  const raw = Option.getOrUndefined(param.style);
+  if (raw === "simple" || raw === "label" || raw === "matrix" || raw === "form" ||
+      raw === "spaceDelimited" || raw === "pipeDelimited" || raw === "deepObject") {
+    return raw;
+  }
+  return defaultStyle(param.location);
+};
+
+const explodeFor = (param: OperationParameter, style: Style): boolean => {
+  const override = Option.getOrUndefined(param.explode);
+  if (override !== undefined) return override;
+  // RFC spec default: only `form` defaults to explode=true; everything
+  // else defaults to false.
+  return style === "form";
+};
+
+const isObjectLike = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+// url-template operators for the RFC-6570 subset of OpenAPI styles.
+const rfcOperator: Partial<Record<Style, "" | "." | ";" | "?">> = {
+  simple: "",
+  label: ".",
+  matrix: ";",
+  form: "?",
+};
+
+/**
+ * Build a URI-template fragment (e.g. `{?name*}`) for a single parameter
+ * and expand it with the given value. Returns the encoded fragment
+ * without any leading `&` — the caller stitches form-style query pieces
+ * together with `&` as needed.
+ */
+const expandRfc = (
+  style: Style,
+  name: string,
+  value: unknown,
+  explode: boolean,
+): string => {
+  const op = rfcOperator[style];
+  if (op === undefined) {
+    throw new Error(`expandRfc called with non-RFC style: ${style}`);
+  }
+  const modifier = explode ? "*" : "";
+  // url-template only accepts primitives / primitive arrays / flat objects
+  // of primitives. Coerce numbers/booleans through as-is; leave strings
+  // alone; stringify arrays/objects element-wise.
+  const tpl = parseTemplate(`{${op}${name}${modifier}}`);
+  return tpl.expand({ [name]: value as never });
+};
+
+// ---------------------------------------------------------------------------
+// Query-string assembly
+//
+// For each query parameter, produce a list of already-encoded pieces like
+// ["tag=a", "tag=b"] or ["user[name]=alice"]. Caller joins with `&`.
+// ---------------------------------------------------------------------------
+
+const encodeFormComponent = (s: string): string =>
+  // RFC 3986 unreserved + standard form encoding — matches what
+  // URLSearchParams would produce except for space (we use %20, which is
+  // legal in query strings and what OpenAPI readers expect).
+  encodeURIComponent(s).replace(/[!'()*]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase());
+
+const queryPiecesForParam = (
+  param: OperationParameter,
+  value: unknown,
+): readonly string[] => {
+  const style = styleFor(param);
+  const explode = explodeFor(param, style);
+  const name = param.name;
+
+  if (style === "form") {
+    // Delegate to url-template: handles primitives, arrays (with explode
+    // toggling between `?tag=a&tag=b` and `?tag=a,b`) and objects
+    // (exploded spreads keys at top level; unexploded joins as
+    // `?obj=key,val,key2,val2`).
+    const expanded = expandRfc("form", name, value, explode);
+    // expanded looks like "?tag=a&tag=b" or "" for empty. Strip leading ?.
+    if (expanded === "") return [];
+    const body = expanded.startsWith("?") ? expanded.slice(1) : expanded;
+    return body === "" ? [] : body.split("&");
+  }
+
+  if (style === "spaceDelimited" || style === "pipeDelimited") {
+    const sep = style === "spaceDelimited" ? "%20" : "|";
+    if (Array.isArray(value)) {
+      if (explode) {
+        return value
+          .filter((v) => v !== undefined && v !== null)
+          .map((v) => `${encodeFormComponent(name)}=${encodeFormComponent(String(v))}`);
+      }
+      const joined = value
+        .filter((v) => v !== undefined && v !== null)
+        .map((v) => encodeFormComponent(String(v)))
+        .join(sep);
+      return joined === "" ? [] : [`${encodeFormComponent(name)}=${joined}`];
+    }
+    // Primitive fallback: behave like form.
+    return [`${encodeFormComponent(name)}=${encodeFormComponent(String(value))}`];
+  }
+
+  if (style === "deepObject") {
+    if (!isObjectLike(value)) return [];
+    const out: string[] = [];
+    // Emit `user[name]=alice&user[role]=admin` with the brackets left
+    // literal — this is what OpenAPI generators and Rails-style servers
+    // expect. `new URL(...)` accepts unencoded `[` and `]` in the
+    // query component.
+    const walk = (prefix: string, v: unknown) => {
+      if (Array.isArray(v)) {
+        for (let i = 0; i < v.length; i++) walk(`${prefix}[${i}]`, v[i]);
+      } else if (isObjectLike(v)) {
+        for (const [k, inner] of Object.entries(v)) {
+          if (inner === undefined) continue;
+          walk(`${prefix}[${encodeFormComponent(k)}]`, inner);
+        }
+      } else if (v !== undefined && v !== null) {
+        out.push(`${prefix}=${encodeFormComponent(String(v))}`);
+      }
+    };
+    walk(encodeFormComponent(name), value);
+    return out;
+  }
+
+  // Any other style in a query slot (simple/label/matrix is unusual here
+  // but spec doesn't outright forbid it) — fall back to form.
+  const expanded = expandRfc("form", name, value, explode);
+  if (expanded === "") return [];
+  const body = expanded.startsWith("?") ? expanded.slice(1) : expanded;
+  return body === "" ? [] : body.split("&");
+};
+
+// ---------------------------------------------------------------------------
+// Path resolution — spec styles: simple (default), label, matrix
+// ---------------------------------------------------------------------------
+
+const pathSegmentForParam = (
+  param: OperationParameter,
+  value: unknown,
+): string => {
+  const style = styleFor(param);
+  const explode = explodeFor(param, style);
+  if (style === "simple" || style === "label" || style === "matrix") {
+    return expandRfc(style, param.name, value, explode);
+  }
+  // Fall back to simple for any odd configuration.
+  return expandRfc("simple", param.name, value, explode);
+};
 
 const resolvePath = Effect.fn("OpenApi.resolvePath")(function* (
   pathTemplate: string,
@@ -58,11 +248,19 @@ const resolvePath = Effect.fn("OpenApi.resolvePath")(function* (
           statusCode: Option.none(),
         });
       }
+      // Optional path param missing — strip the placeholder entirely so
+      // we don't leave a literal `{foo}` on the wire. Rare in practice.
+      resolved = resolved.replaceAll(`{${param.name}}`, "");
       continue;
     }
-    resolved = resolved.replaceAll(`{${param.name}}`, encodeURIComponent(String(value)));
+    resolved = resolved.replaceAll(
+      `{${param.name}}`,
+      pathSegmentForParam(param, value),
+    );
   }
 
+  // Unknown `{name}` placeholders in the template that have no matching
+  // declared parameter — pull from args by name as a last resort.
   const remaining = [...resolved.matchAll(/\{([^{}]+)\}/g)]
     .map((m) => m[1])
     .filter((v): v is string => typeof v === "string");
@@ -155,6 +353,22 @@ const applyHeaders = (
 };
 
 // ---------------------------------------------------------------------------
+// Header param serialization — OpenAPI only really supports `simple` here.
+// ---------------------------------------------------------------------------
+
+const headerValueForParam = (param: OperationParameter, value: unknown): string => {
+  const style = styleFor(param);
+  const explode = explodeFor(param, style);
+  // RFC 6570 `simple` (no operator) produces the right thing for
+  // primitives, arrays ("a,b" — simple explode is the same for arrays),
+  // and objects (`k,v,k2,v2` unexploded or `k=v,k2=v2` exploded). The
+  // RFC-6570 simple expansion will percent-encode space / non-ASCII;
+  // that's acceptable for header values (all HTTP parsers accept
+  // percent-encoded tokens here and callers typically pass ASCII).
+  return expandRfc("simple", param.name, value, explode);
+};
+
+// ---------------------------------------------------------------------------
 // Response helpers
 // ---------------------------------------------------------------------------
 
@@ -196,22 +410,82 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
 
   const resolvedPath = yield* resolvePath(operation.pathTemplate, args, operation.parameters);
 
-  const path = resolvedPath.startsWith("/") ? resolvedPath : `/${resolvedPath}`;
+  // Enforce required non-path params before building the request. Path
+  // params are already enforced in resolvePath.
+  for (const param of operation.parameters) {
+    if (param.location === "path") continue;
+    if (!param.required) continue;
+    const value = readParamValue(args, param);
+    if (value === undefined || value === null) {
+      return yield* new OpenApiInvocationError({
+        message: `Missing required ${param.location} parameter: ${param.name}`,
+        statusCode: Option.none(),
+      });
+    }
+  }
 
-  let request = HttpClientRequest.make(operation.method.toUpperCase() as "GET")(path);
+  // Enforce required request body similarly.
+  if (Option.isSome(operation.requestBody) && operation.requestBody.value.required) {
+    const bodyValue = args.body ?? args.input;
+    if (bodyValue === undefined || bodyValue === null) {
+      return yield* new OpenApiInvocationError({
+        message: `Missing required request body`,
+        statusCode: Option.none(),
+      });
+    }
+  }
 
+  // Build the query string using our style-aware serializer. We
+  // deliberately bypass HttpClientRequest.setUrlParam (which routes
+  // through URLSearchParams and would break pipe/space/deepObject
+  // framing) and splice the query directly onto the URL path.
+  const queryPieces: string[] = [];
   for (const param of operation.parameters) {
     if (param.location !== "query") continue;
     const value = readParamValue(args, param);
     if (value === undefined || value === null) continue;
-    request = HttpClientRequest.setUrlParam(request, param.name, String(value));
+    queryPieces.push(...queryPiecesForParam(param, value));
   }
+
+  const rawPath = resolvedPath.startsWith("/") ? resolvedPath : `/${resolvedPath}`;
+  const path = queryPieces.length > 0
+    ? `${rawPath}${rawPath.includes("?") ? "&" : "?"}${queryPieces.join("&")}`
+    : rawPath;
+
+  let request = HttpClientRequest.make(operation.method.toUpperCase() as "GET")(path);
 
   for (const param of operation.parameters) {
     if (param.location !== "header") continue;
     const value = readParamValue(args, param);
     if (value === undefined || value === null) continue;
-    request = HttpClientRequest.setHeader(request, param.name, String(value));
+    request = HttpClientRequest.setHeader(request, param.name, headerValueForParam(param, value));
+  }
+
+  // Cookie parameters — collect all of them and emit a single
+  // `Cookie: name=value; name2=value2` header. Before this change we
+  // silently dropped them.
+  const cookieParts: string[] = [];
+  for (const param of operation.parameters) {
+    if (param.location !== "cookie") continue;
+    const value = readParamValue(args, param);
+    if (value === undefined || value === null) continue;
+    // RFC 6265 cookie-value is quite permissive; OpenAPI `form` (default)
+    // with explode=false joins arrays as comma lists. Serialize as
+    // `name=value` without further URL-encoding beyond what url-template
+    // emits.
+    const encoded = encodeFormComponent(String(value));
+    cookieParts.push(`${param.name}=${encoded}`);
+  }
+  if (cookieParts.length > 0) {
+    // Merge with any Cookie header already present in resolvedHeaders
+    // (rare, but don't clobber it).
+    const existing = Object.entries(resolvedHeaders).find(
+      ([k]) => k.toLowerCase() === "cookie",
+    );
+    const merged = existing
+      ? `${existing[1]}; ${cookieParts.join("; ")}`
+      : cookieParts.join("; ");
+    request = HttpClientRequest.setHeader(request, "Cookie", merged);
   }
 
   if (Option.isSome(operation.requestBody)) {

--- a/packages/plugins/openapi/src/sdk/parameter-styles.test.ts
+++ b/packages/plugins/openapi/src/sdk/parameter-styles.test.ts
@@ -1,0 +1,494 @@
+// ---------------------------------------------------------------------------
+// Wire-level tests for OpenAPI parameter serialization.
+//
+// These stand up a raw node http server, register a hand-authored spec with
+// various `style` + `explode` combos per parameter location, invoke the
+// resulting tools, and assert exactly what hit the wire (req.url /
+// req.headers). The pre-change implementation used `String(value)` for
+// every parameter, which silently corrupts arrays, deep objects, and
+// anything that requires RFC 6570 expansion. The cases below cover:
+//
+//  - query form default (exploded arrays)           -> ?tag=a&tag=b
+//  - query form explode=false                       -> ?tag=a,b
+//  - query pipeDelimited                            -> ?tag=a|b
+//  - query spaceDelimited                           -> ?tag=a%20b
+//  - query deepObject                               -> ?user[name]=alice...
+//  - query baseline primitive                       -> ?name=alice
+//  - path label                                     -> .red.green.blue
+//  - path matrix                                    -> ;color=red,green,blue
+//  - cookie                                         -> Cookie: session=abc123
+//  - special chars percent-encoded                  -> ?q=hello%20world
+//  - missing required query param                   -> OpenApiInvocationError
+//  - missing required body                          -> OpenApiInvocationError
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import { FetchHttpClient } from "@effect/platform";
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import {
+  createExecutor,
+  definePlugin,
+  makeTestConfig,
+  type InvokeOptions,
+  type SecretProvider,
+} from "@executor/sdk";
+
+import { openApiPlugin } from "./plugin";
+
+const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
+const TEST_SCOPE = "test-scope";
+
+const memoryProvider: SecretProvider = (() => {
+  const store = new Map<string, string>();
+  return {
+    key: "memory",
+    writable: true,
+    get: (id, scope) =>
+      Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
+    set: (id, value, scope) =>
+      Effect.sync(() => {
+        store.set(`${scope}\u0000${id}`, value);
+      }),
+    delete: (id, scope) =>
+      Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
+    list: () => Effect.sync(() => []),
+  };
+})();
+
+const memorySecretsPlugin = definePlugin(() => ({
+  id: "memory-secrets" as const,
+  storage: () => ({}),
+  secretProviders: [memoryProvider],
+}));
+
+// ---------------------------------------------------------------------------
+// Echo server — captures url + headers + method of the most recent request.
+// ---------------------------------------------------------------------------
+
+type Captured = {
+  url: string;
+  method: string;
+  headers: IncomingHttpHeaders;
+  body: string;
+};
+
+const startEchoServer = () =>
+  Effect.acquireRelease(
+    Effect.async<{ baseUrl: string; captured: Captured; close: () => void }>(
+      (resume) => {
+        const captured: Captured = { url: "", method: "", headers: {}, body: "" };
+        const server = createServer((req, res) => {
+          const chunks: Buffer[] = [];
+          req.on("data", (c: Buffer) => chunks.push(c));
+          req.on("end", () => {
+            captured.url = req.url ?? "";
+            captured.method = req.method ?? "";
+            captured.headers = req.headers;
+            captured.body = Buffer.concat(chunks).toString("utf8");
+            res.writeHead(200, { "content-type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+          });
+        });
+        server.listen(0, "127.0.0.1", () => {
+          const port = (server.address() as AddressInfo).port;
+          resume(
+            Effect.succeed({
+              baseUrl: `http://127.0.0.1:${port}`,
+              captured,
+              close: () => server.close(),
+            }),
+          );
+        });
+      },
+    ),
+    (s) => Effect.sync(() => s.close()),
+  );
+
+// ---------------------------------------------------------------------------
+// Spec builder — one operation per style permutation we want to probe.
+// ---------------------------------------------------------------------------
+
+const spec = JSON.stringify({
+  openapi: "3.0.0",
+  info: { title: "ParamStyleTest", version: "1.0.0" },
+  paths: {
+    "/items": {
+      get: {
+        operationId: "listItems",
+        tags: ["items"],
+        parameters: [
+          // Default: form + explode=true
+          {
+            name: "tag",
+            in: "query",
+            required: false,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/items-form-collapsed": {
+      get: {
+        operationId: "listItemsFormCollapsed",
+        tags: ["items"],
+        parameters: [
+          {
+            name: "tag",
+            in: "query",
+            required: false,
+            style: "form",
+            explode: false,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/items-pipe": {
+      get: {
+        operationId: "listItemsPipe",
+        tags: ["items"],
+        parameters: [
+          {
+            name: "tag",
+            in: "query",
+            required: false,
+            style: "pipeDelimited",
+            explode: false,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/items-space": {
+      get: {
+        operationId: "listItemsSpace",
+        tags: ["items"],
+        parameters: [
+          {
+            name: "tag",
+            in: "query",
+            required: false,
+            style: "spaceDelimited",
+            explode: false,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/items-deep": {
+      get: {
+        operationId: "listItemsDeep",
+        tags: ["items"],
+        parameters: [
+          {
+            name: "user",
+            in: "query",
+            required: false,
+            style: "deepObject",
+            explode: true,
+            schema: { type: "object" },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/items-search": {
+      get: {
+        operationId: "searchItems",
+        tags: ["items"],
+        parameters: [
+          {
+            name: "name",
+            in: "query",
+            required: false,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/items-required": {
+      get: {
+        operationId: "requiredQuery",
+        tags: ["items"],
+        parameters: [
+          {
+            name: "id",
+            in: "query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/items-special": {
+      get: {
+        operationId: "specialQuery",
+        tags: ["items"],
+        parameters: [
+          {
+            name: "q",
+            in: "query",
+            required: false,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/paint/{color}": {
+      get: {
+        operationId: "paintLabel",
+        tags: ["paint"],
+        parameters: [
+          {
+            name: "color",
+            in: "path",
+            required: true,
+            style: "label",
+            explode: true,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/paint-matrix/{color}": {
+      get: {
+        operationId: "paintMatrix",
+        tags: ["paint"],
+        parameters: [
+          {
+            name: "color",
+            in: "path",
+            required: true,
+            style: "matrix",
+            explode: false,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/cookie-op": {
+      get: {
+        operationId: "cookieOp",
+        tags: ["cookies"],
+        parameters: [
+          {
+            name: "session",
+            in: "cookie",
+            required: false,
+            schema: { type: "string" },
+          },
+        ],
+        responses: { "200": { description: "ok" } },
+      },
+    },
+    "/submit": {
+      post: {
+        operationId: "submitJson",
+        tags: ["submit"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { type: "object" },
+            },
+          },
+        },
+        responses: { "200": { description: "ok" } },
+      },
+    },
+  },
+});
+
+const makeExec = (baseUrl: string) =>
+  Effect.gen(function* () {
+    const executor = yield* createExecutor(
+      makeTestConfig({
+        plugins: [
+          openApiPlugin({ httpClientLayer: FetchHttpClient.layer }),
+          memorySecretsPlugin(),
+        ] as const,
+      }),
+    );
+    yield* executor.openapi.addSpec({
+      spec,
+      scope: TEST_SCOPE,
+      namespace: "ps",
+      baseUrl,
+    });
+    return executor;
+  });
+
+describe("OpenAPI parameter-style serialization", () => {
+  it.scoped("array in query with default style serializes as ?tag=a&tag=b", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.items.listItems",
+        { tag: ["a", "b"] },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/items?tag=a&tag=b");
+    }),
+  );
+
+  it.scoped("array in query with form+explode=false serializes as ?tag=a,b", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.items.listItemsFormCollapsed",
+        { tag: ["a", "b"] },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/items-form-collapsed?tag=a,b");
+    }),
+  );
+
+  it.scoped("array in query with pipeDelimited serializes as ?tag=a|b", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.items.listItemsPipe",
+        { tag: ["a", "b"] },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/items-pipe?tag=a|b");
+    }),
+  );
+
+  it.scoped("array in query with spaceDelimited serializes as ?tag=a%20b", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.items.listItemsSpace",
+        { tag: ["a", "b"] },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/items-space?tag=a%20b");
+    }),
+  );
+
+  it.scoped(
+    "object in query with deepObject+explode=true serializes nested bracket keys",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, captured } = yield* startEchoServer();
+        const executor = yield* makeExec(baseUrl);
+        yield* executor.tools.invoke(
+          "ps.items.listItemsDeep",
+          { user: { name: "alice", role: "admin" } },
+          autoApprove,
+        );
+        expect(captured.url).toBe("/items-deep?user[name]=alice&user[role]=admin");
+      }),
+  );
+
+  it.scoped("primitive query param baseline", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.items.searchItems",
+        { name: "alice" },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/items-search?name=alice");
+    }),
+  );
+
+  it.scoped("special characters in query get percent-encoded", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.items.specialQuery",
+        { q: "hello world" },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/items-special?q=hello%20world");
+    }),
+  );
+
+  it.scoped("path param with style=label produces a dot-prefixed segment", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.paint.paintLabel",
+        { color: ["red", "green", "blue"] },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/paint/.red.green.blue");
+    }),
+  );
+
+  it.scoped("path param with style=matrix produces a ;-prefixed segment", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.paint.paintMatrix",
+        { color: ["red", "green", "blue"] },
+        autoApprove,
+      );
+      expect(captured.url).toBe("/paint-matrix/;color=red,green,blue");
+    }),
+  );
+
+  it.scoped("cookie parameter is emitted as a Cookie header", () =>
+    Effect.gen(function* () {
+      const { baseUrl, captured } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      yield* executor.tools.invoke(
+        "ps.cookies.cookieOp",
+        { session: "abc123" },
+        autoApprove,
+      );
+      expect(captured.headers.cookie).toBe("session=abc123");
+    }),
+  );
+
+  it.scoped("missing required query param fails with OpenApiInvocationError", () =>
+    Effect.gen(function* () {
+      const { baseUrl } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      const err = yield* Effect.flip(
+        executor.tools.invoke("ps.items.requiredQuery", {}, autoApprove),
+      );
+      // The executor wraps plugin errors as ToolInvocationError; the
+      // underlying message must call out the missing parameter so the
+      // LLM (or a human) knows exactly what to supply.
+      expect(String((err as { message?: string }).message ?? "")).toContain(
+        "Missing required query parameter: id",
+      );
+    }),
+  );
+
+  it.scoped("missing required body fails with OpenApiInvocationError", () =>
+    Effect.gen(function* () {
+      const { baseUrl } = yield* startEchoServer();
+      const executor = yield* makeExec(baseUrl);
+      const err = yield* Effect.flip(
+        executor.tools.invoke("ps.submit.submitJson", {}, autoApprove),
+      );
+      expect(String((err as { message?: string }).message ?? "")).toContain(
+        "Missing required request body",
+      );
+    }),
+  );
+});


### PR DESCRIPTION
## Summary

- Rewrites query/path/header/cookie serialization on top of `url-template` (RFC 6570 reference implementation). Maps OpenAPI `style` + `explode` to the matching RFC 6570 operator — `form` (`""`/`"?"`), `simple` (default), `label` (`"."`), `matrix` (`";"`) — and leaves the exploder to the library.
- Implements `spaceDelimited`, `pipeDelimited`, and `deepObject` by hand since they're OpenAPI-specific and not in RFC 6570.
- Adds Cookie-header emission for `in: cookie` params.
- Enforces `required: true` on non-path params and on request bodies; previously these silently produced malformed requests.
- Query pieces are spliced directly onto the URL path rather than going through `HttpClientRequest.setUrlParam` — Effect's helper routes through `URLSearchParams`, which would re-encode pipes, break `deepObject`, and turn `%20` into `+`.

## Why

The old serializer ignored `style`/`explode` entirely, so any spec that relied on a non-default form (Stripe's `expand`/`limit`, GitHub's `labels`, anything using `matrix` or `label` path params) emitted the wrong wire format and the server either errored or silently dropped the values.

## Test plan

- [x] 12 new tests in `parameter-styles.test.ts` covering: default form explode, form collapsed, pipeDelimited, spaceDelimited, deepObject, primitive baseline, special-char encoding, path label (`.red.green.blue`), path matrix (`;color=red,green,blue`), cookie header, missing required query, missing required body
- [x] `bunx vitest run` in `packages/plugins/openapi` — 48/48 pass
- [x] `bun run typecheck` clean