### PR TITLE
sdk: add skills primitive — per-source runbook notes

### DIFF
--- a/packages/core/execution/src/description.test.ts
+++ b/packages/core/execution/src/description.test.ts
@@ -91,9 +91,12 @@ describe("buildExecuteDescription", () => {
   );
 
   it.effect(
-    "omits the Available namespaces section when no plugins register sources",
+    "always renders the built-in executor.skills namespace so agents can record runbooks",
     () =>
       Effect.gen(function* () {
+        // With no user-supplied plugins, the built-in skills plugin is
+        // still auto-prepended — we want every agent to see the skills
+        // surface by default. This test locks in that contract.
         const executor = yield* createExecutor(
           makeTestConfig({ plugins: [] as const }),
         );
@@ -103,7 +106,8 @@ describe("buildExecuteDescription", () => {
         expect(description).toContain(
           "Execute TypeScript in a sandboxed runtime",
         );
-        expect(description).not.toContain("## Available namespaces");
+        expect(description).toContain("## Available namespaces");
+        expect(description).toContain("`executor.skills`");
       }),
   );
 });

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -152,6 +152,35 @@ export const coreSchema = {
       updated_at: { type: "date", required: true },
     },
   },
+  // Skills — short runbook notes keyed to a source (an integration the
+  // user hooked up). Captured primarily by the model during / after a
+  // first test-run against a freshly-added source; surfaced back to
+  // agents on subsequent invocations via `executor.skills.listForSource`
+  // and via the static `executor.skills.record` tool. Persisting this
+  // knowledge means the next agent doesn't have to re-learn the same
+  // API quirks. See `skills.ts` for the design note.
+  skill: {
+    fields: {
+      id: { type: "string", required: true },
+      scope_id: { type: "string", required: true, index: true },
+      /** Source (integration) this skill applies to — matches `source.id`.
+       *  Indexed because the hot read path is "all skills for source X". */
+      source_id: { type: "string", required: true, index: true },
+      title: { type: "string", required: true },
+      /** Markdown body. Size-bounded at write time (see `skills.ts`)
+       *  so a runaway model can't blow up the tool manifest. */
+      body: { type: "string", required: true },
+      /** Who authored the skill — "model" for agent-recorded notes,
+       *  "user" for manually-authored ones. UI / policy may treat them
+       *  differently. */
+      created_by: { type: "string", required: true },
+      /** Monotonic integer bumped on every overwrite of the same id.
+       *  Lets consumers spot stale cached copies. */
+      version: { type: "number", required: true },
+      created_at: { type: "date", required: true },
+      updated_at: { type: "date", required: true },
+    },
+  },
 } as const satisfies DBSchema;
 
 export type CoreSchema = typeof coreSchema;
@@ -178,6 +207,9 @@ export type SecretRow = InferDBFieldsOutput<CoreSchema["secret"]["fields"]> &
 export type ConnectionRow = InferDBFieldsOutput<
   CoreSchema["connection"]["fields"]
 > &
+  Record<string, unknown>;
+
+export type SkillRow = InferDBFieldsOutput<CoreSchema["skill"]["fields"]> &
   Record<string, unknown>;
 
 // ---------------------------------------------------------------------------

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -74,6 +74,13 @@ import {
 } from "./types";
 import { buildToolTypeScriptPreview } from "./schema-types";
 import { scopeAdapter } from "./scoped-adapter";
+import {
+  makeSkillsStore,
+  type RecordSkillInput,
+  type Skill,
+  type SkillsStore,
+} from "./skills";
+import { skillsPlugin } from "./skills-plugin";
 
 // ---------------------------------------------------------------------------
 // InvokeOptions — passed to `executor.tools.invoke(id, args, options)`.
@@ -224,6 +231,24 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
     >;
     readonly remove: (id: string) => Effect.Effect<void, StorageFailure>;
     readonly providers: () => Effect.Effect<readonly string[]>;
