### PR TITLE
connections: local /connections route + backfill missing secret routing rows

### DIFF
--- a/apps/cloud/scripts/migrate-connections.ts
+++ b/apps/cloud/scripts/migrate-connections.ts
@@ -335,12 +335,6 @@ const main = async () => {
             from secret
             where scope_id = ${b.row.scope_id} and id = any(${secretIds})
           `) as SecretRow[];
-          const missing = secretIds.filter(
-            (id) => !existing.some((r) => r.id === id),
-          );
-          if (missing.length > 0) {
-            throw new Error(`secret row(s) missing: ${missing.join(", ")}`);
-          }
           const alreadyOwned = existing.filter(
             (r) =>
               r.owned_by_connection_id !== null &&
@@ -351,11 +345,36 @@ const main = async () => {
               `secret(s) already owned: ${alreadyOwned.map((r) => `${r.id}(owner=${r.owned_by_connection_id})`).join(", ")}`,
             );
           }
-          await tx`
-            update secret
-            set owned_by_connection_id = ${connectionId}
-            where scope_id = ${b.row.scope_id} and id = any(${secretIds})
-          `;
+          // Some early-onboarded OpenAPI OAuth tokens never got a `secret`
+          // routing row — the pre-refactor `secretsGet` fallback resolved
+          // them via provider enumeration. Backfill the missing rows
+          // pointing at `workos-vault` (the only writable provider on
+          // cloud) so the new SDK's id-indexed fast path finds them.
+          const missing = secretIds.filter(
+            (id) => !existing.some((r) => r.id === id),
+          );
+          for (const id of missing) {
+            const name =
+              id === l.accessTokenSecretId
+                ? `Connection ${connectionId} access token`
+                : `Connection ${connectionId} refresh token`;
+            await tx`
+              insert into secret (
+                id, scope_id, provider, name,
+                owned_by_connection_id, created_at
+              ) values (
+                ${id}, ${b.row.scope_id}, ${"workos-vault"}, ${name},
+                ${connectionId}, now()
+              )
+            `;
+          }
+          if (existing.length > 0) {
+            await tx`
+              update secret
+              set owned_by_connection_id = ${connectionId}
+              where scope_id = ${b.row.scope_id} and id = any(${secretIds})
+            `;
+          }
 
           const nextInvocation = {
             ...(isRecord(b.row.invocation_config) ? b.row.invocation_config : {}),

--- a/apps/local/src/routeTree.gen.ts
+++ b/apps/local/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ToolsRouteImport } from './routes/tools'
 import { Route as SecretsRouteImport } from './routes/secrets'
+import { Route as ConnectionsRouteImport } from './routes/connections'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
 import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$pluginKey'
@@ -23,6 +24,11 @@ const ToolsRoute = ToolsRouteImport.update({
 const SecretsRoute = SecretsRouteImport.update({
   id: '/secrets',
   path: '/secrets',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ConnectionsRoute = ConnectionsRouteImport.update({
+  id: '/connections',
+  path: '/connections',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -43,6 +49,7 @@ const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/connections': typeof ConnectionsRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -50,6 +57,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/connections': typeof ConnectionsRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -58,6 +66,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/connections': typeof ConnectionsRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -67,6 +76,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/connections'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -74,6 +84,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/connections'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -81,6 +92,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/connections'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -89,6 +101,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ConnectionsRoute: typeof ConnectionsRoute
   SecretsRoute: typeof SecretsRoute
   ToolsRoute: typeof ToolsRoute
   SourcesNamespaceRoute: typeof SourcesNamespaceRoute
@@ -109,6 +122,13 @@ declare module '@tanstack/react-router' {
       path: '/secrets'
       fullPath: '/secrets'
       preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/connections': {
+      id: '/connections'
+      path: '/connections'
+      fullPath: '/connections'
+      preLoaderRoute: typeof ConnectionsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -137,6 +157,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ConnectionsRoute: ConnectionsRoute,
   SecretsRoute: SecretsRoute,
   ToolsRoute: ToolsRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,

--- a/apps/local/src/routes/connections.tsx
+++ b/apps/local/src/routes/connections.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ConnectionsPage } from "@executor/react/pages/connections";
+
+export const Route = createFileRoute("/connections")({
+  component: () => <ConnectionsPage />,
+});

--- a/apps/local/src/server/migrate-connections.ts
+++ b/apps/local/src/server/migrate-connections.ts
@@ -128,6 +128,15 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
   const selectSecret = sqlite.prepare(
     "SELECT id, owned_by_connection_id FROM secret WHERE scope_id = ? AND id = ?",
   );
+  const selectAnySecretProvider = sqlite.prepare(
+    "SELECT provider FROM secret WHERE scope_id = ? LIMIT 1",
+  );
+  const insertSecret = sqlite.prepare(
+    `INSERT INTO secret (
+       id, scope_id, provider, name,
+       owned_by_connection_id, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+  );
   const updateSource = sqlite.prepare(
     "UPDATE openapi_source SET oauth2 = ?, invocation_config = ? WHERE scope_id = ? AND id = ?",
   );
@@ -199,13 +208,6 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
           | { id: string; owned_by_connection_id: string | null }
           | undefined,
     );
