### PR TITLE
Parse GraphQL store rows with Schema

### DIFF
--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "@effect/vitest";
-import { Effect } from "effect";
+import { Data, Effect } from "effect";
 
 import {
   ConnectionId,
@@ -18,6 +18,8 @@ import { graphqlPlugin } from "./plugin";
 import type { IntrospectionResult } from "./introspect";
 
 const TEST_SCOPE = "test-scope";
+
+class TestServerAddressError extends Data.TaggedError("TestServerAddressError")<{}> {}
 
 // ---------------------------------------------------------------------------
 // Mock introspection response
@@ -95,14 +97,12 @@ const makeMemorySecretsPlugin = () => {
   const provider: SecretProvider = {
     key: "memory",
     writable: true,
-    get: (id, scope) =>
-      Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
+    get: (id, scope) => Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
     set: (id, value, scope) =>
       Effect.sync(() => {
         store.set(`${scope}\u0000${id}`, value);
       }),
-    delete: (id, scope) =>
-      Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
+    delete: (id, scope) => Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
     list: () =>
       Effect.sync(() =>
         Array.from(store.keys()).map((key) => {
@@ -144,9 +144,7 @@ describe("graphqlPlugin", () => {
       const queryTool = tools.find((t) => t.id === "test_api.query.hello");
       expect(queryTool?.description).toBe("Say hello");
 
-      const mutationTool = tools.find(
-        (t) => t.id === "test_api.mutation.setGreeting",
-      );
+      const mutationTool = tools.find((t) => t.id === "test_api.mutation.setGreeting");
       expect(mutationTool?.description).toBe("Set greeting message");
     }),
   );
@@ -218,14 +216,10 @@ describe("graphqlPlugin", () => {
       });
 
       const tools = yield* executor.tools.list();
-      const mutationTool = tools.find(
-        (t) => t.id === "approval_test.mutation.setGreeting",
-      );
+      const mutationTool = tools.find((t) => t.id === "approval_test.mutation.setGreeting");
       expect(mutationTool).toBeDefined();
       expect(mutationTool!.annotations?.requiresApproval).toBe(true);
-      expect(mutationTool!.annotations?.approvalDescription).toBe(
-        "mutation setGreeting",
-      );
+      expect(mutationTool!.annotations?.approvalDescription).toBe("mutation setGreeting");
 
       const queryTool = tools.find((t) => t.id === "approval_test.query.hello");
       expect(queryTool).toBeDefined();
@@ -233,108 +227,111 @@ describe("graphqlPlugin", () => {
     }),
   );
 
-  it.effect(
-    "updateSource patches endpoint/headers without re-registering",
-    () =>
-      Effect.gen(function* () {
-        const executor = yield* createExecutor(
-          makeTestConfig({ plugins: [graphqlPlugin()] as const }),
-        );
+  it.effect("updateSource patches endpoint/headers without re-registering", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [graphqlPlugin()] as const }),
+      );
 
-        yield* executor.graphql.addSource({
-          endpoint: "http://localhost:4000/graphql",
-          scope: "test-scope",
-          introspectionJson,
-          namespace: "patched",
-        });
+      yield* executor.graphql.addSource({
+        endpoint: "http://localhost:4000/graphql",
+        scope: "test-scope",
+        introspectionJson,
+        namespace: "patched",
+      });
 
-        yield* executor.graphql.updateSource("patched", TEST_SCOPE, {
-          endpoint: "http://localhost:5000/graphql",
-          headers: { "x-custom": "abc" },
-        });
+      yield* executor.graphql.updateSource("patched", TEST_SCOPE, {
+        endpoint: "http://localhost:5000/graphql",
+        headers: { "x-custom": "abc" },
+      });
 
-        const source = yield* executor.graphql.getSource("patched", TEST_SCOPE);
-        expect(source?.endpoint).toBe("http://localhost:5000/graphql");
-        expect(source?.headers).toEqual({ "x-custom": "abc" });
+      const source = yield* executor.graphql.getSource("patched", TEST_SCOPE);
+      expect(source?.endpoint).toBe("http://localhost:5000/graphql");
+      expect(source?.headers).toEqual({ "x-custom": "abc" });
 
-        // Tools still present (no re-register happened, but they were
-        // already there from addSource and haven't been removed).
-        const tools = yield* executor.tools.list();
-        expect(tools.filter((t) => t.sourceId === "patched").length).toBe(2);
-      }),
+      // Tools still present (no re-register happened, but they were
+      // already there from addSource and haven't been removed).
+      const tools = yield* executor.tools.list();
+      expect(tools.filter((t) => t.sourceId === "patched").length).toBe(2);
+    }),
   );
 
   it.effect("invokes OAuth-backed sources with a bearer token", () =>
     Effect.gen(function* () {
       const http = yield* Effect.promise(() => import("node:http"));
       let authorizationHeader: string | null = null;
-      const server = http.createServer((req, res) => {
-        authorizationHeader = req.headers.authorization ?? null;
-        res.setHeader("content-type", "application/json");
-        res.end(JSON.stringify({ data: { hello: "Hello Ada" } }));
-      });
-      yield* Effect.callback<void, Error>((resume) => {
-        server.listen(0, "127.0.0.1", () => resume(Effect.void));
-        server.once("error", (error) => resume(Effect.fail(error)));
-      });
+      const server = yield* Effect.acquireRelease(
+        Effect.callback<
+          {
+            readonly server: ReturnType<typeof http.createServer>;
+            readonly port: number;
+          },
+          Error | TestServerAddressError
+        >((resume) => {
+          const server = http.createServer((req, res) => {
+            authorizationHeader = req.headers.authorization ?? null;
+            res.setHeader("content-type", "application/json");
+            res.end(JSON.stringify({ data: { hello: "Hello Ada" } }));
+          });
+          server.listen(0, "127.0.0.1", () => {
+            const address = server.address();
+            if (!address || typeof address === "string") {
+              resume(Effect.fail(new TestServerAddressError()));
+              return;
+            }
+            resume(Effect.succeed({ server, port: address.port }));
+          });
+          server.once("error", (error) => resume(Effect.fail(error)));
+        }),
+        ({ server }) =>
+          Effect.callback<void>((resume) => {
+            server.close(() => resume(Effect.void));
+          }).pipe(Effect.ignore),
+      );
 
-      try {
-        const address = server.address();
-        if (!address || typeof address === "string") {
-          throw new Error("Expected TCP test server address");
-        }
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
+        }),
+      );
 
-        const executor = yield* createExecutor(
-          makeTestConfig({
-            plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
+      const connectionId = ConnectionId.make("graphql-oauth2-test");
+      yield* executor.connections.create(
+        new CreateConnectionInput({
+          id: connectionId,
+          scope: ScopeId.make(TEST_SCOPE),
+          provider: "oauth2",
+          identityLabel: "GraphQL Test",
+          accessToken: new TokenMaterial({
+            secretId: SecretId.make(`${connectionId}.access_token`),
+            name: "GraphQL Access Token",
+            value: "secret-token",
           }),
-        );
+          refreshToken: null,
+          expiresAt: null,
+          oauthScope: null,
+          providerState: null,
+        }),
+      );
 
-        const connectionId = ConnectionId.make("graphql-oauth2-test");
-        yield* executor.connections.create(
-          new CreateConnectionInput({
-            id: connectionId,
-            scope: ScopeId.make(TEST_SCOPE),
-            provider: "oauth2",
-            identityLabel: "GraphQL Test",
-            accessToken: new TokenMaterial({
-              secretId: SecretId.make(`${connectionId}.access_token`),
-              name: "GraphQL Access Token",
-              value: "secret-token",
-            }),
-            refreshToken: null,
-            expiresAt: null,
-            oauthScope: null,
-            providerState: null,
-          }),
-        );
+      yield* executor.graphql.addSource({
+        endpoint: `http://127.0.0.1:${server.port}/graphql`,
+        scope: TEST_SCOPE,
+        introspectionJson,
+        namespace: "oauth_graph",
+        auth: { kind: "oauth2", connectionId },
+      });
 
-        yield* executor.graphql.addSource({
-          endpoint: `http://127.0.0.1:${address.port}/graphql`,
-          scope: TEST_SCOPE,
-          introspectionJson,
-          namespace: "oauth_graph",
-          auth: { kind: "oauth2", connectionId },
-        });
+      const result = yield* executor.tools.invoke("oauth_graph.query.hello", {
+        name: "Ada",
+      });
 
-        const result = yield* executor.tools.invoke("oauth_graph.query.hello", {
-          name: "Ada",
-        });
-
-        expect(result).toEqual({
-          status: 200,
-          data: { hello: "Hello Ada" },
-          errors: null,
-        });
-        expect(authorizationHeader).toBe("Bearer secret-token");
-      } finally {
-        yield* Effect.promise(
-          () =>
-            new Promise<void>((resolve, reject) => {
-              server.close((error) => (error ? reject(error) : resolve()));
-            }),
-        );
-      }
+      expect(result).toEqual({
+        status: 200,
+        data: { hello: "Hello Ada" },
+        errors: null,
+      });
+      expect(authorizationHeader).toBe("Bearer secret-token");
     }),
   );
 
