### PR TITLE
[codex] Optimize source detail storage reads

### DIFF
--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { makeMemoryAdapter } from "@executor/storage-core/testing/memory";
+import type { DBAdapter, Where } from "@executor/storage-core";
 
 import { makeInMemoryBlobStore } from "./blob";
 import { collectSchemas, createExecutor } from "./executor";
@@ -16,6 +17,32 @@ import { makeTestConfig } from "./testing";
 import type { SecretProvider } from "./secrets";
 import { ScopeId, SecretId } from "./ids";
 import { Scope } from "./scope";
+
+type FindManyCall = {
+  readonly model: string;
+  readonly where?: readonly Where[];
+};
+
+const recordFindMany = (
+  adapter: DBAdapter,
+  calls: FindManyCall[],
+): DBAdapter => ({
+  ...adapter,
+  findMany: (data) => {
+    calls.push({ model: data.model, where: data.where });
+    return adapter.findMany(data);
+  },
+  transaction: (callback) =>
+    adapter.transaction((trx) =>
+      callback({
+        ...trx,
+        findMany: (data) => {
+          calls.push({ model: data.model, where: data.where });
+          return trx.findMany(data);
+        },
+      }),
+    ),
+});
 
 // ---------------------------------------------------------------------------
 // Tiny test plugin — declares a static source with two control tools, a
@@ -203,6 +230,33 @@ describe("createExecutor", () => {
 
       const tools = yield* executor.tools.list({ query: "echo" });
       expect(tools.map((t) => t.id)).toEqual(["test.control.echo"]);
+    }),
+  );
+
+  it.effect("pushes sourceId tool list filters into storage", () =>
+    Effect.gen(function* () {
+      const config = makeTestConfig({ plugins: [testPlugin()] as const });
+      const findManyCalls: FindManyCall[] = [];
+      const executor = yield* createExecutor({
+        ...config,
+        adapter: recordFindMany(config.adapter, findManyCalls),
+      });
+      yield* executor.test.addThing("thing1", "hello");
+      yield* executor.test.addThing("thing2", "goodbye");
+
+      findManyCalls.length = 0;
+      const tools = yield* executor.tools.list({ sourceId: "thing1" });
+
+      expect(tools.map((t) => t.id).sort()).toEqual([
+        "thing1.read",
+        "thing1.write",
+      ]);
+      const toolRead = findManyCalls.find((call) => call.model === "tool");
+      expect(toolRead?.where).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ field: "source_id", value: "thing1" }),
+        ]),
+      );
     }),
   );
 

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1875,7 +1875,12 @@ export const createExecutor = <
 
     const listTools = (filter?: ToolListFilter) =>
       Effect.gen(function* () {
-        const dynamic = yield* core.findMany({ model: "tool" });
+        const dynamic = yield* core.findMany({
+          model: "tool",
+          where: filter?.sourceId
+            ? [{ field: "source_id", value: filter.sourceId }]
+            : undefined,
+        });
         // Dedup by tool id, innermost scope winning — same reason as
         // `listSources` above: a shadowed id must surface as one entry
         // (the inner one), not two.

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -13,6 +13,7 @@ import { NodeHttpServer } from "@effect/platform-node";
 
 import {
   createExecutor,
+  type DBAdapter,
   definePlugin,
   makeTestConfig,
   Scope,
@@ -21,6 +22,7 @@ import {
   SetSecretInput,
   type InvokeOptions,
   type SecretProvider,
+  type Where,
 } from "@executor/sdk";
 
 const TEST_SCOPE = "test-scope";
@@ -28,6 +30,32 @@ import { openApiPlugin } from "./plugin";
 import { OAuth2Auth } from "./types";
 
 const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
+
+type FindManyCall = {
+  readonly model: string;
+  readonly where?: readonly Where[];
+};
+
+const recordFindMany = (
+  adapter: DBAdapter,
+  calls: FindManyCall[],
+): DBAdapter => ({
+  ...adapter,
+  findMany: (data) => {
+    calls.push({ model: data.model, where: data.where });
+    return adapter.findMany(data);
+  },
+  transaction: (callback) =>
+    adapter.transaction((trx) =>
+      callback({
+        ...trx,
+        findMany: (data) => {
+          calls.push({ model: data.model, where: data.where });
+          return trx.findMany(data);
+        },
+      }),
+    ),
+});
 
 // ---------------------------------------------------------------------------
 // In-memory secrets provider plugin — registered alongside openapi so
@@ -517,6 +545,47 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       expect(userView?.scope).toBe(USER_SCOPE as string);
       expect(orgView?.name).toBe("Org Source");
       expect(orgView?.scope).toBe(ORG_SCOPE as string);
+    }),
+  );
+
+  it.effect("getSource resolves inherited config without listing every OpenAPI source", () =>
+    Effect.gen(function* () {
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+      const config = makeTestConfig({
+        scopes: stackedScopes,
+        plugins: [
+          openApiPlugin({ httpClientLayer: clientLayer }),
+          memorySecretsPlugin(),
+        ] as const,
+      });
+      const findManyCalls: FindManyCall[] = [];
+
+      const executor = yield* createExecutor({
+        ...config,
+        adapter: recordFindMany(config.adapter, findManyCalls),
+      });
+
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: ORG_SCOPE as string,
+        namespace: "shared",
+        baseUrl: "https://org.example.com",
+        name: "Org Source",
+      });
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: USER_SCOPE as string,
+        namespace: "shared",
+        baseUrl: "",
+        name: "User Source",
+      });
+
+      findManyCalls.length = 0;
+      const userView = yield* executor.openapi.getSource("shared", USER_SCOPE as string);
+
+      expect(userView?.config.baseUrl).toBe("https://org.example.com");
+      expect(findManyCalls.some((call) => call.model === "openapi_source")).toBe(false);
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -471,14 +471,13 @@ const resolveEffectiveSourceConfig = (
   Effect.gen(function* () {
     const rank = new Map(ctx.scopes.map((scope, index) => [scope.id as string, index] as const));
     const baseRank = rank.get(base.scope) ?? Infinity;
-    const fallback = (yield* ctx.storage.listSources())
-      .filter((source) => source.namespace === base.namespace)
-      .filter((source) => (rank.get(source.scope) ?? Infinity) > baseRank)
-      .sort(
-        (a, b) =>
-          (rank.get(a.scope) ?? Infinity) -
-          (rank.get(b.scope) ?? Infinity),
-      )[0];
+    let fallback: StoredSource | null = null;
+    for (let index = baseRank + 1; index < ctx.scopes.length; index++) {
+      const scope = ctx.scopes[index];
+      if (!scope) continue;
+      fallback = yield* ctx.storage.getSource(base.namespace, scope.id as string);
+      if (fallback) break;
+    }
 
     if (!fallback) {
       return {


### PR DESCRIPTION
## Summary

- Pushes `sourceId` filters into `executor.tools.list` storage reads so source detail pages avoid loading every dynamic tool before filtering.
- Resolves inherited OpenAPI source config with targeted fallback-scope lookups instead of listing every OpenAPI source.
- Adds regression tests that assert the storage access shape for both paths.

## Validation

- `vitest run src/executor.test.ts` in `packages/core/sdk`
- `vitest run src/sdk/plugin.test.ts` in `packages/plugins/openapi`
- `bun run typecheck` in `packages/core/sdk`
- `bun run typecheck` in `packages/plugins/openapi`
