### PR TITLE
Stabilize GraphQL extraction errors

### DIFF
--- a/packages/plugins/graphql/src/sdk/extract.ts
+++ b/packages/plugins/graphql/src/sdk/extract.ts
@@ -251,8 +251,8 @@ export const extract = (
         definitions,
       };
     },
-    catch: (err) =>
+    catch: () =>
       new GraphqlExtractionError({
-        message: `Failed to extract GraphQL schema: ${err instanceof Error ? err.message : String(err)}`,
+        message: "Failed to extract GraphQL schema",
       }),
   });


### PR DESCRIPTION
## Summary
- stop deriving GraphQL extraction messages from unknown thrown values
- keep extraction failures in the typed GraphQL error channel

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/graphql/src/sdk/extract.ts --deny-warnings
- bun run --cwd packages/plugins/graphql typecheck