### PR TITLE
Pass plugin clientConfig through to the client bundle

### DIFF
--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -349,6 +349,20 @@ export interface PluginSpec<
    *  structurally impossible. */
   readonly storage: (deps: StorageDeps<TSchema>) => TStore;
 
+  /** JSON-serializable config the plugin wants its `./client` bundle to
+   *  see. The Vite plugin reads this off each `executor.config.ts` spec
+   *  at build time and bakes it into the virtual `plugins-client`
+   *  module by calling the plugin's default `./client` export as a
+   *  factory: `__p(<JSON.stringify(clientConfig)>)`. Plugins that don't
+   *  set this stay as bare-value default exports — no churn.
+   *
+   *  Use this when a server-side option (e.g. `dangerouslyAllowStdioMCP`)
+   *  needs to drive client UI behaviour: declaring it once in
+   *  `executor.config.ts` flows through to the bundle automatically,
+   *  with no runtime fetch and no parallel client-side flag to keep in
+   *  sync. */
+  readonly clientConfig?: unknown;
+
   /** Build the plugin's extension API. The returned object becomes
    *  `executor[plugin.id]` and is also the `self` passed to
    *  `staticSources`. Field order matters: `extension` MUST appear

--- a/packages/core/vite-plugin/src/index.ts
+++ b/packages/core/vite-plugin/src/index.ts
@@ -132,11 +132,16 @@ export default function executorVitePlugin(
     const jsoncPath = resolveJsoncPath();
     const fromDir = configPath ? dirname(configPath) : projectRoot;
 
-    // Collect packageNames in priority order: static config first,
+    // Collect plugin entries in priority order: static config first,
     // jsonc second. De-duplicate by package name — if both list the
     // same plugin, only one import is emitted. (Static wins for the
     // ordering of `plugins` array, which matters for nav order.)
-    const packageNames: string[] = [];
+    //
+    // `clientConfig` only flows in via the static config path: it
+    // lives on the runtime `PluginSpec` returned by
+    // `definePlugin(...)`, which is only available when we jiti-load
+    // the TS module. The jsonc path carries package names only.
+    const entries: Array<{ readonly pkg: string; readonly clientConfig?: unknown }> = [];
     const seen = new Set<string>();
 
     if (configPath) {
@@ -156,7 +161,11 @@ export default function executorVitePlugin(
         if (!spec.packageName) continue;
         if (seen.has(spec.packageName)) continue;
         seen.add(spec.packageName);
-        packageNames.push(spec.packageName);
+        const clientConfig = (spec as { clientConfig?: unknown }).clientConfig;
+        entries.push({
+          pkg: spec.packageName,
+          ...(clientConfig !== undefined ? { clientConfig } : {}),
+        });
       }
     }
 
@@ -164,15 +173,15 @@ export default function executorVitePlugin(
       for (const pkg of readJsoncPlugins(jsoncPath)) {
         if (seen.has(pkg)) continue;
         seen.add(pkg);
-        packageNames.push(pkg);
+        entries.push({ pkg });
       }
     }
 
     const lines: string[] = [];
-    const exportNames: string[] = [];
+    const exportExpressions: string[] = [];
 
-    for (const pkg of packageNames) {
-      const resolved = tryResolveClient(pkg, fromDir);
+    for (const entry of entries) {
+      const resolved = tryResolveClient(entry.pkg, fromDir);
       if (!resolved) {
         // package was listed but didn't resolve. Likely culprits:
         // a typo, a package that hasn't published `./client` in its
@@ -180,22 +189,31 @@ export default function executorVitePlugin(
         // loudly so the dev sees their plugin's UI is missing instead
         // of silently shipping a host without it.
         console.warn(
-          `[@executor-js/vite-plugin] plugin package "${pkg}" listed but ` +
-            `${pkg}/client could not be resolved from ${fromDir}. The ` +
+          `[@executor-js/vite-plugin] plugin package "${entry.pkg}" listed but ` +
+            `${entry.pkg}/client could not be resolved from ${fromDir}. The ` +
             `plugin's UI will not be bundled. Check that the package is ` +
             `installed and exports a \`./client\` subpath in its ` +
             `package.json.`,
         );
         continue;
       }
-      const ident = `__executor_plugin_${exportNames.length}`;
-      lines.push(`import ${ident} from ${JSON.stringify(`${pkg}/client`)};`);
-      exportNames.push(ident);
+      const ident = `__executor_plugin_${exportExpressions.length}`;
+      lines.push(`import ${ident} from ${JSON.stringify(`${entry.pkg}/client`)};`);
+      // Plugins that surface a `clientConfig` default-export a factory
+      // `(config?) => ClientPluginSpec`; everyone else default-exports
+      // a bare `ClientPluginSpec` value. We emit a call only when we
+      // have config to thread through, so existing plugins need no
+      // changes to keep working.
+      exportExpressions.push(
+        entry.clientConfig !== undefined
+          ? `${ident}(${JSON.stringify(entry.clientConfig)})`
+          : ident,
+      );
     }
 
     cachedSource =
       `${lines.join("\n")}\n` +
-      `export const plugins = [${exportNames.join(", ")}];\n`;
+      `export const plugins = [${exportExpressions.join(", ")}];\n`;
     return cachedSource;
   };
 

--- a/packages/plugins/mcp/src/react/plugin-client.tsx
+++ b/packages/plugins/mcp/src/react/plugin-client.tsx
@@ -1,21 +1,33 @@
 // ---------------------------------------------------------------------------
-// @executor-js/plugin-mcp/client — `defineClientPlugin` entry.
+// @executor-js/plugin-mcp/client — `defineClientPlugin` factory entry.
 //
-// Bakes `allowStdio: true` into the source plugin shipped via the
-// virtual `plugins-client` module — that's the local-app default and
-// the source plugin's UI options only matter when the server-side flag
-// is also on. Hosts that want stdio off can keep importing
-// `createMcpSourcePlugin({ allowStdio: false })` from `./react`
-// directly and bypass the virtual module.
+// Default-exports a factory rather than a value: at build time the
+// `@executor-js/vite-plugin` reads each plugin spec's `clientConfig`
+// from `executor.config.ts` and emits `__p(<JSON.stringify(clientConfig)>)`
+// into the virtual `plugins-client` module. So `allowStdio` flows from
+// the server-side `mcpPlugin({ dangerouslyAllowStdioMCP })` straight
+// into the bundle — no parallel client-side flag, no per-host shim,
+// no runtime fetch.
 // ---------------------------------------------------------------------------
 
 import { defineClientPlugin } from "@executor-js/sdk/client";
 
 import { createMcpSourcePlugin } from "./source-plugin";
 
-const mcpSourcePlugin = createMcpSourcePlugin({ allowStdio: true });
+export interface McpClientConfig {
+  /**
+   * Mirrors `dangerouslyAllowStdioMCP` on the server-side plugin. When
+   * false, the AddMcpSource UI hides the stdio tab and stdio presets.
+   * Defaults to false — same default as the server flag.
+   */
+  readonly allowStdio?: boolean;
+}
 
