### PR TITLE
[codex] fix patch release data upgrades

### DIFF
--- a/.changeset/data-upgrade-paths.md
+++ b/.changeset/data-upgrade-paths.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Fix local data upgrade paths for legacy OAuth connection backfills and OpenAPI inline credential rewrites.

--- a/.skills/cli-release/SKILL.md
+++ b/.skills/cli-release/SKILL.md
@@ -26,7 +26,9 @@ Does **not** ship in the CLI:
 
 - Prior convention in this repo uses **`patch`** bumps for feature-heavy releases (see `.changeset/executor-1.4.6-beta.md` for precedent). Don't push back on patch unless there are genuine SemVer-breaking API changes to a library consumer surface.
 - Breaking CLI UX changes (removed flags, changed argv shape) have historically still been `patch` bumps. Follow the owner's call — ask, don't assume `minor`.
-- Only `apps/cli/package.json` version should move during Version Packages PRs. `@executor-js/*` library packages have their own publish path.
+- Normal release/patch PRs must add a `.changeset/*.md` file with frontmatter like `"executor": patch`. Do **not** directly bump `apps/cli/package.json` or `bun.lock` in a feature/fix PR.
+- Only the Changesets-generated `Version Packages` PR should move `apps/cli/package.json`. If a normal PR directly changes that version, merging it to `main` can make `.github/workflows/release.yml` tag the commit and dispatch `publish-executor-package.yml`, causing an immediate CLI publish.
+- `@executor-js/*` library packages have their own publish path.
 
 ## Release notes: curated, not auto-generated
 

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -50,6 +50,8 @@ Tool dispatch, plugins, storage, schema, and transport are now fully instrumente
 - Per-scope blob and secret lookups now use a single `IN` query instead of N per-scope round-trips.
 
 ## Fixes
+- Upgrade: preserve legacy OAuth connection backfills after the `connection.kind` column is removed.
+- OpenAPI: refreshing or editing sources with legacy inline secret/OAuth config now materializes the new source binding rows instead of dropping credentials.
 - Keychain: skip provider registration when the OS backend is unreachable (no more startup failure when running headless on Linux without a keyring).
 - Local server: return 404 for missing static assets instead of serving HTML.
 - Tests: Windows compatibility across the suite.

