### PR TITLE
Remove redundant OpenAPI credential casts

### DIFF
--- a/packages/plugins/openapi/src/sdk/credential-status.test.ts
+++ b/packages/plugins/openapi/src/sdk/credential-status.test.ts
@@ -11,8 +11,8 @@ import {
 const userScope = ScopeId.make("user");
 const orgScope = ScopeId.make("org");
 const scopeRanks = new Map([
-  [userScope as string, 0],
-  [orgScope as string, 1],
+  [userScope, 0],
+  [orgScope, 1],
 ]);
 
 const source: SourceForCredentialStatus = {
@@ -41,11 +41,11 @@ const bindings = (
       slot === "oauth2:oauth2:connection"
         ? {
             kind: "connection",
-            connectionId: ConnectionId.make(`${scopeId as string}-connection`),
+            connectionId: ConnectionId.make(`${scopeId}-connection`),
           }
         : {
             kind: "secret",
-            secretId: SecretId.make(`${scopeId as string}-${slot}`),
+            secretId: SecretId.make(`${scopeId}-${slot}`),
           },
   }));
 

--- a/packages/plugins/openapi/src/sdk/credential-status.ts
+++ b/packages/plugins/openapi/src/sdk/credential-status.ts
@@ -23,7 +23,7 @@ export type SourceForCredentialStatus = {
 };
 
 const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
-  ranks.get(scopeId as string) ?? Number.MAX_SAFE_INTEGER;
+  ranks.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
 
 export const effectiveBindingForScope = (
   rows: readonly BindingRowForCredentialStatus[],
@@ -60,7 +60,7 @@ const hasConnectionBinding = (
   const binding = effectiveBindingForScope(rows, slot, targetScope, ranks);
   if (binding?.value.kind !== "connection") return false;
   return liveConnectionIds
-    ? liveConnectionIds.has(binding.value.connectionId as string)
+    ? liveConnectionIds.has(binding.value.connectionId)
     : true;
 };
 
@@ -83,7 +83,7 @@ export function missingCredentialLabels(
   const liveConnectionIds = rawLiveConnectionIds
     ? rawLiveConnectionIds instanceof Set
       ? rawLiveConnectionIds
-      : new Set([...rawLiveConnectionIds].map((id) => id as string))
+      : new Set(rawLiveConnectionIds)
     : undefined;
 
   for (const [headerName, value] of Object.entries(source.config.headers ?? {})) {


### PR DESCRIPTION
## Summary
- remove redundant branded string casts from credential status logic
- keep tests using inferred/branded values directly

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/openapi/src/sdk/credential-status.ts packages/plugins/openapi/src/sdk/credential-status.test.ts --deny-warnings
- bun run --cwd packages/plugins/openapi typecheck
- node ../../../node_modules/vitest/vitest.mjs run src/sdk/credential-status.test.ts