### PR TITLE
Fix cloud MCP boundary lint

### DIFF
--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -145,6 +145,7 @@ const makeDbHandle = (options: {
   return {
     sql,
     db: drizzle(sql, { schema: combinedSchema }) as DrizzleDb,
+    // oxlint-disable-next-line executor/no-promise-catch -- boundary: postgres.js close is best-effort during DO/runtime cleanup
     end: () => sql.end({ timeout: 0 }).catch(() => undefined),
   };
 };
@@ -268,9 +269,13 @@ export class McpSessionDO extends DurableObject {
       this.transportJsonResponseMode = null;
 
       await Promise.all([
+        // oxlint-disable-next-line executor/no-promise-catch -- boundary: Durable Object storage cleanup is best-effort after session invalidation
         this.ctx.storage.delete(TRANSPORT_STATE_KEY).catch(() => false),
+        // oxlint-disable-next-line executor/no-promise-catch -- boundary: Durable Object storage cleanup is best-effort after session invalidation
         this.ctx.storage.delete(SESSION_META_KEY).catch(() => false),
+        // oxlint-disable-next-line executor/no-promise-catch -- boundary: Durable Object storage cleanup is best-effort after session invalidation
         this.ctx.storage.delete(LAST_ACTIVITY_KEY).catch(() => false),
+        // oxlint-disable-next-line executor/no-promise-catch -- boundary: Durable Object alarm cleanup is best-effort after session invalidation
         this.ctx.storage.deleteAlarm().catch(() => undefined),
       ]);
     }).pipe(Effect.withSpan("mcp.session.clear_state"));
@@ -322,6 +327,7 @@ export class McpSessionDO extends DurableObject {
       }
       if (self.mcpServer) {
         const mcpServer = self.mcpServer;
+        // oxlint-disable-next-line executor/no-promise-catch -- boundary: MCP SDK close failure is ignored during best-effort runtime teardown
         yield* Effect.promise(() => mcpServer.close().catch(() => undefined));
         self.mcpServer = null;
       }
@@ -332,7 +338,10 @@ export class McpSessionDO extends DurableObject {
       }
       self.initialized = false;
       self.transportJsonResponseMode = null;
-    }).pipe(Effect.orDie);
+    }).pipe(
+      // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: DO cleanup has no typed failure surface
+      Effect.orDie,
+    );
   }
 
   private installRuntime(
@@ -388,6 +397,7 @@ export class McpSessionDO extends DurableObject {
           "mcp.request.session_id_present": !!request.headers.get("mcp-session-id"),
         },
       }),
+      // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: cold DO restore is re-entered from Promise-only Durable Object method
       Effect.orDie,
     );
   }
@@ -409,7 +419,11 @@ export class McpSessionDO extends DurableObject {
       yield* Effect.annotateCurrentSpan({
         "mcp.session.transport_upgraded_json_response": true,
       });
-    }).pipe(Effect.withSpan("McpSessionDO.ensureJsonResponseTransportForPost"), Effect.orDie);
+    }).pipe(
+      Effect.withSpan("McpSessionDO.ensureJsonResponseTransportForPost"),
+      // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: transport rebuild is internal DO runtime state
+      Effect.orDie,
+    );
   }
 
   private validateSessionOwner(request: Request): Effect.Effect<Response | null> {
@@ -435,17 +449,15 @@ export class McpSessionDO extends DurableObject {
     const self = this;
     return Effect.gen(function* () {
       const dbHandle = makeEphemeralDb();
-      try {
-        const sessionMeta = yield* resolveSessionMeta(token.organizationId, token.userId).pipe(
-          Effect.provide(makeResolveOrganizationServices(dbHandle)),
-        );
-        yield* Effect.promise(() => self.saveSessionMeta(sessionMeta)).pipe(
-          Effect.withSpan("mcp.session.save_meta"),
-        );
-        return sessionMeta;
-      } finally {
-        yield* Effect.promise(() => dbHandle.end());
-      }
+      return yield* resolveSessionMeta(token.organizationId, token.userId).pipe(
+        Effect.provide(makeResolveOrganizationServices(dbHandle)),
+        Effect.tap((sessionMeta) =>
+          Effect.promise(() => self.saveSessionMeta(sessionMeta)).pipe(
+            Effect.withSpan("mcp.session.save_meta"),
+          ),
+        ),
+        Effect.ensuring(Effect.promise(() => dbHandle.end())),
+      );
     }).pipe(Effect.withSpan("mcp.session.resolve_and_store_meta"));
   }
 
@@ -463,6 +475,7 @@ export class McpSessionDO extends DurableObject {
         }),
         (eff) => withIncomingParent(incoming, eff),
         Effect.provide(DoTelemetryLive),
