### PR TITLE
Fix executor typed boundary lint

### DIFF
--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -10,10 +10,7 @@ import {
   type TypedAdapter,
 } from "@executor-js/storage-core";
 
-import {
-  pluginBlobStore,
-  type BlobStore,
-} from "./blob";
+import { pluginBlobStore, type BlobStore } from "./blob";
 import {
   ConnectionProviderState,
   ConnectionRef,
@@ -81,11 +78,7 @@ import type {
   StorageDeps,
 } from "./plugin";
 import type { Scope } from "./scope";
-import {
-  SecretRef,
-  SetSecretInput,
-  type SecretProvider,
-} from "./secrets";
+import { SecretRef, SetSecretInput, type SecretProvider } from "./secrets";
 import { Usage } from "./usages";
 import {
   ToolSchema,
@@ -126,9 +119,7 @@ export interface InvokeOptions {
 const acceptAllHandler: ElicitationHandler = () =>
   Effect.succeed(new ElicitationResponse({ action: "accept" }));
 
-const resolveElicitationHandler = (
-  onElicitation: OnElicitation,
-): ElicitationHandler =>
+const resolveElicitationHandler = (onElicitation: OnElicitation): ElicitationHandler =>
   onElicitation === "accept-all" ? acceptAllHandler : onElicitation;
 
 // ---------------------------------------------------------------------------
@@ -148,16 +139,12 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
   readonly scopes: readonly Scope[];
 
   readonly tools: {
-    readonly list: (
-      filter?: ToolListFilter,
-    ) => Effect.Effect<readonly Tool[], StorageFailure>;
+    readonly list: (filter?: ToolListFilter) => Effect.Effect<readonly Tool[], StorageFailure>;
     /** Fetch a tool's full schema view: JSON schemas with `$defs`
      *  attached from the core `definition` table, plus TypeScript
      *  preview strings rendered from them. Returns `null` for unknown
      *  tool ids. */
-    readonly schema: (
-      toolId: string,
-    ) => Effect.Effect<ToolSchema | null, StorageFailure>;
+    readonly schema: (toolId: string) => Effect.Effect<ToolSchema | null, StorageFailure>;
     /** Every `$defs` entry across every source, grouped by source id.
      *  Used for bulk schema export and downstream TypeScript rendering. */
     readonly definitions: () => Effect.Effect<
@@ -206,12 +193,8 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
      *  only, never calls the provider. Use this for UI state ("secret
      *  missing, prompt to add") to avoid keychain permission prompts
      *  or 1password IPC roundtrips on a pre-flight check. */
-    readonly status: (
-      id: string,
-    ) => Effect.Effect<"resolved" | "missing", StorageFailure>;
-    readonly set: (
-      input: SetSecretInput,
-    ) => Effect.Effect<SecretRef, StorageFailure>;
+    readonly status: (id: string) => Effect.Effect<"resolved" | "missing", StorageFailure>;
+    readonly set: (input: SetSecretInput) => Effect.Effect<SecretRef, StorageFailure>;
     /** Delete a bare (non-connection-owned) secret. Connection-owned
      *  secrets are rejected with `SecretOwnedByConnectionError` — use
      *  `connections.remove` instead. Refuses with `SecretInUseError`
@@ -219,37 +202,24 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
      *  show the `usages(id)` list and ask the user to detach first. */
     readonly remove: (
       id: string,
-    ) => Effect.Effect<
-      void,
-      SecretOwnedByConnectionError | SecretInUseError | StorageFailure
-    >;
+    ) => Effect.Effect<void, SecretOwnedByConnectionError | SecretInUseError | StorageFailure>;
     readonly list: () => Effect.Effect<readonly SecretRef[], StorageFailure>;
     /** All places this secret is referenced — fans out across every
      *  plugin's `usagesForSecret`. Used by the Secrets-tab "Used by"
      *  list and by `remove` for its RESTRICT check. */
-    readonly usages: (
-      id: string,
-    ) => Effect.Effect<readonly Usage[], StorageFailure>;
+    readonly usages: (id: string) => Effect.Effect<readonly Usage[], StorageFailure>;
     readonly providers: () => Effect.Effect<readonly string[]>;
   };
 
   readonly connections: {
-    readonly get: (
-      id: string,
-    ) => Effect.Effect<ConnectionRef | null, StorageFailure>;
+    readonly get: (id: string) => Effect.Effect<ConnectionRef | null, StorageFailure>;
     readonly list: () => Effect.Effect<readonly ConnectionRef[], StorageFailure>;
     readonly create: (
       input: CreateConnectionInput,
-    ) => Effect.Effect<
-      ConnectionRef,
-      ConnectionProviderNotRegisteredError | StorageFailure
-    >;
+    ) => Effect.Effect<ConnectionRef, ConnectionProviderNotRegisteredError | StorageFailure>;
     readonly updateTokens: (
       input: UpdateConnectionTokensInput,
-    ) => Effect.Effect<
-      ConnectionRef,
-      ConnectionNotFoundError | StorageFailure
-    >;
+    ) => Effect.Effect<ConnectionRef, ConnectionNotFoundError | StorageFailure>;
     readonly setIdentityLabel: (
       id: string,
       label: string | null,
@@ -267,14 +237,10 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
     >;
     /** Refuses with `ConnectionInUseError` if any plugin reports the
      *  connection as in use. */
-    readonly remove: (
-      id: string,
-    ) => Effect.Effect<void, ConnectionInUseError | StorageFailure>;
+    readonly remove: (id: string) => Effect.Effect<void, ConnectionInUseError | StorageFailure>;
     /** All places this connection is referenced — fans out across every
      *  plugin's `usagesForConnection`. */
-    readonly usages: (
-      id: string,
-    ) => Effect.Effect<readonly Usage[], StorageFailure>;
+    readonly usages: (id: string) => Effect.Effect<readonly Usage[], StorageFailure>;
     readonly providers: () => Effect.Effect<readonly string[]>;
   };
 
@@ -289,28 +255,20 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
     readonly list: () => Effect.Effect<readonly ToolPolicy[], StorageFailure>;
     /** Create a new policy. Defaults to the top of the target scope's
      *  list (highest precedence) when `position` is omitted. */
-    readonly create: (
-      input: CreateToolPolicyInput,
-    ) => Effect.Effect<ToolPolicy, StorageFailure>;
-    readonly update: (
-      input: UpdateToolPolicyInput,
-    ) => Effect.Effect<ToolPolicy, StorageFailure>;
+    readonly create: (input: CreateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
+    readonly update: (input: UpdateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
     readonly remove: (id: string) => Effect.Effect<void, StorageFailure>;
     /** Resolve the effective policy for a tool id by walking the scope-
      *  stacked policy list with first-match-wins semantics. Returns
      *  `undefined` when no rule matches (caller falls back to the
      *  plugin's `resolveAnnotations` output). */
-    readonly resolve: (
-      toolId: string,
-    ) => Effect.Effect<PolicyMatch | undefined, StorageFailure>;
+    readonly resolve: (toolId: string) => Effect.Effect<PolicyMatch | undefined, StorageFailure>;
   };
 
   readonly close: () => Effect.Effect<void, StorageFailure>;
 } & PluginExtensions<TPlugins>;
 
-export interface ExecutorConfig<
-  TPlugins extends readonly AnyPlugin[] = [],
-> {
+export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = []> {
   /**
    * Precedence-ordered scope stack. Innermost first; typical shape is
    * `[userInOrgScope, orgScope]`. Reads on scoped tables walk the
@@ -339,18 +297,19 @@ export interface ExecutorConfig<
 // manifest) before constructing the executor.
 // ---------------------------------------------------------------------------
 
-export const collectSchemas = (
-  plugins: readonly AnyPlugin[],
-): DBSchema => {
+export const collectSchemas = (plugins: readonly AnyPlugin[]): DBSchema => {
   const merged: Record<string, DBSchema[string]> = { ...coreSchema };
   for (const plugin of plugins) {
     if (!plugin.schema) continue;
     for (const [modelKey, model] of Object.entries(plugin.schema)) {
       if (merged[modelKey]) {
-        throw new Error(
-          `Duplicate model "${modelKey}" contributed by plugin "${plugin.id}"` +
+        // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: collectSchemas is a synchronous configuration API
+        throw new StorageError({
+          message:
+            `Duplicate model "${modelKey}" contributed by plugin "${plugin.id}"` +
             ` (reserved by core or another plugin)`,
-        );
+          cause: undefined,
+        });
       }
       merged[modelKey] = model as DBSchema[string];
     }
@@ -375,10 +334,7 @@ const rowToSource = (row: SourceRow): Source => ({
   runtime: false,
 });
 
-const staticDeclToSource = (
-  decl: StaticSourceDecl,
-  pluginId: string,
-): Source => ({
+const staticDeclToSource = (decl: StaticSourceDecl, pluginId: string): Source => ({
   id: decl.id,
   scopeId: undefined,
   kind: decl.kind,
@@ -394,17 +350,12 @@ const staticDeclToSource = (
 const decodeJsonColumn = (value: unknown): unknown => {
   if (value === null || value === undefined) return undefined;
   if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
+  return Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(value).pipe(
+    Option.getOrElse(() => value),
+  );
 };
 
-const rowToTool = (
-  row: ToolRow,
-  annotations?: ToolAnnotations,
-): Tool => ({
+const rowToTool = (row: ToolRow, annotations?: ToolAnnotations): Tool => ({
   id: row.id,
   sourceId: row.source_id,
   pluginId: row.plugin_id,
@@ -579,10 +530,9 @@ const toolMatchesFilter = (tool: Tool, filter: ToolListFilter): boolean => {
 // query through the same sql.begin connection. This is what makes nested
 // writes atomic on postgres + Hyperdrive without deadlocking a pool of 1.
 // ---------------------------------------------------------------------------
-const activeAdapterRef = Context.Reference<DBTransactionAdapter | null>(
-  "executor/ActiveAdapter",
-  { defaultValue: () => null },
-);
+const activeAdapterRef = Context.Reference<DBTransactionAdapter | null>("executor/ActiveAdapter", {
+  defaultValue: () => null,
+});
 
 // A `DBAdapter` whose methods dispatch to the active adapter (tx handle or
 // root) on every call. Stable identity for consumers (plugin storage,
@@ -593,7 +543,7 @@ const buildAdapterRouter = (root: DBAdapter): DBAdapter => {
     use: (active: DBTransactionAdapter) => Effect.Effect<A, E>,
   ): Effect.Effect<A, E> =>
     Effect.flatMap(Effect.service(activeAdapterRef), (active) =>
-      use((active ?? (root as DBTransactionAdapter))),
+      use(active ?? (root as DBTransactionAdapter)),
     );
 
   return {
@@ -646,27 +596,21 @@ interface PluginRuntime {
   readonly ctx: PluginCtx<unknown>;
 }
 
-export const createExecutor = <
-  const TPlugins extends readonly AnyPlugin[] = [],
->(
+export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>(
   config: ExecutorConfig<TPlugins>,
-): Effect.Effect<Executor<TPlugins>, Error> =>
+): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
   Effect.gen(function* () {
     const defaultPlugins = (): TPlugins => {
       const empty: readonly AnyPlugin[] = [];
       return empty as TPlugins;
     };
-    const {
-      scopes,
-      adapter: rootAdapter,
-      blobs,
-      plugins = defaultPlugins(),
-    } = config;
+    const { scopes, adapter: rootAdapter, blobs, plugins = defaultPlugins() } = config;
 
     if (scopes.length === 0) {
-      return yield* Effect.fail(
-        new Error("createExecutor requires a non-empty scopes array"),
-      );
+      return yield* new StorageError({
+        message: "createExecutor requires a non-empty scopes array",
+        cause: undefined,
+      });
     }
 
     // Scope-wrap the root adapter so every read on a tenant-scoped
@@ -677,12 +621,8 @@ export const createExecutor = <
     // visible. Only tables whose schema declares `scope_id` are
     // scoped.
     const schema = collectSchemas(plugins);
-    const scopeIds = scopes.map((s) => s.id as string);
-    const scopedRoot = scopeAdapter(
-      rootAdapter,
-      { scopes: scopeIds },
-      schema,
-    );
+    const scopeIds = scopes.map((s) => s.id);
+    const scopedRoot = scopeAdapter(rootAdapter, { scopes: scopeIds }, schema);
     const adapter = buildAdapterRouter(scopedRoot);
     const core = typedAdapter<CoreSchema>(adapter);
 
@@ -703,9 +643,7 @@ export const createExecutor = <
       ["google-discovery:google", "oauth2"],
       ["google-discovery:oauth2", "oauth2"],
     ]);
-    const resolveConnectionProvider = (
-      key: string,
-    ): ConnectionProvider | undefined => {
+    const resolveConnectionProvider = (key: string): ConnectionProvider | undefined => {
       const direct = connectionProviders.get(key);
       if (direct) return direct;
       const canonical = connectionProviderAliases.get(key);
@@ -760,8 +698,12 @@ export const createExecutor = <
     // Rows whose scope isn't in the stack get pushed to the end (they
     // shouldn't reach us — the adapter filters by `scope_id IN (stack)` —
     // but guarding here means a stray row can't silently win).
-    const scopeRank = (row: { scope_id: unknown }) =>
-      scopePrecedence.get(row.scope_id as string) ?? Infinity;
+    const rowScopeId = (row: { readonly scope_id: unknown }) =>
+      typeof row.scope_id === "string" ? row.scope_id : null;
+    const scopeRank = (row: { readonly scope_id: unknown }) => {
+      const scopeId = rowScopeId(row);
+      return scopeId === null ? Infinity : (scopePrecedence.get(scopeId) ?? Infinity);
+    };
 
     // Pick the innermost-scope row on a findOne-by-id against a scoped
     // model. The scope-wrapped adapter returns rows from every scope in
@@ -770,9 +712,7 @@ export const createExecutor = <
     // and wrong when a user has shadowed an outer default. Callers that
     // need a single logical row (invoke, tool schema, source removal)
     // must go through this path so the innermost write always wins.
-    const findInnermost = <T extends { scope_id: unknown }>(
-      rows: readonly T[],
-    ): T | null => {
+    const findInnermost = <T extends { scope_id: unknown }>(rows: readonly T[]): T | null => {
       if (rows.length === 0) return null;
       let winner: T | undefined;
       let best = Infinity;
@@ -786,9 +726,7 @@ export const createExecutor = <
       return winner ?? null;
     };
 
-    const secretRowsForId = (
-      id: string,
-    ): Effect.Effect<readonly SecretRow[], StorageFailure> =>
+    const secretRowsForId = (id: string): Effect.Effect<readonly SecretRow[], StorageFailure> =>
       core.findMany({
         model: "secret",
         where: [{ field: "id", value: id }],
@@ -799,15 +737,11 @@ export const createExecutor = <
       rows: readonly SecretRow[],
     ): Effect.Effect<string | null, StorageFailure> =>
       Effect.gen(function* () {
-        const ordered = [...rows].sort(
-          (a, b) =>
-            (scopePrecedence.get(a.scope_id as string) ?? Infinity) -
-            (scopePrecedence.get(b.scope_id as string) ?? Infinity),
-        );
+        const ordered = [...rows].sort((a, b) => scopeRank(a) - scopeRank(b));
         for (const row of ordered) {
-          const provider = secretProviders.get(row.provider as string);
+          const provider = secretProviders.get(row.provider);
           if (!provider) continue;
-          const value = yield* provider.get(id, row.scope_id as string);
+          const value = yield* provider.get(id, row.scope_id);
           if (value !== null) return value;
         }
 
@@ -819,14 +753,10 @@ export const createExecutor = <
         // enumeration fallback doesn't know which scope the value
         // lives in; flat providers ignore the arg.
         const fallbackScope = scopeIds[0]!;
-        const candidates = [...secretProviders.values()].filter(
-          (p) => p.list,
-        );
+        const candidates = [...secretProviders.values()].filter((p) => p.list);
         const values = yield* Effect.all(
           candidates.map((p) =>
-            p
-              .get(id, fallbackScope)
-              .pipe(Effect.catch(() => Effect.succeed(null))),
+            p.get(id, fallbackScope).pipe(Effect.catch(() => Effect.succeed(null))),
           ),
           { concurrency: "unbounded" },
         );
@@ -844,51 +774,40 @@ export const createExecutor = <
         // must not expose them even if a token secret id is leaked.
         const rows = yield* secretRowsForId(id);
         const owned = rows.find((row) => row.owned_by_connection_id);
-        if (owned) {
-          return yield* Effect.fail(
-            new SecretOwnedByConnectionError({
-              secretId: SecretId.make(id),
-              connectionId: ConnectionId.make(
-                owned.owned_by_connection_id as string,
-              ),
-            }),
-          );
+        const ownedByConnectionId = owned?.owned_by_connection_id;
+        if (ownedByConnectionId) {
+          return yield* new SecretOwnedByConnectionError({
+            secretId: SecretId.make(id),
+            connectionId: ConnectionId.make(ownedByConnectionId),
+          });
         }
         return yield* resolveSecretValueFromRows(id, rows);
       });
 
-    const connectionSecretGet = (
-      id: string,
-    ): Effect.Effect<string | null, StorageFailure> =>
+    const connectionSecretGet = (id: string): Effect.Effect<string | null, StorageFailure> =>
       Effect.gen(function* () {
         const rows = yield* secretRowsForId(id);
         return yield* resolveSecretValueFromRows(id, rows);
       });
 
     const secretRouteHasBackingValue = (row: SecretRow) => {
-      const provider = secretProviders.get(row.provider as string);
+      const provider = secretProviders.get(row.provider);
       if (!provider?.has) return Effect.succeed(true);
-      return provider
-        .has(row.id as string, row.scope_id as string)
-        .pipe(Effect.catch(() => Effect.succeed(false)));
+      return provider.has(row.id, row.scope_id).pipe(Effect.catch(() => Effect.succeed(false)));
     };
 
-    const secretsSet = (
-      input: SetSecretInput,
-    ): Effect.Effect<SecretRef, StorageFailure> =>
+    const secretsSet = (input: SetSecretInput): Effect.Effect<SecretRef, StorageFailure> =>
       Effect.gen(function* () {
         // Validate the write target up front. The adapter would reject
         // an out-of-stack scope too, but catching it here gives a
         // clearer error before we touch the provider.
-        if (!scopeIds.includes(input.scope as string)) {
-          return yield* Effect.fail(
-            new StorageError({
-              message:
-                `secrets.set targets scope "${input.scope}" which is not ` +
-                `in the executor's scope stack [${scopeIds.join(", ")}].`,
-              cause: undefined,
-            }),
-          );
+        if (!scopeIds.includes(input.scope)) {
+          return yield* new StorageError({
+            message:
+              `secrets.set targets scope "${input.scope}" which is not ` +
+              `in the executor's scope stack [${scopeIds.join(", ")}].`,
+            cause: undefined,
+          });
         }
 
         // Pick provider: explicit or first-writable. Misconfiguration
@@ -899,12 +818,10 @@ export const createExecutor = <
         if (input.provider) {
           target = secretProviders.get(input.provider);
           if (!target) {
-            return yield* Effect.fail(
-              new StorageError({
-                message: `Unknown secret provider: ${input.provider}`,
-                cause: undefined,
-              }),
-            );
+            return yield* new StorageError({
+              message: `Unknown secret provider: ${input.provider}`,
+              cause: undefined,
+            });
           }
         } else {
           for (const provider of secretProviders.values()) {
@@ -914,24 +831,20 @@ export const createExecutor = <
             }
           }
           if (!target) {
-            return yield* Effect.fail(
-              new StorageError({
-                message: "No writable secret providers registered",
-                cause: undefined,
-              }),
-            );
+            return yield* new StorageError({
+              message: "No writable secret providers registered",
+              cause: undefined,
+            });
           }
         }
         if (!target.writable || !target.set) {
-          return yield* Effect.fail(
-            new StorageError({
-              message: `Secret provider "${target.key}" is read-only`,
-              cause: undefined,
-            }),
-          );
+          return yield* new StorageError({
+            message: `Secret provider "${target.key}" is read-only`,
+            cause: undefined,
+          });
         }
 
-        yield* target.set(input.id, input.value, input.scope as string);
+        yield* target.set(input.id, input.value, input.scope);
 
         // Upsert metadata row in the core `secret` table at the
         // caller-named scope. Pin the delete to `scope_id = input.scope`
@@ -979,9 +892,7 @@ export const createExecutor = <
     // errors fail the whole call so a transient plugin failure can't be
     // mistaken for "no usages" and let through a delete that creates
     // dangling refs.
-    const secretsUsagesStrict = (
-      id: string,
-    ): Effect.Effect<readonly Usage[], StorageFailure> =>
+    const secretsUsagesStrict = (id: string): Effect.Effect<readonly Usage[], StorageFailure> =>
       Effect.gen(function* () {
         const secretId = SecretId.make(id);
         const perPlugin = yield* Effect.all(
@@ -1006,9 +917,7 @@ export const createExecutor = <
         return perPlugin.flat();
       });
 
-    const secretsUsages = (
-      id: string,
-    ): Effect.Effect<readonly Usage[], StorageFailure> =>
+    const secretsUsages = (id: string): Effect.Effect<readonly Usage[], StorageFailure> =>
       Effect.gen(function* () {
         const secretId = SecretId.make(id);
         const perPlugin = yield* Effect.all(
@@ -1020,10 +929,9 @@ export const createExecutor = <
                 args: { secretId },
               }).pipe(
                 Effect.catchCause((cause: unknown) =>
-                  Effect.logWarning(
-                    `usagesForSecret failed for plugin ${r.plugin.id}`,
-                    cause,
-                  ).pipe(Effect.as([] as readonly Usage[])),
+                  Effect.logWarning(`usagesForSecret failed for plugin ${r.plugin.id}`, cause).pipe(
+                    Effect.as([] as readonly Usage[]),
+                  ),
                 ),
               ),
             ),
@@ -1032,9 +940,7 @@ export const createExecutor = <
         return perPlugin.flat();
       });
 
-    const connectionsUsagesStrict = (
-      id: string,
-    ): Effect.Effect<readonly Usage[], StorageFailure> =>
+    const connectionsUsagesStrict = (id: string): Effect.Effect<readonly Usage[], StorageFailure> =>
       Effect.gen(function* () {
         const connectionId = ConnectionId.make(id);
         const perPlugin = yield* Effect.all(
@@ -1059,9 +965,7 @@ export const createExecutor = <
         return perPlugin.flat();
       });
 
-    const connectionsUsages = (
-      id: string,
-    ): Effect.Effect<readonly Usage[], StorageFailure> =>
+    const connectionsUsages = (id: string): Effect.Effect<readonly Usage[], StorageFailure> =>
       Effect.gen(function* () {
         const connectionId = ConnectionId.make(id);
         const perPlugin = yield* Effect.all(
@@ -1087,10 +991,7 @@ export const createExecutor = <
 
     const secretsRemove = (
       id: string,
-    ): Effect.Effect<
-      void,
-      SecretOwnedByConnectionError | SecretInUseError | StorageFailure
-    > =>
+    ): Effect.Effect<void, SecretOwnedByConnectionError | SecretInUseError | StorageFailure> =>
       Effect.gen(function* () {
         // Remove is shadowing-aware: drop only the innermost-scope row.
         // Removing a user-scope override on a secret that also has an
@@ -1107,14 +1008,10 @@ export const createExecutor = <
         // Refuse to delete connection-owned secrets. The connection owns
         // the lifecycle — callers must go through connections.remove.
         if (target && target.owned_by_connection_id) {
-          return yield* Effect.fail(
-            new SecretOwnedByConnectionError({
-              secretId: SecretId.make(id),
-              connectionId: ConnectionId.make(
-                target.owned_by_connection_id as string,
-              ),
-            }),
-          );
+          return yield* new SecretOwnedByConnectionError({
+            secretId: SecretId.make(id),
+            connectionId: ConnectionId.make(target.owned_by_connection_id),
+          });
         }
         // RESTRICT: refuse if any source/binding still references this
         // secret AND deleting the innermost row would leave the reference
@@ -1129,16 +1026,13 @@ export const createExecutor = <
         if (willDangle) {
           const usages = yield* secretsUsagesStrict(id);
           if (usages.length > 0) {
-            return yield* Effect.fail(
-              new SecretInUseError({
-                secretId: SecretId.make(id),
-                usageCount: usages.length,
-              }),
-            );
+            return yield* new SecretInUseError({
+              secretId: SecretId.make(id),
+              usageCount: usages.length,
+            });
           }
         }
-        const targetScope = (target?.scope_id as string | undefined) ??
-          scopeIds[0]!;
+        const targetScope = target?.scope_id ?? scopeIds[0]!;
 
         const deleters = [...secretProviders.values()].filter(
           (p): p is typeof p & { delete: NonNullable<typeof p.delete> } =>
@@ -1195,19 +1089,15 @@ export const createExecutor = <
         // leak them back in below.
         const allRows = yield* core.findMany({ model: "secret" });
         const connectionOwnedIds = new Set(
-          allRows
-            .filter((r) => r.owned_by_connection_id)
-            .map((r) => r.id as string),
+          allRows.filter((r) => r.owned_by_connection_id).map((r) => r.id),
         );
         const rows = allRows.filter((r) => !r.owned_by_connection_id);
-        const precedence = new Map<string, number>();
-        scopeIds.forEach((id, index) => precedence.set(id, index));
-        const pick = (row: typeof rows[number]) => {
+        const pick = (row: (typeof rows)[number]) => {
           const existing = byId.get(row.id);
-          const incomingScope = row.scope_id as string;
-          const incomingRank = precedence.get(incomingScope) ?? Number.MAX_SAFE_INTEGER;
+          const incomingScope = row.scope_id;
+          const incomingRank = scopeRank(row);
           if (existing) {
-            const existingRank = precedence.get(existing.scopeId as string) ?? Number.MAX_SAFE_INTEGER;
+            const existingRank = scopePrecedence.get(existing.scopeId) ?? Infinity;
             if (existingRank <= incomingRank) return;
           }
           byId.set(
@@ -1217,10 +1107,7 @@ export const createExecutor = <
               scopeId: ScopeId.make(incomingScope),
               name: row.name,
               provider: row.provider,
-              createdAt:
-                row.created_at instanceof Date
-                  ? row.created_at
-                  : new Date(row.created_at as string),
+              createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
             }),
           );
         };
@@ -1235,17 +1122,13 @@ export const createExecutor = <
         // whole list. Merge in registration order afterwards so the
         // "first provider wins" precedence stays deterministic.
         const attribution = scopes[0]!.id;
-        const listers = [...secretProviders.entries()].filter(
-          ([, p]) => p.list,
-        );
+        const listers = [...secretProviders.entries()].filter(([, p]) => p.list);
         const lists = yield* Effect.all(
           listers.map(([key, p]) =>
-            p
-              .list!()
-              .pipe(
-                Effect.catch(() => Effect.succeed([] as const)),
-                Effect.map((entries) => ({ key, entries })),
-              ),
+            p.list!().pipe(
+              Effect.catch(() => Effect.succeed([] as const)),
+              Effect.map((entries) => ({ key, entries })),
+            ),
           ),
           { concurrency: "unbounded" },
         );
@@ -1294,35 +1177,22 @@ export const createExecutor = <
     // behavior under the new SDK orchestration stays identical.
     const CONNECTION_REFRESH_SKEW_MS = 60_000;
 
-    const decodeProviderState = Schema.decodeUnknownOption(
-      ConnectionProviderState,
-    );
+    const decodeProviderState = Schema.decodeUnknownOption(ConnectionProviderState);
 
     const rowToConnection = (row: ConnectionRow): ConnectionRef =>
       new ConnectionRef({
-        id: ConnectionId.make(row.id as string),
-        scopeId: ScopeId.make(row.scope_id as string),
-        provider: row.provider as string,
-        identityLabel: (row.identity_label as string | null | undefined) ?? null,
-        accessTokenSecretId: SecretId.make(row.access_token_secret_id as string),
+        id: ConnectionId.make(row.id),
+        scopeId: ScopeId.make(row.scope_id),
+        provider: row.provider,
+        identityLabel: row.identity_label ?? null,
+        accessTokenSecretId: SecretId.make(row.access_token_secret_id),
         refreshTokenSecretId:
-          row.refresh_token_secret_id != null
-            ? SecretId.make(row.refresh_token_secret_id as string)
-            : null,
-        expiresAt:
-          row.expires_at != null ? Number(row.expires_at as number) : null,
-        oauthScope: (row.scope as string | null | undefined) ?? null,
-        providerState: Option.getOrNull(
-          decodeProviderState(decodeJsonColumn(row.provider_state)),
-        ),
-        createdAt:
-          row.created_at instanceof Date
-            ? row.created_at
-            : new Date(row.created_at as string),
-        updatedAt:
-          row.updated_at instanceof Date
-            ? row.updated_at
-            : new Date(row.updated_at as string),
+          row.refresh_token_secret_id != null ? SecretId.make(row.refresh_token_secret_id) : null,
+        expiresAt: row.expires_at != null ? Number(row.expires_at) : null,
+        oauthScope: row.scope ?? null,
+        providerState: Option.getOrNull(decodeProviderState(decodeJsonColumn(row.provider_state))),
+        createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
+        updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at),
       });
 
     const findInnermostConnectionRow = (
@@ -1336,29 +1206,24 @@ export const createExecutor = <
         return findInnermost(rows as readonly ConnectionRow[]);
       });
 
-    const connectionsGet = (
-      id: string,
-    ): Effect.Effect<ConnectionRef | null, StorageFailure> =>
+    const connectionsGet = (id: string): Effect.Effect<ConnectionRef | null, StorageFailure> =>
       Effect.gen(function* () {
         const row = yield* findInnermostConnectionRow(id);
         return row ? rowToConnection(row) : null;
       });
 
-    const connectionsList = (): Effect.Effect<
-      readonly ConnectionRef[],
-      StorageFailure
-    > =>
+    const connectionsList = (): Effect.Effect<readonly ConnectionRef[], StorageFailure> =>
       Effect.gen(function* () {
         const rows = yield* core.findMany({ model: "connection" });
         // Dedup by id, innermost scope wins — same rule as sources/tools.
         const byId = new Map<string, ConnectionRow>();
         const byIdRank = new Map<string, number>();
         for (const row of rows as readonly ConnectionRow[]) {
-          const rank = scopeRank(row as { scope_id: unknown });
-          const existing = byIdRank.get(row.id as string);
+          const rank = scopeRank(row);
+          const existing = byIdRank.get(row.id);
           if (existing === undefined || rank < existing) {
-            byId.set(row.id as string, row);
-            byIdRank.set(row.id as string, rank);
+            byId.set(row.id, row);
+            byIdRank.set(row.id, rank);
           }
         }
         return [...byId.values()].map(rowToConnection);
@@ -1367,33 +1232,27 @@ export const createExecutor = <
     // Write a secret value through a specific provider, bypassing the
     // bare-secrets ownership check so the SDK can stamp
     // `owned_by_connection_id` atomically alongside a connection row.
-    const writeOwnedSecret = (
-      params: {
-        id: string;
-        scope: string;
-        name: string;
-        value: string;
-        provider: string;
-        ownedByConnectionId: string;
-      },
-    ): Effect.Effect<void, StorageFailure> =>
+    const writeOwnedSecret = (params: {
+      id: string;
+      scope: string;
+      name: string;
+      value: string;
+      provider: string;
+      ownedByConnectionId: string;
+    }): Effect.Effect<void, StorageFailure> =>
       Effect.gen(function* () {
         const target = secretProviders.get(params.provider);
         if (!target) {
-          return yield* Effect.fail(
-            new StorageError({
-              message: `Unknown secret provider: ${params.provider}`,
-              cause: undefined,
-            }),
-          );
+          return yield* new StorageError({
+            message: `Unknown secret provider: ${params.provider}`,
+            cause: undefined,
+          });
         }
         if (!target.writable || !target.set) {
-          return yield* Effect.fail(
-            new StorageError({
-              message: `Secret provider "${target.key}" is read-only`,
-              cause: undefined,
-            }),
-          );
+          return yield* new StorageError({
+            message: `Secret provider "${target.key}" is read-only`,
+            cause: undefined,
+          });
         }
         yield* target.set(params.id, params.value, params.scope);
 
@@ -1426,50 +1285,39 @@ export const createExecutor = <
         if (requested) {
           const p = secretProviders.get(requested);
           if (!p) {
-            return yield* Effect.fail(
-              new StorageError({
-                message: `Unknown secret provider: ${requested}`,
-                cause: undefined,
-              }),
-            );
+            return yield* new StorageError({
+              message: `Unknown secret provider: ${requested}`,
+              cause: undefined,
+            });
           }
           return p;
         }
         for (const p of secretProviders.values()) {
           if (p.writable && p.set) return p;
         }
-        return yield* Effect.fail(
-          new StorageError({
-            message: "No writable secret providers registered",
-            cause: undefined,
-          }),
-        );
+        return yield* new StorageError({
+          message: "No writable secret providers registered",
+          cause: undefined,
+        });
       });
 
     const connectionsCreate = (
       input: CreateConnectionInput,
-    ): Effect.Effect<
-      ConnectionRef,
-      ConnectionProviderNotRegisteredError | StorageFailure
-    > =>
+    ): Effect.Effect<ConnectionRef, ConnectionProviderNotRegisteredError | StorageFailure> =>
       Effect.gen(function* () {
-        if (!scopeIds.includes(input.scope as string)) {
-          return yield* Effect.fail(
-            new StorageError({
-              message:
-                `connections.create targets scope "${input.scope}" which is not ` +
-                `in the executor's scope stack [${scopeIds.join(", ")}].`,
-              cause: undefined,
-            }),
-          );
+        if (!scopeIds.some((scopeId) => scopeId === input.scope)) {
+          return yield* new StorageError({
+            message:
+              `connections.create targets scope "${input.scope}" which is not ` +
+              `in the executor's scope stack [${scopeIds.join(", ")}].`,
+            cause: undefined,
+          });
         }
         if (!resolveConnectionProvider(input.provider)) {
-          return yield* Effect.fail(
-            new ConnectionProviderNotRegisteredError({
-              provider: input.provider,
-              connectionId: input.id,
-            }),
-          );
+          return yield* new ConnectionProviderNotRegisteredError({
+            provider: input.provider,
+            connectionId: input.id,
+          });
         }
 
         const writable = yield* pickWritableProvider();
@@ -1484,40 +1332,39 @@ export const createExecutor = <
             yield* core.delete({
               model: "connection",
               where: [
-                { field: "id", value: input.id as string },
-                { field: "scope_id", value: input.scope as string },
+                { field: "id", value: input.id },
+                { field: "scope_id", value: input.scope },
               ],
             });
 
             yield* writeOwnedSecret({
-              id: input.accessToken.secretId as string,
-              scope: input.scope as string,
+              id: input.accessToken.secretId,
+              scope: input.scope,
               name: input.accessToken.name,
               value: input.accessToken.value,
               provider: writable.key,
-              ownedByConnectionId: input.id as string,
+              ownedByConnectionId: input.id,
             });
             if (input.refreshToken) {
               yield* writeOwnedSecret({
-                id: input.refreshToken.secretId as string,
-                scope: input.scope as string,
+                id: input.refreshToken.secretId,
+                scope: input.scope,
                 name: input.refreshToken.name,
                 value: input.refreshToken.value,
                 provider: writable.key,
-                ownedByConnectionId: input.id as string,
+                ownedByConnectionId: input.id,
               });
             }
 
             yield* core.create({
               model: "connection",
               data: {
-                id: input.id as string,
-                scope_id: input.scope as string,
+                id: input.id,
+                scope_id: input.scope,
                 provider: input.provider,
                 identity_label: input.identityLabel ?? undefined,
-                access_token_secret_id: input.accessToken.secretId as string,
-                refresh_token_secret_id:
-                  input.refreshToken?.secretId ?? undefined,
+                access_token_secret_id: input.accessToken.secretId,
+                refresh_token_secret_id: input.refreshToken?.secretId ?? undefined,
                 expires_at: input.expiresAt ?? undefined,
                 scope: input.oauthScope ?? undefined,
                 provider_state: input.providerState ?? undefined,
@@ -1533,8 +1380,7 @@ export const createExecutor = <
               provider: input.provider,
               identityLabel: input.identityLabel,
               accessTokenSecretId: input.accessToken.secretId,
-              refreshTokenSecretId:
-                input.refreshToken?.secretId ?? null,
+              refreshTokenSecretId: input.refreshToken?.secretId ?? null,
               expiresAt: input.expiresAt,
               oauthScope: input.oauthScope,
               providerState: input.providerState,
@@ -1552,53 +1398,41 @@ export const createExecutor = <
     // configs still resolve.
     const connectionsUpdateTokens = (
       input: UpdateConnectionTokensInput,
-    ): Effect.Effect<
-      ConnectionRef,
-      ConnectionNotFoundError | StorageFailure
-    > =>
+    ): Effect.Effect<ConnectionRef, ConnectionNotFoundError | StorageFailure> =>
       Effect.gen(function* () {
-        const row = yield* findInnermostConnectionRow(input.id as string);
+        const row = yield* findInnermostConnectionRow(input.id);
         if (!row) {
-          return yield* Effect.fail(
-            new ConnectionNotFoundError({ connectionId: input.id }),
-          );
+          return yield* new ConnectionNotFoundError({ connectionId: input.id });
         }
         const writable = yield* pickWritableProvider();
-        const accessName =
-          `Connection ${input.id as string} access token`;
-        const refreshName =
-          `Connection ${input.id as string} refresh token`;
+        const accessName = `Connection ${input.id} access token`;
+        const refreshName = `Connection ${input.id} refresh token`;
 
         return yield* adapter.transaction(() =>
           Effect.gen(function* () {
             yield* writeOwnedSecret({
-              id: row.access_token_secret_id as string,
-              scope: row.scope_id as string,
+              id: row.access_token_secret_id,
+              scope: row.scope_id,
               name: accessName,
               value: input.accessToken,
               provider: writable.key,
-              ownedByConnectionId: row.id as string,
+              ownedByConnectionId: row.id,
             });
             const rotatedRefresh = input.refreshToken ?? undefined;
-            if (
-              rotatedRefresh &&
-              row.refresh_token_secret_id
-            ) {
+            if (rotatedRefresh && row.refresh_token_secret_id) {
               yield* writeOwnedSecret({
-                id: row.refresh_token_secret_id as string,
-                scope: row.scope_id as string,
+                id: row.refresh_token_secret_id,
+                scope: row.scope_id,
                 name: refreshName,
                 value: rotatedRefresh,
                 provider: writable.key,
-                ownedByConnectionId: row.id as string,
+                ownedByConnectionId: row.id,
               });
             }
             const now = new Date();
             const patch: Record<string, unknown> = { updated_at: now };
-            if (input.expiresAt !== undefined)
-              patch.expires_at = input.expiresAt ?? undefined;
-            if (input.oauthScope !== undefined)
-              patch.scope = input.oauthScope ?? undefined;
+            if (input.expiresAt !== undefined) patch.expires_at = input.expiresAt ?? undefined;
+            if (input.oauthScope !== undefined) patch.scope = input.oauthScope ?? undefined;
             if (input.providerState !== undefined)
               patch.provider_state = input.providerState ?? undefined;
             if (input.identityLabel !== undefined)
@@ -1606,18 +1440,16 @@ export const createExecutor = <
             yield* core.update({
               model: "connection",
               where: [
-                { field: "id", value: row.id as string },
-                { field: "scope_id", value: row.scope_id as string },
+                { field: "id", value: row.id },
+                { field: "scope_id", value: row.scope_id },
               ],
               update: patch,
             });
-            const updated = yield* findInnermostConnectionRow(
-              row.id as string,
-            );
+            const updated = yield* findInnermostConnectionRow(row.id);
             if (!updated) {
-              return yield* Effect.fail(
-                new ConnectionNotFoundError({ connectionId: input.id }),
-              );
+              return yield* new ConnectionNotFoundError({
+                connectionId: input.id,
+              });
             }
             return rowToConnection(updated);
           }),
@@ -1631,17 +1463,15 @@ export const createExecutor = <
       Effect.gen(function* () {
         const row = yield* findInnermostConnectionRow(id);
         if (!row) {
-          return yield* Effect.fail(
-            new ConnectionNotFoundError({
-              connectionId: ConnectionId.make(id),
-            }),
-          );
+          return yield* new ConnectionNotFoundError({
+            connectionId: ConnectionId.make(id),
+          });
         }
         yield* core.update({
           model: "connection",
           where: [
             { field: "id", value: id },
-            { field: "scope_id", value: row.scope_id as string },
+            { field: "scope_id", value: row.scope_id },
           ],
           update: {
             identity_label: label ?? undefined,
@@ -1667,15 +1497,13 @@ export const createExecutor = <
         if (willDangle) {
           const usages = yield* connectionsUsagesStrict(id);
           if (usages.length > 0) {
-            return yield* Effect.fail(
-              new ConnectionInUseError({
-                connectionId: ConnectionId.make(id),
-                usageCount: usages.length,
-              }),
-            );
+            return yield* new ConnectionInUseError({
+              connectionId: ConnectionId.make(id),
+              usageCount: usages.length,
+            });
           }
         }
-        const scope = row.scope_id as string;
+        const scope = row.scope_id;
         yield* adapter.transaction(() =>
           Effect.gen(function* () {
             // Find every owned secret at this scope and drop through
@@ -1697,14 +1525,16 @@ export const createExecutor = <
             for (const secret of owned) {
               yield* Effect.all(
                 deleters.map((p) =>
-                  p.delete(secret.id as string, scope).pipe(
-                    Effect.catchCause((cause) =>
-                      Effect.logWarning(
-                        `Failed to delete connection-owned secret from provider ${p.key}`,
-                        cause,
-                      ).pipe(Effect.as(false)),
+                  p
+                    .delete(secret.id, scope)
+                    .pipe(
+                      Effect.catchCause((cause) =>
+                        Effect.logWarning(
+                          `Failed to delete connection-owned secret from provider ${p.key}`,
+                          cause,
+                        ).pipe(Effect.as(false)),
+                      ),
                     ),
-                  ),
                 ),
                 { concurrency: "unbounded" },
               );
@@ -1743,26 +1573,20 @@ export const createExecutor = <
     // The actual work of a single refresh cycle, factored out so the
     // concurrency gate (`connectionsAccessToken`) stays readable. Runs
     // for the fiber that wins the `refreshInFlight` race.
-    const performRefresh = (
-      ref: ConnectionRef,
-    ): Effect.Effect<string, AccessTokenError> =>
+    const performRefresh = (ref: ConnectionRef): Effect.Effect<string, AccessTokenError> =>
       Effect.gen(function* () {
         const provider = resolveConnectionProvider(ref.provider);
         if (!provider) {
-          return yield* Effect.fail(
-            new ConnectionProviderNotRegisteredError({
-              provider: ref.provider,
-              connectionId: ref.id,
-            }),
-          );
+          return yield* new ConnectionProviderNotRegisteredError({
+            provider: ref.provider,
+            connectionId: ref.id,
+          });
         }
         if (!provider.refresh) {
-          return yield* Effect.fail(
-            new ConnectionRefreshNotSupportedError({
-              connectionId: ref.id,
-              provider: ref.provider,
-            }),
-          );
+          return yield* new ConnectionRefreshNotSupportedError({
+            connectionId: ref.id,
+            provider: ref.provider,
+          });
         }
 
         const refreshTokenValue = ref.refreshTokenSecretId
@@ -1774,31 +1598,28 @@ export const createExecutor = <
         // stored refresh token can't recover. Translate into the
         // caller-visible "re-authenticate" error so the UI can
         // prompt sign-in instead of silently retrying.
-        const rawResult: Result.Result<
-          ConnectionRefreshResult,
-          ConnectionRefreshError
-        > = yield* Effect.result(
-          provider.refresh({
-            connectionId: ref.id,
-            scopeId: ref.scopeId,
-            identityLabel: ref.identityLabel,
-            refreshToken: refreshTokenValue,
-            providerState: ref.providerState,
-            oauthScope: ref.oauthScope,
-          }),
-        );
+        const rawResult: Result.Result<ConnectionRefreshResult, ConnectionRefreshError> =
+          yield* Effect.result(
+            provider.refresh({
+              connectionId: ref.id,
+              scopeId: ref.scopeId,
+              identityLabel: ref.identityLabel,
+              refreshToken: refreshTokenValue,
+              providerState: ref.providerState,
+              oauthScope: ref.oauthScope,
+            }),
+          );
         if (Result.isFailure(rawResult)) {
           const err = rawResult.failure;
           if (err.reauthRequired) {
-            return yield* Effect.fail(
-              new ConnectionReauthRequiredError({
-                connectionId: err.connectionId,
-                provider: ref.provider,
-                message: err.message,
-              }),
-            );
+            return yield* new ConnectionReauthRequiredError({
+              connectionId: err.connectionId,
+              provider: ref.provider,
+              // oxlint-disable-next-line executor/no-unknown-error-message -- typed: ConnectionRefreshError.message is provider-facing domain data, not an unknown caught error
+              message: err["message"],
+            });
           }
-          return yield* Effect.fail(err);
+          return yield* err;
         }
         const result = rawResult.success;
 
@@ -1826,28 +1647,21 @@ export const createExecutor = <
     // observes the Deferred and awaits its completion. The Deferred is
     // pulled out of the map before the refresh result resolves so
     // later invokes don't reuse a completed slot.
-    const connectionsAccessToken = (
-      id: string,
-    ): Effect.Effect<string, AccessTokenError> =>
+    const connectionsAccessToken = (id: string): Effect.Effect<string, AccessTokenError> =>
       Effect.gen(function* () {
         const row = yield* findInnermostConnectionRow(id);
         if (!row) {
-          return yield* Effect.fail(
-            new ConnectionNotFoundError({
-              connectionId: ConnectionId.make(id),
-            }),
-          );
+          return yield* new ConnectionNotFoundError({
+            connectionId: ConnectionId.make(id),
+          });
         }
         const ref = rowToConnection(row);
         const now = Date.now();
         const needsRefresh =
-          ref.expiresAt !== null &&
-          ref.expiresAt - CONNECTION_REFRESH_SKEW_MS <= now;
+          ref.expiresAt !== null && ref.expiresAt - CONNECTION_REFRESH_SKEW_MS <= now;
 
         if (!needsRefresh) {
-          const current = yield* connectionSecretGet(
-            ref.accessTokenSecretId,
-          );
+          const current = yield* connectionSecretGet(ref.accessTokenSecretId);
           if (current !== null) return current;
           // Fall through to refresh if the stored token vanished — a
           // genuinely-missing secret with no way to refresh is a
@@ -1901,17 +1715,12 @@ export const createExecutor = <
       rawAdapter: adapter,
       secretsGet: (id) =>
         secretsGet(id).pipe(
-          Effect.catchTag("SecretOwnedByConnectionError", () =>
-            Effect.succeed(null),
-          ),
+          Effect.catchTag("SecretOwnedByConnectionError", () => Effect.succeed(null)),
         ),
       secretsSet: (input) => secretsSet(input),
       connectionsCreate: (input) => connectionsCreate(input),
     });
-    connectionProviders.set(
-      oauthBundle.connectionProvider.key,
-      oauthBundle.connectionProvider,
-    );
+    connectionProviders.set(oauthBundle.connectionProvider.key, oauthBundle.connectionProvider);
 
     // ------------------------------------------------------------------
     // Plugin wiring — build ctx, run extension, populate static pools,
@@ -1919,9 +1728,10 @@ export const createExecutor = <
     // ------------------------------------------------------------------
     for (const plugin of plugins) {
       if (runtimes.has(plugin.id)) {
-        return yield* Effect.fail(
-          new Error(`Duplicate plugin id: ${plugin.id}`),
-        );
+        return yield* new StorageError({
+          message: `Duplicate plugin id: ${plugin.id}`,
+          cause: undefined,
+        });
       }
 
       // Plugin-facing typed view. `StorageError` and `UniqueViolationError`
@@ -1957,22 +1767,18 @@ export const createExecutor = <
                 // share the same string space. Fails as `StorageError`
                 // so the HTTP edge surfaces it as `InternalError(traceId)`.
                 if (staticSources.has(input.id)) {
-                  return yield* Effect.fail(
-                    new StorageError({
-                      message: `Source id "${input.id}" collides with a static source`,
-                      cause: undefined,
-                    }),
-                  );
+                  return yield* new StorageError({
+                    message: `Source id "${input.id}" collides with a static source`,
+                    cause: undefined,
+                  });
                 }
                 for (const tool of input.tools) {
                   const fqid = `${input.id}.${tool.name}`;
                   if (staticTools.has(fqid)) {
-                    return yield* Effect.fail(
-                      new StorageError({
-                        message: `Tool id "${fqid}" collides with a static tool`,
-                        cause: undefined,
-                      }),
-                    );
+                    return yield* new StorageError({
+                      message: `Tool id "${fqid}" collides with a static tool`,
+                      cause: undefined,
+                    });
                   }
                 }
                 // Wrap in adapter.transaction so a standalone register()
@@ -1981,9 +1787,7 @@ export const createExecutor = <
                 // the router short-circuits to the active tx handle
                 // instead of opening a nested sql.begin — that nested
                 // sql.begin is the postgres.js + pool=1 deadlock path.
-                yield* adapter.transaction(() =>
-                  writeSourceInput(core, plugin.id, input),
-                );
+                yield* adapter.transaction(() => writeSourceInput(core, plugin.id, input));
               }),
             unregister: (sourceId: string) =>
               // `unregister` is scoped to a specific source row — look up
@@ -2001,32 +1805,28 @@ export const createExecutor = <
                   });
                   const row = findInnermost(rows);
                   if (!row) return;
-                  yield* deleteSourceById(
-                    core,
-                    sourceId,
-                    row.scope_id as string,
-                  );
+                  yield* deleteSourceById(core, sourceId, row.scope_id);
                 }),
               ),
             update: (input) =>
-              core.update({
-                model: "source",
-                where: [
-                  { field: "id", value: input.id },
-                  { field: "scope_id", value: input.scope },
-                ],
-                update: {
-                  ...(input.name !== undefined ? { name: input.name } : {}),
-                  ...(input.url !== undefined ? { url: input.url ?? undefined } : {}),
-                  updated_at: new Date(),
-                },
-              }).pipe(Effect.asVoid),
+              core
+                .update({
+                  model: "source",
+                  where: [
+                    { field: "id", value: input.id },
+                    { field: "scope_id", value: input.scope },
+                  ],
+                  update: {
+                    ...(input.name !== undefined ? { name: input.name } : {}),
+                    ...(input.url !== undefined ? { url: input.url ?? undefined } : {}),
+                    updated_at: new Date(),
+                  },
+                })
+                .pipe(Effect.asVoid),
           },
           definitions: {
             register: (input: DefinitionsInput) =>
-              adapter.transaction(() =>
-                writeDefinitions(core, plugin.id, input),
-              ),
+              adapter.transaction(() => writeDefinitions(core, plugin.id, input)),
           },
         },
         secrets: {
@@ -2040,8 +1840,7 @@ export const createExecutor = <
           list: () => connectionsListForCtx(),
           create: (input) => connectionsCreate(input),
           updateTokens: (input) => connectionsUpdateTokens(input),
-          setIdentityLabel: (id, label) =>
-            connectionsSetIdentityLabel(id, label),
+          setIdentityLabel: (id, label) => connectionsSetIdentityLabel(id, label),
           accessToken: (id) => connectionsAccessToken(id),
           remove: (id) => connectionsRemove(id),
         },
@@ -2052,45 +1851,36 @@ export const createExecutor = <
         // propagate unchanged; storage failures also stay typed
         // (`StorageFailure`) so the HTTP edge wrapper can translate them.
         transaction: <A, E>(effect: Effect.Effect<A, E>) =>
-          adapter.transaction(() => effect) as Effect.Effect<
-            A,
-            E | StorageFailure
-          >,
+          adapter.transaction(() => effect) as Effect.Effect<A, E | StorageFailure>,
       };
 
       // Build extension FIRST so it's available as `self` when resolving
       // staticSources. Field ordering in the plugin spec matters — TS
       // infers TExtension from `extension`'s return type, then NoInfer
       // locks `self` to that inferred type on `staticSources`.
-      const extension: object = plugin.extension
-        ? plugin.extension(ctx)
-        : {};
+      const extension: object = plugin.extension ? plugin.extension(ctx) : {};
       if (plugin.extension) {
         extensions[plugin.id] = extension;
       }
 
       // Resolve static declarations to the in-memory pools. NO DB WRITES.
-      const decls = plugin.staticSources
-        ? plugin.staticSources(extension)
-        : [];
+      const decls = plugin.staticSources ? plugin.staticSources(extension) : [];
       for (const source of decls) {
         if (staticSources.has(source.id)) {
-          return yield* Effect.fail(
-            new Error(
-              `Duplicate static source id: ${source.id} (plugin ${plugin.id})`,
-            ),
-          );
+          return yield* new StorageError({
+            message: `Duplicate static source id: ${source.id} (plugin ${plugin.id})`,
+            cause: undefined,
+          });
         }
         staticSources.set(source.id, { source, pluginId: plugin.id });
 
         for (const tool of source.tools) {
           const fqid = `${source.id}.${tool.name}`;
           if (staticTools.has(fqid)) {
-            return yield* Effect.fail(
-              new Error(
-                `Duplicate static tool id: ${fqid} (plugin ${plugin.id})`,
-              ),
-            );
+            return yield* new StorageError({
+              message: `Duplicate static tool id: ${fqid} (plugin ${plugin.id})`,
+              cause: undefined,
+            });
           }
           staticTools.set(fqid, {
             source,
@@ -2111,11 +1901,10 @@ export const createExecutor = <
         const providers = Effect.isEffect(raw) ? yield* raw : raw;
         for (const provider of providers) {
           if (secretProviders.has(provider.key)) {
-            return yield* Effect.fail(
-              new Error(
-                `Duplicate secret provider key: ${provider.key} (from plugin ${plugin.id})`,
-              ),
-            );
+            return yield* new StorageError({
+              message: `Duplicate secret provider key: ${provider.key} (from plugin ${plugin.id})`,
+              cause: undefined,
+            });
           }
           secretProviders.set(provider.key, provider);
         }
@@ -2129,11 +1918,10 @@ export const createExecutor = <
         const providers = Effect.isEffect(raw) ? yield* raw : raw;
         for (const provider of providers) {
           if (connectionProviders.has(provider.key)) {
-            return yield* Effect.fail(
-              new Error(
-                `Duplicate connection provider key: ${provider.key} (from plugin ${plugin.id})`,
-              ),
-            );
+            return yield* new StorageError({
+              message: `Duplicate connection provider key: ${provider.key} (from plugin ${plugin.id})`,
+              cause: undefined,
+            });
           }
           connectionProviders.set(provider.key, provider);
         }
@@ -2151,7 +1939,7 @@ export const createExecutor = <
         // two rows — their override and the outer default — which is
         // inconsistent with how `secrets.list` and every other list
         // surface dedup shadowed entries.
-        const byId = new Map<string, typeof dynamic[number]>();
+        const byId = new Map<string, (typeof dynamic)[number]>();
         const byIdRank = new Map<string, number>();
         for (const row of dynamic) {
           const rank = scopeRank(row);
@@ -2201,10 +1989,7 @@ export const createExecutor = <
           [...groups],
           ([key, groupRows]) =>
             Effect.gen(function* () {
-              const [pluginId, sourceId] = key.split("\u0000") as [
-                string,
-                string,
-              ];
+              const [pluginId, sourceId] = key.split("\u0000") as [string, string];
               const runtime = runtimes.get(pluginId);
               if (!runtime?.plugin.resolveAnnotations) return undefined;
               return yield* runtime.plugin.resolveAnnotations({
@@ -2228,14 +2013,12 @@ export const createExecutor = <
       Effect.gen(function* () {
         const dynamic = yield* core.findMany({
           model: "tool",
-          where: filter?.sourceId
-            ? [{ field: "source_id", value: filter.sourceId }]
-            : undefined,
+          where: filter?.sourceId ? [{ field: "source_id", value: filter.sourceId }] : undefined,
         });
         // Dedup by tool id, innermost scope winning — same reason as
         // `listSources` above: a shadowed id must surface as one entry
         // (the inner one), not two.
-        const byId = new Map<string, typeof dynamic[number]>();
+        const byId = new Map<string, (typeof dynamic)[number]>();
         const byIdRank = new Map<string, number>();
         for (const row of dynamic) {
           const rank = scopeRank(row);
@@ -2261,9 +2044,7 @@ export const createExecutor = <
         for (const row of dynamicDeduped) {
           out.push(rowToTool(row, annotations.get(row.id)));
         }
-        const filtered = filter
-          ? out.filter((t) => toolMatchesFilter(t, filter))
-          : out;
+        const filtered = filter ? out.filter((t) => toolMatchesFilter(t, filter)) : out;
 
         // Drop tools blocked by user policy unless the caller explicitly
         // asked to see them (the settings UI does, agent surfaces don't).
@@ -2306,7 +2087,7 @@ export const createExecutor = <
           model: "definition",
           where: [{ field: "source_id", value: sourceId }],
         });
-        const winners = new Map<string, { row: typeof defRows[number]; rank: number }>();
+        const winners = new Map<string, { row: (typeof defRows)[number]; rank: number }>();
         for (const row of defRows) {
           const rank = scopeRank(row);
           const existing = winners.get(row.name);
@@ -2432,7 +2213,7 @@ export const createExecutor = <
     const toolsDefinitions = () =>
       Effect.gen(function* () {
         const rows = yield* core.findMany({ model: "definition" });
-        const winners = new Map<string, { row: typeof rows[number]; rank: number }>();
+        const winners = new Map<string, { row: (typeof rows)[number]; rank: number }>();
         for (const row of rows) {
           const key = `${row.source_id}\u0000${row.name}`;
           const rank = scopeRank(row);
@@ -2453,19 +2234,13 @@ export const createExecutor = <
         return out;
       });
 
-    const defaultElicitationHandler = resolveElicitationHandler(
-      config.onElicitation,
-    );
+    const defaultElicitationHandler = resolveElicitationHandler(config.onElicitation);
     const pickHandler = (options: InvokeOptions | undefined): ElicitationHandler =>
       options?.onElicitation
         ? resolveElicitationHandler(options.onElicitation)
         : defaultElicitationHandler;
 
-    const buildElicit = (
-      toolId: string,
-      args: unknown,
-      handler: ElicitationHandler,
-    ): Elicit => {
+    const buildElicit = (toolId: string, args: unknown, handler: ElicitationHandler): Elicit => {
       return (request: ElicitationRequest) =>
         Effect.gen(function* () {
           const tid = ToolId.make(toolId);
@@ -2494,8 +2269,7 @@ export const createExecutor = <
     // used as today.
     // ------------------------------------------------------------------
 
-    const loadAllPolicies = () =>
-      core.findMany({ model: "tool_policy" });
+    const loadAllPolicies = () => core.findMany({ model: "tool_policy" });
 
     const resolveToolPolicyForId = (toolId: string) =>
       Effect.gen(function* () {
@@ -2539,13 +2313,13 @@ export const createExecutor = <
         }
       });
 
-    const invokeTool = (
-      toolId: string,
-      args: unknown,
-      options?: InvokeOptions,
-    ) => {
+    const invokeTool = (toolId: string, args: unknown, options?: InvokeOptions) => {
       const handler = pickHandler(options);
       return Effect.gen(function* () {
+        const formatInvocationCauseMessage = (cause: unknown): string => {
+          // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: preserve public invoke error message wrapping for unknown plugin failures
+          return cause instanceof Error ? cause.message : String(cause);
+        };
         const wrapInvocationError = <A, E>(
           effect: Effect.Effect<A, E>,
         ): Effect.Effect<A, ToolInvocationError> =>
@@ -2554,8 +2328,7 @@ export const createExecutor = <
               (cause) =>
                 new ToolInvocationError({
                   toolId: ToolId.make(toolId),
-                  message:
-                    cause instanceof Error ? cause.message : String(cause),
+                  message: formatInvocationCauseMessage(cause),
                   cause,
                 }),
             ),
@@ -2583,13 +2356,9 @@ export const createExecutor = <
             "executor.source_kind": staticEntry.source.kind,
             "executor.plugin_id": staticEntry.pluginId,
           });
-          yield* enforceApproval(
-            staticEntry.tool.annotations,
-            toolId,
-            args,
-            policy,
-            handler,
-          ).pipe(Effect.withSpan("executor.tool.enforce_approval"));
+          yield* enforceApproval(staticEntry.tool.annotations, toolId, args, policy, handler).pipe(
+            Effect.withSpan("executor.tool.enforce_approval"),
+          );
           return yield* wrapInvocationError(
             staticEntry.tool.handler({
               ctx: staticEntry.ctx,
@@ -2702,14 +2471,10 @@ export const createExecutor = <
               yield* runtime.plugin.removeSource({
                 ctx: runtime.ctx,
                 sourceId,
-                scope: sourceRow.scope_id as string,
+                scope: sourceRow.scope_id,
               });
             }
-            yield* deleteSourceById(
-              core,
-              sourceId,
-              sourceRow.scope_id as string,
-            );
+            yield* deleteSourceById(core, sourceId, sourceRow.scope_id);
           }),
         );
       });
@@ -2730,7 +2495,7 @@ export const createExecutor = <
           yield* runtime.plugin.refreshSource({
             ctx: runtime.ctx,
             sourceId,
-            scope: sourceRow.scope_id as string,
+            scope: sourceRow.scope_id,
           });
         }
       });
@@ -2739,9 +2504,7 @@ export const createExecutor = <
     // `detect` hook. Collect all non-null results. Plugin-level detect
     // implementations should swallow fetch errors and return null, so
     // one flaky plugin doesn't block the whole dispatch.
-    const detectionConfidenceScore = (
-      confidence: SourceDetectionResult["confidence"],
-    ) => {
+    const detectionConfidenceScore = (confidence: SourceDetectionResult["confidence"]) => {
       switch (confidence) {
         case "high":
           return 3;
@@ -2763,24 +2526,19 @@ export const createExecutor = <
           if (result) results.push(result);
         }
         return results.sort(
-          (a, b) =>
-            detectionConfidenceScore(b.confidence) -
-            detectionConfidenceScore(a.confidence),
+          (a, b) => detectionConfidenceScore(b.confidence) - detectionConfidenceScore(a.confidence),
         );
       });
 
     // Per-source definitions accessor — one query, one mapping pass.
-    const sourceDefinitions = (sourceId: string) =>
-      loadDefinitionsForSource(sourceId);
+    const sourceDefinitions = (sourceId: string) => loadDefinitionsForSource(sourceId);
 
     // Existence check for user-facing secret pickers. Core `secret`
     // rows are routing metadata; when a provider can answer `has()`,
     // confirm the backing value still exists. Providers without `has()`
     // remain conservative so keychain/1password don't need to return
     // the value or prompt just to populate picker/status UI.
-    const secretsStatus = (
-      id: string,
-    ): Effect.Effect<"resolved" | "missing", StorageFailure> =>
+    const secretsStatus = (id: string): Effect.Effect<"resolved" | "missing", StorageFailure> =>
       Effect.gen(function* () {
         const rows = yield* secretRowsForId(id);
         if (rows.some((row) => row.owned_by_connection_id)) return "missing";
@@ -2853,7 +2611,7 @@ export const createExecutor = <
           });
           let min: string | null = null;
           for (const row of existing) {
-            const p = row.position as string;
+            const p = row.position;
             if (min === null || p < min) min = p;
           }
           position = generateKeyBetween(null, min);
@@ -2923,13 +2681,13 @@ export const createExecutor = <
           model: "tool_policy",
           where: [
             { field: "id", value: input.id },
-            { field: "scope_id", value: row.scope_id as string },
+            { field: "scope_id", value: row.scope_id },
           ],
           update: {
-            pattern: updated.pattern as string,
-            action: updated.action as string,
-            position: updated.position as string,
-            updated_at: updated.updated_at as Date,
+            pattern: updated.pattern,
+            action: updated.action,
+            position: updated.position,
+            updated_at: updated.updated_at,
           },
         });
         return rowToToolPolicy(updated);
@@ -2944,9 +2702,7 @@ export const createExecutor = <
         .pipe(Effect.asVoid, Effect.withSpan("executor.policies.remove"));
 
     const policiesResolve = (toolId: string) =>
-      resolveToolPolicyForId(toolId).pipe(
-        Effect.withSpan("executor.policies.resolve"),
-      );
+      resolveToolPolicyForId(toolId).pipe(Effect.withSpan("executor.policies.resolve"));
 
     const close = () =>
       Effect.gen(function* () {
@@ -2984,10 +2740,7 @@ export const createExecutor = <
         remove: secretsRemove,
         list: secretsList,
         usages: secretsUsages,
-        providers: () =>
-          Effect.sync(
-            () => Array.from(secretProviders.keys()) as readonly string[],
-          ),
+        providers: () => Effect.sync(() => Array.from(secretProviders.keys()) as readonly string[]),
       },
       connections: {
         get: connectionsGet,
@@ -2999,10 +2752,7 @@ export const createExecutor = <
         remove: connectionsRemove,
         usages: connectionsUsages,
         providers: () =>
-          Effect.sync(
-            () =>
-              Array.from(connectionProviders.keys()) as readonly string[],
-          ),
+          Effect.sync(() => Array.from(connectionProviders.keys()) as readonly string[]),
       },
       oauth: oauthBundle.service,
       policies: {
@@ -3020,7 +2770,6 @@ export const createExecutor = <
     // those leak via the helper functions and won't be cleaned until
     // every plugin tightens its surface to typed errors. The runtime
     // shape matches `Executor<TPlugins>`.
-    const toExecutor = (value: unknown): Executor<TPlugins> =>
-      value as Executor<TPlugins>;
+    const toExecutor = (value: unknown): Executor<TPlugins> => value as Executor<TPlugins>;
     return toExecutor(Object.assign(base, extensions));
   });


### PR DESCRIPTION
## Summary
- replace executor startup, secret, connection, invoke, and policy lint escape hatches with typed Effect failures where behavior is domain-level
- parse JSON columns with Effect Schema instead of raw JSON.parse
- remove redundant primitive casts across scoped rows while preserving shadowing behavior

## Verification
- bunx oxlint --format=unix packages/core/sdk/src/executor.ts
- bun run --cwd packages/core/sdk typecheck
- bun run --cwd packages/core/sdk test src/executor.test.ts src/connections.test.ts src/policies.test.ts src/error-handling.test.ts