### PR TITLE
Clean up MCP manifest option handling

### DIFF
--- a/packages/plugins/mcp/src/sdk/manifest.ts
+++ b/packages/plugins/mcp/src/sdk/manifest.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Option, Schema } from "effect";
 
 import { McpToolAnnotations } from "./types";
 
@@ -51,7 +51,7 @@ const decodeListToolsResult = Schema.decodeUnknownOption(ListToolsResult);
 const decodeServerInfo = Schema.decodeUnknownOption(ServerInfo);
 
 export const isListToolsResult = (value: unknown): boolean =>
-  decodeListToolsResult(value)._tag === "Some";
+  Option.isSome(decodeListToolsResult(value));
 
 // ---------------------------------------------------------------------------
 // Tool ID sanitization
@@ -86,14 +86,19 @@ export const extractManifestFromListToolsResult = (
 ): McpToolManifest => {
   const seen = new Map<string, number>();
 
-  const listed = decodeListToolsResult(listToolsResult).pipe((opt) =>
-    opt._tag === "Some" ? opt.value.tools : [],
+  const listed = decodeListToolsResult(listToolsResult).pipe(
+    Option.map((result) => result.tools),
+    Option.getOrElse(() => []),
   );
 
-  const server = decodeServerInfo(metadata?.serverInfo).pipe((opt): McpServerMetadata | null =>
-    opt._tag === "Some"
-      ? { name: opt.value.name ?? null, version: opt.value.version ?? null }
-      : null,
+  const server = decodeServerInfo(metadata?.serverInfo).pipe(
+    Option.map(
+      (info): McpServerMetadata => ({
+        name: info.name ?? null,
+        version: info.version ?? null,
+      }),
+    ),
+    Option.getOrNull,
   );
 
   const tools = listed.flatMap((tool): McpToolManifestEntry[] => {
@@ -126,11 +131,8 @@ const slugify = (value: string): string =>
     .replace(/^_+|_+$/g, "");
 
 const hostnameOf = (url: string): string | null => {
-  try {
-    return new URL(url).hostname;
-  } catch {
-    return null;
-  }
+  if (!URL.canParse(url)) return null;
+  return new URL(url).hostname;
 };
 
 const basenameOf = (path: string): string => path.trim().split(/[\\/]/).pop() ?? path.trim();


### PR DESCRIPTION
## Summary
- replace manual Option tag checks with Option helpers
- avoid try/catch URL parsing in nullable hostname extraction
- keep manifest extraction behavior unchanged for invalid URLs and undecodable metadata

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/mcp/src/sdk/manifest.ts --format json
- bun run typecheck (packages/plugins/mcp)
- bunx vitest run src/sdk/plugin.test.ts