### PR TITLE
Use promiseExit in OpenAPI source UI

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
-import { Option } from "effect";
+import { Exit, Option } from "effect";
 
 import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk/core";
 import { startOAuth } from "@executor-js/react/api/atoms";
@@ -92,6 +92,17 @@ const substituteUrlVariables = (url: string, values: Record<string, string>): st
   return out;
 };
 
+const hasStringMessage = (value: unknown): value is { readonly message: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "message" in value &&
+  typeof (value as { readonly message?: unknown }).message === "string";
+
+const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string => {
+  const error = Exit.findErrorOption(exit);
+  return Option.isSome(error) && hasStringMessage(error.value) ? error.value.message : fallback;
+};
+
 export const openApiOAuthConnectionId = (
   namespaceSlug: string,
   flow: OAuth2Preset["flow"],
@@ -109,25 +120,13 @@ export const openApiOAuthConnectionId = (
  */
 export function resolveOAuthUrl(url: string, baseUrl: string): string {
   if (!url) return url;
-  try {
-    new URL(url);
-    return url;
-  } catch {
-    if (!baseUrl) return url;
-    try {
-      return new URL(url, baseUrl).toString();
-    } catch {
-      return url;
-    }
-  }
+  if (URL.canParse(url)) return url;
+  if (!baseUrl || !URL.canParse(url, baseUrl)) return url;
+  return new URL(url, baseUrl).toString();
 }
 
 export function inferOAuthIssuerUrl(authorizationUrl: string): string | null {
-  try {
-    return new URL(authorizationUrl).origin;
-  } catch {
-    return null;
-  }
+  return URL.canParse(authorizationUrl) ? new URL(authorizationUrl).origin : null;
 }
 
 type StrategySelection =
@@ -242,10 +241,10 @@ export default function AddOpenApiSource(props: {
 
   const scopeId = useScope();
   const userScope = useUserScope();
-  const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promise" });
-  const doAdd = useAtomSet(addOpenApiSpec, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
-  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promise" });
+  const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promiseExit" });
+  const doAdd = useAtomSet(addOpenApiSpec, { mode: "promiseExit" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
+  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promiseExit" });
   const { beginAdd } = usePendingSources();
   const secretList = useSecretPickerSecrets();
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
@@ -371,45 +370,46 @@ export default function AddOpenApiSource(props: {
     setAnalyzing(true);
     setAnalyzeError(null);
     setAddError(null);
-    try {
-      const credentials = serializeHttpCredentials(specFetchCredentials);
-      const result = await doPreview({
-        params: { scopeId },
-        payload: {
-          spec: specUrl,
-          specFetchCredentials: credentials,
-        },
-      });
-      setPreview(result);
-
-      const firstServer = result.servers[0];
-      if (firstServer) {
-        setSelectedServerIndex(0);
-        setVariableSelections(defaultSelectionsFor(firstServer));
-        setCustomBaseUrl("");
-      } else {
-        setSelectedServerIndex(-1);
-        setVariableSelections({});
-        setCustomBaseUrl("");
-      }
-
-      const firstPreset = result.headerPresets[0];
-      if (firstPreset) {
-        setStrategy({ kind: "header", presetIndex: 0 });
-        setCustomHeaders(entriesFromSpecPreset(firstPreset));
-      } else {
-        // No header presets — default to "custom" so the headers editor is
-        // visible immediately. Specs with no `security` block (e.g. Microsoft
-        // Graph) would otherwise leave the user staring at just the
-        // Authentication heading with no way to add headers.
-        setStrategy({ kind: "custom" });
-        setCustomHeaders([]);
-      }
-    } catch (e) {
-      setAnalyzeError(e instanceof Error ? e.message : "Failed to parse spec");
-    } finally {
+    const credentials = serializeHttpCredentials(specFetchCredentials);
+    const previewExit = await doPreview({
+      params: { scopeId },
+      payload: {
+        spec: specUrl,
+        specFetchCredentials: credentials,
+      },
+    });
+    if (Exit.isFailure(previewExit)) {
+      setAnalyzeError(errorMessageFromExit(previewExit, "Failed to parse spec"));
       setAnalyzing(false);
+      return;
     }
+    const result = previewExit.value;
+    setPreview(result);
+
+    const firstServer = result.servers[0];
+    if (firstServer) {
+      setSelectedServerIndex(0);
+      setVariableSelections(defaultSelectionsFor(firstServer));
+      setCustomBaseUrl("");
+    } else {
+      setSelectedServerIndex(-1);
+      setVariableSelections({});
+      setCustomBaseUrl("");
+    }
+
+    const firstPreset = result.headerPresets[0];
+    if (firstPreset) {
+      setStrategy({ kind: "header", presetIndex: 0 });
+      setCustomHeaders(entriesFromSpecPreset(firstPreset));
+    } else {
+      // No header presets — default to "custom" so the headers editor is
+      // visible immediately. Specs with no `security` block (e.g. Microsoft
+      // Graph) would otherwise leave the user staring at just the
+      // Authentication heading with no way to add headers.
+      setStrategy({ kind: "custom" });
+      setCustomHeaders([]);
+    }
+    setAnalyzing(false);
   };
 
   handleAnalyzeRef.current = handleAnalyze;
@@ -470,122 +470,128 @@ export default function AddOpenApiSource(props: {
     if (!selectedOAuth2Preset || !oauth2ClientIdSecretId || !preview) return;
     oauth.cancel();
     setOauth2Error(null);
-    try {
-      const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
+    const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
 
-      const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
+    const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
 
-      if (selectedOAuth2Preset.flow === "clientCredentials") {
-        // RFC 6749 §4.4: no user-interactive consent step. The client_secret
-        // is mandatory; the backend exchanges tokens inline and returns a
-        // completed OAuth2Auth we can attach to the source directly.
-        if (!oauth2ClientSecretSecretId) {
-          setOauth2Error("client_credentials requires a client secret");
-          return;
-        }
-        setStartingOAuth(true);
-        const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
-        const response = await doStartOAuth({
+    if (selectedOAuth2Preset.flow === "clientCredentials") {
+      // RFC 6749 §4.4: no user-interactive consent step. The client_secret
+      // is mandatory; the backend exchanges tokens inline and returns a
+      // completed OAuth2Auth we can attach to the source directly.
+      if (!oauth2ClientSecretSecretId) {
+        setOauth2Error("client_credentials requires a client secret");
+        return;
+      }
+      setStartingOAuth(true);
+      const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
+      const startExit = await doStartOAuth({
+        params: { scopeId },
+        payload: {
+          endpoint: tokenUrl,
+          redirectUrl: tokenUrl,
+          connectionId,
+          tokenScope: scopeId,
+          strategy: {
+            kind: "client-credentials",
+            tokenEndpoint: tokenUrl,
+            clientIdSecretId: oauth2ClientIdSecretId,
+            clientSecretSecretId: oauth2ClientSecretSecretId,
+            scopes: [...oauth2SelectedScopes],
+          },
+          pluginId: "openapi",
+          identityLabel: `${displayName} OAuth`,
+        },
+      });
+      setStartingOAuth(false);
+      if (Exit.isFailure(startExit)) {
+        setOauth2Error(errorMessageFromExit(startExit, "Failed to start OAuth"));
+        return;
+      }
+      const response = startExit.value;
+      if (!response.completedConnection) {
+        setOauth2Error("client_credentials flow did not mint a connection");
+        return;
+      }
+      setOauth2AuthState({
+        fingerprint: selectedOAuth2Fingerprint,
+        auth: new OAuth2Auth({
+          kind: "oauth2",
+          connectionId: response.completedConnection.connectionId,
+          securitySchemeName: selectedOAuth2Preset.securitySchemeName,
+          flow: "clientCredentials",
+          tokenUrl,
+          authorizationUrl: null,
+          clientIdSecretId: oauth2ClientIdSecretId,
+          clientSecretSecretId: oauth2ClientSecretSecretId,
+          scopes: [...oauth2SelectedScopes],
+        }),
+      });
+      setOauth2Error(null);
+      return;
+    }
+
+    const authorizationUrl = resolveOAuthUrl(
+      Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
+      resolvedBaseUrl,
+    );
+    const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
+
+    await oauth.openAuthorization({
+      run: async () => {
+        const startExit = await doStartOAuth({
           params: { scopeId },
           payload: {
-            endpoint: tokenUrl,
-            redirectUrl: tokenUrl,
-            connectionId,
-            tokenScope: scopeId as string,
+            endpoint: authorizationUrl,
+            connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
+            tokenScope: scopeId,
+            redirectUrl: oauth2RedirectUrl,
             strategy: {
-              kind: "client-credentials",
+              kind: "authorization-code",
+              authorizationEndpoint: authorizationUrl,
               tokenEndpoint: tokenUrl,
+              issuerUrl,
               clientIdSecretId: oauth2ClientIdSecretId,
-              clientSecretSecretId: oauth2ClientSecretSecretId,
+              clientSecretSecretId: oauth2ClientSecretSecretId ?? null,
               scopes: [...oauth2SelectedScopes],
             },
             pluginId: "openapi",
             identityLabel: `${displayName} OAuth`,
           },
         });
-        setStartingOAuth(false);
-        if (!response.completedConnection) {
-          setOauth2Error("client_credentials flow did not mint a connection");
-          return;
+        if (Exit.isFailure(startExit)) {
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- OAuth popup adapter boundary expects rejected run promises for start errors.
+          throw errorMessageFromExit(startExit, "Failed to start OAuth");
         }
+        const response = startExit.value;
+        if (response.authorizationUrl === null) {
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- OAuth popup adapter boundary expects rejected run promises for start errors.
+          throw "Unexpected response flow from server";
+        }
+        return {
+          sessionId: response.sessionId,
+          authorizationUrl: response.authorizationUrl,
+        };
+      },
+      onSuccess: (result) => {
         setOauth2AuthState({
           fingerprint: selectedOAuth2Fingerprint,
           auth: new OAuth2Auth({
             kind: "oauth2",
-            connectionId: response.completedConnection.connectionId,
+            connectionId: result.connectionId,
             securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-            flow: "clientCredentials",
+            flow: "authorizationCode",
             tokenUrl,
-            authorizationUrl: null,
+            authorizationUrl,
+            issuerUrl,
             clientIdSecretId: oauth2ClientIdSecretId,
             clientSecretSecretId: oauth2ClientSecretSecretId,
             scopes: [...oauth2SelectedScopes],
           }),
         });
         setOauth2Error(null);
-        return;
-      }
-
-      const authorizationUrl = resolveOAuthUrl(
-        Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
-        resolvedBaseUrl,
-      );
-      const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
-
-      await oauth.openAuthorization({
-        run: async () => {
-          const response = await doStartOAuth({
-            params: { scopeId },
-            payload: {
-              endpoint: authorizationUrl,
-              connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
-              tokenScope: scopeId as string,
-              redirectUrl: oauth2RedirectUrl,
-              strategy: {
-                kind: "authorization-code",
-                authorizationEndpoint: authorizationUrl,
-                tokenEndpoint: tokenUrl,
-                issuerUrl,
-                clientIdSecretId: oauth2ClientIdSecretId,
-                clientSecretSecretId: oauth2ClientSecretSecretId ?? null,
-                scopes: [...oauth2SelectedScopes],
-              },
-              pluginId: "openapi",
-              identityLabel: `${displayName} OAuth`,
-            },
-          });
-          if (response.authorizationUrl === null) {
-            throw new Error("Unexpected response flow from server");
-          }
-          return {
-            sessionId: response.sessionId,
-            authorizationUrl: response.authorizationUrl,
-          };
-        },
-        onSuccess: (result) => {
-          setOauth2AuthState({
-            fingerprint: selectedOAuth2Fingerprint,
-            auth: new OAuth2Auth({
-              kind: "oauth2",
-              connectionId: result.connectionId,
-              securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-              flow: "authorizationCode",
-              tokenUrl,
-              authorizationUrl,
-              issuerUrl,
-              clientIdSecretId: oauth2ClientIdSecretId,
-              clientSecretSecretId: oauth2ClientSecretSecretId,
-              scopes: [...oauth2SelectedScopes],
-            }),
-          });
-          setOauth2Error(null);
-        },
-        onError: setOauth2Error,
-      });
-    } catch (e) {
-      setStartingOAuth(false);
-      setOauth2Error(e instanceof Error ? e.message : "Failed to start OAuth");
-    }
+      },
+      onError: setOauth2Error,
+    });
   }, [
     selectedOAuth2Preset,
     oauth2ClientIdSecretId,
@@ -621,103 +627,94 @@ export default function AddOpenApiSource(props: {
       kind: "openapi",
       url: resolvedBaseUrl || undefined,
     });
-    try {
-      const result = await doAdd({
+    const addExit = await doAdd({
+      params: { scopeId },
+      payload: {
+        spec: specUrl,
+        specFetchCredentials: serializeHttpCredentials(specFetchCredentials),
+        name: identity.name.trim() || undefined,
+        namespace: slugifyNamespace(identity.namespace) || undefined,
+        baseUrl: resolvedBaseUrl || undefined,
+        ...(hasHeaders ? { headers: configuredHeaders } : {}),
+        ...(Object.keys(serializeHttpCredentials(runtimeCredentials).queryParams).length > 0
+          ? { queryParams: serializeHttpCredentials(runtimeCredentials).queryParams }
+          : {}),
+        ...(configuredOAuth2 ? { oauth2: configuredOAuth2 } : {}),
+      },
+      reactivityKeys: addSpecWriteKeys,
+    });
+
+    if (Exit.isFailure(addExit)) {
+      setAddError(errorMessageFromExit(addExit, "Failed to add source"));
+      setAdding(false);
+      placeholder.done();
+      return;
+    }
+
+    const sourceId = addExit.value.namespace;
+    const sourceScope = ScopeId.make(scopeId);
+    const bindingScope = ScopeId.make(userScope);
+
+    const setBinding = async (
+      slot: string,
+      value:
+        | { readonly kind: "secret"; readonly secretId: SecretId }
+        | { readonly kind: "connection"; readonly connectionId: ConnectionId },
+    ): Promise<boolean> => {
+      const bindingExit = await doSetBinding({
         params: { scopeId },
         payload: {
-          spec: specUrl,
-          specFetchCredentials: serializeHttpCredentials(specFetchCredentials),
-          name: identity.name.trim() || undefined,
-          namespace: slugifyNamespace(identity.namespace) || undefined,
-          baseUrl: resolvedBaseUrl || undefined,
-          ...(hasHeaders ? { headers: configuredHeaders } : {}),
-          ...(Object.keys(serializeHttpCredentials(runtimeCredentials).queryParams).length > 0
-            ? { queryParams: serializeHttpCredentials(runtimeCredentials).queryParams }
-            : {}),
-          ...(configuredOAuth2 ? { oauth2: configuredOAuth2 } : {}),
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot,
+          value,
         },
-        reactivityKeys: addSpecWriteKeys,
+        reactivityKeys: bindingWriteKeys,
       });
-
-      const sourceId = result.namespace;
-      const sourceScope = ScopeId.make(scopeId);
-      const bindingScope = ScopeId.make(userScope);
-
-      for (const binding of headerBindings) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: binding.slot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(binding.secretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
+      if (Exit.isFailure(bindingExit)) {
+        setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
+        setAdding(false);
+        placeholder.done();
+        return false;
       }
+      return true;
+    };
 
-      if (configuredOAuth2 && oauth2ClientIdSecretId) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.clientIdSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientIdSecretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      if (configuredOAuth2?.clientSecretSlot && oauth2ClientSecretSecretId) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.clientSecretSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientSecretSecretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      if (configuredOAuth2 && oauth2Auth) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.connectionSlot,
-            value: {
-              kind: "connection",
-              connectionId: ConnectionId.make(oauth2Auth.connectionId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      props.onComplete();
-    } catch (e) {
-      setAddError(e instanceof Error ? e.message : "Failed to add source");
-      setAdding(false);
-    } finally {
-      placeholder.done();
+    for (const binding of headerBindings) {
+      const saved = await setBinding(binding.slot, {
+        kind: "secret",
+        secretId: SecretId.make(binding.secretId),
+      });
+      if (!saved) return;
     }
+
+    if (configuredOAuth2 && oauth2ClientIdSecretId) {
+      const saved = await setBinding(configuredOAuth2.clientIdSlot, {
+        kind: "secret",
+        secretId: SecretId.make(oauth2ClientIdSecretId),
+      });
+      if (!saved) return;
+    }
+
+    if (configuredOAuth2?.clientSecretSlot && oauth2ClientSecretSecretId) {
+      const saved = await setBinding(configuredOAuth2.clientSecretSlot, {
+        kind: "secret",
+        secretId: SecretId.make(oauth2ClientSecretSecretId),
+      });
+      if (!saved) return;
+    }
+
+    if (configuredOAuth2 && oauth2Auth) {
+      const saved = await setBinding(configuredOAuth2.connectionSlot, {
+        kind: "connection",
+        connectionId: ConnectionId.make(oauth2Auth.connectionId),
+      });
+      if (!saved) return;
+    }
+
+    placeholder.done();
+    props.onComplete();
   };
 
   // ---- Render ----

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { Exit, Option } from "effect";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
 import { connectionsAtom, sourceAtom, startOAuth } from "@executor-js/react/api/atoms";
@@ -79,7 +80,7 @@ const openApiOAuthConnectionId = (
   targetScope: ScopeId,
 ): ConnectionId =>
   ConnectionId.make(
-    `openapi-oauth-${slugify(sourceId)}-${slugify(securitySchemeName)}-${shortHash(targetScope as string)}`,
+    `openapi-oauth-${slugify(sourceId)}-${slugify(securitySchemeName)}-${shortHash(targetScope)}`,
   );
 
 const bindingSecretId = (sourceId: string, slot: string, scopeId: string): string =>
@@ -89,6 +90,17 @@ const effectiveClientSecretSlot = (oauth2: {
   readonly securitySchemeName: string;
   readonly clientSecretSlot: string | null;
 }): string => oauth2.clientSecretSlot ?? oauth2ClientSecretSlot(oauth2.securitySchemeName);
+
+const hasStringMessage = (value: unknown): value is { readonly message: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "message" in value &&
+  typeof (value as { readonly message?: unknown }).message === "string";
+
+const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string => {
+  const error = Exit.findErrorOption(exit);
+  return Option.isSome(error) && hasStringMessage(error.value) ? error.value.message : fallback;
+};
 
 const exactBindingForScope = (
   rows: readonly {
@@ -101,7 +113,7 @@ const exactBindingForScope = (
 ) => rows.find((row) => row.slot === slot && row.scopeId === scopeId) ?? null;
 
 const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
-  ranks.get(scopeId as string) ?? Number.MAX_SAFE_INTEGER;
+  ranks.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
 
 const effectiveBindingForScope = (
   rows: readonly {
@@ -150,7 +162,7 @@ export default function EditOpenApiSource(props: {
   const sourceScopeId = sourceSummary?.scopeId ?? displayScope;
   const sourceScope = ScopeId.make(sourceScopeId);
   const scopeRanks = useMemo(
-    () => new Map(scopeStack.map((scope, index) => [scope.id as string, index] as const)),
+    () => new Map(scopeStack.map((scope, index) => [scope.id, index] as const)),
     [scopeStack],
   );
 
@@ -161,10 +173,10 @@ export default function EditOpenApiSource(props: {
   const connectionsResult = useAtomValue(connectionsAtom(displayScope));
   const secretList = useSecretPickerSecrets();
 
-  const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promise" });
-  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promise" });
-  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
+  const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promiseExit" });
+  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promiseExit" });
+  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, { mode: "promiseExit" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
     popupName: OPENAPI_OAUTH_POPUP_NAME,
     popupBlockedMessage: "OAuth popup was blocked by the browser",
@@ -233,19 +245,18 @@ export default function EditOpenApiSource(props: {
           oauth2: source.config.oauth2,
         },
         reactivityKeys: openApiWriteKeys,
-      })
-        .then(() => {
-          if (sourceSaveSeq.current !== seq) return;
-          setSourceSaveState("saved");
-          window.setTimeout(() => {
-            if (sourceSaveSeq.current === seq) setSourceSaveState("idle");
-          }, 1600);
-        })
-        .catch((e: unknown) => {
-          if (sourceSaveSeq.current !== seq) return;
+      }).then((exit) => {
+        if (sourceSaveSeq.current !== seq) return;
+        if (Exit.isFailure(exit)) {
           setSourceSaveState("idle");
-          setError(e instanceof Error ? e.message : "Failed to save source details");
-        });
+          setError(errorMessageFromExit(exit, "Failed to save source details"));
+          return;
+        }
+        setSourceSaveState("saved");
+        window.setTimeout(() => {
+          if (sourceSaveSeq.current === seq) setSourceSaveState("idle");
+        }, 1600);
+      });
     }, 600);
 
     return () => window.clearTimeout(timeout);
@@ -321,44 +332,40 @@ export default function EditOpenApiSource(props: {
     if (!trimmed) return;
     setBusyKey(inputKey);
     setError(null);
-    try {
-      await doSetBinding({
-        params: { scopeId: displayScope },
-        payload: {
-          sourceId: props.sourceId,
-          sourceScope,
-          scope: targetScope,
-          slot,
-          value: { kind: "secret", secretId: SecretId.make(trimmed) },
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save credential binding");
-    } finally {
-      setBusyKey(null);
+    const exit = await doSetBinding({
+      params: { scopeId: displayScope },
+      payload: {
+        sourceId: props.sourceId,
+        sourceScope,
+        scope: targetScope,
+        slot,
+        value: { kind: "secret", secretId: SecretId.make(trimmed) },
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(errorMessageFromExit(exit, "Failed to save credential binding"));
     }
+    setBusyKey(null);
   };
 
   const clearBinding = async (targetScope: ScopeId, slot: string) => {
     setBusyKey(`${targetScope}:${slot}:clear`);
     setError(null);
-    try {
-      await doRemoveBinding({
-        params: { scopeId: displayScope },
-        payload: {
-          sourceId: props.sourceId,
-          sourceScope,
-          slot,
-          scope: targetScope,
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to clear credential binding");
-    } finally {
-      setBusyKey(null);
+    const exit = await doRemoveBinding({
+      params: { scopeId: displayScope },
+      payload: {
+        sourceId: props.sourceId,
+        sourceScope,
+        slot,
+        scope: targetScope,
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(errorMessageFromExit(exit, "Failed to clear credential binding"));
     }
+    setBusyKey(null);
   };
 
   const connectOAuth = async (targetScope: ScopeId) => {
@@ -410,35 +417,114 @@ export default function EditOpenApiSource(props: {
     setPendingOAuthConnection({
       scopeId: targetScope,
       slot: oauth2.connectionSlot,
-      connectionId: connectionId as string,
+      connectionId,
     });
     setError(null);
-    try {
-      const displayName = source.name;
-      const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
-      if (oauth2.flow === "clientCredentials") {
-        const response = await doStartOAuth({
+    const displayName = source.name;
+    const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
+    if (oauth2.flow === "clientCredentials") {
+      const startExit = await doStartOAuth({
+        params: { scopeId: displayScope },
+        payload: {
+          endpoint: tokenUrl,
+          redirectUrl: tokenUrl,
+          connectionId,
+          tokenScope: targetScope,
+          strategy: {
+            kind: "client-credentials",
+            tokenEndpoint: tokenUrl,
+            clientIdSecretId,
+            clientSecretSecretId: clientSecretValue!.secretId,
+            scopes: [...oauth2.scopes],
+          },
+          pluginId: "openapi",
+          identityLabel: `${displayName} OAuth`,
+        },
+      });
+      if (Exit.isFailure(startExit)) {
+        setError(errorMessageFromExit(startExit, "Failed to connect OAuth"));
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+        return;
+      }
+      const response = startExit.value;
+      if (!response.completedConnection) {
+        setError("Unexpected OAuth response");
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+        return;
+      }
+      const bindingExit = await doSetBinding({
+        params: { scopeId: displayScope },
+        payload: {
+          sourceId: props.sourceId,
+          sourceScope,
+          scope: targetScope,
+          slot: oauth2.connectionSlot,
+          value: {
+            kind: "connection",
+            connectionId: ConnectionId.make(response.completedConnection.connectionId),
+          },
+        },
+        reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
+      });
+      if (Exit.isFailure(bindingExit)) {
+        setError(errorMessageFromExit(bindingExit, "Failed to connect OAuth"));
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+        return;
+      }
+      setPendingOAuthConnection(null);
+      setBusyKey(null);
+      return;
+    }
+
+    const authorizationUrl = resolveOAuthUrl(
+      oauth2.authorizationUrl ?? "",
+      source.config.baseUrl ?? "",
+    );
+    const issuerUrl = oauth2.issuerUrl ?? inferOAuthIssuerUrl(authorizationUrl);
+    await oauth.openAuthorization({
+      run: async () => {
+        const startExit = await doStartOAuth({
           params: { scopeId: displayScope },
           payload: {
-            endpoint: tokenUrl,
-            redirectUrl: tokenUrl,
-            connectionId: connectionId as string,
-            tokenScope: targetScope as string,
+            endpoint: authorizationUrl,
+            connectionId,
+            tokenScope: targetScope,
+            redirectUrl: oauth2RedirectUrl,
             strategy: {
-              kind: "client-credentials",
+              kind: "authorization-code",
+              authorizationEndpoint: authorizationUrl,
               tokenEndpoint: tokenUrl,
+              issuerUrl,
               clientIdSecretId,
-              clientSecretSecretId: clientSecretValue!.secretId,
+              clientSecretSecretId:
+                clientSecretBinding && isSecretBindingValue(clientSecretBinding.value)
+                  ? clientSecretBinding.value.secretId
+                  : null,
               scopes: [...oauth2.scopes],
             },
             pluginId: "openapi",
             identityLabel: `${displayName} OAuth`,
           },
         });
-        if (!response.completedConnection) {
-          throw new Error("Unexpected OAuth response");
+        if (Exit.isFailure(startExit)) {
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- OAuth popup adapter boundary expects rejected run promises for start errors.
+          throw errorMessageFromExit(startExit, "Failed to connect OAuth");
         }
-        await doSetBinding({
+        const response = startExit.value;
+        if (response.authorizationUrl === null) {
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- OAuth popup adapter boundary expects rejected run promises for start errors.
+          throw "Unexpected OAuth response";
+        }
+        return {
+          sessionId: response.sessionId,
+          authorizationUrl: response.authorizationUrl,
+        };
+      },
+      onSuccess: async (result) => {
+        const bindingExit = await doSetBinding({
           params: { scopeId: displayScope },
           payload: {
             sourceId: props.sourceId,
@@ -447,83 +533,26 @@ export default function EditOpenApiSource(props: {
             slot: oauth2.connectionSlot,
             value: {
               kind: "connection",
-              connectionId: ConnectionId.make(response.completedConnection.connectionId),
+              connectionId: ConnectionId.make(result.connectionId),
             },
           },
           reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
         });
+        if (Exit.isFailure(bindingExit)) {
+          setError(errorMessageFromExit(bindingExit, "Failed to connect OAuth"));
+          setPendingOAuthConnection(null);
+          setBusyKey(null);
+          return;
+        }
         setPendingOAuthConnection(null);
         setBusyKey(null);
-        return;
-      }
-
-      const authorizationUrl = resolveOAuthUrl(
-        oauth2.authorizationUrl ?? "",
-        source.config.baseUrl ?? "",
-      );
-      const issuerUrl = oauth2.issuerUrl ?? inferOAuthIssuerUrl(authorizationUrl);
-      await oauth.openAuthorization({
-        run: async () => {
-          const response = await doStartOAuth({
-            params: { scopeId: displayScope },
-            payload: {
-              endpoint: authorizationUrl,
-              connectionId: connectionId as string,
-              tokenScope: targetScope as string,
-              redirectUrl: oauth2RedirectUrl,
-              strategy: {
-                kind: "authorization-code",
-                authorizationEndpoint: authorizationUrl,
-                tokenEndpoint: tokenUrl,
-                issuerUrl,
-                clientIdSecretId,
-                clientSecretSecretId:
-                  clientSecretBinding && isSecretBindingValue(clientSecretBinding.value)
-                    ? clientSecretBinding.value.secretId
-                    : null,
-                scopes: [...oauth2.scopes],
-              },
-              pluginId: "openapi",
-              identityLabel: `${displayName} OAuth`,
-            },
-          });
-          if (response.authorizationUrl === null) {
-            throw new Error("Unexpected OAuth response");
-          }
-          return {
-            sessionId: response.sessionId,
-            authorizationUrl: response.authorizationUrl,
-          };
-        },
-        onSuccess: async (result) => {
-          await doSetBinding({
-            params: { scopeId: displayScope },
-            payload: {
-              sourceId: props.sourceId,
-              sourceScope,
-              scope: targetScope,
-              slot: oauth2.connectionSlot,
-              value: {
-                kind: "connection",
-                connectionId: ConnectionId.make(result.connectionId),
-              },
-            },
-            reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
-          });
-          setPendingOAuthConnection(null);
-          setBusyKey(null);
-        },
-        onError: (message) => {
-          setError(message);
-          setPendingOAuthConnection(null);
-          setBusyKey(null);
-        },
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to connect OAuth");
-      setPendingOAuthConnection(null);
-      setBusyKey(null);
-    }
+      },
+      onError: (message) => {
+        setError(message);
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+      },
+    });
   };
 
   return (
@@ -590,10 +619,10 @@ export default function EditOpenApiSource(props: {
               </CardStackEntryContent>
               <FilterTabs
                 tabs={credentialScopes.map((entry) => ({
-                  value: entry.scopeId as string,
+                  value: entry.scopeId,
                   label: entry.label,
                 }))}
-                value={activeCredentialScopeId as string}
+                value={activeCredentialScopeId}
                 onChange={setSelectedCredentialScope}
               />
             </CardStackEntry>
@@ -618,9 +647,9 @@ export default function EditOpenApiSource(props: {
                 isSecretBindingValue(effective.value);
               const currentSecretId =
                 exact && isSecretBindingValue(exact.value)
-                  ? (exact.value.secretId as string)
+                  ? exact.value.secretId
                   : inherited && effective && isSecretBindingValue(effective.value)
-                    ? (effective.value.secretId as string)
+                    ? effective.value.secretId
                     : null;
               return (
                 <CardStackEntryField


### PR DESCRIPTION
## Summary
- convert OpenAPI source UI mutations from promise try/catch to promiseExit
- preserve user-facing fallback messages through explicit Exit failure handling
- remove redundant casts and URL parsing try/catch in the source forms

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/openapi/src/react/AddOpenApiSource.tsx packages/plugins/openapi/src/react/EditOpenApiSource.tsx --deny-warnings
- bun run typecheck (packages/plugins/openapi)