### PR TITLE
Use typed assertions in policy code

### DIFF
--- a/packages/core/sdk/src/policies.test.ts
+++ b/packages/core/sdk/src/policies.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Result } from "effect";
+import { Effect, Predicate, Result } from "effect";
 import { generateKeyBetween } from "fractional-indexing";
 
 import type { ToolPolicyRow } from "./core-schema";
@@ -149,7 +149,7 @@ describe("resolveToolPolicy", () => {
       ROW("outer", "vercel.*", "block", "a0", "org"),
       ROW("inner", "vercel.dns.create", "approve", "a0", "user"),
     ];
-    const rank = (row: { scope_id: unknown }) =>
+    const rank = (row: Pick<ToolPolicyRow, "scope_id">) =>
       row.scope_id === "user" ? 0 : 1;
     const result = resolveToolPolicy(
       "vercel.dns.create",
@@ -274,8 +274,8 @@ const policyTestPlugin = definePlugin(() => ({
     for (const row of toolRows) {
       // Make tools whose name contains "delete" require approval by
       // default — mirrors openapi's HTTP-method heuristic in spirit.
-      out[row.id as string] = {
-        requiresApproval: (row.name as string).toLowerCase().includes("delete"),
+      out[row.id] = {
+        requiresApproval: row.name.toLowerCase().includes("delete"),
       };
     }
     return Effect.succeed(out);
@@ -526,10 +526,11 @@ describe("blocked tools", () => {
       );
       expect(Result.isFailure(result)).toBe(true);
       if (!Result.isFailure(result)) return;
-      expect((result.failure as { _tag?: string })._tag).toBe(
-        "ToolBlockedError",
+      expect(Predicate.isTagged("ToolBlockedError")(result.failure)).toBe(
+        true,
       );
-      expect((result.failure as { pattern?: string }).pattern).toBe("vercel.*");
+      if (!Predicate.isTagged("ToolBlockedError")(result.failure)) return;
+      expect(result.failure.pattern).toBe("vercel.*");
     }),
   );
 });
@@ -583,9 +584,9 @@ describe("approve / require_approval interaction with annotations", () => {
       );
       expect(Result.isFailure(result)).toBe(true);
       if (!Result.isFailure(result)) return;
-      expect((result.failure as { _tag?: string })._tag).toBe(
-        "ElicitationDeclinedError",
-      );
+      expect(
+        Predicate.isTagged("ElicitationDeclinedError")(result.failure),
+      ).toBe(true);
     }),
   );
 

--- a/packages/core/sdk/src/policies.ts
+++ b/packages/core/sdk/src/policies.ts
@@ -134,22 +134,22 @@ export const isValidPattern = (pattern: string): boolean => {
 // `generateKeyBetween(null, min)` from independent clients) would otherwise
 // flip on every refetch.
 export const comparePolicyRow = (
-  a: { position: unknown; id: unknown },
-  b: { position: unknown; id: unknown },
+  a: Pick<ToolPolicyRow, "position" | "id">,
+  b: Pick<ToolPolicyRow, "position" | "id">,
 ): number => {
-  const pa = a.position as string;
-  const pb = b.position as string;
+  const pa = a.position;
+  const pb = b.position;
   if (pa < pb) return -1;
   if (pa > pb) return 1;
-  const ia = a.id as string;
-  const ib = b.id as string;
+  const ia = a.id;
+  const ib = b.id;
   return ia < ib ? -1 : ia > ib ? 1 : 0;
 };
 
 export const resolveToolPolicy = (
   toolId: string,
   policies: readonly ToolPolicyRow[],
-  scopeRank: (row: { scope_id: unknown }) => number,
+  scopeRank: (row: Pick<ToolPolicyRow, "scope_id">) => number,
 ): PolicyMatch | undefined => {
   if (policies.length === 0) return undefined;
   const sorted = [...policies].sort((a, b) => {
@@ -159,11 +159,11 @@ export const resolveToolPolicy = (
     return comparePolicyRow(a, b);
   });
   for (const row of sorted) {
-    if (matchPattern(row.pattern as string, toolId)) {
+    if (matchPattern(row.pattern, toolId)) {
       return {
         action: row.action as ToolPolicyAction,
-        pattern: row.pattern as string,
-        policyId: row.id as string,
+        pattern: row.pattern,
+        policyId: row.id,
       };
     }
   }
@@ -201,7 +201,7 @@ const liftUser = (match: PolicyMatch): EffectivePolicy => ({
 export const resolveEffectivePolicy = (
   toolId: string,
   policies: readonly ToolPolicyRow[],
-  scopeRank: (row: { scope_id: unknown }) => number,
+  scopeRank: (row: Pick<ToolPolicyRow, "scope_id">) => number,
   defaultRequiresApproval?: boolean,
 ): EffectivePolicy => {
   const match = resolveToolPolicy(toolId, policies, scopeRank);
@@ -231,13 +231,13 @@ export const effectivePolicyFromSorted = (
 // ---------------------------------------------------------------------------
 
 export const rowToToolPolicy = (row: ToolPolicyRow): ToolPolicy => ({
-  id: PolicyId.make(row.id as string),
-  scopeId: ScopeId.make(row.scope_id as string),
-  pattern: row.pattern as string,
+  id: PolicyId.make(row.id),
+  scopeId: ScopeId.make(row.scope_id),
+  pattern: row.pattern,
   action: row.action as ToolPolicyAction,
-  position: row.position as string,
-  createdAt: row.created_at as Date,
-  updatedAt: row.updated_at as Date,
+  position: row.position,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove redundant casts in policy row handling
- replace manual tag checks in policy tests with Predicate helpers

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/sdk/src/policies.ts packages/core/sdk/src/policies.test.ts --deny-warnings
- bun run typecheck (packages/core/sdk)
- bunx vitest run src/policies.test.ts (packages/core/sdk)