### PR TITLE
storage-drizzle: retry transient Hyperdrive connection drops

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -354,7 +354,9 @@
         "effect": "catalog:",
       },
       "devDependencies": {
+        "@effect/vitest": "catalog:",
         "typescript": "catalog:",
+        "vitest": "catalog:",
       },
     },
     "packages/core/storage-file": {

--- a/packages/core/storage-drizzle/package.json
+++ b/packages/core/storage-drizzle/package.json
@@ -7,6 +7,7 @@
     ".": "./src/index.ts"
   },
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsgo --noEmit",
     "typecheck:slow": "tsc --noEmit"
   },
@@ -16,6 +17,8 @@
     "effect": "catalog:"
   },
   "devDependencies": {
-    "typescript": "catalog:"
+    "@effect/vitest": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/core/storage-drizzle/src/adapter.test.ts
+++ b/packages/core/storage-drizzle/src/adapter.test.ts
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------
+// Transient retry — protects against Hyperdrive handing us a stale pooled
+// connection that drops mid-query. We retry StorageErrors whose message
+// contains known transient markers; everything else fails fast.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit, Schedule } from "effect";
+import { StorageError, UniqueViolationError } from "@executor/storage-core";
+
+import { isTransientStorageError } from "./adapter";
+
+const transientMsg =
+  "[storage-drizzle] findOne select failed: Network connection lost.";
+
+describe("isTransientStorageError", () => {
+  it.for([
+    "[storage-drizzle] findOne select failed: Network connection lost.",
+    "[storage-drizzle] findMany select failed: write CONNECTION_CLOSED e3b8b6d4dd90718f2a253e4d77d5ff00.hyperdrive.local:5432",
+    "[storage-drizzle] insert returning failed: ECONNRESET",
+    "[storage-drizzle] findMany select failed: Connection terminated unexpectedly",
+  ])("returns true for %s", (message) => {
+    expect(
+      isTransientStorageError(new StorageError({ message, cause: null })),
+    ).toBe(true);
+  });
+
+  it("returns false for unique violation", () => {
+    expect(isTransientStorageError(new UniqueViolationError({}))).toBe(false);
+  });
+
+  it("returns false for unrelated storage errors", () => {
+    expect(
+      isTransientStorageError(
+        new StorageError({ message: "syntax error at or near", cause: null }),
+      ),
+    ).toBe(false);
+  });
+});
+
+// Mirrors the runPromise retry policy so we catch drift if it changes.
+const retryPolicy = {
+  while: isTransientStorageError,
+  times: 2,
+  schedule: Schedule.exponential("1 millis"),
+} as const;
+
+describe("transient retry policy", () => {
+  it.live("retries transient failures and eventually succeeds", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const result = yield* Effect.suspend(() => {
+        calls++;
+        if (calls < 3) {
+          return Effect.fail(
+            new StorageError({ message: transientMsg, cause: null }),
+          );
+        }
+        return Effect.succeed("ok");
+      }).pipe(Effect.retry(retryPolicy));
+
+      expect(result).toBe("ok");
+      expect(calls).toBe(3);
+    }),
+  );
+
+  it.live("gives up after exhausting retries", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const exit = yield* Effect.exit(
+        Effect.suspend(() => {
+          calls++;
+          return Effect.fail(
+            new StorageError({ message: transientMsg, cause: null }),
+          );
+        }).pipe(Effect.retry(retryPolicy)),
+      );
+
+      expect(Exit.isFailure(exit)).toBe(true);
+      expect(calls).toBe(3); // 1 initial + 2 retries
+    }),
+  );
+
+  it.live("does not retry unique violations", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      yield* Effect.exit(
+        Effect.suspend(() => {
+          calls++;
+          return Effect.fail(new UniqueViolationError({ model: "widget" }));
+        }).pipe(Effect.retry(retryPolicy)),
+      );
+
+      expect(calls).toBe(1);
+    }),
+  );
+
+  it.live("does not retry non-transient storage errors", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      yield* Effect.exit(
+        Effect.suspend(() => {
+          calls++;
+          return Effect.fail(
+            new StorageError({
+              message: "[storage-drizzle] findOne select failed: syntax error",
+              cause: null,
+            }),
+          );
+        }).pipe(Effect.retry(retryPolicy)),
+      );
+
+      expect(calls).toBe(1);
+    }),
+  );
+});

--- a/packages/core/storage-drizzle/src/adapter.ts
+++ b/packages/core/storage-drizzle/src/adapter.ts
@@ -11,7 +11,7 @@
 //     generation, encode/decode all happen in storage-core
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
+import { Effect, Schedule } from "effect";
 import {
   and,
   asc,
@@ -297,15 +297,48 @@ const classifyError = (
   });
 };
 
