### PR TITLE
docs: add Symphony smoke test note

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ bun dev
 
 The dev server starts at `http://127.0.0.1:4788`.
 
+### Symphony smoke test
+
+This repository was used to smoke test Symphony's executor workspace flow: clone, edit docs, validate, and publish from a configured workspace.
+
 ## Community
 
 Join the Discord: [https://discord.gg/eF29HBHwM6](https://discord.gg/eF29HBHwM6)

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The dev server starts at `http://127.0.0.1:4788`.
 
 ### Symphony smoke test
 
-This repository was used to smoke test Symphony's executor workspace flow: clone, edit docs, validate, and publish from a configured workspace.
+hello world from the Symphony executor workspace smoke test.
 
 ## Community
 


### PR DESCRIPTION
## Summary

- Adds a short README note recording the Symphony executor workspace smoke test.

## Validation

- bunx oxfmt --check README.md
- Confirmed the Symphony dashboard API shows EXE-7 running in this workspace with scripts: setup, dev, lint, test, publish.

Linear: EXE-7