### PR TITLE
connections: migrate legacy MCP + google-discovery oauth rows

### DIFF
--- a/apps/cloud/scripts/migrate-mcp-connections.ts
+++ b/apps/cloud/scripts/migrate-mcp-connections.ts
@@ -1,0 +1,336 @@
+// ---------------------------------------------------------------------------
+// MCP OAuth legacy → Connection backfill (cloud)
+// ---------------------------------------------------------------------------
+//
+// Companion to migrate-connections.ts (which handled OpenAPI). Same shape,
+// different table: scans `mcp_source`, finds rows whose `config.auth` is
+// still on the pre-refactor inline-OAuth shape, mints a stable per-source
+// Connection row, backfills the secret routing rows, and rewrites
+// `config.auth` to the `{kind:"oauth2", connectionId}` pointer.
+//
+// Dry-run by default. `--apply` runs the per-row transactions.
+//
+// Run (dry-run):
+//   op run --env-file=.env.production -- bun run scripts/migrate-mcp-connections.ts
+// Run (apply):
+//   op run --env-file=.env.production -- bun run scripts/migrate-mcp-connections.ts --apply
+
+import { Option, Schema } from "effect";
+import postgres from "postgres";
+
+import { McpConnectionAuth } from "@executor/plugin-mcp";
+
+const APPLY = process.argv.includes("--apply");
+
+// ---------------------------------------------------------------------------
+// Legacy MCP oauth2 auth shape (pre-refactor). Inlined — this script is the
+// only place that still needs to know about it. Once cloud + local have
+// run this migration, the file can be deleted.
+// ---------------------------------------------------------------------------
+
+const JsonObject = Schema.Record({ key: Schema.String, value: Schema.Unknown });
+
+const LegacyMcpOAuth2 = Schema.Struct({
+  kind: Schema.Literal("oauth2"),
+  accessTokenSecretId: Schema.String,
+  refreshTokenSecretId: Schema.NullOr(Schema.String),
+  tokenType: Schema.optionalWith(Schema.String, { default: () => "Bearer" }),
+  expiresAt: Schema.NullOr(Schema.Number),
+  scope: Schema.NullOr(Schema.String),
+  clientInformation: Schema.optionalWith(Schema.NullOr(JsonObject), {
+    default: () => null,
+  }),
+  authorizationServerUrl: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+  resourceMetadataUrl: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+});
+type LegacyMcpOAuth2 = typeof LegacyMcpOAuth2.Type;
+
+const decodeCurrentAuth = Schema.decodeUnknownOption(McpConnectionAuth);
+const decodeLegacy = Schema.decodeUnknownOption(LegacyMcpOAuth2);
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+// ---------------------------------------------------------------------------
+// Row classification
+// ---------------------------------------------------------------------------
+
+type Row = {
+  scope_id: string;
+  id: string;
+  name: string;
+  config: unknown;
+};
+
+type Bucket =
+  | { kind: "non-remote"; row: Row }
+  | { kind: "no-oauth"; row: Row }
+  | { kind: "current"; row: Row }
+  | { kind: "legacy-migratable"; row: Row; legacy: LegacyMcpOAuth2; endpoint: string }
+  | { kind: "legacy-blocked"; row: Row; legacy: LegacyMcpOAuth2; reason: string }
+  | { kind: "unknown"; row: Row; shape: string };
+
+const classifyRow = (row: Row): Bucket => {
+  if (!isRecord(row.config)) return { kind: "unknown", row, shape: typeof row.config };
+  if (row.config.transport !== "remote") return { kind: "non-remote", row };
+  const auth = row.config.auth;
+  if (!isRecord(auth)) return { kind: "no-oauth", row };
+  if (auth.kind !== "oauth2") return { kind: "no-oauth", row };
+
+  if (Option.isSome(decodeCurrentAuth(auth))) return { kind: "current", row };
+
+  const legacyOption = decodeLegacy(auth);
+  if (Option.isSome(legacyOption)) {
+    const legacy = legacyOption.value;
+    const endpoint =
+      typeof row.config.endpoint === "string" ? row.config.endpoint : null;
+    if (!endpoint) {
+      return {
+        kind: "legacy-blocked",
+        row,
+        legacy,
+        reason: "config.endpoint missing",
+      };
+    }
+    if (legacy.clientInformation === null) {
+      return {
+        kind: "legacy-blocked",
+        row,
+        legacy,
+        reason: "clientInformation missing — DCR never completed",
+      };
+    }
+    return { kind: "legacy-migratable", row, legacy, endpoint };
+  }
+
+  const shape = `{${Object.keys(auth).sort().join(",")}}`;
+  return { kind: "unknown", row, shape };
+};
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+type SecretRow = {
+  id: string;
+  scope_id: string;
+  owned_by_connection_id: string | null;
+};
+
+const main = async () => {
+  const connectionString =
+    process.env.DATABASE_URL || process.env.HYPERDRIVE_CONNECTION_STRING || "";
+  if (!connectionString) {
+    console.error(
+      "DATABASE_URL not set (try: op run --env-file=.env.production -- ...)",
+    );
+    process.exit(1);
+  }
+
+  const sql = postgres(connectionString, {
+    max: 1,
+    onnotice: () => undefined,
+    ssl: "require",
+  });
+
+  try {
+    const rows = (await sql<Row[]>`
+      select scope_id, id, name, config
+      from mcp_source
+    `) as Row[];
+
+    console.log(`\nScanned ${rows.length} mcp_source row(s)`);
+    console.log(APPLY ? "Mode: APPLY (writes enabled)\n" : "Mode: DRY-RUN (no writes)\n");
+
+    const buckets = rows.map(classifyRow);
+
+    const counts = {
+      "non-remote": 0,
+      "no-oauth": 0,
+      current: 0,
+      "legacy-migratable": 0,
+      "legacy-blocked": 0,
+      unknown: 0,
+    };
+    for (const b of buckets) counts[b.kind]++;
+
+    console.log("Classification:");
+    console.log(`  non-remote (stdio):        ${counts["non-remote"]}`);
+    console.log(`  no oauth2 auth:            ${counts["no-oauth"]}`);
+    console.log(`  already on new shape:      ${counts.current}`);
+    console.log(`  legacy — would migrate:    ${counts["legacy-migratable"]}`);
+    console.log(`  legacy — blocked:          ${counts["legacy-blocked"]}`);
+    console.log(`  unrecognized shape:        ${counts.unknown}\n`);
+
+    const migratable = buckets.filter(
+      (b): b is Extract<Bucket, { kind: "legacy-migratable" }> =>
+        b.kind === "legacy-migratable",
+    );
+    const blocked = buckets.filter(
+      (b) => b.kind === "legacy-blocked" || b.kind === "unknown",
+    );
+
+    for (const b of blocked) {
+      const ref = `${b.row.scope_id}/${b.row.id}`;
+      if (b.kind === "legacy-blocked") {
+        console.log(`[BLOCKED] ${ref}`);
+        console.log(`  reason: ${b.reason}`);
+      } else if (b.kind === "unknown") {
+        console.log(`[UNKNOWN] ${ref}`);
+        console.log(`  shape: ${b.shape}`);
+      }
+      console.log();
+    }
+
+    for (const b of migratable) {
+      const ref = `${b.row.scope_id}/${b.row.id}`;
+      console.log(`[migratable] ${ref}`);
+      console.log(`  endpoint:           ${b.endpoint}`);
+      console.log(`  accessTokenSecret:  ${b.legacy.accessTokenSecretId}`);
+      console.log(
+        `  refreshTokenSecret: ${b.legacy.refreshTokenSecretId ?? "(null)"}`,
+      );
+      console.log(
+        `  authServerUrl:      ${b.legacy.authorizationServerUrl ?? "(null)"}`,
+      );
+      console.log();
+    }
+
+    if (blocked.length > 0) {
+      console.log(
+        `ABORT: ${blocked.length} row(s) blocked or unrecognized; inspect above and fix or delete before re-running.`,
+      );
+      process.exit(2);
+    }
+
+    if (!APPLY) {
+      console.log(`OK: ${migratable.length} row(s) would migrate. Re-run with --apply.`);
+      return;
+    }
+
+    if (migratable.length === 0) {
+      console.log("Nothing to migrate.");
+      return;
+    }
+
+    let applied = 0;
+    let failed = 0;
+    for (const b of migratable) {
+      const ref = `${b.row.scope_id}/${b.row.id}`;
+      const connectionId = `mcp-oauth2-${b.row.id}`;
+      const l = b.legacy;
+      const providerState = {
+        endpoint: b.endpoint,
+        tokenType: l.tokenType,
+        clientInformation: l.clientInformation!,
+        authorizationServerUrl: l.authorizationServerUrl,
+        authorizationServerMetadata: null,
+        resourceMetadataUrl: l.resourceMetadataUrl,
+        resourceMetadata: null,
+      };
+      const authPointer = { kind: "oauth2" as const, connectionId };
+      const nextConfig = { ...(isRecord(b.row.config) ? b.row.config : {}), auth: authPointer };
+
+      try {
+        await sql.begin(async (tx) => {
+          await tx`
+            insert into connection (
+              id, scope_id, provider, kind, identity_label,
+              access_token_secret_id, refresh_token_secret_id,
+              expires_at, scope, provider_state,
+              created_at, updated_at
+            ) values (
+              ${connectionId},
+              ${b.row.scope_id},
+              ${"mcp:oauth2"},
+              ${"user"},
+              ${b.row.name},
+              ${l.accessTokenSecretId},
+              ${l.refreshTokenSecretId},
+              ${l.expiresAt},
+              ${l.scope},
+              ${tx.json(providerState)},
+              now(),
+              now()
+            )
+          `;
+
+          const secretIds = [l.accessTokenSecretId];
+          if (l.refreshTokenSecretId) secretIds.push(l.refreshTokenSecretId);
+
+          const existing = (await tx<SecretRow[]>`
+            select id, scope_id, owned_by_connection_id
+            from secret
+            where scope_id = ${b.row.scope_id} and id = any(${secretIds})
+          `) as SecretRow[];
+          const alreadyOwned = existing.filter(
+            (r) =>
+              r.owned_by_connection_id !== null &&
+              r.owned_by_connection_id !== connectionId,
+          );
+          if (alreadyOwned.length > 0) {
+            throw new Error(
+              `secret(s) already owned: ${alreadyOwned.map((r) => `${r.id}(owner=${r.owned_by_connection_id})`).join(", ")}`,
+            );
+          }
+          // Backfill any missing routing rows pointing at workos-vault, the
+          // only writable provider on cloud. Matches the openapi migration.
+          const missing = secretIds.filter(
+            (id) => !existing.some((r) => r.id === id),
+          );
+          for (const id of missing) {
+            const name =
+              id === l.accessTokenSecretId
+                ? `Connection ${connectionId} access token`
+                : `Connection ${connectionId} refresh token`;
+            await tx`
+              insert into secret (
+                id, scope_id, provider, name,
+                owned_by_connection_id, created_at
+              ) values (
+                ${id}, ${b.row.scope_id}, ${"workos-vault"}, ${name},
+                ${connectionId}, now()
+              )
+            `;
+          }
+          if (existing.length > 0) {
+            await tx`
+              update secret
+              set owned_by_connection_id = ${connectionId}
+              where scope_id = ${b.row.scope_id} and id = any(${secretIds})
+            `;
+          }
+
+          await tx`
+            update mcp_source
+            set config = ${tx.json(nextConfig)}
+            where scope_id = ${b.row.scope_id} and id = ${b.row.id}
+          `;
+        });
+        applied++;
+        console.log(`  [OK]   ${ref} -> ${connectionId}`);
+      } catch (err) {
+        failed++;
+        console.log(
+          `  [FAIL] ${ref}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    console.log();
+    console.log(`Applied: ${applied}`);
+    console.log(`Failed:  ${failed}`);
+    if (failed > 0) process.exit(3);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+};
+
+main().catch((err) => {
+  console.error("migrate-mcp-connections failed:", err);
+  process.exit(1);
+});

--- a/apps/cloud/scripts/migrate-mcp-connections.ts
+++ b/apps/cloud/scripts/migrate-mcp-connections.ts
@@ -97,14 +97,6 @@ const classifyRow = (row: Row): Bucket => {
         reason: "config.endpoint missing",
       };
     }
-    if (legacy.clientInformation === null) {
-      return {
-        kind: "legacy-blocked",
-        row,
-        legacy,
-        reason: "clientInformation missing — DCR never completed",
-      };
-    }
     return { kind: "legacy-migratable", row, legacy, endpoint };
   }
 
@@ -230,7 +222,7 @@ const main = async () => {
       const providerState = {
         endpoint: b.endpoint,
         tokenType: l.tokenType,
-        clientInformation: l.clientInformation!,
+        clientInformation: l.clientInformation,
         authorizationServerUrl: l.authorizationServerUrl,
         authorizationServerMetadata: null,
         resourceMetadataUrl: l.resourceMetadataUrl,

--- a/apps/cloud/scripts/migrate-mcp-connections.ts
+++ b/apps/cloud/scripts/migrate-mcp-connections.ts
@@ -21,6 +21,7 @@ import postgres from "postgres";
 import { McpConnectionAuth } from "@executor/plugin-mcp";
 
 const APPLY = process.argv.includes("--apply");
+const DUMP_BLOCKED = process.argv.includes("--dump-blocked");
 
 // ---------------------------------------------------------------------------
 // Legacy MCP oauth2 auth shape (pre-refactor). Inlined — this script is the
@@ -182,6 +183,9 @@ const main = async () => {
       } else if (b.kind === "unknown") {
         console.log(`[UNKNOWN] ${ref}`);
         console.log(`  shape: ${b.shape}`);
+      }
+      if (DUMP_BLOCKED && isRecord(b.row.config)) {
+        console.log(`  auth: ${JSON.stringify(b.row.config.auth, null, 2)}`);
       }
       console.log();
     }

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -14,7 +14,7 @@ import {
   readLegacySecrets,
   type LegacySecret,
 } from "./db-upgrade";
-import { migrateOpenApiOAuthConnections } from "./migrate-connections";
+import { migrateLegacyConnections } from "./migrate-connections";
 
 import {
   Scope,
@@ -137,9 +137,10 @@ const createLocalExecutorLayer = () => {
       if (legacySecrets.length > 0) {
         importLegacySecrets(sqlite, scopeId, legacySecrets);
       }
-      // Upgrade pre-connection OpenAPI OAuth rows onto the new Connection
-      // pointer shape. Idempotent + no-op when there's nothing to migrate.
-      yield* Effect.promise(() => migrateOpenApiOAuthConnections(sqlite));
+      // Upgrade pre-connection openapi/mcp/google-discovery rows onto the
+      // new Connection pointer shape. Idempotent + no-op when there's
+      // nothing to migrate.
+      yield* Effect.promise(() => migrateLegacyConnections(sqlite));
       const configPath = resolveConfigPath(cwd);
       const configFile = makeFileConfigSink({
         path: configPath,

--- a/apps/local/src/server/migrate-connections.ts
+++ b/apps/local/src/server/migrate-connections.ts
@@ -1,16 +1,16 @@
 // ---------------------------------------------------------------------------
-// OpenAPI OAuth legacy → Connection backfill (local)
+// OAuth legacy → Connection backfill (local)
 // ---------------------------------------------------------------------------
 //
-// Runs at boot time right after `migrate()`. For every `openapi_source`
-// row still on the pre-refactor OAuth2 shape, mints a Connection row,
-// re-parents the referenced secret(s) to it, and rewrites both the
-// top-level `oauth2` column and the nested `invocation_config.oauth2`
-// copy to the new pointer shape.
+// Runs at boot time right after `migrate()`. For every row still on the
+// pre-refactor inline-OAuth shape (openapi_source, mcp_source,
+// google_discovery_source), mints a Connection row, re-parents the
+// referenced secret(s) to it, and rewrites the source's stored auth to
+// the new pointer shape.
 //
 // Self-contained: the only plugin imports are current-shape parsing
-// helpers. The pre-refactor shape is defined inline — this file is the
-// last place in the codebase that still needs to know about it.
+// helpers. Each legacy shape is defined inline — this file is the last
+// place in the codebase that still needs to know about them.
 
 import { Database } from "bun:sqlite";
 import { randomUUID } from "node:crypto";
@@ -21,10 +21,150 @@ import {
   resolveSpecText,
   OAuth2Auth,
 } from "@executor/plugin-openapi";
+import { McpConnectionAuth } from "@executor/plugin-mcp";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+const isString = (v: unknown): v is string => typeof v === "string";
+
+const JsonObject = Schema.Record({ key: Schema.String, value: Schema.Unknown });
+
+/** Pre-flight: bail unless the drizzle migration that added the Connection
+ *  table + `secret.owned_by_connection_id` has completed. */
+const connectionsReady = (sqlite: Database): boolean => {
+  const secretColumns = sqlite
+    .prepare("PRAGMA table_info('secret')")
+    .all() as ReadonlyArray<{ readonly name: string }>;
+  if (!secretColumns.some((c) => c.name === "owned_by_connection_id")) return false;
+  const connectionTable = sqlite
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='connection'")
+    .get();
+  return connectionTable !== null && connectionTable !== undefined;
+};
+
+const tableExists = (sqlite: Database, name: string): boolean => {
+  const row = sqlite
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?")
+    .get(name);
+  return row !== null && row !== undefined;
+};
+
+type SecretRow = { id: string; owned_by_connection_id: string | null };
+
+/** Shared: re-parent the pointed-to secret ids to the new connection,
+ *  backfilling any missing routing rows. Returns `null` on success, an
+ *  error message string on skip. */
+const rewireSecrets = (
+  sqlite: Database,
+  scopeId: string,
+  connectionId: string,
+  secretIds: ReadonlyArray<string>,
+  namesByIndex: ReadonlyArray<string>,
+): string | null => {
+  const selectSecret = sqlite.prepare(
+    "SELECT id, owned_by_connection_id FROM secret WHERE scope_id = ? AND id = ?",
+  );
+  const selectAnySecretProvider = sqlite.prepare(
+    "SELECT provider FROM secret WHERE scope_id = ? LIMIT 1",
+  );
+  const updateSecretOwner = sqlite.prepare(
+    "UPDATE secret SET owned_by_connection_id = ? WHERE scope_id = ? AND id = ?",
+  );
+  const insertSecret = sqlite.prepare(
+    `INSERT INTO secret (
+       id, scope_id, provider, name,
+       owned_by_connection_id, created_at
+     ) VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+
+  const rows = secretIds.map(
+    (sid) => selectSecret.get(scopeId, sid) as SecretRow | undefined,
+  );
+  const alreadyOwned = rows
+    .filter((r): r is SecretRow => !!r)
+    .filter(
+      (r) =>
+        r.owned_by_connection_id !== null &&
+        r.owned_by_connection_id !== connectionId,
+    );
+  if (alreadyOwned.length > 0) return "secret(s) already owned";
+
+  // Early-onboarded rows never got a `secret` routing row — pre-refactor
+  // `secretsGet` resolved them via provider enumeration. Pick the
+  // provider already in use at this scope (or fall back to keychain) so
+  // the new id-indexed fast path resolves. If we guess wrong the SDK's
+  // enumerate-fallback still works.
+  const missingCount = rows.filter((r) => r === undefined).length;
+  let fallbackProvider: string | null = null;
+  if (missingCount > 0) {
+    const existing = selectAnySecretProvider.get(scopeId) as
+      | { provider: string }
+      | undefined;
+    fallbackProvider = existing?.provider ?? "keychain";
+  }
+
+  const now = Date.now();
+  for (let i = 0; i < secretIds.length; i++) {
+    const sid = secretIds[i]!;
+    if (rows[i] === undefined) {
+      insertSecret.run(sid, scopeId, fallbackProvider!, namesByIndex[i]!, connectionId, now);
+    } else {
+      updateSecretOwner.run(connectionId, scopeId, sid);
+    }
+  }
+  return null;
+};
+
+const insertConnectionRow = (
+  sqlite: Database,
+  params: {
+    id: string;
+    scopeId: string;
+    provider: string;
+    identityLabel: string;
+    accessTokenSecretId: string;
+    refreshTokenSecretId: string | null;
+    expiresAt: number | null;
+    scope: string | null;
+    providerState: unknown;
+  },
+): void => {
+  const stmt = sqlite.prepare(
+    `INSERT INTO connection (
+       id, scope_id, provider, kind, identity_label,
+       access_token_secret_id, refresh_token_secret_id,
+       expires_at, scope, provider_state,
+       created_at, updated_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const now = Date.now();
+  stmt.run(
+    params.id,
+    params.scopeId,
+    params.provider,
+    "user",
+    params.identityLabel,
+    params.accessTokenSecretId,
+    params.refreshTokenSecretId,
+    params.expiresAt,
+    params.scope,
+    JSON.stringify(params.providerState),
+    now,
+    now,
+  );
+};
+
+// ---------------------------------------------------------------------------
+// OpenAPI — legacy shape
+// ---------------------------------------------------------------------------
 
 const OAuth2Flow = Schema.Literal("authorizationCode", "clientCredentials");
 
-class LegacyOAuth2Auth extends Schema.Class<LegacyOAuth2Auth>("LegacyOAuth2Auth")({
+class LegacyOpenApiOAuth2 extends Schema.Class<LegacyOpenApiOAuth2>("LegacyOpenApiOAuth2")({
   kind: Schema.Literal("oauth2"),
   securitySchemeName: Schema.String,
   flow: OAuth2Flow,
@@ -39,12 +179,8 @@ class LegacyOAuth2Auth extends Schema.Class<LegacyOAuth2Auth>("LegacyOAuth2Auth"
   scopes: Schema.Array(Schema.String),
 }) {}
 
-const decodeCurrent = Schema.decodeUnknownOption(OAuth2Auth);
-const decodeLegacy = Schema.decodeUnknownOption(LegacyOAuth2Auth);
-
-const isRecord = (v: unknown): v is Record<string, unknown> =>
-  typeof v === "object" && v !== null && !Array.isArray(v);
-const isString = (v: unknown): v is string => typeof v === "string";
+const decodeOpenApiCurrent = Schema.decodeUnknownOption(OAuth2Auth);
+const decodeOpenApiLegacy = Schema.decodeUnknownOption(LegacyOpenApiOAuth2);
 
 const extractAuthorizationUrl = async (
   rawSpec: string,
@@ -78,7 +214,7 @@ const extractAuthorizationUrl = async (
     : null;
 };
 
-type Row = {
+type OpenApiRow = {
   scope_id: string;
   id: string;
   name: string;
@@ -87,56 +223,15 @@ type Row = {
   oauth2: string | null;
 };
 
-/**
- * Scan `openapi_source`, migrate any row still on the legacy OAuth2 shape
- * to a fresh Connection row + pointer. Idempotent — rows already on the
- * current shape are skipped. Logs one line per migrated row.
- */
-export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<void> => {
-  // The 0002_lively_sue_storm migration introduced the `connection` table
-  // and added `secret.owned_by_connection_id`. If those aren't present yet,
-  // the drizzle `migrate()` call upstream hasn't finished — bail.
-  const secretColumns = sqlite
-    .prepare("PRAGMA table_info('secret')")
-    .all() as ReadonlyArray<{ readonly name: string }>;
-  if (!secretColumns.some((c) => c.name === "owned_by_connection_id")) {
-    return;
-  }
-  const connectionTable = sqlite
-    .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='connection'")
-    .get();
-  if (!connectionTable) return;
-
+const migrateOpenApi = async (sqlite: Database): Promise<void> => {
+  if (!tableExists(sqlite, "openapi_source")) return;
   const rows = sqlite
     .prepare(
       "SELECT scope_id, id, name, spec, invocation_config, oauth2 FROM openapi_source",
     )
-    .all() as ReadonlyArray<Row>;
+    .all() as ReadonlyArray<OpenApiRow>;
   if (rows.length === 0) return;
 
-  const insertConnection = sqlite.prepare(
-    `INSERT INTO connection (
-       id, scope_id, provider, kind, identity_label,
-       access_token_secret_id, refresh_token_secret_id,
-       expires_at, scope, provider_state,
-       created_at, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  );
-  const updateSecretOwner = sqlite.prepare(
-    "UPDATE secret SET owned_by_connection_id = ? WHERE scope_id = ? AND id = ?",
-  );
-  const selectSecret = sqlite.prepare(
-    "SELECT id, owned_by_connection_id FROM secret WHERE scope_id = ? AND id = ?",
-  );
-  const selectAnySecretProvider = sqlite.prepare(
-    "SELECT provider FROM secret WHERE scope_id = ? LIMIT 1",
-  );
-  const insertSecret = sqlite.prepare(
-    `INSERT INTO secret (
-       id, scope_id, provider, name,
-       owned_by_connection_id, created_at
-     ) VALUES (?, ?, ?, ?, ?, ?)`,
-  );
   const updateSource = sqlite.prepare(
     "UPDATE openapi_source SET oauth2 = ?, invocation_config = ? WHERE scope_id = ? AND id = ?",
   );
@@ -161,9 +256,9 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
     }
     const primary = invocation.oauth2 ?? oauth2Col;
     if (primary == null) continue;
-    if (Option.isSome(decodeCurrent(primary))) continue;
+    if (Option.isSome(decodeOpenApiCurrent(primary))) continue;
 
-    const legacyOption = decodeLegacy(primary);
+    const legacyOption = decodeOpenApiLegacy(primary);
     if (Option.isNone(legacyOption)) continue;
     const legacy = legacyOption.value;
 
@@ -174,7 +269,7 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
     );
     if (legacy.flow === "authorizationCode" && authorizationUrl === null) {
       console.warn(
-        `[migrate-connections] skip ${row.scope_id}/${row.id}: authorizationCode flow but authorizationUrl unavailable`,
+        `[migrate-connections] skip openapi ${row.scope_id}/${row.id}: authorizationCode flow but authorizationUrl unavailable`,
       );
       continue;
     }
@@ -200,78 +295,26 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
     };
 
     const secretIds = [legacy.accessTokenSecretId];
-    if (legacy.refreshTokenSecretId) secretIds.push(legacy.refreshTokenSecretId);
-
-    const secretRows = secretIds.map(
-      (sid) =>
-        selectSecret.get(row.scope_id, sid) as
-          | { id: string; owned_by_connection_id: string | null }
-          | undefined,
-    );
-    const alreadyOwned = secretRows
-      .filter((s): s is { id: string; owned_by_connection_id: string | null } => !!s)
-      .filter(
-        (s) =>
-          s.owned_by_connection_id !== null &&
-          s.owned_by_connection_id !== connectionId,
-      );
-    if (alreadyOwned.length > 0) {
-      console.warn(
-        `[migrate-connections] skip ${row.scope_id}/${row.id}: secret(s) already owned`,
-      );
-      continue;
-    }
-    // Early-onboarded OpenAPI OAuth tokens never got a `secret` routing
-    // row — pre-refactor `secretsGet` resolved them via provider
-    // enumeration. Pick the provider already in use at this scope (or
-    // fall back to keychain) so the new id-indexed fast path resolves;
-    // if we guess wrong the SDK's enumerate-fallback still works.
-    const missingIndexes = secretIds
-      .map((_, i) => i)
-      .filter((i) => secretRows[i] === undefined);
-    let fallbackProvider: string | null = null;
-    if (missingIndexes.length > 0) {
-      const existing = selectAnySecretProvider.get(row.scope_id) as
-        | { provider: string }
-        | undefined;
-      fallbackProvider = existing?.provider ?? "keychain";
+    const secretNames = [`Connection ${connectionId} access token`];
+    if (legacy.refreshTokenSecretId) {
+      secretIds.push(legacy.refreshTokenSecretId);
+      secretNames.push(`Connection ${connectionId} refresh token`);
     }
 
-    const now = Date.now();
     const txn = sqlite.transaction(() => {
-      insertConnection.run(
-        connectionId,
-        row.scope_id,
-        "openapi:oauth2",
-        "user",
-        row.name,
-        legacy.accessTokenSecretId,
-        legacy.refreshTokenSecretId,
-        legacy.expiresAt,
-        legacy.scope,
-        JSON.stringify(providerState),
-        now,
-        now,
-      );
-      for (let i = 0; i < secretIds.length; i++) {
-        const sid = secretIds[i]!;
-        if (secretRows[i] === undefined) {
-          const name =
-            sid === legacy.accessTokenSecretId
-              ? `Connection ${connectionId} access token`
-              : `Connection ${connectionId} refresh token`;
-          insertSecret.run(
-            sid,
-            row.scope_id,
-            fallbackProvider!,
-            name,
-            connectionId,
-            now,
-          );
-        } else {
-          updateSecretOwner.run(connectionId, row.scope_id, sid);
-        }
-      }
+      insertConnectionRow(sqlite, {
+        id: connectionId,
+        scopeId: row.scope_id,
+        provider: "openapi:oauth2",
+        identityLabel: row.name,
+        accessTokenSecretId: legacy.accessTokenSecretId,
+        refreshTokenSecretId: legacy.refreshTokenSecretId,
+        expiresAt: legacy.expiresAt,
+        scope: legacy.scope,
+        providerState,
+      });
+      const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      if (err) throw new Error(err);
       const nextInvocation = { ...invocation, oauth2: oauth2Pointer };
       updateSource.run(
         JSON.stringify(oauth2Pointer),
@@ -283,12 +326,268 @@ export const migrateOpenApiOAuthConnections = async (sqlite: Database): Promise<
     try {
       txn();
       console.log(
-        `[migrate-connections] ${row.scope_id}/${row.id} -> ${connectionId}`,
+        `[migrate-connections] openapi ${row.scope_id}/${row.id} -> ${connectionId}`,
       );
     } catch (err) {
       console.warn(
-        `[migrate-connections] fail ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        `[migrate-connections] fail openapi ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
+};
+
+// ---------------------------------------------------------------------------
+// MCP — legacy shape
+// ---------------------------------------------------------------------------
+
+const LegacyMcpOAuth2 = Schema.Struct({
+  kind: Schema.Literal("oauth2"),
+  accessTokenSecretId: Schema.String,
+  refreshTokenSecretId: Schema.NullOr(Schema.String),
+  tokenType: Schema.optionalWith(Schema.String, { default: () => "Bearer" }),
+  expiresAt: Schema.NullOr(Schema.Number),
+  scope: Schema.NullOr(Schema.String),
+  clientInformation: Schema.optionalWith(Schema.NullOr(JsonObject), {
+    default: () => null,
+  }),
+  authorizationServerUrl: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+  resourceMetadataUrl: Schema.optionalWith(Schema.NullOr(Schema.String), {
+    default: () => null,
+  }),
+});
+
+const decodeMcpCurrent = Schema.decodeUnknownOption(McpConnectionAuth);
+const decodeMcpLegacy = Schema.decodeUnknownOption(LegacyMcpOAuth2);
+
+type McpRow = {
+  scope_id: string;
+  id: string;
+  name: string;
+  config: string;
+};
+
+const migrateMcp = (sqlite: Database): void => {
+  if (!tableExists(sqlite, "mcp_source")) return;
+  const rows = sqlite
+    .prepare("SELECT scope_id, id, name, config FROM mcp_source")
+    .all() as ReadonlyArray<McpRow>;
+  if (rows.length === 0) return;
+
+  const updateSource = sqlite.prepare(
+    "UPDATE mcp_source SET config = ? WHERE scope_id = ? AND id = ?",
+  );
+
+  for (const row of rows) {
+    let config: Record<string, unknown> = {};
+    try {
+      const parsed = JSON.parse(row.config) as unknown;
+      if (!isRecord(parsed)) continue;
+      config = parsed;
+    } catch {
+      continue;
+    }
+    if (config.transport !== "remote") continue;
+    const auth = config.auth;
+    if (!isRecord(auth) || auth.kind !== "oauth2") continue;
+
+    if (Option.isSome(decodeMcpCurrent(auth))) continue;
+
+    const legacyOption = decodeMcpLegacy(auth);
+    if (Option.isNone(legacyOption)) continue;
+    const legacy = legacyOption.value;
+
+    const endpoint = typeof config.endpoint === "string" ? config.endpoint : null;
+    if (!endpoint) {
+      console.warn(
+        `[migrate-connections] skip mcp ${row.scope_id}/${row.id}: endpoint missing`,
+      );
+      continue;
+    }
+    if (legacy.clientInformation === null) {
+      console.warn(
+        `[migrate-connections] skip mcp ${row.scope_id}/${row.id}: clientInformation missing (DCR never completed)`,
+      );
+      continue;
+    }
+
+    const connectionId = `mcp-oauth2-${row.id}`;
+    const providerState = {
+      endpoint,
+      tokenType: legacy.tokenType,
+      clientInformation: legacy.clientInformation,
+      authorizationServerUrl: legacy.authorizationServerUrl,
+      authorizationServerMetadata: null,
+      resourceMetadataUrl: legacy.resourceMetadataUrl,
+      resourceMetadata: null,
+    };
+    const authPointer = { kind: "oauth2" as const, connectionId };
+    const nextConfig = { ...config, auth: authPointer };
+
+    const secretIds = [legacy.accessTokenSecretId];
+    const secretNames = [`Connection ${connectionId} access token`];
+    if (legacy.refreshTokenSecretId) {
+      secretIds.push(legacy.refreshTokenSecretId);
+      secretNames.push(`Connection ${connectionId} refresh token`);
+    }
+
+    const txn = sqlite.transaction(() => {
+      insertConnectionRow(sqlite, {
+        id: connectionId,
+        scopeId: row.scope_id,
+        provider: "mcp:oauth2",
+        identityLabel: row.name,
+        accessTokenSecretId: legacy.accessTokenSecretId,
+        refreshTokenSecretId: legacy.refreshTokenSecretId,
+        expiresAt: legacy.expiresAt,
+        scope: legacy.scope,
+        providerState,
+      });
+      const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      if (err) throw new Error(err);
+      updateSource.run(JSON.stringify(nextConfig), row.scope_id, row.id);
+    });
+    try {
+      txn();
+      console.log(
+        `[migrate-connections] mcp ${row.scope_id}/${row.id} -> ${connectionId}`,
+      );
+    } catch (err) {
+      console.warn(
+        `[migrate-connections] fail mcp ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// google-discovery — legacy shape
+// ---------------------------------------------------------------------------
+
+const LegacyGoogleDiscoveryOAuth2 = Schema.Struct({
+  kind: Schema.Literal("oauth2"),
+  clientIdSecretId: Schema.String,
+  clientSecretSecretId: Schema.NullOr(Schema.String),
+  accessTokenSecretId: Schema.String,
+  refreshTokenSecretId: Schema.NullOr(Schema.String),
+  tokenType: Schema.optionalWith(Schema.String, { default: () => "Bearer" }),
+  expiresAt: Schema.NullOr(Schema.Number),
+  scope: Schema.NullOr(Schema.String),
+  scopes: Schema.Array(Schema.String),
+});
+
+const CurrentGoogleDiscoveryOAuth2 = Schema.Struct({
+  kind: Schema.Literal("oauth2"),
+  connectionId: Schema.String,
+  clientIdSecretId: Schema.String,
+  clientSecretSecretId: Schema.NullOr(Schema.String),
+  scopes: Schema.Array(Schema.String),
+});
+
+const decodeGoogleCurrent = Schema.decodeUnknownOption(CurrentGoogleDiscoveryOAuth2);
+const decodeGoogleLegacy = Schema.decodeUnknownOption(LegacyGoogleDiscoveryOAuth2);
+
+type GoogleRow = {
+  scope_id: string;
+  id: string;
+  name: string;
+  config: string;
+};
+
+const migrateGoogleDiscovery = (sqlite: Database): void => {
+  if (!tableExists(sqlite, "google_discovery_source")) return;
+  const rows = sqlite
+    .prepare("SELECT scope_id, id, name, config FROM google_discovery_source")
+    .all() as ReadonlyArray<GoogleRow>;
+  if (rows.length === 0) return;
+
+  const updateSource = sqlite.prepare(
+    "UPDATE google_discovery_source SET config = ?, updated_at = ? WHERE scope_id = ? AND id = ?",
+  );
+
+  for (const row of rows) {
+    let config: Record<string, unknown> = {};
+    try {
+      const parsed = JSON.parse(row.config) as unknown;
+      if (!isRecord(parsed)) continue;
+      config = parsed;
+    } catch {
+      continue;
+    }
+    const auth = config.auth;
+    if (!isRecord(auth) || auth.kind !== "oauth2") continue;
+
+    if (Option.isSome(decodeGoogleCurrent(auth))) continue;
+
+    const legacyOption = decodeGoogleLegacy(auth);
+    if (Option.isNone(legacyOption)) continue;
+    const legacy = legacyOption.value;
+
+    const connectionId = `google-discovery-oauth2-${randomUUID()}`;
+    const providerState = {
+      clientIdSecretId: legacy.clientIdSecretId,
+      clientSecretSecretId: legacy.clientSecretSecretId,
+      scopes: legacy.scopes,
+    };
+    const authPointer = {
+      kind: "oauth2" as const,
+      connectionId,
+      clientIdSecretId: legacy.clientIdSecretId,
+      clientSecretSecretId: legacy.clientSecretSecretId,
+      scopes: legacy.scopes,
+    };
+    const nextConfig = { ...config, auth: authPointer };
+
+    const secretIds = [legacy.accessTokenSecretId];
+    const secretNames = [`Connection ${connectionId} access token`];
+    if (legacy.refreshTokenSecretId) {
+      secretIds.push(legacy.refreshTokenSecretId);
+      secretNames.push(`Connection ${connectionId} refresh token`);
+    }
+
+    const txn = sqlite.transaction(() => {
+      insertConnectionRow(sqlite, {
+        id: connectionId,
+        scopeId: row.scope_id,
+        provider: "google-discovery:oauth2",
+        identityLabel: row.name,
+        accessTokenSecretId: legacy.accessTokenSecretId,
+        refreshTokenSecretId: legacy.refreshTokenSecretId,
+        expiresAt: legacy.expiresAt,
+        scope: legacy.scope,
+        providerState,
+      });
+      const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      if (err) throw new Error(err);
+      updateSource.run(JSON.stringify(nextConfig), Date.now(), row.scope_id, row.id);
+    });
+    try {
+      txn();
+      console.log(
+        `[migrate-connections] google-discovery ${row.scope_id}/${row.id} -> ${connectionId}`,
+      );
+    } catch (err) {
+      console.warn(
+        `[migrate-connections] fail google-discovery ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Umbrella
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan openapi_source, mcp_source, and google_discovery_source; migrate
+ * any row still on its plugin's legacy inline-OAuth shape to a fresh
+ * Connection row + pointer. Idempotent — rows already on the current
+ * shape are skipped. Logs one line per migrated row.
+ */
+export const migrateLegacyConnections = async (sqlite: Database): Promise<void> => {
+  if (!connectionsReady(sqlite)) return;
+  await migrateOpenApi(sqlite);
+  migrateMcp(sqlite);
+  migrateGoogleDiscovery(sqlite);
 };

--- a/apps/local/src/server/migrate-connections.ts
+++ b/apps/local/src/server/migrate-connections.ts
@@ -405,13 +405,6 @@ const migrateMcp = (sqlite: Database): void => {
       );
       continue;
     }
-    if (legacy.clientInformation === null) {
-      console.warn(
-        `[migrate-connections] skip mcp ${row.scope_id}/${row.id}: clientInformation missing (DCR never completed)`,
-      );
-      continue;
-    }
-
     const connectionId = `mcp-oauth2-${row.id}`;
     const providerState = {
       endpoint,

--- a/packages/plugins/mcp/src/sdk/index.ts
+++ b/packages/plugins/mcp/src/sdk/index.ts
@@ -20,3 +20,5 @@ export {
   type McpSchema,
   type McpStoredSource,
 } from "./binding-store";
+
+export { McpConnectionAuth } from "./types";

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -304,7 +304,11 @@ const MCP_OAUTH2_PROVIDER_KEY = "mcp:oauth2" as const;
 const OAuth2ProviderState = Schema.Struct({
   endpoint: Schema.String,
   tokenType: Schema.String,
-  clientInformation: McpJsonObject,
+  // Nullable to accommodate early-onboarded sources where DCR client
+  // registration was never persisted back onto the source. Refresh fails
+  // fast on null and surfaces a "re-sign-in required" error, which the UI
+  // turns into a Reconnect prompt.
+  clientInformation: Schema.NullOr(McpJsonObject),
   authorizationServerUrl: Schema.NullOr(Schema.String),
   authorizationServerMetadata: Schema.NullOr(McpJsonObject),
   resourceMetadataUrl: Schema.NullOr(Schema.String),
@@ -1289,6 +1293,14 @@ export const mcpPlugin = definePlugin(
                     cause,
                   }),
               });
+
+              if (state.clientInformation === null) {
+                return yield* new ConnectionRefreshError({
+                  connectionId: input.connectionId,
+                  message:
+                    "mcp:oauth2 connection has no clientInformation — re-sign-in required (legacy row; DCR was never persisted)",
+                });
+              }
 
               const authServerUrl =
                 state.authorizationServerUrl ??


### PR DESCRIPTION
## Summary

PR #358's Connection refactor only shipped a migration for OpenAPI OAuth rows. `mcp_source` and `google_discovery_source` rows still on the pre-refactor inline-OAuth shape point at nothing after the refactor — observed as "MCP server has a broken OAuth config (missing connectionId)".

- `apps/cloud/scripts/migrate-mcp-connections.ts` — companion to the existing openapi migration, scoped to the cloud's `mcp_source` table. Dry-run by default, `--apply` to commit. Mints stable `mcp-oauth2-\${sourceId}` connections, backfills any missing secret routing rows at `workos-vault`, rewrites `config.auth` to the `{kind:"oauth2", connectionId}` pointer.
- `apps/local/src/server/migrate-connections.ts` — refactored into plugin-specific migrators (`openapi` / `mcp` / `google-discovery`) sharing `insertConnectionRow` + `rewireSecrets` helpers. Exposed as a single `migrateLegacyConnections()` called at boot. Local covers all three plugins; cloud only runs openapi + mcp (no google-discovery plugin registered there).
- `packages/plugins/mcp/src/sdk/index.ts` — export `McpConnectionAuth` so migration scripts can decode the current pointer shape without reaching into internals.

Blocked rows (dry-run aborts):
- MCP rows where `clientInformation` is null — DCR never completed, nothing to migrate; delete the source and re-add.
- MCP rows missing `config.endpoint` — malformed, inspect by hand.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run typecheck` green
- [x] `apps/local` vitest suite green
- [ ] Cloud dry-run: `op run --env-file=.env.production -- bun run scripts/migrate-mcp-connections.ts`
- [ ] Cloud apply: `... --apply`
- [ ] Local: delete + re-add an MCP source, confirm it lands on the pointer shape; boot with a legacy-shape row and confirm migration log line