### PR TITLE
Decode GraphQL store rows with Schema

### DIFF
--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@effect/vitest";
-import { Effect } from "effect";
+import { Data, Effect, Predicate } from "effect";
+import type { AddressInfo } from "node:net";
 
 import {
   ConnectionId,
@@ -18,6 +19,10 @@ import { graphqlPlugin } from "./plugin";
 import type { IntrospectionResult } from "./introspect";
 
 const TEST_SCOPE = "test-scope";
+
+class TestServerAddressError extends Data.TaggedError("TestServerAddressError")<{
+  readonly message: string;
+}> {}
 
 // ---------------------------------------------------------------------------
 // Mock introspection response
@@ -268,74 +273,89 @@ describe("graphqlPlugin", () => {
     Effect.gen(function* () {
       const http = yield* Effect.promise(() => import("node:http"));
       let authorizationHeader: string | null = null;
-      const server = http.createServer((req, res) => {
-        authorizationHeader = req.headers.authorization ?? null;
-        res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify({ data: { hello: "Hello Ada" } }));
-      });
-      yield* Effect.callback<void, Error>((resume) => {
-        server.listen(0, "127.0.0.1", () => resume(Effect.void));
-        server.once("error", (error) => resume(Effect.fail(error)));
-      });
+      const { port } = yield* Effect.acquireRelease(
+        Effect.callback<
+          { port: number; close: () => Effect.Effect<void, Error> },
+          Error | TestServerAddressError
+        >((resume) => {
+          const server = http.createServer((req, res) => {
+            authorizationHeader = req.headers.authorization ?? null;
+            res.setHeader("content-type", "application/json");
+            res.end(JSON.stringify({ data: { hello: "Hello Ada" } }));
+          });
+          server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            if (!address || typeof address === "string") {
+              resume(
+                Effect.fail(
+                  new TestServerAddressError({
+                    message: "Expected TCP test server address",
+                  }),
+                ),
+              );
+              return;
+            }
+            resume(
+              Effect.succeed({
+                port: (address as AddressInfo).port,
+                close: () =>
+                  Effect.callback<void, Error>((closeResume) => {
+                    server.close((error) =>
+                      closeResume(error ? Effect.fail(error) : Effect.void),
+                    );
+                  }),
+              }),
+            );
+          });
+          server.once("error", (error) => resume(Effect.fail(error)));
+        }),
+        ({ close }) => close(),
+      );
 
-      try {
-        const address = server.address();
-        if (!address || typeof address === "string") {
-          throw new Error("Expected TCP test server address");
-        }
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
+        }),
+      );
 
