### PR TITLE
Release SDK packages and CLI

### DIFF
--- a/.changeset/release-sdk-cli.md
+++ b/.changeset/release-sdk-cli.md
@@ -1,0 +1,6 @@
+---
+"@executor-js/sdk": patch
+"executor": patch
+---
+
+Release the SDK packages and CLI.

--- a/tests/release-bootstrap-smoke.test.ts
+++ b/tests/release-bootstrap-smoke.test.ts
@@ -107,6 +107,7 @@ describe("release bootstrap smoke", () => {
     const assetPath = join(distDir, assetName);
     const tempRoot = await mkdtemp(join(tmpdir(), "executor-release-bootstrap-"));
     const installedPackageDir = join(tempRoot, "executor");
+    const dataDir = join(tempRoot, "data");
 
     await cp(wrapperDir, installedPackageDir, { recursive: true });
 
@@ -179,6 +180,10 @@ describe("release bootstrap smoke", () => {
         [join(installedPackageDir, "bin", "executor"), "web", "--port", String(webPort)],
         {
           cwd: installedPackageDir,
+          env: {
+            ...process.env,
+            EXECUTOR_DATA_DIR: dataDir,
+          },
           stdio: ["ignore", "pipe", "pipe"],
         },
       );


### PR DESCRIPTION
## Summary
- add a Changesets patch release request for the SDK package group and executor CLI
- isolate the release bootstrap smoke test data directory so local SQLite state cannot leak into the wrapper web launch

## Verification
- bunx changeset status --verbose
- bun run test:release:bootstrap