### PR TITLE
fix(runtime-dynamic-worker): preserve Blob/Uint8Array across the dispatcher boundary

### DIFF
--- a/packages/kernel/runtime-dynamic-worker/src/executor.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/executor.ts
@@ -136,7 +136,12 @@ const renderTransportMessage = (value: unknown): string => {
     return value.message;
   }
 
-  if (typeof value === "object" && value !== null && "message" in value && typeof value.message === "string") {
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "message" in value &&
+    typeof value.message === "string"
+  ) {
     return value.message;
   }
 
@@ -156,8 +161,12 @@ const renderTransportMessage = (value: unknown): string => {
 };
 
 export const serializeWorkerCause = (cause: Cause.Cause<unknown>): SerializedWorkerError => {
-  const failures = cause.reasons.filter(Cause.isFailReason).map((reason) => serializeWorkerErrorValue(reason.error));
-  const defects = cause.reasons.filter(Cause.isDieReason).map((reason) => serializeWorkerErrorValue(reason.defect));
+  const failures = cause.reasons
+    .filter(Cause.isFailReason)
+    .map((reason) => serializeWorkerErrorValue(reason.error));
+  const defects = cause.reasons
+    .filter(Cause.isDieReason)
+    .map((reason) => serializeWorkerErrorValue(reason.defect));
   const interrupted = cause.reasons.some(Cause.isInterruptReason);
   const primary = failures[0] ?? defects[0] ?? null;
   const kind =

--- a/packages/kernel/runtime-dynamic-worker/src/executor.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/executor.ts
@@ -215,10 +215,93 @@ export const renderWorkerError = (error: SerializedWorkerError): string => {
   return error.message;
 };
 
-const encodeWorkerRpcResponse = (response: WorkerRpcResponse): string => JSON.stringify(response);
+export type { WorkerRpcResponse };
 
-export const decodeWorkerRpcResponse = (raw: string): WorkerRpcResponse =>
-  JSON.parse(raw) as WorkerRpcResponse;
+// ---------------------------------------------------------------------------
+// Blob/File codec (both directions across the dispatcher boundary)
+//
+// Workers RPC's structured-clone allow-list excludes `Blob` / `File`, so
+// we encode them to a tagged ArrayBuffer envelope and rehydrate on the
+// far side. Symmetric in both directions: sandbox encodes args + host
+// rehydrates them; host encodes result + sandbox rehydrates it. The
+// matching encoder lives inside `module-template.ts` because it runs in
+// the dynamic Worker isolate. `ArrayBuffer` / typed arrays / primitives
+// cross structured clone natively.
+// ---------------------------------------------------------------------------
+
+type BinaryEnvelope = {
+  readonly __executorBinary: 1;
+  readonly kind: "blob" | "file";
+  readonly type: string;
+  readonly name?: string;
+  readonly lastModified?: number;
+  readonly buffer: ArrayBuffer;
+};
+
+const isBinaryEnvelope = (value: unknown): value is BinaryEnvelope =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { __executorBinary?: unknown }).__executorBinary === 1 &&
+  (value as { buffer?: unknown }).buffer instanceof ArrayBuffer &&
+  typeof (value as { type?: unknown }).type === "string";
+
+const isPlainObject = (value: object): boolean => {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+const rehydrateBinary = (value: unknown): unknown => {
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return value;
+  if (isBinaryEnvelope(value)) {
+    if (value.kind === "file" && typeof value.name === "string") {
+      return new File([value.buffer], value.name, {
+        type: value.type,
+        ...(typeof value.lastModified === "number" ? { lastModified: value.lastModified } : {}),
+      });
+    }
+    return new Blob([value.buffer], { type: value.type });
+  }
+  if (Array.isArray(value)) return value.map(rehydrateBinary);
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = rehydrateBinary(v);
+  }
+  return out;
+};
+
+// Async because `Blob.arrayBuffer()` is async. Used on tool results before
+// the dispatcher hands them back to the sandbox.
+const encodeBinary = async (value: unknown): Promise<unknown> => {
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return value;
+  if (typeof File !== "undefined" && value instanceof File) {
+    return {
+      __executorBinary: 1 as const,
+      kind: "file" as const,
+      type: value.type,
+      name: value.name,
+      lastModified: value.lastModified,
+      buffer: await value.arrayBuffer(),
+    };
+  }
+  if (value instanceof Blob) {
+    return {
+      __executorBinary: 1 as const,
+      kind: "blob" as const,
+      type: value.type,
+      buffer: await value.arrayBuffer(),
+    };
+  }
+  if (Array.isArray(value)) return Promise.all(value.map(encodeBinary));
+  if (!isPlainObject(value)) return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = await encodeBinary(v);
+  }
+  return out;
+};
 
 // ---------------------------------------------------------------------------
 // ToolDispatcher — bridges RPC calls back to SandboxToolInvoker