-export default defineClientPlugin({
-  id: "mcp" as const,
-  sourcePlugin: mcpSourcePlugin,
-});
+export default function createMcpClientPlugin(config?: McpClientConfig) {
+  return defineClientPlugin({
+    id: "mcp" as const,
+    sourcePlugin: createMcpSourcePlugin({
+      allowStdio: config?.allowStdio ?? false,
+    }),
+  });
+}

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -438,6 +438,12 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
   return {
     id: "mcp" as const,
     packageName: "@executor-js/plugin-mcp",
+    // Surfaced to the client bundle via the Vite plugin (see
+    // `@executor-js/vite-plugin`). The MCP `./client` factory reads
+    // `allowStdio` and gates the stdio tab + presets in AddMcpSource —
+    // so the server's `dangerouslyAllowStdioMCP` flag is the single
+    // source of truth for both runtime and UI.
+    clientConfig: { allowStdio },
     schema: mcpSchema,
     storage: (deps): McpBindingStore => makeMcpStore(deps),
 


### PR DESCRIPTION
Plugins can now set a JSON-serializable `clientConfig` on their server spec; the Vite plugin reads it from `executor.config.ts` and threads it into the virtual `plugins-client` module by calling the plugin's `./client` default export as a factory.

Used to drop the duplicated stdio flag in MCP — `dangerouslyAllowStdioMCP` on the server now drives whether the AddMcpSource UI shows the stdio tab and presets, with no parallel client-side config.

Existing plugins without a `clientConfig` keep their bare-value default exports and need no changes.