### PR TITLE
[codex] fix MCP invalid bearer handling

### DIFF
--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -94,29 +94,31 @@ export const McpAuthLive = Layer.succeed(McpAuth, {
         yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_bearer" });
         return null;
       }
-      try {
-        const { payload } = yield* Effect.promise(() =>
+      const verified = yield* Effect.either(
+        Effect.promise(() =>
           jwtVerify(authHeader.slice(BEARER_PREFIX.length), jwks, {
             issuer: AUTHKIT_DOMAIN,
           }),
-        ).pipe(Effect.withSpan("mcp.auth.jwt_verify"));
-        if (!payload.sub) {
-          yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
-          return null;
-        }
-        const token = {
-          accountId: payload.sub,
-          organizationId: (payload.org_id as string | undefined) ?? null,
-        };
-        yield* Effect.annotateCurrentSpan({
-          "mcp.auth.outcome": "verified",
-          "mcp.auth.has_organization": !!token.organizationId,
-        });
-        return token;
-      } catch {
+        ).pipe(Effect.withSpan("mcp.auth.jwt_verify")),
+      );
+      if (verified._tag === "Left") {
         yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "invalid" });
         return null;
       }
+      const { payload } = verified.right;
+      if (!payload.sub) {
+        yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
+        return null;
+      }
+      const token = {
+        accountId: payload.sub,
+        organizationId: (payload.org_id as string | undefined) ?? null,
+      };
+      yield* Effect.annotateCurrentSpan({
+        "mcp.auth.outcome": "verified",
+        "mcp.auth.has_organization": !!token.organizationId,
+      });
+      return token;
     }).pipe(Effect.withSpan("mcp.auth.verify_bearer")),
 });
 


### PR DESCRIPTION
## Summary
- Treat failed MCP bearer JWT verification as an invalid auth result instead of an Effect failure.
- Preserve existing span annotations for missing, invalid, and verified auth outcomes.

## Root Cause
The auth verifier used `try/catch` around a yielded Effect. Rejections from the JWT verification promise were represented in the Effect error channel, so the JavaScript catch block did not handle them. Invalid or expired bearer tokens could therefore escape to the request-level failure handler and be reported as internal server errors.

## Impact
Invalid MCP bearer tokens should now receive the normal unauthorized response path instead of producing internal error events.

## Validation
- Reviewed the Sentry/Axiom traces that showed invalid bearer verification escaping as 500s.
- Attempted `tsc --noEmit --project apps/cloud/tsconfig.json`; it still exits nonzero due existing Effect language-service diagnostics elsewhere in the repo.
