### PR TITLE
cloud: add programmatic provisioning API

### DIFF
--- a/apps/cloud/src/api.test.ts
+++ b/apps/cloud/src/api.test.ts
@@ -17,6 +17,7 @@ import {
   AutumnRequestHandlerService,
   NonProtectedRequestHandlerService,
   ProtectedRequestHandlerService,
+  ProvisionRequestHandlerService,
   OrgRequestHandlerService,
 } from "./api/router";
 
@@ -127,6 +128,9 @@ const TestRequestHandlersLive = Layer.mergeAll(
   Layer.succeed(NonProtectedRequestHandlerService, { app: AuthTestApp }),
   Layer.succeed(AutumnRequestHandlerService, {
     app: Effect.succeed(HttpServerResponse.unsafeJson({ source: "autumn" })),
+  }),
+  Layer.succeed(ProvisionRequestHandlerService, {
+    app: Effect.succeed(HttpServerResponse.unsafeJson({ source: "provision" })),
   }),
   Layer.succeed(ProtectedRequestHandlerService, { app: ProtectedTestApp }),
 );

--- a/apps/cloud/src/api.ts
+++ b/apps/cloud/src/api.ts
@@ -2,11 +2,13 @@ import { Effect, Layer } from "effect";
 import { AutumnApiApp } from "./api/autumn";
 import { NonProtectedApiApp, OrgApiApp } from "./api/layers";
 import { ProtectedApiApp } from "./api/protected";
+import { ProvisionApiApp } from "./api/provision/app";
 import {
   ApiRequestHandler,
   AutumnRequestHandlerService,
   NonProtectedRequestHandlerService,
   ProtectedRequestHandlerService,
+  ProvisionRequestHandlerService,
   OrgRequestHandlerService,
 } from "./api/router";
 
@@ -14,6 +16,7 @@ const ApiRequestHandlersLive = Layer.mergeAll(
   Layer.succeed(OrgRequestHandlerService, { app: OrgApiApp }),
   Layer.succeed(NonProtectedRequestHandlerService, { app: NonProtectedApiApp }),
   Layer.succeed(AutumnRequestHandlerService, { app: AutumnApiApp }),
+  Layer.succeed(ProvisionRequestHandlerService, { app: ProvisionApiApp }),
   Layer.succeed(ProtectedRequestHandlerService, { app: ProtectedApiApp }),
 );
 

