### PR TITLE
Use Cause.prettyErrors so Sentry never sees a raw CauseImpl

### DIFF
--- a/apps/cloud/src/api/error-response.ts
+++ b/apps/cloud/src/api/error-response.ts
@@ -1,9 +1,10 @@
-import * as Sentry from "@sentry/cloudflare";
 import { Cause, Data, Effect, Result } from "effect";
 import {
   HttpServerRespondable,
   HttpServerResponse,
 } from "effect/unstable/http";
+
+import { captureCause } from "../observability";
 
 // Implements `Respondable` so the framework's default cause→response
 // pipeline (`HttpServerRespondable.toResponseOrElse`) renders this as the
@@ -15,7 +16,7 @@ export class HttpResponseError extends Data.TaggedError("HttpResponseError")<{
   readonly message: string;
 }> {
   [HttpServerRespondable.symbol](): Effect.Effect<HttpServerResponse.HttpServerResponse> {
-    if (this.status >= 500) Sentry.captureException(this);
+    if (this.status >= 500) captureCause(this);
     return Effect.succeed(
       HttpServerResponse.jsonUnsafe(
         { error: this.message, code: this.code },
@@ -48,26 +49,11 @@ const toHttpResponseError = (error: unknown): HttpResponseError => {
       });
 };
 
-// Sentry's `captureException` can't extract a real Error from an Effect
-// `Cause` — it logs a `'CauseImpl' captured as exception` warning. Squash
-// to a plain value and stash the pretty-printed cause as an extra.
-const captureSentryError = (error: unknown): void => {
-  if (Cause.isCause(error)) {
-    const pretty = Cause.pretty(error);
-    Sentry.captureException(Cause.squash(error), (scope) => {
-      scope.setExtra("cause", pretty);
-      return scope;
-    });
-  } else {
-    Sentry.captureException(error);
-  }
-};
-
 export const isServerError = (error: unknown): boolean => toHttpResponseError(error).status >= 500;
 
 export const toErrorResponse = (error: unknown): Response => {
   const mapped = toHttpResponseError(error);
-  if (mapped.status >= 500) captureSentryError(error);
+  if (mapped.status >= 500) captureCause(error);
   return Response.json({ error: mapped.message, code: mapped.code }, { status: mapped.status });
 };
 
@@ -78,7 +64,7 @@ export const toErrorServerResponse = (error: unknown): HttpServerResponse.HttpSe
       "[api] toErrorServerResponse error:",
       Cause.isCause(error) ? Cause.pretty(error) : error instanceof Error ? error.stack : error,
     );
-    captureSentryError(error);
+    captureCause(error);
   }
   return HttpServerResponse.jsonUnsafe(
     { error: mapped.message, code: mapped.code },

--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -7,7 +7,6 @@ import { createTraceState } from "@opentelemetry/api";
 import { Cause, Data, Effect, Layer } from "effect";
 import * as OtelTracer from "@effect/opentelemetry/Tracer";
 import type * as Tracer from "effect/Tracer";
-import * as Sentry from "@sentry/cloudflare";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TransportState } from "agents/mcp";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -29,6 +28,7 @@ import { DbService, combinedSchema, resolveConnectionString } from "./services/d
 import { makeExecutionStack } from "./services/execution-stack";
 import { makeMcpWorkerTransport, type McpWorkerTransport } from "./services/mcp-worker-transport";
 import { DoTelemetryLive } from "./services/telemetry";
