### PR TITLE
Fix storage test boundary lint

### DIFF
--- a/packages/core/storage-core/src/testing/conformance.ts
+++ b/packages/core/storage-core/src/testing/conformance.ts
@@ -13,7 +13,7 @@
 
 import { describe, it } from "@effect/vitest";
 import { expect } from "@effect/vitest";
-import { Effect, Result } from "effect";
+import { Data, Effect, Result } from "effect";
 
 import type { DBAdapter } from "../adapter";
 import type { DBSchema } from "../schema";
@@ -75,14 +75,13 @@ export type WithAdapter = <A, E>(
   fn: (adapter: DBAdapter) => Effect.Effect<A, E>,
 ) => Effect.Effect<A, E | Error>;
 
+class TransactionRollbackTestError extends Data.TaggedError("TransactionRollbackTestError")<{}> {}
+
 // ---------------------------------------------------------------------------
 // Suite
 // ---------------------------------------------------------------------------
 
-export const runAdapterConformance = (
-  name: string,
-  withAdapter: WithAdapter,
-): void => {
+export const runAdapterConformance = (name: string, withAdapter: WithAdapter): void => {
   describe(`conformance: ${name}`, () => {
     const withDefaultsInput = (
       value: unknown,
@@ -136,9 +135,7 @@ export const runAdapterConformance = (
           expect(found!.id).toBe(created.id);
           expect(found!.enabled).toBe(true);
           expect(found!.createdAt instanceof Date).toBe(true);
-          expect(found!.createdAt.toISOString()).toBe(
-            "2026-04-15T00:00:00.000Z",
-          );
+          expect(found!.createdAt.toISOString()).toBe("2026-04-15T00:00:00.000Z");
           expect(found!.metadata).toEqual({ slug: "gh", tags: ["a", "b"] });
         }),
       ),
@@ -161,7 +158,7 @@ export const runAdapterConformance = (
           });
           const found = yield* adapter.findOne<{ createdAt: Date }>({
             model: "source",
-            where: [{ field: "id", value: row.id as string }],
+            where: [{ field: "id", value: row.id }],
           });
           expect(found!.createdAt.toISOString()).toBe(d.toISOString());
         }),
@@ -381,10 +378,7 @@ export const runAdapterConformance = (
             model: "source",
             where: [{ field: "priority", value: 5, operator: "gte" }],
           });
-          expect(highPriority.map((r) => r.name).sort()).toEqual([
-            "github-edge",
-            "gitlab",
-          ]);
+          expect(highPriority.map((r) => r.name).sort()).toEqual(["github-edge", "gitlab"]);
         }),
       ),
     );
@@ -516,9 +510,7 @@ export const runAdapterConformance = (
             update: { touchedAt: explicitDate },
           });
           expect(updated).not.toBeNull();
-          expect(updated!.touchedAt.toISOString()).toBe(
-            explicitDate.toISOString(),
-          );
+          expect(updated!.touchedAt.toISOString()).toBe(explicitDate.toISOString());
           // Sanity: omitting touchedAt should trigger onUpdate.
           const hookDriven = yield* adapter.update<{
             id: string;
@@ -530,9 +522,7 @@ export const runAdapterConformance = (
             update: { name: "rename" },
           });
           expect(hookDriven).not.toBeNull();
-          expect(hookDriven!.touchedAt.toISOString()).toBe(
-            "2099-01-01T00:00:00.000Z",
-          );
+          expect(hookDriven!.touchedAt.toISOString()).toBe("2099-01-01T00:00:00.000Z");
         }),
       ),
     );
@@ -546,7 +536,7 @@ export const runAdapterConformance = (
               Effect.gen(function* () {
                 yield* trx.create({ model: "tag", data: { label: "tx1" } });
                 yield* trx.create({ model: "tag", data: { label: "tx2" } });
-                return yield* Effect.fail(new Error("boom"));
+                return yield* new TransactionRollbackTestError();
               }),
             )
             .pipe(Effect.result);
