### PR TITLE
Clean up Slack contact route boundaries

### DIFF
--- a/apps/cloud/src/api/slack.ts
+++ b/apps/cloud/src/api/slack.ts
@@ -1,15 +1,21 @@
 import { env } from "cloudflare:workers";
-import { Effect } from "effect";
+import { Cause, Effect, Schema } from "effect";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
 import { SlackService } from "../services/slack";
-import {
-  HttpResponseError,
-  isServerError,
-  toErrorServerResponse,
-} from "./error-response";
+import { HttpResponseError, isServerError, toErrorServerResponse } from "./error-response";
 
 const isValidEmail = (s: string): boolean => /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s);
+
+const SlackContactBody = Schema.Struct({
+  email: Schema.optional(Schema.Unknown),
+  name: Schema.optional(Schema.Unknown),
+  note: Schema.optional(Schema.Unknown),
+  organization: Schema.optional(Schema.Unknown),
+  turnstileToken: Schema.optional(Schema.Unknown),
+});
+
+const decodeSlackContactBody = Schema.decodeUnknownEffect(SlackContactBody);
 
 const verifyTurnstile = (token: string, remoteIp: string | null) =>
   Effect.tryPromise({
@@ -31,37 +37,29 @@ const verifyTurnstile = (token: string, remoteIp: string | null) =>
       const json = (await res.json()) as { success: boolean; "error-codes"?: string[] };
       return { success: json.success, errorCodes: json["error-codes"] ?? [] };
     },
-    catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
+    catch: () => ({ success: false as const }),
   });
 
 const handler = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
 
   if (request.method !== "POST") {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 405,
-        code: "method_not_allowed",
-        message: "Method not allowed",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 405,
+      code: "method_not_allowed",
+      message: "Method not allowed",
+    });
   }
 
-  const body = (yield* Effect.mapError(
-    request.json,
+  const body = yield* Effect.mapError(
+    Effect.flatMap(request.json, decodeSlackContactBody),
     () =>
       new HttpResponseError({
         status: 400,
         code: "invalid_json",
         message: "Invalid request body",
       }),
-  )) as {
-    email?: unknown;
-    name?: unknown;
-    note?: unknown;
-    organization?: unknown;
-    turnstileToken?: unknown;
-  };
+  );
 
   const trimmed = (v: unknown, max: number): string | undefined =>
     typeof v === "string" && v.trim().length > 0 ? v.trim().slice(0, max) : undefined;
@@ -73,36 +71,30 @@ const handler = Effect.gen(function* () {
   const turnstileToken = typeof body.turnstileToken === "string" ? body.turnstileToken : "";
 
   if (!isValidEmail(email)) {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 400,
-        code: "invalid_email",
-        message: "A valid email is required",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 400,
+      code: "invalid_email",
+      message: "A valid email is required",
+    });
   }
 
   if (!turnstileToken) {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 400,
-        code: "captcha_required",
-        message: "Captcha verification is required.",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 400,
+      code: "captcha_required",
+      message: "Captcha verification is required.",
+    });
   }
 
   const remoteIp = request.headers["cf-connecting-ip"] ?? null;
   const verification = yield* verifyTurnstile(turnstileToken, remoteIp);
   if (!verification.success) {
     console.error("[slack] turnstile verification failed:", verification);
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 403,
-        code: "captcha_failed",
-        message: "Captcha verification failed. Please try again.",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 403,
+      code: "captcha_failed",
+      message: "Captcha verification failed. Please try again.",
+    });
   }
 
   // Global daily channel-creation cap — bounds the worst case if Turnstile is
@@ -110,17 +102,15 @@ const handler = Effect.gen(function* () {
   // this binding is a single shared bucket keyed at "global".
   const limit = yield* Effect.tryPromise({
     try: () => env.SLACK_INVITE_LIMITER.limit({ key: "global" }),
-    catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
+    catch: () => ({ success: false as const }),
   });
   if (!limit.success) {
     console.error("[slack] global rate limit hit");
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 429,
-        code: "rate_limited",
-        message: "We're getting more contact requests than usual. Please try again later.",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 429,
+      code: "rate_limited",
+      message: "We're getting more contact requests than usual. Please try again later.",
+    });
   }
 
   const slack = yield* SlackService;
@@ -144,7 +134,7 @@ const handler = Effect.gen(function* () {
 }).pipe(
   Effect.catchCause((err) => {
     if (isServerError(err)) {
-      console.error("[slack] request failed:", err instanceof Error ? err.stack : err);
+      console.error("[slack] request failed:", Cause.pretty(err));
     }
     return Effect.succeed(toErrorServerResponse(err));
   }),


### PR DESCRIPTION
## Summary
- parse Slack contact request bodies through Effect Schema before field handling
- yield HttpResponseError values directly from the Effect generator
- remove unknown error stringification from Turnstile/rate-limit fallbacks and server-error logging

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/api/slack.ts --format json
- bun run typecheck (apps/cloud)
- bunx vitest run --config vitest.node.config.ts src/services/sources-api.node.test.ts