### PR TITLE
Parse local migration test rows with Schema

### DIFF
--- a/apps/local/src/server/migrate-google-discovery-bindings.test.ts
+++ b/apps/local/src/server/migrate-google-discovery-bindings.test.ts
@@ -4,8 +4,9 @@
 // containing auth/credentials), runs the migration, asserts the new
 // columns and child tables are populated.
 
-import { describe, expect, it } from "@effect/vitest";
+import { afterEach, describe, expect, it } from "@effect/vitest";
 import { Database } from "bun:sqlite";
+import { Schema } from "effect";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -16,189 +17,195 @@ import { PRE_0007_SQL, stampPriorMigrationsApplied } from "./__test-helpers__/pr
 
 const MIGRATIONS_FOLDER = join(import.meta.dirname, "../../drizzle");
 
+const migratedConfig = Schema.Struct({
+  auth: Schema.optional(Schema.Unknown),
+  service: Schema.String,
+});
+const decodeMigratedConfig = Schema.decodeUnknownSync(Schema.fromJsonString(migratedConfig));
+
+const tempDirs = new Set<string>();
+
+const createTempDbPath = () => {
+  const dir = mkdtempSync(join(tmpdir(), "gd-mig-"));
+  tempDirs.add(dir);
+  return join(dir, "test.sqlite");
+};
+
 describe("0007_normalize_plugin_secret_refs (google-discovery)", () => {
-  it("flattens oauth2 auth into columns", () => {
-    const dir = mkdtempSync(join(tmpdir(), "gd-mig-"));
-    const dbPath = join(dir, "test.sqlite");
-    try {
-      const db = new Database(dbPath);
-      db.exec(PRE_0007_SQL);
-      stampPriorMigrationsApplied(db);
-
-      db.prepare(
-        "INSERT INTO google_discovery_source (scope_id, id, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-      ).run(
-        "default-scope",
-        "drive",
-        "Drive",
-        JSON.stringify({
-          name: "Drive",
-          discoveryUrl: "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
-          service: "drive",
-          version: "v3",
-          rootUrl: "https://www.googleapis.com/",
-          servicePath: "drive/v3/",
-          auth: {
-            kind: "oauth2",
-            connectionId: "conn-1",
-            clientIdSecretId: "client-id",
-            clientSecretSecretId: "client-secret",
-            scopes: ["https://www.googleapis.com/auth/drive"],
-          },
-        }),
-        Date.now(),
-        Date.now(),
-      );
-
-      db.close();
-      const drizzleDb = drizzle(new Database(dbPath));
-      migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
-
-      const after = new Database(dbPath, { readonly: true });
-      const row = after
-        .prepare(
-          "SELECT auth_kind, auth_connection_id, auth_client_id_secret_id, auth_client_secret_secret_id, auth_scopes, config FROM google_discovery_source WHERE id = ?",
-        )
-        .get("drive") as Record<string, string | null>;
-      expect(row.auth_kind).toBe("oauth2");
-      expect(row.auth_connection_id).toBe("conn-1");
-      expect(row.auth_client_id_secret_id).toBe("client-id");
-      expect(row.auth_client_secret_secret_id).toBe("client-secret");
-      // auth_scopes column is text-typed (string[] gets stored as JSON in sqlite).
-      expect(row.auth_scopes).toContain("drive");
-      // The auth key should be stripped from config json.
-      const config = JSON.parse(row.config!);
-      expect(config.auth).toBeUndefined();
-      expect(config.service).toBe("drive");
-      after.close();
-    } finally {
+  afterEach(() => {
+    for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
+    tempDirs.clear();
+  });
+
+  it("flattens oauth2 auth into columns", () => {
+    const dbPath = createTempDbPath();
+    const db = new Database(dbPath);
+    db.exec(PRE_0007_SQL);
+    stampPriorMigrationsApplied(db);
+
+    db.prepare(
+      "INSERT INTO google_discovery_source (scope_id, id, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(
+      "default-scope",
+      "drive",
+      "Drive",
+      JSON.stringify({
+        name: "Drive",
+        discoveryUrl: "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest",
+        service: "drive",
+        version: "v3",
+        rootUrl: "https://www.googleapis.com/",
+        servicePath: "drive/v3/",
+        auth: {
+          kind: "oauth2",
+          connectionId: "conn-1",
+          clientIdSecretId: "client-id",
+          clientSecretSecretId: "client-secret",
+          scopes: ["https://www.googleapis.com/auth/drive"],
+        },
+      }),
+      Date.now(),
+      Date.now(),
+    );
+
+    db.close();
+    const drizzleDb = drizzle(new Database(dbPath));
+    migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+
+    const after = new Database(dbPath, { readonly: true });
+    const row = after
+      .prepare(
+        "SELECT auth_kind, auth_connection_id, auth_client_id_secret_id, auth_client_secret_secret_id, auth_scopes, config FROM google_discovery_source WHERE id = ?",
+      )
+      .get("drive") as Record<string, string | null>;
+    expect(row.auth_kind).toBe("oauth2");
+    expect(row.auth_connection_id).toBe("conn-1");
+    expect(row.auth_client_id_secret_id).toBe("client-id");
+    expect(row.auth_client_secret_secret_id).toBe("client-secret");
+    // auth_scopes column is text-typed (string[] gets stored as JSON in sqlite).
+    expect(row.auth_scopes).toContain("drive");
+    // The auth key should be stripped from config json.
+    const config = decodeMigratedConfig(row.config);
+    expect(config.auth).toBeUndefined();
+    expect(config.service).toBe("drive");
+    after.close();
   });
 
   it("explodes credentials.headers and queryParams into child rows", () => {
-    const dir = mkdtempSync(join(tmpdir(), "gd-mig-"));
-    const dbPath = join(dir, "test.sqlite");
-    try {
-      const db = new Database(dbPath);
-      db.exec(PRE_0007_SQL);
-      stampPriorMigrationsApplied(db);
+    const dbPath = createTempDbPath();
+    const db = new Database(dbPath);
+    db.exec(PRE_0007_SQL);
+    stampPriorMigrationsApplied(db);
 
-      db.prepare(
-        "INSERT INTO google_discovery_source (scope_id, id, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-      ).run(
-        "default-scope",
-        "with-creds",
-        "With Creds",
-        JSON.stringify({
-          name: "With Creds",
-          discoveryUrl: "https://example.com/discovery",
-          service: "svc",
-          version: "v1",
-          rootUrl: "https://example.com/",
-          servicePath: "svc/v1/",
-          auth: { kind: "none" },
-          credentials: {
-            headers: {
-              "X-Static": "literal",
-              Authorization: { secretId: "tok-secret", prefix: "Bearer " },
-            },
-            queryParams: {
-              api_key: { secretId: "key-secret" },
-            },
+    db.prepare(
+      "INSERT INTO google_discovery_source (scope_id, id, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(
+      "default-scope",
+      "with-creds",
+      "With Creds",
+      JSON.stringify({
+        name: "With Creds",
+        discoveryUrl: "https://example.com/discovery",
+        service: "svc",
+        version: "v1",
+        rootUrl: "https://example.com/",
+        servicePath: "svc/v1/",
+        auth: { kind: "none" },
+        credentials: {
+          headers: {
+            "X-Static": "literal",
+            Authorization: { secretId: "tok-secret", prefix: "Bearer " },
           },
-        }),
-        Date.now(),
-        Date.now(),
-      );
+          queryParams: {
+            api_key: { secretId: "key-secret" },
+          },
+        },
+      }),
+      Date.now(),
+      Date.now(),
+    );
 
-      db.close();
-      const drizzleDb = drizzle(new Database(dbPath));
-      migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+    db.close();
+    const drizzleDb = drizzle(new Database(dbPath));
+    migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
 
-      const after = new Database(dbPath, { readonly: true });
-      const headers = after
-        .prepare(
-          "SELECT name, kind, text_value, secret_id, secret_prefix FROM google_discovery_source_credential_header WHERE source_id = ? ORDER BY name",
-        )
-        .all("with-creds") as ReadonlyArray<Record<string, string | null>>;
-      expect(headers).toHaveLength(2);
-      const byName = new Map(headers.map((h) => [h.name!, h]));
-      expect(byName.get("X-Static")).toMatchObject({
-        kind: "text",
-        text_value: "literal",
-      });
-      expect(byName.get("Authorization")).toMatchObject({
-        kind: "secret",
-        secret_id: "tok-secret",
-        secret_prefix: "Bearer ",
-      });
+    const after = new Database(dbPath, { readonly: true });
+    const headers = after
+      .prepare(
+        "SELECT name, kind, text_value, secret_id, secret_prefix FROM google_discovery_source_credential_header WHERE source_id = ? ORDER BY name",
+      )
+      .all("with-creds") as ReadonlyArray<Record<string, string | null>>;
+    expect(headers).toHaveLength(2);
+    const byName = new Map(headers.map((h) => [h.name!, h]));
+    expect(byName.get("X-Static")).toMatchObject({
+      kind: "text",
+      text_value: "literal",
+    });
+    expect(byName.get("Authorization")).toMatchObject({
+      kind: "secret",
+      secret_id: "tok-secret",
+      secret_prefix: "Bearer ",
+    });
 
-      const params = after
-        .prepare(
-          "SELECT name, secret_id FROM google_discovery_source_credential_query_param WHERE source_id = ?",
-        )
-        .all("with-creds") as ReadonlyArray<Record<string, string>>;
-      expect(params).toHaveLength(1);
-      expect(params[0]).toMatchObject({ name: "api_key", secret_id: "key-secret" });
+    const params = after
+      .prepare(
+        "SELECT name, secret_id FROM google_discovery_source_credential_query_param WHERE source_id = ?",
+      )
+      .all("with-creds") as ReadonlyArray<Record<string, string>>;
+    expect(params).toHaveLength(1);
+    expect(params[0]).toMatchObject({ name: "api_key", secret_id: "key-secret" });
 
-      after.close();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    after.close();
   });
 
   it("survives auth.kind=none with no credentials", () => {
-    const dir = mkdtempSync(join(tmpdir(), "gd-mig-"));
-    const dbPath = join(dir, "test.sqlite");
-    try {
-      const db = new Database(dbPath);
-      db.exec(PRE_0007_SQL);
-      stampPriorMigrationsApplied(db);
+    const dbPath = createTempDbPath();
+    const db = new Database(dbPath);
+    db.exec(PRE_0007_SQL);
+    stampPriorMigrationsApplied(db);
 
-      db.prepare(
-        "INSERT INTO google_discovery_source (scope_id, id, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
-      ).run(
-        "default-scope",
-        "bare",
-        "Bare",
-        JSON.stringify({
-          name: "Bare",
-          discoveryUrl: "https://example.com/discovery",
-          service: "svc",
-          version: "v1",
-          rootUrl: "https://example.com/",
-          servicePath: "svc/v1/",
-          auth: { kind: "none" },
-        }),
-        Date.now(),
-        Date.now(),
-      );
+    db.prepare(
+      "INSERT INTO google_discovery_source (scope_id, id, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    ).run(
+      "default-scope",
+      "bare",
+      "Bare",
+      JSON.stringify({
+        name: "Bare",
+        discoveryUrl: "https://example.com/discovery",
+        service: "svc",
+        version: "v1",
+        rootUrl: "https://example.com/",
+        servicePath: "svc/v1/",
+        auth: { kind: "none" },
+      }),
+      Date.now(),
+      Date.now(),
+    );
 
-      db.close();
-      const drizzleDb = drizzle(new Database(dbPath));
-      migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+    db.close();
+    const drizzleDb = drizzle(new Database(dbPath));
+    migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
 
-      const after = new Database(dbPath, { readonly: true });
-      const row = after
+    const after = new Database(dbPath, { readonly: true });
+    const row = after
+      .prepare(
+        "SELECT auth_kind, auth_connection_id, auth_scopes FROM google_discovery_source WHERE id = ?",
+      )
+      .get("bare") as Record<string, string | null>;
+    expect(row.auth_kind).toBe("none");
+    expect(row.auth_connection_id).toBeNull();
+
+    const headerCount = (
+      after
         .prepare(
-          "SELECT auth_kind, auth_connection_id, auth_scopes FROM google_discovery_source WHERE id = ?",
+          "SELECT count(*) as n FROM google_discovery_source_credential_header WHERE source_id = ?",
         )
-        .get("bare") as Record<string, string | null>;
-      expect(row.auth_kind).toBe("none");
-      expect(row.auth_connection_id).toBeNull();
-
-      const headerCount = (
-        after
-          .prepare(
-            "SELECT count(*) as n FROM google_discovery_source_credential_header WHERE source_id = ?",
-          )
-          .get("bare") as { n: number }
-      ).n;
-      expect(headerCount).toBe(0);
-      after.close();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+        .get("bare") as { n: number }
+    ).n;
+    expect(headerCount).toBe(0);
+    after.close();
   });
 });

--- a/apps/local/src/server/migrate-graphql-bindings.test.ts
+++ b/apps/local/src/server/migrate-graphql-bindings.test.ts
@@ -4,8 +4,9 @@
 // run the migration, assert that the JSON unpacks into the new
 // normalized columns / child tables and that the JSON columns are gone.
 
-import { describe, expect, it } from "@effect/vitest";
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
 import { Database } from "bun:sqlite";
+import { Schema } from "effect";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -16,231 +17,266 @@ import { PRE_0007_SQL, stampPriorMigrationsApplied } from "./__test-helpers__/pr
 
 const MIGRATIONS_FOLDER = join(import.meta.dirname, "../../drizzle");
 
+const NullableString = Schema.NullOr(Schema.String);
+
+const GraphqlAuthRow = Schema.Struct({
+  auth_kind: Schema.String,
+  auth_connection_id: NullableString,
+});
+
+const TableInfoRow = Schema.Struct({
+  name: Schema.String,
+});
+
+const GraphqlHeaderRow = Schema.Struct({
+  name: Schema.String,
+  kind: Schema.String,
+  text_value: NullableString,
+  secret_id: NullableString,
+  secret_prefix: NullableString,
+});
+
+const GraphqlQueryParamRow = Schema.Struct({
+  kind: Schema.String,
+  secret_id: Schema.String,
+});
+
+const CountRow = Schema.Struct({
+  n: Schema.Number,
+});
+
+const GraphqlHeaderIdRow = Schema.Struct({
+  id: Schema.String,
+  source_id: Schema.String,
+  name: Schema.String,
+  text_value: Schema.String,
+});
+
+const decodeAuthRow = Schema.decodeUnknownSync(GraphqlAuthRow);
+const decodeTableInfoRows = Schema.decodeUnknownSync(Schema.Array(TableInfoRow));
+const decodeHeaderRows = Schema.decodeUnknownSync(Schema.Array(GraphqlHeaderRow));
+const decodeQueryParamRow = Schema.decodeUnknownSync(GraphqlQueryParamRow);
+const decodeCountRow = Schema.decodeUnknownSync(CountRow);
+const decodeHeaderIdRows = Schema.decodeUnknownSync(
+  Schema.Array(GraphqlHeaderIdRow),
+);
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "graphql-mig-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
 describe("0007_normalize_plugin_secret_refs (graphql)", () => {
   it("flattens auth json into auth_kind/auth_connection_id columns", () => {
-    const dir = mkdtempSync(join(tmpdir(), "graphql-mig-"));
     const dbPath = join(dir, "test.sqlite");
-    try {
-      const db = new Database(dbPath);
-      db.exec(PRE_0007_SQL);
-      stampPriorMigrationsApplied(db);
+    const db = new Database(dbPath);
+    db.exec(PRE_0007_SQL);
+    stampPriorMigrationsApplied(db);
 
-      db.prepare(
-        "INSERT INTO graphql_source (scope_id, id, name, endpoint, auth) VALUES (?, ?, ?, ?, ?)",
-      ).run(
-        "default-scope",
-        "github",
-        "GitHub",
-        "https://api.github.com/graphql",
-        JSON.stringify({ kind: "oauth2", connectionId: "conn-1" }),
-      );
+    db.prepare(
+      "INSERT INTO graphql_source (scope_id, id, name, endpoint, auth) VALUES (?, ?, ?, ?, ?)",
+    ).run(
+      "default-scope",
+      "github",
+      "GitHub",
+      "https://api.github.com/graphql",
+      JSON.stringify({ kind: "oauth2", connectionId: "conn-1" }),
+    );
 
-      db.close();
+    db.close();
 
-      const drizzleDb = drizzle(new Database(dbPath));
-      migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+    const drizzleDb = drizzle(new Database(dbPath));
+    migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
 
-      const after = new Database(dbPath, { readonly: true });
-      const row = after
+    const after = new Database(dbPath, { readonly: true });
+    const row = decodeAuthRow(
+      after
         .prepare(
           "SELECT auth_kind, auth_connection_id FROM graphql_source WHERE id = ?",
         )
-        .get("github") as { auth_kind: string; auth_connection_id: string };
-      expect(row.auth_kind).toBe("oauth2");
-      expect(row.auth_connection_id).toBe("conn-1");
-      // Old json column is gone.
-      const cols = after
+        .get("github"),
+    );
+    expect(row.auth_kind).toBe("oauth2");
+    expect(row.auth_connection_id).toBe("conn-1");
+    // Old json column is gone.
+    const cols = decodeTableInfoRows(
+      after
         .prepare("PRAGMA table_info('graphql_source')")
-        .all() as ReadonlyArray<{ name: string }>;
-      expect(cols.some((c) => c.name === "auth")).toBe(false);
-      expect(cols.some((c) => c.name === "headers")).toBe(false);
-      expect(cols.some((c) => c.name === "query_params")).toBe(false);
-      after.close();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+        .all(),
+    );
+    expect(cols.some((c) => c.name === "auth")).toBe(false);
+    expect(cols.some((c) => c.name === "headers")).toBe(false);
+    expect(cols.some((c) => c.name === "query_params")).toBe(false);
+    after.close();
   });
 
   it("explodes header/query_param json into child rows", () => {
-    const dir = mkdtempSync(join(tmpdir(), "graphql-mig-"));
     const dbPath = join(dir, "test.sqlite");
-    try {
-      const db = new Database(dbPath);
-      db.exec(PRE_0007_SQL);
-      stampPriorMigrationsApplied(db);
+    const db = new Database(dbPath);
+    db.exec(PRE_0007_SQL);
+    stampPriorMigrationsApplied(db);
 
-      const headers = {
-        // Literal text header.
-        "X-Static": "literal-value",
-        // Secret-backed header without prefix.
-        Authorization: { secretId: "sec-token" },
-        // Secret-backed with prefix.
-        "X-Bearer": { secretId: "sec-bearer", prefix: "Bearer " },
-      };
-      const queryParams = {
-        api_key: { secretId: "sec-key" },
-      };
+    const headers = {
+      // Literal text header.
+      "X-Static": "literal-value",
+      // Secret-backed header without prefix.
+      Authorization: { secretId: "sec-token" },
+      // Secret-backed with prefix.
+      "X-Bearer": { secretId: "sec-bearer", prefix: "Bearer " },
+    };
+    const queryParams = {
+      api_key: { secretId: "sec-key" },
+    };
 
-      db.prepare(
-        "INSERT INTO graphql_source (scope_id, id, name, endpoint, headers, query_params, auth) VALUES (?, ?, ?, ?, ?, ?, ?)",
-      ).run(
-        "default-scope",
-        "example",
-        "Example",
-        "https://example.com/graphql",
-        JSON.stringify(headers),
-        JSON.stringify(queryParams),
-        JSON.stringify({ kind: "none" }),
-      );
+    db.prepare(
+      "INSERT INTO graphql_source (scope_id, id, name, endpoint, headers, query_params, auth) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    ).run(
+      "default-scope",
+      "example",
+      "Example",
+      "https://example.com/graphql",
+      JSON.stringify(headers),
+      JSON.stringify(queryParams),
+      JSON.stringify({ kind: "none" }),
+    );
 
-      db.close();
+    db.close();
 
-      const drizzleDb = drizzle(new Database(dbPath));
-      migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+    const drizzleDb = drizzle(new Database(dbPath));
+    migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
 
-      const after = new Database(dbPath, { readonly: true });
-      const headerRows = after
+    const after = new Database(dbPath, { readonly: true });
+    const headerRows = decodeHeaderRows(
+      after
         .prepare(
           "SELECT name, kind, text_value, secret_id, secret_prefix FROM graphql_source_header WHERE source_id = ? ORDER BY name",
         )
-        .all("example") as ReadonlyArray<{
-        name: string;
-        kind: string;
-        text_value: string | null;
-        secret_id: string | null;
-        secret_prefix: string | null;
-      }>;
-      expect(headerRows).toHaveLength(3);
+        .all("example"),
+    );
+    expect(headerRows).toHaveLength(3);
 
-      const byName = new Map(headerRows.map((r) => [r.name, r]));
-      expect(byName.get("X-Static")).toMatchObject({
-        kind: "text",
-        text_value: "literal-value",
-        secret_id: null,
-      });
-      expect(byName.get("Authorization")).toMatchObject({
-        kind: "secret",
-        text_value: null,
-        secret_id: "sec-token",
-        secret_prefix: null,
-      });
-      expect(byName.get("X-Bearer")).toMatchObject({
-        kind: "secret",
-        secret_id: "sec-bearer",
-        secret_prefix: "Bearer ",
-      });
+    const byName = new Map(headerRows.map((r) => [r.name, r]));
+    expect(byName.get("X-Static")).toMatchObject({
+      kind: "text",
+      text_value: "literal-value",
+      secret_id: null,
+    });
+    expect(byName.get("Authorization")).toMatchObject({
+      kind: "secret",
+      text_value: null,
+      secret_id: "sec-token",
+      secret_prefix: null,
+    });
+    expect(byName.get("X-Bearer")).toMatchObject({
+      kind: "secret",
+      secret_id: "sec-bearer",
+      secret_prefix: "Bearer ",
+    });
 
-      const paramRow = after
+    const paramRow = decodeQueryParamRow(
+      after
         .prepare(
           "SELECT kind, secret_id FROM graphql_source_query_param WHERE source_id = ?",
         )
-        .get("example") as { kind: string; secret_id: string };
-      expect(paramRow).toMatchObject({ kind: "secret", secret_id: "sec-key" });
+        .get("example"),
+    );
+    expect(paramRow).toMatchObject({ kind: "secret", secret_id: "sec-key" });
 
-      after.close();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    after.close();
   });
 
   it("handles graphql_source rows with null json (empty config)", () => {
-    const dir = mkdtempSync(join(tmpdir(), "graphql-mig-"));
     const dbPath = join(dir, "test.sqlite");
-    try {
-      const db = new Database(dbPath);
-      db.exec(PRE_0007_SQL);
-      stampPriorMigrationsApplied(db);
+    const db = new Database(dbPath);
+    db.exec(PRE_0007_SQL);
+    stampPriorMigrationsApplied(db);
 
-      db.prepare(
-        "INSERT INTO graphql_source (scope_id, id, name, endpoint) VALUES (?, ?, ?, ?)",
-      ).run("default-scope", "bare", "Bare", "https://bare.example/graphql");
-      db.close();
+    db.prepare(
+      "INSERT INTO graphql_source (scope_id, id, name, endpoint) VALUES (?, ?, ?, ?)",
+    ).run("default-scope", "bare", "Bare", "https://bare.example/graphql");
+    db.close();
 
-      const drizzleDb = drizzle(new Database(dbPath));
-      migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+    const drizzleDb = drizzle(new Database(dbPath));
+    migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
 
-      const after = new Database(dbPath, { readonly: true });
-      const row = after
+    const after = new Database(dbPath, { readonly: true });
+    const row = decodeAuthRow(
+      after
         .prepare(
           "SELECT auth_kind, auth_connection_id FROM graphql_source WHERE id = ?",
         )
-        .get("bare") as { auth_kind: string; auth_connection_id: string | null };
-      expect(row.auth_kind).toBe("none");
-      expect(row.auth_connection_id).toBeNull();
+        .get("bare"),
+    );
+    expect(row.auth_kind).toBe("none");
+    expect(row.auth_connection_id).toBeNull();
 
-      const headerCount = (
-        after
-          .prepare(
-            "SELECT count(*) as n FROM graphql_source_header WHERE source_id = ?",
-          )
-          .get("bare") as { n: number }
-      ).n;
-      expect(headerCount).toBe(0);
-      after.close();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+    const headerCount = decodeCountRow(
+      after
+        .prepare(
+          "SELECT count(*) as n FROM graphql_source_header WHERE source_id = ?",
+        )
+        .get("bare"),
+    ).n;
+    expect(headerCount).toBe(0);
+    after.close();
   });
 
   it("does not collapse child rows whose source/name pairs share colon-concatenated ids", () => {
-    const dir = mkdtempSync(join(tmpdir(), "graphql-mig-"));
     const dbPath = join(dir, "test.sqlite");
-    try {
-      const db = new Database(dbPath);
-      db.exec(PRE_0007_SQL);
-      stampPriorMigrationsApplied(db);
+    const db = new Database(dbPath);
+    db.exec(PRE_0007_SQL);
+    stampPriorMigrationsApplied(db);
 
-      const insert = db.prepare(
-        "INSERT INTO graphql_source (scope_id, id, name, endpoint, headers) VALUES (?, ?, ?, ?, ?)",
-      );
-      insert.run(
-        "default-scope",
-        "a:b",
-        "First",
-        "https://first.example/graphql",
-        JSON.stringify({ c: "first" }),
-      );
-      insert.run(
-        "default-scope",
-        "a",
-        "Second",
-        "https://second.example/graphql",
-        JSON.stringify({ "b:c": "second" }),
-      );
-      db.close();
+    const insert = db.prepare(
+      "INSERT INTO graphql_source (scope_id, id, name, endpoint, headers) VALUES (?, ?, ?, ?, ?)",
+    );
+    insert.run(
+      "default-scope",
+      "a:b",
+      "First",
+      "https://first.example/graphql",
+      JSON.stringify({ c: "first" }),
+    );
+    insert.run(
+      "default-scope",
+      "a",
+      "Second",
+      "https://second.example/graphql",
+      JSON.stringify({ "b:c": "second" }),
+    );
+    db.close();
 
-      const drizzleDb = drizzle(new Database(dbPath));
-      migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
+    const drizzleDb = drizzle(new Database(dbPath));
+    migrate(drizzleDb, { migrationsFolder: MIGRATIONS_FOLDER });
 
-      const after = new Database(dbPath, { readonly: true });
-      const rows = after
+    const after = new Database(dbPath, { readonly: true });
+    const rows = decodeHeaderIdRows(
+      after
         .prepare(
           "SELECT id, source_id, name, text_value FROM graphql_source_header ORDER BY source_id, name",
         )
-        .all() as ReadonlyArray<{
-        id: string;
-        source_id: string;
-        name: string;
-        text_value: string;
-      }>;
-      expect(rows).toHaveLength(2);
-      expect(rows).toEqual([
-        {
-          id: '["a","b:c"]',
-          source_id: "a",
-          name: "b:c",
-          text_value: "second",
-        },
-        {
-          id: '["a:b","c"]',
-          source_id: "a:b",
-          name: "c",
-          text_value: "first",
-        },
-      ]);
-      after.close();
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
+        .all(),
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows).toEqual([
+      {
+        id: '["a","b:c"]',
+        source_id: "a",
+        name: "b:c",
+        text_value: "second",
+      },
+      {
+        id: '["a:b","c"]',
+        source_id: "a:b",
+        name: "c",
+        text_value: "first",
+      },
+    ]);
+    after.close();
   });
 });


### PR DESCRIPTION
## Summary
- move GraphQL and Google Discovery migration temp cleanup into lifecycle hooks
- decode migrated SQLite rows/config with Effect Schema instead of raw casts/JSON.parse

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/local/src/server/migrate-graphql-bindings.test.ts apps/local/src/server/migrate-google-discovery-bindings.test.ts --deny-warnings
- bun run --cwd apps/local typecheck
- bunx --bun vitest run src/server/migrate-graphql-bindings.test.ts src/server/migrate-google-discovery-bindings.test.ts