### PR TITLE
Harden MCP auth metadata and transport wrapper

### DIFF
--- a/apps/cloud/src/mcp-flow.test.ts
+++ b/apps/cloud/src/mcp-flow.test.ts
@@ -29,6 +29,7 @@ import {
   runInDurableObject,
   SELF,
 } from "cloudflare:test";
+import { Effect } from "effect";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { makeTestBearer } from "./test-bearer";
@@ -39,7 +40,7 @@ import { makeTestBearer } from "./test-bearer";
 
 const BASE = "https://test-resource.example.com";
 const MCP_URL = `${BASE}/mcp`;
-const OAUTH_RESOURCE_URL = `${BASE}/.well-known/oauth-protected-resource`;
+const OAUTH_RESOURCE_URL = `${BASE}/.well-known/oauth-protected-resource/mcp`;
 
 const JSON_AND_SSE = "application/json, text/event-stream";
 const CONTENT_TYPE_JSON = "application/json";
@@ -167,7 +168,7 @@ describe("/.well-known/oauth-protected-resource", () => {
 
     const body = (await response.json()) as Record<string, unknown>;
     expect(body).toEqual({
-      resource: "https://test-resource.example.com",
+      resource: "https://test-resource.example.com/mcp",
       authorization_servers: ["https://test-authkit.example.com"],
       bearer_methods_supported: ["header"],
       scopes_supported: [],
@@ -186,7 +187,7 @@ describe("/mcp unauthorized", () => {
     const wwwAuth = response.headers.get("www-authenticate") ?? "";
     expect(wwwAuth).toContain("Bearer resource_metadata=");
     expect(wwwAuth).toContain(
-      "https://test-resource.example.com/.well-known/oauth-protected-resource",
+      "https://test-resource.example.com/.well-known/oauth-protected-resource/mcp",
     );
     expect(await response.json()).toEqual({ error: "unauthorized" });
   });
@@ -270,6 +271,42 @@ describe("/mcp notification responses", () => {
     expect(notificationResponse.headers.get("content-type")).toBeNull();
     expect(await notificationResponse.text()).toBe("");
   });
+});
+
+describe("/mcp session restore", () => {
+  it("restores an initialized SDK transport from durable storage", async () => {
+    const orgId = nextOrgId();
+    await seedOrg(orgId);
+
+    const initializeResponse = await mcpPost({
+      bearer: makeTestBearer(nextAccountId(), orgId),
+      body: INITIALIZE_REQUEST,
+    });
+    expect(initializeResponse.status).toBe(200);
+    const sessionId = initializeResponse.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    const ns = env.MCP_SESSION;
+    const stub = ns.get(ns.idFromString(sessionId!));
+    await runInDurableObject(stub, async (instance) => {
+      await Effect.runPromise(
+        (instance as unknown as { closeRuntime: () => Effect.Effect<void> }).closeRuntime(),
+      );
+    });
+
+    const response = await mcpPost({
+      bearer: makeTestBearer(nextAccountId(), orgId),
+      sessionId,
+      body: TOOLS_LIST_REQUEST,
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      readonly jsonrpc: string;
+      readonly result?: { readonly tools?: ReadonlyArray<{ readonly name: string }> };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.result?.tools?.some((tool) => tool.name === "execute")).toBe(true);
+  }, 15_000);
 });
 
 describe("McpSessionDO alarm lifecycle", () => {

--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -327,6 +327,38 @@ const connectClient = async (
 // ---------------------------------------------------------------------------
 
 layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it) => {
+  it.effect("returns 401 for malformed bearer tokens through the production auth layer", () =>
+    Effect.gen(function* () {
+      const { baseUrl } = yield* Worker;
+      const response = yield* Effect.promise(() =>
+        fetch(new URL("/__test__/real-auth-mcp", baseUrl), {
+          method: "POST",
+          headers: {
+            accept: "application/json, text/event-stream",
+            authorization: "Bearer bogus",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "mcp-miniflare-invalid-bearer", version: "0" },
+            },
+          }),
+        }),
+      );
+      expect(response.status).toBe(401);
+      expect(response.headers.get("www-authenticate") ?? "").toContain(
+        "https://test-resource.example.com/.well-known/oauth-protected-resource/mcp",
+      );
+      const body = yield* Effect.promise(() => response.json());
+      expect(body).toEqual({ error: "unauthorized" });
+    }), 30_000,
+  );
+
   it.effect("completes the initialize handshake via SDK", () =>
     Effect.gen(function* () {
       const { baseUrl, seedOrg } = yield* Worker;

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -9,7 +9,7 @@ import * as OtelTracer from "@effect/opentelemetry/Tracer";
 import type * as Tracer from "effect/Tracer";
 import * as Sentry from "@sentry/cloudflare";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { WorkerTransport, type TransportState } from "agents/mcp";
+import type { TransportState } from "agents/mcp";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
@@ -27,6 +27,10 @@ import { UserStoreService } from "./auth/context";
 import { resolveOrganization } from "./auth/resolve-organization";
 import { DbService, combinedSchema, resolveConnectionString } from "./services/db";
 import { makeExecutionStack } from "./services/execution-stack";
+import {
+  makeMcpWorkerTransport,
+  type McpWorkerTransport,
+} from "./services/mcp-worker-transport";
 import { DoTelemetryLive } from "./services/telemetry";
 
 // ---------------------------------------------------------------------------
@@ -187,7 +191,7 @@ const resolveSessionMeta = Effect.fn("McpSessionDO.resolveSessionMeta")(function
 export class McpSessionDO extends DurableObject {
   private readonly instanceCreatedAt = Date.now();
   private mcpServer: McpServer | null = null;
-  private transport: WorkerTransport | null = null;
+  private transport: McpWorkerTransport | null = null;
   private initialized = false;
   private lastActivityMs = 0;
   private dbHandle: DbHandle | null = null;
@@ -291,14 +295,12 @@ export class McpSessionDO extends DurableObject {
         parentSpan: () => self.currentRequestSpan ?? undefined,
         debug: env.EXECUTOR_MCP_DEBUG === "true",
       }).pipe(Effect.withSpan("McpSessionDO.createExecutorMcpServer"));
-      const transport = new WorkerTransport({
+      const transport = yield* makeMcpWorkerTransport({
         sessionIdGenerator: () => self.ctx.id.toString(),
         storage: self.makeStorage(),
         enableJsonResponse: options.enableJsonResponse,
       });
-      yield* Effect.promise(() => mcpServer.connect(transport)).pipe(
-        Effect.withSpan("McpSessionDO.transport.connect"),
-      );
+      yield* transport.connect(mcpServer);
       return { mcpServer, transport };
     }).pipe(
       Effect.withSpan("McpSessionDO.createRuntime"),
@@ -308,17 +310,19 @@ export class McpSessionDO extends DurableObject {
 
   private closeRuntime(): Effect.Effect<void> {
     const self = this;
-    return Effect.promise(async () => {
+    return Effect.gen(function* () {
       if (self.transport) {
-        await self.transport.close().catch(() => undefined);
+        yield* self.transport.close();
         self.transport = null;
       }
       if (self.mcpServer) {
-        await self.mcpServer.close().catch(() => undefined);
+        const mcpServer = self.mcpServer;
+        yield* Effect.promise(() => mcpServer.close().catch(() => undefined));
         self.mcpServer = null;
       }
       if (self.dbHandle) {
-        await self.dbHandle.end();
+        const dbHandle = self.dbHandle;
+        yield* Effect.promise(() => dbHandle.end());
         self.dbHandle = null;
       }
       self.initialized = false;
@@ -522,7 +526,7 @@ export class McpSessionDO extends DurableObject {
       yield* Effect.promise(() => self.markActivity()).pipe(
         Effect.withSpan("McpSessionDO.markActivity"),
       );
-      const response = yield* Effect.promise(() => transport.handleRequest(request)).pipe(
+      const response = yield* transport.handleRequest(request).pipe(
         Effect.withSpan("McpSessionDO.transport.handleRequest", {
           attributes: {
             "mcp.request.method": request.method,

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -17,7 +17,7 @@
 import { env } from "cloudflare:workers";
 import { HttpApp, HttpServerRequest, HttpServerResponse } from "@effect/platform";
 import * as Sentry from "@sentry/cloudflare";
-import { Context, Effect, Layer, Option, Schema } from "effect";
+import { Context, Data, Effect, Layer, Option, Schema } from "effect";
 import { createRemoteJWKSet, jwtVerify } from "jose";
 
 import { TelemetryLive } from "./services/telemetry";
@@ -43,7 +43,12 @@ const CORS_PREFLIGHT_HEADERS = {
   "access-control-expose-headers": "mcp-session-id",
 } as const;
 
-const WWW_AUTHENTICATE = `Bearer resource_metadata="${RESOURCE_ORIGIN}/.well-known/oauth-protected-resource"`;
+const MCP_PATH = "/mcp";
+const PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource/mcp";
+const PROTECTED_RESOURCE_METADATA_URL = `${RESOURCE_ORIGIN}${PROTECTED_RESOURCE_METADATA_PATH}`;
+const RESOURCE_URL = `${RESOURCE_ORIGIN}${MCP_PATH}`;
+
+const WWW_AUTHENTICATE = `Bearer resource_metadata="${PROTECTED_RESOURCE_METADATA_URL}"`;
 
 // ---------------------------------------------------------------------------
 // Response helpers
@@ -86,6 +91,19 @@ export class McpAuth extends Context.Tag("@executor/cloud/McpAuth")<
   }
 >() {}
 
+export class McpJwtVerificationError extends Data.TaggedError("McpJwtVerificationError")<{
+  readonly cause: unknown;
+}> {}
+
+const verifyJwt = (token: string) =>
+  Effect.tryPromise({
+    try: () =>
+      jwtVerify(token, jwks, {
+        issuer: AUTHKIT_DOMAIN,
+      }),
+    catch: (cause) => new McpJwtVerificationError({ cause }),
+  }).pipe(Effect.withSpan("mcp.auth.jwt_verify"));
+
 export const McpAuthLive = Layer.succeed(McpAuth, {
   verifyBearer: (request) =>
     Effect.gen(function* () {
@@ -94,18 +112,16 @@ export const McpAuthLive = Layer.succeed(McpAuth, {
         yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_bearer" });
         return null;
       }
-      const verified = yield* Effect.either(
-        Effect.promise(() =>
-          jwtVerify(authHeader.slice(BEARER_PREFIX.length), jwks, {
-            issuer: AUTHKIT_DOMAIN,
+      const verified = yield* verifyJwt(authHeader.slice(BEARER_PREFIX.length)).pipe(
+        Effect.catchTag("McpJwtVerificationError", () =>
+          Effect.gen(function* () {
+            yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "invalid" });
+            return null;
           }),
-        ).pipe(Effect.withSpan("mcp.auth.jwt_verify")),
+        ),
       );
-      if (verified._tag === "Left") {
-        yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "invalid" });
-        return null;
-      }
-      const { payload } = verified.right;
+      if (!verified) return null;
+      const { payload } = verified;
       if (!payload.sub) {
         yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
         return null;
@@ -336,7 +352,7 @@ const annotateMcpRequest = (
 
 const protectedResourceMetadata = Effect.sync(() =>
   jsonResponse({
-    resource: RESOURCE_ORIGIN,
+    resource: RESOURCE_URL,
     authorization_servers: [AUTHKIT_DOMAIN],
     bearer_methods_supported: ["header"],
     scopes_supported: [],
@@ -528,6 +544,17 @@ const withPropagationHeaders = (
   return new Request(request, { headers });
 };
 
+const withMcpResponseHeaders = (response: Response): Response => {
+  const headers = new Headers(response.headers);
+  headers.set("access-control-allow-origin", "*");
+  headers.set("access-control-expose-headers", "mcp-session-id");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
 /**
  * Forward a request to an existing session DO. Wrapping the DO's `Response`
  * with `HttpServerResponse.raw` lets streaming bodies (SSE) pass through
@@ -550,7 +577,7 @@ const forwardToExistingSession = (request: Request, sessionId: string, peek: boo
       }),
     );
     const annotated = peek ? yield* peekAndAnnotate(raw) : raw;
-    return HttpServerResponse.raw(annotated);
+    return HttpServerResponse.raw(withMcpResponseHeaders(annotated));
   });
 
 const dispatchPost = (request: Request, token: VerifiedToken) =>
@@ -585,7 +612,7 @@ const dispatchPost = (request: Request, token: VerifiedToken) =>
       }),
     );
     const annotated = yield* peekAndAnnotate(raw);
-    return HttpServerResponse.raw(annotated);
+    return HttpServerResponse.raw(withMcpResponseHeaders(annotated));
   });
 
 const dispatchGet = (request: Request) => {
@@ -615,8 +642,8 @@ type McpRoute = "mcp" | "oauth-protected-resource" | "oauth-authorization-server
  * points.
  */
 export const classifyMcpPath = (pathname: string): McpRoute => {
-  if (pathname === "/mcp") return "mcp";
-  if (pathname === "/.well-known/oauth-protected-resource") return "oauth-protected-resource";
+  if (pathname === MCP_PATH) return "mcp";
+  if (pathname === PROTECTED_RESOURCE_METADATA_PATH) return "oauth-protected-resource";
   if (pathname === "/.well-known/oauth-authorization-server") return "oauth-authorization-server";
   return null;
 };

--- a/apps/cloud/src/services/mcp-worker-transport.ts
+++ b/apps/cloud/src/services/mcp-worker-transport.ts
@@ -1,0 +1,39 @@
+import { WorkerTransport, type WorkerTransportOptions } from "agents/mcp";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Data, Effect } from "effect";
+
+export class McpWorkerTransportError extends Data.TaggedError("McpWorkerTransportError")<{
+  readonly cause: unknown;
+}> {}
+
+export type McpWorkerTransport = Readonly<{
+  transport: WorkerTransport;
+  connect: (server: McpServer) => Effect.Effect<void, McpWorkerTransportError>;
+  handleRequest: (request: Request) => Effect.Effect<Response, McpWorkerTransportError>;
+  close: () => Effect.Effect<void>;
+}>;
+
+export const makeMcpWorkerTransport = (
+  options: WorkerTransportOptions,
+): Effect.Effect<McpWorkerTransport> =>
+  Effect.sync(() => {
+    const transport = new WorkerTransport(options);
+
+    const use = <A>(name: string, fn: () => Promise<A>) =>
+      Effect.tryPromise({
+        try: fn,
+        catch: (cause) => new McpWorkerTransportError({ cause }),
+      }).pipe(Effect.withSpan(`mcp.worker_transport.${name}`));
+
+    return {
+      transport,
+      connect: (server: McpServer) => use("connect", () => server.connect(transport)),
+      handleRequest: (request: Request) =>
+        use("handle_request", () => transport.handleRequest(request)),
+      close: () =>
+        Effect.promise(() => transport.close().catch(() => undefined)).pipe(
+          Effect.withSpan("mcp.worker_transport.close"),
+          Effect.orDie,
+        ),
+    } satisfies McpWorkerTransport;
+  }).pipe(Effect.withSpan("mcp.worker_transport.make"));

--- a/apps/cloud/src/test-worker.ts
+++ b/apps/cloud/src/test-worker.ts
@@ -18,7 +18,7 @@ import { Effect, Layer } from "effect";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres, { type Sql } from "postgres";
 
-import { McpAuth, classifyMcpPath, mcpApp } from "./mcp";
+import { McpAuth, McpAuthLive, classifyMcpPath, mcpApp } from "./mcp";
 import { organizations } from "./services/schema";
 import { parseTestBearer } from "./test-bearer";
 import { DoTelemetryLive } from "./services/telemetry";
@@ -89,11 +89,20 @@ const testMcpFetch = HttpApp.toWebHandler(
   mcpApp.pipe(Effect.provide(Layer.mergeAll(TestMcpAuthLive, DoTelemetryLive))),
 );
 
+const realAuthMcpFetch = HttpApp.toWebHandler(
+  mcpApp.pipe(Effect.provide(Layer.mergeAll(McpAuthLive, DoTelemetryLive))),
+);
+
 export default {
   async fetch(request: Request, envArg: Record<string, unknown>): Promise<Response> {
     const url = new URL(request.url);
     if (url.pathname === "/__test__/seed-org" && request.method === "POST") {
       return handleSeedOrg(request, envArg);
+    }
+    if (url.pathname === "/__test__/real-auth-mcp") {
+      const mcpUrl = new URL(request.url);
+      mcpUrl.pathname = "/mcp";
+      return realAuthMcpFetch(new Request(mcpUrl, request));
     }
     if (classifyMcpPath(url.pathname) !== null) {
       return testMcpFetch(request);


### PR DESCRIPTION
## Summary
- keep Cloudflare `WorkerTransport` as the MCP runtime transport and wrap it with an Effect-native adapter
- align protected resource metadata and `WWW-Authenticate` with the path-specific MCP resource metadata endpoint
- map malformed/invalid JWT verification failures into typed Effect auth failures so they return `401` instead of route-level `500`
- preserve WorkerTransport durable restore behavior and add cold-restore and malformed-bearer regressions
- keep CORS exposure on forwarded MCP responses

## Verification
- `bun run --cwd apps/cloud typecheck`
- `bun run --cwd apps/cloud vitest run src/mcp-flow.test.ts`
- `bun run --cwd apps/cloud vitest run --config vitest.node.config.ts src/mcp-miniflare.e2e.node.test.ts`
- `bun run lint`