### PR TITLE
fix: keep executor.jsonc in sync with source add/remove

### DIFF
--- a/apps/local/src/server/config-sync.test.ts
+++ b/apps/local/src/server/config-sync.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { translateMcpAuth } from "./config-sync";
+
+describe("translateMcpAuth", () => {
+  it("returns undefined when no auth is configured", () => {
+    expect(translateMcpAuth(undefined)).toBeUndefined();
+  });
+
+  it("preserves the kind=none variant", () => {
+    expect(translateMcpAuth({ kind: "none" })).toEqual({ kind: "none" });
+  });
+
+  it("preserves oauth2 connectionId so the source keeps its OAuth link across boots", () => {
+    expect(translateMcpAuth({ kind: "oauth2", connectionId: "mcp-oauth2-linear" })).toEqual({
+      kind: "oauth2",
+      connectionId: "mcp-oauth2-linear",
+    });
+  });
+
+  it("strips the secret-public-ref prefix from header auth", () => {
+    expect(
+      translateMcpAuth({
+        kind: "header",
+        headerName: "Authorization",
+        secret: "secret-public-ref:my-token",
+        prefix: "Bearer ",
+      }),
+    ).toEqual({
+      kind: "header",
+      headerName: "Authorization",
+      secretId: "my-token",
+      prefix: "Bearer ",
+    });
+  });
+
+  it("passes through a raw secret id when no prefix is present", () => {
+    expect(
+      translateMcpAuth({
+        kind: "header",
+        headerName: "X-Api-Key",
+        secret: "raw-id",
+      }),
+    ).toEqual({
+      kind: "header",
+      headerName: "X-Api-Key",
+      secretId: "raw-id",
+      prefix: undefined,
+    });
+  });
+});

--- a/apps/local/src/server/config-sync.ts
+++ b/apps/local/src/server/config-sync.ts
@@ -10,9 +10,15 @@ import { join } from "node:path";
 import * as fs from "node:fs";
 import * as jsonc from "jsonc-parser";
 
-import type { SourceConfig, ExecutorFileConfig, ConfigHeaderValue } from "@executor-js/config";
+import type {
+  SourceConfig,
+  ExecutorFileConfig,
+  ConfigHeaderValue,
+  McpAuthConfig,
+} from "@executor-js/config";
 import { SECRET_REF_PREFIX } from "@executor-js/config";
 import type { ScopeId } from "@executor-js/sdk";
+import type { McpConnectionAuthInput } from "@executor-js/plugin-mcp";
 
 import type { LocalExecutor } from "./executor";
 
@@ -48,6 +54,28 @@ const translateHeaders = (
     out[k] = translateHeader(v);
   }
   return out;
+};
+
+// MCP auth translation: file format → plugin format. The header variant
+// stores credentials as `secret-public-ref:<id>`; the plugin SDK takes the
+// raw secret id. The oauth2 variant is structurally identical.
+export const translateMcpAuth = (
+  auth: McpAuthConfig | undefined,
+): McpConnectionAuthInput | undefined => {
+  if (!auth) return undefined;
+  if (auth.kind === "none") return { kind: "none" };
+  if (auth.kind === "header") {
+    const secretId = auth.secret.startsWith(SECRET_REF_PREFIX)
+      ? auth.secret.slice(SECRET_REF_PREFIX.length)
+      : auth.secret;
+    return {
+      kind: "header",
+      headerName: auth.headerName,
+      secretId,
+      prefix: auth.prefix,
+    };
+  }
+  return { kind: "oauth2", connectionId: auth.connectionId };
 };
 
 // ---------------------------------------------------------------------------
@@ -128,6 +156,7 @@ const addSourceFromConfig = (
           queryParams: s.queryParams,
           headers: s.headers,
           namespace: s.namespace,
+          auth: translateMcpAuth(s.auth),
         })
         .pipe(Effect.asVoid);
     }),

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -1109,6 +1109,9 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
             yield* ctx.storage.removeSource(sourceId, scope);
           }),
         );
+        if (options?.configFile) {
+          yield* options.configFile.removeSource(sourceId);
+        }
       }),
 
     usagesForSecret: () => Effect.succeed([]),

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1784,6 +1784,9 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             yield* ctx.storage.removeSource(sourceId, scope);
           }),
         );
+        if (options?.configFile) {
+          yield* options.configFile.removeSource(sourceId);
+        }
       }),
 
     usagesForSecret: () => Effect.succeed([]),

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -27,6 +27,7 @@ import {
   type Where,
 } from "@executor-js/sdk";
 import { memorySecretsPlugin } from "@executor-js/sdk/testing";
+import type { ConfigFileSink } from "@executor-js/config";
 
 const TEST_SCOPE = "test-scope";
 import { openApiPlugin } from "./plugin";