@@ -227,7 +310,12 @@ export const decodeWorkerRpcResponse = (raw: string): WorkerRpcResponse =>
 /**
  * An `RpcTarget` passed to the dynamic Worker so that sandboxed code can
  * invoke tools on the host. The dynamic worker calls
- * `__dispatcher.call(path, argsJson)` over Workers RPC.
+ * `__dispatcher.call(path, args)` over Workers RPC. `Uint8Array` /
+ * `ArrayBuffer` cross structured clone natively; `Blob` / `File` are
+ * encoded sandbox-side as a tagged envelope and rehydrated here via
+ * `rehydrateBinary` before the invoker sees them. JSON serialization on
+ * this hop would replace those values with `"{}"` or numeric-keyed
+ * objects, which is what broke `multipart/form-data` uploads.
  *
  * Each call is wrapped in an `executor.tool.rpc_dispatch` span so the
  * tool-invocation shell (Workers RPC roundtrip → local invoker →
@@ -248,15 +336,17 @@ export class ToolDispatcher extends RpcTarget {
     this.#runPromise = runPromise;
   }
 
-  async call(path: string, argsJson: string): Promise<string> {
-    const args = argsJson ? JSON.parse(argsJson) : undefined;
-
+  async call(path: string, args: unknown): Promise<WorkerRpcResponse> {
+    const decodedArgs = rehydrateBinary(args);
     return this.#runPromise(
-      this.#invoker.invoke({ path, args }).pipe(
-        Effect.map(
-          (value): WorkerRpcResponse => ({
-            ok: true,
-            result: value,
+      this.#invoker.invoke({ path, args: decodedArgs }).pipe(
+        Effect.flatMap((value) =>
+          Effect.tryPromise({
+            try: (): Promise<WorkerRpcResponse> =>
+              encodeBinary(value).then((result) => ({ ok: true, result })),
+            // Encoding failed (e.g. Blob.arrayBuffer rejected) — surface
+            // it as a normal failure envelope rather than throwing.
+            catch: (cause) => cause,
           }),
         ),
         Effect.catchCause((cause) =>
@@ -265,11 +355,9 @@ export class ToolDispatcher extends RpcTarget {
             error: serializeWorkerCause(cause),
           }),
         ),
-        Effect.map(encodeWorkerRpcResponse),
         Effect.withSpan("executor.tool.rpc_dispatch", {
           attributes: {
             "mcp.tool.name": path,
-            "executor.tool.args_length": argsJson.length,
           },
         }),
       ),

--- a/packages/kernel/runtime-dynamic-worker/src/invocation.test.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/invocation.test.ts
@@ -144,7 +144,10 @@ describe("makeDynamicWorkerExecutor", () => {
     const invoker = makeInvoker(() => null);
 
     const result = await Effect.runPromise(
-      executor.execute(["Use this snippet.", "", "```ts", "async () => 42", "```"].join("\n"), invoker),
+      executor.execute(
+        ["Use this snippet.", "", "```ts", "async () => 42", "```"].join("\n"),
+        invoker,
+      ),
     );
 
     expect(result.error).toBeUndefined();
@@ -392,7 +395,11 @@ describe("makeDynamicWorkerExecutor", () => {
       );
 
       expect(result.error).toBeUndefined();
-      expect(result.result).toEqual({ kind: "Uint8Array", length: 4, bytes: [0xca, 0xfe, 0xba, 0xbe] });
+      expect(result.result).toEqual({
+        kind: "Uint8Array",
+        length: 4,
+        bytes: [0xca, 0xfe, 0xba, 0xbe],
+      });
     }),
   );
 
@@ -414,5 +421,4 @@ describe("makeDynamicWorkerExecutor", () => {
       expect(result.result).toEqual({ kind: "Blob", type: "text/plain", text: "DOWNLOAD" });
     }),
   );
-
 });

--- a/packages/kernel/runtime-dynamic-worker/src/invocation.test.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/invocation.test.ts
@@ -6,7 +6,6 @@ import * as Effect from "effect/Effect";
 import type { SandboxToolInvoker } from "@executor-js/codemode-core";
 import {
   ToolDispatcher,
-  decodeWorkerRpcResponse,
   makeDynamicWorkerExecutor,
   renderWorkerError,
   serializeWorkerCause,
@@ -35,15 +34,15 @@ describe("ToolDispatcher", () => {
     const invoker = makeInvoker(({ args }) => args);
     const dispatcher = new ToolDispatcher(invoker, Effect.runPromise);
 
-    const result = await dispatcher.call("test.tool", '{"key":"value"}');
-    expect(decodeWorkerRpcResponse(result)).toEqual({ ok: true, result: { key: "value" } });
+    const result = await dispatcher.call("test.tool", { key: "value" });
+    expect(result).toEqual({ ok: true, result: { key: "value" } });
   });
 
   it("serializes tagged failures into a structured error envelope", async () => {
     const dispatcher = new ToolDispatcher(failingInvoker("tool broke"), Effect.runPromise);
 
-    const result = await dispatcher.call("broken.tool", "{}");
-    expect(decodeWorkerRpcResponse(result)).toMatchObject({
+    const result = await dispatcher.call("broken.tool", {});
+    expect(result).toMatchObject({
       ok: false,
       error: {
         kind: "fail",
@@ -68,8 +67,8 @@ describe("ToolDispatcher", () => {
       Effect.runPromise,
     );
 
-    const result = await dispatcher.call("broken.tool", "{}");
-    expect(decodeWorkerRpcResponse(result)).toEqual({
+    const result = await dispatcher.call("broken.tool", {});
+    expect(result).toEqual({
       ok: false,
       error: {
         kind: "fail",
@@ -94,8 +93,8 @@ describe("ToolDispatcher", () => {
     const invoker = makeInvoker(({ args }) => args);
     const dispatcher = new ToolDispatcher(invoker, Effect.runPromise);
 
-    const result = await dispatcher.call("test.tool", "");
-    expect(decodeWorkerRpcResponse(result)).toEqual({ ok: true, result: undefined });
+    const result = await dispatcher.call("test.tool", undefined);
+    expect(result).toEqual({ ok: true, result: undefined });
   });
 
   it("passes the tool path correctly", async () => {
@@ -106,7 +105,7 @@ describe("ToolDispatcher", () => {
     });
     const dispatcher = new ToolDispatcher(invoker, Effect.runPromise);
 
-    await dispatcher.call("my.deep.tool.path", "{}");
+    await dispatcher.call("my.deep.tool.path", {});
     expect(capturedPath).toBe("my.deep.tool.path");
   });
 });
@@ -319,4 +318,101 @@ describe("makeDynamicWorkerExecutor", () => {
 
     expect(result.error).toBeDefined();
   });
+
+  // Multipart/form-data uploads (OpenAI Files API, any spec with a
+  // `multipart/form-data` body) need Blob/File/Uint8Array values to
+  // survive the sandbox→host RPC hop intact. JSON.stringify turns a Blob
+  // into "{}" and a Uint8Array into a numeric-keyed object, so
+  // `coerceFormDataRecord` produces a malformed multipart part and the
+  // upstream server 400s.
+  it.effect("preserves Uint8Array tool args across the dispatcher boundary", () =>
+    Effect.gen(function* () {
+      const executor = makeDynamicWorkerExecutor({ loader });
+      let captured: { file?: unknown } = {};
+      const invoker = makeInvoker(({ args }) => {
+        captured = (args ?? {}) as { file?: unknown };
+        return null;
+      });
+
+      yield* executor.execute(
+        `async () => {
+          const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+          await tools.uploads.send({ file: bytes });
+        }`,
+        invoker,
+      );
+
+      expect(captured.file).toBeInstanceOf(Uint8Array);
+      expect(Array.from(captured.file as Uint8Array)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    }),
+  );
+
+  it.effect("preserves Blob tool args across the dispatcher boundary", () =>
+    Effect.gen(function* () {
+      const executor = makeDynamicWorkerExecutor({ loader });
+      let captured: { file?: unknown } = {};
+      const invoker = makeInvoker(({ args }) => {
+        captured = (args ?? {}) as { file?: unknown };
+        return null;
+      });
+
+      const result = yield* executor.execute(
+        `async () => {
+          const file = new Blob(["hello multipart"], { type: "text/plain" });
+          await tools.uploads.send({ file });
+        }`,
+        invoker,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(captured.file).toBeInstanceOf(Blob);
+      const blob = captured.file as Blob;
+      expect(blob.type).toBe("text/plain");
+      const body = yield* Effect.promise(() => blob.text());
+      expect(body).toBe("hello multipart");
+    }),
+  );
+
+  // Symmetric direction: tool RESULT contains Blob/Uint8Array/File. Workers
+  // RPC has the same "Could not serialize Blob" limit on the way back, so
+  // tool implementations that return file-like data need the host→sandbox
+  // codec too. This pins down which types survive both directions.
+  it.effect("returns Uint8Array tool results to the sandbox intact", () =>
+    Effect.gen(function* () {
+      const executor = makeDynamicWorkerExecutor({ loader });
+      const invoker = makeInvoker(() => new Uint8Array([0xca, 0xfe, 0xba, 0xbe]));
+
+      const result = yield* executor.execute(
+        `async () => {
+          const bytes = await tools.download.fetch({});
+          if (!(bytes instanceof Uint8Array)) return { kind: typeof bytes, ctor: bytes && bytes.constructor && bytes.constructor.name };
+          return { kind: 'Uint8Array', length: bytes.length, bytes: Array.from(bytes) };
+        }`,
+        invoker,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.result).toEqual({ kind: "Uint8Array", length: 4, bytes: [0xca, 0xfe, 0xba, 0xbe] });
+    }),
+  );
+
+  it.effect("returns Blob tool results to the sandbox intact", () =>
+    Effect.gen(function* () {
+      const executor = makeDynamicWorkerExecutor({ loader });
+      const invoker = makeInvoker(() => new Blob(["DOWNLOAD"], { type: "text/plain" }));
+
+      const result = yield* executor.execute(
+        `async () => {
+          const blob = await tools.download.fetch({});
+          if (!(blob instanceof Blob)) return { kind: typeof blob };
+          return { kind: 'Blob', type: blob.type, text: await blob.text() };
+        }`,
+        invoker,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.result).toEqual({ kind: "Blob", type: "text/plain", text: "DOWNLOAD" });
+    }),
+  );
+
 });

--- a/packages/kernel/runtime-dynamic-worker/src/module-template.ts
+++ b/packages/kernel/runtime-dynamic-worker/src/module-template.ts
@@ -7,6 +7,13 @@
  * 2. Creates a recursive `tools` Proxy that dispatches calls via RPC.
  * 3. Executes the normalised user code with a `Promise.race` timeout.
  * 4. Returns `{ result, error?, logs }`.
+ *
+ * Tool args cross the dispatcher boundary via Workers RPC, not JSON, so
+ * `Uint8Array` / `ArrayBuffer` survive intact. `Blob` / `File` aren't on
+ * RPC's structured-clone allow-list, so we encode them to a tagged
+ * envelope (`__encodeBinary`) and the host rehydrates them. This is
+ * required for any tool whose upstream wants `multipart/form-data`
+ * (OpenAI Files API, etc.).
  */
 export const buildExecutorModule = (body: string, timeoutMs: number): string =>
   [
@@ -65,6 +72,58 @@ export const buildExecutorModule = (body: string, timeoutMs: number): string =>
     "      };",
     "    };",
     "",
+    // Blob/File aren't on Workers RPC's structured-clone allow-list, so
+    // we encode them to a tagged ArrayBuffer envelope before the call and
+    // the host rehydrates them — and symmetrically the host encodes
+    // Blob/File results which we rehydrate here. ArrayBuffer / typed
+    // arrays cross natively.
+    "    const __isPlainObject = (v) => {",
+    "      const p = Object.getPrototypeOf(v);",
+    "      return p === Object.prototype || p === null;",
+    "    };",
+    "    const __isBinaryEnvelope = (v) =>",
+    "      v && typeof v === 'object' && v.__executorBinary === 1 &&",
+    "      v.buffer instanceof ArrayBuffer && typeof v.type === 'string';",
+    "    const __encodeBinary = async (value) => {",
+    "      if (value === null || typeof value !== 'object') return value;",
+    "      if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return value;",
+    "      if (typeof File !== 'undefined' && value instanceof File) {",
+    "        return {",
+    "          __executorBinary: 1,",
+    "          kind: 'file',",
+    "          type: value.type,",
+    "          name: value.name,",
+    "          lastModified: value.lastModified,",
+    "          buffer: await value.arrayBuffer(),",
+    "        };",
+    "      }",
+    "      if (value instanceof Blob) {",
+    "        return { __executorBinary: 1, kind: 'blob', type: value.type, buffer: await value.arrayBuffer() };",
+    "      }",
+    "      if (Array.isArray(value)) return Promise.all(value.map(__encodeBinary));",
+    "      if (!__isPlainObject(value)) return value;",
+    "      const out = {};",
+    "      for (const [k, v] of Object.entries(value)) out[k] = await __encodeBinary(v);",
+    "      return out;",
+    "    };",
+    "    const __decodeBinary = (value) => {",
+    "      if (value === null || typeof value !== 'object') return value;",
+    "      if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return value;",
+    "      if (__isBinaryEnvelope(value)) {",
+    "        if (value.kind === 'file' && typeof value.name === 'string') {",
+    "          return new File([value.buffer], value.name, {",
+    "            type: value.type,",
+    "            ...(typeof value.lastModified === 'number' ? { lastModified: value.lastModified } : {}),",
+    "          });",
+    "        }",
+    "        return new Blob([value.buffer], { type: value.type });",
+    "      }",
+    "      if (Array.isArray(value)) return value.map(__decodeBinary);",
+    "      if (!__isPlainObject(value)) return value;",
+    "      const out = {};",
+    "      for (const [k, v] of Object.entries(value)) out[k] = __decodeBinary(v);",
+    "      return out;",
+    "    };",
     "    const __makeToolsProxy = (path = []) => new Proxy(() => undefined, {",
     "      get(_target, prop) {",
     "        if (prop === 'then' || typeof prop === 'symbol') return undefined;",
@@ -73,13 +132,14 @@ export const buildExecutorModule = (body: string, timeoutMs: number): string =>
     "      apply(_target, _thisArg, args) {",
     "        const toolPath = path.join('.');",
     "        if (!toolPath) throw new Error('Tool path missing in invocation');",
-    "        return __dispatcher.call(toolPath, JSON.stringify(args[0] ?? {})).then((raw) => {",
-    "          const data = JSON.parse(raw);",
+    "        return (async () => {",
+    "          const encoded = await __encodeBinary(args[0]);",
+    "          const data = await __dispatcher.call(toolPath, encoded);",
     "          if (!data.ok) {",
     "            throw (data.error && data.error.primary !== null ? data.error.primary : data.error.message);",
     "          }",
-    "          return data.result;",
-    "        });",
+    "          return __decodeBinary(data.result);",
+    "        })();",
     "      },",
     "    });",
     "    const tools = __makeToolsProxy();",


### PR DESCRIPTION
The sandbox→host RPC bridge JSON.stringify'd every tool argument before
crossing the Worker RPC boundary, and JSON.parse'd it on the host side.
Binary values were silently destroyed: `new Blob([...])` arrived as
`{}`, and `new Uint8Array([...])` arrived as a numeric-keyed object.
Multipart upload tools (OpenAI Files API, anything with a
`multipart/form-data` request body) then produced malformed parts and
upstream servers returned 400.

Switches the dispatcher from `(path: string, argsJson: string) => string`
to `(path: string, args: unknown) => WorkerRpcResponse`, so structured
clone carries `Uint8Array` / `ArrayBuffer` natively. Workers RPC
excludes `Blob` / `File` from its allow-list, so we add a small codec
that walks args and results in both directions and round-trips them as
tagged ArrayBuffer envelopes (`{ __executorBinary: 1, kind, type, name?,
lastModified?, buffer }`). The same codec runs symmetrically on tool
results so a tool returning a Blob (e.g. file downloads) survives the
host→sandbox hop.

Adds repro tests for both directions:
- Uint8Array arg survives intact
- Blob arg survives with type
- Uint8Array result returns to user code
- Blob result returns with type and bytes

Existing dispatcher tests update from the JSON-string contract to the
structured-value contract; nothing outside this package consumed the
dropped `encodeWorkerRpcResponse` / `decodeWorkerRpcResponse` helpers.