### PR TITLE
Add secret/connection usages SDK surface

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1939,7 +1939,7 @@
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
-    "@rhyssul/portless": ["@rhyssul/portless@0.13.0", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-6Hc5jcNVmEmbQUK4YT6hGNxNbDob8ZrB6izFLxZOq8P9ExS6eeBJQA9J55K67unNGWOiA77xUaSBut3SzqcYgA=="],
+    "@rhyssul/portless": ["@rhyssul/portless@0.13.3", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-oPvwXJIIkRg2i1CUEUsz8sAdFSf0Fzzv+NmaacAsi6ZZTHxDOofbO6fGInVnbESIFOu4k8a/rXOZRF0aqLAUgw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
 

--- a/packages/core/api/src/connections/api.ts
+++ b/packages/core/api/src/connections/api.ts
@@ -3,7 +3,9 @@ import { Schema } from "effect";
 
 import {
   ConnectionId,
+  ConnectionInUseError,
   ScopeId,
+  Usage,
 } from "@executor-js/sdk";
 
 import { InternalError } from "../observability";
@@ -34,6 +36,8 @@ const ConnectionRefResponse = Schema.Struct({
 // Group
 // ---------------------------------------------------------------------------
 
+const ConnectionInUse = ConnectionInUseError.annotate({ httpApiStatus: 409 });
+
 export const ConnectionsApi = HttpApiGroup.make("connections")
   .add(
     HttpApiEndpoint.get("list", "/scopes/:scopeId/connections", {
@@ -46,6 +50,17 @@ export const ConnectionsApi = HttpApiGroup.make("connections")
     HttpApiEndpoint.delete("remove", "/scopes/:scopeId/connections/:connectionId", {
       params: ConnectionParams,
       success: Schema.Struct({ removed: Schema.Boolean }),
-      error: InternalError,
+      error: [InternalError, ConnectionInUse],
     }),
+  )
+  .add(
+    HttpApiEndpoint.get(
+      "usages",
+      "/scopes/:scopeId/connections/:connectionId/usages",
+      {
+        params: ConnectionParams,
+        success: Schema.Array(Usage),
+        error: InternalError,
+      },
+    ),
   );

--- a/packages/core/api/src/handlers/connections.ts
+++ b/packages/core/api/src/handlers/connections.ts
@@ -40,5 +40,13 @@ export const ConnectionsHandlers = HttpApiBuilder.group(
             return { removed: true };
           }),
         ),
+      )
+      .handle("usages", ({ params: path }) =>
+        capture(
+          Effect.gen(function* () {
+            const executor = yield* ExecutorService;
+            return yield* executor.connections.usages(path.connectionId);
+          }),
+        ),
       ),
 );

--- a/packages/core/api/src/handlers/secrets.ts
+++ b/packages/core/api/src/handlers/secrets.ts
@@ -51,5 +51,11 @@ export const SecretsHandlers = HttpApiBuilder.group(ExecutorApi, "secrets", (han
         yield* executor.secrets.remove(path.secretId);
         return { removed: true };
       })),
+    )
+    .handle("usages", ({ params: path }) =>
+      capture(Effect.gen(function* () {
+        const executor = yield* ExecutorService;
+        return yield* executor.secrets.usages(path.secretId);
+      })),
     ),
 );

--- a/packages/core/api/src/secrets/api.ts
+++ b/packages/core/api/src/secrets/api.ts
@@ -3,9 +3,11 @@ import { Schema } from "effect";
 import {
   ScopeId,
   SecretId,
+  SecretInUseError,
   SecretNotFoundError,
   SecretOwnedByConnectionError,
   SecretResolutionError,
+  Usage,
 } from "@executor-js/sdk";
 
 import { InternalError } from "../observability";