-    const missing = secretIds.filter((_, i) => secretRows[i] === undefined);
-    if (missing.length > 0) {
-      console.warn(
-        `[migrate-connections] skip ${row.scope_id}/${row.id}: missing secret(s) ${missing.join(", ")}`,
-      );
-      continue;
-    }
     const alreadyOwned = secretRows
       .filter((s): s is { id: string; owned_by_connection_id: string | null } => !!s)
       .filter(
@@ -218,6 +220,21 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
         `[migrate-connections] skip ${row.scope_id}/${row.id}: secret(s) already owned`,
       );
       continue;
+    }
+    // Early-onboarded OpenAPI OAuth tokens never got a `secret` routing
+    // row — pre-refactor `secretsGet` resolved them via provider
+    // enumeration. Pick the provider already in use at this scope (or
+    // fall back to keychain) so the new id-indexed fast path resolves;
+    // if we guess wrong the SDK's enumerate-fallback still works.
+    const missingIndexes = secretIds
+      .map((_, i) => i)
+      .filter((i) => secretRows[i] === undefined);
+    let fallbackProvider: string | null = null;
+    if (missingIndexes.length > 0) {
+      const existing = selectAnySecretProvider.get(row.scope_id) as
+        | { provider: string }
+        | undefined;
+      fallbackProvider = existing?.provider ?? "keychain";
     }
 
     const now = Date.now();
@@ -236,8 +253,24 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
         now,
         now,
       );
-      for (const sid of secretIds) {
-        updateSecretOwner.run(connectionId, row.scope_id, sid);
+      for (let i = 0; i < secretIds.length; i++) {
+        const sid = secretIds[i]!;
+        if (secretRows[i] === undefined) {
+          const name =
+            sid === legacy.accessTokenSecretId
+              ? `Connection ${connectionId} access token`
+              : `Connection ${connectionId} refresh token`;
+          insertSecret.run(
+            sid,
+            row.scope_id,
+            fallbackProvider!,
+            name,
+            connectionId,
+            now,
+          );
+        } else {
+          updateSecretOwner.run(connectionId, row.scope_id, sid);
+        }
       }
       const nextInvocation = { ...invocation, oauth2: oauth2Pointer };
       updateSource.run(

--- a/apps/local/src/web/shell.tsx
+++ b/apps/local/src/web/shell.tsx
@@ -305,6 +305,7 @@ function SidebarContent(props: {
 }) {
   const isHome = props.pathname === "/";
   const isSecrets = props.pathname === "/secrets";
+  const isConnections = props.pathname === "/connections";
 
   return (
     <>
@@ -319,6 +320,7 @@ function SidebarContent(props: {
       <nav className="flex flex-1 flex-col overflow-y-auto p-2">
         <ScopeLabel />
         <NavItem to="/" label="Sources" active={isHome} onNavigate={props.onNavigate} />
+        <NavItem to="/connections" label="Connections" active={isConnections} onNavigate={props.onNavigate} />
         <NavItem to="/secrets" label="Secrets" active={isSecrets} onNavigate={props.onNavigate} />
 
         {/* Sources list */}


### PR DESCRIPTION
## Summary

Two fallouts from #358 surfaced during the cloud migration apply:

- **Local had no `/connections` page.** Cloud got the route (`apps/cloud/src/routes/connections.tsx`) but the equivalent wasn't added for local. Adds `apps/local/src/routes/connections.tsx` (mirrors cloud), wires a \"Connections\" nav item into the sidebar, and lets the TanStack router regenerate the routeTree.

- **Missing `secret` routing rows broke the migration backfill.** Both `migrate-connections` scripts assumed every legacy OAuth access/refresh token had a row in the `secret` table. Three early-onboarded cloud sources (Spotify / DealCloud / Microsoft Graph) had their token values in WorkOS Vault but no routing row — the pre-refactor `secretsGet` resolved them via the enumerate-fallback (`list()`-capable providers). The new id-indexed fast path needs the row. Both scripts now backfill the missing row alongside flipping ownership:
  - cloud: hardcoded `workos-vault` (the only writable provider).
  - local: the provider already in use at the scope, falling back to `keychain`.

  If the provider pick is wrong, the SDK's enumeration fallback at `packages/core/sdk/src/executor.ts:684-703` still resolves the value — worst case the user sees `Reconnect`.

## Test plan

- [ ] `pnpm -w check` clean (typecheck, lint pass locally).
- [ ] Cloud: re-run `bun run scripts/migrate-connections.ts --apply` — the 3 previously-failing rows now apply; `secret` table gains routing rows for `openapi_*_access_token` / `_refresh_token` with `provider = 'workos-vault'` and `owned_by_connection_id` set.
- [ ] Cloud: post-apply, Spotify / DealCloud / Microsoft Graph sources show in `/connections` and invocation still works without re-sign-in.
- [ ] Local: `/connections` nav item renders, page loads.
- [ ] Local: boot with a DB containing a legacy OpenAPI OAuth row whose secrets lack routing rows — row migrates, source usable post-boot.