### PR TITLE
Use stable blob store error messages

### DIFF
--- a/packages/core/storage-file/src/blob-store.ts
+++ b/packages/core/storage-file/src/blob-store.ts
@@ -35,13 +35,11 @@ export interface MakeSqliteBlobStoreOptions {
 
 const wrapErr =
   (op: string) =>
-  (cause: unknown): StorageError => {
-    const msg = cause instanceof Error ? cause.message : String(cause);
-    return new StorageError({
-      message: `[storage-file] blob ${op}: ${msg}`,
+  (cause: unknown): StorageError =>
+    new StorageError({
+      message: `[storage-file] blob ${op} failed`,
       cause,
     });
-  };
 
 export const makeSqliteBlobStore = (
   options: MakeSqliteBlobStoreOptions,

--- a/packages/core/storage-postgres/src/blob-store.ts
+++ b/packages/core/storage-postgres/src/blob-store.ts
@@ -36,13 +36,11 @@ export interface MakePostgresBlobStoreOptions {
 
 const wrapErr =
   (op: string) =>
-  (cause: unknown): StorageError => {
-    const msg = cause instanceof Error ? cause.message : String(cause);
-    return new StorageError({
-      message: `[storage-postgres] blob ${op}: ${msg}`,
+  (cause: unknown): StorageError =>
+    new StorageError({
+      message: `[storage-postgres] blob ${op} failed`,
       cause,
     });
-  };
 
 export const makePostgresBlobStore = (
   options: MakePostgresBlobStoreOptions,


### PR DESCRIPTION
## Summary
- stop deriving blob-store StorageError messages from unknown host errors
- keep original causes on StorageError for capture/debugging
- apply the same stable message shape to sqlite and postgres blob stores

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/storage-file/src/blob-store.ts packages/core/storage-postgres/src/blob-store.ts --deny-warnings
- git diff --check
- bun run --cwd packages/core/storage-file typecheck
- bun run --cwd packages/core/storage-postgres typecheck