### PR TITLE
Fix: Add margin-top to hero section

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -25,7 +25,7 @@ import Layout from '../layouts/Layout.astro'
 
     <div class="max-w-[1200px] mx-auto px-6 sm:px-10 w-full">
       <!-- Text centered -->
-      <div class="text-center max-w-2xl mx-auto mb-16">
+      <div class="text-center max-w-2xl mx-auto mt-10 mb-16">
         <h1 class="rise-d1 font-display text-[clamp(3rem,7vw,5.5rem)] leading-[0.95] tracking-tight mb-8">
           <span class="text-ink">Your missing<br /></span><span class="italic text-teal">execution&nbsp;layer</span>
         </h1>


### PR DESCRIPTION
Hero had no margin top, making main heading too close to the header. After `mt-10` is applied, the main hero is more evenly spaced:


| Before | After |
|--------|--------|
| <img width="371" height="803" alt="Screenshot 2026-04-28 at 23 05 26" src="https://github.com/user-attachments/assets/226b15b5-8406-41d0-b233-5d27f5115e69" /> | <img width="371" height="803" alt="Screenshot 2026-04-28 at 23 05 22" src="https://github.com/user-attachments/assets/609992c8-fa7c-4cdd-af4f-f6db78491a73" /> |
| <img width="1905" height="967" alt="Screenshot 2026-04-28 at 23 05 11" src="https://github.com/user-attachments/assets/54505e80-ab11-467d-999d-061b2afbd603" />  | <img width="1905" height="967" alt="Screenshot 2026-04-28 at 23 04 53" src="https://github.com/user-attachments/assets/314e4860-0acb-4533-bb5b-1220ac4df96e" /> | 