### PR TITLE
Fix MCP SDK store and test boundaries

### DIFF
--- a/packages/plugins/mcp/src/sdk/binding-store.ts
+++ b/packages/plugins/mcp/src/sdk/binding-store.ts
@@ -16,13 +16,9 @@
 // and is owned by `ctx.oauth`.
 // ---------------------------------------------------------------------------
 
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 
-import {
-  defineSchema,
-  type StorageDeps,
-  type StorageFailure,
-} from "@executor-js/sdk/core";
+import { defineSchema, type StorageDeps, type StorageFailure } from "@executor-js/sdk/core";
 
 import {
   McpToolBinding,
@@ -119,15 +115,18 @@ const encodeSourceData = Schema.encodeSync(McpStoredSourceData);
 
 const decodeBinding = Schema.decodeUnknownSync(McpToolBinding);
 const encodeBinding = Schema.encodeSync(McpToolBinding);
+const decodeJson = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown));
 
 const coerceJson = (value: unknown): unknown => {
   if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
+  return Option.getOrElse(decodeJson(value), () => value);
 };
+
+const hasStringFields = <const Fields extends readonly string[]>(
+  row: Record<string, unknown>,
+  fields: Fields,
+): row is Record<Fields[number], string> & Record<string, unknown> =>
+  fields.every((field) => typeof row[field] === "string");
 
 // --- auth column packing/unpacking ------------------------------------------
 
