### PR TITLE
Refactor cloud API routing to be Effect v4 native

### DIFF
--- a/apps/cloud/src/api.test.ts
+++ b/apps/cloud/src/api.test.ts
@@ -1,33 +1,35 @@
-import { HttpApi, HttpApiBuilder, HttpApiClient, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
-import { FetchHttpClient, HttpClient, HttpEffect, HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import {
+  HttpApi,
+  HttpApiBuilder,
+  HttpApiClient,
+  HttpApiEndpoint,
+  HttpApiGroup,
+} from "effect/unstable/httpapi";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpRouter,
+  HttpServer,
+  HttpServerResponse,
+} from "effect/unstable/http";
 import { expect, layer } from "@effect/vitest";
 import { Effect, Layer, Schema } from "effect";
 
-import {
-  ApiRequestHandler,
-  AutumnRequestHandlerService,
-  NonProtectedRequestHandlerService,
-  ProtectedRequestHandlerService,
-  OrgRequestHandlerService,
-} from "./api/router";
-
 const SourceResponse = Schema.Struct({ source: Schema.String });
+
+// ---------------------------------------------------------------------------
+// Test APIs — mirror the prod paths but with stub handlers.
+// ---------------------------------------------------------------------------
 
 const OrgGroup = HttpApiGroup.make("org").add(
   HttpApiEndpoint.get("ping", "/org/ping", { success: SourceResponse }),
 );
 const OrgTestApi = HttpApi.make("orgApi").add(OrgGroup);
-const OrgTestHandlers = HttpApiBuilder.group(OrgTestApi, "org", (handlers) =>
-  handlers.handle("ping", () => Effect.succeed({ source: "org" })),
-);
 
 const AuthGroup = HttpApiGroup.make("auth").add(
   HttpApiEndpoint.get("me", "/auth/me", { success: SourceResponse }),
 );
-const AuthApi = HttpApi.make("authApi").add(AuthGroup);
-const AuthHandlers = HttpApiBuilder.group(AuthApi, "auth", (handlers) =>
-  handlers.handle("me", () => Effect.succeed({ source: "auth" })),
-);
+const AuthTestApi = HttpApi.make("authApi").add(AuthGroup);
 
 const ProtectedGroup = HttpApiGroup.make("protected")
   .add(HttpApiEndpoint.get("scope", "/scope", { success: SourceResponse }))
@@ -43,92 +45,103 @@ const ProtectedGroup = HttpApiGroup.make("protected")
       success: SourceResponse,
     }),
   );
