### PR TITLE
Switch npm packaging to single-package + version-aliases (codex pattern)

### DIFF
--- a/.changeset/single-npm-package-aliases.md
+++ b/.changeset/single-npm-package-aliases.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Switch the npm packaging to a single-package + version-aliases shape (codex pattern). All platform variants now publish under one npm name (`executor`) with platform-tagged versions (`1.4.14-linux-x64`, `1.4.14-darwin-arm64`, ...), referenced from the wrapper's `optionalDependencies` via `npm:` alias specs. No new package names to claim or configure trusted publishing for.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -1,7 +1,9 @@
 ## Highlights
 
-### Platform binaries distributed via `optionalDependencies`
-The CLI now ships its native binary as one of several `executor-<plat>-<arch>` packages listed under `optionalDependencies`, the same pattern esbuild/swc/opencode use. npm and bun only fetch the matching binary, and there's no postinstall network call — `npm i -g executor` and `bun i -g executor` (which blocks postinstall by default) both work. For machines without node at all, install via `curl … install.sh | bash`.
+### Platform binaries distributed via `optionalDependencies` (codex-style)
+The CLI now ships its native binary via per-platform variants of the same `executor` npm package — one wrapper plus eight platform-tagged versions (`1.4.14-linux-x64`, `1.4.14-darwin-arm64`, ...) referenced from the wrapper's `optionalDependencies` via `npm:` alias specs. npm and bun only fetch the variant matching the current `os`/`cpu`, and there's no postinstall network call — `npm i -g executor` and `bun i -g executor` (which blocks postinstall by default) both work. For machines without node at all, install via `curl … install.sh | bash`.
+
+This shape (modeled on codex's `@openai/codex` packaging) means new platforms ship without claiming new npm names — one trusted-publishing config on the `executor` package covers everything. **1.4.13 was a partial release that only made it to GitHub Releases, not npm; 1.4.14 is the first release of this packaging on npm.**
 
 ### MCP sources honor upstream `destructiveHint`
 MCP sources now read `destructiveHint` from upstream tool annotations. Tools marked destructive will require approval before running, surfaced via MCP elicitation. Refresh existing sources (or remove + re-add) to pick up annotations on tools added before this change.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -1,9 +1,9 @@
 ## Highlights
 
-### Platform binaries distributed via `optionalDependencies` (codex-style)
-The CLI now ships its native binary via per-platform variants of the same `executor` npm package — one wrapper plus eight platform-tagged versions (`1.4.14-linux-x64`, `1.4.14-darwin-arm64`, ...) referenced from the wrapper's `optionalDependencies` via `npm:` alias specs. npm and bun only fetch the variant matching the current `os`/`cpu`, and there's no postinstall network call — `npm i -g executor` and `bun i -g executor` (which blocks postinstall by default) both work. For machines without node at all, install via `curl … install.sh | bash`.
+### Install paths fixed
+`npm i -g executor` and `bun i -g executor` both work cleanly on a fresh machine. For machines without node, `curl … install.sh | bash` does the same thing.
 
-This shape (modeled on codex's `@openai/codex` packaging) means new platforms ship without claiming new npm names — one trusted-publishing config on the `executor` package covers everything. **1.4.13 was a partial release that only made it to GitHub Releases, not npm; 1.4.14 is the first release of this packaging on npm.**
+> 1.4.13 was a partial release — it only made it to GitHub Releases, not npm. If you tried `npm i -g executor` and got 1.4.12, that's why. 1.4.14 is the first complete release.
 
 ### MCP sources honor upstream `destructiveHint`
 MCP sources now read `destructiveHint` from upstream tool annotations. Tools marked destructive will require approval before running, surfaced via MCP elicitation. Refresh existing sources (or remove + re-add) to pick up annotations on tools added before this change.

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -65,8 +65,15 @@ const ALL_TARGETS: Target[] = [
 
 const platformName = (t: Target) => (t.os === "win32" ? "windows" : t.os);
 
-const targetPackageName = (t: Target) =>
-  ["executor", platformName(t), t.arch, t.abi].filter(Boolean).join("-");
+/** Per-platform suffix used in dist directory names, npm dist-tags, and the
+ *  semver prerelease segment of variant package versions. e.g. "linux-x64",
+ *  "linux-x64-musl", "darwin-arm64". */
+const platformTag = (t: Target) =>
+  [platformName(t), t.arch, t.abi].filter(Boolean).join("-");
+
+/** Dist directory name (e.g. dist/executor-linux-x64). Only used as a build
+ *  artifact convention; the actual npm package name inside is `executor`. */
+const targetPackageName = (t: Target) => `executor-${platformTag(t)}`;
 
 const bunTargetKeys = [
   "linux-x64",
@@ -311,17 +318,25 @@ const buildBinaries = async (targets: Target[], mode: BuildMode) => {
         console.log(`  OK: ${version.trim()}`);
       }
 
-      // Platform package.json. No `bin` field on purpose — the wrapper's
-      // launcher walks node_modules to locate `bin/executor` directly. Adding
-      // a bin here would race with the wrapper for the global `executor`
-      // entry under flat installs.
+      // Variant package.json. All variants publish to the SAME npm package
+      // name (`executor`) under platform-tagged versions (e.g.
+      // `1.4.14-linux-x64`). The wrapper references each variant via an
+      // `npm:` alias in its optionalDependencies. This mirrors codex's
+      // pattern and avoids ever having to claim a new npm package name when
+      // a new platform is added — a single trusted-publishing config on the
+      // `executor` package covers everything.
+      //
+      // No `bin` field on purpose — the wrapper's launcher resolves the
+      // platform binary via require.resolve on the alias name and execs it.
+      const tag = platformTag(target);
+      const variantVersion = `${meta.version}-${tag}`;
       await writeFile(
         join(outDir, "package.json"),
         JSON.stringify(
           {
-            name,
-            version: meta.version,
-            description: `${meta.description} (${name})`,
+            name: meta.name,
+            version: variantVersion,
+            description: `${meta.description} (${tag})`,
             os: [target.os],
             cpu: [target.arch],
             homepage: meta.homepage,
@@ -334,7 +349,12 @@ const buildBinaries = async (targets: Target[], mode: BuildMode) => {
         ) + "\n",
       );
 
-      binaries[name] = meta.version;
+      // The local alias name (`executor-linux-x64`, ...) is what the
+      // wrapper's launcher passes to require.resolve at runtime. It's
+      // bound at install time by npm's `npm:executor@<variant-version>`
+      // alias spec in optionalDependencies.
+      const aliasName = `${meta.name}-${tag}`;
+      binaries[aliasName] = `npm:${meta.name}@${variantVersion}`;
     }
 
     return binaries;
@@ -376,8 +396,14 @@ const buildWrapperPackage = async (binaries: Record<string, string>) => {
         repository: meta.repository,
         license: meta.license,
         bin: { executor: "bin/executor" },
-        // Per-platform compiled binaries. npm/bun install only the entry
-        // matching the current os/cpu; everything else is a no-op.
+        // Per-platform compiled binaries published as platform-tagged
+        // versions of `executor` itself, referenced via npm:alias specs:
+        //   "executor-linux-x64": "npm:executor@1.4.14-linux-x64"
+        // npm/bun fetch only the variant matching the current os/cpu (set
+        // on each variant's package.json); everything else is a no-op.
+        // The local alias name on the left is what the launcher passes to
+        // require.resolve at runtime — npm puts the variant at
+        // `node_modules/executor-<plat>-<arch>/` so resolution just works.
         optionalDependencies: binaries,
         engines: {
           node: ">=20",
@@ -539,23 +565,45 @@ const publishPackedPackage = async (pkgDir: string, channel: string) => {
   }
 };
 
+/** Extract the platform-tag suffix from a variant version string.
+ *  e.g. "1.4.14-linux-x64" -> "linux-x64".
+ *  Variants get a per-platform npm dist-tag (not `latest` or `beta`) so
+ *  publishing them doesn't move the channel pointer. The wrapper alone
+ *  drives `latest`/`beta`. */
+const variantTagFromVersion = (version: string): string => {
+  const idx = version.indexOf("-");
+  if (idx === -1) {
+    throw new Error(
+      `Variant version missing platform-tag suffix (expected '<base>-<tag>'): ${version}`,
+    );
+  }
+  return version.slice(idx + 1);
+};
+
 const publish = async (channel: string) => {
   const meta = await readMetadata();
 
-  // Publish per-platform packages first so the wrapper's
-  // optionalDependencies resolve to packages that already exist on npm
-  // by the time anyone installs the wrapper.
+  // Variants publish first so the wrapper's optionalDependencies resolve.
+  // All variants and the wrapper publish to the same npm package
+  // (`executor`) — variants under platform-tagged versions, wrapper under
+  // the channel tag. Single trusted-publishing config covers everything.
   const platformDirs: string[] = [];
   for (const entry of new Bun.Glob("executor-*/package.json").scanSync({ cwd: distDir })) {
     platformDirs.push(join(distDir, dirname(entry)));
   }
   platformDirs.sort();
 
-  console.log(`Publishing ${platformDirs.length} platform package(s)...`);
-  await Promise.all(platformDirs.map((dir) => publishPackedPackage(dir, channel)));
+  console.log(`Publishing ${platformDirs.length} platform variant(s)...`);
+  await Promise.all(
+    platformDirs.map(async (dir) => {
+      const pkg = (await Bun.file(join(dir, "package.json")).json()) as { version: string };
+      const tag = variantTagFromVersion(pkg.version);
+      await publishPackedPackage(dir, tag);
+    }),
+  );
 
   const wrapperDir = join(distDir, meta.name);
-  console.log(`Publishing wrapper ${wrapperDir}...`);
+  console.log(`Publishing wrapper ${wrapperDir} under @${channel}...`);
   await publishPackedPackage(wrapperDir, channel);
 };
 
@@ -573,20 +621,23 @@ const ZIP_ASSET_SCRIPT = [
 ].join("\n");
 
 const createReleaseAssets = async () => {
+  // The dir name (e.g. "executor-linux-x64") still encodes the platform tag.
+  // Don't read `pkg.name` here — under the npm:alias pattern every variant's
+  // package.json has the same `name: "executor"`, so all assets would collide
+  // on the same filename.
   for (const entry of new Bun.Glob("executor-*/package.json").scanSync({ cwd: distDir })) {
-    const pkgDir = join(distDir, dirname(entry));
-    const pkg = await Bun.file(join(pkgDir, "package.json")).json();
-    const name = pkg.name as string;
+    const dirName = dirname(entry);
+    const pkgDir = join(distDir, dirName);
 
-    if (name.includes("linux")) {
-      await $`tar -czf ${join(distDir, `${name}.tar.gz`)} *`.cwd(join(pkgDir, "bin"));
+    if (dirName.includes("linux")) {
+      await $`tar -czf ${join(distDir, `${dirName}.tar.gz`)} *`.cwd(join(pkgDir, "bin"));
     } else {
-      await $`python3 -c ${ZIP_ASSET_SCRIPT} ${join(distDir, `${name}.zip`)}`.cwd(
+      await $`python3 -c ${ZIP_ASSET_SCRIPT} ${join(distDir, `${dirName}.zip`)}`.cwd(
         join(pkgDir, "bin"),
       );
     }
 
-    console.log(`Created release asset: ${name}`);
+    console.log(`Created release asset: ${dirName}`);
   }
 };
 


### PR DESCRIPTION
## Summary

The previous packaging treated each platform binary as its own npm package (`executor-linux-x64`, `executor-darwin-arm64`, ...). That worked under NPM_TOKEN auth but **breaks under trusted publishing the moment we introduce new platform names** — trusted publishing requires each package to be pre-claimed and configured per-package on npm.com, which can't happen in the same release that introduces them.

This is exactly why v1.4.13's npm publish failed: npm 404'd `PUT https://registry.npmjs.org/executor-darwin-arm64` because trusted publishing can't claim a brand-new name. v1.4.13 made it to GitHub Releases (binaries published) but never to npm (latest still 1.4.12).

Codex avoids this by publishing every platform binary as a different *version* of the **same** npm package, referenced via `npm:` alias specs from the wrapper. We adopt the same shape:

- All publishes target the npm package `executor`. The wrapper publishes at `1.4.x`; each variant publishes at `1.4.x-<platform-tag>` (e.g. `1.4.14-linux-x64`, `1.4.14-darwin-arm64`, ...) with `os`/`cpu` set on each.
- The wrapper's `optionalDependencies` use the npm:alias form:
  ```
  "executor-linux-x64": "npm:executor@1.4.14-linux-x64"
  ```
  The left side is the local install-name node uses for `require.resolve` at runtime; the right side is the real registry spec.
- Variants publish under per-platform npm dist-tags (`linux-x64`, `darwin-arm64`, ...) so they don't move `latest`/`beta`. The wrapper alone drives the channel pointer.
- One trusted-publishing config on `executor` covers everything — new platforms in the future require zero npm.com configuration.

## Build script changes (`apps/cli/src/build.ts`)

- New helper `platformTag(t)` returning just the `<os>-<arch>(-<abi>)` suffix; `targetPackageName(t)` still returns `executor-<tag>` for dist directory naming.
- `buildBinaries` writes variant `package.json` with `name: "executor"` and `version: "<base>-<tag>"`. The `binaries` map (passed to `buildWrapperPackage`) now contains alias-name → npm:alias-spec.
- `buildWrapperPackage` writes `optionalDependencies` as-is from `binaries` — same shape, just the values are now npm:alias specs.
- `publish()` derives a per-platform tag from the variant's version and passes it to `npm publish --tag` so each variant publishes under its platform tag. The wrapper publishes under the channel tag last.
- `createReleaseAssets` reads the dist DIR name (still `executor-<tag>`) rather than `pkg.name` (now uniformly `executor`), so per-platform tarballs/zips don't collide.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run lint:release-notes` — clean
- [x] `bun run --cwd apps/cli typecheck` — clean
- [x] `bun run test:release:bootstrap` — passes (smoke test layout unchanged; the local alias name `executor-linux-x64` is what npm puts in node_modules under both old and new schemes)
- [x] `bun run release:publish:dry-run` — produces all 9 packages and 8 per-platform release-asset archives with correct filenames
- [x] **Vercel sandbox end-to-end test:**
  - `bun install -g executor-linux-x64@<variant.tgz> <wrapper.tgz>` works (the originally-broken case)
  - `bun add` project-local with same syntax works
  - `executor --version` returns v1.4.13
  - `executor web` boots, `/api/executions` runs JS, tool invocation reaches the upstream mock OpenAPI server (full chain)
  - Verified `node_modules/executor-linux-x64/package.json` has `name: "executor"` (proves npm:alias correctly maps a local install name to a real-package version)
- [ ] CI green
- [ ] After merge: Version Packages PR opens with bump to 1.4.14, merge it, watch the publish workflow succeed (this time)

## Note on v1.4.13

1.4.13 was a partial release (only GitHub Releases, not npm). 1.4.14 is the first npm release of the new packaging. Curl-installer users on 1.4.13 are unaffected; npm-installer users will jump 1.4.12 → 1.4.14.

## Companion PR

#493 (notes-rolling) drops the `next.md` → `v<version>.md` archive ritual. Doesn't affect this change; mergeable in either order.