### PR TITLE
Drop release-notes archiving — single rolling next.md

### DIFF
--- a/.skills/cli-release/SKILL.md
+++ b/.skills/cli-release/SKILL.md
@@ -37,10 +37,11 @@ The owner doesn't want GitHub's auto-generated "PR title by @user" list. Release
 **`apps/cli/release-notes/next.md` is the canonical user-facing changelog.** Per-package workspace `CHANGELOG.md` files were removed in late 2026 — they were empty stubs and changesets does not regenerate them under `changelog: false`. Don't create them.
 
 ### How it's wired
-`apps/cli/src/release.ts:198` picks the notes file in this order:
-1. `apps/cli/release-notes/v<version>.md` (archived per release)
-2. `apps/cli/release-notes/next.md` (rolling draft)
-3. Fall back to `gh release create --generate-notes`
+`apps/cli/src/release.ts` reads `apps/cli/release-notes/next.md` and uses
+its contents as the GitHub Release body. If the file is missing or empty,
+falls back to `gh release create --generate-notes`. There's no
+per-version archive in the repo — historical release bodies live on
+GitHub Releases (durable, indexed, linkable).
 
 ### Writing conventions
 Structure release-notes files as:
@@ -83,12 +84,13 @@ Do not `Thanks` maintainers, bots, or the repo owner — the lint script rejects
 - The `.changeset/*.md` body can be a one-liner pointing at the release-notes section it expands; users read the GitHub release body, not the changeset.
 - Frontmatter is `"executor": patch` (or `minor`/`major` if owner says so).
 
-### Post-release archival (manual)
-After a release publishes, rename `apps/cli/release-notes/next.md` → `apps/cli/release-notes/v<version>.md` and commit on `main` (or in a small follow-up PR). This:
-- Preserves the historical notes file-by-version (matches `release.ts`'s preferred lookup path).
-- Resets `next.md` absence so the next cycle starts from a blank file — no chance of last release's content leaking into the next one.
-
-`release.ts` falls back to `next.md` if `v<version>.md` is missing, so skipping the rename won't break a publish; it just leaves stale content in `next.md` for the next release.
+### Starting a new release cycle
+There's no post-release rename step. When you start work on the next
+release, replace the existing `next.md` content with new entries — the
+previous cycle's content is already preserved on the matching `vX.Y.Z`
+GitHub Release page, so overwriting locally is safe. If `next.md` content
+looks stale (i.e. mentions features already shipped), that's the signal
+to clear it.
 
 ## Beta release flow
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -54,18 +54,19 @@ To pack the `@executor-js/*` library packages without publishing:
 
 ## Release notes
 
-User-facing release notes live in `apps/cli/release-notes/`:
+User-facing release notes live at `apps/cli/release-notes/next.md` —
+one rolling file. **This is the single source of truth users see.** Edit
+it whenever you ship a user-visible change.
 
-- `next.md` — rolling draft for the next release. **This is the single
-  source of truth users see.** Edit it whenever you ship a user-visible
-  change.
-- `v<version>.md` — archived per-release snapshots. After a release
-  publishes, rename `next.md` to `v<version>.md` so the next cycle starts
-  blank.
+`apps/cli/src/release.ts` reads `next.md` and uses its contents as the
+GitHub Release body. If the file is missing or empty it falls back to
+`gh release create --generate-notes` (auto-generated from PR titles).
 
-`apps/cli/src/release.ts` reads `v<tag>.md` first, falls back to
-`next.md`, and only invokes `gh release create --generate-notes` if both
-are absent.
+There's no per-version archive in the repo — historical release bodies
+live on GitHub Releases (durable, indexed, linkable). When you start a
+new release cycle, replace the existing `next.md` content with your new
+entries; the previous cycle's content is already preserved on the
+matching `vX.Y.Z` release page.
 
 ### Authoring rules
 

--- a/apps/cli/src/release.ts
+++ b/apps/cli/src/release.ts
@@ -195,13 +195,10 @@ const syncGitHubRelease = async (input: {
     return;
   }
 
-  const versionedNotes = resolve(cliRoot, "release-notes", `${input.tag}.md`);
-  const fallbackNotes = resolve(cliRoot, "release-notes", "next.md");
-  const notesFile = existsSync(versionedNotes)
-    ? versionedNotes
-    : existsSync(fallbackNotes)
-      ? fallbackNotes
-      : null;
+  // Single rolling release-notes file. Historical release bodies live on
+  // GitHub Releases — we don't archive per-version copies in the repo.
+  const notesPath = resolve(cliRoot, "release-notes", "next.md");
+  const notesFile = existsSync(notesPath) ? notesPath : null;
 
   const args = [
     "release",


### PR DESCRIPTION
## Summary

We were the outlier among CLIs in this space — opencode, codex, openclaw all manage release notes differently, and **none of them rename a draft file to a version-stamped one after each release**:
- **opencode**: generates GitHub Releases bodies from git log + AI at release time, nothing committed.
- **codex**: git-cliff over conventional commits, root `CHANGELOG.md` redirects to GitHub Releases.
- **openclaw**: appends to a single `CHANGELOG.md` with a `## Unreleased` section (no rename ritual).

The `next.md` → `v<version>.md` rename was easy to forget and didn't add value: historical release bodies are already preserved on GitHub Releases.

## Changes

- `apps/cli/src/release.ts` — drop the `v<tag>.md` lookup; only read `release-notes/next.md`. Fall back to `gh release --generate-notes` when missing.
- `RELEASING.md` — replace the rename-after-release instructions with "next.md is the single rolling file; replace its content when you start a new release cycle".
- `.skills/cli-release/SKILL.md` — same.

## Test plan

- [x] `bun run --cwd apps/cli typecheck` — clean
- [x] `bun run lint` — clean
- [ ] CI green

## Note on cycle hygiene

There's no automatic clearing of `next.md` after a release. The "is content stale?" check is left to whoever opens the next PR — if `next.md` mentions features already shipped, that's the signal to clear it. The previous cycle's content is preserved on the matching `vX.Y.Z` GitHub Release page, so overwriting locally is safe.

Could automate (workflow truncates `next.md` after a successful publish) — would do as follow-up if the manual pattern proves error-prone in practice.