### PR TITLE
Add changeset for CLI patch release

### DIFF
--- a/.changeset/tools-policy-menu.md
+++ b/.changeset/tools-policy-menu.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Set tool policies from the Tools page. New per-row action menu (Always run / Require approval / Block / Clear) on every tree row — works on individual tools and on dotted-prefix categories. New rules auto-place by specificity so adding a category rule never silently shadows an existing tool-level override. The local UI also picks up a dedicated Policies tab for reviewing and reordering rules.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -3,6 +3,9 @@
 ### MCP sources honor upstream `destructiveHint`
 MCP sources now read `destructiveHint` from upstream tool annotations. Tools marked destructive will require approval before running, surfaced via MCP elicitation. Refresh existing sources (or remove + re-add) to pick up annotations on tools added before this change.
 
+### Set tool policies from the Tools page
+The local UI gains a **Policies** tab for managing approval rules, plus a per-row action menu on the Tools tree. Hover any tool or category and pick **Always run / Require approval / Block / Clear** — leaf rows save a rule for the exact tool id, group rows save a `prefix.*` wildcard. New rules are auto-placed by specificity so a freshly-added group rule never silently shadows an existing leaf rule. The same menu is available from the tool detail header and from any source-detail page.
+
 ### Per-user OAuth for OpenAPI and MCP sources
 OpenAPI and MCP sources now carry first-class **Connections** — a per-user sign-in state decoupled from the source definition itself.
 


### PR DESCRIPTION
## Summary
- `.changeset/tools-policy-menu.md` bumps `executor` (patch) for the per-tool/category policy action menu and Policies tab landed in #470 + #472.
- Adds a "Set tool policies from the Tools page" highlight to `apps/cli/release-notes/next.md`.

## Test plan
- [ ] `bun changeset status` shows `executor` patch only.