### PR TITLE
test: unblock v1.4.8 publish — drop inline-code call from smoke test

### DIFF
--- a/tests/release-bootstrap-smoke.test.ts
+++ b/tests/release-bootstrap-smoke.test.ts
@@ -228,15 +228,6 @@ describe("release bootstrap smoke", () => {
         const docsResponse = await fetch(`http://127.0.0.1:${webPort}/docs`);
         expect(docsResponse.status, `${webStdout}\n${webStderr}`).toBe(200);
 
-        // Verify code execution works end-to-end in the compiled binary
-        const callResult = await runCommand(
-          installedBinaryPath,
-          ["call", "return 2+2"],
-          installedPackageDir,
-        );
-        expect(callResult.exitCode, `call failed:\n${callResult.stderr}`).toBe(0);
-        expect(callResult.stdout.trim()).toContain("4");
-
         const secondRun = await runCommand(
           process.execPath,
           [join(installedPackageDir, "bin", "executor"), "--help"],


### PR DESCRIPTION
## Summary

The v1.4.8 \`Publish Executor\` workflow ([run](https://github.com/RhysSullivan/executor/actions/runs/24763652650)) failed at \`release:check\` because \`tests/release-bootstrap-smoke.test.ts\` still runs \`executor call "return 2+2"\` — the pre-1.4.8 inline-code form. Commit 14695e0a (\`refactor(cli): make call tool-invocation only\`) removed inline code from \`call\`, so the assertion now errors with \`Tool path segments must contain only letters, numbers, '.', '_' or '-'\` and the publish step never runs.

Dropping the obsolete assertion. The rest of the test already covers the meaningful end-to-end behaviour (compiled binary boots, serves HTML + JS + CSS, \`/docs\` responds, second invocation uses the cached binary), and there's no equivalent CLI surface to reintroduce the code-execution check against.

Once this is merged, we'll force-move \`v1.4.8\` to the fixed commit and redispatch the publish workflow — nothing was ever published under \`v1.4.8\` on npm or GitHub Releases.

## Test plan

- [x] \`bun run test:release:bootstrap\` passes locally (~20s).
- [ ] After merge: \`Publish Executor\` workflow succeeds on the re-pointed \`v1.4.8\` tag.