### PR TITLE
Clean cloud auth and org test failures

### DIFF
--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -270,7 +270,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
               },
             );
             deleteCookie("wos-session", { path: "/" });
-            return yield* Effect.fail(new WorkOSError());
+            return yield* new WorkOSError();
           }
 
           setCookie("wos-session", refreshed, COOKIE_OPTIONS);
@@ -341,7 +341,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
             yield* Effect.logWarning("acceptInvitation: invitation has no organizationId", {
               invitationId: payload.invitationId,
             });
-            return yield* Effect.fail(new WorkOSError());
+            return yield* new WorkOSError();
           }
 
           // Mirror the org locally so domain tables can FK against it.
@@ -369,7 +369,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
               },
             );
             deleteCookie("wos-session", { path: "/" });
-            return yield* Effect.fail(new WorkOSError());
+            return yield* new WorkOSError();
           }
 
           setCookie("wos-session", refreshed, COOKIE_OPTIONS);

--- a/apps/cloud/src/org/handlers.test.ts
+++ b/apps/cloud/src/org/handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { Data, Effect, Layer } from "effect";
 
 import { AuthContext } from "../auth/middleware";
 import { WorkOSAuth, type WorkOSAuthService } from "../auth/workos";
@@ -21,15 +21,24 @@ type StubOverrides = {
   listOrgRoles?: StubFn;
 };
 
+class UnstubbedWorkOSMethod extends Data.TaggedError("UnstubbedWorkOSMethod")<{
+  method: string;
+}> {}
+
 const stubWorkOS = (overrides: StubOverrides = {}) =>
   Layer.succeed(
     WorkOSAuth,
     new Proxy({} as WorkOSAuthService, {
       get: (_target, prop) => {
-        if (prop in overrides) return (overrides as Record<string, unknown>)[prop as string];
-        return () => {
-          throw new Error(`WorkOSAuth.${String(prop)} not stubbed`);
-        };
+        if (typeof prop === "string" && prop in overrides) {
+          return overrides[prop as keyof StubOverrides];
+        }
+        return () =>
+          Effect.fail(
+            new UnstubbedWorkOSMethod({
+              method: typeof prop === "string" ? prop : (prop.description ?? "symbol"),
+            }),
+          );
       },
     }),
   );


### PR DESCRIPTION
## Summary
- yield WorkOS tagged errors directly in cloud auth handlers
- replace org handler test fallback throws with typed Effect failures

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/auth/handlers.ts apps/cloud/src/org/handlers.test.ts --deny-warnings
- bun run --cwd apps/cloud typecheck
- node ../../node_modules/vitest/vitest.mjs run src/org/handlers.test.ts