### PR TITLE
Fix source name persistence (#391)

### DIFF
--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -101,7 +101,7 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
                 ].join(" ")}
               >
                 <SourceFavicon url={s.url} />
-                <span className="flex-1 truncate">{s.name}</span>
+                <span className="flex-1 truncate" title={s.name}>{s.name}</span>
                 <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">
                   {s.kind}
                 </span>

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -719,7 +719,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           );
 
           const existing = yield* ctx.storage.getSource(namespace, scope);
-          const sourceName = manifest.server?.name ?? existing?.name ?? namespace;
+          const sourceName = existing?.name ?? manifest.server?.name ?? namespace;
 
           yield* ctx
             .transaction(
@@ -782,13 +782,24 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             ...(input.auth !== undefined ? { auth: input.auth } : {}),
             ...(input.queryParams !== undefined ? { queryParams: input.queryParams } : {}),
           };
+          const nextName = input.name?.trim() || existing.name;
 
-          yield* ctx.storage.putSource({
-            namespace,
-            scope,
-            name: input.name?.trim() || existing.name,
-            config: updatedConfig,
-          });
+          yield* ctx.transaction(
+            Effect.gen(function* () {
+              yield* ctx.storage.putSource({
+                namespace,
+                scope,
+                name: nextName,
+                config: updatedConfig,
+              });
+              yield* ctx.core.sources.update({
+                id: namespace,
+                scope,
+                name: nextName,
+                url: updatedConfig.endpoint,
+              });
+            }),
+          );
         }).pipe(
           Effect.withSpan("mcp.plugin.update_source", {
             attributes: { "mcp.source.namespace": namespace },


### PR DESCRIPTION
## Summary

Partial fix for #391 — three of the four reported problems:

- **Custom MCP source names get clobbered on refresh.** `refreshSource` was preferring the MCP server's manifest name over the user's saved name (`manifest.server?.name ?? existing?.name ?? namespace`). Flipped to `existing?.name ?? manifest.server?.name ?? namespace` so user renames survive a refresh.
- **Editing a source name doesn't update the sidebar/home page until full reload.** `updateSource` was writing to plugin storage but never updating the executor's in-memory source row. Added a `ctx.core.sources.update({ id, scope, name, url })` call inside the same `ctx.transaction` as the storage write so both stay in sync atomically.
- **Long source names get truncated in the cloud sidebar with no way to read them.** Added `title={s.name}` so the full name shows in a hover tooltip. (Resizable sidebar intentionally out of scope here.)

Still open from #391 (separate PR): secret label editing — there's no `update` handler in the secrets API today.

## Test plan

- [x] `bun run --cwd packages/plugins/mcp typecheck`
- [x] `bun run --cwd apps/cloud typecheck`
- [x] `bun run --cwd packages/plugins/mcp test` — 46/46 pass
- [ ] Manual: rename an MCP source, verify the sidebar updates without reload
- [ ] Manual: refresh a renamed source, verify the custom name is preserved
- [ ] Manual: hover a long source name in the sidebar, verify tooltip shows full name