+import { captureCause } from "./observability";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -624,12 +624,8 @@ export class McpSessionDO extends DurableObject {
     }).pipe(
       Effect.catchCause((cause) =>
         Effect.sync(() => {
-          const pretty = Cause.pretty(cause);
-          console.error("[mcp-session] handleRequest error:", pretty);
-          Sentry.captureException(Cause.squash(cause), (scope) => {
-            scope.setExtra("cause", pretty);
-            return scope;
-          });
+          console.error("[mcp-session] handleRequest error:", Cause.pretty(cause));
+          captureCause(cause);
           return jsonRpcError(500, -32603, "Internal error");
         }),
       ),

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -16,10 +16,10 @@
 
 import { env } from "cloudflare:workers";
 import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
-import * as Sentry from "@sentry/cloudflare";
 import { Cause, Context, Effect, Layer, Option, Schema } from "effect";
 
 import { createCachedRemoteJWKSet } from "./jwks-cache";
+import { captureCause } from "./observability";
 import { TelemetryLive } from "./services/telemetry";
 import {
   McpJwtVerificationError,
@@ -697,12 +697,8 @@ export const mcpApp: Effect.Effect<
   Effect.withSpan("mcp.request"),
   Effect.catchCause((cause) =>
     Effect.sync(() => {
-      const pretty = Cause.pretty(cause);
-      console.error("[mcp] request failed:", pretty);
-      Sentry.captureException(Cause.squash(cause), (scope) => {
-        scope.setExtra("cause", pretty);
-        return scope;
-      });
+      console.error("[mcp] request failed:", Cause.pretty(cause));
+      captureCause(cause);
       return jsonRpcError(500, -32603, "Internal server error");
     }),
   ),

--- a/apps/cloud/src/observability.test.ts
+++ b/apps/cloud/src/observability.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "@effect/vitest";
+import { vi } from "vitest";
+import { Cause } from "effect";
+
+const captureException = vi.fn<(...args: unknown[]) => string | undefined>();
+
+vi.mock("@sentry/cloudflare", () => ({
+  captureException: (...args: unknown[]) => captureException(...args),
+}));
+
+const { captureCause } = await import("./observability");
+
+// Mirrors Sentry core's `is.isError`: it picks the proper-Error path iff
+// `Object.prototype.toString.call(x) === "[object Error]"`. Anything that
+// fails this check goes down the synthetic "<className> captured as exception
+// with keys: ..." path that produced the original CauseImpl Sentry issue.
+const looksLikeErrorToSentry = (value: unknown): boolean =>
+  Object.prototype.toString.call(value) === "[object Error]";
+
+describe("captureCause", () => {
+  it("hands Sentry a real Error when the defect is itself a Cause", () => {
+    captureException.mockReset();
+
+    // Reproduces the production chain: an inner runPromise rejects with a
+    // CauseImpl (from Effect v4's causeSquash), Effect.promise re-wraps it
+    // as Die(CauseImpl), and the outer catchCause receives this shape.
+    const innerCause = Cause.fail(new Error("inner failure"));
+    const outerCause = Cause.die(innerCause);
+
+    captureCause(outerCause);
+
+    expect(captureException).toHaveBeenCalledTimes(1);
+    const [primary] = captureException.mock.calls[0]!;
+    expect(looksLikeErrorToSentry(primary)).toBe(true);
+  });
+
+  it("hands Sentry a real Error for an ordinary failed Cause", () => {
+    captureException.mockReset();
+    captureCause(Cause.fail(new Error("plain failure")));
+    const [primary] = captureException.mock.calls[0]!;
+    expect(looksLikeErrorToSentry(primary)).toBe(true);
+  });
+
+  it("forwards non-Cause inputs as-is", () => {
+    captureException.mockReset();
+    const err = new Error("raw");
+    captureCause(err);
+    expect(captureException).toHaveBeenCalledWith(err);
+  });
+});

--- a/apps/cloud/src/observability.test.ts
+++ b/apps/cloud/src/observability.test.ts
@@ -1,14 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
-import { vi } from "vitest";
 import { Cause } from "effect";
 
-const captureException = vi.fn<(...args: unknown[]) => string | undefined>();
-
-vi.mock("@sentry/cloudflare", () => ({
-  captureException: (...args: unknown[]) => captureException(...args),
-}));
-
-const { captureCause } = await import("./observability");
+import { sentryPayloadForCause } from "./observability";
 
 // Mirrors Sentry core's `is.isError`: it picks the proper-Error path iff
 // `Object.prototype.toString.call(x) === "[object Error]"`. Anything that
@@ -17,34 +10,29 @@ const { captureCause } = await import("./observability");
 const looksLikeErrorToSentry = (value: unknown): boolean =>
   Object.prototype.toString.call(value) === "[object Error]";
 
-describe("captureCause", () => {
+describe("sentryPayloadForCause", () => {
   it("hands Sentry a real Error when the defect is itself a Cause", () => {
-    captureException.mockReset();
-
     // Reproduces the production chain: an inner runPromise rejects with a
     // CauseImpl (from Effect v4's causeSquash), Effect.promise re-wraps it
     // as Die(CauseImpl), and the outer catchCause receives this shape.
     const innerCause = Cause.fail(new Error("inner failure"));
     const outerCause = Cause.die(innerCause);
 
-    captureCause(outerCause);
+    const { primary, pretty } = sentryPayloadForCause(outerCause);
 
-    expect(captureException).toHaveBeenCalledTimes(1);
-    const [primary] = captureException.mock.calls[0]!;
     expect(looksLikeErrorToSentry(primary)).toBe(true);
+    expect(pretty).not.toBeNull();
   });
 
   it("hands Sentry a real Error for an ordinary failed Cause", () => {
-    captureException.mockReset();
-    captureCause(Cause.fail(new Error("plain failure")));
-    const [primary] = captureException.mock.calls[0]!;
+    const { primary } = sentryPayloadForCause(Cause.fail(new Error("plain failure")));
     expect(looksLikeErrorToSentry(primary)).toBe(true);
   });
 
-  it("forwards non-Cause inputs as-is", () => {
-    captureException.mockReset();
+  it("forwards non-Cause inputs as-is with no pretty cause attached", () => {
     const err = new Error("raw");
-    captureCause(err);
-    expect(captureException).toHaveBeenCalledWith(err);
+    const { primary, pretty } = sentryPayloadForCause(err);
+    expect(primary).toBe(err);
+    expect(pretty).toBeNull();
   });
 });

--- a/apps/cloud/src/observability.ts
+++ b/apps/cloud/src/observability.ts
@@ -27,19 +27,35 @@ const truncate = (s: string): string =>
     ? s
     : `${s.slice(0, MAX_CONSOLE_CAUSE_CHARS)}\n…[truncated ${s.length - MAX_CONSOLE_CAUSE_CHARS} chars]`;
 
+// Sentry's `captureException` can't serialize Effect's `CauseImpl` (it logs
+// `'CauseImpl' captured as exception with keys: reasons, ~effect/Cause` and
+// drops the real failure). `Cause.squash` isn't enough on its own: when an
+// inner `runPromise` rejects with a CauseImpl from its own `causeSquash`
+// (Effect v4's behaviour), `Effect.promise` re-wraps it as `Die(causeImpl)`,
+// and `Cause.squash(outer)` then hands the CauseImpl straight back. Use
+// `Cause.prettyErrors` instead — it always produces real `Error` instances,
+// even for non-Error defects (including a CauseImpl defect, which gets
+// wrapped via `causePrettyMessage`).
+export const captureCause = (input: unknown): string | undefined => {
+  if (Cause.isCause(input)) {
+    const pretty = Cause.pretty(input);
+    const errors = Cause.prettyErrors(input);
+    const primary = errors[0] ?? new Error(pretty);
+    return Sentry.captureException(primary, (scope) => {
+      scope.setExtra("cause", pretty);
+      return scope;
+    });
+  }
+  return Sentry.captureException(input);
+};
+
 export const ErrorCaptureLive: Layer.Layer<ErrorCapture> = Layer.succeed(
   ErrorCapture,
   ErrorCapture.of({
     captureException: (cause) =>
       Effect.sync(() => {
-        const squashed = Cause.squash(cause);
-        const pretty = Cause.pretty(cause);
-        console.error("[api] unhandled cause:", truncate(pretty));
-        const eventId = Sentry.captureException(squashed, (scope) => {
-          scope.setExtra("cause", pretty);
-          return scope;
-        });
-        return eventId ?? "";
+        console.error("[api] unhandled cause:", truncate(Cause.pretty(cause)));
+        return captureCause(cause) ?? "";
       }),
   }),
 );

--- a/apps/cloud/src/observability.ts
+++ b/apps/cloud/src/observability.ts
@@ -36,17 +36,23 @@ const truncate = (s: string): string =>
 // `Cause.prettyErrors` instead — it always produces real `Error` instances,
 // even for non-Error defects (including a CauseImpl defect, which gets
 // wrapped via `causePrettyMessage`).
-export const captureCause = (input: unknown): string | undefined => {
+export const sentryPayloadForCause = (
+  input: unknown,
+): { primary: unknown; pretty: string | null } => {
   if (Cause.isCause(input)) {
     const pretty = Cause.pretty(input);
     const errors = Cause.prettyErrors(input);
-    const primary = errors[0] ?? new Error(pretty);
-    return Sentry.captureException(primary, (scope) => {
-      scope.setExtra("cause", pretty);
-      return scope;
-    });
+    return { primary: errors[0] ?? new Error(pretty), pretty };
   }
-  return Sentry.captureException(input);
+  return { primary: input, pretty: null };
+};
+
+export const captureCause = (input: unknown): string | undefined => {
+  const { primary, pretty } = sentryPayloadForCause(input);
+  return Sentry.captureException(primary, (scope) => {
+    if (pretty !== null) scope.setExtra("cause", pretty);
+    return scope;
+  });
 };
 
 export const ErrorCaptureLive: Layer.Layer<ErrorCapture> = Layer.succeed(


### PR DESCRIPTION
## Summary
- Follow-up to the previous Effect-Cause-to-Sentry fix: `Cause.squash(cause)` is single-level and returns the underlying value verbatim, so when a defect happens to be another `CauseImpl` (which Effect v4 produces naturally) we hand that straight to `Sentry.captureException` and the issue resurfaces as `'CauseImpl' captured as exception with keys: reasons, ~effect/Cause`.
- The path that triggers it: an inner `Effect.runPromise` rejects with whatever `causeSquash(innerCause)` returns — for some shapes that's a `CauseImpl`. The promise is consumed by `Effect.promise(() => ...)` which converts the rejection into `Die(causeImpl)`. The outer `catchCause` then has a Cause whose only defect is itself a Cause, and the previous helper's single squash hands it back unchanged.
- Switch the four call sites onto a shared `captureCause` helper in `observability.ts` that uses `Cause.prettyErrors(cause)[0]` instead. The underlying `causePrettyError` always builds a real `globalThis.Error` (even for non-Error defects, including Cause-shaped ones), so Sentry core's `is.isError` check picks the proper-Error path and we get a real message + stack instead of the synthetic "captured as exception" event.

## Test plan
- [x] `bun x vitest run src/observability.test.ts` — new regression test reproduces the `Die(Cause(...))` shape and asserts the value reaching `Sentry.captureException` satisfies `Object.prototype.toString.call(x) === "[object Error]"` (the exact discriminator Sentry core's `getException` uses to pick the proper-Error path vs the synthetic path).
- [x] `bun run typecheck` clean for `apps/cloud`.
- [ ] Verify in production after deploy that no new `'CauseImpl' captured as exception` events appear on the MCP route.