### PR TITLE
Fix release changelog placeholders

### DIFF
--- a/examples/all-plugins/CHANGELOG.md
+++ b/examples/all-plugins/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/example-all-plugins changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/cli/CHANGELOG.md
+++ b/packages/core/cli/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/cli changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/storage-core/CHANGELOG.md
+++ b/packages/core/storage-core/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/storage-core changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/storage-drizzle/CHANGELOG.md
+++ b/packages/core/storage-drizzle/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/storage-drizzle changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.


### PR DESCRIPTION
## Summary
- add missing Changesets-compatible changelog placeholders for packages in the computed release set
- fixes the main Release workflow failure when changesets/action reads generated changelog updates

## Verification
- disposable-tree `bun run changeset:version` passed