+// Hyperdrive (Cloudflare's Postgres pooler) periodically hands out a
+// stale pooled connection that drops the write mid-query. Drizzle
+// surfaces this as a driver error we classify into a StorageError whose
+// message contains "Network connection lost" or "CONNECTION_CLOSED".
+// Retrying on a fresh pooled connection almost always succeeds, so we
+// retry transient errors twice with short exponential backoff. Unique
+// violations and anything else fail fast.
+export const isTransientStorageError = (err: StorageFailure): boolean => {
+  if (err._tag !== "StorageError") return false;
+  const msg = err.message;
+  return (
+    msg.includes("Network connection lost") ||
+    msg.includes("CONNECTION_CLOSED") ||
+    msg.includes("Connection terminated") ||
+    msg.includes("ECONNRESET")
+  );
+};
+
+const transientRetrySchedule = Schedule.exponential("50 millis");
+
+const withTransientRetry = <T>(
+  effect: Effect.Effect<T, StorageFailure>,
+): Effect.Effect<T, StorageFailure> =>
+  effect.pipe(
+    Effect.retry({
+      while: isTransientStorageError,
+      times: 2,
+      schedule: transientRetrySchedule,
+    }),
+  );
+
 const runPromise = <T>(
   op: string,
   fn: () => Promise<T>,
   model?: string,
 ): Effect.Effect<T, StorageFailure> =>
-  Effect.tryPromise({
-    try: fn,
-    catch: (cause) => classifyError(op, model, cause),
-  });
+  withTransientRetry(
+    Effect.tryPromise({
+      try: fn,
+      catch: (cause) => classifyError(op, model, cause),
+    }),
+  );
 
 // ---------------------------------------------------------------------------
 // withReturning — mirrors better-auth's helper. sqlite + pg support

--- a/packages/core/storage-drizzle/src/index.ts
+++ b/packages/core/storage-drizzle/src/index.ts
@@ -12,6 +12,7 @@
 
 export {
   drizzleAdapter,
+  isTransientStorageError,
   type DrizzleAdapterOptions,
   type DrizzleProvider,
   type DrizzleDB,

--- a/packages/core/storage-drizzle/vitest.config.ts
+++ b/packages/core/storage-drizzle/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

- Wrap `runPromise` in `@executor/storage-drizzle/adapter.ts` with `Effect.retry` — up to 2 retries with 50ms exponential backoff.
- Gate retries on `isTransientStorageError`: StorageError messages containing `Network connection lost`, `CONNECTION_CLOSED`, `Connection terminated`, or `ECONNRESET`. `UniqueViolationError` and all other errors still fail fast.
- Predicate is exported from the package entrypoint for testability.

## Motivation

Axiom shows periodic bursts of StorageErrors where Hyperdrive hands us a stale pooled connection and drops the query mid-flight. Example from prod (last 6h):

```
StorageError: [storage-drizzle] findOne select failed: Network connection lost.
StorageError: [storage-drizzle] findMany select failed: write CONNECTION_CLOSED e3b8...hyperdrive.local:5432
```

These surface as:
- 500 on `POST /mcp` from Claude.ai (the Claude-User UA)
- 500 on `GET /api/scopes/.../openapi/sources/*` dashboard routes
- Ripple failures in the `McpSessionDO` bootstrap path when the session runtime first reads metadata

A single bad connection typically kills one statement — the next attempt lands on a fresh pooled conn and succeeds. Retrying once (up to twice) is the Cloudflare-recommended remediation for this class of Hyperdrive error.

## Scope

- Retry happens at the single-statement level inside `runPromise`. Transactions (`pg` native and raw `BEGIN/COMMIT` paths) are not wrapped — retrying a statement inside a dead transaction is a no-op and will fail fast.
- Only `StorageError` is considered retryable (never `UniqueViolationError`).
- Worst-case added latency on a real outage: ~150ms (2 retries with 50/100ms exponential backoff) before surfacing the failure.

## Test plan

- [x] New unit tests in `packages/core/storage-drizzle/src/adapter.test.ts` cover:
  - `isTransientStorageError` true/false matrix across real Hyperdrive messages, unique violations, and unrelated storage errors
  - Retry policy retries transient failures and eventually succeeds
  - Retry policy gives up after 2 retries
  - Retry policy does not retry unique violations
  - Retry policy does not retry non-transient storage errors
- [x] `bun run test` in `@executor/storage-drizzle` — 10 passing
- [x] `bun run test` in `@executor/storage-postgres` — 21 passing (drizzle conformance suite against PGlite)
- [x] `bun run test` in `@executor/storage-file` — 21 passing (drizzle conformance against sqlite)
- [x] `bun run typecheck` in `@executor/storage-drizzle` — clean