### PR TITLE
[codex] Use Effect resource cleanup in schema test

### DIFF
--- a/apps/cloud/src/services/db.schema.test.ts
+++ b/apps/cloud/src/services/db.schema.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, expect, it } from "@effect/vitest";
 import { drizzle } from "drizzle-orm/postgres-js";
+import { Effect } from "effect";
 import postgres from "postgres";
 
 import * as cloudSchema from "./schema";
@@ -44,20 +45,26 @@ describe("combinedSchema", () => {
   // getters could theoretically drop tables if evaluated before their
   // declarations. Construct a drizzle instance and walk its fullSchema
   // to catch that class of bug too.
-  it("drizzle(combinedSchema) exposes every table under _.fullSchema", () => {
+  it.effect("drizzle(combinedSchema) exposes every table under _.fullSchema", () =>
     // postgres() lazily connects — safe to build with a dummy url, we
     // never .query() so no socket is opened.
-    const sql = postgres("postgres://u:p@127.0.0.1:1/x", { max: 1 });
-    try {
-      const db = drizzle(sql, { schema: combinedSchema });
-      const drizzleInternals = (value: unknown): { _: { fullSchema: Record<string, unknown> } } =>
-        value as { _: { fullSchema: Record<string, unknown> } };
-      const fullSchema = drizzleInternals(db)._.fullSchema;
-      for (const key of Object.keys(executorSchema)) {
-        expect(fullSchema, `fullSchema missing "${key}"`).toHaveProperty(key);
-      }
-    } finally {
-      sql.end({ timeout: 0 }).catch(() => undefined);
-    }
-  });
+    Effect.acquireRelease(
+      Effect.sync(() => postgres("postgres://u:p@127.0.0.1:1/x", { max: 1 })),
+      (sql) => Effect.promise(() => sql.end({ timeout: 0 })),
+    ).pipe(
+      Effect.flatMap((sql) =>
+        Effect.sync(() => {
+          const db = drizzle(sql, { schema: combinedSchema });
+          const drizzleInternals = (
+            value: unknown,
+          ): { _: { fullSchema: Record<string, unknown> } } =>
+            value as { _: { fullSchema: Record<string, unknown> } };
+          const fullSchema = drizzleInternals(db)._.fullSchema;
+          for (const key of Object.keys(executorSchema)) {
+            expect(fullSchema, `fullSchema missing "${key}"`).toHaveProperty(key);
+          }
+        }),
+      ),
+    ),
+  );
 });


### PR DESCRIPTION
## Summary
- convert the schema smoke test to `it.effect`
- manage the postgres handle with `Effect.acquireRelease`
- remove try/finally and Promise cleanup from the test body

## Validation
- `bun run typecheck` in `apps/cloud`
- `node ../../node_modules/vitest/vitest.mjs run src/services/db.schema.test.ts` in `apps/cloud`
- `bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/services/db.schema.test.ts --deny-warnings`

Stacked on #535.