+        // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: Durable Object init method can only reject its Promise
         Effect.orDie,
       ),
     );
@@ -511,6 +524,7 @@ export class McpSessionDO extends DurableObject {
           return yield* Effect.failCause(cause);
         }),
       ),
+      // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: doInit is called only from Promise-only Durable Object init
       Effect.orDie,
     );
   }

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -16,7 +16,7 @@
 
 import { env } from "cloudflare:workers";
 import { HttpEffect, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
-import { Cause, Context, Effect, Layer, Option, Schema } from "effect";
+import { Cause, Context, Effect, Layer, Option, Predicate, Result, Schema } from "effect";
 
 import { createCachedRemoteJWKSet } from "./jwks-cache";
 import { captureCause } from "./observability";
@@ -171,7 +171,7 @@ export const McpAuthLive = Layer.succeed(McpAuth)({
       }),
     );
     if (!verified) return mcpUnauthorized("invalid_token", "The access token is invalid");
-    if ("_tag" in verified) return verified;
+    if (Predicate.isTagged(verified, "Unauthorized")) return verified;
     if (!verified.accountId) {
       yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
       return mcpUnauthorized("invalid_token", "The access token is invalid");
@@ -211,8 +211,7 @@ type CfRequestMetadata = {
 const requestWithCf = (request: Request): Request & { cf?: CfRequestMetadata } =>
   request as Request & { cf?: CfRequestMetadata };
 
-const getCfMeta = (request: Request): CfRequestMetadata =>
-  requestWithCf(request).cf ?? {};
+const getCfMeta = (request: Request): CfRequestMetadata => requestWithCf(request).cf ?? {};
 
 const HEADERS_TO_DUMP = [
   "accept",
@@ -285,22 +284,28 @@ const InitializeParams = Schema.Struct({
 const NamedParams = Schema.Struct({ name: Schema.optional(Schema.String) });
 const UriParams = Schema.Struct({ uri: Schema.optional(Schema.String) });
 
-const decodeJsonRpcEnvelope = Schema.decodeUnknownOption(JsonRpcEnvelope);
+const decodeJsonRpcEnvelopeString = Schema.decodeUnknownOption(
+  Schema.fromJsonString(JsonRpcEnvelope),
+);
 const decodeInitializeParams = Schema.decodeUnknownOption(InitializeParams);
 const decodeNamedParams = Schema.decodeUnknownOption(NamedParams);
 const decodeUriParams = Schema.decodeUnknownOption(UriParams);
 const decodeElicitationReplyResult = Schema.decodeUnknownOption(ElicitationReplyResult);
 
+const isMcpAuthorized = (value: McpAuthResult): value is McpAuthorizedResult =>
+  Predicate.isTagged(value, "Authorized");
+const isMcpUnauthorized = (value: McpAuthResult): value is McpUnauthorizedResult =>
+  Predicate.isTagged(value, "Unauthorized");
+
 const readJsonRpcEnvelope = (request: Request): Effect.Effect<Option.Option<JsonRpcEnvelope>> =>
-  Effect.promise(async () => {
-    try {
-      const text = await request.clone().text();
-      if (!text) return Option.none();
-      return decodeJsonRpcEnvelope(JSON.parse(text));
-    } catch {
-      return Option.none();
-    }
-  }).pipe(Effect.withSpan("mcp.request.read_json_rpc"));
+  Effect.tryPromise({
+    try: () => request.clone().text(),
+    catch: () => undefined,
+  }).pipe(
+    Effect.map((text) => (text ? decodeJsonRpcEnvelopeString(text) : Option.none())),
+    Effect.catchCause(() => Effect.succeed(Option.none())),
+    Effect.withSpan("mcp.request.read_json_rpc"),
+  );
 
 const methodAttrs = (envelope: JsonRpcEnvelope): Record<string, unknown> => {
   const params = envelope.params ?? {};
@@ -409,15 +414,14 @@ const protectedResourceMetadata = Effect.sync(() =>
   }),
 );
 
-const authorizationServerMetadata = Effect.promise(async () => {
-  try {
+const authorizationServerMetadata = Effect.tryPromise({
+  try: async () => {
     const res = await fetch(`${AUTHKIT_DOMAIN}/.well-known/oauth-authorization-server`);
     if (!res.ok) return jsonResponse({ error: "upstream_error" }, 502);
     return jsonResponse(await res.json());
-  } catch {
-    return jsonResponse({ error: "upstream_error" }, 502);
-  }
-});
+  },
+  catch: () => undefined,
+}).pipe(Effect.catchCause(() => Effect.succeed(jsonResponse({ error: "upstream_error" }, 502))));
 
 // ---------------------------------------------------------------------------
 // DO dispatch
@@ -545,7 +549,7 @@ const authorizeMcpOrganization = (
       Effect.catchCause((error) =>
         Effect.gen(function* () {
           yield* Effect.annotateCurrentSpan({
-            "mcp.auth.organization_authorize_error": String(error),
+            "mcp.auth.organization_authorize_error": Cause.pretty(error),
           });
           return false;
         }),
@@ -662,7 +666,7 @@ export const mcpApp: Effect.Effect<
   const auth = yield* McpAuth;
   const authResult = yield* auth.verifyBearer(request).pipe(Effect.result);
 
-  if (authResult._tag === "Failure") {
+  if (Result.isFailure(authResult)) {
     yield* annotateMcpRequest(request, {
       token: null,
       parseBody: request.method === "POST",
@@ -675,11 +679,11 @@ export const mcpApp: Effect.Effect<
   // POST bodies are JSON-RPC payloads worth parsing; GET (SSE) and DELETE
   // don't carry one.
   yield* annotateMcpRequest(request, {
-    token: authValue._tag === "Authorized" ? authValue.token : null,
+    token: isMcpAuthorized(authValue) ? authValue.token : null,
     parseBody: request.method === "POST",
   });
 
-  if (authValue._tag === "Unauthorized") {
+  if (isMcpUnauthorized(authValue)) {
     return unauthorized(authValue, PROTECTED_RESOURCE_METADATA_URL);
   }
   const token = authValue.token;

--- a/apps/cloud/src/mcp/response-peek.ts
+++ b/apps/cloud/src/mcp/response-peek.ts
@@ -1,23 +1,57 @@
 import * as Sentry from "@sentry/cloudflare";
-import { Effect } from "effect";
+import { Cause, Data, Effect, Exit, Option, Schema } from "effect";
 
 import { jsonRpcWebResponse } from "./responses";
 
 const SSE_PEEK_TIMEOUT_MS = 10_000;
 
-type SandboxOutcome = {
-  readonly status?: string;
-  readonly error?: { readonly kind?: string; readonly message?: string };
-};
+class ResponseBodyTimeoutError extends Data.TaggedError("ResponseBodyTimeoutError")<{
+  readonly timeoutMs: number;
+}> {}
 
-type JsonRpcResponseBody = {
-  readonly jsonrpc?: string;
-  readonly error?: { readonly code?: number; readonly message?: string };
-  readonly result?: {
-    readonly isError?: boolean;
-    readonly structuredContent?: SandboxOutcome;
-  };
-};
+class ResponseBodyReadError extends Data.TaggedError("ResponseBodyReadError") {}
+
+class McpInternalJsonRpcError extends Data.TaggedError("McpInternalJsonRpcError")<{
+  readonly message: string;
+}> {}
+
+const ResponseBodyTimeoutErrorData = Schema.Struct({
+  _tag: Schema.Literal("ResponseBodyTimeoutError"),
+  timeoutMs: Schema.Number,
+});
+const decodeResponseBodyTimeoutError = Schema.decodeUnknownOption(ResponseBodyTimeoutErrorData);
+
+const SandboxOutcomeSchema = Schema.Struct({
+  status: Schema.optional(Schema.String),
+  error: Schema.optional(
+    Schema.Struct({
+      kind: Schema.optional(Schema.String),
+      message: Schema.optional(Schema.String),
+    }),
+  ),
+});
+
+const JsonRpcResponseBodySchema = Schema.Struct({
+  jsonrpc: Schema.optional(Schema.String),
+  error: Schema.optional(
+    Schema.Struct({
+      code: Schema.optional(Schema.Number),
+      message: Schema.optional(Schema.String),
+    }),
+  ),
+  result: Schema.optional(
+    Schema.Struct({
+      isError: Schema.optional(Schema.Boolean),
+      structuredContent: Schema.optional(SandboxOutcomeSchema),
+    }),
+  ),
+});
+
+const decodeJsonRpcResponseBody = Schema.decodeUnknownOption(
+  Schema.fromJsonString(JsonRpcResponseBodySchema),
+);
+
+type JsonRpcResponseBody = typeof JsonRpcResponseBodySchema.Type;
 
 const responseBodyShape = (body: string): string => {
   const trimmed = body.trimStart();
@@ -31,18 +65,18 @@ const responseBodyShape = (body: string): string => {
 
 const parseFirstJsonRpc = (contentType: string, body: string): JsonRpcResponseBody | null => {
   if (!body) return null;
-  try {
-    if (contentType.includes("text/event-stream")) {
-      for (const line of body.split(/\r?\n/)) {
-        if (line.startsWith("data:")) return JSON.parse(line.slice(5).trimStart());
+  if (contentType.includes("text/event-stream")) {
+    for (const line of body.split(/\r?\n/)) {
+      if (line.startsWith("data:")) {
+        return Option.getOrNull(decodeJsonRpcResponseBody(line.slice(5).trimStart()));
       }
-      return null;
     }
-    if (contentType.includes("application/json")) return JSON.parse(body);
-    return null;
-  } catch {
     return null;
   }
+  if (contentType.includes("application/json")) {
+    return Option.getOrNull(decodeJsonRpcResponseBody(body));
+  }
+  return null;
 };
 
 const jsonRpcResponseAttrs = (payload: JsonRpcResponseBody | null): Record<string, unknown> => {
@@ -52,8 +86,10 @@ const jsonRpcResponseAttrs = (payload: JsonRpcResponseBody | null): Record<strin
   if (err && typeof err === "object") {
     attrs["mcp.rpc.is_error"] = true;
     if (typeof err.code === "number") attrs["mcp.rpc.error.code"] = err.code;
-    if (typeof err.message === "string") {
-      attrs["mcp.rpc.error.message"] = err.message.slice(0, 500);
+    // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: schema-decoded JSON-RPC error message is protocol telemetry
+    const { message } = err;
+    if (typeof message === "string") {
+      attrs["mcp.rpc.error.message"] = message.slice(0, 500);
     }
   }
   if (payload.result?.isError === true) attrs["mcp.tool.result.is_error"] = true;
@@ -61,19 +97,13 @@ const jsonRpcResponseAttrs = (payload: JsonRpcResponseBody | null): Record<strin
   if (structured && typeof structured.status === "string") {
     attrs["mcp.tool.sandbox.status"] = structured.status;
     if (structured.error?.kind) attrs["mcp.tool.sandbox.error.kind"] = structured.error.kind;
-    if (typeof structured.error?.message === "string") {
-      attrs["mcp.tool.sandbox.error.message"] = structured.error.message.slice(0, 500);
+    const message = structured.error?.["message"];
+    if (typeof message === "string") {
+      attrs["mcp.tool.sandbox.error.message"] = message.slice(0, 500);
     }
   }
   return attrs;
 };
-
-class ResponseBodyTimeoutError extends Error {
-  constructor(readonly timeoutMs: number) {
-    super(`Timed out waiting for MCP response body after ${timeoutMs}ms`);
-    this.name = "ResponseBodyTimeoutError";
-  }
-}
 
 const readResponseText = async (response: Response, timeoutMs: number | null): Promise<string> => {
   if (timeoutMs === null) return await response.text();
@@ -85,11 +115,14 @@ const readResponseText = async (response: Response, timeoutMs: number | null): P
   let timeout: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeout = setTimeout(() => {
+      // oxlint-disable-next-line executor/no-promise-catch -- boundary: best-effort stream cancellation inside timeout callback
       void reader.cancel().catch(() => undefined);
-      reject(new ResponseBodyTimeoutError(timeoutMs));
+      // oxlint-disable-next-line executor/no-promise-reject -- boundary: Promise.race timeout adapter for Web ReadableStream
+      reject(new ResponseBodyTimeoutError({ timeoutMs }));
     }, timeoutMs);
   });
   const readPromise = (async () => {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Web stream reader cleanup must clear host timeout after success or failure
     try {
       let text = "";
       for (;;) {
@@ -125,9 +158,18 @@ const withoutBodyHeaders = (response: Response) => {
   });
 };
 
+const isResponseBodyTimeoutError = (error: unknown) =>
+  Option.isSome(decodeResponseBodyTimeoutError(error));
+
+const responsePeekError = (error: unknown): ResponseBodyTimeoutError | ResponseBodyReadError =>
+  Option.match(decodeResponseBodyTimeoutError(error), {
+    onNone: () => new ResponseBodyReadError(),
+    onSome: ({ timeoutMs }) => new ResponseBodyTimeoutError({ timeoutMs }),
+  });
+
 const responseReadFailure = (error: unknown) =>
   Effect.gen(function* () {
-    const timedOut = error instanceof ResponseBodyTimeoutError;
+    const timedOut = isResponseBodyTimeoutError(error);
     yield* Effect.annotateCurrentSpan({
       "mcp.response.status_code": timedOut ? 504 : 500,
       "mcp.response.content_type": "application/json",
@@ -135,7 +177,7 @@ const responseReadFailure = (error: unknown) =>
       "mcp.response.body.length": 0,
       "mcp.response.jsonrpc.detected": true,
       "mcp.peek_response.timed_out": timedOut,
-      "mcp.peek_response.error": String(error),
+      "mcp.peek_response.error": timedOut ? "ResponseBodyTimeoutError" : "ResponseBodyReadError",
     });
     return jsonRpcWebResponse(
       timedOut ? 504 : 500,
@@ -149,8 +191,8 @@ const responseReadFailure = (error: unknown) =>
 const reportInternalJsonRpcError = (payload: JsonRpcResponseBody | null) =>
   Effect.sync(() => {
     if (payload?.error?.code !== -32603) return;
-    const msg = payload.error.message ?? "unknown";
-    Sentry.captureException(new Error(`MCP internal error (-32603): ${msg}`));
+    const message = payload.error["message"] ?? "unknown";
+    Sentry.captureException(new McpInternalJsonRpcError({ message }));
   });
 
 export const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
@@ -167,21 +209,29 @@ export const peekAndAnnotate = (response: Response): Effect.Effect<Response> =>
 
     const isSseResponse = contentType.includes("text/event-stream");
     const timeoutMs = isSseResponse ? SSE_PEEK_TIMEOUT_MS : null;
-    const textResult = yield* Effect.result(Effect.tryPromise({
-      try: () => readResponseText(response, timeoutMs),
-      catch: (error) => error,
-    }).pipe(
-      Effect.withSpan("mcp.peek_response", {
-        attributes: {
-          "http.response.content_type": contentType,
-          "http.response.status_code": response.status,
-          "mcp.peek_response.timeout_ms": timeoutMs ?? 0,
-        },
-      }),
-    ));
-    if (textResult._tag === "Failure") return yield* responseReadFailure(textResult.failure);
+    const textExit = yield* Effect.exit(
+      Effect.tryPromise({
+        try: () => readResponseText(response, timeoutMs),
+        catch: responsePeekError,
+      }).pipe(
+        Effect.withSpan("mcp.peek_response", {
+          attributes: {
+            "http.response.content_type": contentType,
+            "http.response.status_code": response.status,
+            "mcp.peek_response.timeout_ms": timeoutMs ?? 0,
+          },
+        }),
+      ),
+    );
+    if (Exit.isFailure(textExit)) {
+      const error = Option.getOrElse(
+        Cause.findErrorOption(textExit.cause),
+        () => new ResponseBodyReadError(),
+      );
+      return yield* responseReadFailure(error);
+    }
 
-    const text = textResult.success;
+    const text = textExit.value;
     const payload = parseFirstJsonRpc(contentType, text);
     yield* Effect.annotateCurrentSpan({
       "mcp.response.status_code": response.status,


### PR DESCRIPTION
## Summary
- parse MCP JSON payloads with Effect Schema instead of raw JSON.parse
- replace manual tag checks with typed Predicate/Result/Exit helpers
- keep narrow boundary suppressions for Durable Object and Web stream cleanup surfaces

## Verification
- bunx oxlint --format=unix apps/cloud/src/mcp.ts apps/cloud/src/mcp-session.ts apps/cloud/src/mcp/response-peek.ts
- bun run --cwd apps/cloud typecheck
- cd apps/cloud && node ../../node_modules/vitest/vitest.mjs run --config vitest.config.ts src/mcp-flow.test.ts
- cd apps/cloud && node ../../node_modules/vitest/vitest.mjs run --config vitest.node.config.ts src/mcp-session.e2e.node.test.ts