### PR TITLE
[codex] Skip annotations for metadata tool lists

### DIFF
--- a/packages/core/api/src/handlers/sources.ts
+++ b/packages/core/api/src/handlers/sources.ts
@@ -42,7 +42,10 @@ export const SourcesHandlers = HttpApiBuilder.group(ExecutorApi, "sources", (han
     .handle("tools", ({ path }) =>
       capture(Effect.gen(function* () {
         const executor = yield* ExecutorService;
-        const tools = yield* executor.tools.list({ sourceId: path.sourceId });
+        const tools = yield* executor.tools.list({
+          sourceId: path.sourceId,
+          includeAnnotations: false,
+        });
         return tools.map((t) => ({
           id: ToolId.make(t.id),
           pluginId: t.pluginId,

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -287,7 +287,7 @@ export const searchTools = Effect.fn("executor.tools.search")(function* (
     return [] as ReadonlyArray<ToolDiscoveryResult>;
   }
 
-  const all = yield* executor.tools.list().pipe(Effect.orDie);
+  const all = yield* executor.tools.list({ includeAnnotations: false }).pipe(Effect.orDie);
   const results = all
     .filter((tool: Tool) => matchesNamespace(tool, options?.namespace))
     .map((tool: Tool) => scoreToolMatch(tool, query))
@@ -320,7 +320,7 @@ export const listExecutorSources = Effect.fn("executor.sources.list")(function* 
         });
 
   // Single query for all tools, then count per source in memory.
-  const allTools = yield* executor.tools.list().pipe(Effect.orDie);
+  const allTools = yield* executor.tools.list({ includeAnnotations: false }).pipe(Effect.orDie);
   const toolCountBySource = new Map<string, number>();
   for (const tool of allTools) {
     toolCountBySource.set(tool.sourceId, (toolCountBySource.get(tool.sourceId) ?? 0) + 1);

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -61,6 +61,8 @@ const testSchema = defineSchema({
   },
 });
 
+let testAnnotationResolveCount = 0;
+
 const testPlugin = definePlugin(() => ({
   id: "test" as const,
   schema: testSchema,
@@ -141,6 +143,7 @@ const testPlugin = definePlugin(() => ({
   // Purely computed from the tool's name — no data persisted on the row.
   resolveAnnotations: ({ toolRows }) =>
     Effect.sync(() => {
+      testAnnotationResolveCount++;
       const out: Record<string, { requiresApproval: boolean; approvalDescription?: string }> = {};
       for (const row of toolRows) {
         if (row.name === "write") {
@@ -257,6 +260,28 @@ describe("createExecutor", () => {
           expect.objectContaining({ field: "source_id", value: "thing1" }),
         ]),
       );
+    }),
+  );
+
+  it.effect("can list tools without resolving dynamic annotations", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [testPlugin()] as const }),
+      );
+      yield* executor.test.addThing("thing1", "hello");
+      testAnnotationResolveCount = 0;
+
+      const tools = yield* executor.tools.list({
+        sourceId: "thing1",
+        includeAnnotations: false,
+      });
+
+      expect(testAnnotationResolveCount).toBe(0);
+      expect(tools.map((t) => t.id).sort()).toEqual([
+        "thing1.read",
+        "thing1.write",
+      ]);
+      expect(tools.every((tool) => tool.annotations === undefined)).toBe(true);
     }),
   );
 

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1895,9 +1895,12 @@ export const createExecutor = <
           }
         }
         const dynamicDeduped = [...byId.values()];
-        const annotations = yield* resolveAnnotationsFor(dynamicDeduped).pipe(
-          Effect.withSpan("executor.tools.list.annotations"),
-        );
+        const annotations =
+          filter?.includeAnnotations === false
+            ? new Map<string, ToolAnnotations>()
+            : yield* resolveAnnotationsFor(dynamicDeduped).pipe(
+                Effect.withSpan("executor.tools.list.annotations"),
+              );
 
         const out: Tool[] = [];
         // Static tools — annotations from the declaration, not a resolver.

--- a/packages/core/sdk/src/types.ts
+++ b/packages/core/sdk/src/types.ts
@@ -105,4 +105,6 @@ export interface ToolListFilter {
   readonly sourceId?: string;
   /** Case-insensitive substring match against `name` OR `description`. */
   readonly query?: string;
+  /** Resolve plugin-derived annotations. Defaults to true. */
+  readonly includeAnnotations?: boolean;
 }


### PR DESCRIPTION
## Summary

- Adds an `includeAnnotations` option to tool listing so metadata-only callers can avoid plugin annotation resolution.
- Uses metadata-only tool lists for source detail tools, sandbox tool search, and executor source tool-count discovery.
- Adds a regression test proving dynamic annotation resolution is skipped when callers opt out.

## Why

Source detail pages only need tool id/name/plugin/description for the tree. Resolving OpenAPI annotations forces extra plugin storage reads that are only needed for invocation enforcement or UIs that actually display policy metadata.

## Validation

- `vitest run src/executor.test.ts` in `packages/core/sdk`
- `vitest run src/tool-invoker.test.ts` in `packages/core/execution`
- `bun run typecheck` in `packages/core/sdk`
- `bun run typecheck` in `packages/core/api`
- `bun run typecheck` in `packages/core/execution`
