### PR TITLE
Fix MCP DCR + tool discovery against strict / Workers-incompatible servers

### DIFF
--- a/packages/core/sdk/src/oauth-discovery.test.ts
+++ b/packages/core/sdk/src/oauth-discovery.test.ts
@@ -201,6 +201,33 @@ describe("registerDynamicClient", () => {
     expect(body.token_endpoint_auth_method).toBe("none");
   });
 
+  // Todoist's DCR returns 200 OK with the client information body
+  // instead of the RFC 7591-mandated 201 Created. oauth4webapi's
+  // `processDynamicClientRegistrationResponse` rejects that as
+  // "unexpected HTTP status code"; we accept both.
+  it("treats HTTP 200 as success (Todoist-style non-conformance)", async () => {
+    installFetchRouter([
+      {
+        match: () => true,
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "tdd_abc",
+              redirect_uris: ["https://app.example.com/cb"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+    const info = await Effect.runPromise(
+      registerDynamicClient({
+        registrationEndpoint: "https://todoist.com/oauth/register",
+        metadata: { redirect_uris: ["https://app.example.com/cb"] },
+      }),
+    );
+    expect(info.client_id).toBe("tdd_abc");
+  });
+
   it("surfaces AS error responses with the error body", async () => {
     installFetchRouter([
       {

--- a/packages/core/sdk/src/oauth-discovery.ts
+++ b/packages/core/sdk/src/oauth-discovery.ts
@@ -385,8 +385,11 @@ export const discoverAuthorizationServerMetadata = (
 // ---------------------------------------------------------------------------
 // RFC 7591 — Dynamic Client Registration
 //
-// Delegates to `oauth4webapi.dynamicClientRegistrationRequest` +
-// `processDynamicClientRegistrationResponse`.
+// Hand-rolled instead of delegating to oauth4webapi. The library's
+// `processDynamicClientRegistrationResponse` requires the AS return
+// HTTP 201 Created (RFC 7591 §3.2.1), but Todoist (and others) return
+// 200 OK on success. We accept both, and still surface 4xx OAuth error
+// envelopes the same way oauth4webapi would.
 // ---------------------------------------------------------------------------
 
 export interface RegisterDynamicClientInput {
@@ -395,95 +398,167 @@ export interface RegisterDynamicClientInput {
   readonly initialAccessToken?: string | null;
 }
 
-const asForDcr = (
-  registrationEndpoint: string,
-): oauth.AuthorizationServer => {
-  const url = new URL(registrationEndpoint);
-  return {
-    issuer: `${url.protocol}//${url.host}`,
-    registration_endpoint: registrationEndpoint,
-  };
+// Internal failure modes — collapsed into `OAuthDiscoveryError` at the
+// boundary. Tagged so we can match without `instanceof`.
+class DcrErrorBody extends Data.TaggedError("DcrErrorBody")<{
+  readonly status: number;
+  readonly error: string;
+  readonly error_description?: string;
+}> {}
+
+class DcrTransport extends Data.TaggedError("DcrTransport")<{
+  readonly message: string;
+  readonly status?: number;
+  readonly cause?: unknown;
+}> {}
+
+const buildDcrBody = (m: DynamicClientMetadata): Record<string, unknown> => {
+  const body: Record<string, unknown> = { redirect_uris: [...m.redirect_uris] };
+  if (m.client_name !== undefined) body.client_name = m.client_name;
+  if (m.grant_types !== undefined) body.grant_types = [...m.grant_types];
+  if (m.response_types !== undefined) body.response_types = [...m.response_types];
+  if (m.token_endpoint_auth_method !== undefined) {
+    body.token_endpoint_auth_method = m.token_endpoint_auth_method;
+  }
+  if (m.scope !== undefined) body.scope = m.scope;
+  if (m.application_type !== undefined) body.application_type = m.application_type;
+  if (m.client_uri !== undefined) body.client_uri = m.client_uri;
+  if (m.logo_uri !== undefined) body.logo_uri = m.logo_uri;
+  if (m.contacts !== undefined) body.contacts = [...m.contacts];
+  if (m.software_id !== undefined) body.software_id = m.software_id;
+  if (m.software_version !== undefined) body.software_version = m.software_version;
+  if (m.extra) for (const [k, v] of Object.entries(m.extra)) body[k] = v;
+  return body;
+};
+
+const interpretDcrFailure = (
+  status: number,
+  text: string,
+): DcrErrorBody | DcrTransport => {
+  // RFC 6749 error envelope: `{error, error_description?}` with 4xx.
+  if (status >= 400 && status < 500) {
+    const parsed = Result.try({
+      try: () => (text ? (JSON.parse(text) as unknown) : null),
+      catch: () => null,
+    });
+    const body = Result.isSuccess(parsed) ? parsed.success : null;
+    if (
+      body &&
+      typeof body === "object" &&
+      "error" in body &&
+      typeof body.error === "string" &&
+      body.error.length > 0
+    ) {
+      const desc =
+        "error_description" in body && typeof body.error_description === "string"
+          ? body.error_description
+          : undefined;
+      return new DcrErrorBody({ status, error: body.error, error_description: desc });
+    }
+  }
+  return new DcrTransport({
+    message: `Dynamic Client Registration endpoint returned status ${status}${text ? ` — ${text.slice(0, 200)}` : ""}`,
+    status,
+  });
 };
 
 export const registerDynamicClient = (
   input: RegisterDynamicClientInput,
   options: DiscoveryRequestOptions = {},
 ): Effect.Effect<OAuthClientInformation, OAuthDiscoveryError> =>
-  Effect.tryPromise({
-    try: async () => {
-      const as = asForDcr(input.registrationEndpoint);
-      const m = input.metadata;
-      const clientMetadata: Record<string, unknown> = {
-        redirect_uris: [...m.redirect_uris],
-      };
-      if (m.client_name !== undefined) clientMetadata.client_name = m.client_name;
-      if (m.grant_types !== undefined) clientMetadata.grant_types = [...m.grant_types];
-      if (m.response_types !== undefined) clientMetadata.response_types = [...m.response_types];
-      if (m.token_endpoint_auth_method !== undefined) {
-        clientMetadata.token_endpoint_auth_method = m.token_endpoint_auth_method;
-      }
-      if (m.scope !== undefined) clientMetadata.scope = m.scope;
-      if (m.application_type !== undefined) clientMetadata.application_type = m.application_type;
-      if (m.client_uri !== undefined) clientMetadata.client_uri = m.client_uri;
-      if (m.logo_uri !== undefined) clientMetadata.logo_uri = m.logo_uri;
-      if (m.contacts !== undefined) clientMetadata.contacts = [...m.contacts];
-      if (m.software_id !== undefined) clientMetadata.software_id = m.software_id;
-      if (m.software_version !== undefined) clientMetadata.software_version = m.software_version;
-      if (m.extra) for (const [k, v] of Object.entries(m.extra)) clientMetadata[k] = v;
+  Effect.gen(function* () {
+    const url = new URL(input.registrationEndpoint);
+    if (
+      url.protocol !== "https:" &&
+      !isLoopbackHttpUrl(input.registrationEndpoint)
+    ) {
+      return yield* new DcrTransport({
+        message: `registration_endpoint must be HTTPS or a loopback HTTP URL (got ${url.protocol}//${url.host})`,
+      });
+    }
 
-      const reqOptions: Record<string, unknown> = oauth4webapiOptions(options);
-      if (isLoopbackHttpUrl(input.registrationEndpoint)) {
-        (reqOptions as { [oauth.allowInsecureRequests]?: boolean })[
-          oauth.allowInsecureRequests
-        ] = true;
-      }
-      if (input.initialAccessToken) {
-        reqOptions.initialAccessToken = input.initialAccessToken;
-      }
+    const headers: Record<string, string> = {
+      "content-type": "application/json",
+      accept: "application/json",
+    };
+    if (input.initialAccessToken) {
+      headers.authorization = `Bearer ${input.initialAccessToken}`;
+    }
 
-      const response = await oauth.dynamicClientRegistrationRequest(
-        as,
-        clientMetadata as Partial<oauth.Client>,
-        reqOptions,
+    const fetchImpl = options.fetch ?? globalThis.fetch;
+    const timeoutMs = options.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS;
+    const response = yield* Effect.tryPromise({
+      try: () =>
+        fetchImpl(input.registrationEndpoint, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(buildDcrBody(input.metadata)),
+          signal: AbortSignal.timeout(timeoutMs),
+        }),
+      catch: (cause) =>
+        new DcrTransport({
+          message: `Dynamic Client Registration request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+          cause,
+        }),
+    });
+
+    // Accept both 200 and 201 as success — RFC 7591 mandates 201, but
+    // Todoist (and others) return 200 OK with the client information body.
+    if (response.status !== 200 && response.status !== 201) {
+      const text = yield* Effect.promise(() =>
+        response.text().catch(() => ""),
       );
-      const client = await oauth.processDynamicClientRegistrationResponse(
-        response,
-      );
-      return client as OAuthClientInformation;
-    },
-    catch: (cause) => {
-      // `oauth4webapi` throws `ResponseBodyError` for RFC 6749 error
-      // envelopes (carrying `.status`, `.error`, `.error_description`).
-      // Preserve the HTTP status + error code so the plugin layer can
-      // surface specific failures (`invalid_client_metadata` →
-      // `client_metadata is wrong`) without regex-ing the message.
-      if (cause instanceof oauth.ResponseBodyError) {
-        return discoveryError(
-          `Dynamic Client Registration failed: ${cause.error}${
-            cause.error_description ? ` — ${cause.error_description}` : ""
-          }`,
-          { status: cause.status, cause },
-        );
-      }
-      return discoveryError(
-        `Dynamic Client Registration failed: ${cause instanceof Error ? cause.message : String(cause)}`,
-        { cause },
-      );
-    },
-  }).pipe(
-    Effect.flatMap((raw) =>
-      decodeClientInformation(raw).pipe(
-        Effect.mapError(
-          (err) =>
-            new OAuthDiscoveryError({
-              message: `Dynamic Client Registration response is malformed: ${
-                Schema.isSchemaError(err) ? err.message : String(err)
-              }`,
-              cause: err,
-            }),
-        ),
+      return yield* interpretDcrFailure(response.status, text);
+    }
+
+    const text = yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: (cause) =>
+        new DcrTransport({
+          message: "Dynamic Client Registration response could not be read",
+          status: response.status,
+          cause,
+        }),
+    });
+    const json = yield* Effect.try({
+      try: () => JSON.parse(text) as unknown,
+      catch: (cause) =>
+        new DcrTransport({
+          message: "Dynamic Client Registration response was not valid JSON",
+          status: response.status,
+          cause,
+        }),
+    });
+    return yield* decodeClientInformation(json).pipe(
+      Effect.mapError(
+        (err) =>
+          new OAuthDiscoveryError({
+            message: `Dynamic Client Registration response is malformed: ${
+              Schema.isSchemaError(err) ? err.message : String(err)
+            }`,
+            cause: err,
+          }),
       ),
-    ),
+    );
+  }).pipe(
+    Effect.catchTags({
+      DcrErrorBody: (err) =>
+        Effect.fail(
+          discoveryError(
+            `Dynamic Client Registration failed: ${err.error}${
+              err.error_description ? ` — ${err.error_description}` : ""
+            }`,
+            { status: err.status, cause: err },
+          ),
+        ),
+      DcrTransport: (err) =>
+        Effect.fail(
+          discoveryError(`Dynamic Client Registration failed: ${err.message}`, {
+            status: err.status,
+            cause: err.cause ?? err,
+          }),
+        ),
+    }),
   );
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -2,6 +2,7 @@ import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { CfWorkerJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/cfworker";
 import { Effect } from "effect";
 
 // NOTE: `StdioClientTransport` is NOT imported eagerly. The upstream module
@@ -56,10 +57,19 @@ const buildEndpointUrl = (endpoint: string, queryParams: Record<string, string>)
   return url;
 };
 
+// Use the cfworker JSON Schema validator instead of the SDK's default
+// (Ajv). Ajv compiles schemas via `new Function(...)`, which throws
+// `Code generation from strings disallowed for this context` when the
+// MCP plugin runs inside a Cloudflare Worker (executor.sh). The
+// cfworker validator does not use code generation and works in every
+// runtime we ship to.
 const createClient = (): Client =>
   new Client(
     { name: "executor-mcp", version: "0.1.0" },
-    { capabilities: { elicitation: { form: {}, url: {} } } },
+    {
+      capabilities: { elicitation: { form: {}, url: {} } },
+      jsonSchemaValidator: new CfWorkerJsonSchemaValidator(),
+    },
   );
 
 const connectionFromClient = (client: Client): McpConnection => ({


### PR DESCRIPTION
## Summary

Two independent bugs blocked adding MCP servers whose authorization server returns RFC-7591-non-conformant responses, or whose tool schemas trigger code generation during validation. Both reproduced while wiring up Todoist's MCP server (`https://ai.todoist.net/mcp`) on the deployed cloud.

### 1. DCR: accept HTTP 200 (not just 201)

`oauth4webapi.processDynamicClientRegistrationResponse` hard-codes `201 Created` as the only success status (RFC 7591 §3.2.1 mandates 201). Todoist's `https://todoist.com/oauth/register` returns a perfectly valid `200 OK` with the `{client_id, ...}` body, so oauth4webapi treats it as an error and throws `\"response\" is not a conform Dynamic Client Registration Endpoint response (unexpected HTTP status code)`. That bubbles up to the user as `Dynamic authorization setup failed: Dynamic Client Registration failed: ...`.

Replaced the `oauth.dynamicClientRegistrationRequest` + `processDynamicClientRegistrationResponse` calls in `registerDynamicClient` with a hand-rolled `fetch` that:
- Accepts both `200` and `201` as success.
- Parses 4xx responses with `{error, error_description}` envelopes into a `DcrErrorBody` tagged error, preserving `status` so the existing test contract (`status === 400`, message contains `invalid_client_metadata`) keeps holding.
- Routes everything else (network failures, non-JSON bodies, non-loopback HTTP endpoints) through a `DcrTransport` tagged error.
- Collapses both into `OAuthDiscoveryError` at the boundary via `Effect.catchTags`, matching the function's existing public surface.

### 2. listTools: use a code-gen-free JSON Schema validator

The MCP SDK's default `jsonSchemaValidator` is `AjvJsonSchemaValidator`. Ajv compiles schemas with `new Function(\`${self}\`, \`${scope}\`, sourceCode)`. Cloudflare Workers blocks that with `Code generation from strings disallowed for this context`, which surfaces as `MCP discovery failed: Failed listing MCP tools: Code generation from strings disallowed for this context` the moment `client.listTools()` runs `cacheToolMetadata()`.

Pass `CfWorkerJsonSchemaValidator` to the `Client` constructor in `packages/plugins/mcp/src/sdk/connection.ts`. Same package (`@modelcontextprotocol/sdk/validation/cfworker`), no new dep, validates the same JSON Schema input via interpretation rather than codegen, works in every runtime we ship to.

## Test plan

- [x] `vitest run packages/core/sdk/src/oauth-discovery.test.ts` — 12 pass (existing 11 + new regression for `200` success body)
- [x] `tsgo --noEmit` clean for both `@executor-js/sdk` and `@executor-js/plugin-mcp`
- [x] `vitest run` for the mcp plugin matches main's pre-existing failure profile (the 12 failures are unrelated zod-API breakage in test fixtures, identical pre/post)
- [ ] Smoke: `add MCP source` flow against `https://ai.todoist.net/mcp` reaches "tools listed" instead of `Dynamic authorization setup failed` / `Code generation from strings disallowed`