+  };
+
+  /** Skills — durable runbook notes keyed to a source. See `skills.ts`
+   *  for the design note. Typical consume path at agent-invoke time:
+   *    `const skills = yield* executor.skills.listForSource(src.id)`
+   *  then prepend the rendered bodies to the system prompt near the
+   *  tool manifest. */
+  readonly skills: {
+    readonly record: (
+      input: RecordSkillInput,
+    ) => Effect.Effect<Skill, StorageFailure>;
+    readonly list: (
+      sourceId?: string,
+    ) => Effect.Effect<readonly Skill[], StorageFailure>;
+    readonly listForSource: (
+      sourceId: string,
+    ) => Effect.Effect<readonly Skill[], StorageFailure>;
+    readonly remove: (id: string) => Effect.Effect<void, StorageFailure>;
   };
 
   readonly close: () => Effect.Effect<void, StorageFailure>;
@@ -566,7 +591,7 @@ export const createExecutor = <
       scopes,
       adapter: rootAdapter,
       blobs,
-      plugins = [] as unknown as TPlugins,
+      plugins: userPlugins = [] as unknown as TPlugins,
     } = config;
 
     if (scopes.length === 0) {
@@ -574,6 +599,15 @@ export const createExecutor = <
         new Error("createExecutor requires a non-empty scopes array"),
       );
     }
+
+    // Auto-prepend the built-in skills plugin so every executor exposes
+    // the `executor.skills.*` static tools without the host having to
+    // register them. Skipped if the host already opted in explicitly
+    // (e.g. in tests that want to assert against a bare executor).
+    const hasSkillsPlugin = userPlugins.some((p) => p.id === "executor-skills");
+    const plugins = (
+      hasSkillsPlugin ? userPlugins : [skillsPlugin(), ...userPlugins]
+    ) as unknown as TPlugins;
 
     // Scope-wrap the root adapter so every read on a tenant-scoped
     // table filters by `scope_id IN (scopes)` and every write's
@@ -658,6 +692,16 @@ export const createExecutor = <
       }
       return winner ?? null;
     };
+
+    // Skills store — plain DB-backed helper shared between the executor
+    // surface (`executor.skills.*`) and ctx (`ctx.core.skills.*`). The
+    // store is scope-aware via `scopeRank`, but record() requires the
+    // caller to pick a target scope explicitly, same rule as every
+    // other scoped write in the SDK.
+    const skillsStore: SkillsStore = makeSkillsStore(core, scopeRank);
+    const defaultSkillScope = scopeIds[0]!;
+    const recordSkill = (input: RecordSkillInput) =>
+      skillsStore.record({ ...input, scope: input.scope ?? defaultSkillScope });
 
     const secretsGet = (
       id: string,
@@ -1577,6 +1621,12 @@ export const createExecutor = <
                 writeDefinitions(core, plugin.id, input),
               ),
           },
+          skills: {
+            record: (input) => recordSkill(input),
+            listForSource: (sourceId) => skillsStore.listForSource(sourceId),
+            list: () => skillsStore.list(),
+            remove: (id) => skillsStore.remove(id),
+          },
         },
         secrets: {
           get: (id) => secretsGet(id),
@@ -2276,6 +2326,13 @@ export const createExecutor = <
             () =>
               Array.from(connectionProviders.keys()) as readonly string[],
           ),
+      },
+      skills: {
+        record: recordSkill,
+        list: (sourceId?: string) =>
+          sourceId ? skillsStore.listForSource(sourceId) : skillsStore.list(),
+        listForSource: skillsStore.listForSource,
+        remove: skillsStore.remove,
       },
       close,
     };

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -65,6 +65,7 @@ export {
   type DefinitionRow,
   type SecretRow,
   type ConnectionRow,
+  type SkillRow,
   type DefinitionsInput,
   type ToolAnnotations,
 } from "./core-schema";
@@ -138,6 +139,15 @@ export {
   createExecutor,
   collectSchemas,
 } from "./executor";
