### PR TITLE
Clean cloud service boundaries

### DIFF
--- a/apps/cloud/src/mcp-flow.test.ts
+++ b/apps/cloud/src/mcp-flow.test.ts
@@ -137,7 +137,7 @@ const seedOrg = async (id: string, name = "MCP Flow Org"): Promise<void> => {
 beforeAll(() => {
   // Env presence guard — avoids confusing errors downstream if the test
   // wrangler forgot to bind something the DO needs.
-  if (!env.MCP_SESSION) throw new Error("MCP_SESSION binding missing from test wrangler");
+  expect(env.MCP_SESSION, "MCP_SESSION binding missing from test wrangler").toBeDefined();
 });
 
 afterAll(() => undefined);
@@ -384,18 +384,32 @@ describe("/mcp session restore", () => {
     const getResponse = await mcpGet({ bearer, sessionId: sessionId! });
     expect(getResponse.status).toBe(200);
     expect(getResponse.headers.get("content-type") ?? "").toContain("text/event-stream");
-    await getResponse.body?.cancel().catch(() => undefined);
+    const responseBody = getResponse.body;
+    if (responseBody) {
+      await Effect.runPromise(
+        Effect.ignore(
+          Effect.tryPromise({
+            try: () => responseBody.cancel(),
+            catch: () => "ResponseBodyCancelFailed" as const,
+          }),
+        ),
+      );
+    }
 
-    const response = await Promise.race([
+    const postResult = await Promise.race([
       mcpPost({
         bearer,
         sessionId,
         body: TOOLS_LIST_REQUEST,
-      }),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("POST did not return after GET restore")), 5_000),
+      }).then((response) => ({ kind: "response" as const, response })),
+      new Promise<{ readonly kind: "timeout" }>((resolve) =>
+        setTimeout(() => resolve({ kind: "timeout" }), 5_000),
       ),
     ]);
+    expect(postResult).toEqual(expect.objectContaining({ kind: "response" }));
+    if (postResult.kind !== "response") return;
+
+    const response = postResult.response;
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type") ?? "").toContain("application/json");
     const body = (await response.json()) as {

--- a/apps/cloud/src/services/autumn.ts
+++ b/apps/cloud/src/services/autumn.ts
@@ -12,7 +12,8 @@ import { Context, Data, Effect, Layer } from "effect";
 // ---------------------------------------------------------------------------
 
 export class AutumnError extends Data.TaggedError("AutumnError")<{
-  cause: unknown;
+  message: string;
+  cause?: unknown;
 }> {}
 
 // ---------------------------------------------------------------------------
@@ -38,8 +39,8 @@ const make = Effect.sync(() => {
   const secretKey = env.AUTUMN_SECRET_KEY;
 
   if (!secretKey) {
-    const notConfigured = Effect.die(
-      new Error("Autumn not configured — AUTUMN_SECRET_KEY is empty"),
+    const notConfigured = Effect.fail(
+      new AutumnError({ message: "Autumn not configured: AUTUMN_SECRET_KEY is empty" }),
     );
     return {
       use: () => notConfigured,
@@ -52,22 +53,27 @@ const make = Effect.sync(() => {
   const use = <A>(fn: (client: Autumn) => Promise<A>) =>
     Effect.tryPromise({
       try: () => fn(client),
-      catch: (cause) => new AutumnError({ cause }),
+      catch: (cause) => new AutumnError({ message: "Autumn SDK request failed", cause }),
     }).pipe(Effect.withSpan(`autumn.${fn.name ?? "use"}`));
 
   const trackExecution = (organizationId: string) =>
     Effect.gen(function* () {
       yield* Effect.annotateCurrentSpan({ "autumn.customer.id": organizationId });
-      const outcome = yield* Effect.result(
-        use((c) => c.track({ customerId: organizationId, featureId: "executions", value: 1 })),
+      yield* use((c) =>
+        c.track({ customerId: organizationId, featureId: "executions", value: 1 }),
+      ).pipe(
+        Effect.catchTag("AutumnError", (error) =>
+          Effect.gen(function* () {
+            // Silent billing data loss is worth paging on — autumn.trackExecution
+            // is fire-and-forget so the caller doesn't handle it themselves.
+            yield* Effect.sync(() => {
+              console.error("[billing] track failed:", error);
+              Sentry.captureException(error);
+            });
+            yield* Effect.annotateCurrentSpan({ "autumn.track.failed": true });
+          }),
+        ),
       );
-      if (outcome._tag === "Failure") {
-        // Silent billing data loss is worth paging on — autumn.trackExecution
-        // is fire-and-forget so the caller doesn't handle it themselves.
-        console.error("[billing] track failed:", outcome.failure);
-        Sentry.captureException(outcome.failure);
-        yield* Effect.annotateCurrentSpan({ "autumn.track.failed": true });
-      }
     }).pipe(Effect.withSpan("autumn.trackExecution"));
 
   return { use, trackExecution } satisfies IAutumnService;

--- a/apps/cloud/src/services/slack.ts
+++ b/apps/cloud/src/services/slack.ts
@@ -5,7 +5,7 @@
 // ---------------------------------------------------------------------------
 
 import { env } from "cloudflare:workers";
-import { Context, Data, Effect, Layer } from "effect";
+import { Context, Data, Effect, Layer, Schema } from "effect";
 
 export class SlackError extends Data.TaggedError("SlackError")<{
   method: string;
@@ -40,41 +40,82 @@ const randomSuffix = (): string => {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 };
 
-type SlackResponse = { ok: boolean; error?: string } & Record<string, unknown>;
+const SlackErrorResponse = Schema.Struct({
+  ok: Schema.Literal(false),
+  error: Schema.optional(Schema.String),
+});
+
+const SlackChannel = Schema.Struct({ id: Schema.String, name: Schema.String });
+
+const SlackPostMessageResponse = Schema.Struct({ ok: Schema.Literal(true) });
+
+const SlackCreateChannelResponse = Schema.Struct({
+  ok: Schema.Literal(true),
+  channel: SlackChannel,
+});
+
+const SlackSharedInviteResponse = Schema.Struct({
+  ok: Schema.Literal(true),
+  invite_id: Schema.String,
+  url: Schema.String,
+});
 
 const make = Effect.sync(() => {
   const token = env.SLACK_BOT_TOKEN;
 
   if (!token) {
     const notConfigured = (method: string) =>
-      Effect.fail(
-        new SlackError({ method, error: "SLACK_BOT_TOKEN is not configured" }),
-      );
+      Effect.fail(new SlackError({ method, error: "SLACK_BOT_TOKEN is not configured" }));
     return {
       createConnectInvite: () => notConfigured("createConnectInvite"),
     } satisfies ISlackService;
   }
 
-  const call = <A extends SlackResponse>(method: string, body: Record<string, unknown>) =>
-    Effect.tryPromise({
-      try: async (): Promise<A> => {
-        const res = await fetch(`https://slack.com/api/${method}`, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json; charset=utf-8",
-            authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify(body),
-        });
-        const json = (await res.json()) as A;
-        if (!json.ok) throw new Error(json.error ?? "unknown_slack_error");
-        return json;
-      },
-      catch: (cause) =>
-        new SlackError({
+  const call = <A extends { ok: true }>(
+    method: string,
+    body: Record<string, unknown>,
+    successSchema: Schema.Decoder<A>,
+  ) =>
+    Effect.gen(function* () {
+      const json = yield* Effect.tryPromise({
+        try: async (): Promise<unknown> => {
+          const res = await fetch(`https://slack.com/api/${method}`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json; charset=utf-8",
+              authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify(body),
+          });
+          return res.json();
+        },
+        catch: () =>
+          new SlackError({
+            method,
+            error: "Failed to read Slack API response",
+          }),
+      });
+
+      const response = yield* Schema.decodeUnknownEffect(
+        Schema.Union([successSchema, SlackErrorResponse]),
+      )(json).pipe(
+        Effect.mapError(
+          () =>
+            new SlackError({
+              method,
+              error: "Unexpected Slack API response",
+            }),
+        ),
+      );
+
+      if (!response.ok) {
+        return yield* new SlackError({
           method,
-          error: cause instanceof Error ? cause.message : String(cause),
-        }),
+          error: response.error ?? "unknown_slack_error",
+        });
+      }
+
+      return response;
     }).pipe(Effect.withSpan(`slack.${method}`));
 
   const createConnectInvite: ISlackService["createConnectInvite"] = ({
@@ -87,10 +128,7 @@ const make = Effect.sync(() => {
       // Slack channel names: lowercase, no spaces, max 80 chars, unique per workspace.
       const baseName = `shared-${slugifyEmail(email)}`.slice(0, 80);
       const tryCreate = (n: string) =>
-        call<SlackResponse & { channel: { id: string; name: string } }>(
-          "conversations.create",
-          { name: n, is_private: false },
-        );
+        call("conversations.create", { name: n, is_private: false }, SlackCreateChannelResponse);
 
       const created = yield* tryCreate(baseName).pipe(
         Effect.catchTag("SlackError", (err) =>
@@ -108,12 +146,16 @@ const make = Effect.sync(() => {
         note ? `Note: ${note}` : null,
       ].filter(Boolean) as string[];
 
-      yield* call<SlackResponse>("chat.postMessage", {
-        channel: channel.id,
-        text: helloLines.join("\n"),
-      });
+      yield* call(
+        "chat.postMessage",
+        {
+          channel: channel.id,
+          text: helloLines.join("\n"),
+        },
+        SlackPostMessageResponse,
+      );
 
-      const invite = yield* call<SlackResponse & { invite_id: string; url: string }>(
+      const invite = yield* call(
         "conversations.inviteShared",
         {
           channel: channel.id,
@@ -122,15 +164,14 @@ const make = Effect.sync(() => {
           // which is what we want for a focused 1:1 support conversation.
           external_limited: true,
         },
+        SlackSharedInviteResponse,
       );
 
       return {
         channel: { id: channel.id, name: channel.name },
         invite: { invite_id: invite.invite_id, url: invite.url },
       };
-    }).pipe(
-      Effect.withSpan("slack.createConnectInvite", { attributes: { "slack.email": email } }),
-    );
+    }).pipe(Effect.withSpan("slack.createConnectInvite", { attributes: { "slack.email": email } }));
 
   return { createConnectInvite } satisfies ISlackService;
 });


### PR DESCRIPTION
## Summary
- parse Slack API responses with Effect Schema and typed Slack failures
- turn Autumn billing failures into typed errors while keeping tracking best-effort
- remove raw Error and Promise rejection paths from the MCP flow test

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/services/slack.ts apps/cloud/src/services/autumn.ts apps/cloud/src/mcp-flow.test.ts --deny-warnings
- bun run --cwd apps/cloud typecheck
- node ../../node_modules/vitest/vitest.mjs run src/mcp-flow.test.ts