### PR TITLE
Fix MCP OAuth bearer challenges

### DIFF
--- a/apps/cloud/src/mcp-flow.test.ts
+++ b/apps/cloud/src/mcp-flow.test.ts
@@ -186,7 +186,8 @@ describe("/mcp unauthorized", () => {
     const response = await mcpPost({ body: INITIALIZE_REQUEST });
     expect(response.status).toBe(401);
     const wwwAuth = response.headers.get("www-authenticate") ?? "";
-    expect(wwwAuth).toContain('Bearer error="unauthorized"');
+    expect(wwwAuth).toContain("Bearer resource_metadata=");
+    expect(wwwAuth).not.toContain("error=");
     expect(wwwAuth).toContain('resource_metadata="');
     expect(wwwAuth).toContain(
       "https://test-resource.example.com/.well-known/oauth-protected-resource/mcp",

--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -351,7 +351,10 @@ layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it)
         }),
       );
       expect(response.status).toBe(401);
-      expect(response.headers.get("www-authenticate") ?? "").toContain(
+      const wwwAuth = response.headers.get("www-authenticate") ?? "";
+      expect(wwwAuth).toContain('Bearer error="invalid_token"');
+      expect(wwwAuth).toContain('error_description="The access token is invalid"');
+      expect(wwwAuth).toContain(
         "https://test-resource.example.com/.well-known/oauth-protected-resource/mcp",
       );
       const body = yield* Effect.promise(() => response.json());

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -60,11 +60,52 @@ const PROTECTED_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource/
 const PROTECTED_RESOURCE_METADATA_URL = `${RESOURCE_ORIGIN}${PROTECTED_RESOURCE_METADATA_PATH}`;
 const RESOURCE_URL = `${RESOURCE_ORIGIN}${MCP_PATH}`;
 
-const WWW_AUTHENTICATE = [
-  'Bearer error="unauthorized"',
-  'error_description="Authorization needed"',
-  `resource_metadata="${PROTECTED_RESOURCE_METADATA_URL}"`,
-].join(", ");
+type McpUnauthorizedReason = "missing_bearer" | "invalid_token";
+
+type McpAuthorizedResult = {
+  readonly _tag: "Authorized";
+  readonly token: VerifiedToken;
+};
+
+type McpUnauthorizedResult = {
+  readonly _tag: "Unauthorized";
+  readonly reason: McpUnauthorizedReason;
+  readonly description?: string;
+};
+
+export type McpAuthResult = McpAuthorizedResult | McpUnauthorizedResult;
+
+export const mcpAuthorized = (token: VerifiedToken): McpAuthorizedResult => ({
+  _tag: "Authorized",
+  token,
+});
+
+export const mcpUnauthorized = (
+  reason: McpUnauthorizedReason,
+  description?: string,
+): McpUnauthorizedResult => ({
+  _tag: "Unauthorized",
+  reason,
+  description,
+});
+
+const quoteAuthParam = (value: string) =>
+  `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+
+const bearerChallenge = (auth: McpUnauthorizedResult) => {
+  const params =
+    auth.reason === "missing_bearer"
+      ? [`resource_metadata=${quoteAuthParam(PROTECTED_RESOURCE_METADATA_URL)}`]
+      : [
+          'error="invalid_token"',
+          `error_description=${quoteAuthParam(
+            auth.description ?? "The access token is invalid or expired",
+          )}`,
+          `resource_metadata=${quoteAuthParam(PROTECTED_RESOURCE_METADATA_URL)}`,
+        ];
+
+  return `Bearer ${params.join(", ")}`;
+};
 
 // ---------------------------------------------------------------------------
 // Response helpers
@@ -76,13 +117,14 @@ const jsonResponse = (body: unknown, status = 200) =>
 const jsonRpcError = (status: number, code: number, message: string) =>
   HttpServerResponse.unsafeJson({ jsonrpc: "2.0", error: { code, message }, id: null }, { status });
 
-const unauthorized = HttpServerResponse.unsafeJson(
-  { error: "unauthorized" },
-  {
-    status: 401,
-    headers: { ...CORS_ALLOW_ORIGIN, "www-authenticate": WWW_AUTHENTICATE },
-  },
-);
+const unauthorized = (auth: McpUnauthorizedResult) =>
+  HttpServerResponse.unsafeJson(
+    { error: "unauthorized" },
+    {
+      status: 401,
+      headers: { ...CORS_ALLOW_ORIGIN, "www-authenticate": bearerChallenge(auth) },
+    },
+  );
 
 const corsPreflight = HttpServerResponse.empty({
   status: 204,
@@ -98,7 +140,7 @@ export class McpAuth extends Context.Tag("@executor/cloud/McpAuth")<
   {
     readonly verifyBearer: (
       request: Request,
-    ) => Effect.Effect<VerifiedToken | null, McpJwtVerificationError>;
+    ) => Effect.Effect<McpAuthResult, McpJwtVerificationError>;
   }
 >() {}
 
@@ -139,7 +181,7 @@ export const McpAuthLive = Layer.succeed(McpAuth, {
     const authHeader = request.headers.get("authorization");
     if (!authHeader?.startsWith(BEARER_PREFIX)) {
       yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_bearer" });
-      return null;
+      return mcpUnauthorized("missing_bearer");
     }
     const verified = yield* verifyJwt(authHeader.slice(BEARER_PREFIX.length)).pipe(
       Effect.catchTag("McpJwtVerificationError", (error) => {
@@ -149,20 +191,26 @@ export const McpAuthLive = Layer.succeed(McpAuth, {
             "mcp.auth.outcome": "invalid",
             "mcp.auth.invalid_reason": error.reason,
           });
-          return null;
+          return mcpUnauthorized(
+            "invalid_token",
+            error.reason === "expired"
+              ? "The access token expired"
+              : "The access token is invalid",
+          );
         });
       }),
     );
-    if (!verified) return null;
+    if (!verified) return mcpUnauthorized("invalid_token", "The access token is invalid");
+    if ("_tag" in verified) return verified;
     if (!verified.accountId) {
       yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
-      return null;
+      return mcpUnauthorized("invalid_token", "The access token is invalid");
     }
     yield* Effect.annotateCurrentSpan({
       "mcp.auth.outcome": "verified",
       "mcp.auth.has_organization": !!verified.organizationId,
     });
-    return verified;
+    return mcpAuthorized(verified);
   }),
 });
 
@@ -797,14 +845,18 @@ export const mcpApp: Effect.Effect<
   if (route === "oauth-authorization-server") return yield* authorizationServerMetadata;
 
   const auth = yield* McpAuth;
-  const token = yield* auth.verifyBearer(request);
+  const authResult = yield* auth.verifyBearer(request);
 
   // Annotate before dispatch so even 401s show up with what we know. Only
   // POST bodies are JSON-RPC payloads worth parsing; GET (SSE) and DELETE
   // don't carry one.
-  yield* annotateMcpRequest(request, { token, parseBody: request.method === "POST" });
+  yield* annotateMcpRequest(request, {
+    token: authResult._tag === "Authorized" ? authResult.token : null,
+    parseBody: request.method === "POST",
+  });
 
-  if (!token) return unauthorized;
+  if (authResult._tag === "Unauthorized") return unauthorized(authResult);
+  const token = authResult.token;
   switch (request.method) {
     case "POST":
       return yield* dispatchPost(request, token);

--- a/apps/cloud/src/test-worker.ts
+++ b/apps/cloud/src/test-worker.ts
@@ -24,7 +24,9 @@ import {
   McpOrganizationAuth,
   McpOrganizationAuthLive,
   classifyMcpPath,
+  mcpAuthorized,
   mcpApp,
+  mcpUnauthorized,
 } from "./mcp";
 import { organizations } from "./services/schema";
 import { parseTestBearer } from "./test-bearer";
@@ -36,8 +38,9 @@ const TestMcpAuthLive = Layer.succeed(McpAuth, {
   verifyBearer: (request) =>
     Effect.sync(() => {
       const header = request.headers.get("authorization");
-      if (!header?.startsWith("Bearer ")) return null;
-      return parseTestBearer(header.slice("Bearer ".length));
+      if (!header?.startsWith("Bearer ")) return mcpUnauthorized("missing_bearer");
+      const token = parseTestBearer(header.slice("Bearer ".length));
+      return token ? mcpAuthorized(token) : mcpUnauthorized("invalid_token");
     }),
 });
 


### PR DESCRIPTION
## Summary

- distinguish missing bearer credentials from invalid or expired MCP bearer tokens
- return `WWW-Authenticate` challenges that keep bare discovery responses to `resource_metadata` and reserve `invalid_token` for bad credentials
- update MCP flow and Miniflare coverage for the challenge shape

## Context

This fixes the Executor/server side of the MCP OAuth behavior we debugged. It gives MCP clients the protected-resource metadata challenge they need for initial discovery, while still returning an OAuth-style `invalid_token` challenge when a supplied access token is malformed or expired.

This does not try to work around the separate Codex client issue where multiple long-lived Codex processes can hold stale in-memory rotating refresh tokens. That needs to be fixed in Codex by reloading stored MCP OAuth credentials before refresh, or by reloading and retrying once after a refresh failure if another process already rotated the token.

## Testing

- `bun run typecheck` in `apps/cloud`
- `bunx vitest run src/mcp-flow.test.ts` in `apps/cloud`
- `bunx vitest run --config vitest.node.config.ts src/mcp-miniflare.e2e.node.test.ts` in `apps/cloud`
