### PR TITLE
Clean up MCP connection error messages

### DIFF
--- a/packages/plugins/mcp/src/sdk/connection.ts
+++ b/packages/plugins/mcp/src/sdk/connection.ts
@@ -87,12 +87,10 @@ const connectClient = (input: {
 
     yield* Effect.tryPromise({
       try: () => client.connect(transportInstance),
-      catch: (cause) =>
+      catch: () =>
         new McpConnectionError({
           transport: input.transport,
-          message: `Failed connecting via ${input.transport}: ${
-            cause instanceof Error ? cause.message : String(cause)
-          }`,
+          message: `Failed connecting via ${input.transport}`,
         }),
     }).pipe(
       Effect.withSpan("plugin.mcp.connection.handshake", {
@@ -124,12 +122,10 @@ export const createMcpConnector = (input: ConnectorInput): McpConnector => {
       // `node:child_process`) is only loaded when stdio is actually used.
       const { createStdioTransport } = yield* Effect.tryPromise({
         try: () => import("./stdio-connector"),
-        catch: (cause) =>
+        catch: () =>
           new McpConnectionError({
             transport: "stdio",
-            message: `Failed to load stdio transport module: ${
-              cause instanceof Error ? cause.message : String(cause)
-            }`,
+            message: "Failed to load stdio transport module",
           }),
       });
 


### PR DESCRIPTION
## Summary
- remove unknown native error stringification from MCP connection failures
- keep serialized McpConnectionError messages stable for client-facing output
- leave connection error schema unchanged because it has no internal cause slot

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/mcp/src/sdk/connection.ts --format json
- bun run typecheck (packages/plugins/mcp)
- bunx vitest run src/sdk/connection-pool.test.ts src/sdk/probe-shape.test.ts