### PR TITLE
Normalize WorkOS Vault errors

### DIFF
--- a/packages/plugins/workos-vault/src/sdk/client.ts
+++ b/packages/plugins/workos-vault/src/sdk/client.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
   WorkOS as WorkOSClient,
 } from "@workos-inc/node/worker";
-import { Data, Effect, Result } from "effect";
+import { Data, Effect, Option, Result, Schema } from "effect";
 
 export interface WorkOSVaultObjectMetadata {
   readonly context: Record<string, unknown>;
@@ -20,44 +20,49 @@ export interface WorkOSVaultObject {
   readonly value?: string;
 }
 
-// Minimal shape carrying an HTTP-style status code. Production WorkOS errors
-// (`GenericServerException`/`NotFoundException`) and test fakes both populate
-// a numeric `status`, so the boundary normalises against this named type
-// rather than probing arbitrary unknown shapes.
-interface ErrorWithStatus extends Error {
-  readonly status: number;
-}
+const WORKOS_KEK_NOT_READY_MESSAGE =
+  "KEK was created but is not yet ready. This request can be retried.";
 
-const isErrorWithStatus = (cause: unknown): cause is ErrorWithStatus =>
-  cause instanceof Error && typeof (cause as ErrorWithStatus).status === "number";
+const CauseWithStatusSchema = Schema.Struct({
+  status: Schema.Number,
+});
 
 const statusFromWorkOSCause = (cause: unknown): number | undefined => {
   if (cause instanceof GenericServerException || cause instanceof NotFoundException) {
     return cause.status;
   }
-  if (isErrorWithStatus(cause)) return cause.status;
-  return undefined;
+  return Option.match(Schema.decodeUnknownOption(CauseWithStatusSchema)(cause), {
+    onNone: () => undefined,
+    onSome: (decoded) => decoded.status,
+  });
 };
 
-const messageFromWorkOSCause = (cause: unknown): string =>
-  cause instanceof Error ? cause.message : typeof cause === "string" ? cause : "";
+const isKekNotReadyWorkOSCause = (cause: unknown): boolean =>
+  cause instanceof GenericServerException &&
+  // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: WorkOS only exposes this retryable Vault condition through its SDK exception message
+  cause.message.endsWith(WORKOS_KEK_NOT_READY_MESSAGE);
 
 export class WorkOSVaultClientError extends Data.TaggedError("WorkOSVaultClientError")<{
   readonly cause: unknown;
   readonly message: string;
   readonly operation: string;
+  readonly retryKind?: "kek_not_ready";
   readonly status?: number;
 }> {
   constructor(options: {
     readonly cause: unknown;
     readonly message?: string;
     readonly operation: string;
+    readonly retryKind?: "kek_not_ready";
     readonly status?: number;
   }) {
     super({
       cause: options.cause,
-      message: options.message ?? messageFromWorkOSCause(options.cause),
+      message: options.message ?? `WorkOS Vault ${options.operation} failed`,
       operation: options.operation,
+      retryKind:
+        options.retryKind ??
+        (isKekNotReadyWorkOSCause(options.cause) ? "kek_not_ready" : undefined),
       status: options.status ?? statusFromWorkOSCause(options.cause),
     });
   }

--- a/packages/plugins/workos-vault/src/sdk/secret-store.ts
+++ b/packages/plugins/workos-vault/src/sdk/secret-store.ts
@@ -158,7 +158,7 @@ const isStatusError = (error: WorkOSVaultClientError, status: number): boolean =
   error.status === status;
 
 const isKekNotReadyError = (error: WorkOSVaultClientError): boolean =>
-  error.message.includes("KEK was created but is not yet ready");
+  error.retryKind === "kek_not_ready";
 
 // Default context builder. Each semantic piece of a scope id lives in
 // its own vault-context key so WorkOS's KEK matcher sees individual
@@ -302,9 +302,6 @@ const deleteSecretValue = (
     return true;
   });
 
-const formatVaultError = (error: WorkOSVaultClientError): StorageError =>
-  new StorageError({ message: error.message, cause: error.cause });
-
 // ---------------------------------------------------------------------------
 // makeWorkOSVaultSecretProvider — builds a SecretProvider backed by
 // WorkOS Vault for values and the plugin's own metadata table for
@@ -343,7 +340,13 @@ export const makeWorkOSVaultSecretProvider = (
         const meta = yield* store.get(id, scope);
         if (!meta) return null;
         const object = yield* loadSecretObject(client, prefix, scope, id).pipe(
-          Effect.mapError(formatVaultError),
+          Effect.mapError(
+            (error) =>
+              new StorageError({
+                message: "WorkOS Vault secret read failed",
+                cause: error,
+              }),
+          ),
         );
         if (!object || !object.value) return null;
         return object.value;
@@ -353,7 +356,13 @@ export const makeWorkOSVaultSecretProvider = (
       Effect.gen(function* () {
         const existing = yield* store.get(id, scope);
         yield* upsertSecretValue(client, prefix, scope, id, value, contextForScope).pipe(
-          Effect.mapError(formatVaultError),
+          Effect.mapError(
+            (error) =>
+              new StorageError({
+                message: "WorkOS Vault secret write failed",
+                cause: error,
+              }),
+          ),
         );
         yield* store.upsert({
           id,
@@ -369,7 +378,13 @@ export const makeWorkOSVaultSecretProvider = (
         const meta = yield* store.get(id, scope);
         if (!meta) return false;
         yield* deleteSecretValue(client, prefix, scope, id).pipe(
-          Effect.mapError(formatVaultError),
+          Effect.mapError(
+            (error) =>
+              new StorageError({
+                message: "WorkOS Vault secret delete failed",
+                cause: error,
+              }),
+          ),
         );
         yield* store.remove(id, scope);
         return true;


### PR DESCRIPTION
## Summary
- normalize WorkOS Vault status through Schema and stable client messages
- keep KEK retry classification typed at the SDK boundary
- map secret-store operations to stable StorageError messages with preserved causes

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/workos-vault/src/sdk/client.ts packages/plugins/workos-vault/src/sdk/secret-store.ts --deny-warnings
- bun run --cwd packages/plugins/workos-vault typecheck