### PR TITLE
Handle invited users on first sign-in

### DIFF
--- a/apps/cloud/src/auth/api.ts
+++ b/apps/cloud/src/auth/api.ts
@@ -43,9 +43,38 @@ const CreateOrganizationResponse = Schema.Struct({
   name: Schema.String,
 });
 
+// `state` is optional — some WorkOS-initiated redirects arrive at the
+// callback without the state we set on /auth/login. The CSRF check is
+// only enforced when state is present (see callback handler).
 const AuthCallbackSearch = Schema.Struct({
   code: Schema.String,
-  state: Schema.String,
+  state: Schema.optional(Schema.String),
+});
+
+const PendingInvitationInviter = Schema.Struct({
+  email: Schema.String,
+  name: Schema.NullOr(Schema.String),
+});
+
+const PendingInvitation = Schema.Struct({
+  id: Schema.String,
+  organizationId: Schema.String,
+  organizationName: Schema.String,
+  createdAt: Schema.String,
+  inviter: Schema.NullOr(PendingInvitationInviter),
+});
+
+const PendingInvitationsResponse = Schema.Struct({
+  invitations: Schema.Array(PendingInvitation),
+});
+
+const AcceptInvitationBody = Schema.Struct({
+  invitationId: Schema.String,
+});
+
+const AcceptInvitationResponse = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
 });
 
 export const AUTH_PATHS = {
@@ -92,6 +121,19 @@ export class CloudAuthApi extends HttpApiGroup.make("cloudAuth")
     HttpApiEndpoint.post("createOrganization", "/auth/create-organization", {
       payload: CreateOrganizationBody,
       success: CreateOrganizationResponse,
+      error: AuthErrors,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("pendingInvitations", "/auth/pending-invitations", {
+      success: PendingInvitationsResponse,
+      error: WorkOSError,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.post("acceptInvitation", "/auth/accept-invitation", {
+      payload: AcceptInvitationBody,
+      success: AcceptInvitationResponse,
       error: AuthErrors,
     }),
   )

--- a/apps/cloud/src/auth/handlers.node.test.ts
+++ b/apps/cloud/src/auth/handlers.node.test.ts
@@ -7,6 +7,7 @@ import type { Effect as EffectType } from "effect/Effect";
 import { CloudAuthPublicApi } from "./api";
 import { CloudAuthPublicHandlers } from "./handlers";
 import { UserStoreService } from "./context";
+import { WorkOSError } from "./errors";
 import { WorkOSAuth } from "./workos";
 
 const TestAuthPublicApi = HttpApi.make("cloudWeb").add(CloudAuthPublicApi);
@@ -108,6 +109,33 @@ describe("Auth callback handlers", () => {
     }),
   );
 
+  // Some WorkOS-initiated redirects don't include a state parameter.
+  // The schema treats state as optional; the handler skips the CSRF
+  // check when state is absent and proceeds with the code exchange.
+  it.effect("accepts a callback without state", () =>
+    Effect.gen(function* () {
+      const fetch = makeAuthFetch({
+        authenticateWithCode: () =>
+          Effect.succeed({
+            user: fakeUser,
+            accessToken: "access_token",
+            refreshToken: "refresh_token",
+            organizationId: "org_1",
+            sealedSession: "sealed_session_no_state",
+          } satisfies AuthenticateWithCodeResult),
+      });
+
+      const response = yield* Effect.promise(() =>
+        fetch(new Request("http://test.local/auth/callback?code=stateless-code")),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/");
+      const setCookie = response.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("wos-session=sealed_session_no_state");
+    }),
+  );
+
   it.effect("sets the session cookie and clears login state on matching callback state", () =>
     Effect.gen(function* () {
       const fetch = makeAuthFetch({
@@ -136,6 +164,95 @@ describe("Auth callback handlers", () => {
       expect(setCookie).toContain("Max-Age=604800");
       expect(setCookie).toContain("wos-login-state=");
       expect(setCookie).toContain("Max-Age=0");
+    }),
+  );
+
+  // Regression: an invited user signing in for the first time has only a
+  // *pending* membership (the WorkOS-side representation of an unaccepted
+  // invitation). The callback used to pick `data[0]` regardless of status
+  // and call refreshSession into that org, which 400s and surfaces as
+  // WorkOSError → 500. We now skip pending memberships entirely.
+  it.effect("does not refresh into a pending membership; leaves session org-less", () =>
+    Effect.gen(function* () {
+      let refreshCalls = 0;
+      const fetch = makeAuthFetch({
+        authenticateWithCode: () =>
+          Effect.succeed({
+            user: fakeUser,
+            accessToken: "access_token",
+            refreshToken: "refresh_token",
+            sealedSession: "sealed_session_no_org",
+          } satisfies AuthenticateWithCodeResult),
+        listUserMemberships: (() =>
+          Effect.succeed({
+            data: [
+              {
+                organizationId: "org_pending",
+                status: "pending",
+              },
+            ],
+          })) as unknown as WorkOSAuth["Service"]["listUserMemberships"],
+        refreshSession: () =>
+          Effect.sync(() => {
+            refreshCalls++;
+            return null;
+          }),
+      });
+
+      const response = yield* Effect.promise(() =>
+        fetch(
+          new Request("http://test.local/auth/callback?code=code&state=state_2", {
+            headers: { cookie: "wos-login-state=state_2" },
+          }),
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/");
+      expect(refreshCalls).toBe(0);
+      const setCookie = response.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("wos-session=sealed_session_no_org");
+    }),
+  );
+
+  // Regression: even with an active membership, if WorkOS rejects the
+  // refresh (e.g. membership just revoked, brief race), the callback
+  // should still succeed with an org-less session rather than 500.
+  it.effect("falls through to org-less session when refresh fails", () =>
+    Effect.gen(function* () {
+      const fetch = makeAuthFetch({
+        authenticateWithCode: () =>
+          Effect.succeed({
+            user: fakeUser,
+            accessToken: "access_token",
+            refreshToken: "refresh_token",
+            sealedSession: "sealed_session_fallback",
+          } satisfies AuthenticateWithCodeResult),
+        listUserMemberships: (() =>
+          Effect.succeed({
+            data: [
+              {
+                organizationId: "org_active",
+                status: "active",
+              },
+            ],
+          })) as unknown as WorkOSAuth["Service"]["listUserMemberships"],
+        refreshSession: (() =>
+          Effect.fail(new WorkOSError())) as WorkOSAuth["Service"]["refreshSession"],
+      });
+
+      const response = yield* Effect.promise(() =>
+        fetch(
+          new Request("http://test.local/auth/callback?code=code&state=state_3", {
+            headers: { cookie: "wos-login-state=state_3" },
+          }),
+        ),
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get("location")).toBe("/");
+      const setCookie = response.headers.get("set-cookie") ?? "";
+      expect(setCookie).toContain("wos-session=sealed_session_fallback");
     }),
   );
 });

--- a/apps/cloud/src/auth/handlers.node.test.ts
+++ b/apps/cloud/src/auth/handlers.node.test.ts
@@ -183,6 +183,10 @@ describe("Auth callback handlers", () => {
             refreshToken: "refresh_token",
             sealedSession: "sealed_session_no_org",
           } satisfies AuthenticateWithCodeResult),
+        // The handler only reads `data[*].organizationId` and
+        // `data[*].status`, so we stub a minimal shape matching that
+        // contract instead of hand-rolling the full WorkOS SDK types.
+        // oxlint-disable-next-line executor/no-double-cast
         listUserMemberships: (() =>
           Effect.succeed({
             data: [
@@ -228,6 +232,9 @@ describe("Auth callback handlers", () => {
             refreshToken: "refresh_token",
             sealedSession: "sealed_session_fallback",
           } satisfies AuthenticateWithCodeResult),
+        // Same minimal-shape stub as above — see comment in the
+        // pending-membership test.
+        // oxlint-disable-next-line executor/no-double-cast
         listUserMemberships: (() =>
           Effect.succeed({
             data: [

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -110,11 +110,17 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
           const workos = yield* WorkOSAuth;
           const users = yield* UserStoreService;
           const cookieState = request.cookies[STATE_COOKIE] ?? null;
-          if (!cookieState || !timingSafeEqual(cookieState, query.state)) {
-            return deleteResponseCookie(
-              HttpServerResponse.text("Invalid login state", { status: 400 }),
-              STATE_COOKIE,
-            );
+          // CSRF check is only enforced when the redirect carries a state
+          // value — some WorkOS-initiated redirects don't include one.
+          // When state is present, it MUST match the cookie we set on
+          // /login.
+          if (query.state !== undefined) {
+            if (!cookieState || !timingSafeEqual(cookieState, query.state)) {
+              return deleteResponseCookie(
+                HttpServerResponse.text("Invalid login state", { status: 400 }),
+                STATE_COOKIE,
+              );
+            }
           }
 
           const result = yield* workos.authenticateWithCode(query.code);
@@ -124,19 +130,24 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
 
           let sealedSession = result.sealedSession;
 
-          // If the auth response didn't surface an org but the user already
-          // belongs to one, rehydrate the session with it. If they have no
-          // memberships at all, leave the session org-less — the frontend
-          // AuthGate will render the onboarding flow. We never auto-create
-          // organizations on login.
+          // If the auth response didn't surface an org but the user is already
+          // an *active* member of one, rehydrate the session with it. Pending
+          // memberships (which represent unaccepted invitations on WorkOS's
+          // side) are skipped — refreshing into one 400s, and silently
+          // attaching an unaccepted org would also bypass invite consent.
+          // If they have no active memberships, leave the session org-less —
+          // AuthGate's onboarding flow surfaces pending invites and the
+          // create-org form. We never auto-create organizations on login.
           if (!result.organizationId && sealedSession) {
             const memberships = yield* workos.listUserMemberships(result.user.id);
-            const existing = memberships.data[0];
-            if (existing) {
-              const refreshed = yield* workos.refreshSession(
-                sealedSession,
-                existing.organizationId,
-              );
+            const existingActive = memberships.data.find((m) => m.status === "active");
+            if (existingActive) {
+              // Best-effort refresh — if WorkOS rejects (e.g. the membership
+              // was just revoked), fall through to an org-less session rather
+              // than 500ing the entire callback.
+              const refreshed = yield* workos
+                .refreshSession(sealedSession, existingActive.organizationId)
+                .pipe(Effect.orElseSucceed(() => null));
               if (refreshed) sealedSession = refreshed;
             }
           }
@@ -254,6 +265,105 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
               {
                 userId: session.accountId,
                 newOrgId: org.id,
+                refreshReturnedSession: refreshed != null,
+                verifiedOrgId: verified?.organizationId ?? null,
+              },
+            );
+            deleteCookie("wos-session", { path: "/" });
+            return yield* Effect.fail(new WorkOSError());
+          }
+
+          setCookie("wos-session", refreshed, COOKIE_OPTIONS);
+          return { id: org.id, name: org.name };
+        }),
+      )
+      .handle("pendingInvitations", () =>
+        Effect.gen(function* () {
+          const workos = yield* WorkOSAuth;
+          const session = yield* SessionContext;
+
+          const invitations = yield* workos.listInvitationsByEmail(session.email);
+          const pending = invitations.data.filter(
+            (i) => i.state === "pending" && i.organizationId !== null,
+          );
+
+          // Resolve org names + inviter identities in parallel. Treat
+          // individual failures as "skip the field" rather than failing the
+          // whole list — a stale invitation pointing at a deleted org
+          // shouldn't block the user from seeing the others, and a missing
+          // inviter is normal (admin-/API-created invitations have no
+          // inviter user).
+          const enriched = yield* Effect.all(
+            pending.map((inv) =>
+              Effect.gen(function* () {
+                const org = yield* workos
+                  .getOrganization(inv.organizationId!)
+                  .pipe(Effect.orElseSucceed(() => null));
+                if (!org) return null;
+                const inviter = inv.inviterUserId
+                  ? yield* workos.getUser(inv.inviterUserId).pipe(
+                      Effect.map((u) => ({
+                        email: u.email,
+                        name:
+                          [u.firstName, u.lastName].filter(Boolean).join(" ") || null,
+                      })),
+                      Effect.orElseSucceed(() => null),
+                    )
+                  : null;
+                return {
+                  id: inv.id,
+                  organizationId: org.id,
+                  organizationName: org.name,
+                  createdAt: inv.createdAt,
+                  inviter,
+                };
+              }),
+            ),
+            { concurrency: "unbounded" },
+          );
+
+          return {
+            invitations: enriched.filter((i): i is NonNullable<typeof i> => i !== null),
+          };
+        }),
+      )
+      .handle("acceptInvitation", ({ payload }) =>
+        Effect.gen(function* () {
+          const workos = yield* WorkOSAuth;
+          const users = yield* UserStoreService;
+          const session = yield* SessionContext;
+
+          const invitation = yield* workos.acceptInvitation(payload.invitationId);
+
+          // Defensive: invitations created without an org shouldn't reach
+          // this UI, but the SDK type allows null so guard anyway.
+          if (!invitation.organizationId) {
+            yield* Effect.logWarning("acceptInvitation: invitation has no organizationId", {
+              invitationId: payload.invitationId,
+            });
+            return yield* Effect.fail(new WorkOSError());
+          }
+
+          // Mirror the org locally so domain tables can FK against it.
+          const org = yield* workos.getOrganization(invitation.organizationId);
+          yield* users.use((s) => s.upsertOrganization({ id: org.id, name: org.name }));
+
+          // Attach the just-accepted org to the current session. Same shape
+          // as createOrganization: refresh + verify; if we can't pin the
+          // session in-place, clear the cookie and let the user bounce
+          // through login again. The acceptance has already succeeded
+          // server-side, so the next login will pick up the membership.
+          const refreshed = yield* workos.refreshSession(session.sealedSession, org.id);
+          const verified = refreshed
+            ? yield* workos.authenticateSealedSession(refreshed)
+            : null;
+
+          if (!refreshed || !verified || verified.organizationId !== org.id) {
+            yield* Effect.logWarning(
+              "acceptInvitation: unable to attach org to current session",
+              {
+                userId: session.accountId,
+                orgId: org.id,
                 refreshReturnedSession: refreshed != null,
                 verifiedOrgId: verified?.organizationId ?? null,
               },

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -185,6 +185,14 @@ const make = Effect.gen(function* () {
         })),
       ),
 
+    /** List invitations for an email address (across all orgs). */
+    listInvitationsByEmail: (email: string) =>
+      use((wos) => wos.userManagement.listInvitations({ email })),
+
+    /** Accept an invitation; returns the (now accepted) invitation. */
+    acceptInvitation: (invitationId: string) =>
+      use((wos) => wos.userManagement.acceptInvitation(invitationId)),
+
     /** Remove an organization membership. */
     deleteOrgMembership: (membershipId: string) =>
       use((wos) => wos.userManagement.deleteOrganizationMembership(membershipId)),

--- a/apps/cloud/src/web/auth.tsx
+++ b/apps/cloud/src/web/auth.tsx
@@ -42,6 +42,13 @@ export const organizationsAtom = Atom.refreshOnWindowFocus(
 export const switchOrganization = CloudApiClient.mutation("cloudAuth", "switchOrganization");
 export const createOrganization = CloudApiClient.mutation("cloudAuth", "createOrganization");
 
+export const pendingInvitationsAtom = CloudApiClient.query("cloudAuth", "pendingInvitations", {
+  timeToLive: "1 minute",
+  reactivityKeys: [ReactivityKey.auth],
+});
+
+export const acceptInvitation = CloudApiClient.mutation("cloudAuth", "acceptInvitation");
+
 // ---------------------------------------------------------------------------
 // Provider + hook
 // ---------------------------------------------------------------------------

--- a/apps/cloud/src/web/pages/onboarding.tsx
+++ b/apps/cloud/src/web/pages/onboarding.tsx
@@ -1,14 +1,72 @@
+import { useState } from "react";
+import { useAtomValue, useAtomSet } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import * as Exit from "effect/Exit";
+import { authWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { Button } from "@executor-js/react/components/button";
+import { Skeleton } from "@executor-js/react/components/skeleton";
 
 import { AUTH_PATHS } from "../../auth/api";
-import { useAuth } from "../auth";
+import { acceptInvitation, pendingInvitationsAtom, useAuth } from "../auth";
 import {
   CreateOrganizationFields,
   useCreateOrganizationForm,
 } from "../components/create-organization-form";
 
+type PendingInvitation = {
+  id: string;
+  organizationId: string;
+  organizationName: string;
+  createdAt: string;
+  inviter: { email: string; name: string | null } | null;
+};
+
+const formatRelativeTime = (iso: string): string => {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "";
+  const diffMs = Date.now() - then;
+  const min = Math.floor(diffMs / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hrs = Math.floor(min / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+};
+
 export const OnboardingPage = () => {
   const auth = useAuth();
+  const invitationsResult = useAtomValue(pendingInvitationsAtom);
+  const doAccept = useAtomSet(acceptInvitation, { mode: "promiseExit" });
+
+  const [acceptingId, setAcceptingId] = useState<string | null>(null);
+  const [errorByInvitationId, setErrorByInvitationId] = useState<Record<string, string>>({});
+
+  const handleAccept = async (invitation: PendingInvitation) => {
+    setAcceptingId(invitation.id);
+    setErrorByInvitationId((prev) => {
+      if (!(invitation.id in prev)) return prev;
+      const next = { ...prev };
+      delete next[invitation.id];
+      return next;
+    });
+    const exit = await doAccept({
+      payload: { invitationId: invitation.id },
+      reactivityKeys: authWriteKeys,
+    });
+    setAcceptingId(null);
+    if (!Exit.isSuccess(exit)) {
+      setErrorByInvitationId((prev) => ({
+        ...prev,
+        [invitation.id]: "Couldn't accept this invitation. Try again or ask the inviter to resend.",
+      }));
+    }
+  };
 
   const suggestedName =
     auth.status === "authenticated" &&
@@ -19,38 +77,70 @@ export const OnboardingPage = () => {
 
   const form = useCreateOrganizationForm({
     defaultName: suggestedName,
-    // The server sets a cookie for the new (or cleared) org on both success and
-    // failure. The authWriteKeys passed at the mutation site auto-invalidate
-    // authAtom so AuthGate re-routes into Shell or LoginPage as appropriate.
     onSuccess: () => {},
   });
+
+  const isLoading = AsyncResult.isInitial(invitationsResult) || AsyncResult.isWaiting(invitationsResult);
+  const invitations = AsyncResult.match(invitationsResult, {
+    onInitial: () => [] as readonly PendingInvitation[],
+    onFailure: () => [] as readonly PendingInvitation[],
+    onSuccess: ({ value }) => value.invitations,
+  });
+
+  const count = invitations.length;
+  const sole = count === 1 ? invitations[0]! : null;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="mx-auto flex w-full max-w-sm flex-col gap-6">
-        <div className="flex flex-col gap-2">
-          <h1 className="font-serif text-3xl">Create your organization</h1>
-          <p className="text-sm text-muted-foreground">
-            Organizations group your sources, secrets, and teammates. You can invite others once
-            it's set up.
-          </p>
-        </div>
+        <header className="flex flex-col gap-2">
+          <h1 className="font-serif text-3xl">
+            {isLoading
+              ? "Loading"
+              : count === 0
+                ? "Create your organization"
+                : "You've been invited"}
+          </h1>
+          {!isLoading && count === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Organizations group your sources, secrets, and teammates. You can invite others once
+              it's set up.
+            </p>
+          )}
+        </header>
 
-        <CreateOrganizationFields
-          name={form.name}
-          onNameChange={(name) => {
-            form.setName(name);
-            if (form.error) form.setError(null);
-          }}
-          error={form.error}
-          onSubmit={() => void form.submit()}
-        />
+        {isLoading && <InvitationsSkeleton />}
 
-        <div className="flex items-center justify-between gap-3">
+        {!isLoading && sole && (
+          <SingleInvitationView
+            invitation={sole}
+            accepting={acceptingId === sole.id}
+            error={errorByInvitationId[sole.id] ?? null}
+            onAccept={() => void handleAccept(sole)}
+          />
+        )}
+
+        {!isLoading && count > 1 && (
+          <MultiInvitationsView
+            invitations={invitations}
+            acceptingId={acceptingId}
+            errorByInvitationId={errorByInvitationId}
+            onAccept={(inv) => void handleAccept(inv)}
+          />
+        )}
+
+        {!isLoading && (count === 0 || sole || count > 1) && (
+          <CreateOrgSection
+            isPrimary={count === 0}
+            form={form}
+          />
+        )}
+
+        <footer className="flex items-center justify-center">
           {/* oxlint-disable-next-line react/forbid-elements */}
           <button
             type="button"
-            className="text-xs text-muted-foreground hover:text-foreground"
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
             onClick={async () => {
               await fetch(AUTH_PATHS.logout, { method: "POST" });
               window.location.href = "/";
@@ -58,15 +148,171 @@ export const OnboardingPage = () => {
           >
             Sign out
           </button>
-          <Button
-            size="sm"
-            onClick={() => void form.submit()}
-            disabled={!form.canSubmit || form.creating}
-          >
-            {form.creating ? "Creating…" : "Create organization"}
-          </Button>
-        </div>
+        </footer>
       </div>
     </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+
+const InvitationsSkeleton = () => (
+  <div className="flex flex-col gap-2.5">
+    <InvitationRowSkeleton />
+    <InvitationRowSkeleton />
+  </div>
+);
+
+const InvitationRowSkeleton = () => (
+  <div className="flex items-center gap-3 rounded-md border border-border px-3 py-2.5">
+    <div className="flex flex-1 flex-col gap-1.5">
+      <Skeleton className="h-3.5 w-2/5" />
+      <Skeleton className="h-3 w-3/5" />
+    </div>
+    <Skeleton className="h-8 w-16 rounded-md" />
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+
+const InviterAttribution = ({ invitation }: { invitation: PendingInvitation }) => {
+  const inviterLabel = invitation.inviter
+    ? invitation.inviter.name && invitation.inviter.name.length > 0
+      ? `${invitation.inviter.name} (${invitation.inviter.email})`
+      : invitation.inviter.email
+    : null;
+  const time = formatRelativeTime(invitation.createdAt);
+  return (
+    <p className="truncate text-xs text-muted-foreground">
+      {inviterLabel ? (
+        <>
+          Invited by <span className="text-foreground/80">{inviterLabel}</span>
+          {time && <span> · {time}</span>}
+        </>
+      ) : (
+        <>Invited{time ? ` ${time}` : ""}</>
+      )}
+    </p>
+  );
+};
+
+// ---------------------------------------------------------------------------
+
+const SingleInvitationView = ({
+  invitation,
+  accepting,
+  error,
+  onAccept,
+}: {
+  invitation: PendingInvitation;
+  accepting: boolean;
+  error: string | null;
+  onAccept: () => void;
+}) => (
+  <section aria-label="Invitation" className="flex flex-col gap-3">
+    <div className="flex flex-col gap-0.5 rounded-md border border-border px-3 py-2.5">
+      <p className="truncate text-sm font-medium leading-tight">{invitation.organizationName}</p>
+      <InviterAttribution invitation={invitation} />
+    </div>
+
+    {error && <p className="text-xs text-destructive">{error}</p>}
+
+    <Button onClick={onAccept} disabled={accepting} className="w-full" size="sm">
+      {accepting ? "Joining…" : "Accept invitation"}
+    </Button>
+  </section>
+);
+
+// ---------------------------------------------------------------------------
+
+const MultiInvitationsView = ({
+  invitations,
+  acceptingId,
+  errorByInvitationId,
+  onAccept,
+}: {
+  invitations: readonly PendingInvitation[];
+  acceptingId: string | null;
+  errorByInvitationId: Record<string, string>;
+  onAccept: (invitation: PendingInvitation) => void;
+}) => (
+  <section aria-label="Invitations" className="flex flex-col gap-2">
+    <ul className="flex flex-col gap-2">
+      {invitations.map((invitation) => {
+        const isAccepting = acceptingId === invitation.id;
+        const isOtherAccepting = acceptingId !== null && !isAccepting;
+        const error = errorByInvitationId[invitation.id] ?? null;
+        return (
+          <li key={invitation.id} className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-3 rounded-md border border-border px-3 py-2.5">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium leading-tight">
+                  {invitation.organizationName}
+                </p>
+                <InviterAttribution invitation={invitation} />
+              </div>
+              <Button
+                size="sm"
+                onClick={() => onAccept(invitation)}
+                disabled={isAccepting || isOtherAccepting}
+              >
+                {isAccepting ? "Joining…" : "Accept"}
+              </Button>
+            </div>
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </li>
+        );
+      })}
+    </ul>
+  </section>
+);
+
+// ---------------------------------------------------------------------------
+
+const CreateOrgSection = ({
+  isPrimary,
+  form,
+}: {
+  isPrimary: boolean;
+  form: ReturnType<typeof useCreateOrganizationForm>;
+}) => {
+  const [expanded, setExpanded] = useState(isPrimary);
+
+  if (!isPrimary && !expanded) {
+    return (
+      <div className="text-center text-xs text-muted-foreground">
+        {/* oxlint-disable-next-line react/forbid-elements */}
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="underline-offset-4 transition-colors hover:text-foreground hover:underline"
+        >
+          Or create a new organization
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <section aria-label="Create organization" className="flex flex-col gap-3">
+      <CreateOrganizationFields
+        name={form.name}
+        onNameChange={(name) => {
+          form.setName(name);
+          if (form.error) form.setError(null);
+        }}
+        error={form.error}
+        onSubmit={() => void form.submit()}
+      />
+      <div className="flex justify-end">
+        <Button
+          size="sm"
+          onClick={() => void form.submit()}
+          disabled={!form.canSubmit || form.creating}
+        >
+          {form.creating ? "Creating…" : "Create organization"}
+        </Button>
+      </div>
+    </section>
   );
 };


### PR DESCRIPTION
## Summary

- Invited users with an unaccepted invitation were 500ing on the auth callback. The handler picked the first membership returned by WorkOS (which can be `pending` for unaccepted invites) and tried to refresh the session into it, which 400s. Now the rehydrate path filters to active memberships and treats refresh failure as best-effort.
- Onboarding now surfaces pending invitations so invited users can explicitly accept them. Inviter (name + email) and relative invite age are shown alongside the org name as a phishing signal — bypasses the WorkOS consent gate that the invite-link click would have provided.
- Callback schema relaxed to allow stateless redirects; CSRF check is still enforced when `state` is present.

New endpoints:
- `GET /auth/pending-invitations`
- `POST /auth/accept-invitation`

## Test plan

- [x] Unit: callback skips a pending-only membership and leaves session org-less
- [x] Unit: callback falls through to org-less session when refresh fails
- [x] Unit: callback accepts a redirect without `state` (CSRF check skipped)
- [x] Unit: callback still rejects mismatched `state` when present
- [ ] Manual: sign in as invited user → onboarding shows the invite with inviter attribution → click Accept → land in the org
- [ ] Manual: sign in as user with no invites → onboarding shows create-org form
- [ ] Manual: multi-invite case — list renders, only one Accept active at a time, per-row error on failure