+
+// Skills — runbook notes keyed to a source.
+export {
+  Skill,
+  MAX_SKILL_BODY_BYTES,
+  MAX_SKILLS_PER_SOURCE,
+  type RecordSkillInput,
+} from "./skills";
+export { skillsPlugin } from "./skills-plugin";
 
 // CLI config
 export {

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -21,6 +21,7 @@ import type {
   ToolRow,
 } from "./core-schema";
 import type { SourceDetectionResult } from "./types";
+import type { RecordSkillInput, Skill } from "./skills";
 import type {
   ElicitationDeclinedError,
   ElicitationHandler,
@@ -125,6 +126,20 @@ export interface PluginCtx<TStore = unknown> {
       readonly register: (
         input: DefinitionsInput,
       ) => Effect.Effect<void, StorageFailure>;
+    };
+    /** Skills — runbook notes keyed to a source. Plugin-owned tool
+     *  handlers (notably the built-in skills plugin's `record` tool)
+     *  write here; external consumers go through `executor.skills.*`
+     *  directly. See `skills.ts` for the design note. */
+    readonly skills: {
+      readonly record: (
+        input: RecordSkillInput,
+      ) => Effect.Effect<Skill, StorageFailure>;
+      readonly listForSource: (
+        sourceId: string,
+      ) => Effect.Effect<readonly Skill[], StorageFailure>;
+      readonly list: () => Effect.Effect<readonly Skill[], StorageFailure>;
+      readonly remove: (id: string) => Effect.Effect<void, StorageFailure>;
     };
   };
 

--- a/packages/core/sdk/src/skills-plugin.ts
+++ b/packages/core/sdk/src/skills-plugin.ts
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------
+// Built-in skills plugin — a static source (`executor.skills`) with three
+// tools the model can call directly: `record`, `list`, `delete`.
+//
+// Auto-prepended by `createExecutor` (see `executor.ts`) so every host
+// ships the skills tool surface without needing to register a plugin.
+//
+// The handlers delegate to `ctx.core.skills.*` — no storage of its own.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+
+import { definePlugin } from "./plugin";
+import {
+  deleteSkillInputSchema,
+  listSkillsInputSchema,
+  recordSkillInputSchema,
+  type RecordSkillInput,
+} from "./skills";
+
+export const skillsPlugin = definePlugin(() => ({
+  id: "executor-skills" as const,
+  storage: () => ({}),
+  staticSources: () => [
+    {
+      id: "executor.skills",
+      kind: "control",
+      name: "Executor Skills",
+      tools: [
+        {
+          name: "record",
+          description:
+            "Persist a short runbook note (markdown body + title) against an integration (a source id). Future invocations load these notes automatically. Use when you've just learned something non-obvious about an API while running a test case against it.",
+          inputSchema: recordSkillInputSchema,
+          handler: ({ ctx, args }) =>
+            ctx.core.skills.record(args as RecordSkillInput),
+        },
+        {
+          name: "list",
+          description:
+            "List skills — durable runbook notes captured against integrations. Pass sourceId to scope to one integration.",
+          inputSchema: listSkillsInputSchema,
+          handler: ({ ctx, args }) =>
+            Effect.gen(function* () {
+              const { sourceId } = (args as { sourceId?: string }) ?? {};
+              if (sourceId) return yield* ctx.core.skills.listForSource(sourceId);
+              return yield* ctx.core.skills.list();
+            }),
+        },
+        {
+          name: "delete",
+          description: "Remove a skill by id.",
+          inputSchema: deleteSkillInputSchema,
+          handler: ({ ctx, args }) =>
+            Effect.gen(function* () {
+              const { id } = args as { id: string };
+              yield* ctx.core.skills.remove(id);
+              return { ok: true };
+            }),
+        },
+      ],
+    },
+  ],
+}));

--- a/packages/core/sdk/src/skills.test.ts
+++ b/packages/core/sdk/src/skills.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { createExecutor } from "./executor";
+import { definePlugin } from "./plugin";
+import { MAX_SKILL_BODY_BYTES } from "./skills";
+import { makeTestConfig } from "./testing";
+
+// ---------------------------------------------------------------------------
+// Tiny plugin that registers a dynamic source so skills have something
+// real to attach to — mirrors the MCP / OpenAPI onboarding shape without
+// pulling in either plugin.
+// ---------------------------------------------------------------------------
+
+const integrationPlugin = definePlugin(() => ({
+  id: "integration" as const,
+  storage: () => ({}),
+  extension: (ctx) => ({
+    registerSource: (id: string) =>
+      ctx.core.sources.register({
+        id,
+        scope: ctx.scopes[0]!.id,
+        kind: "integration",
+        name: id,
+        canRemove: true,
+        tools: [{ name: "probe", description: "probe" }],
+      }),
+  }),
+}));
+
+describe("executor.skills", () => {
+  it.effect("record a skill and list it for its source", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [integrationPlugin()] as const }),
+      );
+      yield* executor.integration.registerSource("axiom");
+
+      const recorded = yield* executor.skills.record({
+        sourceId: "axiom",
+        title: "APL pagination",
+        body: "Results page with `next_cursor`; pass as `cursor` query param.",
+      });
+      expect(recorded.title).toBe("APL pagination");
+      expect(recorded.createdBy).toBe("model");
+      expect(recorded.version).toBe(1);
+
+      const skills = yield* executor.skills.listForSource("axiom");
+      expect(skills.length).toBe(1);
+      expect(skills[0]!.body).toContain("next_cursor");
+    }),
+  );
+
+  it.effect("record overwrites same id and bumps version", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [integrationPlugin()] as const }),
+      );
+      yield* executor.integration.registerSource("axiom");
+
+      const first = yield* executor.skills.record({
+        id: "apl-pagination",
+        sourceId: "axiom",
+        title: "APL pagination",
+        body: "v1",
+      });
+      expect(first.version).toBe(1);
+
+      const second = yield* executor.skills.record({
+        id: "apl-pagination",
+        sourceId: "axiom",
+        title: "APL pagination",
+        body: "v2",
+      });
+      expect(second.version).toBe(2);
+      expect(second.body).toBe("v2");
+
+      const skills = yield* executor.skills.listForSource("axiom");
+      expect(skills.length).toBe(1);
+      expect(skills[0]!.body).toBe("v2");
+    }),
+  );
+
+  it.effect("record via the static tool surface (record_skill)", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [integrationPlugin()] as const }),
+      );
+      yield* executor.integration.registerSource("linear");
+
+      // The auto-prepended skillsPlugin registers this static source.
+      const tools = yield* executor.tools.list();
+      expect(tools.map((t) => t.id)).toContain("executor.skills.record");
+
+      const recorded = yield* executor.tools.invoke("executor.skills.record", {
+        sourceId: "linear",
+        title: "issue filter syntax",
+        body: "Use `state.name = \"Done\"` in the filter string.",
+      });
+      expect((recorded as { title: string }).title).toBe(
+        "issue filter syntax",
+      );
+
+      const listed = yield* executor.tools.invoke("executor.skills.list", {
+        sourceId: "linear",
+      });
+      expect(Array.isArray(listed)).toBe(true);
+      expect((listed as readonly { sourceId: string }[]).length).toBe(1);
+    }),
+  );
+
+  it.effect("include-on-invoke: skills surface near the tool manifest", () =>
+    Effect.gen(function* () {
+      // The consume contract: a host building a system prompt / tool
+      // manifest for a given source calls listForSource(sourceId) and
+      // gets every runbook note back, newest first, bounded by the
+      // per-source cap.
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [integrationPlugin()] as const }),
+      );
+      yield* executor.integration.registerSource("stripe");
+
+      const older = yield* executor.skills.record({
+        sourceId: "stripe",
+        title: "older",
+        body: "older",
+      });
+      const newer = yield* executor.skills.record({
+        sourceId: "stripe",
+        title: "newer",
+        body: "newer",
+      });
+
+      const skills = yield* executor.skills.listForSource("stripe");
+      // Both should be present; even if timestamps tie in the memory
+      // adapter, the projection carries them back so the ordering is
+      // observable — older's updated_at <= newer's.
+      expect(skills.length).toBe(2);
+      expect(skills.map((s) => s.id).sort()).toEqual(
+        [older.id, newer.id].sort(),
+      );
+      expect(
+        skills[0]!.updatedAt.getTime() >= skills[1]!.updatedAt.getTime(),
+      ).toBe(true);
+    }),
+  );
+
+  it.effect("delete removes a skill", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [integrationPlugin()] as const }),
+      );
+      yield* executor.integration.registerSource("gh");
+
+      const recorded = yield* executor.skills.record({
+        id: "gh-quirk",
+        sourceId: "gh",
+        title: "quirk",
+        body: "body",
+      });
+
+      yield* executor.skills.remove(recorded.id);
+
+      const skills = yield* executor.skills.listForSource("gh");
+      expect(skills.length).toBe(0);
+    }),
+  );
+
+  it.effect("clamps body to MAX_SKILL_BODY_BYTES", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [integrationPlugin()] as const }),
+      );
+      yield* executor.integration.registerSource("big");
+
+      const huge = "x".repeat(MAX_SKILL_BODY_BYTES * 2);
+      const recorded = yield* executor.skills.record({
+        sourceId: "big",
+        title: "huge",
+        body: huge,
+      });
+      expect(recorded.body.length).toBeLessThanOrEqual(MAX_SKILL_BODY_BYTES);
+      expect(recorded.body.endsWith("[truncated]")).toBe(true);
+    }),
+  );
+
+  it.effect("ctx.core.skills.record works from a plugin handler", () =>
+    Effect.gen(function* () {
+      // A plugin's own static handler can call ctx.core.skills.record —
+      // e.g. an onboarding flow that persists a note the moment a
+      // source is first connected.
+      const onboardPlugin = definePlugin(() => ({
+        id: "onboard" as const,
+        storage: () => ({}),
+        staticSources: () => [
+          {
+            id: "onboard.ctl",
+            kind: "control",
+            name: "Onboard",
+            tools: [
+              {
+                name: "onboarded",
+                description: "record a baseline skill",
+                handler: ({ ctx }) =>
+                  ctx.core.skills.record({
+                    sourceId: "baseline-src",
+                    title: "baseline",
+                    body: "auto-recorded on first connect",
+                    createdBy: "user",
+                  }),
+              },
+            ],
+          },
+        ],
+      }));
+
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [onboardPlugin()] as const }),
+      );
+      const result = yield* executor.tools.invoke("onboard.ctl.onboarded", {});
+      expect((result as { createdBy: string }).createdBy).toBe("user");
+
+      const skills = yield* executor.skills.listForSource("baseline-src");
+      expect(skills.length).toBe(1);
+      expect(skills[0]!.createdBy).toBe("user");
+    }),
+  );
+});

