### PR TITLE
Use typed OAuth API boundaries

### DIFF
--- a/apps/cloud/src/services/sources-api.node.test.ts
+++ b/apps/cloud/src/services/sources-api.node.test.ts
@@ -4,7 +4,7 @@
 // single org.
 
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Result, Schema } from "effect";
 import http from "node:http";
 import { readFileSync } from "node:fs";
 import type { AddressInfo } from "node:net";
@@ -173,6 +173,11 @@ const GRAPHQL_INTROSPECTION_RESPONSE = {
   },
 };
 
+const GraphqlRequestSchema = Schema.Struct({
+  query: Schema.optional(Schema.String),
+  variables: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
+});
+
 const startGraphqlServer = () => {
   const requests: Array<{ readonly query: string; readonly variables: unknown }> = [];
   const server = http.createServer(async (req, res) => {
@@ -182,10 +187,9 @@ const startGraphqlServer = () => {
       return;
     }
 
-    const parsed = JSON.parse(await readBody(req)) as {
-      readonly query?: string;
-      readonly variables?: Record<string, unknown>;
-    };
+    const parsed = await Schema.decodeUnknownPromise(Schema.fromJsonString(GraphqlRequestSchema))(
+      await readBody(req),
+    );
     const query = parsed.query ?? "";
     requests.push({ query, variables: parsed.variables ?? null });
 
@@ -411,9 +415,8 @@ describe("sources api (HTTP)", () => {
         }),
       );
 
-      if (execution.status !== "completed") {
-        throw new Error(`Expected completed execution, got ${execution.status}`);
-      }
+      expect(execution.status).toBe("completed");
+      if (execution.status !== "completed") return;
       expect(execution.isError).toBe(false);
       expect(execution.structured).toMatchObject({
         status: "completed",
@@ -448,7 +451,7 @@ describe("sources api (HTTP)", () => {
           })
           .pipe(Effect.result),
       );
-      expect(addResult._tag).toBe("Failure");
+      expect(Result.isFailure(addResult)).toBe(true);
 
       const fetched = yield* asOrg(org, (client) =>
         client.mcp.getSource({ params: { scopeId, namespace } }),
@@ -518,9 +521,8 @@ describe("sources api (HTTP)", () => {
         }),
       );
 
-      if (execution.status !== "completed") {
-        throw new Error(`Expected completed execution, got ${execution.status}`);
-      }
+      expect(execution.status).toBe("completed");
+      if (execution.status !== "completed") return;
       expect(execution.isError).toBe(false);
       expect(execution.structured).toMatchObject({
         status: "completed",
@@ -587,9 +589,8 @@ describe("sources api (HTTP)", () => {
         }),
       );
 
-      if (execution.status !== "completed") {
-        throw new Error(`Expected completed execution, got ${execution.status}`);
-      }
+      expect(execution.status).toBe("completed");
+      if (execution.status !== "completed") return;
       expect(execution.isError).toBe(false);
       expect(execution.structured).toMatchObject({
         status: "completed",
@@ -635,7 +636,7 @@ describe("sources api (HTTP)", () => {
           .remove({ params: { scopeId: ScopeId.make(org), sourceId: ghost } })
           .pipe(Effect.result),
       );
-      expect(result._tag).toBe("Success");
+      expect(Result.isSuccess(result)).toBe(true);
     }),
   );
 
@@ -651,7 +652,7 @@ describe("sources api (HTTP)", () => {
           .remove({ params: { scopeId: ScopeId.make(org), sourceId: "openapi" } })
           .pipe(Effect.result),
       );
-      expect(result._tag).toBe("Failure");
+      expect(Result.isFailure(result)).toBe(true);
     }),
   );
 

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -6,7 +6,7 @@
 
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { HttpServerResponse } from "effect/unstable/http";
-import { Effect } from "effect";
+import { Effect, Option, Predicate, Schema } from "effect";
 
 import { runOAuthCallback } from "../oauth-popup";
 import {
@@ -39,19 +39,35 @@ const resolveOAuthSecretBackedMap = <E extends OAuthProbeError | OAuthStartError
     onError: (_error, name) => makeError(`Secret not found for "${name}"`),
   }).pipe(
     Effect.mapError((error) =>
-      error instanceof OAuthProbeError || error instanceof OAuthStartError
+      Predicate.isTagged(error, "OAuthProbeError") || Predicate.isTagged(error, "OAuthStartError")
         ? (error as E)
         : makeError("Secret resolution failed"),
     ),
   );
 
+const decodeOAuthStartError = Schema.decodeUnknownOption(OAuthStartError);
+const decodeOAuthCompleteError = Schema.decodeUnknownOption(OAuthCompleteError);
+const decodeOAuthProbeError = Schema.decodeUnknownOption(OAuthProbeError);
+const decodeOAuthSessionNotFoundError = Schema.decodeUnknownOption(OAuthSessionNotFoundError);
+
+const getOAuthErrorMessage = <A extends { readonly message: string }>(
+  error: unknown,
+  decode: (input: unknown) => Option.Option<A>,
+): string | undefined =>
+  Option.match(decode(error), {
+    onNone: () => undefined,
+    onSome: (oauthError) => oauthError.message,
+  });
+
 const toPopupErrorMessage = (error: unknown): string => {
-  if (error instanceof OAuthStartError) return error.message;
-  if (error instanceof OAuthCompleteError) return error.message;
-  if (error instanceof OAuthProbeError) return error.message;
-  if (error instanceof OAuthSessionNotFoundError) {
-    return `OAuth session not found: ${error.sessionId}`;
-  }
+  const message =
+    getOAuthErrorMessage(error, decodeOAuthStartError) ??
+    getOAuthErrorMessage(error, decodeOAuthCompleteError) ??
+    getOAuthErrorMessage(error, decodeOAuthProbeError);
+  if (message) return message;
+
+  const sessionNotFound = decodeOAuthSessionNotFoundError(error);
+  if (Option.isSome(sessionNotFound)) return `OAuth session not found: ${sessionNotFound.value.sessionId}`;
   return "Authentication failed";
 };
 
@@ -147,7 +163,9 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
                   Effect.tapError((cause) =>
                     Effect.logError("OAuth callback completion failed", cause),
                   ),
-                  Effect.catchCause(() => Effect.fail(new Error("Authentication failed"))),
+                  Effect.catchCause(() =>
+                    Effect.fail(new OAuthCompleteError({ message: "Authentication failed" })),
+                  ),
                 ),
             urlParams,
             toErrorMessage: toPopupErrorMessage,


### PR DESCRIPTION
## Summary
- replace OAuth handler tagged-error instanceof checks with Effect-compatible handling
- parse sources API test request JSON with Effect Schema
- use Result helpers instead of manual tag checks in sources API tests

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/api/src/handlers/oauth.ts apps/cloud/src/services/sources-api.node.test.ts --deny-warnings
- bun run typecheck (packages/core/api)
- bun run typecheck and node ../../node_modules/vitest/vitest.mjs run --config vitest.node.config.ts src/services/sources-api.node.test.ts (apps/cloud)