### PR TITLE
Remove Slack contact feature

### DIFF
--- a/apps/cloud/src/api/slack.ts
+++ b/apps/cloud/src/api/slack.ts
@@ -11,29 +11,6 @@ import {
 
 const isValidEmail = (s: string): boolean => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s);
 
-const verifyTurnstile = (token: string, remoteIp: string | null) =>
-  Effect.tryPromise({
-    try: async () => {
-      const secret = env.TURNSTILE_SECRET_KEY;
-      if (!secret) {
-        // Turnstile is unconfigured — fail closed in prod, but allow dev to
-        // boot without it. We treat empty secret as "skip" so the form works
-        // before secrets are wired; remove this branch once you've set the
-        // secret in every environment.
-        return { success: true, skipped: true };
-      }
-      const form = new URLSearchParams({ secret, response: token });
-      if (remoteIp) form.set("remoteip", remoteIp);
-      const res = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
-        method: "POST",
-        body: form,
-      });
-      const json = (await res.json()) as { success: boolean; "error-codes"?: string[] };
-      return { success: json.success, errorCodes: json["error-codes"] ?? [] };
-    },
-    catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
-  });
-
 const handler = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
 
@@ -57,20 +34,14 @@ const handler = Effect.gen(function* () {
       }),
   )) as {
     email?: unknown;
-    name?: unknown;
-    note?: unknown;
     organization?: unknown;
-    turnstileToken?: unknown;
   };
 
   const trimmed = (v: unknown, max: number): string | undefined =>
     typeof v === "string" && v.trim().length > 0 ? v.trim().slice(0, max) : undefined;
 
   const email = typeof body.email === "string" ? body.email.trim() : "";
-  const name = trimmed(body.name, 200);
-  const note = trimmed(body.note, 2000);
   const organization = trimmed(body.organization, 200);