--- a/packages/core/sdk/src/skills.ts
+++ b/packages/core/sdk/src/skills.ts
@@ -1,0 +1,299 @@
+// ---------------------------------------------------------------------------
+// Skills — first-class storage for "runbook notes" keyed to a source
+// (an integration the user has hooked up: an MCP server, an OpenAPI spec,
+// etc.). The recurring pain this fixes:
+//
+//   1. User hooks up a new integration.
+//   2. User asks the model to run a test case against it.
+//   3. The model learns API quirks (auth edge cases, pagination shape,
+//      required headers, error messages).
+//   4. Today that knowledge is thrown away.
+//
+// The smallest reasonable primitive here is a scoped row keyed by
+// (scope, source_id, id) that carries a human-readable markdown body.
+// On future invocations, agents see the skill first via
+// `executor.skills.listForSource(sourceId)` or via the static `record`
+// tool's sibling `list` tool, and skip re-learning.
+//
+// Where it lives:
+//  - Table: `skill` in `coreSchema` — skills cut across plugins. A skill
+//    belongs to a Source (plugin-agnostic id), not to any one plugin's
+//    private store. Putting it in the core schema means every host
+//    (CLI, MCP server, react app) sees the same table without each
+//    having to thread a `skills` plugin through config.
+//  - API: `executor.skills.*` for host code; `ctx.core.skills.*` for
+//    plugin-owned tool handlers that want to inline a `record()`.
+//  - Tool surface: a built-in static plugin (`skillsPlugin`, auto-
+//    prepended by `createExecutor`) exposes `executor.skills.record`,
+//    `executor.skills.list`, `executor.skills.delete` as tools so
+//    models can call them directly.
+//
+// Size caps: `body` is clamped to MAX_SKILL_BODY_BYTES at write time
+// and each source is capped at MAX_SKILLS_PER_SOURCE most-recent rows
+// on read. This keeps the consume path ("load all skills and prepend
+// to the system prompt") bounded regardless of how chatty the model is.
+// ---------------------------------------------------------------------------
+
+import { Effect, Schema } from "effect";
+import type { StorageFailure, TypedAdapter } from "@executor/storage-core";
+
+import type { CoreSchema, SkillRow } from "./core-schema";
+
+// ---------------------------------------------------------------------------
+// Caps. Hard-coded because this is a "small correct primitive" — tuning
+// knobs can be added once real usage signals a need.
+// ---------------------------------------------------------------------------
+
+/** Max UTF-8 bytes for a single skill body. Longer input is truncated
+ *  with a trailing marker; this is a correctness floor, not a policy. */
+export const MAX_SKILL_BODY_BYTES = 8 * 1024;
+/** Cap applied to the per-source list at read time. Newest first. */
+export const MAX_SKILLS_PER_SOURCE = 16;
+
+// ---------------------------------------------------------------------------
+// Public projection. Returned by `executor.skills.*`.
+// ---------------------------------------------------------------------------
+
+export class Skill extends Schema.Class<Skill>("Skill")({
+  id: Schema.String,
+  sourceId: Schema.String,
+  scopeId: Schema.String,
+  title: Schema.String,
+  body: Schema.String,
+  createdBy: Schema.Literal("model", "user"),
+  version: Schema.Number,
+  createdAt: Schema.Date,
+  updatedAt: Schema.Date,
+}) {}
+
+export interface RecordSkillInput {
+  /** Source this skill belongs to — an entry in `executor.sources.list()`. */
+  readonly sourceId: string;
+  /** Stable id. If an existing row with this id exists (at this scope),
+   *  the record is overwritten and `version` is bumped. If omitted, a
+   *  fresh id is minted from the title. */
+  readonly id?: string;
+  readonly title: string;
+  readonly body: string;
+  /** Defaults to "model". Hosts that call record() on behalf of the
+   *  user should override to "user". */
+  readonly createdBy?: "model" | "user";
+  /** Target scope. Defaults to innermost scope of the executor's stack
+   *  so per-user skills don't leak across tenants. */
+  readonly scope?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const slug = (s: string): string =>
+  s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
+    .slice(0, 64) || "skill";
+
+const clampBody = (body: string): string => {
+  // Byte-length check, not code-unit length, so mostly-ASCII and
+  // mostly-emoji bodies both hit the same structural cap.
+  const encoded = new TextEncoder().encode(body);
+  if (encoded.byteLength <= MAX_SKILL_BODY_BYTES) return body;
+  const sliced = encoded.slice(0, MAX_SKILL_BODY_BYTES - 32);
+  return new TextDecoder().decode(sliced) + "\n\n[truncated]";
+};
+
+const rowToSkill = (row: SkillRow): Skill =>
+  new Skill({
+    id: row.id as string,
+    sourceId: row.source_id as string,
+    scopeId: row.scope_id as string,
+    title: row.title as string,
+    body: row.body as string,
+    createdBy: ((row.created_by as string) === "user" ? "user" : "model") as
+      | "model"
+      | "user",
+    version: Number(row.version ?? 1),
+    createdAt: row.created_at as Date,
+    updatedAt: row.updated_at as Date,
+  });
+
+// ---------------------------------------------------------------------------
+// Store — pure data-access layer used by both the executor surface and the
+// plugin-facing ctx.core.skills bridge. Takes a resolved scope string so
+// callers don't have to thread scopes through every function.
+// ---------------------------------------------------------------------------
+
+export interface SkillsStore {
+  readonly record: (
+    input: RecordSkillInput & { readonly scope: string },
+  ) => Effect.Effect<Skill, StorageFailure>;
+  readonly listForSource: (
+    sourceId: string,
+  ) => Effect.Effect<readonly Skill[], StorageFailure>;
+  readonly list: () => Effect.Effect<readonly Skill[], StorageFailure>;
+  readonly remove: (id: string) => Effect.Effect<void, StorageFailure>;
+}
+
+export const makeSkillsStore = (
+  core: TypedAdapter<CoreSchema, StorageFailure>,
+  scopeRank: (row: { scope_id: unknown }) => number,
+): SkillsStore => {
+  const record: SkillsStore["record"] = (input) =>
+    Effect.gen(function* () {
+      const now = new Date();
+      const id = input.id ?? `${slug(input.title)}-${now.getTime()}`;
+      const body = clampBody(input.body);
+      const createdBy = input.createdBy ?? "model";
+
+      const existingRows = yield* core.findMany({
+        model: "skill",
+        where: [
+          { field: "id", value: id },
+          { field: "source_id", value: input.sourceId },
+        ],
+      });
+      // Overwrite must target the same (id, scope) row — don't silently
+      // bump an outer-scope skill's version from an inner-scope caller.
+      const existing = existingRows.find(
+        (r) => (r.scope_id as string) === input.scope,
+      );
+
+      if (existing) {
+        const nextVersion = Number(existing.version ?? 1) + 1;
+        yield* core.updateMany({
+          model: "skill",
+          where: [
+            { field: "id", value: id },
+            { field: "scope_id", value: input.scope },
+          ],
+          update: {
+            title: input.title,
+            body,
+            created_by: createdBy,
+            version: nextVersion,
+            updated_at: now,
+          },
+        });
+        return rowToSkill({
+          ...(existing as SkillRow),
+          title: input.title,
+          body,
+          created_by: createdBy,
+          version: nextVersion,
+          updated_at: now,
+        });
+      }
+
+      const row = yield* core.create({
+        model: "skill",
+        data: {
+          id,
+          scope_id: input.scope,
+          source_id: input.sourceId,
+          title: input.title,
+          body,
+          created_by: createdBy,
+          version: 1,
+          created_at: now,
+          updated_at: now,
+        },
+        forceAllowId: true,
+      });
+      return rowToSkill(row as SkillRow);
+    });
+
+  // Innermost-scope wins on id collisions so a user's scope shadow takes
+  // precedence over an org-wide skill with the same id — same convention
+  // as sources / tools / connections.
+  const dedupInnermost = (rows: readonly SkillRow[]): SkillRow[] => {
+    const byId = new Map<string, { row: SkillRow; rank: number }>();
+    for (const row of rows) {
+      const rank = scopeRank(row);
+      const existing = byId.get(row.id as string);
+      if (!existing || rank < existing.rank) {
+        byId.set(row.id as string, { row, rank });
+      }
+    }
+    return [...byId.values()].map((v) => v.row);
+  };
+
+  const listForSource: SkillsStore["listForSource"] = (sourceId) =>
+    Effect.gen(function* () {
+      const rows = yield* core.findMany({
+        model: "skill",
+        where: [{ field: "source_id", value: sourceId }],
+      });
+      const deduped = dedupInnermost(rows);
+      // Newest first, then hard-cap.
+      deduped.sort(
+        (a, b) =>
+          (b.updated_at as Date).getTime() - (a.updated_at as Date).getTime(),
+      );
+      return deduped.slice(0, MAX_SKILLS_PER_SOURCE).map(rowToSkill);
+    });
+
+  const list: SkillsStore["list"] = () =>
+    Effect.gen(function* () {
+      const rows = yield* core.findMany({ model: "skill" });
+      const deduped = dedupInnermost(rows);
+      deduped.sort(
+        (a, b) =>
+          (b.updated_at as Date).getTime() - (a.updated_at as Date).getTime(),
+      );
+      return deduped.map(rowToSkill);
+    });
+
+  const remove: SkillsStore["remove"] = (id) =>
+    core
+      .deleteMany({ model: "skill", where: [{ field: "id", value: id }] })
+      .pipe(Effect.asVoid);
+
+  return { record, listForSource, list, remove };
+};
+
+// ---------------------------------------------------------------------------
+// JSON schemas for the static tool surface. Kept minimal — just the shape
+// the agent-facing tools expose.
+// ---------------------------------------------------------------------------
+
+export const recordSkillInputSchema = {
+  type: "object",
+  properties: {
+    sourceId: { type: "string", description: "Source id this skill applies to" },
+    title: { type: "string" },
+    body: {
+      type: "string",
+      description:
+        "Markdown body. Succinct runbook-style notes about the integration: auth quirks, required headers, pagination shape, error recovery.",
+    },
+    id: {
+      type: "string",
+      description:
+        "Optional stable id. Pass the id returned by a previous record() call to overwrite; omit to mint a fresh one.",
+    },
+  },
+  required: ["sourceId", "title", "body"],
+  additionalProperties: false,
+} as const;
+
+export const listSkillsInputSchema = {
+  type: "object",
+  properties: {
+    sourceId: {
+      type: "string",
+      description:
+        "Only return skills for this source. Omit to list every skill across every integration.",
+    },
+  },
+  additionalProperties: false,
+} as const;
+
+export const deleteSkillInputSchema = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+  },
+  required: ["id"],
+  additionalProperties: false,
+} as const;

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -147,23 +147,26 @@ describe("mcpPlugin", () => {
     }),
   );
 
