### PR TITLE
[codex] fix MCP stdio startup stdout

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -566,9 +566,32 @@ const runDaemonSession = (input: {
 // Stdio MCP session
 // ---------------------------------------------------------------------------
 
+const withStdoutReroutedToStderr = async <A>(body: () => Promise<A>): Promise<A> => {
+  const originalWrite = process.stdout.write;
+  const originalLog = console.log;
+  const originalInfo = console.info;
+  const originalDebug = console.debug;
+  const stderrWrite = process.stderr.write.bind(process.stderr);
+
+  process.stdout.write = ((...args: Parameters<typeof process.stdout.write>) =>
+    stderrWrite(...args)) as typeof process.stdout.write;
+  console.log = console.error.bind(console);
+  console.info = console.error.bind(console);
+  console.debug = console.error.bind(console);
+
+  try {
+    return await body();
+  } finally {
+    process.stdout.write = originalWrite;
+    console.log = originalLog;
+    console.info = originalInfo;
+    console.debug = originalDebug;
+  }
+};
+
 const runStdioMcpSession = () =>
   Effect.gen(function* () {
-    const executor = yield* Effect.promise(() => getExecutor());
+    const executor = yield* Effect.promise(() => withStdoutReroutedToStderr(() => getExecutor()));
     yield* Effect.promise(() =>
       runMcpStdioServer({ executor, codeExecutor: makeQuickJsExecutor() }),
     );


### PR DESCRIPTION
## What changed

- Routes stdout-style startup logs to stderr while `executor mcp` initializes the local executor.
- Restores stdout before connecting the stdio MCP transport, keeping JSON-RPC output clean for clients.

## Why

Codex failed to connect to the local stdio MCP server because startup logs were emitted on stdout before the MCP protocol began. Codex then tried to parse that log text as JSON-RPC and reported:

```text
serde error expected value at line 1 column 2
```

## Validation

- `bunx vitest run --config vitest.config.ts src/stdio-integration.test.ts` from `packages/hosts/mcp`
- `bun run --cwd apps/cli typecheck`
- Reproduced the Codex CLI connection path before and after the fix; after the fix Codex recognized the server as `executor` and started the `execute` MCP tool call.
