### PR TITLE
Fix core OAuth typed boundaries

### DIFF
--- a/packages/core/sdk/src/oauth-discovery.ts
+++ b/packages/core/sdk/src/oauth-discovery.ts
@@ -18,7 +18,7 @@
 // callers actually need.
 // ---------------------------------------------------------------------------
 
-import { Data, Effect, Result, Schema } from "effect";
+import { Data, Effect, Option, Predicate, Result, Schema } from "effect";
 import * as oauth from "oauth4webapi";
 
 import {
@@ -37,23 +37,11 @@ import {
  *  token-endpoint failures. A plugin's refresh path should never have
  *  to inspect error messages to tell "metadata drifted, re-discover"
  *  apart from "refresh token is no longer honoured". */
-export class OAuthDiscoveryError extends Data.TaggedError(
-  "OAuthDiscoveryError",
-)<{
+export class OAuthDiscoveryError extends Data.TaggedError("OAuthDiscoveryError")<{
   readonly message: string;
   readonly status?: number;
   readonly cause?: unknown;
 }> {}
-
-const discoveryError = (
-  message: string,
-  options: { status?: number; cause?: unknown } = {},
-): OAuthDiscoveryError =>
-  new OAuthDiscoveryError({
-    message,
-    status: options.status,
-    cause: options.cause,
-  });
 
 // ---------------------------------------------------------------------------
 // Schemas (narrow structural parsing — the RFCs leave many fields
@@ -61,6 +49,11 @@ const discoveryError = (
 // ---------------------------------------------------------------------------
 
 const StringArray = Schema.Array(Schema.String);
+const JsonValueSchema = Schema.fromJsonString(Schema.Unknown);
+const DcrErrorBodySchema = Schema.Struct({
+  error: Schema.NonEmptyString,
+  error_description: Schema.optional(Schema.String),
+});
 
 export const OAuthProtectedResourceMetadataSchema = Schema.Struct({
   resource: Schema.optional(Schema.String),
@@ -69,8 +62,7 @@ export const OAuthProtectedResourceMetadataSchema = Schema.Struct({
   bearer_methods_supported: Schema.optional(StringArray),
   resource_documentation: Schema.optional(Schema.String),
 }).annotate({ identifier: "OAuthProtectedResourceMetadata" });
-export type OAuthProtectedResourceMetadata =
-  typeof OAuthProtectedResourceMetadataSchema.Type;
+export type OAuthProtectedResourceMetadata = typeof OAuthProtectedResourceMetadataSchema.Type;
 
 export const OAuthAuthorizationServerMetadataSchema = Schema.Struct({
   issuer: Schema.String,
@@ -87,8 +79,7 @@ export const OAuthAuthorizationServerMetadataSchema = Schema.Struct({
   userinfo_endpoint: Schema.optional(Schema.String),
   id_token_signing_alg_values_supported: Schema.optional(StringArray),
 }).annotate({ identifier: "OAuthAuthorizationServerMetadata" });
-export type OAuthAuthorizationServerMetadata =
-  typeof OAuthAuthorizationServerMetadataSchema.Type;
+export type OAuthAuthorizationServerMetadata = typeof OAuthAuthorizationServerMetadataSchema.Type;
 
 export type DynamicClientMetadata = {
   readonly client_name?: string;
@@ -127,15 +118,9 @@ export const OAuthClientInformationSchema = Schema.Struct({
 }).annotate({ identifier: "OAuthClientInformation" });
 export type OAuthClientInformation = typeof OAuthClientInformationSchema.Type;
 
-const decodeResourceMetadata = Schema.decodeUnknownEffect(
-  OAuthProtectedResourceMetadataSchema,
-);
-const decodeAuthServerMetadata = Schema.decodeUnknownEffect(
-  OAuthAuthorizationServerMetadataSchema,
-);
-const decodeClientInformation = Schema.decodeUnknownEffect(
-  OAuthClientInformationSchema,
-);
+const decodeResourceMetadata = Schema.decodeUnknownEffect(OAuthProtectedResourceMetadataSchema);
+const decodeAuthServerMetadata = Schema.decodeUnknownEffect(OAuthAuthorizationServerMetadataSchema);
+const decodeClientInformation = Schema.decodeUnknownEffect(OAuthClientInformationSchema);
 
 export interface DiscoveryRequestOptions {
   /** Injected for tests. Defaults to the global `fetch`. */
@@ -154,21 +139,26 @@ export interface DiscoveryRequestOptions {
 
 const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version";
 
-const isLoopbackHttpUrl = (value: string): boolean => {
+const parseUrlOption = (value: string): URL | null => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform URL parser
   try {
-    const url = new URL(value);
-    if (url.protocol !== "http:") return false;
-    const hostname = url.hostname.toLowerCase();
-    return (
-      hostname === "localhost" ||
-      hostname === "0.0.0.0" ||
-      hostname === "::1" ||
-      hostname === "[::1]" ||
-      hostname.startsWith("127.")
-    );
+    return new URL(value);
   } catch {
-    return false;
+    return null;
   }
+};
+
+const isLoopbackHttpUrl = (value: string): boolean => {
+  const parsed = parseUrlOption(value);
+  if (!parsed || parsed.protocol !== "http:") return false;
+  const hostname = parsed.hostname.toLowerCase();
+  return (
+    hostname === "localhost" ||
+    hostname === "0.0.0.0" ||
+    hostname === "::1" ||
+    hostname === "[::1]" ||
+    hostname.startsWith("127.")
+  );
 };
 
 const oauth4webapiOptions = (
@@ -178,9 +168,7 @@ const oauth4webapiOptions = (
   const out: Record<string, unknown> = {};
   if (options.fetch) (out as { [customFetch]?: typeof fetch })[customFetch] = options.fetch;
   if (targetUrl && isLoopbackHttpUrl(targetUrl)) {
-    (out as { [oauth.allowInsecureRequests]?: boolean })[
-      oauth.allowInsecureRequests
-    ] = true;
+    (out as { [oauth.allowInsecureRequests]?: boolean })[oauth.allowInsecureRequests] = true;
   }
   const signal = AbortSignal.timeout(options.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS);
   out.signal = signal;
@@ -231,8 +219,7 @@ export const discoverProtectedResourceMetadata = (
   resourceUrl: string,
   options: DiscoveryRequestOptions = {},
 ): Effect.Effect<
-  | { readonly metadataUrl: string; readonly metadata: OAuthProtectedResourceMetadata }
-  | null,
+  { readonly metadataUrl: string; readonly metadata: OAuthProtectedResourceMetadata } | null,
   OAuthDiscoveryError
 > =>
   Effect.gen(function* () {
@@ -260,30 +247,35 @@ export const discoverProtectedResourceMetadata = (
           }
           const text = await response.text();
           if (text.length === 0) return "skip" as const;
-          return { status: response.status, body: JSON.parse(text) } as const;
+          return { status: response.status, body: text } as const;
         },
         catch: (cause) =>
-          discoveryError(
-            `Failed to fetch ${url}: ${cause instanceof Error ? cause.message : String(cause)}`,
-            { cause },
-          ),
+          new OAuthDiscoveryError({
+            message: `Failed to fetch ${url}`,
+            cause,
+          }),
       });
       if (result === "skip") continue;
       if (!("body" in result)) {
-        return yield* Effect.fail(
-          discoveryError(
-            `Protected resource metadata returned status ${result.status}`,
-            { status: result.status },
-          ),
-        );
+        return yield* new OAuthDiscoveryError({
+          message: `Protected resource metadata returned status ${result.status}`,
+          status: result.status,
+        });
       }
-      const metadata = yield* decodeResourceMetadata(result.body).pipe(
+      const parsedBody = yield* Schema.decodeUnknownEffect(JsonValueSchema)(result.body).pipe(
         Effect.mapError(
           (err) =>
             new OAuthDiscoveryError({
-              message: `Protected resource metadata is malformed: ${
-                Schema.isSchemaError(err) ? err.message : String(err)
-              }`,
+              message: "Protected resource metadata is malformed: invalid JSON",
+              cause: err,
+            }),
+        ),
+      );
+      const metadata = yield* decodeResourceMetadata(parsedBody).pipe(
+        Effect.mapError(
+          (err) =>
+            new OAuthDiscoveryError({
+              message: "Protected resource metadata is malformed: invalid shape",
               cause: err,
             }),
         ),
@@ -308,9 +300,7 @@ const wellKnownUrlFor = (
 ): string => {
   // Mirrors the library's own well-known composition so the URL we
   // surface matches what was actually fetched.
-  const suffix = algorithm === "oauth2"
-    ? "oauth-authorization-server"
-    : "openid-configuration";
+  const suffix = algorithm === "oauth2" ? "oauth-authorization-server" : "openid-configuration";
   return issuerPath && issuerPath !== "/"
     ? `${issuerOrigin}/.well-known/${suffix}${issuerPath}`
     : `${issuerOrigin}/.well-known/${suffix}`;
@@ -320,11 +310,10 @@ export const discoverAuthorizationServerMetadata = (
   issuer: string,
   options: DiscoveryRequestOptions = {},
 ): Effect.Effect<
-  | {
-      readonly metadataUrl: string;
-      readonly metadata: OAuthAuthorizationServerMetadata;
-    }
-  | null,
+  {
+    readonly metadataUrl: string;
+    readonly metadata: OAuthAuthorizationServerMetadata;
+  } | null,
   OAuthDiscoveryError
 > =>
   Effect.gen(function* () {
@@ -349,13 +338,11 @@ export const discoverAuthorizationServerMetadata = (
           };
         },
         catch: (cause) => {
-          if (cause instanceof OAuthDiscoveryError) return cause;
-          return discoveryError(
-            `Discovery (${algorithm}) failed for ${issuer}: ${
-              cause instanceof Error ? cause.message : String(cause)
-            }`,
-            { cause },
-          );
+          if (Predicate.isTagged("OAuthDiscoveryError")(cause)) return cause;
+          return new OAuthDiscoveryError({
+            message: `Discovery (${algorithm}) failed for ${issuer}`,
+            cause,
+          });
         },
       }).pipe(
         // If one algorithm fails mid-roundtrip (network, parse, issuer
@@ -370,9 +357,7 @@ export const discoverAuthorizationServerMetadata = (
         Effect.mapError(
           (err) =>
             new OAuthDiscoveryError({
-              message: `Authorization server metadata is malformed: ${
-                Schema.isSchemaError(err) ? err.message : String(err)
-              }`,
+              message: "Authorization server metadata is malformed: invalid shape",
               cause: err,
             }),
         ),
@@ -431,29 +416,19 @@ const buildDcrBody = (m: DynamicClientMetadata): Record<string, unknown> => {
   return body;
 };
 
-const interpretDcrFailure = (
-  status: number,
-  text: string,
-): DcrErrorBody | DcrTransport => {
+const interpretDcrFailure = (status: number, text: string): DcrErrorBody | DcrTransport => {
   // RFC 6749 error envelope: `{error, error_description?}` with 4xx.
   if (status >= 400 && status < 500) {
-    const parsed = Result.try({
-      try: () => (text ? (JSON.parse(text) as unknown) : null),
-      catch: () => null,
-    });
-    const body = Result.isSuccess(parsed) ? parsed.success : null;
-    if (
-      body &&
-      typeof body === "object" &&
-      "error" in body &&
-      typeof body.error === "string" &&
-      body.error.length > 0
-    ) {
-      const desc =
-        "error_description" in body && typeof body.error_description === "string"
-          ? body.error_description
-          : undefined;
-      return new DcrErrorBody({ status, error: body.error, error_description: desc });
+    const parsedJson = Schema.decodeUnknownOption(JsonValueSchema)(text);
+    const parsed = Option.isSome(parsedJson)
+      ? Schema.decodeUnknownOption(DcrErrorBodySchema)(parsedJson.value)
+      : Option.none();
+    if (Option.isSome(parsed)) {
+      return new DcrErrorBody({
+        status,
+        error: parsed.value.error,
+        error_description: parsed.value.error_description,
+      });
     }
   }
   return new DcrTransport({
@@ -468,10 +443,7 @@ export const registerDynamicClient = (
 ): Effect.Effect<OAuthClientInformation, OAuthDiscoveryError> =>
   Effect.gen(function* () {
     const url = new URL(input.registrationEndpoint);
-    if (
-      url.protocol !== "https:" &&
-      !isLoopbackHttpUrl(input.registrationEndpoint)
-    ) {
+    if (url.protocol !== "https:" && !isLoopbackHttpUrl(input.registrationEndpoint)) {
       return yield* new DcrTransport({
         message: `registration_endpoint must be HTTPS or a loopback HTTP URL (got ${url.protocol}//${url.host})`,
       });
@@ -497,7 +469,7 @@ export const registerDynamicClient = (
         }),
       catch: (cause) =>
         new DcrTransport({
-          message: `Dynamic Client Registration request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+          message: "Dynamic Client Registration request failed",
           cause,
         }),
     });
@@ -505,9 +477,15 @@ export const registerDynamicClient = (
     // Accept both 200 and 201 as success — RFC 7591 mandates 201, but
     // Todoist (and others) return 200 OK with the client information body.
     if (response.status !== 200 && response.status !== 201) {
-      const text = yield* Effect.promise(() =>
-        response.text().catch(() => ""),
-      );
+      const text = yield* Effect.tryPromise({
+        try: () => response.text(),
+        catch: (cause) =>
+          new DcrTransport({
+            message: "Dynamic Client Registration error response could not be read",
+            status: response.status,
+            cause,
+          }),
+      }).pipe(Effect.catchTag("DcrTransport", () => Effect.succeed("")));
       return yield* interpretDcrFailure(response.status, text);
     }
 
@@ -520,22 +498,21 @@ export const registerDynamicClient = (
           cause,
         }),
     });
-    const json = yield* Effect.try({
-      try: () => JSON.parse(text) as unknown,
-      catch: (cause) =>
-        new DcrTransport({
-          message: "Dynamic Client Registration response was not valid JSON",
-          status: response.status,
-          cause,
-        }),
-    });
+    const json = yield* Schema.decodeUnknownEffect(JsonValueSchema)(text).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DcrTransport({
+            message: "Dynamic Client Registration response was not valid JSON",
+            status: response.status,
+            cause,
+          }),
+      ),
+    );
     return yield* decodeClientInformation(json).pipe(
       Effect.mapError(
         (err) =>
           new OAuthDiscoveryError({
-            message: `Dynamic Client Registration response is malformed: ${
-              Schema.isSchemaError(err) ? err.message : String(err)
-            }`,
+            message: "Dynamic Client Registration response is malformed: invalid shape",
             cause: err,
           }),
       ),
@@ -544,16 +521,18 @@ export const registerDynamicClient = (
     Effect.catchTags({
       DcrErrorBody: (err) =>
         Effect.fail(
-          discoveryError(
-            `Dynamic Client Registration failed: ${err.error}${
+          new OAuthDiscoveryError({
+            message: `Dynamic Client Registration failed: ${err.error}${
               err.error_description ? ` — ${err.error_description}` : ""
             }`,
-            { status: err.status, cause: err },
-          ),
+            status: err.status,
+            cause: err,
+          }),
         ),
       DcrTransport: (err) =>
         Effect.fail(
-          discoveryError(`Dynamic Client Registration failed: ${err.message}`, {
+          new OAuthDiscoveryError({
+            message: "Dynamic Client Registration failed",
             status: err.status,
             cause: err.cause ?? err,
           }),
@@ -630,11 +609,10 @@ export const beginDynamicAuthorization = (
 
     const authorizationServerUrl = (() => {
       if (prior.authorizationServerUrl) return prior.authorizationServerUrl;
-      const fromResource =
-        resource && resource.metadata.authorization_servers?.[0];
+      const fromResource = resource && resource.metadata.authorization_servers?.[0];
       if (fromResource) return fromResource;
-      const u = new URL(input.endpoint);
-      return `${u.protocol}//${u.host}`;
+      const u = parseUrlOption(input.endpoint);
+      return u ? `${u.protocol}//${u.host}` : input.endpoint;
     })();
 
     const authServer =
@@ -643,35 +621,26 @@ export const beginDynamicAuthorization = (
             metadata: prior.authorizationServerMetadata,
             metadataUrl: prior.authorizationServerMetadataUrl,
           }
-        : yield* discoverAuthorizationServerMetadata(
-            authorizationServerUrl,
-            options,
-          );
+        : yield* discoverAuthorizationServerMetadata(authorizationServerUrl, options);
 
     if (!authServer) {
-      return yield* Effect.fail(
-        discoveryError(
-          `No OAuth authorization server metadata at ${authorizationServerUrl}`,
-        ),
-      );
+      return yield* new OAuthDiscoveryError({
+        message: `No OAuth authorization server metadata at ${authorizationServerUrl}`,
+      });
     }
 
     const pkceMethods = authServer.metadata.code_challenge_methods_supported ?? [];
     if (pkceMethods.length > 0 && !pkceMethods.includes("S256")) {
-      return yield* Effect.fail(
-        discoveryError(
-          `Authorization server does not support PKCE S256 (advertised: ${pkceMethods.join(", ")})`,
-        ),
-      );
+      return yield* new OAuthDiscoveryError({
+        message: `Authorization server does not support PKCE S256 (advertised: ${pkceMethods.join(", ")})`,
+      });
     }
 
     const responseTypes = authServer.metadata.response_types_supported ?? [];
     if (responseTypes.length > 0 && !responseTypes.includes("code")) {
-      return yield* Effect.fail(
-        discoveryError(
-          `Authorization server does not support response_type=code (advertised: ${responseTypes.join(", ")})`,
-        ),
-      );
+      return yield* new OAuthDiscoveryError({
+        message: `Authorization server does not support response_type=code (advertised: ${responseTypes.join(", ")})`,
+      });
     }
 
     const baseClientMetadata: DynamicClientMetadata = {
@@ -689,9 +658,10 @@ export const beginDynamicAuthorization = (
         const reg = authServer.metadata.registration_endpoint;
         if (!reg) {
           return Effect.fail(
-            discoveryError(
-              "Authorization server does not advertise registration_endpoint — cannot auto-register a client",
-            ),
+            new OAuthDiscoveryError({
+              message:
+                "Authorization server does not advertise registration_endpoint — cannot auto-register a client",
+            }),
           );
         }
         return registerDynamicClient(
@@ -701,9 +671,7 @@ export const beginDynamicAuthorization = (
       })());
 
     const codeVerifier = createPkceCodeVerifier();
-    const codeChallenge = yield* Effect.promise(() =>
-      createPkceCodeChallenge(codeVerifier),
-    );
+    const codeChallenge = yield* Effect.promise(() => createPkceCodeChallenge(codeVerifier));
     const scopes = input.scopes ?? authServer.metadata.scopes_supported ?? [];
 
     const authorizationUrl = buildAuthorizationUrl({

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -35,13 +35,9 @@
 // every strategy because refresh semantics are strategy-independent.
 // ---------------------------------------------------------------------------
 
-import { Effect, Schema } from "effect";
+import { Effect, Option, Predicate, Schema } from "effect";
 
-import type {
-  DBAdapter,
-  StorageFailure,
-  TypedAdapter,
-} from "@executor-js/storage-core";
+import type { DBAdapter, StorageFailure, TypedAdapter } from "@executor-js/storage-core";
 
 import {
   ConnectionRefreshError,
@@ -52,9 +48,7 @@ import {
   type ConnectionRefreshResult,
   type ConnectionRef,
 } from "./connections";
-import type {
-  ConnectionProviderNotRegisteredError,
-} from "./errors";
+import type { ConnectionProviderNotRegisteredError } from "./errors";
 import type { CoreSchema } from "./core-schema";
 import { ConnectionId, ScopeId, SecretId } from "./ids";
 import { SetSecretInput, type SecretRef } from "./secrets";
@@ -100,6 +94,8 @@ import {
 
 const OAuthAuthorizationServerMetadataJson = Schema.Record(Schema.String, Schema.Unknown);
 const OAuthClientInformationJson = Schema.Record(Schema.String, Schema.Unknown);
+const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown);
+const JsonValueSchema = Schema.fromJsonString(Schema.Unknown);
 
 const DynamicDcrSessionPayload = Schema.Struct({
   kind: Schema.Literal("dynamic-dcr"),
@@ -110,9 +106,7 @@ const DynamicDcrSessionPayload = Schema.Struct({
   authorizationServerMetadata: OAuthAuthorizationServerMetadataJson,
   clientInformation: OAuthClientInformationJson,
   resourceMetadataUrl: Schema.NullOr(Schema.String),
-  resourceMetadata: Schema.NullOr(
-    Schema.Record(Schema.String, Schema.Unknown),
-  ),
+  resourceMetadata: Schema.NullOr(Schema.Record(Schema.String, Schema.Unknown)),
   scopes: Schema.Array(Schema.String),
 });
 
@@ -122,7 +116,9 @@ const AuthorizationCodeSessionPayload = Schema.Struct({
   codeVerifier: Schema.String,
   authorizationEndpoint: Schema.String,
   tokenEndpoint: Schema.String,
-  issuerUrl: Schema.NullOr(Schema.String).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  issuerUrl: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefaultType(Effect.succeed(null)),
+  ),
   clientIdSecretId: Schema.String,
   clientSecretSecretId: Schema.NullOr(Schema.String),
   scopes: Schema.Array(Schema.String),
@@ -144,22 +140,22 @@ const encodeSessionPayload = Schema.encodeSync(OAuthSessionPayload);
 
 const coerceJson = (value: unknown): unknown => {
   if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
+  const parsed = Schema.decodeUnknownOption(JsonValueSchema)(value);
+  return Option.isSome(parsed) ? parsed.value : value;
 };
 
 const stringArray = (value: unknown): readonly string[] =>
-  Array.isArray(value)
-    ? value.filter((scope): scope is string => typeof scope === "string")
-    : [];
+  Array.isArray(value) ? value.filter((scope): scope is string => typeof scope === "string") : [];
 
 const originOrNull = (value: unknown): string | null => {
   if (typeof value !== "string") return null;
+  return parseUrlOption(value)?.origin ?? null;
+};
+
+const parseUrlOption = (value: string): URL | null => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform URL parser
   try {
-    return new URL(value).origin;
+    return new URL(value);
   } catch {
     return null;
   }
@@ -167,8 +163,8 @@ const originOrNull = (value: unknown): string | null => {
 
 const decodeProviderState = (value: unknown): OAuthProviderState => {
   const raw = coerceJson(value);
-  const record =
-    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
+  const decodedRecord = Schema.decodeUnknownOption(UnknownRecord)(raw);
+  const record = Option.isSome(decodedRecord) ? decodedRecord.value : null;
 
   if (record && !("kind" in record) && "flow" in record && "tokenUrl" in record) {
     const flow = record.flow;
@@ -196,12 +192,7 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
     }
   }
 
-  if (
-    record &&
-    !("kind" in record) &&
-    "clientIdSecretId" in record &&
-    "scopes" in record
-  ) {
+  if (record && !("kind" in record) && "clientIdSecretId" in record && "scopes" in record) {
     const scopes = stringArray(record.scopes);
     return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
       kind: "authorization-code",
@@ -214,48 +205,38 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
     });
   }
 
-  if (
-    record &&
-    !("kind" in record) &&
-    "clientInformation" in record &&
-    "endpoint" in record
-  ) {
-    const clientInformation =
-      record.clientInformation && typeof record.clientInformation === "object"
-        ? (record.clientInformation as Record<string, unknown>)
-        : null;
+  if (record && !("kind" in record) && "clientInformation" in record && "endpoint" in record) {
+    const decodedClientInformation = Schema.decodeUnknownOption(UnknownRecord)(
+      record.clientInformation,
+    );
+    const clientInformation = Option.isSome(decodedClientInformation)
+      ? decodedClientInformation.value
+      : null;
+    const decodedAuthorizationServerMetadata = Schema.decodeUnknownOption(UnknownRecord)(
+      record.authorizationServerMetadata,
+    );
+    const authorizationServerMetadata = Option.isSome(decodedAuthorizationServerMetadata)
+      ? decodedAuthorizationServerMetadata.value
+      : null;
     return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
       kind: "dynamic-dcr",
       tokenEndpoint:
         typeof record.tokenEndpoint === "string"
           ? record.tokenEndpoint
-          : record.authorizationServerMetadata &&
-              typeof record.authorizationServerMetadata === "object" &&
-              typeof (record.authorizationServerMetadata as Record<string, unknown>)
-                .token_endpoint === "string"
-            ? ((record.authorizationServerMetadata as Record<string, unknown>)
-                .token_endpoint as string)
+          : typeof authorizationServerMetadata?.token_endpoint === "string"
+            ? authorizationServerMetadata.token_endpoint
             : "",
       issuerUrl:
-        record.authorizationServerMetadata &&
-        typeof record.authorizationServerMetadata === "object" &&
-        typeof (record.authorizationServerMetadata as Record<string, unknown>).issuer ===
-          "string"
-          ? ((record.authorizationServerMetadata as Record<string, unknown>)
-              .issuer as string)
+        typeof authorizationServerMetadata?.issuer === "string"
+          ? authorizationServerMetadata.issuer
           : null,
       authorizationServerUrl:
-        typeof record.authorizationServerUrl === "string"
-          ? record.authorizationServerUrl
-          : null,
+        typeof record.authorizationServerUrl === "string" ? record.authorizationServerUrl : null,
       authorizationServerMetadataUrl:
         typeof record.authorizationServerMetadataUrl === "string"
           ? record.authorizationServerMetadataUrl
           : null,
-      clientId:
-        typeof clientInformation?.client_id === "string"
-          ? clientInformation.client_id
-          : "",
+      clientId: typeof clientInformation?.client_id === "string" ? clientInformation.client_id : "",
       clientSecretSecretId: null,
       clientAuth: "body",
       scope: null,
@@ -288,10 +269,7 @@ export interface OAuthServiceDeps {
    *  `complete` (and from `start` for `client-credentials`). */
   readonly connectionsCreate: (
     input: CreateConnectionInput,
-  ) => Effect.Effect<
-    ConnectionRef,
-    ConnectionProviderNotRegisteredError | StorageFailure
-  >;
+  ) => Effect.Effect<ConnectionRef, ConnectionProviderNotRegisteredError | StorageFailure>;
   /** Random session id generator. Tests override to make outputs
    *  deterministic. */
   readonly newSessionId?: () => string;
@@ -304,9 +282,9 @@ const defaultSessionId = (): string => {
   if (crypto?.randomUUID) return `oauth2_session_${crypto.randomUUID()}`;
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `oauth2_session_${Array.from(bytes, (byte) =>
-    byte.toString(16).padStart(2, "0"),
-  ).join("")}`;
+  return `oauth2_session_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )}`;
 };
 
 const secretIdPart = (value: string): string =>
@@ -328,11 +306,7 @@ const oauthSecretId = (
 const scopedSessionId = (scopeId: string, sessionId: string): string =>
   `${sessionId}_${secretIdPart(scopeId).slice(0, 24)}`;
 
-const terminalRefreshErrors = new Set([
-  "invalid_grant",
-  "invalid_client",
-  "unauthorized_client",
-]);
+const terminalRefreshErrors = new Set(["invalid_grant", "invalid_client", "unauthorized_client"]);
 
 // ---------------------------------------------------------------------------
 // Service factory
@@ -347,19 +321,16 @@ export const makeOAuth2Service = (
   // -------------------------------------------------------------------
   // probe
   // -------------------------------------------------------------------
-  const probe = (
-    input: OAuthProbeInput,
-  ): Effect.Effect<OAuthProbeResult, OAuthProbeError> =>
+  const probe = (input: OAuthProbeInput): Effect.Effect<OAuthProbeResult, OAuthProbeError> =>
     Effect.gen(function* () {
-      const resource = yield* discoverProtectedResourceMetadata(
-        input.endpoint,
-        { resourceHeaders: input.headers, resourceQueryParams: input.queryParams },
-      ).pipe(
-        Effect.catchTag("OAuthDiscoveryError", (err) =>
+      const resource = yield* discoverProtectedResourceMetadata(input.endpoint, {
+        resourceHeaders: input.headers,
+        resourceQueryParams: input.queryParams,
+      }).pipe(
+        Effect.catchTag("OAuthDiscoveryError", () =>
           Effect.fail(
             new OAuthProbeError({
-              message: `Protected resource metadata probe failed: ${err.message}`,
-
+              message: "Protected resource metadata probe failed",
             }),
           ),
         ),
@@ -368,29 +339,19 @@ export const makeOAuth2Service = (
       const authorizationServerUrl = (() => {
         const fromResource = resource?.metadata.authorization_servers?.[0];
         if (fromResource) return fromResource;
-        try {
-          const u = new URL(input.endpoint);
-          return `${u.protocol}//${u.host}`;
-        } catch {
-          return null;
-        }
+        const u = parseUrlOption(input.endpoint);
+        return u ? `${u.protocol}//${u.host}` : null;
       })();
 
       const authServer = authorizationServerUrl
-        ? yield* discoverAuthorizationServerMetadata(
-            authorizationServerUrl,
-          ).pipe(
-            Effect.catchTag("OAuthDiscoveryError", () =>
-              Effect.succeed(null),
-            ),
+        ? yield* discoverAuthorizationServerMetadata(authorizationServerUrl).pipe(
+            Effect.catchTag("OAuthDiscoveryError", () => Effect.succeed(null)),
           )
         : null;
 
       const supportsDynamicRegistration = !!(
         authServer?.metadata.registration_endpoint &&
-        (authServer.metadata.token_endpoint_auth_methods_supported ?? []).includes(
-          "none",
-        )
+        (authServer.metadata.token_endpoint_auth_methods_supported ?? []).includes("none")
       );
 
       // Bearer challenge probe — POST the endpoint unauth, look for
@@ -400,47 +361,40 @@ export const makeOAuth2Service = (
       // challenge").
       const isBearerChallengeEndpoint = yield* Effect.tryPromise({
         try: async (): Promise<boolean> => {
-          const controller = new AbortController();
-          const timer = setTimeout(() => controller.abort(), 6_000);
-          try {
-            const probeUrl = new URL(input.endpoint);
-            for (const [key, value] of Object.entries(input.queryParams ?? {})) {
-              probeUrl.searchParams.set(key, value);
-            }
-            const response = await fetch(probeUrl.toString(), {
-              method: "POST",
-              headers: {
-                ...(input.headers ?? {}),
-                "content-type": "application/json",
-                accept: "application/json, text/event-stream",
-              },
-              body: JSON.stringify({
-                jsonrpc: "2.0",
-                id: 1,
-                method: "initialize",
-                params: {
-                  protocolVersion: "2025-06-18",
-                  capabilities: {},
-                  clientInfo: { name: "executor-probe", version: "0" },
-                },
-              }),
-              signal: controller.signal,
-            });
-            if (response.status !== 401) return false;
-            const wwwAuth =
-              response.headers.get("www-authenticate") ??
-              response.headers.get("WWW-Authenticate");
-            return !!wwwAuth && /^\s*bearer\b/i.test(wwwAuth);
-          } finally {
-            clearTimeout(timer);
+          const probeUrl = parseUrlOption(input.endpoint);
+          if (!probeUrl) return false;
+          for (const [key, value] of Object.entries(input.queryParams ?? {})) {
+            probeUrl.searchParams.set(key, value);
           }
+          const response = await fetch(probeUrl.toString(), {
+            method: "POST",
+            headers: {
+              ...(input.headers ?? {}),
+              "content-type": "application/json",
+              accept: "application/json, text/event-stream",
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "initialize",
+              params: {
+                protocolVersion: "2025-06-18",
+                capabilities: {},
+                clientInfo: { name: "executor-probe", version: "0" },
+              },
+            }),
+            signal: AbortSignal.timeout(6_000),
+          });
+          if (response.status !== 401) return false;
+          const wwwAuth =
+            response.headers.get("www-authenticate") ?? response.headers.get("WWW-Authenticate");
+          return !!wwwAuth && /^\s*bearer\b/i.test(wwwAuth);
         },
         catch: () => null,
       }).pipe(Effect.catch(() => Effect.succeed(false)));
 
       return {
-        resourceMetadata:
-          (resource?.metadata as Record<string, unknown> | undefined) ?? null,
+        resourceMetadata: (resource?.metadata as Record<string, unknown> | undefined) ?? null,
         resourceMetadataUrl: resource?.metadataUrl ?? null,
         authorizationServerMetadata:
           (authServer?.metadata as Record<string, unknown> | undefined) ?? null,
@@ -459,20 +413,22 @@ export const makeOAuth2Service = (
     strategy: OAuthDynamicDcrStrategy,
   ): Effect.Effect<OAuthStartResult, OAuthStartError | StorageFailure> =>
     Effect.gen(function* () {
-      const started = yield* beginDynamicAuthorization({
-        endpoint: input.endpoint,
-        redirectUrl: input.redirectUrl,
-        state: "",
-        scopes: strategy.scopes,
-      }, {
-        resourceHeaders: input.headers,
-        resourceQueryParams: input.queryParams,
-      }).pipe(
-        Effect.catchTag("OAuthDiscoveryError", (err) =>
+      const started = yield* beginDynamicAuthorization(
+        {
+          endpoint: input.endpoint,
+          redirectUrl: input.redirectUrl,
+          state: "",
+          scopes: strategy.scopes,
+        },
+        {
+          resourceHeaders: input.headers,
+          resourceQueryParams: input.queryParams,
+        },
+      ).pipe(
+        Effect.catchTag("OAuthDiscoveryError", () =>
           Effect.fail(
             new OAuthStartError({
-              message: `Dynamic authorization setup failed: ${err.message}`,
-
+              message: "Dynamic authorization setup failed",
             }),
           ),
         ),
@@ -492,10 +448,7 @@ export const makeOAuth2Service = (
         authorizationUrl: started.state.authorizationServerMetadata.authorization_endpoint,
         clientId: started.state.clientInformation.client_id,
         redirectUrl: input.redirectUrl,
-        scopes:
-          strategy.scopes ??
-          started.state.authorizationServerMetadata.scopes_supported ??
-          [],
+        scopes: strategy.scopes ?? started.state.authorizationServerMetadata.scopes_supported ?? [],
         state: sessionId,
         codeChallenge,
       });
@@ -505,22 +458,20 @@ export const makeOAuth2Service = (
         identityLabel: input.identityLabel ?? null,
         codeVerifier: started.codeVerifier,
         authorizationServerUrl: started.state.authorizationServerUrl,
-        authorizationServerMetadataUrl:
-          started.state.authorizationServerMetadataUrl,
-        authorizationServerMetadata:
-          started.state.authorizationServerMetadata as Record<string, unknown>,
+        authorizationServerMetadataUrl: started.state.authorizationServerMetadataUrl,
+        authorizationServerMetadata: started.state.authorizationServerMetadata as Record<
+          string,
+          unknown
+        >,
         clientInformation: (() => {
           const value: unknown = started.state.clientInformation;
           return value as Record<string, unknown>;
         })(),
         resourceMetadataUrl: started.state.resourceMetadataUrl,
         resourceMetadata:
-          (started.state.resourceMetadata as Record<string, unknown> | null) ??
-          null,
+          (started.state.resourceMetadata as Record<string, unknown> | null) ?? null,
         scopes: [
-          ...(strategy.scopes ??
-            started.state.authorizationServerMetadata.scopes_supported ??
-            []),
+          ...(strategy.scopes ?? started.state.authorizationServerMetadata.scopes_supported ?? []),
         ],
       };
 
@@ -544,25 +495,22 @@ export const makeOAuth2Service = (
   ): Effect.Effect<OAuthStartResult, OAuthStartError | StorageFailure> =>
     Effect.gen(function* () {
       const clientId = yield* deps.secretsGet(strategy.clientIdSecretId).pipe(
-        Effect.mapError((err) =>
-          // Storage failure propagates; null returns aren't errors — the
-          // branch below handles them.
-          err,
+        Effect.mapError(
+          (err) =>
+            // Storage failure propagates; null returns aren't errors — the
+            // branch below handles them.
+            err,
         ),
       );
       if (clientId === null) {
-        return yield* Effect.fail(
-          new OAuthStartError({
-            message: `client_id secret "${strategy.clientIdSecretId}" not found`,
-          }),
-        );
+        return yield* new OAuthStartError({
+          message: `client_id secret "${strategy.clientIdSecretId}" not found`,
+        });
       }
 
       const sessionId = scopedSessionId(input.tokenScope, newSessionId());
       const codeVerifier = createPkceCodeVerifier();
-      const codeChallenge = yield* Effect.promise(() =>
-        createPkceCodeChallenge(codeVerifier),
-      );
+      const codeChallenge = yield* Effect.promise(() => createPkceCodeChallenge(codeVerifier));
 
       const authorizationUrl = buildAuthorizationUrl({
         authorizationUrl: strategy.authorizationEndpoint,
@@ -611,11 +559,9 @@ export const makeOAuth2Service = (
       const clientId = yield* deps.secretsGet(strategy.clientIdSecretId);
       const clientSecret = yield* deps.secretsGet(strategy.clientSecretSecretId);
       if (clientId === null || clientSecret === null) {
-        return yield* Effect.fail(
-          new OAuthStartError({
-            message: "client_id / client_secret secret not found",
-          }),
-        );
+        return yield* new OAuthStartError({
+          message: "client_id / client_secret secret not found",
+        });
       }
 
       const tokens = yield* exchangeClientCredentials({
@@ -627,18 +573,15 @@ export const makeOAuth2Service = (
         clientAuth: strategy.clientAuth ?? "body",
       }).pipe(
         Effect.mapError(
-          (err) =>
+          () =>
             new OAuthStartError({
-              message: `Client credentials exchange failed: ${err.message}`,
-
+              message: "Client credentials exchange failed",
             }),
         ),
       );
 
       const expiresAt =
-        typeof tokens.expires_in === "number"
-          ? now() + tokens.expires_in * 1000
-          : null;
+        typeof tokens.expires_in === "number" ? now() + tokens.expires_in * 1000 : null;
 
       const providerState: OAuthProviderState = {
         kind: "client-credentials",
@@ -666,19 +609,17 @@ export const makeOAuth2Service = (
             refreshToken: null,
             expiresAt,
             oauthScope: tokens.scope ?? null,
-            providerState: Schema.encodeSync(OAuthProviderStateSchema)(
-              providerState,
-            ) as Record<string, unknown>,
+            providerState: Schema.encodeSync(OAuthProviderStateSchema)(providerState) as Record<
+              string,
+              unknown
+            >,
           }),
         )
         .pipe(
           Effect.mapError(
-            (err) =>
+            () =>
               new OAuthStartError({
-                message: `Failed to mint connection: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-
+                message: "Failed to mint connection",
               }),
           ),
         );
@@ -709,22 +650,24 @@ export const makeOAuth2Service = (
     payload: OAuthSessionPayload;
     strategyKind: string;
   }): Effect.Effect<void, StorageFailure> =>
-    deps.adapter.create({
-      model: "oauth2_session",
-      data: {
-        id: args.sessionId,
-        scope_id: args.input.tokenScope,
-        plugin_id: args.input.pluginId,
-        strategy: args.strategyKind,
-        connection_id: args.input.connectionId,
-        token_scope: args.input.tokenScope,
-        redirect_url: args.input.redirectUrl,
-        payload: encodeSessionPayload(args.payload) as Record<string, unknown>,
-        expires_at: now() + OAUTH2_SESSION_TTL_MS,
-        created_at: new Date(),
-      },
-      forceAllowId: true,
-    }).pipe(Effect.asVoid);
+    deps.adapter
+      .create({
+        model: "oauth2_session",
+        data: {
+          id: args.sessionId,
+          scope_id: args.input.tokenScope,
+          plugin_id: args.input.pluginId,
+          strategy: args.strategyKind,
+          connection_id: args.input.connectionId,
+          token_scope: args.input.tokenScope,
+          redirect_url: args.input.redirectUrl,
+          payload: encodeSessionPayload(args.payload) as Record<string, unknown>,
+          expires_at: now() + OAUTH2_SESSION_TTL_MS,
+          created_at: new Date(),
+        },
+        forceAllowId: true,
+      })
+      .pipe(Effect.asVoid);
 
   // -------------------------------------------------------------------
   // complete — exchange the code, mint the Connection, delete the session
@@ -741,53 +684,45 @@ export const makeOAuth2Service = (
         where: [{ field: "id", value: input.state }],
       });
       if (!row) {
-        return yield* Effect.fail(
-          new OAuthSessionNotFoundError({ sessionId: input.state }),
-        );
+        return yield* new OAuthSessionNotFoundError({ sessionId: input.state });
       }
 
       const deleteSession = deps.adapter.delete({
         model: "oauth2_session",
         where: [
           { field: "id", value: input.state },
-          { field: "scope_id", value: row.scope_id as string },
+          { field: "scope_id", value: row.scope_id },
         ],
       });
 
       if (input.error) {
         yield* deleteSession;
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: `Authorization server returned error: ${input.error}`,
-            code: input.error,
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: `Authorization server returned error: ${input.error}`,
+          code: input.error,
+        });
       }
       if (!input.code) {
         yield* deleteSession;
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: "Missing authorization code",
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: "Missing authorization code",
+        });
       }
       const expiresAt = Number(row.expires_at as number | bigint);
       if (expiresAt <= now()) {
         yield* deleteSession;
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: "OAuth session expired",
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: "OAuth session expired",
+        });
       }
 
       const payload = decodeSessionPayload(coerceJson(row.payload));
       const endpoint = ""; // not stored on the row — the payload's own
-                          // endpoint fields drive exchange; we just need
-                          // a display string for the identity label.
-      const connectionId = row.connection_id as string;
-      const tokenScope = row.token_scope as string;
-      const redirectUrl = row.redirect_url as string;
+      // endpoint fields drive exchange; we just need
+      // a display string for the identity label.
+      const connectionId = row.connection_id;
+      const tokenScope = row.token_scope;
+      const redirectUrl = row.redirect_url;
 
       // Dispatch to the strategy-specific exchange.
       const exchangeResult = yield* (() => {
@@ -795,11 +730,7 @@ export const makeOAuth2Service = (
           case "dynamic-dcr":
             return exchangeDynamicDcr(payload, input.code, redirectUrl);
           case "authorization-code":
-            return exchangeAuthorizationCodeStrategy(
-              payload,
-              input.code,
-              redirectUrl,
-            );
+            return exchangeAuthorizationCodeStrategy(payload, input.code, redirectUrl);
         }
       })().pipe(Effect.tapError(() => deleteSession));
 
@@ -828,11 +759,9 @@ export const makeOAuth2Service = (
           .pipe(
             Effect.as(secretId),
             Effect.mapError(
-              (err) =>
+              () =>
                 new OAuthCompleteError({
-                  message: `Failed to persist DCR client_secret: ${
-                    err instanceof Error ? err.message : String(err)
-                  }`,
+                  message: "Failed to persist DCR client_secret",
                 }),
             ),
           );
@@ -842,21 +771,21 @@ export const makeOAuth2Service = (
         payload.kind === "dynamic-dcr"
           ? {
               kind: "dynamic-dcr",
-              tokenEndpoint: (payload.authorizationServerMetadata as {
-                token_endpoint: string;
-              }).token_endpoint,
+              tokenEndpoint: (
+                payload.authorizationServerMetadata as {
+                  token_endpoint: string;
+                }
+              ).token_endpoint,
               issuerUrl:
-                (payload.authorizationServerMetadata as { issuer?: string }).issuer ??
-                null,
+                (payload.authorizationServerMetadata as { issuer?: string }).issuer ?? null,
               authorizationServerUrl: payload.authorizationServerUrl,
-              authorizationServerMetadataUrl:
-                payload.authorizationServerMetadataUrl,
-              idTokenSigningAlgValuesSupported:
-                (payload.authorizationServerMetadata as {
+              authorizationServerMetadataUrl: payload.authorizationServerMetadataUrl,
+              idTokenSigningAlgValuesSupported: (
+                payload.authorizationServerMetadata as {
                   id_token_signing_alg_values_supported?: string[];
-                }).id_token_signing_alg_values_supported,
-              clientId: (payload.clientInformation as { client_id: string })
-                .client_id,
+                }
+              ).id_token_signing_alg_values_supported,
+              clientId: (payload.clientInformation as { client_id: string }).client_id,
               clientSecretSecretId: dynamicClientSecretSecretId,
               clientAuth:
                 (payload.clientInformation as { token_endpoint_auth_method?: string })
@@ -901,19 +830,17 @@ export const makeOAuth2Service = (
               : null,
             expiresAt: connectionExpiresAt,
             oauthScope: exchangeResult.tokens.scope ?? null,
-            providerState: Schema.encodeSync(OAuthProviderStateSchema)(
-              providerState,
-            ) as Record<string, unknown>,
+            providerState: Schema.encodeSync(OAuthProviderStateSchema)(providerState) as Record<
+              string,
+              unknown
+            >,
           }),
         )
         .pipe(
           Effect.mapError(
-            (err) =>
+            () =>
               new OAuthCompleteError({
-                message: `Failed to mint connection: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-
+                message: "Failed to mint connection",
               }),
           ),
         );
@@ -962,19 +889,14 @@ export const makeOAuth2Service = (
         redirectUrl,
         codeVerifier: payload.codeVerifier,
         code,
-        idTokenSigningAlgValuesSupported:
-          md.id_token_signing_alg_values_supported,
-        clientAuth:
-          ci.token_endpoint_auth_method === "client_secret_basic"
-            ? "basic"
-            : "body",
+        idTokenSigningAlgValuesSupported: md.id_token_signing_alg_values_supported,
+        clientAuth: ci.token_endpoint_auth_method === "client_secret_basic" ? "basic" : "body",
       }).pipe(
         Effect.mapError(
           (err) =>
             new OAuthCompleteError({
-              message: `Token exchange failed: ${err.message}`,
+              message: "Token exchange failed",
               code: err.error,
-
             }),
         ),
       );
@@ -988,28 +910,21 @@ export const makeOAuth2Service = (
     payload: Extract<OAuthSessionPayload, { kind: "authorization-code" }>,
     code: string,
     redirectUrl: string,
-  ): Effect.Effect<
-    ExchangeResult,
-    OAuthCompleteError | StorageFailure
-  > =>
+  ): Effect.Effect<ExchangeResult, OAuthCompleteError | StorageFailure> =>
     Effect.gen(function* () {
       const clientId = yield* deps.secretsGet(payload.clientIdSecretId);
       if (clientId === null) {
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: `client_id secret "${payload.clientIdSecretId}" not found`,
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: `client_id secret "${payload.clientIdSecretId}" not found`,
+        });
       }
       const clientSecret = payload.clientSecretSecretId
         ? yield* deps.secretsGet(payload.clientSecretSecretId)
         : null;
       if (payload.clientSecretSecretId && clientSecret === null) {
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: `client_secret secret "${payload.clientSecretSecretId}" not found`,
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: `client_secret secret "${payload.clientSecretSecretId}" not found`,
+        });
       }
 
       const tokens = yield* exchangeAuthorizationCode({
@@ -1025,9 +940,8 @@ export const makeOAuth2Service = (
         Effect.mapError(
           (err) =>
             new OAuthCompleteError({
-              message: `Token exchange failed: ${err.message}`,
+              message: "Token exchange failed",
               code: err.error,
-
             }),
         ),
       );
@@ -1048,7 +962,7 @@ export const makeOAuth2Service = (
         model: "oauth2_session",
         where: [
           { field: "id", value: sessionId },
-          { field: "scope_id", value: row.scope_id as string },
+          { field: "scope_id", value: row.scope_id },
         ],
       });
     });
@@ -1071,9 +985,7 @@ export const makeOAuth2Service = (
           catch: (cause) =>
             new ConnectionRefreshError({
               connectionId: input.connectionId,
-              message: `oauth2 providerState is malformed: ${
-                cause instanceof Error ? cause.message : String(cause)
-              }`,
+              message: "oauth2 providerState is malformed",
               cause,
             }),
         });
@@ -1095,22 +1007,16 @@ export const makeOAuth2Service = (
             case "dynamic-dcr":
               return Effect.gen(function* () {
                 const csec = state.clientSecretSecretId
-                  ? yield* deps
-                      .secretsGet(state.clientSecretSecretId)
-                      .pipe(
-                        Effect.mapError(
-                          (cause) =>
-                            new ConnectionRefreshError({
-                              connectionId: input.connectionId,
-                              message: `Failed to resolve DCR client_secret: ${
-                                cause instanceof Error
-                                  ? cause.message
-                                  : String(cause)
-                              }`,
-                              cause,
-                            }),
-                        ),
-                      )
+                  ? yield* deps.secretsGet(state.clientSecretSecretId).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new ConnectionRefreshError({
+                            connectionId: input.connectionId,
+                            message: "Failed to resolve DCR client_secret",
+                            cause,
+                          }),
+                      ),
+                    )
                   : null;
                 if (state.clientSecretSecretId && csec === null) {
                   return yield* new ConnectionRefreshError({
@@ -1124,22 +1030,16 @@ export const makeOAuth2Service = (
             case "authorization-code":
             case "client-credentials":
               return Effect.gen(function* () {
-                const cid = yield* deps
-                  .secretsGet(state.clientIdSecretId)
-                  .pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new ConnectionRefreshError({
-                          connectionId: input.connectionId,
-                          message: `Failed to resolve client_id secret: ${
-                            cause instanceof Error
-                              ? cause.message
-                              : String(cause)
-                          }`,
-                          cause,
-                        }),
-                    ),
-                  );
+                const cid = yield* deps.secretsGet(state.clientIdSecretId).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new ConnectionRefreshError({
+                        connectionId: input.connectionId,
+                        message: "Failed to resolve client_id secret",
+                        cause,
+                      }),
+                  ),
+                );
                 if (cid === null) {
                   return yield* new ConnectionRefreshError({
                     connectionId: input.connectionId,
@@ -1148,22 +1048,16 @@ export const makeOAuth2Service = (
                   });
                 }
                 const csec = state.clientSecretSecretId
-                  ? yield* deps
-                      .secretsGet(state.clientSecretSecretId)
-                      .pipe(
-                        Effect.mapError(
-                          (cause) =>
-                            new ConnectionRefreshError({
-                              connectionId: input.connectionId,
-                              message: `Failed to resolve client_secret: ${
-                                cause instanceof Error
-                                  ? cause.message
-                                  : String(cause)
-                              }`,
-                              cause,
-                            }),
-                        ),
-                      )
+                  ? yield* deps.secretsGet(state.clientSecretSecretId).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new ConnectionRefreshError({
+                            connectionId: input.connectionId,
+                            message: "Failed to resolve client_secret",
+                            cause,
+                          }),
+                      ),
+                    )
                   : null;
                 if (state.clientSecretSecretId && csec === null) {
                   return yield* new ConnectionRefreshError({
@@ -1179,32 +1073,25 @@ export const makeOAuth2Service = (
 
         const tokenEndpoint = yield* (() => {
           if (state.tokenEndpoint) return Effect.succeed(state.tokenEndpoint);
-          if (
-            state.kind === "dynamic-dcr" &&
-            state.authorizationServerUrl
-          ) {
-            return discoverAuthorizationServerMetadata(
-              state.authorizationServerUrl,
-            ).pipe(
+          if (state.kind === "dynamic-dcr" && state.authorizationServerUrl) {
+            return discoverAuthorizationServerMetadata(state.authorizationServerUrl).pipe(
               Effect.flatMap((metadata) =>
                 metadata?.metadata.token_endpoint
                   ? Effect.succeed(metadata.metadata.token_endpoint)
                   : Effect.fail(
                       new ConnectionRefreshError({
                         connectionId: input.connectionId,
-                        message:
-                          "oauth2 legacy MCP providerState is missing token endpoint",
+                        message: "oauth2 legacy MCP providerState is missing token endpoint",
                         reauthRequired: true,
                       }),
                     ),
               ),
               Effect.mapError((cause) =>
-                cause instanceof ConnectionRefreshError
+                Predicate.isTagged("ConnectionRefreshError")(cause)
                   ? cause
                   : new ConnectionRefreshError({
                       connectionId: input.connectionId,
-                      message:
-                        "Failed to discover token endpoint for legacy MCP OAuth connection",
+                      message: "Failed to discover token endpoint for legacy MCP OAuth connection",
                       reauthRequired: true,
                       cause,
                     }),
@@ -1220,56 +1107,51 @@ export const makeOAuth2Service = (
           );
         })();
 
-        const tokens = yield* (state.kind === "client-credentials"
-          ? exchangeClientCredentials({
-              tokenUrl: tokenEndpoint,
-              clientId,
-              clientSecret: clientSecret ?? "",
-              scopes: state.scopes,
-              scopeSeparator: state.scopeSeparator,
-              clientAuth: state.clientAuth,
-            })
-          : refreshAccessToken({
-              tokenUrl: tokenEndpoint,
-              issuerUrl:
-                state.kind === "dynamic-dcr" || state.kind === "authorization-code"
-                  ? (state.issuerUrl ?? undefined)
-                  : undefined,
-              clientId,
-              clientSecret: clientSecret ?? undefined,
-              refreshToken: input.refreshToken!,
-              scopes:
-                state.kind === "dynamic-dcr" || state.kind === "authorization-code"
-                  ? state.scopes
-                  : undefined,
-              scopeSeparator:
-                state.kind === "dynamic-dcr" || state.kind === "authorization-code"
-                  ? state.scopeSeparator
-                  : undefined,
-              clientAuth: state.clientAuth,
-              idTokenSigningAlgValuesSupported:
-                state.kind === "dynamic-dcr"
-                  ? state.idTokenSigningAlgValuesSupported
-                  : undefined,
-            })).pipe(
+        const tokens = yield* (
+          state.kind === "client-credentials"
+            ? exchangeClientCredentials({
+                tokenUrl: tokenEndpoint,
+                clientId,
+                clientSecret: clientSecret ?? "",
+                scopes: state.scopes,
+                scopeSeparator: state.scopeSeparator,
+                clientAuth: state.clientAuth,
+              })
+            : refreshAccessToken({
+                tokenUrl: tokenEndpoint,
+                issuerUrl:
+                  state.kind === "dynamic-dcr" || state.kind === "authorization-code"
+                    ? (state.issuerUrl ?? undefined)
+                    : undefined,
+                clientId,
+                clientSecret: clientSecret ?? undefined,
+                refreshToken: input.refreshToken!,
+                scopes:
+                  state.kind === "dynamic-dcr" || state.kind === "authorization-code"
+                    ? state.scopes
+                    : undefined,
+                scopeSeparator:
+                  state.kind === "dynamic-dcr" || state.kind === "authorization-code"
+                    ? state.scopeSeparator
+                    : undefined,
+                clientAuth: state.clientAuth,
+                idTokenSigningAlgValuesSupported:
+                  state.kind === "dynamic-dcr" ? state.idTokenSigningAlgValuesSupported : undefined,
+              })
+        ).pipe(
           Effect.mapError(
             (err) =>
               new ConnectionRefreshError({
                 connectionId: input.connectionId,
-                message: `OAuth refresh failed: ${err.message}`,
+                message: "OAuth refresh failed",
                 // Terminal RFC 6749 §5.2 errors mean retrying won't heal it.
-                reauthRequired: err.error
-                  ? terminalRefreshErrors.has(err.error)
-                  : false,
-
+                reauthRequired: err.error ? terminalRefreshErrors.has(err.error) : false,
               }),
           ),
         );
 
         const expiresAt =
-          typeof tokens.expires_in === "number"
-            ? now() + tokens.expires_in * 1000
-            : null;
+          typeof tokens.expires_in === "number" ? now() + tokens.expires_in * 1000 : null;
 
         const result: ConnectionRefreshResult = {
           accessToken: tokens.access_token,
@@ -1293,9 +1175,5 @@ export const makeOAuth2Service = (
 
 const safeHostname = (value: string | null): string | null => {
   if (!value) return null;
-  try {
-    return new URL(value).host;
-  } catch {
-    return value;
-  }
+  return parseUrlOption(value)?.host ?? value;
 };

--- a/packages/plugins/openapi/src/sdk/oauth-refresh.test.ts
+++ b/packages/plugins/openapi/src/sdk/oauth-refresh.test.ts
@@ -13,14 +13,19 @@
 // ---------------------------------------------------------------------------
 
 import { afterEach, expect, layer } from "@effect/vitest";
-import { Effect, Layer, Schema } from "effect";
-import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
+import { Effect, Layer, Predicate, Schema } from "effect";
+import {
+  HttpApi,
+  HttpApiBuilder,
+  HttpApiEndpoint,
+  HttpApiGroup,
+  OpenApi,
+} from "effect/unstable/httpapi";
 import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 
 import {
   ConnectionId,
-  ConnectionReauthRequiredError,
   CreateConnectionInput,
   ScopeId,
   SecretId,
@@ -90,23 +95,26 @@ const mockTokenFetch = (
   handler: (body: URLSearchParams) => Effect.Effect<Response, never, never> | Promise<Response>,
 ) => {
   const calls: TokenCall[] = [];
-  globalThis.fetch = Object.assign(async (_input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof _input === "string" ? _input : _input.toString();
-    if (!url.includes("token.example.com")) {
-      return originalFetch(_input, init);
-    }
-    const bodyText =
-      init?.body instanceof URLSearchParams
-        ? init.body.toString()
-        : typeof init?.body === "string"
-          ? init.body
-          : "";
-    const body = new URLSearchParams(bodyText);
-    calls.push({ body });
-    const out = handler(body);
-    if (Effect.isEffect(out)) return await Effect.runPromise(out);
-    return await out;
-  }, { preconnect: originalFetch.preconnect });
+  globalThis.fetch = Object.assign(
+    async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof _input === "string" ? _input : _input.toString();
+      if (!url.includes("token.example.com")) {
+        return originalFetch(_input, init);
+      }
+      const bodyText =
+        init?.body instanceof URLSearchParams
+          ? init.body.toString()
+          : typeof init?.body === "string"
+            ? init.body
+            : "";
+      const body = new URLSearchParams(bodyText);
+      calls.push({ body });
+      const out = handler(body);
+      if (Effect.isEffect(out)) return await Effect.runPromise(out);
+      return await out;
+    },
+    { preconnect: originalFetch.preconnect },
+  );
   return { calls };
 };
 
@@ -127,25 +135,26 @@ const makeExecutor = () =>
     const memoryProvider: SecretProvider = {
       key: "memory",
       writable: true,
-      get: (id, scope) =>
-        Effect.sync(() => secretStore.get(keyOf(scope, id)) ?? null),
+      get: (id, scope) => Effect.sync(() => secretStore.get(keyOf(scope, id)) ?? null),
       set: (id, value, scope) =>
         Effect.sync(() => {
           secretStore.set(keyOf(scope, id), value);
         }),
-      delete: (id, scope) =>
-        Effect.sync(() => secretStore.delete(keyOf(scope, id))),
+      delete: (id, scope) => Effect.sync(() => secretStore.delete(keyOf(scope, id))),
     };
     const memorySecretsPlugin = definePlugin(() => ({
       id: "memory-secrets" as const,
       storage: () => ({}),
       secretProviders: [memoryProvider],
     }));
-      const clientLayer = FetchHttpClient.layer;
-      const server = yield* HttpServer.HttpServer;
-      const address = server.address;
-      if (address._tag !== "TcpAddress") return yield* Effect.die("test server must bind to TCP");
-      const baseUrl = `http://127.0.0.1:${address.port}`;
+    const clientLayer = FetchHttpClient.layer;
+    const server = yield* HttpServer.HttpServer;
+    const address = server.address;
+    if (!Predicate.isTagged("TcpAddress")(address)) {
+      // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: test harness cannot continue without a TCP test server address
+      return yield* Effect.die("test server must bind to TCP");
+    }
+    const baseUrl = `http://127.0.0.1:${address.port}`;
     const plugins = [
       openApiPlugin({ httpClientLayer: clientLayer }),
       memorySecretsPlugin(),
@@ -198,11 +207,7 @@ type ExecutorValue = EffectSuccess<ReturnType<typeof makeExecutor>>["executor"];
 // Seed an authorizationCode Connection with an already-expired access
 // token and a stored refresh token. The test's mock token endpoint
 // decides what comes back on `grant_type=refresh_token`.
-const seedExpiredConnection = (
-  executor: ExecutorValue,
-  scopeId: ScopeId,
-  connectionId: string,
-) =>
+const seedExpiredConnection = (executor: ExecutorValue, scopeId: ScopeId, connectionId: string) =>
   Effect.gen(function* () {
     yield* executor.connections.create(
       new CreateConnectionInput({
@@ -249,169 +254,144 @@ const seedExpiredConnection = (
 // ---------------------------------------------------------------------------
 
 layer(TestLayer)("OpenAPI oauth refresh", (it) => {
-  it.effect(
-    "expired access_token is refreshed via grant_type=refresh_token before invoke",
-    () =>
-      Effect.gen(function* () {
-        const { executor, scopeId, baseUrl } = yield* makeExecutor();
-        const { calls } = mockTokenFetch(
-          () =>
-            Effect.succeed(
-              new Response(
-                JSON.stringify({
-                  access_token: "fresh-access-v2",
-                  token_type: "Bearer",
-                  refresh_token: "refresh-v2",
-                  expires_in: 3600,
-                }),
-                { status: 200, headers: { "content-type": "application/json" } },
-              ),
-            ),
-        );
-
-        const auth = yield* seedExpiredConnection(
-          executor,
-          scopeId,
-          "conn-refresh-ok",
-        );
-
-        yield* executor.openapi.addSpec({
-          spec: specJson,
-          scope: String(scopeId),
-          namespace: "petstore",
-          baseUrl,
-          oauth2: auth,
-        });
-
-        const result = (yield* executor.tools.invoke(
-          "petstore.items.echoHeaders",
-          {},
-          autoApprove,
-        )) as { data: { authorization?: string } | null; error: unknown };
-
-        expect(result.error).toBeNull();
-        // Proves the refresh landed: invoke carried the fresh token,
-        // not the expired one we seeded.
-        expect(result.data?.authorization).toBe("Bearer fresh-access-v2");
-        expect(calls).toHaveLength(1);
-        expect(calls[0]!.body.get("grant_type")).toBe("refresh_token");
-        expect(calls[0]!.body.get("refresh_token")).toBe("refresh-v1");
-
-        // Connection row is patched with the new expiry so the next
-        // invoke in-window doesn't trip a second refresh.
-        const conn = yield* executor.connections.get("conn-refresh-ok");
-        expect(conn).not.toBeNull();
-        expect(conn!.expiresAt).not.toBeNull();
-        expect(conn!.expiresAt!).toBeGreaterThan(Date.now() + 3_000_000);
-      }),
-  );
-
-  it.effect(
-    "concurrent invokes with an expired token issue exactly one refresh",
-    () =>
-      Effect.gen(function* () {
-        const { executor, scopeId, baseUrl } = yield* makeExecutor();
-        const { calls } = mockTokenFetch(
-          () =>
-            Effect.succeed(
-              new Response(
-                JSON.stringify({
-                  access_token: "fresh-access-v2",
-                  token_type: "Bearer",
-                  refresh_token: "refresh-v2",
-                  expires_in: 3600,
-                }),
-                { status: 200, headers: { "content-type": "application/json" } },
-              ),
-            ),
-        );
-
-        const auth = yield* seedExpiredConnection(
-          executor,
-          scopeId,
-          "conn-refresh-concurrent",
-        );
-
-        yield* executor.openapi.addSpec({
-          spec: specJson,
-          scope: String(scopeId),
-          namespace: "petstore",
-          baseUrl,
-          oauth2: auth,
-        });
-
-        const invokes = yield* Effect.all(
-          [1, 2, 3, 4, 5].map(() =>
-            executor.tools.invoke(
-              "petstore.items.echoHeaders",
-              {},
-              autoApprove,
-            ),
+  it.effect("expired access_token is refreshed via grant_type=refresh_token before invoke", () =>
+    Effect.gen(function* () {
+      const { executor, scopeId, baseUrl } = yield* makeExecutor();
+      const { calls } = mockTokenFetch(() =>
+        Effect.succeed(
+          new Response(
+            JSON.stringify({
+              access_token: "fresh-access-v2",
+              token_type: "Bearer",
+              refresh_token: "refresh-v2",
+              expires_in: 3600,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
           ),
-          { concurrency: "unbounded" },
-        );
+        ),
+      );
 
-        for (const r of invokes) {
-          const res = r as {
-            data: { authorization?: string } | null;
-            error: unknown;
-          };
-          expect(res.error).toBeNull();
-          expect(res.data?.authorization).toBe("Bearer fresh-access-v2");
-        }
-        // Critical assertion: the SDK's dedup collapses every parallel
-        // invoke into one call to the token endpoint. Anything more
-        // means we're hammering the AS under load.
-        expect(calls).toHaveLength(1);
-      }),
+      const auth = yield* seedExpiredConnection(executor, scopeId, "conn-refresh-ok");
+
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: String(scopeId),
+        namespace: "petstore",
+        baseUrl,
+        oauth2: auth,
+      });
+
+      const result = (yield* executor.tools.invoke(
+        "petstore.items.echoHeaders",
+        {},
+        autoApprove,
+      )) as { data: { authorization?: string } | null; error: unknown };
+
+      expect(result.error).toBeNull();
+      // Proves the refresh landed: invoke carried the fresh token,
+      // not the expired one we seeded.
+      expect(result.data?.authorization).toBe("Bearer fresh-access-v2");
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.body.get("grant_type")).toBe("refresh_token");
+      expect(calls[0]!.body.get("refresh_token")).toBe("refresh-v1");
+
+      // Connection row is patched with the new expiry so the next
+      // invoke in-window doesn't trip a second refresh.
+      const conn = yield* executor.connections.get("conn-refresh-ok");
+      expect(conn).not.toBeNull();
+      expect(conn!.expiresAt).not.toBeNull();
+      expect(conn!.expiresAt!).toBeGreaterThan(Date.now() + 3_000_000);
+    }),
   );
 
-  it.effect(
-    "invalid_grant from refresh surfaces as ConnectionReauthRequiredError",
-    () =>
-      Effect.gen(function* () {
-        const { executor, scopeId, baseUrl } = yield* makeExecutor();
-        mockTokenFetch(
-          () =>
-            Effect.succeed(
-              new Response(
-                JSON.stringify({
-                  error: "invalid_grant",
-                  error_description: "Refresh token revoked",
-                }),
-                { status: 400, headers: { "content-type": "application/json" } },
-              ),
-            ),
-        );
+  it.effect("concurrent invokes with an expired token issue exactly one refresh", () =>
+    Effect.gen(function* () {
+      const { executor, scopeId, baseUrl } = yield* makeExecutor();
+      const { calls } = mockTokenFetch(() =>
+        Effect.succeed(
+          new Response(
+            JSON.stringify({
+              access_token: "fresh-access-v2",
+              token_type: "Bearer",
+              refresh_token: "refresh-v2",
+              expires_in: 3600,
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        ),
+      );
 
-        const auth = yield* seedExpiredConnection(
-          executor,
-          scopeId,
-          "conn-refresh-dead",
-        );
+      const auth = yield* seedExpiredConnection(executor, scopeId, "conn-refresh-concurrent");
 
-        yield* executor.openapi.addSpec({
-          spec: specJson,
-          scope: String(scopeId),
-          namespace: "petstore",
-          baseUrl,
-          oauth2: auth,
-        });
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: String(scopeId),
+        namespace: "petstore",
+        baseUrl,
+        oauth2: auth,
+      });
 
-        // Tool invocation currently wraps connection errors in a
-        // generic Error (see openapi invokeTool), so we assert against
-        // the `accessToken` call directly too — that's the surface
-        // the UI bridges use to trigger re-auth.
-        const flipped = yield* executor.connections
-          .accessToken("conn-refresh-dead")
-          .pipe(Effect.flip);
-        expect(flipped._tag).toBe("ConnectionReauthRequiredError");
-        expect((flipped as ConnectionReauthRequiredError).provider).toBe(
-          "openapi:oauth2",
-        );
-        expect(
-          (flipped as ConnectionReauthRequiredError).message,
-        ).toMatch(/invalid_grant|revoked/i);
-      }),
+      const invokes = yield* Effect.all(
+        [1, 2, 3, 4, 5].map(() =>
+          executor.tools.invoke("petstore.items.echoHeaders", {}, autoApprove),
+        ),
+        { concurrency: "unbounded" },
+      );
+
+      for (const r of invokes) {
+        const res = r as {
+          data: { authorization?: string } | null;
+          error: unknown;
+        };
+        expect(res.error).toBeNull();
+        expect(res.data?.authorization).toBe("Bearer fresh-access-v2");
+      }
+      // Critical assertion: the SDK's dedup collapses every parallel
+      // invoke into one call to the token endpoint. Anything more
+      // means we're hammering the AS under load.
+      expect(calls).toHaveLength(1);
+    }),
+  );
+
+  it.effect("invalid_grant from refresh surfaces as ConnectionReauthRequiredError", () =>
+    Effect.gen(function* () {
+      const { executor, scopeId, baseUrl } = yield* makeExecutor();
+      mockTokenFetch(() =>
+        Effect.succeed(
+          new Response(
+            JSON.stringify({
+              error: "invalid_grant",
+              error_description: "Refresh token revoked",
+            }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          ),
+        ),
+      );
+
+      const auth = yield* seedExpiredConnection(executor, scopeId, "conn-refresh-dead");
+
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: String(scopeId),
+        namespace: "petstore",
+        baseUrl,
+        oauth2: auth,
+      });
+
+      // Tool invocation currently wraps connection errors in a
+      // generic Error (see openapi invokeTool), so we assert against
+      // the `accessToken` call directly too — that's the surface
+      // the UI bridges use to trigger re-auth.
+      const flipped = yield* executor.connections.accessToken("conn-refresh-dead").pipe(
+        Effect.flip,
+        Effect.flatMap((error) =>
+          Predicate.isTagged("ConnectionReauthRequiredError")(error)
+            ? Effect.succeed(error)
+            : Effect.fail(error),
+        ),
+      );
+      expect(flipped.provider).toBe("openapi:oauth2");
+      expect(flipped.message).toBe("OAuth refresh failed");
+    }),
   );
 });


### PR DESCRIPTION
## Summary
- replace OAuth JSON and URL boundary handling with Effect Schema and typed helpers
- preserve causes while using stable typed OAuth error messages
- update the OpenAPI refresh assertion for stable reauth copy instead of provider detail leakage

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/sdk/src/oauth-service.ts packages/core/sdk/src/oauth-discovery.ts packages/plugins/openapi/src/sdk/oauth-refresh.test.ts --deny-warnings
- bunx oxfmt --check packages/core/sdk/src/oauth-service.ts packages/core/sdk/src/oauth-discovery.ts packages/plugins/openapi/src/sdk/oauth-refresh.test.ts
- bun run --cwd packages/core/sdk typecheck
- bun run --cwd packages/core/sdk test src/oauth-discovery.test.ts src/oauth-helpers.test.ts
- bun run --cwd packages/plugins/openapi typecheck
- bun run --cwd packages/plugins/openapi test src/sdk/oauth-refresh.test.ts