### PR TITLE
Share repeated React UI and OAuth helpers

### DIFF
--- a/apps/cloud/src/routes/org.tsx
+++ b/apps/cloud/src/routes/org.tsx
@@ -21,6 +21,7 @@ import {
 import { Button } from "@executor/react/components/button";
 import { Badge } from "@executor/react/components/badge";
 import { CopyButton } from "@executor/react/components/copy-button";
+import { ErrorMessage } from "@executor/react/components/error-message";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import {
@@ -273,11 +274,7 @@ function OrgPage() {
                 ))}
               </div>
             ),
-            onFailure: () => (
-              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-                <p className="text-sm text-destructive">Failed to load domains</p>
-              </div>
-            ),
+            onFailure: () => <ErrorMessage message="Failed to load domains" spacious />,
             onSuccess: ({ value }) => {
               if (value.domains.length === 0) {
                 return (
@@ -326,11 +323,7 @@ function OrgPage() {
               ))}
             </div>
           ),
-          onFailure: () => (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">Failed to load members</p>
-            </div>
-          ),
+          onFailure: () => <ErrorMessage message="Failed to load members" spacious />,
           onSuccess: ({ value }) => {
             const members = value.members;
             const filtered = search
@@ -677,11 +670,7 @@ function InviteDialog(props: {
             </div>
           )}
 
-          {state.status === "error" && state.error && (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-              <p className="text-sm text-destructive">{state.error}</p>
-            </div>
-          )}
+          {state.status === "error" && state.error && <ErrorMessage message={state.error} />}
         </div>
 
         <DialogFooter>

--- a/apps/cloud/src/web/components/create-organization-form.tsx
+++ b/apps/cloud/src/web/components/create-organization-form.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 import { authWriteKeys } from "@executor/react/api/reactivity-keys";
+import { ErrorMessage } from "@executor/react/components/error-message";
 import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 
@@ -82,11 +83,7 @@ export function CreateOrganizationFields(props: {
         />
       </div>
 
-      {props.error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-          <p className="text-sm text-destructive">{props.error}</p>
-        </div>
-      )}
+      {props.error && <ErrorMessage message={props.error} />}
     </div>
   );
 }

--- a/packages/plugins/google-discovery/src/react/GoogleDiscoverySignInButton.tsx
+++ b/packages/plugins/google-discovery/src/react/GoogleDiscoverySignInButton.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet, useAtomValue, Result } from "@effect-atom/atom-react";
 
