### PR TITLE
[codex] fix OpenAPI OAuth cleanup

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -95,7 +95,7 @@ const substituteUrlVariables = (url: string, values: Record<string, string>): st
   return out;
 };
 
-const openApiOAuthConnectionId = (
+export const openApiOAuthConnectionId = (
   namespaceSlug: string,
   flow: OAuth2Preset["flow"],
 ): string =>

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -41,6 +41,7 @@ import {
   OPENAPI_OAUTH_CALLBACK_PATH,
   OPENAPI_OAUTH_CHANNEL,
   OPENAPI_OAUTH_POPUP_NAME,
+  openApiOAuthConnectionId,
   resolveOAuthUrl,
 } from "./AddOpenApiSource";
 import { oauth2ClientSecretSlot } from "../sdk/store";
@@ -393,9 +394,7 @@ export default function EditOpenApiSource(props: {
     const connectionId =
       existingConnection && isConnectionBindingValue(existingConnection.value)
         ? existingConnection.value.connectionId
-        : ConnectionId.make(
-            `openapi-oauth-${slugify(props.sourceId)}-${slugify(oauth2.securitySchemeName)}-${slugify(targetScope)}`,
-          );
+        : ConnectionId.make(openApiOAuthConnectionId(props.sourceId, oauth2.flow));
 
     setBusyKey(`${targetScope}:${oauth2.connectionSlot}:connect`);
     setError(null);

--- a/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.test.ts
@@ -64,6 +64,7 @@ const makeMetadata = (
 const makeFakeClient = (options?: {
   readonly conflictOnNextSecretUpdate?: boolean;
   readonly rejectNamesWithColon?: boolean;
+  readonly rejectReadNamesLongerThan?: number;
 }): WorkOSVaultClient => {
   const objects = new Map<string, WorkOSVaultObject>();
   let sequence = 0;
@@ -104,6 +105,12 @@ const makeFakeClient = (options?: {
 
     readObjectByName: async (name: string) => {
       if (options?.rejectNamesWithColon && name.includes(":")) {
+        throw new FakeInvalidRequestError(`Invalid object name "${name}"`);
+      }
+      if (
+        options?.rejectReadNamesLongerThan !== undefined &&
+        name.length > options.rejectReadNamesLongerThan
+      ) {
         throw new FakeInvalidRequestError(`Invalid object name "${name}"`);
       }
       const object = objects.get(name);
@@ -256,6 +263,29 @@ describe("WorkOS Vault secret provider", () => {
       yield* executor.secrets.remove("remove-me");
 
       expect(yield* executor.secrets.get("remove-me")).toBeNull();
+      expect(yield* executor.secrets.list()).toHaveLength(0);
+    }),
+  );
+
+  it.effect("treats invalid Vault object names as missing during removal", () =>
+    Effect.gen(function* () {
+      const client = makeFakeClient({ rejectReadNamesLongerThan: 80 });
+      const executor = yield* makeExecutor(client);
+      const longSecretId = SecretId.make(
+        "openapi-oauth-dealcloud-api-oauth2-user-org-user-01kp6xm1zpvqvtpj77f0yv4eax.access_token",
+      );
+
+      yield* executor.secrets.set(
+        new SetSecretInput({
+          id: longSecretId,
+          scope: ScopeId.make("test-scope"),
+          name: "Long connection token",
+          value: "token",
+        }),
+      );
+
+      yield* executor.secrets.remove(longSecretId);
+
       expect(yield* executor.secrets.list()).toHaveLength(0);
     }),
   );

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -238,6 +238,7 @@ const loadSecretObject = (
 ): Effect.Effect<WorkOSVaultObject | null, WorkOSVaultClientError, never> =>
   client.readObjectByName(secretObjectName(prefix, scopeId, secretId)).pipe(
     Effect.catchAll((error) => {
+      if (isStatusError(error, 400)) return Effect.succeed(null);
       if (!isStatusError(error, 404)) return Effect.fail(error);
 
       const encodedName = secretObjectName(prefix, scopeId, secretId);


### PR DESCRIPTION
## Summary
- Reuse the stable OpenAPI OAuth connection id helper from both add and edit flows.
- Avoid generating edit-flow connection ids that include full scope identifiers.
- Treat invalid WorkOS Vault object-name lookups as missing during secret cleanup.
- Add a regression test for cleanup when Vault rejects a generated object name.

## Root Cause
The edit flow could create a new OAuth connection id using source, scheme, and full target scope text. That id was later used in backing secret names. For long scoped ids, Vault name lookup can reject the object name before cleanup can remove local metadata. The add flow already used shorter stable ids; the edit flow was inconsistent.

## Impact
OpenAPI OAuth reconnect and cleanup flows use stable, shorter ids consistently, and stale metadata cleanup no longer fails when Vault rejects an object-name lookup.

## Validation
- `vitest run src/sdk/secret-store.test.ts --config vitest.config.ts`
- `vitest run src/sdk/multi-scope-oauth.test.ts src/sdk/client-credentials-oauth.test.ts --config vitest.config.ts`
