### PR TITLE
fix mcp jwt auth telemetry

### DIFF
--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -25,6 +25,7 @@ declare global {
       EXECUTOR_MCP_DEBUG?: string;
       MCP_AUTHKIT_DOMAIN?: string;
       MCP_RESOURCE_ORIGIN?: string;
+      MCP_STRICT_AUDIENCE?: string;
       NODE_ENV?: string;
 
       // Shared with frontend

--- a/apps/cloud/src/mcp-auth.ts
+++ b/apps/cloud/src/mcp-auth.ts
@@ -1,5 +1,6 @@
-import { Effect, Data } from "effect";
+import { Data, Effect } from "effect";
 import { jwtVerify, type JWTVerifyGetKey } from "jose";
+import { JWTExpired } from "jose/errors";
 
 export type VerifiedToken = {
   /** The WorkOS account ID (user ID). */
@@ -10,6 +11,7 @@ export type VerifiedToken = {
 
 export class McpJwtVerificationError extends Data.TaggedError("McpJwtVerificationError")<{
   readonly cause: unknown;
+  readonly reason: "expired" | "invalid";
 }> {}
 
 export const verifyMcpAccessToken = Effect.fn("mcp.auth.jwt_verify")(function* (
@@ -26,7 +28,11 @@ export const verifyMcpAccessToken = Effect.fn("mcp.auth.jwt_verify")(function* (
         issuer: options.issuer,
         ...(options.audience ? { audience: options.audience } : {}),
       }),
-    catch: (cause) => new McpJwtVerificationError({ cause }),
+    catch: (cause) =>
+      new McpJwtVerificationError({
+        cause,
+        reason: cause instanceof JWTExpired ? "expired" : "invalid",
+      }),
   });
 
   if (!payload.sub) return null;

--- a/apps/cloud/src/mcp-flow.test.ts
+++ b/apps/cloud/src/mcp-flow.test.ts
@@ -185,7 +185,8 @@ describe("/mcp unauthorized", () => {
     const response = await mcpPost({ body: INITIALIZE_REQUEST });
     expect(response.status).toBe(401);
     const wwwAuth = response.headers.get("www-authenticate") ?? "";
-    expect(wwwAuth).toContain("Bearer resource_metadata=");
+    expect(wwwAuth).toContain('Bearer error="unauthorized"');
+    expect(wwwAuth).toContain('resource_metadata="');
     expect(wwwAuth).toContain(
       "https://test-resource.example.com/.well-known/oauth-protected-resource/mcp",
     );

--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -478,6 +478,8 @@ layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it)
       expect(handleSpan.attributes["mcp.request.method"]).toBeDefined();
       // 200 for normal POSTs, 202 for notifications/initialized.
       expect([200, 202]).toContain(handleSpan.attributes["mcp.response.status_code"]);
+      expect(handleSpan.attributes["mcp.response.content_type"]).toEqual(expect.any(String));
+      expect(handleSpan.attributes["mcp.transport.enable_json_response"]).toBe(true);
 
       // init runs once per new session and should appear on the initialize POST.
       yield* Effect.promise(() =>

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -27,10 +27,7 @@ import { UserStoreService } from "./auth/context";
 import { resolveOrganization } from "./auth/resolve-organization";
 import { DbService, combinedSchema, resolveConnectionString } from "./services/db";
 import { makeExecutionStack } from "./services/execution-stack";
-import {
-  makeMcpWorkerTransport,
-  type McpWorkerTransport,
-} from "./services/mcp-worker-transport";
+import { makeMcpWorkerTransport, type McpWorkerTransport } from "./services/mcp-worker-transport";
 import { DoTelemetryLive } from "./services/telemetry";
 
 // ---------------------------------------------------------------------------
@@ -171,23 +168,22 @@ const makeResolveOrganizationServices = (dbHandle: DbHandle) => {
 // child span from the outer `McpSessionDO.init` / `McpSessionDO.handleRequest`
 // trace. Tracer comes from the outermost `Effect.provide(DoTelemetryLive)`
 // at the DO method boundary.
-const makeSessionServices = (dbHandle: DbHandle) =>
-  makeResolveOrganizationServices(dbHandle);
+const makeSessionServices = (dbHandle: DbHandle) => makeResolveOrganizationServices(dbHandle);
 
 const resolveSessionMeta = Effect.fn("McpSessionDO.resolveSessionMeta")(function* (
   organizationId: string,
   userId: string,
 ) {
-    const org = yield* resolveOrganization(organizationId);
-    if (!org) {
-      return yield* new OrganizationNotFoundError({ organizationId });
-    }
-    return {
-      organizationId: org.id,
-      organizationName: org.name,
-      userId,
-    } satisfies SessionMeta;
-  });
+  const org = yield* resolveOrganization(organizationId);
+  if (!org) {
+    return yield* new OrganizationNotFoundError({ organizationId });
+  }
+  return {
+    organizationId: org.id,
+    organizationName: org.name,
+    userId,
+  } satisfies SessionMeta;
+});
 
 // ---------------------------------------------------------------------------
 // Durable Object
@@ -201,6 +197,7 @@ export class McpSessionDO extends DurableObject {
   private lastActivityMs = 0;
   private dbHandle: DbHandle | null = null;
   private sessionMeta: SessionMeta | null = null;
+  private transportJsonResponseMode: boolean | null = null;
   // Updated at the start of each `handleRequest` so the host-mcp server's
   // `parentSpan` getter — invoked by the MCP SDK's deferred tool callbacks
   // after `transport.handleRequest()` has already returned its streaming
@@ -268,6 +265,7 @@ export class McpSessionDO extends DurableObject {
       this.sessionMeta = null;
       this.initialized = false;
       this.lastActivityMs = 0;
+      this.transportJsonResponseMode = null;
 
       await Promise.all([
         this.ctx.storage.delete(TRANSPORT_STATE_KEY).catch(() => false),
@@ -306,6 +304,7 @@ export class McpSessionDO extends DurableObject {
         storage: self.makeStorage(),
         enableJsonResponse: options.enableJsonResponse,
       });
+      self.transportJsonResponseMode = options.enableJsonResponse ?? false;
       yield* transport.connect(mcpServer);
       return { mcpServer, transport };
     }).pipe(
@@ -332,12 +331,11 @@ export class McpSessionDO extends DurableObject {
         self.dbHandle = null;
       }
       self.initialized = false;
+      self.transportJsonResponseMode = null;
     }).pipe(Effect.orDie);
   }
 
-  private restoreRuntimeFromStorage(
-    request: Request,
-  ): Effect.Effect<"restored" | "missing_meta"> {
+  private restoreRuntimeFromStorage(request: Request): Effect.Effect<"restored" | "missing_meta"> {
     const self = this;
     return Effect.gen(function* () {
       if (self.initialized && self.transport) return "restored" as const;
@@ -385,8 +383,7 @@ export class McpSessionDO extends DurableObject {
       const accountId = request.headers.get(INTERNAL_ACCOUNT_ID_HEADER);
       const organizationId = request.headers.get(INTERNAL_ORGANIZATION_ID_HEADER);
       const matches =
-        accountId === sessionMeta.userId &&
-        organizationId === sessionMeta.organizationId;
+        accountId === sessionMeta.userId && organizationId === sessionMeta.organizationId;
 
       yield* Effect.annotateCurrentSpan({
         "mcp.session.owner_match": matches,
@@ -401,10 +398,9 @@ export class McpSessionDO extends DurableObject {
     return Effect.gen(function* () {
       const dbHandle = makeEphemeralDb();
       try {
-        const sessionMeta = yield* resolveSessionMeta(
-          token.organizationId,
-          token.userId,
-        ).pipe(Effect.provide(makeResolveOrganizationServices(dbHandle)));
+        const sessionMeta = yield* resolveSessionMeta(token.organizationId, token.userId).pipe(
+          Effect.provide(makeResolveOrganizationServices(dbHandle)),
+        );
         yield* Effect.promise(() => self.saveSessionMeta(sessionMeta)).pipe(
           Effect.withSpan("mcp.session.save_meta"),
         );
@@ -507,6 +503,8 @@ export class McpSessionDO extends DurableObject {
         Effect.tap((response) =>
           Effect.annotateCurrentSpan({
             "mcp.response.status_code": response.status,
+            "mcp.response.content_type": response.headers.get("content-type") ?? "",
+            "mcp.transport.enable_json_response": self.transportJsonResponseMode ?? false,
           }),
         ),
         Effect.ensuring(
@@ -563,20 +561,18 @@ export class McpSessionDO extends DurableObject {
         Effect.withSpan("McpSessionDO.transport.handleRequest", {
           attributes: {
             "mcp.request.method": request.method,
-            "mcp.request.content_type":
-              request.headers.get("content-type") ?? "",
-            "mcp.request.content_length":
-              request.headers.get("content-length") ?? "",
+            "mcp.request.content_type": request.headers.get("content-type") ?? "",
+            "mcp.request.content_length": request.headers.get("content-length") ?? "",
           },
         }),
       );
       yield* Effect.annotateCurrentSpan({
         "mcp.response.status_code": response.status,
+        "mcp.response.content_type": response.headers.get("content-type") ?? "",
+        "mcp.transport.enable_json_response": self.transportJsonResponseMode ?? false,
       });
       if (request.method === "DELETE") {
-        yield* Effect.promise(() => self.cleanup()).pipe(
-          Effect.withSpan("mcp.session.cleanup"),
-        );
+        yield* Effect.promise(() => self.cleanup()).pipe(Effect.withSpan("mcp.session.cleanup"));
       }
       return response;
     }).pipe(

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -21,11 +21,7 @@ import { Context, Effect, Either, Layer, Option, Schema } from "effect";
 import { createRemoteJWKSet } from "jose";
 
 import { TelemetryLive } from "./services/telemetry";
-import {
-  McpJwtVerificationError,
-  verifyMcpAccessToken,
-  type VerifiedToken,
-} from "./mcp-auth";
+import { verifyMcpAccessToken, type VerifiedToken } from "./mcp-auth";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -121,30 +117,33 @@ const verifyJwt = (token: string) =>
 
 export const McpAuthLive = Layer.succeed(McpAuth, {
   verifyBearer: Effect.fn("mcp.auth.verify_bearer")(function* (request) {
-      const authHeader = request.headers.get("authorization");
-      if (!authHeader?.startsWith(BEARER_PREFIX)) {
-        yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_bearer" });
-        return null;
-      }
-      const verified = yield* verifyJwt(authHeader.slice(BEARER_PREFIX.length)).pipe(
-        Effect.catchTag("McpJwtVerificationError", () =>
-          Effect.gen(function* () {
-            yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "invalid" });
-            return null;
-          }),
-        ),
-      );
-      if (!verified) return null;
-      if (!verified.accountId) {
-        yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
-        return null;
-      }
-      yield* Effect.annotateCurrentSpan({
-        "mcp.auth.outcome": "verified",
-        "mcp.auth.has_organization": !!verified.organizationId,
-      });
-      return verified;
-    }),
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader?.startsWith(BEARER_PREFIX)) {
+      yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_bearer" });
+      return null;
+    }
+    const verified = yield* verifyJwt(authHeader.slice(BEARER_PREFIX.length)).pipe(
+      Effect.catchTag("McpJwtVerificationError", (error) =>
+        Effect.gen(function* () {
+          yield* Effect.annotateCurrentSpan({
+            "mcp.auth.outcome": "invalid",
+            "mcp.auth.invalid_reason": error.reason,
+          });
+          return null;
+        }),
+      ),
+    );
+    if (!verified) return null;
+    if (!verified.accountId) {
+      yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
+      return null;
+    }
+    yield* Effect.annotateCurrentSpan({
+      "mcp.auth.outcome": "verified",
+      "mcp.auth.has_organization": !!verified.organizationId,
+    });
+    return verified;
+  }),
 });
 
 // ---------------------------------------------------------------------------
@@ -270,7 +269,9 @@ const methodAttrs = (envelope: JsonRpcEnvelope): Record<string, unknown> => {
           ...(init.clientInfo?.name && { "mcp.client.name": init.clientInfo.name }),
           ...(init.clientInfo?.version && { "mcp.client.version": init.clientInfo.version }),
           ...(init.clientInfo?.title && { "mcp.client.title": init.clientInfo.title }),
-          "mcp.client.capability.keys": Object.keys(init.capabilities ?? {}).sort().join(","),
+          "mcp.client.capability.keys": Object.keys(init.capabilities ?? {})
+            .sort()
+            .join(","),
         }),
       });
     case "tools/call":
@@ -408,6 +409,16 @@ type JsonRpcErrorBody = {
   };
 };
 
+const responseBodyShape = (body: string): string => {
+  const trimmed = body.trimStart();
+  if (!trimmed) return "empty";
+  if (trimmed.startsWith("{")) return "json-object";
+  if (trimmed.startsWith("[")) return "json-array";
+  if (trimmed.startsWith("event:") || trimmed.startsWith("data:")) return "sse";
+  if (trimmed.startsWith("<")) return "html-or-xml";
+  return "other";
+};
+
 const parseFirstJsonRpc = (contentType: string, body: string): JsonRpcErrorBody | null => {
   if (!body) return null;
   try {
@@ -457,8 +468,16 @@ const rpcResponseAttrs = (payload: JsonRpcErrorBody | null): Record<string, unkn
 
 const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
   Effect.gen(function* () {
+    const contentType = response.headers.get("content-type") ?? "";
     if (response.status === 202) {
       // MCP Streamable HTTP accepts notification-only POSTs with 202 and no body.
+      yield* Effect.annotateCurrentSpan({
+        "mcp.response.status_code": response.status,
+        "mcp.response.content_type": contentType,
+        "mcp.response.body.shape": "empty",
+        "mcp.response.body.length": 0,
+        "mcp.response.jsonrpc.detected": false,
+      });
       const headers = new Headers(response.headers);
       headers.delete("content-type");
       headers.delete("content-length");
@@ -468,9 +487,18 @@ const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
         headers,
       });
     }
-    if (!response.body) return response;
-    // The DO returns a streaming SSE Response (POST responses aren't
-    // `enableJsonResponse`'d in prod), so `response.text()` blocks on the
+    if (!response.body) {
+      yield* Effect.annotateCurrentSpan({
+        "mcp.response.status_code": response.status,
+        "mcp.response.content_type": contentType,
+        "mcp.response.body.shape": "empty",
+        "mcp.response.body.length": 0,
+        "mcp.response.jsonrpc.detected": false,
+      });
+      return response;
+    }
+    // The DO can return a streaming SSE response for older in-memory
+    // sessions, so `response.text()` blocks on the
     // entire downstream execution — RPC into the dynamic Worker, tool
     // invocations back to the host, result serialisation. Carving this
     // into its own span pins "worker drain time" on the trace so you can
@@ -478,12 +506,19 @@ const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
     const text = yield* Effect.promise(() => response.text()).pipe(
       Effect.withSpan("mcp.peek_response", {
         attributes: {
-          "http.response.content_type": response.headers.get("content-type") ?? "",
+          "http.response.content_type": contentType,
           "http.response.status_code": response.status,
         },
       }),
     );
-    const payload = parseFirstJsonRpc(response.headers.get("content-type") ?? "", text);
+    const payload = parseFirstJsonRpc(contentType, text);
+    yield* Effect.annotateCurrentSpan({
+      "mcp.response.status_code": response.status,
+      "mcp.response.content_type": contentType,
+      "mcp.response.body.length": text.length,
+      "mcp.response.body.shape": responseBodyShape(text),
+      "mcp.response.jsonrpc.detected": payload?.jsonrpc === "2.0",
+    });
     const attrs = rpcResponseAttrs(payload);
     if (Object.keys(attrs).length > 0) {
       yield* Effect.annotateCurrentSpan(attrs);
@@ -527,9 +562,7 @@ const currentTraceparent = Effect.map(Effect.currentSpan, (span) => {
   return `00-${span.traceId}-${span.spanId}-${flags}`;
 }).pipe(Effect.orElseSucceed(() => undefined));
 
-const currentPropagationHeaders = (
-  request: Request,
-): Effect.Effect<IncomingPropagationHeaders> =>
+const currentPropagationHeaders = (request: Request): Effect.Effect<IncomingPropagationHeaders> =>
   Effect.map(currentTraceparent, (traceparent) => ({
     traceparent,
     tracestate: request.headers.get("tracestate") ?? undefined,
@@ -644,7 +677,8 @@ const dispatchPost = (request: Request, token: VerifiedToken) =>
 
 const dispatchGet = (request: Request, token: VerifiedToken) => {
   const sessionId = request.headers.get("mcp-session-id");
-  if (!sessionId) return Effect.succeed(jsonRpcError(400, -32000, "mcp-session-id header required for SSE"));
+  if (!sessionId)
+    return Effect.succeed(jsonRpcError(400, -32000, "mcp-session-id header required for SSE"));
   return forwardToExistingSession(request, sessionId, false, token);
 };
 


### PR DESCRIPTION
## Summary
- convert MCP JWT verification failures into typed Effect auth errors recovered as invalid auth outcomes
- add MCP response-shape telemetry for diagnosing malformed streamable HTTP responses
- record DO transport JSON-response mode in telemetry and assert it in the miniflare span test

## Tests
- bun run --cwd apps/cloud typecheck
- bun run --cwd apps/cloud vitest run src/mcp-flow.test.ts
- bun run --cwd apps/cloud vitest run --config vitest.node.config.ts src/mcp-miniflare.e2e.node.test.ts -t "reports the McpSessionDO.handleRequest span"