### PR TITLE
Clean core API observability errors

### DIFF
--- a/packages/core/api/src/observability.test.ts
+++ b/packages/core/api/src/observability.test.ts
@@ -32,7 +32,7 @@ describe("capture", () => {
   it.effect("translates StorageError to InternalError with ErrorCapture trace id", () =>
     Effect.gen(function* () {
       const { layer, seen } = yield* makeRecorder("trace-abc");
-      const err = new StorageError({ message: "db down", cause: new Error("x") });
+      const err = new StorageError({ message: "db down", cause: "x" });
 
       const eff = capture(Effect.fail(err));
       const result = yield* Effect.flip(eff).pipe(Effect.provide(layer));
@@ -81,7 +81,7 @@ describe("capture", () => {
         DomainError
       >;
       const result = yield* Effect.flip(capture(eff));
-      expect(result._tag).toBe("DomainError");
+      expect(result).toBeInstanceOf(DomainError);
     }),
   );
 });

--- a/packages/core/api/src/observability.ts
+++ b/packages/core/api/src/observability.ts
@@ -97,6 +97,7 @@ export const capture = <A, E, R>(
   eff: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, Exclude<E, StorageFailure> | InternalError, R> =>
   (eff as Effect.Effect<A, E | StorageFailure, R>).pipe(
+    // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: unique conflicts that reach the HTTP edge are unexpected defects captured by observabilityMiddleware
     Effect.catchTag("UniqueViolationError", (err) => Effect.die(err)),
     Effect.catchTag("StorageError", (err) =>
       resolveCapture.pipe(
@@ -126,14 +127,14 @@ export const captureEngineError = <A, R>(
 ): Effect.Effect<A, InternalError, R> =>
   eff.pipe(
     Effect.catch((err) =>
-      err instanceof InternalError
+      Schema.is(InternalError)(err)
         ? Effect.fail(err)
         : resolveCapture.pipe(
             Effect.flatMap((c) => c.captureException(Cause.fail(err))),
             Effect.flatMap((traceId) =>
               Effect.fail(new InternalError({ traceId })),
             ),
-          ),
+        ),
     ),
   );
 


### PR DESCRIPTION
## Summary
- use Schema.is for InternalError recognition
- keep the unique-violation HTTP edge escalation explicit
- remove raw Error construction and manual tag assertion from observability tests

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/api/src/observability.ts packages/core/api/src/observability.test.ts --deny-warnings
- bun run --cwd packages/core/api typecheck
- bun run --cwd packages/core/api test src/observability.test.ts