### PR TITLE
google-discovery: swap onboarding UI to shared /oauth/* surface, drop per-plugin routes

### DIFF
--- a/packages/plugins/google-discovery/src/api/group.ts
+++ b/packages/plugins/google-discovery/src/api/group.ts
@@ -9,7 +9,6 @@ import {
 import { InternalError } from "@executor/api";
 
 import {
-  GoogleDiscoveryOAuthError,
   GoogleDiscoveryParseError,
   GoogleDiscoverySourceError,
 } from "../sdk/errors";
@@ -75,44 +74,9 @@ const UpdateSourceResponse = Schema.Struct({
   updated: Schema.Boolean,
 });
 
-const StartOAuthPayload = Schema.Struct({
-  name: Schema.String,
-  discoveryUrl: Schema.String,
-  clientIdSecretId: Schema.String,
-  clientSecretSecretId: Schema.optional(Schema.NullOr(Schema.String)),
-  redirectUrl: Schema.String,
-  scopes: Schema.optional(Schema.Array(Schema.String)),
-  /** Optional executor scope that will own the resulting Connection. */
-  tokenScope: Schema.optional(Schema.String),
-});
-
-const StartOAuthResponse = Schema.Struct({
-  sessionId: Schema.String,
-  authorizationUrl: Schema.String,
-  scopes: Schema.Array(Schema.String),
-});
-
-const CompleteOAuthPayload = Schema.Struct({
-  state: Schema.String,
-  code: Schema.optional(Schema.String),
-  error: Schema.optional(Schema.String),
-});
-
-const CompleteOAuthResponse = Schema.Struct({
-  kind: Schema.Literal("oauth2"),
-  /** Id of the Connection the SDK minted. The caller stores it on the
-   *  source's `oauth2` field and resolves tokens via `ctx.connections`. */
-  connectionId: Schema.String,
-});
-
-const OAuthCallbackParams = Schema.Struct({
-  state: Schema.String,
-  code: Schema.optional(Schema.String),
-  error: Schema.optional(Schema.String),
-  error_description: Schema.optional(Schema.String),
-});
-
-const HtmlResponse = HttpApiSchema.Text({ contentType: "text/html" });
+// OAuth start/complete/callback payloads/responses live on the shared
+// `/scopes/:scopeId/oauth/*` group in `@executor/api` now — no
+// plugin-specific OAuth schemas needed here.
 
 export class GoogleDiscoveryApiError extends Schema.TaggedError<GoogleDiscoveryApiError>()(
   "GoogleDiscoveryApiError",
@@ -153,21 +117,6 @@ export class GoogleDiscoveryGroup extends HttpApiGroup.make("googleDiscovery")
       .addSuccess(UpdateSourceResponse),
   )
   .add(
-    HttpApiEndpoint.post("startOAuth")`/scopes/${scopeIdParam}/google-discovery/oauth/start`
-      .setPayload(StartOAuthPayload)
-      .addSuccess(StartOAuthResponse),
-  )
-  .add(
-    HttpApiEndpoint.post("completeOAuth")`/scopes/${scopeIdParam}/google-discovery/oauth/complete`
-      .setPayload(CompleteOAuthPayload)
-      .addSuccess(CompleteOAuthResponse),
-  )
-  .add(
-    HttpApiEndpoint.get("oauthCallback")`/google-discovery/oauth/callback`
-      .setUrlParams(OAuthCallbackParams)
-      .addSuccess(HtmlResponse),
-  )
-  .add(
     HttpApiEndpoint.get(
       "getSource",
     )`/scopes/${scopeIdParam}/google-discovery/sources/${namespaceParam}`
@@ -176,15 +125,9 @@ export class GoogleDiscoveryGroup extends HttpApiGroup.make("googleDiscovery")
   // Errors declared once at the group level — every endpoint inherits.
   // `InternalError` is the shared opaque 500 translated at the HTTP edge
   // by `withCapture`. The others are 4xx domain errors carrying their
-  // status via `HttpApiSchema.annotations`; handlers return them through
-  // the typed channel and HttpApi encodes them directly. We only list
-  // errors a Google Discovery *group* endpoint can surface —
-  // `GoogleDiscoveryInvocationError` is thrown inside `invokeTool` which
-  // is reached via the core `tools.invoke` endpoint, not any Google
-  // Discovery-group endpoint, so it doesn't belong here.
+  // status via `HttpApiSchema.annotations`.
   .addError(InternalError)
   .addError(GoogleDiscoveryApiError)
-  .addError(GoogleDiscoveryOAuthError)
   .addError(GoogleDiscoveryParseError)
   .addError(GoogleDiscoverySourceError)
   .addError(OAuthStartError)

--- a/packages/plugins/google-discovery/src/api/handlers.test.ts
+++ b/packages/plugins/google-discovery/src/api/handlers.test.ts
@@ -23,8 +23,6 @@ const failingExtension: GoogleDiscoveryPluginExtension = {
   probeDiscovery: () => Effect.die(new Error("Not implemented")),
   addSource: () => unused,
   removeSource: (_namespace: string, _scope: string) => unused,
-  startOAuth: () => unused,
-  completeOAuth: () => Effect.die(new Error("Not implemented")),
   getSource: (_namespace: string, _scope: string) => Effect.succeed(null),
   updateSource: () => unused,
 };

--- a/packages/plugins/google-discovery/src/api/handlers.ts
+++ b/packages/plugins/google-discovery/src/api/handlers.ts
@@ -1,15 +1,11 @@
-import { HttpApiBuilder, HttpServerResponse } from "@effect/platform";
+import { HttpApiBuilder } from "@effect/platform";
 import { Context, Effect } from "effect";
-
-import { runOAuthCallback } from "@executor/plugin-oauth2/http";
 
 import { addGroup, capture } from "@executor/api";
 import type {
   GoogleDiscoveryAddSourceInput,
-  GoogleDiscoveryOAuthAuthResult,
   GoogleDiscoveryPluginExtension,
 } from "../sdk/plugin";
-import { GoogleDiscoveryOAuthError } from "../sdk/errors";
 import { GoogleDiscoveryGroup } from "./group";
 
 // ---------------------------------------------------------------------------
@@ -34,11 +30,6 @@ export class GoogleDiscoveryExtensionService extends Context.Tag("GoogleDiscover
 
 const ExecutorApiWithGoogleDiscovery = addGroup(GoogleDiscoveryGroup);
 
-const GOOGLE_DISCOVERY_OAUTH_CHANNEL = "executor:google-discovery-oauth-result";
-
-const toPopupErrorMessage = (error: unknown): string =>
-  error instanceof GoogleDiscoveryOAuthError ? error.message : "Authentication failed";
-
 // ---------------------------------------------------------------------------
 // Handlers
 //
@@ -50,8 +41,8 @@ const toPopupErrorMessage = (error: unknown): string =>
 // captured + downgraded to `InternalError(traceId)` by the API-level
 // observability middleware.
 //
-// No `sanitize*`, no `liftDomainErrors`, no per-handler error mapping.
-// If you find yourself adding error-handling here you're in the wrong layer.
+// OAuth start/complete/callback live on the shared `/scopes/:scopeId/oauth/*`
+// group in `@executor/api` now — the plugin has no OAuth-specific handlers.
 // ---------------------------------------------------------------------------
 
 export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
@@ -74,30 +65,6 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
           });
         })),
       )
