### PR TITLE
openapi: remove annotation_policy

### DIFF
--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -649,18 +649,14 @@ export const invokeWithLayer = (
 // Derive annotations from HTTP method
 // ---------------------------------------------------------------------------
 
-const DEFAULT_REQUIRE_APPROVAL = new Set(["post", "put", "patch", "delete"]);
+const REQUIRE_APPROVAL = new Set(["post", "put", "patch", "delete"]);
 
 export const annotationsForOperation = (
   method: string,
   pathTemplate: string,
-  policy?: { readonly requireApprovalFor?: readonly string[] },
 ): { requiresApproval?: boolean; approvalDescription?: string } => {
   const m = method.toLowerCase();
-  const requireSet = policy?.requireApprovalFor
-    ? new Set(policy.requireApprovalFor.map((v) => v.toLowerCase()))
-    : DEFAULT_REQUIRE_APPROVAL;
-  if (!requireSet.has(m)) return {};
+  if (!REQUIRE_APPROVAL.has(m)) return {};
   return {
     requiresApproval: true,
     approvalDescription: `${method.toUpperCase()} ${pathTemplate}`,

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -7,7 +7,6 @@ import {
 } from "@executor/sdk";
 
 import {
-  AnnotationPolicy,
   HeaderValue,
   InvocationConfig,
   OAuth2Auth,
@@ -37,7 +36,6 @@ export const openapiSchema = defineSchema({
       base_url: { type: "string", required: false },
       headers: { type: "json", required: false },
       oauth2: { type: "json", required: false },
-      annotation_policy: { type: "json", required: false },
       invocation_config: { type: "json", required: true },
     },
   },
@@ -74,7 +72,6 @@ export interface SourceConfig {
   readonly namespace?: string;
   readonly headers?: Record<string, HeaderValue>;
   readonly oauth2?: OAuth2Auth;
-  readonly annotationPolicy?: AnnotationPolicy;
 }
 
 export interface StoredSource {

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -201,19 +201,6 @@ export class OAuth2Auth extends Schema.Class<OAuth2Auth>("OpenApiOAuth2Auth")({
   scopes: Schema.Array(Schema.String),
 }) {}
 
-// ---------------------------------------------------------------------------
-// Annotation policy — per-source override of the HTTP-method-based default
-// for `requiresApproval`. If `requireApprovalFor` is set, it replaces the
-// default set ({POST, PUT, PATCH, DELETE}) wholesale: any method present
-// requires approval, any method absent does not.
-// ---------------------------------------------------------------------------
-
-export class AnnotationPolicy extends Schema.Class<AnnotationPolicy>(
-  "OpenApiAnnotationPolicy",
-)({
-  requireApprovalFor: Schema.optional(Schema.Array(HttpMethod)),
-}) {}
-
 export class InvocationConfig extends Schema.Class<InvocationConfig>("InvocationConfig")({
   baseUrl: Schema.String,
   /** Headers applied to every request. Values can reference secrets. */


### PR DESCRIPTION
## Summary
- Dead code removal: the per-source annotation policy override was never wired up — no caller passed `policy` to `annotationsForOperation`, and no plugin surface wrote `annotation_policy` / `annotationPolicy`.
- Drops the `annotation_policy` column on `openapi_source`, the `AnnotationPolicy` Schema class, `SourceConfig.annotationPolicy`, and the dead `policy` parameter on `annotationsForOperation`.
- `requiresApproval` still defaults to POST/PUT/PATCH/DELETE via the same constant (renamed `DEFAULT_REQUIRE_APPROVAL` → `REQUIRE_APPROVAL`).

## Test plan
- [x] `bun run typecheck` in `packages/plugins/openapi`
- [x] `bunx vitest run` in `packages/plugins/openapi` (53/53 passing)