### PR TITLE
Use typed failures in OpenAPI multi-scope tests

### DIFF
--- a/packages/plugins/openapi/src/sdk/multi-scope-bearer.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-bearer.test.ts
@@ -32,6 +32,7 @@ import {
   ScopeId,
   SecretId,
   SetSecretInput,
+  ToolInvocationError,
   type InvokeOptions,
   type SecretProvider,
 } from "@executor-js/sdk";
@@ -170,7 +171,7 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
         // -------------------------------------------------------------
         yield* adminExec.openapi.addSpec({
           spec: specJson,
-          scope: orgScope.id as string,
+          scope: String(orgScope.id),
           namespace: "vercel",
           baseUrl,
           headers: {
@@ -344,7 +345,7 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
 
         yield* adminExec.openapi.addSpec({
           spec: specJson,
-          scope: orgScope.id as string,
+          scope: String(orgScope.id),
           namespace: "vercel",
           baseUrl,
           headers: {
@@ -481,7 +482,7 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
 
         yield* adminExec.openapi.addSpec({
           spec: specJson,
-          scope: orgScope.id as string,
+          scope: String(orgScope.id),
           namespace: "vercel",
           baseUrl,
           headers: {
@@ -553,9 +554,9 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
 
         yield* aliceExec.openapi.removeSourceBinding(
           "vercel",
-          orgScope.id as string,
+          String(orgScope.id),
           "auth:token",
-          aliceScope.id as string,
+          String(aliceScope.id),
         );
 
         const fallbackResult = (yield* aliceExec.tools.invoke(
@@ -579,10 +580,10 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
           }),
         );
 
-        yield* adminExec.openapi.removeSpec("vercel", orgScope.id as string);
+        yield* adminExec.openapi.removeSpec("vercel", String(orgScope.id));
         yield* adminExec.openapi.addSpec({
           spec: specJson,
-          scope: orgScope.id as string,
+          scope: String(orgScope.id),
           namespace: "vercel",
           baseUrl,
           headers: {
@@ -596,16 +597,18 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
 
         const bindingsAfterReadd = yield* aliceExec.openapi.listSourceBindings(
           "vercel",
-          orgScope.id as string,
+          String(orgScope.id),
         );
         expect(bindingsAfterReadd).toEqual([]);
 
         const error = yield* Effect.flip(
           aliceExec.tools.invoke("vercel.projects.list", {}, autoApprove),
         );
-        expect((error as { _tag: string })._tag).toBe("ToolInvocationError");
-        expect((error as { message: string }).message).toContain(
-          'Missing binding for header "Authorization"',
+        expect(error).toBeInstanceOf(ToolInvocationError);
+        expect(error).toEqual(
+          expect.objectContaining({
+            message: expect.stringContaining('Missing binding for header "Authorization"'),
+          }),
         );
       }),
   );
@@ -657,20 +660,20 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
 
       yield* adminExec.openapi.addSpec({
         spec: specJson,
-        scope: orgScope.id as string,
+        scope: String(orgScope.id),
         namespace: "vercel",
         baseUrl: "https://api.vercel.example",
       });
 
       yield* aliceExec.openapi.addSpec({
         spec: specJson,
-        scope: aliceScope.id as string,
+        scope: String(aliceScope.id),
         namespace: "vercel",
       });
 
       const source = yield* aliceExec.openapi.getSource(
         "vercel",
-        aliceScope.id as string,
+        String(aliceScope.id),
       );
       expect(source?.scope).toBe(aliceScope.id);
       expect(source?.config.baseUrl).toBe("https://api.vercel.example");
@@ -739,7 +742,7 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
 
       yield* adminExec.openapi.addSpec({
         spec: specJson,
-        scope: orgScope.id as string,
+        scope: String(orgScope.id),
         namespace: "vercel",
         baseUrl,
         headers: {
@@ -752,7 +755,7 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
       });
       yield* aliceExec.openapi.addSpec({
         spec: specJson,
-        scope: aliceScope.id as string,
+        scope: String(aliceScope.id),
         namespace: "vercel",
       });
 

--- a/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
@@ -9,7 +9,7 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, expect, layer } from "@effect/vitest";
-import { Effect, Layer, Schema } from "effect";
+import { Data, Effect, Layer, Predicate, Schema } from "effect";
 import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
 import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
@@ -32,6 +32,10 @@ import { openApiPlugin } from "./plugin";
 import { OAuth2Auth } from "./types";
 
 const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
+
+class TestInvariantError extends Data.TaggedError("TestInvariantError")<{
+  readonly message: string;
+}> {}
 
 // ---------------------------------------------------------------------------
 // Test API — a single endpoint that echoes the Authorization header so the
@@ -137,7 +141,9 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       const clientLayer = FetchHttpClient.layer;
       const server = yield* HttpServer.HttpServer;
       const address = server.address;
-      if (address._tag !== "TcpAddress") return yield* Effect.die("test server must bind to TCP");
+      if (!Predicate.isTagged(address, "TcpAddress")) {
+        return yield* new TestInvariantError({ message: "test server must bind to TCP" });
+      }
       const baseUrl = `http://127.0.0.1:${address.port}`;
       const plugins = [
         openApiPlugin({ httpClientLayer: clientLayer }),
@@ -257,10 +263,10 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       );
       const bobStart = yield* startAuthorizationCode(bobExec, startInputFor("bob", bobScope.id));
       if (aliceStart.authorizationUrl === null) {
-        throw new Error("expected authorizationCode flow for alice");
+        return yield* new TestInvariantError({ message: "expected authorizationCode flow for alice" });
       }
       if (bobStart.authorizationUrl === null) {
-        throw new Error("expected authorizationCode flow for bob");
+        return yield* new TestInvariantError({ message: "expected authorizationCode flow for bob" });
       }
 
       const aliceAuth = yield* aliceExec.oauth.complete({
@@ -306,14 +312,14 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       // -------------------------------------------------------------
       yield* aliceExec.openapi.addSpec({
         spec: specJson,
-        scope: aliceScope.id as string,
+        scope: String(aliceScope.id),
         namespace: "petstore",
         baseUrl,
         oauth2: aliceOAuth2Auth,
       });
       yield* bobExec.openapi.addSpec({
         spec: specJson,
-        scope: bobScope.id as string,
+        scope: String(bobScope.id),
         namespace: "petstore",
         baseUrl,
         oauth2: bobOAuth2Auth,
@@ -351,7 +357,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       expect(String(bobConn?.scopeId)).toBe("user-bob");
 
       const adminConnectionIds = new Set(
-        (yield* adminExec.connections.list()).map((c) => c.id as string),
+        (yield* adminExec.connections.list()).map((c) => String(c.id)),
       );
       expect(adminConnectionIds).not.toContain(String(aliceAuth.connectionId));
       expect(adminConnectionIds).not.toContain(String(bobAuth.connectionId));
@@ -406,7 +412,9 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       const clientLayer = FetchHttpClient.layer;
       const server = yield* HttpServer.HttpServer;
       const address = server.address;
-      if (address._tag !== "TcpAddress") return yield* Effect.die("test server must bind to TCP");
+      if (!Predicate.isTagged(address, "TcpAddress")) {
+        return yield* new TestInvariantError({ message: "test server must bind to TCP" });
+      }
       const baseUrl = `http://127.0.0.1:${address.port}`;
       const plugins = [
         openApiPlugin({ httpClientLayer: clientLayer }),
@@ -541,7 +549,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
             endpoint: input.tokenUrl,
             redirectUrl: input.tokenUrl,
             connectionId: input.connectionId,
-            tokenScope: tokenScope as string,
+            tokenScope: String(tokenScope),
             pluginId: "openapi",
             identityLabel: `${input.displayName} OAuth`,
             strategy: {
@@ -553,7 +561,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
             },
           });
           if (!started.completedConnection) {
-            throw new Error("expected clientCredentials flow");
+            return yield* new TestInvariantError({ message: "expected clientCredentials flow" });
           }
           return new OAuth2Auth({
             kind: "oauth2",
@@ -575,7 +583,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       const adminAuth = yield* startClientCredentials(adminExec, orgScope.id, startInput);
       yield* adminExec.openapi.addSpec({
         spec: specJson,
-        scope: orgScope.id as string,
+        scope: String(orgScope.id),
         namespace: "petstore",
         baseUrl,
         oauth2: adminAuth,
@@ -624,7 +632,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       // (4) Each user's invocation resolves their OWN row and gets
       // their OWN token — not whatever the last signer happened to
       // mint. This is the core multi-user regression.
-      yield* aliceExec.openapi.updateSource("petstore", orgScope.id as string, {
+      yield* aliceExec.openapi.updateSource("petstore", String(orgScope.id), {
         oauth2: aliceAuth,
       });
       const aliceResult = (yield* aliceExec.tools.invoke(


### PR DESCRIPTION
## Summary
- replace test Effect.die/raw throws with a local tagged test error
- remove redundant scope casts and manual tag/message assertions

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts packages/plugins/openapi/src/sdk/multi-scope-bearer.test.ts --deny-warnings
- bun run typecheck (packages/plugins/openapi)
- bunx vitest run src/sdk/multi-scope-oauth.test.ts src/sdk/multi-scope-bearer.test.ts (packages/plugins/openapi)