### PR TITLE
openapi: allow saving OAuth2 source before sign-in

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -70,6 +70,16 @@ const substituteUrlVariables = (url: string, values: Record<string, string>): st
 };
 
 /**
+ * Stable placeholder connection id used when saving a source without
+ * completing the OAuth flow. OpenApiSignInButton rewrites `oauth2.connectionId`
+ * to a freshly minted id on first sign-in, so this only needs to be
+ * deterministic per-namespace and distinct from any real connection id
+ * (real ids are `openapi-oauth2-${uuid}`).
+ */
+const openApiOAuthConnectionId = (namespaceSlug: string): string =>
+  `openapi-oauth2-pending-${namespaceSlug || "default"}`;
+
+/**
  * OpenAPI 3.x requires OAuth2 tokenUrl/authorizationUrl to be absolute,
  * but some specs ship relative paths like `/api/rest/v1/oauth/token`.
  * Resolve them against the source's chosen baseUrl so the backend can
@@ -270,8 +280,18 @@ export default function AddOpenApiSource(props: {
   const selectedOAuth2Preset: OAuth2Preset | null =
     strategy.kind === "oauth2" ? (oauth2Presets[strategy.presetIndex] ?? null) : null;
 
+  // OAuth is "ready to save" without completing the flow as long as we have
+  // enough metadata to run sign-in later: a preset, a client id secret, and —
+  // for clientCredentials — a client secret. Each user signs in via
+  // OpenApiSignInButton on the source detail page; innermost-wins scope
+  // shadowing resolves tokens per-user at invoke time.
+  const oauth2DeferrableReady =
+    selectedOAuth2Preset !== null &&
+    oauth2ClientIdSecretId !== null &&
+    (selectedOAuth2Preset.flow !== "clientCredentials" ||
+      oauth2ClientSecretSecretId !== null);
   const oauth2Ready =
-    strategy.kind !== "oauth2" || oauth2Auth !== null;
+    strategy.kind !== "oauth2" || oauth2Auth !== null || oauth2DeferrableReady;
 
   const canAdd =
     preview !== null &&
@@ -523,6 +543,40 @@ export default function AddOpenApiSource(props: {
       kind: "openapi",
       url: resolvedBaseUrl || undefined,
     });
+    // If the user picked oauth2 but didn't complete sign-in, persist a
+    // deferred OAuth2Auth with a stable placeholder connectionId so the
+    // source lands with its OAuth config intact. OpenApiSignInButton
+    // rewrites the pointer once a user actually signs in.
+    let oauth2ToSave: OAuth2Auth | null = oauth2Auth;
+    if (
+      !oauth2ToSave &&
+      strategy.kind === "oauth2" &&
+      selectedOAuth2Preset &&
+      oauth2ClientIdSecretId
+    ) {
+      const tokenUrl = resolveOAuthUrl(
+        selectedOAuth2Preset.tokenUrl,
+        resolvedBaseUrl,
+      );
+      const authorizationUrl =
+        selectedOAuth2Preset.flow === "authorizationCode"
+          ? resolveOAuthUrl(
+              Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
+              resolvedBaseUrl,
+            ) || null
+          : null;
+      oauth2ToSave = new OAuth2Auth({
+        kind: "oauth2",
+        connectionId: openApiOAuthConnectionId(namespace),
+        securitySchemeName: selectedOAuth2Preset.securitySchemeName,
+        flow: selectedOAuth2Preset.flow,
+        tokenUrl,
+        authorizationUrl,
+        clientIdSecretId: oauth2ClientIdSecretId,
+        clientSecretSecretId: oauth2ClientSecretSecretId,
+        scopes: [...oauth2SelectedScopes],
+      });
+    }
     try {
       await doAdd({
         path: { scopeId },
@@ -532,7 +586,7 @@ export default function AddOpenApiSource(props: {
           namespace: slugifyNamespace(identity.namespace) || undefined,
           baseUrl: resolvedBaseUrl || undefined,
           ...(hasHeaders ? { headers: allHeaders } : {}),
-          ...(oauth2Auth ? { oauth2: oauth2Auth } : {}),
+          ...(oauth2ToSave ? { oauth2: oauth2ToSave } : {}),
         },
         reactivityKeys: sourceWriteKeys,
       });
@@ -960,14 +1014,20 @@ export default function AddOpenApiSource(props: {
                     </Button>
                   </div>
                 ) : (
-                  <Button
-                    variant="secondary"
-                    onClick={handleConnectOAuth2}
-                    disabled={!oauth2ClientIdSecretId || resolvedBaseUrl.length === 0}
-                    className="w-full"
-                  >
-                    Connect via OAuth
-                  </Button>
+                  <div className="flex flex-col gap-1.5">
+                    <Button
+                      variant="secondary"
+                      onClick={handleConnectOAuth2}
+                      disabled={!oauth2ClientIdSecretId || resolvedBaseUrl.length === 0}
+                      className="w-full"
+                    >
+                      Connect via OAuth
+                    </Button>
+                    <p className="text-[11px] text-muted-foreground">
+                      Optional — you can save the source now and each user can sign
+                      in from the source detail page later.
+                    </p>
+                  </div>
                 )}
 
                 {oauth2Error && (

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -25,6 +25,7 @@ import {
 
 const TEST_SCOPE = "test-scope";
 import { openApiPlugin } from "./plugin";
+import { OAuth2Auth } from "./types";
 
 const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
 
@@ -602,5 +603,70 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       expect(orgView?.name).toBe("Org Source");
       expect(orgView?.config.baseUrl).toBe("https://org.example.com");
     }),
+  );
+
+  it.effect(
+    "addSpec persists a source with deferred OAuth2Auth (no live connection yet)",
+    () =>
+      Effect.gen(function* () {
+        const httpClient = yield* HttpClient.HttpClient;
+        const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              openApiPlugin({ httpClientLayer: clientLayer }),
+              memorySecretsPlugin(),
+            ] as const,
+          }),
+        );
+
+        // A team-shared client id secret, but no live connection for this
+        // scope — the admin is saving the source and deferring sign-in
+        // to individual users.
+        yield* executor.secrets.set(
+          new SetSecretInput({
+            id: SecretId.make("acme-client-id"),
+            scope: ScopeId.make(TEST_SCOPE),
+            name: "Acme Client ID",
+            value: "client-abc",
+          }),
+        );
+
+        const deferredAuth = new OAuth2Auth({
+          kind: "oauth2",
+          connectionId: "openapi-oauth2-pending-deferred",
+          securitySchemeName: "oauth2",
+          flow: "authorizationCode",
+          tokenUrl: "https://auth.example.com/token",
+          authorizationUrl: "https://auth.example.com/authorize",
+          clientIdSecretId: "acme-client-id",
+          clientSecretSecretId: null,
+          scopes: ["read:items"],
+        });
+
+        const result = yield* executor.openapi.addSpec({
+          spec: specJson,
+          scope: TEST_SCOPE,
+          namespace: "deferred",
+          baseUrl: "https://api.example.com",
+          oauth2: deferredAuth,
+        });
+
+        expect(result.toolCount).toBeGreaterThan(0);
+
+        const stored = yield* executor.openapi.getSource("deferred", TEST_SCOPE);
+        expect(stored).not.toBeNull();
+        expect(stored?.config.oauth2?.connectionId).toBe(
+          "openapi-oauth2-pending-deferred",
+        );
+        expect(stored?.config.oauth2?.clientIdSecretId).toBe("acme-client-id");
+        expect(stored?.config.oauth2?.flow).toBe("authorizationCode");
+
+        // Tools should be listed even without a live connection; invocation
+        // is what requires the token, not registration.
+        const tools = yield* executor.tools.list();
+        expect(tools.some((t) => t.id.startsWith("deferred."))).toBe(true);
+      }),
   );
 });


### PR DESCRIPTION
## Summary

Companion to #364 — the same defer-sign-in pattern applied to OpenAPI sources. Selecting OAuth2 as the auth strategy when adding a spec no longer forces the admin to complete the authorization flow before Save. The source is persisted with its OAuth config intact and a stable placeholder \`connectionId\`; each user later mints their own backing connection via \`OpenApiSignInButton\` on the source detail page. The sign-in handler already rewrites \`oauth2.connectionId\` on success, so the placeholder just has to be distinct from any real \`openapi-oauth2-\${uuid}\` and deterministic per-namespace.

## What lands

- \`packages/plugins/openapi/src/react/AddOpenApiSource.tsx\`
  - New \`openApiOAuthConnectionId(namespaceSlug)\` → \`openapi-oauth2-pending-\${slug}\`.
  - \`oauth2DeferrableReady\` drops the \`oauth2Auth !== null\` gate. Save is legal with a preset + client id secret (plus client secret for \`clientCredentials\`) — enough metadata for the deferred sign-in path to run later.
  - \`handleAdd\` builds a deferred \`OAuth2Auth\` (placeholder \`connectionId\`, real \`tokenUrl\` / \`authorizationUrl\` / \`clientIdSecretId\` / \`clientSecretSecretId\` / \`scopes\`) when \`oauth2Auth\` is null but the strategy is oauth2. If the user did complete the flow, the previously-set \`oauth2Auth\` is used as-is.
  - Hint text under \"Connect via OAuth\": *Optional — you can save the source now and each user can sign in from the source detail page later.*
- \`packages/plugins/openapi/src/sdk/plugin.test.ts\` — regression test: \`addSpec\` with a deferred \`OAuth2Auth\` persists the source, registers tools, and the stored \`oauth2\` carries the placeholder \`connectionId\` + real metadata. No \`ctx.connections.*\` call happens at save time.

## No plugin-side changes

\`addSpec\` → \`rebuildSource\` parses the spec and persists tool defs without resolving the connection. The access token is only fetched at invoke time (\`accessToken(auth.connectionId)\`), so a placeholder \`connectionId\` is fine until a user signs in.

## Test plan

- [ ] Manual: add an OpenAPI spec with an OAuth2 security scheme, pick a preset, enter a client id secret, **don't** click Connect via OAuth, click Add source. Confirm the source lands and \`OpenApiSignInButton\` renders Sign in.
- [ ] Manual: click Sign in, complete the flow, confirm tools invoke successfully.
- [ ] \`bun run --filter=@executor/plugin-openapi test\` — 38/38 (37 prior + 1 new). Typecheck clean.