-        const executor = yield* createExecutor(
-          makeTestConfig({
-            plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
+      const connectionId = ConnectionId.make("graphql-oauth2-test");
+      yield* executor.connections.create(
+        new CreateConnectionInput({
+          id: connectionId,
+          scope: ScopeId.make(TEST_SCOPE),
+          provider: "oauth2",
+          identityLabel: "GraphQL Test",
+          accessToken: new TokenMaterial({
+            secretId: SecretId.make(`${connectionId}.access_token`),
+            name: "GraphQL Access Token",
+            value: "secret-token",
           }),
-        );
+          refreshToken: null,
+          expiresAt: null,
+          oauthScope: null,
+          providerState: null,
+        }),
+      );
 
-        const connectionId = ConnectionId.make("graphql-oauth2-test");
-        yield* executor.connections.create(
-          new CreateConnectionInput({
-            id: connectionId,
-            scope: ScopeId.make(TEST_SCOPE),
-            provider: "oauth2",
-            identityLabel: "GraphQL Test",
-            accessToken: new TokenMaterial({
-              secretId: SecretId.make(`${connectionId}.access_token`),
-              name: "GraphQL Access Token",
-              value: "secret-token",
-            }),
-            refreshToken: null,
-            expiresAt: null,
-            oauthScope: null,
-            providerState: null,
-          }),
-        );
+      yield* executor.graphql.addSource({
+        endpoint: `http://127.0.0.1:${port}/graphql`,
+        scope: TEST_SCOPE,
+        introspectionJson,
+        namespace: "oauth_graph",
+        auth: { kind: "oauth2", connectionId },
+      });
 
-        yield* executor.graphql.addSource({
-          endpoint: `http://127.0.0.1:${address.port}/graphql`,
-          scope: TEST_SCOPE,
-          introspectionJson,
-          namespace: "oauth_graph",
-          auth: { kind: "oauth2", connectionId },
-        });
+      const result = yield* executor.tools.invoke("oauth_graph.query.hello", {
+        name: "Ada",
+      });
 
-        const result = yield* executor.tools.invoke("oauth_graph.query.hello", {
-          name: "Ada",
-        });
-
-        expect(result).toEqual({
-          status: 200,
-          data: { hello: "Hello Ada" },
-          errors: null,
-        });
-        expect(authorizationHeader).toBe("Bearer secret-token");
-      } finally {
-        yield* Effect.promise(
-          () =>
-            new Promise<void>((resolve, reject) => {
-              server.close((error) => (error ? reject(error) : resolve()));
-            }),
-        );
-      }
-    }),
+      expect(result).toEqual({
+        status: 200,
+        data: { hello: "Hello Ada" },
+        errors: null,
+      });
+      expect(authorizationHeader).toBe("Bearer secret-token");
+    }).pipe(Effect.scoped),
   );
 
   it.effect("static graphql.addSource delegates to extension", () =>
@@ -387,7 +407,7 @@ describe("graphqlPlugin", () => {
       // Org-level base source
       yield* executor.graphql.addSource({
         endpoint: "http://org.example.com/graphql",
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "Org Source",
@@ -396,7 +416,7 @@ describe("graphqlPlugin", () => {
       // Per-user shadow with the same namespace
       yield* executor.graphql.addSource({
         endpoint: "http://user.example.com/graphql",
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "User Source",
@@ -404,20 +424,20 @@ describe("graphqlPlugin", () => {
 
       const userView = yield* executor.graphql.getSource(
         "shared",
-        USER_SCOPE as string,
+        USER_SCOPE,
       );
       const orgView = yield* executor.graphql.getSource(
         "shared",
-        ORG_SCOPE as string,
+        ORG_SCOPE,
       );
 
       // Both rows must coexist — innermost-wins reads come from the
       // executor; the store's scope-pinned getters return the exact row.
       expect(userView?.name).toBe("User Source");
-      expect(userView?.scope).toBe(USER_SCOPE as string);
+      expect(userView?.scope).toBe(USER_SCOPE);
       expect(userView?.endpoint).toBe("http://user.example.com/graphql");
       expect(orgView?.name).toBe("Org Source");
-      expect(orgView?.scope).toBe(ORG_SCOPE as string);
+      expect(orgView?.scope).toBe(ORG_SCOPE);
       expect(orgView?.endpoint).toBe("http://org.example.com/graphql");
     }),
   );
@@ -433,28 +453,28 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://org.example.com/graphql",
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "Org Source",
       });
       yield* executor.graphql.addSource({
         endpoint: "http://user.example.com/graphql",
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "User Source",
       });
 
-      yield* executor.graphql.removeSource("shared", USER_SCOPE as string);
+      yield* executor.graphql.removeSource("shared", USER_SCOPE);
 
       const userView = yield* executor.graphql.getSource(
         "shared",
-        USER_SCOPE as string,
+        USER_SCOPE,
       );
       const orgView = yield* executor.graphql.getSource(
         "shared",
-        ORG_SCOPE as string,
+        ORG_SCOPE,
       );
 
       expect(userView).toBeNull();
@@ -474,31 +494,31 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://org.example.com/graphql",
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "Org Source",
       });
       yield* executor.graphql.addSource({
         endpoint: "http://user.example.com/graphql",
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "User Source",
       });
 
-      yield* executor.graphql.updateSource("shared", USER_SCOPE as string, {
+      yield* executor.graphql.updateSource("shared", USER_SCOPE, {
         name: "User Renamed",
         endpoint: "http://user-new.example.com/graphql",
       });
 
       const userView = yield* executor.graphql.getSource(
         "shared",
-        USER_SCOPE as string,
+        USER_SCOPE,
       );
       const orgView = yield* executor.graphql.getSource(
         "shared",
-        ORG_SCOPE as string,
+        ORG_SCOPE,
       );
 
       expect(userView?.name).toBe("User Renamed");
@@ -577,7 +597,7 @@ describe("graphqlPlugin", () => {
       const result = yield* executor.secrets.remove(SecretId.make("locked")).pipe(
         Effect.flip,
       );
-      expect((result as { _tag: string })._tag).toBe("SecretInUseError");
+      expect(Predicate.isTagged("SecretInUseError")(result)).toBe(true);
 
       // After detaching the source, remove succeeds.
       yield* executor.graphql.removeSource("ref", TEST_SCOPE);

--- a/packages/plugins/graphql/src/sdk/store.ts
+++ b/packages/plugins/graphql/src/sdk/store.ts
@@ -1,8 +1,9 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 
 import {
   defineSchema,
   type StorageDeps,
+  StorageError,
   type StorageFailure,
 } from "@executor-js/sdk/core";
 
@@ -116,25 +117,70 @@ export interface StoredOperation {
 
 // Persisted JSON shape for an OperationBinding. Reconstructed into a
 // Schema.Class instance on read.
-interface BindingJson {
-  readonly kind: "query" | "mutation";
-  readonly fieldName: string;
-  readonly operationString: string;
-  readonly variableNames: readonly string[];
-}
+const BindingJson = Schema.Struct({
+  kind: Schema.Literals(["query", "mutation"]),
+  fieldName: Schema.String,
+  operationString: Schema.String,
+  variableNames: Schema.Array(Schema.String),
+});
+type BindingJson = typeof BindingJson.Type;
 
-const decodeBinding = (value: unknown): OperationBinding => {
-  const data =
+const SourceRow = Schema.Struct({
+  id: Schema.String,
+  scope_id: Schema.String,
+  name: Schema.String,
+  endpoint: Schema.String,
+  auth_kind: Schema.Literals(["none", "oauth2"]),
+  auth_connection_id: Schema.optional(Schema.NullOr(Schema.String)),
+});
+type SourceRow = typeof SourceRow.Type;
+
+const ChildValueRow = Schema.Struct({
+  name: Schema.String,
+  kind: Schema.Literals(["text", "secret"]),
+  text_value: Schema.optional(Schema.NullOr(Schema.String)),
+  secret_id: Schema.optional(Schema.NullOr(Schema.String)),
+  secret_prefix: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+const OperationRow = Schema.Struct({
+  id: Schema.String,
+  source_id: Schema.String,
+  binding: Schema.Unknown,
+});
+
+const ChildUsageRowSchema = Schema.Struct({
+  source_id: Schema.String,
+  scope_id: Schema.String,
+  name: Schema.String,
+});
+/** Flat row shape returned by the usage-lookup helpers. Mirrors the new
+ *  child-table columns so callers can build a `Usage` without
+ *  re-decoding. */
+export type ChildUsageRow = typeof ChildUsageRowSchema.Type;
+
+const storageDecodeError = (message: string) => (cause: unknown) =>
+  new StorageError({ message, cause });
+
+const decodeBinding = (
+  value: unknown,
+): Effect.Effect<OperationBinding, StorageFailure> =>
+  (
     typeof value === "string"
-      ? (JSON.parse(value) as BindingJson)
-      : (value as BindingJson);
-  return new OperationBinding({
-    kind: data.kind,
-    fieldName: data.fieldName,
-    operationString: data.operationString,
-    variableNames: [...data.variableNames],
-  });
-};
+      ? Schema.decodeUnknownEffect(Schema.fromJsonString(BindingJson))(value)
+      : Schema.decodeUnknownEffect(BindingJson)(value)
+  ).pipe(
+    Effect.map(
+      (data) =>
+        new OperationBinding({
+          kind: data.kind,
+          fieldName: data.fieldName,
+          operationString: data.operationString,
+          variableNames: [...data.variableNames],
+        }),
+    ),
+    Effect.mapError(storageDecodeError("Invalid stored GraphQL operation binding")),
+  );
 
 const encodeBinding = (binding: OperationBinding): BindingJson => ({
   kind: binding.kind,
@@ -151,22 +197,34 @@ const toJsonRecord = (value: unknown): Record<string, unknown> =>
 // shape; `secret_prefix` is optional and only populated when present in
 // the original config.
 const rowsToValueMap = (
-  rows: readonly Record<string, unknown>[],
-): Record<string, HeaderValue> => {
-  const out: Record<string, HeaderValue> = {};
-  for (const row of rows) {
-    const name = row.name as string;
-    if (row.kind === "secret" && typeof row.secret_id === "string") {
-      const prefix = row.secret_prefix as string | undefined | null;
-      out[name] = prefix
-        ? { secretId: row.secret_id, prefix }
-        : { secretId: row.secret_id };
-    } else if (row.kind === "text" && typeof row.text_value === "string") {
-      out[name] = row.text_value;
+  rows: readonly unknown[],
+): Effect.Effect<Record<string, HeaderValue>, StorageFailure> =>
+  Effect.gen(function* () {
+    const decoded = yield* Schema.decodeUnknownEffect(Schema.Array(ChildValueRow))(
+      rows,
+    ).pipe(
+      Effect.mapError(storageDecodeError("Invalid stored GraphQL child rows")),
+    );
+    const out: Record<string, HeaderValue> = {};
+    for (const row of decoded) {
+      if (
+        row.kind === "secret" &&
+        row.secret_id !== undefined &&
+        row.secret_id !== null
+      ) {
+        out[row.name] = row.secret_prefix
+          ? { secretId: row.secret_id, prefix: row.secret_prefix }
+          : { secretId: row.secret_id };
+      } else if (
+        row.kind === "text" &&
+        row.text_value !== undefined &&
+        row.text_value !== null
+      ) {
+        out[row.name] = row.text_value;
+      }
     }
-  }
-  return out;
-};
+    return out;
+  });
 
 // Encode one entry of a SecretBackedValue map into a child row. Used by
 // the writer for both `graphql_source_header` and
@@ -201,11 +259,8 @@ const valueToChildRow = (
   };
 };
 
-const rowToAuth = (row: Record<string, unknown>): GraphqlSourceAuth => {
-  if (
-    row.auth_kind === "oauth2" &&
-    typeof row.auth_connection_id === "string"
-  ) {
+const rowToAuth = (row: SourceRow): GraphqlSourceAuth => {
+  if (row.auth_kind === "oauth2" && row.auth_connection_id) {
     return { kind: "oauth2", connectionId: row.auth_connection_id };
   }
   return { kind: "none" };
@@ -226,15 +281,6 @@ const rowToAuth = (row: Record<string, unknown>): GraphqlSourceAuth => {
 // `path.scopeId` for HTTP, `toolRow.scope_id` / `input.scope` for
 // invokeTool/lifecycle) so every keyed mutation targets exactly one
 // row.
-/** Flat row shape returned by the usage-lookup helpers. Mirrors the new
- *  child-table columns so callers can build a `Usage` without
- *  re-decoding. */
-export interface ChildUsageRow {
-  readonly source_id: string;
-  readonly scope_id: string;
-  readonly name: string;
-}
-
 export interface GraphqlStore {
   readonly upsertSource: (
     input: StoredGraphqlSource,
@@ -323,7 +369,7 @@ export const makeDefaultGraphqlStore = ({
           { field: "scope_id", value: scope },
         ],
       })
-      .pipe(Effect.map(rowsToValueMap));
+      .pipe(Effect.flatMap(rowsToValueMap));
 
   const loadQueryParams = (sourceId: string, scope: string) =>
     db
@@ -334,32 +380,44 @@ export const makeDefaultGraphqlStore = ({
           { field: "scope_id", value: scope },
         ],
       })
-      .pipe(Effect.map(rowsToValueMap));
+      .pipe(Effect.flatMap(rowsToValueMap));
 
   const rowToSourceWithChildren = (
-    row: Record<string, unknown>,
+    row: unknown,
   ): Effect.Effect<StoredGraphqlSource, StorageFailure> =>
     Effect.gen(function* () {
-      const sourceId = row.id as string;
-      const scope = row.scope_id as string;
+      const sourceRow = yield* Schema.decodeUnknownEffect(SourceRow)(row).pipe(
+        Effect.mapError(storageDecodeError("Invalid stored GraphQL source row")),
+      );
+      const sourceId = sourceRow.id;
+      const scope = sourceRow.scope_id;
       const headers = yield* loadHeaders(sourceId, scope);
       const queryParams = yield* loadQueryParams(sourceId, scope);
       return {
         namespace: sourceId,
         scope,
-        name: row.name as string,
-        endpoint: row.endpoint as string,
+        name: sourceRow.name,
+        endpoint: sourceRow.endpoint,
         headers,
         queryParams,
-        auth: rowToAuth(row),
+        auth: rowToAuth(sourceRow),
       };
     });
 
-  const rowToOperation = (row: Record<string, unknown>): StoredOperation => ({
-    toolId: row.id as string,
-    sourceId: row.source_id as string,
-    binding: decodeBinding(row.binding),
-  });
+  const rowToOperation = (
+    row: unknown,
+  ): Effect.Effect<StoredOperation, StorageFailure> =>
+    Effect.gen(function* () {
+      const operationRow = yield* Schema.decodeUnknownEffect(OperationRow)(row).pipe(
+        Effect.mapError(storageDecodeError("Invalid stored GraphQL operation row")),
+      );
+      const binding = yield* decodeBinding(operationRow.binding);
+      return {
+        toolId: operationRow.id,
+        sourceId: operationRow.source_id,
+        binding,
+      };
+    });
 
   // Replace child rows for a source by deleting then bulk-inserting. Used
   // by both upsertSource (full rewrite) and updateSourceMeta (partial
@@ -540,7 +598,9 @@ export const makeDefaultGraphqlStore = ({
             { field: "scope_id", value: scope },
           ],
         })
-        .pipe(Effect.map((row) => (row ? rowToOperation(row) : null))),
+        .pipe(
+          Effect.flatMap((row) => (row ? rowToOperation(row) : Effect.succeed(null))),
+        ),
 
     listOperationsBySource: (sourceId, scope) =>
       db
@@ -551,7 +611,7 @@ export const makeDefaultGraphqlStore = ({
             { field: "scope_id", value: scope },
           ],
         })
-        .pipe(Effect.map((rows) => rows.map(rowToOperation))),
+        .pipe(Effect.flatMap((rows) => Effect.forEach(rows, rowToOperation))),
 
     removeSource: (namespace, scope) => deleteSource(namespace, scope),
 
@@ -562,14 +622,11 @@ export const makeDefaultGraphqlStore = ({
           where: [{ field: "secret_id", value: secretId }],
         })
         .pipe(
-          Effect.map((rows) =>
-            rows.map(
-              (r): ChildUsageRow => ({
-                source_id: r.source_id as string,
-                scope_id: r.scope_id as string,
-                name: r.name as string,
-              }),
-            ),
+          Effect.flatMap((rows) =>
+            Schema.decodeUnknownEffect(Schema.Array(ChildUsageRowSchema))(rows),
+          ),
+          Effect.mapError(
+            storageDecodeError("Invalid stored GraphQL header usage rows"),
           ),
         ),
 
@@ -580,14 +637,11 @@ export const makeDefaultGraphqlStore = ({
           where: [{ field: "secret_id", value: secretId }],
         })
         .pipe(
-          Effect.map((rows) =>
-            rows.map(
-              (r): ChildUsageRow => ({
-                source_id: r.source_id as string,
-                scope_id: r.scope_id as string,
-                name: r.name as string,
-              }),
-            ),
+          Effect.flatMap((rows) =>
+            Schema.decodeUnknownEffect(Schema.Array(ChildUsageRowSchema))(rows),
+          ),
+          Effect.mapError(
+            storageDecodeError("Invalid stored GraphQL query param usage rows"),
           ),
         ),
 
@@ -603,12 +657,19 @@ export const makeDefaultGraphqlStore = ({
         // row's name + scope. Synthesize a minimal StoredGraphqlSource
         // shape with empty headers/params so the type matches without
         // a wasted child fetch.
-        return rows.map(
+        const sourceRows = yield* Schema.decodeUnknownEffect(Schema.Array(SourceRow))(
+          rows,
+        ).pipe(
+          Effect.mapError(
+            storageDecodeError("Invalid stored GraphQL source usage rows"),
+          ),
+        );
+        return sourceRows.map(
           (row): StoredGraphqlSource => ({
-            namespace: row.id as string,
-            scope: row.scope_id as string,
-            name: row.name as string,
-            endpoint: row.endpoint as string,
+            namespace: row.id,
+            scope: row.scope_id,
+            name: row.name,
+            endpoint: row.endpoint,
             headers: {},
             queryParams: {},
             auth: rowToAuth(row),
@@ -624,11 +685,18 @@ export const makeDefaultGraphqlStore = ({
         // graphql source table is small in practice (one row per
         // endpoint).
         const rows = yield* db.findMany({ model: "graphql_source" });
+        const sourceRows = yield* Schema.decodeUnknownEffect(Schema.Array(SourceRow))(
+          rows,
+        ).pipe(
+          Effect.mapError(
+            storageDecodeError("Invalid stored GraphQL source name rows"),
+          ),
+        );
         const requested = new Set(keys);
         const out = new Map<string, string>();
-        for (const r of rows) {
-          const key = `${r.scope_id as string}:${r.id as string}`;
-          if (requested.has(key)) out.set(key, r.name as string);
+        for (const r of sourceRows) {
+          const key = `${r.scope_id}:${r.id}`;
+          if (requested.has(key)) out.set(key, r.name);
         }
         return out;
       }),


### PR DESCRIPTION
## Summary
- decode persisted GraphQL rows and bindings with Effect Schema
- keep invalid stored data in typed StorageError failures
- replace test cleanup/tag assertions with Effect-aware helpers

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/graphql/src/sdk/plugin.test.ts packages/plugins/graphql/src/sdk/store.ts --deny-warnings
- bun run typecheck (packages/plugins/graphql)
- bunx vitest run src/sdk/plugin.test.ts (packages/plugins/graphql)