### PR TITLE
Clarify shared UI and config boundaries

### DIFF
--- a/packages/core/config/src/sink.ts
+++ b/packages/core/config/src/sink.ts
@@ -52,8 +52,7 @@ export interface ConfigFileSinkOptions {
 }
 
 const defaultOnError = (op: "upsert" | "remove", err: unknown): void => {
-  const msg = err instanceof Error ? err.message : String(err);
-  console.warn(`[config-sink] ${op} failed: ${msg}`);
+  console.warn(`[config-sink] ${op} failed`, err);
 };
 
 export const makeFileConfigSink = (

--- a/packages/react/src/components/field.tsx
+++ b/packages/react/src/components/field.tsx
@@ -191,14 +191,17 @@ function FieldError({
       return null;
     }
 
+    // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: FieldError receives typed UI validation messages, not thrown errors
     const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()];
 
     if (uniqueErrors?.length == 1) {
+      // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: FieldError receives typed UI validation messages, not thrown errors
       return uniqueErrors[0]?.message;
     }
 
     return (
       <ul className="ml-4 flex list-disc flex-col gap-1">
+        {/* oxlint-disable-next-line executor/no-unknown-error-message -- boundary: FieldError receives typed UI validation messages, not thrown errors */}
         {uniqueErrors.map((error, index) => error?.message && <li key={index}>{error.message}</li>)}
       </ul>
     );


### PR DESCRIPTION
## Summary
- mark FieldError message reads as typed UI validation boundary reads
- stop stringifying unknown config sink errors into customer-style messages
- log config sink causes separately while preserving best-effort behavior

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/react/src/components/field.tsx packages/core/config/src/sink.ts --deny-warnings
- git diff --check
- bun run --cwd packages/react typecheck
- bun run --cwd packages/core/config typecheck