### PR TITLE
[codex] Reclassify MCP observability noise

### DIFF
--- a/apps/cloud/src/mcp-auth.ts
+++ b/apps/cloud/src/mcp-auth.ts
@@ -1,6 +1,6 @@
-import { Data, Effect } from "effect";
+import { Data, Effect, Either } from "effect";
 import { jwtVerify, type JWTVerifyGetKey } from "jose";
-import { JWTExpired } from "jose/errors";
+import { JOSEError, JWKSInvalid, JWKSTimeout, JWTExpired } from "jose/errors";
 
 export type VerifiedToken = {
   /** The WorkOS account ID (user ID). */
@@ -11,34 +11,74 @@ export type VerifiedToken = {
 
 export class McpJwtVerificationError extends Data.TaggedError("McpJwtVerificationError")<{
   readonly cause: unknown;
-  readonly reason: "expired" | "invalid";
+  readonly reason: "expired" | "invalid" | "system";
 }> {}
 
-export const verifyMcpAccessToken = Effect.fn("mcp.auth.jwt_verify")(function* (
+const classifyJwtVerificationError = (cause: unknown): McpJwtVerificationError =>
+  new McpJwtVerificationError({
+    cause,
+    reason:
+      cause instanceof JWTExpired
+        ? "expired"
+        : cause instanceof JWKSTimeout ||
+            cause instanceof JWKSInvalid ||
+            !(cause instanceof JOSEError)
+          ? "system"
+          : "invalid",
+  });
+
+const isExpectedJwtVerificationError = (error: McpJwtVerificationError): boolean =>
+  error.reason === "expired" || error.reason === "invalid";
+
+const withJwtVerificationSpan = <A>(
+  effect: Effect.Effect<A, McpJwtVerificationError>,
+): Effect.Effect<A, McpJwtVerificationError> =>
+  effect.pipe(
+    Effect.either,
+    Effect.flatMap((outcome) =>
+      Effect.gen(function* () {
+        if (Either.isRight(outcome)) {
+          yield* Effect.annotateCurrentSpan({ "mcp.auth.jwt_verify.outcome": "verified" });
+          return outcome;
+        }
+
+        yield* Effect.annotateCurrentSpan({
+          "mcp.auth.jwt_verify.outcome": outcome.left.reason,
+        });
+
+        return isExpectedJwtVerificationError(outcome.left)
+          ? outcome
+          : yield* Effect.fail(outcome.left);
+      }),
+    ),
+    Effect.withSpan("mcp.auth.jwt_verify"),
+    Effect.flatMap((outcome) =>
+      Either.isRight(outcome) ? Effect.succeed(outcome.right) : Effect.fail(outcome.left),
+    ),
+  );
+
+export const verifyMcpAccessToken = (
   token: string,
   jwks: JWTVerifyGetKey,
   options: {
     readonly issuer: string;
     readonly audience?: string;
   },
-) {
-  const { payload } = yield* Effect.tryPromise({
-    try: () =>
-      jwtVerify(token, jwks, {
-        issuer: options.issuer,
-        ...(options.audience ? { audience: options.audience } : {}),
-      }),
-    catch: (cause) =>
-      new McpJwtVerificationError({
-        cause,
-        reason: cause instanceof JWTExpired ? "expired" : "invalid",
-      }),
+) =>
+  Effect.gen(function* () {
+    const { payload } = yield* Effect.tryPromise({
+      try: () =>
+        jwtVerify(token, jwks, {
+          issuer: options.issuer,
+          ...(options.audience ? { audience: options.audience } : {}),
+        }),
+      catch: classifyJwtVerificationError,
+    }).pipe(withJwtVerificationSpan);
+
+    if (!payload.sub) return null;
+
+    return {
+      accountId: payload.sub,
+      organizationId: (payload.org_id as string | undefined) ?? null,
+    } satisfies VerifiedToken;
   });
-
-  if (!payload.sub) return null;
-
-  return {
-    accountId: payload.sub,
-    organizationId: (payload.org_id as string | undefined) ?? null,
-  } satisfies VerifiedToken;
-});

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -21,7 +21,7 @@ import { Context, Effect, Either, Layer, Option, Schema } from "effect";
 import { createRemoteJWKSet } from "jose";
 
 import { TelemetryLive } from "./services/telemetry";
-import { verifyMcpAccessToken, type VerifiedToken } from "./mcp-auth";
+import { McpJwtVerificationError, verifyMcpAccessToken, type VerifiedToken } from "./mcp-auth";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -87,7 +87,9 @@ const corsPreflight = HttpServerResponse.empty({
 export class McpAuth extends Context.Tag("@executor/cloud/McpAuth")<
   McpAuth,
   {
-    readonly verifyBearer: (request: Request) => Effect.Effect<VerifiedToken | null>;
+    readonly verifyBearer: (
+      request: Request,
+    ) => Effect.Effect<VerifiedToken | null, McpJwtVerificationError>;
   }
 >() {}
 
@@ -123,15 +125,16 @@ export const McpAuthLive = Layer.succeed(McpAuth, {
       return null;
     }
     const verified = yield* verifyJwt(authHeader.slice(BEARER_PREFIX.length)).pipe(
-      Effect.catchTag("McpJwtVerificationError", (error) =>
-        Effect.gen(function* () {
+      Effect.catchTag("McpJwtVerificationError", (error) => {
+        if (error.reason === "system") return Effect.fail(error);
+        return Effect.gen(function* () {
           yield* Effect.annotateCurrentSpan({
             "mcp.auth.outcome": "invalid",
             "mcp.auth.invalid_reason": error.reason,
           });
           return null;
-        }),
-      ),
+        });
+      }),
     );
     if (!verified) return null;
     if (!verified.accountId) {

--- a/packages/plugins/workos-vault/src/sdk/client.ts
+++ b/packages/plugins/workos-vault/src/sdk/client.ts
@@ -1,6 +1,6 @@
 import type { WorkOS } from "@workos-inc/node/worker";
 import { WorkOS as WorkOSClient } from "@workos-inc/node/worker";
-import { Data, Effect } from "effect";
+import { Data, Effect, Either } from "effect";
 
 export interface WorkOSVaultObjectMetadata {
   readonly context: Record<string, unknown>;
@@ -47,10 +47,16 @@ export interface WorkOSVaultCredentials {
   readonly clientId: string;
 }
 
+interface WorkOSVaultUseOptions {
+  readonly expectedErrorStatuses?: readonly number[];
+  readonly expectedErrorOutcome?: string;
+}
+
 export interface WorkOSVaultClient {
   readonly use: <A>(
     operation: string,
     fn: (client: WorkOSVaultSdk) => Promise<A>,
+    options?: WorkOSVaultUseOptions,
   ) => Effect.Effect<A, WorkOSVaultClientError, never>;
   readonly createObject: (options: {
     readonly name: string;
@@ -70,24 +76,80 @@ export interface WorkOSVaultClient {
   }) => Effect.Effect<void, WorkOSVaultClientError, never>;
 }
 
-export const makeWorkOSVaultClient = (
-  workos: Pick<WorkOS, "vault">,
-): WorkOSVaultClient => {
+const vaultErrorStatus = (error: WorkOSVaultClientError): number | null => {
+  const cause = error.cause;
+  return typeof cause === "object" &&
+    cause !== null &&
+    "status" in cause &&
+    typeof (cause as { readonly status: unknown }).status === "number"
+    ? (cause as { readonly status: number }).status
+    : null;
+};
+
+const isExpectedVaultError = (
+  error: WorkOSVaultClientError,
+  options: WorkOSVaultUseOptions | undefined,
+): boolean => {
+  const status = vaultErrorStatus(error);
+  return status !== null && (options?.expectedErrorStatuses?.includes(status) ?? false);
+};
+
+export const makeWorkOSVaultClient = (workos: Pick<WorkOS, "vault">): WorkOSVaultClient => {
   const client: WorkOSVaultSdk = workos.vault;
 
   const use = <A>(
     operation: string,
     fn: (vault: WorkOSVaultSdk) => Promise<A>,
-  ): Effect.Effect<A, WorkOSVaultClientError, never> =>
-    Effect.tryPromise({
+    options?: WorkOSVaultUseOptions,
+  ): Effect.Effect<A, WorkOSVaultClientError, never> => {
+    const attempt = Effect.tryPromise({
       try: () => fn(client),
       catch: (cause) => new WorkOSVaultClientError({ cause, operation }),
-    }).pipe(Effect.withSpan(`workos_vault.${operation}`));
+    });
+
+    const observed = attempt.pipe(
+      Effect.either,
+      Effect.flatMap((outcome) =>
+        Effect.gen(function* () {
+          if (Either.isRight(outcome)) {
+            yield* Effect.annotateCurrentSpan({ "workos_vault.outcome": "ok" });
+            return outcome;
+          }
+
+          const status = vaultErrorStatus(outcome.left);
+          if (isExpectedVaultError(outcome.left, options)) {
+            yield* Effect.annotateCurrentSpan({
+              "workos_vault.outcome": options?.expectedErrorOutcome ?? "expected_error",
+              "workos_vault.status": status ?? "unknown",
+            });
+            return outcome;
+          }
+
+          yield* Effect.annotateCurrentSpan({
+            "workos_vault.outcome": "error",
+            "workos_vault.status": status ?? "unknown",
+          });
+          return yield* Effect.fail(outcome.left);
+        }),
+      ),
+      Effect.withSpan(`workos_vault.${operation}`),
+    );
+
+    return observed.pipe(
+      Effect.flatMap((outcome) =>
+        Either.isRight(outcome) ? Effect.succeed(outcome.right) : Effect.fail(outcome.left),
+      ),
+    );
+  };
 
   return {
     use,
     createObject: (options) => use("create_object", (vault) => vault.createObject(options)),
-    readObjectByName: (name) => use("read_object_by_name", (vault) => vault.readObjectByName(name)),
+    readObjectByName: (name) =>
+      use("read_object_by_name", (vault) => vault.readObjectByName(name), {
+        expectedErrorOutcome: "expected_missing_object",
+        expectedErrorStatuses: [400, 404],
+      }),
     updateObject: (options) => use("update_object", (vault) => vault.updateObject(options)),
     deleteObject: (options) => use("delete_object", (vault) => vault.deleteObject(options)),
   };


### PR DESCRIPTION
## Summary

Reclassifies expected MCP auth and WorkOS Vault lookup failures so normal user-facing/protocol outcomes do not show up as backend errors in telemetry.

- Treat expired/invalid JWT verification as expected auth outcomes while preserving JWKS/system failures as real errors.
- Let WorkOS Vault read lookups opt into expected 400/404 statuses and annotate those spans as missing-object outcomes.
- Preserve existing request behavior while reducing noisy red spans in Axiom/Sentry.

## Validation

- `vitest run --config vitest.node.config.ts src/mcp-auth.node.test.ts`
- `vitest run src/sdk/secret-store.test.ts`
- `bun run typecheck` in `apps/cloud`
- `bun run typecheck` in `packages/plugins/workos-vault`
