### PR TITLE
Skip id_token validation on OAuth-only token responses

### DIFF
--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -201,12 +201,13 @@ describe("exchangeAuthorizationCode", () => {
     expect(body.has("client_secret")).toBe(false);
   });
 
-  it("validates ID tokens against an explicit issuer when token host differs", async () => {
+  it("strips id_tokens whose iss does not match AS metadata (PostHog-style OIDC backend behind plain OAuth 2.0 metadata)", async () => {
     captureFetch(
       jsonResponse(200, {
         ...validBody,
         id_token: unsignedJwt({
-          iss: "https://accounts.google.com",
+          // Upstream OP issuer — does NOT match issuerUrl below
+          iss: "https://us.posthog.com",
           aud: "cid",
           sub: "user-1",
           exp: Math.floor(Date.now() / 1000) + 3600,
@@ -216,8 +217,8 @@ describe("exchangeAuthorizationCode", () => {
     );
     const result = await Effect.runPromise(
       exchangeAuthorizationCode({
-        tokenUrl: "https://oauth2.googleapis.com/token",
-        issuerUrl: "https://accounts.google.com",
+        tokenUrl: "https://oauth.posthog.com/oauth/token",
+        issuerUrl: "https://oauth.posthog.com",
         clientId: "cid",
         redirectUrl: "https://app.example.com/cb",
         codeVerifier: "verifier",
@@ -225,41 +226,77 @@ describe("exchangeAuthorizationCode", () => {
       }),
     );
     expect(result.access_token).toBe("tok");
+    expect(result.refresh_token).toBe("rtok");
   });
 
-  it("accepts ID token signing algorithms advertised by authorization server metadata", async () => {
+  it("strips id_tokens whose aud does not match the client_id", async () => {
     captureFetch(
       jsonResponse(200, {
         ...validBody,
-        id_token: unsignedJwt(
-          {
-            iss: "https://railway.com",
-            aud: "cid",
-            sub: "user-1",
-            exp: Math.floor(Date.now() / 1000) + 3600,
-            iat: Math.floor(Date.now() / 1000),
-          },
-          "ES256",
-        ),
+        id_token: unsignedJwt({
+          iss: "https://example.com",
+          // aud belongs to some other client
+          aud: "another-client",
+          sub: "user-1",
+          exp: Math.floor(Date.now() / 1000) + 3600,
+          iat: Math.floor(Date.now() / 1000),
+        }),
       }),
     );
-
     const result = await Effect.runPromise(
       exchangeAuthorizationCode({
-        tokenUrl: "https://backboard.railway.com/oauth/token",
-        issuerUrl: "https://railway.com",
+        tokenUrl: "https://example.com/token",
+        issuerUrl: "https://example.com",
         clientId: "cid",
         redirectUrl: "https://app.example.com/cb",
         codeVerifier: "verifier",
         code: "abc",
-        idTokenSigningAlgValuesSupported: ["ES256"],
       }),
     );
-
     expect(result.access_token).toBe("tok");
   });
 
-  it("ignores unusable ID tokens when the access-token response is otherwise valid", async () => {
+  it("happy path: token endpoint with no id_token still parses normally", async () => {
+    captureFetch(jsonResponse(200, validBody));
+    const result = await Effect.runPromise(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+      }),
+    );
+    expect(result.access_token).toBe("tok");
+    expect(result.refresh_token).toBe("rtok");
+    expect(result.expires_in).toBe(3600);
+  });
+
+  it("still surfaces RFC 6749 §5.2 error envelopes after the id_token strip", async () => {
+    captureFetch(
+      jsonResponse(400, {
+        error: "invalid_grant",
+        error_description: "authorization code expired",
+      }),
+    );
+    const exit = await Effect.runPromiseExit(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const failure = JSON.stringify(exit.cause);
+    expect(failure).toContain("OAuth2Error");
+    expect(failure).toContain("invalid_grant");
+    expect(failure).toContain("authorization code expired");
+  });
+
+  it("strips id_tokens with algorithms not advertised in AS metadata (e.g. ES256 without supported list)", async () => {
     captureFetch(
       jsonResponse(200, {
         ...validBody,
@@ -420,12 +457,12 @@ describe("refreshAccessToken", () => {
     expect(body.has("scope")).toBe(false);
   });
 
-  it("validates refreshed ID tokens against an explicit issuer", async () => {
+  it("strips refreshed id_tokens whose iss does not match AS metadata", async () => {
     captureFetch(
       jsonResponse(200, {
         ...validBody,
         id_token: unsignedJwt({
-          iss: "https://accounts.google.com",
+          iss: "https://us.posthog.com",
           aud: "cid",
           sub: "user-1",
           exp: Math.floor(Date.now() / 1000) + 3600,
@@ -435,8 +472,8 @@ describe("refreshAccessToken", () => {
     );
     const result = await Effect.runPromise(
       refreshAccessToken({
-        tokenUrl: "https://oauth2.googleapis.com/token",
-        issuerUrl: "https://accounts.google.com",
+        tokenUrl: "https://oauth.posthog.com/oauth/token",
+        issuerUrl: "https://oauth.posthog.com",
         clientId: "cid",
         refreshToken: "old",
       }),
@@ -444,37 +481,7 @@ describe("refreshAccessToken", () => {
     expect(result.access_token).toBe("tok2");
   });
 
-  it("accepts refreshed ID token signing algorithms advertised by authorization server metadata", async () => {
-    captureFetch(
-      jsonResponse(200, {
-        ...validBody,
-        id_token: unsignedJwt(
-          {
-            iss: "https://railway.com",
-            aud: "cid",
-            sub: "user-1",
-            exp: Math.floor(Date.now() / 1000) + 3600,
-            iat: Math.floor(Date.now() / 1000),
-          },
-          "ES256",
-        ),
-      }),
-    );
-
-    const result = await Effect.runPromise(
-      refreshAccessToken({
-        tokenUrl: "https://backboard.railway.com/oauth/token",
-        issuerUrl: "https://railway.com",
-        clientId: "cid",
-        refreshToken: "old",
-        idTokenSigningAlgValuesSupported: ["ES256"],
-      }),
-    );
-
-    expect(result.access_token).toBe("tok2");
-  });
-
-  it("ignores unusable refreshed ID tokens when the access-token response is otherwise valid", async () => {
+  it("strips refreshed id_tokens with algorithms not advertised in AS metadata", async () => {
     captureFetch(
       jsonResponse(200, {
         ...validBody,
@@ -501,6 +508,19 @@ describe("refreshAccessToken", () => {
     );
 
     expect(result.access_token).toBe("tok2");
+  });
+
+  it("happy path: refresh response with no id_token parses normally", async () => {
+    captureFetch(jsonResponse(200, validBody));
+    const result = await Effect.runPromise(
+      refreshAccessToken({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        refreshToken: "old",
+      }),
+    );
+    expect(result.access_token).toBe("tok2");
+    expect(result.expires_in).toBe(3600);
   });
 });
 

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -224,59 +224,43 @@ const tokenResponseFrom = (
   scope: r.scope,
 });
 
-const isUnexpectedIdTokenAlg = (cause: unknown): boolean =>
-  cause instanceof Error &&
-  cause.message.includes('unexpected JWT "alg" header parameter');
-
-const looseTokenResponseFrom = (body: unknown): OAuth2TokenResponse => {
-  if (typeof body !== "object" || body === null) {
-    throw new Error("token endpoint response body is not an object");
+// MCP source connections are pure OAuth 2.0 — we never request `openid` and
+// never consume `id_token`. Some providers (PostHog, etc.) front an OIDC
+// backend and emit an `id_token` anyway; oauth4webapi then strict-validates
+// its claims against the AS metadata and rejects mismatches we don't care
+// about. Strip the field before delegation.
+const stripIdToken = async (response: Response): Promise<Response> => {
+  const body = await response
+    .clone()
+    .json()
+    .catch(() => null);
+  if (
+    !body ||
+    typeof body !== "object" ||
+    !("id_token" in (body as Record<string, unknown>))
+  ) {
+    return response;
   }
-  const record = body as Record<string, unknown>;
-  if (typeof record.access_token !== "string" || !record.access_token) {
-    throw new Error('token endpoint response is missing "access_token"');
-  }
-  const expiresIn =
-    typeof record.expires_in === "number"
-      ? record.expires_in
-      : typeof record.expires_in === "string"
-        ? Number.parseFloat(record.expires_in)
-        : undefined;
-  if (expiresIn !== undefined && !Number.isFinite(expiresIn)) {
-    throw new Error('token endpoint response has invalid "expires_in"');
-  }
-  return {
-    access_token: record.access_token,
-    token_type:
-      typeof record.token_type === "string" ? record.token_type : undefined,
-    refresh_token:
-      typeof record.refresh_token === "string"
-        ? record.refresh_token
-        : undefined,
-    expires_in: expiresIn,
-    scope: typeof record.scope === "string" ? record.scope : undefined,
-  };
+  const { id_token: _ignored, ...rest } = body as Record<string, unknown>;
+  return new Response(JSON.stringify(rest), {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
 };
 
 const processTokenEndpointResponse = async (
   as: oauth.AuthorizationServer,
   client: oauth.Client,
   response: Response,
-): Promise<OAuth2TokenResponse> => {
-  const fallback = response.clone();
-  try {
-    return tokenResponseFrom(
-      await oauth.processGenericTokenEndpointResponse(as, client, response),
-    );
-  } catch (cause) {
-    if (!isUnexpectedIdTokenAlg(cause)) throw cause;
-    // Some OAuth-only providers include an ID token even when their metadata
-    // does not advertise enough OIDC signing metadata for strict validation.
-    // Executor stores only access/refresh tokens for source auth, so tolerate
-    // an unusable ID token after the access token response itself is valid.
-    return looseTokenResponseFrom(await fallback.json());
-  }
-};
+): Promise<OAuth2TokenResponse> =>
+  tokenResponseFrom(
+    await oauth.processGenericTokenEndpointResponse(
+      as,
+      client,
+      await stripIdToken(response),
+    ),
+  );
 
 // ---------------------------------------------------------------------------
 // Exchange authorization code → tokens
@@ -425,18 +409,12 @@ export const refreshAccessToken = (
           additionalParameters,
         },
       );
-      const fallback = response.clone();
-      try {
-        const result = await oauth.processRefreshTokenResponse(
-          as,
-          client,
-          response,
-        );
-        return tokenResponseFrom(result);
-      } catch (cause) {
-        if (!isUnexpectedIdTokenAlg(cause)) throw cause;
-        return looseTokenResponseFrom(await fallback.json());
-      }
+      const result = await oauth.processRefreshTokenResponse(
+        as,
+        client,
+        await stripIdToken(response),
+      );
+      return tokenResponseFrom(result);
     },
     catch: toOAuth2Error,
   });


### PR DESCRIPTION
## Summary
- Some OAuth providers run an OIDC-capable backend behind a plain OAuth 2.0 surface (RFC 8414 `oauth-authorization-server` discovery). Their token endpoint emits an `id_token` even when the client never requested `openid` and never registered as an OIDC client.
- `oauth4webapi`'s `processGenericTokenEndpointResponse` strict-validates any `id_token` it sees against AS metadata (`iss`, `aud`, required claims, signing alg). When the provider's id_token claims don't match — common with this hybrid setup — the access_token portion of the response (which is perfectly valid and is all we use) is rejected, surfacing as "Authentication failed" in the UI.
- We never consume the id_token. Strip it from the response body before delegation so OIDC validation has nothing to reject.

The previous code carried a single string-match tolerance for one specific quirk (`unexpected JWT "alg" header parameter`) and fell back to a manual JSON parser. That allowlist approach needed a new exception for every provider variation (`iss`, `aud`, multi-`aud` + missing `azp`, missing required claim, etc.). The strip removes the entire class at the source while keeping every other piece of the library's correctness — content-type checks, RFC 6749 §5.2 error envelope, WWW-Authenticate parsing, scope/token_type validation.

Applied to both auth-code grant (`processTokenEndpointResponse`) and refresh grant (`processRefreshTokenResponse`).

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun run test` in `packages/core/sdk` — 174/174
- [x] New tests in `oauth-helpers.test.ts`: mismatched `iss` (code + refresh paths), mismatched `aud`, no-id_token happy path, RFC 6749 §5.2 error envelope regression guard, alg-not-advertised case
- [ ] Manual: sign in to a previously-failing provider end-to-end after deploy