@@ -367,12 +364,20 @@ describe("graphqlPlugin", () => {
   // scenario is reproducible against the pre-fix store.
   // -------------------------------------------------------------------------
 
-  const ORG_SCOPE = ScopeId.make("org-scope");
-  const USER_SCOPE = ScopeId.make("user-scope");
+  const ORG_SCOPE = "org-scope";
+  const USER_SCOPE = "user-scope";
 
   const stackedScopes = [
-    new Scope({ id: USER_SCOPE, name: "user", createdAt: new Date() }),
-    new Scope({ id: ORG_SCOPE, name: "org", createdAt: new Date() }),
+    new Scope({
+      id: ScopeId.make(USER_SCOPE),
+      name: "user",
+      createdAt: new Date(),
+    }),
+    new Scope({
+      id: ScopeId.make(ORG_SCOPE),
+      name: "org",
+      createdAt: new Date(),
+    }),
   ] as const;
 
   it.effect("shadowed addSource does not wipe the outer-scope source", () =>
@@ -387,7 +392,7 @@ describe("graphqlPlugin", () => {
       // Org-level base source
       yield* executor.graphql.addSource({
         endpoint: "http://org.example.com/graphql",
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "Org Source",
@@ -396,28 +401,22 @@ describe("graphqlPlugin", () => {
       // Per-user shadow with the same namespace
       yield* executor.graphql.addSource({
         endpoint: "http://user.example.com/graphql",
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "User Source",
       });
 
-      const userView = yield* executor.graphql.getSource(
-        "shared",
-        USER_SCOPE as string,
-      );
-      const orgView = yield* executor.graphql.getSource(
-        "shared",
-        ORG_SCOPE as string,
-      );
+      const userView = yield* executor.graphql.getSource("shared", USER_SCOPE);
+      const orgView = yield* executor.graphql.getSource("shared", ORG_SCOPE);
 
       // Both rows must coexist — innermost-wins reads come from the
       // executor; the store's scope-pinned getters return the exact row.
       expect(userView?.name).toBe("User Source");
-      expect(userView?.scope).toBe(USER_SCOPE as string);
+      expect(userView?.scope).toBe(USER_SCOPE);
       expect(userView?.endpoint).toBe("http://user.example.com/graphql");
       expect(orgView?.name).toBe("Org Source");
-      expect(orgView?.scope).toBe(ORG_SCOPE as string);
+      expect(orgView?.scope).toBe(ORG_SCOPE);
       expect(orgView?.endpoint).toBe("http://org.example.com/graphql");
     }),
   );
@@ -433,29 +432,23 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://org.example.com/graphql",
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "Org Source",
       });
       yield* executor.graphql.addSource({
         endpoint: "http://user.example.com/graphql",
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "User Source",
       });
 
-      yield* executor.graphql.removeSource("shared", USER_SCOPE as string);
+      yield* executor.graphql.removeSource("shared", USER_SCOPE);
 
-      const userView = yield* executor.graphql.getSource(
-        "shared",
-        USER_SCOPE as string,
-      );
-      const orgView = yield* executor.graphql.getSource(
-        "shared",
-        ORG_SCOPE as string,
-      );
+      const userView = yield* executor.graphql.getSource("shared", USER_SCOPE);
+      const orgView = yield* executor.graphql.getSource("shared", ORG_SCOPE);
 
       expect(userView).toBeNull();
       expect(orgView?.name).toBe("Org Source");
@@ -474,32 +467,26 @@ describe("graphqlPlugin", () => {
 
       yield* executor.graphql.addSource({
         endpoint: "http://org.example.com/graphql",
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "Org Source",
       });
       yield* executor.graphql.addSource({
         endpoint: "http://user.example.com/graphql",
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         introspectionJson,
         namespace: "shared",
         name: "User Source",
       });
 
-      yield* executor.graphql.updateSource("shared", USER_SCOPE as string, {
+      yield* executor.graphql.updateSource("shared", USER_SCOPE, {
         name: "User Renamed",
         endpoint: "http://user-new.example.com/graphql",
       });
 
-      const userView = yield* executor.graphql.getSource(
-        "shared",
-        USER_SCOPE as string,
-      );
-      const orgView = yield* executor.graphql.getSource(
-        "shared",
-        ORG_SCOPE as string,
-      );
+      const userView = yield* executor.graphql.getSource("shared", USER_SCOPE);
+      const orgView = yield* executor.graphql.getSource("shared", ORG_SCOPE);
 
       expect(userView?.name).toBe("User Renamed");
       expect(userView?.endpoint).toBe("http://user-new.example.com/graphql");
@@ -536,7 +523,9 @@ describe("graphqlPlugin", () => {
         scope: TEST_SCOPE,
         introspectionJson,
         namespace: "with_secret",
-        headers: { Authorization: { secretId: "api-key", prefix: "Bearer " } },
+        headers: {
+          Authorization: { secretId: "api-key", prefix: "Bearer " },
+        },
         queryParams: { token: { secretId: "api-key" } },
       });
 
@@ -575,9 +564,10 @@ describe("graphqlPlugin", () => {
       });
 
       const result = yield* executor.secrets.remove(SecretId.make("locked")).pipe(
-        Effect.flip,
+        Effect.as("removed"),
+        Effect.catchTag("SecretInUseError", () => Effect.succeed("SecretInUseError" as const)),
       );
-      expect((result as { _tag: string })._tag).toBe("SecretInUseError");
+      expect(result).toBe("SecretInUseError");
 
       // After detaching the source, remove succeeds.
       yield* executor.graphql.removeSource("ref", TEST_SCOPE);

--- a/packages/plugins/graphql/src/sdk/store.ts
+++ b/packages/plugins/graphql/src/sdk/store.ts
@@ -1,10 +1,6 @@
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 
-import {
-  defineSchema,
-  type StorageDeps,
-  type StorageFailure,
-} from "@executor-js/sdk/core";
+import { defineSchema, type StorageDeps, type StorageFailure } from "@executor-js/sdk/core";
 
 import {
   OperationBinding,
@@ -114,53 +110,63 @@ export interface StoredOperation {
   readonly binding: OperationBinding;
 }
 
-// Persisted JSON shape for an OperationBinding. Reconstructed into a
-// Schema.Class instance on read.
-interface BindingJson {
-  readonly kind: "query" | "mutation";
-  readonly fieldName: string;
-  readonly operationString: string;
-  readonly variableNames: readonly string[];
-}
-
 const decodeBinding = (value: unknown): OperationBinding => {
-  const data =
-    typeof value === "string"
-      ? (JSON.parse(value) as BindingJson)
-      : (value as BindingJson);
-  return new OperationBinding({
-    kind: data.kind,
-    fieldName: data.fieldName,
-    operationString: data.operationString,
-    variableNames: [...data.variableNames],
-  });
+  if (typeof value === "string") {
+    return Schema.decodeUnknownSync(Schema.fromJsonString(OperationBinding))(value);
+  }
+  return Schema.decodeUnknownSync(OperationBinding)(value);
 };
 
-const encodeBinding = (binding: OperationBinding): BindingJson => ({
-  kind: binding.kind,
-  fieldName: binding.fieldName,
-  operationString: binding.operationString,
-  variableNames: [...binding.variableNames],
+const encodeBinding = Schema.encodeSync(OperationBinding);
+
+const toJsonRecord = (value: unknown): Record<string, unknown> => value as Record<string, unknown>;
+
+const SourceRow = Schema.Struct({
+  id: Schema.String,
+  scope_id: Schema.String,
+  name: Schema.String,
+  endpoint: Schema.String,
+  auth_kind: Schema.Literals(["none", "oauth2"]),
+  auth_connection_id: Schema.NullOr(Schema.String).pipe(Schema.optionalKey),
 });
 
-const toJsonRecord = (value: unknown): Record<string, unknown> =>
-  value as Record<string, unknown>;
+const ChildValueRow = Schema.Struct({
+  name: Schema.String,
+  kind: Schema.Literals(["text", "secret"]),
+  text_value: Schema.NullOr(Schema.String).pipe(Schema.optionalKey),
+  secret_id: Schema.NullOr(Schema.String).pipe(Schema.optionalKey),
+  secret_prefix: Schema.NullOr(Schema.String).pipe(Schema.optionalKey),
+});
+
+const OperationRow = Schema.Struct({
+  id: Schema.String,
+  source_id: Schema.String,
+  binding: Schema.Unknown,
+});
+
+const ChildUsageRowSchema = Schema.Struct({
+  source_id: Schema.String,
+  scope_id: Schema.String,
+  name: Schema.String,
+});
+
+const decodeSourceRow = Schema.decodeUnknownSync(SourceRow);
+const decodeChildValueRow = Schema.decodeUnknownSync(ChildValueRow);
+const decodeOperationRow = Schema.decodeUnknownSync(OperationRow);
+const decodeChildUsageRow = Schema.decodeUnknownSync(ChildUsageRowSchema);
 
 // Header / query-param rows: collapse the flat columns back into a
 // `SecretBackedValue` map keyed by header name. `kind` discriminates the
 // shape; `secret_prefix` is optional and only populated when present in
 // the original config.
-const rowsToValueMap = (
-  rows: readonly Record<string, unknown>[],
-): Record<string, HeaderValue> => {
+const rowsToValueMap = (rows: readonly Record<string, unknown>[]): Record<string, HeaderValue> => {
   const out: Record<string, HeaderValue> = {};
-  for (const row of rows) {
-    const name = row.name as string;
+  for (const rawRow of rows) {
+    const row = decodeChildValueRow(rawRow);
+    const name = row.name;
     if (row.kind === "secret" && typeof row.secret_id === "string") {
-      const prefix = row.secret_prefix as string | undefined | null;
-      out[name] = prefix
-        ? { secretId: row.secret_id, prefix }
-        : { secretId: row.secret_id };
+      const prefix = row.secret_prefix;
+      out[name] = prefix ? { secretId: row.secret_id, prefix } : { secretId: row.secret_id };
     } else if (row.kind === "text" && typeof row.text_value === "string") {
       out[name] = row.text_value;
     }
@@ -201,11 +207,8 @@ const valueToChildRow = (
   };
 };
 
-const rowToAuth = (row: Record<string, unknown>): GraphqlSourceAuth => {
-  if (
-    row.auth_kind === "oauth2" &&
-    typeof row.auth_connection_id === "string"
-  ) {
+const rowToAuth = (row: typeof SourceRow.Type): GraphqlSourceAuth => {
+  if (row.auth_kind === "oauth2" && typeof row.auth_connection_id === "string") {
     return { kind: "oauth2", connectionId: row.auth_connection_id };
   }
   return { kind: "none" };
@@ -229,11 +232,7 @@ const rowToAuth = (row: Record<string, unknown>): GraphqlSourceAuth => {
 /** Flat row shape returned by the usage-lookup helpers. Mirrors the new
  *  child-table columns so callers can build a `Usage` without
  *  re-decoding. */
-export interface ChildUsageRow {
-  readonly source_id: string;
-  readonly scope_id: string;
-  readonly name: string;
-}
+export type ChildUsageRow = typeof ChildUsageRowSchema.Type;
 
 export interface GraphqlStore {
   readonly upsertSource: (
@@ -258,10 +257,7 @@ export interface GraphqlStore {
     scope: string,
   ) => Effect.Effect<StoredGraphqlSource | null, StorageFailure>;
 
-  readonly listSources: () => Effect.Effect<
-    readonly StoredGraphqlSource[],
-    StorageFailure
-  >;
+  readonly listSources: () => Effect.Effect<readonly StoredGraphqlSource[], StorageFailure>;
 
   readonly getOperationByToolId: (
     toolId: string,
@@ -273,10 +269,7 @@ export interface GraphqlStore {
     scope: string,
   ) => Effect.Effect<readonly StoredOperation[], StorageFailure>;
 
-  readonly removeSource: (
-    namespace: string,
-    scope: string,
-  ) => Effect.Effect<void, StorageFailure>;
+  readonly removeSource: (namespace: string, scope: string) => Effect.Effect<void, StorageFailure>;
 
   // ---------------------------------------------------------------------
   // Usage lookups — power `usagesForSecret` / `usagesForConnection`.
@@ -340,26 +333,30 @@ export const makeDefaultGraphqlStore = ({
     row: Record<string, unknown>,
   ): Effect.Effect<StoredGraphqlSource, StorageFailure> =>
     Effect.gen(function* () {
-      const sourceId = row.id as string;
-      const scope = row.scope_id as string;
+      const source = decodeSourceRow(row);
+      const sourceId = source.id;
+      const scope = source.scope_id;
       const headers = yield* loadHeaders(sourceId, scope);
       const queryParams = yield* loadQueryParams(sourceId, scope);
       return {
         namespace: sourceId,
         scope,
-        name: row.name as string,
-        endpoint: row.endpoint as string,
+        name: source.name,
+        endpoint: source.endpoint,
         headers,
         queryParams,
-        auth: rowToAuth(row),
+        auth: rowToAuth(source),
       };
     });
 
-  const rowToOperation = (row: Record<string, unknown>): StoredOperation => ({
-    toolId: row.id as string,
-    sourceId: row.source_id as string,
-    binding: decodeBinding(row.binding),
-  });
+  const rowToOperation = (row: Record<string, unknown>): StoredOperation => {
+    const operation = decodeOperationRow(row);
+    return {
+      toolId: operation.id,
+      sourceId: operation.source_id,
+      binding: decodeBinding(operation.binding),
+    };
+  };
 
   // Replace child rows for a source by deleting then bulk-inserting. Used
   // by both upsertSource (full rewrite) and updateSourceMeta (partial
@@ -382,9 +379,7 @@ export const makeDefaultGraphqlStore = ({
       if (entries.length === 0) return;
       yield* db.createMany({
         model,
-        data: entries.map(([name, value]) =>
-          valueToChildRow(sourceId, scope, name, value),
-        ),
+        data: entries.map(([name, value]) => valueToChildRow(sourceId, scope, name, value)),
         forceAllowId: true,
       });
     });
@@ -433,8 +428,7 @@ export const makeDefaultGraphqlStore = ({
             name: input.name,
             endpoint: input.endpoint,
             auth_kind: input.auth.kind,
-            auth_connection_id:
-              input.auth.kind === "oauth2" ? input.auth.connectionId : undefined,
+            auth_connection_id: input.auth.kind === "oauth2" ? input.auth.connectionId : undefined,
           },
           forceAllowId: true,
         });
@@ -479,8 +473,7 @@ export const makeDefaultGraphqlStore = ({
         if (patch.endpoint !== undefined) update.endpoint = patch.endpoint;
         if (patch.auth !== undefined) {
           update.auth_kind = patch.auth.kind;
-          update.auth_connection_id =
-            patch.auth.kind === "oauth2" ? patch.auth.connectionId : null;
+          update.auth_connection_id = patch.auth.kind === "oauth2" ? patch.auth.connectionId : null;
         }
         if (Object.keys(update).length > 0) {
           yield* db.update({
@@ -493,20 +486,10 @@ export const makeDefaultGraphqlStore = ({
           });
         }
         if (patch.headers !== undefined) {
-          yield* replaceChildren(
-            "graphql_source_header",
-            namespace,
-            scope,
-            patch.headers,
-          );
+          yield* replaceChildren("graphql_source_header", namespace, scope, patch.headers);
         }
         if (patch.queryParams !== undefined) {
-          yield* replaceChildren(
-            "graphql_source_query_param",
-            namespace,
-            scope,
-            patch.queryParams,
-          );
+          yield* replaceChildren("graphql_source_query_param", namespace, scope, patch.queryParams);
         }
       }),
 
@@ -561,17 +544,7 @@ export const makeDefaultGraphqlStore = ({
           model: "graphql_source_header",
           where: [{ field: "secret_id", value: secretId }],
         })
-        .pipe(
-          Effect.map((rows) =>
-            rows.map(
-              (r): ChildUsageRow => ({
-                source_id: r.source_id as string,
-                scope_id: r.scope_id as string,
-                name: r.name as string,
-              }),
-            ),
-          ),
-        ),
+        .pipe(Effect.map((rows) => rows.map((row): ChildUsageRow => decodeChildUsageRow(row)))),
 
     findQueryParamRowsBySecret: (secretId) =>
       db
@@ -579,41 +552,30 @@ export const makeDefaultGraphqlStore = ({
           model: "graphql_source_query_param",
           where: [{ field: "secret_id", value: secretId }],
         })
-        .pipe(
-          Effect.map((rows) =>
-            rows.map(
-              (r): ChildUsageRow => ({
-                source_id: r.source_id as string,
-                scope_id: r.scope_id as string,
-                name: r.name as string,
-              }),
-            ),
-          ),
-        ),
+        .pipe(Effect.map((rows) => rows.map((row): ChildUsageRow => decodeChildUsageRow(row)))),
 
     findSourcesByConnection: (connectionId) =>
       Effect.gen(function* () {
         const rows = yield* db.findMany({
           model: "graphql_source",
-          where: [
-            { field: "auth_connection_id", value: connectionId },
-          ],
+          where: [{ field: "auth_connection_id", value: connectionId }],
         });
         // Skip the children load — usage callers only need the parent
         // row's name + scope. Synthesize a minimal StoredGraphqlSource
         // shape with empty headers/params so the type matches without
         // a wasted child fetch.
-        return rows.map(
-          (row): StoredGraphqlSource => ({
-            namespace: row.id as string,
-            scope: row.scope_id as string,
-            name: row.name as string,
-            endpoint: row.endpoint as string,
+        return rows.map((rawRow): StoredGraphqlSource => {
+          const row = decodeSourceRow(rawRow);
+          return {
+            namespace: row.id,
+            scope: row.scope_id,
+            name: row.name,
+            endpoint: row.endpoint,
             headers: {},
             queryParams: {},
             auth: rowToAuth(row),
-          }),
-        );
+          };
+        });
       }),
 
     lookupSourceNames: (keys) =>
@@ -626,9 +588,10 @@ export const makeDefaultGraphqlStore = ({
         const rows = yield* db.findMany({ model: "graphql_source" });
         const requested = new Set(keys);
         const out = new Map<string, string>();
-        for (const r of rows) {
-          const key = `${r.scope_id as string}:${r.id as string}`;
-          if (requested.has(key)) out.set(key, r.name as string);
+        for (const rawRow of rows) {
+          const row = decodeSourceRow(rawRow);
+          const key = `${row.scope_id}:${row.id}`;
+          if (requested.has(key)) out.set(key, row.name);
         }
         return out;
       }),


### PR DESCRIPTION
## Summary
- decode GraphQL store rows and operation bindings with Effect Schema
- derive child usage row types from the schema
- convert plugin test cleanup to Effect acquire/release

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/graphql/src/sdk/store.ts packages/plugins/graphql/src/sdk/plugin.test.ts --deny-warnings
- bunx oxfmt --check packages/plugins/graphql/src/sdk/store.ts packages/plugins/graphql/src/sdk/plugin.test.ts
- bun run --cwd packages/plugins/graphql typecheck
- bun run --cwd packages/plugins/graphql test src/sdk/plugin.test.ts