### PR TITLE
Clean up connection migration boundaries

### DIFF
--- a/apps/local/src/server/migrate-connections.ts
+++ b/apps/local/src/server/migrate-connections.ts
@@ -32,11 +32,25 @@ const isRecord = (v: unknown): v is Record<string, unknown> =>
 const isString = (v: unknown): v is string => typeof v === "string";
 
 const JsonObject = Schema.Record(Schema.String, Schema.Unknown);
+const decodeJsonObjectString = Schema.decodeUnknownOption(
+  Schema.fromJsonString(JsonObject),
+);
 
 const decodeUnknownOptionAs =
   <A>(schema: Schema.Decoder<A>) =>
   (input: unknown): Option.Option<A> =>
     Schema.decodeUnknownOption(schema)(input);
+
+const parseJsonObjectOption = (input: string): Option.Option<Record<string, unknown>> =>
+  decodeJsonObjectString(input);
+
+const parseJsonOption = (input: string): Option.Option<unknown> =>
+  Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown))(input);
+
+const getBoundaryErrorMessage = (error: unknown): string => {
+  // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: Bun SQLite transaction failures are thrown values; keep legacy log text stable.
+  return error instanceof Error ? error.message : String(error);
+};
 
 /** Pre-flight: bail unless the drizzle migration that added the Connection
  *  table + `secret.owned_by_connection_id` has completed. */
@@ -280,20 +294,13 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
   for (const row of rows) {
     let invocation: Record<string, unknown> = {};
     if (row.invocation_config) {
-      try {
-        const parsed = JSON.parse(row.invocation_config) as unknown;
-        if (isRecord(parsed)) invocation = parsed;
-      } catch {
-        continue;
-      }
+      const parsed = parseJsonObjectOption(row.invocation_config);
+      if (Option.isNone(parsed)) continue;
+      invocation = parsed.value;
     }
     let oauth2Col: unknown = null;
     if (row.oauth2) {
-      try {
-        oauth2Col = JSON.parse(row.oauth2) as unknown;
-      } catch {
-        // fall through
-      }
+      oauth2Col = Option.getOrNull(parseJsonOption(row.oauth2));
     }
     const primary = invocation.oauth2 ?? oauth2Col;
     if (primary == null) continue;
@@ -355,6 +362,7 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
         providerState,
       });
       const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: Bun SQLite transactions roll back only when the callback throws.
       if (err) throw new Error(err);
       if (hasInvocationConfig) {
         const nextInvocation = { ...invocation, oauth2: oauth2Pointer };
@@ -372,6 +380,7 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
         );
       }
     });
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Bun SQLite transaction throws are contained and converted to migration warning logs.
     try {
       txn();
       console.log(
@@ -379,7 +388,7 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
       );
     } catch (err) {
       console.warn(
-        `[migrate-connections] fail openapi ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        `[migrate-connections] fail openapi ${row.scope_id}/${row.id}: ${getBoundaryErrorMessage(err)}`,
       );
     }
   }
@@ -451,13 +460,9 @@ const migrateMcp = (sqlite: Database): void => {
 
   for (const row of rows) {
     let config: Record<string, unknown> = {};
-    try {
-      const parsed = JSON.parse(row.config) as unknown;
-      if (!isRecord(parsed)) continue;
-      config = parsed;
-    } catch {
-      continue;
-    }
+    const parsed = parseJsonObjectOption(row.config);
+    if (Option.isNone(parsed)) continue;
+    config = parsed.value;
     if (config.transport !== "remote") continue;
     const auth = config.auth;
     if (!isRecord(auth) || auth.kind !== "oauth2") continue;
@@ -514,6 +519,7 @@ const migrateMcp = (sqlite: Database): void => {
         providerState,
       });
       const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: Bun SQLite transactions roll back only when the callback throws.
       if (err) throw new Error(err);
       if (updateConfigAndAuth) {
         updateConfigAndAuth.run(
@@ -526,6 +532,7 @@ const migrateMcp = (sqlite: Database): void => {
         updateConfig.run(JSON.stringify(nextConfig), row.scope_id, row.id);
       }
     });
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Bun SQLite transaction throws are contained and converted to migration warning logs.
     try {
       txn();
       console.log(
@@ -533,7 +540,7 @@ const migrateMcp = (sqlite: Database): void => {
       );
     } catch (err) {
       console.warn(
-        `[migrate-connections] fail mcp ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        `[migrate-connections] fail mcp ${row.scope_id}/${row.id}: ${getBoundaryErrorMessage(err)}`,
       );
     }
   }
@@ -592,13 +599,9 @@ const migrateGoogleDiscovery = (sqlite: Database): void => {
 
   for (const row of rows) {
     let config: Record<string, unknown> = {};
-    try {
-      const parsed = JSON.parse(row.config) as unknown;
-      if (!isRecord(parsed)) continue;
-      config = parsed;
-    } catch {
-      continue;
-    }
+    const parsed = parseJsonObjectOption(row.config);
+    if (Option.isNone(parsed)) continue;
+    config = parsed.value;
     const auth = config.auth;
     if (!isRecord(auth) || auth.kind !== "oauth2") continue;
 
@@ -643,9 +646,11 @@ const migrateGoogleDiscovery = (sqlite: Database): void => {
         providerState,
       });
       const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: Bun SQLite transactions roll back only when the callback throws.
       if (err) throw new Error(err);
       updateSource.run(JSON.stringify(nextConfig), Date.now(), row.scope_id, row.id);
     });
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Bun SQLite transaction throws are contained and converted to migration warning logs.
     try {
       txn();
       console.log(
@@ -653,7 +658,7 @@ const migrateGoogleDiscovery = (sqlite: Database): void => {
       );
     } catch (err) {
       console.warn(
-        `[migrate-connections] fail google-discovery ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        `[migrate-connections] fail google-discovery ${row.scope_id}/${row.id}: ${getBoundaryErrorMessage(err)}`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- parse migration JSON fields with Effect Schema decoders
- preserve invalid JSON skip/fallback behavior while removing JSON.parse
- keep Bun SQLite rollback throws behind narrow boundary suppressions
- centralize thrown transaction error formatting for warning logs

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/local/src/server/migrate-connections.ts --format json
- bunx --bun vitest run src/server/migrate-connections.test.ts
- bun run typecheck (apps/local) currently blocked by unrelated worker edits in packages/plugins/mcp/src/sdk/binding-store.ts