### PR TITLE
Share SDK and plugin helper code

### DIFF
--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -128,6 +128,8 @@ export {
   type Elicit,
   definePlugin,
   defineSchema,
+  providerStateCodec,
+  resolveOAuthClientSecrets,
 } from "./plugin";
 
 // Executor

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import type {
   DBAdapter,
   DBSchema,
@@ -7,10 +7,10 @@ import type {
 } from "@executor/storage-core";
 
 import type { PluginBlobStore } from "./blob";
+import { ConnectionRefreshError } from "./connections";
 import type {
   ConnectionProvider,
   ConnectionRef,
-  ConnectionRefreshError,
   CreateConnectionInput,
   UpdateConnectionTokensInput,
 } from "./connections";
@@ -34,6 +34,7 @@ import type {
   ConnectionRefreshNotSupportedError,
   SecretOwnedByConnectionError,
 } from "./errors";
+import type { ConnectionId } from "./ids";
 import type { Scope } from "./scope";
 import type { SecretProvider, SecretRef, SetSecretInput } from "./secrets";
 
@@ -79,6 +80,53 @@ export interface StorageDeps<TSchema extends DBSchema | undefined = undefined> {
 // ---------------------------------------------------------------------------
 
 export const defineSchema = <const S extends DBSchema>(schema: S): S => schema;
+
+export const providerStateCodec = <A, I>(schema: Schema.Schema<A, I, never>) => {
+  const encode = Schema.encodeSync(schema);
+  return {
+    decode: Schema.decodeUnknownSync(schema),
+    toRecord: (state: A): Record<string, unknown> =>
+      encode(state) as unknown as Record<string, unknown>,
+  } as const;
+};
+
+export const resolveOAuthClientSecrets = (input: {
+  readonly ctx: Pick<PluginCtx, "secrets">;
+  readonly connectionId: ConnectionId;
+  readonly clientIdSecretId: string;
+  readonly clientSecretSecretId: string | null;
+}) =>
+  Effect.gen(function* () {
+    const clientId = yield* input.ctx.secrets.get(input.clientIdSecretId).pipe(
+      Effect.mapError(
+        (err) =>
+          new ConnectionRefreshError({
+            connectionId: input.connectionId,
+            message: `Failed to resolve client id secret: ${err.message}`,
+            cause: err,
+          }),
+      ),
+    );
+    if (clientId === null) {
+      return yield* new ConnectionRefreshError({
+        connectionId: input.connectionId,
+        message: `Missing client id secret: ${input.clientIdSecretId}`,
+      });
+    }
+    const clientSecret = input.clientSecretSecretId
+      ? yield* input.ctx.secrets.get(input.clientSecretSecretId).pipe(
+          Effect.mapError(
+            (err) =>
+              new ConnectionRefreshError({
+                connectionId: input.connectionId,
+                message: `Failed to resolve client secret: ${err.message}`,
+                cause: err,
+              }),
+          ),
+        )
+      : null;
+    return { clientId, clientSecret } as const;
+  });
 
 // ---------------------------------------------------------------------------
 // Elicit — suspends the fiber, calls the invoke-time elicitation

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -17,6 +17,8 @@ import {
   SourceDetectionResult,
   TokenMaterial,
   definePlugin,
+  providerStateCodec,
+  resolveOAuthClientSecrets,
   type ConnectionProvider,
   type ConnectionRefreshInput,
   type ConnectionRefreshResult,
@@ -258,13 +260,8 @@ const OAuth2ProviderState = Schema.Struct({
 });
 type OAuth2ProviderState = typeof OAuth2ProviderState.Type;
 
-const encodeProviderState = Schema.encodeSync(OAuth2ProviderState);
-const decodeProviderState = Schema.decodeUnknownSync(OAuth2ProviderState);
-
-const toProviderStateRecord = (
-  state: OAuth2ProviderState,
-): Record<string, unknown> =>
-  encodeProviderState(state) as unknown as Record<string, unknown>;
+const { decode: decodeProviderState, toRecord: toProviderStateRecord } =
+  providerStateCodec(OAuth2ProviderState);
 
 // ---------------------------------------------------------------------------
 // Register a parsed manifest against the executor core + plugin storage.
@@ -714,35 +711,12 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
             });
           }
 
