### PR TITLE
Share storage blob error wrapping

### DIFF
--- a/packages/core/storage-core/src/errors.ts
+++ b/packages/core/storage-core/src/errors.ts
@@ -27,6 +27,12 @@ export class StorageError extends Data.TaggedError("StorageError")<{
   readonly cause: unknown;
 }> {}
 
+export const wrapStorageError = (prefix: string, op: string) => (cause: unknown): StorageError =>
+  new StorageError({
+    message: `[${prefix}] ${op}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    cause,
+  });
+
 /**
  * Typed unique-constraint violation. Plugins are expected to
  * `Effect.catchTag` this and translate to their own user-facing error.

--- a/packages/core/storage-core/src/index.ts
+++ b/packages/core/storage-core/src/index.ts
@@ -15,7 +15,7 @@ export { typedAdapter, type TypedAdapter } from "./typed";
 
 export { createAdapter, type CreateAdapterOptions } from "./factory";
 
-export { StorageError, UniqueViolationError } from "./errors";
+export { StorageError, UniqueViolationError, wrapStorageError } from "./errors";
 
 export {
   whereOperators,

--- a/packages/core/storage-file/src/blob-store.ts
+++ b/packages/core/storage-file/src/blob-store.ts
@@ -13,7 +13,7 @@ import { and, eq, inArray, sql as drizzleSql } from "drizzle-orm";
 import { primaryKey, sqliteTable, text } from "drizzle-orm/sqlite-core";
 
 import type { BlobStore } from "@executor/sdk";
-import { StorageError } from "@executor/storage-core";
+import { wrapStorageError } from "@executor/storage-core";
 
 export const blobTable = sqliteTable(
   "blob",
@@ -33,15 +33,7 @@ export interface MakeSqliteBlobStoreOptions {
   readonly db: DrizzleSqliteDB;
 }
 
-const wrapErr =
-  (op: string) =>
-  (cause: unknown): StorageError => {
-    const msg = cause instanceof Error ? cause.message : String(cause);
-    return new StorageError({
-      message: `[storage-file] blob ${op}: ${msg}`,
-      cause,
-    });
-  };
+const wrapErr = (op: string) => wrapStorageError("storage-file", `blob ${op}`);
 
 export const makeSqliteBlobStore = (
   options: MakeSqliteBlobStoreOptions,

--- a/packages/core/storage-postgres/src/blob-store.ts
+++ b/packages/core/storage-postgres/src/blob-store.ts
@@ -15,7 +15,7 @@ import type { PgDatabase } from "drizzle-orm/pg-core";
 import { pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 
 import type { BlobStore } from "@executor/sdk";
-import { StorageError } from "@executor/storage-core";
+import { wrapStorageError } from "@executor/storage-core";
 
 export const blobTable = pgTable(
   "blob",
@@ -34,15 +34,7 @@ export interface MakePostgresBlobStoreOptions {
   readonly db: DrizzlePgDB;
 }
 
-const wrapErr =
-  (op: string) =>
-  (cause: unknown): StorageError => {
-    const msg = cause instanceof Error ? cause.message : String(cause);
-    return new StorageError({
-      message: `[storage-postgres] blob ${op}: ${msg}`,
-      cause,
-    });
-  };
+const wrapErr = (op: string) => wrapStorageError("storage-postgres", `blob ${op}`);
 
 export const makePostgresBlobStore = (
   options: MakePostgresBlobStoreOptions,


### PR DESCRIPTION
Expose a shared storage-core helper for repeated blob StorageError wrapping and reuse it in file and Postgres blob stores while preserving existing error message prefixes.