@@ -52,6 +54,7 @@ const SecretResolution = SecretResolutionError.annotate(
 const SecretOwnedByConnection = SecretOwnedByConnectionError.annotate(
   { httpApiStatus: 409 },
 );
+const SecretInUse = SecretInUseError.annotate({ httpApiStatus: 409 });
 
 // ---------------------------------------------------------------------------
 // Group
@@ -84,6 +87,13 @@ export const SecretsApi = HttpApiGroup.make("secrets")
     HttpApiEndpoint.delete("remove", "/scopes/:scopeId/secrets/:secretId", {
       params: SecretParams,
       success: Schema.Struct({ removed: Schema.Boolean }),
-      error: [InternalError, SecretNotFound, SecretOwnedByConnection],
+      error: [InternalError, SecretNotFound, SecretOwnedByConnection, SecretInUse],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("usages", "/scopes/:scopeId/secrets/:secretId/usages", {
+      params: SecretParams,
+      success: Schema.Array(Usage),
+      error: InternalError,
     }),
   );

--- a/packages/core/execution/src/promise.ts
+++ b/packages/core/execution/src/promise.ts
@@ -101,6 +101,7 @@ const wrapPromiseExecutor = (pe: PromiseExecutor): EffectExecutor => ({
     set: (input) => fromPromise(() => pe.secrets.set(input)),
     remove: (id) => fromPromise(() => pe.secrets.remove(id)),
     list: () => fromPromise(() => pe.secrets.list()),
+    usages: (id) => fromPromise(() => pe.secrets.usages(id)),
     providers: () => fromPromise(() => pe.secrets.providers()),
   },
   connections: {
@@ -111,6 +112,7 @@ const wrapPromiseExecutor = (pe: PromiseExecutor): EffectExecutor => ({
     setIdentityLabel: (id, label) => fromPromise(() => pe.connections.setIdentityLabel(id, label)),
     accessToken: (id) => fromPromise(() => pe.connections.accessToken(id)),
     remove: (id) => fromPromise(() => pe.connections.remove(id)),
+    usages: (id) => fromPromise(() => pe.connections.usages(id)),
     providers: () => fromPromise(() => pe.connections.providers()),
   },
   oauth: {

--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -98,6 +98,21 @@ export class SecretOwnedByConnectionError extends Schema.TaggedErrorClass<Secret
   },
 ) {}
 
+/** Raised when `secrets.remove(id)` is called on a secret that's still
+ *  referenced by one or more sources / bindings across plugins. The UI's
+ *  "Used by" list tells the user which sources to detach first. App-
+ *  level RESTRICT — the codebase doesn't enforce DB-level FKs because
+ *  composite `(scope_id, id)` PKs make single-column references
+ *  impossible to constrain in sqlite. `usageCount` is a hint for the
+ *  caller; the full list is queryable via `secrets.usages(id)`. */
+export class SecretInUseError extends Schema.TaggedErrorClass<SecretInUseError>()(
+  "SecretInUseError",
+  {
+    secretId: SecretId,
+    usageCount: Schema.Number,
+  },
+) {}
+
 // ---------------------------------------------------------------------------
 // Connections
 // ---------------------------------------------------------------------------
@@ -141,6 +156,16 @@ export class ConnectionReauthRequiredError extends Schema.TaggedErrorClass<Conne
   },
 ) {}
 
+/** Raised when `connections.remove(id)` is called on a connection that's
+ *  still referenced by sources / bindings. Mirrors `SecretInUseError`. */
+export class ConnectionInUseError extends Schema.TaggedErrorClass<ConnectionInUseError>()(
+  "ConnectionInUseError",
+  {
+    connectionId: ConnectionId,
+    usageCount: Schema.Number,
+  },
+) {}
+
 // ---------------------------------------------------------------------------
 // Union type for convenience in signatures.
 // ---------------------------------------------------------------------------
@@ -156,7 +181,9 @@ export type ExecutorError =
   | SecretNotFoundError
   | SecretResolutionError
   | SecretOwnedByConnectionError
+  | SecretInUseError
   | ConnectionNotFoundError
   | ConnectionProviderNotRegisteredError
   | ConnectionRefreshNotSupportedError
-  | ConnectionReauthRequiredError;
+  | ConnectionReauthRequiredError
+  | ConnectionInUseError;

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -44,12 +44,14 @@ import {
   type ElicitationRequest,
 } from "./elicitation";
 import {
+  ConnectionInUseError,
   ConnectionNotFoundError,
   ConnectionProviderNotRegisteredError,
   ConnectionReauthRequiredError,
   ConnectionRefreshNotSupportedError,
   NoHandlerError,
   PluginNotLoadedError,
+  SecretInUseError,
   SecretOwnedByConnectionError,
   SourceRemovalNotAllowedError,
   ToolBlockedError,
@@ -84,6 +86,7 @@ import {
   SetSecretInput,
   type SecretProvider,
 } from "./secrets";
+import { Usage } from "./usages";
 import {
   ToolSchema,
   type Source,
@@ -211,11 +214,22 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
     ) => Effect.Effect<SecretRef, StorageFailure>;
     /** Delete a bare (non-connection-owned) secret. Connection-owned
      *  secrets are rejected with `SecretOwnedByConnectionError` — use
-     *  `connections.remove` instead. */
+     *  `connections.remove` instead. Refuses with `SecretInUseError`
+     *  if any plugin reports the secret as in use; the caller should
+     *  show the `usages(id)` list and ask the user to detach first. */
     readonly remove: (
       id: string,
-    ) => Effect.Effect<void, SecretOwnedByConnectionError | StorageFailure>;
+    ) => Effect.Effect<
+      void,
+      SecretOwnedByConnectionError | SecretInUseError | StorageFailure
+    >;
     readonly list: () => Effect.Effect<readonly SecretRef[], StorageFailure>;
+    /** All places this secret is referenced — fans out across every
+     *  plugin's `usagesForSecret`. Used by the Secrets-tab "Used by"
+     *  list and by `remove` for its RESTRICT check. */
+    readonly usages: (
+      id: string,
+    ) => Effect.Effect<readonly Usage[], StorageFailure>;
     readonly providers: () => Effect.Effect<readonly string[]>;
   };
 
@@ -251,7 +265,16 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
       | ConnectionRefreshError
       | StorageFailure
     >;
-    readonly remove: (id: string) => Effect.Effect<void, StorageFailure>;
+    /** Refuses with `ConnectionInUseError` if any plugin reports the
+     *  connection as in use. */
+    readonly remove: (
+      id: string,
+    ) => Effect.Effect<void, ConnectionInUseError | StorageFailure>;
+    /** All places this connection is referenced — fans out across every
+     *  plugin's `usagesForConnection`. */
+    readonly usages: (
+      id: string,
+    ) => Effect.Effect<readonly Usage[], StorageFailure>;
     readonly providers: () => Effect.Effect<readonly string[]>;
   };
 