@@ -847,6 +848,47 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       const remaining = yield* executor.tools.list();
       const ids = remaining.map((t) => t.id).sort();
       expect(ids).toEqual(["executor.openapi.addSource", "executor.openapi.previewSpec"]);
+    }),
+  );
+
+  it.effect("executor.sources.remove writes back to configFile (engine-level remove)", () =>
+    Effect.gen(function* () {
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+
+      const removeCalls: string[] = [];
+      const upsertCalls: string[] = [];
+      const configFile: ConfigFileSink = {
+        upsertSource: (source) =>
+          Effect.sync(() => {
+            upsertCalls.push(source.namespace ?? "");
+          }),
+        removeSource: (namespace) =>
+          Effect.sync(() => {
+            removeCalls.push(namespace);
+          }),
+      };
+
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [
+            openApiPlugin({ httpClientLayer: clientLayer, configFile }),
+            memorySecretsPlugin(),
+          ] as const,
+        }),
+      );
+
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: TEST_SCOPE,
+        namespace: "removable",
+        baseUrl: "",
+      });
+      expect(upsertCalls).toEqual(["removable"]);
+
+      yield* executor.sources.remove({ id: "removable", targetScope: TEST_SCOPE });
+
+      expect(removeCalls).toEqual(["removable"]);
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -1337,6 +1337,9 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
             yield* ctx.storage.removeSource(sourceId, scope);
           }),
         );
+        if (options?.configFile) {
+          yield* options.configFile.removeSource(sourceId);
+        }
       }),
 
     // OpenAPI credential usages are reported by the core `credential_binding`


### PR DESCRIPTION
## Summary

Two related bugs caused `executor.jsonc` and the runtime DB to drift out of sync, so sources resurrected after a UI delete and OAuth `auth` blocks vanished after a restart. Both are reproducible against `executor@1.4.9`.

- Engine-level `removeSource` hook in the openapi, mcp, and graphql plugins now mirrors the SDK-level `removeSpec` / `removeSource` and writes back to `configFile`.
- `apps/local` config-sync now translates `McpAuthConfig` → `McpConnectionAuth` and forwards it to `executor.mcp.addSource`, so remote MCP `auth` survives boot.

## Why

### Bug 1 — engine-level remove never updates `executor.jsonc`

The SDK methods (`openapi.removeSpec`, `mcp.removeSource`, `graphql.removeSource`) correctly call `ctx.storage.removeSource(...)` *and* `configFile.removeSource(...)`. The plugin lifecycle hook also named `removeSource` — used by the engine's `executor.sources.remove` and therefore by the HTTP `sources.remove` handler and the web UI delete button — only deleted plugin storage rows. The DB was cleaned, but the file wasn't.

On the next boot, `apps/local` boot-sync read `executor.jsonc`, saw the still-present source entry, and re-upserted it into the DB. From the user's perspective, deleted sources resurrected after every restart.

### Bug 2 — boot-sync silently strips MCP `auth`

`apps/local/src/server/config-sync.ts` rebuilt the `executor.mcp.addSource(...)` call for remote MCP sources without passing `source.auth`. `addSource` then wrote back to `executor.jsonc` via `configFile.upsertSource(...)` with `auth: undefined` — so `{ kind: "oauth2", connectionId: ... }` blocks silently disappeared from the file on the very first restart. The next restart saw a source with no auth, hit a 401 on connect, and registered zero tools.

The OAuth connection row and keychain tokens themselves remained intact in the DB; the file just lost the pointer.

## Validation

- [x] `bunx --bun vitest run` in `packages/plugins/openapi` — 64/64 (incl. new regression test asserting `executor.sources.remove` triggers `configFile.removeSource`)
- [x] `bunx --bun vitest run` in `packages/plugins/mcp` — 30/30
- [x] `bunx --bun vitest run` in `packages/plugins/graphql` — 14/14
- [x] `bunx --bun vitest run` in `packages/core/sdk` — 90/90
- [x] `bunx --bun vitest run` in `apps/local` — 23/23 (incl. new `config-sync.test.ts` covering all `McpAuthConfig` variants)
- [x] `bun run typecheck` clean across `apps/local`, `packages/plugins/{openapi,mcp,graphql}`
- [x] End-to-end repro on a local `executor web`:
  - Bug 1: added the GitHub OpenAPI spec via UI, deleted via UI, restarted — `executor.jsonc` correctly omits the source and the DB stays clean (was reappearing pre-fix)
  - Bug 2: configured Linear MCP via UI OAuth, restarted — `auth: { kind: "oauth2", connectionId: ... }` block is preserved in `executor.jsonc` and 33 Linear tools load (was silently 401'ing pre-fix)