### PR TITLE
Fix MCP tool failure responses

### DIFF
--- a/packages/hosts/mcp/src/server.test.ts
+++ b/packages/hosts/mcp/src/server.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { ClientCapabilities } from "@modelcontextprotocol/sdk/types.js";
+import type * as Cause from "effect/Cause";
 
 import { FormElicitation, ToolId, UrlElicitation } from "@executor/sdk";
 import type { ExecutionEngine, ExecutionResult } from "@executor/execution";
@@ -14,12 +15,16 @@ import { createExecutorMcpServer } from "./server";
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeStubEngine = (overrides: {
-  execute?: ExecutionEngine["execute"];
-  executeWithPause?: ExecutionEngine["executeWithPause"];
-  resume?: ExecutionEngine["resume"];
+class TestExecutionError extends Data.TaggedError("TestExecutionError")<{
+  readonly message: string;
+}> {}
+
+const makeStubEngine = <E extends Cause.YieldableError = never>(overrides: {
+  execute?: ExecutionEngine<E>["execute"];
+  executeWithPause?: ExecutionEngine<E>["executeWithPause"];
+  resume?: ExecutionEngine<E>["resume"];
   description?: string;
-}): ExecutionEngine => ({
+}): ExecutionEngine<E> => ({
   execute: overrides.execute ?? (() => Effect.succeed({ result: "default" })),
   executeWithPause:
     overrides.executeWithPause ??
@@ -29,8 +34,8 @@ const makeStubEngine = (overrides: {
 });
 
 /** Connect a real MCP Client to our executor MCP server over in-memory transports. */
-const withClient = async (
-  engine: ExecutionEngine,
+const withClient = async <E extends Cause.YieldableError>(
+  engine: ExecutionEngine<E>,
   capabilities: ClientCapabilities,
   fn: (client: Client) => Promise<void>,
 ) => {
@@ -107,6 +112,44 @@ describe("MCP host server — client with elicitation", () => {
       });
       expect(result.content).toEqual([{ type: "text", text: "ran: 1+1" }]);
       expect(result.isError).toBeFalsy();
+    });
+  });
+
+  it("execute tool resolves failed engine effects as MCP error results", async () => {
+    const engine = makeStubEngine({
+      execute: () => Effect.fail(new TestExecutionError({ message: "Unexpected token ':'" })),
+    });
+
+    await withClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: { code: "const x: any = 1;" },
+      });
+      expect(textOf(result)).toBe("Error: Unexpected token ':'");
+      expect(result.structuredContent).toEqual({
+        status: "error",
+        error: "Unexpected token ':'",
+      });
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  it("execute tool hides defect details in MCP error results", async () => {
+    const engine = makeStubEngine({
+      execute: () => Effect.die(new Error("secret internal detail")),
+    });
+
+    await withClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: { code: "run" },
+      });
+      expect(textOf(result)).toBe("Error: Tool execution failed");
+      expect(result.structuredContent).toEqual({
+        status: "error",
+        error: "Tool execution failed",
+      });
+      expect(result.isError).toBe(true);
     });
   });
 

--- a/packages/hosts/mcp/src/server.ts
+++ b/packages/hosts/mcp/src/server.ts
@@ -1,4 +1,5 @@
-import { Effect, Match, Runtime } from "effect";
+import { Effect, Match, Option, Runtime } from "effect";
+import * as Cause from "effect/Cause";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
   jsonSchemaValidator,
@@ -14,7 +15,6 @@ import type {
   ElicitationContext,
   ElicitationRequest,
 } from "@executor/sdk";
-import type * as Cause from "effect/Cause";
 import type * as Tracer from "effect/Tracer";
 import {
   createExecutionEngine,
@@ -224,6 +224,28 @@ const toMcpPausedResult = (formatted: ReturnType<typeof formatPausedExecution>):
   structuredContent: formatted.structured,
 });
 
+const formatFailureMessage = (value: unknown): string | null => {
+  if (value instanceof Error) return value.message;
+  if (typeof value === "object" && value !== null && "message" in value) {
+    const message = (value as { readonly message?: unknown }).message;
+    if (typeof message === "string" && message.length > 0) return message;
+  }
+  if (typeof value === "string" && value.length > 0) return value;
+  return null;
+};
+
+const toMcpFailureResult = (cause: Cause.Cause<unknown>): McpToolResult => {
+  const failure = Cause.failureOption(cause);
+  const text = Option.isSome(failure)
+    ? (formatFailureMessage(failure.value) ?? "Tool execution failed")
+    : "Tool execution failed";
+  return {
+    content: [{ type: "text", text: `Error: ${text}` }],
+    structuredContent: { status: "error", error: text },
+    isError: true,
+  };
+};
+
 const parseJsonContent = (raw: string): Record<string, unknown> | undefined => {
   if (raw === "{}") return undefined;
   let parsed: unknown;
@@ -274,6 +296,14 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       const parent = resolveParentSpan();
       return parent ? Effect.withParentSpan(effect, parent) : effect;
     };
+    const runToolEffect = <EffE>(effect: Effect.Effect<McpToolResult, EffE>) =>
+      Runtime.runPromise(runtime)(
+        anchor(effect).pipe(
+          Effect.catchAllCause((cause) =>
+            Effect.succeed(toMcpFailureResult(cause)),
+          ),
+        ),
+      );
 
     const server = yield* Effect.sync(
       () =>
@@ -374,7 +404,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           description,
           inputSchema: { code: z.string().trim().min(1) },
         },
-        ({ code }) => Runtime.runPromise(runtime)(anchor(executeCode(code))),
+        ({ code }) => runToolEffect(executeCode(code)),
       ),
     ).pipe(
       Effect.withSpan("mcp.host.register_tool", {
@@ -402,9 +432,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           },
         },
         ({ executionId, action, content: rawContent }) =>
-          Runtime.runPromise(runtime)(
-            anchor(resumeExecution(executionId, action, parseJsonContent(rawContent))),
-          ),
+          runToolEffect(resumeExecution(executionId, action, parseJsonContent(rawContent))),
       ),
     ).pipe(
       Effect.withSpan("mcp.host.register_tool", {


### PR DESCRIPTION
## Summary
- convert failed MCP execute/resume Effect callbacks into normal MCP tool error results
- preserve structured error responses so clients do not depend on rejected transport callbacks
- add MCP host coverage for failed engine execution returning `isError: true`

## Tests
- `../../../node_modules/.bin/vitest run src/server.test.ts --config vitest.config.ts`
- `npm run typecheck`