### PR TITLE
Make destructive MCPs require approval by default

### DIFF
--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -1,5 +1,8 @@
 ## Highlights
 
+### MCP sources honor upstream `destructiveHint`
+MCP sources now read `destructiveHint` from upstream tool annotations. Tools marked destructive will require approval before running, surfaced via MCP elicitation. Refresh existing sources (or remove + re-add) to pick up annotations on tools added before this change.
+
 ### Per-user OAuth for OpenAPI and MCP sources
 OpenAPI and MCP sources now carry first-class **Connections** — a per-user sign-in state decoupled from the source definition itself.
 

--- a/packages/plugins/mcp/src/sdk/binding-store.ts
+++ b/packages/plugins/mcp/src/sdk/binding-store.ts
@@ -96,6 +96,14 @@ export interface McpStoredSource {
 // `input.scope` for invokeTool/lifecycle) so every keyed mutation
 // targets exactly one row.
 export interface McpBindingStore {
+  readonly listBindingsBySource: (
+    namespace: string,
+    scope: string,
+  ) => Effect.Effect<
+    ReadonlyArray<{ readonly toolId: string; readonly binding: McpToolBinding }>,
+    StorageFailure
+  >;
+
   readonly getBinding: (
     toolId: string,
     scope: string,
@@ -138,6 +146,21 @@ export const makeMcpStore = ({
   adapter: db,
 }: StorageDeps<McpSchema>): McpBindingStore => {
   return {
+    listBindingsBySource: (namespace, scope) =>
+      Effect.gen(function* () {
+        const rows = yield* db.findMany({
+          model: "mcp_binding",
+          where: [
+            { field: "source_id", value: namespace },
+            { field: "scope_id", value: scope },
+          ],
+        });
+        return rows.map((row) => ({
+          toolId: row.id,
+          binding: decodeBinding(coerceJson(row.binding)),
+        }));
+      }),
+
     getBinding: (toolId, scope) =>
       Effect.gen(function* () {
         const row = yield* db.findOne({

--- a/packages/plugins/mcp/src/sdk/elicitation.test.ts
+++ b/packages/plugins/mcp/src/sdk/elicitation.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
-import * as http from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 
 import {
@@ -14,6 +12,7 @@ import {
 } from "@executor-js/sdk";
 
 import { mcpPlugin } from "./plugin";
+import { serveMcpServer } from "./test-utils";
 
 // ---------------------------------------------------------------------------
 // Test MCP server on a real HTTP port
@@ -70,64 +69,7 @@ function createTestMcpServer() {
   return server;
 }
 
-type TestServer = {
-  readonly url: string;
-  readonly httpServer: http.Server;
-  /** Number of MCP sessions created (each connect = 1 session) */
-  readonly sessionCount: () => number;
-};
-
-const serveMcpServer = Effect.acquireRelease(
-  Effect.callback<TestServer, Error>((resume) => {
-    const transports = new Map<string, StreamableHTTPServerTransport>();
-    let sessions = 0;
-
-    const httpServer = http.createServer(async (req, res) => {
-      const sessionId = req.headers["mcp-session-id"] as string | undefined;
-
-      if (sessionId) {
-        const transport = transports.get(sessionId);
-        if (!transport) {
-          res.writeHead(404);
-          res.end("Session not found");
-          return;
-        }
-        await transport.handleRequest(req, res);
-        return;
-      }
-
-      // New session — create a fresh McpServer per connection
-      const mcpServer = createTestMcpServer();
-      sessions++;
-
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => crypto.randomUUID(),
-        onsessioninitialized: (sid) => {
-          transports.set(sid, transport);
-        },
-      });
-
-      await mcpServer.connect(transport);
-      await transport.handleRequest(req, res);
-    });
-
-    httpServer.listen(0, () => {
-      const addr = httpServer.address();
-      const port = typeof addr === "object" && addr ? addr.port : 0;
-      resume(
-        Effect.succeed({
-          url: `http://127.0.0.1:${port}`,
-          httpServer,
-          sessionCount: () => sessions,
-        }),
-      );
-    });
-  }),
-  ({ httpServer }) =>
-    Effect.sync(() => {
-      httpServer.close();
-    }),
-);
+const serveElicitationTestServer = serveMcpServer(createTestMcpServer);
 
 // ---------------------------------------------------------------------------
 // Helper — create executor with MCP plugin pointed at test server
@@ -156,7 +98,7 @@ const makeTestExecutor = (serverUrl: string) =>
 describe("MCP elicitation (end-to-end)", () => {
   it.effect("form elicitation accepted → tool returns approved result", () =>
     Effect.gen(function* () {
-      const server = yield* serveMcpServer;
+      const server = yield* serveElicitationTestServer;
       const executor = yield* makeTestExecutor(server.url);
 
       const tools = yield* executor.tools.list();
@@ -192,7 +134,7 @@ describe("MCP elicitation (end-to-end)", () => {
 
   it.effect("form elicitation declined → tool returns denied result", () =>
     Effect.gen(function* () {
-      const server = yield* serveMcpServer;
+      const server = yield* serveElicitationTestServer;
       const executor = yield* makeTestExecutor(server.url);
       const tools = yield* executor.tools.list();
       const gatedEcho = tools.find((t) => t.name === "gated_echo")!;
@@ -216,7 +158,7 @@ describe("MCP elicitation (end-to-end)", () => {
 
   it.effect("tool without elicitation works normally", () =>
     Effect.gen(function* () {
-      const server = yield* serveMcpServer;
+      const server = yield* serveElicitationTestServer;
       const executor = yield* makeTestExecutor(server.url);
       const tools = yield* executor.tools.list();
       const simpleEcho = tools.find((t) => t.name === "simple_echo")!;
@@ -235,7 +177,7 @@ describe("MCP elicitation (end-to-end)", () => {
 
   it.effect("addSource preserves the configured display name over server metadata", () =>
     Effect.gen(function* () {
-      const server = yield* serveMcpServer;
+      const server = yield* serveElicitationTestServer;
       const executor = yield* createExecutor(
         makeTestConfig({
           plugins: [mcpPlugin()] as const,
@@ -259,7 +201,7 @@ describe("MCP elicitation (end-to-end)", () => {
 
   it.effect("handler receives correct toolId, args, and FormElicitation schema", () =>
     Effect.gen(function* () {
-      const server = yield* serveMcpServer;
+      const server = yield* serveElicitationTestServer;
       const executor = yield* makeTestExecutor(server.url);
       const tools = yield* executor.tools.list();
       const gatedEcho = tools.find((t) => t.name === "gated_echo")!;
@@ -304,7 +246,7 @@ describe("MCP elicitation (end-to-end)", () => {
 
   it.effect("connection is reused across multiple tool calls to the same source", () =>
     Effect.gen(function* () {
-      const server = yield* serveMcpServer;
+      const server = yield* serveElicitationTestServer;
       const executor = yield* makeTestExecutor(server.url);
       const tools = yield* executor.tools.list();
       const simpleEcho = tools.find((t) => t.name === "simple_echo")!;

--- a/packages/plugins/mcp/src/sdk/manifest.ts
+++ b/packages/plugins/mcp/src/sdk/manifest.ts
@@ -1,5 +1,7 @@
 import { Schema } from "effect";
 
+import { McpToolAnnotations } from "./types";
+
 // ---------------------------------------------------------------------------
 // Output types
 // ---------------------------------------------------------------------------
@@ -10,6 +12,7 @@ export interface McpToolManifestEntry {
   readonly description: string | null;
   readonly inputSchema?: unknown;
   readonly outputSchema?: unknown;
+  readonly annotations?: McpToolAnnotations;
 }
 
 export interface McpServerMetadata {
@@ -32,6 +35,7 @@ const ListedTool = Schema.Struct({
   inputSchema: Schema.optional(Schema.Unknown),
   parameters: Schema.optional(Schema.Unknown),
   outputSchema: Schema.optional(Schema.Unknown),
+  annotations: Schema.optional(McpToolAnnotations),
 });
 
 const ListToolsResult = Schema.Struct({
@@ -103,6 +107,7 @@ export const extractManifestFromListToolsResult = (
         description: tool.description ?? null,
         inputSchema: tool.inputSchema ?? tool.parameters,
         outputSchema: tool.outputSchema,
+        annotations: tool.annotations,
       },
     ];
   });

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
 import {
   ConnectionId,
@@ -20,6 +22,7 @@ import {
   deriveMcpNamespace,
   joinToolPath,
 } from "./manifest";
+import { serveMcpServer } from "./test-utils";
 
 // ---------------------------------------------------------------------------
 // Memory secrets plugin — without a writable provider in the stack,
@@ -114,6 +117,22 @@ describe("extractManifestFromListToolsResult", () => {
       );
       expect(result.server?.name).toBe("test-server");
       expect(result.server?.version).toBe("1.0.0");
+    }),
+  );
+
+  it.effect("decodes upstream tool annotations", () =>
+    Effect.sync(() => {
+      const result = extractManifestFromListToolsResult({
+        tools: [
+          { name: "delete", annotations: { destructiveHint: true } },
+          { name: "list", annotations: { readOnlyHint: true } },
+          { name: "ping" },
+        ],
+      });
+
+      expect(result.tools[0]!.annotations?.destructiveHint).toBe(true);
+      expect(result.tools[1]!.annotations?.readOnlyHint).toBe(true);
+      expect(result.tools[2]!.annotations).toBeUndefined();
     }),
   );
 });
@@ -615,5 +634,106 @@ describe("mcpPlugin", () => {
           "mcp-oauth2-team_mcp",
         );
       }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// destructiveHint → requiresApproval (end-to-end with a real local server)
+// ---------------------------------------------------------------------------
+
+const createAnnotationsTestServer = () => {
+  const mcpServer = new McpServer(
+    { name: "annotations-test-server", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  mcpServer.registerTool(
+    "delete",
+    {
+      description: "A destructive tool",
+      inputSchema: { id: z.string() },
+      annotations: { destructiveHint: true },
+    },
+    async () => ({ content: [] }),
+  );
+
+  mcpServer.registerTool(
+    "delete_titled",
+    {
+      description: "A destructive tool with a title annotation",
+      inputSchema: { id: z.string() },
+      annotations: { destructiveHint: true, title: "Delete dataset" },
+    },
+    async () => ({ content: [] }),
+  );
+
+  mcpServer.registerTool(
+    "list",
+    {
+      description: "A read-only tool",
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    async () => ({ content: [] }),
+  );
+
+  mcpServer.registerTool(
+    "ping",
+    { description: "An unannotated tool", inputSchema: {} },
+    async () => ({ content: [] }),
+  );
+
+  return mcpServer;
+};
+
+const serveAnnotationsTestServer = serveMcpServer(createAnnotationsTestServer);
+
+describe("MCP destructiveHint → requiresApproval", () => {
+  it.effect("destructiveHint becomes requiresApproval, others stay false", () =>
+    Effect.gen(function* () {
+      const server = yield* serveAnnotationsTestServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [mcpPlugin()] as const }),
+      );
+      yield* executor.mcp.addSource({
+        transport: "remote",
+        scope: "test-scope",
+        name: "annotations-test",
+        endpoint: server.url,
+      });
+
+      const tools = yield* executor.tools.list();
+
+      const deleteTool = tools.find((t) => t.name === "delete");
+      expect(deleteTool?.annotations?.requiresApproval).toBe(true);
+
+      const listTool = tools.find((t) => t.name === "list");
+      expect(listTool?.annotations?.requiresApproval).toBeFalsy();
+
+      const pingTool = tools.find((t) => t.name === "ping");
+      expect(pingTool?.annotations?.requiresApproval).toBeFalsy();
+    }),
+  );
+
+  it.effect("uses annotations.title as approvalDescription when present", () =>
+    Effect.gen(function* () {
+      const server = yield* serveAnnotationsTestServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [mcpPlugin()] as const }),
+      );
+      yield* executor.mcp.addSource({
+        transport: "remote",
+        scope: "test-scope",
+        name: "annotations-test",
+        endpoint: server.url,
+      });
+
+      const tools = yield* executor.tools.list();
+      const deleteTitled = tools.find((t) => t.name === "delete_titled");
+      expect(deleteTitled?.annotations?.requiresApproval).toBe(true);
+      expect(deleteTitled?.annotations?.approvalDescription).toBe(
+        "Delete dataset",
+      );
+    }),
   );
 });

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -8,6 +8,7 @@ import {
   resolveSecretBackedMap as resolveSharedSecretBackedMap,
   type PluginCtx,
   type StorageFailure,
+  type ToolAnnotations,
 } from "@executor-js/sdk/core";
 
 import {
@@ -143,6 +144,7 @@ const toBinding = (entry: McpToolManifestEntry): McpToolBinding =>
     description: entry.description,
     inputSchema: entry.inputSchema,
     outputSchema: entry.outputSchema,
+    annotations: entry.annotations,
   });
 
 // ---------------------------------------------------------------------------
@@ -945,13 +947,38 @@ export const mcpPlugin = definePlugin<
         }),
       ),
 
-    // MCP tools never require approval at the tool level — elicitation is
-    // handled mid-invocation by the server via the elicit capability.
-    resolveAnnotations: ({ toolRows }) =>
-      Effect.sync(() => {
-        const out: Record<string, { requiresApproval: boolean }> = {};
+    // Honor upstream destructiveHint from MCP ToolAnnotations.
+    // Bindings are fetched per scope so shadowed sources (e.g. an org-level
+    // source overridden per-user) each resolve against their own scope's
+    // row rather than collapsing onto whichever row the scoped adapter
+    // sees first.
+    resolveAnnotations: ({ ctx, sourceId, toolRows }) =>
+      Effect.gen(function* () {
+        const scopes = new Set(toolRows.map((row) => row.scope_id));
+        const entries = yield* Effect.forEach(
+          [...scopes],
+          (scope) =>
+            Effect.gen(function* () {
+              const list = yield* ctx.storage.listBindingsBySource(sourceId, scope);
+              const byId = new Map(list.map((e) => [e.toolId, e.binding]));
+              return [scope, byId] as const;
+            }),
+          { concurrency: "unbounded" },
+        );
+        const byScope = new Map(entries);
+
+        const out: Record<string, ToolAnnotations> = {};
         for (const row of toolRows) {
-          out[row.id] = { requiresApproval: false };
+          const binding = byScope.get(row.scope_id)?.get(row.id);
+          const ann = binding?.annotations;
+          if (ann?.destructiveHint === true) {
+            out[row.id] = {
+              requiresApproval: true,
+              approvalDescription: ann.title ?? binding?.toolName ?? row.id,
+            };
+          } else {
+            out[row.id] = { requiresApproval: false };
+          }
         }
         return out;
       }),

--- a/packages/plugins/mcp/src/sdk/test-utils.ts
+++ b/packages/plugins/mcp/src/sdk/test-utils.ts
@@ -1,0 +1,69 @@
+import { Effect } from "effect";
+import * as http from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+export type McpTestServer = {
+  readonly url: string;
+  readonly httpServer: http.Server;
+  /** Number of MCP sessions created (each connect = 1 session) */
+  readonly sessionCount: () => number;
+};
+
+/**
+ * Spin up a real HTTP server backed by a fresh `McpServer` per session,
+ * with proper session routing via `mcp-session-id`. The factory is invoked
+ * once per new session, so tools registered inside it are isolated per
+ * connection (matching the SDK's own server/transport coupling).
+ */
+export const serveMcpServer = (factory: () => McpServer) =>
+  Effect.acquireRelease(
+    Effect.callback<McpTestServer, Error>((resume) => {
+      const transports = new Map<string, StreamableHTTPServerTransport>();
+      let sessions = 0;
+
+      const httpServer = http.createServer(async (req, res) => {
+        const sessionId = req.headers["mcp-session-id"] as string | undefined;
+
+        if (sessionId) {
+          const transport = transports.get(sessionId);
+          if (!transport) {
+            res.writeHead(404);
+            res.end("Session not found");
+            return;
+          }
+          await transport.handleRequest(req, res);
+          return;
+        }
+
+        const mcpServer = factory();
+        sessions++;
+
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: () => crypto.randomUUID(),
+          onsessioninitialized: (sid) => {
+            transports.set(sid, transport);
+          },
+        });
+
+        await mcpServer.connect(transport);
+        await transport.handleRequest(req, res);
+      });
+
+      httpServer.listen(0, () => {
+        const addr = httpServer.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        resume(
+          Effect.succeed({
+            url: `http://127.0.0.1:${port}`,
+            httpServer,
+            sessionCount: () => sessions,
+          }),
+        );
+      });
+    }),
+    ({ httpServer }) =>
+      Effect.sync(() => {
+        httpServer.close();
+      }),
+  );

--- a/packages/plugins/mcp/src/sdk/types.ts
+++ b/packages/plugins/mcp/src/sdk/types.ts
@@ -90,10 +90,20 @@ export type McpStoredSourceData = typeof McpStoredSourceData.Type;
 // Tool binding — maps a registered ToolId back to the MCP tool name
 // ---------------------------------------------------------------------------
 
+export const McpToolAnnotations = Schema.Struct({
+  title: Schema.optional(Schema.String),
+  readOnlyHint: Schema.optional(Schema.Boolean),
+  destructiveHint: Schema.optional(Schema.Boolean),
+  idempotentHint: Schema.optional(Schema.Boolean),
+  openWorldHint: Schema.optional(Schema.Boolean),
+});
+export type McpToolAnnotations = typeof McpToolAnnotations.Type;
+
 export class McpToolBinding extends Schema.Class<McpToolBinding>("McpToolBinding")({
   toolId: Schema.String,
   toolName: Schema.String,
   description: Schema.NullOr(Schema.String),
   inputSchema: Schema.optional(Schema.Unknown),
   outputSchema: Schema.optional(Schema.Unknown),
+  annotations: Schema.optional(McpToolAnnotations),
 }) {}


### PR DESCRIPTION
Read upstream [MCP tool annotations](https://modelcontextprotocol.io/specification/2025-11-25/schema#toolannotations) during discovery and persist them on the binding. Tools with `destructiveHint: true` now resolve to `requiresApproval` at tools.list time, with annotations.title (when set) used as the approval description.

Notes:
- listBindingsBySource is called per scope present in toolRows so shadowed sources (e.g. an org-level source overridden per-user) each pin to their own scope's binding instead of collapsing onto whichever row the scoped adapter sees first.
- To avoid duplication, I extracted the elicitation test's HTTP+MCP harness into a shared helper, `test-utils.ts` so the new annotations tests can reuse it.