@@ -945,9 +968,69 @@ export const createExecutor = <
         });
       });
 
+    // Fan out across every plugin that contributes `usagesForSecret`. Each
+    // plugin queries its own normalized columns through its scoped adapter,
+    // so scope filtering is automatic. We swallow per-plugin errors to a
+    // logWarning rather than letting one buggy plugin take out the whole
+    // call — usage queries should never block the user.
+    const secretsUsages = (
+      id: string,
+    ): Effect.Effect<readonly Usage[], StorageFailure> =>
+      Effect.gen(function* () {
+        const secretId = SecretId.make(id);
+        const perPlugin = yield* Effect.all(
+          [...runtimes.values()]
+            .filter((r) => r.plugin.usagesForSecret)
+            .map((r) =>
+              r.plugin.usagesForSecret!({
+                ctx: r.ctx,
+                args: { secretId },
+              }).pipe(
+                Effect.catchCause((cause: unknown) =>
+                  Effect.logWarning(
+                    `usagesForSecret failed for plugin ${r.plugin.id}`,
+                    cause,
+                  ).pipe(Effect.as([] as readonly Usage[])),
+                ),
+              ),
+            ),
+          { concurrency: "unbounded" },
+        );
+        return perPlugin.flat();
+      });
+
+    const connectionsUsages = (
+      id: string,
+    ): Effect.Effect<readonly Usage[], StorageFailure> =>
+      Effect.gen(function* () {
+        const connectionId = ConnectionId.make(id);
+        const perPlugin = yield* Effect.all(
+          [...runtimes.values()]
+            .filter((r) => r.plugin.usagesForConnection)
+            .map((r) =>
+              r.plugin.usagesForConnection!({
+                ctx: r.ctx,
+                args: { connectionId },
+              }).pipe(
+                Effect.catchCause((cause: unknown) =>
+                  Effect.logWarning(
+                    `usagesForConnection failed for plugin ${r.plugin.id}`,
+                    cause,
+                  ).pipe(Effect.as([] as readonly Usage[])),
+                ),
+              ),
+            ),
+          { concurrency: "unbounded" },
+        );
+        return perPlugin.flat();
+      });
+
     const secretsRemove = (
       id: string,
-    ): Effect.Effect<void, SecretOwnedByConnectionError | StorageFailure> =>
+    ): Effect.Effect<
+      void,
+      SecretOwnedByConnectionError | SecretInUseError | StorageFailure
+    > =>
       Effect.gen(function* () {
         // Remove is shadowing-aware: drop only the innermost-scope row.
         // Removing a user-scope override on a secret that also has an
@@ -970,6 +1053,20 @@ export const createExecutor = <
               connectionId: ConnectionId.make(
                 target.owned_by_connection_id as string,
               ),
+            }),
+          );
+        }
+        // RESTRICT: refuse if any source/binding still references this
+        // secret. App-level FK enforcement — sqlite can't enforce a real
+        // FK on the composite-PK `secret` table from a single column.
+        // Caller's UI shows `usages(id)` so the user knows what to detach
+        // before retrying.
+        const usages = yield* secretsUsages(id);
+        if (usages.length > 0) {
+          return yield* Effect.fail(
+            new SecretInUseError({
+              secretId: SecretId.make(id),
+              usageCount: usages.length,
             }),
           );
         }
