### PR TITLE
Simplify tenant isolation assertions

### DIFF
--- a/apps/cloud/src/services/tenant-isolation.node.test.ts
+++ b/apps/cloud/src/services/tenant-isolation.node.test.ts
@@ -76,15 +76,13 @@ describe("tenant isolation (HTTP)", () => {
         }),
       );
 
-      const result = yield* asOrg(orgB, (client) =>
-        client.openapi
-          .getSource({ params: { scopeId: ScopeId.make(orgB), namespace: namespaceA } })
-          .pipe(Effect.result),
+      const source = yield* asOrg(orgB, (client) =>
+        client.openapi.getSource({
+          params: { scopeId: ScopeId.make(orgB), namespace: namespaceA },
+        }),
       );
 
-      expect(result._tag).toBe("Success");
-      if (result._tag !== "Success") return;
-      expect(result.success).toBeNull();
+      expect(source).toBeNull();
     }),
   );
 
@@ -121,15 +119,13 @@ describe("tenant isolation (HTTP)", () => {
         }),
       );
 
-      const result = yield* asOrg(orgB, (client) =>
-        client.secrets
-          .status({ params: { scopeId: ScopeId.make(orgB), secretId: SecretId.make(secretIdA) } })
-          .pipe(Effect.result),
+      const status = yield* asOrg(orgB, (client) =>
+        client.secrets.status({
+          params: { scopeId: ScopeId.make(orgB), secretId: SecretId.make(secretIdA) },
+        }),
       );
 
-      expect(result._tag).toBe("Success");
-      if (result._tag !== "Success") return;
-      expect(result.success.status).toBe("missing");
+      expect(status.status).toBe("missing");
     }),
   );
 


### PR DESCRIPTION
## Summary
- remove manual Effect result tag checks from tenant isolation tests
- yield expected-success client calls directly inside it.effect
- keep assertions focused on null/missing cross-tenant visibility

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/services/tenant-isolation.node.test.ts --deny-warnings
- git diff --check
- bun run typecheck (apps/cloud)
- node ../../node_modules/vitest/vitest.mjs run --config vitest.node.config.ts src/services/tenant-isolation.node.test.ts (apps/cloud)