-import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
+import { oauthPopupFailureHandlers, oauthRedirectUrl, openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
 import { useScope } from "@executor/react/api/scope-context";
 import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
 import { connectionsAtom } from "@executor/react/api/atoms";
@@ -61,10 +61,7 @@ export default function GoogleDiscoverySignInButton(props: { sourceId: string })
     connections !== null &&
     connections.some((c) => c.id === oauth2.connectionId);
 
-  const redirectUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}${CALLBACK_PATH}`
-      : CALLBACK_PATH;
+  const redirectUrl = oauthRedirectUrl(CALLBACK_PATH);
 
   const handleSignIn = useCallback(async () => {
     if (!oauth2 || !source) return;
@@ -118,16 +115,7 @@ export default function GoogleDiscoverySignInButton(props: { sourceId: string })
             );
           }
         },
-        onClosed: () => {
-          cleanupRef.current = null;
-          setBusy(false);
-          setError("Sign-in cancelled — popup was closed before completing the flow.");
-        },
-        onOpenFailed: () => {
-          cleanupRef.current = null;
-          setBusy(false);
-          setError("Sign-in popup was blocked by the browser");
-        },
+        ...oauthPopupFailureHandlers({ cleanupRef, setBusy, setError }),
       });
     } catch (e) {
       setBusy(false);

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -14,6 +14,7 @@ import {
 } from "@executor/react/plugins/source-identity";
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor/react/components/button";
+import { ErrorMessage } from "@executor/react/components/error-message";
 import {
   CardStack,
   CardStackContent,
@@ -137,11 +138,7 @@ export default function AddGraphqlSource(props: {
       </section>
 
       {/* Error */}
-      {addError && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-          <p className="text-[12px] text-destructive">{addError}</p>
-        </div>
-      )}
+      {addError && <ErrorMessage message={addError} small />}
 
       <FloatActions>
         <Button variant="ghost" onClick={props.onCancel} disabled={adding}>

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -24,6 +24,7 @@ import { FieldLabel } from "@executor/react/components/field";
 import { Input } from "@executor/react/components/input";
 import { Badge } from "@executor/react/components/badge";
 import type { StoredGraphqlSource } from "../sdk/store";
+import { ErrorMessage } from "@executor/react/components/error-message";
 
 // UI only needs the fields the API exposes; `scope` on the SDK interface
 // isn't part of the HTTP response.
@@ -131,11 +132,7 @@ function EditForm(props: {
         />
       </section>
 
-      {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-          <p className="text-sm text-destructive">{error}</p>
-        </div>
-      )}
+      {error && <ErrorMessage message={error} />}
 
       <div className="flex items-center justify-between border-t border-border pt-4">
         <Button variant="ghost" onClick={props.onSave}>

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -3,6 +3,7 @@ import { useAtomSet } from "@effect-atom/atom-react";
 
 import { useScope } from "@executor/react/api/scope-context";
 import { Button } from "@executor/react/components/button";
+import { ErrorMessage } from "@executor/react/components/error-message";
 import {
   CardStack,
   CardStackContent,
@@ -964,9 +965,7 @@ export default function AddMcpSource(props: {
           {/* Error (OAuth / add source). Probe errors show inline on the field. */}
           {otherError && (
             <div className="space-y-2">
-              <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-                <p className="text-[12px] text-destructive">{otherError}</p>
-              </div>
+              <ErrorMessage message={otherError} small />
               <Button
                 variant="outline"
                 size="sm"
@@ -1046,11 +1045,7 @@ export default function AddMcpSource(props: {
           />
 
           {/* Stdio error */}
-          {stdioError && (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-              <p className="text-[12px] text-destructive">{stdioError}</p>
-            </div>
-          )}
+          {stdioError && <ErrorMessage message={stdioError} small />}
 
           <FloatActions>
             <Button variant="ghost" onClick={props.onCancel} disabled={stdioAdding}>

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -17,6 +17,7 @@ import { Input } from "@executor/react/components/input";
 import { Label } from "@executor/react/components/label";
 import { Badge } from "@executor/react/components/badge";
 import type { McpStoredSourceSchemaType } from "../sdk/stored-source";
+import { ErrorMessage } from "@executor/react/components/error-message";
 
 // ---------------------------------------------------------------------------
 // Editable header entry
@@ -170,11 +171,7 @@ function RemoteEditForm(props: {
         </Button>
       </section>
 
-      {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-          <p className="text-sm text-destructive">{error}</p>
-        </div>
-      )}
+      {error && <ErrorMessage message={error} />}
 
       <div className="flex items-center justify-between border-t border-border pt-4">
         <Button variant="ghost" onClick={props.onSave}>

--- a/packages/plugins/mcp/src/react/McpSignInButton.tsx
+++ b/packages/plugins/mcp/src/react/McpSignInButton.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet, useAtomValue, Result } from "@effect-atom/atom-react";
 
-import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
+import { oauthPopupFailureHandlers, oauthRedirectUrl, openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
 import { useScope } from "@executor/react/api/scope-context";
 import { sourceWriteKeys } from "@executor/react/api/reactivity-keys";
 import { connectionsAtom } from "@executor/react/api/atoms";
@@ -62,10 +62,7 @@ export default function McpSignInButton(props: { sourceId: string }) {
     connections !== null &&
     connections.some((c) => c.id === oauth2.connectionId);
 
-  const redirectUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}${CALLBACK_PATH}`
-      : CALLBACK_PATH;
+  const redirectUrl = oauthRedirectUrl(CALLBACK_PATH);
 
   const handleSignIn = useCallback(async () => {
     if (!remote || !oauth2 || !source) return;
@@ -112,16 +109,7 @@ export default function McpSignInButton(props: { sourceId: string }) {
             );
           }
         },
