### PR TITLE
Clean MCP probe shape boundaries

### DIFF
--- a/packages/plugins/mcp/src/sdk/probe-shape.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.test.ts
@@ -8,16 +8,23 @@ type FetchStub = (
   init?: Parameters<typeof fetch>[1],
 ) => Promise<Response>;
 
+interface FetchFailure {
+  readonly failure: unknown;
+}
+
 const asFetch = (stub: FetchStub): typeof fetch => stub as typeof fetch;
 
 /**
  * Build a `fetch`-compatible stub that returns the given `Response` (or
- * throws the given error) regardless of input. `fetch`'s exact signature
+ * rejects with the given failure) regardless of input. `fetch`'s exact signature
  * is a union; a narrow closure is enough for the probe.
  */
-const stubFetch = (result: Response | Error): typeof fetch =>
+const stubFetch = (result: Response | FetchFailure): typeof fetch =>
   asFetch(async (_input, _init) => {
-    if (result instanceof Error) throw result;
+    if ("failure" in result) {
+      // oxlint-disable-next-line promise/prefer-await-to-then, executor/no-promise-reject -- boundary: fetch-compatible test stub must reject like fetch
+      return Promise.reject(result.failure);
+    }
     return result;
   });
 
@@ -25,7 +32,10 @@ const stubFetchSequence = (results: readonly Response[]): typeof fetch => {
   let index = 0;
   return asFetch(async (_input, _init) => {
     const result = results[index++];
-    if (!result) throw new Error("unexpected fetch");
+    if (!result) {
+      // oxlint-disable-next-line promise/prefer-await-to-then, executor/no-promise-reject -- boundary: fetch-compatible test stub must reject like fetch
+      return Promise.reject({ message: "unexpected fetch" });
+    }
     return result;
   });
 };
