### PR TITLE
Use promiseExit in GraphQL source UI

### DIFF
--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
+import * as Exit from "effect/Exit";
 
 import { useScope } from "@executor-js/react/api/scope-context";
 import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
@@ -55,7 +56,7 @@ export default function AddGraphqlSource(props: {
   const [tokens, setTokens] = useState<OAuthCompletionPayload | null>(null);
 
   const scopeId = useScope();
-  const doAdd = useAtomSet(addGraphqlSource, { mode: "promise" });
+  const doAdd = useAtomSet(addGraphqlSource, { mode: "promiseExit" });
   const { beginAdd } = usePendingSources();
   const secretList = useSecretPickerSecrets();
   const oauth = useOAuthPopupFlow({
@@ -118,35 +119,36 @@ export default function AddGraphqlSource(props: {
       kind: "graphql",
       url: trimmedEndpoint || undefined,
     });
-    try {
-      await doAdd({
-        params: { scopeId },
-        payload: {
-          endpoint: trimmedEndpoint,
-          name: identity.name.trim() || undefined,
-          namespace: slugifyNamespace(identity.namespace) || undefined,
-          ...(Object.keys(headerMap).length > 0 ? { headers: headerMap } : {}),
-          ...(Object.keys(queryParams).length > 0
-            ? { queryParams: queryParams as Record<string, HeaderValue> }
-            : {}),
-          ...(authMode === "oauth2" && tokens
-            ? {
-                auth: {
-                  kind: "oauth2" as const,
-                  connectionId: tokens.connectionId,
-                },
-              }
-            : {}),
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-      props.onComplete();
-    } catch (e) {
-      setAddError(e instanceof Error ? e.message : "Failed to add source");
+    const exit = await doAdd({
+      params: { scopeId },
+      payload: {
+        endpoint: trimmedEndpoint,
+        name: identity.name.trim() || undefined,
+        namespace: slugifyNamespace(identity.namespace) || undefined,
+        ...(Object.keys(headerMap).length > 0 ? { headers: headerMap } : {}),
+        ...(Object.keys(queryParams).length > 0
+          ? { queryParams: queryParams as Record<string, HeaderValue> }
+          : {}),
+        ...(authMode === "oauth2" && tokens
+          ? {
+              auth: {
+                kind: "oauth2" as const,
+                connectionId: tokens.connectionId,
+              },
+            }
+          : {}),
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    placeholder.done();
+
+    if (Exit.isFailure(exit)) {
+      setAddError("Failed to add source");
       setAdding(false);
-    } finally {
-      placeholder.done();
+      return;
     }
+
+    props.onComplete();
   };
 
   return (

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
+import * as Exit from "effect/Exit";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { graphqlSourceAtom, updateGraphqlSource } from "./atoms";
 import { useScope } from "@executor-js/react/api/scope-context";
@@ -41,7 +42,7 @@ const graphqlOAuthConnectionId = (namespaceSlug: string): string =>
 
 function EditForm(props: { sourceId: string; initial: EditableSource; onSave: () => void }) {
   const scopeId = useScope();
-  const doUpdate = useAtomSet(updateGraphqlSource, { mode: "promise" });
+  const doUpdate = useAtomSet(updateGraphqlSource, { mode: "promiseExit" });
   const secretList = useSecretPickerSecrets();
 
   const identity = useSourceIdentity({
@@ -71,34 +72,36 @@ function EditForm(props: { sourceId: string; initial: EditableSource; onSave: ()
     setSaving(true);
     setError(null);
     const { headers, queryParams } = serializeHttpCredentials(credentials);
-    try {
-      await doUpdate({
-        params: { scopeId, namespace: props.sourceId },
-        payload: {
-          name: identity.name.trim() || undefined,
-          endpoint: endpoint.trim() || undefined,
-          headers,
-          queryParams: queryParams as Record<string, HeaderValue>,
-          auth:
-            authMode === "oauth2"
-              ? {
-                  kind: "oauth2",
-                  connectionId:
-                    props.initial.auth.kind === "oauth2"
-                      ? props.initial.auth.connectionId
-                      : graphqlOAuthConnectionId(props.initial.namespace),
-                }
-              : { kind: "none" },
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-      setDirty(false);
-      props.onSave();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to update source");
-    } finally {
+    const exit = await doUpdate({
+      params: { scopeId, namespace: props.sourceId },
+      payload: {
+        name: identity.name.trim() || undefined,
+        endpoint: endpoint.trim() || undefined,
+        headers,
+        queryParams: queryParams as Record<string, HeaderValue>,
+        auth:
+          authMode === "oauth2"
+            ? {
+                kind: "oauth2",
+                connectionId:
+                  props.initial.auth.kind === "oauth2"
+                    ? props.initial.auth.connectionId
+                    : graphqlOAuthConnectionId(props.initial.namespace),
+              }
+            : { kind: "none" },
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+
+    if (Exit.isFailure(exit)) {
+      setError("Failed to update source");
       setSaving(false);
+      return;
     }
+
+    setDirty(false);
+    props.onSave();
+    setSaving(false);
   };
 
   return (


### PR DESCRIPTION
## Summary
- switch GraphQL source add/update UI mutations to promiseExit
- handle failed exits with stable UI messages
- preserve optimistic placeholder cleanup before success/failure branching

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/graphql/src/react/AddGraphqlSource.tsx packages/plugins/graphql/src/react/EditGraphqlSource.tsx --deny-warnings
- git diff --check
- bun run typecheck (packages/plugins/graphql)