### PR TITLE
[codex] Fix OpenAPI personal credential status

### DIFF
--- a/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
@@ -3,101 +3,14 @@ import { Result, useAtomValue } from "@effect-atom/atom-react";
 import { connectionsAtom, sourceAtom } from "@executor/react/api/atoms";
 import { Badge } from "@executor/react/components/badge";
 import { Button } from "@executor/react/components/button";
-import { useScope, useScopeStack } from "@executor/react/api/scope-context";
+import { useScope, useScopeStack, useUserScope } from "@executor/react/api/scope-context";
 import { ScopeId } from "@executor/sdk";
 
 import { openApiSourceAtom, openApiSourceBindingsAtom } from "./atoms";
-import { oauth2ClientSecretSlot } from "../sdk/store";
-import type { OpenApiSourceBindingValue } from "../sdk/types";
-
-type BindingRow = {
-  readonly slot: string;
-  readonly scopeId: ScopeId;
-  readonly value: OpenApiSourceBindingValue;
-};
-
-type SourceForStatus = {
-  readonly config: {
-    readonly headers?: Record<string, string | { readonly slot: string; readonly prefix?: string }>;
-    readonly oauth2?: {
-      readonly securitySchemeName: string;
-      readonly flow: "authorizationCode" | "clientCredentials";
-      readonly clientIdSlot: string;
-      readonly clientSecretSlot: string | null;
-      readonly connectionSlot: string;
-    };
-  };
-};
-
-const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
-  ranks.get(scopeId as string) ?? Number.MAX_SAFE_INTEGER;
-
-const effectiveBindingForScope = (
-  rows: readonly BindingRow[],
-  slot: string,
-  targetScope: ScopeId,
-  ranks: ReadonlyMap<string, number>,
-) =>
-  rows.find(
-    (row) =>
-      row.slot === slot &&
-      scopeRank(ranks, row.scopeId) >= scopeRank(ranks, targetScope),
-  ) ?? null;
-
-const hasSecretBinding = (
-  rows: readonly BindingRow[],
-  slot: string,
-  targetScope: ScopeId,
-  ranks: ReadonlyMap<string, number>,
-) => effectiveBindingForScope(rows, slot, targetScope, ranks)?.value.kind === "secret";
-
-const hasConnectionBinding = (
-  rows: readonly BindingRow[],
-  slot: string,
-  targetScope: ScopeId,
-  ranks: ReadonlyMap<string, number>,
-) => effectiveBindingForScope(rows, slot, targetScope, ranks)?.value.kind === "connection";
-
-const effectiveClientSecretSlot = (oauth2: {
-  readonly securitySchemeName: string;
-  readonly clientSecretSlot: string | null;
-}): string => oauth2.clientSecretSlot ?? oauth2ClientSecretSlot(oauth2.securitySchemeName);
-
-function missingCredentialLabels(
-  source: SourceForStatus,
-  bindings: readonly BindingRow[],
-  targetScope: ScopeId,
-  ranks: ReadonlyMap<string, number>,
-): string[] {
-  const missing: string[] = [];
-
-  for (const [headerName, value] of Object.entries(source.config.headers ?? {})) {
-    if (typeof value === "string") continue;
-    if (!hasSecretBinding(bindings, value.slot, targetScope, ranks)) {
-      missing.push(headerName);
-    }
-  }
-
-  const oauth2 = source.config.oauth2;
-  if (!oauth2) return missing;
-
-  if (!hasSecretBinding(bindings, oauth2.clientIdSlot, targetScope, ranks)) {
-    missing.push("Client ID");
-  }
-
-  const clientSecretSlot = effectiveClientSecretSlot(oauth2);
-  if (!hasSecretBinding(bindings, clientSecretSlot, targetScope, ranks)) {
-    missing.push("Client Secret");
-  }
-
-  if (!hasConnectionBinding(bindings, oauth2.connectionSlot, targetScope, ranks)) {
-    missing.push(
-      oauth2.flow === "clientCredentials" ? "OAuth client connection" : "OAuth sign-in",
-    );
-  }
-
-  return missing;
-}
+import {
+  effectiveBindingForScope,
+  missingCredentialLabels,
+} from "../sdk/credential-status";
 
 function ConnectedBadge() {
   return (
@@ -146,6 +59,7 @@ export default function OpenApiSourceSummary(props: {
   onAction?: () => void;
 }) {
   const displayScope = useScope();
+  const userScope = useUserScope();
   const scopeStack = useScopeStack();
   const summaryResult = useAtomValue(sourceAtom(props.sourceId, displayScope));
   const sourceScopeId =
@@ -177,10 +91,11 @@ export default function OpenApiSourceSummary(props: {
   const scopeRanks = new Map(
     scopeStack.map((scope, index) => [scope.id as string, index] as const),
   );
+  const credentialTargetScope = userScope;
   const missing = missingCredentialLabels(
     source,
     bindings,
-    ScopeId.make(displayScope),
+    credentialTargetScope,
     scopeRanks,
   );
 
@@ -212,13 +127,14 @@ export default function OpenApiSourceSummary(props: {
   if (!oauth2) return null;
   if (!connectionsLoaded) return <CheckingCredentialsBadge />;
   const connections = connectionsResult.value;
-  const connectionBinding = bindings.find(
-    (binding) =>
-      binding.slot === oauth2.connectionSlot &&
-      binding.value.kind === "connection",
+  const connectionBinding = effectiveBindingForScope(
+    bindings,
+    oauth2.connectionSlot,
+    credentialTargetScope,
+    scopeRanks,
   );
   const connectionId =
-    connectionBinding?.value.kind === "connection"
+    connectionBinding && connectionBinding.value.kind === "connection"
       ? connectionBinding.value.connectionId
       : null;
 

--- a/packages/plugins/openapi/src/sdk/credential-status.test.ts
+++ b/packages/plugins/openapi/src/sdk/credential-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ConnectionId, ScopeId, SecretId } from "@executor/sdk";
+
+import {
+  effectiveBindingForScope,
+  missingCredentialLabels,
+  type BindingRowForCredentialStatus,
+  type SourceForCredentialStatus,
+} from "./credential-status";
+
+const userScope = ScopeId.make("user");
+const orgScope = ScopeId.make("org");
+const scopeRanks = new Map([
+  [userScope as string, 0],
+  [orgScope as string, 1],
+]);
+
+const source: SourceForCredentialStatus = {
+  config: {
+    headers: {
+      Authorization: { kind: "binding", slot: "header:authorization", prefix: "Bearer " },
+    },
+    oauth2: {
+      securitySchemeName: "oauth2",
+      flow: "clientCredentials",
+      clientIdSlot: "oauth2:oauth2:client-id",
+      clientSecretSlot: "oauth2:oauth2:client-secret",
+      connectionSlot: "oauth2:oauth2:connection",
+    },
+  },
+};
+
+const bindings = (
+  scopeId: ScopeId,
+  slots: readonly string[],
+): readonly BindingRowForCredentialStatus[] =>
+  slots.map((slot) => ({
+    slot,
+    scopeId,
+    value:
+      slot === "oauth2:oauth2:connection"
+        ? {
+            kind: "connection",
+            connectionId: ConnectionId.make(`${scopeId as string}-connection`),
+          }
+        : {
+            kind: "secret",
+            secretId: SecretId.make(`${scopeId as string}-${slot}`),
+          },
+  }));
+
+const allSlots = [
+  "header:authorization",
+  "oauth2:oauth2:client-id",
+  "oauth2:oauth2:client-secret",
+  "oauth2:oauth2:connection",
+] as const;
+
+describe("OpenAPI credential status", () => {
+  it("treats personal bindings as satisfying the user's credential status for an org source", () => {
+    expect(
+      missingCredentialLabels(source, bindings(userScope, allSlots), userScope, scopeRanks),
+    ).toEqual([]);
+  });
+
+  it("falls back to shared org bindings when the user has no personal override", () => {
+    expect(
+      missingCredentialLabels(source, bindings(orgScope, allSlots), userScope, scopeRanks),
+    ).toEqual([]);
+  });
+
+  it("does not treat personal bindings as satisfying org-level credential status", () => {
+    expect(
+      missingCredentialLabels(source, bindings(userScope, allSlots), orgScope, scopeRanks),
+    ).toEqual([
+      "Authorization",
+      "Client ID",
+      "Client Secret",
+      "OAuth client connection",
+    ]);
+  });
+
+  it("prefers the personal binding over a shared org binding", () => {
+    const binding = effectiveBindingForScope(
+      [
+        ...bindings(orgScope, ["oauth2:oauth2:connection"]),
+        ...bindings(userScope, ["oauth2:oauth2:connection"]),
+      ],
+      "oauth2:oauth2:connection",
+      userScope,
+      scopeRanks,
+    );
+
+    expect(binding?.scopeId).toEqual(userScope);
+  });
+});

--- a/packages/plugins/openapi/src/sdk/credential-status.ts
+++ b/packages/plugins/openapi/src/sdk/credential-status.ts
@@ -1,0 +1,99 @@
+import type { ScopeId } from "@executor/sdk";
+
+import { oauth2ClientSecretSlot } from "./store";
+import type { ConfiguredHeaderValue, OpenApiSourceBindingValue } from "./types";
+
+export type BindingRowForCredentialStatus = {
+  readonly slot: string;
+  readonly scopeId: ScopeId;
+  readonly value: OpenApiSourceBindingValue;
+};
+
+export type SourceForCredentialStatus = {
+  readonly config: {
+    readonly headers?: Record<string, ConfiguredHeaderValue>;
+    readonly oauth2?: {
+      readonly securitySchemeName: string;
+      readonly flow: "authorizationCode" | "clientCredentials";
+      readonly clientIdSlot: string;
+      readonly clientSecretSlot: string | null;
+      readonly connectionSlot: string;
+    };
+  };
+};
+
+const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
+  ranks.get(scopeId as string) ?? Number.MAX_SAFE_INTEGER;
+
+export const effectiveBindingForScope = (
+  rows: readonly BindingRowForCredentialStatus[],
+  slot: string,
+  targetScope: ScopeId,
+  ranks: ReadonlyMap<string, number>,
+): BindingRowForCredentialStatus | null =>
+  rows
+    .filter(
+      (row) =>
+        row.slot === slot &&
+        scopeRank(ranks, row.scopeId) >= scopeRank(ranks, targetScope),
+    )
+    .sort(
+      (a, b) =>
+        scopeRank(ranks, a.scopeId) -
+        scopeRank(ranks, b.scopeId),
+    )[0] ?? null;
+
+const hasSecretBinding = (
+  rows: readonly BindingRowForCredentialStatus[],
+  slot: string,
+  targetScope: ScopeId,
+  ranks: ReadonlyMap<string, number>,
+) => effectiveBindingForScope(rows, slot, targetScope, ranks)?.value.kind === "secret";
+
+const hasConnectionBinding = (
+  rows: readonly BindingRowForCredentialStatus[],
+  slot: string,
+  targetScope: ScopeId,
+  ranks: ReadonlyMap<string, number>,
+) => effectiveBindingForScope(rows, slot, targetScope, ranks)?.value.kind === "connection";
+
+const effectiveClientSecretSlot = (oauth2: {
+  readonly securitySchemeName: string;
+  readonly clientSecretSlot: string | null;
+}): string => oauth2.clientSecretSlot ?? oauth2ClientSecretSlot(oauth2.securitySchemeName);
+
+export function missingCredentialLabels(
+  source: SourceForCredentialStatus,
+  bindings: readonly BindingRowForCredentialStatus[],
+  targetScope: ScopeId,
+  ranks: ReadonlyMap<string, number>,
+): string[] {
+  const missing: string[] = [];
+
+  for (const [headerName, value] of Object.entries(source.config.headers ?? {})) {
+    if (typeof value === "string") continue;
+    if (!hasSecretBinding(bindings, value.slot, targetScope, ranks)) {
+      missing.push(headerName);
+    }
+  }
+
+  const oauth2 = source.config.oauth2;
+  if (!oauth2) return missing;
+
+  if (!hasSecretBinding(bindings, oauth2.clientIdSlot, targetScope, ranks)) {
+    missing.push("Client ID");
+  }
+
+  const clientSecretSlot = effectiveClientSecretSlot(oauth2);
+  if (!hasSecretBinding(bindings, clientSecretSlot, targetScope, ranks)) {
+    missing.push("Client Secret");
+  }
+
+  if (!hasConnectionBinding(bindings, oauth2.connectionSlot, targetScope, ranks)) {
+    missing.push(
+      oauth2.flow === "clientCredentials" ? "OAuth client connection" : "OAuth sign-in",
+    );
+  }
+
+  return missing;
+}

--- a/packages/react/src/plugins/headers-list.tsx
+++ b/packages/react/src/plugins/headers-list.tsx
@@ -36,8 +36,6 @@ export interface HeadersListProps {
   readonly targetScope?: ScopeId;
   /** Alias for `targetScope`, used by source flows that choose a write scope. */
   readonly writeScope?: ScopeId;
-  /** Allow configuring a secret id reference without creating a value yet. */
-  readonly allowReferenceOnly?: boolean;
 }
 
 export function HeadersList({
@@ -50,7 +48,6 @@ export function HeadersList({
   sourceName,
   targetScope,
   writeScope,
-  allowReferenceOnly = true,
 }: HeadersListProps) {
   const [picking, setPicking] = useState(false);
   const canAddMore = !singleHeader || headers.length === 0;
@@ -118,7 +115,6 @@ export function HeadersList({
                 existingSecrets={existingSecrets}
                 sourceName={sourceName}
                 targetScope={targetScope ?? writeScope}
-                allowReferenceOnly={allowReferenceOnly}
               />
             ))}
             {canAddMore && <AddHeaderRow onClick={() => setPicking(true)} />}

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -75,7 +75,6 @@ export function InlineCreateSecret(props: {
   onCancel: () => void;
   targetScope?: ScopeId;
   writeScope?: ScopeId;
-  allowReferenceOnly?: boolean;
 }) {
   const [nameOverride, setNameOverride] = useState<string | null>(null);
   const [idOverride, setIdOverride] = useState<string | null>(null);
@@ -112,11 +111,6 @@ export function InlineCreateSecret(props: {
       setError(e instanceof Error ? e.message : "Failed to save secret");
       setSaving(false);
     }
-  };
-
-  const handleUseReferenceOnly = () => {
-    if (!secretId.trim()) return;
-    props.onCreated(secretId.trim());
   };
 
   return (
@@ -176,16 +170,6 @@ export function InlineCreateSecret(props: {
         <Button variant="outline" size="xs" onClick={props.onCancel}>
           Cancel
         </Button>
-        {props.allowReferenceOnly && (
-          <Button
-            variant="outline"
-            size="xs"
-            onClick={handleUseReferenceOnly}
-            disabled={!secretId.trim() || saving}
-          >
-            Use ID only
-          </Button>
-        )}
         <Button
           size="xs"
           onClick={handleSave}
@@ -334,7 +318,6 @@ export function SecretHeaderAuthRow(props: {
   sourceName?: string;
   targetScope?: ScopeId;
   writeScope?: ScopeId;
-  allowReferenceOnly?: boolean;
 }) {
   const [creating, setCreating] = useState(false);
   const nameInputId = useId();
@@ -353,7 +336,6 @@ export function SecretHeaderAuthRow(props: {
     sourceName,
     targetScope,
     writeScope,
-    allowReferenceOnly = true,
   } = props;
 
   const isCustom = presetKey === "custom" || presetKey === undefined;
@@ -372,7 +354,6 @@ export function SecretHeaderAuthRow(props: {
         }}
         onCancel={() => setCreating(false)}
         targetScope={targetScope ?? writeScope}
-        allowReferenceOnly={allowReferenceOnly}
       />
     );
   }
@@ -455,7 +436,6 @@ export function CreatableSecretPicker(props: {
   readonly placeholder?: string;
   readonly targetScope?: ScopeId;
   readonly suggestedId?: string;
-  readonly allowReferenceOnly?: boolean;
   /**
    * Display name of the source the secret belongs to (e.g. "Stripe").
    * Combined with `secretLabel` to produce a suggested name/ID.
@@ -474,7 +454,6 @@ export function CreatableSecretPicker(props: {
     secretLabel,
     targetScope,
     suggestedId: suggestedIdProp,
-    allowReferenceOnly = true,
     writeScope,
   } = props;
   const [creating, setCreating] = useState(false);
@@ -493,7 +472,6 @@ export function CreatableSecretPicker(props: {
         }}
         onCancel={() => setCreating(false)}
         targetScope={targetScope ?? writeScope}
-        allowReferenceOnly={allowReferenceOnly}
       />
     );
   }


### PR DESCRIPTION
## Summary

Removes the `Use ID only` escape hatch from shared secret creation flows.

Fixes OpenAPI credential status so org-owned sources evaluate "your credentials" against the current user's scope. Personal credentials now clear the needs-credentials banner even when no org credential exists, while shared org credentials still work as fallback.

## Validation

- `bun run --filter='@executor/plugin-openapi' typecheck`
- `cd packages/plugins/openapi && bunx vitest run src/sdk/credential-status.test.ts`
- `git diff --check`