### PR TITLE
Fix storage typed boundary lint

### DIFF
--- a/packages/core/storage-core/src/factory.ts
+++ b/packages/core/storage-core/src/factory.ts
@@ -25,7 +25,7 @@
 //     to running the callback against the current adapter
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
+import { Effect, Option, Schema } from "effect";
 
 import type {
   CleanedWhere,
@@ -72,8 +72,7 @@ const withApplyDefault = (
   // when they passed null for a required field (upstream convention —
   // explicit null on an optional/nullable field is preserved). Without the
   // `required` gate we'd silently overwrite legitimate null writes.
-  const triggerDefault =
-    value === undefined || (field.required === true && value === null);
+  const triggerDefault = value === undefined || (field.required === true && value === null);
   if (triggerDefault && field.defaultValue !== undefined) {
     return typeof field.defaultValue === "function"
       ? (field.defaultValue as () => DBPrimitive)()
@@ -96,9 +95,7 @@ export interface CreateAdapterOptions {
  * Wrap a CustomAdapter into a full DBAdapter that applies schema-driven
  * transforms. This is the single codepath every backend shares.
  */
-export const createAdapter = (
-  options: CreateAdapterOptions,
-): DBAdapter => {
+export const createAdapter = (options: CreateAdapterOptions): DBAdapter => {
   const { schema, adapter: inner } = options;
   const typedOutput = <T>(value: unknown): T => value as T;
   const config: Required<
@@ -111,7 +108,8 @@ export const createAdapter = (
       | "supportsArrays"
       | "disableIdGeneration"
     >
-  > & DBAdapterFactoryConfig = {
+  > &
+    DBAdapterFactoryConfig = {
     ...options.config,
     supportsJSON: options.config.supportsJSON ?? false,
     supportsDates: options.config.supportsDates ?? true,
@@ -127,47 +125,34 @@ export const createAdapter = (
     return defaultGenerateId();
   };
 
-  const getModelDef = (
-    model: string,
-  ): Effect.Effect<DBSchema[string], StorageError> =>
+  const getModelDef = (model: string): Effect.Effect<DBSchema[string], StorageError> =>
     Effect.gen(function* () {
       const def = schema[model];
       if (!def) {
-        return yield* Effect.fail(
-          new StorageError({
-            message: `[storage-core] unknown model "${model}"`,
-            cause: undefined,
-          }),
-        );
+        return yield* new StorageError({
+          message: `[storage-core] unknown model "${model}"`,
+          cause: undefined,
+        });
       }
       return def;
     });
-
-  // Sync accessor for call sites that can't sit inside Effect.gen (cleanWhere,
-  // getModelName, getPhysicalField). These are all fed model names that have
-  // already been validated upstream by the typed API, so unknown-model throws
-  // here are a caller bug, not a runtime failure channel.
-  const getModelDefSync = (model: string): DBSchema[string] => {
-    const def = schema[model];
-    if (!def) throw new Error(`[storage-core] unknown model "${model}"`);
-    return def;
-  };
 
   // Map physical table name → logical model key, for renaming incoming model
   // arg in mapKeysTransformInput/Output when callers pass physical names.
   // We deliberately *don't* support plural or physical-name inputs — our
   // plugins always pass the logical key — so getModelName is identity.
-  const getModelName = (model: string): string =>
-    getModelDefSync(model).modelName ?? model;
+  const getModelName = (model: string): Effect.Effect<string, StorageError> =>
+    getModelDef(model).pipe(Effect.map((def) => def.modelName ?? model));
 
   // Field name (logical → physical). Honors mapKeysTransformInput override.
-  const getPhysicalField = (model: string, logical: string): string => {
-    if (logical === "id") return config.mapKeysTransformInput?.["id"] ?? "id";
-    const override = config.mapKeysTransformInput?.[logical];
-    if (override) return override;
-    const attr = getModelDefSync(model).fields[logical];
-    return attr?.fieldName ?? logical;
-  };
+  const getPhysicalField = (model: string, logical: string): Effect.Effect<string, StorageError> =>
+    Effect.gen(function* () {
+      if (logical === "id") return config.mapKeysTransformInput?.["id"] ?? "id";
+      const override = config.mapKeysTransformInput?.[logical];
+      if (override) return override;
+      const attr = (yield* getModelDef(model)).fields[logical];
+      return attr?.fieldName ?? logical;
+    });
 
   // Inverse of mapKeysTransformOutput: on the output path we may need to
   // rename a logical field to a different output key for the caller (symmetric
@@ -180,10 +165,7 @@ export const createAdapter = (
   // Value encode / decode based on supports* flags.
   // ---------------------------------------------------------------------------
 
-  const encodeValue = (
-    attr: DBFieldAttribute | undefined,
-    value: unknown,
-  ): unknown => {
+  const encodeValue = (attr: DBFieldAttribute | undefined, value: unknown): unknown => {
     if (value === undefined) return undefined;
     if (value === null) return null;
     if (!attr) return value;
@@ -216,19 +198,17 @@ export const createAdapter = (
     return value;
   };
 
-  const decodeValue = (
-    attr: DBFieldAttribute | undefined,
-    value: unknown,
-  ): unknown => {
+  const decodeJsonFallback = (value: string): unknown =>
+    Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(value).pipe(
+      Option.getOrElse((): unknown => value),
+    );
+
+  const decodeValue = (attr: DBFieldAttribute | undefined, value: unknown): unknown => {
     if (value === undefined || value === null) return value;
     if (!attr) return value;
     const type = attr.type;
     if (type === "json" && typeof value === "string") {
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value;
-      }
+      return decodeJsonFallback(value);
     }
     if (type === "date") {
       if (value instanceof Date) return value;
@@ -240,15 +220,8 @@ export const createAdapter = (
     if (type === "boolean" && typeof value === "number") {
       return value === 1;
     }
-    if (
-      (type === "string[]" || type === "number[]") &&
-      typeof value === "string"
-    ) {
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value;
-      }
+    if ((type === "string[]" || type === "number[]") && typeof value === "string") {
+      return decodeJsonFallback(value);
     }
     if (type === "number" && typeof value === "string") {
       const n = Number(value);
@@ -274,9 +247,9 @@ export const createAdapter = (
       // id handling on create
       if (action === "create") {
         if (forceAllowId && "id" in data && data.id !== undefined && data.id !== null) {
-          out[getPhysicalField(model, "id")] = data.id;
+          out[yield* getPhysicalField(model, "id")] = data.id;
         } else if (!config.disableIdGeneration) {
-          out[getPhysicalField(model, "id")] = idGen(model);
+          out[yield* getPhysicalField(model, "id")] = idGen(model);
         }
       }
 
@@ -293,11 +266,7 @@ export const createAdapter = (
           !(value instanceof Date) &&
           typeof value === "string"
         ) {
-          try {
-            value = new Date(value);
-          } catch {
-            // leave as-is
-          }
+          value = new Date(value);
         }
 
         // defaultValue / onUpdate
@@ -313,7 +282,7 @@ export const createAdapter = (
               try: () => res as Promise<DBPrimitive>,
               catch: (cause) =>
                 new StorageError({
-                  message: `[storage-core] transform.input for "${model}.${logical}" failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+                  message: `[storage-core] transform.input for "${model}.${logical}" failed`,
                   cause,
                 }),
             });
@@ -324,7 +293,7 @@ export const createAdapter = (
 
         if (value === undefined) continue;
 
-        const physical = getPhysicalField(model, logical);
+        const physical = yield* getPhysicalField(model, logical);
         let encoded = encodeValue(attr, value);
 
         // customTransformInput — user-land per-field hook, runs after the
@@ -337,7 +306,7 @@ export const createAdapter = (
             fieldAttributes: attr,
             field: physical,
             action,
-            model: getModelName(model),
+            model: yield* getModelName(model),
             schema,
           });
         }
@@ -363,7 +332,7 @@ export const createAdapter = (
       const out: Record<string, unknown> = {};
 
       // id always returned
-      const idPhysical = getPhysicalField(model, "id");
+      const idPhysical = yield* getPhysicalField(model, "id");
       const idOutputKey = getOutputKey("id");
       if (idPhysical in row && row[idPhysical] !== undefined) {
         out[idOutputKey] = row[idPhysical];
@@ -376,7 +345,7 @@ export const createAdapter = (
         if (attr.returned === false) continue;
         if (select && select.length > 0 && !select.includes(logical)) continue;
 
-        const physical = getPhysicalField(model, logical);
+        const physical = yield* getPhysicalField(model, logical);
         if (!(physical in row)) continue;
 
         let value: unknown = decodeValue(attr, row[physical]);
@@ -388,7 +357,7 @@ export const createAdapter = (
               try: () => res as Promise<DBPrimitive>,
               catch: (cause) =>
                 new StorageError({
-                  message: `[storage-core] transform.output for "${model}.${logical}" failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+                  message: `[storage-core] transform.output for "${model}.${logical}" failed`,
                   cause,
                 }),
             });
@@ -405,7 +374,7 @@ export const createAdapter = (
             fieldAttributes: attr,
             field: logical,
             select: select ?? [],
-            model: getModelName(model),
+            model: yield* getModelName(model),
             schema,
           });
         }
@@ -441,95 +410,94 @@ export const createAdapter = (
   // join that the schema can't resolve is a bug, not a runtime state.
   // ---------------------------------------------------------------------------
 
-  const resolveJoin = (base: string, join: JoinOption): JoinConfig => {
-    const baseDef = getModelDefSync(base);
-    const out: JoinConfig = {};
-    for (const [target, raw] of Object.entries(join)) {
-      if (raw === false) continue;
-      const targetDef = getModelDefSync(target);
-      const limit =
-        typeof raw === "object" && raw.limit !== undefined ? raw.limit : undefined;
+  const resolveJoin = (base: string, join: JoinOption): Effect.Effect<JoinConfig, StorageFailure> =>
+    Effect.gen(function* () {
+      const baseDef = yield* getModelDef(base);
+      const out: JoinConfig = {};
+      for (const [target, raw] of Object.entries(join)) {
+        if (raw === false) continue;
+        const targetDef = yield* getModelDef(target);
+        const limit = typeof raw === "object" && raw.limit !== undefined ? raw.limit : undefined;
 
-      // child → parent
-      let found: JoinConfig[string] | undefined;
-      for (const [fieldName, attr] of Object.entries(baseDef.fields)) {
-        if (attr.references?.model === target) {
-          found = {
-            on: {
-              from: getPhysicalField(base, fieldName),
-              to:
-                getPhysicalField(target, attr.references.field) ||
-                attr.references.field,
-            },
-            relation: "one-to-one",
-            ...(limit !== undefined ? { limit } : {}),
-          };
-          break;
-        }
-      }
-      // parent → children
-      if (!found) {
-        for (const [fieldName, attr] of Object.entries(targetDef.fields)) {
-          if (attr.references?.model === base) {
+        // child → parent
+        let found: JoinConfig[string] | undefined;
+        for (const [fieldName, attr] of Object.entries(baseDef.fields)) {
+          if (attr.references?.model === target) {
             found = {
               on: {
-                from:
-                  getPhysicalField(base, attr.references.field) ||
-                  attr.references.field,
-                to: getPhysicalField(target, fieldName),
+                from: yield* getPhysicalField(base, fieldName),
+                to:
+                  (yield* getPhysicalField(target, attr.references.field)) || attr.references.field,
               },
-              relation: "one-to-many",
+              relation: "one-to-one",
               ...(limit !== undefined ? { limit } : {}),
             };
             break;
           }
         }
+        // parent → children
+        if (!found) {
+          for (const [fieldName, attr] of Object.entries(targetDef.fields)) {
+            if (attr.references?.model === base) {
+              found = {
+                on: {
+                  from:
+                    (yield* getPhysicalField(base, attr.references.field)) || attr.references.field,
+                  to: yield* getPhysicalField(target, fieldName),
+                },
+                relation: "one-to-many",
+                ...(limit !== undefined ? { limit } : {}),
+              };
+              break;
+            }
+          }
+        }
+        if (!found) {
+          return yield* new StorageError({
+            message: `[storage-core] cannot resolve join "${base}" -> "${target}": neither model declares a \`references\` for the other`,
+            cause: undefined,
+          });
+        }
+        out[target] = found;
       }
-      if (!found) {
-        throw new Error(
-          `[storage-core] cannot resolve join "${base}" → "${target}": neither model declares a \`references\` for the other`,
-        );
-      }
-      out[target] = found;
-    }
-    return out;
-  };
+      return out;
+    });
 
   const cleanWhere = (
     model: string,
     where: readonly Where[] | undefined,
-  ): CleanedWhere[] | undefined => {
-    if (!where) return undefined;
-    const def = getModelDefSync(model);
-    return where.map((w) => {
-      const operator = w.operator ?? "eq";
-      const connector = w.connector ?? "AND";
-      const mode = w.mode ?? "sensitive";
-      const logical = w.field;
-      const attr =
-        logical === "id" ? undefined : def.fields[logical];
-      const physical = getPhysicalField(model, logical);
+  ): Effect.Effect<CleanedWhere[] | undefined, StorageFailure> =>
+    Effect.gen(function* () {
+      if (!where) return undefined;
+      const def = yield* getModelDef(model);
+      const out: CleanedWhere[] = [];
+      for (const w of where) {
+        const operator = w.operator ?? "eq";
+        const connector = w.connector ?? "AND";
+        const mode = w.mode ?? "sensitive";
+        const logical = w.field;
+        const attr = logical === "id" ? undefined : def.fields[logical];
+        const physical = yield* getPhysicalField(model, logical);
 
-      let value: Where["value"] = w.value;
-      if (attr) {
-        if (Array.isArray(value)) {
-          value = (value as unknown[]).map((v) =>
-            encodeValue(attr, v),
-          ) as typeof value;
-        } else {
-          value = encodeValue(attr, value) as typeof value;
+        let value: Where["value"] = w.value;
+        if (attr) {
+          if (Array.isArray(value)) {
+            value = (value as unknown[]).map((v) => encodeValue(attr, v)) as typeof value;
+          } else {
+            value = encodeValue(attr, value) as typeof value;
+          }
         }
-      }
 
-      return {
-        operator,
-        connector,
-        mode,
-        field: physical,
-        value,
-      } satisfies CleanedWhere;
+        out.push({
+          operator,
+          connector,
+          mode,
+          field: physical,
+          value,
+        } satisfies CleanedWhere);
+      }
+      return out;
     });
-  };
 
   // ---------------------------------------------------------------------------
   // Transform skip helpers — disableTransformInput/Output let backend authors
@@ -577,10 +545,7 @@ export const createAdapter = (
           const decoded: unknown[] = [];
           for (const n of nested) {
             if (n && typeof n === "object") {
-              const t = yield* transformOutput(
-                target,
-                n as Record<string, unknown>,
-              );
+              const t = yield* transformOutput(target, n as Record<string, unknown>);
               decoded.push(t);
             } else {
               decoded.push(n);
@@ -588,10 +553,7 @@ export const createAdapter = (
           }
           merged[target] = decoded;
         } else if (typeof nested === "object") {
-          merged[target] = yield* transformOutput(
-            target,
-            nested as Record<string, unknown>,
-          );
+          merged[target] = yield* transformOutput(target, nested as Record<string, unknown>);
         } else {
           merged[target] = nested;
         }
@@ -604,9 +566,7 @@ export const createAdapter = (
     row: Record<string, unknown> | null,
     select?: string[],
   ): Effect.Effect<Record<string, unknown> | null, StorageFailure> =>
-    config.disableTransformOutput
-      ? Effect.succeed(row)
-      : transformOutput(model, row, select);
+    config.disableTransformOutput ? Effect.succeed(row) : transformOutput(model, row, select);
 
   // ---------------------------------------------------------------------------
   // DBAdapter surface
@@ -629,7 +589,7 @@ export const createAdapter = (
           data.forceAllowId === true,
         );
         const res = yield* inner.create({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           data: input,
           select: data.select,
         });
@@ -672,18 +632,14 @@ export const createAdapter = (
           );
         }
         const res = yield* inner.createMany({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           data: inputs,
         });
         const out: R[] = [];
         for (const row of res) {
           out.push(
             typedOutput<R>(
-              yield* maybeTransformOutput(
-                data.model,
-                row as Record<string, unknown>,
-                undefined,
-              ),
+              yield* maybeTransformOutput(data.model, row as Record<string, unknown>, undefined),
             ),
           );
         }
@@ -705,10 +661,10 @@ export const createAdapter = (
       join?: JoinOption | undefined;
     }) =>
       Effect.gen(function* () {
-        const where = cleanWhere(data.model, data.where) ?? [];
-        const join = data.join ? resolveJoin(data.model, data.join) : undefined;
+        const where = (yield* cleanWhere(data.model, data.where)) ?? [];
+        const join = data.join ? yield* resolveJoin(data.model, data.join) : undefined;
         const res = yield* inner.findOne<Record<string, unknown>>({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           where,
           select: data.select,
           join,
@@ -735,16 +691,16 @@ export const createAdapter = (
       join?: JoinOption | undefined;
     }) =>
       Effect.gen(function* () {
-        const where = cleanWhere(data.model, data.where);
+        const where = yield* cleanWhere(data.model, data.where);
         const sortBy = data.sortBy
           ? {
-              field: getPhysicalField(data.model, data.sortBy.field),
+              field: yield* getPhysicalField(data.model, data.sortBy.field),
               direction: data.sortBy.direction,
             }
           : undefined;
-        const join = data.join ? resolveJoin(data.model, data.join) : undefined;
+        const join = data.join ? yield* resolveJoin(data.model, data.join) : undefined;
         const res = yield* inner.findMany<Record<string, unknown>>({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           where,
           limit: data.limit,
           select: data.select,
@@ -770,9 +726,9 @@ export const createAdapter = (
 
     count: (data: { model: string; where?: Where[] | undefined }) =>
       Effect.gen(function* () {
-        const where = cleanWhere(data.model, data.where);
+        const where = yield* cleanWhere(data.model, data.where);
         return yield* inner.count({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           where,
         });
       }).pipe(
@@ -784,21 +740,12 @@ export const createAdapter = (
         }),
       ),
 
-    update: <T>(data: {
-      model: string;
-      where: Where[];
-      update: Record<string, unknown>;
-    }) =>
+    update: <T>(data: { model: string; where: Where[]; update: Record<string, unknown> }) =>
       Effect.gen(function* () {
-        const where = cleanWhere(data.model, data.where) ?? [];
-        const update = yield* maybeTransformInput(
-          data.model,
-          data.update,
-          "update",
-          false,
-        );
+        const where = (yield* cleanWhere(data.model, data.where)) ?? [];
+        const update = yield* maybeTransformInput(data.model, data.update, "update", false);
         const res = yield* inner.update<Record<string, unknown>>({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           where,
           update,
         });
@@ -813,21 +760,12 @@ export const createAdapter = (
         }),
       ),
 
-    updateMany: (data: {
-      model: string;
-      where: Where[];
-      update: Record<string, unknown>;
-    }) =>
+    updateMany: (data: { model: string; where: Where[]; update: Record<string, unknown> }) =>
       Effect.gen(function* () {
-        const where = cleanWhere(data.model, data.where) ?? [];
-        const update = yield* maybeTransformInput(
-          data.model,
-          data.update,
-          "update",
-          false,
-        );
+        const where = (yield* cleanWhere(data.model, data.where)) ?? [];
+        const update = yield* maybeTransformInput(data.model, data.update, "update", false);
         return yield* inner.updateMany({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           where,
           update,
         });
@@ -842,9 +780,9 @@ export const createAdapter = (
 
     delete: (data: { model: string; where: Where[] }) =>
       Effect.gen(function* () {
-        const where = cleanWhere(data.model, data.where) ?? [];
+        const where = (yield* cleanWhere(data.model, data.where)) ?? [];
         yield* inner.delete({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           where,
         });
       }).pipe(
@@ -858,9 +796,9 @@ export const createAdapter = (
 
     deleteMany: (data: { model: string; where: Where[] }) =>
       Effect.gen(function* () {
-        const where = cleanWhere(data.model, data.where) ?? [];
+        const where = (yield* cleanWhere(data.model, data.where)) ?? [];
         return yield* inner.deleteMany({
-          model: getModelName(data.model),
+          model: yield* getModelName(data.model),
           where,
         });
       }).pipe(
@@ -872,9 +810,7 @@ export const createAdapter = (
         }),
       ),
 
-    transaction: <R, E>(
-      callback: (trx: DBTransactionAdapter) => Effect.Effect<R, E>,
-    ) => {
+    transaction: <R, E>(callback: (trx: DBTransactionAdapter) => Effect.Effect<R, E>) => {
       const txFn = config.transaction;
       const ran = !txFn ? callback(self) : txFn(callback);
       return ran.pipe(
@@ -890,9 +826,7 @@ export const createAdapter = (
     // Forward the backend's createSchema verbatim. Upstream better-auth
     // mutates the `tables` set here to drop session when secondaryStorage
     // is set; we intentionally don't replicate that auth-specific concern.
-    createSchema: inner.createSchema
-      ? (props) => inner.createSchema!(props)
-      : undefined,
+    createSchema: inner.createSchema ? (props) => inner.createSchema!(props) : undefined,
 
     // Expose the full factory config + the inner adapter's own options to
     // plugin authors at runtime. Mirrors upstream's `options` field on

--- a/packages/core/storage-drizzle/src/adapter.ts
+++ b/packages/core/storage-drizzle/src/adapter.ts
@@ -11,7 +11,7 @@
 //     generation, encode/decode all happen in storage-core
 // ---------------------------------------------------------------------------
 
-import { Effect, Result, Schedule } from "effect";
+import { Effect, Predicate, Result, Schedule } from "effect";
 import {
   and,
   asc,
@@ -41,11 +41,7 @@ import type {
   DBSchema,
   JoinConfig,
 } from "@executor-js/storage-core";
-import {
-  StorageError,
-  UniqueViolationError,
-  createAdapter,
-} from "@executor-js/storage-core";
+import { StorageError, UniqueViolationError, createAdapter } from "@executor-js/storage-core";
 
 // Mirrors `StorageFailure` from @executor-js/storage-core/adapter — kept
 // local so we don't force a new named export on the public index. Both
@@ -59,8 +55,7 @@ type DrizzleTransactionCapable = {
   transaction: <A>(fn: (tx: unknown) => Promise<A>) => Promise<A>;
 };
 const rowAs = <T>(row: Record<string, unknown>): T => row as T;
-const rowsAs = <T>(rows: readonly Record<string, unknown>[]): T[] =>
-  rows.map(rowAs<T>);
+const rowsAs = <T>(rows: readonly Record<string, unknown>[]): T[] => rows.map(rowAs<T>);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -101,11 +96,9 @@ const ilikeOrLike = (col: AnyTable, pattern: string, provider: DrizzleProvider) 
   return sql`LOWER(${col}) LIKE LOWER(${pattern})`;
 };
 
-const insensitiveEq = (col: AnyTable, value: string) =>
-  sql`LOWER(${col}) = LOWER(${value})`;
+const insensitiveEq = (col: AnyTable, value: string) => sql`LOWER(${col}) = LOWER(${value})`;
 
-const insensitiveNe = (col: AnyTable, value: string) =>
-  sql`LOWER(${col}) <> LOWER(${value})`;
+const insensitiveNe = (col: AnyTable, value: string) => sql`LOWER(${col}) <> LOWER(${value})`;
 
 // ---------------------------------------------------------------------------
 // Where compiler — CleanedWhere[] → drizzle-orm SQL
@@ -123,109 +116,114 @@ const buildCond = (
   table: AnyTable,
   w: CleanedWhere,
   provider: DrizzleProvider,
-): SQL | undefined => {
-  const col = table[w.field];
-  if (!col) {
-    throw new Error(
-      `[storage-drizzle] unknown column "${w.field}" on drizzle table`,
-    );
-  }
-  const mode = w.mode;
-  const isInsensitive =
-    mode === "insensitive" &&
-    (typeof w.value === "string" ||
-      (Array.isArray(w.value) &&
-        (w.value as unknown[]).every((v) => typeof v === "string")));
+): Effect.Effect<SQL | undefined, StorageFailure> =>
+  Effect.gen(function* () {
+    const col = table[w.field];
+    if (!col) {
+      return yield* new StorageError({
+        message: `[storage-drizzle] unknown column "${w.field}" on drizzle table`,
+        cause: undefined,
+      });
+    }
+    const mode = w.mode;
+    const isInsensitive =
+      mode === "insensitive" &&
+      (typeof w.value === "string" ||
+        (Array.isArray(w.value) && (w.value as unknown[]).every((v) => typeof v === "string")));
 
-  switch (w.operator) {
-    case "in":
-      if (!Array.isArray(w.value))
-        throw new Error("Value must be an array for `in`");
-      if (isInsensitive) {
-        const values = w.value as readonly string[];
-        if (values.length === 0) return sql`1 = 0`;
-        const lowered = values.map((v) => v.toLowerCase());
-        return sql`LOWER(${col}) IN ${lowered}`;
-      }
-      return inArray(col, w.value as unknown[]);
-    case "not_in":
-      if (!Array.isArray(w.value))
-        throw new Error("Value must be an array for `not_in`");
-      if (isInsensitive) {
-        const values = w.value as readonly string[];
-        if (values.length === 0) return sql`1 = 1`;
-        const lowered = values.map((v) => v.toLowerCase());
-        return sql`LOWER(${col}) NOT IN ${lowered}`;
-      }
-      return notInArray(col, w.value as unknown[]);
-    case "contains":
-      if (isInsensitive && typeof w.value === "string") {
-        return ilikeOrLike(col, `%${w.value}%`, provider);
-      }
-      return like(col, `%${w.value}%`);
-    case "starts_with":
-      if (isInsensitive && typeof w.value === "string") {
-        return ilikeOrLike(col, `${w.value}%`, provider);
-      }
-      return like(col, `${w.value}%`);
-    case "ends_with":
-      if (isInsensitive && typeof w.value === "string") {
-        return ilikeOrLike(col, `%${w.value}`, provider);
-      }
-      return like(col, `%${w.value}`);
-    case "lt":
-      return lt(col, w.value);
-    case "lte":
-      return lte(col, w.value);
-    case "gt":
-      return gt(col, w.value);
-    case "gte":
-      return gte(col, w.value);
-    case "ne":
-      if (w.value === null) return isNotNull(col);
-      if (isInsensitive && typeof w.value === "string") {
-        return insensitiveNe(col, w.value);
-      }
-      return ne(col, w.value);
-    case "eq":
-    default:
-      if (w.value === null) return isNull(col);
-      if (isInsensitive && typeof w.value === "string") {
-        return insensitiveEq(col, w.value);
-      }
-      return eq(col, w.value);
-  }
-};
+    switch (w.operator) {
+      case "in":
+        if (!Array.isArray(w.value)) {
+          return yield* new StorageError({
+            message: "Value must be an array for `in`",
+            cause: w,
+          });
+        }
+        if (isInsensitive) {
+          const values = w.value as readonly string[];
+          if (values.length === 0) return sql`1 = 0`;
+          const lowered = values.map((v) => v.toLowerCase());
+          return sql`LOWER(${col}) IN ${lowered}`;
+        }
+        return inArray(col, w.value as unknown[]);
+      case "not_in":
+        if (!Array.isArray(w.value)) {
+          return yield* new StorageError({
+            message: "Value must be an array for `not_in`",
+            cause: w,
+          });
+        }
+        if (isInsensitive) {
+          const values = w.value as readonly string[];
+          if (values.length === 0) return sql`1 = 1`;
+          const lowered = values.map((v) => v.toLowerCase());
+          return sql`LOWER(${col}) NOT IN ${lowered}`;
+        }
+        return notInArray(col, w.value as unknown[]);
+      case "contains":
+        if (isInsensitive && typeof w.value === "string") {
+          return ilikeOrLike(col, `%${w.value}%`, provider);
+        }
+        return like(col, `%${w.value}%`);
+      case "starts_with":
+        if (isInsensitive && typeof w.value === "string") {
+          return ilikeOrLike(col, `${w.value}%`, provider);
+        }
+        return like(col, `${w.value}%`);
+      case "ends_with":
+        if (isInsensitive && typeof w.value === "string") {
+          return ilikeOrLike(col, `%${w.value}`, provider);
+        }
+        return like(col, `%${w.value}`);
+      case "lt":
+        return lt(col, w.value);
+      case "lte":
+        return lte(col, w.value);
+      case "gt":
+        return gt(col, w.value);
+      case "gte":
+        return gte(col, w.value);
+      case "ne":
+        if (w.value === null) return isNotNull(col);
+        if (isInsensitive && typeof w.value === "string") {
+          return insensitiveNe(col, w.value);
+        }
+        return ne(col, w.value);
+      case "eq":
+      default:
+        if (w.value === null) return isNull(col);
+        if (isInsensitive && typeof w.value === "string") {
+          return insensitiveEq(col, w.value);
+        }
+        return eq(col, w.value);
+    }
+  });
 
 const compileWhere = (
   table: AnyTable,
   where: readonly CleanedWhere[] | undefined,
   provider: DrizzleProvider,
-): SQL | undefined => {
-  if (!where || where.length === 0) return undefined;
-  if (where.length === 1) {
-    return buildCond(table, where[0]!, provider);
-  }
-  const andGroup = where.filter(
-    (w) => w.connector === "AND" || !w.connector,
-  );
-  const orGroup = where.filter((w) => w.connector === "OR");
-  const andClause =
-    andGroup.length > 0
-      ? and(...andGroup.map((w) => buildCond(table, w, provider)))
-      : undefined;
-  const orClause =
-    orGroup.length > 0
-      ? or(...orGroup.map((w) => buildCond(table, w, provider)))
-      : undefined;
-  if (andClause && orClause) return and(andClause, orClause);
-  return andClause ?? orClause;
-};
+): Effect.Effect<SQL | undefined, StorageFailure> =>
+  Effect.gen(function* () {
+    if (!where || where.length === 0) return undefined;
+    if (where.length === 1) {
+      return yield* buildCond(table, where[0]!, provider);
+    }
+    const andGroup = where.filter((w) => w.connector === "AND" || !w.connector);
+    const orGroup = where.filter((w) => w.connector === "OR");
+    const andClause =
+      andGroup.length > 0
+        ? and(...(yield* Effect.all(andGroup.map((w) => buildCond(table, w, provider)))))
+        : undefined;
+    const orClause =
+      orGroup.length > 0
+        ? or(...(yield* Effect.all(orGroup.map((w) => buildCond(table, w, provider)))))
+        : undefined;
+    if (andClause && orClause) return and(andClause, orClause);
+    return andClause ?? orClause;
+  });
 
-const rowIdentityClause = (
-  table: AnyTable,
-  row: Record<string, unknown>,
-): SQL => {
+const rowIdentityClause = (table: AnyTable, row: Record<string, unknown>): SQL => {
   const idClause = eq(table.id, row.id);
   if (table.scope_id && typeof row.scope_id === "string") {
     return and(eq(table.scope_id, row.scope_id), idClause) as SQL;
@@ -301,19 +299,23 @@ const unwrapDriverCause = (cause: unknown): unknown => {
   return cur;
 };
 
-const classifyError = (
-  op: string,
-  model: string | undefined,
-  cause: unknown,
-): StorageFailure => {
+const hasStringMessage = (value: unknown): value is { readonly message: string } =>
+  typeof value === "object" &&
+  value !== null &&
+  "message" in value &&
+  typeof value.message === "string";
+
+const readStringMessage = (value: { readonly message: string }): string => value.message;
+
+const classifyError = (op: string, model: string | undefined, cause: unknown): StorageFailure => {
   const driverCause = unwrapDriverCause(cause);
   if (isUniqueViolation(driverCause)) {
-    return model !== undefined
-      ? new UniqueViolationError({ model })
-      : new UniqueViolationError({});
+    return model !== undefined ? new UniqueViolationError({ model }) : new UniqueViolationError({});
   }
   return new StorageError({
-    message: `[storage-drizzle] ${op} failed: ${driverCause instanceof Error ? driverCause.message : String(driverCause)}`,
+    message: `[storage-drizzle] ${op} failed${
+      hasStringMessage(driverCause) ? `: ${readStringMessage(driverCause)}` : ""
+    }`,
     cause: driverCause,
   });
 };
@@ -326,8 +328,9 @@ const classifyError = (
 // retry transient errors twice with short exponential backoff. Unique
 // violations and anything else fail fast.
 export const isTransientStorageError = (err: StorageFailure): boolean => {
-  if (err._tag !== "StorageError") return false;
-  const msg = err.message;
+  if (!Predicate.isTagged(err, "StorageError")) return false;
+  if (!hasStringMessage(err)) return false;
+  const msg = readStringMessage(err);
   return (
     msg.includes("Network connection lost") ||
     msg.includes("CONNECTION_CLOSED") ||
@@ -387,21 +390,16 @@ const withReturning = (
           model,
         )) as Record<string, unknown>[];
         if (!rows[0])
-          return yield* Effect.fail(
-            new StorageError({
-              message: "[storage-drizzle] mysql insert: no row returned",
-              cause: undefined,
-            }),
-          );
+          return yield* new StorageError({
+            message: "[storage-drizzle] mysql insert: no row returned",
+            cause: undefined,
+          });
         return rows[0];
       }
-      return yield* Effect.fail(
-        new StorageError({
-          message:
-            "[storage-drizzle] mysql insert: id not provided, cannot recover row",
-          cause: undefined,
-        }),
-      );
+      return yield* new StorageError({
+        message: "[storage-drizzle] mysql insert: id not provided, cannot recover row",
+        cause: undefined,
+      });
     }
     const rows = (yield* runPromise(
       "insert returning",
@@ -409,12 +407,10 @@ const withReturning = (
       model,
     )) as Record<string, unknown>[];
     if (!rows[0])
-      return yield* Effect.fail(
-        new StorageError({
-          message: "[storage-drizzle] insert returned no rows",
-          cause: undefined,
-        }),
-      );
+      return yield* new StorageError({
+        message: "[storage-drizzle] insert returned no rows",
+        cause: undefined,
+      });
     return rows[0];
   });
 
@@ -426,15 +422,18 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
   const { db, provider } = options;
   const fullSchema: Record<string, AnyTable> = db._.fullSchema ?? {};
 
-  const getTable = (model: string): AnyTable => {
-    const t = fullSchema[model];
-    if (!t)
-      throw new Error(
-        `[storage-drizzle] unknown model "${model}" — not found in db._.fullSchema. ` +
-          `Make sure the table is exported from the generated schema and passed to drizzle().`,
-      );
-    return t;
-  };
+  const getTable = (model: string): Effect.Effect<AnyTable, StorageFailure> =>
+    Effect.gen(function* () {
+      const t = fullSchema[model];
+      if (!t)
+        return yield* new StorageError({
+          message:
+            `[storage-drizzle] unknown model "${model}" - not found in db._.fullSchema. ` +
+            `Make sure the table is exported from the generated schema and passed to drizzle().`,
+          cause: undefined,
+        });
+      return t;
+    });
 
   const backendAttrs = (model: string) => ({
     "executor.storage.backend": "drizzle" as const,
@@ -450,23 +449,16 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     data: T;
     select?: string[] | undefined;
   }) =>
-      Effect.gen(function* () {
-        const table = getTable(model);
-        const builder = db.insert(table).values(data);
-        const row = yield* withReturning(
-          db,
-          provider,
-          table,
-          builder,
-          data,
-          model,
-        );
-        return rowAs<typeof data>(row);
-      }).pipe(
-        Effect.withSpan("executor.storage.backend.create", {
-          attributes: backendAttrs(model),
-        }),
-      );
+    Effect.gen(function* () {
+      const table = yield* getTable(model);
+      const builder = db.insert(table).values(data);
+      const row = yield* withReturning(db, provider, table, builder, data, model);
+      return rowAs<typeof data>(row);
+    }).pipe(
+      Effect.withSpan("executor.storage.backend.create", {
+        attributes: backendAttrs(model),
+      }),
+    );
 
   const createMany: CustomAdapter["createMany"] = <T extends Record<string, unknown>>({
     model,
@@ -477,7 +469,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
   }) =>
     Effect.gen(function* () {
       if (data.length === 0) return [];
-      const table = getTable(model);
+      const table = yield* getTable(model);
       const CHUNK = 500;
       const all: Record<string, unknown>[] = [];
       for (let i = 0; i < data.length; i += CHUNK) {
@@ -510,8 +502,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     join?: JoinConfig | undefined;
   }) =>
     Effect.gen(function* () {
-      const table = getTable(model);
-      const clause = compileWhere(table, where, provider);
+      const table = yield* getTable(model);
+      const clause = yield* compileWhere(table, where, provider);
       if (join && db.query && db.query[model]) {
         const includes = buildIncludes(join);
         const rows = (yield* runPromise(
@@ -529,11 +521,10 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
       }
       let q = db.select().from(table);
       if (clause) q = q.where(clause);
-      const rows = (yield* runPromise(
-        "findOne select",
-        () => q.limit(1),
-        model,
-      )) as Record<string, unknown>[];
+      const rows = (yield* runPromise("findOne select", () => q.limit(1), model)) as Record<
+        string,
+        unknown
+      >[];
       return rows[0] ? rowAs<T>(rows[0]) : null;
     }).pipe(
       Effect.withSpan("executor.storage.backend.find_one", {
@@ -558,8 +549,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
     join?: JoinConfig | undefined;
   }) =>
     Effect.gen(function* () {
-      const table = getTable(model);
-      const clause = compileWhere(table, where, provider);
+      const table = yield* getTable(model);
+      const clause = yield* compileWhere(table, where, provider);
       if (join && db.query && db.query[model]) {
         const includes = buildIncludes(join);
         const opts: Record<string, unknown> = {
@@ -588,8 +579,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
         q = q.orderBy(fn(col));
       }
       if (limit !== undefined) q = q.limit(limit);
-      else if (offset !== undefined && provider === "sqlite")
-        q = q.limit(Number.MAX_SAFE_INTEGER);
+      else if (offset !== undefined && provider === "sqlite") q = q.limit(Number.MAX_SAFE_INTEGER);
       if (offset !== undefined) q = q.offset(offset);
       const rows = (yield* runPromise(
         "findMany select",
@@ -603,14 +593,18 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
       }),
     );
 
-  const updateOne: CustomAdapter["update"] = <T>({ model, where, update }: {
+  const updateOne: CustomAdapter["update"] = <T>({
+    model,
+    where,
+    update,
+  }: {
     model: string;
     where: CleanedWhere[];
     update: T;
   }) =>
     Effect.gen(function* () {
-      const table = getTable(model);
-      const clause = compileWhere(table, where, provider);
+      const table = yield* getTable(model);
+      const clause = yield* compileWhere(table, where, provider);
       let findQ = db.select().from(table);
       if (clause) findQ = findQ.where(clause);
       const matched = (yield* runPromise(
@@ -631,11 +625,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
         )) as Record<string, unknown>[];
         return rows[0] ? rowAs<T>(rows[0]) : null;
       }
-      yield* runPromise(
-        "mysql update execute",
-        () => updQ.execute(),
-        model,
-      );
+      yield* runPromise("mysql update execute", () => updQ.execute(), model);
       const reread = (yield* runPromise(
         "mysql update reread",
         () => db.select().from(table).where(identity).limit(1),
@@ -667,15 +657,13 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     count: ({ model, where }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         let q = db.select({ c: count() }).from(table);
         if (clause) q = q.where(clause);
-        const rows = (yield* runPromise(
-          "count select",
-          () => Promise.resolve(q),
-          model,
-        )) as { c: number | string | bigint }[];
+        const rows = (yield* runPromise("count select", () => Promise.resolve(q), model)) as {
+          c: number | string | bigint;
+        }[];
         const raw = rows[0]?.c ?? 0;
         return typeof raw === "number" ? raw : Number(raw);
       }).pipe(
@@ -688,8 +676,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     updateMany: ({ model, where, update }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         // Count first for the return value (sqlite's .run returns changes
         // but we don't want to rely on that in the generic path)
         let countQ = db.select({ c: count() }).from(table);
@@ -703,11 +691,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
         if (n === 0) return 0;
         let updQ = db.update(table).set(update);
         if (clause) updQ = updQ.where(clause);
-        yield* runPromise(
-          "updateMany execute",
-          () => Promise.resolve(updQ),
-          model,
-        );
+        yield* runPromise("updateMany execute", () => Promise.resolve(updQ), model);
         return n;
       }).pipe(
         Effect.withSpan("executor.storage.backend.update_many", {
@@ -717,8 +701,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     delete: ({ model, where }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         // Mirror in-memory semantics: delete first matching row only
         let findQ = db.select().from(table);
         if (clause) findQ = findQ.where(clause);
@@ -742,8 +726,8 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
 
     deleteMany: ({ model, where }) =>
       Effect.gen(function* () {
-        const table = getTable(model);
-        const clause = compileWhere(table, where, provider);
+        const table = yield* getTable(model);
+        const clause = yield* compileWhere(table, where, provider);
         let countQ = db.select({ c: count() }).from(table);
         if (clause) countQ = countQ.where(clause);
         const rows = (yield* runPromise(
@@ -755,11 +739,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
         if (n === 0) return 0;
         let delQ = db.delete(table);
         if (clause) delQ = delQ.where(clause);
-        yield* runPromise(
-          "deleteMany exec",
-          () => Promise.resolve(delQ),
-          model,
-        );
+        yield* runPromise("deleteMany exec", () => Promise.resolve(delQ), model);
         return n;
       }).pipe(
         Effect.withSpan("executor.storage.backend.delete_many", {
@@ -783,11 +763,9 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
   //   mysql: same raw-statement path as sqlite, untested in-tree.
   const txFn: DBAdapterFactoryConfig["transaction"] = options.supportsTransaction
     ? <R, E>(
-        cb: (trx: Parameters<DBAdapter["transaction"]>[0] extends (
-          t: infer T,
-        ) => unknown
-          ? T
-          : never) => Effect.Effect<R, E>,
+        cb: (
+          trx: Parameters<DBAdapter["transaction"]>[0] extends (t: infer T) => unknown ? T : never,
+        ) => Effect.Effect<R, E>,
       ) => {
         if (provider === "pg") {
           // Wrap drizzle's real transaction. The nested adapter runs
@@ -810,6 +788,7 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
                   supportsTransaction: false,
                 }) as TxShape;
                 const exit = await Effect.runPromise(Effect.result(cb(nested)));
+                // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: drizzle transaction callbacks require throwing to trigger rollback
                 if (Result.isFailure(exit)) throw new TxFailure(exit.failure);
                 return exit.success;
               }),
@@ -837,18 +816,23 @@ export const drizzleAdapter = (options: DrizzleAdapterOptions): DBAdapter => {
               ? dbAny.execute.bind(dbAny)
               : undefined;
           const runStmt = (stmt: string) =>
-            Effect.try({
-              try: () => {
-                if (!runner) {
-                  throw new Error("drizzle db has neither run() nor execute()");
-                }
-                const res = runner(sql.raw(stmt));
-                if (res && typeof (res as { then?: unknown }).then === "function") {
-                  return res as Promise<unknown>;
-                }
-                return res;
-              },
-              catch: (cause) => classifyError(stmt, undefined, cause),
+            Effect.gen(function* () {
+              if (!runner) {
+                return yield* new StorageError({
+                  message: "drizzle db has neither run() nor execute()",
+                  cause: undefined,
+                });
+              }
+              return yield* Effect.try({
+                try: () => {
+                  const res = runner(sql.raw(stmt));
+                  if (res && typeof (res as { then?: unknown }).then === "function") {
+                    return res as Promise<unknown>;
+                  }
+                  return res;
+                },
+                catch: (cause) => classifyError(stmt, undefined, cause),
+              });
             });
           const maybePromise = yield* runStmt("BEGIN");
           if (maybePromise && typeof (maybePromise as { then?: unknown }).then === "function") {


### PR DESCRIPTION
## Summary
- move storage model/table/where validation into typed StorageError failures
- parse persisted JSON fallback values through Effect Schema
- keep drizzle rollback throwing contained to the transaction adapter boundary

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/storage-core/src/factory.ts packages/core/storage-drizzle/src/adapter.ts --deny-warnings
- bunx oxfmt --check packages/core/storage-core/src/factory.ts packages/core/storage-drizzle/src/adapter.ts
- bun run --cwd packages/core/storage-core typecheck
- bun run --cwd packages/core/storage-core test
- bun run --cwd packages/core/storage-drizzle typecheck
- bun run --cwd packages/core/storage-drizzle test