-      .handle("startOAuth", ({ payload }) =>
-        capture(Effect.gen(function* () {
-          const ext = yield* GoogleDiscoveryExtensionService;
-          return yield* ext.startOAuth({
-            name: payload.name,
-            discoveryUrl: payload.discoveryUrl,
-            clientIdSecretId: payload.clientIdSecretId,
-            clientSecretSecretId: payload.clientSecretSecretId,
-            redirectUrl: payload.redirectUrl,
-            scopes: payload.scopes,
-            tokenScope: payload.tokenScope,
-          });
-        })),
-      )
-      .handle("completeOAuth", ({ payload }) =>
-        capture(Effect.gen(function* () {
-          const ext = yield* GoogleDiscoveryExtensionService;
-          return yield* ext.completeOAuth({
-            state: payload.state,
-            code: payload.code,
-            error: payload.error,
-          });
-        })),
-      )
       .handle("getSource", ({ path }) =>
         capture(Effect.gen(function* () {
           const ext = yield* GoogleDiscoveryExtensionService;
@@ -112,27 +79,6 @@ export const GoogleDiscoveryHandlers = HttpApiBuilder.group(
             auth: payload.auth,
           });
           return { updated: true };
-        })),
-      )
-      .handle("oauthCallback", ({ urlParams }) =>
-        capture(Effect.gen(function* () {
-          const ext = yield* GoogleDiscoveryExtensionService;
-          const html = yield* runOAuthCallback<
-            GoogleDiscoveryOAuthAuthResult,
-            unknown,
-            never
-          >({
-            complete: ({ state, code, error }) =>
-              ext.completeOAuth({
-                state,
-                code: code ?? undefined,
-                error: error ?? undefined,
-              }),
-            urlParams,
-            toErrorMessage: toPopupErrorMessage,
-            channelName: GOOGLE_DISCOVERY_OAUTH_CHANNEL,
-          });
-          return yield* HttpServerResponse.html(html);
         })),
       ),
 );

--- a/packages/plugins/google-discovery/src/promise.ts
+++ b/packages/plugins/google-discovery/src/promise.ts
@@ -3,8 +3,5 @@ export type {
   GoogleDiscoveryPluginExtension,
   GoogleDiscoveryAddSourceInput,
   GoogleDiscoveryProbeResult,
-  GoogleDiscoveryOAuthStartInput,
-  GoogleDiscoveryOAuthStartResponse,
-  GoogleDiscoveryOAuthCompleteInput,
-  GoogleDiscoveryOAuthAuthResult,
+  GoogleDiscoveryUpdateSourceInput,
 } from "./sdk/plugin";

--- a/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
@@ -2,16 +2,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet, useAtomValue, Result } from "@effect-atom/atom-react";
 
 import {
+  secretsAtom,
+  setSecret,
+  startOAuth,
+} from "@executor/react/api/atoms";
+import {
   openOAuthPopup,
   type OAuthPopupResult,
-} from "@executor/plugin-oauth2/react";
-
-import { secretsAtom, setSecret } from "@executor/react/api/atoms";
+} from "@executor/react/api/oauth-popup";
 import { usePendingSources } from "@executor/react/api/optimistic";
 import { secretWriteKeys, sourceWriteKeys } from "@executor/react/api/reactivity-keys";
 import { useScope } from "@executor/react/api/scope-context";
 import { SecretPicker, type SecretPickerSecret } from "@executor/react/plugins/secret-picker";
