### PR TITLE
Clean up MCP discovery failures

### DIFF
--- a/packages/plugins/mcp/src/sdk/discover.ts
+++ b/packages/plugins/mcp/src/sdk/discover.ts
@@ -27,10 +27,10 @@ export const discoverTools = (
     // Acquire connection
     const connection = yield* connector.pipe(
       Effect.mapError(
-        (err) =>
+        () =>
           new McpToolDiscoveryError({
             stage: "connect",
-            message: `Failed connecting to MCP server: ${err.message}`,
+            message: "Failed connecting to MCP server",
           }),
       ),
     );
@@ -38,23 +38,28 @@ export const discoverTools = (
     // List tools
     const listResult = yield* Effect.tryPromise({
       try: () => connection.client.listTools(),
-      catch: (cause) =>
+      catch: () =>
         new McpToolDiscoveryError({
           stage: "list_tools",
-          message: `Failed listing MCP tools: ${
-            cause instanceof Error ? cause.message : String(cause)
-          }`,
+          message: "Failed listing MCP tools",
         }),
     });
 
     if (!isListToolsResult(listResult)) {
-      yield* Effect.promise(() => connection.close().catch(() => {}));
-      return yield* Effect.fail(
-        new McpToolDiscoveryError({
-          stage: "list_tools",
-          message: "MCP listTools response did not match the expected schema",
+      yield* Effect.ignore(
+        Effect.tryPromise({
+          try: () => connection.close(),
+          catch: () =>
+            new McpToolDiscoveryError({
+              stage: "list_tools",
+              message: "Failed closing MCP connection",
+            }),
         }),
       );
+      return yield* new McpToolDiscoveryError({
+        stage: "list_tools",
+        message: "MCP listTools response did not match the expected schema",
+      });
     }
 
     const manifest = extractManifestFromListToolsResult(listResult, {
@@ -62,7 +67,16 @@ export const discoverTools = (
     });
 
     // Close the connection after discovery
-    yield* Effect.promise(() => connection.close().catch(() => {}));
+    yield* Effect.ignore(
+      Effect.tryPromise({
+        try: () => connection.close(),
+        catch: () =>
+          new McpToolDiscoveryError({
+            stage: "list_tools",
+            message: "Failed closing MCP connection",
+          }),
+      }),
+    );
 
     return manifest;
   });


### PR DESCRIPTION
## Summary
- replace native MCP discovery error detail with stable serialized messages
- model best-effort connection close cleanup with Effect.tryPromise and Effect.ignore
- yield typed discovery schema failures directly from the generator

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/mcp/src/sdk/discover.ts --format json
- bun run typecheck (packages/plugins/mcp)
- bunx vitest run src/sdk/plugin.test.ts src/sdk/probe-shape.test.ts