### PR TITLE
Mark JSON schema adapter boundaries

### DIFF
--- a/packages/kernel/core/src/json-schema.ts
+++ b/packages/kernel/core/src/json-schema.ts
@@ -33,6 +33,7 @@ const pointerToPath = (pointer: string | undefined): ReadonlyArray<PropertyKey> 
 
 const toIssueMessage = (error: ErrorObject): string => {
   const keyword = error.keyword.trim();
+  // oxlint-disable-next-line executor/no-unknown-error-message -- typed AJV ErrorObject exposes optional validation message copy
   const message = (error.message ?? "Invalid value").trim();
   return keyword.length > 0 ? `${keyword}: ${message}` : message;
 };
@@ -44,6 +45,7 @@ export const standardSchemaFromJsonSchema = (
     fallback?: StandardSchema;
   },
 ): StandardSchema => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: AJV compile throws for invalid schemas and this adapter preserves fallback behavior
   try {
     const validate = ajv.compile(schema as Record<string, unknown>);
 


### PR DESCRIPTION
## Summary
- keep AJV validation message and compile fallback behavior unchanged
- document the narrow adapter boundaries with lint suppressions

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/kernel/core/src/json-schema.ts --deny-warnings
- bun run --cwd packages/kernel/core typecheck