### PR TITLE
Clean up storage-drizzle typed failures

### DIFF
--- a/packages/core/storage-drizzle/src/adapter.ts
+++ b/packages/core/storage-drizzle/src/adapter.ts
@@ -11,7 +11,7 @@
 //     generation, encode/decode all happen in storage-core
 // ---------------------------------------------------------------------------
 
-import { Effect, Result, Schedule } from "effect";
+import { Effect, Option, Predicate, Result, Schedule, Schema } from "effect";
 import {
   and,
   asc,
@@ -123,104 +123,123 @@ const buildCond = (
   table: AnyTable,
   w: CleanedWhere,
   provider: DrizzleProvider,
-): SQL | undefined => {
-  const col = table[w.field];
-  if (!col) {
-    throw new Error(
-      `[storage-drizzle] unknown column "${w.field}" on drizzle table`,
-    );
-  }
-  const mode = w.mode;
-  const isInsensitive =
-    mode === "insensitive" &&
-    (typeof w.value === "string" ||
-      (Array.isArray(w.value) &&
-        (w.value as unknown[]).every((v) => typeof v === "string")));
+): Effect.Effect<SQL | undefined, StorageError> =>
+  Effect.gen(function* () {
+    const col = table[w.field];
+    if (!col) {
+      return yield* new StorageError({
+        message: `[storage-drizzle] unknown column "${w.field}" on drizzle table`,
+        cause: w,
+      });
+    }
+    const mode = w.mode;
+    const isInsensitive =
+      mode === "insensitive" &&
+      (typeof w.value === "string" ||
+        (Array.isArray(w.value) &&
+          (w.value as unknown[]).every((v) => typeof v === "string")));
 
-  switch (w.operator) {
-    case "in":
-      if (!Array.isArray(w.value))
-        throw new Error("Value must be an array for `in`");
-      if (isInsensitive) {
-        const values = w.value as readonly string[];
-        if (values.length === 0) return sql`1 = 0`;
-        const lowered = values.map((v) => v.toLowerCase());
-        return sql`LOWER(${col}) IN ${lowered}`;
-      }
-      return inArray(col, w.value as unknown[]);
-    case "not_in":
-      if (!Array.isArray(w.value))
-        throw new Error("Value must be an array for `not_in`");
-      if (isInsensitive) {
-        const values = w.value as readonly string[];
-        if (values.length === 0) return sql`1 = 1`;
-        const lowered = values.map((v) => v.toLowerCase());
-        return sql`LOWER(${col}) NOT IN ${lowered}`;
-      }
-      return notInArray(col, w.value as unknown[]);
-    case "contains":
-      if (isInsensitive && typeof w.value === "string") {
-        return ilikeOrLike(col, `%${w.value}%`, provider);
-      }
-      return like(col, `%${w.value}%`);
-    case "starts_with":
-      if (isInsensitive && typeof w.value === "string") {
-        return ilikeOrLike(col, `${w.value}%`, provider);
-      }
-      return like(col, `${w.value}%`);
-    case "ends_with":
-      if (isInsensitive && typeof w.value === "string") {
-        return ilikeOrLike(col, `%${w.value}`, provider);
-      }
-      return like(col, `%${w.value}`);
-    case "lt":
-      return lt(col, w.value);
-    case "lte":
-      return lte(col, w.value);
-    case "gt":
-      return gt(col, w.value);
-    case "gte":
-      return gte(col, w.value);
-    case "ne":
-      if (w.value === null) return isNotNull(col);
-      if (isInsensitive && typeof w.value === "string") {
-        return insensitiveNe(col, w.value);
-      }
-      return ne(col, w.value);
-    case "eq":
-    default:
-      if (w.value === null) return isNull(col);
-      if (isInsensitive && typeof w.value === "string") {
-        return insensitiveEq(col, w.value);
-      }
-      return eq(col, w.value);
-  }
-};
+    switch (w.operator) {
+      case "in":
+        if (!Array.isArray(w.value)) {
+          return yield* new StorageError({
+            message: "[storage-drizzle] value must be an array for `in`",
+            cause: w,
+          });
+        }
+        if (isInsensitive) {
+          const values = w.value as readonly string[];
+          if (values.length === 0) return sql`1 = 0`;
+          const lowered = values.map((v) => v.toLowerCase());
+          return sql`LOWER(${col}) IN ${lowered}`;
+        }
+        return inArray(col, w.value as unknown[]);
+      case "not_in":
+        if (!Array.isArray(w.value)) {
+          return yield* new StorageError({
+            message: "[storage-drizzle] value must be an array for `not_in`",
+            cause: w,
+          });
+        }
+        if (isInsensitive) {
+          const values = w.value as readonly string[];
+          if (values.length === 0) return sql`1 = 1`;
+          const lowered = values.map((v) => v.toLowerCase());
+          return sql`LOWER(${col}) NOT IN ${lowered}`;
+        }
+        return notInArray(col, w.value as unknown[]);
+      case "contains":
+        if (isInsensitive && typeof w.value === "string") {
+          return ilikeOrLike(col, `%${w.value}%`, provider);
+        }
+        return like(col, `%${w.value}%`);
+      case "starts_with":
+        if (isInsensitive && typeof w.value === "string") {
+          return ilikeOrLike(col, `${w.value}%`, provider);
+        }
+        return like(col, `${w.value}%`);
+      case "ends_with":
+        if (isInsensitive && typeof w.value === "string") {
+          return ilikeOrLike(col, `%${w.value}`, provider);
+        }
+        return like(col, `%${w.value}`);
+      case "lt":
+        return lt(col, w.value);
+      case "lte":
+        return lte(col, w.value);
+      case "gt":
+        return gt(col, w.value);
+      case "gte":
+        return gte(col, w.value);
+      case "ne":
+        if (w.value === null) return isNotNull(col);
+        if (isInsensitive && typeof w.value === "string") {
+          return insensitiveNe(col, w.value);
+        }
+        return ne(col, w.value);
+      case "eq":
+      default:
+        if (w.value === null) return isNull(col);
+        if (isInsensitive && typeof w.value === "string") {
+          return insensitiveEq(col, w.value);
+        }
+        return eq(col, w.value);
+    }
+  });
 
 const compileWhere = (
   table: AnyTable,
   where: readonly CleanedWhere[] | undefined,
   provider: DrizzleProvider,
-): SQL | undefined => {
-  if (!where || where.length === 0) return undefined;
-  if (where.length === 1) {
-    return buildCond(table, where[0]!, provider);
-  }
-  const andGroup = where.filter(
-    (w) => w.connector === "AND" || !w.connector,
-  );
-  const orGroup = where.filter((w) => w.connector === "OR");
-  const andClause =
-    andGroup.length > 0
-      ? and(...andGroup.map((w) => buildCond(table, w, provider)))
-      : undefined;
-  const orClause =
-    orGroup.length > 0
-      ? or(...orGroup.map((w) => buildCond(table, w, provider)))
-      : undefined;
-  if (andClause && orClause) return and(andClause, orClause);
-  return andClause ?? orClause;
-};
+): Effect.Effect<SQL | undefined, StorageError> =>
+  Effect.gen(function* () {
+    if (!where || where.length === 0) return undefined;
+    if (where.length === 1) {
+      return yield* buildCond(table, where[0]!, provider);
+    }
+    const andGroup = where.filter(
+      (w) => w.connector === "AND" || !w.connector,
+    );
+    const orGroup = where.filter((w) => w.connector === "OR");
+    const andConds: (SQL | undefined)[] = [];
+    for (const w of andGroup) {
+      andConds.push(yield* buildCond(table, w, provider));
+    }
+    const orConds: (SQL | undefined)[] = [];
+    for (const w of orGroup) {
+      orConds.push(yield* buildCond(table, w, provider));
+    }
+    const andClause =
+      andGroup.length > 0
+        ? and(...andConds)
+        : undefined;
+    const orClause =
+      orGroup.length > 0
+        ? or(...orConds)
+        : undefined;
+    if (andClause && orClause) return and(andClause, orClause);
+    return andClause ?? orClause;
+  });
 
 const rowIdentityClause = (
   table: AnyTable,
@@ -301,6 +320,15 @@ const unwrapDriverCause = (cause: unknown): unknown => {
   return cur;
 };
 
+const getDriverMessage = (cause: unknown): string => {
+  if (typeof cause === "string") return cause;
+  const decoded = Schema.decodeUnknownOption(
+    Schema.Struct({ message: Schema.String }),
+  )(cause);
+  if (Option.isSome(decoded)) return decoded.value.message;
+  return "driver error";
+};
+
 const classifyError = (
   op: string,
   model: string | undefined,
@@ -312,8 +340,9 @@ const classifyError = (
       ? new UniqueViolationError({ model })
       : new UniqueViolationError({});
   }
+  const message = getDriverMessage(driverCause);
   return new StorageError({
-    message: `[storage-drizzle] ${op} failed: ${driverCause instanceof Error ? driverCause.message : String(driverCause)}`,
+    message: `[storage-drizzle] ${op} failed: ${message}`,
     cause: driverCause,
   });
 };
@@ -326,8 +355,9 @@ const classifyError = (
 // retry transient errors twice with short exponential backoff. Unique
 // violations and anything else fail fast.
 export const isTransientStorageError = (err: StorageFailure): boolean => {
-  if (err._tag !== "StorageError") return false;
-  const msg = err.message;
+  if (!Predicate.isTagged("StorageError")(err)) return false;
+  const storageError = err as StorageError;
+  const msg = storageError.message;
   return (
     msg.includes("Network connection lost") ||
     msg.includes("CONNECTION_CLOSED") ||
@@ -386,35 +416,31 @@ const withReturning = (
           () => db.select().from(table).where(eq(table.id, data.id)).limit(1),
           model,
         )) as Record<string, unknown>[];
-        if (!rows[0])
-          return yield* Effect.fail(
-            new StorageError({
-              message: "[storage-drizzle] mysql insert: no row returned",
-              cause: undefined,
-            }),
-          );
+        if (!rows[0]) {
+          return yield* new StorageError({
+            message: "[storage-drizzle] mysql insert: no row returned",
+            cause: undefined,
+          });
+        }
         return rows[0];
       }
-      return yield* Effect.fail(
-        new StorageError({
-          message:
-            "[storage-drizzle] mysql insert: id not provided, cannot recover row",
-          cause: undefined,
-        }),
-      );
+      return yield* new StorageError({
+        message:
+          "[storage-drizzle] mysql insert: id not provided, cannot recover row",
+        cause: undefined,
+      });
     }
     const rows = (yield* runPromise(
       "insert returning",
       () => builder.returning(),
       model,
     )) as Record<string, unknown>[];
-    if (!rows[0])
-      return yield* Effect.fail(
-        new StorageError({
-          message: "[storage-drizzle] insert returned no rows",
-          cause: undefined,
-        }),
-      );
+    if (!rows[0]) {
+      return yield* new StorageError({
+        message: "[storage-drizzle] insert returned no rows",
+        cause: undefined,
+      });
+    }
     return rows[0];
   });
 