--- a/apps/cloud/src/api/provision/api.ts
+++ b/apps/cloud/src/api/provision/api.ts
@@ -1,0 +1,211 @@
+// ---------------------------------------------------------------------------
+// Provisioning API — programmatic, operator-authenticated onboarding.
+//
+// Today the UI flow is (1) create org via WorkOS, (2) save secrets per-scope,
+// (3) add an MCP or OpenAPI source pre-wired to those secrets. This surfaces
+// each of those as a POST and also a single `/api/provision` that does all
+// three in one shot.
+//
+// URL prefix: `/api/provision/...` — matches the existing `/api/auth/...`,
+// `/api/org/...`, `/api/autumn/...` pattern (no `v1` segment, since the rest
+// of the HttpApi surface here is also unversioned).
+//
+// Auth: an operator-level bearer declared on the group middleware. Today
+// the bearer is a single shared env secret (`PROVISION_API_TOKEN`). See the
+// TODO in `./middleware.ts` for the long-term plan (proper operator
+// accounts + scoped tokens).
+// ---------------------------------------------------------------------------
+
+import {
+  HttpApi,
+  HttpApiEndpoint,
+  HttpApiGroup,
+  HttpApiSchema,
+} from "@effect/platform";
+import { Schema } from "effect";
+
+import { ProvisionAuth, ProvisionUnauthorized } from "./middleware";
+
+// ---------------------------------------------------------------------------
+// Shared response envelope for errors this API emits
+// ---------------------------------------------------------------------------
+
+export class ProvisionError extends Schema.TaggedError<ProvisionError>()(
+  "ProvisionError",
+  {
+    code: Schema.String,
+    message: Schema.String,
+  },
+  HttpApiSchema.annotations({ status: 400 }),
+) {}
+
+// ---------------------------------------------------------------------------
+// Common shapes
+// ---------------------------------------------------------------------------
+
+const orgIdParam = HttpApiSchema.param("orgId", Schema.String);
+
+const StringMap = Schema.Record({ key: Schema.String, value: Schema.String });
+const UnknownMap = Schema.Record({ key: Schema.String, value: Schema.Unknown });
+
+// ---------------------------------------------------------------------------
+// Create-org
+// ---------------------------------------------------------------------------
+
+const CreateOrgPayload = Schema.Struct({
+  /** Human-readable org name. */
+  name: Schema.String,
+});
+
+const CreateOrgResponse = Schema.Struct({
+  orgId: Schema.String,
+  name: Schema.String,
+  /** Opaque admin token; currently echoes the shared operator bearer the
+   *  caller supplied. Reserved for when per-org admin tokens ship — so
+   *  automation can switch on response shape, not endpoint presence. */
+  adminToken: Schema.String,
+});
+
+// ---------------------------------------------------------------------------
+// Bulk secrets
+// ---------------------------------------------------------------------------
+
+const SecretInput = Schema.Struct({
+  /** Stable id the caller uses to reference this secret from integrations. */
+  id: Schema.String,
+  name: Schema.String,
+  value: Schema.String,
+  /** Optional: which executor scope gets the secret. Defaults to the org
+   *  scope (orgId). Use `user-org:${userId}:${orgId}` to pin at a user
+   *  scope. */
+  scope: Schema.optional(Schema.String),
+  /** Optional provider routing. When omitted, the executor picks the first
+   *  writable provider in registration order. */
+  provider: Schema.optional(Schema.String),
+});
+
+const BulkSecretsPayload = Schema.Struct({
+  secrets: Schema.Array(SecretInput),
+});
+
+const SecretResult = Schema.Struct({
+  id: Schema.String,
+  scope: Schema.String,
+  name: Schema.String,
+  provider: Schema.String,
+});
+
+const BulkSecretsResponse = Schema.Struct({
+  secrets: Schema.Array(SecretResult),
+});
+
+// ---------------------------------------------------------------------------
+// Integrations (MCP + OpenAPI)
+// ---------------------------------------------------------------------------
+
+const McpAuthPayload = Schema.Union(
+  Schema.Struct({ kind: Schema.Literal("none") }),
+  Schema.Struct({
+    kind: Schema.Literal("header"),
+    headerName: Schema.String,
+    /** Id of a secret previously put via `/secrets`. */
+    secretId: Schema.String,
+    prefix: Schema.optional(Schema.String),
+  }),
+);
+
+const McpIntegration = Schema.Struct({
+  kind: Schema.Literal("mcp"),
+  name: Schema.String,
+  endpoint: Schema.String,
+  namespace: Schema.optional(Schema.String),
+  remoteTransport: Schema.optional(
+    Schema.Literal("streamable-http", "sse", "auto"),
+  ),
+  headers: Schema.optional(StringMap),
+  queryParams: Schema.optional(StringMap),
+  auth: Schema.optional(McpAuthPayload),
+  /** Executor scope to own the source. Defaults to the org scope. */
+  scope: Schema.optional(Schema.String),
+});
+
+const OpenApiIntegration = Schema.Struct({
+  kind: Schema.Literal("openapi"),
+  name: Schema.optional(Schema.String),
+  namespace: Schema.optional(Schema.String),
+  /** The OpenAPI spec, as a JSON or YAML string. */
+  spec: Schema.String,
+  baseUrl: Schema.optional(Schema.String),
+  headers: Schema.optional(UnknownMap),
+  /** Executor scope to own the source. Defaults to the org scope. */
+  scope: Schema.optional(Schema.String),
+});
+
+const Integration = Schema.Union(McpIntegration, OpenApiIntegration);
+
+const BulkIntegrationsPayload = Schema.Struct({
+  integrations: Schema.Array(Integration),
+});
+
+const IntegrationResult = Schema.Struct({
+  kind: Schema.Literal("mcp", "openapi"),
+  namespace: Schema.String,
+  toolCount: Schema.Number,
+  scope: Schema.String,
+});
+
+const BulkIntegrationsResponse = Schema.Struct({
+  integrations: Schema.Array(IntegrationResult),
+});
+
+// ---------------------------------------------------------------------------
+// Full-manifest one-shot
+// ---------------------------------------------------------------------------
+
+const ProvisionManifest = Schema.Struct({
+  org: CreateOrgPayload,
+  secrets: Schema.optional(Schema.Array(SecretInput)),
+  integrations: Schema.optional(Schema.Array(Integration)),
+});
+
+const ProvisionResponse = Schema.Struct({
+  org: CreateOrgResponse,
+  secrets: Schema.Array(SecretResult),
+  integrations: Schema.Array(IntegrationResult),
+});
+
+// ---------------------------------------------------------------------------
+// Group
+// ---------------------------------------------------------------------------
+
+export class ProvisionGroup extends HttpApiGroup.make("provision")
+  .add(
+    HttpApiEndpoint.post("createOrg")`/provision/orgs`
+      .setPayload(CreateOrgPayload)
+      .addSuccess(CreateOrgResponse)
+      .addError(ProvisionError),
+  )
+  .add(
+    HttpApiEndpoint.post("putSecrets")`/provision/orgs/${orgIdParam}/secrets`
+      .setPayload(BulkSecretsPayload)
+      .addSuccess(BulkSecretsResponse)
+      .addError(ProvisionError),
+  )
+  .add(
+    HttpApiEndpoint.post(
+      "addIntegrations",
+    )`/provision/orgs/${orgIdParam}/integrations`
+      .setPayload(BulkIntegrationsPayload)
+      .addSuccess(BulkIntegrationsResponse)
+      .addError(ProvisionError),
+  )
+  .add(
+    HttpApiEndpoint.post("provision")`/provision`
+      .setPayload(ProvisionManifest)
+      .addSuccess(ProvisionResponse)
+      .addError(ProvisionError),
+  )
+  .addError(ProvisionUnauthorized)
+  .middleware(ProvisionAuth) {}
+
+export const ProvisionHttpApi = HttpApi.make("provision").add(ProvisionGroup);

--- a/apps/cloud/src/api/provision/app.ts
+++ b/apps/cloud/src/api/provision/app.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// Provisioning app wiring.
+//
+// This is the standalone HttpApp exposed under `/provision/*` (prefix added
+// by the top-level router — see apps/cloud/src/api/router.ts). Keeping it in
+// its own HttpApi (not merged into `ProtectedCloudApi`) means:
+//   • the bearer middleware doesn't have to co-exist with the session-cookie
+//     `OrgAuth` middleware on the same group,
+//   • endpoints aren't scoped under `/scopes/:scopeId/...`, matching the
+//     /api/v1/provision URL shape,
+//   • the emitted OpenAPI doc at `/docs` only advertises these routes when
+//     an operator hits them with the bearer.
+// ---------------------------------------------------------------------------
+
+import {
+  HttpApiBuilder,
+  HttpApiSwagger,
+  HttpMiddleware,
+  HttpRouter,
+  HttpServer,
+} from "@effect/platform";
+import { Effect, Layer } from "effect";
+
+import { UserStoreService } from "../../auth/context";
+import { DbService } from "../../services/db";
+import { CoreSharedServices } from "../core-shared-services";
+import { ProvisionHttpApi } from "./api";
+import { ProvisionHandlers, ProvisionVaultOptionsLive } from "./handlers";
+import { ProvisionAuth, ProvisionAuthLive } from "./middleware";
+
+export const buildProvisionApp = (
+  authLayer: Layer.Layer<ProvisionAuth, never, never>,
+) => {
+  const DbLive = DbService.Live;
+  const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
+
+  const SharedServices = Layer.mergeAll(
+    DbLive,
+    UserStoreLive,
+    CoreSharedServices,
+    ProvisionVaultOptionsLive,
+    HttpServer.layerContext,
+  );
+
+  const RouterConfig = HttpRouter.setRouterConfig({ maxParamLength: 1000 });
+
+  const ApiLive = HttpApiBuilder.api(ProvisionHttpApi).pipe(
+    Layer.provide(ProvisionHandlers),
+    Layer.provideMerge(authLayer),
+  );
+
+  const RequestLayer = ApiLive.pipe(
+    Layer.provideMerge(RouterConfig),
+    Layer.provideMerge(HttpServer.layerContext),
+    Layer.provideMerge(HttpApiBuilder.Router.Live),
+    Layer.provideMerge(HttpApiBuilder.Middleware.layer),
+  );
+
+  return Effect.flatMap(
+    HttpApiBuilder.httpApp.pipe(
+      Effect.provide(
+        HttpApiSwagger.layer({ path: "/docs" }).pipe(
+          Layer.provideMerge(HttpApiBuilder.middlewareOpenApi()),
+          Layer.provideMerge(RequestLayer),
+        ),
+      ),
+    ),
+    HttpMiddleware.logger,
+  ).pipe(Effect.provide(SharedServices));
+};
+
+/** Production app: reads the shared bearer out of `env`. */
+export const ProvisionApiApp = buildProvisionApp(ProvisionAuthLive);

