### PR TITLE
Mark core boundary escape hatches

### DIFF
--- a/packages/core/execution/src/promise.ts
+++ b/packages/core/execution/src/promise.ts
@@ -58,6 +58,7 @@ export type ExecutionEngine = {
  * Wrap a Promise-style executor into the Effect shape the engine consumes.
  */
 const fromPromise = <A>(try_: () => Promise<A>): Effect.Effect<A> =>
+  // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: Promise executor facade has already erased the SDK typed error channel
   Effect.tryPromise({ try: try_, catch: (cause) => cause }).pipe(Effect.orDie);
 
 type EffectInvokeOptions = Parameters<EffectExecutor["tools"]["invoke"]>[2];
@@ -144,6 +145,7 @@ export const toPromiseExecutionEngine = <E extends Cause.YieldableError>(
     Effect.runPromise(
       engine.execute(code, {
         onElicitation: (ctx) =>
+          // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: host-provided Promise elicitation callback is outside the Effect error model
           Effect.tryPromise(() => options.onElicitation(ctx)).pipe(Effect.orDie),
       }),
     ),

--- a/packages/core/sdk/src/client.ts
+++ b/packages/core/sdk/src/client.ts
@@ -285,6 +285,7 @@ export function ExecutorPluginsProvider(
 const usePluginsCtx = (hookName: string): ExecutorPluginsContextValue => {
   const ctx = useContext(ExecutorPluginsContext);
   if (!ctx) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: React hook invariant
     throw new Error(
       `${hookName} must be called inside an <ExecutorPluginsProvider>.`,
     );


### PR DESCRIPTION
## Summary
- narrow existing Promise facade escape hatches to explicit boundary suppressions
- keep the React hook invariant throw as a boundary-only exception

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/execution/src/promise.ts packages/core/sdk/src/client.ts --deny-warnings
- bun run --cwd packages/core/execution typecheck
- bun run --cwd packages/core/sdk typecheck