### PR TITLE
Plugin internals import from @executor-js/sdk/core

### DIFF
--- a/packages/core/execution/src/description.ts
+++ b/packages/core/execution/src/description.ts
@@ -1,5 +1,5 @@
 import { Effect } from "effect";
-import type { Executor, Source } from "@executor-js/sdk";
+import type { Executor, Source } from "@executor-js/sdk/core";
 
 /**
  * Builds a tool description dynamically.

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -7,7 +7,7 @@ import type {
   ElicitationResponse,
   ElicitationHandler,
   ElicitationContext,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 import { CodeExecutionError } from "@executor-js/codemode-core";
 import type { CodeExecutor, ExecuteResult, SandboxToolInvoker } from "@executor-js/codemode-core";
 

--- a/packages/core/execution/src/promise.ts
+++ b/packages/core/execution/src/promise.ts
@@ -17,7 +17,7 @@ import type {
   ElicitationContext,
   ElicitationResponse,
   Executor as PromiseExecutor,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 import type { CodeExecutionError, CodeExecutor, ExecuteResult } from "@executor-js/codemode-core";
 
 import {

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -6,7 +6,7 @@ import type {
   ToolSchema,
   InvokeOptions,
   Source,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 import type { SandboxToolInvoker } from "@executor-js/codemode-core";
 import { ExecutionToolError } from "./errors";
 

--- a/packages/plugins/file-secrets/src/index.ts
+++ b/packages/plugins/file-secrets/src/index.ts
@@ -7,7 +7,7 @@ import {
   StorageError,
   type PluginCtx,
   type SecretProvider,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 // ---------------------------------------------------------------------------
 // XDG data dir resolution

--- a/packages/plugins/google-discovery/src/api/group.ts
+++ b/packages/plugins/google-discovery/src/api/group.ts
@@ -1,6 +1,6 @@
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
 import { Schema } from "effect";
-import { ScopeId, SecretBackedValue } from "@executor-js/sdk";
+import { ScopeId, SecretBackedValue } from "@executor-js/sdk/core";
 import { InternalError } from "@executor-js/api";
 
 import { GoogleDiscoveryParseError, GoogleDiscoverySourceError } from "../sdk/errors";

--- a/packages/plugins/google-discovery/src/react/atoms.ts
+++ b/packages/plugins/google-discovery/src/react/atoms.ts
@@ -1,4 +1,4 @@
-import type { ScopeId } from "@executor-js/sdk";
+import type { ScopeId } from "@executor-js/sdk/core";
 import { ReactivityKey } from "@executor-js/react/api/reactivity-keys";
 import { GoogleDiscoveryClient } from "./client";
 

--- a/packages/plugins/google-discovery/src/react/oauth.ts
+++ b/packages/plugins/google-discovery/src/react/oauth.ts
@@ -1,4 +1,4 @@
-import type { OAuthStrategy } from "@executor-js/sdk";
+import type { OAuthStrategy } from "@executor-js/sdk/core";
 
 export const GOOGLE_DISCOVERY_OAUTH_POPUP_NAME = "google-discovery-oauth";
 

--- a/packages/plugins/google-discovery/src/sdk/binding-store.ts
+++ b/packages/plugins/google-discovery/src/sdk/binding-store.ts
@@ -19,7 +19,7 @@ import {
   defineSchema,
   type StorageDeps,
   type StorageFailure,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   GoogleDiscoveryMethodBinding,

--- a/packages/plugins/google-discovery/src/sdk/invoke.ts
+++ b/packages/plugins/google-discovery/src/sdk/invoke.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer, Option } from "effect";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "@effect/platform";
 
-import type { PluginCtx, StorageFailure } from "@executor-js/sdk";
+import type { PluginCtx, StorageFailure } from "@executor-js/sdk/core";
 
 import {
   GoogleDiscoveryInvocationError,

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -7,7 +7,7 @@ import {
   type PluginCtx,
   type StorageFailure,
   type ToolAnnotations,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   googleDiscoverySchema,

--- a/packages/plugins/google-discovery/src/sdk/types.ts
+++ b/packages/plugins/google-discovery/src/sdk/types.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { SecretBackedValue } from "@executor-js/sdk";
+import { SecretBackedValue } from "@executor-js/sdk/core";
 
 export const GoogleDiscoveryHttpMethod = Schema.Literal(
   "get",

--- a/packages/plugins/graphql/src/api/group.ts
+++ b/packages/plugins/graphql/src/api/group.ts
@@ -1,6 +1,6 @@
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
 import { Schema } from "effect";
-import { ScopeId } from "@executor-js/sdk";
+import { ScopeId } from "@executor-js/sdk/core";
 import { InternalError } from "@executor-js/api";
 
 import {

--- a/packages/plugins/graphql/src/react/atoms.ts
+++ b/packages/plugins/graphql/src/react/atoms.ts
@@ -1,4 +1,4 @@
-import type { ScopeId } from "@executor-js/sdk";
+import type { ScopeId } from "@executor-js/sdk/core";
 import { ReactivityKey } from "@executor-js/react/api/reactivity-keys";
 import { GraphqlClient } from "./client";
 

--- a/packages/plugins/graphql/src/sdk/invoke.ts
+++ b/packages/plugins/graphql/src/sdk/invoke.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer, Option } from "effect";
 import { HttpClient, HttpClientRequest } from "@effect/platform";
-import { resolveSecretBackedMap } from "@executor-js/sdk";
+import { resolveSecretBackedMap } from "@executor-js/sdk/core";
 
 import { GraphqlInvocationError } from "./errors";
 import { type HeaderValue, type OperationBinding, InvocationResult } from "./types";

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -8,7 +8,7 @@ import {
   type StorageFailure,
   type ToolAnnotations,
   type ToolRow,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   headersToConfigValues,

--- a/packages/plugins/graphql/src/sdk/store.ts
+++ b/packages/plugins/graphql/src/sdk/store.ts
@@ -4,7 +4,7 @@ import {
   defineSchema,
   type StorageDeps,
   type StorageFailure,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   OperationBinding,

--- a/packages/plugins/graphql/src/sdk/types.ts
+++ b/packages/plugins/graphql/src/sdk/types.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { SecretBackedValue } from "@executor-js/sdk";
+import { SecretBackedValue } from "@executor-js/sdk/core";
 
 // ---------------------------------------------------------------------------
 // GraphQL operation kind

--- a/packages/plugins/keychain/src/index.ts
+++ b/packages/plugins/keychain/src/index.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 
-import { definePlugin, type PluginCtx } from "@executor-js/sdk";
+import { definePlugin, type PluginCtx } from "@executor-js/sdk/core";
 
 import {
   deletePassword,

--- a/packages/plugins/keychain/src/provider.ts
+++ b/packages/plugins/keychain/src/provider.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 
-import { StorageError, type SecretProvider } from "@executor-js/sdk";
+import { StorageError, type SecretProvider } from "@executor-js/sdk/core";
 
 import { getPassword, setPassword, deletePassword } from "./keyring";
 

--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -1,6 +1,6 @@
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
 import { Schema } from "effect";
-import { ScopeId, SecretBackedMap } from "@executor-js/sdk";
+import { ScopeId, SecretBackedMap } from "@executor-js/sdk/core";
 import { InternalError } from "@executor-js/api";
 
 import { McpConnectionError, McpToolDiscoveryError } from "../sdk/errors";

--- a/packages/plugins/mcp/src/react/atoms.ts
+++ b/packages/plugins/mcp/src/react/atoms.ts
@@ -1,4 +1,4 @@
-import type { ScopeId } from "@executor-js/sdk";
+import type { ScopeId } from "@executor-js/sdk/core";
 import { ReactivityKey } from "@executor-js/react/api/reactivity-keys";
 import { McpClient } from "./client";
 

--- a/packages/plugins/mcp/src/sdk/binding-store.ts
+++ b/packages/plugins/mcp/src/sdk/binding-store.ts
@@ -10,7 +10,7 @@ import {
   defineSchema,
   type StorageDeps,
   type StorageFailure,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import { McpToolBinding, McpStoredSourceData } from "./types";
 

--- a/packages/plugins/mcp/src/sdk/invoke.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.ts
@@ -19,7 +19,7 @@ import {
   UrlElicitation,
   type Elicit,
   type ElicitationRequest,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import { McpConnectionError, McpInvocationError } from "./errors";
 import type { McpConnection } from "./connection";

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -8,7 +8,7 @@ import {
   resolveSecretBackedMap as resolveSharedSecretBackedMap,
   type PluginCtx,
   type StorageFailure,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   makeMcpStore,

--- a/packages/plugins/mcp/src/sdk/types.ts
+++ b/packages/plugins/mcp/src/sdk/types.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { SecretBackedMap, SecretBackedValue } from "@executor-js/sdk";
+import { SecretBackedMap, SecretBackedValue } from "@executor-js/sdk/core";
 
 export { SecretBackedMap, SecretBackedValue };
 

--- a/packages/plugins/onepassword/src/api/group.ts
+++ b/packages/plugins/onepassword/src/api/group.ts
@@ -1,6 +1,6 @@
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
 import { Schema } from "effect";
-import { ScopeId } from "@executor-js/sdk";
+import { ScopeId } from "@executor-js/sdk/core";
 import { InternalError } from "@executor-js/api";
 
 import { OnePasswordError } from "../sdk/errors";

--- a/packages/plugins/onepassword/src/react/atoms.ts
+++ b/packages/plugins/onepassword/src/react/atoms.ts
@@ -1,4 +1,4 @@
-import type { ScopeId } from "@executor-js/sdk";
+import type { ScopeId } from "@executor-js/sdk/core";
 import { ReactivityKey } from "@executor-js/react/api/reactivity-keys";
 import { OnePasswordClient } from "./client";
 

--- a/packages/plugins/onepassword/src/sdk/plugin.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.ts
@@ -7,7 +7,7 @@ import {
   type PluginBlobStore,
   type SecretProvider,
   type StorageFailure,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import { OnePasswordConfig, Vault, ConnectionStatus } from "./types";
 import type { OnePasswordAuth } from "./types";

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -1,6 +1,6 @@
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema } from "@effect/platform";
 import { Schema } from "effect";
-import { ScopeId, SecretBackedValue } from "@executor-js/sdk";
+import { ScopeId, SecretBackedValue } from "@executor-js/sdk/core";
 import { InternalError } from "@executor-js/api";
 
 import { OpenApiParseError, OpenApiExtractionError, OpenApiOAuthError } from "../sdk/errors";

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect-atom/atom-react";
 import { Option } from "effect";
 
-import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk";
+import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk/core";
 import { startOAuth } from "@executor-js/react/api/atoms";
 import { useScope, useUserScope } from "@executor-js/react/api/scope-context";
 import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -18,7 +18,7 @@ import {
 import { FilterTabs } from "@executor-js/react/components/filter-tabs";
 import { Input } from "@executor-js/react/components/input";
 import { sourceWriteKeys as openApiWriteKeys } from "@executor-js/react/api/reactivity-keys";
-import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk";
+import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk/core";
 import { CreatableSecretPicker } from "@executor-js/react/plugins/secret-header-auth";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import {

--- a/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
@@ -4,7 +4,7 @@ import { connectionsAtom, sourceAtom } from "@executor-js/react/api/atoms";
 import { Badge } from "@executor-js/react/components/badge";
 import { Button } from "@executor-js/react/components/button";
 import { useScope, useScopeStack, useUserScope } from "@executor-js/react/api/scope-context";
-import { ScopeId } from "@executor-js/sdk";
+import { ScopeId } from "@executor-js/sdk/core";
 
 import { openApiSourceAtom, openApiSourceBindingsAtom } from "./atoms";
 import {

--- a/packages/plugins/openapi/src/react/atoms.ts
+++ b/packages/plugins/openapi/src/react/atoms.ts
@@ -1,4 +1,4 @@
-import type { ScopeId } from "@executor-js/sdk";
+import type { ScopeId } from "@executor-js/sdk/core";
 import { ReactivityKey } from "@executor-js/react/api/reactivity-keys";
 import { OpenApiClient } from "./client";
 

--- a/packages/plugins/openapi/src/sdk/credential-status.ts
+++ b/packages/plugins/openapi/src/sdk/credential-status.ts
@@ -1,4 +1,4 @@
-import type { ConnectionId, ScopeId } from "@executor-js/sdk";
+import type { ConnectionId, ScopeId } from "@executor-js/sdk/core";
 
 import { oauth2ClientSecretSlot } from "./store";
 import type { ConfiguredHeaderValue, OpenApiSourceBindingValue } from "./types";

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer, Option } from "effect";
 import { HttpClient, HttpClientRequest } from "@effect/platform";
 
-import type { SecretOwnedByConnectionError, StorageFailure } from "@executor-js/sdk";
+import type { SecretOwnedByConnectionError, StorageFailure } from "@executor-js/sdk/core";
 
 import { OpenApiInvocationError } from "./errors";
 import {

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -13,7 +13,7 @@ import {
   type StorageFailure,
   type ToolAnnotations,
   type ToolRow,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   headersToConfigValues,

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -6,7 +6,7 @@ import {
   StorageError,
   type StorageDeps,
   type StorageFailure,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   ConfiguredHeaderValue,

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { ConnectionId, ScopeId, SecretBackedValue, SecretId } from "@executor-js/sdk";
+import { ConnectionId, ScopeId, SecretBackedValue, SecretId } from "@executor-js/sdk/core";
 
 // ---------------------------------------------------------------------------
 // Branded IDs

--- a/packages/plugins/workos-vault/src/sdk/plugin.ts
+++ b/packages/plugins/workos-vault/src/sdk/plugin.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 
-import { definePlugin } from "@executor-js/sdk";
+import { definePlugin } from "@executor-js/sdk/core";
 
 import {
   makeConfiguredWorkOSVaultClient,

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -7,7 +7,7 @@ import {
   type SecretProvider,
   type StorageDeps,
   type StorageFailure,
-} from "@executor-js/sdk";
+} from "@executor-js/sdk/core";
 
 import {
   WorkOSVaultClientError,


### PR DESCRIPTION
## Summary

- The bare `@executor-js/sdk` path resolves to the Promise build, which only re-exports the small end-user surface (`createExecutor`, ID brands, errors, elicitation types).
- Plugin chunks importing `definePlugin`, `defineSchema`, `StorageError`, `SecretBackedValue`, `SecretBackedMap`, `resolveSecretBackedMap`, `ConnectionId`, etc. from the bare path threw `Export named X not found` at module init when installed from the published tarballs.
- Switch every plugin-internal import to `@executor-js/sdk/core` (the full Effect surface). End-user READMEs and examples keep the bare path.

## Test plan

- [x] Typecheck passes (33/33 packages)
- [x] All seven publishable plugin dists rebuilt; every chunk now references only `@executor-js/sdk/core`
- [ ] CI green