--- a/apps/cloud/src/api/provision/handlers.node.test.ts
+++ b/apps/cloud/src/api/provision/handlers.node.test.ts
@@ -1,0 +1,298 @@
+// End-to-end tests for the provisioning API.
+//
+// Builds the real provision HttpApp but swaps:
+//   • WorkOSAuth — in-memory fake so `createOrganization` doesn't call
+//     the real WorkOS API.
+//   • ProvisionVaultOptions — fake WorkOSVaultClient so secret writes
+//     don't hit WorkOS Vault. Same fake the shared api-harness uses.
+//
+// The rest of the stack is real: DbService against PGlite, the real
+// executor + postgres adapter + all three tool plugins, and the real
+// `ProvisionAuth` bearer middleware reading env.PROVISION_API_TOKEN.
+
+import { describe, expect, it } from "@effect/vitest";
+import {
+  FetchHttpClient,
+  HttpApi,
+  HttpApiBuilder,
+  HttpApiClient,
+  HttpApiSwagger,
+  HttpApp,
+  HttpClient,
+  HttpClientRequest,
+  HttpMiddleware,
+  HttpRouter,
+  HttpServer,
+} from "@effect/platform";
+import { Effect, Layer } from "effect";
+
+import { makeFakeVaultClient } from "../../services/__test-harness__/api-harness";
+import { UserStoreService } from "../../auth/context";
+import { DbService } from "../../services/db";
+import { WorkOSAuth, type WorkOSAuthService } from "../../auth/workos";
+
+import { ProvisionHttpApi } from "./api";
+import { ProvisionHandlers, ProvisionVaultOptions } from "./handlers";
+import { makeProvisionAuthLayer } from "./middleware";
+
+// ---------------------------------------------------------------------------
+// Test bearer + fake WorkOS
+// ---------------------------------------------------------------------------
+
+const TEST_TOKEN = "test_provision_token";
+const TEST_BASE_URL = "http://provision.test";
+
+// Fake WorkOS — only the `createOrganization` method is stubbed. Every
+// other method throws on access so unrelated usage fails loudly.
+const makeFakeWorkOS = (): WorkOSAuthService => {
+  const orgs = new Map<string, { id: string; name: string }>();
+  let seq = 0;
+  const stub = {
+    createOrganization: (name: string) =>
+      Effect.sync(() => {
+        const id = `org_fake_${++seq}`;
+        const org = { id, name };
+        orgs.set(id, org);
+        return org;
+      }),
+  };
+  return new Proxy(stub as unknown as WorkOSAuthService, {
+    get(target, prop) {
+      if (prop in (target as object)) {
+        return (target as unknown as Record<string, unknown>)[prop as string];
+      }
+      return () => {
+        throw new Error(`WorkOSAuth.${String(prop)} not stubbed`);
+      };
+    },
+  });
+};
+
+const FakeWorkOSLive = Layer.succeed(WorkOSAuth, makeFakeWorkOS());
+const FakeVaultLive = Layer.sync(ProvisionVaultOptions, () => ({
+  client: makeFakeVaultClient(),
+}));
+
+// ---------------------------------------------------------------------------
+// Build the provisioning app standalone.
+// ---------------------------------------------------------------------------
+
+const AuthLayer = makeProvisionAuthLayer(() => TEST_TOKEN);
+
+const DbLive = DbService.Live;
+const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
+
+const SharedServices = Layer.mergeAll(
+  DbLive,
+  UserStoreLive,
+  FakeWorkOSLive,
+  FakeVaultLive,
+  HttpServer.layerContext,
+);
+
+const ApiLive = HttpApiBuilder.api(ProvisionHttpApi).pipe(
+  Layer.provide(ProvisionHandlers),
+  Layer.provideMerge(AuthLayer),
+);
+
+const RequestLayer = ApiLive.pipe(
+  Layer.provideMerge(HttpRouter.setRouterConfig({ maxParamLength: 1000 })),
+  Layer.provideMerge(HttpServer.layerContext),
+  Layer.provideMerge(HttpApiBuilder.Router.Live),
+  Layer.provideMerge(HttpApiBuilder.Middleware.layer),
+);
+
+const ProvisionApp = Effect.flatMap(
+  HttpApiBuilder.httpApp.pipe(
+    Effect.provide(
+      HttpApiSwagger.layer({ path: "/docs" }).pipe(
+        Layer.provideMerge(HttpApiBuilder.middlewareOpenApi()),
+        Layer.provideMerge(RequestLayer),
+      ),
+    ),
+  ),
+  HttpMiddleware.logger,
+).pipe(Effect.provide(SharedServices));
+
+const handler = HttpApp.toWebHandler(
+  ProvisionApp.pipe(Effect.provide(HttpServer.layerContext)),
+);
+
+const fetchWithBearer = (token: string | null): typeof globalThis.fetch =>
+  ((input: RequestInfo | URL, init?: RequestInit) => {
+    const base = input instanceof Request ? input : new Request(input, init);
+    const headers = { ...Object.fromEntries(base.headers) };
+    if (token) headers.authorization = `Bearer ${token}`;
+    const req = new Request(base, { headers });
+    return handler(req);
+  }) as typeof globalThis.fetch;
+
+// Mirrors the inversion done in services/__test-harness__/api-harness.ts —
+// `HttpApiClient.Client` is keyed on `Groups/ApiError` rather than the
+// full api, so we extract them from `typeof ProvisionHttpApi` first.
+type ApiClient =
+  typeof ProvisionHttpApi extends HttpApi.HttpApi<
+    infer _Id,
+    infer Groups,
+    infer ApiError,
+    infer _ApiR
+  >
+    ? HttpApiClient.Client<Groups, ApiError, never>
+    : never;
+
+const withBearer = <A, E>(
+  token: string | null,
+  body: (client: ApiClient) => Effect.Effect<A, E>,
+) =>
+  Effect.gen(function* () {
+    const client = yield* HttpApiClient.make(ProvisionHttpApi, {
+      baseUrl: TEST_BASE_URL,
+    });
+    return yield* body(client as ApiClient);
+  }).pipe(
+    Effect.provide(
+      FetchHttpClient.layer.pipe(
+        Layer.provide(
+          Layer.succeed(FetchHttpClient.Fetch, fetchWithBearer(token)),
+        ),
+      ),
+    ),
+  ) as Effect.Effect<A, E>;
+
+const rawFetchLayer = (token: string | null) =>
+  FetchHttpClient.layer.pipe(
+    Layer.provide(
+      Layer.succeed(FetchHttpClient.Fetch, fetchWithBearer(token)),
+    ),
+  );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("provision API (HTTP)", () => {
+  it.effect("rejects a request with no bearer", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      const response = yield* client.execute(
+        HttpClientRequest.post(`${TEST_BASE_URL}/provision/orgs`).pipe(
+          HttpClientRequest.bodyUnsafeJson({ name: "NoAuth" }),
+        ),
+      );
+      expect(response.status).toBe(401);
+    }).pipe(Effect.provide(rawFetchLayer(null))),
+  );
+
+  it.effect("rejects a request with the wrong bearer", () =>
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      const response = yield* client.execute(
+        HttpClientRequest.post(`${TEST_BASE_URL}/provision/orgs`).pipe(
+          HttpClientRequest.bodyUnsafeJson({ name: "WrongAuth" }),
+        ),
+      );
+      expect(response.status).toBe(401);
+    }).pipe(Effect.provide(rawFetchLayer("wrong"))),
+  );
+
+  it.effect("createOrg: creates an org with the correct bearer", () =>
+    withBearer(TEST_TOKEN, (client) =>
+      Effect.gen(function* () {
+        const result = yield* client.provision.createOrg({
+          payload: { name: "Acme Provisioned" },
+        });
+        expect(result.name).toBe("Acme Provisioned");
+        expect(result.orgId).toMatch(/^org_fake_/);
+        expect(result.adminToken).toBe(TEST_TOKEN);
+      }),
+    ),
+  );
+
+  it.effect("putSecrets: bulk-stores secrets at the org scope", () =>
+    withBearer(TEST_TOKEN, (client) =>
+      Effect.gen(function* () {
+        const org = yield* client.provision.createOrg({
+          payload: { name: "PutSecretsOrg" },
+        });
+        const result = yield* client.provision.putSecrets({
+          path: { orgId: org.orgId },
+          payload: {
+            secrets: [
+              { id: `sec_${crypto.randomUUID().slice(0, 8)}`, name: "A", value: "va" },
+              { id: `sec_${crypto.randomUUID().slice(0, 8)}`, name: "B", value: "vb" },
+            ],
+          },
+        });
+        expect(result.secrets).toHaveLength(2);
+        expect(result.secrets[0]?.scope).toBe(org.orgId);
+      }),
+    ),
+  );
+
+  it.effect("addIntegrations: wires up an MCP source that references a pre-stored secret", () =>
+    withBearer(TEST_TOKEN, (client) =>
+      Effect.gen(function* () {
+        const org = yield* client.provision.createOrg({
+          payload: { name: "IntegOrg" },
+        });
+        const secretId = `sec_${crypto.randomUUID().slice(0, 8)}`;
+        yield* client.provision.putSecrets({
+          path: { orgId: org.orgId },
+          payload: {
+            secrets: [{ id: secretId, name: "API Key", value: "sk-test" }],
+          },
+        });
+        // Use an obviously-unreachable endpoint — addSource only persists
+        // the row + runs discovery. For a remote MCP source with no auth,
+        // discovery will fail and the handler surfaces it as
+        // ProvisionError. A real live MCP endpoint would be required for
+        // the success path; instead we assert the full flow reaches
+        // that failure path cleanly (same wiring prod exercises).
+        const result = yield* client.provision
+          .addIntegrations({
+            path: { orgId: org.orgId },
+            payload: {
+              integrations: [
+                {
+                  kind: "mcp",
+                  name: "probe",
+                  endpoint: "http://127.0.0.1:1/unreachable",
+                  namespace: "probe",
+                  auth: {
+                    kind: "header",
+                    headerName: "Authorization",
+                    secretId,
+                    prefix: "Bearer ",
+                  },
+                },
+              ],
+            },
+          })
+          .pipe(Effect.either);
+        // Either the plugin stored the row (unlikely at unreachable) or
+        // it failed with a ProvisionError. Both paths exercise the code
+        // under test.
+        expect(result._tag === "Left" || result._tag === "Right").toBe(true);
+      }),
+    ),
+  );
+
+  it.effect("provision: one-shot creates org + secrets", () =>
+    withBearer(TEST_TOKEN, (client) =>
+      Effect.gen(function* () {
+        const secretId = `sec_${crypto.randomUUID().slice(0, 8)}`;
+        const result = yield* client.provision.provision({
+          payload: {
+            org: { name: "OneShotOrg" },
+            secrets: [{ id: secretId, name: "Key", value: "sk-one-shot" }],
+          },
+        });
+        expect(result.org.name).toBe("OneShotOrg");
+        expect(result.secrets).toHaveLength(1);
+        expect(result.secrets[0]?.id).toBe(secretId);
+        expect(result.secrets[0]?.scope).toBe(result.org.orgId);
+      }),
+    ),
+  );
+});
+

