### PR TITLE
Use typed MCP runtime boundaries

### DIFF
--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -16,7 +16,7 @@
 
 import { env } from "cloudflare:workers";
 import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
-import { Cause, Context, Effect, Layer, Option, Schema } from "effect";
+import { Cause, Context, Effect, Layer, Option, Predicate, Result, Schema } from "effect";
 
 import { createCachedRemoteJWKSet } from "./jwks-cache";
 import { captureCause } from "./observability";
@@ -171,7 +171,7 @@ export const McpAuthLive = Layer.succeed(McpAuth)({
       }),
     );
     if (!verified) return mcpUnauthorized("invalid_token", "The access token is invalid");
-    if ("_tag" in verified) return verified;
+    if (isMcpUnauthorized(verified)) return verified;
     if (!verified.accountId) {
       yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
       return mcpUnauthorized("invalid_token", "The access token is invalid");
@@ -285,22 +285,25 @@ const InitializeParams = Schema.Struct({
 const NamedParams = Schema.Struct({ name: Schema.optional(Schema.String) });
 const UriParams = Schema.Struct({ uri: Schema.optional(Schema.String) });
 
-const decodeJsonRpcEnvelope = Schema.decodeUnknownOption(JsonRpcEnvelope);
+const decodeJsonRpcEnvelopeJson = (text: string): Option.Option<JsonRpcEnvelope> =>
+  Schema.decodeUnknownOption(Schema.fromJsonString(JsonRpcEnvelope))(text);
 const decodeInitializeParams = Schema.decodeUnknownOption(InitializeParams);
 const decodeNamedParams = Schema.decodeUnknownOption(NamedParams);
 const decodeUriParams = Schema.decodeUnknownOption(UriParams);
 const decodeElicitationReplyResult = Schema.decodeUnknownOption(ElicitationReplyResult);
 
+const isMcpAuthorized = Predicate.isTagged("Authorized");
+const isMcpUnauthorized = Predicate.isTagged("Unauthorized");
+
 const readJsonRpcEnvelope = (request: Request): Effect.Effect<Option.Option<JsonRpcEnvelope>> =>
-  Effect.promise(async () => {
-    try {
-      const text = await request.clone().text();
-      if (!text) return Option.none();
-      return decodeJsonRpcEnvelope(JSON.parse(text));
-    } catch {
-      return Option.none();
-    }
-  }).pipe(Effect.withSpan("mcp.request.read_json_rpc"));
+  Effect.tryPromise({
+    try: () => request.clone().text(),
+    catch: () => undefined,
+  }).pipe(
+    Effect.map((text) => (text ? decodeJsonRpcEnvelopeJson(text) : Option.none())),
+    Effect.catchCause(() => Effect.succeed(Option.none())),
+    Effect.withSpan("mcp.request.read_json_rpc"),
+  );
 
 const methodAttrs = (envelope: JsonRpcEnvelope): Record<string, unknown> => {
   const params = envelope.params ?? {};
@@ -409,15 +412,14 @@ const protectedResourceMetadata = Effect.sync(() =>
   }),
 );
 
-const authorizationServerMetadata = Effect.promise(async () => {
-  try {
+const authorizationServerMetadata = Effect.tryPromise({
+  try: async () => {
     const res = await fetch(`${AUTHKIT_DOMAIN}/.well-known/oauth-authorization-server`);
     if (!res.ok) return jsonResponse({ error: "upstream_error" }, 502);
     return jsonResponse(await res.json());
-  } catch {
-    return jsonResponse({ error: "upstream_error" }, 502);
-  }
-});
+  },
+  catch: () => undefined,
+}).pipe(Effect.catchCause(() => Effect.succeed(jsonResponse({ error: "upstream_error" }, 502))));
 
 // ---------------------------------------------------------------------------
 // DO dispatch
@@ -545,7 +547,7 @@ const authorizeMcpOrganization = (
       Effect.catchCause((error) =>
         Effect.gen(function* () {
           yield* Effect.annotateCurrentSpan({
-            "mcp.auth.organization_authorize_error": String(error),
+            "mcp.auth.organization_authorize_error": Cause.pretty(error),
           });
           return false;
         }),
@@ -662,7 +664,7 @@ export const mcpApp: Effect.Effect<
   const auth = yield* McpAuth;
   const authResult = yield* auth.verifyBearer(request).pipe(Effect.result);
 
-  if (authResult._tag === "Failure") {
+  if (Result.isFailure(authResult)) {
     yield* annotateMcpRequest(request, {
       token: null,
       parseBody: request.method === "POST",
@@ -675,11 +677,11 @@ export const mcpApp: Effect.Effect<
   // POST bodies are JSON-RPC payloads worth parsing; GET (SSE) and DELETE
   // don't carry one.
   yield* annotateMcpRequest(request, {
-    token: authValue._tag === "Authorized" ? authValue.token : null,
+    token: isMcpAuthorized(authValue) ? authValue.token : null,
     parseBody: request.method === "POST",
   });
 
-  if (authValue._tag === "Unauthorized") {
+  if (isMcpUnauthorized(authValue)) {
     return unauthorized(authValue, PROTECTED_RESOURCE_METADATA_URL);
   }
   const token = authValue.token;

--- a/apps/local/src/server/mcp.ts
+++ b/apps/local/src/server/mcp.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Cause, Effect, Exit } from "effect";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
@@ -20,6 +20,18 @@ const jsonError = (status: number, code: number, message: string): Response =>
     headers: { "content-type": "application/json" },
   });
 
+const closeIgnoringFailure = (close: (() => Promise<void>) | undefined): Promise<void> =>
+  close
+    ? Effect.runPromise(
+        Effect.ignore(
+          Effect.tryPromise({
+            try: close,
+            catch: (cause) => cause,
+          }),
+        ),
+      )
+    : Promise.resolve();
+
 export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpRequestHandler => {
   const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
   const servers = new Map<string, McpServer>();
@@ -29,8 +41,8 @@ export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpReq
     const s = servers.get(id);
     transports.delete(id);
     servers.delete(id);
-    if (opts.transport) await t?.close().catch(() => undefined);
-    if (opts.server) await s?.close().catch(() => undefined);
+    if (opts.transport) await closeIgnoringFailure(t?.close.bind(t));
+    if (opts.server) await closeIgnoringFailure(s?.close.bind(s));
   };
 
   return {
@@ -59,24 +71,34 @@ export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpReq
         if (sid) void dispose(sid, { server: true });
       };
 
-      try {
-        created = await Effect.runPromise(createExecutorMcpServer(config));
-        await created.connect(transport);
-        const response = await transport.handleRequest(request);
+      const responseExit = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          created = yield* createExecutorMcpServer(config);
+          yield* Effect.tryPromise({
+            try: () => created!.connect(transport),
+            catch: (cause) => cause,
+          });
+          return yield* Effect.tryPromise({
+            try: () => transport.handleRequest(request),
+            catch: (cause) => cause,
+          });
+        }),
+      );
 
+      if (Exit.isSuccess(responseExit)) {
         if (!transport.sessionId) {
-          await transport.close().catch(() => undefined);
-          await created.close().catch(() => undefined);
+          await closeIgnoringFailure(transport.close.bind(transport));
+          await closeIgnoringFailure(created?.close.bind(created));
         }
-        return response;
-      } catch (error) {
-        console.error("[mcp] handleRequest error:", error instanceof Error ? error.stack : error);
-        if (!transport.sessionId) {
-          await transport.close().catch(() => undefined);
-          await created?.close().catch(() => undefined);
-        }
-        return jsonError(500, -32603, "Internal server error");
+        return responseExit.value;
       }
+
+      console.error("[mcp] handleRequest error:", Cause.pretty(responseExit.cause));
+      if (!transport.sessionId) {
+        await closeIgnoringFailure(transport.close.bind(transport));
+        await closeIgnoringFailure(created?.close.bind(created));
+      }
+      return jsonError(500, -32603, "Internal server error");
     },
 
     close: async () => {
@@ -109,11 +131,23 @@ export const runMcpStdioServer = async (config: ExecutorMcpServerConfig): Promis
       process.stdin.once("close", finish);
     });
 
-  try {
-    await server.connect(transport);
-    await waitForExit();
-  } finally {
-    await transport.close().catch(() => undefined);
-    await server.close().catch(() => undefined);
+  const exit = await Effect.runPromiseExit(
+    Effect.gen(function* () {
+      yield* Effect.tryPromise({
+        try: () => server.connect(transport),
+        catch: (cause) => cause,
+      });
+      yield* Effect.tryPromise({
+        try: waitForExit,
+        catch: (cause) => cause,
+      });
+    }),
+  );
+
+  await closeIgnoringFailure(transport.close.bind(transport));
+  await closeIgnoringFailure(server.close.bind(server));
+
+  if (Exit.isFailure(exit)) {
+    await Effect.runPromise(Effect.failCause(exit.cause));
   }
 };


### PR DESCRIPTION
## Summary
- replace MCP runtime manual tag/result checks with Effect helpers
- parse JSON request envelopes with Effect Schema
- keep local MCP cleanup/error responses stable through Effect boundaries

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/mcp.ts apps/local/src/server/mcp.ts --deny-warnings
- bun run typecheck (apps/cloud)
- bun run typecheck and bunx --bun vitest run src/server/mcp-oauth.test.ts (apps/local)