### PR TITLE
Remove MCP cross-user redundant casts

### DIFF
--- a/packages/plugins/mcp/src/sdk/cross-user-isolation.test.ts
+++ b/packages/plugins/mcp/src/sdk/cross-user-isolation.test.ts
@@ -69,9 +69,9 @@ const makeSharedOrgExecutors = () =>
     return {
       execA,
       execB,
-      aInnerId: aInnerId as string,
-      bInnerId: bInnerId as string,
-      orgScopeId: orgScopeId as string,
+      aInnerId,
+      bInnerId,
+      orgScopeId,
     };
   });
 


### PR DESCRIPTION
## Summary
- keep branded scope ids flowing through MCP cross-user isolation tests without primitive casts

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/mcp/src/sdk/cross-user-isolation.test.ts --deny-warnings
- bun run --cwd packages/plugins/mcp typecheck
- node ../../../node_modules/vitest/vitest.mjs run src/sdk/cross-user-isolation.test.ts