@@ -140,7 +150,7 @@ describe("probeMcpEndpointShape", () => {
   it.effect("reports transport failure as unreachable", () =>
     Effect.gen(function* () {
       const result = yield* probeMcpEndpointShape("https://missing/", {
-        fetch: stubFetch(new TypeError("fetch failed")),
+        fetch: stubFetch({ failure: { message: "fetch failed" } }),
       });
       expect(result.kind).toBe("unreachable");
     }),

--- a/packages/plugins/mcp/src/sdk/probe-shape.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.ts
@@ -30,7 +30,7 @@
 // round-trip, no DCR — every non-MCP endpoint exits here.
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
+import { Data, Effect, Option, Schema } from "effect";
 
 /** MCP initialize request body used as the shape probe. Any real MCP
  *  server either answers it (unauth-OK server) or returns the spec-
@@ -60,6 +60,27 @@ const readHeader = (headers: Headers, name: string): string | null => {
     if (k.toLowerCase() === lower) return v;
   }
   return null;
+};
+
+class ProbeTransportError extends Data.TaggedError("ProbeTransportError")<{
+  readonly reason: string;
+  readonly cause: unknown;
+}> {}
+
+const ErrorMessageShape = Schema.Struct({ message: Schema.String });
+const decodeErrorMessageShape = Schema.decodeUnknownOption(ErrorMessageShape);
+
+const reasonFromBoundaryCause = (cause: unknown): string => {
+  const messageShape = decodeErrorMessageShape(cause);
+  if (Option.isSome(messageShape)) return messageShape.value.message;
+  if (typeof cause === "string") return cause;
+  if (typeof cause === "number" || typeof cause === "boolean" || typeof cause === "bigint") {
+    return `${cause}`;
+  }
+  if (typeof cause === "symbol") return cause.description ?? "symbol";
+  if (cause === null) return "null";
+  if (typeof cause === "undefined") return "undefined";
+  return "fetch failed";
 };
 
 export type McpShapeProbeResult =
@@ -99,85 +120,86 @@ export const probeMcpEndpointShape = (
   Effect.gen(function* () {
     const fetchImpl = options.fetch ?? globalThis.fetch;
     const timeoutMs = options.timeoutMs ?? 8_000;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
 
     const outcome = yield* Effect.tryPromise({
       try: async (): Promise<McpShapeProbeResult> => {
-        const controller = new AbortController();
-        const timer = setTimeout(() => controller.abort(), timeoutMs);
-        try {
-          const classify = (response: Response, method: "GET" | "POST") => {
-            if (response.status === 401) {
-              const wwwAuth = readHeader(response.headers, "www-authenticate");
-              if (wwwAuth && /^\s*bearer\b/i.test(wwwAuth)) {
-                return { kind: "mcp", requiresAuth: true } as const;
-              }
-              return {
-                kind: "not-mcp",
-                reason:
-                  "401 without Bearer WWW-Authenticate — not an MCP auth challenge",
-              } as const;
+        const classify = (response: Response, method: "GET" | "POST") => {
+          if (response.status === 401) {
+            const wwwAuth = readHeader(response.headers, "www-authenticate");
+            if (wwwAuth && /^\s*bearer\b/i.test(wwwAuth)) {
+              return { kind: "mcp", requiresAuth: true } as const;
             }
-
-            if (response.status >= 200 && response.status < 300) {
-              if (method === "GET") {
-                const contentType = readHeader(response.headers, "content-type") ?? "";
-                if (!/^\s*text\/event-stream\b/i.test(contentType)) {
-                  return {
-                    kind: "not-mcp",
-                    reason: "GET response is not an SSE stream",
-                  } as const;
-                }
-              }
-              return { kind: "mcp", requiresAuth: false } as const;
-            }
-
-            return null;
-          };
-
-          const url = new URL(endpoint);
-          for (const [key, value] of Object.entries(options.queryParams ?? {})) {
-            url.searchParams.set(key, value);
+            return {
+              kind: "not-mcp",
+              reason:
+                "401 without Bearer WWW-Authenticate — not an MCP auth challenge",
+            } as const;
           }
-          const authHeaders = options.headers ?? {};
 
-          const postResponse = await fetchImpl(url, {
-            method: "POST",
-            headers: {
-              ...authHeaders,
-              "content-type": "application/json",
-              accept: "application/json, text/event-stream",
-            },
-            body: INITIALIZE_BODY,
+          if (response.status >= 200 && response.status < 300) {
+            if (method === "GET") {
+              const contentType = readHeader(response.headers, "content-type") ?? "";
+              if (!/^\s*text\/event-stream\b/i.test(contentType)) {
+                return {
+                  kind: "not-mcp",
+                  reason: "GET response is not an SSE stream",
+                } as const;
+              }
+            }
+            return { kind: "mcp", requiresAuth: false } as const;
+          }
+
+          return null;
+        };
+
+        const url = new URL(endpoint);
+        for (const [key, value] of Object.entries(options.queryParams ?? {})) {
+          url.searchParams.set(key, value);
+        }
+        const authHeaders = options.headers ?? {};
+
+        const postResponse = await fetchImpl(url, {
+          method: "POST",
+          headers: {
+            ...authHeaders,
+            "content-type": "application/json",
+            accept: "application/json, text/event-stream",
+          },
+          body: INITIALIZE_BODY,
+          signal: controller.signal,
+        });
+
+        const postResult = classify(postResponse, "POST");
+        if (postResult) return postResult;
+
+        if ([404, 405, 406, 415].includes(postResponse.status)) {
+          const getResponse = await fetchImpl(url, {
+            method: "GET",
+            headers: { ...authHeaders, accept: "text/event-stream" },
             signal: controller.signal,
           });
-
-          const postResult = classify(postResponse, "POST");
-          if (postResult) return postResult;
-
-          if ([404, 405, 406, 415].includes(postResponse.status)) {
-            const getResponse = await fetchImpl(url, {
-              method: "GET",
-              headers: { ...authHeaders, accept: "text/event-stream" },
-              signal: controller.signal,
-            });
-            const getResult = classify(getResponse, "GET");
-            if (getResult) return getResult;
-          }
-
-          return {
-            kind: "not-mcp",
-            reason: `unexpected status ${postResponse.status} for initialize`,
-          };
-        } finally {
-          clearTimeout(timer);
+          const getResult = classify(getResponse, "GET");
+          if (getResult) return getResult;
         }
+
+        return {
+          kind: "not-mcp",
+          reason: `unexpected status ${postResponse.status} for initialize`,
+        };
       },
-      catch: (cause) => cause,
+      catch: (cause) =>
+        new ProbeTransportError({
+          reason: reasonFromBoundaryCause(cause),
+          cause,
+        }),
     }).pipe(
+      Effect.ensuring(Effect.sync(() => clearTimeout(timer))),
       Effect.catch((cause) =>
         Effect.succeed<McpShapeProbeResult>({
           kind: "unreachable",
-          reason: cause instanceof Error ? cause.message : String(cause),
+          reason: cause.reason,
         }),
       ),
     );


### PR DESCRIPTION
## Summary
- map probe fetch failures through a local typed error
- clear probe timeouts with Effect ensuring
- update fetch stubs to preserve rejection behavior without raw Error construction

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/mcp/src/sdk/probe-shape.ts packages/plugins/mcp/src/sdk/probe-shape.test.ts --deny-warnings
- bun run --cwd packages/plugins/mcp typecheck
- node ../../../node_modules/vitest/vitest.mjs run src/sdk/probe-shape.test.ts