### PR TITLE
Share app executor and drizzle configs

### DIFF
--- a/apps/cloud/drizzle.config.ts
+++ b/apps/cloud/drizzle.config.ts
@@ -1,24 +1,3 @@
-import { defineConfig } from "drizzle-kit";
+import { cloudDrizzleConfig } from "../shared/drizzle-config";
 
-// drizzle-kit studio reads `dbCredentials.url`; everything else (generate,
-// migrate) ignores it. Default to the local PGlite socket started by
-// `bun run dev:db`; override via `DATABASE_URL` for prod studio sessions.
-// drizzle-kit uses node-postgres (`pg`) for studio and the `ssl` option in
-// dbCredentials doesn't reliably reach the pool — append `sslmode=require`
-// directly to the URL instead, which `pg` honours.
-const DEFAULT_DEV_URL = "postgresql://postgres:postgres@127.0.0.1:5433/postgres";
-
-const withSslMode = (url: string): string => {
-  if (url.includes("127.0.0.1") || url.includes("localhost")) return url;
-  if (/[?&]sslmode=/.test(url)) return url;
-  return url + (url.includes("?") ? "&" : "?") + "sslmode=require";
-};
-
-export default defineConfig({
-  schema: ["./src/services/schema.ts", "./src/services/executor-schema.ts"],
-  out: "./drizzle",
-  dialect: "postgresql",
-  dbCredentials: {
-    url: withSslMode(process.env.DATABASE_URL ?? DEFAULT_DEV_URL),
-  },
-});
+export default cloudDrizzleConfig();

--- a/apps/cloud/executor.config.ts
+++ b/apps/cloud/executor.config.ts
@@ -1,25 +1,3 @@
-import { defineExecutorConfig } from "@executor/sdk";
-import { openApiPlugin } from "@executor/plugin-openapi";
-import { mcpPlugin } from "@executor/plugin-mcp";
-import { graphqlPlugin } from "@executor/plugin-graphql";
-import { workosVaultPlugin } from "@executor/plugin-workos-vault";
+import { executorSchemaConfig } from "../shared/executor-schema-config";
 
-// ---------------------------------------------------------------------------
-// Executor config for CLI schema generation.
-//
-// The CLI reads `plugins` + `dialect` to produce a drizzle schema file.
-// Plugin credentials are stubs — the CLI only reads `plugin.schema`,
-// never calls the plugin at runtime.
-// ---------------------------------------------------------------------------
-
-export default defineExecutorConfig({
-  dialect: "pg",
-  plugins: [
-    openApiPlugin(),
-    mcpPlugin({ dangerouslyAllowStdioMCP: false }),
-    graphqlPlugin(),
-    workosVaultPlugin({
-      credentials: { apiKey: "", clientId: "" },
-    }),
-  ],
-});
+export default executorSchemaConfig({ dialect: "pg", allowStdioMcp: false, workosVault: true });

--- a/apps/local/drizzle.config.ts
+++ b/apps/local/drizzle.config.ts
@@ -1,7 +1,3 @@
-import { defineConfig } from "drizzle-kit";
+import { localDrizzleConfig } from "../shared/drizzle-config";
 
-export default defineConfig({
-  schema: "./src/server/executor-schema.ts",
-  out: "./drizzle",
-  dialect: "sqlite",
-});
+export default localDrizzleConfig();

--- a/apps/local/executor.config.ts
+++ b/apps/local/executor.config.ts
@@ -1,23 +1,3 @@
-import { defineExecutorConfig } from "@executor/sdk";
-import { openApiPlugin } from "@executor/plugin-openapi";
-import { mcpPlugin } from "@executor/plugin-mcp";
-import { googleDiscoveryPlugin } from "@executor/plugin-google-discovery";
-import { graphqlPlugin } from "@executor/plugin-graphql";
+import { executorSchemaConfig } from "../shared/executor-schema-config";
 
-// ---------------------------------------------------------------------------
-// Executor config for CLI schema generation (local / sqlite).
-//
-// The CLI reads `plugins` + `dialect` to produce a drizzle schema file.
-// Only plugins with a `schema` need to be listed — keychain,
-// file-secrets, and onepassword are runtime-only (no DB tables).
-// ---------------------------------------------------------------------------
-
-export default defineExecutorConfig({
-  dialect: "sqlite",
-  plugins: [
-    openApiPlugin(),
-    mcpPlugin({ dangerouslyAllowStdioMCP: true }),
-    googleDiscoveryPlugin(),
-    graphqlPlugin(),
-  ],
-});
+export default executorSchemaConfig({ dialect: "sqlite", allowStdioMcp: true, googleDiscovery: true });

--- a/apps/shared/drizzle-config.ts
+++ b/apps/shared/drizzle-config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "drizzle-kit";
+
+const withSslMode = (url: string): string =>
+  url.includes("127.0.0.1") || url.includes("localhost") || /[?&]sslmode=/.test(url)
+    ? url
+    : url + (url.includes("?") ? "&" : "?") + "sslmode=require";
+
+export const localDrizzleConfig = () =>
+  defineConfig({ schema: "./src/server/executor-schema.ts", out: "./drizzle", dialect: "sqlite" });
+
+export const cloudDrizzleConfig = () =>
+  defineConfig({
+    schema: ["./src/services/schema.ts", "./src/services/executor-schema.ts"],
+    out: "./drizzle",
+    dialect: "postgresql",
+    dbCredentials: {
+      url: withSslMode(process.env.DATABASE_URL ?? "postgresql://postgres:postgres@127.0.0.1:5433/postgres"),
+    },
+  });

--- a/apps/shared/executor-schema-config.ts
+++ b/apps/shared/executor-schema-config.ts
@@ -1,0 +1,25 @@
+import { defineExecutorConfig } from "@executor/sdk";
+import { googleDiscoveryPlugin } from "@executor/plugin-google-discovery";
+import { graphqlPlugin } from "@executor/plugin-graphql";
+import { mcpPlugin } from "@executor/plugin-mcp";
+import { openApiPlugin } from "@executor/plugin-openapi";
+import { workosVaultPlugin } from "@executor/plugin-workos-vault";
+
+export const executorSchemaConfig = (options: {
+  readonly dialect: "pg" | "sqlite";
+  readonly allowStdioMcp: boolean;
+  readonly googleDiscovery?: boolean;
+  readonly workosVault?: boolean;
+}) =>
+  defineExecutorConfig({
+    dialect: options.dialect,
+    plugins: [
+      openApiPlugin(),
+      mcpPlugin({ dangerouslyAllowStdioMCP: options.allowStdioMcp }),
+      ...(options.googleDiscovery ? [googleDiscoveryPlugin()] : []),
+      graphqlPlugin(),
+      ...(options.workosVault
+        ? [workosVaultPlugin({ credentials: { apiKey: "", clientId: "" } })]
+        : []),
+    ],
+  });


### PR DESCRIPTION
Move duplicated cloud/local executor schema-generation and drizzle config boilerplate into shared app config helpers while preserving dialects, plugin lists, MCP stdio settings, WorkOS vault inclusion, and cloud sslmode handling.