### PR TITLE
Clean local server tooling boundaries

### DIFF
--- a/apps/local/src/server/main.ts
+++ b/apps/local/src/server/main.ts
@@ -42,10 +42,21 @@ export type ServerHandlers = {
 };
 
 const closeServerHandlers = async (handlers: ServerHandlers): Promise<void> => {
-  await Promise.all([
-    handlers.api.dispose().catch(() => undefined),
-    handlers.mcp.close().catch(() => undefined),
-  ]);
+  await Effect.runPromise(
+    Effect.all(
+      [
+        Effect.tryPromise({
+          try: () => handlers.api.dispose(),
+          catch: (cause) => cause,
+        }).pipe(Effect.ignore),
+        Effect.tryPromise({
+          try: () => handlers.mcp.close(),
+          catch: (cause) => cause,
+        }).pipe(Effect.ignore),
+      ],
+      { concurrency: "unbounded" },
+    ),
+  );
 };
 
 export const createServerHandlers = async (): Promise<ServerHandlers> => {
@@ -107,5 +118,10 @@ export const getServerHandlers = (): Promise<ServerHandlers> =>
   serverHandlersRuntime.runPromise(ServerHandlersService.asEffect());
 
 export const disposeServerHandlers = async (): Promise<void> => {
-  await serverHandlersRuntime.dispose().catch(() => undefined);
+  await Effect.runPromise(
+    Effect.tryPromise({
+      try: () => serverHandlersRuntime.dispose(),
+      catch: (cause) => cause,
+    }).pipe(Effect.ignore),
+  );
 };

--- a/apps/local/vite.config.ts
+++ b/apps/local/vite.config.ts
@@ -6,10 +6,12 @@ import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import executorVitePlugin from "@executor-js/vite-plugin";
 
+// oxlint-disable-next-line executor/no-json-parse -- boundary: Vite config reads package metadata from package.json
 const rootPackage = JSON.parse(
   readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
 ) as { version: string; homepage?: string; repository?: string | { url?: string } };
 
+// oxlint-disable-next-line executor/no-json-parse -- boundary: Vite config reads package metadata from package.json
 const cliPackage = JSON.parse(
   readFileSync(new URL("../cli/package.json", import.meta.url), "utf8"),
 ) as { version?: string };
@@ -43,6 +45,7 @@ function executorApiPlugin(): Plugin {
 
         if (!isApi && !isMcp) return next();
 
+        // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Vite middleware must convert handler failures into HTTP 500 responses
         try {
           if (!handlers) {
             const { getServerHandlers } = await import("./src/server/main");


### PR DESCRIPTION
## Summary
- replace local server best-effort Promise catches with Effect cleanup
- mark Vite package metadata parsing and middleware error conversion as narrow tooling boundaries

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/local/src/server/main.ts apps/local/vite.config.ts --deny-warnings
- bun run --cwd apps/local typecheck
- bun run --cwd apps/local build