### PR TITLE
Clean cloud auth and Autumn boundaries

### DIFF
--- a/apps/cloud/src/api/autumn.ts
+++ b/apps/cloud/src/api/autumn.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:workers";
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
 import {
   HttpRouter,
   HttpServerRequest,
@@ -30,13 +30,11 @@ const handler = Effect.gen(function* () {
   const session = yield* workos.authenticateRequest(webRequest);
 
   if (!session || !session.organizationId) {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 401,
-        code: "unauthorized",
-        message: "Unauthorized",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 401,
+      code: "unauthorized",
+      message: "Unauthorized",
+    });
   }
 
   const url = new URL(webRequest.url);
@@ -74,20 +72,18 @@ const handler = Effect.gen(function* () {
 
   if (statusCode >= 400) {
     console.error("[autumn] upstream error:", statusCode, response);
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: statusCode,
-        code: "billing_request_failed",
-        message: "Billing request failed",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: statusCode,
+      code: "billing_request_failed",
+      message: "Billing request failed",
+    });
   }
 
   return HttpServerResponse.jsonUnsafe(response, { status: statusCode });
 }).pipe(
   Effect.catchCause((err) => {
     if (isServerError(err)) {
-      console.error("[autumn] request failed:", err instanceof Error ? err.stack : err);
+      console.error("[autumn] request failed:", Cause.pretty(err));
     }
     return Effect.succeed(toErrorServerResponse(err));
   }),

--- a/apps/cloud/src/auth/handlers.node.test.ts
+++ b/apps/cloud/src/auth/handlers.node.test.ts
@@ -1,7 +1,7 @@
 import { HttpApiBuilder, HttpApi } from "effect/unstable/httpapi";
 import { HttpRouter, HttpServer } from "effect/unstable/http";
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Layer } from "effect";
+import { Data, Effect, Layer } from "effect";
 import type { Effect as EffectType } from "effect/Effect";
 
 import { CloudAuthPublicApi } from "./api";
@@ -31,15 +31,22 @@ const fakeUser: AuthenticateWithCodeResult["user"] = {
   metadata: {},
 };
 
+class UnstubbedWorkOSMethod extends Data.TaggedError("UnstubbedWorkOSMethod")<{
+  method: string;
+}> {}
+
 const makeAuthFetch = (workos: Partial<WorkOSAuth["Service"]>) => {
   const WorkOSTest = Layer.succeed(
     WorkOSAuth,
     new Proxy(workos as WorkOSAuth["Service"], {
       get: (target, prop) => {
         if (prop in target) return target[prop as keyof typeof target];
-        return () => {
-          throw new Error(`WorkOSAuth.${String(prop)} not stubbed`);
-        };
+        return () =>
+          Effect.fail(
+            new UnstubbedWorkOSMethod({
+              method: typeof prop === "string" ? prop : (prop.description ?? "symbol"),
+            }),
+          );
       },
     }),
   );

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -3,11 +3,17 @@
 // ---------------------------------------------------------------------------
 
 import { env } from "cloudflare:workers";
-import { Context, Effect, Layer } from "effect";
+import { Context, Data, Effect, Layer } from "effect";
 import { GeneratePortalLinkIntent, WorkOS } from "@workos-inc/node/worker";
 import { WorkOSError, tryPromiseService, withServiceLogging } from "./errors";
 
 const COOKIE_NAME = "wos-session";
+const INVALID_COOKIE_PASSWORD_MESSAGE =
+  "WORKOS_COOKIE_PASSWORD must be at least 32 characters";
+
+class WorkOSAuthConfigurationError extends Data.TaggedError("WorkOSAuthConfigurationError")<{
+  readonly message: string;
+}> {}
 
 // ---------------------------------------------------------------------------
 // Service
@@ -19,7 +25,9 @@ const make = Effect.gen(function* () {
   const cookiePassword = env.WORKOS_COOKIE_PASSWORD;
 
   if (!cookiePassword || cookiePassword.length < 32) {
-    return yield* Effect.die(new Error("WORKOS_COOKIE_PASSWORD must be at least 32 characters"));
+    return yield* new WorkOSAuthConfigurationError({
+      message: INVALID_COOKIE_PASSWORD_MESSAGE,
+    });
   }
 
   const workos = new WorkOS({ apiKey, clientId });

--- a/apps/cloud/src/observability.test.ts
+++ b/apps/cloud/src/observability.test.ts
@@ -15,6 +15,7 @@ describe("sentryPayloadForCause", () => {
     // Reproduces the production chain: an inner runPromise rejects with a
     // CauseImpl (from Effect v4's causeSquash), Effect.promise re-wraps it
     // as Die(CauseImpl), and the outer catchCause receives this shape.
+    // oxlint-disable-next-line executor/no-error-constructor -- boundary: observability test must build a real Error for Sentry-compatible payload assertions
     const innerCause = Cause.fail(new Error("inner failure"));
     const outerCause = Cause.die(innerCause);
 
@@ -25,11 +26,13 @@ describe("sentryPayloadForCause", () => {
   });
 
   it("hands Sentry a real Error for an ordinary failed Cause", () => {
+    // oxlint-disable-next-line executor/no-error-constructor -- boundary: observability test must build a real Error for Sentry-compatible payload assertions
     const { primary } = sentryPayloadForCause(Cause.fail(new Error("plain failure")));
     expect(looksLikeErrorToSentry(primary)).toBe(true);
   });
 
   it("forwards non-Cause inputs as-is with no pretty cause attached", () => {
+    // oxlint-disable-next-line executor/no-error-constructor -- boundary: observability test must build a real Error for Sentry-compatible payload assertions
     const err = new Error("raw");
     const { primary, pretty } = sentryPayloadForCause(err);
     expect(primary).toBe(err);


### PR DESCRIPTION
## Summary
- yield Autumn HTTP errors directly and log failed causes with Cause.pretty
- replace WorkOS auth startup defects/test fallbacks with typed failures
- keep observability tests explicit about real Error payload boundaries

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/cloud/src/api/autumn.ts apps/cloud/src/auth/handlers.node.test.ts apps/cloud/src/auth/workos.ts apps/cloud/src/observability.test.ts --deny-warnings
- bun run --cwd apps/cloud typecheck
- node ../../node_modules/vitest/vitest.mjs run src/observability.test.ts src/auth/handlers.node.test.ts