-import { SecretId } from "@executor/sdk";
+import { OAUTH_POPUP_MESSAGE_TYPE, SecretId } from "@executor/sdk";
 import { Badge } from "@executor/react/components/badge";
 import { Button } from "@executor/react/components/button";
 import {
@@ -45,7 +48,22 @@ import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { RadioGroup, RadioGroupItem } from "@executor/react/components/radio-group";
 import { IOSSpinner, Spinner } from "@executor/react/components/spinner";
-import { addGoogleDiscoverySource, probeGoogleDiscovery, startGoogleDiscoveryOAuth } from "./atoms";
+import { addGoogleDiscoverySource, probeGoogleDiscovery } from "./atoms";
+
+// ---------------------------------------------------------------------------
+// Google OAuth constants — the plugin bakes these in because Google only
+// serves a single OAuth authorization + token URL for every Discovery API.
+// ---------------------------------------------------------------------------
+
+const GOOGLE_AUTHORIZATION_URL =
+  "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+const GOOGLE_EXTRA_AUTHORIZATION_PARAMS = {
+  access_type: "offline",
+  include_granted_scopes: "true",
+  prompt: "consent",
+} as const;
 
 type GoogleAuthKind = "none" | "oauth2";
 
@@ -374,10 +392,20 @@ type OAuthAuth = {
   scopes: string[];
 };
 
-type GoogleOAuthPopupResult = OAuthPopupResult<OAuthAuth>;
+// Popup callback payload. The shared /oauth/callback route returns the
+// minted connection id — the UI stitches the rest from fields it already
+// has (clientIdSecretId, clientSecretSecretId, scopes).
+type CompletionPayload = {
+  connectionId: string;
+  expiresAt: number | null;
+  scope: string | null;
+};
 
-const OAUTH_RESULT_CHANNEL = "executor:google-discovery-oauth-result";
 const OAUTH_POPUP_NAME = "google-discovery-oauth";