@@ -1488,10 +1585,21 @@ export const createExecutor = <
 
     const connectionsRemove = (
       id: string,
-    ): Effect.Effect<void, StorageFailure> =>
+    ): Effect.Effect<void, ConnectionInUseError | StorageFailure> =>
       Effect.gen(function* () {
         const row = yield* findInnermostConnectionRow(id);
         if (!row) return;
+        // RESTRICT: refuse if any source/binding still references the
+        // connection. Same rationale as `secretsRemove`.
+        const usages = yield* connectionsUsages(id);
+        if (usages.length > 0) {
+          return yield* Effect.fail(
+            new ConnectionInUseError({
+              connectionId: ConnectionId.make(id),
+              usageCount: usages.length,
+            }),
+          );
+        }
         const scope = row.scope_id as string;
         yield* adapter.transaction(() =>
           Effect.gen(function* () {
@@ -2800,6 +2908,7 @@ export const createExecutor = <
         set: secretsSet,
         remove: secretsRemove,
         list: secretsList,
+        usages: secretsUsages,
         providers: () =>
           Effect.sync(
             () => Array.from(secretProviders.keys()) as readonly string[],
@@ -2813,6 +2922,7 @@ export const createExecutor = <
         setIdentityLabel: connectionsSetIdentityLabel,
         accessToken: connectionsAccessToken,
         remove: connectionsRemove,
+        usages: connectionsUsages,
         providers: () =>
           Effect.sync(
             () =>

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -55,10 +55,12 @@ export {
   SecretNotFoundError,
   SecretResolutionError,
   SecretOwnedByConnectionError,
+  SecretInUseError,
   ConnectionNotFoundError,
   ConnectionProviderNotRegisteredError,
   ConnectionRefreshNotSupportedError,
   ConnectionReauthRequiredError,
+  ConnectionInUseError,
   type ExecutorError,
 } from "./errors";
 
@@ -117,6 +119,13 @@ export {
   resolveSecretBackedMap,
   type ResolveSecretBackedMapOptions,
 } from "./secret-backed-value";
+
+// Usage tracking — secret/connection refs across plugins
+export {
+  Usage,
+  type UsagesForSecretInput,
+  type UsagesForConnectionInput,
+} from "./usages";
 
 // Connections
 export {

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -29,15 +29,18 @@ import type {
   ElicitationResponse,
 } from "./elicitation";
 import type {
+  ConnectionInUseError,
   ConnectionNotFoundError,
   ConnectionProviderNotRegisteredError,
   ConnectionReauthRequiredError,
   ConnectionRefreshNotSupportedError,
+  SecretInUseError,
   SecretOwnedByConnectionError,
 } from "./errors";
 import type { OAuthService } from "./oauth";
 import type { Scope } from "./scope";
 import type { SecretProvider, SecretRef, SetSecretInput } from "./secrets";
+import type { Usage, UsagesForConnectionInput, UsagesForSecretInput } from "./usages";
 
 // ---------------------------------------------------------------------------
 // StorageDeps — backing passed to a plugin's `storage` factory. The only
@@ -160,10 +163,15 @@ export interface PluginCtx<TStore = unknown> {
     /** Delete a secret from its pinned provider and the core table.
      *  Rejects with `SecretOwnedByConnectionError` if the row is owned
      *  by a connection — callers must go through `connections.remove`
-     *  to drop the whole sign-in. */
+     *  to drop the whole sign-in. Rejects with `SecretInUseError` if
+     *  any plugin reports the secret as in use; the caller should ask
+     *  the user to detach the listed sources first. */
     readonly remove: (
       id: string,
-    ) => Effect.Effect<void, SecretOwnedByConnectionError | StorageFailure>;
+    ) => Effect.Effect<
+      void,
+      SecretOwnedByConnectionError | SecretInUseError | StorageFailure
+    >;
   };
 
   /** Connections — product-level sign-in state. Owns backing secret
@@ -206,7 +214,12 @@ export interface PluginCtx<TStore = unknown> {
       | ConnectionRefreshError
       | StorageFailure
     >;
-    readonly remove: (id: string) => Effect.Effect<void, StorageFailure>;
+    /** Refuses with `ConnectionInUseError` if any plugin reports the
+     *  connection as in use. Caller surfaces the `usages` list to the
+     *  user. */
+    readonly remove: (
+      id: string,
+    ) => Effect.Effect<void, ConnectionInUseError | StorageFailure>;
   };
 
   /** Shared OAuth service. Plugins use this to probe/start/complete OAuth
@@ -445,6 +458,26 @@ export interface PluginSpec<
     readonly sourceId: string;
     readonly toolRows: readonly ToolRow[];
   }) => Effect.Effect<Record<string, ToolAnnotations>, unknown>;
+
+  /** Find every place a secret id is referenced by this plugin's stored
+   *  rows. Implementations query their normalized columns (e.g.
+   *  `WHERE secret_id = $1`) and return one `Usage` per hit, with
+   *  `ownerKind` / `slot` tagging the location. The executor fans out
+   *  across all plugins and the result powers the Secrets-tab "Used
+   *  by" list and the deletion-blocking check in `secrets.remove`.
+   *
+   *  Plugins that never store secret refs (secret-provider-only
+   *  plugins like keychain / file-secrets / 1password) omit this. */
+  readonly usagesForSecret?: (input: {
+    readonly ctx: PluginCtx<TStore>;
+    readonly args: UsagesForSecretInput;
+  }) => Effect.Effect<readonly Usage[], unknown>;
+
+  /** Same shape as `usagesForSecret`, but for connection refs. */
+  readonly usagesForConnection?: (input: {
+    readonly ctx: PluginCtx<TStore>;
+    readonly args: UsagesForConnectionInput;
+  }) => Effect.Effect<readonly Usage[], unknown>;
 
   /** Called when `executor.sources.remove(id)` targets a source owned
    *  by this plugin. Plugin-side cleanup only; the executor deletes

--- a/packages/core/sdk/src/usages.ts
+++ b/packages/core/sdk/src/usages.ts
@@ -1,0 +1,42 @@
+import { Schema } from "effect";
+
+import { ScopeId, SecretId, ConnectionId } from "./ids";
+
+// ---------------------------------------------------------------------------
+// Usage — one row per place a secret or connection is referenced. Each
+// plugin contributes its own usages via `usagesForSecret` /
+// `usagesForConnection`; the executor fans out and concatenates.
+//
+// `pluginId` identifies the plugin that owns the reference. `ownerKind`
+// is plugin-defined (e.g. "openapi-source-oauth2", "mcp-source-auth",
+// "graphql-source-header"); the UI groups by it for a "used in N
+// sources / M bindings" summary. `slot` describes which field within
+// the owner holds the ref ("oauth2.client_secret", "header:Authorization",
+// "binding:value") so the user can locate it.
+//
+// `ownerName` is resolved by JOIN at query time from the parent source /
+// binding row. It's nullable because a plugin may have an owner that has
+// no human-readable name (e.g. an unnamed binding row).
+//
+// `scopeId` is the scope the owner row lives in — plugins query through
+// their scoped adapter (which auto-filters by `scope_id IN (stack)`), so
+// usages from outer scopes naturally surface alongside inner ones; the
+// UI uses the scope to render a per-scope label next to each entry.
+// ---------------------------------------------------------------------------
+
+export class Usage extends Schema.Class<Usage>("Usage")({
+  pluginId: Schema.String,
+  scopeId: ScopeId,
+  ownerKind: Schema.String,
+  ownerId: Schema.String,
+  ownerName: Schema.NullOr(Schema.String),
+  slot: Schema.String,
+}) {}
+
+export interface UsagesForSecretInput {
+  readonly secretId: SecretId;
+}
+
+export interface UsagesForConnectionInput {
+  readonly connectionId: ConnectionId;
+}

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -1,4 +1,10 @@
-import { PolicyId, type ScopeId, type ToolId, type SecretId } from "@executor-js/sdk";
+import {
+  PolicyId,
+  type ConnectionId,
+  type ScopeId,
+  type SecretId,
+  type ToolId,
+} from "@executor-js/sdk";
 import * as Atom from "effect/unstable/reactivity/Atom";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
@@ -70,6 +76,34 @@ export const connectionsAtom = (scopeId: ScopeId) =>
     params: { scopeId },
     timeToLive: "30 seconds",
     reactivityKeys: [ReactivityKey.connections],
+  });
+
+export const secretUsagesAtom = (scopeId: ScopeId, secretId: SecretId) =>
+  ExecutorApiClient.query("secrets", "usages", {
+    params: { scopeId, secretId },
+    timeToLive: "30 seconds",
+    // Refresh whenever any source / connection / secret changes — adding
+    // an oauth source pulls in a new connection-secret link and we want
+    // the usage list to reflect it.
+    reactivityKeys: [
+      ReactivityKey.secrets,
+      ReactivityKey.sources,
+      ReactivityKey.connections,
+    ],
+  });
+
+export const connectionUsagesAtom = (
+  scopeId: ScopeId,
+  connectionId: ConnectionId,
+) =>
+  ExecutorApiClient.query("connections", "usages", {
+    params: { scopeId, connectionId },
+    timeToLive: "30 seconds",
+    reactivityKeys: [
+      ReactivityKey.connections,
+      ReactivityKey.sources,
+      ReactivityKey.secrets,
+    ],
   });
 
 export const policiesAtom = (scopeId: ScopeId) =>

--- a/packages/react/src/pages/connections.tsx
+++ b/packages/react/src/pages/connections.tsx
@@ -1,9 +1,10 @@
-import { useAtomSet } from "@effect/atom-react";
+import { Suspense } from "react";
+import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { ConnectionId } from "@executor-js/sdk";
+import { ConnectionId, type ScopeId } from "@executor-js/sdk";
 import { toast } from "sonner";
 
-import { removeConnection } from "../api/atoms";
+import { connectionUsagesAtom, removeConnection } from "../api/atoms";
 import { useConnectionsWithPendingRemovals, usePendingConnectionRemovals } from "../api/optimistic";
 import { connectionWriteKeys } from "../api/reactivity-keys";
 import { useScope, useScopeStack } from "../hooks/use-scope";
@@ -51,10 +52,44 @@ const connectionScopeLabel = (
 };
 
 // ---------------------------------------------------------------------------
+// Used-by footer — same shape as the secrets page. Returns null when a
+// connection isn't referenced anywhere so newly-created connections
+// don't get a stray "Used by 0" line before any source binds to them.
+// ---------------------------------------------------------------------------
+
+function ConnectionUsageFooter(props: {
+  scopeId: ScopeId;
+  connectionId: ConnectionId;
+}) {
+  const usages = useAtomValue(
+    connectionUsagesAtom(props.scopeId, props.connectionId),
+  );
+  return AsyncResult.match(usages, {
+    onInitial: () => null,
+    onFailure: () => null,
+    onSuccess: ({ value }) => {
+      if (value.length === 0) return null;
+      const labels = value
+        .map((u) => u.ownerName ?? u.ownerId)
+        .filter((s, i, a) => a.indexOf(s) === i);
+      const visible = labels.slice(0, 3);
+      const hidden = labels.length - visible.length;
+      return (
+        <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
+          Used by {visible.join(", ")}
+          {hidden > 0 ? ` +${hidden} more` : ""}
+        </CardStackEntryDescription>
+      );
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Connection row
 // ---------------------------------------------------------------------------
 
 function ConnectionRow(props: {
+  scopeId: ScopeId;
   connection: {
     id: string;
     scopeId: string;
@@ -80,6 +115,12 @@ function ConnectionRow(props: {
         <CardStackEntryDescription className="text-xs text-muted-foreground">
           {displayProvider(connection.provider)}
         </CardStackEntryDescription>
+        <Suspense fallback={null}>
+          <ConnectionUsageFooter
+            scopeId={props.scopeId}
+            connectionId={ConnectionId.make(connection.id)}
+          />
+        </Suspense>
       </CardStackEntryContent>
       <CardStackEntryActions>
         <Badge variant="outline">{scopeLabel}</Badge>
@@ -185,6 +226,7 @@ export function ConnectionsPage() {
                     }) => (
                       <ConnectionRow
                         key={c.id}
+                        scopeId={scopeId}
                         connection={{
                           id: c.id,
                           scopeId: c.scopeId,

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -1,10 +1,10 @@
 import { useMemo, useState, Suspense } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { secretsAtom, removeSecret } from "../api/atoms";
+import { secretsAtom, secretUsagesAtom, removeSecret } from "../api/atoms";
 import { secretWriteKeys } from "../api/reactivity-keys";
 import { useSecretProviderPlugins } from "@executor-js/sdk/client";
-import { SecretId } from "@executor-js/sdk";
+import { SecretId, type ScopeId } from "@executor-js/sdk";
 import { SecretForm } from "../plugins/secret-form";
 import { useScope } from "../hooks/use-scope";
 import {
@@ -123,10 +123,43 @@ function AddSecretDialogContent(props: {
 }
 
 // ---------------------------------------------------------------------------
+// Used-by footer — fetched per-secret. Keeps the list compact: shows the
+// count plus the first few owner names, with a "+N more" tail. Empty
+// state collapses to nothing so secrets that aren't referenced anywhere
+// don't get a noisy "Used by 0" line.
+// ---------------------------------------------------------------------------
+
+function SecretUsageFooter(props: {
+  scopeId: ScopeId;
+  secretId: SecretId;
+}) {
+  const usages = useAtomValue(secretUsagesAtom(props.scopeId, props.secretId));
+  return AsyncResult.match(usages, {
+    onInitial: () => null,
+    onFailure: () => null,
+    onSuccess: ({ value }) => {
+      if (value.length === 0) return null;
+      const labels = value
+        .map((u) => u.ownerName ?? u.ownerId)
+        .filter((s, i, a) => a.indexOf(s) === i);
+      const visible = labels.slice(0, 3);
+      const hidden = labels.length - visible.length;
+      return (
+        <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
+          Used by {visible.join(", ")}
+          {hidden > 0 ? ` +${hidden} more` : ""}
+        </CardStackEntryDescription>
+      );
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Secret row
 // ---------------------------------------------------------------------------
 
 function SecretRow(props: {
+  scopeId: ScopeId;
   showProvider: boolean;
   secret: { id: string; name: string; provider?: string };
   onRemove: () => void;
@@ -147,6 +180,12 @@ function SecretRow(props: {
             {secret.id}
           </span>
         </CardStackEntryTitle>
+        <Suspense fallback={null}>
+          <SecretUsageFooter
+            scopeId={props.scopeId}
+            secretId={SecretId.make(secret.id)}
+          />
+        </Suspense>
       </CardStackEntryContent>
       <CardStackEntryActions>
         {showProvider && secret.provider && <Badge variant="outline">{secret.provider}</Badge>}
@@ -306,6 +345,7 @@ export function SecretsPage(props: {
                     }) => (
                       <SecretRow
                         key={s.id}
+                        scopeId={scopeId}
                         showProvider={showProviderInfo}
                         secret={{
                           id: s.id,


### PR DESCRIPTION
## Summary

- Plugins gain optional `usagesForSecret` / `usagesForConnection` callbacks. The executor fans out across them via `executor.secrets.usages(id)` / `executor.connections.usages(id)`, returning a flat list of `Usage` rows that describe where a given secret or connection is referenced.
- `secrets.remove` / `connections.remove` are now RESTRICT — they refuse with `SecretInUseError` / `ConnectionInUseError` when any plugin reports the id as in use, surfacing the count to the caller.
- API exposes `GET /scopes/:scopeId/secrets/:secretId/usages` and the connection equivalent. React atoms + a "Used by …" footer on each row in the Secrets and Connections tabs round out the surface.

No plugin implements `usagesFor*` yet, so the footer is empty everywhere and remove still succeeds for everything. This is the foundation for follow-up commits that move secret/connection refs out of plugin-private JSON columns into normalized columns/child tables; once those land, the footer populates and remove starts blocking real usages.

## Test plan
- [x] `bunx --bun turbo typecheck --filter='!@executor-js/local'` — 33/33 packages clean
- [x] `bunx --bun vitest run` in the SDK package — 172/172 pass
- [ ] Manual: open Secrets and Connections tabs in the local app, confirm rows render unchanged (no usage rows yet)