@@ -571,128 +561,120 @@ export const runAdapterConformance = (
       ),
     );
 
-    it.effect(
-      "where: mixed AND/OR grouping follows upstream split-group semantics",
-      () =>
-        // Locks in better-auth drizzle adapter's `convertWhereClause`
-        // semantics: AND-connector clauses and OR-connector clauses split
-        // into two groups, recombined as `(AND…) AND (OR…)`. For
-        // [{priority=1, AND}, {priority=10, OR}, {enabled=true, AND}],
-        // that's `(priority=1 AND enabled=true) AND (priority=10)` which
-        // can never match a single row — while a left-to-right fold
-        // would give `((priority=1 OR priority=10) AND enabled=true)`
-        // and return two rows. We assert the upstream reading.
-        withAdapter((adapter) =>
-          Effect.gen(function* () {
-            yield* adapter.createMany({
-              model: "source",
-              data: [
-                { name: "lhs", priority: 1, enabled: true },
-                { name: "rhs", priority: 10, enabled: true },
-                { name: "off", priority: 1, enabled: false },
-              ],
-            });
-            const rows = yield* adapter.findMany<{ name: string }>({
-              model: "source",
-              where: [
-                { field: "priority", value: 1, connector: "AND" },
-                { field: "priority", value: 10, connector: "OR" },
-                { field: "enabled", value: true, connector: "AND" },
-              ],
-            });
-            // Upstream split-group: (priority=1 AND enabled=true) AND
-            // (priority=10). `lhs` has priority=1 (fails the OR group's
-            // priority=10 check) and `rhs` has priority=10 (fails the
-            // AND group's priority=1 check) — both reject.
-            expect(rows.map((r) => r.name)).toEqual([]);
+    it.effect("where: mixed AND/OR grouping follows upstream split-group semantics", () =>
+      // Locks in better-auth drizzle adapter's `convertWhereClause`
+      // semantics: AND-connector clauses and OR-connector clauses split
+      // into two groups, recombined as `(AND…) AND (OR…)`. For
+      // [{priority=1, AND}, {priority=10, OR}, {enabled=true, AND}],
+      // that's `(priority=1 AND enabled=true) AND (priority=10)` which
+      // can never match a single row — while a left-to-right fold
+      // would give `((priority=1 OR priority=10) AND enabled=true)`
+      // and return two rows. We assert the upstream reading.
+      withAdapter((adapter) =>
+        Effect.gen(function* () {
+          yield* adapter.createMany({
+            model: "source",
+            data: [
+              { name: "lhs", priority: 1, enabled: true },
+              { name: "rhs", priority: 10, enabled: true },
+              { name: "off", priority: 1, enabled: false },
+            ],
+          });
+          const rows = yield* adapter.findMany<{ name: string }>({
+            model: "source",
+            where: [
+              { field: "priority", value: 1, connector: "AND" },
+              { field: "priority", value: 10, connector: "OR" },
+              { field: "enabled", value: true, connector: "AND" },
+            ],
+          });
+          // Upstream split-group: (priority=1 AND enabled=true) AND
+          // (priority=10). `lhs` has priority=1 (fails the OR group's
+          // priority=10 check) and `rhs` has priority=10 (fails the
+          // AND group's priority=1 check) — both reject.
+          expect(rows.map((r) => r.name)).toEqual([]);
 
-            // Sanity: a pure disjunction still works.
-            const both = yield* adapter.findMany<{ name: string }>({
-              model: "source",
-              where: [
-                { field: "priority", value: 1, connector: "OR" },
-                { field: "priority", value: 10, connector: "OR" },
-              ],
-              sortBy: { field: "name", direction: "asc" },
-            });
-            expect(both.map((r) => r.name)).toEqual(["lhs", "off", "rhs"]);
-          }),
-        ),
+          // Sanity: a pure disjunction still works.
+          const both = yield* adapter.findMany<{ name: string }>({
+            model: "source",
+            where: [
+              { field: "priority", value: 1, connector: "OR" },
+              { field: "priority", value: 10, connector: "OR" },
+            ],
+            sortBy: { field: "name", direction: "asc" },
+          });
+          expect(both.map((r) => r.name)).toEqual(["lhs", "off", "rhs"]);
+        }),
+      ),
     );
 
-    it.effect(
-      "findMany resolves join: source → source_tag (one-to-many)",
-      () =>
-        withAdapter((adapter) =>
-          Effect.gen(function* () {
-            const src = yield* adapter.create<{ id: string; name: string }>({
-              model: "source",
-              data: { name: "joined-source" },
-            });
-            yield* adapter.createMany({
-              model: "source_tag",
-              data: [
-                { sourceId: src.id, note: "first" },
-                { sourceId: src.id, note: "second" },
-              ],
-            });
+    it.effect("findMany resolves join: source → source_tag (one-to-many)", () =>
+      withAdapter((adapter) =>
+        Effect.gen(function* () {
+          const src = yield* adapter.create<{ id: string; name: string }>({
+            model: "source",
+            data: { name: "joined-source" },
+          });
+          yield* adapter.createMany({
+            model: "source_tag",
+            data: [
+              { sourceId: src.id, note: "first" },
+              { sourceId: src.id, note: "second" },
+            ],
+          });
 
-            const many = yield* adapter.findMany<{
-              id: string;
-              name: string;
-              source_tag: ReadonlyArray<{ note: string; sourceId: string }>;
-            }>({
-              model: "source",
-              where: [{ field: "id", value: src.id }],
-              join: { source_tag: true },
-            });
-            expect(many).toHaveLength(1);
-            const parent = many[0]!;
-            expect(parent.name).toBe("joined-source");
-            expect(Array.isArray(parent.source_tag)).toBe(true);
-            expect(parent.source_tag).toHaveLength(2);
-            expect(
-              parent.source_tag.map((t) => t.note).sort(),
-            ).toEqual(["first", "second"]);
-          }),
-        ),
+          const many = yield* adapter.findMany<{
+            id: string;
+            name: string;
+            source_tag: ReadonlyArray<{ note: string; sourceId: string }>;
+          }>({
+            model: "source",
+            where: [{ field: "id", value: src.id }],
+            join: { source_tag: true },
+          });
+          expect(many).toHaveLength(1);
+          const parent = many[0]!;
+          expect(parent.name).toBe("joined-source");
+          expect(Array.isArray(parent.source_tag)).toBe(true);
+          expect(parent.source_tag).toHaveLength(2);
+          expect(parent.source_tag.map((t) => t.note).sort()).toEqual(["first", "second"]);
+        }),
+      ),
     );
 
-    it.effect(
-      "findOne resolves join: source_tag → source (one-to-one)",
-      () =>
-        withAdapter((adapter) =>
-          Effect.gen(function* () {
-            const src = yield* adapter.create<{ id: string; name: string }>({
-              model: "source",
-              data: { name: "owner" },
-            });
-            const child = yield* adapter.create<{
-              id: string;
-              sourceId: string;
-              note: string;
-            }>({
-              model: "source_tag",
-              data: { sourceId: src.id, note: "only" },
-            });
+    it.effect("findOne resolves join: source_tag → source (one-to-one)", () =>
+      withAdapter((adapter) =>
+        Effect.gen(function* () {
+          const src = yield* adapter.create<{ id: string; name: string }>({
+            model: "source",
+            data: { name: "owner" },
+          });
+          const child = yield* adapter.create<{
+            id: string;
+            sourceId: string;
+            note: string;
+          }>({
+            model: "source_tag",
+            data: { sourceId: src.id, note: "only" },
+          });
 
-            const found = yield* adapter.findOne<{
-              id: string;
-              note: string;
-              sourceId: string;
-              source: { id: string; name: string } | null;
-            }>({
-              model: "source_tag",
-              where: [{ field: "id", value: child.id }],
-              join: { source: true },
-            });
-            expect(found).not.toBeNull();
-            expect(found!.note).toBe("only");
-            expect(found!.source).not.toBeNull();
-            expect(found!.source!.id).toBe(src.id);
-            expect(found!.source!.name).toBe("owner");
-          }),
-        ),
+          const found = yield* adapter.findOne<{
+            id: string;
+            note: string;
+            sourceId: string;
+            source: { id: string; name: string } | null;
+          }>({
+            model: "source_tag",
+            where: [{ field: "id", value: child.id }],
+            join: { source: true },
+          });
+          expect(found).not.toBeNull();
+          expect(found!.note).toBe("only");
+          expect(found!.source).not.toBeNull();
+          expect(found!.source!.id).toBe(src.id);
+          expect(found!.source!.name).toBe("owner");
+        }),
+      ),
     );
 
     it.effect("nested writes inside a transaction see the tx state", () =>

--- a/packages/core/storage-core/src/testing/memory.ts
+++ b/packages/core/storage-core/src/testing/memory.ts
@@ -31,11 +31,7 @@ type Row = Record<string, unknown>;
 type Store = Record<string, Row[]>;
 type Comparable = string | number | boolean | Date;
 
-const compare = (
-  a: unknown,
-  b: unknown,
-  op: "gt" | "gte" | "lt" | "lte",
-): boolean => {
+const compare = (a: unknown, b: unknown, op: "gt" | "gte" | "lt" | "lte"): boolean => {
   if (
     !(
       typeof a === "string" ||
@@ -43,12 +39,7 @@ const compare = (
       typeof a === "boolean" ||
       a instanceof Date
     ) ||
-    !(
-      typeof b === "string" ||
-      typeof b === "number" ||
-      typeof b === "boolean" ||
-      b instanceof Date
-    )
+    !(typeof b === "string" || typeof b === "number" || typeof b === "boolean" || b instanceof Date)
   ) {
     return false;
   }
@@ -74,27 +65,25 @@ const evalClause = (record: Row, clause: CleanedWhere): boolean => {
   const isInsensitive =
     mode === "insensitive" &&
     (typeof value === "string" ||
-      (Array.isArray(value) &&
-        (value as unknown[]).every((v) => typeof v === "string")));
+      (Array.isArray(value) && (value as unknown[]).every((v) => typeof v === "string")));
 
   const lhs = record[field];
-  const lowerStr = (v: unknown) =>
-    typeof v === "string" ? v.toLowerCase() : v;
+  const lowerStr = (v: unknown) => (typeof v === "string" ? v.toLowerCase() : v);
 
   const cmp = (a: unknown, b: unknown): boolean =>
     isInsensitive ? lowerStr(a) === lowerStr(b) : a === b;
   switch (operator) {
     case "in":
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: sync test adapter predicate preserves invalid where-clause failure semantics
       if (!Array.isArray(value)) throw new Error("Value must be an array");
       return (value as unknown[]).some((v) => cmp(lhs, v));
     case "not_in":
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: sync test adapter predicate preserves invalid where-clause failure semantics
       if (!Array.isArray(value)) throw new Error("Value must be an array");
       return !(value as unknown[]).some((v) => cmp(lhs, v));
     case "contains": {
       if (typeof lhs !== "string" || typeof value !== "string") return false;
-      return isInsensitive
-        ? lhs.toLowerCase().includes(value.toLowerCase())
-        : lhs.includes(value);
+      return isInsensitive ? lhs.toLowerCase().includes(value.toLowerCase()) : lhs.includes(value);
     }
     case "starts_with": {
       if (typeof lhs !== "string" || typeof value !== "string") return false;
@@ -104,9 +93,7 @@ const evalClause = (record: Row, clause: CleanedWhere): boolean => {
     }
     case "ends_with": {
       if (typeof lhs !== "string" || typeof value !== "string") return false;
-      return isInsensitive
-        ? lhs.toLowerCase().endsWith(value.toLowerCase())
-        : lhs.endsWith(value);
+      return isInsensitive ? lhs.toLowerCase().endsWith(value.toLowerCase()) : lhs.endsWith(value);
     }
     case "ne":
       return !cmp(lhs, value);
@@ -135,14 +122,10 @@ const evalClause = (record: Row, clause: CleanedWhere): boolean => {
 const matchAll = (record: Row, where: readonly CleanedWhere[]): boolean => {
   if (where.length === 0) return true;
   if (where.length === 1) return evalClause(record, where[0]!);
-  const andGroup = where.filter(
-    (w) => w.connector === "AND" || !w.connector,
-  );
+  const andGroup = where.filter((w) => w.connector === "AND" || !w.connector);
   const orGroup = where.filter((w) => w.connector === "OR");
-  const andResult =
-    andGroup.length === 0 ? true : andGroup.every((w) => evalClause(record, w));
-  const orResult =
-    orGroup.length === 0 ? true : orGroup.some((w) => evalClause(record, w));
+  const andResult = andGroup.length === 0 ? true : andGroup.every((w) => evalClause(record, w));
+  const orResult = orGroup.length === 0 ? true : orGroup.some((w) => evalClause(record, w));
   return andResult && orResult;
 };
 
@@ -167,9 +150,7 @@ export interface MakeMemoryAdapterOptions {
   readonly generateId?: () => string;
 }
 
-export const makeMemoryAdapter = (
-  options: MakeMemoryAdapterOptions,
-): DBAdapter => {
+export const makeMemoryAdapter = (options: MakeMemoryAdapterOptions): DBAdapter => {
   let store: Store = {};
 
   const tableFor = (model: string): Row[] => {
@@ -186,9 +167,7 @@ export const makeMemoryAdapter = (
     const out: Row = { ...base };
     for (const [target, cfg] of Object.entries(join)) {
       const targetRows = tableFor(target);
-      const matches = targetRows.filter(
-        (r) => r[cfg.on.to] === base[cfg.on.from],
-      );
+      const matches = targetRows.filter((r) => r[cfg.on.to] === base[cfg.on.from]);
       if (cfg.relation === "one-to-one") {
         out[target] = matches[0] ?? null;
       } else {
@@ -328,11 +307,9 @@ export const makeMemoryAdapter = (
 
   // Snapshot-based transaction: clone on entry, restore on failure.
   const txFn: DBAdapterFactoryConfig["transaction"] = <R, E>(
-    cb: (trx: Parameters<DBAdapter["transaction"]>[0] extends (
-      t: infer T,
-    ) => unknown
-      ? T
-      : never) => Effect.Effect<R, E>,
+    cb: (
+      trx: Parameters<DBAdapter["transaction"]>[0] extends (t: infer T) => unknown ? T : never,
+    ) => Effect.Effect<R, E>,
   ) =>
     Effect.gen(function* () {
       const snapshot = cloneStore(store);
@@ -353,9 +330,7 @@ export const makeMemoryAdapter = (
       supportsDates: true,
       supportsBooleans: true,
       supportsArrays: true,
-      customIdGenerator: options.generateId
-        ? () => options.generateId!()
-        : undefined,
+      customIdGenerator: options.generateId ? () => options.generateId!() : undefined,
       transaction: txFn,
     },
     adapter: custom,


### PR DESCRIPTION
## Summary
- keep invalid where-clause failures explicit in the memory test adapter
- replace conformance rollback Error fixture with a typed tagged failure
- remove redundant primitive casts from storage conformance tests

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/core/storage-core/src/testing/memory.ts packages/core/storage-core/src/testing/conformance.ts --deny-warnings
- bunx oxfmt --check packages/core/storage-core/src/testing/memory.ts packages/core/storage-core/src/testing/conformance.ts
- bun run --cwd packages/core/storage-core typecheck
- bun run --cwd packages/core/storage-core test