+const OAUTH_CALLBACK_PATH = "/api/oauth/callback";
+
+const googleDiscoveryOAuthConnectionId = (namespaceSlug: string): string =>
+  `google-discovery-oauth2-${namespaceSlug || "default"}`;
 
 export default function AddGoogleDiscoverySource(props: {
   readonly onComplete: () => void;
@@ -408,11 +436,15 @@ export default function AddGoogleDiscoverySource(props: {
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showScopes, setShowScopes] = useState(false);
+  const resolvedNamespace =
+    slugifyNamespace(identity.namespace) ||
+    slugifyNamespace(probe?.name ?? selectedTemplate?.name ?? "") ||
+    "google";
 
   const scopeId = useScope();
   const doProbe = useAtomSet(probeGoogleDiscovery, { mode: "promise" });
   const doAdd = useAtomSet(addGoogleDiscoverySource, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startGoogleDiscoveryOAuth, { mode: "promise" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
   const secrets = useAtomValue(secretsAtom(scopeId));
   const { beginAdd } = usePendingSources();
 
@@ -496,32 +528,48 @@ export default function AddGoogleDiscoverySource(props: {
     setStartingOAuth(true);
     setError(null);
     try {
+      const connectionId = googleDiscoveryOAuthConnectionId(resolvedNamespace);
+      const scopes = [...probe.scopes];
+      const redirectUrl = `${window.location.origin}${OAUTH_CALLBACK_PATH}`;
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
-          name: identity.name.trim() || probe.name,
-          discoveryUrl: discoveryUrl.trim(),
-          clientIdSecretId,
-          clientSecretSecretId,
-          redirectUrl: `${window.location.origin}/api/google-discovery/oauth/callback`,
-          scopes: probe.scopes,
+          endpoint: discoveryUrl.trim(),
+          redirectUrl,
+          connectionId,
+          strategy: {
+            kind: "authorization-code",
+            authorizationEndpoint: GOOGLE_AUTHORIZATION_URL,
+            tokenEndpoint: GOOGLE_TOKEN_URL,
+            clientIdSecretId,
+            clientSecretSecretId,
+            scopes,
+            extraAuthorizationParams: GOOGLE_EXTRA_AUTHORIZATION_PARAMS,
+          },
+          pluginId: "google-discovery",
         },
       });
 
-      oauthCleanup.current = openOAuthPopup<OAuthAuth>({
+      if (response.authorizationUrl === null) {
+        setStartingOAuth(false);
+        setError("OAuth start did not produce an authorization URL");
+        return;
+      }
+
+      oauthCleanup.current = openOAuthPopup<CompletionPayload>({
         url: response.authorizationUrl,
         popupName: OAUTH_POPUP_NAME,
-        channelName: OAUTH_RESULT_CHANNEL,
-        onResult: (result: GoogleOAuthPopupResult) => {
+        channelName: OAUTH_POPUP_MESSAGE_TYPE,
+        onResult: (result: OAuthPopupResult<CompletionPayload>) => {
           oauthCleanup.current = null;
           setStartingOAuth(false);
           if (result.ok) {
             setOauthAuth({
               kind: "oauth2",
               connectionId: result.connectionId,
-              clientIdSecretId: result.clientIdSecretId,
-              clientSecretSecretId: result.clientSecretSecretId,
-              scopes: [...result.scopes],
+              clientIdSecretId,
+              clientSecretSecretId,
+              scopes,
             });
             setError(null);
           } else {
@@ -538,7 +586,15 @@ export default function AddGoogleDiscoverySource(props: {
       setStartingOAuth(false);
       setError(e instanceof Error ? e.message : "Failed to start OAuth");
     }
-  }, [probe, doStartOAuth, scopeId, identity, discoveryUrl, clientIdSecretId, clientSecretSecretId]);
+  }, [
+    probe,
+    doStartOAuth,
+    scopeId,
+    discoveryUrl,
+    clientIdSecretId,
+    clientSecretSecretId,
+    resolvedNamespace,
+  ]);
 
   const handleCancelOAuth = useCallback(() => {
     oauthCleanup.current?.();
@@ -551,7 +607,7 @@ export default function AddGoogleDiscoverySource(props: {
     setAdding(true);
     setError(null);
     const displayName = identity.name.trim() || probe.name;
-    const namespace = slugifyNamespace(identity.namespace) || probe.name;
+    const namespace = resolvedNamespace;
     const placeholder = beginAdd({
       id: namespace,
       name: displayName,
@@ -563,7 +619,7 @@ export default function AddGoogleDiscoverySource(props: {
         payload: {
           name: displayName,
           discoveryUrl: discoveryUrl.trim(),
-          namespace: slugifyNamespace(identity.namespace) || undefined,
+          namespace,
           auth:
             authKind === "oauth2" && oauthAuth
               ? {
@@ -584,7 +640,18 @@ export default function AddGoogleDiscoverySource(props: {
     } finally {
       placeholder.done();
     }
-  }, [probe, doAdd, identity, discoveryUrl, authKind, oauthAuth, props, scopeId, beginAdd]);
+  }, [
+    probe,
+    doAdd,
+    identity,
+    discoveryUrl,
+    authKind,
+    oauthAuth,
+    props,
+    scopeId,
+    beginAdd,
+    resolvedNamespace,
+  ]);
 
   const addDisabled =
     !probe || adding || (authKind === "oauth2" && (!canUseOAuth || oauthAuth === null));

--- a/packages/plugins/google-discovery/src/react/GoogleDiscoverySignInButton.tsx
+++ b/packages/plugins/google-discovery/src/react/GoogleDiscoverySignInButton.tsx
@@ -1,46 +1,65 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet, useAtomValue, Result } from "@effect-atom/atom-react";
 
-import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
+import {
+  connectionsAtom,
+  startOAuth,
+} from "@executor/react/api/atoms";
+import {
+  openOAuthPopup,
+  type OAuthPopupResult,
+} from "@executor/react/api/oauth-popup";
 import { useScope } from "@executor/react/api/scope-context";
-import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
-import { connectionsAtom } from "@executor/react/api/atoms";
+import {
+  connectionWriteKeys,
+  sourceWriteKeys,
+} from "@executor/react/api/reactivity-keys";
+import { OAUTH_POPUP_MESSAGE_TYPE } from "@executor/sdk";
 import { Button } from "@executor/react/components/button";
 
 import {
   googleDiscoverySourceAtom,
-  startGoogleDiscoveryOAuth,
   updateGoogleDiscoverySource,
 } from "./atoms";
 
 // ---------------------------------------------------------------------------
 // GoogleDiscoverySignInButton — top-bar action on the source detail page.
 //
-// Reads the source's stored `GoogleDiscoveryAuth`, re-runs the authorization
-// code flow via popup using the same `clientIdSecretId` / `clientSecretSecretId`
-// / `scopes` the source was originally configured with, and on success
-// rewrites the source's auth pointer to the freshly minted connection id.
-// Works whether or not the previous Connection still exists — source-owned
+// Drives the shared /scopes/:scopeId/oauth/{start,callback} surface with
+// a Google-specific `authorization-code` strategy. On success rewrites
+// the source's auth pointer to the freshly minted connection id. Works
+// whether or not the previous Connection still exists — source-owned
 // OAuth config is the source of truth.
 // ---------------------------------------------------------------------------
 
-const CALLBACK_PATH = "/api/google-discovery/oauth/callback";
-const POPUP_NAME = "google-discovery-oauth";
-const CHANNEL_NAME = "executor:google-discovery-oauth-result";
+const GOOGLE_AUTHORIZATION_URL =
+  "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 
-type GoogleOAuthPopupPayload = {
-  kind: "oauth2";
+const GOOGLE_EXTRA_AUTHORIZATION_PARAMS = {
+  access_type: "offline",
+  include_granted_scopes: "true",
+  prompt: "consent",
+} as const;
+
+const OAUTH_CALLBACK_PATH = "/api/oauth/callback";
+const POPUP_NAME = "google-discovery-oauth";
+const signInWriteKeys = [
+  ...sourceWriteKeys,
+  ...connectionWriteKeys,
+] as const;
+
+type CompletionPayload = {
   connectionId: string;
-  clientIdSecretId: string;
-  clientSecretSecretId: string | null;
-  scopes: readonly string[];
+  expiresAt: number | null;
+  scope: string | null;
 };
 
 export default function GoogleDiscoverySignInButton(props: { sourceId: string }) {
   const scopeId = useScope();
   const sourceResult = useAtomValue(googleDiscoverySourceAtom(scopeId, props.sourceId));
   const connectionsResult = useAtomValue(connectionsAtom(scopeId));
-  const doStartOAuth = useAtomSet(startGoogleDiscoveryOAuth, { mode: "promise" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
   const doUpdate = useAtomSet(updateGoogleDiscoverySource, { mode: "promise" });
 
   const [busy, setBusy] = useState(false);
@@ -63,8 +82,8 @@ export default function GoogleDiscoverySignInButton(props: { sourceId: string })
 
   const redirectUrl =
     typeof window !== "undefined"
-      ? `${window.location.origin}${CALLBACK_PATH}`
-      : CALLBACK_PATH;
+      ? `${window.location.origin}${OAUTH_CALLBACK_PATH}`
+      : OAUTH_CALLBACK_PATH;
 
   const handleSignIn = useCallback(async () => {
     if (!oauth2 || !source) return;
@@ -73,23 +92,38 @@ export default function GoogleDiscoverySignInButton(props: { sourceId: string })
     setBusy(true);
     setError(null);
     try {
+      const connectionId = oauth2.connectionId;
+      const scopes = [...oauth2.scopes];
       const response = await doStartOAuth({
         path: { scopeId },
         payload: {
-          name: source.name,
-          discoveryUrl: source.config.discoveryUrl,
-          clientIdSecretId: oauth2.clientIdSecretId,
-          clientSecretSecretId: oauth2.clientSecretSecretId,
+          endpoint: source.config.discoveryUrl,
           redirectUrl,
-          scopes: [...oauth2.scopes],
+          connectionId,
+          strategy: {
+            kind: "authorization-code",
+            authorizationEndpoint: GOOGLE_AUTHORIZATION_URL,
+            tokenEndpoint: GOOGLE_TOKEN_URL,
+            clientIdSecretId: oauth2.clientIdSecretId,
+            clientSecretSecretId: oauth2.clientSecretSecretId,
+            scopes,
+            extraAuthorizationParams: GOOGLE_EXTRA_AUTHORIZATION_PARAMS,
+          },
+          pluginId: "google-discovery",
         },
       });
 
-      cleanupRef.current = openOAuthPopup<GoogleOAuthPopupPayload>({
+      if (response.authorizationUrl === null) {
+        setBusy(false);
+        setError("OAuth start did not produce an authorization URL");
+        return;
+      }
+
+      cleanupRef.current = openOAuthPopup<CompletionPayload>({
         url: response.authorizationUrl,
         popupName: POPUP_NAME,
-        channelName: CHANNEL_NAME,
-        onResult: async (result: OAuthPopupResult<GoogleOAuthPopupPayload>) => {
+        channelName: OAUTH_POPUP_MESSAGE_TYPE,
+        onResult: async (result: OAuthPopupResult<CompletionPayload>) => {
           cleanupRef.current = null;
           if (!result.ok) {
             setBusy(false);
@@ -103,12 +137,12 @@ export default function GoogleDiscoverySignInButton(props: { sourceId: string })
                 auth: {
                   kind: "oauth2",
                   connectionId: result.connectionId,
-                  clientIdSecretId: result.clientIdSecretId,
-                  clientSecretSecretId: result.clientSecretSecretId,
-                  scopes: result.scopes,
+                  clientIdSecretId: oauth2.clientIdSecretId,
+                  clientSecretSecretId: oauth2.clientSecretSecretId,
+                  scopes,
                 },
               },
-              reactivityKeys: sourceWriteKeys,
+              reactivityKeys: signInWriteKeys,
             });
             setBusy(false);
           } catch (e) {

--- a/packages/plugins/google-discovery/src/react/atoms.ts
+++ b/packages/plugins/google-discovery/src/react/atoms.ts
@@ -2,12 +2,20 @@ import type { ScopeId } from "@executor/sdk";
 import { ReactivityKey } from "@executor/react/api/reactivity-keys";
 import { GoogleDiscoveryClient } from "./client";
 
+// ---------------------------------------------------------------------------
+// Query atoms
+// ---------------------------------------------------------------------------
+
 export const googleDiscoverySourceAtom = (scopeId: ScopeId, namespace: string) =>
   GoogleDiscoveryClient.query("googleDiscovery", "getSource", {
     path: { scopeId, namespace },
     timeToLive: "15 seconds",
     reactivityKeys: [ReactivityKey.sources, ReactivityKey.tools],
   });
+
+// ---------------------------------------------------------------------------
+// Mutation atoms
+// ---------------------------------------------------------------------------
 
 export const probeGoogleDiscovery = GoogleDiscoveryClient.mutation(
   "googleDiscovery",
@@ -21,11 +29,6 @@ export const updateGoogleDiscoverySource = GoogleDiscoveryClient.mutation(
   "googleDiscovery",
   "updateSource",
 );
-export const startGoogleDiscoveryOAuth = GoogleDiscoveryClient.mutation(
-  "googleDiscovery",
-  "startOAuth",
-);
-export const completeGoogleDiscoveryOAuth = GoogleDiscoveryClient.mutation(
-  "googleDiscovery",
-  "completeOAuth",
-);
+// OAuth flow atoms live on `@executor/react/api/atoms` now —
+// `startOAuth`, `completeOAuth`, `probeOAuth`, `cancelOAuth` — one
+// pair serves every OAuth-capable plugin.

--- a/packages/plugins/google-discovery/src/react/index.ts
+++ b/packages/plugins/google-discovery/src/react/index.ts
@@ -2,7 +2,5 @@ export { googleDiscoverySourcePlugin } from "./source-plugin";
 export { GoogleDiscoveryClient } from "./client";
 export {
   addGoogleDiscoverySource,
-  completeGoogleDiscoveryOAuth,
   probeGoogleDiscovery,
-  startGoogleDiscoveryOAuth,
 } from "./atoms";

--- a/packages/plugins/google-discovery/src/sdk/index.ts
+++ b/packages/plugins/google-discovery/src/sdk/index.ts
@@ -1,12 +1,9 @@
 export { googleDiscoveryPlugin } from "./plugin";
 export type {
   GoogleDiscoveryAddSourceInput,
-  GoogleDiscoveryOAuthAuthResult,
-  GoogleDiscoveryOAuthCompleteInput,
-  GoogleDiscoveryOAuthStartInput,
-  GoogleDiscoveryOAuthStartResponse,
   GoogleDiscoveryPluginExtension,
   GoogleDiscoveryProbeResult,
+  GoogleDiscoveryUpdateSourceInput,
 } from "./plugin";
 export { extractGoogleDiscoveryManifest } from "./document";
 export {
@@ -31,7 +28,6 @@ export {
   GoogleDiscoveryParameterLocation,
   GoogleDiscoveryStoredSourceData,
 } from "./types";
-export type { GoogleDiscoveryOAuthSession } from "./types";
 export {
   GoogleDiscoveryInvocationError,
   GoogleDiscoveryOAuthError,

--- a/packages/plugins/google-discovery/src/sdk/plugin.test.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.test.ts
@@ -193,7 +193,12 @@ describe("Google Discovery plugin", () => {
     }),
   );
 
-  it.effect("starts oauth using discovery scopes", () =>
+  // OAuth start/complete are driven via ctx.oauth now — the UI stitches
+  // the strategy config (Google endpoints + extras) and calls the shared
+  // /scopes/:scopeId/oauth/{start,complete} surface. The connection id
+  // is chosen client-side and stamped onto the source's auth config.
+
+  it.effect("starts oauth using caller-supplied discovery scopes", () =>
     Effect.gen(function* () {
       const handle = yield* Effect.promise(() => startServer());
       try {
@@ -212,18 +217,38 @@ describe("Google Discovery plugin", () => {
           }),
         );
 
-        const result = yield* executor.googleDiscovery.startOAuth({
-          name: "Google Drive",
-          discoveryUrl: handle.discoveryUrl,
-          clientIdSecretId: "google-client-id",
+        const connectionId = "google-discovery-oauth2-test-start";
+        const result = yield* executor.oauth.start({
+          endpoint: handle.discoveryUrl,
           redirectUrl: "http://localhost/callback",
+          connectionId,
+          tokenScope: "test-scope",
+          strategy: {
+            kind: "authorization-code",
+            authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+            tokenEndpoint: "https://oauth2.googleapis.com/token",
+            clientIdSecretId: "google-client-id",
+            clientSecretSecretId: null,
+            scopes: ["https://www.googleapis.com/auth/drive"],
+            extraAuthorizationParams: {
+              access_type: "offline",
+              include_granted_scopes: "true",
+              prompt: "consent",
+            },
+          },
+          pluginId: "google-discovery",
         });
 
+        if (result.authorizationUrl === null) {
+          throw new Error("expected an authorization URL for authorization-code");
+        }
         const authorizationUrl = new URL(result.authorizationUrl);
-        expect(result.scopes).toContain("https://www.googleapis.com/auth/drive");
         expect(authorizationUrl.searchParams.get("client_id")).toBe("client-123");
         expect(authorizationUrl.searchParams.get("access_type")).toBe("offline");
         expect(authorizationUrl.searchParams.get("prompt")).toBe("consent");
+        expect(authorizationUrl.searchParams.get("scope")).toBe(
+          "https://www.googleapis.com/auth/drive",
+        );
 
         yield* executor.close();
       } finally {
@@ -232,7 +257,7 @@ describe("Google Discovery plugin", () => {
     }),
   );
 
-  it.effect("completes oauth and stores token secrets", () =>
+  it.effect("completes oauth and stores token secrets on a connection", () =>
     Effect.gen(function* () {
       const handle = yield* Effect.promise(() => startServer());
       try {
@@ -289,26 +314,39 @@ describe("Google Discovery plugin", () => {
         }) as typeof fetch);
 
         try {
-          const started = yield* executor.googleDiscovery.startOAuth({
-            name: "Google Drive",
-            discoveryUrl: handle.discoveryUrl,
-            clientIdSecretId: "google-client-id",
-            clientSecretSecretId: "google-client-secret",
+          const connectionId = "google-discovery-oauth2-test-complete";
+          const started = yield* executor.oauth.start({
+            endpoint: handle.discoveryUrl,
             redirectUrl: "http://localhost/callback",
+            connectionId,
+            tokenScope: "test-scope",
+            strategy: {
+              kind: "authorization-code",
+              authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+              tokenEndpoint: "https://oauth2.googleapis.com/token",
+              clientIdSecretId: "google-client-id",
+              clientSecretSecretId: "google-client-secret",
+              scopes: ["https://www.googleapis.com/auth/drive"],
+              extraAuthorizationParams: {
+                access_type: "offline",
+                include_granted_scopes: "true",
+                prompt: "consent",
+              },
+            },
+            pluginId: "google-discovery",
           });
 
-          const auth = yield* executor.googleDiscovery.completeOAuth({
+          const completed = yield* executor.oauth.complete({
             state: started.sessionId,
             code: "code-123",
           });
 
-          expect(auth.kind).toBe("oauth2");
-          expect(auth.connectionId).toMatch(/^google-discovery-oauth2-/);
+          expect(completed.connectionId).toBe(connectionId);
 
           // Tokens live on the SDK connection — resolving via
           // ctx.connections.accessToken returns the minted value.
           const accessToken = yield* executor.connections.accessToken(
-            auth.connectionId as Parameters<typeof executor.connections.accessToken>[0],
+            completed.connectionId as Parameters<typeof executor.connections.accessToken>[0],
           );
           expect(accessToken).toBe("access-token-value");
 
@@ -317,8 +355,8 @@ describe("Google Discovery plugin", () => {
           const secretIds = new Set(
             (yield* executor.secrets.list()).map((s) => s.id as unknown as string),
           );
-          expect(secretIds).not.toContain(`${auth.connectionId}.access_token`);
-          expect(secretIds).not.toContain(`${auth.connectionId}.refresh_token`);
+          expect(secretIds).not.toContain(`${completed.connectionId}.access_token`);
+          expect(secretIds).not.toContain(`${completed.connectionId}.refresh_token`);
         } finally {
           fetchMock.mockRestore();
           yield* executor.close();

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -1,13 +1,8 @@
-import { randomUUID } from "node:crypto";
-
 import { Effect, Option } from "effect";
 
 import {
   SourceDetectionResult,
   definePlugin,
-  type OAuthCompleteError,
-  type OAuthSessionNotFoundError,
-  type OAuthStartError,
   type PluginCtx,
   type StorageFailure,
   type ToolAnnotations,
@@ -22,23 +17,9 @@ import {
 import { extractGoogleDiscoveryManifest } from "./document";
 import { annotationsForOperation, invokeGoogleDiscoveryTool } from "./invoke";
 import {
-  GoogleDiscoveryOAuthError,
   GoogleDiscoveryParseError,
   GoogleDiscoverySourceError,
 } from "./errors";
-// Google-specific OAuth constants — copied here so the plugin is
-// self-contained (no more per-plugin `oauth.ts` helper file). Token
-// endpoint + authorize endpoint live on the connection's providerState
-// after sign-in, so refresh routes through the core handler unchanged.
-const GOOGLE_AUTHORIZATION_URL =
-  "https://accounts.google.com/o/oauth2/v2/auth";
-const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
-
-const GOOGLE_EXTRA_AUTHORIZATION_PARAMS = {
-  access_type: "offline",
-  include_granted_scopes: "true",
-  prompt: "consent",
-} as const;
 import type {
   GoogleDiscoveryAuth,
   GoogleDiscoveryManifest,
@@ -84,49 +65,12 @@ export interface GoogleDiscoveryUpdateSourceInput {
   readonly auth?: GoogleDiscoveryAuth;
 }
 
-export interface GoogleDiscoveryOAuthStartInput {
-  readonly name: string;
-  readonly discoveryUrl: string;
-  readonly clientIdSecretId: string;
-  readonly clientSecretSecretId?: string | null;
-  readonly redirectUrl: string;
-  readonly scopes?: readonly string[];
-  /** Executor scope that will own the resulting Connection + its backing
-   *  secrets. Defaults to `ctx.scopes[0].id` (innermost / per-user). */
-  readonly tokenScope?: string;
-}
-
-export interface GoogleDiscoveryOAuthStartResponse {
-  readonly sessionId: string;
-  readonly authorizationUrl: string;
-  readonly scopes: readonly string[];
-}
-
-export interface GoogleDiscoveryOAuthCompleteInput {
-  readonly state: string;
-  readonly code?: string;
-  readonly error?: string;
-}
-
-/**
- * Completed OAuth auth handed back to the caller (either an HTTP client or
- * a static-tool handler). Carries the full API-level OAuth config so the
- * caller can stamp it onto the source's `GoogleDiscoveryAuth` — that makes
- * sign-in reproducible from the source detail page without depending on
- * the prior Connection still existing.
- */
-export interface GoogleDiscoveryOAuthAuthResult {
-  readonly kind: "oauth2";
-  readonly connectionId: string;
-}
-
 /**
  * Errors any Google Discovery extension method may surface.
  */
 export type GoogleDiscoveryExtensionFailure =
   | GoogleDiscoveryParseError
   | GoogleDiscoverySourceError
-  | GoogleDiscoveryOAuthError
   | StorageFailure;
 
 export interface GoogleDiscoveryPluginExtension {
@@ -146,22 +90,6 @@ export interface GoogleDiscoveryPluginExtension {
     namespace: string,
     scope: string,
   ) => Effect.Effect<void, StorageFailure>;
-  readonly startOAuth: (
-    input: GoogleDiscoveryOAuthStartInput,
-  ) => Effect.Effect<
-    GoogleDiscoveryOAuthStartResponse,
-    | GoogleDiscoveryParseError
-    | GoogleDiscoverySourceError
-    | GoogleDiscoveryOAuthError
-    | OAuthStartError
-    | StorageFailure
-  >;
-  readonly completeOAuth: (
-    input: GoogleDiscoveryOAuthCompleteInput,
-  ) => Effect.Effect<
-    GoogleDiscoveryOAuthAuthResult,
-    OAuthCompleteError | OAuthSessionNotFoundError | StorageFailure
-  >;
   readonly getSource: (
     namespace: string,
     scope: string,
@@ -382,70 +310,10 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
         }),
       ),
 
-    // Thin forwarders over `ctx.oauth.*`. Core owns the session table,
-    // the PKCE machinery, and the refresh handler. The plugin only
-    // carries Google-specific knobs — scope discovery from the
-    // discovery document and the `access_type=offline`/`prompt=consent`
-    // extras — into the core OAuth strategy config.
-    startOAuth: (input) =>
-      Effect.gen(function* () {
-        const text = yield* fetchDiscoveryDocument(input.discoveryUrl);
-        const manifest = yield* extractGoogleDiscoveryManifest(text);
-        const scopes =
-          input.scopes && input.scopes.length > 0
-            ? [...input.scopes]
-            : Object.keys(
-                manifest.oauthScopes._tag === "Some" ? manifest.oauthScopes.value : {},
-              ).sort();
-        if (scopes.length === 0) {
-          return yield* new GoogleDiscoveryOAuthError({
-            message: "This Google Discovery document does not declare any OAuth scopes",
-          });
-        }
-        const tokenScope = input.tokenScope ?? (ctx.scopes[0]!.id as string);
-        const connectionId = `google-discovery-oauth2-${randomUUID()}`;
-        const result = yield* ctx.oauth.start({
-          endpoint: normalizeDiscoveryUrl(input.discoveryUrl),
-          redirectUrl: input.redirectUrl,
-          connectionId,
-          tokenScope,
-          strategy: {
-            kind: "authorization-code" as const,
-            authorizationEndpoint: GOOGLE_AUTHORIZATION_URL,
-            tokenEndpoint: GOOGLE_TOKEN_URL,
-            clientIdSecretId: input.clientIdSecretId,
-            clientSecretSecretId: input.clientSecretSecretId ?? null,
-            scopes,
-            extraAuthorizationParams: GOOGLE_EXTRA_AUTHORIZATION_PARAMS,
-          },
-          pluginId: "google-discovery",
-        });
-        if (result.authorizationUrl === null) {
-          return yield* new GoogleDiscoveryOAuthError({
-            message:
-              "OAuth service did not emit an authorization URL — authorizationCode flow requires one",
-          });
-        }
-        return {
-          sessionId: result.sessionId,
-          authorizationUrl: result.authorizationUrl,
-          scopes,
-        };
-      }),
-
-    completeOAuth: (input) =>
-      ctx.oauth
-        .complete({
-          state: input.state,
-          code: input.code,
-          error: input.error,
-        })
-        .pipe(
-          Effect.map((completed) => ({
-            kind: "oauth2" as const,
-            connectionId: completed.connectionId,
-          })),
-        ),
+    // OAuth start/complete live on `ctx.oauth` now — the UI calls
+    // the shared `/scopes/:scopeId/oauth/*` endpoints directly with a
+    // Google-specific `authorization-code` strategy and writes the
+    // resulting connection back via `updateSource`.
 
     getSource: (namespace, scope) => ctx.storage.getSource(namespace, scope),
 

--- a/packages/plugins/google-discovery/src/sdk/types.ts
+++ b/packages/plugins/google-discovery/src/sdk/types.ts
@@ -115,21 +115,3 @@ export interface GoogleDiscoverySourceMeta {
   readonly namespace: string;
   readonly name: string;
 }
-
-/** Pending OAuth session persisted between startOAuth and completeOAuth */
-export const GoogleDiscoveryOAuthSession = Schema.Struct({
-  discoveryUrl: Schema.String,
-  name: Schema.String,
-  clientIdSecretId: Schema.String,
-  clientSecretSecretId: Schema.NullOr(Schema.String),
-  redirectUrl: Schema.String,
-  scopes: Schema.Array(Schema.String),
-  codeVerifier: Schema.String,
-  /** Executor scope that will own the resulting Connection + its backing
-   *  secrets. Typically the innermost (per-user) scope. */
-  tokenScope: Schema.String,
-  /** Pre-decided Connection id stamped at completeOAuth time so a retried
-   *  callback lands on the same id. */
-  connectionId: Schema.String,
-});
-export type GoogleDiscoveryOAuthSession = typeof GoogleDiscoveryOAuthSession.Type;


### PR DESCRIPTION
Same cutover as the MCP and OpenAPI consolidations. The UI owns the
Google-specific knobs — authorization/token URLs, `access_type=offline`,
`include_granted_scopes=true`, `prompt=consent` — and passes them through
the shared `strategy: {kind: "authorization-code", ...}` payload. Core
handles the session table, PKCE, code exchange, and connection mint.

- Delete the three google-discovery HTTP routes (startOAuth,
  completeOAuth, oauthCallback) and their handlers.
- Delete startOAuth/completeOAuth extension methods from the plugin SDK
  plus every associated type (GoogleDiscoveryOAuthStartInput/Response,
  GoogleDiscoveryOAuthCompleteInput, GoogleDiscoveryOAuthAuthResult,
  GoogleDiscoveryOAuthSession).
- Rewrite AddGoogleDiscoverySource.tsx and GoogleDiscoverySignInButton.tsx
  to drive the shared `startOAuth` atom + `openOAuthPopup` helper, and
  stitch the plugin's `GoogleDiscoveryAuth` client-side from the minted
  connection id plus the caller's own client secret refs.
- Migrate plugin.test.ts OAuth flow tests to `exec.oauth.start/complete`.

Net: -194 lines.