### PR TITLE
perf(tools.list): fan out annotation resolution concurrently

### DIFF
--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1844,18 +1844,30 @@ export const createExecutor = <
           else groups.set(key, [row]);
         }
 
-        for (const [key, groupRows] of groups) {
-          const [pluginId, sourceId] = key.split("\u0000") as [
-            string,
-            string,
-          ];
-          const runtime = runtimes.get(pluginId);
-          if (!runtime?.plugin.resolveAnnotations) continue;
-          const map = yield* runtime.plugin.resolveAnnotations({
-            ctx: runtime.ctx,
-            sourceId,
-            toolRows: groupRows,
-          });
+        // Each (plugin_id, source_id) group is an independent DB read,
+        // so fan them out concurrently. Yielding them serially stacks
+        // ~200-300ms storage round-trips end-to-end and dominates the
+        // `executor.tools.list.annotations` span.
+        const maps = yield* Effect.forEach(
+          [...groups],
+          ([key, groupRows]) =>
+            Effect.gen(function* () {
+              const [pluginId, sourceId] = key.split("\u0000") as [
+                string,
+                string,
+              ];
+              const runtime = runtimes.get(pluginId);
+              if (!runtime?.plugin.resolveAnnotations) return undefined;
+              return yield* runtime.plugin.resolveAnnotations({
+                ctx: runtime.ctx,
+                sourceId,
+                toolRows: groupRows,
+              });
+            }),
+          { concurrency: "unbounded" },
+        );
+        for (const map of maps) {
+          if (!map) continue;
           for (const [toolId, annotations] of Object.entries(map)) {
             result.set(toolId, annotations);
           }

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -592,11 +592,20 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
       const typedCtx = ctx as PluginCtx<GoogleDiscoveryStore>;
       const scopes = new Set<string>();
       for (const row of toolRows) scopes.add(row.scope_id as string);
-      const byScope = new Map<string, ReadonlyMap<string, GoogleDiscoveryMethodBinding>>();
-      for (const scope of scopes) {
-        const bindings = yield* typedCtx.storage.getBindingsForSource(sourceId, scope);
-        byScope.set(scope, bindings);
-      }
+      // One getBindingsForSource per scope is independent storage
+      // work; run them in parallel so a shadowed source doesn't
+      // serialise two ~200ms reads back-to-back in the caller's
+      // `executor.tools.list.annotations` span.
+      const entries = yield* Effect.forEach(
+        [...scopes],
+        (scope) =>
+          Effect.gen(function* () {
+            const bindings = yield* typedCtx.storage.getBindingsForSource(sourceId, scope);
+            return [scope, bindings] as const;
+          }),
+        { concurrency: "unbounded" },
+      );
+      const byScope = new Map<string, ReadonlyMap<string, GoogleDiscoveryMethodBinding>>(entries);
       const out: Record<string, ToolAnnotations> = {};
       for (const row of toolRows) {
         const binding = byScope.get(row.scope_id as string)?.get(row.id);

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -534,16 +534,25 @@ export const graphqlPlugin = definePlugin(
           for (const row of toolRows as readonly ToolRow[]) {
             scopes.add(row.scope_id as string);
           }
-          const byScope = new Map<string, Map<string, OperationBinding>>();
-          for (const scope of scopes) {
-            const ops = yield* ctx.storage.listOperationsBySource(
-              sourceId,
-              scope,
-            );
-            const byId = new Map<string, OperationBinding>();
-            for (const op of ops) byId.set(op.toolId, op.binding);
-            byScope.set(scope, byId);
-          }
+          // One listOperationsBySource per scope is independent storage
+          // work; run them in parallel so a shadowed source doesn't
+          // serialise two ~200ms reads back-to-back in the caller's
+          // `executor.tools.list.annotations` span.
+          const entries = yield* Effect.forEach(
+            [...scopes],
+            (scope) =>
+              Effect.gen(function* () {
+                const ops = yield* ctx.storage.listOperationsBySource(
+                  sourceId,
+                  scope,
+                );
+                const byId = new Map<string, OperationBinding>();
+                for (const op of ops) byId.set(op.toolId, op.binding);
+                return [scope, byId] as const;
+              }),
+            { concurrency: "unbounded" },
+          );
+          const byScope = new Map<string, Map<string, OperationBinding>>(entries);
 
           const out: Record<string, ToolAnnotations> = {};
           for (const row of toolRows as readonly ToolRow[]) {

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -1017,13 +1017,22 @@ export const openApiPlugin = definePlugin(
           for (const row of toolRows as readonly ToolRow[]) {
             scopes.add(row.scope_id as string);
           }
-          const byScope = new Map<string, Map<string, OperationBinding>>();
-          for (const scope of scopes) {
-            const ops = yield* ctx.storage.listOperationsBySource(sourceId, scope);
-            const byId = new Map<string, OperationBinding>();
-            for (const op of ops) byId.set(op.toolId, op.binding);
-            byScope.set(scope, byId);
-          }
+          // One listOperationsBySource per scope is independent storage
+          // work; run them in parallel so a shadowed source doesn't
+          // serialise two ~200ms reads back-to-back in the caller's
+          // `executor.tools.list.annotations` span.
+          const entries = yield* Effect.forEach(
+            [...scopes],
+            (scope) =>
+              Effect.gen(function* () {
+                const ops = yield* ctx.storage.listOperationsBySource(sourceId, scope);
+                const byId = new Map<string, OperationBinding>();
+                for (const op of ops) byId.set(op.toolId, op.binding);
+                return [scope, byId] as const;
+              }),
+            { concurrency: "unbounded" },
+          );
+          const byScope = new Map<string, Map<string, OperationBinding>>(entries);
 
           const out: Record<string, ToolAnnotations> = {};
           for (const row of toolRows as readonly ToolRow[]) {


### PR DESCRIPTION
## Summary

- Parallelise the per-plugin-group loop in `resolveAnnotationsFor` (`packages/core/sdk/src/executor.ts`).
- Parallelise the per-scope `listOperationsBySource` / `getBindingsForSource` loops inside the openapi, graphql, and google-discovery plugins.

## Why

Axiom traces on `executor-cloud` over the last 24h (299 requests):

| span | p50 | p90 | p99 |
|---|---|---|---|
| `executor.tools.list` | 1.30s | 2.21s | 3.16s |
| `executor.tools.list.annotations` | 1.13s | 1.89s | 2.75s |

The annotations span is ~85–90% of the total. Each one spawns on average **7.79 child `executor.storage.find_many` calls (max 11)**, run strictly serially — example trace `8c03cd1cf39d2fe6e155ee1884f9e2e8` has 8 children at ~200–300ms each, stacked back-to-back into 1.82s.

Two nested `for..yield*` loops were responsible:

1. `executor.ts:1847` — `for (const [key, groupRows] of groups) { yield* plugin.resolveAnnotations(...) }`, one (plugin_id, source_id) group at a time.
2. `plugins/{openapi,graphql,google-discovery}/src/sdk/plugin.ts` — `for (const scope of scopes) { yield* storage.listOperationsBySource(...) }`, one scope at a time for shadowed sources.

Both sets of reads are independent. Swapping each for `Effect.forEach(..., { concurrency: \"unbounded\" })` should collapse the annotations span from sum-of-children (~1.9s p90) to max-of-children (~300–400ms), taking `executor.tools.list` p90 from ~2.2s to ~700–800ms. The `core.findMany({ model: \"tool\" })` that runs before annotations (~390ms) still sets the floor.

The mcp plugin's `resolveAnnotations` is pure (`Effect.sync`) and needs no change.

## Test plan

- [x] `bun run --cwd packages/core/sdk typecheck` — clean
- [x] `bun run --cwd packages/plugins/{openapi,graphql,google-discovery} typecheck` — clean
- [x] `bun run --cwd packages/core/sdk test` — 88/88 pass
- [x] `bun run --cwd packages/plugins/openapi test` — 54/54 pass
- [x] `bun run --cwd packages/plugins/graphql test` — 14/14 pass
- [x] `bun run --cwd packages/plugins/google-discovery test` — 9/9 pass
- [x] `bun run lint` — 0 warnings / 0 errors
- [ ] Post-deploy: confirm `executor.tools.list.annotations` p90 drops on Axiom `executor-cloud`