### PR TITLE
Restore CHANGELOG.md stubs — fix release.yml ENOENT

### DIFF
--- a/.skills/cli-release/SKILL.md
+++ b/.skills/cli-release/SKILL.md
@@ -34,7 +34,7 @@ Does **not** ship in the CLI:
 
 The owner doesn't want GitHub's auto-generated "PR title by @user" list. Release notes live at `apps/cli/release-notes/` and `apps/cli/src/release.ts` prefers them over `--generate-notes`.
 
-**`apps/cli/release-notes/next.md` is the canonical user-facing changelog.** Per-package workspace `CHANGELOG.md` files were removed in late 2026 — they were empty stubs and changesets does not regenerate them under `changelog: false`. Don't create them.
+**`apps/cli/release-notes/next.md` is the canonical user-facing changelog.** Per-package workspace `CHANGELOG.md` files are one-line stubs required by `changesets/action@v1` (the GitHub Action wrapping the CLI in `release.yml`) — it reads each bumped package's `CHANGELOG.md` to build the Version Packages PR description and crashes with `ENOENT` if any is missing. The stubs satisfy that read; don't put release content in them.
 
 ### How it's wired
 `apps/cli/src/release.ts` reads `apps/cli/release-notes/next.md` and uses

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -118,8 +118,11 @@ release-notes section it expands.
 - Changesets owns the published CLI version via `apps/cli/package.json`.
 - Only `apps/cli/package.json` should change during release versioning; the rest of the workspace is not version-synced for release PRs.
 - Changesets changelog file generation is disabled (`changelog: false`
-  in `.changeset/config.json`). Per-package `CHANGELOG.md` files used to
-  exist as compatibility stubs but were removed — changesets does not
-  recreate them with `changelog: false`.
+  in `.changeset/config.json`), but per-package `CHANGELOG.md` stubs are
+  still committed. The `changesets/action@v1` GitHub Action (the wrapper
+  around the CLI used in `release.yml`) reads each bumped package's
+  `CHANGELOG.md` to build the Version Packages PR description and crashes
+  with `ENOENT` if any are missing. The stubs satisfy that read; the
+  changesets CLI alone doesn't need them.
 - The publish workflow supports either npm trusted publishing or an `NPM_TOKEN` secret.
 - Re-running the publish workflow for the same tag is safe for packages that are already on npm; existing versions are skipped.

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,0 +1,5 @@
+# executor changelog
+
+This file exists so Changesets' release PR workflow can update package release metadata.
+
+Canonical user-facing release notes are published on GitHub Releases.

--- a/apps/cloud/CHANGELOG.md
+++ b/apps/cloud/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/cloud

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/desktop

--- a/apps/local/CHANGELOG.md
+++ b/apps/local/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/local

--- a/apps/marketing/CHANGELOG.md
+++ b/apps/marketing/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/marketing

--- a/examples/all-plugins/CHANGELOG.md
+++ b/examples/all-plugins/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/example-all-plugins changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/examples/promise-sdk/CHANGELOG.md
+++ b/examples/promise-sdk/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/example-promise-sdk

--- a/packages/core/api/CHANGELOG.md
+++ b/packages/core/api/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/api changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/cli/CHANGELOG.md
+++ b/packages/core/cli/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/cli changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/config/CHANGELOG.md
+++ b/packages/core/config/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/config changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/execution/CHANGELOG.md
+++ b/packages/core/execution/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/execution changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/sdk/CHANGELOG.md
+++ b/packages/core/sdk/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/core changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/storage-core/CHANGELOG.md
+++ b/packages/core/storage-core/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/storage-core changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/storage-drizzle/CHANGELOG.md
+++ b/packages/core/storage-drizzle/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/storage-drizzle changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/storage-file/CHANGELOG.md
+++ b/packages/core/storage-file/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/storage-file changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/core/storage-postgres/CHANGELOG.md
+++ b/packages/core/storage-postgres/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/storage-postgres

--- a/packages/hosts/mcp/CHANGELOG.md
+++ b/packages/hosts/mcp/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/host-mcp changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/kernel/core/CHANGELOG.md
+++ b/packages/kernel/core/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/codemode-core changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/kernel/ir/CHANGELOG.md
+++ b/packages/kernel/ir/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/ir changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/kernel/runtime-deno-subprocess/CHANGELOG.md
+++ b/packages/kernel/runtime-deno-subprocess/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/runtime-deno-subprocess changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/kernel/runtime-dynamic-worker/CHANGELOG.md
+++ b/packages/kernel/runtime-dynamic-worker/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/runtime-dynamic-worker

--- a/packages/kernel/runtime-quickjs/CHANGELOG.md
+++ b/packages/kernel/runtime-quickjs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/runtime-quickjs changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/file-secrets/CHANGELOG.md
+++ b/packages/plugins/file-secrets/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/plugin-file-secrets changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/google-discovery/CHANGELOG.md
+++ b/packages/plugins/google-discovery/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/plugin-google-discovery changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/graphql/CHANGELOG.md
+++ b/packages/plugins/graphql/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/plugin-graphql changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/keychain/CHANGELOG.md
+++ b/packages/plugins/keychain/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/plugin-keychain changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/mcp/CHANGELOG.md
+++ b/packages/plugins/mcp/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/plugin-mcp changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/onepassword/CHANGELOG.md
+++ b/packages/plugins/onepassword/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/plugin-onepassword changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/openapi/CHANGELOG.md
+++ b/packages/plugins/openapi/CHANGELOG.md
@@ -1,0 +1,4 @@
+# @executor-js/plugin-openapi changelog
+
+This file exists for Changesets release workflow compatibility.
+Canonical user-facing release notes are published on GitHub Releases.

--- a/packages/plugins/workos-vault/CHANGELOG.md
+++ b/packages/plugins/workos-vault/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/plugin-workos-vault

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/react


### PR DESCRIPTION
## Summary

Reverts the CHANGELOG.md deletions from #491. Restores 31 one-line stubs.

## Why

#491 deleted the empty workspace `CHANGELOG.md` files based on an empirical test that the changesets CLI didn't regenerate them. **That test only exercised the CLI.** The `changesets/action@v1` GitHub Action wrapping the CLI in `release.yml` also reads each bumped package's `CHANGELOG.md` to build the Version Packages PR description, and crashes with ENOENT when any is missing.

After #491 + #495 merged, the release workflow on `4d0709b7` failed with:

```
Error: ENOENT: no such file or directory, open '/home/runner/work/executor/executor/apps/cli/CHANGELOG.md'
    at file:///home/runner/work/_actions/changesets/action/v1/dist/index.js:61:49311
```

This blocks the Version Packages PR from opening, which blocks the 1.4.14 release.

## Changes

- Restore all 31 `CHANGELOG.md` stubs from `1eb32c86^`.
- `RELEASING.md` + `.skills/cli-release/SKILL.md` — explain why the stubs exist (required by `changesets/action@v1`, not by the CLI), so this regression doesn't recur.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run lint:release-notes` — clean
- [ ] After merge: `release.yml` succeeds and opens the Version Packages PR for 1.4.14