### PR TITLE
Serialize variant publishes; skip already-published on retry (codex pattern)

### DIFF
--- a/.changeset/serialize-variant-publishes.md
+++ b/.changeset/serialize-variant-publishes.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Serialize platform-variant npm publishes and skip already-published versions on retry. All variants target the same `executor` package; concurrent PUTs hit npm's 409 packument-conflict, and `npm view` propagation races meant the pre-check could miss a freshly-published version. Mirrors codex's `rust-release.yml` skip pattern.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -3,7 +3,7 @@
 ### Install paths fixed
 `npm i -g executor` and `bun i -g executor` both work cleanly on a fresh machine. For machines without node, `curl … install.sh | bash` does the same thing.
 
-> 1.4.13 was a partial release — it only made it to GitHub Releases, not npm. If you tried `npm i -g executor` and got 1.4.12, that's why. 1.4.14 is the first complete release.
+> 1.4.13 and 1.4.14 were partial releases that didn't make it to npm cleanly. If you tried `npm i -g executor@latest` and got an older version, that's why. 1.4.15 is the first complete release of the new packaging.
 
 ### MCP sources honor upstream `destructiveHint`
 MCP sources now read `destructiveHint` from upstream tool annotations. Tools marked destructive will require approval before running, surfaced via MCP elicitation. Refresh existing sources (or remove + re-add) to pick up annotations on tools added before this change.

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -550,6 +550,12 @@ const packageAlreadyPublished = async (pkgDir: string) => {
   return (await proc.exited) === 0;
 };
 
+/** Recognize npm error output for "this version already exists." Used to
+ *  make publish retries idempotent — if a previous workflow run got partway
+ *  through and crashed, we should skip what's already on the registry and
+ *  push the rest. Mirrors codex's `rust-release.yml` skip pattern. */
+const ALREADY_PUBLISHED_RE = /previously published|cannot publish over|version already exists/i;
+
 const publishPackedPackage = async (pkgDir: string, channel: string) => {
   if (await packageAlreadyPublished(pkgDir)) {
     console.log(`Skipping ${pkgDir}; package version already exists on npm.`);
@@ -558,11 +564,29 @@ const publishPackedPackage = async (pkgDir: string, channel: string) => {
 
   await $`bun pm pack`.cwd(pkgDir);
 
-  if (process.env.GITHUB_ACTIONS === "true") {
-    await $`npm publish *.tgz --access public --tag ${channel} --provenance`.cwd(pkgDir);
-  } else {
-    await $`npm publish *.tgz --access public --tag ${channel}`.cwd(pkgDir);
+  const provenance = process.env.GITHUB_ACTIONS === "true" ? ["--provenance"] : [];
+  const result =
+    await $`npm publish *.tgz --access public --tag ${channel} ${provenance}`
+      .cwd(pkgDir)
+      .nothrow()
+      .quiet();
+
+  const stdout = result.stdout.toString();
+  const stderr = result.stderr.toString();
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+
+  if (result.exitCode === 0) return;
+
+  // The pre-check via `npm view` has a propagation race — even when an
+  // earlier publish in this same run committed, `npm view` may 404 for a few
+  // seconds. Treat "already published" errors as success on retry.
+  if (ALREADY_PUBLISHED_RE.test(stderr) || ALREADY_PUBLISHED_RE.test(stdout)) {
+    console.log(`Skipping ${pkgDir}; npm reported version already published.`);
+    return;
   }
+
+  throw new Error(`npm publish failed for ${pkgDir} (exit ${result.exitCode})`);
 };
 
 /** Extract the platform-tag suffix from a variant version string.
@@ -593,14 +617,19 @@ const publish = async (channel: string) => {
   }
   platformDirs.sort();
 
+  // Publish variants sequentially. They all PUT to the same npm package
+  // (`executor`), and the registry rejects concurrent packument updates with
+  // 409 Conflict ("Failed to save packument. A common cause is if you try to
+  // publish a new package before the previous package has been fully
+  // processed.") — that's exactly what happened on v1.4.14's first attempt,
+  // where 3 of 8 raced through and the rest 409'd. Serial is plenty fast
+  // (~5s per variant × 8 ≈ 40s).
   console.log(`Publishing ${platformDirs.length} platform variant(s)...`);
-  await Promise.all(
-    platformDirs.map(async (dir) => {
-      const pkg = (await Bun.file(join(dir, "package.json")).json()) as { version: string };
-      const tag = variantTagFromVersion(pkg.version);
-      await publishPackedPackage(dir, tag);
-    }),
-  );
+  for (const dir of platformDirs) {
+    const pkg = (await Bun.file(join(dir, "package.json")).json()) as { version: string };
+    const tag = variantTagFromVersion(pkg.version);
+    await publishPackedPackage(dir, tag);
+  }
 
   const wrapperDir = join(distDir, meta.name);
   console.log(`Publishing wrapper ${wrapperDir} under @${channel}...`);


### PR DESCRIPTION
## Summary

v1.4.14's publish workflow ran but only **3 of 8 platform variants** made it onto npm — the wrapper never published, so `npm view executor@latest` still returns 1.4.12.

Two bugs in the publish flow, both fixed here by mirroring codex's `rust-release.yml` publish loop:

1. **Parallel publishes hit 409.** Variants were published via `Promise.all`. They all PUT to the same `executor` package, and npm rejects concurrent packument updates:
   ```
   npm error 409 Conflict - PUT https://registry.npmjs.org/executor
   Failed to save packument. A common cause is if you try to publish a new package
   before the previous package has been fully processed.
   ```
   Replaced with a serial `for...of` loop. Codex does the same in a single bash for-loop.

2. **`npm view` propagation race.** Even with serial publishes, `npm view <name>@<version>` can return 404 for a few seconds after a successful publish. The pre-check could let a publish through, then `npm publish` would reject with "version already exists". Catch that output and treat as success on retry — codex does the same with `grep -qiE "previously published|cannot publish over|version already exists"`.

Together these make the workflow safe to re-run after a partial failure.

## Bump to 1.4.15

Orphaned `1.4.14-*` variants on npm (`darwin-arm64`, `darwin-x64`, `linux-x64-musl`) are harmless and don't conflict with `1.4.15-*`. Skipping straight to 1.4.15 keeps the version line clean.

## Test plan

- [x] `bun run --cwd apps/cli typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run lint:release-notes` — clean
- [x] `bun run release:publish:dry-run` — produces all 9 packages + 8 platform release-asset archives
- [ ] CI green
- [ ] After merge: Version Packages PR → merge → publish workflow succeeds → `npm view executor@latest` returns 1.4.15