### PR TITLE
Set policies from the tools tree

### DIFF
--- a/packages/core/api/src/handlers/tools.ts
+++ b/packages/core/api/src/handlers/tools.ts
@@ -11,7 +11,14 @@ export const ToolsHandlers = HttpApiBuilder.group(ExecutorApi, "tools", (handler
     .handle("list", () =>
       capture(Effect.gen(function* () {
         const executor = yield* ExecutorService;
-        const tools = yield* executor.tools.list();
+        // Tools page is a management view — include policy-blocked tools
+        // (so users can unblock them) and load annotations so the row can
+        // show the plugin's default approval state when no user rule
+        // matches. Mirrors the per-source `sources.tools` handler.
+        const tools = yield* executor.tools.list({
+          includeAnnotations: true,
+          includeBlocked: true,
+        });
         return tools.map((t) => ({
           id: ToolId.make(t.id),
           pluginId: t.pluginId,
@@ -19,6 +26,7 @@ export const ToolsHandlers = HttpApiBuilder.group(ExecutorApi, "tools", (handler
           name: t.name,
           description: t.description,
           mayElicit: t.annotations?.mayElicit,
+          requiresApproval: t.annotations?.requiresApproval,
         }));
       })),
     )

--- a/packages/core/api/src/tools/api.ts
+++ b/packages/core/api/src/tools/api.ts
@@ -24,6 +24,7 @@ const ToolMetadataResponse = Schema.Struct({
   name: Schema.String,
   description: Schema.optional(Schema.String),
   mayElicit: Schema.optional(Schema.Boolean),
+  requiresApproval: Schema.optional(Schema.Boolean),
 });
 
 const ToolSchemaResponse = Schema.Struct({

--- a/packages/react/src/components/tool-detail.tsx
+++ b/packages/react/src/components/tool-detail.tsx
@@ -5,31 +5,31 @@ import { toolSchemaAtom } from "../api/atoms";
 import { ScopeId, ToolId, type EffectivePolicy, type ToolPolicyAction } from "@executor-js/sdk";
 import { Badge } from "./badge";
 import { Button } from "./button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
 import { Markdown } from "./markdown";
 import { SchemaExplorer } from "./schema-explorer";
 import { ExpandableCodeBlock } from "./expandable-code-block";
 import { CardStack, CardStackHeader, CardStackContent } from "./card-stack";
 import { CopyButton } from "./copy-button";
-import { ChevronRight } from "lucide-react";
-
-const POLICY_LABEL: Record<ToolPolicyAction, string> = {
-  approve: "Auto-approve",
-  require_approval: "Require approval",
-  block: "Blocked",
-};
-
-const POLICY_VARIANT: Record<
-  ToolPolicyAction,
-  "default" | "secondary" | "outline" | "destructive"
-> = {
-  approve: "secondary",
-  require_approval: "outline",
-  block: "destructive",
-};
+import { ChevronRight, ChevronDownIcon } from "lucide-react";
+import { cn } from "../lib/utils";
+import {
+  POLICY_ACTION_LABEL,
+  POLICY_ACTIONS_IN_ORDER,
+  POLICY_BADGE_VARIANT,
+  POLICY_STATE_LABEL,
+} from "../lib/policy-display";
 
 // Render the effective policy as a badge. User policies show the
 // matched pattern; plugin defaults read "Default: <action>". Silent for
-// the auto-approve plugin default — that's the safe state and the
+// the always-run plugin default — that's the safe state and the
 // header would just be noise.
 const policyBadgeFor = (policy: EffectivePolicy) => {
   if (policy.source === "plugin-default" && policy.action === "approve") {
@@ -37,16 +37,16 @@ const policyBadgeFor = (policy: EffectivePolicy) => {
   }
   if (policy.source === "user") {
     return {
-      variant: POLICY_VARIANT[policy.action],
+      variant: POLICY_BADGE_VARIANT[policy.action],
       title: `Matched policy: ${policy.pattern}`,
-      text: `${POLICY_LABEL[policy.action]} · ${policy.pattern}`,
+      text: `${POLICY_STATE_LABEL[policy.action]} · ${policy.pattern}`,
       className: "font-mono text-[10px]",
     };
   }
   return {
     variant: "outline" as const,
     title: "No matching policy — plugin default applies",
-    text: `Default: ${POLICY_LABEL[policy.action]}`,
+    text: `Default: ${POLICY_STATE_LABEL[policy.action]}`,
     className: "text-[10px] text-muted-foreground",
   };
 };
@@ -94,6 +94,10 @@ export function ToolDetail(props: {
   /** Resolved effective policy — user-authored or plugin-default,
    *  unified into one shape. Surfaces in the header. */
   policy?: EffectivePolicy;
+  /** When provided, the policy badge becomes a dropdown trigger that
+   *  applies a user rule to this tool's exact id. */
+  onSetPolicy?: (pattern: string, action: ToolPolicyAction) => void;
+  onClearPolicy?: (pattern: string) => void;
 }) {
   const toolContract = useAtomValue(toolSchemaAtom(props.scopeId, props.toolId as ToolId));
   const [tab, setTab] = useState<"schema" | "typescript">("schema");
@@ -136,16 +140,12 @@ export function ToolDetail(props: {
           <div className="mt-1 flex items-center gap-2">
             <h3 className="text-base font-semibold text-foreground truncate">{displayName}</h3>
             <CopyButton value={props.toolId} label="Copy tool ID" />
-            {(() => {
-              if (!props.policy) return null;
-              const badge = policyBadgeFor(props.policy);
-              if (!badge) return null;
-              return (
-                <Badge variant={badge.variant} title={badge.title} className={badge.className}>
-                  {badge.text}
-                </Badge>
-              );
-            })()}
+            <PolicyBadgeMenu
+              toolName={props.toolName}
+              policy={props.policy}
+              onSetPolicy={props.onSetPolicy}
+              onClearPolicy={props.onClearPolicy}
+            />
           </div>
           {props.toolDescription && (
             <div className="mt-1.5 max-w-lg text-sm text-muted-foreground line-clamp-2">
@@ -241,6 +241,99 @@ export function ToolDetail(props: {
         })}
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// PolicyBadgeMenu — clickable header badge that opens the same
+// Always run / Require approval / Block / Clear menu the tree row uses.
+// Falls back to a plain Badge when no actions are provided.
+// ---------------------------------------------------------------------------
+
+function PolicyBadgeMenu(props: {
+  toolName: string;
+  policy?: EffectivePolicy;
+  onSetPolicy?: (pattern: string, action: ToolPolicyAction) => void;
+  onClearPolicy?: (pattern: string) => void;
+}) {
+  const interactive = !!props.onSetPolicy;
+  // The "Clear" affordance only makes sense when there's a user rule
+  // pinned to this exact tool id — clearing a wildcard rule from a
+  // single tool's detail header would silently affect siblings.
+  const hasExactUserRule =
+    props.policy?.source === "user" && props.policy.pattern === props.toolName;
+  const currentAction = hasExactUserRule ? props.policy?.action : undefined;
+
+  if (!interactive) {
+    if (!props.policy) return null;
+    const badge = policyBadgeFor(props.policy);
+    if (!badge) return null;
+    return (
+      <Badge variant={badge.variant} title={badge.title} className={badge.className}>
+        {badge.text}
+      </Badge>
+    );
+  }
+
+  // Interactive trigger always renders, even when the effective policy
+  // would otherwise be "silent" (auto-approve plugin-default), so the
+  // user can click it to override.
+  const badge = props.policy ? policyBadgeFor(props.policy) : null;
+  const triggerLabel = badge?.text ?? "Set policy";
+  const triggerVariant = badge?.variant ?? "outline";
+  const triggerTitle = badge?.title ?? "Set policy";
+  const triggerClassName = badge?.className ?? "text-[10px] text-muted-foreground";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          aria-label={triggerTitle}
+          className="h-auto rounded-none p-0 hover:bg-transparent"
+        >
+          <Badge
+            variant={triggerVariant}
+            title={triggerTitle}
+            className={cn(
+              triggerClassName,
+              "cursor-pointer gap-1 pr-1.5 transition-opacity hover:opacity-80",
+            )}
+          >
+            {triggerLabel}
+            <ChevronDownIcon aria-hidden className="size-3 opacity-70" />
+          </Badge>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel className="font-mono text-xs">{props.toolName}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {POLICY_ACTIONS_IN_ORDER.map((action) => (
+          <DropdownMenuItem
+            key={action}
+            onSelect={() => props.onSetPolicy?.(props.toolName, action)}
+          >
+            <span className="flex-1">{POLICY_ACTION_LABEL[action]}</span>
+            {currentAction === action && (
+              <span aria-hidden className="text-muted-foreground">
+                ✓
+              </span>
+            )}
+          </DropdownMenuItem>
+        ))}
+        {hasExactUserRule && props.onClearPolicy && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => props.onClearPolicy?.(props.toolName)}
+              className="text-muted-foreground"
+            >
+              Clear
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/packages/react/src/components/tool-tree.tsx
+++ b/packages/react/src/components/tool-tree.tsx
@@ -1,9 +1,23 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronRightIcon, SearchIcon, XIcon } from "lucide-react";
+import { ChevronRightIcon, MoreHorizontalIcon, SearchIcon, XIcon } from "lucide-react";
 import type { EffectivePolicy, ToolPolicyAction } from "@executor-js/sdk";
 import { Button } from "./button";
 import { Input } from "./input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./dropdown-menu";
 import { cn } from "../lib/utils";
+import {
+  POLICY_ACTION_LABEL,
+  POLICY_ACTIONS_IN_ORDER,
+  POLICY_INDICATOR_COLOR,
+  POLICY_STATE_LABEL,
+} from "../lib/policy-display";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -20,30 +34,7 @@ export interface ToolSummary {
   readonly policy: EffectivePolicy;
 }
 
-// Color + label for the per-row policy indicator. Mirrors the badges on
-// the /policies page so the same action looks the same everywhere.
-const POLICY_INDICATOR: Record<
-  ToolPolicyAction,
-  { readonly label: string; readonly dot: string; readonly ring: string }
-> = {
-  approve: {
-    label: "Auto-approve",
-    dot: "bg-emerald-500",
-    ring: "ring-emerald-500/70",
-  },
-  require_approval: {
-    label: "Require approval",
-    dot: "bg-amber-500",
-    ring: "ring-amber-500/70",
-  },
-  block: {
-    label: "Blocked",
-    dot: "bg-destructive",
-    ring: "ring-destructive/70",
-  },
-};
-
-// What the dot looks like for a given effective policy. Auto-approve as
+// What the dot looks like for a given effective policy. Always-run as
 // a plugin default is silent (the safe state — no point cluttering every
 // row); everything else gets a dot. User policies are filled, plugin
 // defaults are hollow rings.
@@ -51,17 +42,16 @@ const indicatorFor = (policy: EffectivePolicy) => {
   if (policy.source === "plugin-default" && policy.action === "approve") {
     return null;
   }
-  const ind = POLICY_INDICATOR[policy.action];
+  const colors = POLICY_INDICATOR_COLOR[policy.action];
+  const stateLabel = POLICY_STATE_LABEL[policy.action];
   const filled = policy.source === "user";
   const label =
     policy.source === "user"
-      ? `${ind.label} (matched ${policy.pattern})`
-      : `Plugin default: ${ind.label}`;
+      ? `${stateLabel} (matched ${policy.pattern})`
+      : `Plugin default: ${stateLabel}`;
   return {
     label,
-    className: filled
-      ? ind.dot
-      : cn("bg-transparent ring-1", ind.ring),
+    className: filled ? colors.dot : cn("bg-transparent ring-1", colors.ring),
   };
 };
 
@@ -224,8 +214,24 @@ export function ToolTree(props: {
   tools: readonly ToolSummary[];
   selectedToolId: string | null;
   onSelect: (toolId: string) => void;
+  /** When provided, each row gets a hover-revealed action menu that
+   *  applies (or clears) a user policy for that exact node. Leaf rows
+   *  emit the tool's full dotted id; group rows emit `prefix.*`. */
+  onSetPolicy?: (pattern: string, action: ToolPolicyAction) => void;
+  onClearPolicy?: (pattern: string) => void;
+  /** Sorted user-authored policies (most-precedent first). Used to
+   *  decide whether a node has its own exact-pattern user rule today
+   *  (so the menu can show a "Clear" option). Optional — when absent,
+   *  the menu hides "Clear". */
+  policies?: ReadonlyArray<{ readonly pattern: string; readonly action: ToolPolicyAction }>;
 }) {
-  const { tools, selectedToolId, onSelect } = props;
+  const { tools, selectedToolId, onSelect, onSetPolicy, onClearPolicy, policies } = props;
+  const exactPatterns = useMemo(() => {
+    if (!policies) return new Map<string, ToolPolicyAction>();
+    const m = new Map<string, ToolPolicyAction>();
+    for (const p of policies) m.set(p.pattern, p.action);
+    return m;
+  }, [policies]);
   const [search, setSearch] = useState("");
   const [manualOpen, setManualOpen] = useState<Set<string>>(() => new Set());
   const searchRef = useRef<HTMLInputElement>(null);
@@ -342,16 +348,23 @@ export function ToolTree(props: {
                 active={row.tool.id === selectedToolId}
                 onSelect={() => onSelect(row.tool.id)}
                 search={search}
+                onSetPolicy={onSetPolicy}
+                onClearPolicy={onClearPolicy}
+                exactRule={exactPatterns.get(row.tool.name)}
               />
             ) : (
               <ToolGroupRow
                 key={row.path}
+                path={row.path}
                 segment={row.segment}
                 depth={row.depth}
                 count={row.count}
                 open={row.open}
                 onToggle={() => toggleGroup(row.path)}
                 search={search}
+                onSetPolicy={onSetPolicy}
+                onClearPolicy={onClearPolicy}
+                exactRule={exactPatterns.get(`${row.path}.*`)}
               />
             ),
           )
@@ -370,34 +383,127 @@ const rowIndent = (depth: number) => 12 + depth * 16;
 const rowBaseClasses =
   "relative flex h-auto w-full items-center justify-start gap-2 rounded-none py-2 text-xs font-normal transition-[background-color] duration-150";
 
+function PolicyActionMenu(props: {
+  pattern: string;
+  /** Action of an existing user rule with this exact pattern, if any.
+   *  When set, the menu shows a "Clear" option and marks the active
+   *  action with a check. */
+  current?: ToolPolicyAction;
+  onSet: (pattern: string, action: ToolPolicyAction) => void;
+  onClear?: (pattern: string) => void;
+  align?: "start" | "end";
+  /** When true, the trigger is rendered. Otherwise children are not
+   *  emitted at all and the row falls back to its plain layout. */
+  triggerLabel: string;
+  triggerClassName?: string;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={props.triggerLabel}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "size-5 shrink-0 text-muted-foreground hover:text-foreground",
+            props.triggerClassName,
+          )}
+        >
+          <MoreHorizontalIcon className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align={props.align ?? "end"}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <DropdownMenuLabel className="font-mono text-xs">{props.pattern}</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {POLICY_ACTIONS_IN_ORDER.map((action) => (
+          <DropdownMenuItem
+            key={action}
+            onSelect={() => props.onSet(props.pattern, action)}
+          >
+            <span className="flex-1">{POLICY_ACTION_LABEL[action]}</span>
+            {props.current === action && (
+              <span aria-hidden className="text-muted-foreground">
+                ✓
+              </span>
+            )}
+          </DropdownMenuItem>
+        ))}
+        {props.current && props.onClear && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onSelect={() => props.onClear?.(props.pattern)}
+              className="text-muted-foreground"
+            >
+              Clear
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 function ToolGroupRow(props: {
+  path: string;
   segment: string;
   depth: number;
   count: number;
   open: boolean;
   onToggle: () => void;
   search: string;
+  onSetPolicy?: (pattern: string, action: ToolPolicyAction) => void;
+  onClearPolicy?: (pattern: string) => void;
+  exactRule?: ToolPolicyAction;
 }) {
+  const showActions = !!props.onSetPolicy;
   return (
-    <Button
-      variant="ghost"
-      aria-expanded={props.open}
-      onClick={props.onToggle}
-      className={cn(rowBaseClasses, "hover:bg-accent/60")}
-      style={{ paddingLeft: rowIndent(props.depth), paddingRight: 12 }}
-    >
-      <ChevronRightIcon
-        aria-hidden
-        className={cn(
-          "size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
-          props.open && "rotate-90",
-        )}
-      />
-      <span className="min-w-0 flex-1 truncate text-left font-mono text-xs text-foreground">
-        {highlightMatch(props.segment, props.search)}
-      </span>
-      <span className="shrink-0 tabular-nums text-xs text-muted-foreground">{props.count}</span>
-    </Button>
+    <div className="group/tt-row relative flex items-stretch hover:bg-accent/60">
+      <Button
+        variant="ghost"
+        aria-expanded={props.open}
+        onClick={props.onToggle}
+        className={cn(rowBaseClasses, "hover:bg-transparent")}
+        style={{
+          paddingLeft: rowIndent(props.depth),
+          paddingRight: showActions ? 36 : 12,
+        }}
+      >
+        <ChevronRightIcon
+          aria-hidden
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground transition-transform duration-150",
+            props.open && "rotate-90",
+          )}
+        />
+        <span className="min-w-0 flex-1 truncate text-left font-mono text-xs text-foreground">
+          {highlightMatch(props.segment, props.search)}
+        </span>
+        <span className="shrink-0 tabular-nums text-xs text-muted-foreground">{props.count}</span>
+      </Button>
+      {showActions && (
+        <div
+          className={cn(
+            "absolute right-1.5 top-1/2 -translate-y-1/2 transition-opacity",
+            props.exactRule
+              ? "opacity-100"
+              : "opacity-0 group-hover/tt-row:opacity-100 focus-within:opacity-100",
+          )}
+        >
+          <PolicyActionMenu
+            pattern={`${props.path}.*`}
+            current={props.exactRule}
+            onSet={props.onSetPolicy!}
+            onClear={props.onClearPolicy}
+            triggerLabel={`Set policy for ${props.path}.*`}
+          />
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -408,33 +514,65 @@ function ToolLeafRow(props: {
   active: boolean;
   onSelect: () => void;
   search: string;
+  onSetPolicy?: (pattern: string, action: ToolPolicyAction) => void;
+  onClearPolicy?: (pattern: string) => void;
+  exactRule?: ToolPolicyAction;
 }) {
   const label = props.tool.name.split(".").pop() ?? props.tool.name;
   const indicator = indicatorFor(props.tool.policy);
+  const showActions = !!props.onSetPolicy;
   return (
-    <Button
-      ref={props.buttonRef}
-      variant="ghost"
-      onClick={props.onSelect}
+    <div
       className={cn(
-        rowBaseClasses,
+        "group/tt-row relative flex items-stretch",
         props.active
-          ? "bg-primary/15 text-foreground ring-1 ring-inset ring-primary/40 hover:bg-primary/20"
-          : "text-foreground/80 hover:bg-accent/60 hover:text-foreground",
-        props.tool.policy.action === "block" && !props.active && "opacity-60",
+          ? "bg-primary/15 ring-1 ring-inset ring-primary/40 hover:bg-primary/20"
+          : "hover:bg-accent/60",
+        props.tool.policy.action === "block" && !props.active && "opacity-70",
       )}
-      style={{ paddingLeft: rowIndent(props.depth) + 20, paddingRight: 12 }}
     >
-      <span className="flex-1 truncate text-left font-mono">
-        {highlightMatch(label, props.search)}
-      </span>
-      {indicator && (
-        <span
-          aria-label={indicator.label}
-          title={indicator.label}
-          className={cn("shrink-0 size-1.5 rounded-full", indicator.className)}
-        />
+      <Button
+        ref={props.buttonRef}
+        variant="ghost"
+        onClick={props.onSelect}
+        className={cn(
+          rowBaseClasses,
+          props.active ? "text-foreground hover:bg-transparent" : "text-foreground/80 hover:bg-transparent hover:text-foreground",
+        )}
+        style={{
+          paddingLeft: rowIndent(props.depth) + 20,
+          paddingRight: showActions ? 36 : 12,
+        }}
+      >
+        <span className="flex-1 truncate text-left font-mono">
+          {highlightMatch(label, props.search)}
+        </span>
+        {indicator && (
+          <span
+            aria-label={indicator.label}
+            title={indicator.label}
+            className={cn("shrink-0 size-1.5 rounded-full", indicator.className)}
+          />
+        )}
+      </Button>
+      {showActions && (
+        <div
+          className={cn(
+            "absolute right-1.5 top-1/2 -translate-y-1/2 transition-opacity",
+            props.exactRule
+              ? "opacity-100"
+              : "opacity-0 group-hover/tt-row:opacity-100 focus-within:opacity-100",
+          )}
+        >
+          <PolicyActionMenu
+            pattern={props.tool.name}
+            current={props.exactRule}
+            onSet={props.onSetPolicy!}
+            onClear={props.onClearPolicy}
+            triggerLabel={`Set policy for ${props.tool.name}`}
+          />
+        </div>
       )}
-    </Button>
+    </div>
   );
 }

--- a/packages/react/src/hooks/use-policy-actions.ts
+++ b/packages/react/src/hooks/use-policy-actions.ts
@@ -1,0 +1,128 @@
+import { useCallback, useMemo } from "react";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { generateKeyBetween } from "fractional-indexing";
+import { PolicyId, type ScopeId, type ToolPolicyAction } from "@executor-js/sdk";
+
+import {
+  createPolicyOptimistic,
+  policiesOptimisticAtom,
+  removePolicyOptimistic,
+  updatePolicyOptimistic,
+} from "../api/atoms";
+import { policyWriteKeys } from "../api/reactivity-keys";
+
+// Specificity score for ordering. Higher = more specific = should sit at a
+// lower position-key (higher precedence). New rules are auto-placed below
+// any more-specific existing rules so a freshly-added group rule never
+// silently shadows an existing leaf rule.
+//   `*`            → 0
+//   `vercel.*`     → 2  (1 literal segment, wildcard)
+//   `vercel.dns.*` → 4  (2 literal segments, wildcard)
+//   `vercel.dns`   → 5  (2 literal segments, exact — beats same-prefix wildcard)
+//   `vercel.dns.create` → 7  (3 literal segments, exact)
+const specificity = (pattern: string): number => {
+  if (pattern === "*") return 0;
+  if (pattern.endsWith(".*")) {
+    const prefix = pattern.slice(0, -2);
+    return prefix.split(".").length * 2;
+  }
+  return pattern.split(".").length * 2 + 1;
+};
+
+export interface PolicyAction {
+  /** Set the action on a pattern. If a user rule with this exact pattern
+   *  already exists, update it. Otherwise create with auto-placed
+   *  position so more-specific rules keep precedence. */
+  readonly set: (pattern: string, action: ToolPolicyAction) => Promise<void>;
+  /** Remove the user rule with this exact pattern, if any. No-op if none. */
+  readonly clear: (pattern: string) => Promise<void>;
+  /** True while a write is in flight. */
+  readonly busy: boolean;
+}
+
+export const usePolicyActions = (scopeId: ScopeId): PolicyAction => {
+  const policies = useAtomValue(policiesOptimisticAtom(scopeId));
+  const doCreate = useAtomSet(createPolicyOptimistic(scopeId), { mode: "promise" });
+  const doUpdate = useAtomSet(updatePolicyOptimistic(scopeId), { mode: "promise" });
+  const doRemove = useAtomSet(removePolicyOptimistic(scopeId), { mode: "promise" });
+
+  // Sorted by position ASC (lowest position = highest precedence first),
+  // matching server evaluation order. Optimistic placeholder rows carry
+  // `position: ""` and sort to the very top — that's fine for lookup but
+  // they're skipped when computing insert position.
+  const sorted = useMemo(() => {
+    if (!AsyncResult.isSuccess(policies)) return [] as ReadonlyArray<{
+      readonly id: string;
+      readonly pattern: string;
+      readonly action: ToolPolicyAction;
+      readonly position: string;
+    }>;
+    return [...policies.value].sort((a, b) => {
+      if (a.position < b.position) return -1;
+      if (a.position > b.position) return 1;
+      return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    });
+  }, [policies]);
+
+  const busy = policies.waiting;
+
+  const computePosition = useCallback(
+    (newPattern: string): string | undefined => {
+      const committed = sorted.filter((r) => r.position !== "");
+      if (committed.length === 0) return undefined;
+      const newScore = specificity(newPattern);
+      // Walk down the list (most-precedent first); place the new rule
+      // just before the first existing rule whose specificity is <= the
+      // new one. That way more-specific rules stay above us, and we win
+      // against everything equally or less specific.
+      let idx = committed.findIndex((r) => specificity(r.pattern) <= newScore);
+      if (idx === -1) idx = committed.length; // append at bottom
+      const prev = idx === 0 ? null : committed[idx - 1]!.position;
+      const next = idx === committed.length ? null : committed[idx]!.position;
+      return generateKeyBetween(prev, next);
+    },
+    [sorted],
+  );
+
+  const findExact = useCallback(
+    (pattern: string) => sorted.find((r) => r.pattern === pattern && r.position !== ""),
+    [sorted],
+  );
+
+  const set = useCallback(
+    async (pattern: string, action: ToolPolicyAction) => {
+      const existing = findExact(pattern);
+      if (existing) {
+        if (existing.action === action) return;
+        await doUpdate({
+          params: { scopeId, policyId: PolicyId.make(existing.id) },
+          payload: { action },
+          reactivityKeys: policyWriteKeys,
+        });
+        return;
+      }
+      const position = computePosition(pattern);
+      await doCreate({
+        params: { scopeId },
+        payload: position === undefined ? { pattern, action } : { pattern, action, position },
+        reactivityKeys: policyWriteKeys,
+      });
+    },
+    [scopeId, doCreate, doUpdate, findExact, computePosition],
+  );
+
+  const clear = useCallback(
+    async (pattern: string) => {
+      const existing = findExact(pattern);
+      if (!existing) return;
+      await doRemove({
+        params: { scopeId, policyId: PolicyId.make(existing.id) },
+        reactivityKeys: policyWriteKeys,
+      });
+    },
+    [scopeId, doRemove, findExact],
+  );
+
+  return { set, clear, busy };
+};

--- a/packages/react/src/lib/policy-display.ts
+++ b/packages/react/src/lib/policy-display.ts
@@ -1,0 +1,50 @@
+// Shared display strings + colors for tool policy actions. Three views
+// (Tools tree row dot, Tool detail header badge, Policies page row badge
+// + select) need to render the same action consistently — keeping the
+// labels here lets a rename ("Auto-approve" → "Always run") happen in
+// one place. Splitting `state` vs `action` labels because `block` reads
+// as "Blocked" when describing current state, "Block" as a verb in menus.
+
+import type { ToolPolicyAction } from "@executor-js/sdk";
+
+/** Verb form — menus, select items, "what should this rule do". */
+export const POLICY_ACTION_LABEL: Record<ToolPolicyAction, string> = {
+  approve: "Always run",
+  require_approval: "Require approval",
+  block: "Block",
+};
+
+/** State form — badges, indicator tooltips, "what is the current
+ *  state". Diverges from the verb form for `block` only. */
+export const POLICY_STATE_LABEL: Record<ToolPolicyAction, string> = {
+  ...POLICY_ACTION_LABEL,
+  block: "Blocked",
+};
+
+/** Badge variant per action — semantic color via the Badge component. */
+export const POLICY_BADGE_VARIANT: Record<
+  ToolPolicyAction,
+  "default" | "secondary" | "outline" | "destructive"
+> = {
+  approve: "secondary",
+  require_approval: "outline",
+  block: "destructive",
+};
+
+/** Dot + ring color classes for the per-row indicator in `ToolTree`.
+ *  Filled dot = user-authored rule; ring-only = plugin default. */
+export const POLICY_INDICATOR_COLOR: Record<
+  ToolPolicyAction,
+  { readonly dot: string; readonly ring: string }
+> = {
+  approve: { dot: "bg-emerald-500", ring: "ring-emerald-500/70" },
+  require_approval: { dot: "bg-amber-500", ring: "ring-amber-500/70" },
+  block: { dot: "bg-destructive", ring: "ring-destructive/70" },
+};
+
+/** Canonical display order for select items / menu options. */
+export const POLICY_ACTIONS_IN_ORDER: ReadonlyArray<ToolPolicyAction> = [
+  "approve",
+  "require_approval",
+  "block",
+];

--- a/packages/react/src/pages/policies.tsx
+++ b/packages/react/src/pages/policies.tsx
@@ -15,6 +15,11 @@ import { policyWriteKeys } from "../api/reactivity-keys";
 import { useScope } from "../hooks/use-scope";
 import { badgeVariants } from "../components/badge";
 import { cn } from "../lib/utils";
+import {
+  POLICY_ACTION_LABEL,
+  POLICY_ACTIONS_IN_ORDER,
+  POLICY_BADGE_VARIANT,
+} from "../lib/policy-display";
 import { Button } from "../components/button";
 import {
   CardStack,
@@ -56,25 +61,6 @@ const comparePolicy = (posA: string, idA: string, posB: string, idB: string): nu
   if (idA < idB) return -1;
   if (idA > idB) return 1;
   return 0;
-};
-
-// ---------------------------------------------------------------------------
-// Action display
-// ---------------------------------------------------------------------------
-
-const actionLabels: Record<ToolPolicyAction, string> = {
-  approve: "Auto-approve",
-  require_approval: "Require approval",
-  block: "Block",
-};
-
-const actionVariants: Record<
-  ToolPolicyAction,
-  "default" | "secondary" | "outline" | "destructive"
-> = {
-  approve: "secondary",
-  require_approval: "outline",
-  block: "destructive",
 };
 
 // ---------------------------------------------------------------------------
@@ -160,9 +146,11 @@ function AddPolicyForm(props: {
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="approve">{actionLabels.approve}</SelectItem>
-            <SelectItem value="require_approval">{actionLabels.require_approval}</SelectItem>
-            <SelectItem value="block">{actionLabels.block}</SelectItem>
+            {POLICY_ACTIONS_IN_ORDER.map((a) => (
+              <SelectItem key={a} value={a}>
+                {POLICY_ACTION_LABEL[a]}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>
@@ -207,18 +195,20 @@ function PolicyRow(props: {
           <SelectPrimitiveTrigger
             className={cn(
               badgeVariants({
-                variant: actionVariants[props.policy.action],
+                variant: POLICY_BADGE_VARIANT[props.policy.action],
               }),
               "cursor-pointer pr-1.5 gap-1 transition-[opacity,box-shadow] hover:opacity-80 focus-visible:outline-none data-[state=open]:ring-2 data-[state=open]:ring-ring/50",
             )}
           >
-            {actionLabels[props.policy.action]}
+            {POLICY_ACTION_LABEL[props.policy.action]}
             <ChevronDownIcon className="size-3 opacity-70" />
           </SelectPrimitiveTrigger>
           <SelectContent position="popper" align="end">
-            <SelectItem value="approve">{actionLabels.approve}</SelectItem>
-            <SelectItem value="require_approval">{actionLabels.require_approval}</SelectItem>
-            <SelectItem value="block">{actionLabels.block}</SelectItem>
+            {POLICY_ACTIONS_IN_ORDER.map((a) => (
+              <SelectItem key={a} value={a}>
+                {POLICY_ACTION_LABEL[a]}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
         <DropdownMenu>

--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -16,6 +16,7 @@ import { ToolTree } from "../components/tool-tree";
 import { ToolDetail, ToolDetailEmpty } from "../components/tool-detail";
 import type { ToolSummary } from "../components/tool-tree";
 import { useScope } from "../hooks/use-scope";
+import { usePolicyActions } from "../hooks/use-policy-actions";
 import type { SourcePlugin } from "../plugins/source-plugin";
 import { Button } from "../components/button";
 import { Badge } from "../components/badge";
@@ -34,6 +35,7 @@ export function SourceDetailPage(props: {
   const refreshTools = useAtomRefresh(sourceToolsAtom(namespace, scopeId));
   const doRemove = useAtomSet(removeSource, { mode: "promise" });
   const doRefresh = useAtomSet(refreshSource, { mode: "promise" });
+  const policyActions = usePolicyActions(scopeId);
   const navigate = useNavigate();
 
   // HMR: refresh source tools when the backend is hot-reloaded
@@ -74,6 +76,16 @@ export function SourceDetailPage(props: {
     [policies],
   );
 
+  const sortedPolicies = useMemo(
+    () =>
+      [...policyList].sort((a, b) => {
+        if (a.position < b.position) return -1;
+        if (a.position > b.position) return 1;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      }),
+    [policyList],
+  );
+
   const sourceTools: ToolSummary[] = useMemo(() => {
     if (!AsyncResult.isSuccess(tools)) return [];
     return tools.value.map(
@@ -85,7 +97,10 @@ export function SourceDetailPage(props: {
         readonly requiresApproval?: boolean;
       }) => ({
         id: t.id,
-        name: t.name,
+        // Tree path + saved pattern must be the canonical tool id, so
+        // policy rules created from the row actually match at resolve
+        // time. The leaf label is still the short last segment.
+        name: t.id,
         pluginKey: t.pluginId,
         description: t.description,
         policy: effectivePolicyFromSorted(t.id, policyList, t.requiresApproval),
@@ -247,6 +262,9 @@ export function SourceDetailPage(props: {
                     tools={sourceTools}
                     selectedToolId={selectedToolId}
                     onSelect={setSelectedToolId}
+                    onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
+                    onClearPolicy={(pattern) => void policyActions.clear(pattern)}
+                    policies={sortedPolicies}
                   />
                 </div>
 
@@ -259,6 +277,8 @@ export function SourceDetailPage(props: {
                       toolDescription={selectedTool.description}
                       scopeId={scopeId}
                       policy={selectedTool.policy}
+                      onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
+                      onClearPolicy={(pattern) => void policyActions.clear(pattern)}
                     />
                   ) : (
                     <ToolDetailEmpty hasTools={sourceTools.length > 0} />

--- a/packages/react/src/pages/tools.tsx
+++ b/packages/react/src/pages/tools.tsx
@@ -1,79 +1,158 @@
+import { useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { toolsAtom } from "../api/atoms";
+import { effectivePolicyFromSorted } from "@executor-js/sdk";
+
+import { policiesOptimisticAtom, toolsAtom } from "../api/atoms";
 import { useScope } from "../hooks/use-scope";
-import { Badge } from "../components/badge";
+import { usePolicyActions } from "../hooks/use-policy-actions";
+import { ToolTree, type ToolSummary } from "../components/tool-tree";
+import { ToolDetail, ToolDetailEmpty } from "../components/tool-detail";
+import { Button } from "../components/button";
+import { Skeleton } from "../components/skeleton";
 
 export function ToolsPage() {
   const scopeId = useScope();
   const tools = useAtomValue(toolsAtom(scopeId));
+  const policies = useAtomValue(policiesOptimisticAtom(scopeId));
+  const policyActions = usePolicyActions(scopeId);
+
+  const [selectedToolId, setSelectedToolId] = useState<string | null>(null);
+
+  const policyList = useMemo(
+    () => (AsyncResult.isSuccess(policies) ? policies.value : []),
+    [policies],
+  );
+
+  const sortedPolicies = useMemo(
+    () =>
+      [...policyList].sort((a, b) => {
+        if (a.position < b.position) return -1;
+        if (a.position > b.position) return 1;
+        return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      }),
+    [policyList],
+  );
+
+  const summaries: ToolSummary[] = useMemo(() => {
+    if (!AsyncResult.isSuccess(tools)) return [];
+    return tools.value.map(
+      (t: {
+        readonly id: string;
+        readonly name: string;
+        readonly pluginId: string;
+        readonly description?: string;
+        readonly requiresApproval?: boolean;
+      }) => ({
+        id: t.id,
+        // Tree path + saved pattern must be the canonical tool id
+        // (`stripe_api.account.getAccount`), not the short `t.name`
+        // which strips the source prefix and would never match at
+        // resolution time.
+        name: t.id,
+        pluginKey: t.pluginId,
+        description: t.description,
+        policy: effectivePolicyFromSorted(t.id, sortedPolicies, t.requiresApproval),
+      }),
+    );
+  }, [tools, sortedPolicies]);
+
+  const selectedTool = useMemo(
+    () => summaries.find((t) => t.id === selectedToolId) ?? null,
+    [summaries, selectedToolId],
+  );
 
   return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">
-        {/* Header */}
-        <div className="flex items-end justify-between mb-8">
-          <div>
-            <h1 className="font-display text-3xl tracking-tight text-foreground lg:text-4xl">
-              Tools
-            </h1>
-            <p className="mt-1.5 text-sm text-muted-foreground">
-              All registered tools across your connected sources.
-            </p>
-          </div>
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+      {/* Header bar */}
+      <div className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background/95 px-4 backdrop-blur-sm">
+        <div className="flex min-w-0 items-center gap-3">
+          <h2 className="truncate text-sm font-semibold text-foreground">Tools</h2>
+          {AsyncResult.isSuccess(tools) && (
+            <span className="hidden text-xs tabular-nums text-muted-foreground sm:block">
+              {summaries.length} {summaries.length === 1 ? "tool" : "tools"}
+            </span>
+          )}
         </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button asChild variant="outline" size="sm">
+            <Link to="/policies">Manage policies</Link>
+          </Button>
+        </div>
+      </div>
 
-        {AsyncResult.match(tools, {
-          onInitial: () => <p className="text-sm text-muted-foreground">Loading tools…</p>,
-          onFailure: () => <p className="text-sm text-destructive">Failed to load tools</p>,
-          onSuccess: ({ value }) =>
-            value.length === 0 ? (
-              <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border py-20">
-                <div className="flex size-12 items-center justify-center rounded-2xl bg-muted text-muted-foreground mb-4">
-                  <svg viewBox="0 0 16 16" className="size-5">
-                    <path
-                      d="M4 2h8l1 3H3l1-3zM3 6h10v8H3V6z"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.2"
-                    />
-                  </svg>
-                </div>
-                <p className="text-sm font-medium text-foreground/70 mb-1">No tools registered</p>
-                <p className="text-sm text-muted-foreground">
+      {AsyncResult.match(tools, {
+        onInitial: () => <ToolsPageSkeleton />,
+        onFailure: () => <div className="p-6 text-sm text-destructive">Failed to load tools</div>,
+        onSuccess: () =>
+          summaries.length === 0 ? (
+            <div className="flex min-h-0 flex-1 items-center justify-center">
+              <div className="text-center">
+                <p className="text-sm font-medium text-foreground/70">No tools registered</p>
+                <p className="mt-1 text-sm text-muted-foreground">
                   Add a source to start discovering tools.
                 </p>
               </div>
-            ) : (
-              <div className="grid gap-2">
-                {value.map(
-                  (t: {
-                    readonly id: string;
-                    readonly name: string;
-                    readonly description?: string;
-                    readonly sourceId: string;
-                  }) => (
-                    <div
-                      key={t.id}
-                      className="flex items-start justify-between gap-3 rounded-xl border border-border bg-card px-5 py-3.5 transition-colors hover:border-primary/25 hover:bg-card/90"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="text-sm font-semibold text-foreground truncate font-mono">
-                          {t.name}
-                        </p>
-                        {t.description && (
-                          <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
-                            {t.description}
-                          </p>
-                        )}
-                      </div>
-                      <Badge variant="secondary">{t.sourceId}</Badge>
-                    </div>
-                  ),
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1 overflow-hidden">
+              <div className="flex w-72 shrink-0 flex-col border-r border-border/60 lg:w-80 xl:w-[22rem]">
+                <ToolTree
+                  tools={summaries}
+                  selectedToolId={selectedToolId}
+                  onSelect={setSelectedToolId}
+                  onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
+                  onClearPolicy={(pattern) => void policyActions.clear(pattern)}
+                  policies={sortedPolicies}
+                />
+              </div>
+              <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                {selectedTool ? (
+                  <ToolDetail
+                    toolId={selectedTool.id}
+                    toolName={selectedTool.name}
+                    toolDescription={selectedTool.description}
+                    scopeId={scopeId}
+                    policy={selectedTool.policy}
+                    onSetPolicy={(pattern, action) => void policyActions.set(pattern, action)}
+                    onClearPolicy={(pattern) => void policyActions.clear(pattern)}
+                  />
+                ) : (
+                  <ToolDetailEmpty hasTools={summaries.length > 0} />
                 )}
               </div>
-            ),
-        })}
+            </div>
+          ),
+      })}
+    </div>
+  );
+}
+
+function ToolsPageSkeleton() {
+  return (
+    <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="flex w-72 shrink-0 flex-col gap-1 border-r border-border/60 p-3 lg:w-80 xl:w-[22rem]">
+        <Skeleton className="mb-2 h-8 w-full rounded-md" />
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+            <Skeleton className="size-4 shrink-0 rounded" />
+            <Skeleton className="h-3.5" style={{ width: `${55 + ((i * 13) % 35)}%` }} />
+          </div>
+        ))}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col gap-6 overflow-hidden p-6">
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="h-4 w-80" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <div className="flex flex-col gap-3">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-20 w-full rounded-md" />
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-20 w-full rounded-md" />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Tools page (and source-detail) gain a hover-revealed action menu on each tree row: **Always run / Require approval / Block / Clear**. Leaf rows submit the canonical tool id (`stripe_api.account.getAccount`); group rows submit the category wildcard (`stripe_api.account.*`). The detail-pane policy badge is also clickable and opens the same menu.
- New `usePolicyActions(scopeId)` hook centralizes the create/update/clear flow and **auto-places** new rules by specificity (longer/exact patterns sit above shorter wildcards) so a freshly-added group rule never silently shadows an existing leaf rule.
- ToolsPage rewritten to the same tree+detail layout source-detail uses; "Manage policies" link in the header for review/reorder.
- `tools.list` API now returns `requiresApproval` and includes blocked tools, mirroring `sources.tools` so the cross-source view can render plugin-default indicators.
- Shared display strings/colors moved to `lib/policy-display.ts` (used by tool-tree, tool-detail, policies page) so the action labels rename in one place.

Follow-up to #470 (now merged) — adds the actual UX so users can set policies from the tools view instead of having to type patterns into the policies page.

## Test plan
- [ ] On `/tools`: hover a row → "..." trigger → pick Block → row's indicator dot turns red, tool fades.
- [ ] Set a leaf to **Always run** under a group that's blocked → confirm the leaf rule is auto-placed *above* the group rule on `/policies` (first-match-wins keeps the leaf precedent).
- [ ] Click "Manage policies" → policies show in expected order, badges display the same labels (`Blocked` / `Always run` / `Require approval`).
- [ ] On a source-detail page: same hover-menu works; same auto-placement.
- [ ] `bun run --filter @executor-js/sdk test` passes (no behavior change in the matcher).