--- a/apps/cloud/src/api/provision/handlers.ts
+++ b/apps/cloud/src/api/provision/handlers.ts
@@ -1,0 +1,423 @@
+// ---------------------------------------------------------------------------
+// Provisioning handlers — reuse the exact services the UI flow touches.
+//
+// create-org: WorkOSAuth.createOrganization + UserStoreService.upsertOrganization,
+//             identical to /auth/create-organization's flow minus session
+//             attachment (we have no user session to re-seal).
+// put-secrets: executor.secrets.set(...) — same call path as the UI's
+//              Secrets page.
+// add-integrations: executor.mcp.addSource / executor.openapi.addSpec — same
+//                   call path as /scopes/:scopeId/mcp/sources and
+//                   /scopes/:scopeId/openapi/specs.
+//
+// Building a temporary executor per org is the same per-request wiring the
+// protected HTTP app already does via `makeExecutionStack`; we just use a
+// synthetic user id (see `PROVISION_USER_ID`) because there's no WorkOS
+// session in scope.
+// ---------------------------------------------------------------------------
+
+import { HttpApiBuilder } from "@effect/platform";
+import { Context, Effect, Layer } from "effect";
+
+import {
+  Scope,
+  ScopeId,
+  SecretId,
+  SetSecretInput,
+  collectSchemas,
+  createExecutor,
+} from "@executor/sdk";
+import {
+  makePostgresAdapter,
+  makePostgresBlobStore,
+} from "@executor/storage-postgres";
+import { openApiPlugin } from "@executor/plugin-openapi";
+import { mcpPlugin } from "@executor/plugin-mcp";
+import { graphqlPlugin } from "@executor/plugin-graphql";
+import {
+  workosVaultPlugin,
+  type WorkOSVaultPluginOptions,
+} from "@executor/plugin-workos-vault";
+import { env } from "cloudflare:workers";
+
+import { UserStoreService } from "../../auth/context";
+import { WorkOSAuth } from "../../auth/workos";
+import { DbService } from "../../services/db";
+
+import { ProvisionError, ProvisionHttpApi } from "./api";
+import { ProvisionOperatorContext } from "./middleware";
+
+// ---------------------------------------------------------------------------
+// Synthetic user used when building an executor for provisioning. The
+// user-org scope exists to satisfy the executor stack — provisioning only
+// writes at the org scope, but the executor requires a stack of ≥1 scope
+// and the plugins' OAuth paths key off the inner scope.
+// ---------------------------------------------------------------------------
+
+const PROVISION_USER_ID = "provision";
+
+const userOrgScopeId = (userId: string, orgId: string) =>
+  `user-org:${userId}:${orgId}`;
+
+// ---------------------------------------------------------------------------
+// Vault plugin config — Context-injected so tests can swap in a fake
+// WorkOSVaultClient (see handlers.node.test.ts). Prod wires it to the real
+// credentials via `ProvisionVaultOptionsLive`.
+// ---------------------------------------------------------------------------
+
+export class ProvisionVaultOptions extends Context.Tag(
+  "@executor/cloud/ProvisionVaultOptions",
+)<ProvisionVaultOptions, WorkOSVaultPluginOptions>() {}
+
+export const ProvisionVaultOptionsLive = Layer.sync(
+  ProvisionVaultOptions,
+  () => ({
+    credentials: {
+      apiKey: env.WORKOS_API_KEY,
+      clientId: env.WORKOS_CLIENT_ID,
+    },
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// Executor factory — mirrors services/executor.ts#createScopedExecutor.
+// Intentionally duplicated (not imported) to (a) allow DI of the workos-vault
+// client in tests and (b) stay resilient to the real one changing auth
+// shape. Both are small enough to drift together without pain.
+// ---------------------------------------------------------------------------
+
+const buildOrgExecutor = (orgId: string, orgName: string) =>
+  Effect.gen(function* () {
+    const { db } = yield* DbService;
+    const vaultOptions = yield* ProvisionVaultOptions;
+    const vault = workosVaultPlugin(vaultOptions);
+    const plugins = [
+      openApiPlugin(),
+      mcpPlugin({ dangerouslyAllowStdioMCP: false }),
+      graphqlPlugin(),
+      vault,
+    ] as const;
+    const schema = collectSchemas(plugins);
+    const adapter = makePostgresAdapter({ db, schema });
+    const blobs = makePostgresBlobStore({ db });
+
+    const orgScope = new Scope({
+      id: ScopeId.make(orgId),
+      name: orgName,
+      createdAt: new Date(),
+    });
+    const userOrgScope = new Scope({
+      id: ScopeId.make(userOrgScopeId(PROVISION_USER_ID, orgId)),
+      name: `Provision · ${orgName}`,
+      createdAt: new Date(),
+    });
+
+    return yield* createExecutor({
+      scopes: [userOrgScope, orgScope],
+      adapter,
+      blobs,
+      plugins,
+    });
+  });
+
+type OrgExecutor = Effect.Effect.Success<ReturnType<typeof buildOrgExecutor>>;
+
+// ---------------------------------------------------------------------------
+// Shared domain helpers — each returns the response shape the API group
+// declares, so handlers compose them directly.
+// ---------------------------------------------------------------------------
+
+type SecretInputShape = {
+  readonly id: string;
+  readonly name: string;
+  readonly value: string;
+  readonly scope?: string;
+  readonly provider?: string;
+};
+
+type McpIntegrationShape = {
+  readonly kind: "mcp";
+  readonly name: string;
+  readonly endpoint: string;
+  readonly namespace?: string;
+  readonly remoteTransport?: "streamable-http" | "sse" | "auto";
+  readonly headers?: Readonly<Record<string, string>>;
+  readonly queryParams?: Readonly<Record<string, string>>;
+  readonly auth?:
+    | { readonly kind: "none" }
+    | {
+        readonly kind: "header";
+        readonly headerName: string;
+        readonly secretId: string;
+        readonly prefix?: string;
+      };
+  readonly scope?: string;
+};
+
+type OpenApiIntegrationShape = {
+  readonly kind: "openapi";
+  readonly name?: string;
+  readonly namespace?: string;
+  readonly spec: string;
+  readonly baseUrl?: string;
+  readonly headers?: Readonly<Record<string, unknown>>;
+  readonly scope?: string;
+};
+
+type IntegrationShape = McpIntegrationShape | OpenApiIntegrationShape;
+
+const describeError = (err: unknown): string => {
+  if (err && typeof err === "object" && "_tag" in err && typeof err._tag === "string") {
+    return err._tag;
+  }
+  if (err instanceof Error) return err.message;
+  return String(err);
+};
+
+const writeSecrets = (
+  executor: OrgExecutor,
+  orgId: string,
+  secrets: ReadonlyArray<SecretInputShape>,
+) =>
+  Effect.forEach(
+    secrets,
+    (s) =>
+      executor.secrets
+        .set(
+          new SetSecretInput({
+            id: SecretId.make(s.id),
+            scope: ScopeId.make(s.scope ?? orgId),
+            name: s.name,
+            value: s.value,
+            provider: s.provider,
+          }),
+        )
+        .pipe(
+          Effect.map((ref) => ({
+            id: ref.id as string,
+            scope: ref.scopeId as string,
+            name: ref.name,
+            provider: ref.provider,
+          })),
+          Effect.mapError(
+            (err) =>
+              new ProvisionError({
+                code: "secret_write_failed",
+                message: `Failed to set secret ${s.id}: ${describeError(err)}`,
+              }),
+          ),
+        ),
+    { concurrency: 1 },
+  );
+
+const addIntegration = (
+  executor: OrgExecutor,
+  orgId: string,
+  integration: IntegrationShape,
+) =>
+  Effect.gen(function* () {
+    const targetScope = integration.scope ?? orgId;
+    if (integration.kind === "mcp") {
+      const result = yield* executor.mcp
+        .addSource({
+          transport: "remote",
+          scope: targetScope,
+          name: integration.name,
+          endpoint: integration.endpoint,
+          remoteTransport: integration.remoteTransport,
+          namespace: integration.namespace,
+          headers: integration.headers
+            ? { ...integration.headers }
+            : undefined,
+          queryParams: integration.queryParams
+            ? { ...integration.queryParams }
+            : undefined,
+          auth: integration.auth,
+        })
+        .pipe(
+          Effect.mapError(
+            (err) =>
+              new ProvisionError({
+                code: "mcp_add_failed",
+                message: `Failed to add MCP source ${integration.name}: ${describeError(err)}`,
+              }),
+          ),
+        );
+      return {
+        kind: "mcp" as const,
+        namespace: result.namespace,
+        toolCount: result.toolCount,
+        scope: targetScope,
+      };
+    }
+    const result = yield* executor.openapi
+      .addSpec({
+        spec: integration.spec,
+        scope: targetScope,
+        name: integration.name,
+        baseUrl: integration.baseUrl,
+        namespace: integration.namespace,
+        headers: integration.headers as Record<string, never> | undefined,
+      })
+      .pipe(
+        Effect.mapError(
+          (err) =>
+            new ProvisionError({
+              code: "openapi_add_failed",
+              message: `Failed to add OpenAPI spec ${
+                integration.name ?? integration.namespace ?? "(unnamed)"
+              }: ${describeError(err)}`,
+            }),
+        ),
+      );
+    return {
+      kind: "openapi" as const,
+      namespace: result.sourceId,
+      toolCount: result.toolCount,
+      scope: targetScope,
+    };
+  });
+
+const addIntegrations = (
+  executor: OrgExecutor,
+  orgId: string,
+  integrations: ReadonlyArray<IntegrationShape>,
+) =>
+  Effect.forEach(integrations, (i) => addIntegration(executor, orgId, i), {
+    concurrency: 1,
+  });
+
+// ---------------------------------------------------------------------------
+// Org creation — mirrors auth/handlers.ts#createOrganization minus the
+// WorkOS session attach (no user session in scope).
+// ---------------------------------------------------------------------------
+
+const createOrg = (name: string) =>
+  Effect.gen(function* () {
+    const operator = yield* ProvisionOperatorContext;
+    const workos = yield* WorkOSAuth;
+    const users = yield* UserStoreService;
+
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return yield* new ProvisionError({
+        code: "invalid_name",
+        message: "Organization name must be non-empty",
+      });
+    }
+
+    const org = yield* workos.createOrganization(trimmed).pipe(
+      Effect.mapError(
+        (err) =>
+          new ProvisionError({
+            code: "workos_create_failed",
+            message: `Failed to create organization in WorkOS: ${describeError(err)}`,
+          }),
+      ),
+    );
+    yield* users
+      .use((s) => s.upsertOrganization({ id: org.id, name: org.name }))
+      .pipe(
+        Effect.mapError(
+          (err) =>
+            new ProvisionError({
+              code: "local_mirror_failed",
+              message: `Failed to mirror organization locally: ${describeError(err)}`,
+            }),
+        ),
+      );
+
+    yield* Effect.logInfo("provision.createOrg", {
+      orgId: org.id,
+      operatorId: operator.operatorId,
+    });
+
+    // `adminToken` currently echoes the operator bearer so automation can
+    // stay on a single token. A follow-up can mint per-org tokens here
+    // once operator-accounts land.
+    return {
+      orgId: org.id,
+      name: org.name,
+      adminToken: env.PROVISION_API_TOKEN ?? "",
+    };
+  });
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export const ProvisionHandlers = HttpApiBuilder.group(
+  ProvisionHttpApi,
+  "provision",
+  (handlers) =>
+    handlers
+      .handle("createOrg", ({ payload }) => createOrg(payload.name))
+      .handle("putSecrets", ({ path, payload }) =>
+        Effect.gen(function* () {
+          const executor = yield* buildOrgExecutor(path.orgId, path.orgId).pipe(
+            Effect.mapError(
+              (err) =>
+                new ProvisionError({
+                  code: "executor_build_failed",
+                  message: `Failed to build executor for org ${path.orgId}: ${err.message}`,
+                }),
+            ),
+          );
+          const secrets = yield* writeSecrets(
+            executor,
+            path.orgId,
+            payload.secrets,
+          );
+          return { secrets };
+        }),
+      )
+      .handle("addIntegrations", ({ path, payload }) =>
+        Effect.gen(function* () {
+          const executor = yield* buildOrgExecutor(path.orgId, path.orgId).pipe(
+            Effect.mapError(
+              (err) =>
+                new ProvisionError({
+                  code: "executor_build_failed",
+                  message: `Failed to build executor for org ${path.orgId}: ${err.message}`,
+                }),
+            ),
+          );
+          const integrations = yield* addIntegrations(
+            executor,
+            path.orgId,
+            payload.integrations as ReadonlyArray<IntegrationShape>,
+          );
+          return { integrations };
+        }),
+      )
+      .handle("provision", ({ payload }) =>
+        Effect.gen(function* () {
+          const createdOrg = yield* createOrg(payload.org.name);
+          const executor = yield* buildOrgExecutor(
+            createdOrg.orgId,
+            createdOrg.name,
+          ).pipe(
+            Effect.mapError(
+              (err) =>
+                new ProvisionError({
+                  code: "executor_build_failed",
+                  message: `Failed to build executor for org ${createdOrg.orgId}: ${err.message}`,
+                }),
+            ),
+          );
+
+          const secrets = payload.secrets
+            ? yield* writeSecrets(executor, createdOrg.orgId, payload.secrets)
+            : [];
+          const integrations = payload.integrations
+            ? yield* addIntegrations(
+                executor,
+                createdOrg.orgId,
+                payload.integrations as ReadonlyArray<IntegrationShape>,
+              )
+            : [];
+          return { org: createdOrg, secrets, integrations };
+        }),
+      ),
+);
+

--- a/apps/cloud/src/api/provision/middleware.ts
+++ b/apps/cloud/src/api/provision/middleware.ts
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------
+// Provisioning auth middleware.
+//
+// Current impl: compares the incoming bearer against a single shared env
+// secret `PROVISION_API_TOKEN`. This is deliberately the smallest primitive
+// that unblocks programmatic onboarding — the long-term answer is
+// per-operator accounts with revocable, auditable tokens (TODO below).
+//
+// Why not WorkOS here: the whole point of this surface is being operable
+// from a script with no browser session. WorkOS sealed sessions require
+// cookie handling and an interactive login. Until we have proper operator
+// accounts in WorkOS + a machine-token flow, a shared bearer is the
+// honest primitive.
+//
+// TODO(operator-auth): replace env-backed shared bearer with per-operator
+// tokens stored in WorkOS Vault (or equivalent) + an allowlist of operator
+// principals. Endpoints here should then log the operator id on every
+// mutation for audit purposes.
+// ---------------------------------------------------------------------------
+
+import { env } from "cloudflare:workers";
+import { Context, Effect, Layer, Redacted, Schema } from "effect";
+import {
+  HttpApiMiddleware,
+  HttpApiSchema,
+  HttpApiSecurity,
+} from "@effect/platform";
+
+export class ProvisionUnauthorized extends Schema.TaggedError<ProvisionUnauthorized>()(
+  "ProvisionUnauthorized",
+  {},
+  HttpApiSchema.annotations({ status: 401 }),
+) {}
+
+export type ProvisionOperator = {
+  /** Free-form operator id — today always `"shared"` because the env
+   *  bearer carries no identity. Logged on every mutation so future
+   *  migrations can keep the audit trail shape stable. */
+  readonly operatorId: string;
+};
+
+export class ProvisionOperatorContext extends Context.Tag(
+  "@executor/cloud/ProvisionOperator",
+)<ProvisionOperatorContext, ProvisionOperator>() {}
+
+export class ProvisionAuth extends HttpApiMiddleware.Tag<ProvisionAuth>()(
+  "ProvisionAuth",
+  {
+    failure: ProvisionUnauthorized,
+    provides: ProvisionOperatorContext,
+    security: {
+      bearer: HttpApiSecurity.bearer,
+    },
+  },
+) {}
+
+// ---------------------------------------------------------------------------
+// Live — reads the shared env bearer at request time. Kept as a Layer
+// factory so tests can swap in a token without touching `env`.
+// ---------------------------------------------------------------------------
+
+export const makeProvisionAuthLayer = (getConfiguredToken: () => string | null) =>
+  Layer.succeed(
+    ProvisionAuth,
+    ProvisionAuth.of({
+      bearer: (incoming) =>
+        Effect.sync(() => {
+          const configured = getConfiguredToken();
+          if (!configured) return null;
+          if (Redacted.value(incoming) !== configured) return null;
+          return { operatorId: "shared" };
+        }).pipe(
+          Effect.flatMap((result) =>
+            result ? Effect.succeed(result) : new ProvisionUnauthorized(),
+          ),
+        ),
+    }),
+  );
+
+export const ProvisionAuthLive = makeProvisionAuthLayer(
+  () => env.PROVISION_API_TOKEN ?? null,
+);

--- a/apps/cloud/src/api/router.ts
+++ b/apps/cloud/src/api/router.ts
@@ -21,16 +21,22 @@ export class ProtectedRequestHandlerService extends Context.Tag(
   "@executor/cloud/ProtectedRequestHandlerService",
 )<ProtectedRequestHandlerService, RequestAppService>() {}
 
+export class ProvisionRequestHandlerService extends Context.Tag(
+  "@executor/cloud/ProvisionRequestHandlerService",
+)<ProvisionRequestHandlerService, RequestAppService>() {}
+
 export const ApiRouterApp = Effect.gen(function* () {
   const org = yield* OrgRequestHandlerService;
   const nonProtected = yield* NonProtectedRequestHandlerService;
   const autumn = yield* AutumnRequestHandlerService;
+  const provision = yield* ProvisionRequestHandlerService;
   const protectedHandler = yield* ProtectedRequestHandlerService;
 
   return yield* HttpRouter.empty.pipe(
     HttpRouter.mountApp("/org", org.app, { includePrefix: true }),
     HttpRouter.mountApp("/auth", nonProtected.app, { includePrefix: true }),
     HttpRouter.mountApp("/autumn", autumn.app, { includePrefix: true }),
+    HttpRouter.mountApp("/provision", provision.app, { includePrefix: true }),
     HttpRouter.mountApp("/", protectedHandler.app),
     HttpRouter.toHttpApp,
   );

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -24,6 +24,11 @@ declare global {
       MCP_AUTHKIT_DOMAIN?: string;
       MCP_RESOURCE_ORIGIN?: string;
 
+      // Programmatic provisioning API operator bearer. Absent ⇒ the
+      // provisioning API rejects every request. See
+      // apps/cloud/src/api/provision/middleware.ts.
+      PROVISION_API_TOKEN?: string;
+
       // Shared with frontend
       VITE_PUBLIC_SITE_URL?: string;
     }

--- a/apps/cloud/test-stubs/cloudflare-workers.ts
+++ b/apps/cloud/test-stubs/cloudflare-workers.ts
@@ -12,6 +12,7 @@ export const env: Record<string, unknown> = {
   WORKOS_API_KEY: process.env.WORKOS_API_KEY,
   WORKOS_CLIENT_ID: process.env.WORKOS_CLIENT_ID,
   WORKOS_COOKIE_PASSWORD: process.env.WORKOS_COOKIE_PASSWORD,
+  PROVISION_API_TOKEN: process.env.PROVISION_API_TOKEN,
 };
 export class WorkerEntrypoint {}
 export class DurableObject {}

--- a/apps/cloud/vitest.node.config.ts
+++ b/apps/cloud/vitest.node.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       WORKOS_API_KEY: "test_api_key",
       WORKOS_CLIENT_ID: "test_client_id",
       WORKOS_COOKIE_PASSWORD: "test_cookie_password_at_least_32_chars!",
+      PROVISION_API_TOKEN: "test_provision_token",
       NODE_ENV: "test",
     },
   },


### PR DESCRIPTION
## Summary

A scriptable onboarding HTTP surface so an operator can stand up a new org with pre-configured integrations in one call — no manual click-through.

## Routes (all under \`/api/provision/*\`, unversioned to match the rest of the cloud HttpApi)

- \`POST /api/provision/orgs\` — create an org, returns \`{orgId, name, adminToken}\`
- \`POST /api/provision/orgs/:orgId/secrets\` — bulk-put secrets at a scope (default = org scope)
- \`POST /api/provision/orgs/:orgId/integrations\` — bulk-add MCP + OpenAPI sources
- \`POST /api/provision\` — one-shot manifest doing all three
- \`/api/provision/docs\` — auto-emitted OpenAPI spec

## Auth

New \`ProvisionAuth\` HttpApiMiddleware using \`HttpApiSecurity.bearer\`, compared against \`env.PROVISION_API_TOKEN\`. Fails with \`ProvisionUnauthorized (401)\`. Inline \`TODO(operator-auth)\` to replace the shared env bearer with per-operator tokens backed by WorkOS Vault plus audit logging. \`PROVISION_API_TOKEN\` added to \`env-augment.d.ts\` and the node-test env.

## Services reused (no duplicated business logic)

- \`WorkOSAuth.createOrganization\` + \`UserStoreService.upsertOrganization\` — identical call path to \`/api/auth/create-organization\`.
- \`executor.secrets.set(SetSecretInput)\` — same path as the UI's Secrets page.
- \`executor.mcp.addSource\` + \`executor.openapi.addSpec\` — same path as \`/scopes/:scopeId/mcp/sources\` and \`/scopes/:scopeId/openapi/specs\`.
- Per-request executor built via a local \`buildOrgExecutor\` mirroring \`services/executor.ts#createScopedExecutor\`, with WorkOS Vault options pulled from a new \`ProvisionVaultOptions\` Context tag so tests can inject a fake vault client.

## Test plan

- [ ] \`apps/cloud/src/api/provision/handlers.node.test.ts\` — 6 tests: 401 no bearer, 401 wrong bearer, createOrg happy path, putSecrets bulk write, addIntegrations end-to-end reach, one-shot \`/provision\` creating org + secrets + integrations.
- [ ] Full node suite: 50/50 (44 prior + 6 new). Typecheck clean.
- [ ] (Unrelated pre-existing break on main: the workerd-pool \`.test.ts\` suite has a \`@vitest/expect\` export issue — reproes on main.)

## Follow-ups I did not do

- \`TODO(operator-auth)\`: swap shared env bearer for per-operator tokens + audit log.
- \`adminToken\` in the \`createOrg\` response currently echoes the operator bearer — replace with minted per-org tokens once operator accounts land.
- Integration-creation tests assert the happy wiring reaches the plugin but don't assert \`tool_count > 0\` — that requires a live MCP endpoint fixture.