### PR TITLE
[codex] Fix scoped source config inheritance

### DIFF
--- a/packages/plugins/graphql/src/api/handlers.ts
+++ b/packages/plugins/graphql/src/api/handlers.ts
@@ -56,7 +56,7 @@ export const GraphqlHandlers = HttpApiBuilder.group(ExecutorApiWithGraphql, "gra
         });
         return {
           toolCount: result.toolCount,
-          namespace: payload.namespace ?? "graphql",
+          namespace: result.namespace,
         };
       })),
     )

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -98,6 +98,7 @@ describe("graphqlPlugin", () => {
         namespace: "test_api",
       });
       expect(result.toolCount).toBe(2);
+      expect(result.namespace).toBe("test_api");
 
       const tools = yield* executor.tools.list();
       const ids = tools.map((t) => t.id);
@@ -249,7 +250,7 @@ describe("graphqlPlugin", () => {
         introspectionJson,
         namespace: "via_static",
       });
-      expect(result).toEqual({ toolCount: 2 });
+      expect(result).toEqual({ toolCount: 2, namespace: "via_static" });
 
       const tools = yield* executor.tools.list();
       expect(

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -95,7 +95,10 @@ export interface GraphqlPluginExtension {
   /** Add a GraphQL endpoint and register its operations as tools */
   readonly addSource: (
     config: GraphqlSourceConfig,
-  ) => Effect.Effect<{ readonly toolCount: number }, GraphqlExtensionFailure>;
+  ) => Effect.Effect<
+    { readonly toolCount: number; readonly namespace: string },
+    GraphqlExtensionFailure
+  >;
 
   /** Remove all tools from a previously added GraphQL source by namespace.
    *  `scope` pins the cleanup to the exact row — without it a shadowed
@@ -411,7 +414,6 @@ export const graphqlPlugin = definePlugin(
                     )
                   : Effect.void,
               ),
-              Effect.map(({ toolCount }) => ({ toolCount })),
             ),
 
           removeSource: (namespace, scope) =>

--- a/packages/plugins/openapi/src/sdk/multi-scope-bearer.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-bearer.test.ts
@@ -606,4 +606,176 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
         );
       }),
   );
+
+  it.effect("user-scope source shadows inherit the org baseUrl", () =>
+    Effect.gen(function* () {
+      const memorySecretsPlugin = definePlugin(() => ({
+        id: "memory-secrets" as const,
+        storage: () => ({}),
+        secretProviders: [],
+      }));
+
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+      const plugins = [
+        openApiPlugin({ httpClientLayer: clientLayer }),
+        memorySecretsPlugin(),
+      ] as const;
+
+      const schema = collectSchemas(plugins);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const now = new Date();
+      const orgScope = new Scope({
+        id: ScopeId.make("org"),
+        name: "acme-org",
+        createdAt: now,
+      });
+      const aliceScope = new Scope({
+        id: ScopeId.make("user-alice"),
+        name: "alice",
+        createdAt: now,
+      });
+
+      const adminExec = yield* createExecutor({
+        scopes: [orgScope],
+        adapter,
+        blobs,
+        plugins,
+      });
+      const aliceExec = yield* createExecutor({
+        scopes: [aliceScope, orgScope],
+        adapter,
+        blobs,
+        plugins,
+      });
+
+      yield* adminExec.openapi.addSpec({
+        spec: specJson,
+        scope: orgScope.id as string,
+        namespace: "vercel",
+        baseUrl: "https://api.vercel.example",
+      });
+
+      yield* aliceExec.openapi.addSpec({
+        spec: specJson,
+        scope: aliceScope.id as string,
+        namespace: "vercel",
+      });
+
+      const source = yield* aliceExec.openapi.getSource(
+        "vercel",
+        aliceScope.id as string,
+      );
+      expect(source?.scope).toBe(aliceScope.id);
+      expect(source?.config.baseUrl).toBe("https://api.vercel.example");
+    }),
+  );
+
+  it.effect("user-scope source shadows resolve inherited org bindings at the org source scope", () =>
+    Effect.gen(function* () {
+      const secretStore = new Map<string, string>();
+      const key = (scope: string, id: string) => `${scope}\u0000${id}`;
+      const memoryProvider: SecretProvider = {
+        key: "memory",
+        writable: true,
+        get: (id, scope) =>
+          Effect.sync(() => secretStore.get(key(scope, id)) ?? null),
+        set: (id, value, scope) =>
+          Effect.sync(() => {
+            secretStore.set(key(scope, id), value);
+          }),
+        delete: (id, scope) =>
+          Effect.sync(() => secretStore.delete(key(scope, id))),
+      };
+      const memorySecretsPlugin = definePlugin(() => ({
+        id: "memory-secrets" as const,
+        storage: () => ({}),
+        secretProviders: [memoryProvider],
+      }));
+
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+      const plugins = [
+        openApiPlugin({ httpClientLayer: clientLayer }),
+        memorySecretsPlugin(),
+      ] as const;
+
+      const schema = collectSchemas(plugins);
+      const adapter = makeMemoryAdapter({ schema });
+      const blobs = makeInMemoryBlobStore();
+      const now = new Date();
+      const orgScope = new Scope({
+        id: ScopeId.make("org"),
+        name: "acme-org",
+        createdAt: now,
+      });
+      const aliceScope = new Scope({
+        id: ScopeId.make("user-alice"),
+        name: "alice",
+        createdAt: now,
+      });
+
+      const adminExec = yield* createExecutor({
+        scopes: [orgScope],
+        adapter,
+        blobs,
+        plugins,
+      });
+      const aliceExec = yield* createExecutor({
+        scopes: [aliceScope, orgScope],
+        adapter,
+        blobs,
+        plugins,
+      });
+
+      yield* adminExec.openapi.addSpec({
+        spec: specJson,
+        scope: orgScope.id as string,
+        namespace: "vercel",
+        baseUrl: "",
+        headers: {
+          Authorization: new ConfiguredHeaderBinding({
+            kind: "binding",
+            slot: "auth:token",
+            prefix: "Bearer ",
+          }),
+        },
+      });
+      yield* aliceExec.openapi.addSpec({
+        spec: specJson,
+        scope: aliceScope.id as string,
+        namespace: "vercel",
+      });
+
+      yield* aliceExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("alice_vercel_pat"),
+          scope: aliceScope.id,
+          name: "Alice Vercel PAT",
+          value: "alice-token",
+        }),
+      );
+      yield* aliceExec.openapi.setSourceBinding(
+        new OpenApiSourceBindingInput({
+          sourceId: "vercel",
+          sourceScope: orgScope.id,
+          scope: aliceScope.id,
+          slot: "auth:token",
+          value: {
+            kind: "secret",
+            secretId: SecretId.make("alice_vercel_pat"),
+          },
+        }),
+      );
+
+      const result = (yield* aliceExec.tools.invoke(
+        "vercel.projects.list",
+        {},
+        autoApprove,
+      )) as { data: { authorization?: string } | null; error: unknown };
+      expect(result.error).toBeNull();
+      expect(result.data?.authorization).toBe("Bearer alice-token");
+    }),
+  );
 });

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -458,9 +458,50 @@ const canonicalizeOAuth2 = (
   };
 };
 
+interface EffectiveSourceConfig {
+  readonly config: SourceConfig;
+  readonly headersSource: StoredSource;
+  readonly oauth2Source: StoredSource;
+}
+
 const resolveEffectiveSourceConfig = (
+  ctx: PluginCtx<OpenapiStore>,
   base: StoredSource,
-): Effect.Effect<SourceConfig, never> => Effect.succeed(base.config);
+): Effect.Effect<EffectiveSourceConfig, StorageFailure> =>
+  Effect.gen(function* () {
+    const rank = new Map(ctx.scopes.map((scope, index) => [scope.id as string, index] as const));
+    const baseRank = rank.get(base.scope) ?? Infinity;
+    const fallback = (yield* ctx.storage.listSources())
+      .filter((source) => source.namespace === base.namespace)
+      .filter((source) => (rank.get(source.scope) ?? Infinity) > baseRank)
+      .sort(
+        (a, b) =>
+          (rank.get(a.scope) ?? Infinity) -
+          (rank.get(b.scope) ?? Infinity),
+      )[0];
+
+    if (!fallback) {
+      return {
+        config: base.config,
+        headersSource: base,
+        oauth2Source: base,
+      };
+    }
+
+    const hasBaseHeaders = Object.keys(base.config.headers ?? {}).length > 0;
+    return {
+      config: {
+        ...base.config,
+        sourceUrl: base.config.sourceUrl ?? fallback.config.sourceUrl,
+        baseUrl: base.config.baseUrl || fallback.config.baseUrl,
+        namespace: base.config.namespace ?? fallback.config.namespace,
+        headers: hasBaseHeaders ? base.config.headers : fallback.config.headers,
+        oauth2: base.config.oauth2 ?? fallback.config.oauth2,
+      },
+      headersSource: hasBaseHeaders ? base : fallback,
+      oauth2Source: base.config.oauth2 ? base : fallback,
+    };
+  });
 
 const resolveConfiguredHeaders = (
   ctx: PluginCtx<OpenapiStore>,
@@ -741,8 +782,9 @@ export const openApiPlugin = definePlugin(
       Effect.gen(function* () {
         const existing = yield* ctx.storage.getSource(sourceId, scope);
         if (!existing) return;
-        const resolvedConfig = yield* resolveEffectiveSourceConfig(existing);
-        const sourceUrl = existing.config.sourceUrl;
+        const effective = yield* resolveEffectiveSourceConfig(ctx, existing);
+        const resolvedConfig = effective.config;
+        const sourceUrl = resolvedConfig.sourceUrl;
         if (!sourceUrl) return;
         const specText = yield* resolveSpecText(sourceUrl).pipe(
           Effect.provide(httpClientLayer),
@@ -754,8 +796,8 @@ export const openApiPlugin = definePlugin(
           name: existing.name,
           baseUrl: resolvedConfig.baseUrl,
           namespace: existing.namespace,
-          headers: resolvedConfig.headers,
-          oauth2: resolvedConfig.oauth2,
+          headers: existing.config.headers,
+          oauth2: existing.config.oauth2,
         });
       });
 
@@ -819,10 +861,10 @@ export const openApiPlugin = definePlugin(
             Effect.gen(function* () {
               const source = yield* ctx.storage.getSource(namespace, scope);
               if (!source) return null;
-              const config = yield* resolveEffectiveSourceConfig(source);
+              const effective = yield* resolveEffectiveSourceConfig(ctx, source);
               return {
                 ...source,
-                config,
+                config: effective.config,
               };
             }),
 
@@ -1246,12 +1288,13 @@ export const openApiPlugin = definePlugin(
             );
           }
 
-          const config = yield* resolveEffectiveSourceConfig(source);
+          const effective = yield* resolveEffectiveSourceConfig(ctx, source);
+          const config = effective.config;
           const resolvedHeaders = yield* resolveConfiguredHeaders(ctx, {
             sourceId: op.sourceId,
-            sourceScope: toolScope,
+            sourceScope: effective.headersSource.scope,
             headers: config.headers ?? {},
-            legacyHeaders: source.legacy?.headers,
+            legacyHeaders: effective.headersSource.legacy?.headers,
           }).pipe(
             Effect.mapError((err) => new Error(err.message)),
           );
@@ -1263,9 +1306,9 @@ export const openApiPlugin = definePlugin(
           if (config.oauth2) {
             const connectionId = yield* resolveOAuthConnectionId(ctx, {
               sourceId: op.sourceId,
-              sourceScope: toolScope,
+              sourceScope: effective.oauth2Source.scope,
               oauth2: config.oauth2,
-              legacyOAuth2: source.legacy?.oauth2,
+              legacyOAuth2: effective.oauth2Source.legacy?.oauth2,
             });
             if (!connectionId) {
               return yield* Effect.fail(


### PR DESCRIPTION
## Summary

- Fix OpenAPI user-scope source shadows so missing base/source URL config falls back to the nearest outer source.
- Preserve the source scope that owns inherited OpenAPI header and OAuth config, so bindings resolve against the correct source row while secrets/connections still resolve per caller scope.
- Return the actual GraphQL source namespace from addSource instead of guessing in the HTTP handler.

## Root Cause

OpenAPI invocation selected the innermost source row, but per-user source shadows may omit base URL, headers, or OAuth config that lives on the shared org source. The previous effective-config shim copied values without tracking which source row owned binding slots, so inherited headers could be resolved against the wrong source scope.

## Validation

- bunx vitest run src/sdk --config vitest.config.ts (packages/plugins/openapi)
- bunx vitest run src/sdk/plugin.test.ts --config vitest.config.ts (packages/plugins/graphql)
- bun run typecheck (packages/plugins/openapi)
- bun run typecheck (packages/plugins/graphql)