-        onClosed: () => {
-          cleanupRef.current = null;
-          setBusy(false);
-          setError("Sign-in cancelled — popup was closed before completing the flow.");
-        },
-        onOpenFailed: () => {
-          cleanupRef.current = null;
-          setBusy(false);
-          setError("Sign-in popup was blocked by the browser");
-        },
+        ...oauthPopupFailureHandlers({ cleanupRef, setBusy, setError }),
       });
     } catch (e) {
       setBusy(false);

--- a/packages/plugins/oauth2/src/react.ts
+++ b/packages/plugins/oauth2/src/react.ts
@@ -18,6 +18,26 @@ export type { OAuthPopupResult } from "./popup-types";
 
 export const isOAuthPopupResult = sharedIsOAuthPopupResult;
 
+export const oauthRedirectUrl = (callbackPath: string): string =>
+  typeof window !== "undefined" ? `${window.location.origin}${callbackPath}` : callbackPath;
+
+export const oauthPopupFailureHandlers = (input: {
+  readonly cleanupRef: { current: (() => void) | null };
+  readonly setBusy: (busy: boolean) => void;
+  readonly setError: (error: string) => void;
+}) => ({
+  onClosed: () => {
+    input.cleanupRef.current = null;
+    input.setBusy(false);
+    input.setError("Sign-in cancelled — popup was closed before completing the flow.");
+  },
+  onOpenFailed: () => {
+    input.cleanupRef.current = null;
+    input.setBusy(false);
+    input.setError("Sign-in popup was blocked by the browser");
+  },
+});
+
 // ---------------------------------------------------------------------------
 // openOAuthPopup
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 import { Option } from "effect";
 
-import { openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
+import { oauthRedirectUrl, openOAuthPopup, type OAuthPopupResult } from "@executor/plugin-oauth2/react";
 import { ConnectionId, ScopeId, SecretId } from "@executor/sdk";
 
 import { useScope, useUserScope } from "@executor/react/api/scope-context";
@@ -39,6 +39,7 @@ import {
 import { useSecretPickerSecrets } from "@executor/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor/react/components/button";
 import { CopyButton } from "@executor/react/components/copy-button";
+import { ErrorMessage } from "@executor/react/components/error-message";
 import {
   CardStack,
   CardStackContent,
@@ -86,6 +87,7 @@ import {
 export const OPENAPI_OAUTH_CHANNEL = "executor:openapi-oauth-result";
 export const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
 export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/openapi/oauth/callback";
+export const openApiOAuthRedirectUrl = (): string => oauthRedirectUrl(OPENAPI_OAUTH_CALLBACK_PATH);
 
 const substituteUrlVariables = (url: string, values: Record<string, string>): string => {
   let out = url;
@@ -304,10 +306,7 @@ export default function AddOpenApiSource(props: {
   }
 
   const oauth2Presets: readonly OAuth2Preset[] = preview?.oauth2Presets ?? [];
-  const oauth2RedirectUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}${OPENAPI_OAUTH_CALLBACK_PATH}`
-      : OPENAPI_OAUTH_CALLBACK_PATH;
+  const oauth2RedirectUrl = openApiOAuthRedirectUrl();
   // Stable source id derivation. Matches the value `handleAdd` sends as
   // `namespace`, and is also the default credential key when the user
   // does not provide a more explicit shared connection id.
@@ -794,11 +793,7 @@ export default function AddOpenApiSource(props: {
         </CardStack>
       ) : null}
 
-      {analyzeError && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-          <p className="text-[12px] text-destructive">{analyzeError}</p>
-        </div>
-      )}
+      {analyzeError && <ErrorMessage message={analyzeError} small />}
 
       {/* ── Everything below appears after analysis ── */}
       {preview && (
@@ -1158,11 +1153,7 @@ export default function AddOpenApiSource(props: {
           </section>
 
           {/* Add error */}
-          {addError && (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-              <p className="text-[12px] text-destructive">{addError}</p>
-            </div>
-          )}
+          {addError && <ErrorMessage message={addError} small />}
         </>
       )}
 

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -38,13 +38,14 @@ import {
   updateOpenApiSource,
 } from "./atoms";
 import {
-  OPENAPI_OAUTH_CALLBACK_PATH,
   OPENAPI_OAUTH_CHANNEL,
   OPENAPI_OAUTH_POPUP_NAME,
+  openApiOAuthRedirectUrl,
   resolveOAuthUrl,
 } from "./AddOpenApiSource";
 import { oauth2ClientSecretSlot } from "../sdk/store";
 import type { OpenApiSourceBindingValue } from "../sdk/types";
+import { ErrorMessage } from "@executor/react/components/error-message";
 
 type SlotDef =
   | {
@@ -158,10 +159,7 @@ export default function EditOpenApiSource(props: {
     Result.isSuccess(bindingsResult) ? bindingsResult.value : [];
   const connections =
     Result.isSuccess(connectionsResult) ? connectionsResult.value : [];
-  const oauth2RedirectUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}${OPENAPI_OAUTH_CALLBACK_PATH}`
-      : OPENAPI_OAUTH_CALLBACK_PATH;
+  const oauth2RedirectUrl = openApiOAuthRedirectUrl();
 
   const [name, setName] = useState(source?.name ?? "");
   const [baseUrl, setBaseUrl] = useState(source?.config.baseUrl ?? "");
@@ -442,10 +440,7 @@ export default function EditOpenApiSource(props: {
         oauth2.authorizationUrl ?? "",
         source.config.baseUrl ?? "",
       );
-      const redirectUrl =
-        typeof window !== "undefined"
-          ? `${window.location.origin}${OPENAPI_OAUTH_CALLBACK_PATH}`
-          : OPENAPI_OAUTH_CALLBACK_PATH;
+      const redirectUrl = openApiOAuthRedirectUrl();
       const response = await doStartOAuth({
         path: { scopeId: displayScope },
         payload: {
@@ -746,11 +741,7 @@ export default function EditOpenApiSource(props: {
         </CardStackContent>
       </CardStack>
 
-      {error && (
-        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-          <p className="text-sm text-destructive">{error}</p>
-        </div>
-      )}
+      {error && <ErrorMessage message={error} />}
 
       <div className="flex items-center justify-start border-t border-border pt-4">
         <Button variant="ghost" onClick={props.onSave}>

--- a/packages/react/src/components/code-block.tsx
+++ b/packages/react/src/components/code-block.tsx
@@ -11,6 +11,7 @@ import {
 } from "../lib/shiki";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
+import { CheckIcon, CopyIcon } from "./copy-icons";
 
 // ---------------------------------------------------------------------------
 // Language detection
@@ -24,39 +25,6 @@ function detectLanguage(code: string, hint?: string): string {
   if (trimmed.startsWith("---")) return "yaml";
   return "json";
 }
-
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-const CopyIcon = () => (
-  <svg viewBox="0 0 16 16" className="size-3">
-    <rect
-      x="5"
-      y="5"
-      width="8"
-      height="8"
-      rx="1"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.2"
-    />
-    <path d="M3 11V3h8" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-  </svg>
-);
-
-const CheckIcon = () => (
-  <svg viewBox="0 0 16 16" className="size-3">
-    <path
-      d="M3 8l3 3 7-7"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.4"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
 
 // ---------------------------------------------------------------------------
 // Highlight hook

--- a/packages/react/src/components/copy-icons.tsx
+++ b/packages/react/src/components/copy-icons.tsx
@@ -1,0 +1,12 @@
+export const CopyIcon = () => (
+  <svg viewBox="0 0 16 16" className="size-3">
+    <rect x="5" y="5" width="8" height="8" rx="1" fill="none" stroke="currentColor" strokeWidth="1.2" />
+    <path d="M3 11V3h8" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+  </svg>
+);
+
+export const CheckIcon = () => (
+  <svg viewBox="0 0 16 16" className="size-3">
+    <path d="M3 8l3 3 7-7" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);

--- a/packages/react/src/components/entry-actions-menu.tsx
+++ b/packages/react/src/components/entry-actions-menu.tsx
@@ -1,0 +1,35 @@
+import { Button } from "./button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
+
+export function KebabRemoveMenu(props: { label: string; onRemove: () => void }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-7 opacity-0 transition-opacity group-hover/card-stack-entry:opacity-100 group-focus-within/card-stack-entry:opacity-100 data-[state=open]:opacity-100"
+        >
+          <svg viewBox="0 0 16 16" className="size-3">
+            <circle cx="8" cy="3" r="1.2" fill="currentColor" />
+            <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+            <circle cx="8" cy="13" r="1.2" fill="currentColor" />
+          </svg>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuItem
+          className="text-destructive focus:text-destructive text-sm"
+          onClick={props.onRemove}
+        >
+          {props.label}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/react/src/components/error-message.tsx
+++ b/packages/react/src/components/error-message.tsx
@@ -1,0 +1,7 @@
+export function ErrorMessage(props: { message: string; small?: boolean; spacious?: boolean }) {
+  return (
+    <div className={`rounded-lg border border-destructive/30 bg-destructive/5 ${props.spacious ? "px-4 py-3" : "px-3 py-2"}`}>
+      <p className={`${props.small ? "text-[12px]" : "text-sm"} text-destructive`}>{props.message}</p>
+    </div>
+  );
+}

--- a/packages/react/src/components/expandable-code-block.tsx
+++ b/packages/react/src/components/expandable-code-block.tsx
@@ -7,6 +7,7 @@ import {
 } from "../lib/shiki";
 import { cn } from "../lib/utils";
 import { Button } from "./button";
+import { CheckIcon, CopyIcon } from "./copy-icons";
 import type { ThemedToken } from "shiki/core";
 
 // ---------------------------------------------------------------------------
@@ -65,39 +66,6 @@ const formatTypeScript = (code: string): string => {
 
   return result;
 };
-
-// ---------------------------------------------------------------------------
-// Copy icons
-// ---------------------------------------------------------------------------
-
-const CopyIcon = () => (
-  <svg viewBox="0 0 16 16" className="size-3">
-    <rect
-      x="5"
-      y="5"
-      width="8"
-      height="8"
-      rx="1"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.2"
-    />
-    <path d="M3 11V3h8" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
-  </svg>
-);
-
-const CheckIcon = () => (
-  <svg viewBox="0 0 16 16" className="size-3">
-    <path
-      d="M3 8l3 3 7-7"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.4"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
 
 // ---------------------------------------------------------------------------
 // Shiki tokenization hook — non-blocking

--- a/packages/react/src/pages/connections.tsx
+++ b/packages/react/src/pages/connections.tsx
@@ -9,7 +9,8 @@ import {
 import { connectionWriteKeys } from "../api/reactivity-keys";
 import { useScope, useScopeStack } from "../hooks/use-scope";
 import { Badge } from "../components/badge";
-import { Button } from "../components/button";
+import { ErrorMessage } from "../components/error-message";
+import { KebabRemoveMenu } from "../components/entry-actions-menu";
 import {
   CardStack,
   CardStackContent,
@@ -20,13 +21,6 @@ import {
   CardStackEntryTitle,
   CardStackHeader,
 } from "../components/card-stack";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../components/dropdown-menu";
-
 // ---------------------------------------------------------------------------
 // Provider display
 // ---------------------------------------------------------------------------
@@ -85,29 +79,7 @@ function ConnectionRow(props: {
       </CardStackEntryContent>
       <CardStackEntryActions>
         <Badge variant="outline">{scopeLabel}</Badge>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 opacity-0 transition-opacity group-hover/card-stack-entry:opacity-100 group-focus-within/card-stack-entry:opacity-100 data-[state=open]:opacity-100"
-            >
-              <svg viewBox="0 0 16 16" className="size-3">
-                <circle cx="8" cy="3" r="1.2" fill="currentColor" />
-                <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-                <circle cx="8" cy="13" r="1.2" fill="currentColor" />
-              </svg>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
-            <DropdownMenuItem
-              className="text-destructive focus:text-destructive text-sm"
-              onClick={props.onRemove}
-            >
-              Remove
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <KebabRemoveMenu label="Remove" onRemove={props.onRemove} />
       </CardStackEntryActions>
     </CardStackEntry>
   );
@@ -161,13 +133,7 @@ export function ConnectionsPage() {
               </p>
             </div>
           ),
-          onFailure: () => (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">
-                Failed to load connections
-              </p>
-            </div>
-          ),
+          onFailure: () => <ErrorMessage message="Failed to load connections" spacious />,
           onSuccess: ({ value }) => (
             <CardStack>
               <CardStackHeader>Connections</CardStackHeader>

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -17,12 +17,7 @@ import {
 import { Button } from "../components/button";
 import { Input } from "../components/input";
 import { Label } from "../components/label";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../components/dropdown-menu";
+import { KebabRemoveMenu } from "../components/entry-actions-menu";
 import {
   Select,
   SelectContent,
@@ -41,6 +36,7 @@ import {
   CardStackHeader,
 } from "../components/card-stack";
 import { Badge } from "../components/badge";
+import { ErrorMessage } from "@executor/react/components/error-message";
 
 type SecretStorageOption = {
   readonly label: string;
@@ -198,11 +194,7 @@ function AddSecretDialog(props: {
             )}
           </div>
 
-          {error && (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-              <p className="text-sm text-destructive">{error}</p>
-            </div>
-          )}
+          {error && <ErrorMessage message={error} />}
         </div>
 
         <DialogFooter>
@@ -244,29 +236,7 @@ function SecretRow(props: {
       </CardStackEntryContent>
       <CardStackEntryActions>
         {showProvider && secret.provider && <Badge variant="outline">{secret.provider}</Badge>}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 opacity-0 transition-opacity group-hover/card-stack-entry:opacity-100 group-focus-within/card-stack-entry:opacity-100 data-[state=open]:opacity-100"
-            >
-              <svg viewBox="0 0 16 16" className="size-3">
-                <circle cx="8" cy="3" r="1.2" fill="currentColor" />
-                <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-                <circle cx="8" cy="13" r="1.2" fill="currentColor" />
-              </svg>
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
-            <DropdownMenuItem
-              className="text-destructive focus:text-destructive text-sm"
-              onClick={props.onRemove}
-            >
-              Remove secret
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <KebabRemoveMenu label="Remove secret" onRemove={props.onRemove} />
       </CardStackEntryActions>
     </CardStackEntry>
   );
@@ -356,11 +326,7 @@ export function SecretsPage(props: {
               <p className="text-sm text-muted-foreground">Loading secrets…</p>
             </div>
           ),
-          onFailure: () => (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3">
-              <p className="text-sm text-destructive">Failed to load secrets</p>
-            </div>
-          ),
+          onFailure: () => <ErrorMessage message="Failed to load secrets" spacious />,
           onSuccess: ({ value }) => (
             <CardStack>
               <CardStackHeader>Secrets</CardStackHeader>


### PR DESCRIPTION
Introduce shared React UI atoms for repeated destructive errors, card action menus, code-block icons, and browser OAuth popup/redirect handling.

This preserves the existing user-facing messages, spacing variants, SVG paths, and OAuth popup success/error behavior.