-          const clientId = yield* ctx.secrets.get(state.clientIdSecretId).pipe(
-            Effect.mapError(
-              (err) =>
-                new ConnectionRefreshError({
-                  connectionId: input.connectionId,
-                  message: `Failed to resolve client id secret: ${err.message}`,
-                  cause: err,
-                }),
-            ),
-          );
-          if (clientId === null) {
-            return yield* new ConnectionRefreshError({
-              connectionId: input.connectionId,
-              message: `Missing client id secret: ${state.clientIdSecretId}`,
-            });
-          }
-
-          const clientSecret = state.clientSecretSecretId
-            ? yield* ctx.secrets.get(state.clientSecretSecretId).pipe(
-                Effect.mapError(
-                  (err) =>
-                    new ConnectionRefreshError({
-                      connectionId: input.connectionId,
-                      message: `Failed to resolve client secret: ${err.message}`,
-                      cause: err,
-                    }),
-                ),
-              )
-            : null;
+          const { clientId, clientSecret } = yield* resolveOAuthClientSecrets({
+            ctx,
+            connectionId: input.connectionId,
+            clientIdSecretId: state.clientIdSecretId,
+            clientSecretSecretId: state.clientSecretSecretId,
+          });
 
           const tokenResponse: OAuth2TokenResponse = yield* refreshAccessToken({
             tokenUrl: GOOGLE_TOKEN_URL,

--- a/packages/plugins/graphql/src/sdk/extract.ts
+++ b/packages/plugins/graphql/src/sdk/extract.ts
@@ -20,7 +20,7 @@ import {
 // ---------------------------------------------------------------------------
 
 /** Unwrap NON_NULL / LIST wrappers to get the leaf type name */
-const unwrapTypeName = (ref: IntrospectionTypeRef): string => {
+export const unwrapTypeName = (ref: IntrospectionTypeRef): string => {
   if (ref.name) return ref.name;
   if (ref.ofType) return unwrapTypeName(ref.ofType);
   return "Unknown";
@@ -164,7 +164,7 @@ const buildInputSchema = (
 };
 
 /** Format a type ref back to GraphQL type notation (e.g. "[String!]!") */
-const formatTypeRef = (ref: IntrospectionTypeRef): string => {
+export const formatTypeRef = (ref: IntrospectionTypeRef): string => {
   switch (ref.kind) {
     case "NON_NULL":
       return ref.ofType ? `${formatTypeRef(ref.ofType)}!` : "Unknown!";

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -24,7 +24,7 @@ import {
   type IntrospectionField,
   type IntrospectionTypeRef,
 } from "./introspect";
-import { extract } from "./extract";
+import { extract, formatTypeRef, unwrapTypeName } from "./extract";
 import { GraphqlExtractionError, GraphqlIntrospectionError } from "./errors";
 import { invokeWithLayer, resolveHeaders } from "./invoke";
 import {
@@ -140,23 +140,6 @@ const namespaceFromEndpoint = (endpoint: string): string => {
   } catch {
     return "graphql";
   }
-};
-
-const formatTypeRef = (ref: IntrospectionTypeRef): string => {
-  switch (ref.kind) {
-    case "NON_NULL":
-      return ref.ofType ? `${formatTypeRef(ref.ofType)}!` : "Unknown!";
-    case "LIST":
-      return ref.ofType ? `[${formatTypeRef(ref.ofType)}]` : "[Unknown]";
-    default:
-      return ref.name ?? "Unknown";
-  }
-};
-
-const unwrapTypeName = (ref: IntrospectionTypeRef): string => {
-  if (ref.name) return ref.name;
-  if (ref.ofType) return unwrapTypeName(ref.ofType);
-  return "Unknown";
 };
 
 const buildSelectionSet = (

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -20,6 +20,7 @@ import {
   SourceDetectionResult,
   TokenMaterial,
   definePlugin,
+  providerStateCodec,
   type ConnectionProvider,
   type ConnectionRefreshInput,
   type ConnectionRefreshResult,
@@ -316,13 +317,8 @@ const OAuth2ProviderState = Schema.Struct({
 });
 type OAuth2ProviderState = typeof OAuth2ProviderState.Type;
 
-const encodeProviderState = Schema.encodeSync(OAuth2ProviderState);
-const decodeProviderState = Schema.decodeUnknownSync(OAuth2ProviderState);
-
-const toProviderStateRecord = (
-  state: OAuth2ProviderState,
-): Record<string, unknown> =>
-  encodeProviderState(state) as unknown as Record<string, unknown>;
+const { decode: decodeProviderState, toRecord: toProviderStateRecord } =
+  providerStateCodec(OAuth2ProviderState);
 
 const remoteConnectionError = (message: string) =>
   new McpConnectionError({ transport: "remote", message });

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -23,6 +23,8 @@ import {
   SourceDetectionResult,
   TokenMaterial,
   definePlugin,
+  providerStateCodec,
+  resolveOAuthClientSecrets,
   type ConnectionProvider,
   type ConnectionRefreshInput,
   type ConnectionRefreshResult,
@@ -601,13 +603,8 @@ const OAuth2ProviderState = Schema.Struct({
 });
 type OAuth2ProviderState = typeof OAuth2ProviderState.Type;
 
-const encodeProviderState = Schema.encodeSync(OAuth2ProviderState);
-const decodeProviderState = Schema.decodeUnknownSync(OAuth2ProviderState);
-
-const toProviderStateRecord = (
-  state: OAuth2ProviderState,
-): Record<string, unknown> =>
-  encodeProviderState(state) as unknown as Record<string, unknown>;
+const { decode: decodeProviderState, toRecord: toProviderStateRecord } =
+  providerStateCodec(OAuth2ProviderState);
 
 // ---------------------------------------------------------------------------
 // Plugin factory
@@ -1465,35 +1462,12 @@ export const openApiPlugin = definePlugin(
                   }),
               });
 
-              const clientId = yield* ctx.secrets.get(state.clientIdSecretId).pipe(
-                Effect.mapError(
-                  (err) =>
-                    new ConnectionRefreshError({
-                      connectionId: input.connectionId,
-                      message: `Failed to resolve client id secret: ${err.message}`,
-                      cause: err,
-                    }),
-                ),
-              );
-              if (clientId === null) {
-                return yield* new ConnectionRefreshError({
-                  connectionId: input.connectionId,
-                  message: `Missing client id secret: ${state.clientIdSecretId}`,
-                });
-              }
-
-              const clientSecret = state.clientSecretSecretId
-                ? yield* ctx.secrets.get(state.clientSecretSecretId).pipe(
-                    Effect.mapError(
-                      (err) =>
-                        new ConnectionRefreshError({
-                          connectionId: input.connectionId,
-                          message: `Failed to resolve client secret: ${err.message}`,
-                          cause: err,
-                        }),
-                    ),
-                  )
-                : null;
+              const { clientId, clientSecret } = yield* resolveOAuthClientSecrets({
+                ctx,
+                connectionId: input.connectionId,
+                clientIdSecretId: state.clientIdSecretId,
+                clientSecretSecretId: state.clientSecretSecretId,
+              });
 
               // RFC 6749 §5.2 terminal error codes — the AS has told us
               // the stored grant is unusable, so no amount of retries


### PR DESCRIPTION
Centralize duplicated provider_state schema codecs, OAuth client-secret resolution, and GraphQL type-reference helpers across plugin implementations.

Effect schemas remain typed with never context where required, ConnectionId stays branded for refresh errors, and plugin public APIs are preserved.