--- a/apps/local/src/server/migrate-connections.test.ts
+++ b/apps/local/src/server/migrate-connections.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { Database } from "bun:sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { migrateLegacyConnections } from "./migrate-connections";
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "executor-migrate-connections-"));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+const columnNames = (db: Database, table: string): ReadonlyArray<string> =>
+  (
+    db.prepare(`PRAGMA table_info('${table}')`).all() as ReadonlyArray<{
+      readonly name: string;
+    }>
+  ).map((column) => column.name);
+
+describe("migrateLegacyConnections", () => {
+  it("backfills legacy MCP OAuth rows after connection.kind has been dropped", async () => {
+    const db = new Database(join(workDir, "data.db"));
+    migrate(drizzle(db), {
+      migrationsFolder: join(import.meta.dirname, "../../drizzle"),
+    });
+
+    expect(columnNames(db, "connection")).not.toContain("kind");
+
+    const now = Date.now();
+    db.prepare(
+      "INSERT INTO secret (scope_id, id, name, provider, created_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("scope-1", "access-token", "Access token", "keychain", now);
+    db.prepare(
+      "INSERT INTO secret (scope_id, id, name, provider, created_at) VALUES (?, ?, ?, ?, ?)",
+    ).run("scope-1", "refresh-token", "Refresh token", "keychain", now);
+    db.prepare(
+      "INSERT INTO mcp_source (scope_id, id, name, config, created_at) VALUES (?, ?, ?, ?, ?)",
+    ).run(
+      "scope-1",
+      "remote-mcp",
+      "Remote MCP",
+      JSON.stringify({
+        transport: "remote",
+        endpoint: "https://example.com/mcp",
+        auth: {
+          kind: "oauth2",
+          accessTokenSecretId: "access-token",
+          refreshTokenSecretId: "refresh-token",
+          tokenType: "Bearer",
+          expiresAt: null,
+          scope: "read",
+          clientInformation: null,
+          authorizationServerUrl: null,
+          resourceMetadataUrl: null,
+        },
+      }),
+      now,
+    );
+
+    await migrateLegacyConnections(db);
+
+    const connection = db
+      .prepare(
+        "SELECT id, provider, access_token_secret_id, refresh_token_secret_id FROM connection WHERE scope_id = ?",
+      )
+      .get("scope-1") as
+      | {
+          readonly id: string;
+          readonly provider: string;
+          readonly access_token_secret_id: string;
+          readonly refresh_token_secret_id: string | null;
+        }
+      | undefined;
+    expect(connection).toEqual({
+      id: "mcp-oauth2-remote-mcp",
+      provider: "mcp:oauth2",
+      access_token_secret_id: "access-token",
+      refresh_token_secret_id: "refresh-token",
+    });
+
+    const source = db
+      .prepare("SELECT config FROM mcp_source WHERE scope_id = ? AND id = ?")
+      .get("scope-1", "remote-mcp") as { readonly config: string };
+    expect(JSON.parse(source.config).auth).toEqual({
+      kind: "oauth2",
+      connectionId: "mcp-oauth2-remote-mcp",
+    });
+
+    const ownedSecrets = db
+      .prepare(
+        "SELECT id, owned_by_connection_id FROM secret WHERE scope_id = ? ORDER BY id",
+      )
+      .all("scope-1");
+    expect(ownedSecrets).toEqual([
+      {
+        id: "access-token",
+        owned_by_connection_id: "mcp-oauth2-remote-mcp",
+      },
+      {
+        id: "refresh-token",
+        owned_by_connection_id: "mcp-oauth2-remote-mcp",
+      },
+    ]);
+
+    db.close();
+  });
+});

--- a/apps/local/src/server/migrate-connections.ts
+++ b/apps/local/src/server/migrate-connections.ts
@@ -53,6 +53,13 @@ const tableExists = (sqlite: Database, name: string): boolean => {
   return row !== null && row !== undefined;
 };
 
+const columnExists = (sqlite: Database, table: string, column: string): boolean => {
+  const columns = sqlite
+    .prepare(`PRAGMA table_info('${table.replaceAll("'", "''")}')`)
+    .all() as ReadonlyArray<{ readonly name: string }>;
+  return columns.some((c) => c.name === column);
+};
+
 type SecretRow = { id: string; owned_by_connection_id: string | null };
 
 /** Shared: re-parent the pointed-to secret ids to the new connection,
@@ -133,20 +140,30 @@ const insertConnectionRow = (
     providerState: unknown;
   },
 ): void => {
-  const stmt = sqlite.prepare(
-    `INSERT INTO connection (
-       id, scope_id, provider, kind, identity_label,
-       access_token_secret_id, refresh_token_secret_id,
-       expires_at, scope, provider_state,
-       created_at, updated_at
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-  );
+  const hasKind = columnExists(sqlite, "connection", "kind");
+  const stmt = hasKind
+    ? sqlite.prepare(
+        `INSERT INTO connection (
+           id, scope_id, provider, kind, identity_label,
+           access_token_secret_id, refresh_token_secret_id,
+           expires_at, scope, provider_state,
+           created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+    : sqlite.prepare(
+        `INSERT INTO connection (
+           id, scope_id, provider, identity_label,
+           access_token_secret_id, refresh_token_secret_id,
+           expires_at, scope, provider_state,
+           created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
   const now = Date.now();
-  stmt.run(
+  const values = [
     params.id,
     params.scopeId,
     params.provider,
-    "user",
+    ...(hasKind ? ["user"] : []),
     params.identityLabel,
     params.accessTokenSecretId,
     params.refreshTokenSecretId,
@@ -155,7 +172,8 @@ const insertConnectionRow = (
     JSON.stringify(params.providerState),
     now,
     now,
-  );
+  ];
+  stmt.run(...values);
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -795,8 +795,8 @@ export const openApiPlugin = definePlugin(
           name: existing.name,
           baseUrl: resolvedConfig.baseUrl,
           namespace: existing.namespace,
-          headers: existing.config.headers,
-          oauth2: existing.config.oauth2,
+          headers: existing.legacy?.headers ?? existing.config.headers,
+          oauth2: existing.legacy?.oauth2 ?? existing.config.oauth2,
         });
       });
 
@@ -872,9 +872,17 @@ export const openApiPlugin = definePlugin(
               const existing = yield* ctx.storage.getSource(namespace, scope);
               if (!existing) return;
               const canonicalHeaders =
-                input.headers !== undefined ? canonicalizeHeaders(input.headers) : null;
+                input.headers !== undefined
+                  ? canonicalizeHeaders(input.headers)
+                  : existing.legacy?.headers
+                    ? canonicalizeHeaders(existing.legacy.headers)
+                    : null;
               const canonicalOAuth2 =
-                input.oauth2 !== undefined ? canonicalizeOAuth2(input.oauth2) : null;
+                input.oauth2 !== undefined
+                  ? canonicalizeOAuth2(input.oauth2)
+                  : existing.legacy?.oauth2
+                    ? canonicalizeOAuth2(existing.legacy.oauth2)
+                    : null;
               yield* ctx.storage.updateSourceMeta(namespace, scope, {
                 name: input.name?.trim() || undefined,
                 baseUrl: input.baseUrl,


### PR DESCRIPTION
## Summary

Prepare the next CLI patch release through Changesets with two data-upgrade fixes:

- keep legacy OAuth connection backfills working after the `connection.kind` column is removed
- materialize OpenAPI source binding rows when legacy inline header/OAuth source config is refreshed or edited

## Why

The release adds `openapi_source_binding` and removes the now-unused `connection.kind` column. The old connection backfill still wrote `kind`, and OpenAPI legacy config had read-time fallback but could lose credential bindings during rewrite paths. These fixes keep existing local data upgradeable without forcing users to reconnect or re-enter credentials.

This PR includes a patch changeset for `executor`. It does not directly bump `apps/cli/package.json`; merging should create/update the Changesets version PR, and publishing should happen only after that version PR is merged.

## Validation

- `bunx --bun vitest run src/server/migrate-connections.test.ts`
- `bunx --bun vitest run src/server/db-upgrade.test.ts`
- `bunx --bun vitest run src/sdk/plugin.test.ts`
- `bun run --cwd apps/local typecheck`
- `bun run --filter='@executor/plugin-openapi' typecheck`
- `bun run --cwd apps/cli typecheck`
- `bun run release:check` before switching from direct version bump to changeset