@@ -426,15 +452,19 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
   const { db, provider } = options;
   const fullSchema: Record<string, AnyTable> = db._.fullSchema ?? {};
 
-  const getTable = (model: string): AnyTable => {
-    const t = fullSchema[model];
-    if (!t)
-      throw new Error(
-        `[storage-drizzle] unknown model "${model}" — not found in db._.fullSchema. ` +
-          `Make sure the table is exported from the generated schema and passed to drizzle().`,
-      );
-    return t;
-  };
+  const getTable = (model: string): Effect.Effect<AnyTable, StorageError> =>
+    Effect.gen(function* () {
+      const t = fullSchema[model];
+      if (!t) {
+        return yield* new StorageError({
+          message:
+            `[storage-drizzle] unknown model "${model}" — not found in db._.fullSchema. ` +
+            `Make sure the table is exported from the generated schema and passed to drizzle().`,
+          cause: undefined,
+        });
+      }
+      return t;
+    });
 
   const backendAttrs = (model: string) => ({
     "executor.storage.backend": "drizzle" as const,
@@ -451,7 +481,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     select?: string[] | undefined;
   }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
+        const table = yield* getTable(model);
         const builder = db.insert(table).values(data);
         const row = yield* withReturning(
           db,
@@ -477,7 +507,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
   }) =>
     Effect.gen(function* () {
       if (data.length === 0) return [];
-      const table = getTable(model);
+      const table = yield* getTable(model);
       const CHUNK = 500;
       const all: Record<string, unknown>[] = [];
       for (let i = 0; i < data.length; i += CHUNK) {
@@ -510,8 +540,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     join?: JoinConfig | undefined;
   }) =>
     Effect.gen(function* () {
-      const table = getTable(model);
-      const clause = compileWhere(table, where, provider);
+      const table = yield* getTable(model);
+      const clause = yield* compileWhere(table, where, provider);
       if (join && db.query && db.query[model]) {
         const includes = buildIncludes(join);
         const rows = (yield* runPromise(
@@ -558,8 +588,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     join?: JoinConfig | undefined;
   }) =>
     Effect.gen(function* () {
-      const table = getTable(model);
-      const clause = compileWhere(table, where, provider);
+      const table = yield* getTable(model);
+      const clause = yield* compileWhere(table, where, provider);
       if (join && db.query && db.query[model]) {
         const includes = buildIncludes(join);
         const opts: Record<string, unknown> = {
@@ -609,8 +639,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     update: T;
   }) =>
     Effect.gen(function* () {
-      const table = getTable(model);
-      const clause = compileWhere(table, where, provider);
+      const table = yield* getTable(model);
+      const clause = yield* compileWhere(table, where, provider);
       let findQ = db.select().from(table);
       if (clause) findQ = findQ.where(clause);
       const matched = (yield* runPromise(
@@ -667,8 +697,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     count: ({ model, where }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         let q = db.select({ c: count() }).from(table);
         if (clause) q = q.where(clause);
         const rows = (yield* runPromise(
@@ -688,8 +718,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     updateMany: ({ model, where, update }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         // Count first for the return value (sqlite's .run returns changes
         // but we don't want to rely on that in the generic path)
         let countQ = db.select({ c: count() }).from(table);
@@ -717,8 +747,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     delete: ({ model, where }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         // Mirror in-memory semantics: delete first matching row only
         let findQ = db.select().from(table);
         if (clause) findQ = findQ.where(clause);
@@ -742,8 +772,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     deleteMany: ({ model, where }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         let countQ = db.select({ c: count() }).from(table);
         if (clause) countQ = countQ.where(clause);
         const rows = (yield* runPromise(
@@ -810,6 +840,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
                   supportsTransaction: false,
                 }) as TxShape;
                 const exit = await Effect.runPromise(Effect.result(cb(nested)));
+                // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: drizzle rolls back native transactions when the callback rejects
                 if (Result.isFailure(exit)) throw new TxFailure(exit.failure);
                 return exit.success;
               }),
@@ -837,18 +868,23 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
               ? dbAny.execute.bind(dbAny)
               : undefined;
           const runStmt = (stmt: string) =>
-            Effect.try({
-              try: () => {
-                if (!runner) {
-                  throw new Error("drizzle db has neither run() nor execute()");
-                }
-                const res = runner(sql.raw(stmt));
-                if (res && typeof (res as { then?: unknown }).then === "function") {
-                  return res as Promise<unknown>;
-                }
-                return res;
-              },
-              catch: (cause) => classifyError(stmt, undefined, cause),
+            Effect.gen(function* () {
+              if (!runner) {
+                return yield* new StorageError({
+                  message: "[storage-drizzle] db has neither run() nor execute()",
+                  cause: undefined,
+                });
+              }
+              return yield* Effect.try({
+                try: () => {
+                  const res = runner(sql.raw(stmt));
+                  if (res && typeof (res as { then?: unknown }).then === "function") {
+                    return res as Promise<unknown>;
+                  }
+                  return res;
+                },
+                catch: (cause) => classifyError(stmt, undefined, cause),
+              });
             });
           const maybePromise = yield* runStmt("BEGIN");
           if (maybePromise && typeof (maybePromise as { then?: unknown }).then === "function") {


### PR DESCRIPTION
## Summary
- convert drizzle table and where compilation failures into typed StorageError values
- keep driver error messages stable without instanceof Error or String(cause)
- preserve transient retry classification for string driver causes
- keep the native drizzle rollback throw as a narrow boundary exception

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/storage-drizzle/src/adapter.ts --format json
- bun run typecheck (packages/core/storage-drizzle)
- bunx vitest run src/adapter.test.ts