-  const turnstileToken = typeof body.turnstileToken === "string" ? body.turnstileToken : "";
 
   if (!isValidEmail(email)) {
     return yield* Effect.fail(
@@ -82,32 +53,8 @@ const handler = Effect.gen(function* () {
     );
   }
 
-  if (!turnstileToken) {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 400,
-        code: "captcha_required",
-        message: "Captcha verification is required.",
-      }),
-    );
-  }
-
-  const remoteIp = request.headers["cf-connecting-ip"] ?? null;
-  const verification = yield* verifyTurnstile(turnstileToken, remoteIp);
-  if (!verification.success) {
-    console.error("[slack] turnstile verification failed:", verification);
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 403,
-        code: "captcha_failed",
-        message: "Captcha verification failed. Please try again.",
-      }),
-    );
-  }
-
-  // Global daily channel-creation cap — bounds the worst case if Turnstile is
-  // bypassed somehow. Per-IP gating belongs at the edge (Cloudflare Rules);
-  // this binding is a single shared bucket keyed at "global".
+  // Global rate limit — single shared bucket keyed at "global". Per-IP gating
+  // belongs at the edge (Cloudflare Rules).
   const limit = yield* Effect.tryPromise({
     try: () => env.SLACK_INVITE_LIMITER.limit({ key: "global" }),
     catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
@@ -124,7 +71,7 @@ const handler = Effect.gen(function* () {
   }
 
   const slack = yield* SlackService;
-  const { invite } = yield* slack.createConnectInvite({ email, name, note, organization }).pipe(
+  const { invite } = yield* slack.createConnectInvite({ email, organization }).pipe(
     Effect.tapError((err) =>
       Effect.sync(() => {
         console.error(`[slack] ${err.method} failed:`, err.error);

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -25,11 +25,6 @@ declare global {
 
       // Contact / Slack Connect
       SLACK_BOT_TOKEN?: string;
-      // Turnstile (Cloudflare CAPTCHA) — used to gate the public Slack-contact
-      // endpoint. Sitekey is public and ships in `vars`; secret is set via
-      // `wrangler secret put TURNSTILE_SECRET_KEY`.
-      TURNSTILE_SECRET_KEY?: string;
-      VITE_PUBLIC_TURNSTILE_SITEKEY?: string;
       // Cloudflare ratelimit binding declared in wrangler.jsonc — caps total
       // Slack-contact channel creations across all callers.
       SLACK_INVITE_LIMITER: { limit: (input: { key: string }) => Promise<{ success: boolean }> };

--- a/apps/cloud/src/routes/billing_.plans.tsx
+++ b/apps/cloud/src/routes/billing_.plans.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useAuth } from "../web/auth";
 import { useCustomer, useListPlans } from "autumn-js/react";
@@ -16,7 +16,6 @@ import {
 } from "@executor-js/react/components/dialog";
 import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
-import { Textarea } from "@executor-js/react/components/textarea";
 
 type Plan = NonNullable<ReturnType<typeof useListPlans>["data"]>[number];
 
@@ -310,40 +309,27 @@ function SlackContactCta() {
   const auth = useAuth();
   const signedIn = auth.status === "authenticated" ? auth : null;
   const prefillEmail = signedIn?.user.email ?? "";
-  const prefillName = signedIn?.user.name ?? "";
   const orgName = signedIn?.organization?.name ?? "";
 
-  const turnstileSiteKey = import.meta.env.VITE_PUBLIC_TURNSTILE_SITEKEY ?? "";
   const [open, setOpen] = useState(false);
   const [email, setEmail] = useState(prefillEmail);
-  const [name, setName] = useState(prefillName);
-  const [note, setNote] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [inviteUrl, setInviteUrl] = useState<string | null>(null);
-  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
 
   // Hydrate prefill once auth resolves (it starts as `loading` on first render).
   useEffect(() => {
     if (prefillEmail && !email) setEmail(prefillEmail);
-    if (prefillName && !name) setName(prefillName);
-  }, [prefillEmail, prefillName]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [prefillEmail]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const reset = () => {
     setEmail(prefillEmail);
-    setName(prefillName);
-    setNote("");
     setError(null);
     setInviteUrl(null);
-    setTurnstileToken(null);
   };
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!turnstileToken) {
-      setError("Please complete the captcha first.");
-      return;
-    }
     setSubmitting(true);
     setError(null);
     try {
@@ -352,10 +338,7 @@ function SlackContactCta() {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
           email,
-          name: name || undefined,
-          note: note || undefined,
           organization: orgName || undefined,
-          turnstileToken,
         }),
       });
       const data = (await res.json().catch(() => ({}))) as { url?: string; error?: string };
@@ -368,9 +351,6 @@ function SlackContactCta() {
       setError("Network error. Please try again.");
     } finally {
       setSubmitting(false);
-      // Turnstile tokens are single-use server-side — clear so the widget
-      // re-issues a fresh one on retry.
-      setTurnstileToken(null);
     }
   };
 
@@ -445,29 +425,6 @@ function SlackContactCta() {
                     placeholder="you@company.com"
                   />
                 </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="slack-contact-name">Name (optional)</Label>
-                  <Input
-                    id="slack-contact-name"
-                    autoComplete="name"
-                    value={name}
-                    onChange={(e) => setName(e.currentTarget.value)}
-                    placeholder="Ada Lovelace"
-                  />
-                </div>
-                <div className="grid gap-2">
-                  <Label htmlFor="slack-contact-note">What's on your mind? (optional)</Label>
-                  <Textarea
-                    id="slack-contact-note"
-                    rows={3}
-                    value={note}
-                    onChange={(e) => setNote(e.currentTarget.value)}
-                    placeholder="Pricing question, integration help, anything…"
-                  />
-                </div>
-                {turnstileSiteKey && (
-                  <TurnstileWidget siteKey={turnstileSiteKey} onToken={setTurnstileToken} />
-                )}
                 {error && <p className="text-sm text-destructive">{error}</p>}
               </div>
               <DialogFooter>
@@ -476,10 +433,7 @@ function SlackContactCta() {
                     Cancel
                   </Button>
                 </DialogClose>
-                <Button
-                  type="submit"
-                  disabled={submitting || !email || (!!turnstileSiteKey && !turnstileToken)}
-                >
+                <Button type="submit" disabled={submitting || !email}>
                   {submitting ? "Sending…" : "Send invite"}
                 </Button>
               </DialogFooter>
@@ -509,86 +463,6 @@ function MailIcon({ className }: { className?: string }) {
       <path strokeLinecap="round" strokeLinejoin="round" d="M3 7l9 6 9-6M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
     </svg>
   );
-}
-
-type TurnstileApi = {
-  render: (
-    el: HTMLElement,
-    opts: {
-      sitekey: string;
-      callback?: (token: string) => void;
-      "error-callback"?: () => void;
-      "expired-callback"?: () => void;
-      theme?: "light" | "dark" | "auto";
-    },
-  ) => string;
-  remove: (id: string) => void;
-};
-
-declare global {
-  interface Window {
-    turnstile?: TurnstileApi;
-  }
-}
-
-function TurnstileWidget({
-  siteKey,
-  onToken,
-}: {
-  siteKey: string;
-  onToken: (token: string | null) => void;
-}) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const widgetIdRef = useRef<string | null>(null);
-  const onTokenRef = useRef(onToken);
-  onTokenRef.current = onToken;
-
-  useEffect(() => {
-    let cancelled = false;
-    const render = () => {
-      if (cancelled || !containerRef.current || !window.turnstile) return;
-      if (widgetIdRef.current) {
-        window.turnstile.remove(widgetIdRef.current);
-        widgetIdRef.current = null;
-      }
-      widgetIdRef.current = window.turnstile.render(containerRef.current, {
-        sitekey: siteKey,
-        callback: (token) => onTokenRef.current(token),
-        "error-callback": () => onTokenRef.current(null),
-        "expired-callback": () => onTokenRef.current(null),
-      });
-    };
-
-    if (window.turnstile) {
-      render();
-    } else {
-      const existing = document.querySelector<HTMLScriptElement>("script[data-turnstile]");
-      if (existing) {
-        existing.addEventListener("load", render);
-        return () => {
-          cancelled = true;
-          existing.removeEventListener("load", render);
-        };
-      }
-      const script = document.createElement("script");
-      script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
-      script.async = true;
-      script.defer = true;
-      script.dataset.turnstile = "1";
-      script.addEventListener("load", render);
-      document.head.appendChild(script);
-    }
-
-    return () => {
-      cancelled = true;
-      if (widgetIdRef.current && window.turnstile) {
-        window.turnstile.remove(widgetIdRef.current);
-        widgetIdRef.current = null;
-      }
-    };
-  }, [siteKey]);
-
-  return <div ref={containerRef} className="flex justify-center" />;
 }
 
 function SlackMark({ className }: { className?: string }) {

--- a/apps/cloud/src/services/slack.ts
+++ b/apps/cloud/src/services/slack.ts
@@ -15,8 +15,6 @@ export class SlackError extends Data.TaggedError("SlackError")<{
 export type ISlackService = Readonly<{
   createConnectInvite: (input: {
     email: string;
-    name?: string;
-    note?: string;
     organization?: string;
   }) => Effect.Effect<
     {
@@ -27,8 +25,8 @@ export type ISlackService = Readonly<{
   >;
 }>;
 
-const slugifyEmail = (email: string): string =>
-  email
+const slugify = (s: string): string =>
+  s
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
@@ -79,13 +77,13 @@ const make = Effect.sync(() => {
 
   const createConnectInvite: ISlackService["createConnectInvite"] = ({
     email,
-    name,
-    note,
     organization,
   }) =>
     Effect.gen(function* () {
-      // Slack channel names: lowercase, no spaces, max 80 chars, unique per workspace.
-      const baseName = `shared-${slugifyEmail(email)}`.slice(0, 80);
+      // Slack channel names: lowercase, no spaces, max 80 chars, unique per
+      // workspace. Use the org name when available; fall back to the email
+      // local-part for unauthenticated submissions.
+      const baseName = slugify(organization ?? email).slice(0, 80) || "contact";
       const tryCreate = (n: string) =>
         call<SlackResponse & { channel: { id: string; name: string } }>(
           "conversations.create",
@@ -101,27 +99,18 @@ const make = Effect.sync(() => {
       );
       const channel = created.channel;
 
-      const helloLines = [
-        `:wave: New contact from pricing page: ${email}`,
-        name ? `Name: ${name}` : null,
-        organization ? `Org: ${organization}` : null,
-        note ? `Note: ${note}` : null,
-      ].filter(Boolean) as string[];
-
-      yield* call<SlackResponse>("chat.postMessage", {
-        channel: channel.id,
-        text: helloLines.join("\n"),
-      });
-
       const invite = yield* call<SlackResponse & { invite_id: string; url: string }>(
         "conversations.inviteShared",
         {
           channel: channel.id,
           emails: [email],
-          // `external_limited: true` scopes the guest to just this channel,
-          // which is what we want for a focused 1:1 support conversation.
-          external_limited: true,
         },
+      );
+
+      // Best-effort: leave the channel so the bot doesn't sit in every
+      // contact channel forever. Don't fail the request if leave errors.
+      yield* call<SlackResponse>("conversations.leave", { channel: channel.id }).pipe(
+        Effect.ignore,
       );
 
       return {

--- a/apps/cloud/wrangler.jsonc
+++ b/apps/cloud/wrangler.jsonc
@@ -54,15 +54,12 @@
   "vars": {
     "VITE_PUBLIC_SITE_URL": "https://executor.sh",
     "VITE_PUBLIC_POSTHOG_KEY": "phc_nNLrNMALpRsfrEkZovUkfMxYbcJvHnsJHeoSPavprgLL",
-    // Replace with your Turnstile production sitekey before going live. The
-    // test key always passes — fine for local dev, useless in prod.
-    "VITE_PUBLIC_TURNSTILE_SITEKEY": "1x00000000000000000000AA",
   },
   // Cloudflare's `simple` ratelimit only supports 10s or 60s windows — it's
-  // burst protection, not a true daily cap. With Turnstile gating the form,
-  // 5/min keeps the worst-case sustained throughput to ~7k channels/day,
-  // which is bounded enough as a backstop. For an actual daily ceiling,
-  // layer a Durable Object counter on top.
+  // burst protection, not a true daily cap. 5/min keeps the worst-case
+  // sustained throughput to ~7k channels/day, which is bounded enough as a
+  // backstop. For an actual daily ceiling, layer a Durable Object counter
+  // on top.
   "ratelimits": [
     {
       "name": "SLACK_INVITE_LIMITER",


### PR DESCRIPTION
## Summary
- Removes the pricing-page Slack Connect contact form (frontend + backend).
- Drops the Slack route, service, router/layer wiring, env vars, and the Cloudflare ratelimit binding the form relied on.

## Test plan
- [ ] Build the cloud app and confirm typecheck passes.
- [ ] Load the pricing page and confirm it renders with the CTA gone.
- [ ] Confirm `POST /api/contact/slack` 404s.