### PR TITLE
Use promiseExit in source UI boundaries

### DIFF
--- a/apps/marketing/src/pages/api/detect.ts
+++ b/apps/marketing/src/pages/api/detect.ts
@@ -45,6 +45,7 @@ function formatTools(tools: readonly Tool[]) {
 }
 
 export const POST: APIRoute = async ({ request }) => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Astro route converts request/parsing failures to a stable HTTP response
   try {
     const body = (await request.json()) as { url?: string };
     const url = body.url?.trim();
@@ -55,6 +56,7 @@ export const POST: APIRoute = async ({ request }) => {
       });
     }
 
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform validator for request input
     try {
       new URL(url);
     } catch {
@@ -70,6 +72,7 @@ export const POST: APIRoute = async ({ request }) => {
       });
       const executor = yield* createExecutor(config);
 
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: ensure executor cleanup runs after best-effort marketing detection
       try {
         // Detect what kind of source lives at this URL
         const detected = yield* executor.sources.detect(url).pipe(Effect.timeout("10 seconds"));

--- a/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
+import { Exit, Option, Schema } from "effect";
 
 import { usePendingSources } from "@executor-js/react/api/optimistic";
 import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
@@ -95,24 +96,50 @@ type GoogleDiscoveryTemplate = GoogleDiscoveryPreset & {
 };
 
 const GOOGLE_G_ICON = "https://fonts.gstatic.com/s/i/productlogos/googleg/v6/192px.svg";
+const PublicErrorMessage = Schema.Struct({
+  _tag: Schema.Literals([
+    "GoogleDiscoveryParseError",
+    "GoogleDiscoveryOAuthError",
+    "GoogleDiscoverySourceError",
+  ]),
+  message: Schema.String,
+});
+
+const messageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string => {
+  const error = Exit.findErrorOption(exit);
+  if (Option.isNone(error)) return fallback;
+  const errorMessage = Schema.decodeUnknownOption(PublicErrorMessage)(error.value);
+  return Option.match(errorMessage, {
+    onNone: () => fallback,
+    onSome: (value) => value.message,
+  });
+};
+
+const parseUrlOption = (value: string): URL | null => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform URL parser
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+};
 
 function parseGoogleDiscoveryPreset(preset: GoogleDiscoveryPreset): GoogleDiscoveryTemplate {
-  try {
-    const url = new URL(preset.url);
-    const parts = url.pathname.split("/").filter(Boolean);
-    const apisIndex = parts.indexOf("apis");
-    const service = apisIndex >= 0 ? parts[apisIndex + 1] : undefined;
-    const version =
-      apisIndex >= 0 ? parts[apisIndex + 2] : (url.searchParams.get("version") ?? undefined);
-    return {
-      ...preset,
-      discoveryUrl: preset.url,
-      service: service ?? url.hostname.replace(/\.googleapis\.com$/, ""),
-      version: version ?? "",
-    };
-  } catch {
+  const url = parseUrlOption(preset.url);
+  if (!url) {
     return { ...preset, discoveryUrl: preset.url, service: preset.id, version: "" };
   }
+  const parts = url.pathname.split("/").filter(Boolean);
+  const apisIndex = parts.indexOf("apis");
+  const service = apisIndex >= 0 ? parts[apisIndex + 1] : undefined;
+  const version =
+    apisIndex >= 0 ? parts[apisIndex + 2] : (url.searchParams.get("version") ?? undefined);
+  return {
+    ...preset,
+    discoveryUrl: preset.url,
+    service: service ?? url.hostname.replace(/\.googleapis\.com$/, ""),
+    version: version ?? "",
+  };
 }
 
 const GOOGLE_DISCOVERY_TEMPLATES = googleDiscoveryPresets.map(parseGoogleDiscoveryPreset);
@@ -202,8 +229,8 @@ export default function AddGoogleDiscoverySource(props: {
     "google";
 
   const scopeId = useScope();
-  const doProbe = useAtomSet(probeGoogleDiscovery, { mode: "promise" });
-  const doAdd = useAtomSet(addGoogleDiscoverySource, { mode: "promise" });
+  const doProbe = useAtomSet(probeGoogleDiscovery, { mode: "promiseExit" });
+  const doAdd = useAtomSet(addGoogleDiscoverySource, { mode: "promiseExit" });
   const { beginAdd } = usePendingSources();
   const secretList = useSecretPickerSecrets();
   const oauth = useOAuthPopupFlow({
@@ -235,25 +262,26 @@ export default function AddGoogleDiscoverySource(props: {
     setError(null);
     setOauthAuth(null);
     setShowScopes(false);
-    try {
-      const result = await doProbe({
-        params: { scopeId },
-        payload: { discoveryUrl: discoveryUrl.trim() },
-      });
-      setProbe({
-        ...result,
-        scopes: [...result.scopes],
-        operations: [...result.operations],
-      });
-      if (result.scopes.length === 0) {
-        setAuthKind("none");
-      }
-    } catch (e) {
+    const exit = await doProbe({
+      params: { scopeId },
+      payload: { discoveryUrl: discoveryUrl.trim() },
+    });
+    if (Exit.isFailure(exit)) {
       setProbe(null);
-      setError(e instanceof Error ? e.message : "Failed to inspect discovery document");
-    } finally {
       setLoadingProbe(false);
+      setError(messageFromExit(exit, "Failed to inspect discovery document"));
+      return;
     }
+    const result = exit.value;
+    setProbe({
+      ...result,
+      scopes: [...result.scopes],
+      operations: [...result.operations],
+    });
+    if (result.scopes.length === 0) {
+      setAuthKind("none");
+    }
+    setLoadingProbe(false);
   }, [discoveryUrl, doProbe, scopeId]);
 
   // Keep the latest handleProbe in a ref so the debounced effect can call it
@@ -331,33 +359,32 @@ export default function AddGoogleDiscoverySource(props: {
       name: displayName,
       kind: "google-discovery",
     });
-    try {
-      await doAdd({
-        params: { scopeId },
-        payload: {
-          name: displayName,
-          discoveryUrl: discoveryUrl.trim(),
-          namespace,
-          auth:
-            authKind === "oauth2" && oauthAuth
-              ? {
-                  kind: "oauth2" as const,
-                  connectionId: oauthAuth.connectionId,
-                  clientIdSecretId: oauthAuth.clientIdSecretId,
-                  clientSecretSecretId: oauthAuth.clientSecretSecretId,
-                  scopes: oauthAuth.scopes,
-                }
-              : { kind: "none" as const },
-        },
-        reactivityKeys: [...sourceWriteKeys],
-      });
-      props.onComplete();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to add source");
+    const exit = await doAdd({
+      params: { scopeId },
+      payload: {
+        name: displayName,
+        discoveryUrl: discoveryUrl.trim(),
+        namespace,
+        auth:
+          authKind === "oauth2" && oauthAuth
+            ? {
+                kind: "oauth2" as const,
+                connectionId: oauthAuth.connectionId,
+                clientIdSecretId: oauthAuth.clientIdSecretId,
+                clientSecretSecretId: oauthAuth.clientSecretSecretId,
+                scopes: oauthAuth.scopes,
+              }
+            : { kind: "none" as const },
+      },
+      reactivityKeys: [...sourceWriteKeys],
+    });
+    placeholder.done();
+    if (Exit.isFailure(exit)) {
+      setError(messageFromExit(exit, "Failed to add source"));
       setAdding(false);
-    } finally {
-      placeholder.done();
+      return;
     }
+    props.onComplete();
   }, [
     probe,
     doAdd,

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -1,5 +1,6 @@
 import { useReducer, useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { useAtomSet } from "@effect/atom-react";
+import { Exit, Option, Schema } from "effect";
 
 import { useScope } from "@executor-js/react/api/scope-context";
 import { Button } from "@executor-js/react/components/button";
@@ -52,6 +53,21 @@ import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { usePendingSources } from "@executor-js/react/api/optimistic";
 import { probeMcpEndpoint, addMcpSource } from "./atoms";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
+
+const PublicErrorMessage = Schema.Struct({
+  _tag: Schema.Literals(["McpConnectionError", "McpToolDiscoveryError", "McpOAuthError"]),
+  message: Schema.String,
+});
+
+const messageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string => {
+  const error = Exit.findErrorOption(exit);
+  if (Option.isNone(error)) return fallback;
+  const errorMessage = Schema.decodeUnknownOption(PublicErrorMessage)(error.value);
+  return Option.match(errorMessage, {
+    onNone: () => fallback,
+    onSome: (value) => value.message,
+  });
+};
 
 // ---------------------------------------------------------------------------
 // Preset lookup
@@ -268,8 +284,8 @@ export default function AddMcpSource(props: {
   );
 
   const scopeId = useScope();
-  const doProbe = useAtomSet(probeMcpEndpoint, { mode: "promise" });
-  const doAdd = useAtomSet(addMcpSource, { mode: "promise" });
+  const doProbe = useAtomSet(probeMcpEndpoint, { mode: "promiseExit" });
+  const doAdd = useAtomSet(addMcpSource, { mode: "promiseExit" });
   const { beginAdd } = usePendingSources();
   const secretList = useSecretPickerSecrets();
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
@@ -333,24 +349,24 @@ export default function AddMcpSource(props: {
 
   const handleProbe = useCallback(async () => {
     dispatch({ type: "probe-start" });
-    try {
-      const { headers, queryParams } = serializeHttpCredentials(remoteCredentials);
-      const result = await doProbe({
-        params: { scopeId },
-        payload: {
-          endpoint: state.url.trim(),
-          ...(Object.keys(headers).length > 0 ? { headers } : {}),
-          ...(Object.keys(queryParams).length > 0 ? { queryParams } : {}),
-        },
-      });
-      setRemoteAuthMode(result.requiresOAuth ? "oauth2" : "none");
-      dispatch({ type: "probe-ok", probe: result });
-    } catch (e) {
+    const { headers, queryParams } = serializeHttpCredentials(remoteCredentials);
+    const exit = await doProbe({
+      params: { scopeId },
+      payload: {
+        endpoint: state.url.trim(),
+        ...(Object.keys(headers).length > 0 ? { headers } : {}),
+        ...(Object.keys(queryParams).length > 0 ? { queryParams } : {}),
+      },
+    });
+    if (Exit.isFailure(exit)) {
       dispatch({
         type: "probe-fail",
-        error: e instanceof Error ? e.message : "Failed to connect",
+        error: messageFromExit(exit, "Failed to connect"),
       });
+      return;
     }
+    setRemoteAuthMode(exit.value.requiresOAuth ? "oauth2" : "none");
+    dispatch({ type: "probe-ok", probe: exit.value });
   }, [state.url, scopeId, doProbe, remoteCredentials]);
 
   // Keep the latest handleProbe in a ref so the debounced effect can call it
@@ -473,33 +489,30 @@ export default function AddMcpSource(props: {
       kind: "mcp",
       url: state.url.trim(),
     });
-    try {
-      await doAdd({
-        params: { scopeId },
-        payload: {
-          transport: "remote" as const,
-          name: displayName,
-          namespace: slugNamespace || undefined,
-          endpoint: state.url.trim(),
-          auth,
-          ...(Object.keys(remoteRequestHeaders).length > 0
-            ? { headers: remoteRequestHeaders }
-            : {}),
-          ...(Object.keys(credentials.queryParams).length > 0
-            ? { queryParams: credentials.queryParams }
-            : {}),
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-      props.onComplete();
-    } catch (e) {
+    const exit = await doAdd({
+      params: { scopeId },
+      payload: {
+        transport: "remote" as const,
+        name: displayName,
+        namespace: slugNamespace || undefined,
+        endpoint: state.url.trim(),
+        auth,
+        ...(Object.keys(remoteRequestHeaders).length > 0 ? { headers: remoteRequestHeaders } : {}),
+        ...(Object.keys(credentials.queryParams).length > 0
+          ? { queryParams: credentials.queryParams }
+          : {}),
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    placeholder.done();
+    if (Exit.isFailure(exit)) {
       dispatch({
         type: "add-fail",
-        error: e instanceof Error ? e.message : "Failed to add source",
+        error: messageFromExit(exit, "Failed to add source"),
       });
-    } finally {
-      placeholder.done();
+      return;
     }
+    props.onComplete();
   }, [
     probe,
     remoteAuthMode,
@@ -553,26 +566,25 @@ export default function AddMcpSource(props: {
       name: displayName,
       kind: "mcp",
     });
-    try {
-      await doAdd({
-        params: { scopeId },
-        payload: {
-          transport: "stdio" as const,
-          name: displayName,
-          namespace: slugNamespace || undefined,
-          command: cmd,
-          args: parseStdioArgs(stdioArgs),
-          env: parseStdioEnv(stdioEnv),
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-      props.onComplete();
-    } catch (e) {
-      setStdioError(e instanceof Error ? e.message : "Failed to add source");
+    const exit = await doAdd({
+      params: { scopeId },
+      payload: {
+        transport: "stdio" as const,
+        name: displayName,
+        namespace: slugNamespace || undefined,
+        command: cmd,
+        args: parseStdioArgs(stdioArgs),
+        env: parseStdioEnv(stdioEnv),
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    placeholder.done();
+    if (Exit.isFailure(exit)) {
+      setStdioError(messageFromExit(exit, "Failed to add source"));
       setStdioAdding(false);
-    } finally {
-      placeholder.done();
+      return;
     }
+    props.onComplete();
   }, [stdioCommand, stdioArgs, stdioEnv, stdioIdentity, doAdd, scopeId, props, beginAdd]);
 
   // ---- Render ----

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
-import { Option } from "effect";
+import { Effect, Exit, Option, Schema } from "effect";
 
 import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk/core";
 import { startOAuth } from "@executor-js/react/api/atoms";
@@ -83,6 +83,31 @@ import {
 
 export const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
 export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/oauth/callback";
+const PublicErrorMessage = Schema.Struct({
+  _tag: Schema.Literals(["OpenApiParseError", "OpenApiExtractionError", "OpenApiOAuthError"]),
+  message: Schema.String,
+});
+
+const messageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string => {
+  const error = Exit.findErrorOption(exit);
+  if (Option.isNone(error)) return fallback;
+  const errorMessage = Schema.decodeUnknownOption(PublicErrorMessage)(error.value);
+  return Option.match(errorMessage, {
+    onNone: () => fallback,
+    onSome: (value) => value.message,
+  });
+};
+
+const failPromise = <A,>(message: string): Promise<A> => Effect.runPromise(Effect.fail(message));
+
+const parseUrlOption = (url: string, baseUrl?: string): URL | null => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform URL parser
+  try {
+    return baseUrl === undefined ? new URL(url) : new URL(url, baseUrl);
+  } catch {
+    return null;
+  }
+};
 
 const substituteUrlVariables = (url: string, values: Record<string, string>): string => {
   let out = url;
@@ -109,25 +134,15 @@ export const openApiOAuthConnectionId = (
  */
 export function resolveOAuthUrl(url: string, baseUrl: string): string {
   if (!url) return url;
-  try {
-    new URL(url);
+  if (parseUrlOption(url)) {
     return url;
-  } catch {
-    if (!baseUrl) return url;
-    try {
-      return new URL(url, baseUrl).toString();
-    } catch {
-      return url;
-    }
   }
+  if (!baseUrl) return url;
+  return parseUrlOption(url, baseUrl)?.toString() ?? url;
 }
 
 export function inferOAuthIssuerUrl(authorizationUrl: string): string | null {
-  try {
-    return new URL(authorizationUrl).origin;
-  } catch {
-    return null;
-  }
+  return parseUrlOption(authorizationUrl)?.origin ?? null;
 }
 
 type StrategySelection =
@@ -242,10 +257,10 @@ export default function AddOpenApiSource(props: {
 
   const scopeId = useScope();
   const userScope = useUserScope();
-  const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promise" });
-  const doAdd = useAtomSet(addOpenApiSpec, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
-  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promise" });
+  const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promiseExit" });
+  const doAdd = useAtomSet(addOpenApiSpec, { mode: "promiseExit" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
+  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promiseExit" });
   const { beginAdd } = usePendingSources();
   const secretList = useSecretPickerSecrets();
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
@@ -371,45 +386,46 @@ export default function AddOpenApiSource(props: {
     setAnalyzing(true);
     setAnalyzeError(null);
     setAddError(null);
-    try {
-      const credentials = serializeHttpCredentials(specFetchCredentials);
-      const result = await doPreview({
-        params: { scopeId },
-        payload: {
-          spec: specUrl,
-          specFetchCredentials: credentials,
-        },
-      });
-      setPreview(result);
-
-      const firstServer = result.servers[0];
-      if (firstServer) {
-        setSelectedServerIndex(0);
-        setVariableSelections(defaultSelectionsFor(firstServer));
-        setCustomBaseUrl("");
-      } else {
-        setSelectedServerIndex(-1);
-        setVariableSelections({});
-        setCustomBaseUrl("");
-      }
-
-      const firstPreset = result.headerPresets[0];
-      if (firstPreset) {
-        setStrategy({ kind: "header", presetIndex: 0 });
-        setCustomHeaders(entriesFromSpecPreset(firstPreset));
-      } else {
-        // No header presets — default to "custom" so the headers editor is
-        // visible immediately. Specs with no `security` block (e.g. Microsoft
-        // Graph) would otherwise leave the user staring at just the
-        // Authentication heading with no way to add headers.
-        setStrategy({ kind: "custom" });
-        setCustomHeaders([]);
-      }
-    } catch (e) {
-      setAnalyzeError(e instanceof Error ? e.message : "Failed to parse spec");
-    } finally {
+    const credentials = serializeHttpCredentials(specFetchCredentials);
+    const previewExit = await doPreview({
+      params: { scopeId },
+      payload: {
+        spec: specUrl,
+        specFetchCredentials: credentials,
+      },
+    });
+    if (Exit.isFailure(previewExit)) {
+      setAnalyzeError(messageFromExit(previewExit, "Failed to parse spec"));
       setAnalyzing(false);
+      return;
     }
+    const result = previewExit.value;
+    setPreview(result);
+
+    const firstServer = result.servers[0];
+    if (firstServer) {
+      setSelectedServerIndex(0);
+      setVariableSelections(defaultSelectionsFor(firstServer));
+      setCustomBaseUrl("");
+    } else {
+      setSelectedServerIndex(-1);
+      setVariableSelections({});
+      setCustomBaseUrl("");
+    }
+
+    const firstPreset = result.headerPresets[0];
+    if (firstPreset) {
+      setStrategy({ kind: "header", presetIndex: 0 });
+      setCustomHeaders(entriesFromSpecPreset(firstPreset));
+    } else {
+      // No header presets — default to "custom" so the headers editor is
+      // visible immediately. Specs with no `security` block (e.g. Microsoft
+      // Graph) would otherwise leave the user staring at just the
+      // Authentication heading with no way to add headers.
+      setStrategy({ kind: "custom" });
+      setCustomHeaders([]);
+    }
+    setAnalyzing(false);
   };
 
   handleAnalyzeRef.current = handleAnalyze;
@@ -470,122 +486,126 @@ export default function AddOpenApiSource(props: {
     if (!selectedOAuth2Preset || !oauth2ClientIdSecretId || !preview) return;
     oauth.cancel();
     setOauth2Error(null);
-    try {
-      const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
+    const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
 
-      const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
+    const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
 
-      if (selectedOAuth2Preset.flow === "clientCredentials") {
-        // RFC 6749 §4.4: no user-interactive consent step. The client_secret
-        // is mandatory; the backend exchanges tokens inline and returns a
-        // completed OAuth2Auth we can attach to the source directly.
-        if (!oauth2ClientSecretSecretId) {
-          setOauth2Error("client_credentials requires a client secret");
-          return;
-        }
-        setStartingOAuth(true);
-        const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
-        const response = await doStartOAuth({
+    if (selectedOAuth2Preset.flow === "clientCredentials") {
+      // RFC 6749 §4.4: no user-interactive consent step. The client_secret
+      // is mandatory; the backend exchanges tokens inline and returns a
+      // completed OAuth2Auth we can attach to the source directly.
+      if (!oauth2ClientSecretSecretId) {
+        setOauth2Error("client_credentials requires a client secret");
+        return;
+      }
+      setStartingOAuth(true);
+      const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
+      const startExit = await doStartOAuth({
+        params: { scopeId },
+        payload: {
+          endpoint: tokenUrl,
+          redirectUrl: tokenUrl,
+          connectionId,
+          tokenScope: scopeId,
+          strategy: {
+            kind: "client-credentials",
+            tokenEndpoint: tokenUrl,
+            clientIdSecretId: oauth2ClientIdSecretId,
+            clientSecretSecretId: oauth2ClientSecretSecretId,
+            scopes: [...oauth2SelectedScopes],
+          },
+          pluginId: "openapi",
+          identityLabel: `${displayName} OAuth`,
+        },
+      });
+      setStartingOAuth(false);
+      if (Exit.isFailure(startExit)) {
+        setOauth2Error(messageFromExit(startExit, "Failed to start OAuth"));
+        return;
+      }
+      const response = startExit.value;
+      if (!response.completedConnection) {
+        setOauth2Error("client_credentials flow did not mint a connection");
+        return;
+      }
+      setOauth2AuthState({
+        fingerprint: selectedOAuth2Fingerprint,
+        auth: new OAuth2Auth({
+          kind: "oauth2",
+          connectionId: response.completedConnection.connectionId,
+          securitySchemeName: selectedOAuth2Preset.securitySchemeName,
+          flow: "clientCredentials",
+          tokenUrl,
+          authorizationUrl: null,
+          clientIdSecretId: oauth2ClientIdSecretId,
+          clientSecretSecretId: oauth2ClientSecretSecretId,
+          scopes: [...oauth2SelectedScopes],
+        }),
+      });
+      setOauth2Error(null);
+      return;
+    }
+
+    const authorizationUrl = resolveOAuthUrl(
+      Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
+      resolvedBaseUrl,
+    );
+    const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
+
+    await oauth.openAuthorization({
+      run: async () => {
+        const startExit = await doStartOAuth({
           params: { scopeId },
           payload: {
-            endpoint: tokenUrl,
-            redirectUrl: tokenUrl,
-            connectionId,
-            tokenScope: scopeId as string,
+            endpoint: authorizationUrl,
+            connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
+            tokenScope: scopeId,
+            redirectUrl: oauth2RedirectUrl,
             strategy: {
-              kind: "client-credentials",
+              kind: "authorization-code",
+              authorizationEndpoint: authorizationUrl,
               tokenEndpoint: tokenUrl,
+              issuerUrl,
               clientIdSecretId: oauth2ClientIdSecretId,
-              clientSecretSecretId: oauth2ClientSecretSecretId,
+              clientSecretSecretId: oauth2ClientSecretSecretId ?? null,
               scopes: [...oauth2SelectedScopes],
             },
             pluginId: "openapi",
             identityLabel: `${displayName} OAuth`,
           },
         });
-        setStartingOAuth(false);
-        if (!response.completedConnection) {
-          setOauth2Error("client_credentials flow did not mint a connection");
-          return;
+        if (Exit.isFailure(startExit)) {
+          return failPromise(messageFromExit(startExit, "Failed to start OAuth"));
         }
+        const response = startExit.value;
+        if (response.authorizationUrl === null) {
+          return failPromise("Unexpected response flow from server");
+        }
+        return {
+          sessionId: response.sessionId,
+          authorizationUrl: response.authorizationUrl,
+        };
+      },
+      onSuccess: (result) => {
         setOauth2AuthState({
           fingerprint: selectedOAuth2Fingerprint,
           auth: new OAuth2Auth({
             kind: "oauth2",
-            connectionId: response.completedConnection.connectionId,
+            connectionId: result.connectionId,
             securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-            flow: "clientCredentials",
+            flow: "authorizationCode",
             tokenUrl,
-            authorizationUrl: null,
+            authorizationUrl,
+            issuerUrl,
             clientIdSecretId: oauth2ClientIdSecretId,
             clientSecretSecretId: oauth2ClientSecretSecretId,
             scopes: [...oauth2SelectedScopes],
           }),
         });
         setOauth2Error(null);
-        return;
-      }
-
-      const authorizationUrl = resolveOAuthUrl(
-        Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
-        resolvedBaseUrl,
-      );
-      const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
-
-      await oauth.openAuthorization({
-        run: async () => {
-          const response = await doStartOAuth({
-            params: { scopeId },
-            payload: {
-              endpoint: authorizationUrl,
-              connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
-              tokenScope: scopeId as string,
-              redirectUrl: oauth2RedirectUrl,
-              strategy: {
-                kind: "authorization-code",
-                authorizationEndpoint: authorizationUrl,
-                tokenEndpoint: tokenUrl,
-                issuerUrl,
-                clientIdSecretId: oauth2ClientIdSecretId,
-                clientSecretSecretId: oauth2ClientSecretSecretId ?? null,
-                scopes: [...oauth2SelectedScopes],
-              },
-              pluginId: "openapi",
-              identityLabel: `${displayName} OAuth`,
-            },
-          });
-          if (response.authorizationUrl === null) {
-            throw new Error("Unexpected response flow from server");
-          }
-          return {
-            sessionId: response.sessionId,
-            authorizationUrl: response.authorizationUrl,
-          };
-        },
-        onSuccess: (result) => {
-          setOauth2AuthState({
-            fingerprint: selectedOAuth2Fingerprint,
-            auth: new OAuth2Auth({
-              kind: "oauth2",
-              connectionId: result.connectionId,
-              securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-              flow: "authorizationCode",
-              tokenUrl,
-              authorizationUrl,
-              issuerUrl,
-              clientIdSecretId: oauth2ClientIdSecretId,
-              clientSecretSecretId: oauth2ClientSecretSecretId,
-              scopes: [...oauth2SelectedScopes],
-            }),
-          });
-          setOauth2Error(null);
-        },
-        onError: setOauth2Error,
-      });
-    } catch (e) {
-      setStartingOAuth(false);
-      setOauth2Error(e instanceof Error ? e.message : "Failed to start OAuth");
-    }
+      },
+      onError: setOauth2Error,
+    });
   }, [
     selectedOAuth2Preset,
     oauth2ClientIdSecretId,
@@ -621,103 +641,127 @@ export default function AddOpenApiSource(props: {
       kind: "openapi",
       url: resolvedBaseUrl || undefined,
     });
-    try {
-      const result = await doAdd({
+    const addExit = await doAdd({
+      params: { scopeId },
+      payload: {
+        spec: specUrl,
+        specFetchCredentials: serializeHttpCredentials(specFetchCredentials),
+        name: identity.name.trim() || undefined,
+        namespace: slugifyNamespace(identity.namespace) || undefined,
+        baseUrl: resolvedBaseUrl || undefined,
+        ...(hasHeaders ? { headers: configuredHeaders } : {}),
+        ...(Object.keys(serializeHttpCredentials(runtimeCredentials).queryParams).length > 0
+          ? { queryParams: serializeHttpCredentials(runtimeCredentials).queryParams }
+          : {}),
+        ...(configuredOAuth2 ? { oauth2: configuredOAuth2 } : {}),
+      },
+      reactivityKeys: addSpecWriteKeys,
+    });
+    if (Exit.isFailure(addExit)) {
+      placeholder.done();
+      setAddError(messageFromExit(addExit, "Failed to add source"));
+      setAdding(false);
+      return;
+    }
+
+    const sourceId = addExit.value.namespace;
+    const sourceScope = ScopeId.make(scopeId);
+    const bindingScope = ScopeId.make(userScope);
+
+    for (const binding of headerBindings) {
+      const bindingExit = await doSetBinding({
         params: { scopeId },
         payload: {
-          spec: specUrl,
-          specFetchCredentials: serializeHttpCredentials(specFetchCredentials),
-          name: identity.name.trim() || undefined,
-          namespace: slugifyNamespace(identity.namespace) || undefined,
-          baseUrl: resolvedBaseUrl || undefined,
-          ...(hasHeaders ? { headers: configuredHeaders } : {}),
-          ...(Object.keys(serializeHttpCredentials(runtimeCredentials).queryParams).length > 0
-            ? { queryParams: serializeHttpCredentials(runtimeCredentials).queryParams }
-            : {}),
-          ...(configuredOAuth2 ? { oauth2: configuredOAuth2 } : {}),
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: binding.slot,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(binding.secretId),
+          },
         },
-        reactivityKeys: addSpecWriteKeys,
+        reactivityKeys: bindingWriteKeys,
       });
-
-      const sourceId = result.namespace;
-      const sourceScope = ScopeId.make(scopeId);
-      const bindingScope = ScopeId.make(userScope);
-
-      for (const binding of headerBindings) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: binding.slot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(binding.secretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
+      if (Exit.isFailure(bindingExit)) {
+        placeholder.done();
+        setAddError(messageFromExit(bindingExit, "Failed to add source"));
+        setAdding(false);
+        return;
       }
-
-      if (configuredOAuth2 && oauth2ClientIdSecretId) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.clientIdSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientIdSecretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      if (configuredOAuth2?.clientSecretSlot && oauth2ClientSecretSecretId) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.clientSecretSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientSecretSecretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      if (configuredOAuth2 && oauth2Auth) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.connectionSlot,
-            value: {
-              kind: "connection",
-              connectionId: ConnectionId.make(oauth2Auth.connectionId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      props.onComplete();
-    } catch (e) {
-      setAddError(e instanceof Error ? e.message : "Failed to add source");
-      setAdding(false);
-    } finally {
-      placeholder.done();
     }
+
+    if (configuredOAuth2 && oauth2ClientIdSecretId) {
+      const bindingExit = await doSetBinding({
+        params: { scopeId },
+        payload: {
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: configuredOAuth2.clientIdSlot,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(oauth2ClientIdSecretId),
+          },
+        },
+        reactivityKeys: bindingWriteKeys,
+      });
+      if (Exit.isFailure(bindingExit)) {
+        placeholder.done();
+        setAddError(messageFromExit(bindingExit, "Failed to add source"));
+        setAdding(false);
+        return;
+      }
+    }
+
+    if (configuredOAuth2?.clientSecretSlot && oauth2ClientSecretSecretId) {
+      const bindingExit = await doSetBinding({
+        params: { scopeId },
+        payload: {
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: configuredOAuth2.clientSecretSlot,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(oauth2ClientSecretSecretId),
+          },
+        },
+        reactivityKeys: bindingWriteKeys,
+      });
+      if (Exit.isFailure(bindingExit)) {
+        placeholder.done();
+        setAddError(messageFromExit(bindingExit, "Failed to add source"));
+        setAdding(false);
+        return;
+      }
+    }
+
+    if (configuredOAuth2 && oauth2Auth) {
+      const bindingExit = await doSetBinding({
+        params: { scopeId },
+        payload: {
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: configuredOAuth2.connectionSlot,
+          value: {
+            kind: "connection",
+            connectionId: ConnectionId.make(oauth2Auth.connectionId),
+          },
+        },
+        reactivityKeys: bindingWriteKeys,
+      });
+      if (Exit.isFailure(bindingExit)) {
+        placeholder.done();
+        setAddError(messageFromExit(bindingExit, "Failed to add source"));
+        setAdding(false);
+        return;
+      }
+    }
+
+    placeholder.done();
+    props.onComplete();
   };
 
   // ---- Render ----

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { Effect, Exit, Option, Schema } from "effect";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
 import { connectionsAtom, sourceAtom, startOAuth } from "@executor-js/react/api/atoms";
@@ -79,11 +80,36 @@ const openApiOAuthConnectionId = (
   targetScope: ScopeId,
 ): ConnectionId =>
   ConnectionId.make(
-    `openapi-oauth-${slugify(sourceId)}-${slugify(securitySchemeName)}-${shortHash(targetScope as string)}`,
+    `openapi-oauth-${slugify(sourceId)}-${slugify(securitySchemeName)}-${shortHash(targetScope)}`,
   );
 
 const bindingSecretId = (sourceId: string, slot: string, scopeId: string): string =>
   `source-binding-${slugify(sourceId)}-${slugify(slot)}-${slugify(scopeId)}`;
+
+const PublicErrorMessage = Schema.Struct({
+  _tag: Schema.Literals(["OpenApiParseError", "OpenApiExtractionError", "OpenApiOAuthError"]),
+  message: Schema.String,
+});
+const SecretBindingValue = Schema.Struct({
+  kind: Schema.Literal("secret"),
+  secretId: Schema.String,
+});
+const ConnectionBindingValue = Schema.Struct({
+  kind: Schema.Literal("connection"),
+  connectionId: Schema.String,
+});
+
+const messageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string => {
+  const error = Exit.findErrorOption(exit);
+  if (Option.isNone(error)) return fallback;
+  const errorMessage = Schema.decodeUnknownOption(PublicErrorMessage)(error.value);
+  return Option.match(errorMessage, {
+    onNone: () => fallback,
+    onSome: (value) => value.message,
+  });
+};
+
+const failPromise = <A,>(message: string): Promise<A> => Effect.runPromise(Effect.fail(message));
 
 const effectiveClientSecretSlot = (oauth2: {
   readonly securitySchemeName: string;
@@ -101,7 +127,7 @@ const exactBindingForScope = (
 ) => rows.find((row) => row.slot === slot && row.scopeId === scopeId) ?? null;
 
 const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
-  ranks.get(scopeId as string) ?? Number.MAX_SAFE_INTEGER;
+  ranks.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
 
 const effectiveBindingForScope = (
   rows: readonly {
@@ -120,20 +146,12 @@ const effectiveBindingForScope = (
 const isSecretBindingValue = (
   value: unknown,
 ): value is Extract<OpenApiSourceBindingValue, { readonly kind: "secret" }> =>
-  typeof value === "object" &&
-  value !== null &&
-  "kind" in value &&
-  (value as { kind?: unknown }).kind === "secret" &&
-  "secretId" in value;
+  Option.isSome(Schema.decodeUnknownOption(SecretBindingValue)(value));
 
 const isConnectionBindingValue = (
   value: unknown,
 ): value is Extract<OpenApiSourceBindingValue, { readonly kind: "connection" }> =>
-  typeof value === "object" &&
-  value !== null &&
-  "kind" in value &&
-  (value as { kind?: unknown }).kind === "connection" &&
-  "connectionId" in value;
+  Option.isSome(Schema.decodeUnknownOption(ConnectionBindingValue)(value));
 
 export default function EditOpenApiSource(props: {
   readonly sourceId: string;
@@ -150,7 +168,7 @@ export default function EditOpenApiSource(props: {
   const sourceScopeId = sourceSummary?.scopeId ?? displayScope;
   const sourceScope = ScopeId.make(sourceScopeId);
   const scopeRanks = useMemo(
-    () => new Map(scopeStack.map((scope, index) => [scope.id as string, index] as const)),
+    () => new Map(scopeStack.map((scope, index) => [scope.id, index] as const)),
     [scopeStack],
   );
 
@@ -161,10 +179,10 @@ export default function EditOpenApiSource(props: {
   const connectionsResult = useAtomValue(connectionsAtom(displayScope));
   const secretList = useSecretPickerSecrets();
 
-  const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promise" });
-  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promise" });
-  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
+  const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promiseExit" });
+  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promiseExit" });
+  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, { mode: "promiseExit" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
     popupName: OPENAPI_OAUTH_POPUP_NAME,
     popupBlockedMessage: "OAuth popup was blocked by the browser",
@@ -224,28 +242,29 @@ export default function EditOpenApiSource(props: {
       const seq = ++sourceSaveSeq.current;
       setSourceSaveState("saving");
       setError(null);
-      void doUpdate({
-        params: { scopeId: ScopeId.make(sourceScopeId), namespace: props.sourceId },
-        payload: {
-          name: nextName || undefined,
-          baseUrl: nextBaseUrl || undefined,
-          headers: source.config.headers,
-          oauth2: source.config.oauth2,
-        },
-        reactivityKeys: openApiWriteKeys,
-      })
-        .then(() => {
-          if (sourceSaveSeq.current !== seq) return;
-          setSourceSaveState("saved");
-          window.setTimeout(() => {
-            if (sourceSaveSeq.current === seq) setSourceSaveState("idle");
-          }, 1600);
-        })
-        .catch((e: unknown) => {
+      void (async () => {
+        const exit = await doUpdate({
+          params: { scopeId: ScopeId.make(sourceScopeId), namespace: props.sourceId },
+          payload: {
+            name: nextName || undefined,
+            baseUrl: nextBaseUrl || undefined,
+            headers: source.config.headers,
+            oauth2: source.config.oauth2,
+          },
+          reactivityKeys: openApiWriteKeys,
+        });
+        if (Exit.isFailure(exit)) {
           if (sourceSaveSeq.current !== seq) return;
           setSourceSaveState("idle");
-          setError(e instanceof Error ? e.message : "Failed to save source details");
-        });
+          setError(messageFromExit(exit, "Failed to save source details"));
+          return;
+        }
+        if (sourceSaveSeq.current !== seq) return;
+        setSourceSaveState("saved");
+        window.setTimeout(() => {
+          if (sourceSaveSeq.current === seq) setSourceSaveState("idle");
+        }, 1600);
+      })();
     }, 600);
 
     return () => window.clearTimeout(timeout);
@@ -321,44 +340,40 @@ export default function EditOpenApiSource(props: {
     if (!trimmed) return;
     setBusyKey(inputKey);
     setError(null);
-    try {
-      await doSetBinding({
-        params: { scopeId: displayScope },
-        payload: {
-          sourceId: props.sourceId,
-          sourceScope,
-          scope: targetScope,
-          slot,
-          value: { kind: "secret", secretId: SecretId.make(trimmed) },
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save credential binding");
-    } finally {
-      setBusyKey(null);
+    const exit = await doSetBinding({
+      params: { scopeId: displayScope },
+      payload: {
+        sourceId: props.sourceId,
+        sourceScope,
+        scope: targetScope,
+        slot,
+        value: { kind: "secret", secretId: SecretId.make(trimmed) },
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(messageFromExit(exit, "Failed to save credential binding"));
     }
+    setBusyKey(null);
   };
 
   const clearBinding = async (targetScope: ScopeId, slot: string) => {
     setBusyKey(`${targetScope}:${slot}:clear`);
     setError(null);
-    try {
-      await doRemoveBinding({
-        params: { scopeId: displayScope },
-        payload: {
-          sourceId: props.sourceId,
-          sourceScope,
-          slot,
-          scope: targetScope,
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to clear credential binding");
-    } finally {
-      setBusyKey(null);
+    const exit = await doRemoveBinding({
+      params: { scopeId: displayScope },
+      payload: {
+        sourceId: props.sourceId,
+        sourceScope,
+        slot,
+        scope: targetScope,
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(messageFromExit(exit, "Failed to clear credential binding"));
     }
+    setBusyKey(null);
   };
 
   const connectOAuth = async (targetScope: ScopeId) => {
@@ -410,35 +425,109 @@ export default function EditOpenApiSource(props: {
     setPendingOAuthConnection({
       scopeId: targetScope,
       slot: oauth2.connectionSlot,
-      connectionId: connectionId as string,
+      connectionId,
     });
     setError(null);
-    try {
-      const displayName = source.name;
-      const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
-      if (oauth2.flow === "clientCredentials") {
-        const response = await doStartOAuth({
+    const displayName = source.name;
+    const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
+    if (oauth2.flow === "clientCredentials") {
+      const startExit = await doStartOAuth({
+        params: { scopeId: displayScope },
+        payload: {
+          endpoint: tokenUrl,
+          redirectUrl: tokenUrl,
+          connectionId,
+          tokenScope: targetScope,
+          strategy: {
+            kind: "client-credentials",
+            tokenEndpoint: tokenUrl,
+            clientIdSecretId,
+            clientSecretSecretId: clientSecretValue!.secretId,
+            scopes: [...oauth2.scopes],
+          },
+          pluginId: "openapi",
+          identityLabel: `${displayName} OAuth`,
+        },
+      });
+      if (Exit.isFailure(startExit)) {
+        setError(messageFromExit(startExit, "Failed to connect OAuth"));
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+        return;
+      }
+      const response = startExit.value;
+      if (!response.completedConnection) {
+        setError("Unexpected OAuth response");
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+        return;
+      }
+      const bindingExit = await doSetBinding({
+        params: { scopeId: displayScope },
+        payload: {
+          sourceId: props.sourceId,
+          sourceScope,
+          scope: targetScope,
+          slot: oauth2.connectionSlot,
+          value: {
+            kind: "connection",
+            connectionId: ConnectionId.make(response.completedConnection.connectionId),
+          },
+        },
+        reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
+      });
+      if (Exit.isFailure(bindingExit)) {
+        setError(messageFromExit(bindingExit, "Failed to connect OAuth"));
+      }
+      setPendingOAuthConnection(null);
+      setBusyKey(null);
+      return;
+    }
+
+    const authorizationUrl = resolveOAuthUrl(
+      oauth2.authorizationUrl ?? "",
+      source.config.baseUrl ?? "",
+    );
+    const issuerUrl = oauth2.issuerUrl ?? inferOAuthIssuerUrl(authorizationUrl);
+    await oauth.openAuthorization({
+      run: async () => {
+        const startExit = await doStartOAuth({
           params: { scopeId: displayScope },
           payload: {
-            endpoint: tokenUrl,
-            redirectUrl: tokenUrl,
-            connectionId: connectionId as string,
-            tokenScope: targetScope as string,
+            endpoint: authorizationUrl,
+            connectionId,
+            tokenScope: targetScope,
+            redirectUrl: oauth2RedirectUrl,
             strategy: {
-              kind: "client-credentials",
+              kind: "authorization-code",
+              authorizationEndpoint: authorizationUrl,
               tokenEndpoint: tokenUrl,
+              issuerUrl,
               clientIdSecretId,
-              clientSecretSecretId: clientSecretValue!.secretId,
+              clientSecretSecretId:
+                clientSecretBinding && isSecretBindingValue(clientSecretBinding.value)
+                  ? clientSecretBinding.value.secretId
+                  : null,
               scopes: [...oauth2.scopes],
             },
             pluginId: "openapi",
             identityLabel: `${displayName} OAuth`,
           },
         });
-        if (!response.completedConnection) {
-          throw new Error("Unexpected OAuth response");
+        if (Exit.isFailure(startExit)) {
+          return failPromise(messageFromExit(startExit, "Failed to connect OAuth"));
         }
-        await doSetBinding({
+        const response = startExit.value;
+        if (response.authorizationUrl === null) {
+          return failPromise("Unexpected OAuth response");
+        }
+        return {
+          sessionId: response.sessionId,
+          authorizationUrl: response.authorizationUrl,
+        };
+      },
+      onSuccess: async (result) => {
+        const bindingExit = await doSetBinding({
           params: { scopeId: displayScope },
           payload: {
             sourceId: props.sourceId,
@@ -447,83 +536,26 @@ export default function EditOpenApiSource(props: {
             slot: oauth2.connectionSlot,
             value: {
               kind: "connection",
-              connectionId: ConnectionId.make(response.completedConnection.connectionId),
+              connectionId: ConnectionId.make(result.connectionId),
             },
           },
           reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
         });
+        if (Exit.isFailure(bindingExit)) {
+          setError(messageFromExit(bindingExit, "Failed to connect OAuth"));
+          setPendingOAuthConnection(null);
+          setBusyKey(null);
+          return;
+        }
         setPendingOAuthConnection(null);
         setBusyKey(null);
-        return;
-      }
-
-      const authorizationUrl = resolveOAuthUrl(
-        oauth2.authorizationUrl ?? "",
-        source.config.baseUrl ?? "",
-      );
-      const issuerUrl = oauth2.issuerUrl ?? inferOAuthIssuerUrl(authorizationUrl);
-      await oauth.openAuthorization({
-        run: async () => {
-          const response = await doStartOAuth({
-            params: { scopeId: displayScope },
-            payload: {
-              endpoint: authorizationUrl,
-              connectionId: connectionId as string,
-              tokenScope: targetScope as string,
-              redirectUrl: oauth2RedirectUrl,
-              strategy: {
-                kind: "authorization-code",
-                authorizationEndpoint: authorizationUrl,
-                tokenEndpoint: tokenUrl,
-                issuerUrl,
-                clientIdSecretId,
-                clientSecretSecretId:
-                  clientSecretBinding && isSecretBindingValue(clientSecretBinding.value)
-                    ? clientSecretBinding.value.secretId
-                    : null,
-                scopes: [...oauth2.scopes],
-              },
-              pluginId: "openapi",
-              identityLabel: `${displayName} OAuth`,
-            },
-          });
-          if (response.authorizationUrl === null) {
-            throw new Error("Unexpected OAuth response");
-          }
-          return {
-            sessionId: response.sessionId,
-            authorizationUrl: response.authorizationUrl,
-          };
-        },
-        onSuccess: async (result) => {
-          await doSetBinding({
-            params: { scopeId: displayScope },
-            payload: {
-              sourceId: props.sourceId,
-              sourceScope,
-              scope: targetScope,
-              slot: oauth2.connectionSlot,
-              value: {
-                kind: "connection",
-                connectionId: ConnectionId.make(result.connectionId),
-              },
-            },
-            reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
-          });
-          setPendingOAuthConnection(null);
-          setBusyKey(null);
-        },
-        onError: (message) => {
-          setError(message);
-          setPendingOAuthConnection(null);
-          setBusyKey(null);
-        },
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to connect OAuth");
-      setPendingOAuthConnection(null);
-      setBusyKey(null);
-    }
+      },
+      onError: (message) => {
+        setError(message);
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+      },
+    });
   };
 
   return (
@@ -590,10 +622,10 @@ export default function EditOpenApiSource(props: {
               </CardStackEntryContent>
               <FilterTabs
                 tabs={credentialScopes.map((entry) => ({
-                  value: entry.scopeId as string,
+                  value: entry.scopeId,
                   label: entry.label,
                 }))}
-                value={activeCredentialScopeId as string}
+                value={activeCredentialScopeId}
                 onChange={setSelectedCredentialScope}
               />
             </CardStackEntry>
@@ -618,9 +650,9 @@ export default function EditOpenApiSource(props: {
                 isSecretBindingValue(effective.value);
               const currentSecretId =
                 exact && isSecretBindingValue(exact.value)
-                  ? (exact.value.secretId as string)
+                  ? exact.value.secretId
                   : inherited && effective && isSecretBindingValue(effective.value)
-                    ? (effective.value.secretId as string)
+                    ? effective.value.secretId
                     : null;
               return (
                 <CardStackEntryField

--- a/packages/react/src/plugins/secret-form.tsx
+++ b/packages/react/src/plugins/secret-form.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { useAtomSet } from "@effect/atom-react";
+import * as Exit from "effect/Exit";
 
 import { setSecret } from "../api/atoms";
 import { secretWriteKeys } from "../api/reactivity-keys";
@@ -25,10 +26,7 @@ import {
 } from "../components/select";
 import type { VariantProps } from "class-variance-authority";
 
-import {
-  getUniqueSecretId,
-  isSecretIdTaken,
-} from "./secret-id";
+import { getUniqueSecretId, isSecretIdTaken } from "./secret-id";
 
 // ---------------------------------------------------------------------------
 // Context
@@ -78,6 +76,7 @@ const SecretFormContext = createContext<SecretFormContextValue | null>(null);
 function useSecretForm(): SecretFormContextValue {
   const ctx = use(SecretFormContext);
   if (!ctx) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: React context invariant surfaces programmer misuse during render
     throw new Error("SecretForm parts must be rendered inside <SecretForm.Provider>");
   }
   return ctx;
@@ -110,7 +109,7 @@ function SecretFormProvider(props: SecretFormProviderProps) {
 
   const defaultScope = useScope();
   const scopeId = scopeIdProp ?? defaultScope;
-  const doSet = useAtomSet(setSecret, { mode: "promise" });
+  const doSet = useAtomSet(setSecret, { mode: "promiseExit" });
 
   const [state, setState] = useState<SecretFormState>(() => ({
     name: "",
@@ -142,27 +141,27 @@ function SecretFormProvider(props: SecretFormProviderProps) {
   const submit = async () => {
     if (!canSubmit) return;
     setState((s) => ({ ...s, status: { kind: "submitting" } }));
-    try {
-      await doSet({
-        params: { scopeId },
-        payload: {
-          id: SecretId.make(id.trim()),
-          name: displayName || id.trim(),
-          value: state.value.trim(),
-          provider: state.provider === "auto" ? undefined : state.provider,
-        },
-        reactivityKeys: secretWriteKeys,
-      });
-      onCreated(id.trim());
-    } catch (e) {
+    const exit = await doSet({
+      params: { scopeId },
+      payload: {
+        id: SecretId.make(id.trim()),
+        name: displayName || id.trim(),
+        value: state.value.trim(),
+        provider: state.provider === "auto" ? undefined : state.provider,
+      },
+      reactivityKeys: secretWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
       setState((s) => ({
         ...s,
         status: {
           kind: "error",
-          message: e instanceof Error ? e.message : "Failed to save secret",
+          message: "Failed to save secret",
         },
       }));
+      return;
     }
+    onCreated(id.trim());
   };
 
   const value: SecretFormContextValue = {
@@ -255,7 +254,9 @@ function ValueField(props: { revealable?: boolean; placeholder?: string }) {
           </Button>
         )}
       </div>
-      {errored && <FieldError>{state.status.kind === "error" ? state.status.message : ""}</FieldError>}
+      {errored && (
+        <FieldError>{state.status.kind === "error" ? state.status.message : ""}</FieldError>
+      )}
     </Field>
   );
 }


### PR DESCRIPTION
## Summary
- convert source and secret mutation handlers from promise try/catch to promiseExit
- narrow UI error display to stable fallback copy or plugin-domain errors
- keep URL parsing and Astro route handling as contained platform boundaries

## Verification
- bunx oxlint -c .oxlintrc.jsonc apps/marketing/src/pages/api/detect.ts packages/react/src/plugins/secret-form.tsx packages/plugins/openapi/src/react/AddOpenApiSource.tsx packages/plugins/openapi/src/react/EditOpenApiSource.tsx packages/plugins/mcp/src/react/AddMcpSource.tsx packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx --deny-warnings
- bunx oxfmt --check apps/marketing/src/pages/api/detect.ts packages/react/src/plugins/secret-form.tsx packages/plugins/openapi/src/react/AddOpenApiSource.tsx packages/plugins/openapi/src/react/EditOpenApiSource.tsx packages/plugins/mcp/src/react/AddMcpSource.tsx packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
- bun run --cwd packages/plugins/openapi typecheck
- bun run --cwd packages/plugins/mcp typecheck
- bun run --cwd packages/plugins/google-discovery typecheck
- bun run --cwd packages/react typecheck
- bun run --cwd apps/marketing typecheck