### PR TITLE
Handle transient MCP auth and transport hangs

### DIFF
--- a/apps/cloud/src/mcp-flow.test.ts
+++ b/apps/cloud/src/mcp-flow.test.ts
@@ -24,12 +24,7 @@
 // MCP session coverage lives in `mcp-miniflare.e2e.node.test.ts`.
 // ---------------------------------------------------------------------------
 
-import {
-  env,
-  runDurableObjectAlarm,
-  runInDurableObject,
-  SELF,
-} from "cloudflare:test";
+import { env, runDurableObjectAlarm, runInDurableObject, SELF } from "cloudflare:test";
 import { Effect } from "effect";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
@@ -108,6 +103,16 @@ const mcpPost = (init: McpPostInit): Promise<Response> => {
   });
 };
 
+const mcpGet = (init: { readonly bearer: string; readonly sessionId: string }): Promise<Response> =>
+  SELF.fetch(MCP_URL, {
+    method: "GET",
+    headers: {
+      accept: "text/event-stream",
+      authorization: `Bearer ${init.bearer}`,
+      "mcp-session-id": init.sessionId,
+    },
+  });
+
 const seedOrg = async (id: string, name = "MCP Flow Org"): Promise<void> => {
   const response = await SELF.fetch(`${BASE}/__test__/seed-org`, {
     method: "POST",
@@ -146,9 +151,7 @@ describe("/mcp CORS preflight", () => {
 
     expect(response.status).toBe(204);
     expect(response.headers.get("access-control-allow-origin")).toBe("*");
-    expect(response.headers.get("access-control-allow-methods")).toBe(
-      "GET, POST, DELETE, OPTIONS",
-    );
+    expect(response.headers.get("access-control-allow-methods")).toBe("GET, POST, DELETE, OPTIONS");
     const allowedHeaders = response.headers.get("access-control-allow-headers") ?? "";
     expect(allowedHeaders).toContain("mcp-session-id");
     expect(allowedHeaders).toContain("authorization");
@@ -214,6 +217,24 @@ describe("/mcp verified token without org", () => {
     expect(body.jsonrpc).toBe("2.0");
     expect(body.error.code).toBe(-32001);
     expect(body.error.message).toMatch(/No organization/i);
+  });
+});
+
+describe("/mcp transient auth failure", () => {
+  it("returns a retryable JSON-RPC error instead of a generic 500", async () => {
+    const response = await mcpPost({
+      bearer: "test-system-error",
+      body: TOOLS_LIST_REQUEST,
+    });
+    expect(response.status).toBe(503);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    const body = (await response.json()) as {
+      jsonrpc: string;
+      error: { code: number; message: string };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.error.code).toBe(-32001);
+    expect(body.error.message).toMatch(/temporarily unavailable/i);
   });
 });
 
@@ -322,6 +343,53 @@ describe("/mcp session restore", () => {
       body: TOOLS_LIST_REQUEST,
     });
     expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      readonly jsonrpc: string;
+      readonly result?: { readonly tools?: ReadonlyArray<{ readonly name: string }> };
+    };
+    expect(body.jsonrpc).toBe("2.0");
+    expect(body.result?.tools?.some((tool) => tool.name === "execute")).toBe(true);
+  }, 15_000);
+
+  it("keeps JSON POST responses after a session is restored by a GET reconnect", async () => {
+    const orgId = nextOrgId();
+    const accountId = nextAccountId();
+    const bearer = makeTestBearer(accountId, orgId);
+    await seedOrg(orgId);
+
+    const initializeResponse = await mcpPost({
+      bearer,
+      body: INITIALIZE_REQUEST,
+    });
+    expect(initializeResponse.status).toBe(200);
+    const sessionId = initializeResponse.headers.get("mcp-session-id");
+    expect(sessionId).toBeTruthy();
+
+    const ns = env.MCP_SESSION;
+    const stub = ns.get(ns.idFromString(sessionId!));
+    await runInDurableObject(stub, async (instance) => {
+      await Effect.runPromise(
+        (instance as unknown as { closeRuntime: () => Effect.Effect<void> }).closeRuntime(),
+      );
+    });
+
+    const getResponse = await mcpGet({ bearer, sessionId: sessionId! });
+    expect(getResponse.status).toBe(200);
+    expect(getResponse.headers.get("content-type") ?? "").toContain("text/event-stream");
+    await getResponse.body?.cancel().catch(() => undefined);
+
+    const response = await Promise.race([
+      mcpPost({
+        bearer,
+        sessionId,
+        body: TOOLS_LIST_REQUEST,
+      }),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("POST did not return after GET restore")), 5_000),
+      ),
+    ]);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type") ?? "").toContain("application/json");
     const body = (await response.json()) as {
       readonly jsonrpc: string;
       readonly result?: { readonly tools?: ReadonlyArray<{ readonly name: string }> };

--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -58,20 +58,14 @@ const ApproveGroup = HttpApiGroup.make("approve").add(
 const UpstreamApi = HttpApi.make("approveApi").add(ApproveGroup);
 
 const ApproveHandlers = HttpApiBuilder.group(UpstreamApi, "approve", (h) =>
-  h.handle("approveThing", () =>
-    Effect.succeed(new ApprovedResponse({ approved: true })),
-  ),
+  h.handle("approveThing", () => Effect.succeed(new ApprovedResponse({ approved: true }))),
 );
 
-const UpstreamApiLive = HttpApiBuilder.api(UpstreamApi).pipe(
-  Layer.provide(ApproveHandlers),
-);
+const UpstreamApiLive = HttpApiBuilder.api(UpstreamApi).pipe(Layer.provide(ApproveHandlers));
 
 const UpstreamServeLayer = HttpApiBuilder.serve().pipe(
   Layer.provide(UpstreamApiLive),
-  Layer.provideMerge(
-    NodeHttpServer.layer(() => createServer(), { port: 0, host: "127.0.0.1" }),
-  ),
+  Layer.provideMerge(NodeHttpServer.layer(() => createServer(), { port: 0, host: "127.0.0.1" })),
 );
 
 // ---------------------------------------------------------------------------
@@ -187,7 +181,9 @@ const TelemetryReceiverLive = Layer.scoped(
           return;
         }
         let body = "";
-        req.on("data", (chunk) => { body += chunk; });
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
         req.on("end", () => {
           try {
             const payload = JSON.parse(body) as OtlpPayload;
@@ -232,10 +228,7 @@ const TelemetryReceiverLive = Layer.scoped(
     Effect.map((t) => ({
       tracesUrl: t.tracesUrl,
       spans: () => [...t.store],
-      waitForSpan: async (
-        predicate: (s: CapturedSpan) => boolean,
-        timeoutMs = 5_000,
-      ) => {
+      waitForSpan: async (predicate: (s: CapturedSpan) => boolean, timeoutMs = 5_000) => {
         const deadline = Date.now() + timeoutMs;
         for (;;) {
           const hit = t.store.find(predicate);
@@ -322,218 +315,525 @@ const connectClient = async (
   return client;
 };
 
+const initializeSession = async (baseUrl: URL, bearer: string): Promise<string> => {
+  const response = await fetch(new URL("/mcp", baseUrl), {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${bearer}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: "init",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: { name: "mcp-miniflare-manual", version: "0" },
+      },
+    }),
+  });
+  expect(response.status).toBe(200);
+  const sessionId = response.headers.get("mcp-session-id");
+  expect(sessionId).toEqual(expect.any(String));
+  await response.text();
+
+  const initialized = await fetch(new URL("/mcp", baseUrl), {
+    method: "POST",
+    headers: {
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${bearer}`,
+      "content-type": "application/json",
+      "mcp-session-id": sessionId ?? "",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+  });
+  expect(initialized.status).toBe(202);
+  await initialized.text();
+
+  return sessionId ?? "";
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it) => {
-  it.effect("returns 401 for malformed bearer tokens through the production auth layer", () =>
-    Effect.gen(function* () {
-      const { baseUrl } = yield* Worker;
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/__test__/real-auth-mcp", baseUrl), {
+  it.effect(
+    "returns 401 for malformed bearer tokens through the production auth layer",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl } = yield* Worker;
+        const response = yield* Effect.promise(() =>
+          fetch(new URL("/__test__/real-auth-mcp", baseUrl), {
+            method: "POST",
+            headers: {
+              accept: "application/json, text/event-stream",
+              authorization: "Bearer bogus",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "initialize",
+              params: {
+                protocolVersion: "2025-06-18",
+                capabilities: {},
+                clientInfo: { name: "mcp-miniflare-invalid-bearer", version: "0" },
+              },
+            }),
+          }),
+        );
+        expect(response.status).toBe(401);
+        const wwwAuth = response.headers.get("www-authenticate") ?? "";
+        expect(wwwAuth).toContain('Bearer error="invalid_token"');
+        expect(wwwAuth).toContain('error_description="The access token is invalid"');
+        expect(wwwAuth).toContain(
+          "https://test-resource.example.com/.well-known/oauth-protected-resource/mcp",
+        );
+        const body = yield* Effect.promise(() => response.json());
+        expect(body).toEqual({ error: "unauthorized" });
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "completes the initialize handshake via SDK",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const orgId = nextOrgId();
+        yield* Effect.promise(() => seedOrg(orgId, "Miniflare Org"));
+        const client = yield* Effect.promise(() =>
+          connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
+        );
+        expect(client.getServerVersion()?.name).toBe("executor");
+        yield* Effect.promise(() => client.close());
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "lists the execute tool after handshake",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const orgId = nextOrgId();
+        yield* Effect.promise(() => seedOrg(orgId, "List Tools Org"));
+        const client = yield* Effect.promise(() =>
+          connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
+        );
+        const { tools } = yield* Effect.promise(() => client.listTools());
+        expect(tools.map((t) => t.name)).toContain("execute");
+        yield* Effect.promise(() => client.close());
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "executes code end-to-end via tools/call",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const orgId = nextOrgId();
+        yield* Effect.promise(() => seedOrg(orgId, "Execute Org"));
+        const client = yield* Effect.promise(() =>
+          connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
+        );
+        const result = yield* Effect.promise(() =>
+          client.callTool({ name: "execute", arguments: { code: "return 1 + 2" } }),
+        );
+        expect(result.isError).not.toBe(true);
+        const content = (result.content ?? []) as Array<{ type: string; text?: string }>;
+        expect(content.find((c) => c.type === "text")?.text ?? "").toContain("3");
+        yield* Effect.promise(() => client.close());
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "replaces duplicate standalone SSE GET streams for the same session",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const orgId = nextOrgId();
+        const bearer = makeTestBearer(nextAccountId(), orgId);
+        yield* Effect.promise(() => seedOrg(orgId, "Duplicate SSE Org"));
+        const sessionId = yield* Effect.promise(() => initializeSession(baseUrl, bearer));
+
+        const getHeaders = {
+          accept: "text/event-stream",
+          authorization: `Bearer ${bearer}`,
+          "mcp-protocol-version": "2025-11-25",
+          "mcp-session-id": sessionId,
+        };
+        const first = yield* Effect.promise(() =>
+          fetch(new URL("/mcp", baseUrl), { method: "GET", headers: getHeaders }),
+        );
+        expect(first.status).toBe(200);
+
+        const second = yield* Effect.promise(() =>
+          fetch(new URL("/mcp", baseUrl), { method: "GET", headers: getHeaders }),
+        );
+        expect(second.status).toBe(200);
+        expect(second.headers.get("content-type") ?? "").toContain("text/event-stream");
+
+        yield* Effect.promise(async () => {
+          await first.body?.cancel().catch(() => undefined);
+        });
+        yield* Effect.promise(async () => {
+          await second.body?.cancel().catch(() => undefined);
+        });
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "does not replace the active standalone SSE stream for an invalid GET",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const orgId = nextOrgId();
+        const bearer = makeTestBearer(nextAccountId(), orgId);
+        yield* Effect.promise(() => seedOrg(orgId, "Invalid SSE Replacement Org"));
+        const sessionId = yield* Effect.promise(() => initializeSession(baseUrl, bearer));
+
+        const getHeaders = {
+          accept: "text/event-stream",
+          authorization: `Bearer ${bearer}`,
+          "mcp-protocol-version": "2025-11-25",
+          "mcp-session-id": sessionId,
+        };
+        const first = yield* Effect.promise(() =>
+          fetch(new URL("/mcp", baseUrl), { method: "GET", headers: getHeaders }),
+        );
+        expect(first.status).toBe(200);
+        const firstReader = first.body?.getReader();
+        expect(firstReader).toBeDefined();
+
+        const invalid = yield* Effect.promise(() =>
+          fetch(new URL("/mcp", baseUrl), {
+            method: "GET",
+            headers: { ...getHeaders, "mcp-protocol-version": "1999-01-01" },
+          }),
+        );
+        expect(invalid.status).toBe(400);
+        yield* Effect.promise(() => invalid.text());
+
+        const firstRead = yield* Effect.promise(() =>
+          Promise.race([
+            firstReader!.read().then(() => "closed"),
+            new Promise<"open">((resolve) => setTimeout(() => resolve("open"), 100)),
+          ]),
+        );
+        expect(firstRead).toBe("open");
+
+        yield* Effect.promise(async () => {
+          await firstReader?.cancel().catch(() => undefined);
+        });
+      }),
+    30_000,
+  );
+
+  it.effect(
+    "returns tools/call results while standalone SSE GET reconnects churn",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const orgId = nextOrgId();
+        const bearer = makeTestBearer(nextAccountId(), orgId);
+        yield* Effect.promise(() => seedOrg(orgId, "SSE Reconnect Churn Org"));
+        const sessionId = yield* Effect.promise(() => initializeSession(baseUrl, bearer));
+
+        const getHeaders = {
+          accept: "text/event-stream",
+          authorization: `Bearer ${bearer}`,
+          "mcp-protocol-version": "2025-11-25",
+          "mcp-session-id": sessionId,
+        };
+
+        const openSse = () =>
+          fetch(new URL("/mcp", baseUrl), { method: "GET", headers: getHeaders });
+
+        const postResult = fetch(new URL("/mcp", baseUrl), {
           method: "POST",
           headers: {
             accept: "application/json, text/event-stream",
-            authorization: "Bearer bogus",
+            authorization: `Bearer ${bearer}`,
             "content-type": "application/json",
+            "mcp-protocol-version": "2025-11-25",
+            "mcp-session-id": sessionId,
           },
           body: JSON.stringify({
             jsonrpc: "2.0",
-            id: 1,
-            method: "initialize",
+            id: "search",
+            method: "tools/call",
             params: {
-              protocolVersion: "2025-06-18",
-              capabilities: {},
-              clientInfo: { name: "mcp-miniflare-invalid-bearer", version: "0" },
+              name: "execute",
+              arguments: {
+                code: [
+                  "await new Promise((resolve) => setTimeout(resolve, 1_000));",
+                  'return await tools.search({ namespace: "vercel_api", query: "list domains", limit: 8 });',
+                ].join("\n"),
+              },
             },
           }),
-        }),
-      );
-      expect(response.status).toBe(401);
-      const wwwAuth = response.headers.get("www-authenticate") ?? "";
-      expect(wwwAuth).toContain('Bearer error="invalid_token"');
-      expect(wwwAuth).toContain('error_description="The access token is invalid"');
-      expect(wwwAuth).toContain(
-        "https://test-resource.example.com/.well-known/oauth-protected-resource/mcp",
-      );
-      const body = yield* Effect.promise(() => response.json());
-      expect(body).toEqual({ error: "unauthorized" });
-    }), 30_000,
+        });
+
+        const reconnects = yield* Effect.promise(async () => {
+          const responses: Array<Response> = [];
+          for (let i = 0; i < 35; i++) {
+            const response = await openSse();
+            expect(response.status).toBe(200);
+            responses.push(response);
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          return responses;
+        });
+
+        const response = yield* Effect.promise(() =>
+          Promise.race([
+            postResult,
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () => reject(new Error("tools/call did not return during SSE churn")),
+                5_000,
+              ),
+            ),
+          ]),
+        );
+        expect(response.status).toBe(200);
+        const body = (yield* Effect.promise(() => response.json())) as {
+          readonly jsonrpc?: string;
+          readonly id?: string;
+          readonly result?: { readonly content?: ReadonlyArray<{ readonly text?: string }> };
+          readonly error?: unknown;
+        };
+        expect(body).toMatchObject({ jsonrpc: "2.0", id: "search" });
+        expect(body.error).toBeUndefined();
+        expect(body.result).toBeDefined();
+
+        yield* Effect.promise(async () => {
+          await Promise.all(
+            reconnects.map((response) => response.body?.cancel().catch(() => undefined)),
+          );
+        });
+      }),
+    30_000,
   );
 
-  it.effect("completes the initialize handshake via SDK", () =>
-    Effect.gen(function* () {
-      const { baseUrl, seedOrg } = yield* Worker;
-      const orgId = nextOrgId();
-      yield* Effect.promise(() => seedOrg(orgId, "Miniflare Org"));
-      const client = yield* Effect.promise(() =>
-        connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
-      );
-      expect(client.getServerVersion()?.name).toBe("executor");
-      yield* Effect.promise(() => client.close());
-    }), 30_000,
+  it.effect(
+    "returns both overlapping tools/call responses when JSON-RPC ids collide",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const orgId = nextOrgId();
+        const bearer = makeTestBearer(nextAccountId(), orgId);
+        yield* Effect.promise(() => seedOrg(orgId, "Overlapping Request Id Org"));
+        const sessionId = yield* Effect.promise(() => initializeSession(baseUrl, bearer));
+
+        const postExecute = (code: string) =>
+          fetch(new URL("/mcp", baseUrl), {
+            method: "POST",
+            headers: {
+              accept: "application/json, text/event-stream",
+              authorization: `Bearer ${bearer}`,
+              "content-type": "application/json",
+              "mcp-protocol-version": "2025-11-25",
+              "mcp-session-id": sessionId,
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: { name: "execute", arguments: { code } },
+            }),
+          });
+
+        const first = postExecute(
+          ["await new Promise((resolve) => setTimeout(resolve, 500));", 'return "first";'].join(
+            "\n",
+          ),
+        );
+        yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 50)));
+        const second = postExecute('return "second";');
+
+        const responses = yield* Effect.promise(() =>
+          Promise.race([
+            Promise.all([first, second]),
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () => reject(new Error("overlapping tools/call requests did not both return")),
+                5_000,
+              ),
+            ),
+          ]),
+        );
+
+        expect(responses.map((response) => response.status)).toEqual([200, 200]);
+        const bodies = yield* Effect.promise(() =>
+          Promise.all(
+            responses.map(
+              (response) =>
+                response.json() as Promise<{
+                  readonly result?: {
+                    readonly content?: ReadonlyArray<{ readonly text?: string }>;
+                  };
+                  readonly error?: unknown;
+                }>,
+            ),
+          ),
+        );
+        expect(
+          bodies.some((body) => body.result?.content?.some((item) => item.text?.includes("first"))),
+        ).toBe(true);
+        expect(
+          bodies.some((body) =>
+            body.result?.content?.some((item) => item.text?.includes("second")),
+          ),
+        ).toBe(true);
+        expect(bodies.every((body) => body.error === undefined)).toBe(true);
+      }),
+    30_000,
   );
 
-  it.effect("lists the execute tool after handshake", () =>
-    Effect.gen(function* () {
-      const { baseUrl, seedOrg } = yield* Worker;
-      const orgId = nextOrgId();
-      yield* Effect.promise(() => seedOrg(orgId, "List Tools Org"));
-      const client = yield* Effect.promise(() =>
-        connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
-      );
-      const { tools } = yield* Effect.promise(() => client.listTools());
-      expect(tools.map((t) => t.name)).toContain("execute");
-      yield* Effect.promise(() => client.close());
-    }), 30_000,
+  it.effect(
+    "round-trips approval elicitation for a POST openapi operation",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const { specJson } = yield* Upstream;
+        const orgId = nextOrgId();
+        yield* Effect.promise(() => seedOrg(orgId, "Elicit Org"));
+
+        const client = yield* Effect.promise(() =>
+          connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId), {
+            withElicitation: true,
+          }),
+        );
+
+        let elicitCount = 0;
+        client.setRequestHandler(ElicitRequestSchema, async () => {
+          elicitCount++;
+          return { action: "accept" as const, content: {} };
+        });
+
+        // User code inside `execute` (1) registers the upstream as an OpenAPI
+        // source and (2) invokes its POST operation. `annotationsForOperation`
+        // marks the POST as `requiresApproval: true`, which fires
+        // `enforceApproval` in the executor; that goes through the MCP
+        // elicitation handler and lands on `client.setRequestHandler` above.
+        // Tool id is `<namespace>.<group>.<operation>` — Effect's
+        // `HttpApiGroup` name ("approve") becomes part of the sandbox path,
+        // so the invocation reads `tools.approveapi.approve.approveThing`.
+        const code = [
+          `await tools.openapi.addSource({ spec: ${JSON.stringify(specJson)}, namespace: "approveapi" });`,
+          `return await tools.approveapi.approve.approveThing({});`,
+        ].join("\n");
+        const result = yield* Effect.promise(() =>
+          client.callTool({ name: "execute", arguments: { code } }),
+        );
+        expect(result.isError).not.toBe(true);
+        expect(elicitCount).toBeGreaterThan(0);
+        const text =
+          ((result.content ?? []) as Array<{ type: string; text?: string }>).find(
+            (c) => c.type === "text",
+          )?.text ?? "";
+        expect(text).toContain("approved");
+
+        yield* Effect.promise(() => client.close());
+      }),
+    30_000,
   );
 
-  it.effect("executes code end-to-end via tools/call", () =>
-    Effect.gen(function* () {
-      const { baseUrl, seedOrg } = yield* Worker;
-      const orgId = nextOrgId();
-      yield* Effect.promise(() => seedOrg(orgId, "Execute Org"));
-      const client = yield* Effect.promise(() =>
-        connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
-      );
-      const result = yield* Effect.promise(() =>
-        client.callTool({ name: "execute", arguments: { code: "return 1 + 2" } }),
-      );
-      expect(result.isError).not.toBe(true);
-      const content = (result.content ?? []) as Array<{ type: string; text?: string }>;
-      expect(content.find((c) => c.type === "text")?.text ?? "").toContain("3");
-      yield* Effect.promise(() => client.close());
-    }), 30_000,
+  it.effect(
+    "reports the McpSessionDO.handleRequest span via the OTLP exporter",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const receiver = yield* TelemetryReceiver;
+        const orgId = nextOrgId();
+        yield* Effect.promise(() => seedOrg(orgId, "Telemetry Org"));
+        const client = yield* Effect.promise(() =>
+          connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
+        );
+        // Trigger the DO through a multi-step flow so we can assert that
+        // handleRequest spans are reported for every DO hit, not just init.
+        yield* Effect.promise(() => client.listTools());
+        yield* Effect.promise(() =>
+          client.callTool({ name: "execute", arguments: { code: "return 1 + 2" } }),
+        );
+        yield* Effect.promise(() => client.close());
+
+        // The initialize POST carries no session-id; subsequent requests do.
+        // Assert on one of the session-id'd handleRequest spans so we verify
+        // attribute propagation beyond the degenerate init case.
+        const handleSpan = yield* Effect.promise(() =>
+          receiver.waitForSpan(
+            (s) =>
+              s.name === "McpSessionDO.handleRequest" &&
+              s.attributes["mcp.request.session_id_present"] === true,
+          ),
+        );
+        expect(handleSpan.attributes["mcp.request.method"]).toBeDefined();
+        // 200 for normal POSTs, 202 for notifications/initialized.
+        expect([200, 202]).toContain(handleSpan.attributes["mcp.response.status_code"]);
+        expect(handleSpan.attributes["mcp.response.content_type"]).toEqual(expect.any(String));
+        expect(handleSpan.attributes["mcp.transport.enable_json_response"]).toBe(true);
+
+        // init runs once per new session and should appear on the initialize POST.
+        yield* Effect.promise(() => receiver.waitForSpan((s) => s.name === "McpSessionDO.init"));
+      }),
+    30_000,
   );
-
-  it.effect("round-trips approval elicitation for a POST openapi operation", () =>
-    Effect.gen(function* () {
-      const { baseUrl, seedOrg } = yield* Worker;
-      const { specJson } = yield* Upstream;
-      const orgId = nextOrgId();
-      yield* Effect.promise(() => seedOrg(orgId, "Elicit Org"));
-
-      const client = yield* Effect.promise(() =>
-        connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId), {
-          withElicitation: true,
-        }),
-      );
-
-      let elicitCount = 0;
-      client.setRequestHandler(ElicitRequestSchema, async () => {
-        elicitCount++;
-        return { action: "accept" as const, content: {} };
-      });
-
-      // User code inside `execute` (1) registers the upstream as an OpenAPI
-      // source and (2) invokes its POST operation. `annotationsForOperation`
-      // marks the POST as `requiresApproval: true`, which fires
-      // `enforceApproval` in the executor; that goes through the MCP
-      // elicitation handler and lands on `client.setRequestHandler` above.
-      // Tool id is `<namespace>.<group>.<operation>` — Effect's
-      // `HttpApiGroup` name ("approve") becomes part of the sandbox path,
-      // so the invocation reads `tools.approveapi.approve.approveThing`.
-      const code = [
-        `await tools.openapi.addSource({ spec: ${JSON.stringify(specJson)}, namespace: "approveapi" });`,
-        `return await tools.approveapi.approve.approveThing({});`,
-      ].join("\n");
-      const result = yield* Effect.promise(() =>
-        client.callTool({ name: "execute", arguments: { code } }),
-      );
-      expect(result.isError).not.toBe(true);
-      expect(elicitCount).toBeGreaterThan(0);
-      const text = ((result.content ?? []) as Array<{ type: string; text?: string }>)
-        .find((c) => c.type === "text")?.text ?? "";
-      expect(text).toContain("approved");
-
-      yield* Effect.promise(() => client.close());
-    }), 30_000,
-  );
-
-  it.effect("reports the McpSessionDO.handleRequest span via the OTLP exporter", () =>
-    Effect.gen(function* () {
-      const { baseUrl, seedOrg } = yield* Worker;
-      const receiver = yield* TelemetryReceiver;
-      const orgId = nextOrgId();
-      yield* Effect.promise(() => seedOrg(orgId, "Telemetry Org"));
-      const client = yield* Effect.promise(() =>
-        connectClient(baseUrl, makeTestBearer(nextAccountId(), orgId)),
-      );
-      // Trigger the DO through a multi-step flow so we can assert that
-      // handleRequest spans are reported for every DO hit, not just init.
-      yield* Effect.promise(() => client.listTools());
-      yield* Effect.promise(() =>
-        client.callTool({ name: "execute", arguments: { code: "return 1 + 2" } }),
-      );
-      yield* Effect.promise(() => client.close());
-
-      // The initialize POST carries no session-id; subsequent requests do.
-      // Assert on one of the session-id'd handleRequest spans so we verify
-      // attribute propagation beyond the degenerate init case.
-      const handleSpan = yield* Effect.promise(() =>
-        receiver.waitForSpan(
-          (s) =>
-            s.name === "McpSessionDO.handleRequest" &&
-            s.attributes["mcp.request.session_id_present"] === true,
-        ),
-      );
-      expect(handleSpan.attributes["mcp.request.method"]).toBeDefined();
-      // 200 for normal POSTs, 202 for notifications/initialized.
-      expect([200, 202]).toContain(handleSpan.attributes["mcp.response.status_code"]);
-      expect(handleSpan.attributes["mcp.response.content_type"]).toEqual(expect.any(String));
-      expect(handleSpan.attributes["mcp.transport.enable_json_response"]).toBe(true);
-
-      // init runs once per new session and should appear on the initialize POST.
-      yield* Effect.promise(() =>
-        receiver.waitForSpan((s) => s.name === "McpSessionDO.init"),
-      );
-    }), 30_000,
-  );
-
 });
 
 layer(TestEnv, { timeout: 60_000 })("cloud MCP request-id telemetry", (it) => {
-  it.effect("exports MCP JSON-RPC request ids for request-shaped ids", () =>
-    Effect.gen(function* () {
-      const { baseUrl, seedOrg } = yield* Worker;
-      const receiver = yield* TelemetryReceiver;
-      const orgId = nextOrgId();
-      const accountId = nextAccountId();
-      const requestId = `req_${crypto.randomUUID().replace(/-/g, "")}`;
-      yield* Effect.promise(() => seedOrg(orgId, "Request Id Org"));
+  it.effect(
+    "exports MCP JSON-RPC request ids for request-shaped ids",
+    () =>
+      Effect.gen(function* () {
+        const { baseUrl, seedOrg } = yield* Worker;
+        const receiver = yield* TelemetryReceiver;
+        const orgId = nextOrgId();
+        const accountId = nextAccountId();
+        const requestId = `req_${crypto.randomUUID().replace(/-/g, "")}`;
+        yield* Effect.promise(() => seedOrg(orgId, "Request Id Org"));
 
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/mcp", baseUrl), {
-          method: "POST",
-          headers: {
-            accept: "application/json, text/event-stream",
-            authorization: `Bearer ${makeTestBearer(accountId, orgId)}`,
-            "content-type": "application/json",
-          },
-          body: JSON.stringify({
-            jsonrpc: "2.0",
-            id: requestId,
-            method: "initialize",
-            params: {
-              protocolVersion: "2025-06-18",
-              capabilities: {},
-              clientInfo: { name: "mcp-request-id-e2e", version: "0" },
+        const response = yield* Effect.promise(() =>
+          fetch(new URL("/mcp", baseUrl), {
+            method: "POST",
+            headers: {
+              accept: "application/json, text/event-stream",
+              authorization: `Bearer ${makeTestBearer(accountId, orgId)}`,
+              "content-type": "application/json",
             },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: requestId,
+              method: "initialize",
+              params: {
+                protocolVersion: "2025-06-18",
+                capabilities: {},
+                clientInfo: { name: "mcp-request-id-e2e", version: "0" },
+              },
+            }),
           }),
-        }),
-      );
-      expect(response.status).toBe(200);
-      yield* Effect.promise(() => response.text());
+        );
+        expect(response.status).toBe(200);
+        yield* Effect.promise(() => response.text());
 
-      const annotateSpan = yield* Effect.promise(() =>
-        receiver.waitForSpan(
-          (s) =>
-            s.name === "mcp.request.annotate" &&
-            s.attributes["mcp.rpc.id"] === requestId,
-        ),
-      );
-      expect(annotateSpan.attributes["mcp.rpc.method"]).toBe("initialize");
-    }), 30_000,
+        const annotateSpan = yield* Effect.promise(() =>
+          receiver.waitForSpan(
+            (s) => s.name === "mcp.request.annotate" && s.attributes["mcp.rpc.id"] === requestId,
+          ),
+        );
+        expect(annotateSpan.attributes["mcp.rpc.method"]).toBe("initialize");
+      }),
+    30_000,
   );
 });

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -335,6 +335,23 @@ export class McpSessionDO extends DurableObject {
     }).pipe(Effect.orDie);
   }
 
+  private installRuntime(
+    sessionMeta: SessionMeta,
+    options: {
+      readonly dbHandle: DbHandle;
+      readonly enableJsonResponse: boolean;
+    },
+  ) {
+    const self = this;
+    return Effect.gen(function* () {
+      const runtime = yield* self.createConnectedRuntime(sessionMeta, options);
+      self.dbHandle = options.dbHandle;
+      self.mcpServer = runtime.mcpServer;
+      self.transport = runtime.transport;
+      self.initialized = true;
+    });
+  }
+
   private restoreRuntimeFromStorage(request: Request): Effect.Effect<"restored" | "missing_meta"> {
     const self = this;
     return Effect.gen(function* () {
@@ -349,14 +366,14 @@ export class McpSessionDO extends DurableObject {
       }
 
       yield* self.closeRuntime();
-      self.dbHandle = makeLongLivedDb();
-      const runtime = yield* self.createConnectedRuntime(sessionMeta, {
-        dbHandle: self.dbHandle,
-        enableJsonResponse: request.method !== "GET",
+      const dbHandle = makeLongLivedDb();
+      yield* self.installRuntime(sessionMeta, {
+        dbHandle,
+        // GET always returns an SSE stream regardless of this option, but the
+        // session-scoped transport is reused by later POSTs. Keep JSON mode on
+        // across cold restores so a GET reconnect cannot poison future POSTs.
+        enableJsonResponse: true,
       });
-      self.mcpServer = runtime.mcpServer;
-      self.transport = runtime.transport;
-      self.initialized = true;
       yield* Effect.promise(() => self.markActivity()).pipe(
         Effect.withSpan("McpSessionDO.markActivity"),
       );
@@ -373,6 +390,26 @@ export class McpSessionDO extends DurableObject {
       }),
       Effect.orDie,
     );
+  }
+
+  private ensureJsonResponseTransportForPost(request: Request): Effect.Effect<void> {
+    const self = this;
+    return Effect.gen(function* () {
+      if (request.method !== "POST" || self.transportJsonResponseMode === true) return;
+
+      const sessionMeta = yield* self.loadSessionMeta();
+      if (!sessionMeta) return;
+
+      yield* self.closeRuntime();
+      const dbHandle = makeLongLivedDb();
+      yield* self.installRuntime(sessionMeta, {
+        dbHandle,
+        enableJsonResponse: true,
+      });
+      yield* Effect.annotateCurrentSpan({
+        "mcp.session.transport_upgraded_json_response": true,
+      });
+    }).pipe(Effect.withSpan("McpSessionDO.ensureJsonResponseTransportForPost"), Effect.orDie);
   }
 
   private validateSessionOwner(request: Request): Effect.Effect<Response | null> {
@@ -551,9 +588,14 @@ export class McpSessionDO extends DurableObject {
       });
     }
 
-    const transport = this.transport;
     const self = this;
     return Effect.gen(function* () {
+      yield* self.ensureJsonResponseTransportForPost(request);
+      const transport = self.transport;
+      if (!transport) {
+        return jsonRpcError(404, -32001, "Session timed out due to inactivity — please reconnect");
+      }
+
       yield* Effect.promise(() => self.markActivity()).pipe(
         Effect.withSpan("McpSessionDO.markActivity"),
       );

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -30,6 +30,14 @@ import { authorizeOrganization } from "./auth/authorize-organization";
 import { UserStoreService } from "./auth/context";
 import { CoreSharedServices } from "./api/core-shared-services";
 import { DbService } from "./services/db";
+import { peekAndAnnotate } from "./mcp/response-peek";
+import {
+  authTemporarilyUnavailable,
+  CORS_ALLOW_ORIGIN,
+  jsonResponse,
+  jsonRpcError,
+  unauthorized,
+} from "./mcp/responses";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -44,8 +52,6 @@ const jwks = createRemoteJWKSet(new URL(`${AUTHKIT_DOMAIN}/oauth2/jwks`));
 const BEARER_PREFIX = "Bearer ";
 const INTERNAL_ACCOUNT_ID_HEADER = "x-executor-mcp-account-id";
 const INTERNAL_ORGANIZATION_ID_HEADER = "x-executor-mcp-organization-id";
-
-const CORS_ALLOW_ORIGIN = { "access-control-allow-origin": "*" } as const;
 
 const CORS_PREFLIGHT_HEADERS = {
   ...CORS_ALLOW_ORIGIN,
@@ -89,43 +95,6 @@ export const mcpUnauthorized = (
   description,
 });
 
-const quoteAuthParam = (value: string) =>
-  `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
-
-const bearerChallenge = (auth: McpUnauthorizedResult) => {
-  const params =
-    auth.reason === "missing_bearer"
-      ? [`resource_metadata=${quoteAuthParam(PROTECTED_RESOURCE_METADATA_URL)}`]
-      : [
-          'error="invalid_token"',
-          `error_description=${quoteAuthParam(
-            auth.description ?? "The access token is invalid or expired",
-          )}`,
-          `resource_metadata=${quoteAuthParam(PROTECTED_RESOURCE_METADATA_URL)}`,
-        ];
-
-  return `Bearer ${params.join(", ")}`;
-};
-
-// ---------------------------------------------------------------------------
-// Response helpers
-// ---------------------------------------------------------------------------
-
-const jsonResponse = (body: unknown, status = 200) =>
-  HttpServerResponse.unsafeJson(body, { status, headers: CORS_ALLOW_ORIGIN });
-
-const jsonRpcError = (status: number, code: number, message: string) =>
-  HttpServerResponse.unsafeJson({ jsonrpc: "2.0", error: { code, message }, id: null }, { status });
-
-const unauthorized = (auth: McpUnauthorizedResult) =>
-  HttpServerResponse.unsafeJson(
-    { error: "unauthorized" },
-    {
-      status: 401,
-      headers: { ...CORS_ALLOW_ORIGIN, "www-authenticate": bearerChallenge(auth) },
-    },
-  );
-
 const corsPreflight = HttpServerResponse.empty({
   status: 204,
   headers: CORS_PREFLIGHT_HEADERS,
@@ -162,11 +131,7 @@ const verifyJwt = (token: string) =>
 
 const DbLive = DbService.Live;
 const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
-const McpOrganizationAuthServices = Layer.mergeAll(
-  DbLive,
-  UserStoreLive,
-  CoreSharedServices,
-);
+const McpOrganizationAuthServices = Layer.mergeAll(DbLive, UserStoreLive, CoreSharedServices);
 
 export const McpOrganizationAuthLive = Layer.succeed(McpOrganizationAuth, {
   authorize: (accountId, organizationId) =>
@@ -193,9 +158,7 @@ export const McpAuthLive = Layer.succeed(McpAuth, {
           });
           return mcpUnauthorized(
             "invalid_token",
-            error.reason === "expired"
-              ? "The access token expired"
-              : "The access token is invalid",
+            error.reason === "expired" ? "The access token expired" : "The access token is invalid",
           );
         });
       }),
@@ -444,167 +407,6 @@ const authorizationServerMetadata = Effect.promise(async () => {
 });
 
 // ---------------------------------------------------------------------------
-// Response-body peek for JSON-RPC error attrs
-// ---------------------------------------------------------------------------
-//
-// The MCP protocol wraps protocol-level failures (malformed envelope, method
-// not found, invalid params) as `{ error: { code, message } }` in the
-// JSON-RPC response body with HTTP 200 — none of which surface at the HTTP
-// layer or as an Effect failure. Same for tool results carrying
-// `isError: true`. To make those visible in Axiom we peek the first
-// JSON-RPC message out of the DO's response and stamp it onto the
-// surrounding `mcp.request` span.
-//
-// Only applied to non-streaming response shapes (POST/DELETE). GET hops
-// onto a long-lived SSE channel we don't want to consume.
-// ---------------------------------------------------------------------------
-
-type SandboxOutcome = {
-  readonly status?: string;
-  readonly error?: { readonly kind?: string; readonly message?: string };
-};
-
-type JsonRpcErrorBody = {
-  readonly jsonrpc?: string;
-  readonly error?: { readonly code?: number; readonly message?: string };
-  readonly result?: {
-    readonly isError?: boolean;
-    readonly structuredContent?: SandboxOutcome;
-  };
-};
-
-const responseBodyShape = (body: string): string => {
-  const trimmed = body.trimStart();
-  if (!trimmed) return "empty";
-  if (trimmed.startsWith("{")) return "json-object";
-  if (trimmed.startsWith("[")) return "json-array";
-  if (trimmed.startsWith("event:") || trimmed.startsWith("data:")) return "sse";
-  if (trimmed.startsWith("<")) return "html-or-xml";
-  return "other";
-};
-
-const parseFirstJsonRpc = (contentType: string, body: string): JsonRpcErrorBody | null => {
-  if (!body) return null;
-  try {
-    if (contentType.includes("text/event-stream")) {
-      // Grab the first `data:` line from the first SSE event.
-      for (const line of body.split(/\r?\n/)) {
-        if (line.startsWith("data:")) return JSON.parse(line.slice(5).trimStart());
-      }
-      return null;
-    }
-    if (contentType.includes("application/json")) {
-      return JSON.parse(body);
-    }
-    return null;
-  } catch {
-    return null;
-  }
-};
-
-const rpcResponseAttrs = (payload: JsonRpcErrorBody | null): Record<string, unknown> => {
-  // Require a JSON-RPC 2.0 envelope so we don't false-positive on other
-  // JSON shapes the edge happens to return (e.g. the auth-failure body
-  // `{ "error": "unauthorized" }` — not a JSON-RPC error).
-  if (!payload || payload.jsonrpc !== "2.0") return {};
-  const attrs: Record<string, unknown> = {};
-  const err = payload.error;
-  if (err && typeof err === "object") {
-    attrs["mcp.rpc.is_error"] = true;
-    if (typeof err.code === "number") attrs["mcp.rpc.error.code"] = err.code;
-    if (typeof err.message === "string") {
-      attrs["mcp.rpc.error.message"] = err.message.slice(0, 500);
-    }
-  }
-  if (payload.result?.isError === true) {
-    attrs["mcp.tool.result.is_error"] = true;
-  }
-  const sc = payload.result?.structuredContent;
-  if (sc && typeof sc.status === "string") {
-    attrs["mcp.tool.sandbox.status"] = sc.status;
-    if (sc.error?.kind) attrs["mcp.tool.sandbox.error.kind"] = sc.error.kind;
-    if (typeof sc.error?.message === "string") {
-      attrs["mcp.tool.sandbox.error.message"] = sc.error.message.slice(0, 500);
-    }
-  }
-  return attrs;
-};
-
-const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
-  Effect.gen(function* () {
-    const contentType = response.headers.get("content-type") ?? "";
-    if (response.status === 202) {
-      // MCP Streamable HTTP accepts notification-only POSTs with 202 and no body.
-      yield* Effect.annotateCurrentSpan({
-        "mcp.response.status_code": response.status,
-        "mcp.response.content_type": contentType,
-        "mcp.response.body.shape": "empty",
-        "mcp.response.body.length": 0,
-        "mcp.response.jsonrpc.detected": false,
-      });
-      const headers = new Headers(response.headers);
-      headers.delete("content-type");
-      headers.delete("content-length");
-      return new Response(null, {
-        status: response.status,
-        statusText: response.statusText,
-        headers,
-      });
-    }
-    if (!response.body) {
-      yield* Effect.annotateCurrentSpan({
-        "mcp.response.status_code": response.status,
-        "mcp.response.content_type": contentType,
-        "mcp.response.body.shape": "empty",
-        "mcp.response.body.length": 0,
-        "mcp.response.jsonrpc.detected": false,
-      });
-      return response;
-    }
-    // The DO can return a streaming SSE response for older in-memory
-    // sessions, so `response.text()` blocks on the
-    // entire downstream execution — RPC into the dynamic Worker, tool
-    // invocations back to the host, result serialisation. Carving this
-    // into its own span pins "worker drain time" on the trace so you can
-    // tell worker-side waiting apart from any pre/post work on the edge.
-    const text = yield* Effect.promise(() => response.text()).pipe(
-      Effect.withSpan("mcp.peek_response", {
-        attributes: {
-          "http.response.content_type": contentType,
-          "http.response.status_code": response.status,
-        },
-      }),
-    );
-    const payload = parseFirstJsonRpc(contentType, text);
-    yield* Effect.annotateCurrentSpan({
-      "mcp.response.status_code": response.status,
-      "mcp.response.content_type": contentType,
-      "mcp.response.body.length": text.length,
-      "mcp.response.body.shape": responseBodyShape(text),
-      "mcp.response.jsonrpc.detected": payload?.jsonrpc === "2.0",
-    });
-    const attrs = rpcResponseAttrs(payload);
-    if (Object.keys(attrs).length > 0) {
-      yield* Effect.annotateCurrentSpan(attrs);
-    }
-    // Internal-error code -32603 means our server failed handling a
-    // structurally valid request. Unlike -32601 / -32602 ("the client
-    // fucked up"), this is a real bug in our code — route to Sentry so
-    // we get alerted. Protocol-level client errors stay in Axiom.
-    if (payload?.error?.code === -32603) {
-      yield* Effect.sync(() => {
-        const msg = payload.error?.message ?? "unknown";
-        Sentry.captureException(new Error(`MCP internal error (-32603): ${msg}`));
-      });
-    }
-    return new Response(text, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    });
-  });
-
-// ---------------------------------------------------------------------------
 // DO dispatch
 // ---------------------------------------------------------------------------
 
@@ -845,18 +647,29 @@ export const mcpApp: Effect.Effect<
   if (route === "oauth-authorization-server") return yield* authorizationServerMetadata;
 
   const auth = yield* McpAuth;
-  const authResult = yield* auth.verifyBearer(request);
+  const authResult = yield* auth.verifyBearer(request).pipe(Effect.either);
+
+  if (authResult._tag === "Left") {
+    yield* annotateMcpRequest(request, {
+      token: null,
+      parseBody: request.method === "POST",
+    });
+    return yield* authTemporarilyUnavailable(authResult.left);
+  }
+  const authValue = authResult.right;
 
   // Annotate before dispatch so even 401s show up with what we know. Only
   // POST bodies are JSON-RPC payloads worth parsing; GET (SSE) and DELETE
   // don't carry one.
   yield* annotateMcpRequest(request, {
-    token: authResult._tag === "Authorized" ? authResult.token : null,
+    token: authValue._tag === "Authorized" ? authValue.token : null,
     parseBody: request.method === "POST",
   });
 
-  if (authResult._tag === "Unauthorized") return unauthorized(authResult);
-  const token = authResult.token;
+  if (authValue._tag === "Unauthorized") {
+    return unauthorized(authValue, PROTECTED_RESOURCE_METADATA_URL);
+  }
+  const token = authValue.token;
   switch (request.method) {
     case "POST":
       return yield* dispatchPost(request, token);

--- a/apps/cloud/src/mcp/response-peek.ts
+++ b/apps/cloud/src/mcp/response-peek.ts
@@ -1,0 +1,203 @@
+import * as Sentry from "@sentry/cloudflare";
+import { Effect } from "effect";
+
+import { jsonRpcWebResponse } from "./responses";
+
+const SSE_PEEK_TIMEOUT_MS = 10_000;
+
+type SandboxOutcome = {
+  readonly status?: string;
+  readonly error?: { readonly kind?: string; readonly message?: string };
+};
+
+type JsonRpcResponseBody = {
+  readonly jsonrpc?: string;
+  readonly error?: { readonly code?: number; readonly message?: string };
+  readonly result?: {
+    readonly isError?: boolean;
+    readonly structuredContent?: SandboxOutcome;
+  };
+};
+
+const responseBodyShape = (body: string): string => {
+  const trimmed = body.trimStart();
+  if (!trimmed) return "empty";
+  if (trimmed.startsWith("{")) return "json-object";
+  if (trimmed.startsWith("[")) return "json-array";
+  if (trimmed.startsWith("event:") || trimmed.startsWith("data:")) return "sse";
+  if (trimmed.startsWith("<")) return "html-or-xml";
+  return "other";
+};
+
+const parseFirstJsonRpc = (contentType: string, body: string): JsonRpcResponseBody | null => {
+  if (!body) return null;
+  try {
+    if (contentType.includes("text/event-stream")) {
+      for (const line of body.split(/\r?\n/)) {
+        if (line.startsWith("data:")) return JSON.parse(line.slice(5).trimStart());
+      }
+      return null;
+    }
+    if (contentType.includes("application/json")) return JSON.parse(body);
+    return null;
+  } catch {
+    return null;
+  }
+};
+
+const jsonRpcResponseAttrs = (payload: JsonRpcResponseBody | null): Record<string, unknown> => {
+  if (!payload || payload.jsonrpc !== "2.0") return {};
+  const attrs: Record<string, unknown> = {};
+  const err = payload.error;
+  if (err && typeof err === "object") {
+    attrs["mcp.rpc.is_error"] = true;
+    if (typeof err.code === "number") attrs["mcp.rpc.error.code"] = err.code;
+    if (typeof err.message === "string") {
+      attrs["mcp.rpc.error.message"] = err.message.slice(0, 500);
+    }
+  }
+  if (payload.result?.isError === true) attrs["mcp.tool.result.is_error"] = true;
+  const structured = payload.result?.structuredContent;
+  if (structured && typeof structured.status === "string") {
+    attrs["mcp.tool.sandbox.status"] = structured.status;
+    if (structured.error?.kind) attrs["mcp.tool.sandbox.error.kind"] = structured.error.kind;
+    if (typeof structured.error?.message === "string") {
+      attrs["mcp.tool.sandbox.error.message"] = structured.error.message.slice(0, 500);
+    }
+  }
+  return attrs;
+};
+
+class ResponseBodyTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Timed out waiting for MCP response body after ${timeoutMs}ms`);
+    this.name = "ResponseBodyTimeoutError";
+  }
+}
+
+const readResponseText = async (response: Response, timeoutMs: number | null): Promise<string> => {
+  if (timeoutMs === null) return await response.text();
+
+  const reader = response.body?.getReader();
+  if (!reader) return "";
+
+  const decoder = new TextDecoder();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      void reader.cancel().catch(() => undefined);
+      reject(new ResponseBodyTimeoutError(timeoutMs));
+    }, timeoutMs);
+  });
+  const readPromise = (async () => {
+    try {
+      let text = "";
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) return text + decoder.decode();
+        text += decoder.decode(value, { stream: true });
+      }
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  })();
+
+  return await Promise.race([readPromise, timeoutPromise]);
+};
+
+const annotateEmptyResponse = (response: Response, contentType: string) =>
+  Effect.annotateCurrentSpan({
+    "mcp.response.status_code": response.status,
+    "mcp.response.content_type": contentType,
+    "mcp.response.body.shape": "empty",
+    "mcp.response.body.length": 0,
+    "mcp.response.jsonrpc.detected": false,
+  });
+
+const withoutBodyHeaders = (response: Response) => {
+  const headers = new Headers(response.headers);
+  headers.delete("content-type");
+  headers.delete("content-length");
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+};
+
+const responseReadFailure = (error: unknown) =>
+  Effect.gen(function* () {
+    const timedOut = error instanceof ResponseBodyTimeoutError;
+    yield* Effect.annotateCurrentSpan({
+      "mcp.response.status_code": timedOut ? 504 : 500,
+      "mcp.response.content_type": "application/json",
+      "mcp.response.body.shape": "json-object",
+      "mcp.response.body.length": 0,
+      "mcp.response.jsonrpc.detected": true,
+      "mcp.peek_response.timed_out": timedOut,
+      "mcp.peek_response.error": String(error),
+    });
+    return jsonRpcWebResponse(
+      timedOut ? 504 : 500,
+      -32001,
+      timedOut
+        ? "Timed out waiting for MCP response - please retry"
+        : "Failed to read MCP response",
+    );
+  });
+
+const reportInternalJsonRpcError = (payload: JsonRpcResponseBody | null) =>
+  Effect.sync(() => {
+    if (payload?.error?.code !== -32603) return;
+    const msg = payload.error.message ?? "unknown";
+    Sentry.captureException(new Error(`MCP internal error (-32603): ${msg}`));
+  });
+
+export const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
+  Effect.gen(function* () {
+    const contentType = response.headers.get("content-type") ?? "";
+    if (response.status === 202) {
+      yield* annotateEmptyResponse(response, contentType);
+      return withoutBodyHeaders(response);
+    }
+    if (!response.body) {
+      yield* annotateEmptyResponse(response, contentType);
+      return response;
+    }
+
+    const isSseResponse = contentType.includes("text/event-stream");
+    const timeoutMs = isSseResponse ? SSE_PEEK_TIMEOUT_MS : null;
+    const textResult = yield* Effect.tryPromise({
+      try: () => readResponseText(response, timeoutMs),
+      catch: (error) => error,
+    }).pipe(
+      Effect.withSpan("mcp.peek_response", {
+        attributes: {
+          "http.response.content_type": contentType,
+          "http.response.status_code": response.status,
+          "mcp.peek_response.timeout_ms": timeoutMs ?? 0,
+        },
+      }),
+      Effect.either,
+    );
+    if (textResult._tag === "Left") return yield* responseReadFailure(textResult.left);
+
+    const text = textResult.right;
+    const payload = parseFirstJsonRpc(contentType, text);
+    yield* Effect.annotateCurrentSpan({
+      "mcp.response.status_code": response.status,
+      "mcp.response.content_type": contentType,
+      "mcp.response.body.length": text.length,
+      "mcp.response.body.shape": responseBodyShape(text),
+      "mcp.response.jsonrpc.detected": payload?.jsonrpc === "2.0",
+    });
+    const attrs = jsonRpcResponseAttrs(payload);
+    if (Object.keys(attrs).length > 0) yield* Effect.annotateCurrentSpan(attrs);
+    yield* reportInternalJsonRpcError(payload);
+
+    return new Response(text, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  });

--- a/apps/cloud/src/mcp/responses.ts
+++ b/apps/cloud/src/mcp/responses.ts
@@ -1,0 +1,66 @@
+import { HttpServerResponse } from "@effect/platform";
+import { Effect } from "effect";
+
+import type { McpJwtVerificationError } from "../mcp-auth";
+
+export const CORS_ALLOW_ORIGIN = { "access-control-allow-origin": "*" } as const;
+
+type UnauthorizedAuth = {
+  readonly reason: "missing_bearer" | "invalid_token";
+  readonly description?: string;
+};
+
+const quoteAuthParam = (value: string) =>
+  `"${value.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+
+const bearerChallenge = (auth: UnauthorizedAuth, protectedResourceMetadataUrl: string) => {
+  const params =
+    auth.reason === "missing_bearer"
+      ? [`resource_metadata=${quoteAuthParam(protectedResourceMetadataUrl)}`]
+      : [
+          'error="invalid_token"',
+          `error_description=${quoteAuthParam(
+            auth.description ?? "The access token is invalid or expired",
+          )}`,
+          `resource_metadata=${quoteAuthParam(protectedResourceMetadataUrl)}`,
+        ];
+
+  return `Bearer ${params.join(", ")}`;
+};
+
+export const jsonResponse = (body: unknown, status = 200) =>
+  HttpServerResponse.unsafeJson(body, { status, headers: CORS_ALLOW_ORIGIN });
+
+export const jsonRpcError = (status: number, code: number, message: string) =>
+  HttpServerResponse.unsafeJson(
+    { jsonrpc: "2.0", error: { code, message }, id: null },
+    { status, headers: CORS_ALLOW_ORIGIN },
+  );
+
+export const jsonRpcWebResponse = (status: number, code: number, message: string) =>
+  new Response(JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null }), {
+    status,
+    headers: { ...CORS_ALLOW_ORIGIN, "content-type": "application/json" },
+  });
+
+export const unauthorized = (auth: UnauthorizedAuth, protectedResourceMetadataUrl: string) =>
+  HttpServerResponse.unsafeJson(
+    { error: "unauthorized" },
+    {
+      status: 401,
+      headers: {
+        ...CORS_ALLOW_ORIGIN,
+        "www-authenticate": bearerChallenge(auth, protectedResourceMetadataUrl),
+      },
+    },
+  );
+
+export const authTemporarilyUnavailable = (error: McpJwtVerificationError) =>
+  Effect.gen(function* () {
+    yield* Effect.annotateCurrentSpan({
+      "mcp.auth.outcome": "system_error",
+      "mcp.auth.system_error.reason": error.reason,
+      "mcp.auth.system_error.message": String(error.cause).slice(0, 500),
+    });
+    return jsonRpcError(503, -32001, "Authentication temporarily unavailable - please retry");
+  });

--- a/apps/cloud/src/services/mcp-worker-transport.ts
+++ b/apps/cloud/src/services/mcp-worker-transport.ts
@@ -13,11 +13,102 @@ export type McpWorkerTransport = Readonly<{
   close: () => Effect.Effect<void>;
 }>;
 
+type WorkerTransportInternals = {
+  readonly standaloneSseStreamId?: string;
+  readonly streamMapping?: Map<string, { readonly cleanup?: () => void }>;
+};
+
+type JsonRpcLike = {
+  readonly id?: unknown;
+  readonly method?: unknown;
+};
+
+type HandleRequestResult = {
+  readonly response: Response;
+  readonly replacedStandaloneSse: boolean;
+};
+
+const closeExistingStandaloneSse = (transport: WorkerTransport): boolean => {
+  const internals = transport as unknown as WorkerTransportInternals;
+  const streamId = internals.standaloneSseStreamId ?? "_GET_stream";
+  const stream = internals.streamMapping?.get(streamId);
+  if (!stream) return false;
+
+  stream.cleanup?.();
+  internals.streamMapping?.delete(streamId);
+  return true;
+};
+
+const isStandaloneSseGet = (request: Request): boolean =>
+  request.method === "GET" && (request.headers.get("accept") ?? "").includes("text/event-stream");
+
+const jsonRpcRequestIdKey = (id: unknown): string | null => {
+  switch (typeof id) {
+    case "string":
+    case "number":
+    case "boolean":
+      return `${typeof id}:${String(id)}`;
+    default:
+      return null;
+  }
+};
+
+const extractJsonRpcRequestIdKeys = async (request: Request): Promise<ReadonlyArray<string>> => {
+  if (request.method !== "POST") return [];
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("application/json")) return [];
+
+  try {
+    const parsed = (await request.clone().json()) as unknown;
+    const messages = Array.isArray(parsed) ? parsed : [parsed];
+    return messages.flatMap((message) => {
+      if (!message || typeof message !== "object") return [];
+      const rpc = message as JsonRpcLike;
+      if (typeof rpc.method !== "string") return [];
+      const key = jsonRpcRequestIdKey(rpc.id);
+      return key ? [key] : [];
+    });
+  } catch {
+    return [];
+  }
+};
+
+class JsonRpcRequestIdQueue {
+  private readonly inFlight = new Map<string, Promise<void>>();
+
+  async run<A>(request: Request, run: () => Promise<A>): Promise<A> {
+    const ids = [...new Set(await extractJsonRpcRequestIdKeys(request))];
+    if (ids.length === 0) return await run();
+
+    const previous = ids.map((id) => this.inFlight.get(id)).filter((p) => p !== undefined);
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    for (const id of ids) {
+      this.inFlight.set(id, current);
+    }
+
+    try {
+      await Promise.all(previous.map((p) => p.catch(() => undefined)));
+      return await run();
+    } finally {
+      for (const id of ids) {
+        if (this.inFlight.get(id) === current) {
+          this.inFlight.delete(id);
+        }
+      }
+      release();
+    }
+  }
+}
+
 export const makeMcpWorkerTransport = (
   options: WorkerTransportOptions,
 ): Effect.Effect<McpWorkerTransport> =>
   Effect.sync(() => {
     const transport = new WorkerTransport(options);
+    const requestIdQueue = new JsonRpcRequestIdQueue();
 
     const use = <A>(name: string, fn: () => Promise<A>) =>
       Effect.tryPromise({
@@ -25,11 +116,41 @@ export const makeMcpWorkerTransport = (
         catch: (cause) => new McpWorkerTransportError({ cause }),
       }).pipe(Effect.withSpan(`mcp.worker_transport.${name}`));
 
+    const handleWithStandaloneSseReplacement = async (
+      request: Request,
+    ): Promise<HandleRequestResult> => {
+      if (!isStandaloneSseGet(request)) {
+        return {
+          response: await transport.handleRequest(request),
+          replacedStandaloneSse: false,
+        };
+      }
+
+      const initial = await transport.handleRequest(request);
+      if (initial.status !== 409) {
+        return { response: initial, replacedStandaloneSse: false };
+      }
+
+      const replacedStandaloneSse = closeExistingStandaloneSse(transport);
+      return {
+        response: replacedStandaloneSse ? await transport.handleRequest(request) : initial,
+        replacedStandaloneSse,
+      };
+    };
+
     return {
       transport,
       connect: (server: McpServer) => use("connect", () => server.connect(transport)),
       handleRequest: (request: Request) =>
-        use("handle_request", () => transport.handleRequest(request)),
+        Effect.gen(function* () {
+          const result = yield* use("handle_request", () =>
+            requestIdQueue.run(request, () => handleWithStandaloneSseReplacement(request)),
+          );
+          yield* Effect.annotateCurrentSpan({
+            "mcp.transport.replaced_standalone_sse": result.replacedStandaloneSse,
+          });
+          return result.response;
+        }),
       close: () =>
         Effect.promise(() => transport.close().catch(() => undefined)).pipe(
           Effect.withSpan("mcp.worker_transport.close"),

--- a/apps/cloud/src/test-worker.ts
+++ b/apps/cloud/src/test-worker.ts
@@ -28,6 +28,7 @@ import {
   mcpApp,
   mcpUnauthorized,
 } from "./mcp";
+import { McpJwtVerificationError } from "./mcp-auth";
 import { organizations } from "./services/schema";
 import { parseTestBearer } from "./test-bearer";
 import { DoTelemetryLive } from "./services/telemetry";
@@ -36,10 +37,17 @@ export { McpSessionDO } from "./mcp-session";
 
 const TestMcpAuthLive = Layer.succeed(McpAuth, {
   verifyBearer: (request) =>
-    Effect.sync(() => {
+    Effect.gen(function* () {
       const header = request.headers.get("authorization");
       if (!header?.startsWith("Bearer ")) return mcpUnauthorized("missing_bearer");
-      const token = parseTestBearer(header.slice("Bearer ".length));
+      const rawToken = header.slice("Bearer ".length);
+      if (rawToken === "test-system-error") {
+        return yield* Effect.fail(new McpJwtVerificationError({
+          cause: new Error("simulated jwks fetch failure"),
+          reason: "system",
+        }));
+      }
+      const token = parseTestBearer(rawToken);
       return token ? mcpAuthorized(token) : mcpUnauthorized("invalid_token");
     }),
 });


### PR DESCRIPTION
## Summary

- return a retryable JSON-RPC 503 when MCP auth verification hits a transient system failure instead of falling through to a generic 500
- bound SSE response peeking so stale streaming responses cannot hold requests open for minutes
- keep restored sessions in JSON POST mode and serialize overlapping same-id requests to avoid stranded responses during reconnect/concurrency churn
- add worker/miniflare regressions for transient auth failures, GET reconnect restore, duplicate SSE GET replacement, reconnect churn, and overlapping same-id POSTs

## Validation

- bun run lint
- bun run typecheck
- bunx vitest run --config vitest.config.ts src/mcp-flow.test.ts
- bunx vitest run --config vitest.config.ts src/mcp-flow.test.ts -t "transient auth failure"
- bun run --cwd apps/cloud test:node -- mcp-miniflare.e2e.node.test.ts
