### PR TITLE
Use typed failures in memory adapter filters

### DIFF
--- a/packages/core/storage-core/src/testing/memory.ts
+++ b/packages/core/storage-core/src/testing/memory.ts
@@ -26,6 +26,7 @@ import type {
 } from "../adapter";
 import type { DBSchema } from "../schema";
 import { createAdapter } from "../factory";
+import { StorageError } from "../errors";
 
 type Row = Record<string, unknown>;
 type Store = Record<string, Row[]>;
@@ -69,60 +70,70 @@ const compare = (
 const rowAs = <T>(row: Row): T => row as T;
 const rowsAs = <T>(rows: readonly Row[]): T[] => rows.map(rowAs<T>);
 
-const evalClause = (record: Row, clause: CleanedWhere): boolean => {
-  const { field, value, operator, mode } = clause;
-  const isInsensitive =
-    mode === "insensitive" &&
-    (typeof value === "string" ||
-      (Array.isArray(value) &&
-        (value as unknown[]).every((v) => typeof v === "string")));
+const invalidArrayValue = (clause: CleanedWhere) =>
+  new StorageError({
+    message: "Memory adapter where clause expected an array value",
+    cause: clause,
+  });
 
-  const lhs = record[field];
-  const lowerStr = (v: unknown) =>
-    typeof v === "string" ? v.toLowerCase() : v;
+const evalClause = (
+  record: Row,
+  clause: CleanedWhere,
+): Effect.Effect<boolean, StorageFailure> =>
+  Effect.gen(function* () {
+    const { field, value, operator, mode } = clause;
+    const isInsensitive =
+      mode === "insensitive" &&
+      (typeof value === "string" ||
+        (Array.isArray(value) &&
+          (value as unknown[]).every((v) => typeof v === "string")));
 
-  const cmp = (a: unknown, b: unknown): boolean =>
-    isInsensitive ? lowerStr(a) === lowerStr(b) : a === b;
-  switch (operator) {
-    case "in":
-      if (!Array.isArray(value)) throw new Error("Value must be an array");
-      return (value as unknown[]).some((v) => cmp(lhs, v));
-    case "not_in":
-      if (!Array.isArray(value)) throw new Error("Value must be an array");
-      return !(value as unknown[]).some((v) => cmp(lhs, v));
-    case "contains": {
-      if (typeof lhs !== "string" || typeof value !== "string") return false;
-      return isInsensitive
-        ? lhs.toLowerCase().includes(value.toLowerCase())
-        : lhs.includes(value);
+    const lhs = record[field];
+    const lowerStr = (v: unknown) =>
+      typeof v === "string" ? v.toLowerCase() : v;
+
+    const cmp = (a: unknown, b: unknown): boolean =>
+      isInsensitive ? lowerStr(a) === lowerStr(b) : a === b;
+    switch (operator) {
+      case "in":
+        if (!Array.isArray(value)) return yield* invalidArrayValue(clause);
+        return (value as unknown[]).some((v) => cmp(lhs, v));
+      case "not_in":
+        if (!Array.isArray(value)) return yield* invalidArrayValue(clause);
+        return !(value as unknown[]).some((v) => cmp(lhs, v));
+      case "contains": {
+        if (typeof lhs !== "string" || typeof value !== "string") return false;
+        return isInsensitive
+          ? lhs.toLowerCase().includes(value.toLowerCase())
+          : lhs.includes(value);
+      }
+      case "starts_with": {
+        if (typeof lhs !== "string" || typeof value !== "string") return false;
+        return isInsensitive
+          ? lhs.toLowerCase().startsWith(value.toLowerCase())
+          : lhs.startsWith(value);
+      }
+      case "ends_with": {
+        if (typeof lhs !== "string" || typeof value !== "string") return false;
+        return isInsensitive
+          ? lhs.toLowerCase().endsWith(value.toLowerCase())
+          : lhs.endsWith(value);
+      }
+      case "ne":
+        return !cmp(lhs, value);
+      case "gt":
+        return value != null && compare(lhs, value, "gt");
+      case "gte":
+        return value != null && compare(lhs, value, "gte");
+      case "lt":
+        return value != null && compare(lhs, value, "lt");
+      case "lte":
+        return value != null && compare(lhs, value, "lte");
+      case "eq":
+      default:
+        return cmp(lhs, value);
     }
-    case "starts_with": {
-      if (typeof lhs !== "string" || typeof value !== "string") return false;
-      return isInsensitive
-        ? lhs.toLowerCase().startsWith(value.toLowerCase())
-        : lhs.startsWith(value);
-    }
-    case "ends_with": {
-      if (typeof lhs !== "string" || typeof value !== "string") return false;
-      return isInsensitive
-        ? lhs.toLowerCase().endsWith(value.toLowerCase())
-        : lhs.endsWith(value);
-    }
-    case "ne":
-      return !cmp(lhs, value);
-    case "gt":
-      return value != null && compare(lhs, value, "gt");
-    case "gte":
-      return value != null && compare(lhs, value, "gte");
-    case "lt":
-      return value != null && compare(lhs, value, "lt");
-    case "lte":
-      return value != null && compare(lhs, value, "lte");
-    case "eq":
-    default:
-      return cmp(lhs, value);
-  }
-};
+  });
 
 // Split-group AND/OR grouping: clauses with `connector: "AND"` (or no
 // connector) are conjoined, clauses with `connector: "OR"` are disjoined,
@@ -132,22 +143,44 @@ const evalClause = (record: Row, clause: CleanedWhere): boolean => {
 // conformance suite. This diverges from upstream's *memory* adapter, which
 // still uses a left-to-right fold; we prefer drizzle parity so that a
 // plugin that works against memory always works against SQL.
-const matchAll = (record: Row, where: readonly CleanedWhere[]): boolean => {
-  if (where.length === 0) return true;
-  if (where.length === 1) return evalClause(record, where[0]!);
-  const andGroup = where.filter(
-    (w) => w.connector === "AND" || !w.connector,
-  );
-  const orGroup = where.filter((w) => w.connector === "OR");
-  const andResult =
-    andGroup.length === 0 ? true : andGroup.every((w) => evalClause(record, w));
-  const orResult =
-    orGroup.length === 0 ? true : orGroup.some((w) => evalClause(record, w));
-  return andResult && orResult;
-};
+const matchAll = (
+  record: Row,
+  where: readonly CleanedWhere[],
+): Effect.Effect<boolean, StorageFailure> =>
+  Effect.gen(function* () {
+    if (where.length === 0) return true;
+    if (where.length === 1) return yield* evalClause(record, where[0]!);
+    const andGroup = where.filter(
+      (w) => w.connector === "AND" || !w.connector,
+    );
+    const orGroup = where.filter((w) => w.connector === "OR");
+    let andResult = true;
+    for (const clause of andGroup) {
+      if (!(yield* evalClause(record, clause))) {
+        andResult = false;
+        break;
+      }
+    }
+    if (!andResult) return false;
 
-const filterWhere = (rows: Row[], where: readonly CleanedWhere[]): Row[] =>
-  rows.filter((r) => matchAll(r, where));
+    if (orGroup.length === 0) return true;
+    for (const clause of orGroup) {
+      if (yield* evalClause(record, clause)) return true;
+    }
+    return false;
+  });
+
+const filterWhere = (
+  rows: Row[],
+  where: readonly CleanedWhere[],
+): Effect.Effect<Row[], StorageFailure> =>
+  Effect.gen(function* () {
+    const matches: Row[] = [];
+    for (const row of rows) {
+      if (yield* matchAll(row, where)) matches.push(row);
+    }
+    return matches;
+  });
 
 const cloneStore = (s: Store): Store => {
   const out: Store = {};
@@ -209,8 +242,8 @@ export const makeMemoryAdapter = (
     select?: string[] | undefined;
     join?: JoinConfig | undefined;
   }) =>
-    Effect.sync<T | null>(() => {
-      const rows = filterWhere(tableFor(model), where);
+    Effect.gen(function* () {
+      const rows = yield* filterWhere(tableFor(model), where);
       const first = rows[0];
       if (!first) return null;
       return rowAs<T>(join ? attachJoins(first, join) : first);
@@ -232,8 +265,8 @@ export const makeMemoryAdapter = (
     offset?: number | undefined;
     join?: JoinConfig | undefined;
   }) =>
-    Effect.sync<T[]>(() => {
-      let rows = filterWhere(tableFor(model), where ?? []);
+    Effect.gen(function* () {
+      let rows = yield* filterWhere(tableFor(model), where ?? []);
       if (sortBy) {
         const { field, direction } = sortBy;
         const sign = direction === "asc" ? 1 : -1;
@@ -261,8 +294,8 @@ export const makeMemoryAdapter = (
     where: CleanedWhere[];
     update: T;
   }) =>
-    Effect.sync<T | null>(() => {
-      const rows = filterWhere(tableFor(model), where);
+    Effect.gen(function* () {
+      const rows = yield* filterWhere(tableFor(model), where);
       const first = rows[0];
       if (!first) return null;
       Object.assign(first, update as Row);
@@ -289,21 +322,21 @@ export const makeMemoryAdapter = (
     findMany,
 
     count: ({ model, where }) =>
-      Effect.sync(() => filterWhere(tableFor(model), where ?? []).length),
+      Effect.map(filterWhere(tableFor(model), where ?? []), (rows) => rows.length),
 
     update: updateOne,
 
     updateMany: ({ model, where, update }) =>
-      Effect.sync(() => {
-        const rows = filterWhere(tableFor(model), where);
+      Effect.gen(function* () {
+        const rows = yield* filterWhere(tableFor(model), where);
         for (const r of rows) Object.assign(r, update);
         return rows.length;
       }),
 
     delete: ({ model, where }) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         const table = tableFor(model);
-        const matches = filterWhere(table, where);
+        const matches = yield* filterWhere(table, where);
         const first = matches[0];
         if (!first) return;
         const idx = table.indexOf(first);
@@ -311,9 +344,9 @@ export const makeMemoryAdapter = (
       }),
 
     deleteMany: ({ model, where }) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         const table = tableFor(model);
-        const matches = new Set(filterWhere(table, where));
+        const matches = new Set(yield* filterWhere(table, where));
         let count = 0;
         store[model] = table.filter((r) => {
           if (matches.has(r)) {


### PR DESCRIPTION
## Summary
- convert invalid memory adapter in/not_in filter values into StorageError failures
- thread filter evaluation through Effect so failures stay in the storage error channel
- preserve AND/OR short-circuit behavior while removing raw throw/new Error

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/storage-core/src/testing/memory.ts --deny-warnings
- git diff --check
- bun run typecheck (packages/core/storage-core)
- bunx --bun vitest run src/memory.test.ts (packages/core/storage-core)