### PR TITLE
Clean local server boundary cleanup

### DIFF
--- a/apps/local/src/server/config-sync.ts
+++ b/apps/local/src/server/config-sync.ts
@@ -5,7 +5,7 @@
 // plugin in executor.ts.
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
 import { join } from "node:path";
 import * as fs from "node:fs";
 import * as jsonc from "jsonc-parser";
@@ -88,7 +88,7 @@ const addSourceFromConfig = (
   // aware of per-user tenancy. Pin replayed sources to the outermost
   // scope so a future `[user, org]` stack still sees them via org
   // fall-through.
-  const scope = executor.scopes.at(-1)!.id as string;
+  const scope = executor.scopes.at(-1)!.id;
   switch (source.kind) {
     case "openapi":
       return executor.openapi.addSpec({
@@ -157,11 +157,11 @@ export const syncFromConfig = (
       (source) =>
         addSourceFromConfig(executor, source).pipe(
           Effect.map(() => true as const),
-          Effect.catchCause((e) => {
+          Effect.catchCause((cause) => {
             const ns = "namespace" in source ? source.namespace : ("name" in source ? source.name : "unknown");
             console.warn(
               `[config-sync] Failed to load source "${ns}":`,
-              e instanceof Error ? e.message : String(e),
+              Cause.pretty(cause),
             );
             return Effect.succeed(false as const);
           }),

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
-import { Context, Effect, Layer, ManagedRuntime } from "effect";
+import { Context, Data, Effect, Layer, ManagedRuntime } from "effect";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import { homedir, tmpdir } from "node:os";
@@ -107,6 +107,41 @@ class LocalExecutorTag extends Context.Service<LocalExecutorTag, LocalExecutorBu
 
 export type LocalExecutor = LocalExecutorBundle["executor"];
 
+class LocalExecutorDisposeError extends Data.TaggedError(
+  "LocalExecutorDisposeError",
+)<{
+  readonly operation: "createHandle" | "disposeExecutor" | "disposeRuntime";
+  readonly cause: unknown;
+}> {}
+
+const ignorePromiseFailure = (
+  operation: LocalExecutorDisposeError["operation"],
+  try_: () => Promise<unknown>,
+) =>
+  Effect.runPromise(
+    Effect.ignore(
+      Effect.tryPromise({
+        try: try_,
+        catch: (cause) => new LocalExecutorDisposeError({ operation, cause }),
+      }),
+    ),
+  );
+
+const handleOrNull = (promise: ReturnType<typeof createExecutorHandle>) =>
+  Effect.runPromise(
+    Effect.tryPromise({
+      try: () => promise,
+      catch: (cause) =>
+        new LocalExecutorDisposeError({ operation: "createHandle", cause }),
+    }).pipe(
+      Effect.catch(() =>
+        Effect.succeed<Awaited<ReturnType<typeof createExecutorHandle>> | null>(
+          null,
+        ),
+      ),
+    ),
+  );
+
 const createLocalExecutorLayer = () => {
   const { path: dbPath, legacySecrets } = resolveDbPath();
 
@@ -202,8 +237,8 @@ export const createExecutorHandle = async () => {
     executor: bundle.executor,
     plugins: bundle.plugins,
     dispose: async () => {
-      await Effect.runPromise(bundle.executor.close()).catch(() => undefined);
-      await runtime.dispose().catch(() => undefined);
+      await Effect.runPromise(Effect.ignore(bundle.executor.close()));
+      await ignorePromiseFailure("disposeRuntime", () => runtime.dispose());
     },
   };
 };
@@ -226,8 +261,12 @@ export const disposeExecutor = async (): Promise<void> => {
   const currentHandlePromise = sharedHandlePromise;
   sharedHandlePromise = null;
 
-  const handle = await currentHandlePromise?.catch(() => null);
-  await handle?.dispose().catch(() => undefined);
+  const handle = currentHandlePromise
+    ? await handleOrNull(currentHandlePromise)
+    : null;
+  if (handle) {
+    await ignorePromiseFailure("disposeExecutor", () => handle.dispose());
+  }
 };
 
 export const reloadExecutor = () => {


### PR DESCRIPTION
## Summary
- replace local executor promise cleanup catches with Effect cleanup helpers
- remove redundant scope cast and log config sync failures from typed causes

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/local/src/server/config-sync.ts apps/local/src/server/executor.ts --deny-warnings
- bun run --cwd apps/local typecheck