### PR TITLE
Clean up Cloud MCP response peeking

### DIFF
--- a/apps/cloud/src/mcp/response-peek.ts
+++ b/apps/cloud/src/mcp/response-peek.ts
@@ -1,23 +1,40 @@
 import * as Sentry from "@sentry/cloudflare";
-import { Effect } from "effect";
+import { Data, Effect, Option, Predicate, Schema } from "effect";
 
 import { jsonRpcWebResponse } from "./responses";
 
 const SSE_PEEK_TIMEOUT_MS = 10_000;
 
-type SandboxOutcome = {
-  readonly status?: string;
-  readonly error?: { readonly kind?: string; readonly message?: string };
-};
+const SandboxOutcome = Schema.Struct({
+  status: Schema.optional(Schema.String),
+  error: Schema.optional(
+    Schema.Struct({
+      kind: Schema.optional(Schema.String),
+      message: Schema.optional(Schema.String),
+    }),
+  ),
+});
 
-type JsonRpcResponseBody = {
-  readonly jsonrpc?: string;
-  readonly error?: { readonly code?: number; readonly message?: string };
-  readonly result?: {
-    readonly isError?: boolean;
-    readonly structuredContent?: SandboxOutcome;
-  };
-};
+const JsonRpcResponseBody = Schema.Struct({
+  jsonrpc: Schema.optional(Schema.String),
+  error: Schema.optional(
+    Schema.Struct({
+      code: Schema.optional(Schema.Number),
+      message: Schema.optional(Schema.String),
+    }),
+  ),
+  result: Schema.optional(
+    Schema.Struct({
+      isError: Schema.optional(Schema.Boolean),
+      structuredContent: Schema.optional(SandboxOutcome),
+    }),
+  ),
+});
+type JsonRpcResponseBody = typeof JsonRpcResponseBody.Type;
+
+const decodeJsonRpcResponseBodyJson = Schema.decodeUnknownOption(
+  Schema.fromJsonString(JsonRpcResponseBody),
+);
 
 const responseBodyShape = (body: string): string => {
   const trimmed = body.trimStart();
@@ -31,79 +48,108 @@ const responseBodyShape = (body: string): string => {
 
 const parseFirstJsonRpc = (contentType: string, body: string): JsonRpcResponseBody | null => {
   if (!body) return null;
-  try {
-    if (contentType.includes("text/event-stream")) {
-      for (const line of body.split(/\r?\n/)) {
-        if (line.startsWith("data:")) return JSON.parse(line.slice(5).trimStart());
+  if (contentType.includes("text/event-stream")) {
+    for (const line of body.split(/\r?\n/)) {
+      if (line.startsWith("data:")) {
+        return Option.getOrNull(decodeJsonRpcResponseBodyJson(line.slice(5).trimStart()));
       }
-      return null;
     }
-    if (contentType.includes("application/json")) return JSON.parse(body);
-    return null;
-  } catch {
     return null;
   }
+  if (contentType.includes("application/json")) {
+    return Option.getOrNull(decodeJsonRpcResponseBodyJson(body));
+  }
+  return null;
 };
 
 const jsonRpcResponseAttrs = (payload: JsonRpcResponseBody | null): Record<string, unknown> => {
   if (!payload || payload.jsonrpc !== "2.0") return {};
   const attrs: Record<string, unknown> = {};
-  const err = payload.error;
-  if (err && typeof err === "object") {
+  const rpcError = payload.error;
+  if (rpcError && typeof rpcError === "object") {
     attrs["mcp.rpc.is_error"] = true;
-    if (typeof err.code === "number") attrs["mcp.rpc.error.code"] = err.code;
-    if (typeof err.message === "string") {
-      attrs["mcp.rpc.error.message"] = err.message.slice(0, 500);
+    if (typeof rpcError.code === "number") attrs["mcp.rpc.error.code"] = rpcError.code;
+    if (typeof rpcError.message === "string") {
+      attrs["mcp.rpc.error.message"] = rpcError.message.slice(0, 500);
     }
   }
   if (payload.result?.isError === true) attrs["mcp.tool.result.is_error"] = true;
   const structured = payload.result?.structuredContent;
   if (structured && typeof structured.status === "string") {
     attrs["mcp.tool.sandbox.status"] = structured.status;
-    if (structured.error?.kind) attrs["mcp.tool.sandbox.error.kind"] = structured.error.kind;
-    if (typeof structured.error?.message === "string") {
-      attrs["mcp.tool.sandbox.error.message"] = structured.error.message.slice(0, 500);
+    const sandboxError = structured.error;
+    if (sandboxError?.kind) attrs["mcp.tool.sandbox.error.kind"] = sandboxError.kind;
+    if (typeof sandboxError?.message === "string") {
+      attrs["mcp.tool.sandbox.error.message"] = sandboxError.message.slice(0, 500);
     }
   }
   return attrs;
 };
 
-class ResponseBodyTimeoutError extends Error {
-  constructor(readonly timeoutMs: number) {
-    super(`Timed out waiting for MCP response body after ${timeoutMs}ms`);
-    this.name = "ResponseBodyTimeoutError";
-  }
-}
+class ResponseBodyTimeoutError extends Data.TaggedError("ResponseBodyTimeoutError")<{
+  readonly timeoutMs: number;
+}> {}
 
-const readResponseText = async (response: Response, timeoutMs: number | null): Promise<string> => {
-  if (timeoutMs === null) return await response.text();
+class ResponseBodyReadError extends Data.TaggedError("ResponseBodyReadError")<{
+  readonly cause: unknown;
+}> {}
+
+type ResponseBodyReadFailure = ResponseBodyTimeoutError | ResponseBodyReadError;
+
+type ResponseBodyReadOutcome =
+  | { readonly type: "success"; readonly text: string }
+  | { readonly type: "timeout"; readonly timeoutMs: number };
+
+const readResponseTextOutcome = async (
+  response: Response,
+  timeoutMs: number | null,
+): Promise<ResponseBodyReadOutcome> => {
+  if (timeoutMs === null) {
+    return { type: "success", text: await response.text() };
+  }
 
   const reader = response.body?.getReader();
-  if (!reader) return "";
+  if (!reader) return { type: "success", text: "" };
 
   const decoder = new TextDecoder();
   let timeout: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_, reject) => {
+  const timeoutPromise = new Promise<ResponseBodyReadOutcome>((resolve) => {
     timeout = setTimeout(() => {
-      void reader.cancel().catch(() => undefined);
-      reject(new ResponseBodyTimeoutError(timeoutMs));
+      void reader.cancel().then(
+        () => undefined,
+        () => undefined,
+      );
+      resolve({ type: "timeout", timeoutMs });
     }, timeoutMs);
   });
-  const readPromise = (async () => {
-    try {
-      let text = "";
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) return text + decoder.decode();
-        text += decoder.decode(value, { stream: true });
-      }
-    } finally {
-      if (timeout) clearTimeout(timeout);
+  const readPromise = (async (): Promise<ResponseBodyReadOutcome> => {
+    let text = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return { type: "success", text: text + decoder.decode() };
+      text += decoder.decode(value, { stream: true });
     }
-  })();
+  })().finally(() => {
+    if (timeout) clearTimeout(timeout);
+  });
 
   return await Promise.race([readPromise, timeoutPromise]);
 };
+
+const readResponseText = (
+  response: Response,
+  timeoutMs: number | null,
+): Effect.Effect<string, ResponseBodyReadFailure> =>
+  Effect.tryPromise({
+    try: () => readResponseTextOutcome(response, timeoutMs),
+    catch: (cause) => new ResponseBodyReadError({ cause }),
+  }).pipe(
+    Effect.flatMap((outcome) =>
+      outcome.type === "timeout"
+        ? Effect.fail(new ResponseBodyTimeoutError({ timeoutMs: outcome.timeoutMs }))
+        : Effect.succeed(outcome.text),
+    ),
+  );
 
 const annotateEmptyResponse = (response: Response, contentType: string) =>
   Effect.annotateCurrentSpan({
@@ -125,9 +171,9 @@ const withoutBodyHeaders = (response: Response) => {
   });
 };
 
-const responseReadFailure = (error: unknown) =>
+const responseReadFailure = (error: ResponseBodyReadFailure) =>
   Effect.gen(function* () {
-    const timedOut = error instanceof ResponseBodyTimeoutError;
+    const timedOut = Predicate.isTagged(error, "ResponseBodyTimeoutError");
     yield* Effect.annotateCurrentSpan({
       "mcp.response.status_code": timedOut ? 504 : 500,
       "mcp.response.content_type": "application/json",
@@ -135,7 +181,9 @@ const responseReadFailure = (error: unknown) =>
       "mcp.response.body.length": 0,
       "mcp.response.jsonrpc.detected": true,
       "mcp.peek_response.timed_out": timedOut,
-      "mcp.peek_response.error": String(error),
+      "mcp.peek_response.error": timedOut
+        ? "Timed out waiting for MCP response body"
+        : "Failed to read MCP response body",
     });
     return jsonRpcWebResponse(
       timedOut ? 504 : 500,
@@ -150,7 +198,7 @@ const reportInternalJsonRpcError = (payload: JsonRpcResponseBody | null) =>
   Effect.sync(() => {
     if (payload?.error?.code !== -32603) return;
     const msg = payload.error.message ?? "unknown";
-    Sentry.captureException(new Error(`MCP internal error (-32603): ${msg}`));
+    Sentry.captureMessage(`MCP internal JSON-RPC error (-32603): ${msg}`);
   });
 
 export const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
@@ -167,10 +215,7 @@ export const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
 
     const isSseResponse = contentType.includes("text/event-stream");
     const timeoutMs = isSseResponse ? SSE_PEEK_TIMEOUT_MS : null;
-    const textResult = yield* Effect.result(Effect.tryPromise({
-      try: () => readResponseText(response, timeoutMs),
-      catch: (error) => error,
-    }).pipe(
+    return yield* readResponseText(response, timeoutMs).pipe(
       Effect.withSpan("mcp.peek_response", {
         attributes: {
           "http.response.content_type": contentType,
@@ -178,25 +223,28 @@ export const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
           "mcp.peek_response.timeout_ms": timeoutMs ?? 0,
         },
       }),
-    ));
-    if (textResult._tag === "Failure") return yield* responseReadFailure(textResult.failure);
+      Effect.matchEffect({
+        onFailure: responseReadFailure,
+        onSuccess: (text) =>
+          Effect.gen(function* () {
+            const payload = parseFirstJsonRpc(contentType, text);
+            yield* Effect.annotateCurrentSpan({
+              "mcp.response.status_code": response.status,
+              "mcp.response.content_type": contentType,
+              "mcp.response.body.length": text.length,
+              "mcp.response.body.shape": responseBodyShape(text),
+              "mcp.response.jsonrpc.detected": payload?.jsonrpc === "2.0",
+            });
+            const attrs = jsonRpcResponseAttrs(payload);
+            if (Object.keys(attrs).length > 0) yield* Effect.annotateCurrentSpan(attrs);
+            yield* reportInternalJsonRpcError(payload);
 
-    const text = textResult.success;
-    const payload = parseFirstJsonRpc(contentType, text);
-    yield* Effect.annotateCurrentSpan({
-      "mcp.response.status_code": response.status,
-      "mcp.response.content_type": contentType,
-      "mcp.response.body.length": text.length,
-      "mcp.response.body.shape": responseBodyShape(text),
-      "mcp.response.jsonrpc.detected": payload?.jsonrpc === "2.0",
-    });
-    const attrs = jsonRpcResponseAttrs(payload);
-    if (Object.keys(attrs).length > 0) yield* Effect.annotateCurrentSpan(attrs);
-    yield* reportInternalJsonRpcError(payload);
-
-    return new Response(text, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    });
+            return new Response(text, {
+              status: response.status,
+              statusText: response.statusText,
+              headers: response.headers,
+            });
+          }),
+      }),
+    );
   });


### PR DESCRIPTION
## Summary
- parse peeked JSON-RPC responses through Effect Schema instead of raw JSON.parse
- model MCP response body timeout/read failures with typed Data tagged errors
- replace manual Exit/tag handling and synthetic Sentry Error construction with Effect matching and stable telemetry messages

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/mcp/response-peek.ts --format json
- bun run typecheck (apps/cloud)
- bunx vitest run --config vitest.node.config.ts src/mcp-miniflare.e2e.node.test.ts