### PR TITLE
feat(observability): add /api/metrics + opt-in OTLP metrics push

### DIFF
--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@effect-atom/atom-react": "^0.5.0",
+    "@effect/opentelemetry": "^0.63.0",
     "@effect/platform": "catalog:",
     "@effect/platform-node": "catalog:",
     "@executor/api": "workspace:*",

--- a/apps/local/src/server/main.ts
+++ b/apps/local/src/server/main.ts
@@ -35,6 +35,7 @@ import {
 import { getExecutor } from "./executor";
 import { createMcpRequestHandler, type McpRequestHandler } from "./mcp";
 import { ErrorCaptureLive } from "./observability";
+import { startMetricsExport } from "./telemetry";
 
 // ---------------------------------------------------------------------------
 // Local server API — core + all plugin groups
@@ -90,6 +91,11 @@ const closeServerHandlers = async (handlers: ServerHandlers): Promise<void> => {
 export const createServerHandlers = async (): Promise<ServerHandlers> => {
   const executor = await getExecutor();
   const engine = createExecutionEngine({ executor, codeExecutor: makeQuickJsExecutor() });
+
+  // Boot the OTLP metrics exporter if `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
+  // is set. No-op otherwise — the in-process metric registry still
+  // accumulates counters/histograms for `GET /api/metrics`.
+  await Effect.runPromise(startMetricsExport());
 
   // Handlers wrap their own bodies with `capture(...)` — the edge
   // translation lives per-handler, not at service construction.

--- a/apps/local/src/server/telemetry.ts
+++ b/apps/local/src/server/telemetry.ts
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// Metrics export for the local daemon.
+//
+// Gated on `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` (OTel standard env var).
+// When set, wires `@effect/opentelemetry/OtlpMetrics` into a module-scope
+// `ManagedRuntime` so the exporter's timer fiber keeps ticking across
+// requests — per-request scoping would shut down the exporter before the
+// first batch leaves.
+//
+// When unset, `MetricsRuntime` is `null` and nothing pushes; the
+// in-process registry keeps accumulating counters + histograms so
+// `GET /api/metrics` still serves a complete snapshot on demand.
+//
+// Auth: `OTEL_EXPORTER_OTLP_METRICS_HEADERS` follows the OTel spec
+// format — comma-separated `key=value` pairs. For Axiom specifically,
+// that's `Authorization=Bearer xxx,X-Axiom-Dataset=executor-local`.
+// ---------------------------------------------------------------------------
+
+import * as FetchHttpClient from "@effect/platform/FetchHttpClient";
+import * as OtlpMetrics from "@effect/opentelemetry/OtlpMetrics";
+import * as OtlpSerialization from "@effect/opentelemetry/OtlpSerialization";
+import { Effect, Layer, ManagedRuntime } from "effect";
+
+const SERVICE_NAME = "executor-local";
+const SERVICE_VERSION = "1.0.0";
+
+const parseHeaders = (raw: string | undefined): Record<string, string> => {
+  if (!raw) return {};
+  const out: Record<string, string> = {};
+  for (const entry of raw.split(",")) {
+    const idx = entry.indexOf("=");
+    if (idx === -1) continue;
+    const key = entry.slice(0, idx).trim();
+    const value = entry.slice(idx + 1).trim();
+    if (key) out[key] = value;
+  }
+  return out;
+};
+
+const endpoint = process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT;
+const headers = parseHeaders(process.env.OTEL_EXPORTER_OTLP_METRICS_HEADERS);
+
+/**
+ * Module-scope runtime holding the OTLP exporter. Never disposed for the
+ * daemon's lifetime — the exporter's fiber ticks every `exportInterval`
+ * (10s default) regardless of per-request activity. Set to `null` when
+ * no push endpoint is configured, making every `useMetrics` call a no-op.
+ */
+export const MetricsRuntime = endpoint
+  ? ManagedRuntime.make(
+      OtlpMetrics.layer({
+        url: endpoint,
+        resource: { serviceName: SERVICE_NAME, serviceVersion: SERVICE_VERSION },
+        headers,
+      }).pipe(
+        Layer.provide(OtlpSerialization.layerJson),
+        Layer.provide(FetchHttpClient.layer),
+      ),
+    )
+  : null;
+
+/**
+ * Idempotent startup hook. Call once from the daemon's main() to force
+ * the module-scope runtime to boot (which starts the exporter's push
+ * timer). No-op when OTLP is not configured.
+ */
+export const startMetricsExport = (): Effect.Effect<void> =>
+  MetricsRuntime
+    ? Effect.promise(() => MetricsRuntime!.runPromise(Effect.void))
+    : Effect.void;

--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,7 @@
       "version": "1.4.4",
       "dependencies": {
         "@effect-atom/atom-react": "^0.5.0",
+        "@effect/opentelemetry": "^0.63.0",
         "@effect/platform": "catalog:",
         "@effect/platform-node": "catalog:",
         "@executor/api": "workspace:*",

--- a/packages/core/api/src/api.ts
+++ b/packages/core/api/src/api.ts
@@ -6,6 +6,7 @@ import { SourcesApi } from "./sources/api";
 import { SecretsApi } from "./secrets/api";
 import { ConnectionsApi } from "./connections/api";
 import { ExecutionsApi } from "./executions/api";
+import { MetricsApi } from "./metrics/api";
 import { ScopeApi } from "./scope/api";
 
 export const CoreExecutorApi = HttpApi.make("executor")
@@ -14,6 +15,7 @@ export const CoreExecutorApi = HttpApi.make("executor")
   .add(SecretsApi)
   .add(ConnectionsApi)
   .add(ExecutionsApi)
+  .add(MetricsApi)
   .add(ScopeApi)
   .annotateContext(
     OpenApi.annotations({

--- a/packages/core/api/src/handlers/index.ts
+++ b/packages/core/api/src/handlers/index.ts
@@ -6,6 +6,7 @@ import { SecretsHandlers } from "./secrets";
 import { ConnectionsHandlers } from "./connections";
 import { ScopeHandlers } from "./scope";
 import { ExecutionsHandlers } from "./executions";
+import { MetricsHandlers } from "./metrics";
 
 export { ToolsHandlers } from "./tools";
 export { SourcesHandlers } from "./sources";
@@ -13,6 +14,7 @@ export { SecretsHandlers } from "./secrets";
 export { ConnectionsHandlers } from "./connections";
 export { ScopeHandlers } from "./scope";
 export { ExecutionsHandlers } from "./executions";
+export { MetricsHandlers } from "./metrics";
 
 export const CoreHandlers = Layer.mergeAll(
   ToolsHandlers,
@@ -21,4 +23,5 @@ export const CoreHandlers = Layer.mergeAll(
   ConnectionsHandlers,
   ScopeHandlers,
   ExecutionsHandlers,
+  MetricsHandlers,
 );

--- a/packages/core/api/src/handlers/metrics.ts
+++ b/packages/core/api/src/handlers/metrics.ts
@@ -1,0 +1,12 @@
+import { HttpApiBuilder } from "@effect/platform";
+import { Effect } from "effect";
+
+import { ExecutorApi } from "../api";
+import { renderPrometheus } from "../metrics/prometheus";
+
+// `renderPrometheus` reads the process-wide Effect metric registry via
+// `Metric.unsafeSnapshot()`. Synchronous, side-effect-free, no executor
+// services required — handler is minimal.
+export const MetricsHandlers = HttpApiBuilder.group(ExecutorApi, "metrics", (handlers) =>
+  handlers.handle("scrape", () => Effect.sync(() => renderPrometheus())),
+);

--- a/packages/core/api/src/index.ts
+++ b/packages/core/api/src/index.ts
@@ -4,6 +4,7 @@ export { SourcesApi } from "./sources/api";
 export { SecretsApi } from "./secrets/api";
 export { ConnectionsApi } from "./connections/api";
 export { ExecutionsApi } from "./executions/api";
+export { MetricsApi } from "./metrics/api";
 export { ScopeApi } from "./scope/api";
 export {
   InternalError,

--- a/packages/core/api/src/metrics/api.ts
+++ b/packages/core/api/src/metrics/api.ts
@@ -1,0 +1,22 @@
+import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
+
+import { InternalError } from "../observability";
+
+// ---------------------------------------------------------------------------
+// Prometheus text exposition on `GET /api/metrics`.
+//
+// Returns the current in-process `Effect.Metric` snapshot in the spec
+// format: https://prometheus.io/docs/instrumenting/exposition_formats/.
+//
+// Mount notes for hosts:
+// - Self-hosted local daemon: mount unconditionally (operator can scrape).
+// - Cloud: mount under the protected API so each org only sees their own
+//   metrics. The core API group doesn't carry auth middleware itself;
+//   the host app composes that above.
+// ---------------------------------------------------------------------------
+
+const PrometheusResponse = HttpApiSchema.Text({ contentType: "text/plain" });
+
+export class MetricsApi extends HttpApiGroup.make("metrics")
+  .add(HttpApiEndpoint.get("scrape")`/metrics`.addSuccess(PrometheusResponse))
+  .addError(InternalError) {}

--- a/packages/core/api/src/metrics/prometheus.test.ts
+++ b/packages/core/api/src/metrics/prometheus.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Metric, MetricBoundaries } from "effect";
+
+import { renderPrometheus } from "./prometheus";
+
+// ---------------------------------------------------------------------------
+// Integration-style tests against Effect's live `Metric.unsafeSnapshot()`
+// registry. Each test stamps a metric with a unique name so assertions
+// don't collide with values accumulated in prior tests — the registry
+// is process-wide and not reset between tests.
+// ---------------------------------------------------------------------------
+
+const uniqueName = (prefix: string) =>
+  `${prefix}_${Math.random().toString(36).slice(2, 10)}`;
+
+describe("renderPrometheus", () => {
+  it.effect("emits counter HELP + TYPE + sanitized name", () =>
+    Effect.gen(function* () {
+      const name = uniqueName("pr_counter.ticks");
+      const counter = Metric.counter(name, { description: "example counter" });
+      yield* Metric.update(counter, 7);
+
+      const output = renderPrometheus();
+      const sanitized = name.replace(/\./g, "_");
+      expect(output).toMatch(new RegExp(`# HELP ${sanitized} example counter`));
+      expect(output).toMatch(new RegExp(`# TYPE ${sanitized} counter`));
+      expect(output).toMatch(new RegExp(`^${sanitized} 7$`, "m"));
+    }),
+  );
+
+  it.effect("emits histogram bucket lines + +Inf + count + sum", () =>
+    Effect.gen(function* () {
+      const name = uniqueName("pr_hist.ms");
+      const histogram = Metric.histogram(
+        name,
+        MetricBoundaries.linear({ start: 0, width: 10, count: 3 }),
+      );
+      yield* Metric.update(histogram, 5);
+      yield* Metric.update(histogram, 15);
+
+      const output = renderPrometheus();
+      const sanitized = name.replace(/\./g, "_");
+      expect(output).toMatch(new RegExp(`# TYPE ${sanitized} histogram`));
+      expect(output).toMatch(
+        new RegExp(`^${sanitized}_bucket{le="\\+Inf"} 2$`, "m"),
+      );
+      expect(output).toMatch(new RegExp(`^${sanitized}_count 2$`, "m"));
+      expect(output).toMatch(new RegExp(`^${sanitized}_sum 20$`, "m"));
+    }),
+  );
+
+  it.effect("escapes label values with quotes + backslashes", () =>
+    Effect.gen(function* () {
+      const name = uniqueName("pr_labeled");
+      const counter = Metric.counter(name).pipe(
+        Metric.tagged("path", `github.io/search"broken\\"`),
+      );
+      yield* Metric.update(counter, 1);
+
+      const output = renderPrometheus();
+      const sanitized = name.replace(/\./g, "_");
+      // Label values preserve all characters except `\` → `\\`, `"` → `\"`,
+      // `\n` → `\n` (literal). Dots stay; only names are sanitized.
+      expect(output).toContain(`${sanitized}{path="github.io/search\\"broken\\\\\\""} 1`);
+    }),
+  );
+
+  it("emits a single trailing newline for empty snapshots when nothing ever registered", () => {
+    // Can't actually test the empty path in a shared process (other tests
+    // register metrics), so just assert the output always ends in \n.
+    const output = renderPrometheus();
+    expect(output.endsWith("\n")).toBe(true);
+  });
+});

--- a/packages/core/api/src/metrics/prometheus.ts
+++ b/packages/core/api/src/metrics/prometheus.ts
@@ -1,0 +1,186 @@
+// ---------------------------------------------------------------------------
+// Serialize Effect's in-process `Metric.unsafeSnapshot()` into Prometheus
+// text exposition format (spec:
+// https://prometheus.io/docs/instrumenting/exposition_formats/).
+//
+// Powers `GET /api/metrics`. No external deps; the format is small enough
+// to hand-roll, and keeping this in-house avoids pulling in a Prometheus
+// client library for a feature that's secondary to the OTLP push path.
+// ---------------------------------------------------------------------------
+
+import * as Metric from "effect/Metric";
+import type * as MetricKey from "effect/MetricKey";
+import * as MetricState from "effect/MetricState";
+import * as Option from "effect/Option";
+
+/**
+ * Prometheus forbids `.` / `-` / other punctuation in metric names.
+ * Converts `executor.execution.duration_ms` → `executor_execution_duration_ms`.
+ */
+const sanitizeName = (raw: string): string =>
+  raw.replace(/[^a-zA-Z0-9_:]/g, "_");
+
+/**
+ * Prometheus label value escaping: backslash, double-quote, newline.
+ */
+const escapeLabelValue = (raw: string): string =>
+  raw.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/"/g, '\\"');
+
+const formatLabels = (
+  tags: ReadonlyArray<{ readonly key: string; readonly value: string }>,
+  extra?: Record<string, string>,
+): string => {
+  const pairs: string[] = [];
+  for (const tag of tags) {
+    pairs.push(`${sanitizeName(tag.key)}="${escapeLabelValue(tag.value)}"`);
+  }
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) {
+      pairs.push(`${sanitizeName(k)}="${escapeLabelValue(v)}"`);
+    }
+  }
+  return pairs.length === 0 ? "" : `{${pairs.join(",")}}`;
+};
+
+/**
+ * Format a number in Prometheus-friendly form. `Infinity` becomes `+Inf` /
+ * `-Inf`; `NaN` stays as `NaN`. Bigints flattened to numbers.
+ */
+const formatValue = (value: number | bigint): string => {
+  if (typeof value === "bigint") return value.toString(10);
+  if (value === Number.POSITIVE_INFINITY) return "+Inf";
+  if (value === Number.NEGATIVE_INFINITY) return "-Inf";
+  return String(value);
+};
+
+type PrometheusLine = string;
+
+/**
+ * Emit the `# HELP` + `# TYPE` header block for a given metric family,
+ * deduplicated by name (every data point of the same family shares one
+ * header, per Prometheus spec).
+ */
+const emitHeader = (
+  name: string,
+  type: "counter" | "gauge" | "histogram" | "summary",
+  description: string,
+  seen: Set<string>,
+): PrometheusLine[] => {
+  if (seen.has(name)) return [];
+  seen.add(name);
+  const safeDescription = description
+    .replace(/\\/g, "\\\\")
+    .replace(/\n/g, "\\n");
+  return [
+    `# HELP ${name} ${safeDescription || "(no description)"}`,
+    `# TYPE ${name} ${type}`,
+  ];
+};
+
+/**
+ * Serialize a single `MetricPair` (key + state) to zero or more
+ * Prometheus exposition lines. Behavior by state type:
+ *
+ * - `Counter` → single `<name>{tags} <value>` line.
+ * - `Gauge` → single line, TYPE=gauge.
+ * - `Histogram` → one `<name>_bucket{le="X"}` line per bucket (cumulative,
+ *   Prometheus-style), plus `<name>_bucket{le="+Inf"}`, `<name>_count`,
+ *   `<name>_sum`.
+ * - `Frequency` → one counter row per occurrence key, with a synthetic
+ *   `bucket` tag carrying the key.
+ * - `Summary` → `<name>{quantile="X"}` for each quantile, plus
+ *   `<name>_count` and `<name>_sum`.
+ */
+type SnapshotPair = {
+  readonly metricKey: MetricKey.MetricKey.Untyped;
+  readonly metricState: MetricState.MetricState.Untyped;
+};
+
+const formatPair = (pair: SnapshotPair, seen: Set<string>): PrometheusLine[] => {
+  const rawName = pair.metricKey.name;
+  const name = sanitizeName(rawName);
+  const description = Option.getOrElse(pair.metricKey.description, () => "");
+  const tags = pair.metricKey.tags;
+  const state = pair.metricState;
+  const lines: PrometheusLine[] = [];
+
+  if (MetricState.isCounterState(state)) {
+    lines.push(...emitHeader(name, "counter", description, seen));
+    lines.push(`${name}${formatLabels(tags)} ${formatValue(state.count)}`);
+    return lines;
+  }
+
+  if (MetricState.isGaugeState(state)) {
+    lines.push(...emitHeader(name, "gauge", description, seen));
+    lines.push(`${name}${formatLabels(tags)} ${formatValue(state.value)}`);
+    return lines;
+  }
+
+  if (MetricState.isHistogramState(state)) {
+    lines.push(...emitHeader(name, "histogram", description, seen));
+    // Effect's buckets are `[upperBound, cumulativeCount]`. Prometheus
+    // expects cumulative counts already; emit as-is.
+    for (const [upperBound, count] of state.buckets) {
+      lines.push(
+        `${name}_bucket${formatLabels(tags, { le: formatValue(upperBound) })} ${count}`,
+      );
+    }
+    // +Inf bucket required by the spec; equal to total count.
+    lines.push(
+      `${name}_bucket${formatLabels(tags, { le: "+Inf" })} ${state.count}`,
+    );
+    lines.push(`${name}_count${formatLabels(tags)} ${state.count}`);
+    lines.push(`${name}_sum${formatLabels(tags)} ${formatValue(state.sum)}`);
+    return lines;
+  }
+
+  if (MetricState.isSummaryState(state)) {
+    lines.push(...emitHeader(name, "summary", description, seen));
+    for (const [quantile, value] of state.quantiles) {
+      const numeric = Option.getOrElse(value, () => Number.NaN);
+      lines.push(
+        `${name}${formatLabels(tags, { quantile: formatValue(quantile) })} ${formatValue(numeric)}`,
+      );
+    }
+    lines.push(`${name}_count${formatLabels(tags)} ${state.count}`);
+    lines.push(`${name}_sum${formatLabels(tags)} ${formatValue(state.sum)}`);
+    return lines;
+  }
+
+  if (MetricState.isFrequencyState(state)) {
+    // Frequency isn't a first-class Prometheus type — represent it as a
+    // counter family with a synthetic `bucket` label so each occurrence
+    // becomes a distinct time series.
+    lines.push(...emitHeader(name, "counter", description, seen));
+    for (const [bucket, count] of state.occurrences) {
+      lines.push(
+        `${name}${formatLabels(tags, { bucket })} ${count}`,
+      );
+    }
+    return lines;
+  }
+
+  // Unknown metric type — skip silently. Shouldn't happen with current
+  // Effect versions but future additions (e.g. exponential histograms)
+  // would land here.
+  return lines;
+};
+
+/**
+ * Render the current Effect metric snapshot as Prometheus exposition text.
+ * The snapshot is read via `Metric.unsafeSnapshot()` — synchronous, lives
+ * in the process-wide registry.
+ */
+export const renderPrometheus = (): string => {
+  const pairs = Metric.unsafeSnapshot();
+  const seen = new Set<string>();
+  const lines: PrometheusLine[] = [];
+
+  for (const pair of pairs) {
+    lines.push(...formatPair(pair, seen));
+  }
+
+  // Prometheus requires a trailing newline; most scrapers are tolerant
+  // but the spec is specific about it.
+  return lines.length === 0 ? "\n" : lines.join("\n") + "\n";
+};

--- a/packages/core/api/src/server.ts
+++ b/packages/core/api/src/server.ts
@@ -6,4 +6,5 @@ export {
   SecretsHandlers,
   ScopeHandlers,
   ExecutionsHandlers,
+  MetricsHandlers,
 } from "./handlers";


### PR DESCRIPTION
## Stack

Independent of the execution-history stack. Can land in any order.

---

## Summary

Two complementary ways to get Effect's in-process metrics out — one always-on (pull), one opt-in (push). Addresses the \"metrics collected but never exported\" gap. Ships with zero new external dependencies — reuses \`@effect/opentelemetry\` which is already in the workspace.

## What ships

### Pull: \`GET /api/metrics\` in \`@executor/api\`

- New \`MetricsApi\` group + handler.
- Returns Prometheus text exposition format built from \`Metric.unsafeSnapshot()\` — hand-rolled serializer in \`packages/core/api/src/metrics/prometheus.ts\` (~170 lines, no new deps). Handles counters, gauges, histograms (cumulative bucket form + \`+Inf\` + \`_count\` + \`_sum\`), summaries, and frequencies.
- Registered in \`CoreExecutorApi\` + \`CoreHandlers\`, so both apps expose it. **Local** mounts unconditionally (self-host scrape); **cloud** inherits \`OrgAuth\` so each org only sees their own metrics.

### Push: OTLP metrics layer in \`apps/local\` only

- \`apps/local/src/server/telemetry.ts\` wires \`@effect/opentelemetry/OtlpMetrics.layer\` behind the OTel-standard \`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT\` env var. Absent = no push, no cost.
- Auth via \`OTEL_EXPORTER_OTLP_METRICS_HEADERS\` (comma-separated \`key=value\` pairs). For Axiom: \`Authorization=Bearer xxx,X-Axiom-Dataset=executor-local\`.
- Installs in a **module-scope** \`ManagedRuntime\` so the exporter's \`exportInterval\` timer keeps ticking across requests. Per-request scoping would shut down the exporter before the first batch leaves — same constraint the existing cloud DO tracer install documents.

### Cloud push path: deliberately not included

Cloud already has tracing via \`@microlabs/otel-cf-workers\`. Metrics push adds Axiom ingestion cost + cardinality risk that nobody's asked for. The pull endpoint (auth-gated) is there for ops who want to scrape; OTLP push is a follow-up if concretely needed.

## Cardinality policy

Full \`mcp.tool.name\` dimensions kept (namespace + operation, e.g. \`github.repos.get\`). The primary consumer is self-host / local where cardinality is bounded by the operator's own plugin set. Any cloud-side cap is a follow-up.

## Dependency alignment

- \`@effect/opentelemetry@^0.63.0\` added to \`apps/local\`'s \`package.json\` (already in the workspace via \`apps/cloud\` at the same version — no new package fetched, bun.lock entry reuses existing resolution).
- No removals from main's dep graph.
- No changes to \`apps/cloud\` \`package.json\` or telemetry wiring.

## Why Prometheus format for the pull endpoint

- **Local self-host UX**: operator can scrape with a local Prometheus, a \`curl\` one-liner, or eventually a daemon UI panel that renders the text directly. No external collector needed.
- **Format simplicity**: 80 lines serializer, no dep pulled in for what's essentially \`name + labels + value + newline\`.
- **Compatibility**: every observability tool speaks Prometheus scrape. Grafana Agent, Alloy, OpenTelemetry Collector, VictoriaMetrics, Datadog Agent — all of them can scrape and forward.

## Test plan

- [x] \`bun x vitest run\` in \`@executor/api\` — 8/8 passing (4 new Prometheus serializer tests + 4 existing observability tests).
- [x] \`bun x vitest run\` in \`@executor/sdk\` — 90/90.
- [x] \`bun x vitest run\` in \`@executor/hosts/mcp\` — 23/23.
- [x] \`bun x tsc --noEmit\` in \`@executor/api\`, \`apps/local\`, \`apps/cloud\` — all clean.
- [ ] Dev-server smoke (reviewer): start the daemon, \`curl http://localhost:4788/api/metrics\`, verify Prometheus-format output. Optionally set the push env vars, trigger executions, verify metrics land in the backend.

## Follow-ups (out of scope)

- Axiom / Grafana / Prometheus dashboards.
- Cardinality guardrails if cloud OTLP push is ever added.
- Small daemon UI panel that renders the metrics snapshot inline.