### PR TITLE
openapi: response fidelity — per-status schemas, headers, readOnly/writeOnly filtering

### DIFF
--- a/packages/plugins/openapi/src/sdk/definitions.ts
+++ b/packages/plugins/openapi/src/sdk/definitions.ts
@@ -4,6 +4,27 @@
  * Ported from the v3 executor's `definitions.ts`. Turns flat operation IDs like
  * `zones_listZones` into nested paths like `zones.listZones` that the tree UI
  * can render with proper nesting.
+ *
+ * ## Schema selection for LLM tool definitions
+ *
+ * Tool callers (LLMs) take a single input schema and a single output schema
+ * per tool. OpenAPI operations can declare many responses per status code
+ * — `200`, `201`, `default`, per-error schemas — plus request bodies with
+ * their own rules about which fields are server-managed vs. client-settable.
+ *
+ * We resolve that down to a single pair here:
+ *   - Input schema: `operation.inputSchema` — already filtered for
+ *     `readOnly: true` fields in `extract.ts`, so the LLM won't try to
+ *     set server-managed fields like `id` or `created_at` on POSTs.
+ *   - Output schema: `operation.outputSchema` — already filtered for
+ *     `writeOnly: true` fields in `extract.ts`, so the LLM doesn't expect
+ *     `password`-class fields to be present on GETs. The chosen schema
+ *     comes from the first 2xx response that has a body, with `default`
+ *     as a final fallback (see `pickPreferredOutputSchema` in extract.ts).
+ *
+ * Callers that need the full response map (201 vs 200 shape differences,
+ * documented response headers, error-envelope schemas) should read
+ * `operation.responses` directly instead of going through tool definitions.
  */
 
 import type { ExtractedOperation } from "./types";

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -18,6 +18,8 @@ import {
   OperationId,
   OperationParameter,
   OperationRequestBody,
+  OperationResponse,
+  OperationResponseHeader,
   type ParameterLocation,
   ServerInfo,
   ServerVariable,
@@ -39,6 +41,115 @@ const HTTP_METHODS: readonly HttpMethod[] = [
 ];
 
 const VALID_PARAM_LOCATIONS = new Set<string>(["path", "query", "header", "cookie"]);
+
+// ---------------------------------------------------------------------------
+// readOnly / writeOnly schema filtering
+//
+// OpenAPI declares field direction via `readOnly`/`writeOnly` on individual
+// properties. A `readOnly` field (e.g. server-generated `id`, `created_at`)
+// must NOT appear in request bodies — the server ignores it at best and
+// 400s at worst. A `writeOnly` field (e.g. `password`) must NOT appear in
+// responses — it's for input only and never returned. Stripping these
+// before the schema reaches the LLM prevents the tool from being told
+// about fields it can't legally touch in that direction.
+//
+// The walker preserves structure (allOf/oneOf/anyOf, nested properties,
+// items, additionalProperties) but scrubs offending leaf properties from
+// `properties` maps and from `required` lists, and avoids following
+// `$ref`s (refs are normalized elsewhere; the same schema can be used in
+// both directions so rewriting the shared definition would cross-
+// contaminate). This means ref-only schemas are passed through unchanged.
+// ---------------------------------------------------------------------------
+
+type Direction = "input" | "output";
+
+const shouldStripProperty = (propSchema: unknown, direction: Direction): boolean => {
+  if (propSchema == null || typeof propSchema !== "object" || Array.isArray(propSchema)) {
+    return false;
+  }
+  const obj = propSchema as Record<string, unknown>;
+  if (direction === "input" && obj.readOnly === true) return true;
+  if (direction === "output" && obj.writeOnly === true) return true;
+  return false;
+};
+
+// swagger-parser preserves circular $refs as object-identity cycles
+// (same reference on both ends), so the walker needs a visited map to
+// terminate. We seed the cache with the partial result before recursing
+// so that cycle closures in the output mirror cycle closures in the
+// input (A.items → A becomes A'.items → A').
+const filterSchemaForDirection = (node: unknown, direction: Direction): unknown => {
+  const visited = new WeakMap<object, unknown>();
+
+  const walk = (n: unknown): unknown => {
+    if (n == null || typeof n !== "object") return n;
+    const cached = visited.get(n as object);
+    if (cached !== undefined) return cached;
+
+    if (Array.isArray(n)) {
+      const arr: unknown[] = [];
+      visited.set(n as object, arr);
+      for (const item of n) arr.push(walk(item));
+      return arr;
+    }
+
+    const obj = n as Record<string, unknown>;
+
+    if (typeof obj.$ref === "string") {
+      visited.set(n as object, obj);
+      return obj;
+    }
+
+    const result: Record<string, unknown> = {};
+    visited.set(n as object, result);
+    const droppedKeys = new Set<string>();
+
+    for (const [key, value] of Object.entries(obj)) {
+      if (key === "properties" && value != null && typeof value === "object") {
+        const props = value as Record<string, unknown>;
+        const nextProps: Record<string, unknown> = {};
+        for (const [propName, propSchema] of Object.entries(props)) {
+          if (shouldStripProperty(propSchema, direction)) {
+            droppedKeys.add(propName);
+            continue;
+          }
+          nextProps[propName] = walk(propSchema);
+        }
+        result[key] = nextProps;
+      } else if (
+        key === "allOf" ||
+        key === "oneOf" ||
+        key === "anyOf" ||
+        key === "prefixItems"
+      ) {
+        result[key] = Array.isArray(value) ? value.map((item) => walk(item)) : value;
+      } else if (
+        key === "items" ||
+        key === "additionalProperties" ||
+        key === "not" ||
+        key === "if" ||
+        key === "then" ||
+        key === "else"
+      ) {
+        result[key] = walk(value);
+      } else {
+        result[key] = value;
+      }
+    }
+
+    if (droppedKeys.size > 0 && Array.isArray(result.required)) {
+      const next = (result.required as unknown[]).filter(
+        (r) => !(typeof r === "string" && droppedKeys.has(r)),
+      );
+      if (next.length === 0) delete result.required;
+      else result.required = next;
+    }
+
+    return result;
+  };
+
+  return walk(node);
+};
 
 // ---------------------------------------------------------------------------
 // Parameter extraction
@@ -95,33 +206,97 @@ const extractRequestBody = (
   const content = preferredContent(body.content);
   if (!content) return undefined;
 
+  // Strip `readOnly: true` before the schema reaches the LLM's input
+  // surface — the server won't accept those fields on writes.
+  const filteredSchema = content.media.schema
+    ? filterSchemaForDirection(content.media.schema, "input")
+    : undefined;
+
   return new OperationRequestBody({
     required: body.required === true,
     contentType: content.mediaType,
-    schema: Option.fromNullable(content.media.schema),
+    schema: Option.fromNullable(filteredSchema),
   });
 };
 
 // ---------------------------------------------------------------------------
-// Response schema extraction
+// Response extraction
 // ---------------------------------------------------------------------------
 
-const extractOutputSchema = (operation: OperationObject, r: DocResolver): unknown | undefined => {
-  if (!operation.responses) return undefined;
+const extractResponseHeaders = (
+  resp: ResponseObject,
+  r: DocResolver,
+): OperationResponseHeader[] => {
+  if (!resp.headers) return [];
+  const out: OperationResponseHeader[] = [];
+  for (const [name, raw] of Object.entries(resp.headers)) {
+    // Header objects can be $ref'd (to components.headers) or inline,
+    // and the referenced shape extends ParameterBaseObject so we can
+    // pull `schema` / `description` off in both cases.
+    const header = r.resolve<{ description?: string; schema?: unknown }>(raw);
+    if (!header) continue;
+    const schema = header.schema
+      ? filterSchemaForDirection(header.schema, "output")
+      : undefined;
+    out.push(
+      new OperationResponseHeader({
+        name,
+        description: Option.fromNullable(header.description),
+        schema: Option.fromNullable(schema),
+      }),
+    );
+  }
+  return out;
+};
 
-  const entries = Object.entries(operation.responses);
-  const preferred = [
+const extractResponses = (
+  operation: OperationObject,
+  r: DocResolver,
+): Record<string, OperationResponse> => {
+  if (!operation.responses) return {};
+
+  const out: Record<string, OperationResponse> = {};
+
+  for (const [statusCode, ref] of Object.entries(operation.responses)) {
+    const resp = r.resolve<ResponseObject>(ref);
+    if (!resp) continue;
+
+    const content = preferredContent(resp.content);
+    const rawSchema = content?.media.schema;
+    const filteredSchema = rawSchema
+      ? filterSchemaForDirection(rawSchema, "output")
+      : undefined;
+
+    out[statusCode] = new OperationResponse({
+      statusCode,
+      description: Option.fromNullable(resp.description),
+      contentType: Option.fromNullable(content?.mediaType),
+      schema: Option.fromNullable(filteredSchema),
+      headers: extractResponseHeaders(resp, r),
+    });
+  }
+
+  return out;
+};
+
+/**
+ * Pick the "preferred" response's body schema for callers that can only
+ * carry one schema per operation (legacy `outputSchema` surface, LLM tool
+ * definitions that shape a single output). Preference order: the lowest
+ * 2xx status that actually has a body schema, then `default`. Non-2xx
+ * error responses never win here — they're still available on `responses`.
+ */
+const pickPreferredOutputSchema = (
+  responses: Record<string, OperationResponse>,
+): unknown | undefined => {
+  const entries = Object.entries(responses);
+  const ordered = [
     ...entries.filter(([s]) => /^2\d\d$/.test(s)).sort(([a], [b]) => a.localeCompare(b)),
     ...entries.filter(([s]) => s === "default"),
   ];
-
-  for (const [, ref] of preferred) {
-    const resp = r.resolve<ResponseObject>(ref);
-    if (!resp) continue;
-    const content = preferredContent(resp.content);
-    if (content?.media.schema) return content.media.schema;
+  for (const [, resp] of ordered) {
+    if (Option.isSome(resp.schema)) return Option.getOrUndefined(resp.schema);
   }
-
   return undefined;
 };
 
@@ -236,7 +411,8 @@ export const extract = Effect.fn("OpenApi.extract")(function* (doc: ParsedDocume
       const parameters = extractParameters(pathItem, operation, r);
       const requestBody = extractRequestBody(operation, r);
       const inputSchema = buildInputSchema(parameters, requestBody);
-      const outputSchema = extractOutputSchema(operation, r);
+      const responses = extractResponses(operation, r);
+      const outputSchema = pickPreferredOutputSchema(responses);
       const tags = (operation.tags ?? []).filter((t) => t.trim().length > 0);
 
       operations.push(
@@ -251,6 +427,7 @@ export const extract = Effect.fn("OpenApi.extract")(function* (doc: ParsedDocume
           requestBody: Option.fromNullable(requestBody),
           inputSchema: Option.fromNullable(inputSchema),
           outputSchema: Option.fromNullable(outputSchema),
+          responses,
           deprecated: operation.deprecated === true,
         }),
       );

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -61,6 +61,8 @@ export {
   OperationBinding,
   OperationParameter,
   OperationRequestBody,
+  OperationResponse,
+  OperationResponseHeader,
   ServerInfo,
   ServerVariable,
   OperationId,

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -26,6 +26,7 @@ import { OpenApiInvocationError } from "./errors";
 import {
   type HeaderValue,
   type OperationBinding,
+  type OperationResponse,
   InvocationResult,
   type OperationParameter,
 } from "./types";
@@ -389,6 +390,28 @@ const isFormUrlEncoded = (ct: string | null | undefined): boolean =>
 const isMultipartFormData = (ct: string | null | undefined): boolean =>
   normalizeContentType(ct).startsWith("multipart/form-data");
 
+// Pick the spec-declared response that best fits the runtime status:
+// exact code, then NXX wildcard, then `default`. Returns null when the
+// map is absent or nothing applies, so "no responses map" stays
+// distinguishable from "unmatched status" at the call site.
+const matchResponseStatus = (
+  status: number,
+  responses: Record<string, OperationResponse> | undefined,
+): string | null => {
+  if (!responses) return null;
+  const exact = String(status);
+  if (responses[exact]) return exact;
+
+  const hundreds = Math.floor(status / 100);
+  const wildcardUpper = `${hundreds}XX`;
+  const wildcardLower = `${hundreds}xx`;
+  if (responses[wildcardUpper]) return wildcardUpper;
+  if (responses[wildcardLower]) return wildcardLower;
+
+  if (responses["default"]) return "default";
+  return null;
+};
+
 // ---------------------------------------------------------------------------
 // Public API — invoke a single operation
 // ---------------------------------------------------------------------------
@@ -397,6 +420,7 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
   operation: OperationBinding,
   args: Record<string, unknown>,
   resolvedHeaders: Record<string, string>,
+  responses?: Record<string, OperationResponse>,
 ) {
   const client = yield* HttpClient.HttpClient;
 
@@ -551,12 +575,19 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
         : yield* response.text.pipe(mapBodyError);
 
   const ok = status >= 200 && status < 300;
+  const matchedResponseStatus = matchResponseStatus(status, responses);
+  if (matchedResponseStatus !== null) {
+    yield* Effect.annotateCurrentSpan({
+      "plugin.openapi.response.matched_status": matchedResponseStatus,
+    });
+  }
 
   return new InvocationResult({
     status,
     headers: responseHeaders,
     data: ok ? responseBody : null,
     error: ok ? null : responseBody,
+    matchedResponseStatus,
   });
 });
 
@@ -570,6 +601,7 @@ export const invokeWithLayer = (
   baseUrl: string,
   resolvedHeaders: Record<string, string>,
   httpClientLayer: Layer.Layer<HttpClient.HttpClient>,
+  responses?: Record<string, OperationResponse>,
 ) => {
   const clientWithBaseUrl = baseUrl
     ? Layer.effect(
@@ -581,7 +613,7 @@ export const invokeWithLayer = (
       ).pipe(Layer.provide(httpClientLayer))
     : httpClientLayer;
 
-  return invoke(operation, args, resolvedHeaders).pipe(
+  return invoke(operation, args, resolvedHeaders, responses).pipe(
     Effect.provide(clientWithBaseUrl),
     Effect.withSpan("plugin.openapi.invoke", {
       attributes: {

--- a/packages/plugins/openapi/src/sdk/response-fidelity.test.ts
+++ b/packages/plugins/openapi/src/sdk/response-fidelity.test.ts
@@ -1,0 +1,440 @@
+// ---------------------------------------------------------------------------
+// response-fidelity.test.ts
+//
+// Covers the post-refactor guarantees about how extract.ts / invoke.ts
+// handle per-status response schemas, response headers, and
+// `readOnly`/`writeOnly` direction filtering.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import { parse } from "./parse";
+import { extract } from "./extract";
+import { invoke } from "./invoke";
+import {
+  InvocationResult,
+  OperationBinding,
+  type OperationResponse,
+} from "./types";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "@effect/platform";
+import { Layer } from "effect";
+
+// ---------------------------------------------------------------------------
+// Stub HttpClient — returns a fixed status + body without real network I/O.
+//
+// We must hand HttpClient.make a request with an absolute URL (it calls
+// `new URL(request.url)` before invoking the handler), so we pre-pend a
+// dummy origin at the layer boundary.
+// ---------------------------------------------------------------------------
+
+const stubClientLayer = (status: number, body: unknown) =>
+  Layer.succeed(
+    HttpClient.HttpClient,
+    HttpClient.make((request) =>
+      Effect.succeed(
+        HttpClientResponse.fromWeb(
+          request,
+          new Response(JSON.stringify(body), {
+            status,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      ),
+    ).pipe(HttpClient.mapRequest(HttpClientRequest.prependUrl("http://stub.local"))),
+  );
+
+// ---------------------------------------------------------------------------
+// Scenario 1: multi-status response schemas
+//
+// POST /items returns two distinct success shapes — 200 "item returned" vs
+// 201 "created with just the id". Both should be preserved in the extracted
+// operation, and invoke should tag the response with the matched status.
+// ---------------------------------------------------------------------------
+
+const multiStatusSpec = {
+  openapi: "3.0.0",
+  info: { title: "MultiStatus", version: "1.0.0" },
+  paths: {
+    "/items": {
+      post: {
+        operationId: "createItem",
+        responses: {
+          "200": {
+            description: "Item already existed and was returned",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    item: {
+                      type: "object",
+                      properties: { id: { type: "string" }, name: { type: "string" } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "201": {
+            description: "Item was created",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: { id: { type: "string" } },
+                  required: ["id"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("response-fidelity — multi-status response schemas", () => {
+  it.effect("preserves both 200 and 201 schemas on the extracted operation", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(multiStatusSpec));
+      const result = yield* extract(doc);
+      const op = result.operations.find((o) => o.operationId === "createItem")!;
+      expect(op).toBeDefined();
+
+      const responses = op.responses;
+      expect(Object.keys(responses).sort()).toEqual(["200", "201"]);
+
+      const r200 = responses["200"]!;
+      const r201 = responses["201"]!;
+      expect(Option.isSome(r200.schema)).toBe(true);
+      expect(Option.isSome(r201.schema)).toBe(true);
+
+      const s200 = Option.getOrThrow(r200.schema) as Record<string, unknown>;
+      const s201 = Option.getOrThrow(r201.schema) as Record<string, unknown>;
+      expect(s200.properties).toHaveProperty("item");
+      expect(s201.properties).toHaveProperty("id");
+      expect(s201.properties).not.toHaveProperty("item");
+
+      // outputSchema (single-picked) should prefer 200 over 201.
+      expect(Option.isSome(op.outputSchema)).toBe(true);
+      const preferred = Option.getOrThrow(op.outputSchema) as Record<string, unknown>;
+      expect(preferred.properties).toHaveProperty("item");
+    }),
+  );
+
+  it.effect("invoke tags the InvocationResult with the matched status code", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(multiStatusSpec));
+      const result = yield* extract(doc);
+      const op = result.operations.find((o) => o.operationId === "createItem")!;
+      const binding = new OperationBinding({
+        method: op.method,
+        pathTemplate: op.pathTemplate,
+        parameters: [...op.parameters],
+        requestBody: op.requestBody,
+      });
+
+      // Server replies 201 — invoke should look up op.responses["201"].
+      const res201 = (yield* invoke(binding, {}, {}, op.responses).pipe(
+        Effect.provide(stubClientLayer(201, { id: "abc" })),
+      )) as InvocationResult;
+      expect(res201.status).toBe(201);
+      expect(res201.matchedResponseStatus).toBe("201");
+      expect(res201.data).toEqual({ id: "abc" });
+
+      // Server replies 200 — invoke should look up op.responses["200"].
+      const res200 = (yield* invoke(binding, {}, {}, op.responses).pipe(
+        Effect.provide(stubClientLayer(200, { item: { id: "abc", name: "x" } })),
+      )) as InvocationResult;
+      expect(res200.status).toBe(200);
+      expect(res200.matchedResponseStatus).toBe("200");
+
+      // Server replies an undocumented 500 — no schema applies, stays null.
+      const res500 = (yield* invoke(binding, {}, {}, op.responses).pipe(
+        Effect.provide(stubClientLayer(500, { error: "boom" })),
+      )) as InvocationResult;
+      expect(res500.matchedResponseStatus).toBeNull();
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: readOnly on a shared Pet schema — stripped from input, kept
+// in output.
+// ---------------------------------------------------------------------------
+
+const readOnlySpec = {
+  openapi: "3.0.0",
+  info: { title: "ReadOnly", version: "1.0.0" },
+  paths: {
+    "/pets": {
+      post: {
+        operationId: "createPet",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  id: { type: "string", readOnly: true },
+                  name: { type: "string" },
+                  createdAt: { type: "string", readOnly: true },
+                },
+                required: ["id", "name"],
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Created",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string", readOnly: true },
+                    name: { type: "string" },
+                    createdAt: { type: "string", readOnly: true },
+                  },
+                  required: ["id", "name"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/pets/{id}": {
+      get: {
+        operationId: "getPet",
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          "200": {
+            description: "ok",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string", readOnly: true },
+                    name: { type: "string" },
+                    createdAt: { type: "string", readOnly: true },
+                  },
+                  required: ["id", "name"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("response-fidelity — readOnly filtering", () => {
+  it.effect("strips readOnly fields from POST request body + prunes required", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(readOnlySpec));
+      const result = yield* extract(doc);
+      const createPet = result.operations.find((o) => o.operationId === "createPet")!;
+
+      const rb = Option.getOrThrow(createPet.requestBody);
+      const bodySchema = Option.getOrThrow(rb.schema) as Record<string, unknown>;
+      const props = bodySchema.properties as Record<string, unknown>;
+
+      expect(props).not.toHaveProperty("id");
+      expect(props).not.toHaveProperty("createdAt");
+      expect(props).toHaveProperty("name");
+      // `id` was required in the raw schema — it must be removed from required.
+      expect(bodySchema.required).toEqual(["name"]);
+    }),
+  );
+
+  it.effect("keeps readOnly fields on GET output schema", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(readOnlySpec));
+      const result = yield* extract(doc);
+      const getPet = result.operations.find((o) => o.operationId === "getPet")!;
+
+      const outputSchema = Option.getOrThrow(getPet.outputSchema) as Record<string, unknown>;
+      const props = outputSchema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("id");
+      expect(props).toHaveProperty("createdAt");
+      expect(props).toHaveProperty("name");
+    }),
+  );
+
+  it.effect("also keeps readOnly fields on the POST's own response schema", () =>
+    Effect.gen(function* () {
+      // The spec declares `readOnly: true` on `id` in the 201 response shape
+      // too — response-direction schemas must not be stripped the way input
+      // schemas are.
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(readOnlySpec));
+      const result = yield* extract(doc);
+      const createPet = result.operations.find((o) => o.operationId === "createPet")!;
+
+      const r201 = createPet.responses["201"]!;
+      const respSchema = Option.getOrThrow(r201.schema) as Record<string, unknown>;
+      const props = respSchema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("id");
+      expect(props).toHaveProperty("createdAt");
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: writeOnly on `password` — kept in input, stripped from output.
+// ---------------------------------------------------------------------------
+
+const writeOnlySpec = {
+  openapi: "3.0.0",
+  info: { title: "WriteOnly", version: "1.0.0" },
+  paths: {
+    "/users": {
+      post: {
+        operationId: "createUser",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  username: { type: "string" },
+                  password: { type: "string", writeOnly: true },
+                },
+                required: ["username", "password"],
+              },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Created",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string" },
+                    username: { type: "string" },
+                    password: { type: "string", writeOnly: true },
+                  },
+                  required: ["id", "username", "password"],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("response-fidelity — writeOnly filtering", () => {
+  it.effect("keeps writeOnly password on POST request body", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(writeOnlySpec));
+      const result = yield* extract(doc);
+      const createUser = result.operations.find((o) => o.operationId === "createUser")!;
+
+      const rb = Option.getOrThrow(createUser.requestBody);
+      const bodySchema = Option.getOrThrow(rb.schema) as Record<string, unknown>;
+      const props = bodySchema.properties as Record<string, unknown>;
+      expect(props).toHaveProperty("password");
+      expect(props).toHaveProperty("username");
+      expect(bodySchema.required).toEqual(["username", "password"]);
+    }),
+  );
+
+  it.effect("strips writeOnly password from response + prunes required", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(writeOnlySpec));
+      const result = yield* extract(doc);
+      const createUser = result.operations.find((o) => o.operationId === "createUser")!;
+
+      const r201 = createUser.responses["201"]!;
+      const respSchema = Option.getOrThrow(r201.schema) as Record<string, unknown>;
+      const props = respSchema.properties as Record<string, unknown>;
+      expect(props).not.toHaveProperty("password");
+      expect(props).toHaveProperty("id");
+      expect(props).toHaveProperty("username");
+      expect(respSchema.required).toEqual(["id", "username"]);
+    }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: documented response headers extracted into the operation.
+// ---------------------------------------------------------------------------
+
+const headerSpec = {
+  openapi: "3.0.0",
+  info: { title: "HeaderSpec", version: "1.0.0" },
+  paths: {
+    "/rate-limited": {
+      get: {
+        operationId: "getRateLimited",
+        responses: {
+          "200": {
+            description: "ok",
+            headers: {
+              "X-RateLimit-Limit": {
+                description: "The number of requests allowed per window",
+                schema: { type: "integer" },
+              },
+              "X-RateLimit-Remaining": {
+                schema: { type: "integer" },
+              },
+            },
+            content: {
+              "application/json": {
+                schema: { type: "object" },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+describe("response-fidelity — documented response headers", () => {
+  it.effect("lifts header name + schema + description into the response map", () =>
+    Effect.gen(function* () {
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      const doc = yield* parse(JSON.stringify(headerSpec));
+      const result = yield* extract(doc);
+      const op = result.operations.find((o) => o.operationId === "getRateLimited")!;
+
+      const r200: OperationResponse = op.responses["200"]!;
+      const byName = new Map(r200.headers.map((h) => [h.name, h]));
+
+      expect(byName.size).toBe(2);
+
+      const limit = byName.get("X-RateLimit-Limit")!;
+      expect(limit).toBeDefined();
+      expect(Option.getOrNull(limit.description)).toBe(
+        "The number of requests allowed per window",
+      );
+      const limitSchema = Option.getOrThrow(limit.schema) as Record<string, unknown>;
+      expect(limitSchema.type).toBe("integer");
+
+      const remaining = byName.get("X-RateLimit-Remaining")!;
+      expect(remaining).toBeDefined();
+      expect(Option.isNone(remaining.description)).toBe(true);
+      const remainingSchema = Option.getOrThrow(remaining.schema) as Record<string, unknown>;
+      expect(remainingSchema.type).toBe("integer");
+    }),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -49,6 +49,33 @@ export class OperationRequestBody extends Schema.Class<OperationRequestBody>(
   schema: Schema.optionalWith(Schema.Unknown, { as: "Option" }),
 }) {}
 
+/**
+ * A documented response header — when a spec declares
+ * `responses.200.headers.X-RateLimit-Limit.schema`, we surface it here so
+ * downstream consumers (LLM tool definitions, span annotations) know which
+ * headers are part of the API contract vs which are just transport-level.
+ */
+export class OperationResponseHeader extends Schema.Class<OperationResponseHeader>(
+  "OperationResponseHeader",
+)({
+  name: Schema.String,
+  description: Schema.optionalWith(Schema.String, { as: "Option" }),
+  schema: Schema.optionalWith(Schema.Unknown, { as: "Option" }),
+}) {}
+
+/**
+ * A single declared response for an operation, keyed by status code. Holds
+ * the media-type-specific body schema plus any documented headers. Schemas
+ * are already filtered for `writeOnly` in extract.ts before they land here.
+ */
+export class OperationResponse extends Schema.Class<OperationResponse>("OperationResponse")({
+  statusCode: Schema.String,
+  description: Schema.optionalWith(Schema.String, { as: "Option" }),
+  contentType: Schema.optionalWith(Schema.String, { as: "Option" }),
+  schema: Schema.optionalWith(Schema.Unknown, { as: "Option" }),
+  headers: Schema.Array(OperationResponseHeader),
+}) {}
+
 export class ExtractedOperation extends Schema.Class<ExtractedOperation>("ExtractedOperation")({
   operationId: OperationId,
   method: HttpMethod,
@@ -59,7 +86,21 @@ export class ExtractedOperation extends Schema.Class<ExtractedOperation>("Extrac
   parameters: Schema.Array(OperationParameter),
   requestBody: Schema.optionalWith(OperationRequestBody, { as: "Option" }),
   inputSchema: Schema.optionalWith(Schema.Unknown, { as: "Option" }),
+  /**
+   * Preferred output schema for the LLM's view of this tool — the first
+   * 2xx response's body schema, or the `default` response as a fallback.
+   * This is what `compileToolDefinitions` surfaces to callers that can
+   * only carry one schema per tool. For full fidelity use `responses`.
+   *
+   * Already filtered for `writeOnly: true` fields.
+   */
   outputSchema: Schema.optionalWith(Schema.Unknown, { as: "Option" }),
+  /**
+   * All declared responses, keyed by status code (or "default"). Use this
+   * when you care about 201 vs 200 body shape differences, error envelopes,
+   * or documented response headers.
+   */
+  responses: Schema.Record({ key: Schema.String, value: OperationResponse }),
   deprecated: Schema.optionalWith(Schema.Boolean, { default: () => false }),
 }) {}
 
@@ -212,4 +253,11 @@ export class InvocationResult extends Schema.Class<InvocationResult>("Invocation
   headers: Schema.Record({ key: Schema.String, value: Schema.String }),
   data: Schema.NullOr(Schema.Unknown),
   error: Schema.NullOr(Schema.Unknown),
+  /**
+   * The spec status-code key (e.g. "200", "201", "default") whose schema
+   * applied to this response, if the invoker was given a responses map at
+   * call time. `null` when no match was found (or when the invoker was
+   * called without a responses map — its original minimal signature).
+   */
+  matchedResponseStatus: Schema.NullOr(Schema.String),
 }) {}


### PR DESCRIPTION
## Summary

- Extracts the full `{ [status]: OperationResponse }` map per operation instead of picking a single 2xx schema. Existing `outputSchema` is kept as the "preferred single schema" used in LLM tool definitions (first 2xx with a body, `default` fallback).
- Lifts documented response headers (with their schemas + descriptions) into `OperationResponse.headers`.
- Adds a `readOnly` / `writeOnly` schema filter: request-direction schemas have `readOnly` fields (and matching `required` entries) stripped; response-direction schemas have `writeOnly` stripped.
- `invoke()` now records `matchedResponseStatus` on the `InvocationResult` by walking the response map: exact status → NXX wildcard → `default`. Null stays distinct from "no match" so callers can tell them apart.

## Why

The LLM was being handed response schemas that included `readOnly` fields in the input surface and vice-versa — it would either send server-computed fields on creates (rejected) or not know response-only fields existed. Multi-status specs (e.g. 200/201 returning different shapes) also collapsed to whichever schema `preferredContent` happened to pick first.

## Test plan

- [x] `response-fidelity.test.ts` (new) — 8 tests across 4 scenarios
  - Multi-status: 200 and 201 both preserved, `outputSchema` prefers 200, `invoke()` tags `matchedResponseStatus` for 200/201/500
  - `readOnly` stripped from POST body + `required`, kept on GET response, kept on POST's own response
  - `writeOnly` kept on POST body, stripped from response + `required`
  - Documented response headers lifted with name/schema/description
- [x] Cycle guard in `filterSchemaForDirection` — real-world specs (Cloudflare, Stripe) with circular `$ref`s no longer blow the stack
- [x] `bunx vitest run` passes across the package