### PR TITLE
cloud: drop hardcoded VITE_PUBLIC_SENTRY_DSN from wrangler.jsonc

### DIFF
--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -11,6 +11,7 @@ declare global {
       AXIOM_TRACES_URL?: string;
       AXIOM_TRACES_SAMPLE_RATIO?: string;
       SENTRY_DSN?: string;
+      VITE_PUBLIC_SENTRY_DSN?: string;
 
       // Datastore (dev only — prod uses HYPERDRIVE binding)
       DATABASE_URL?: string;

--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -49,7 +49,6 @@
     },
   ],
   "vars": {
-    "VITE_PUBLIC_SENTRY_DSN": "https://e20b1bdeea27008092a4dc0ac303e97a@o4511196985556992.ingest.us.sentry.io/4511197010067456",
     "VITE_PUBLIC_SITE_URL": "https://executor.sh",
   },
 }


### PR DESCRIPTION
## Summary

- Remove the frontend Sentry DSN that was committed in `apps/cloud/wrangler.jsonc` `vars`.
- Add `VITE_PUBLIC_SENTRY_DSN` to the `Cloudflare.Env` type augmentation so worker code can read it from `env` if needed.


## Why a secret, not a `--var` flag at deploy time

`wrangler deploy` without `--keep-vars` wipes any var not present in config or `--var` flags. Using `--var` in the deploy script is fragile — any other deploy path (future GitHub Actions, dashboard-triggered deploy, etc.) would silently drop it, same footgun that motivated `261c7b2d` (`fix: add VITE_PUBLIC_SITE_URL to wrangler vars so it persists across deploys`).

Wrangler secrets, by contrast, are never deleted by deployments regardless of `--keep-vars` or deploy path. This matches how `SENTRY_DSN`, `DATABASE_URL`, `WORKOS_*` are already managed.

```
bun run deploy   # deploys new wrangler.jsonc, clears stale var
op run --env-file=.env.production -- sh -c 'printf "%s" "$VITE_PUBLIC_SENTRY_DSN" | bunx wrangler secret put VITE_PUBLIC_SENTRY_DSN'
```

Brief gap between the two: worker runtime has no `env.VITE_PUBLIC_SENTRY_DSN`, but nothing on the worker reads it today — client bundle has it baked in.

## Test plan

- [ ] `bun run deploy` succeeds and worker still boots.
- [ ] Browser loads `executor.sh`, confirm Sentry init fires (network: POSTs to `/api/sentry-tunnel`).
- [ ] `bunx wrangler secret put VITE_PUBLIC_SENTRY_DSN` succeeds once the old var is cleared.
- [ ] After secret upload, confirm in CF dashboard that `VITE_PUBLIC_SENTRY_DSN` shows as an encrypted secret, not a plaintext var.