@@ -162,7 +161,7 @@ const authToColumns = (auth: McpConnectionAuth): AuthColumns => {
 };
 
 const columnsToAuth = (row: Record<string, unknown>): McpConnectionAuth => {
-  const kind = row.auth_kind as string;
+  const kind = row.auth_kind;
   if (kind === "header" && typeof row.auth_secret_id === "string") {
     const prefix = row.auth_secret_prefix as string | null | undefined;
     return {
@@ -179,9 +178,7 @@ const columnsToAuth = (row: Record<string, unknown>): McpConnectionAuth => {
       kind: "oauth2",
       connectionId: row.auth_connection_id,
       ...(cid ? { clientIdSecretId: cid } : {}),
-      ...(csec !== undefined && csec !== null
-        ? { clientSecretSecretId: csec }
-        : {}),
+      ...(csec !== undefined && csec !== null ? { clientSecretSecretId: csec } : {}),
     };
   }
   return { kind: "none" };
@@ -236,12 +233,11 @@ const rowsToValueMap = (
 ): Record<string, SecretBackedValue> => {
   const out: Record<string, SecretBackedValue> = {};
   for (const row of rows) {
-    const name = row.name as string;
+    if (typeof row.name !== "string") continue;
+    const name = row.name;
     if (row.kind === "secret" && typeof row.secret_id === "string") {
       const prefix = row.secret_prefix as string | undefined | null;
-      out[name] = prefix
-        ? { secretId: row.secret_id, prefix }
-        : { secretId: row.secret_id };
+      out[name] = prefix ? { secretId: row.secret_id, prefix } : { secretId: row.secret_id };
     } else if (row.kind === "text" && typeof row.text_value === "string") {
       out[name] = row.text_value;
     }
@@ -288,7 +284,10 @@ export interface McpBindingStore {
     namespace: string,
     scope: string,
   ) => Effect.Effect<
-    ReadonlyArray<{ readonly toolId: string; readonly binding: McpToolBinding }>,
+    ReadonlyArray<{
+      readonly toolId: string;
+      readonly binding: McpToolBinding;
+    }>,
     StorageFailure
   >;
 
@@ -303,7 +302,10 @@ export interface McpBindingStore {
   readonly putBindings: (
     namespace: string,
     scope: string,
-    entries: ReadonlyArray<{ readonly toolId: string; readonly binding: McpToolBinding }>,
+    entries: ReadonlyArray<{
+      readonly toolId: string;
+      readonly binding: McpToolBinding;
+    }>,
   ) => Effect.Effect<void, StorageFailure>;
 
   readonly removeBindingsByNamespace: (
@@ -320,10 +322,7 @@ export interface McpBindingStore {
     scope: string,
   ) => Effect.Effect<McpStoredSourceData | null, StorageFailure>;
   readonly putSource: (source: McpStoredSource) => Effect.Effect<void, StorageFailure>;
-  readonly removeSource: (
-    namespace: string,
-    scope: string,
-  ) => Effect.Effect<void, StorageFailure>;
+  readonly removeSource: (namespace: string, scope: string) => Effect.Effect<void, StorageFailure>;
 
   // ---------------------------------------------------------------------
   // Usage lookups — back `usagesForSecret` / `usagesForConnection`.
@@ -332,9 +331,7 @@ export interface McpBindingStore {
   /** Source rows whose flattened auth columns reference the given
    *  secret id. The `slot` field on each result tags which column
    *  matched so the caller can produce a precise Usage.slot. */
-  readonly findSourcesBySecret: (
-    secretId: string,
-  ) => Effect.Effect<
+  readonly findSourcesBySecret: (secretId: string) => Effect.Effect<
     readonly {
       readonly namespace: string;
       readonly scope_id: string;
@@ -345,9 +342,7 @@ export interface McpBindingStore {
   >;
 
   /** Source rows whose oauth2 auth points at the given connection id. */
-  readonly findSourcesByConnection: (
-    connectionId: string,
-  ) => Effect.Effect<
+  readonly findSourcesByConnection: (connectionId: string) => Effect.Effect<
     readonly {
       readonly namespace: string;
       readonly scope_id: string;
@@ -379,9 +374,7 @@ export interface McpBindingStore {
 // Factory
 // ---------------------------------------------------------------------------
 
-export const makeMcpStore = ({
-  adapter: db,
-}: StorageDeps<McpSchema>): McpBindingStore => {
+export const makeMcpStore = ({ adapter: db }: StorageDeps<McpSchema>): McpBindingStore => {
   return {
     listBindingsBySource: (namespace, scope) =>
       Effect.gen(function* () {
@@ -486,18 +479,11 @@ export const makeMcpStore = ({
         yield* deleteSourceChildren(source.namespace, source.scope);
 
         const auth: McpConnectionAuth =
-          source.config.transport === "remote"
-            ? source.config.auth
-            : { kind: "none" };
+          source.config.transport === "remote" ? source.config.auth : { kind: "none" };
         const authCols = authToColumns(auth);
-        const headers =
-          source.config.transport === "remote"
-            ? source.config.headers
-            : undefined;
+        const headers = source.config.transport === "remote" ? source.config.headers : undefined;
         const queryParams =
-          source.config.transport === "remote"
-            ? source.config.queryParams
-            : undefined;
+          source.config.transport === "remote" ? source.config.queryParams : undefined;
 
         // The encoded config keeps every plugin-private field but
         // strips auth/headers/queryParams — those moved to columns/
@@ -520,11 +506,7 @@ export const makeMcpStore = ({
           forceAllowId: true,
         });
 
-        const headerRows = valueMapToRows(
-          source.namespace,
-          source.scope,
-          headers,
-        );
+        const headerRows = valueMapToRows(source.namespace, source.scope, headers);
         if (headerRows.length > 0) {
           yield* db.createMany({
             model: "mcp_source_header",
@@ -532,11 +514,7 @@ export const makeMcpStore = ({
             forceAllowId: true,
           });
         }
-        const paramRows = valueMapToRows(
-          source.namespace,
-          source.scope,
-          queryParams,
-        );
+        const paramRows = valueMapToRows(source.namespace, source.scope, queryParams);
         if (paramRows.length > 0) {
           yield* db.createMany({
             model: "mcp_source_query_param",
@@ -579,15 +557,11 @@ export const makeMcpStore = ({
             }),
             db.findMany({
               model: "mcp_source",
-              where: [
-                { field: "auth_client_id_secret_id", value: secretId },
-              ],
+              where: [{ field: "auth_client_id_secret_id", value: secretId }],
             }),
             db.findMany({
               model: "mcp_source",
-              where: [
-                { field: "auth_client_secret_secret_id", value: secretId },
-              ],
+              where: [{ field: "auth_client_secret_secret_id", value: secretId }],
             }),
           ],
           { concurrency: "unbounded" },
@@ -596,19 +570,18 @@ export const makeMcpStore = ({
         for (const r of [...byHeader, ...byClientId, ...byClientSecret]) {
           dedup.set(`${r.scope_id}:${r.id}`, r);
         }
-        return [...dedup.values()].map((row) => ({
-          namespace: row.id as string,
-          scope_id: row.scope_id as string,
-          name: row.name as string,
-          slot:
-            (byHeader as readonly Record<string, unknown>[]).includes(row)
+        return [...dedup.values()]
+          .filter((row) => hasStringFields(row, ["id", "scope_id", "name"]))
+          .map((row) => ({
+            namespace: row.id,
+            scope_id: row.scope_id,
+            name: row.name,
+            slot: (byHeader as readonly Record<string, unknown>[]).includes(row)
               ? "auth.header"
-              : (byClientId as readonly Record<string, unknown>[]).includes(
-                    row,
-                  )
+              : (byClientId as readonly Record<string, unknown>[]).includes(row)
                 ? "auth.oauth2.client_id"
                 : "auth.oauth2.client_secret",
-        }));
+          }));
       }),
 
     findSourcesByConnection: (connectionId) =>
@@ -620,9 +593,9 @@ export const makeMcpStore = ({
         .pipe(
           Effect.map((rows) =>
             rows.map((r) => ({
-              namespace: r.id as string,
-              scope_id: r.scope_id as string,
-              name: r.name as string,
+              namespace: r.id,
+              scope_id: r.scope_id,
+              name: r.name,
               slot: "auth.oauth2.connection",
             })),
           ),
@@ -646,15 +619,15 @@ export const makeMcpStore = ({
         return [
           ...headers.map((r) => ({
             kind: "header" as const,
-            source_id: r.source_id as string,
-            scope_id: r.scope_id as string,
-            name: r.name as string,
+            source_id: r.source_id,
+            scope_id: r.scope_id,
+            name: r.name,
           })),
           ...params.map((r) => ({
             kind: "query_param" as const,
-            source_id: r.source_id as string,
-            scope_id: r.scope_id as string,
-            name: r.name as string,
+            source_id: r.source_id,
+            scope_id: r.scope_id,
+            name: r.name,
           })),
         ];
       }),
@@ -666,8 +639,8 @@ export const makeMcpStore = ({
         const requested = new Set(keys);
         const out = new Map<string, string>();
         for (const r of rows) {
-          const key = `${r.scope_id as string}:${r.id as string}`;
-          if (requested.has(key)) out.set(key, r.name as string);
+          const key = `${r.scope_id}:${r.id}`;
+          if (requested.has(key)) out.set(key, r.name);
         }
         return out;
       }),
@@ -679,10 +652,7 @@ export const makeMcpStore = ({
 
   function deleteSourceChildren(namespace: string, scope: string) {
     return Effect.gen(function* () {
-      for (const model of [
-        "mcp_source_header",
-        "mcp_source_query_param",
-      ] as const) {
+      for (const model of ["mcp_source_header", "mcp_source_query_param"] as const) {
         yield* db.deleteMany({
           model,
           where: [
@@ -740,9 +710,7 @@ export const makeMcpStore = ({
 // Keeps the remaining structural fields (transport, endpoint, etc.) in
 // the JSON config column. Per-transport: only the remote variant has
 // these fields, so this is a no-op for stdio.
-const stripExtractedFields = (
-  encoded: Record<string, unknown>,
-): Record<string, unknown> => {
+const stripExtractedFields = (encoded: Record<string, unknown>): Record<string, unknown> => {
   if (encoded.transport !== "remote") return encoded;
   const { auth, headers, queryParams, ...rest } = encoded;
   void auth;

--- a/packages/plugins/mcp/src/sdk/discover.ts
+++ b/packages/plugins/mcp/src/sdk/discover.ts
@@ -27,10 +27,10 @@ export const discoverTools = (
     // Acquire connection
     const connection = yield* connector.pipe(
       Effect.mapError(
-        (err) =>
+        ({ message }) =>
           new McpToolDiscoveryError({
             stage: "connect",
-            message: `Failed connecting to MCP server: ${err.message}`,
+            message: `Failed connecting to MCP server: ${message}`,
           }),
       ),
     );
@@ -38,23 +38,19 @@ export const discoverTools = (
     // List tools
     const listResult = yield* Effect.tryPromise({
       try: () => connection.client.listTools(),
-      catch: (cause) =>
+      catch: () =>
         new McpToolDiscoveryError({
           stage: "list_tools",
-          message: `Failed listing MCP tools: ${
-            cause instanceof Error ? cause.message : String(cause)
-          }`,
+          message: "Failed listing MCP tools",
         }),
     });
 
     if (!isListToolsResult(listResult)) {
-      yield* Effect.promise(() => connection.close().catch(() => {}));
-      return yield* Effect.fail(
-        new McpToolDiscoveryError({
-          stage: "list_tools",
-          message: "MCP listTools response did not match the expected schema",
-        }),
-      );
+      yield* closeConnection(connection);
+      return yield* new McpToolDiscoveryError({
+        stage: "list_tools",
+        message: "MCP listTools response did not match the expected schema",
+      });
     }
 
     const manifest = extractManifestFromListToolsResult(listResult, {
@@ -62,7 +58,21 @@ export const discoverTools = (
     });
 
     // Close the connection after discovery
-    yield* Effect.promise(() => connection.close().catch(() => {}));
+    yield* closeConnection(connection);
 
     return manifest;
   });
+
+const closeConnection = (connection: {
+  readonly close: () => Promise<void>;
+}): Effect.Effect<void, never> =>
+  Effect.ignore(
+    Effect.tryPromise({
+      try: () => connection.close(),
+      catch: () =>
+        new McpToolDiscoveryError({
+          stage: "list_tools",
+          message: "Failed closing MCP connection",
+        }),
+    }),
+  );

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Result } from "effect";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
@@ -17,11 +17,7 @@ import {
 } from "@executor-js/sdk";
 
 import { mcpPlugin } from "./plugin";
-import {
-  extractManifestFromListToolsResult,
-  deriveMcpNamespace,
-  joinToolPath,
-} from "./manifest";
+import { extractManifestFromListToolsResult, deriveMcpNamespace, joinToolPath } from "./manifest";
 import { serveMcpServer } from "./test-utils";
 
 // ---------------------------------------------------------------------------
@@ -36,14 +32,12 @@ const makeMemorySecretsPlugin = () => {
   const provider: SecretProvider = {
     key: "memory",
     writable: true,
-    get: (id, scope) =>
-      Effect.sync(() => store.get(`${scope}${id}`) ?? null),
+    get: (id, scope) => Effect.sync(() => store.get(`${scope}${id}`) ?? null),
     set: (id, value, scope) =>
       Effect.sync(() => {
         store.set(`${scope}${id}`, value);
       }),
-    delete: (id, scope) =>
-      Effect.sync(() => store.delete(`${scope}${id}`)),
+    delete: (id, scope) => Effect.sync(() => store.delete(`${scope}${id}`)),
     list: () =>
       Effect.sync(() =>
         Array.from(store.keys()).map((k) => {
@@ -158,9 +152,7 @@ describe("deriveMcpNamespace", () => {
 
   it.effect("derives from command", () =>
     Effect.sync(() => {
-      expect(deriveMcpNamespace({ command: "/usr/local/bin/my-mcp-server" })).toBe(
-        "my_mcp_server",
-      );
+      expect(deriveMcpNamespace({ command: "/usr/local/bin/my-mcp-server" })).toBe("my_mcp_server");
     }),
   );
 
@@ -214,9 +206,7 @@ describe("mcpPlugin", () => {
 
   it.effect("sources list is initially empty", () =>
     Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [mcpPlugin()] as const }),
-      );
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
       const sources = yield* executor.sources.list();
       expect(sources).toHaveLength(0);
     }),
@@ -224,9 +214,7 @@ describe("mcpPlugin", () => {
 
   it.effect("tools list is initially empty", () =>
     Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [mcpPlugin()] as const }),
-      );
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
       const tools = yield* executor.tools.list();
       expect(tools).toHaveLength(0);
     }),
@@ -238,9 +226,7 @@ describe("mcpPlugin", () => {
   // still propagates to the caller so boot-time sync logs the reason.
   it.effect("registers source with 0 tools when discovery fails", () =>
     Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [mcpPlugin()] as const }),
-      );
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
 
       const result = yield* executor.mcp
         .addSource({
@@ -256,7 +242,7 @@ describe("mcpPlugin", () => {
         })
         .pipe(Effect.result);
 
-      expect(result._tag).toBe("Failure");
+      expect(Result.isFailure(result)).toBe(true);
 
       const sources = yield* executor.sources.list();
       const broken = sources.find((s) => s.id === "broken_source");
@@ -304,7 +290,11 @@ describe("mcpPlugin", () => {
       readonly remoteTransport: "auto";
       readonly namespace: string;
     }) => Effect.Effect<unknown, unknown>,
-    args: { readonly scope: string; readonly name: string; readonly endpoint: string },
+    args: {
+      readonly scope: string;
+      readonly name: string;
+      readonly endpoint: string;
+    },
   ) =>
     addSource({
       transport: "remote",
@@ -326,28 +316,28 @@ describe("mcpPlugin", () => {
 
       // Org-level base source — discovery fails but row persists.
       yield* seedShadowed(executor.mcp.addSource, {
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         name: "Org Source",
         endpoint: "http://127.0.0.1:1/org-mcp",
       });
 
       // Per-user shadow with the same namespace.
       yield* seedShadowed(executor.mcp.addSource, {
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         name: "User Source",
         endpoint: "http://127.0.0.1:1/user-mcp",
       });
 
-      const userView = yield* executor.mcp.getSource("shared", USER_SCOPE as string);
-      const orgView = yield* executor.mcp.getSource("shared", ORG_SCOPE as string);
+      const userView = yield* executor.mcp.getSource("shared", USER_SCOPE);
+      const orgView = yield* executor.mcp.getSource("shared", ORG_SCOPE);
 
       // Both rows must coexist — the store's scope-pinned getters
       // return the exact row regardless of the scope stack's
       // fall-through order.
       expect(userView?.name).toBe("User Source");
-      expect(userView?.scope).toBe(USER_SCOPE as string);
+      expect(userView?.scope).toBe(USER_SCOPE);
       expect(orgView?.name).toBe("Org Source");
-      expect(orgView?.scope).toBe(ORG_SCOPE as string);
+      expect(orgView?.scope).toBe(ORG_SCOPE);
     }),
   );
 
@@ -361,20 +351,20 @@ describe("mcpPlugin", () => {
       );
 
       yield* seedShadowed(executor.mcp.addSource, {
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         name: "Org Source",
         endpoint: "http://127.0.0.1:1/org-mcp",
       });
       yield* seedShadowed(executor.mcp.addSource, {
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         name: "User Source",
         endpoint: "http://127.0.0.1:1/user-mcp",
       });
 
-      yield* executor.mcp.removeSource("shared", USER_SCOPE as string);
+      yield* executor.mcp.removeSource("shared", USER_SCOPE);
 
-      const userView = yield* executor.mcp.getSource("shared", USER_SCOPE as string);
-      const orgView = yield* executor.mcp.getSource("shared", ORG_SCOPE as string);
+      const userView = yield* executor.mcp.getSource("shared", USER_SCOPE);
+      const orgView = yield* executor.mcp.getSource("shared", ORG_SCOPE);
 
       expect(userView).toBeNull();
       expect(orgView?.name).toBe("Org Source");
@@ -391,23 +381,23 @@ describe("mcpPlugin", () => {
       );
 
       yield* seedShadowed(executor.mcp.addSource, {
-        scope: ORG_SCOPE as string,
+        scope: ORG_SCOPE,
         name: "Org Source",
         endpoint: "http://127.0.0.1:1/org-mcp",
       });
       yield* seedShadowed(executor.mcp.addSource, {
-        scope: USER_SCOPE as string,
+        scope: USER_SCOPE,
         name: "User Source",
         endpoint: "http://127.0.0.1:1/user-mcp",
       });
 
-      yield* executor.mcp.updateSource("shared", USER_SCOPE as string, {
+      yield* executor.mcp.updateSource("shared", USER_SCOPE, {
         name: "User Renamed",
         endpoint: "http://127.0.0.1:1/user-new-mcp",
       });
 
-      const userView = yield* executor.mcp.getSource("shared", USER_SCOPE as string);
-      const orgView = yield* executor.mcp.getSource("shared", ORG_SCOPE as string);
+      const userView = yield* executor.mcp.getSource("shared", USER_SCOPE);
+      const orgView = yield* executor.mcp.getSource("shared", ORG_SCOPE);
 
       expect(userView?.name).toBe("User Renamed");
       expect(userView?.config.transport).toBe("remote");
@@ -460,20 +450,15 @@ describe("mcpPlugin", () => {
       // perspective — it returns Failure because discovery failed, but
       // crucially the source row was persisted so the list surfaces
       // it for subsequent sign-in.
-      expect(result._tag).toBe("Failure");
+      expect(Result.isFailure(result)).toBe(true);
 
-      const stored = yield* executor.mcp.getSource(
-        "deferred_oauth",
-        "test-scope",
-      );
+      const stored = yield* executor.mcp.getSource("deferred_oauth", "test-scope");
       expect(stored).not.toBeNull();
       expect(stored?.config.transport).toBe("remote");
       if (stored?.config.transport !== "remote") return;
       expect(stored.config.auth.kind).toBe("oauth2");
       if (stored.config.auth.kind !== "oauth2") return;
-      expect(stored.config.auth.connectionId).toBe(
-        "mcp-oauth2-deferred_oauth",
-      );
+      expect(stored.config.auth.connectionId).toBe("mcp-oauth2-deferred_oauth");
 
       // Source is visible in the shell list too.
       const sources = yield* executor.sources.list();
@@ -512,128 +497,112 @@ describe("mcpPlugin", () => {
       // connection was ever minted, so the check should be false —
       // i.e. the button would render "Sign in".
       const connections = yield* executor.connections.list();
-      const connectionMatch = connections.find(
-        (c) => c.id === "mcp-oauth2-needs_auth",
-      );
+      const connectionMatch = connections.find((c) => c.id === "mcp-oauth2-needs_auth");
       expect(connectionMatch).toBeUndefined();
 
-      const stored = yield* executor.mcp.getSource(
-        "needs_auth",
-        "test-scope",
-      );
+      const stored = yield* executor.mcp.getSource("needs_auth", "test-scope");
       expect(stored?.config.transport).toBe("remote");
       if (stored?.config.transport !== "remote") return;
       expect(stored.config.auth.kind).toBe("oauth2");
     }),
   );
 
-  it.effect(
-    "signing in as a user transitions the source to connected",
-    () =>
-      Effect.gen(function* () {
-        const USER_SCOPE_ID = ScopeId.make("user-scope");
-        const ORG_SCOPE_ID = ScopeId.make("org-scope");
-        const scopes = [
-          new Scope({
-            id: USER_SCOPE_ID,
-            name: "user",
-            createdAt: new Date(),
-          }),
-          new Scope({
-            id: ORG_SCOPE_ID,
-            name: "org",
-            createdAt: new Date(),
-          }),
-        ] as const;
-        const executor = yield* createExecutor(
-          makeTestConfig({
-            scopes,
-            plugins: [makeMemorySecretsPlugin()(), mcpPlugin()] as const,
-          }),
-        );
+  it.effect("signing in as a user transitions the source to connected", () =>
+    Effect.gen(function* () {
+      const USER_SCOPE_ID = ScopeId.make("user-scope");
+      const ORG_SCOPE_ID = ScopeId.make("org-scope");
+      const scopes = [
+        new Scope({
+          id: USER_SCOPE_ID,
+          name: "user",
+          createdAt: new Date(),
+        }),
+        new Scope({
+          id: ORG_SCOPE_ID,
+          name: "org",
+          createdAt: new Date(),
+        }),
+      ] as const;
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          scopes,
+          plugins: [makeMemorySecretsPlugin()(), mcpPlugin()] as const,
+        }),
+      );
 
-        // Admin saves the oauth2 source at the org scope — no tokens
-        // yet.
-        yield* executor.mcp
-          .addSource({
-            transport: "remote",
-            scope: ORG_SCOPE_ID as string,
-            name: "Team MCP",
+      // Admin saves the oauth2 source at the org scope — no tokens
+      // yet.
+      yield* executor.mcp
+        .addSource({
+          transport: "remote",
+          scope: ORG_SCOPE_ID,
+          name: "Team MCP",
+          endpoint: "http://127.0.0.1:1/team-mcp",
+          remoteTransport: "auto",
+          namespace: "team_mcp",
+          auth: {
+            kind: "oauth2",
+            connectionId: "mcp-oauth2-team_mcp",
+          },
+        })
+        .pipe(Effect.result);
+
+      // Before sign-in: no connection exists at all.
+      const pre = yield* executor.connections.list();
+      expect(pre.find((c) => c.id === "mcp-oauth2-team_mcp")).toBeUndefined();
+
+      // User signs in — the SignInButton flow produces a minted
+      // connection against the same stable id, pinned to the user
+      // scope. This simulates what `completeOAuth` does internally,
+      // including persisting provider state.
+      const connectionId = ConnectionId.make("mcp-oauth2-team_mcp");
+      yield* executor.connections.create(
+        new CreateConnectionInput({
+          id: connectionId,
+          scope: USER_SCOPE_ID,
+          provider: "mcp:oauth2",
+          identityLabel: "user@example.com",
+          accessToken: new TokenMaterial({
+            secretId: SecretId.make(`${connectionId}.access_token`),
+            name: "MCP Access Token",
+            value: "access-token-value",
+          }),
+          refreshToken: null,
+          expiresAt: null,
+          oauthScope: null,
+          providerState: {
             endpoint: "http://127.0.0.1:1/team-mcp",
-            remoteTransport: "auto",
-            namespace: "team_mcp",
-            auth: {
-              kind: "oauth2",
-              connectionId: "mcp-oauth2-team_mcp",
-            },
-          })
-          .pipe(Effect.result);
+            tokenType: "Bearer",
+            clientInformation: { client_id: "fake" },
+            authorizationServerUrl: null,
+            authorizationServerMetadata: null,
+            resourceMetadataUrl: null,
+            resourceMetadata: null,
+          },
+        }),
+      );
 
-        // Before sign-in: no connection exists at all.
-        const pre = yield* executor.connections.list();
-        expect(
-          pre.find((c) => c.id === "mcp-oauth2-team_mcp"),
-        ).toBeUndefined();
+      // After sign-in: the connection exists and its access token
+      // resolves. Source auth config is unchanged — the
+      // connectionId pointer now has a live backing row.
+      const post = yield* executor.connections.list();
+      const match = post.find((c) => c.id === "mcp-oauth2-team_mcp");
+      expect(match).toBeDefined();
+      expect(match?.scopeId).toBe(USER_SCOPE_ID);
 
-        // User signs in — the SignInButton flow produces a minted
-        // connection against the same stable id, pinned to the user
-        // scope. This simulates what `completeOAuth` does internally,
-        // including persisting provider state.
-        const connectionId = ConnectionId.make("mcp-oauth2-team_mcp");
-        yield* executor.connections.create(
-          new CreateConnectionInput({
-            id: connectionId,
-            scope: USER_SCOPE_ID,
-            provider: "mcp:oauth2",
-            identityLabel: "user@example.com",
-            accessToken: new TokenMaterial({
-              secretId: SecretId.make(`${connectionId}.access_token`),
-              name: "MCP Access Token",
-              value: "access-token-value",
-            }),
-            refreshToken: null,
-            expiresAt: null,
-            oauthScope: null,
-            providerState: {
-              endpoint: "http://127.0.0.1:1/team-mcp",
-              tokenType: "Bearer",
-              clientInformation: { client_id: "fake" },
-              authorizationServerUrl: null,
-              authorizationServerMetadata: null,
-              resourceMetadataUrl: null,
-              resourceMetadata: null,
-            },
-          }),
-        );
+      const accessToken = yield* executor.connections.accessToken(connectionId);
+      expect(accessToken).toBe("access-token-value");
 
-        // After sign-in: the connection exists and its access token
-        // resolves. Source auth config is unchanged — the
-        // connectionId pointer now has a live backing row.
-        const post = yield* executor.connections.list();
-        const match = post.find((c) => c.id === "mcp-oauth2-team_mcp");
-        expect(match).toBeDefined();
-        expect(match?.scopeId).toBe(USER_SCOPE_ID);
-
-        const accessToken = yield* executor.connections.accessToken(
-          connectionId,
-        );
-        expect(accessToken).toBe("access-token-value");
-
-        // Source auth still points at the same connectionId — no
-        // migration needed, the UI flipped "Sign in" → "Reconnect" by
-        // virtue of the connection existing.
-        const stored = yield* executor.mcp.getSource(
-          "team_mcp",
-          ORG_SCOPE_ID as string,
-        );
-        expect(stored?.config.transport).toBe("remote");
-        if (stored?.config.transport !== "remote") return;
-        expect(stored.config.auth.kind).toBe("oauth2");
-        if (stored.config.auth.kind !== "oauth2") return;
-        expect(stored.config.auth.connectionId).toBe(
-          "mcp-oauth2-team_mcp",
-        );
-      }),
+      // Source auth still points at the same connectionId — no
+      // migration needed, the UI flipped "Sign in" → "Reconnect" by
+      // virtue of the connection existing.
+      const stored = yield* executor.mcp.getSource("team_mcp", ORG_SCOPE_ID);
+      expect(stored?.config.transport).toBe("remote");
+      if (stored?.config.transport !== "remote") return;
+      expect(stored.config.auth.kind).toBe("oauth2");
+      if (stored.config.auth.kind !== "oauth2") return;
+      expect(stored.config.auth.connectionId).toBe("mcp-oauth2-team_mcp");
+    }),
   );
 
   // -------------------------------------------------------------------------
@@ -645,9 +614,7 @@ describe("mcpPlugin", () => {
 
   it.effect("usagesForSecret aggregates header-auth + headers child rows", () =>
     Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [mcpPlugin()] as const }),
-      );
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
 
       yield* executor.mcp
         .addSource({
@@ -666,17 +633,13 @@ describe("mcpPlugin", () => {
         })
         .pipe(Effect.result);
 
-      const usages = yield* executor.secrets.usages(
-        SecretId.make("shared-key"),
-      );
+      const usages = yield* executor.secrets.usages(SecretId.make("shared-key"));
       expect(usages.length).toBe(2);
       const slots = usages.map((u) => u.slot).sort();
       expect(slots).toEqual(["auth.header", "header:X-Trace"]);
       expect(usages.every((u) => u.pluginId === "mcp")).toBe(true);
 
-      const otherUsages = yield* executor.secrets.usages(
-        SecretId.make("other-secret"),
-      );
+      const otherUsages = yield* executor.secrets.usages(SecretId.make("other-secret"));
       expect(otherUsages.length).toBe(1);
       expect(otherUsages[0].slot).toBe("query_param:ping");
     }),
@@ -684,9 +647,7 @@ describe("mcpPlugin", () => {
 
   it.effect("usagesForConnection finds oauth2-bound mcp sources", () =>
     Effect.gen(function* () {
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [mcpPlugin()] as const }),
-      );
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
 
       yield* executor.mcp
         .addSource({
@@ -699,9 +660,7 @@ describe("mcpPlugin", () => {
         })
         .pipe(Effect.result);
 
-      const usages = yield* executor.connections.usages(
-        ConnectionId.make("conn-xyz"),
-      );
+      const usages = yield* executor.connections.usages(ConnectionId.make("conn-xyz"));
       expect(usages.length).toBe(1);
       expect(usages[0]).toMatchObject({
         pluginId: "mcp",
@@ -768,9 +727,7 @@ describe("MCP destructiveHint → requiresApproval", () => {
   it.effect("destructiveHint becomes requiresApproval, others stay false", () =>
     Effect.gen(function* () {
       const server = yield* serveAnnotationsTestServer;
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [mcpPlugin()] as const }),
-      );
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
       yield* executor.mcp.addSource({
         transport: "remote",
         scope: "test-scope",
@@ -794,9 +751,7 @@ describe("MCP destructiveHint → requiresApproval", () => {
   it.effect("uses annotations.title as approvalDescription when present", () =>
     Effect.gen(function* () {
       const server = yield* serveAnnotationsTestServer;
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [mcpPlugin()] as const }),
-      );
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
       yield* executor.mcp.addSource({
         transport: "remote",
         scope: "test-scope",
@@ -807,9 +762,7 @@ describe("MCP destructiveHint → requiresApproval", () => {
       const tools = yield* executor.tools.list();
       const deleteTitled = tools.find((t) => t.name === "delete_titled");
       expect(deleteTitled?.annotations?.requiresApproval).toBe(true);
-      expect(deleteTitled?.annotations?.approvalDescription).toBe(
-        "Delete dataset",
-      );
+      expect(deleteTitled?.annotations?.approvalDescription).toBe("Delete dataset");
     }),
   );
 });


### PR DESCRIPTION
## Summary
- parse MCP binding rows and test fixtures with Effect Schema
- move discovery cleanup/errors into typed Effect adapters
- replace manual tag/test failure handling with public Effect helpers

## Verification
- bunx oxlint -c .oxlintrc.jsonc packages/plugins/mcp/src/sdk/binding-store.ts packages/plugins/mcp/src/sdk/discover.ts packages/plugins/mcp/src/sdk/plugin.test.ts --deny-warnings
- bunx oxfmt --check packages/plugins/mcp/src/sdk/binding-store.ts packages/plugins/mcp/src/sdk/discover.ts packages/plugins/mcp/src/sdk/plugin.test.ts
- bun run --cwd packages/plugins/mcp typecheck
- bun run --cwd packages/plugins/mcp test src/sdk/plugin.test.ts