### PR TITLE
Add changeset for CLI 1.4.13 release

### DIFF
--- a/.changeset/cli-optional-deps.md
+++ b/.changeset/cli-optional-deps.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Distribute platform binaries via npm `optionalDependencies` instead of a postinstall download from GitHub Releases. Each `executor-<plat>-<arch>` package publishes with `os`/`cpu` filters so npm/bun only fetches the matching binary. Postinstall is a fast-path symlink and always exits 0, with the launcher walking `node_modules` (and falling back between glibc/musl on Linux) at runtime — so blocked postinstalls (e.g. default `bun i -g`) are non-fatal. Adds `scripts/install.sh` for the no-node-at-all case.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -1,5 +1,8 @@
 ## Highlights
 
+### Platform binaries distributed via `optionalDependencies`
+The CLI now ships its native binary as one of several `executor-<plat>-<arch>` packages listed under `optionalDependencies`, the same pattern esbuild/swc/opencode use. npm and bun only fetch the matching binary, and there's no postinstall network call — `npm i -g executor` and `bun i -g executor` (which blocks postinstall by default) both work. For machines without node at all, install via `curl … install.sh | bash`.
+
 ### MCP sources honor upstream `destructiveHint`
 MCP sources now read `destructiveHint` from upstream tool annotations. Tools marked destructive will require approval before running, surfaced via MCP elicitation. Refresh existing sources (or remove + re-add) to pick up annotations on tools added before this change.
 


### PR DESCRIPTION
## Summary
- Patch bump for `executor` (1.4.12 → 1.4.13) covering #488 (platform binaries via `optionalDependencies`).
- Adds release-notes entry under Highlights for the new install path.

## Test plan
- [ ] Changesets bot picks up `.changeset/cli-optional-deps.md` and opens/updates the Version Packages PR after merge.