-  it.effect("sources list is initially empty", () =>
+  it.effect("sources list has no MCP sources initially", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({ plugins: [mcpPlugin()] as const }),
       );
       const sources = yield* executor.sources.list();
-      expect(sources).toHaveLength(0);
+      // Only the built-in skills static source should be present.
+      expect(sources.filter((s) => s.pluginId === "mcp")).toHaveLength(0);
     }),
   );
 
-  it.effect("tools list is initially empty", () =>
+  it.effect("tools list has no MCP tools initially", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({ plugins: [mcpPlugin()] as const }),
       );
       const tools = yield* executor.tools.list();
-      expect(tools).toHaveLength(0);
+      // Built-in executor.skills.* tools are always registered; MCP
+      // itself contributes nothing until addSource() runs.
+      expect(tools.filter((t) => t.pluginId === "mcp")).toHaveLength(0);
     }),
   );
 


### PR DESCRIPTION
## Summary

First-class persistence for what the model learns while testing a new integration. Today: user hooks up an MCP / OpenAPI source → asks the model to run a test case → model figures out auth quirks, pagination shape, required headers → that knowledge is thrown away. This PR makes it a durable, per-source note the model (or a human) can record, and that subsequent invocations see.

**Scope choice: core SDK, not a plugin.** A skill belongs to a Source id, and Source ids cut across plugins (MCP, OpenAPI, etc.), so the primitive lives in \`@executor/sdk\`.

## What lands

- \`packages/core/sdk/src/core-schema.ts\` — new \`skill\` model keyed by \`(id, scope_id, source_id)\`, fields \`{title, body (markdown), createdBy: "model"|"user", version, created_at, updated_at}\`. Body clamped to 8 KiB at write; per-source list capped at 16 newest.
- \`packages/core/sdk/src/skills.ts\` — store + caps, with a ~30-line design note at the top of the file.
- \`packages/core/sdk/src/skills-plugin.ts\` — built-in static plugin exposing model-callable tools. Auto-prepended by the executor so \`executor.skills.record\`, \`.list\`, \`.delete\` are always available.
- \`packages/core/sdk/src/executor.ts\` — wires \`executor.skills.*\` and \`ctx.core.skills.*\` so plugin handlers can record/read directly.
- \`packages/core/sdk/src/plugin.ts\` — extends \`PluginCtx.core\` with \`skills\`.
- \`packages/core/sdk/src/index.ts\` — exports \`Skill\`, \`RecordSkillInput\`, \`skillsPlugin\`, caps, \`SkillRow\`.

**Record + consume surfaces.**
- Record: \`executor.skills.record({sourceId, title, body, id?, createdBy?, scope?})\`. Also \`ctx.core.skills.record(...)\` inside plugin handlers. Also the model-callable tool \`executor.skills.record\` (auto-registered).
- Consume: \`executor.skills.listForSource(sourceId)\` — newest-first, dedup'd innermost-scope-wins, bounded to 16. Intended to be included near the tool manifest by hosts.

## Adjacent test tightening (intentional, not breakage)

- \`description.test.ts\` locks in that \`executor.skills\` appears in Available namespaces.
- MCP plugin's "empty list" tests now filter by \`pluginId\` (the built-in skills source is always present in \`executor.sources.list()\`).

## Test plan

- [ ] \`packages/core/sdk/src/skills.test.ts\` — 7 tests: record + list, overwrite+version bump, invoke via the static tool surface, include-on-invoke ordering, delete, body clamp, plugin handler calling \`ctx.core.skills\`. All green under \`effect/vitest\`.
- [ ] \`@executor/sdk\` full suite 6/6 green. Typecheck green repo-wide.

## Follow-ups I intentionally did not do

- No DB migration generated — \`collectSchemas\` picks up the new model, but \`storage-drizzle\` / \`storage-postgres\` may need a migration depending on how the team lands schema bumps.
- No dedicated REST \`/skills\` HTTP group in \`@executor/api\` — reachable via the tool surface and the executor API today.
- No hook into MCP \`addSource\` / "first test run completed" to proactively prompt the model to record a skill. Ask is "make it first-class", not "auto-invoke" — left for a follow-up.
- No React UI for manually authoring skills.
- Innermost-scope-wins dedup is implemented but not multi-scope tested (\`makeTestConfig\` is single-scope by default). Easy to add when multi-tenant tests are introduced.