### PR TITLE
Policies tab in local + multiplex portless across apps

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun run dev:proxy && concurrently -n db,vite -c blue,green \"bun run dev:db\" \"bun run dev:vite\"",
-    "dev:proxy": "portless proxy start --multiplex --port 1355 --no-tls || true",
+    "dev:proxy": "portless proxy start --multiplex --port 1355 || true",
     "dev:db": "bun run scripts/dev-db.ts",
     "dev:vite": "EXECUTOR_DIRECT_DATABASE_URL=true CLOUDFLARE_INCLUDE_PROCESS_ENV=true op run --env-file=.env.op -- portless --name executor-cloud vite dev",
     "db:schema": "node --import jiti/register ../../packages/core/cli/src/index.ts generate --config ./executor.config.ts --output ./src/services/executor-schema.ts",

--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -7,7 +7,9 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "dev": "portless --name executor-local bunx --bun vite dev",
+    "dev": "bun run dev:proxy && bun run dev:vite",
+    "dev:proxy": "portless proxy start --multiplex --port 1355 || true",
+    "dev:vite": "portless --name executor-local bunx --bun vite dev",
     "build": "bunx --bun vite build",
     "start": "bun run src/serve.ts",
     "db:schema": "node --import jiti/register ../../packages/core/cli/src/index.ts generate --config ./executor.config.ts --output ./src/server/executor-schema.ts",

--- a/apps/local/src/routeTree.gen.ts
+++ b/apps/local/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ToolsRouteImport } from './routes/tools'
 import { Route as SecretsRouteImport } from './routes/secrets'
+import { Route as PoliciesRouteImport } from './routes/policies'
 import { Route as ConnectionsRouteImport } from './routes/connections'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
@@ -24,6 +25,11 @@ const ToolsRoute = ToolsRouteImport.update({
 const SecretsRoute = SecretsRouteImport.update({
   id: '/secrets',
   path: '/secrets',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PoliciesRoute = PoliciesRouteImport.update({
+  id: '/policies',
+  path: '/policies',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ConnectionsRoute = ConnectionsRouteImport.update({
@@ -50,6 +56,7 @@ const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/connections': typeof ConnectionsRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -58,6 +65,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/connections': typeof ConnectionsRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -67,6 +75,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/connections': typeof ConnectionsRoute
+  '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -77,6 +86,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/connections'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -85,6 +95,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/connections'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -93,6 +104,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/connections'
+    | '/policies'
     | '/secrets'
     | '/tools'
     | '/sources/$namespace'
@@ -102,6 +114,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   ConnectionsRoute: typeof ConnectionsRoute
+  PoliciesRoute: typeof PoliciesRoute
   SecretsRoute: typeof SecretsRoute
   ToolsRoute: typeof ToolsRoute
   SourcesNamespaceRoute: typeof SourcesNamespaceRoute
@@ -122,6 +135,13 @@ declare module '@tanstack/react-router' {
       path: '/secrets'
       fullPath: '/secrets'
       preLoaderRoute: typeof SecretsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/policies': {
+      id: '/policies'
+      path: '/policies'
+      fullPath: '/policies'
+      preLoaderRoute: typeof PoliciesRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/connections': {
@@ -158,6 +178,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   ConnectionsRoute: ConnectionsRoute,
+  PoliciesRoute: PoliciesRoute,
   SecretsRoute: SecretsRoute,
   ToolsRoute: ToolsRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,

--- a/apps/local/src/routes/policies.tsx
+++ b/apps/local/src/routes/policies.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PoliciesPage } from "@executor-js/react/pages/policies";
+
+export const Route = createFileRoute("/policies")({
+  component: () => <PoliciesPage />,
+});

--- a/apps/local/src/web/shell.tsx
+++ b/apps/local/src/web/shell.tsx
@@ -305,6 +305,7 @@ function SidebarContent(props: {
   const isHome = props.pathname === "/";
   const isSecrets = props.pathname === "/secrets";
   const isConnections = props.pathname === "/connections";
+  const isPolicies = props.pathname === "/policies";
 
   return (
     <>
@@ -326,6 +327,12 @@ function SidebarContent(props: {
           onNavigate={props.onNavigate}
         />
         <NavItem to="/secrets" label="Secrets" active={isSecrets} onNavigate={props.onNavigate} />
+        <NavItem
+          to="/policies"
+          label="Policies"
+          active={isPolicies}
+          onNavigate={props.onNavigate}
+        />
 
         {/* Sources list */}
         <div className="mt-5 mb-1 px-2.5 text-xs font-medium uppercase tracking-widest text-muted-foreground">

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.5",
   "type": "module",
   "scripts": {
-    "dev": "portless --name executor-marketing astro dev",
+    "dev": "bun run dev:proxy && bun run dev:vite",
+    "dev:proxy": "portless proxy start --multiplex --port 1355 || true",
+    "dev:vite": "portless --name executor-marketing astro dev",
     "build": "astro build",
     "preview": "astro preview",
     "deploy": "astro build && npx wrangler deploy --config dist/server/wrangler.json",


### PR DESCRIPTION
## Summary
- Port the Policies tab from `apps/cloud` to `apps/local` — new `/policies` route renders the shared `PoliciesPage` from `@executor-js/react/pages/policies`, and a Policies nav item was added to the local sidebar shell.
- Make all three apps (cloud, local, marketing) use the same `dev:proxy` + `dev:vite` split with `portless proxy start --multiplex --port 1355`, and drop the `--no-tls` flag from cloud's proxy script so all apps run TLS.

## Test plan
- [ ] `cd apps/local && bun run dev` — policies tab is visible in sidebar, `/policies` resolves and renders the page (no 404)
- [ ] `cd apps/cloud && bun run dev` — proxy still starts, dev still works against TLS
- [ ] `cd apps/marketing && bun run dev` — proxy starts, marketing serves under multiplex
- [ ] Run two of the three apps simultaneously — both register cleanly with the shared port-1355 multiplex proxy