### PR TITLE
openapi: swap onboarding UI to shared /oauth/* surface, drop per-plugin routes

### DIFF
--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -63,84 +63,9 @@ const AddSpecResponse = Schema.Struct({
   namespace: Schema.String,
 });
 
-// ---------------------------------------------------------------------------
-// OAuth payloads / responses
-// ---------------------------------------------------------------------------
-
-// Shared identity fields for both OAuth2 flows.
-//
-// `sourceId` (namespace) pins the resulting Connection *name* to a
-// stable per-source value so repeated sign-ins refresh an existing
-// row per scope instead of spawning a fresh UUID every click. Both
-// flows write at the innermost executor scope by default (per-user
-// row, per-user token), which preserves per-user credentials via
-// scope-stacked secret shadowing.
-//
-// `tokenScope` defaults to `ctx.scopes[0].id` (innermost). Callers
-// can override — e.g. an admin writing an org-wide shared connection
-// — and the SDK validates that the target is in the executor's stack.
-const StartOAuthIdentityFields = {
-  displayName: Schema.String,
-  securitySchemeName: Schema.String,
-  tokenUrl: Schema.String,
-  clientIdSecretId: Schema.String,
-  scopes: Schema.Array(Schema.String),
-  tokenScope: Schema.optional(ScopeId),
-  connectionId: Schema.optional(Schema.String),
-  sourceId: Schema.String,
-} as const;
-
-const StartOAuthPayload = Schema.Union(
-  Schema.Struct({
-    ...StartOAuthIdentityFields,
-    flow: Schema.Literal("authorizationCode"),
-    authorizationUrl: Schema.String,
-    redirectUrl: Schema.String,
-    clientSecretSecretId: Schema.optional(Schema.NullOr(Schema.String)),
-  }),
-  // RFC 6749 §4.4 — no user-interactive step, no session, no popup. The
-  // plugin exchanges tokens inline and returns a completed auth. The
-  // client_secret is required (the grant is client authentication + token
-  // request) and no refresh token is issued (§4.4.3).
-  Schema.Struct({
-    ...StartOAuthIdentityFields,
-    flow: Schema.Literal("clientCredentials"),
-    clientSecretSecretId: Schema.String,
-  }),
-);
-
-const StartOAuthResponse = Schema.Union(
-  Schema.Struct({
-    flow: Schema.Literal("authorizationCode"),
-    sessionId: Schema.String,
-    authorizationUrl: Schema.String,
-    scopes: Schema.Array(Schema.String),
-  }),
-  Schema.Struct({
-    flow: Schema.Literal("clientCredentials"),
-    auth: OAuth2Auth,
-    scopes: Schema.Array(Schema.String),
-  }),
-);
-
-const CompleteOAuthPayload = Schema.Struct({
-  state: Schema.String,
-  code: Schema.optional(Schema.String),
-  error: Schema.optional(Schema.String),
-});
-
-const CompleteOAuthResponse = Schema.Struct({
-  connectionId: Schema.String,
-  expiresAt: Schema.NullOr(Schema.Number),
-  scope: Schema.NullOr(Schema.String),
-});
-
-const OAuthCallbackUrlParams = Schema.Struct({
-  state: Schema.String,
-  code: Schema.optional(Schema.String),
-  error: Schema.optional(Schema.String),
-  error_description: Schema.optional(Schema.String),
-});
+// OAuth start/complete/callback payloads/responses live on the shared
+// `/scopes/:scopeId/oauth/*` group in `@executor/api` now — no
+// OpenAPI-specific OAuth schemas needed here.
 
 // HTTP status on the three domain errors lives on their class
 // declarations in `../sdk/errors.ts` — see the comment there.
@@ -181,25 +106,6 @@ export class OpenApiGroup extends HttpApiGroup.make("openapi")
     HttpApiEndpoint.patch("updateSource")`/scopes/${scopeIdParam}/openapi/sources/${namespaceParam}`
       .setPayload(UpdateSourcePayload)
       .addSuccess(UpdateSourceResponse),
-  )
-  .add(
-    HttpApiEndpoint.post("startOAuth")`/scopes/${scopeIdParam}/openapi/oauth/start`
-      .setPayload(StartOAuthPayload)
-      .addSuccess(StartOAuthResponse),
-  )
-  .add(
-    HttpApiEndpoint.post("completeOAuth")`/scopes/${scopeIdParam}/openapi/oauth/complete`
-      .setPayload(CompleteOAuthPayload)
-      .addSuccess(CompleteOAuthResponse),
-  )
-  .add(
-    HttpApiEndpoint.get("oauthCallback", "/openapi/oauth/callback")
-      .setUrlParams(OAuthCallbackUrlParams)
-      .addSuccess(
-        Schema.Unknown.annotations(
-          HttpApiSchema.annotations({ contentType: "text/html" }),
-        ),
-      ),
   )
   // Errors declared once at the group level — every endpoint inherits.
   // Plugin domain errors carry their own HttpApiSchema status (4xx);

--- a/packages/plugins/openapi/src/api/handlers.ts
+++ b/packages/plugins/openapi/src/api/handlers.ts
@@ -1,31 +1,13 @@
-import { HttpApiBuilder, HttpServerResponse } from "@effect/platform";
+import { HttpApiBuilder } from "@effect/platform";
 import { Context, Effect } from "effect";
 
-import { runOAuthCallback } from "@executor/plugin-oauth2/http";
-
-import { addGroup, capture, InternalError } from "@executor/api";
-import type {
-  OAuthCompleteError,
-  OAuthSessionNotFoundError,
-  StorageFailure,
-} from "@executor/sdk";
-import { OpenApiOAuthError } from "../sdk/errors";
+import { addGroup, capture } from "@executor/api";
 import type {
   OpenApiPluginExtension,
   HeaderValue,
   OpenApiUpdateSourceInput,
 } from "../sdk/plugin";
 import { OpenApiGroup } from "./group";
-
-const OPENAPI_OAUTH_CHANNEL = "executor:openapi-oauth-result";
-
-const toPopupErrorMessage = (error: unknown): string => {
-  if (error instanceof OpenApiOAuthError) return error.message;
-  if (error && typeof error === "object" && "message" in error) {
-    return String((error as { message: unknown }).message);
-  }
-  return "Authentication failed";
-};
 
 // ---------------------------------------------------------------------------
 // Service tag
@@ -57,6 +39,9 @@ const ExecutorApiWithOpenApi = addGroup(OpenApiGroup);
 // schema-encoded to 4xx by HttpApi (see group.ts `.addError(...)` calls).
 // Defects bubble up and are captured + downgraded to `InternalError(traceId)`
 // by the API-level observability middleware.
+//
+// OAuth start/complete/callback live on the shared `/scopes/:scopeId/oauth/*`
+// group in `@executor/api` now — the plugin has no OAuth-specific handlers.
 // ---------------------------------------------------------------------------
 
 export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "openapi", (handlers) =>
@@ -101,76 +86,6 @@ export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "ope
           oauth2: payload.oauth2,
         } as OpenApiUpdateSourceInput);
         return { updated: true };
-      })),
-    )
-    .handle("startOAuth", ({ payload }) =>
-      capture(Effect.gen(function* () {
-        const ext = yield* OpenApiExtensionService;
-        // No tokenScope -> plugin defaults to ctx.scopes[0].id
-        // (innermost) for both OAuth flows.
-        const tokenScope = payload.tokenScope as string | undefined;
-        if (payload.flow === "clientCredentials") {
-          return yield* ext.startOAuth({
-            flow: "clientCredentials",
-            sourceId: payload.sourceId,
-            displayName: payload.displayName,
-            securitySchemeName: payload.securitySchemeName,
-            tokenUrl: payload.tokenUrl,
-            clientIdSecretId: payload.clientIdSecretId,
-            clientSecretSecretId: payload.clientSecretSecretId,
-            scopes: [...payload.scopes],
-            tokenScope,
-            connectionId: payload.connectionId,
-          });
-        }
-        return yield* ext.startOAuth({
-          flow: "authorizationCode",
-          sourceId: payload.sourceId,
-          displayName: payload.displayName,
-          securitySchemeName: payload.securitySchemeName,
-          authorizationUrl: payload.authorizationUrl,
-          tokenUrl: payload.tokenUrl,
-          redirectUrl: payload.redirectUrl,
-          clientIdSecretId: payload.clientIdSecretId,
-          clientSecretSecretId: payload.clientSecretSecretId ?? null,
-          scopes: [...payload.scopes],
-          tokenScope,
-          connectionId: payload.connectionId,
-        });
-      })),
-    )
-    .handle("completeOAuth", ({ payload }) =>
-      capture(Effect.gen(function* () {
-        const ext = yield* OpenApiExtensionService;
-        return yield* ext.completeOAuth({
-          state: payload.state,
-          code: payload.code,
-          error: payload.error,
-        });
-      })),
-    )
-    .handle("oauthCallback", ({ urlParams }) =>
-      // OAuth popup is special: it always returns 200 HTML and renders the
-      // failure into the popup body so the parent window's listener gets a
-      // structured result.
-      capture(Effect.gen(function* () {
-        const ext = yield* OpenApiExtensionService;
-        const html = yield* runOAuthCallback<
-          { connectionId: string; expiresAt: number | null; scope: string | null },
-          OAuthCompleteError | OAuthSessionNotFoundError | StorageFailure | InternalError,
-          never
-        >({
-          complete: ({ state, code, error }) =>
-            ext.completeOAuth({
-              state,
-              code: code ?? undefined,
-              error: error ?? undefined,
-            }),
-          urlParams,
-          toErrorMessage: toPopupErrorMessage,
-          channelName: OPENAPI_OAUTH_CHANNEL,
-        });
-        return yield* HttpServerResponse.html(html);
       })),
     ),
 );

--- a/packages/plugins/openapi/src/promise.ts
+++ b/packages/plugins/openapi/src/promise.ts
@@ -5,7 +5,4 @@ export type {
   OpenApiSpecConfig,
   OpenApiUpdateSourceInput,
   HeaderValue,
-  OpenApiStartOAuthInput,
-  OpenApiStartOAuthResponse,
-  OpenApiCompleteOAuthInput,
 } from "./sdk/plugin";

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -2,8 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 import { Option } from "effect";
 
-import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
-
 import { useScope } from "@executor/react/api/scope-context";
 import {
   connectionWriteKeys,
@@ -60,8 +58,13 @@ import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
 import {
   addOpenApiSpec,
   previewOpenApiSpec,
-  startOpenApiOAuth,
 } from "./atoms";
+import { startOAuth } from "@executor/react/api/atoms";
+import {
+  openOAuthPopup,
+  type OAuthPopupResult,
+} from "@executor/react/api/oauth-popup";
+import { OAUTH_POPUP_MESSAGE_TYPE } from "@executor/sdk";
 import type { SpecPreview, HeaderPreset, OAuth2Preset } from "../sdk/preview";
 import {
   OAuth2Auth,
@@ -70,9 +73,9 @@ import {
   type ServerVariable,
 } from "../sdk/types";
 
-export const OPENAPI_OAUTH_CHANNEL = "executor:openapi-oauth-result";
+export const OPENAPI_OAUTH_CHANNEL = OAUTH_POPUP_MESSAGE_TYPE;
 export const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
-export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/openapi/oauth/callback";
+export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/oauth/callback";
 
 const substituteUrlVariables = (url: string, values: Record<string, string>): string => {
   let out = url;
@@ -221,7 +224,7 @@ export default function AddOpenApiSource(props: {
   const scopeId = useScope();
   const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promise" });
   const doAdd = useAtomSet(addOpenApiSpec, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startOpenApiOAuth, { mode: "promise" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
   const { beginAdd } = usePendingSources();
   const secretList = useSecretPickerSecrets();
 
@@ -433,18 +436,21 @@ export default function AddOpenApiSource(props: {
     setStartingOAuth(true);
     setOauth2Error(null);
     try {
-      const displayName =
-        identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
-
       const tokenUrl = resolveOAuthUrl(
         selectedOAuth2Preset.tokenUrl,
         resolvedBaseUrl,
       );
+      const connectionId = openApiOAuthConnectionId(
+        resolvedSourceId,
+        selectedOAuth2Preset.flow,
+      );
+      const scopes = [...oauth2SelectedScopes];
 
       if (selectedOAuth2Preset.flow === "clientCredentials") {
-        // RFC 6749 §4.4: no user-interactive consent step. The client_secret
-        // is mandatory; the backend exchanges tokens inline and returns a
-        // completed OAuth2Auth we can attach to the source directly.
+        // RFC 6749 §4.4: no user-interactive consent step. The
+        // shared `/oauth/start` mints the Connection inline and
+        // surfaces it under `completedConnection`; we stitch the
+        // full OAuth2Auth from the preset's known metadata.
         if (!oauth2ClientSecretSecretId) {
           setStartingOAuth(false);
           setOauth2Error("client_credentials requires a client secret");
@@ -453,28 +459,37 @@ export default function AddOpenApiSource(props: {
         const response = await doStartOAuth({
           path: { scopeId },
           payload: {
-            sourceId: resolvedSourceId,
-            connectionId: openApiOAuthConnectionId(
-              resolvedSourceId,
-              selectedOAuth2Preset.flow,
-            ),
-            displayName,
-            securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-            flow: "clientCredentials",
-            tokenUrl,
-            clientIdSecretId: oauth2ClientIdSecretId,
-            clientSecretSecretId: oauth2ClientSecretSecretId,
-            scopes: [...oauth2SelectedScopes],
+            endpoint: tokenUrl,
+            redirectUrl: tokenUrl,
+            connectionId,
+            strategy: {
+              kind: "client-credentials",
+              tokenEndpoint: tokenUrl,
+              clientIdSecretId: oauth2ClientIdSecretId,
+              clientSecretSecretId: oauth2ClientSecretSecretId,
+              scopes,
+            },
+            pluginId: "openapi",
           },
         });
         setStartingOAuth(false);
-        if (response.flow !== "clientCredentials") {
-          setOauth2Error("Unexpected response flow from server");
+        if (response.completedConnection === null) {
+          setOauth2Error("client_credentials flow did not mint a connection");
           return;
         }
         setOauth2AuthState({
           fingerprint: selectedOAuth2Fingerprint,
-          auth: response.auth,
+          auth: new OAuth2Auth({
+            kind: "oauth2",
+            connectionId: response.completedConnection.connectionId,
+            securitySchemeName: selectedOAuth2Preset.securitySchemeName,
+            flow: "clientCredentials",
+            tokenUrl,
+            authorizationUrl: null,
+            clientIdSecretId: oauth2ClientIdSecretId,
+            clientSecretSecretId: oauth2ClientSecretSecretId,
+            scopes,
+          }),
         });
         setOauth2Error(null);
         return;
@@ -488,34 +503,42 @@ export default function AddOpenApiSource(props: {
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
-          sourceId: resolvedSourceId,
-          connectionId: openApiOAuthConnectionId(
-            resolvedSourceId,
-            selectedOAuth2Preset.flow,
-          ),
-          displayName,
-          securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-          flow: "authorizationCode",
-          authorizationUrl,
-          tokenUrl,
+          endpoint: tokenUrl,
           redirectUrl: oauth2RedirectUrl,
-          clientIdSecretId: oauth2ClientIdSecretId,
-          clientSecretSecretId: oauth2ClientSecretSecretId,
-          scopes: [...oauth2SelectedScopes],
+          connectionId,
+          strategy: {
+            kind: "authorization-code",
+            authorizationEndpoint: authorizationUrl,
+            tokenEndpoint: tokenUrl,
+            clientIdSecretId: oauth2ClientIdSecretId,
+            clientSecretSecretId: oauth2ClientSecretSecretId,
+            scopes,
+          },
+          pluginId: "openapi",
         },
       });
 
-      if (response.flow !== "authorizationCode") {
+      if (response.authorizationUrl === null) {
         setStartingOAuth(false);
-        setOauth2Error("Unexpected response flow from server");
+        setOauth2Error(
+          "OAuth start did not produce an authorization URL",
+        );
         return;
       }
 
-      oauthCleanup.current = openOAuthPopup<OAuth2Auth>({
+      oauthCleanup.current = openOAuthPopup<{
+        connectionId: string;
+        expiresAt: number | null;
+        scope: string | null;
+      }>({
         url: response.authorizationUrl,
         popupName: OPENAPI_OAUTH_POPUP_NAME,
         channelName: OPENAPI_OAUTH_CHANNEL,
-        onResult: (result: OAuthPopupResult<OAuth2Auth>) => {
+        onResult: (result: OAuthPopupResult<{
+          connectionId: string;
+          expiresAt: number | null;
+          scope: string | null;
+        }>) => {
           oauthCleanup.current = null;
           setStartingOAuth(false);
           if (result.ok) {
@@ -524,13 +547,13 @@ export default function AddOpenApiSource(props: {
               auth: new OAuth2Auth({
                 kind: "oauth2",
                 connectionId: result.connectionId,
-                securitySchemeName: result.securitySchemeName,
-                flow: result.flow,
-                tokenUrl: result.tokenUrl,
-                authorizationUrl: result.authorizationUrl,
-                clientIdSecretId: result.clientIdSecretId,
-                clientSecretSecretId: result.clientSecretSecretId,
-                scopes: result.scopes,
+                securitySchemeName: selectedOAuth2Preset.securitySchemeName,
+                flow: "authorizationCode",
+                tokenUrl,
+                authorizationUrl,
+                clientIdSecretId: oauth2ClientIdSecretId,
+                clientSecretSecretId: oauth2ClientSecretSecretId,
+                scopes,
               }),
             });
             setOauth2Error(null);
@@ -539,7 +562,6 @@ export default function AddOpenApiSource(props: {
           }
         },
         onClosed: () => {
-          // User closed the popup without completing the flow.
           oauthCleanup.current = null;
           setStartingOAuth(false);
           setOauth2Error("OAuth cancelled — popup was closed before completing the flow.");

--- a/packages/plugins/openapi/src/react/OpenApiSignInButton.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSignInButton.tsx
@@ -1,14 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet, useAtomValue, Result } from "@effect-atom/atom-react";
 
-import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
 import { useScope } from "@executor/react/api/scope-context";
 import {
   connectionWriteKeys,
   sourceWriteKeys,
 } from "@executor/react/api/reactivity-keys";
-import { connectionsAtom } from "@executor/react/api/atoms";
+import { connectionsAtom, startOAuth } from "@executor/react/api/atoms";
+import {
+  openOAuthPopup,
+  type OAuthPopupResult,
+} from "@executor/react/api/oauth-popup";
+import { OAUTH_POPUP_MESSAGE_TYPE } from "@executor/sdk";
 import { Button } from "@executor/react/components/button";
+
+import { openApiSourceAtom, updateOpenApiSource } from "./atoms";
+import {
+  OPENAPI_OAUTH_CALLBACK_PATH,
+  OPENAPI_OAUTH_POPUP_NAME,
+} from "./AddOpenApiSource";
+import { OAuth2Auth } from "../sdk/types";
 
 // A successful sign-in mutates BOTH the source row (oauth2 pointer) and
 // the Connections primitive (new/refreshed row + possibly new owned
@@ -20,33 +31,27 @@ const signInWriteKeys = [
   ...connectionWriteKeys,
 ] as const;
 
-import {
-  openApiSourceAtom,
-  startOpenApiOAuth,
-  updateOpenApiSource,
-} from "./atoms";
-import {
-  OPENAPI_OAUTH_CALLBACK_PATH,
-  OPENAPI_OAUTH_CHANNEL,
-  OPENAPI_OAUTH_POPUP_NAME,
-} from "./AddOpenApiSource";
-import { OAuth2Auth } from "../sdk/types";
-
 // ---------------------------------------------------------------------------
 // OpenApiSignInButton — top-bar action on the source detail page
 //
-// Reads the source's stored OAuth2Auth, runs the same OAuth flow as Add
-// (authorizationCode via popup, clientCredentials inline), and on success
-// refreshes the source's stored OAuth2Auth while preserving its logical
-// connection id. Works whether or not the previous connection still
-// exists — source-owned OAuth config is the source of truth.
+// Reads the source's stored OAuth2Auth, runs the same shared OAuth flow
+// as Add (authorizationCode via popup, clientCredentials inline through
+// `/oauth/start`), and on success refreshes the source OAuth2Auth while
+// preserving its logical connection id. Works whether or not the previous
+// connection still exists — source-owned OAuth config is the source of truth.
 // ---------------------------------------------------------------------------
+
+type CompletionPayload = {
+  connectionId: string;
+  expiresAt: number | null;
+  scope: string | null;
+};
 
 export default function OpenApiSignInButton(props: { sourceId: string }) {
   const scopeId = useScope();
   const sourceResult = useAtomValue(openApiSourceAtom(scopeId, props.sourceId));
   const connectionsResult = useAtomValue(connectionsAtom(scopeId));
-  const doStartOAuth = useAtomSet(startOpenApiOAuth, { mode: "promise" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
   const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promise" });
 
   const [busy, setBusy] = useState(false);
@@ -80,7 +85,8 @@ export default function OpenApiSignInButton(props: { sourceId: string }) {
     setBusy(true);
     setError(null);
     try {
-      const displayName = source?.name ?? oauth2.securitySchemeName;
+      const connectionId = oauth2.connectionId;
+      const scopes = [...oauth2.scopes];
 
       if (oauth2.flow === "clientCredentials") {
         if (!oauth2.clientSecretSecretId) {
@@ -91,25 +97,38 @@ export default function OpenApiSignInButton(props: { sourceId: string }) {
         const response = await doStartOAuth({
           path: { scopeId },
           payload: {
-            sourceId: props.sourceId,
-            connectionId: oauth2.connectionId,
-            displayName,
-            securitySchemeName: oauth2.securitySchemeName,
-            flow: "clientCredentials",
-            tokenUrl: oauth2.tokenUrl,
-            clientIdSecretId: oauth2.clientIdSecretId,
-            clientSecretSecretId: oauth2.clientSecretSecretId,
-            scopes: [...oauth2.scopes],
+            endpoint: oauth2.tokenUrl,
+            redirectUrl: oauth2.tokenUrl,
+            connectionId,
+            strategy: {
+              kind: "client-credentials",
+              tokenEndpoint: oauth2.tokenUrl,
+              clientIdSecretId: oauth2.clientIdSecretId,
+              clientSecretSecretId: oauth2.clientSecretSecretId,
+              scopes,
+            },
+            pluginId: "openapi",
           },
         });
-        if (response.flow !== "clientCredentials") {
+        if (response.completedConnection === null) {
           setBusy(false);
-          setError("Unexpected response flow from server");
+          setError("client_credentials flow did not mint a connection");
           return;
         }
+        const nextAuth = new OAuth2Auth({
+          kind: "oauth2",
+          connectionId: response.completedConnection.connectionId,
+          securitySchemeName: oauth2.securitySchemeName,
+          flow: "clientCredentials",
+          tokenUrl: oauth2.tokenUrl,
+          authorizationUrl: null,
+          clientIdSecretId: oauth2.clientIdSecretId,
+          clientSecretSecretId: oauth2.clientSecretSecretId,
+          scopes,
+        });
         await doUpdate({
           path: { scopeId, namespace: props.sourceId },
-          payload: { oauth2: response.auth },
+          payload: { oauth2: nextAuth },
           reactivityKeys: signInWriteKeys,
         });
         setBusy(false);
@@ -125,31 +144,32 @@ export default function OpenApiSignInButton(props: { sourceId: string }) {
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
-          sourceId: props.sourceId,
-          connectionId: oauth2.connectionId,
-          displayName,
-          securitySchemeName: oauth2.securitySchemeName,
-          flow: "authorizationCode",
-          authorizationUrl: oauth2.authorizationUrl,
-          tokenUrl: oauth2.tokenUrl,
+          endpoint: oauth2.tokenUrl,
           redirectUrl,
-          clientIdSecretId: oauth2.clientIdSecretId,
-          clientSecretSecretId: oauth2.clientSecretSecretId ?? undefined,
-          scopes: [...oauth2.scopes],
+          connectionId,
+          strategy: {
+            kind: "authorization-code",
+            authorizationEndpoint: oauth2.authorizationUrl,
+            tokenEndpoint: oauth2.tokenUrl,
+            clientIdSecretId: oauth2.clientIdSecretId,
+            clientSecretSecretId: oauth2.clientSecretSecretId,
+            scopes,
+          },
+          pluginId: "openapi",
         },
       });
 
-      if (response.flow !== "authorizationCode") {
+      if (response.authorizationUrl === null) {
         setBusy(false);
-        setError("Unexpected response flow from server");
+        setError("OAuth start did not produce an authorization URL");
         return;
       }
 
-      cleanupRef.current = openOAuthPopup<OAuth2Auth>({
+      cleanupRef.current = openOAuthPopup<CompletionPayload>({
         url: response.authorizationUrl,
         popupName: OPENAPI_OAUTH_POPUP_NAME,
-        channelName: OPENAPI_OAUTH_CHANNEL,
-        onResult: async (result: OAuthPopupResult<OAuth2Auth>) => {
+        channelName: OAUTH_POPUP_MESSAGE_TYPE,
+        onResult: async (result: OAuthPopupResult<CompletionPayload>) => {
           cleanupRef.current = null;
           if (!result.ok) {
             setBusy(false);
@@ -160,13 +180,13 @@ export default function OpenApiSignInButton(props: { sourceId: string }) {
             const nextAuth = new OAuth2Auth({
               kind: "oauth2",
               connectionId: result.connectionId,
-              securitySchemeName: result.securitySchemeName,
-              flow: result.flow,
-              tokenUrl: result.tokenUrl,
-              authorizationUrl: result.authorizationUrl,
-              clientIdSecretId: result.clientIdSecretId,
-              clientSecretSecretId: result.clientSecretSecretId,
-              scopes: result.scopes,
+              securitySchemeName: oauth2.securitySchemeName,
+              flow: "authorizationCode",
+              tokenUrl: oauth2.tokenUrl,
+              authorizationUrl: oauth2.authorizationUrl,
+              clientIdSecretId: oauth2.clientIdSecretId,
+              clientSecretSecretId: oauth2.clientSecretSecretId,
+              scopes,
             });
             await doUpdate({
               path: { scopeId, namespace: props.sourceId },
@@ -198,7 +218,6 @@ export default function OpenApiSignInButton(props: { sourceId: string }) {
     }
   }, [
     oauth2,
-    source?.name,
     scopeId,
     props.sourceId,
     redirectUrl,

--- a/packages/plugins/openapi/src/react/atoms.ts
+++ b/packages/plugins/openapi/src/react/atoms.ts
@@ -22,7 +22,6 @@ export const previewOpenApiSpec = OpenApiClient.mutation("openapi", "previewSpec
 export const addOpenApiSpec = OpenApiClient.mutation("openapi", "addSpec");
 
 export const updateOpenApiSource = OpenApiClient.mutation("openapi", "updateSource");
-
-export const startOpenApiOAuth = OpenApiClient.mutation("openapi", "startOAuth");
-
-export const completeOpenApiOAuth = OpenApiClient.mutation("openapi", "completeOAuth");
+// OAuth flow atoms live on `@executor/react/api/atoms` now —
+// `startOAuth`, `completeOAuth`, `probeOAuth`, `cancelOAuth` — one
+// pair serves every OAuth-capable plugin.

--- a/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
@@ -2,7 +2,7 @@
 // End-to-end test for the OAuth2 `client_credentials` grant on the OpenAPI
 // plugin. A spec that declares ONLY a `clientCredentials` flow (no
 // authorizationCode, no user-interactive popup, no PKCE) must produce a
-// completed Connection at `startOAuth` time — `ctx.connections.accessToken`
+// completed Connection at `ctx.oauth.start` time — `ctx.connections.accessToken`
 // then resolves the bearer at invoke time.
 // ---------------------------------------------------------------------------
 
@@ -35,6 +35,7 @@ import {
 import { makeMemoryAdapter } from "@executor/storage-core/testing/memory";
 
 import { openApiPlugin } from "./plugin";
+import { OAuth2Auth } from "./types";
 
 const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
 
@@ -216,30 +217,31 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
         });
 
         // ------------------------------------------------------------
-        // startOAuth for clientCredentials: no authorizationUrl, no
-        // popup, no completeOAuth. The plugin exchanges tokens inline,
-        // creates a Connection, and returns a completed OAuth2Auth
-        // that points at it.
+        // ctx.oauth.start with a client-credentials strategy: no
+        // authorizationUrl, no popup, no complete. Core exchanges
+        // tokens inline and mints a Connection surfaced via
+        // completedConnection. The UI stitches OAuth2Auth locally.
         // ------------------------------------------------------------
-        const started = yield* userExec.openapi.startOAuth({
-          sourceId: "petstore",
-          displayName: "Petstore",
-          securitySchemeName: "oauth2",
-          flow: "clientCredentials",
-          tokenUrl: "https://token.example.com/token",
-          clientIdSecretId: "petstore_client_id",
-          clientSecretSecretId: "petstore_client_secret",
-          scopes: ["data"],
-          // tokenScope is intentionally omitted; clientCredentials
-          // writes at the innermost user scope by default.
+        const connectionId = "openapi-oauth2-app-petstore";
+        const started = yield* userExec.oauth.start({
+          endpoint: "https://token.example.com/token",
+          redirectUrl: "https://token.example.com/token",
+          connectionId,
+          tokenScope: userScope.id as unknown as string,
+          strategy: {
+            kind: "client-credentials" as const,
+            tokenEndpoint: "https://token.example.com/token",
+            clientIdSecretId: "petstore_client_id",
+            clientSecretSecretId: "petstore_client_secret",
+            scopes: ["data"],
+          },
+          pluginId: "openapi",
         });
 
-        if (started.flow !== "clientCredentials") {
-          throw new Error("expected clientCredentials flow");
+        if (started.completedConnection === null) {
+          throw new Error("expected client_credentials to mint a Connection inline");
         }
-        expect(started.auth.kind).toBe("oauth2");
-        expect(started.auth.securitySchemeName).toBe("oauth2");
-        expect(started.auth.connectionId).toMatch(/^openapi-oauth2-/);
+        expect(started.completedConnection.connectionId).toBe(connectionId);
 
         // Token endpoint call is RFC 6749 §4.4 compliant.
         expect(calls).toHaveLength(1);
@@ -248,13 +250,25 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
         expect(calls[0]!.clientSecret).toBe("secret-xyz");
         expect(calls[0]!.scope).toBe("data");
 
-        // Add the source with the OAuth2Auth returned by startOAuth.
+        const auth = new OAuth2Auth({
+          kind: "oauth2",
+          connectionId,
+          securitySchemeName: "oauth2",
+          flow: "clientCredentials",
+          tokenUrl: "https://token.example.com/token",
+          authorizationUrl: null,
+          clientIdSecretId: "petstore_client_id",
+          clientSecretSecretId: "petstore_client_secret",
+          scopes: ["data"],
+        });
+
+        // Add the source with the locally-stitched OAuth2Auth.
         yield* userExec.openapi.addSpec({
           spec: specJson,
           scope: userScope.id as string,
           namespace: "petstore",
           baseUrl: "",
-          oauth2: started.auth,
+          oauth2: auth,
         });
 
         // Invoking the tool injects the freshly-minted bearer via
@@ -279,14 +293,14 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
         // `findInnermostConnectionRow`.
         const userConnections = yield* userExec.connections.list();
         const connection = userConnections.find(
-          (c) => c.id === started.auth.connectionId,
+          (c) => c.id === connectionId,
         );
         expect(connection).toBeDefined();
         expect(connection?.scopeId as unknown as string).toBe("user-alice");
         expect(connection?.provider).toBe("oauth2");
         expect(connection?.kind).toBe("app");
         // Stable id derived from sourceId — no UUID-per-click churn.
-        expect(started.auth.connectionId).toBe("openapi-oauth2-app-petstore");
+        expect(connectionId).toBe("openapi-oauth2-app-petstore");
 
         // Access-token secret is owned by the connection and filtered
         // out of the user-facing secret list.
@@ -298,7 +312,7 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
         expect(userSecretIds).toContain("petstore_client_id");
         expect(userSecretIds).toContain("petstore_client_secret");
         expect(userSecretIds).not.toContain(
-          `${started.auth.connectionId}.access_token`,
+          `${connectionId}.access_token`,
         );
 
         // Admin scope sees neither alice's connection nor her token.
@@ -308,7 +322,7 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
           ),
         );
         expect(adminSecretIds).not.toContain(
-          `${started.auth.connectionId}.access_token`,
+          `${connectionId}.access_token`,
         );
       }),
   );

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -12,9 +12,6 @@ export {
   type OpenApiPluginExtension,
   type OpenApiPluginOptions,
   type OpenApiUpdateSourceInput,
-  type OpenApiStartOAuthInput,
-  type OpenApiStartOAuthResponse,
-  type OpenApiCompleteOAuthInput,
 } from "./plugin";
 export {
   openapiSchema,
@@ -59,7 +56,6 @@ export {
   InvocationResult,
   MediaBinding,
   OAuth2Auth,
-  OpenApiOAuthSession,
   OperationBinding,
   OperationParameter,
   OperationRequestBody,

--- a/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
@@ -212,46 +212,40 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         );
 
         // -------------------------------------------------------------
-        // 2. Each user runs startOAuth + completeOAuth to mint a
-        //    per-user Connection.
+        // 2. Each user runs ctx.oauth.start + complete to mint a
+        //    per-user Connection. The UI stamps connectionId into the
+        //    start payload; core mints the Connection on completion.
         // -------------------------------------------------------------
         mockTokenFetch({
           "code-alice": "alice-token",
           "code-bob": "bob-token",
         });
 
-        const startInputFor = (user: string, scope: ScopeId) => ({
-          sourceId: "petstore",
-          displayName: `Petstore (${user})`,
-          securitySchemeName: "oauth2",
-          flow: "authorizationCode" as const,
-          authorizationUrl: "https://auth.example.com/authorize",
-          tokenUrl: "https://token.example.com/token",
+        const connectionId = "openapi-oauth2-user-petstore";
+        const startInputFor = (scope: ScopeId) => ({
+          endpoint: "https://token.example.com/token",
           redirectUrl: "https://app.example.com/oauth/callback",
-          clientIdSecretId: "petstore_client_id",
-          clientSecretSecretId: "petstore_client_secret",
-          scopes: ["read"],
+          connectionId,
           tokenScope: scope as unknown as string,
+          strategy: {
+            kind: "authorization-code" as const,
+            authorizationEndpoint: "https://auth.example.com/authorize",
+            tokenEndpoint: "https://token.example.com/token",
+            clientIdSecretId: "petstore_client_id",
+            clientSecretSecretId: "petstore_client_secret",
+            scopes: ["read"],
+          },
+          pluginId: "openapi",
         });
 
-        const aliceStart = yield* aliceExec.openapi.startOAuth(
-          startInputFor("alice", aliceScope.id),
-        );
-        const bobStart = yield* bobExec.openapi.startOAuth(
-          startInputFor("bob", bobScope.id),
-        );
-        if (aliceStart.flow !== "authorizationCode") {
-          throw new Error("expected authorizationCode flow for alice");
-        }
-        if (bobStart.flow !== "authorizationCode") {
-          throw new Error("expected authorizationCode flow for bob");
-        }
+        const aliceStart = yield* aliceExec.oauth.start(startInputFor(aliceScope.id));
+        const bobStart = yield* bobExec.oauth.start(startInputFor(bobScope.id));
 
-        const aliceCompleted = yield* aliceExec.openapi.completeOAuth({
+        const aliceCompleted = yield* aliceExec.oauth.complete({
           state: aliceStart.sessionId,
           code: "code-alice",
         });
-        const bobCompleted = yield* bobExec.openapi.completeOAuth({
+        const bobCompleted = yield* bobExec.oauth.complete({
           state: bobStart.sessionId,
           code: "code-bob",
         });
@@ -518,46 +512,65 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
           );
         }) as unknown as typeof fetch;
 
-        const startInput = {
-          sourceId: "petstore",
-          connectionId: "shared-petstore-oauth",
-          displayName: "Petstore",
-          securitySchemeName: "oauth2",
-          flow: "clientCredentials" as const,
-          tokenUrl: "https://token.example.com/token",
-          clientIdSecretId: "client_id",
-          clientSecretSecretId: "client_secret",
-          scopes: ["read"],
-        };
+        const stableId = "shared-petstore-oauth";
+        const makeAuth = () =>
+          new OAuth2Auth({
+            kind: "oauth2",
+            connectionId: stableId,
+            securitySchemeName: "oauth2",
+            flow: "clientCredentials",
+            tokenUrl: "https://token.example.com/token",
+            authorizationUrl: null,
+            clientIdSecretId: "client_id",
+            clientSecretSecretId: "client_secret",
+            scopes: ["read"],
+          });
+        const startInputFor = (tokenScope: ScopeId) => ({
+          endpoint: "https://token.example.com/token",
+          redirectUrl: "https://token.example.com/token",
+          connectionId: stableId,
+          tokenScope: tokenScope as unknown as string,
+          strategy: {
+            kind: "client-credentials" as const,
+            tokenEndpoint: "https://token.example.com/token",
+            clientIdSecretId: "client_id",
+            clientSecretSecretId: "client_secret",
+            scopes: ["read"],
+          },
+          pluginId: "openapi",
+        });
 
         // Admin adds the org-scoped source with an initial oauth2
         // pointer — same shape the onboarding UI writes via `addSpec`.
         // Admin's scope stack is [org] so their sign-in resolves the
         // org-level creds and writes the connection at org.
-        const adminAuth = yield* adminExec.openapi.startOAuth(startInput);
-        if (adminAuth.flow !== "clientCredentials") {
-          throw new Error("expected clientCredentials flow");
+        const adminStart = yield* adminExec.oauth.start(startInputFor(orgScope.id));
+        if (adminStart.completedConnection === null) {
+          throw new Error("expected clientCredentials to mint a connection");
         }
+        const adminAuth = makeAuth();
         yield* adminExec.openapi.addSpec({
           spec: specJson,
           scope: orgScope.id as string,
           namespace: "petstore",
           baseUrl: "",
-          oauth2: adminAuth.auth,
+          oauth2: adminAuth,
         });
 
         // Alice signs in → resolves her shadowed user-scope creds
         // (`alice-client`), mints her own token, writes at user-alice.
-        const aliceStart = yield* aliceExec.openapi.startOAuth(startInput);
-        if (aliceStart.flow !== "clientCredentials") {
-          throw new Error("expected clientCredentials flow for alice");
+        const aliceStart = yield* aliceExec.oauth.start(startInputFor(aliceScope.id));
+        if (aliceStart.completedConnection === null) {
+          throw new Error("expected clientCredentials to mint a connection for alice");
         }
+        const aliceAuth = makeAuth();
         // Bob signs in → no user-scope shadow, falls through to the
         // org defaults (`org-client`), writes at user-bob.
-        const bobStart = yield* bobExec.openapi.startOAuth(startInput);
-        if (bobStart.flow !== "clientCredentials") {
-          throw new Error("expected clientCredentials flow for bob");
+        const bobStart = yield* bobExec.oauth.start(startInputFor(bobScope.id));
+        if (bobStart.completedConnection === null) {
+          throw new Error("expected clientCredentials to mint a connection for bob");
         }
+        const bobAuth = makeAuth();
 
         // ---- Regression assertions ----
 
@@ -565,10 +578,12 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         // id — it's a stable *name* carried by the source config. No
         // UUID-per-click churn, and the id does not have to be tied to
         // the source namespace.
-        const stableId = startInput.connectionId;
-        expect(adminAuth.auth.connectionId).toBe(stableId);
-        expect(aliceStart.auth.connectionId).toBe(stableId);
-        expect(bobStart.auth.connectionId).toBe(stableId);
+        expect(adminStart.completedConnection.connectionId).toBe(stableId);
+        expect(aliceStart.completedConnection.connectionId).toBe(stableId);
+        expect(bobStart.completedConnection.connectionId).toBe(stableId);
+        expect(adminAuth.connectionId).toBe(stableId);
+        expect(aliceAuth.connectionId).toBe(stableId);
+        expect(bobAuth.connectionId).toBe(stableId);
 
         // (2) Each user's physical row lives at their own scope. The
         // id *string* collides across scopes intentionally — that's
@@ -602,7 +617,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         yield* aliceExec.openapi.updateSource(
           "petstore",
           orgScope.id as string,
-          { oauth2: aliceStart.auth },
+          { oauth2: aliceAuth },
         );
         const aliceResult = (yield* aliceExec.tools.invoke(
           "petstore.items.echoHeaders",
@@ -625,7 +640,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         const countBefore = (yield* aliceExec.connections.list()).filter(
           (c) => c.id === stableId,
         ).length;
-        yield* aliceExec.openapi.startOAuth(startInput);
+        yield* aliceExec.oauth.start(startInputFor(aliceScope.id));
         const countAfter = (yield* aliceExec.connections.list()).filter(
           (c) => c.id === stableId,
         ).length;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -5,9 +5,6 @@ import type { Layer } from "effect";
 import {
   SourceDetectionResult,
   definePlugin,
-  type OAuthCompleteError,
-  type OAuthSessionNotFoundError,
-  type OAuthStartError,
   type PluginCtx,
   type StorageFailure,
   type ToolAnnotations,
@@ -82,115 +79,6 @@ export interface OpenApiUpdateSourceInput {
   readonly oauth2?: OAuth2Auth;
 }
 
-// ---------------------------------------------------------------------------
-// OAuth2 onboarding inputs / outputs — callers pre-decide identity knobs
-// (display name, scheme name, scopes, target scope) and the SDK mints a
-// Connection when the flow completes. The caller receives an OAuth2Auth
-// carrying just the resulting connection id.
-// ---------------------------------------------------------------------------
-
-interface StartOAuthIdentity {
-  readonly displayName: string;
-  readonly securitySchemeName: string;
-  readonly clientIdSecretId: string;
-  readonly scopes: readonly string[];
-  /** Stable logical Connection id this source should resolve at invoke time.
-   *  Physical ownership still comes from `tokenScope`; the same id can
-   *  have separate rows at user/org scopes. Defaults to the legacy
-   *  source-derived id for compatibility. */
-  readonly connectionId?: string;
-  /**
-   * Source (namespace) the resulting Connection will back. Used as the
-   * compatibility default for the stable Connection *name* so repeat
-   * sign-ins refresh a single row per scope instead of spawning a
-   * fresh UUID every click:
-   *
-   *   clientCredentials → `openapi-oauth2-app-${sourceId}`
-   *   authorizationCode → `openapi-oauth2-user-${sourceId}`
-   *
-   * The resulting Connection is written at the innermost executor
-   * scope so per-user credentials (secrets shadowed at user scope via
-   * `ctx.secrets.get`'s scope-stacked resolution) and per-user consent
-   * (authorizationCode) both produce per-user rows. Because
-   * `findInnermostConnectionRow` resolves by id across the caller's
-   * stack, the single `source.oauth2.connectionId` string on a shared
-   * org source still lets every user reach their own physical row.
-   */
-  readonly sourceId: string;
-  /** Executor scope that will own the resulting Connection (and its
-   *  backing token secrets). Defaults to `ctx.scopes[0].id`. Callers
-   *  can override to write at a different stack scope (e.g. an admin
-   *  writing an org-wide shared connection). */
-  readonly tokenScope?: string;
-}
-
-const defaultOAuthConnectionId = (
-  flow: "authorizationCode" | "clientCredentials",
-  sourceId: string,
-): string =>
-  flow === "clientCredentials"
-    ? `openapi-oauth2-app-${sourceId}`
-    : `openapi-oauth2-user-${sourceId}`;
-
-export interface StartAuthorizationCodeOAuthInput extends StartOAuthIdentity {
-  readonly flow: "authorizationCode";
-  readonly authorizationUrl: string;
-  readonly tokenUrl: string;
-  readonly redirectUrl: string;
-  readonly clientSecretSecretId?: string | null;
-}
-
-/**
- * RFC 6749 §4.4 has no user-interactive step. `startOAuth` exchanges
- * tokens inline, creates the Connection, and returns a completed
- * `OAuth2Auth` pointing at it. No `authorizationUrl`, no session row,
- * no `completeOAuth`.
- */
-export interface StartClientCredentialsOAuthInput extends StartOAuthIdentity {
-  readonly flow: "clientCredentials";
-  readonly tokenUrl: string;
-  /** RFC 6749 §2.3.1 — client_credentials is unusable without the secret. */
-  readonly clientSecretSecretId: string;
-}
-
-export type OpenApiStartOAuthInput =
-  | StartAuthorizationCodeOAuthInput
-  | StartClientCredentialsOAuthInput;
-
-export interface StartAuthorizationCodeOAuthResponse {
-  readonly flow: "authorizationCode";
-  readonly sessionId: string;
-  readonly authorizationUrl: string;
-  readonly scopes: readonly string[];
-}
-
-export interface StartClientCredentialsOAuthResponse {
-  readonly flow: "clientCredentials";
-  /** Completed auth ready to attach to the source's `OAuth2Auth`. */
-  readonly auth: OAuth2Auth;
-  readonly scopes: readonly string[];
-}
-
-export type OpenApiStartOAuthResponse =
-  | StartAuthorizationCodeOAuthResponse
-  | StartClientCredentialsOAuthResponse;
-
-export interface OpenApiCompleteOAuthInput {
-  readonly state: string;
-  readonly code?: string;
-  readonly error?: string;
-}
-
-/** Shape returned by `completeOAuth`. The minted Connection's id is
- *  all the caller needs to stitch together an `OAuth2Auth` value — the
- *  UI already has the securityScheme metadata from the matching
- *  `startOAuth` call. */
-export interface OpenApiCompleteOAuthResponse {
-  readonly connectionId: string;
-  readonly expiresAt: number | null;
-  readonly scope: string | null;
-}
-
 /**
  * Errors any OpenAPI extension method may surface. The first three are
  * plugin-domain tagged errors that flow directly to clients (4xx, each
@@ -230,18 +118,6 @@ export interface OpenApiPluginExtension {
     scope: string,
     input: OpenApiUpdateSourceInput,
   ) => Effect.Effect<void, StorageFailure>;
-  readonly startOAuth: (
-    input: OpenApiStartOAuthInput,
-  ) => Effect.Effect<
-    OpenApiStartOAuthResponse,
-    OpenApiOAuthError | OAuthStartError | StorageFailure
-  >;
-  readonly completeOAuth: (
-    input: OpenApiCompleteOAuthInput,
-  ) => Effect.Effect<
-    OpenApiCompleteOAuthResponse,
-    OAuthCompleteError | OAuthSessionNotFoundError | StorageFailure
-  >;
 }
 
 // ---------------------------------------------------------------------------
@@ -552,111 +428,9 @@ export const openApiPlugin = definePlugin(
               oauth2: input.oauth2,
             }),
 
-          // Thin forwarders over `ctx.oauth.*`. The core service owns
-          // session storage, the code exchange, the Connection mint,
-          // and refresh via the canonical `"oauth2"` ConnectionProvider.
-          // The plugin maps OpenAPI's `flow` string + secret refs onto
-          // the strategy discriminated union the service accepts.
-          startOAuth: (input) =>
-            Effect.gen(function* () {
-              const scopesArray = [...input.scopes];
-              // Innermost = user scope in a stacked [user, org] executor.
-              // Both flows write at the innermost scope so per-user
-              // credentials (secrets shadowed at user scope) and per-user
-              // authorization codes each produce a per-user connection
-              // row. `source.oauth2.connectionId` is a single *name* —
-              // `findInnermostConnectionRow` walks each caller's stack
-              // to resolve the right physical row.
-              const innermostScope = ctx.scopes[0]!.id as string;
-              const tokenScope = input.tokenScope ?? innermostScope;
-              const connectionId =
-                input.connectionId ??
-                defaultOAuthConnectionId(input.flow, input.sourceId);
-
-              const strategy =
-                input.flow === "clientCredentials"
-                  ? ({
-                      kind: "client-credentials" as const,
-                      tokenEndpoint: input.tokenUrl,
-                      clientIdSecretId: input.clientIdSecretId,
-                      clientSecretSecretId: input.clientSecretSecretId,
-                      scopes: scopesArray,
-                    })
-                  : ({
-                      kind: "authorization-code" as const,
-                      authorizationEndpoint: input.authorizationUrl,
-                      tokenEndpoint: input.tokenUrl,
-                      clientIdSecretId: input.clientIdSecretId,
-                      clientSecretSecretId: input.clientSecretSecretId ?? null,
-                      scopes: scopesArray,
-                    });
-
-              const result = yield* ctx.oauth.start({
-                endpoint: input.tokenUrl,
-                // client-credentials doesn't redirect — pass the
-                // plugin's own placeholder URL so the service can
-                // still persist + surface it. For authorizationCode
-                // we use the caller-supplied value.
-                redirectUrl:
-                  input.flow === "authorizationCode"
-                    ? input.redirectUrl
-                    : input.tokenUrl,
-                connectionId,
-                tokenScope,
-                strategy,
-                pluginId: "openapi",
-              });
-
-              if (input.flow === "clientCredentials") {
-                // `client-credentials` mints the Connection inline — no
-                // session row, no browser step. Return the same
-                // `OAuth2Auth` shape the UI expects so it can stamp the
-                // source atomically.
-                const auth = new OAuth2Auth({
-                  kind: "oauth2",
-                  connectionId,
-                  securitySchemeName: input.securitySchemeName,
-                  flow: "clientCredentials",
-                  tokenUrl: input.tokenUrl,
-                  authorizationUrl: null,
-                  clientIdSecretId: input.clientIdSecretId,
-                  clientSecretSecretId: input.clientSecretSecretId ?? null,
-                  scopes: scopesArray,
-                });
-                return {
-                  flow: "clientCredentials" as const,
-                  auth,
-                  scopes: scopesArray,
-                };
-              }
-
-              if (result.authorizationUrl === null) {
-                return yield* new OpenApiOAuthError({
-                  message:
-                    "OAuth service did not emit an authorization URL for the authorizationCode flow",
-                });
-              }
-              return {
-                flow: "authorizationCode" as const,
-                sessionId: result.sessionId,
-                authorizationUrl: result.authorizationUrl,
-                scopes: scopesArray,
-              };
-            }),
-
-          completeOAuth: (input) =>
-            Effect.gen(function* () {
-              const completed = yield* ctx.oauth.complete({
-                state: input.state,
-                code: input.code,
-                error: input.error,
-              });
-              return {
-                connectionId: completed.connectionId,
-                expiresAt: completed.expiresAt,
-                scope: completed.scope,
-              } satisfies OpenApiCompleteOAuthResponse;
-            }),
+          // OAuth start/complete live on `ctx.oauth` now — the UI calls
+          // the shared `/scopes/:scopeId/oauth/*` endpoints directly and
+          // writes the resulting connection back via `updateSource`.
         } satisfies OpenApiPluginExtension;
       },
 

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -215,44 +215,6 @@ export class InvocationConfig extends Schema.Class<InvocationConfig>("Invocation
   oauth2: Schema.optionalWith(OAuth2Auth, { as: "Option" }),
 }) {}
 
-// ---------------------------------------------------------------------------
-// Pending OAuth session — persisted between startOAuth and completeOAuth.
-// All the fields the exchange needs (token endpoint, client credential
-// secret ids, redirect URL, PKCE verifier) plus the pre-decided Connection
-// / secret ids the SDK stamps when the user returns.
-// ---------------------------------------------------------------------------
-
-export class OpenApiOAuthSession extends Schema.Class<OpenApiOAuthSession>(
-  "OpenApiOAuthSession",
-)({
-  /** Display name used for the resulting Connection's identity label. */
-  displayName: Schema.String,
-  securitySchemeName: Schema.String,
-  /** Only authorizationCode reaches this session type. client_credentials
-   *  has no user-interactive step so it creates the Connection inline in
-   *  `startOAuth` without persisting a session. */
-  flow: Schema.Literal("authorizationCode"),
-  tokenUrl: Schema.String,
-  /** Absolute authorization endpoint — persisted so completeOAuth can
-   *  stamp it onto the resulting `OAuth2Auth` for future sign-ins. */
-  authorizationUrl: Schema.String,
-  redirectUrl: Schema.String,
-  clientIdSecretId: Schema.String,
-  clientSecretSecretId: Schema.NullOr(Schema.String),
-  /** Executor scope that will own the resulting Connection (and its
-   *  backing secret rows). Typically the innermost (per-user) scope. */
-  tokenScope: Schema.String,
-  /** Pre-decided Connection id stamped at `completeOAuth` time. */
-  connectionId: Schema.String,
-  /** Pre-decided secret ids for the Connection's access + refresh
-   *  tokens. Fixed at session creation so a retried callback lands
-   *  on the same ids. */
-  accessTokenSecretId: Schema.String,
-  refreshTokenSecretId: Schema.String,
-  scopes: Schema.Array(Schema.String),
-  codeVerifier: Schema.String,
-}) {}
-
 export class InvocationResult extends Schema.Class<InvocationResult>("InvocationResult")({
   status: Schema.Number,
   headers: Schema.Record({ key: Schema.String, value: Schema.String }),


### PR DESCRIPTION
Mirrors the MCP consolidation: the UI calls the shared
/scopes/:scopeId/oauth/{start,complete} endpoints directly, then writes
the resulting connection back to the source via updateSource. The plugin
owns source storage; `ctx.oauth` owns the state machine, session table,
code exchange, and the canonical "oauth2" ConnectionProvider.

- Delete the three OpenAPI-specific HTTP routes (startOAuth, completeOAuth,
  oauthCallback) and their handlers.
- Delete startOAuth/completeOAuth extension methods from the plugin SDK
  plus every associated type (OpenApiStartOAuthInput,
  OpenApiStartOAuthResponse, OpenApiCompleteOAuthInput,
  OpenApiCompleteOAuthResponse, OpenApiOAuthSession).
- Rewrite AddOpenApiSource.tsx and OpenApiSignInButton.tsx to drive the
  shared `startOAuth` atom and stitch the OAuth2Auth client-side.
- Migrate multi-scope-oauth and client-credentials-oauth tests to the
  core contract (exec.oauth.start / exec.oauth.complete).

Net: -355 lines. Plugin code no longer touches session storage, PKCE,
or the token exchange.