-const ProtectedApi = HttpApi.make("protectedApi").add(ProtectedGroup);
-const ProtectedHandlers = HttpApiBuilder.group(ProtectedApi, "protected", (handlers) =>
+const ProtectedTestApi = HttpApi.make("protectedApi").add(ProtectedGroup);
+
+// ---------------------------------------------------------------------------
+// Stub handlers
+// ---------------------------------------------------------------------------
+
+const OrgTestHandlers = HttpApiBuilder.group(OrgTestApi, "org", (handlers) =>
+  handlers.handle("ping", () => Effect.succeed({ source: "org" })),
+);
+
+const AuthHandlers = HttpApiBuilder.group(AuthTestApi, "auth", (handlers) =>
+  handlers.handle("me", () => Effect.succeed({ source: "auth" })),
+);
+
+const ProtectedHandlers = HttpApiBuilder.group(ProtectedTestApi, "protected", (handlers) =>
   handlers
     .handle("scope", () => Effect.succeed({ source: "protected" }))
     .handle("sources", ({ params }) => Effect.succeed({ source: params.scopeId }))
     .handle("resume", () => Effect.succeed({ source: "protected" })),
 );
 
-const toHttpApp = (
-  apiLayer: Parameters<typeof HttpRouter.toWebHandler>[0],
-) =>
-  Effect.gen(function* () {
-    const request = yield* HttpServerRequest.HttpServerRequest;
-    const webRequest = yield* HttpServerRequest.toWeb(request);
-    const web = HttpRouter.toWebHandler(apiLayer, { disableLogger: true });
-    const response = yield* Effect.promise(() => web.handler(webRequest, undefined));
-    return HttpServerResponse.raw(response, { status: response.status, headers: response.headers });
-  });
-
-const OrgTestApp = toHttpApp(
-  HttpApiBuilder.layer(OrgTestApi).pipe(
-    Layer.provide(OrgTestHandlers),
-    Layer.provideMerge(HttpServer.layerServices),
-    Layer.provideMerge(Layer.succeed(HttpRouter.RouterConfig)({ maxParamLength: 1000 })),
-  ) as Parameters<typeof HttpRouter.toWebHandler>[0],
-);
-
-const AuthTestApp = toHttpApp(
-  HttpApiBuilder.layer(AuthApi).pipe(
-    Layer.provide(AuthHandlers),
-    Layer.provideMerge(HttpServer.layerServices),
-    Layer.provideMerge(Layer.succeed(HttpRouter.RouterConfig)({ maxParamLength: 1000 })),
-  ) as Parameters<typeof HttpRouter.toWebHandler>[0],
-);
-
-const ProtectedBaseTestApp = toHttpApp(
-  HttpApiBuilder.layer(ProtectedApi).pipe(
-    Layer.provide(ProtectedHandlers),
-    Layer.provideMerge(HttpServer.layerServices),
-    Layer.provideMerge(Layer.succeed(HttpRouter.RouterConfig)({ maxParamLength: 1000 })),
-  ) as Parameters<typeof HttpRouter.toWebHandler>[0],
-);
+// ---------------------------------------------------------------------------
+// Per-test mode switch — controls a router-level gate that mirrors the prod
+// `ExecutionStackMiddleware`'s short-circuit branches without standing up
+// the full WorkOS / executor stack.
+// ---------------------------------------------------------------------------
 
 type ProtectedMode = "ok" | "none" | "error" | "bad-status";
-
-const testState: {
-  mode: ProtectedMode;
-} = {
-  mode: "ok",
-};
-
+const testState: { mode: ProtectedMode } = { mode: "ok" };
 const resetState = () => {
   testState.mode = "ok";
 };
 
-const ProtectedTestApp = Effect.gen(function* () {
-  if (testState.mode === "none") {
-    return HttpServerResponse.jsonUnsafe(
-      { error: "No organization in session", code: "no_organization" },
-      { status: 403 },
-    );
-  }
-  if (testState.mode === "error") {
-    return HttpServerResponse.jsonUnsafe({ error: "boom" }, { status: 500 });
-  }
-  if (testState.mode === "bad-status") {
-    return HttpServerResponse.jsonUnsafe({ source: "protected" }, { status: 400 });
-  }
-  return yield* ProtectedBaseTestApp;
-});
-
-const TestRequestHandlersLive = Layer.mergeAll(
-  Layer.succeed(OrgRequestHandlerService)({ app: OrgTestApp }),
-  Layer.succeed(NonProtectedRequestHandlerService)({ app: AuthTestApp }),
-  Layer.succeed(AutumnRequestHandlerService)({
-    app: Effect.succeed(HttpServerResponse.jsonUnsafe({ source: "autumn" })),
+// `Effect.suspend` so `testState.mode` is read per request — the
+// middleware function itself runs once at addAll time, wrapping each
+// route's handler. Without `suspend`, only the build-time mode ("ok")
+// would be observed.
+const TestProtectedGate = HttpRouter.middleware()((httpEffect) =>
+  Effect.suspend(() => {
+    if (testState.mode === "none") {
+      return Effect.succeed(
+        HttpServerResponse.jsonUnsafe(
+          { error: "No organization in session", code: "no_organization" },
+          { status: 403 },
+        ),
+      );
+    }
+    if (testState.mode === "error") {
+      return Effect.succeed(
+        HttpServerResponse.jsonUnsafe({ error: "boom" }, { status: 500 }),
+      );
+    }
+    if (testState.mode === "bad-status") {
+      return Effect.succeed(
+        HttpServerResponse.jsonUnsafe({ source: "protected" }, { status: 400 }),
+      );
+    }
+    return httpEffect;
   }),
-  Layer.succeed(ProtectedRequestHandlerService)({ app: ProtectedTestApp }),
+).layer;
+
+// ---------------------------------------------------------------------------
+// Wire test APIs as route layers + autumn route, mirroring prod's structure.
+// ---------------------------------------------------------------------------
+
+const RouterConfig = Layer.succeed(HttpRouter.RouterConfig)({ maxParamLength: 1000 });
+
+const OrgTestLive = HttpApiBuilder.layer(OrgTestApi).pipe(Layer.provide(OrgTestHandlers));
+const AuthTestLive = HttpApiBuilder.layer(AuthTestApi).pipe(Layer.provide(AuthHandlers));
+const ProtectedTestLive = HttpApiBuilder.layer(ProtectedTestApi).pipe(
+  Layer.provide(ProtectedHandlers),
+  Layer.provide(TestProtectedGate),
 );
 
-const requestHandler = Effect.runSync(
-  Effect.map(
-    Effect.provide(ApiRequestHandler, TestRequestHandlersLive),
-    (app) => HttpEffect.toWebHandler(app),
-  ),
+const AutumnTestRoutesLive = HttpRouter.add(
+  "*",
+  "/autumn/*",
+  Effect.succeed(HttpServerResponse.jsonUnsafe({ source: "autumn" })),
 );
+
+const TestApiLive = Layer.mergeAll(
+  OrgTestLive,
+  AuthTestLive,
+  ProtectedTestLive,
+  AutumnTestRoutesLive,
+).pipe(
+  Layer.provideMerge(RouterConfig),
+  Layer.provideMerge(HttpServer.layerServices),
+);
+
+const requestHandler = HttpRouter.toWebHandler(TestApiLive, { disableLogger: true }).handler;
+
+// ---------------------------------------------------------------------------
+// Client setup — route HttpClient calls through the web handler in-process
+// so the suite runs in any runtime (workerd's `NodeHttpServer.layerTest`
+// crashes the isolate).
+// ---------------------------------------------------------------------------
 
 const TestApi = HttpApi.make("testApi")
   .add(OrgGroup)
@@ -140,9 +153,6 @@ const TestApi = HttpApi.make("testApi")
   )
   .add(ProtectedGroup);
 
-// Route HttpClient calls directly through the web handler — no real HTTP
-// server, so the suite runs in any runtime (including workerd, where
-// NodeHttpServer.layerTest crashes the isolate).
 const TEST_BASE_URL = "http://test.local";
 const fetchViaHandler: typeof globalThis.fetch = (input, init) =>
   requestHandler(input instanceof Request ? input : new Request(input, init));
@@ -190,7 +200,7 @@ layer(TestClientLayer)("handleApiRequest", (it) => {
     }),
   );
 
-  it.effect("returns 403 when protected handler returns no organization", () =>
+  it.effect("returns 403 when protected gate short-circuits with no organization", () =>
     Effect.gen(function* () {
       resetState();
       testState.mode = "none";
@@ -214,7 +224,7 @@ layer(TestClientLayer)("handleApiRequest", (it) => {
     }),
   );
 
-  it.effect("preserves protected path params through the outer router", () =>
+  it.effect("preserves protected path params", () =>
     Effect.gen(function* () {
       resetState();
       const client = yield* getClient();
@@ -233,7 +243,7 @@ layer(TestClientLayer)("handleApiRequest", (it) => {
     }),
   );
 
-  it.effect("returns 500 JSON when protected request handling throws", () =>
+  it.effect("returns 500 JSON when protected gate returns 500", () =>
     Effect.gen(function* () {
       resetState();
       testState.mode = "error";

--- a/apps/cloud/src/api.ts
+++ b/apps/cloud/src/api.ts
@@ -1,26 +1,5 @@
-import { Effect, Layer } from "effect";
-import { HttpEffect } from "effect/unstable/http";
-import { AutumnApiApp } from "./api/autumn";
-import { NonProtectedApiApp, OrgApiApp } from "./api/layers";
-import { ProtectedApiApp } from "./api/protected";
-import {
-  ApiRequestHandler,
-  AutumnRequestHandlerService,
-  NonProtectedRequestHandlerService,
-  ProtectedRequestHandlerService,
-  OrgRequestHandlerService,
-} from "./api/router";
+import { HttpRouter } from "effect/unstable/http";
 
-const ApiRequestHandlersLive = Layer.mergeAll(
-  Layer.succeed(OrgRequestHandlerService)({ app: OrgApiApp }),
-  Layer.succeed(NonProtectedRequestHandlerService)({ app: NonProtectedApiApp }),
-  Layer.succeed(AutumnRequestHandlerService)({ app: AutumnApiApp }),
-  Layer.succeed(ProtectedRequestHandlerService)({ app: ProtectedApiApp }),
-);
+import { ApiLive } from "./api/router";
 
-export const handleApiRequest = Effect.runSync(
-  Effect.map(
-    Effect.provide(ApiRequestHandler, ApiRequestHandlersLive),
-    (app) => HttpEffect.toWebHandler(app),
-  ),
-);
+export const handleApiRequest = HttpRouter.toWebHandler(ApiLive).handler;

--- a/apps/cloud/src/api/autumn.ts
+++ b/apps/cloud/src/api/autumn.ts
@@ -1,13 +1,20 @@
 import { env } from "cloudflare:workers";
 import { Effect } from "effect";
-import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import {
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
 import { autumnHandler } from "autumn-js/backend";
 
 import { WorkOSAuth } from "../auth/workos";
-import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
-import { SharedServices } from "./layers";
+import {
+  HttpResponseError,
+  isServerError,
+  toErrorServerResponse,
+} from "./error-response";
 
-export const AutumnApiApp = Effect.gen(function* () {
+const handler = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
   const webRequest = yield* Effect.mapError(
     HttpServerRequest.toWeb(request),
@@ -78,7 +85,6 @@ export const AutumnApiApp = Effect.gen(function* () {
 
   return HttpServerResponse.jsonUnsafe(response, { status: statusCode });
 }).pipe(
-  Effect.provide(SharedServices),
   Effect.catchCause((err) => {
     if (isServerError(err)) {
       console.error("[autumn] request failed:", err instanceof Error ? err.stack : err);
@@ -86,3 +92,5 @@ export const AutumnApiApp = Effect.gen(function* () {
     return Effect.succeed(toErrorServerResponse(err));
   }),
 );
+
+export const AutumnRoutesLive = HttpRouter.add("*", "/autumn/*", handler);

--- a/apps/cloud/src/api/error-response.ts
+++ b/apps/cloud/src/api/error-response.ts
@@ -1,12 +1,29 @@
 import * as Sentry from "@sentry/cloudflare";
-import { Data } from "effect";
-import { HttpServerResponse } from "effect/unstable/http";
+import { Data, Effect } from "effect";
+import {
+  HttpServerRespondable,
+  HttpServerResponse,
+} from "effect/unstable/http";
 
+// Implements `Respondable` so the framework's default cause→response
+// pipeline (`HttpServerRespondable.toResponseOrElse`) renders this as the
+// declared JSON body + status code without an explicit `catchCause` at
+// every error boundary.
 export class HttpResponseError extends Data.TaggedError("HttpResponseError")<{
   readonly status: number;
   readonly code: string;
   readonly message: string;
-}> {}
+}> {
+  [HttpServerRespondable.symbol](): Effect.Effect<HttpServerResponse.HttpServerResponse> {
+    if (this.status >= 500) Sentry.captureException(this);
+    return Effect.succeed(
+      HttpServerResponse.jsonUnsafe(
+        { error: this.message, code: this.code },
+        { status: this.status },
+      ),
+    );
+  }
+}
 
 const toHttpResponseError = (error: unknown): HttpResponseError =>
   error instanceof HttpResponseError

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -1,14 +1,7 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi";
-import { HttpMiddleware, HttpRouter, HttpServer } from "effect/unstable/http";
-import { Effect, Layer } from "effect";
+import { HttpServer } from "effect/unstable/http";
+import { Layer } from "effect";
 
-import { CoreExecutorApi, observabilityMiddleware } from "@executor-js/api";
-import { CoreHandlers } from "@executor-js/api/server";
-import { OpenApiGroup, OpenApiHandlers } from "@executor-js/plugin-openapi/api";
-import { McpGroup, McpHandlers } from "@executor-js/plugin-mcp/api";
-import { GraphqlGroup, GraphqlHandlers } from "@executor-js/plugin-graphql/api";
-
-import { OrgAuth } from "../auth/middleware";
 import { OrgAuthLive, SessionAuthLive } from "../auth/middleware-live";
 import { UserStoreService } from "../auth/context";
 import {
@@ -20,18 +13,15 @@ import { DbService } from "../services/db";
 import { TelemetryLive } from "../services/telemetry";
 import { OrgHttpApi } from "../org/compose";
 import { OrgHandlers } from "../org/handlers";
-import { ErrorCaptureLive } from "../observability";
 
 import { CoreSharedServices } from "./core-shared-services";
+import { ProtectedCloudApi, RouterConfig } from "./protected-layers";
 
-export { CoreSharedServices };
-
-export const ProtectedCloudApi = CoreExecutorApi.add(OpenApiGroup)
-  .add(McpGroup)
-  .add(GraphqlGroup)
-  .middleware(OrgAuth);
-
-const ObservabilityLive = observabilityMiddleware(ProtectedCloudApi);
+export {
+  CoreSharedServices,
+  ProtectedCloudApi,
+  RouterConfig,
+};
 
 const DbLive = DbService.Live;
 const UserStoreLive = UserStoreService.Live.pipe(Layer.provide(DbLive));
@@ -44,47 +34,16 @@ export const SharedServices = Layer.mergeAll(
   TelemetryLive,
 );
 
-export const RouterConfig = Layer.succeed(HttpRouter.RouterConfig)({ maxParamLength: 1000 });
-
-export const ProtectedCloudApiLive = HttpApiBuilder.layer(ProtectedCloudApi).pipe(
-  Layer.provide(
-    Layer.mergeAll(
-      CoreHandlers,
-      OpenApiHandlers,
-      McpHandlers,
-      GraphqlHandlers,
-      OrgAuthLive,
-      ObservabilityLive,
-    ),
-  ),
-  Layer.provide(ErrorCaptureLive),
-);
-
-const NonProtectedApiLive = HttpApiBuilder.layer(NonProtectedApi).pipe(
+// Routes that don't require an authenticated org session — login,
+// callbacks, etc. Mounts at the paths declared inside `NonProtectedApi`.
+export const NonProtectedApiLive = HttpApiBuilder.layer(NonProtectedApi).pipe(
   Layer.provide(Layer.mergeAll(CloudAuthPublicHandlers, CloudSessionAuthHandlers)),
   Layer.provideMerge(SessionAuthLive),
 );
 
-const OrgApiLive = HttpApiBuilder.layer(OrgHttpApi).pipe(
+// Routes scoped to a specific org (membership management, switching, etc.).
+// Auth is enforced by `OrgAuth` middleware declared on `OrgHttpApi`.
+export const OrgApiLive = HttpApiBuilder.layer(OrgHttpApi).pipe(
   Layer.provide(OrgHandlers),
   Layer.provideMerge(OrgAuthLive),
 );
-
-const NonProtectedRequestLayer = NonProtectedApiLive.pipe(
-  Layer.provideMerge(RouterConfig),
-  Layer.provideMerge(HttpServer.layerServices),
-);
-
-const OrgRequestLayer = OrgApiLive.pipe(
-  Layer.provideMerge(RouterConfig),
-);
-
-export const NonProtectedApiApp = Effect.flatMap(
-  HttpRouter.toHttpEffect(NonProtectedRequestLayer),
-  HttpMiddleware.logger,
-).pipe(Effect.provide(SharedServices));
-
-export const OrgApiApp = Effect.flatMap(
-  HttpRouter.toHttpEffect(OrgRequestLayer),
-  HttpMiddleware.logger,
-).pipe(Effect.provide(SharedServices));

--- a/apps/cloud/src/api/protected-layers.ts
+++ b/apps/cloud/src/api/protected-layers.ts
@@ -16,18 +16,23 @@ import { OpenApiGroup, OpenApiHandlers } from "@executor-js/plugin-openapi/api";
 import { McpGroup, McpHandlers } from "@executor-js/plugin-mcp/api";
 import { GraphqlGroup, GraphqlHandlers } from "@executor-js/plugin-graphql/api";
 
-import { OrgAuth } from "../auth/middleware";
-import { OrgAuthLive } from "../auth/middleware-live";
 import { UserStoreService } from "../auth/context";
 import { WorkOSAuth } from "../auth/workos";
 import { AutumnService } from "../services/autumn";
 import { DbService } from "../services/db";
 import { ErrorCaptureLive } from "../observability";
 
+// `ProtectedCloudApi` deliberately does NOT declare `.middleware(OrgAuth)`
+// — auth + per-request execution stack construction live in a single
+// `HttpRouter` middleware (`ExecutionStackMiddleware` in `./protected.ts`)
+// which has the right ordering to provide `AuthContext` AND the executor
+// services to handlers. Putting auth on the API as `HttpApiMiddleware` ran
+// it INSIDE the router middleware (wrong order), and added a second auth
+// pass on top of the existing one in `protected.ts`'s outer effect. The
+// router-middleware approach folds both into one place.
 export const ProtectedCloudApi = CoreExecutorApi.add(OpenApiGroup)
   .add(McpGroup)
-  .add(GraphqlGroup)
-  .middleware(OrgAuth);
+  .add(GraphqlGroup);
 
 const ObservabilityLive = observabilityMiddleware(ProtectedCloudApi);
 
@@ -44,9 +49,9 @@ export const SharedServices = Layer.mergeAll(
 
 export const RouterConfig = Layer.succeed(HttpRouter.RouterConfig)({ maxParamLength: 1000 });
 
-// Every handler the ProtectedCloudApi routes to, minus auth. The test
-// harness builds its own api-live by merging this with a fake OrgAuth
-// layer; prod merges it with OrgAuthLive below.
+// Every handler the ProtectedCloudApi routes to. The test harness builds
+// its own api-live by merging this with its own per-request middleware
+// fakes; prod uses `ProtectedCloudApiLive` below.
 export const ProtectedCloudApiHandlers = Layer.mergeAll(
   CoreHandlers,
   OpenApiHandlers,
@@ -59,8 +64,6 @@ export const ProtectedCloudApiHandlers = Layer.mergeAll(
 // InternalError(traceId)`) AND the observability middleware's defect
 // catchall both see the same Sentry-backed implementation.
 export const ProtectedCloudApiLive = HttpApiBuilder.layer(ProtectedCloudApi).pipe(
-  Layer.provide(
-    Layer.mergeAll(ProtectedCloudApiHandlers, OrgAuthLive, ObservabilityLive),
-  ),
+  Layer.provide(Layer.mergeAll(ProtectedCloudApiHandlers, ObservabilityLive)),
   Layer.provide(ErrorCaptureLive),
 );

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -1,93 +1,114 @@
+// Production wiring for the protected API. Lives outside `protected-layers.ts`
+// because `makeExecutionStack` imports `cloudflare:workers`, which the test
+// harness can't load in the workerd test runtime.
+
 import { HttpApiSwagger } from "effect/unstable/httpapi";
 import {
-  HttpMiddleware,
   HttpRouter,
   HttpServerRequest,
 } from "effect/unstable/http";
 import { Effect, Layer } from "effect";
 
-import { ExecutorService, ExecutionEngineService } from "@executor-js/api/server";
+import {
+  ExecutionEngineService,
+  ExecutorService,
+} from "@executor-js/api/server";
 import { OpenApiExtensionService } from "@executor-js/plugin-openapi/api";
 import { McpExtensionService } from "@executor-js/plugin-mcp/api";
 import { GraphqlExtensionService } from "@executor-js/plugin-graphql/api";
 
+import { AuthContext } from "../auth/middleware";
 import { authorizeOrganization } from "../auth/authorize-organization";
+import { UserStoreService } from "../auth/context";
 import { WorkOSAuth } from "../auth/workos";
+import { AutumnService } from "../services/autumn";
+import { DbService } from "../services/db";
 import { makeExecutionStack } from "../services/execution-stack";
-import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
-import { ProtectedCloudApi, ProtectedCloudApiLive, RouterConfig, SharedServices } from "./layers";
+import { HttpResponseError } from "./error-response";
+import {
+  ProtectedCloudApi,
+  ProtectedCloudApiLive,
+  RouterConfig,
+} from "./protected-layers";
 
-const lookupOrgForRequest = (request: HttpServerRequest.HttpServerRequest) =>
+// One `HttpRouter` middleware that:
+//   1. authenticates the WorkOS sealed session,
+//   2. verifies live org membership (closes the JWT-cache gap — see
+//      `auth/authorize-organization.ts`),
+//   3. resolves the org name,
+//   4. builds the per-request executor + engine,
+//   5. provides `AuthContext` + the execution-stack services to the handler.
+//
+// Replaces both the old outer `Effect.gen` in this file (which did its own
+// WorkOS lookup) and the per-route `OrgAuth` HttpApiMiddleware (which did
+// a second one).
+//
+// Errors are NOT caught here: failures propagate as typed errors and are
+// rendered to a JSON response by the framework's `Respondable` pipeline
+// (see `HttpResponseError` in `./error-response.ts`). Letting `unhandled`
+// pass through is what satisfies `HttpRouter.middleware`'s brand check
+// without any type casts.
+const ExecutionStackMiddleware = HttpRouter.middleware<{
+  provides:
+    | AuthContext
+    | ExecutorService
+    | ExecutionEngineService
+    | OpenApiExtensionService
+    | McpExtensionService
+    | GraphqlExtensionService;
+}>()(
+  // Layer-time setup — capture the long-lived services in a closure so
+  // the per-request function only needs `HttpRouter`-Provided context.
+  // That collapses the middleware's `requires` to `never`, giving us a
+  // real `.layer` (instead of the "Need to .combine(...)" type-error
+  // sentinel that fires when `requires` leaks to non-never).
   Effect.gen(function* () {
-    const webRequest = yield* Effect.mapError(
-      HttpServerRequest.toWeb(request),
-      () =>
-        new HttpResponseError({
-          status: 500,
-          code: "invalid_request",
-          message: "Invalid request",
-        }),
-    );
-    const workos = yield* WorkOSAuth;
-    const session = yield* workos.authenticateRequest(webRequest);
-    if (!session || !session.organizationId) return null;
-
-    const org = yield* authorizeOrganization(session.userId, session.organizationId);
-    if (!org) return null;
-    return { org, userId: session.userId };
-  });
-
-const createProtectedApp = (
-  userId: string,
-  organizationId: string,
-  organizationName: string,
-) =>
-  Effect.gen(function* () {
-    const { executor, engine } = yield* makeExecutionStack(
-      userId,
-      organizationId,
-      organizationName,
-    );
-
-    const requestServices = Layer.mergeAll(
-      Layer.succeed(ExecutorService)(executor),
-      Layer.succeed(ExecutionEngineService)(engine),
-      Layer.succeed(OpenApiExtensionService)(executor.openapi),
-      Layer.succeed(McpExtensionService)(executor.mcp),
-      Layer.succeed(GraphqlExtensionService)(executor.graphql),
-    );
-
-    const protectedApiLayer = ProtectedCloudApiLive.pipe(
-      Layer.provideMerge(HttpApiSwagger.layer(ProtectedCloudApi, { path: "/docs" })),
-      Layer.provideMerge(RouterConfig),
-    );
-
-    return yield* HttpRouter.toHttpEffect(protectedApiLayer).pipe(
-      Effect.flatMap(HttpMiddleware.logger),
-      Effect.provide(requestServices),
-    );
-  });
-
-export const ProtectedApiApp = Effect.gen(function* () {
-  const request = yield* HttpServerRequest.HttpServerRequest;
-  const session = yield* lookupOrgForRequest(request);
-  if (!session) {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 403,
-        code: "no_organization",
-        message: "No organization in session",
-      }),
-    );
-  }
-
-  return yield* createProtectedApp(session.userId, session.org.id, session.org.name);
-}).pipe(
-  Effect.provide(SharedServices),
-  Effect.catchCause((err) => {
-    if (isServerError(err)) {
-      console.error("[api] request failed:", err instanceof Error ? err.stack : err);
-    }
-    return Effect.succeed(toErrorServerResponse(err));
+    const context = yield* Effect.context<
+      WorkOSAuth | UserStoreService | AutumnService | DbService
+    >();
+    return (httpEffect) =>
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const webRequest = yield* HttpServerRequest.toWeb(request);
+        const workos = yield* WorkOSAuth;
+        const session = yield* workos.authenticateRequest(webRequest);
+        if (!session || !session.organizationId) {
+          return yield* new HttpResponseError({
+            status: 403,
+            code: "no_organization",
+            message: "No organization in session",
+          });
+        }
+        const org = yield* authorizeOrganization(session.userId, session.organizationId);
+        if (!org) {
+          return yield* new HttpResponseError({
+            status: 403,
+            code: "no_organization",
+            message: "No organization in session",
+          });
+        }
+        const auth = AuthContext.of({
+          accountId: session.userId,
+          organizationId: org.id,
+          email: session.email,
+          name: `${session.firstName ?? ""} ${session.lastName ?? ""}`.trim() || null,
+          avatarUrl: session.avatarUrl ?? null,
+        });
+        const { executor, engine } = yield* makeExecutionStack(auth.accountId, org.id, org.name);
+        return yield* httpEffect.pipe(
+          Effect.provideService(AuthContext, auth),
+          Effect.provideService(ExecutorService, executor),
+          Effect.provideService(ExecutionEngineService, engine),
+          Effect.provideService(OpenApiExtensionService, executor.openapi),
+          Effect.provideService(McpExtensionService, executor.mcp),
+          Effect.provideService(GraphqlExtensionService, executor.graphql),
+        );
+      }).pipe(Effect.provideContext(context));
   }),
+).layer;
+
+export const ProtectedApiLive = ProtectedCloudApiLive.pipe(
+  Layer.provide(ExecutionStackMiddleware),
+  Layer.provideMerge(HttpApiSwagger.layer(ProtectedCloudApi, { path: "/docs" })),
+  Layer.provideMerge(RouterConfig),
 );

--- a/apps/cloud/src/api/router.ts
+++ b/apps/cloud/src/api/router.ts
@@ -1,56 +1,24 @@
-import { HttpEffect, HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
-import { Context, Effect, Scope } from "effect";
+import { Layer } from "effect";
 
-export type ApiRouteApp = Effect.Effect<
-  HttpServerResponse.HttpServerResponse,
-  unknown,
-  HttpServerRequest.HttpServerRequest | Scope.Scope
->;
+import { AutumnRoutesLive } from "./autumn";
+import {
+  NonProtectedApiLive,
+  OrgApiLive,
+  RouterConfig,
+  SharedServices,
+} from "./layers";
+import { ProtectedApiLive } from "./protected";
 
-type RequestAppService = {
-  readonly app: ApiRouteApp;
-};
-
-export class OrgRequestHandlerService extends Context.Service<OrgRequestHandlerService, RequestAppService>()(
-  "@executor-js/cloud/OrgRequestHandlerService",
-) {}
-
-export class NonProtectedRequestHandlerService extends Context.Service<NonProtectedRequestHandlerService, RequestAppService>()(
-  "@executor-js/cloud/NonProtectedRequestHandlerService",
-) {}
-
-export class AutumnRequestHandlerService extends Context.Service<AutumnRequestHandlerService, RequestAppService>()(
-  "@executor-js/cloud/AutumnRequestHandlerService",
-) {}
-
-export class ProtectedRequestHandlerService extends Context.Service<ProtectedRequestHandlerService, RequestAppService>()(
-  "@executor-js/cloud/ProtectedRequestHandlerService",
-) {}
-
-export const ApiRouterApp = Effect.gen(function* () {
-  const org = yield* OrgRequestHandlerService;
-  const nonProtected = yield* NonProtectedRequestHandlerService;
-  const autumn = yield* AutumnRequestHandlerService;
-  const protectedHandler = yield* ProtectedRequestHandlerService;
-  const asRouteApp = (app: ApiRouteApp) => {
-    const webHandler = HttpEffect.toWebHandler(app);
-    return HttpEffect.fromWebHandler((request) => webHandler(request)).pipe(
-      Effect.catchCause(() =>
-        Effect.succeed(HttpServerResponse.text("Internal Server Error", { status: 500 })),
-      ),
-    );
-  };
-
-  const router = yield* HttpRouter.make;
-  yield* router.add("*", "/org/*", asRouteApp(org.app));
-  yield* router.add("*", "/auth/*", asRouteApp(nonProtected.app));
-  yield* router.add("*", "/autumn/*", asRouteApp(autumn.app));
-  yield* router.add("*", "/scope", asRouteApp(protectedHandler.app));
-  yield* router.add("*", "/scopes/*", asRouteApp(protectedHandler.app));
-  yield* router.add("*", "/executions/*", asRouteApp(protectedHandler.app));
-  yield* router.add("*", "/oauth/*", asRouteApp(protectedHandler.app));
-
-  return router.asHttpEffect();
-});
-
-export const ApiRequestHandler = ApiRouterApp;
+// One router. Each sub-API contributes its routes via `HttpApiBuilder.layer`,
+// which calls `HttpRouter.use(...)` under the hood. Autumn's catch-all proxy
+// is added as a plain `HttpRouter.add` route. They all merge into the same
+// routing table; there is no outer-then-inner router stacking.
+export const ApiLive = Layer.mergeAll(
+  NonProtectedApiLive,
+  OrgApiLive,
+  ProtectedApiLive,
+  AutumnRoutesLive,
+).pipe(
+  Layer.provideMerge(RouterConfig),
+  Layer.provideMerge(SharedServices),
+);

--- a/apps/cloud/src/services/__test-harness__/api-harness.ts
+++ b/apps/cloud/src/services/__test-harness__/api-harness.ts
@@ -16,7 +16,12 @@
 
 import { Effect, Layer } from "effect";
 import { HttpApiBuilder, HttpApiClient, HttpApiSwagger } from "effect/unstable/httpapi";
-import { FetchHttpClient, HttpEffect, HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import {
+  FetchHttpClient,
+  HttpRouter,
+  HttpServer,
+  HttpServerRequest,
+} from "effect/unstable/http";
 
 import {
   ExecutionEngineService,
@@ -48,7 +53,7 @@ import { OpenApiExtensionService } from "@executor-js/plugin-openapi/api";
 import { McpExtensionService } from "@executor-js/plugin-mcp/api";
 import { GraphqlExtensionService } from "@executor-js/plugin-graphql/api";
 
-import { AuthContext, OrgAuth } from "../../auth/middleware";
+import { AuthContext } from "../../auth/middleware";
 import {
   ProtectedCloudApi,
   ProtectedCloudApiHandlers,
@@ -209,10 +214,27 @@ const createTestScopedExecutor = (
 // HTTP plumbing
 // ---------------------------------------------------------------------------
 
-const FakeOrgAuthLive = Layer.succeed(
-  OrgAuth,
-  {
-    cookie: (httpApp) =>
+// Test version of the production `ExecutionStackMiddleware` — reads the
+// `x-test-org-id` (and optional `x-test-user-id`) header, builds a
+// test-scoped executor against the live postgres test db with a fake
+// WorkOS vault, and provides `AuthContext` + the executor services to the
+// handler. Mirrors prod's HttpRouter middleware but with test-mode
+// constructors.
+const TestExecutionStackMiddleware = HttpRouter.middleware<{
+  provides:
+    | AuthContext
+    | ExecutorService
+    | ExecutionEngineService
+    | OpenApiExtensionService
+    | McpExtensionService
+    | GraphqlExtensionService;
+}>()(
+  // Layer-time setup — captures `DbService` so the per-request function
+  // only depends on `HttpRouter`-Provided context. See `api/protected.ts`
+  // for the same pattern.
+  Effect.gen(function* () {
+    const context = yield* Effect.context<DbService>();
+    return (httpEffect) =>
       Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest;
         const orgId = request.headers[TEST_ORG_HEADER];
@@ -224,7 +246,13 @@ const FakeOrgAuthLive = Layer.succeed(
           typeof userHeader === "string" && userHeader.length > 0
             ? userHeader
             : defaultUserFor(orgId);
-        return yield* httpApp.pipe(
+        const orgName = `Org ${orgId}`;
+        const executor = yield* createTestScopedExecutor(userId, orgId, orgName);
+        const engine = createExecutionEngine({
+          executor,
+          codeExecutor: makeQuickJsExecutor(),
+        });
+        return yield* httpEffect.pipe(
           Effect.provideService(
             AuthContext,
             AuthContext.of({
@@ -235,66 +263,26 @@ const FakeOrgAuthLive = Layer.succeed(
               avatarUrl: null,
             }),
           ),
+          Effect.provideService(ExecutorService, executor),
+          Effect.provideService(ExecutionEngineService, engine),
+          Effect.provideService(OpenApiExtensionService, executor.openapi),
+          Effect.provideService(McpExtensionService, executor.mcp),
+          Effect.provideService(GraphqlExtensionService, executor.graphql),
         );
-      }),
-  },
-);
+      }).pipe(Effect.provideContext(context));
+  }),
+).layer;
 
 const TestApiLive = HttpApiBuilder.layer(ProtectedCloudApi).pipe(
-  Layer.provide(Layer.merge(ProtectedCloudApiHandlers, FakeOrgAuthLive)),
+  Layer.provide(ProtectedCloudApiHandlers),
+  Layer.provide(TestExecutionStackMiddleware),
+  Layer.provideMerge(HttpApiSwagger.layer(ProtectedCloudApi, { path: "/docs" })),
+  Layer.provideMerge(RouterConfig),
+  Layer.provideMerge(DbService.Live),
+  Layer.provideMerge(HttpServer.layerServices),
 );
 
-const buildWebHandlerForScope = (userId: string, orgId: string, orgName: string) =>
-  Effect.gen(function* () {
-    const executor = yield* createTestScopedExecutor(userId, orgId, orgName);
-    const engine = createExecutionEngine({ executor, codeExecutor: makeQuickJsExecutor() });
-    const services = Layer.mergeAll(
-      Layer.succeed(ExecutorService)(executor),
-      Layer.succeed(ExecutionEngineService)(engine),
-      Layer.succeed(OpenApiExtensionService)(executor.openapi),
-      Layer.succeed(McpExtensionService)(executor.mcp),
-      Layer.succeed(GraphqlExtensionService)(executor.graphql),
-    );
-    return HttpRouter.toWebHandler(
-      TestApiLive.pipe(
-        Layer.provideMerge(HttpApiSwagger.layer(ProtectedCloudApi, { path: "/docs" })),
-        Layer.provideMerge(services),
-        Layer.provideMerge(RouterConfig),
-        Layer.provideMerge(HttpServer.layerServices),
-      ),
-      { disableLogger: true },
-    );
-  });
-
-const RouterApp = Effect.gen(function* () {
-  const request = yield* HttpServerRequest.HttpServerRequest;
-  const webRequest = yield* HttpServerRequest.toWeb(request);
-  const orgId = request.headers[TEST_ORG_HEADER];
-  if (!orgId || typeof orgId !== "string") {
-    return yield* Effect.die(new Error("missing x-test-org-id"));
-  }
-  const userHeader = request.headers[TEST_USER_HEADER];
-  const userId =
-    typeof userHeader === "string" && userHeader.length > 0
-      ? userHeader
-      : defaultUserFor(orgId);
-  const web = yield* buildWebHandlerForScope(userId, orgId, `Org ${orgId}`);
-  const response = yield* Effect.promise(async () => {
-    try {
-      return await web.handler(webRequest);
-    } finally {
-      await web.dispose();
-    }
-  });
-  return HttpServerResponse.raw(response, { status: response.status, headers: response.headers });
-});
-
-const handler = HttpEffect.toWebHandler(
-  RouterApp.pipe(
-    Effect.provide(DbService.Live),
-    Effect.provide(HttpServer.layerServices),
-  ),
-);
+const handler = HttpRouter.toWebHandler(TestApiLive, { disableLogger: true }).handler;
 
 export const fetchForOrg = (orgId: string): typeof globalThis.fetch =>
   ((input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

The cloud HTTP routing in `apps/cloud/src/api/router.ts` was a tangle of workarounds after the v3→v4 migration:

- **4 wrapper `Context.Service`s** (`OrgRequestHandlerService`, `NonProtectedRequestHandlerService`, `AutumnRequestHandlerService`, `ProtectedRequestHandlerService`) that existed only to inject sub-app effects.
- **`asRouteApp` round-trip** — every sub-app was passed through `HttpEffect.toWebHandler(app)` then `HttpEffect.fromWebHandler(req => webHandler(req))` to bolt independently-built routers under the parent.
- **Two-tier router stack** — each sub-API built its own `HttpRouter` via `HttpApiBuilder.layer + HttpRouter.toHttpEffect`, and that opaque effect was wedged into a top-level `HttpRouter`. Every request walked two routers.
- **Auth done twice** — `ProtectedCloudApi.middleware(OrgAuth)` already authenticated via `OrgAuthLive`, but `protected.ts` *also* ran `lookupOrgForRequest` (full WorkOS round-trip) just to decide which sub-app to dispatch.
- **Generic `catchCause → 500`** in `asRouteApp` swallowed real errors and prevented `OrgAuth`'s typed `Unauthorized` / `NoOrganization` (with `httpApiStatus`) from being honored.

## What changed

One shared `HttpRouter`. Each `HttpApiBuilder.layer(api)` already calls `HttpRouter.use(...)` under the hood, so contributing routes is just merging layers — no mounting, no outer-then-inner stacking. Autumn's catch-all proxy is `HttpRouter.add("*", "/autumn/*", handler)`.

Per-request executor stack construction collapses into a single `HttpRouter.middleware<{provides: ...}>()` that authenticates, verifies live org membership, resolves the org name, builds the executor + engine, and provides `AuthContext` + the execution-stack services to handlers in one place. Replaces both the outer `Effect.gen` lookup *and* the `OrgAuth` HttpApiMiddleware on `ProtectedCloudApi` (which was running auth a second time with wrong ordering).

`HttpResponseError` now implements `HttpServerRespondable` — typed errors self-render to JSON via the framework's cause→response pipeline. That's what eliminates the `catchCause → Effect.succeed` wrappers and the type casts they required (since collapsing E to `never` violates `HttpRouter.middleware`'s `unhandled extends E` brand check).

## Net diff

- `api/router.ts` — 56 lines → 22 lines
- `api/protected.ts` — `lookupOrgForRequest` + `createProtectedApp` outer scaffolding gone; replaced by a single router middleware
- `api/protected-layers.ts` — dropped `.middleware(OrgAuth)` from `ProtectedCloudApi` and the redundant `ExecutionStack` HttpApiMiddleware
- `api/error-response.ts` — `HttpResponseError` implements `Respondable`
- `api/layers.ts` — emits `*ApiLive` Layers instead of `*ApiApp` Effects
- `api/autumn.ts` — became a route Layer
- `api.ts` — three lines: `HttpRouter.toWebHandler(ApiLive).handler`
- `api.test.ts` — drops the four wrapper-service mocks; tests build stub APIs that mount directly on the shared router
- `services/__test-harness__/api-harness.ts` — `buildWebHandlerForScope` + `RouterApp` collapsed into a single test middleware

**Zero `as unknown as` / type casts in the final code.**

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run test` — 42/42 workerd tests pass (including `api.test.ts` for routing semantics + `protected.test.ts` for execution-usage tracking)
- [x] `bun run test:node` — 63/63 node tests pass (including the integration tests that go through the test harness)
- [x] `npx oxlint` clean (0 warnings, 0 errors)
- [ ] Manual smoke test in dev (sign-in flow, protected route, autumn billing endpoint)