### PR TITLE
Org flat-fee billing + Slack/email contact CTA on pricing

### DIFF
--- a/apps/cloud/autumn.config.ts
+++ b/apps/cloud/autumn.config.ts
@@ -1,13 +1,6 @@
 import { feature, item, plan } from "atmn";
 
 // Features
-export const members = feature({
-  id: "members",
-  name: "Members",
-  type: "metered",
-  consumable: false,
-});
-
 export const executions = feature({
   id: "executions",
   name: "Executions",
@@ -28,10 +21,6 @@ export const free = plan({
   autoEnable: true,
   items: [
     item({
-      featureId: members.id,
-      included: 3,
-    }),
-    item({
       featureId: executions.id,
       included: 10000,
       reset: { interval: "month" },
@@ -43,10 +32,6 @@ export const freePayAsYouGo = plan({
   id: "free-pay-as-you-go",
   name: "Free Pay As You Go",
   items: [
-    item({
-      featureId: members.id,
-      included: 3,
-    }),
     item({
       featureId: executions.id,
       included: 10000,
@@ -68,10 +53,6 @@ export const team = plan({
     interval: "month",
   },
   items: [
-    item({
-      featureId: members.id,
-      unlimited: true,
-    }),
     item({
       featureId: executions.id,
       included: 250000,

--- a/apps/cloud/autumn.config.ts
+++ b/apps/cloud/autumn.config.ts
@@ -1,9 +1,9 @@
 import { feature, item, plan } from "atmn";
 
 // Features
-export const seats = feature({
-  id: "seats",
-  name: "Seats",
+export const members = feature({
+  id: "members",
+  name: "Members",
   type: "metered",
   consumable: false,
 });
@@ -15,6 +15,12 @@ export const executions = feature({
   consumable: true,
 });
 
+export const domainVerification = feature({
+  id: "domain-verification",
+  name: "Domain Verification",
+  type: "boolean",
+});
+
 // Plans
 export const free = plan({
   id: "free",
@@ -22,79 +28,62 @@ export const free = plan({
   autoEnable: true,
   items: [
     item({
+      featureId: members.id,
+      included: 3,
+    }),
+    item({
       featureId: executions.id,
-      included: 5000,
+      included: 10000,
       reset: { interval: "month" },
     }),
   ],
 });
 
-export const hobby = plan({
-  id: "hobby",
-  name: "Hobby",
+export const freePayAsYouGo = plan({
+  id: "free-pay-as-you-go",
+  name: "Free Pay As You Go",
+  items: [
+    item({
+      featureId: members.id,
+      included: 3,
+    }),
+    item({
+      featureId: executions.id,
+      included: 10000,
+      price: {
+        amount: 0.2,
+        billingUnits: 1000,
+        billingMethod: "usage_based",
+        interval: "month",
+      },
+    }),
+  ],
+});
+
+export const team = plan({
+  id: "team",
+  name: "Team",
   price: {
-    amount: 10,
+    amount: 49,
     interval: "month",
   },
   items: [
     item({
-      featureId: seats.id,
-      included: 1,
+      featureId: members.id,
+      unlimited: true,
+    }),
+    item({
+      featureId: executions.id,
+      included: 250000,
       price: {
-        amount: 10,
-        billingUnits: 1,
+        amount: 0.2,
+        billingUnits: 1000,
         billingMethod: "usage_based",
         interval: "month",
       },
     }),
     item({
-      featureId: executions.id,
-      included: 50000,
-      reset: { interval: "month" },
-    }),
-  ],
-});
-
-export const professional = plan({
-  id: "professional",
-  name: "Professional",
-  price: {
-    amount: 40,
-    interval: "month",
-  },
-  items: [
-    item({
-      featureId: seats.id,
-      included: 1,
-      price: {
-        amount: 40,
-        billingUnits: 1,
-        billingMethod: "usage_based",
-        interval: "month",
-      },
-    }),
-    item({
-      featureId: executions.id,
-      included: 100000,
-      reset: { interval: "month" },
-    }),
-  ],
-});
-
-// Overage add-on
-export const executionTopUp = plan({
-  id: "execution-top-up",
-  name: "Execution Top-Up",
-  addOn: true,
-  items: [
-    item({
-      featureId: executions.id,
-      price: {
-        amount: 1,
-        billingUnits: 10000,
-        billingMethod: "prepaid",
-        interval: "month",
-      },
+      featureId: domainVerification.id,
     }),
   ],
 });

--- a/apps/cloud/src/api/core-shared-services.ts
+++ b/apps/cloud/src/api/core-shared-services.ts
@@ -15,6 +15,7 @@ import { Layer } from "effect";
 
 import { WorkOSAuth } from "../auth/workos";
 import { AutumnService } from "../services/autumn";
+import { SlackService } from "../services/slack";
 
 /**
  * Services that are independent of how the DB or tracer is provisioned —
@@ -25,4 +26,5 @@ import { AutumnService } from "../services/autumn";
 export const CoreSharedServices = Layer.mergeAll(
   WorkOSAuth.Default,
   AutumnService.Default,
+  SlackService.Default,
 );

--- a/apps/cloud/src/api/error-response.ts
+++ b/apps/cloud/src/api/error-response.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/cloudflare";
-import { Data, Effect } from "effect";
+import { Cause, Data, Effect, Result } from "effect";
 import {
   HttpServerRespondable,
   HttpServerResponse,
@@ -25,14 +25,28 @@ export class HttpResponseError extends Data.TaggedError("HttpResponseError")<{
   }
 }
 
-const toHttpResponseError = (error: unknown): HttpResponseError =>
-  error instanceof HttpResponseError
-    ? error
+const unwrapCause = (error: unknown): unknown => {
+  if (!Cause.isCause(error)) return error;
+
+  const failure = Cause.findError(error);
+  if (Result.isSuccess(failure)) return failure.success;
+
+  const defect = Cause.findDefect(error);
+  if (Result.isSuccess(defect)) return defect.success;
+
+  return error;
+};
+
+const toHttpResponseError = (error: unknown): HttpResponseError => {
+  const unwrapped = unwrapCause(error);
+  return unwrapped instanceof HttpResponseError
+    ? unwrapped
     : new HttpResponseError({
         status: 500,
         code: "internal_server_error",
         message: "Internal server error",
       });
+};
 
 export const isServerError = (error: unknown): boolean => toHttpResponseError(error).status >= 500;
 
@@ -45,7 +59,10 @@ export const toErrorResponse = (error: unknown): Response => {
 export const toErrorServerResponse = (error: unknown): HttpServerResponse.HttpServerResponse => {
   const mapped = toHttpResponseError(error);
   if (mapped.status >= 500) {
-    console.error("[api] toErrorServerResponse error:", error instanceof Error ? error.stack : error);
+    console.error(
+      "[api] toErrorServerResponse error:",
+      error instanceof Error ? error.stack : error,
+    );
     Sentry.captureException(error);
   }
   return HttpServerResponse.jsonUnsafe(

--- a/apps/cloud/src/api/router.ts
+++ b/apps/cloud/src/api/router.ts
@@ -12,6 +12,7 @@ import {
   makeOrgApiLive,
 } from "./layers";
 import { makeProtectedApiLive } from "./protected";
+import { SlackContactRoutesLive } from "./slack";
 
 // One router. Each sub-API contributes its routes via `HttpApiBuilder.layer`,
 // which calls `HttpRouter.use(...)` under the hood. Autumn's catch-all proxy
@@ -32,6 +33,7 @@ export const makeApiLive = (
     makeOrgApiLive(requestScopedLive),
     makeProtectedApiLive(requestScopedLive),
     AutumnRoutesLive,
+    SlackContactRoutesLive,
   ).pipe(
     Layer.provideMerge(RouterConfig),
     Layer.provideMerge(BootSharedServices),

--- a/apps/cloud/src/api/slack.ts
+++ b/apps/cloud/src/api/slack.ts
@@ -1,0 +1,153 @@
+import { env } from "cloudflare:workers";
+import { Effect } from "effect";
+import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+
+import { SlackService } from "../services/slack";
+import {
+  HttpResponseError,
+  isServerError,
+  toErrorServerResponse,
+} from "./error-response";
+
+const isValidEmail = (s: string): boolean => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s);
+
+const verifyTurnstile = (token: string, remoteIp: string | null) =>
+  Effect.tryPromise({
+    try: async () => {
+      const secret = env.TURNSTILE_SECRET_KEY;
+      if (!secret) {
+        // Turnstile is unconfigured — fail closed in prod, but allow dev to
+        // boot without it. We treat empty secret as "skip" so the form works
+        // before secrets are wired; remove this branch once you've set the
+        // secret in every environment.
+        return { success: true, skipped: true };
+      }
+      const form = new URLSearchParams({ secret, response: token });
+      if (remoteIp) form.set("remoteip", remoteIp);
+      const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+        method: "POST",
+        body: form,
+      });
+      const json = (await res.json()) as { success: boolean; "error-codes"?: string[] };
+      return { success: json.success, errorCodes: json["error-codes"] ?? [] };
+    },
+    catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
+  });
+
+const handler = Effect.gen(function* () {
+  const request = yield* HttpServerRequest.HttpServerRequest;
+
+  if (request.method !== "POST") {
+    return yield* Effect.fail(
+      new HttpResponseError({
+        status: 405,
+        code: "method_not_allowed",
+        message: "Method not allowed",
+      }),
+    );
+  }
+
+  const body = (yield* Effect.mapError(
+    request.json,
+    () =>
+      new HttpResponseError({
+        status: 400,
+        code: "invalid_json",
+        message: "Invalid request body",
+      }),
+  )) as {
+    email?: unknown;
+    name?: unknown;
+    note?: unknown;
+    organization?: unknown;
+    turnstileToken?: unknown;
+  };
+
+  const trimmed = (v: unknown, max: number): string | undefined =>
+    typeof v === "string" && v.trim().length > 0 ? v.trim().slice(0, max) : undefined;
+
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  const name = trimmed(body.name, 200);
+  const note = trimmed(body.note, 2000);
+  const organization = trimmed(body.organization, 200);
+  const turnstileToken = typeof body.turnstileToken === "string" ? body.turnstileToken : "";
+
+  if (!isValidEmail(email)) {
+    return yield* Effect.fail(
+      new HttpResponseError({
+        status: 400,
+        code: "invalid_email",
+        message: "A valid email is required",
+      }),
+    );
+  }
+
+  if (!turnstileToken) {
+    return yield* Effect.fail(
+      new HttpResponseError({
+        status: 400,
+        code: "captcha_required",
+        message: "Captcha verification is required.",
+      }),
+    );
+  }
+
+  const remoteIp = request.headers["cf-connecting-ip"] ?? null;
+  const verification = yield* verifyTurnstile(turnstileToken, remoteIp);
+  if (!verification.success) {
+    console.error("[slack] turnstile verification failed:", verification);
+    return yield* Effect.fail(
+      new HttpResponseError({
+        status: 403,
+        code: "captcha_failed",
+        message: "Captcha verification failed. Please try again.",
+      }),
+    );
+  }
+
+  // Global daily channel-creation cap — bounds the worst case if Turnstile is
+  // bypassed somehow. Per-IP gating belongs at the edge (Cloudflare Rules);
+  // this binding is a single shared bucket keyed at "global".
+  const limit = yield* Effect.tryPromise({
+    try: () => env.SLACK_INVITE_LIMITER.limit({ key: "global" }),
+    catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
+  });
+  if (!limit.success) {
+    console.error("[slack] global rate limit hit");
+    return yield* Effect.fail(
+      new HttpResponseError({
+        status: 429,
+        code: "rate_limited",
+        message: "We're getting more contact requests than usual. Please try again later.",
+      }),
+    );
+  }
+
+  const slack = yield* SlackService;
+  const { invite } = yield* slack.createConnectInvite({ email, name, note, organization }).pipe(
+    Effect.tapError((err) =>
+      Effect.sync(() => {
+        console.error(`[slack] ${err.method} failed:`, err.error);
+      }),
+    ),
+    Effect.mapError(
+      () =>
+        new HttpResponseError({
+          status: 500,
+          code: "slack_invite_failed",
+          message: "Couldn't create your Slack invite. Please try again shortly.",
+        }),
+    ),
+  );
+
+  return HttpServerResponse.jsonUnsafe({ url: invite.url }, { status: 200 });
+}).pipe(
+  Effect.catchCause((err) => {
+    if (isServerError(err)) {
+      console.error("[slack] request failed:", err instanceof Error ? err.stack : err);
+    }
+    return Effect.succeed(toErrorServerResponse(err));
+  }),
+);
+
+export const SlackContactRoutesLive = HttpRouter.add("POST", "/contact/slack", handler);

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -10,7 +10,6 @@ import { authorizeOrganization } from "./authorize-organization";
 import { env } from "cloudflare:workers";
 import { WorkOSError } from "./errors";
 import { WorkOSAuth } from "./workos";
-import { AutumnService } from "../services/autumn";
 
 const COOKIE_OPTIONS = {
   path: "/",
@@ -232,13 +231,11 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
         Effect.gen(function* () {
           const workos = yield* WorkOSAuth;
           const users = yield* UserStoreService;
-          const autumn = yield* AutumnService;
           const session = yield* SessionContext;
 
           const name = payload.name.trim();
           const org = yield* workos.createOrganization(name);
           yield* workos.createMembership(org.id, session.accountId, "admin");
-          yield* autumn.trackMemberChange(org.id, 1);
           yield* users.use((s) => s.upsertOrganization({ id: org.id, name: org.name }));
 
           // Try to attach the new org to the current session. This can fail

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -10,6 +10,7 @@ import { authorizeOrganization } from "./authorize-organization";
 import { env } from "cloudflare:workers";
 import { WorkOSError } from "./errors";
 import { WorkOSAuth } from "./workos";
+import { AutumnService } from "../services/autumn";
 
 const COOKIE_OPTIONS = {
   path: "/",
@@ -69,10 +70,8 @@ const setResponseCookie = (
   options: typeof RESPONSE_COOKIE_OPTIONS,
 ) => HttpServerResponse.setCookieUnsafe(response, name, value, options);
 
-const deleteResponseCookie = (
-  response: HttpServerResponse.HttpServerResponse,
-  name: string,
-) => HttpServerResponse.setCookieUnsafe(response, name, "", DELETE_COOKIE_OPTIONS);
+const deleteResponseCookie = (response: HttpServerResponse.HttpServerResponse, name: string) =>
+  HttpServerResponse.setCookieUnsafe(response, name, "", DELETE_COOKIE_OPTIONS);
 
 // ---------------------------------------------------------------------------
 // Single non-protected API surface — public (login/callback) + session
@@ -208,7 +207,9 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           );
 
           return {
-            organizations: organizations.filter((org): org is NonNullable<typeof org> => org !== null),
+            organizations: organizations.filter(
+              (org): org is NonNullable<typeof org> => org !== null,
+            ),
             activeOrganizationId: session.organizationId,
           };
         }),
@@ -231,11 +232,13 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
         Effect.gen(function* () {
           const workos = yield* WorkOSAuth;
           const users = yield* UserStoreService;
+          const autumn = yield* AutumnService;
           const session = yield* SessionContext;
 
           const name = payload.name.trim();
           const org = yield* workos.createOrganization(name);
           yield* workos.createMembership(org.id, session.accountId, "admin");
+          yield* autumn.trackMemberChange(org.id, 1);
           yield* users.use((s) => s.upsertOrganization({ id: org.id, name: org.name }));
 
           // Try to attach the new org to the current session. This can fail
@@ -246,9 +249,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           // cookie and fail loudly; the frontend will bounce to login and
           // the callback's rehydrate path will pick up the new membership.
           const refreshed = yield* workos.refreshSession(session.sealedSession, org.id);
-          const verified = refreshed
-            ? yield* workos.authenticateSealedSession(refreshed)
-            : null;
+          const verified = refreshed ? yield* workos.authenticateSealedSession(refreshed) : null;
 
           if (!refreshed || !verified || verified.organizationId !== org.id) {
             yield* Effect.logWarning(

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -172,6 +172,19 @@ const make = Effect.gen(function* () {
         }),
       ),
 
+    /**
+     * Pending invitations for an organization (i.e. not yet accepted, revoked,
+     * or expired). The SDK's `state` filter doesn't reliably narrow at the
+     * API level, so we filter after.
+     */
+    listPendingInvitations: (organizationId: string) =>
+      use((wos) => wos.userManagement.listInvitations({ organizationId })).pipe(
+        Effect.map((response) => ({
+          ...response,
+          data: response.data.filter((i) => i.state === "pending"),
+        })),
+      ),
+
     /** Remove an organization membership. */
     deleteOrgMembership: (membershipId: string) =>
       use((wos) => wos.userManagement.deleteOrganizationMembership(membershipId)),

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -23,6 +23,17 @@ declare global {
       // Billing
       AUTUMN_SECRET_KEY?: string;
 
+      // Contact / Slack Connect
+      SLACK_BOT_TOKEN?: string;
+      // Turnstile (Cloudflare CAPTCHA) — used to gate the public Slack-contact
+      // endpoint. Sitekey is public and ships in `vars`; secret is set via
+      // `wrangler secret put TURNSTILE_SECRET_KEY`.
+      TURNSTILE_SECRET_KEY?: string;
+      VITE_PUBLIC_TURNSTILE_SITEKEY?: string;
+      // Cloudflare ratelimit binding declared in wrangler.jsonc — caps total
+      // Slack-contact channel creations across all callers.
+      SLACK_INVITE_LIMITER: { limit: (input: { key: string }) => Promise<{ success: boolean }> };
+
       // MCP
       EXECUTOR_MCP_DEBUG?: string;
       MCP_AUTHKIT_DOMAIN?: string;

--- a/apps/cloud/src/org/api.ts
+++ b/apps/cloud/src/org/api.ts
@@ -20,8 +20,15 @@ const OrgMember = Schema.Struct({
   isCurrentUser: Schema.Boolean,
 });
 
+const OrgMemberSeats = Schema.Struct({
+  used: Schema.Number,
+  granted: Schema.Number,
+  unlimited: Schema.Boolean,
+});
+
 const OrgMembersResponse = Schema.Struct({
   members: Schema.Array(OrgMember),
+  seats: OrgMemberSeats,
 });
 
 const OrgRole = Schema.Struct({

--- a/apps/cloud/src/org/handlers.ts
+++ b/apps/cloud/src/org/handlers.ts
@@ -52,24 +52,38 @@ const assertDomainInSessionOrg = (domainId: string) =>
     }
   });
 
+// Per-plan member limits live in code, not Autumn. Members aren't billable
+// usage — they're a permission attached to the plan. We still ask Autumn
+// which plan the org is on (Autumn is the billing source of truth), but
+// the cap itself is a constant here. `null` = unlimited.
+const MEMBER_LIMITS: Record<string, number | null> = {
+  free: 3,
+  "free-pay-as-you-go": 3,
+  team: null,
+};
+const DEFAULT_MEMBER_LIMIT = 3;
+
 // Compute live seat usage from WorkOS truth (active+pending memberships +
-// pending invitations) and the per-plan limit from Autumn. Recomputed on
-// every call — no event-counting drift.
+// pending invitations) and look up the per-plan cap from MEMBER_LIMITS.
+// Recomputed on every call — no event-counting drift.
 const getMemberSeats = (organizationId: string) =>
   Effect.gen(function* () {
     const autumn = yield* AutumnService;
     const workos = yield* WorkOSAuth;
 
-    const limit = yield* autumn.use((client) =>
-      client.check({ customerId: organizationId, featureId: "members" }),
+    const customer = yield* autumn.use((client) =>
+      client.customers.getOrCreate({ customerId: organizationId }),
     );
+    const planId = customer.subscriptions[0]?.planId ?? "free";
+    const limit = planId in MEMBER_LIMITS ? MEMBER_LIMITS[planId] : DEFAULT_MEMBER_LIMIT;
+
     const memberships = yield* workos.listOrgMembers(organizationId);
     const invitations = yield* workos.listPendingInvitations(organizationId);
 
     return {
       used: memberships.data.length + invitations.data.length,
-      granted: limit.balance?.granted ?? 0,
-      unlimited: limit.balance?.unlimited ?? false,
+      granted: limit ?? 0,
+      unlimited: limit === null,
     };
   });
 

--- a/apps/cloud/src/org/handlers.ts
+++ b/apps/cloud/src/org/handlers.ts
@@ -52,21 +52,51 @@ const assertDomainInSessionOrg = (domainId: string) =>
     }
   });
 
+// Compute live seat usage from WorkOS truth (active+pending memberships +
+// pending invitations) and the per-plan limit from Autumn. Recomputed on
+// every call — no event-counting drift.
+const getMemberSeats = (organizationId: string) =>
+  Effect.gen(function* () {
+    const autumn = yield* AutumnService;
+    const workos = yield* WorkOSAuth;
+
+    const limit = yield* autumn.use((client) =>
+      client.check({ customerId: organizationId, featureId: "members" }),
+    );
+    const memberships = yield* workos.listOrgMembers(organizationId);
+    const invitations = yield* workos.listPendingInvitations(organizationId);
+
+    return {
+      used: memberships.data.length + invitations.data.length,
+      granted: limit.balance?.granted ?? 0,
+      unlimited: limit.balance?.unlimited ?? false,
+    };
+  });
+
 const reserveMemberSlot = Effect.gen(function* () {
   const auth = yield* AuthContext;
-  const autumn = yield* AutumnService;
-  const check = yield* autumn
-    .use((client) =>
-      client.check({
-        customerId: auth.organizationId,
-        featureId: "members",
-        requiredBalance: 1,
-        sendEvent: true,
+  const seats = yield* getMemberSeats(auth.organizationId).pipe(
+    Effect.tap((s) =>
+      Effect.logInfo("members.check").pipe(
+        Effect.annotateLogs({
+          "org.id": auth.organizationId,
+          "members.used": s.used,
+          "members.granted": s.granted,
+          "members.unlimited": s.unlimited,
+        }),
+      ),
+    ),
+    Effect.catchCause((cause) =>
+      Effect.gen(function* () {
+        yield* Effect.logError("members.seats lookup failed; failing closed").pipe(
+          Effect.annotateLogs({ "org.id": auth.organizationId, cause: String(cause) }),
+        );
+        return yield* new Forbidden();
       }),
-    )
-    .pipe(Effect.orElseSucceed(() => ({ allowed: true })));
+    ),
+  );
 
-  if (!check.allowed) {
+  if (!seats.unlimited && seats.used >= seats.granted) {
     return yield* new Forbidden();
   }
 });
@@ -78,7 +108,30 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
         const auth = yield* AuthContext;
         const workos = yield* WorkOSAuth;
 
+        // The list endpoint falls back to safe display defaults if the seats
+        // lookup errors — we never want a transient Autumn or WorkOS hiccup
+        // to blank the members page. The actual cap gate lives in
+        // `reserveMemberSlot`, which fails closed.
+        const seats = yield* getMemberSeats(auth.organizationId).pipe(
+          Effect.catchTag("AutumnError", (error) =>
+            Effect.logError("listMembers.seats: autumn lookup failed").pipe(
+              Effect.annotateLogs({ "org.id": auth.organizationId, error: String(error.cause) }),
+              Effect.as({ used: 0, granted: 0, unlimited: false }),
+            ),
+          ),
+        );
+
         const memberships = yield* workos.listOrgMembers(auth.organizationId);
+
+        yield* Effect.logInfo("listMembers.seats").pipe(
+          Effect.annotateLogs({
+            "org.id": auth.organizationId,
+            "members.count": memberships.data.length,
+            "seats.used": seats.used,
+            "seats.granted": seats.granted,
+            "seats.unlimited": seats.unlimited,
+          }),
+        );
 
         const members = yield* Effect.all(
           memberships.data.map((m) =>
@@ -100,7 +153,7 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
           { concurrency: 5 },
         );
 
-        return { members };
+        return { members, seats };
       }),
     )
     .handle("listRoles", () =>
@@ -123,17 +176,14 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
         yield* requireAdmin;
         const auth = yield* AuthContext;
         const workos = yield* WorkOSAuth;
-        const autumn = yield* AutumnService;
 
         yield* reserveMemberSlot;
 
-        const invitation = yield* workos
-          .sendInvitation({
-            email: payload.email,
-            organizationId: auth.organizationId,
-            roleSlug: payload.roleSlug,
-          })
-          .pipe(Effect.tapError(() => autumn.trackMemberChange(auth.organizationId, -1)));
+        const invitation = yield* workos.sendInvitation({
+          email: payload.email,
+          organizationId: auth.organizationId,
+          roleSlug: payload.roleSlug,
+        });
 
         return { id: invitation.id, email: invitation.email };
       }),
@@ -143,10 +193,7 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
         yield* requireAdmin;
         yield* assertMembershipInSessionOrg(params.membershipId);
         const workos = yield* WorkOSAuth;
-        const auth = yield* AuthContext;
-        const autumn = yield* AutumnService;
         yield* workos.deleteOrgMembership(params.membershipId);
-        yield* autumn.trackMemberChange(auth.organizationId, -1);
         return { success: true };
       }),
     )

--- a/apps/cloud/src/org/handlers.ts
+++ b/apps/cloud/src/org/handlers.ts
@@ -52,6 +52,25 @@ const assertDomainInSessionOrg = (domainId: string) =>
     }
   });
 
+const reserveMemberSlot = Effect.gen(function* () {
+  const auth = yield* AuthContext;
+  const autumn = yield* AutumnService;
+  const check = yield* autumn
+    .use((client) =>
+      client.check({
+        customerId: auth.organizationId,
+        featureId: "members",
+        requiredBalance: 1,
+        sendEvent: true,
+      }),
+    )
+    .pipe(Effect.orElseSucceed(() => ({ allowed: true })));
+
+  if (!check.allowed) {
+    return yield* new Forbidden();
+  }
+});
+
 export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
   handlers
     .handle("listMembers", () =>
@@ -104,12 +123,17 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
         yield* requireAdmin;
         const auth = yield* AuthContext;
         const workos = yield* WorkOSAuth;
+        const autumn = yield* AutumnService;
 
-        const invitation = yield* workos.sendInvitation({
-          email: payload.email,
-          organizationId: auth.organizationId,
-          roleSlug: payload.roleSlug,
-        });
+        yield* reserveMemberSlot;
+
+        const invitation = yield* workos
+          .sendInvitation({
+            email: payload.email,
+            organizationId: auth.organizationId,
+            roleSlug: payload.roleSlug,
+          })
+          .pipe(Effect.tapError(() => autumn.trackMemberChange(auth.organizationId, -1)));
 
         return { id: invitation.id, email: invitation.email };
       }),
@@ -119,7 +143,10 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
         yield* requireAdmin;
         yield* assertMembershipInSessionOrg(params.membershipId);
         const workos = yield* WorkOSAuth;
+        const auth = yield* AuthContext;
+        const autumn = yield* AutumnService;
         yield* workos.deleteOrgMembership(params.membershipId);
+        yield* autumn.trackMemberChange(auth.organizationId, -1);
         return { success: true };
       }),
     )

--- a/apps/cloud/src/routes/billing.tsx
+++ b/apps/cloud/src/routes/billing.tsx
@@ -125,19 +125,6 @@ function BillingPage() {
                 )}
               </p>
             </div>
-            {!members.unlimited && members.granted > 0 && (
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
-                <div
-                  className="h-full rounded-full bg-primary transition-all duration-300"
-                  style={
-                    {
-                      "--progress": `${Math.min(100, (members.usage / members.granted) * 100)}%`,
-                      width: "var(--progress)",
-                    } as React.CSSProperties
-                  }
-                />
-              </div>
-            )}
           </div>
         )}
 

--- a/apps/cloud/src/routes/billing.tsx
+++ b/apps/cloud/src/routes/billing.tsx
@@ -10,9 +10,8 @@ export const Route = createFileRoute("/billing")({
 });
 
 const PLAN_TAGLINES: Record<string, string> = {
-  free: "For trying things out",
-  hobby: "For individuals and small teams",
-  professional: "For teams that need more",
+  free: "Free for up to 3 members",
+  team: "$49 per organization",
 };
 
 function BillingPage() {
@@ -53,6 +52,7 @@ function BillingPage() {
   );
 
   const executions = customer?.balances?.executions;
+  const members = customer?.balances?.members;
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
@@ -65,9 +65,7 @@ function BillingPage() {
         <div className="flex items-center justify-between py-4">
           <div>
             <div className="flex items-center gap-2">
-              <p className="text-sm font-medium text-foreground leading-none">
-                {planName}
-              </p>
+              <p className="text-sm font-medium text-foreground leading-none">{planName}</p>
               {isSwitching && (
                 <Badge className="bg-amber-500/10 text-amber-600 dark:text-amber-400">
                   Switching
@@ -113,6 +111,36 @@ function BillingPage() {
         <div className="h-px bg-border/50 my-2" />
 
         {/* Usage */}
+        {members && (
+          <div className="py-4">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-sm font-medium text-foreground">Members</p>
+              <p className="text-sm tabular-nums text-muted-foreground">
+                {members.usage.toLocaleString()}
+                {!members.unlimited && (
+                  <span className="text-muted-foreground">
+                    {" / "}
+                    {members.granted.toLocaleString()}
+                  </span>
+                )}
+              </p>
+            </div>
+            {!members.unlimited && members.granted > 0 && (
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
+                <div
+                  className="h-full rounded-full bg-primary transition-all duration-300"
+                  style={
+                    {
+                      "--progress": `${Math.min(100, (members.usage / members.granted) * 100)}%`,
+                      width: "var(--progress)",
+                    } as React.CSSProperties
+                  }
+                />
+              </div>
+            )}
+          </div>
+        )}
+
         {executions && (
           <div className="py-4">
             <div className="flex items-center justify-between mb-2">

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -386,14 +386,16 @@ function SlackContactCta() {
           }}
         >
           <DialogTrigger asChild>
-            <button
+            <Button
               type="button"
-              className="inline-flex items-center gap-1.5 text-foreground hover:text-primary transition-colors"
+              variant="ghost"
+              size="sm"
+              className="text-foreground hover:text-primary"
             >
               <SlackMark className="size-4" />
               Get in touch on Slack
               <span aria-hidden>→</span>
-            </button>
+            </Button>
           </DialogTrigger>
         <DialogContent>
           {inviteUrl ? (

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -1,8 +1,22 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { useAuth } from "../web/auth";
 import { useCustomer, useListPlans } from "autumn-js/react";
 import { Button } from "@executor-js/react/components/button";
 import { Badge } from "@executor-js/react/components/badge";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@executor-js/react/components/dialog";
+import { Input } from "@executor-js/react/components/input";
+import { Label } from "@executor-js/react/components/label";
+import { Textarea } from "@executor-js/react/components/textarea";
 
 type Plan = NonNullable<ReturnType<typeof useListPlans>["data"]>[number];
 
@@ -10,28 +24,24 @@ export const Route = createFileRoute("/billing_/plans")({
   component: PlansPage,
 });
 
-const PLAN_META: Record<
-  string,
-  { tagline: string; inherits?: string; features: string[] }
-> = {
-  hobby: {
-    tagline: "For individuals and small teams",
+const PLAN_META: Record<string, { tagline: string; inherits?: string; features: string[] }> = {
+  free: {
+    tagline: "For small teams getting started",
     features: [
-      "50,000 included executions per seat",
-      "Up to 5 seats",
-      "60s execution timeout",
+      "Up to 3 members",
+      "10,000 included executions per month",
+      "$0.20 per 1,000 additional executions",
       "Unlimited sources",
-      "$0.30 per 1,000 extra executions",
     ],
   },
-  professional: {
-    tagline: "For teams that need more",
-    inherits: "Hobby",
+  team: {
+    tagline: "For growing organizations",
     features: [
-      "100,000 included executions per seat",
-      "Unlimited seats",
+      "Unlimited members",
+      "250,000 included executions per month",
       "5 minute execution timeout",
       "Join by team domain",
+      "$0.20 per 1,000 additional executions",
     ],
   },
 };
@@ -45,7 +55,7 @@ const ACTION_LABELS: Record<string, string> = {
 };
 
 const ENTERPRISE_FEATURES = [
-  "Self-hosted or dedicated cloud deployment",
+  "Self-hosted or dedicated cloud deployment support",
   "SSO / SAML & SCIM provisioning",
   "Audit logs for every tool call",
   "Dedicated support & onboarding",
@@ -74,8 +84,8 @@ function PlansPage() {
 
   const isLoading = customerLoading || plansLoading;
 
-  const paidPlans = (plans ?? ([] as Plan[])).filter(
-    (p: Plan) => p.id === "hobby" || p.id === "professional",
+  const selfServePlans = (plans ?? ([] as Plan[])).filter(
+    (p: Plan) => p.id === "free" || p.id === "team",
   );
 
   return (
@@ -118,7 +128,7 @@ function PlansPage() {
               isFetching ? "opacity-50 pointer-events-none" : "",
             ].join(" ")}
           >
-            {paidPlans.map((plan: Plan) => {
+            {selfServePlans.map((plan: Plan) => {
               const meta = PLAN_META[plan.id];
               if (!meta) return null;
 
@@ -143,7 +153,7 @@ function PlansPage() {
                         : "border-border",
                   ].join(" ")}
                 >
-                  <div className="flex items-center justify-between">
+                  <div className="flex h-6 items-center justify-between">
                     <p className="text-base font-semibold text-foreground leading-none">
                       {plan.name}
                     </p>
@@ -171,8 +181,11 @@ function PlansPage() {
                     </span>
                     {plan.price?.interval && (
                       <span className="text-sm text-muted-foreground">
-                        USD / seat / {plan.price.interval}
+                        USD / org / {plan.price.interval}
                       </span>
+                    )}
+                    {!plan.price?.interval && (
+                      <span className="text-sm text-muted-foreground">USD</span>
                     )}
                   </div>
 
@@ -218,16 +231,10 @@ function PlansPage() {
                   )}
                   <ul
                     role="list"
-                    className={[
-                      "space-y-2",
-                      meta.inherits ? "mt-2" : "mt-5",
-                    ].join(" ")}
+                    className={["space-y-2", meta.inherits ? "mt-2" : "mt-5"].join(" ")}
                   >
                     {meta.features.map((f) => (
-                      <li
-                        key={f}
-                        className="flex items-start gap-2 text-xs text-muted-foreground"
-                      >
+                      <li key={f} className="flex items-start gap-2 text-xs text-muted-foreground">
                         <svg
                           viewBox="0 0 16 16"
                           fill="none"
@@ -250,19 +257,13 @@ function PlansPage() {
             })}
 
             <div className="flex flex-col rounded-xl border border-border p-5">
-              <div className="flex items-center justify-between">
-                <p className="text-base font-semibold text-foreground leading-none">
-                  Enterprise
-                </p>
+              <div className="flex h-6 items-center justify-between">
+                <p className="text-base font-semibold text-foreground leading-none">Enterprise</p>
               </div>
-              <p className="mt-1 text-sm text-muted-foreground">
-                For orgs with custom needs
-              </p>
+              <p className="mt-1 text-sm text-muted-foreground">For orgs with custom needs</p>
 
               <div className="mt-4 flex items-baseline gap-1.5">
-                <span className="text-2xl font-semibold text-foreground tabular-nums">
-                  Custom
-                </span>
+                <span className="text-2xl font-semibold text-foreground tabular-nums">Custom</span>
               </div>
 
               <div className="mt-4">
@@ -274,15 +275,10 @@ function PlansPage() {
                 </a>
               </div>
 
-              <p className="mt-5 text-xs font-medium text-foreground">
-                Everything in Professional, plus
-              </p>
+              <p className="mt-5 text-xs font-medium text-foreground">Everything in Team, plus</p>
               <ul role="list" className="mt-2 space-y-2">
                 {ENTERPRISE_FEATURES.map((f) => (
-                  <li
-                    key={f}
-                    className="flex items-start gap-2 text-xs text-muted-foreground"
-                  >
+                  <li key={f} className="flex items-start gap-2 text-xs text-muted-foreground">
                     <svg
                       viewBox="0 0 16 16"
                       fill="none"
@@ -303,7 +299,315 @@ function PlansPage() {
             </div>
           </div>
         )}
+
+        <SlackContactCta />
       </div>
     </div>
+  );
+}
+
+function SlackContactCta() {
+  const auth = useAuth();
+  const signedIn = auth.status === "authenticated" ? auth : null;
+  const prefillEmail = signedIn?.user.email ?? "";
+  const prefillName = signedIn?.user.name ?? "";
+  const orgName = signedIn?.organization?.name ?? "";
+
+  const turnstileSiteKey = import.meta.env.VITE_PUBLIC_TURNSTILE_SITEKEY ?? "";
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState(prefillEmail);
+  const [name, setName] = useState(prefillName);
+  const [note, setNote] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [inviteUrl, setInviteUrl] = useState<string | null>(null);
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+
+  // Hydrate prefill once auth resolves (it starts as `loading` on first render).
+  useEffect(() => {
+    if (prefillEmail && !email) setEmail(prefillEmail);
+    if (prefillName && !name) setName(prefillName);
+  }, [prefillEmail, prefillName]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const reset = () => {
+    setEmail(prefillEmail);
+    setName(prefillName);
+    setNote("");
+    setError(null);
+    setInviteUrl(null);
+    setTurnstileToken(null);
+  };
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!turnstileToken) {
+      setError("Please complete the captcha first.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/contact/slack", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          email,
+          name: name || undefined,
+          note: note || undefined,
+          organization: orgName || undefined,
+          turnstileToken,
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { url?: string; error?: string };
+      if (!res.ok) {
+        setError(data.error ?? "Something went wrong. Please try again.");
+        return;
+      }
+      setInviteUrl(data.url ?? null);
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setSubmitting(false);
+      // Turnstile tokens are single-use server-side — clear so the widget
+      // re-issues a fresh one on retry.
+      setTurnstileToken(null);
+    }
+  };
+
+  return (
+    <div className="mt-10 flex flex-col items-center gap-3 border-t border-border pt-8 text-center">
+      <p className="text-sm text-muted-foreground">Got questions?</p>
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm font-medium">
+        <Dialog
+          open={open}
+          onOpenChange={(next) => {
+            setOpen(next);
+            if (!next) reset();
+          }}
+        >
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 text-foreground hover:text-primary transition-colors"
+            >
+              <SlackMark className="size-4" />
+              Get in touch on Slack
+              <span aria-hidden>→</span>
+            </button>
+          </DialogTrigger>
+        <DialogContent>
+          {inviteUrl ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>Check your inbox</DialogTitle>
+                <DialogDescription>
+                  We've created a private Slack channel and emailed you an invite. You can also
+                  open it directly:
+                </DialogDescription>
+              </DialogHeader>
+              <a
+                href={inviteUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-md bg-primary text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                <SlackMark className="size-4" />
+                Open Slack invite
+              </a>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button type="button" variant="outline">
+                    Done
+                  </Button>
+                </DialogClose>
+              </DialogFooter>
+            </>
+          ) : (
+            <form onSubmit={onSubmit}>
+              <DialogHeader>
+                <DialogTitle>Get in touch on Slack</DialogTitle>
+                <DialogDescription>
+                  We'll create a private Slack Connect channel between you and the Executor team.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="grid gap-4 py-4">
+                <div className="grid gap-2">
+                  <Label htmlFor="slack-contact-email">Work email</Label>
+                  <Input
+                    id="slack-contact-email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.currentTarget.value)}
+                    placeholder="you@company.com"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="slack-contact-name">Name (optional)</Label>
+                  <Input
+                    id="slack-contact-name"
+                    autoComplete="name"
+                    value={name}
+                    onChange={(e) => setName(e.currentTarget.value)}
+                    placeholder="Ada Lovelace"
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <Label htmlFor="slack-contact-note">What's on your mind? (optional)</Label>
+                  <Textarea
+                    id="slack-contact-note"
+                    rows={3}
+                    value={note}
+                    onChange={(e) => setNote(e.currentTarget.value)}
+                    placeholder="Pricing question, integration help, anything…"
+                  />
+                </div>
+                {turnstileSiteKey && (
+                  <TurnstileWidget siteKey={turnstileSiteKey} onToken={setTurnstileToken} />
+                )}
+                {error && <p className="text-sm text-destructive">{error}</p>}
+              </div>
+              <DialogFooter>
+                <DialogClose asChild>
+                  <Button type="button" variant="outline" disabled={submitting}>
+                    Cancel
+                  </Button>
+                </DialogClose>
+                <Button
+                  type="submit"
+                  disabled={submitting || !email || (!!turnstileSiteKey && !turnstileToken)}
+                >
+                  {submitting ? "Sending…" : "Send invite"}
+                </Button>
+              </DialogFooter>
+            </form>
+          )}
+        </DialogContent>
+        </Dialog>
+        <span className="text-muted-foreground/60" aria-hidden>
+          ·
+        </span>
+        <a
+          href="mailto:rhys@executor.sh?subject=Executor%20question"
+          className="inline-flex items-center gap-1.5 text-foreground hover:text-primary transition-colors"
+        >
+          <MailIcon className="size-4" />
+          Email us
+          <span aria-hidden>→</span>
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function MailIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" className={className} aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 7l9 6 9-6M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+type TurnstileApi = {
+  render: (
+    el: HTMLElement,
+    opts: {
+      sitekey: string;
+      callback?: (token: string) => void;
+      "error-callback"?: () => void;
+      "expired-callback"?: () => void;
+      theme?: "light" | "dark" | "auto";
+    },
+  ) => string;
+  remove: (id: string) => void;
+};
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+function TurnstileWidget({
+  siteKey,
+  onToken,
+}: {
+  siteKey: string;
+  onToken: (token: string | null) => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const onTokenRef = useRef(onToken);
+  onTokenRef.current = onToken;
+
+  useEffect(() => {
+    let cancelled = false;
+    const render = () => {
+      if (cancelled || !containerRef.current || !window.turnstile) return;
+      if (widgetIdRef.current) {
+        window.turnstile.remove(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+      widgetIdRef.current = window.turnstile.render(containerRef.current, {
+        sitekey: siteKey,
+        callback: (token) => onTokenRef.current(token),
+        "error-callback": () => onTokenRef.current(null),
+        "expired-callback": () => onTokenRef.current(null),
+      });
+    };
+
+    if (window.turnstile) {
+      render();
+    } else {
+      const existing = document.querySelector<HTMLScriptElement>("script[data-turnstile]");
+      if (existing) {
+        existing.addEventListener("load", render);
+        return () => {
+          cancelled = true;
+          existing.removeEventListener("load", render);
+        };
+      }
+      const script = document.createElement("script");
+      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+      script.async = true;
+      script.defer = true;
+      script.dataset.turnstile = "1";
+      script.addEventListener("load", render);
+      document.head.appendChild(script);
+    }
+
+    return () => {
+      cancelled = true;
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+    };
+  }, [siteKey]);
+
+  return <div ref={containerRef} className="flex justify-center" />;
+}
+
+function SlackMark({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" className={className} aria-hidden>
+      <path
+        d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313z"
+        fill="#E01E5A"
+      />
+      <path
+        d="M8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zm0 1.271a2.527 2.527 0 0 1 2.521 2.521 2.527 2.527 0 0 1-2.521 2.521H2.522A2.527 2.527 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312z"
+        fill="#36C5F0"
+      />
+      <path
+        d="M18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zm-1.272 0a2.528 2.528 0 0 1-2.521 2.521 2.527 2.527 0 0 1-2.521-2.521V2.522A2.527 2.527 0 0 1 15.163 0a2.528 2.528 0 0 1 2.521 2.522v6.312z"
+        fill="#2EB67D"
+      />
+      <path
+        d="M15.163 18.956a2.528 2.528 0 0 1 2.521 2.522A2.528 2.528 0 0 1 15.163 24a2.527 2.527 0 0 1-2.521-2.522v-2.522h2.521zm0-1.272a2.527 2.527 0 0 1-2.521-2.521 2.527 2.527 0 0 1 2.521-2.521h6.315A2.527 2.527 0 0 1 24 15.163a2.528 2.528 0 0 1-2.522 2.521h-6.315z"
+        fill="#ECB22E"
+      />
+    </svg>
   );
 }

--- a/apps/cloud/src/routes/org.tsx
+++ b/apps/cloud/src/routes/org.tsx
@@ -124,9 +124,12 @@ function OrgPage() {
   const canUseDomains = customerLoading
     ? false
     : check({ featureId: "domain-verification" }).allowed;
-  const canInviteMember = customerLoading
-    ? false
-    : check({ featureId: "members", requiredBalance: 1 }).allowed;
+  const seats = AsyncResult.match(membersResult, {
+    onInitial: () => null,
+    onFailure: () => null,
+    onSuccess: ({ value }) => value.seats ?? null,
+  });
+  const canInviteMember = !seats ? false : seats.unlimited || seats.used < seats.granted;
   const [inviteOpen, setInviteOpen] = useState(false);
   const [editName, setEditName] = useState(orgName);
   const [savingName, setSavingName] = useState(false);
@@ -256,7 +259,7 @@ function OrgPage() {
           {!canUseDomains && (
             <div className="mb-3 flex items-center justify-between rounded-lg border border-border px-4 py-3">
               <p className="text-sm text-muted-foreground">
-                Domain verification is available on the Team plan.
+                Join by domain is available on the Team plan.
               </p>
               <Link to="/billing/plans">
                 <Button size="sm" variant="outline">
@@ -281,6 +284,7 @@ function OrgPage() {
             ),
             onSuccess: ({ value }) => {
               if (value.domains.length === 0) {
+                if (!canUseDomains) return null;
                 return (
                   <p className="py-6 text-center text-sm text-muted-foreground">
                     No domains yet. Add your company domain so members can join without an invite.
@@ -324,18 +328,6 @@ function OrgPage() {
               </Link>
             )}
           </div>
-          {!canInviteMember && (
-            <div className="mb-3 flex items-center justify-between rounded-lg border border-border px-4 py-3">
-              <p className="text-sm text-muted-foreground">
-                Upgrade to Team to add more than 3 members.
-              </p>
-              <Link to="/billing/plans">
-                <Button size="sm" variant="outline">
-                  View plans
-                </Button>
-              </Link>
-            </div>
-          )}
           <Input
             type="text"
             placeholder="Search by name or email..."

--- a/apps/cloud/src/routes/org.tsx
+++ b/apps/cloud/src/routes/org.tsx
@@ -1,5 +1,6 @@
 import { useReducer, useState } from "react";
-import { Exit } from "effect";
+import { Cause, Exit, Result } from "effect";
+import { Forbidden } from "../org/api";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
@@ -62,21 +63,21 @@ type InviteState = {
   email: string;
   roleSlug: string;
   status: "idle" | "sending" | "error";
-  error: string | null;
+  failure: Cause.Cause<unknown> | null;
 };
 
 const initialInviteState: InviteState = {
   email: "",
   roleSlug: "member",
   status: "idle",
-  error: null,
+  failure: null,
 };
 
 type InviteAction =
   | { type: "setEmail"; email: string }
   | { type: "setRole"; roleSlug: string }
   | { type: "send" }
-  | { type: "error"; message: string }
+  | { type: "error"; cause: Cause.Cause<unknown> }
   | { type: "reset" };
 
 function inviteReducer(state: InviteState, action: InviteAction): InviteState {
@@ -86,9 +87,9 @@ function inviteReducer(state: InviteState, action: InviteAction): InviteState {
     case "setRole":
       return { ...state, roleSlug: action.roleSlug };
     case "send":
-      return { ...state, status: "sending", error: null };
+      return { ...state, status: "sending", failure: null };
     case "error":
-      return { ...state, status: "error", error: action.message };
+      return { ...state, status: "error", failure: action.cause };
     case "reset":
       return initialInviteState;
   }
@@ -606,6 +607,32 @@ function DomainCard({ domain: d, onDelete }: { domain: DomainData; onDelete: () 
   );
 }
 
+function InviteErrorAlert({ cause }: { cause: Cause.Cause<unknown> }) {
+  const failure = Cause.findError(cause);
+  const error = Result.isSuccess(failure) ? failure.success : null;
+
+  if (error instanceof Forbidden) {
+    return (
+      <div className="flex items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+        <p className="text-sm text-destructive">
+          You've reached your member limit. Upgrade to Team to invite more.
+        </p>
+        <Link to="/billing/plans">
+          <Button size="sm" variant="outline">
+            Upgrade
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+      <p className="text-sm text-destructive">Failed to send invitation. Please try again.</p>
+    </div>
+  );
+}
+
 function InviteDialog(props: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
@@ -630,9 +657,9 @@ function InviteDialog(props: {
       toast.success(`Invitation sent to ${state.email.trim()}`);
       dispatch({ type: "reset" });
       props.onOpenChange(false);
-    } else {
-      dispatch({ type: "error", message: "Failed to send invitation" });
+      return;
     }
+    dispatch({ type: "error", cause: exit.cause });
   };
 
   return (
@@ -700,11 +727,7 @@ function InviteDialog(props: {
             </div>
           )}
 
-          {state.status === "error" && state.error && (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
-              <p className="text-sm text-destructive">{state.error}</p>
-            </div>
-          )}
+          {state.status === "error" && state.failure && <InviteErrorAlert cause={state.failure} />}
         </div>
 
         <DialogFooter>

--- a/apps/cloud/src/routes/org.tsx
+++ b/apps/cloud/src/routes/org.tsx
@@ -124,6 +124,9 @@ function OrgPage() {
   const canUseDomains = customerLoading
     ? false
     : check({ featureId: "domain-verification" }).allowed;
+  const canInviteMember = customerLoading
+    ? false
+    : check({ featureId: "members", requiredBalance: 1 }).allowed;
   const [inviteOpen, setInviteOpen] = useState(false);
   const [editName, setEditName] = useState(orgName);
   const [savingName, setSavingName] = useState(false);
@@ -253,7 +256,7 @@ function OrgPage() {
           {!canUseDomains && (
             <div className="mb-3 flex items-center justify-between rounded-lg border border-border px-4 py-3">
               <p className="text-sm text-muted-foreground">
-                Domain verification is available on the Professional plan.
+                Domain verification is available on the Team plan.
               </p>
               <Link to="/billing/plans">
                 <Button size="sm" variant="outline">
@@ -303,11 +306,36 @@ function OrgPage() {
         {/* Members */}
         <section className="mb-10">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-sm font-medium text-foreground">Members</h2>
-            <Button size="sm" className="min-w-32" onClick={() => setInviteOpen(true)}>
-              Invite member
-            </Button>
+            <div>
+              <h2 className="text-sm font-medium text-foreground">Members</h2>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                Free organizations can include up to 3 members.
+              </p>
+            </div>
+            {canInviteMember ? (
+              <Button size="sm" className="min-w-32" onClick={() => setInviteOpen(true)}>
+                Invite member
+              </Button>
+            ) : (
+              <Link to="/billing/plans">
+                <Button size="sm" className="min-w-32">
+                  Upgrade
+                </Button>
+              </Link>
+            )}
           </div>
+          {!canInviteMember && (
+            <div className="mb-3 flex items-center justify-between rounded-lg border border-border px-4 py-3">
+              <p className="text-sm text-muted-foreground">
+                Upgrade to Team to add more than 3 members.
+              </p>
+              <Link to="/billing/plans">
+                <Button size="sm" variant="outline">
+                  View plans
+                </Button>
+              </Link>
+            </div>
+          )}
           <Input
             type="text"
             placeholder="Search by name or email..."

--- a/apps/cloud/src/services/autumn.ts
+++ b/apps/cloud/src/services/autumn.ts
@@ -28,7 +28,6 @@ export type IAutumnService = Readonly<{
    * user-facing request.
    */
   trackExecution: (organizationId: string) => Effect.Effect<void, never, never>;
-  trackMemberChange: (organizationId: string, value: number) => Effect.Effect<void, never, never>;
 }>;
 
 // ---------------------------------------------------------------------------
@@ -45,7 +44,6 @@ const make = Effect.sync(() => {
     return {
       use: () => notConfigured,
       trackExecution: () => Effect.void,
-      trackMemberChange: () => Effect.void,
     } satisfies IAutumnService;
   }
 
@@ -72,23 +70,7 @@ const make = Effect.sync(() => {
       }
     }).pipe(Effect.withSpan("autumn.trackExecution"));
 
-  const trackMemberChange = (organizationId: string, value: number) =>
-    Effect.gen(function* () {
-      yield* Effect.annotateCurrentSpan({
-        "autumn.customer.id": organizationId,
-        "autumn.members.delta": value,
-      });
-      const outcome = yield* Effect.result(
-        use((c) => c.track({ customerId: organizationId, featureId: "members", value })),
-      );
-      if (outcome._tag === "Failure") {
-        console.error("[billing] member tracking failed:", outcome.failure);
-        Sentry.captureException(outcome.failure);
-        yield* Effect.annotateCurrentSpan({ "autumn.track.members.failed": true });
-      }
-    }).pipe(Effect.withSpan("autumn.trackMemberChange"));
-
-  return { use, trackExecution, trackMemberChange } satisfies IAutumnService;
+  return { use, trackExecution } satisfies IAutumnService;
 });
 
 export class AutumnService extends Context.Service<AutumnService, IAutumnService>()(

--- a/apps/cloud/src/services/autumn.ts
+++ b/apps/cloud/src/services/autumn.ts
@@ -28,6 +28,7 @@ export type IAutumnService = Readonly<{
    * user-facing request.
    */
   trackExecution: (organizationId: string) => Effect.Effect<void, never, never>;
+  trackMemberChange: (organizationId: string, value: number) => Effect.Effect<void, never, never>;
 }>;
 
 // ---------------------------------------------------------------------------
@@ -44,6 +45,7 @@ const make = Effect.sync(() => {
     return {
       use: () => notConfigured,
       trackExecution: () => Effect.void,
+      trackMemberChange: () => Effect.void,
     } satisfies IAutumnService;
   }
 
@@ -59,9 +61,7 @@ const make = Effect.sync(() => {
     Effect.gen(function* () {
       yield* Effect.annotateCurrentSpan({ "autumn.customer.id": organizationId });
       const outcome = yield* Effect.result(
-        use((c) =>
-          c.track({ customerId: organizationId, featureId: "executions", value: 1 }),
-        ),
+        use((c) => c.track({ customerId: organizationId, featureId: "executions", value: 1 })),
       );
       if (outcome._tag === "Failure") {
         // Silent billing data loss is worth paging on — autumn.trackExecution
@@ -72,12 +72,27 @@ const make = Effect.sync(() => {
       }
     }).pipe(Effect.withSpan("autumn.trackExecution"));
 
-  return { use, trackExecution } satisfies IAutumnService;
+  const trackMemberChange = (organizationId: string, value: number) =>
+    Effect.gen(function* () {
+      yield* Effect.annotateCurrentSpan({
+        "autumn.customer.id": organizationId,
+        "autumn.members.delta": value,
+      });
+      const outcome = yield* Effect.result(
+        use((c) => c.track({ customerId: organizationId, featureId: "members", value })),
+      );
+      if (outcome._tag === "Failure") {
+        console.error("[billing] member tracking failed:", outcome.failure);
+        Sentry.captureException(outcome.failure);
+        yield* Effect.annotateCurrentSpan({ "autumn.track.members.failed": true });
+      }
+    }).pipe(Effect.withSpan("autumn.trackMemberChange"));
+
+  return { use, trackExecution, trackMemberChange } satisfies IAutumnService;
 });
 
-export class AutumnService extends Context.Service<
-  AutumnService,
-  IAutumnService
->()("@executor-js/cloud/AutumnService") {
+export class AutumnService extends Context.Service<AutumnService, IAutumnService>()(
+  "@executor-js/cloud/AutumnService",
+) {
   static Default = Layer.effect(this)(make);
 }

--- a/apps/cloud/src/services/slack.ts
+++ b/apps/cloud/src/services/slack.ts
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------------
+// Slack service — creates a per-customer Slack Connect channel and emails an
+// invite. Used by the pricing-page "Get in touch on Slack" CTA, modeled on
+// WorkOS's onboarding flow.
+// ---------------------------------------------------------------------------
+
+import { env } from "cloudflare:workers";
+import { Context, Data, Effect, Layer } from "effect";
+
+export class SlackError extends Data.TaggedError("SlackError")<{
+  method: string;
+  error: string;
+}> {}
+
+export type ISlackService = Readonly<{
+  createConnectInvite: (input: {
+    email: string;
+    name?: string;
+    note?: string;
+    organization?: string;
+  }) => Effect.Effect<
+    {
+      channel: { id: string; name: string };
+      invite: { invite_id: string; url: string };
+    },
+    SlackError
+  >;
+}>;
+
+const slugifyEmail = (email: string): string =>
+  email
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+
+const randomSuffix = (): string => {
+  const bytes = new Uint8Array(3);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+};
+
+type SlackResponse = { ok: boolean; error?: string } & Record<string, unknown>;
+
+const make = Effect.sync(() => {
+  const token = env.SLACK_BOT_TOKEN;
+
+  if (!token) {
+    const notConfigured = (method: string) =>
+      Effect.fail(
+        new SlackError({ method, error: "SLACK_BOT_TOKEN is not configured" }),
+      );
+    return {
+      createConnectInvite: () => notConfigured("createConnectInvite"),
+    } satisfies ISlackService;
+  }
+
+  const call = <A extends SlackResponse>(method: string, body: Record<string, unknown>) =>
+    Effect.tryPromise({
+      try: async (): Promise<A> => {
+        const res = await fetch(`https://slack.com/api/${method}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(body),
+        });
+        const json = (await res.json()) as A;
+        if (!json.ok) throw new Error(json.error ?? "unknown_slack_error");
+        return json;
+      },
+      catch: (cause) =>
+        new SlackError({
+          method,
+          error: cause instanceof Error ? cause.message : String(cause),
+        }),
+    }).pipe(Effect.withSpan(`slack.${method}`));
+
+  const createConnectInvite: ISlackService["createConnectInvite"] = ({
+    email,
+    name,
+    note,
+    organization,
+  }) =>
+    Effect.gen(function* () {
+      // Slack channel names: lowercase, no spaces, max 80 chars, unique per workspace.
+      const baseName = `shared-${slugifyEmail(email)}`.slice(0, 80);
+      const tryCreate = (n: string) =>
+        call<SlackResponse & { channel: { id: string; name: string } }>(
+          "conversations.create",
+          { name: n, is_private: false },
+        );
+
+      const created = yield* tryCreate(baseName).pipe(
+        Effect.catchTag("SlackError", (err) =>
+          err.error === "name_taken"
+            ? tryCreate(`${baseName}-${randomSuffix()}`.slice(0, 80))
+            : Effect.fail(err),
+        ),
+      );
+      const channel = created.channel;
+
+      const helloLines = [
+        `:wave: New contact from pricing page: ${email}`,
+        name ? `Name: ${name}` : null,
+        organization ? `Org: ${organization}` : null,
+        note ? `Note: ${note}` : null,
+      ].filter(Boolean) as string[];
+
+      yield* call<SlackResponse>("chat.postMessage", {
+        channel: channel.id,
+        text: helloLines.join("\n"),
+      });
+
+      const invite = yield* call<SlackResponse & { invite_id: string; url: string }>(
+        "conversations.inviteShared",
+        {
+          channel: channel.id,
+          emails: [email],
+          // `external_limited: true` scopes the guest to just this channel,
+          // which is what we want for a focused 1:1 support conversation.
+          external_limited: true,
+        },
+      );
+
+      return {
+        channel: { id: channel.id, name: channel.name },
+        invite: { invite_id: invite.invite_id, url: invite.url },
+      };
+    }).pipe(
+      Effect.withSpan("slack.createConnectInvite", { attributes: { "slack.email": email } }),
+    );
+
+  return { createConnectInvite } satisfies ISlackService;
+});
+
+export class SlackService extends Context.Service<SlackService, ISlackService>()(
+  "@executor-js/cloud/SlackService",
+) {
+  static Default = Layer.effect(this)(make);
+}

--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -54,5 +54,20 @@
   "vars": {
     "VITE_PUBLIC_SITE_URL": "https://executor.sh",
     "VITE_PUBLIC_POSTHOG_KEY": "phc_nNLrNMALpRsfrEkZovUkfMxYbcJvHnsJHeoSPavprgLL",
+    // Replace with your Turnstile production sitekey before going live. The
+    // test key always passes — fine for local dev, useless in prod.
+    "VITE_PUBLIC_TURNSTILE_SITEKEY": "1x00000000000000000000AA",
   },
+  // Cloudflare's `simple` ratelimit only supports 10s or 60s windows — it's
+  // burst protection, not a true daily cap. With Turnstile gating the form,
+  // 5/min keeps the worst-case sustained throughput to ~7k channels/day,
+  // which is bounded enough as a backstop. For an actual daily ceiling,
+  // layer a Durable Object counter on top.
+  "ratelimits": [
+    {
+      "name": "SLACK_INVITE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 5, "period": 60 },
+    },
+  ],
 }

--- a/apps/marketing/src/pages/privacy.astro
+++ b/apps/marketing/src/pages/privacy.astro
@@ -42,7 +42,7 @@ import LegalLayout from "../components/LegalLayout.astro";
     <li>source and integration metadata;</li>
     <li>tool catalogs, schemas, policies, and related configuration;</li>
     <li>secret metadata and connection settings; and</li>
-    <li>billing plan, seat, and execution-usage records.</li>
+    <li>billing plan, membership, and execution-usage records.</li>
   </ul>
 
   <h3>Credentials, secrets, and connected-service data</h3>

--- a/apps/marketing/src/pages/terms.astro
+++ b/apps/marketing/src/pages/terms.astro
@@ -45,7 +45,7 @@ import LegalLayout from "../components/LegalLayout.astro";
 
   <p>
     We may modify, improve, add, or remove features from time to time. We may also impose or change limits on storage,
-    seat counts, execution volume, session duration, integration access, or other usage thresholds.
+    organization membership counts, execution volume, session duration, integration access, or other usage thresholds.
   </p>
 
   <h2>3. Your Content and Responsibilities</h2>
@@ -87,8 +87,9 @@ import LegalLayout from "../components/LegalLayout.astro";
   <h2>6. Subscriptions, Billing, and Auto-Renewal</h2>
   <p>
     Some parts of the Services are offered on a free basis, while others require a paid subscription or usage-based
-    charges. Paid plans may include seat-based pricing, included execution allowances, overage charges, prepaid top-up
-    packages, or similar billing mechanics described in the product at the time of purchase.
+    charges. Paid plans may include organization-level pricing, included member limits, included execution allowances,
+    overage charges, prepaid top-up packages, or similar billing mechanics described in the product at the time of
+    purchase.
   </p>
 
   <p>

--- a/autumn.config.ts
+++ b/autumn.config.ts
@@ -1,104 +1,85 @@
 import { feature, item, plan } from "atmn";
 
 // Features
-export const members = feature({
-  id: "members",
-  name: "Members",
-  type: "metered",
-  consumable: false,
-});
-
 export const executions = feature({
-  id: "executions",
-  name: "Executions",
-  type: "metered",
-  consumable: true,
+	id: 'executions',
+	name: 'Executions',
+	type: 'metered',
+	consumable: true,
 });
 
 export const domainVerification = feature({
-  id: "domain-verification",
-  name: "Domain Verification",
-  type: "boolean",
+	id: 'domain-verification',
+	name: 'Domain Verification',
+	type: 'boolean',
 });
 
-export const seats = feature({
-  id: "seats",
-  name: "Seats",
-  type: "metered",
-  consumable: false,
-  archived: true,
+export const members = feature({
+	id: 'members',
+	name: 'Members',
+	type: 'metered',
+	consumable: false,
+	archived: true,
 });
 
 // Plans
 export const free = plan({
-  id: "free",
-  name: "Free",
-  addOn: false,
-  autoEnable: true,
-  items: [
-    item({
-      featureId: members.id,
-      included: 3,
-    }),
-    item({
-      featureId: executions.id,
-      included: 10000,
-      reset: {
-        interval: "month",
-      },
-    }),
-  ],
+	id: 'free',
+	name: 'Free',
+	addOn: false,
+	autoEnable: true,
+	items: [
+		item({
+			featureId: executions.id,
+			included: 10000,
+			reset: {
+				interval: 'month',
+			},
+		}),
+	],
 });
 
 export const freePayAsYouGo = plan({
-  id: "free-pay-as-you-go",
-  name: "Free Pay As You Go",
-  addOn: false,
-  autoEnable: false,
-  items: [
-    item({
-      featureId: members.id,
-      included: 3,
-    }),
-    item({
-      featureId: executions.id,
-      included: 10000,
-      price: {
-        amount: 0.2,
-        billingUnits: 1000,
-        billingMethod: "usage_based",
-        interval: "month",
-      },
-    }),
-  ],
+	id: 'free-pay-as-you-go',
+	name: 'Free Pay As You Go',
+	addOn: false,
+	autoEnable: false,
+	items: [
+		item({
+			featureId: executions.id,
+			included: 10000,
+			price: {
+				amount: 0.2,
+				billingUnits: 1000,
+				billingMethod: 'usage_based',
+				interval: 'month',
+			},
+		}),
+	],
 });
 
 export const team = plan({
-  id: "team",
-  name: "Team",
-  addOn: false,
-  autoEnable: false,
-  price: {
-    amount: 49,
-    interval: "month",
-  },
-  items: [
-    item({
-      featureId: members.id,
-      unlimited: true,
-    }),
-    item({
-      featureId: executions.id,
-      included: 250000,
-      price: {
-        amount: 0.2,
-        billingUnits: 1000,
-        billingMethod: "usage_based",
-        interval: "month",
-      },
-    }),
-    item({
-      featureId: domainVerification.id,
-    }),
-  ],
+	id: 'team',
+	name: 'Team',
+	addOn: false,
+	autoEnable: false,
+	price: {
+		amount: 49,
+		interval: 'month',
+	},
+	items: [
+		item({
+			featureId: executions.id,
+			included: 250000,
+			price: {
+				amount: 0.2,
+				billingUnits: 1000,
+				billingMethod: 'usage_based',
+				interval: 'month',
+			},
+		}),
+		item({
+			featureId: domainVerification.id,
+		}),
+	],
 });

--- a/autumn.config.ts
+++ b/autumn.config.ts
@@ -1,9 +1,9 @@
 import { feature, item, plan } from "atmn";
 
 // Features
-export const seats = feature({
-  id: "seats",
-  name: "Seats",
+export const members = feature({
+  id: "members",
+  name: "Members",
   type: "metered",
   consumable: false,
 });
@@ -21,89 +21,84 @@ export const domainVerification = feature({
   type: "boolean",
 });
 
+export const seats = feature({
+  id: "seats",
+  name: "Seats",
+  type: "metered",
+  consumable: false,
+  archived: true,
+});
+
 // Plans
 export const free = plan({
   id: "free",
   name: "Free",
+  addOn: false,
   autoEnable: true,
   items: [
     item({
+      featureId: members.id,
+      included: 3,
+    }),
+    item({
       featureId: executions.id,
-      included: 5000,
-      reset: { interval: "month" },
+      included: 10000,
+      reset: {
+        interval: "month",
+      },
     }),
   ],
 });
 
-export const hobby = plan({
-  id: "hobby",
-  name: "Hobby",
-  price: {
-    amount: 10,
-    interval: "month",
-  },
+export const freePayAsYouGo = plan({
+  id: "free-pay-as-you-go",
+  name: "Free Pay As You Go",
+  addOn: false,
+  autoEnable: false,
   items: [
     item({
-      featureId: seats.id,
-      included: 1,
-      price: {
-        amount: 10,
-        billingUnits: 1,
-        billingMethod: "usage_based",
-        interval: "month",
-      },
+      featureId: members.id,
+      included: 3,
     }),
     item({
       featureId: executions.id,
-      included: 50000,
-      reset: { interval: "month" },
+      included: 10000,
+      price: {
+        amount: 0.2,
+        billingUnits: 1000,
+        billingMethod: "usage_based",
+        interval: "month",
+      },
     }),
   ],
 });
 
-export const professional = plan({
-  id: "professional",
-  name: "Professional",
+export const team = plan({
+  id: "team",
+  name: "Team",
+  addOn: false,
+  autoEnable: false,
   price: {
-    amount: 40,
+    amount: 49,
     interval: "month",
   },
   items: [
     item({
-      featureId: seats.id,
-      included: 1,
-      price: {
-        amount: 40,
-        billingUnits: 1,
-        billingMethod: "usage_based",
-        interval: "month",
-      },
+      featureId: members.id,
+      unlimited: true,
     }),
     item({
       featureId: executions.id,
-      included: 100000,
-      reset: { interval: "month" },
+      included: 250000,
+      price: {
+        amount: 0.2,
+        billingUnits: 1000,
+        billingMethod: "usage_based",
+        interval: "month",
+      },
     }),
     item({
       featureId: domainVerification.id,
-    }),
-  ],
-});
-
-// Overage add-on
-export const executionTopUp = plan({
-  id: "execution-top-up",
-  name: "Execution Top-Up",
-  addOn: true,
-  items: [
-    item({
-      featureId: executions.id,
-      price: {
-        amount: 1,
-        billingUnits: 10000,
-        billingMethod: "prepaid",
-        interval: "month",
-      },
     }),
   ],
 });


### PR DESCRIPTION
## Summary

## Test plan

- [ ] /billing and /billing/plans render correctly on Free, Free PAYG, and Team
- [ ] Plan cards' buttons stay vertically aligned regardless of which plan has the \"Your plan\" / \"Canceling\" / \"Scheduled\" badge
- [ ] Slack CTA dialog: prefills email/name from signed-in user, submits, returns invite URL
- [ ] Slack CTA: empty / invalid email / missing turnstile token → expected 400s
- [ ] Slack CTA: server-side errors (e.g. ratelimit, name_taken) only show the generic client message
- [ ] Email link opens mailto:rhys@executor.sh
- [ ] After 6 rapid submissions in 60s, the 6th hits the global ratelimit and returns 429
- [ ] Privacy / terms pages render with updated copy

## Follow-ups (not in this PR)

- Replace dev Turnstile test keys with real prod sitekey + secret before public launch
- Consider Durable Object daily counter on top of the 5/min burst limit if abuse becomes a real signal
- Auto-archive empty Slack channels via cron after N days
- Manually delete archived `hobby`/`professional` plans from the Autumn prod dashboard if the clutter bothers you