### PR TITLE
Fix OnePassword plugin boundary lint

### DIFF
--- a/packages/plugins/onepassword/src/sdk/plugin.ts
+++ b/packages/plugins/onepassword/src/sdk/plugin.ts
@@ -10,19 +10,12 @@ import {
 } from "@executor-js/sdk/core";
 
 import { OnePasswordGroup } from "../api/group";
-import {
-  OnePasswordExtensionService,
-  OnePasswordHandlers,
-} from "../api/handlers";
+import { OnePasswordExtensionService, OnePasswordHandlers } from "../api/handlers";
 
 import { OnePasswordConfig, Vault, ConnectionStatus } from "./types";
 import type { OnePasswordAuth } from "./types";
 import { OnePasswordError } from "./errors";
-import {
-  makeOnePasswordService,
-  type ResolvedAuth,
-  type OnePasswordService,
-} from "./service";
+import { makeOnePasswordService, type ResolvedAuth, type OnePasswordService } from "./service";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -50,38 +43,6 @@ export type OnePasswordExtensionFailure = OnePasswordError | StorageFailure;
 // Plugin extension — public API on executor.onepassword
 // ---------------------------------------------------------------------------
 
-export interface OnePasswordExtension {
-  /** Configure the 1Password connection */
-  readonly configure: (
-    config: OnePasswordConfig,
-  ) => Effect.Effect<void, StorageFailure>;
-
-  /** Get current configuration (if any) */
-  readonly getConfig: () => Effect.Effect<
-    OnePasswordConfig | null,
-    OnePasswordExtensionFailure
-  >;
-
-  /** Remove the 1Password configuration */
-  readonly removeConfig: () => Effect.Effect<void, StorageFailure>;
-
-  /** Check connection status */
-  readonly status: () => Effect.Effect<
-    ConnectionStatus,
-    OnePasswordExtensionFailure
-  >;
-
-  /** List accessible vaults (requires auth) */
-  readonly listVaults: (
-    auth: OnePasswordAuth,
-  ) => Effect.Effect<ReadonlyArray<Vault>, OnePasswordExtensionFailure>;
-
-  /** Resolve a secret directly by op:// URI */
-  readonly resolve: (
-    uri: string,
-  ) => Effect.Effect<string, OnePasswordExtensionFailure>;
-}
-
 // ---------------------------------------------------------------------------
 // Typed config store — single blob, JSON encoded. Blob I/O failures surface
 // as `StorageError` (HTTP edge translates to `InternalError`); decode
@@ -94,20 +55,17 @@ export interface OnePasswordStore {
     OnePasswordConfig | null,
     StorageError | OnePasswordError
   >;
-  readonly saveConfig: (
-    config: OnePasswordConfig,
-  ) => Effect.Effect<void, StorageError>;
+  readonly saveConfig: (config: OnePasswordConfig) => Effect.Effect<void, StorageError>;
   readonly deleteConfig: () => Effect.Effect<void, StorageError>;
 }
 
-const decodeConfig = Schema.decodeUnknownSync(OnePasswordConfig);
+const decodeConfig = Schema.decodeUnknownEffect(Schema.fromJsonString(OnePasswordConfig));
 
-const blobStorageError = (operation: string) =>
+const blobStorageError =
+  (operation: string) =>
   (cause: unknown): StorageError =>
     new StorageError({
-      message: `onepassword blob ${operation}: ${
-        cause instanceof Error ? cause.message : String(cause)
-      }`,
+      message: `onepassword blob ${operation} failed`,
       cause,
     });
 
@@ -123,14 +81,15 @@ export const makeOnePasswordStore = (
       Effect.mapError(blobStorageError("read")),
       Effect.flatMap((raw) => {
         if (raw === null) return Effect.succeed(null);
-        return Effect.try({
-          try: () => decodeConfig(JSON.parse(raw)),
-          catch: (cause) =>
-            new OnePasswordError({
-              operation: "config decode",
-              message: cause instanceof Error ? cause.message : String(cause),
-            }),
-        });
+        return decodeConfig(raw).pipe(
+          Effect.mapError(
+            () =>
+              new OnePasswordError({
+                operation: "config decode",
+                message: "Failed to decode 1Password config",
+              }),
+          ),
+        );
       }),
     ),
 
@@ -168,13 +127,13 @@ const resolveAuth = (
     });
   }
   return ctx.secrets.get(auth.tokenSecretId).pipe(
-    Effect.mapError((err) =>
-      "_tag" in err && err._tag === "SecretOwnedByConnectionError"
-        ? new OnePasswordError({
-            operation: "auth resolution",
-            message: `Service account token secret "${auth.tokenSecretId}" not found`,
-          })
-        : err,
+    Effect.catchTag("SecretOwnedByConnectionError", () =>
+      Effect.fail(
+        new OnePasswordError({
+          operation: "auth resolution",
+          message: `Service account token secret "${auth.tokenSecretId}" not found`,
+        }),
+      ),
     ),
     Effect.flatMap((token) => {
       if (token === null) {
@@ -200,9 +159,7 @@ const getServiceFromConfig = (
   preferSdk: boolean | undefined,
 ): Effect.Effect<OnePasswordService, OnePasswordError | StorageFailure> =>
   resolveAuth(config.auth, ctx).pipe(
-    Effect.flatMap((resolved) =>
-      makeOnePasswordService(resolved, { timeoutMs, preferSdk }),
-    ),
+    Effect.flatMap((resolved) => makeOnePasswordService(resolved, { timeoutMs, preferSdk })),
   );
 
 // ---------------------------------------------------------------------------
@@ -241,10 +198,7 @@ const makeProvider = (
   list: () =>
     ctx.storage.getConfig().pipe(
       Effect.flatMap((config) => {
-        if (!config)
-          return Effect.succeed(
-            [] as ReadonlyArray<{ id: string; name: string }>,
-          );
+        if (!config) return Effect.succeed([] as ReadonlyArray<{ id: string; name: string }>);
         return getServiceFromConfig(config, ctx, timeoutMs, preferSdk).pipe(
           Effect.flatMap((svc) => svc.listItems(config.vaultId)),
           Effect.map(
@@ -253,11 +207,69 @@ const makeProvider = (
           ),
         );
       }),
-      Effect.orElseSucceed(
-        () => [] as ReadonlyArray<{ id: string; name: string }>,
-      ),
+      Effect.orElseSucceed(() => [] as ReadonlyArray<{ id: string; name: string }>),
     ),
 });
+
+const makeOnePasswordExtension = (
+  ctx: PluginCtx<OnePasswordStore>,
+  timeoutMs: number,
+  preferSdk: boolean | undefined,
+) => {
+  return {
+    configure: (config: OnePasswordConfig) => ctx.storage.saveConfig(config),
+
+    getConfig: () => ctx.storage.getConfig(),
+
+    removeConfig: () => ctx.storage.deleteConfig(),
+
+    status: () =>
+      Effect.gen(function* () {
+        const config = yield* ctx.storage.getConfig();
+        if (!config) {
+          return new ConnectionStatus({
+            connected: false,
+            error: "Not configured",
+          });
+        }
+        const svc = yield* getServiceFromConfig(config, ctx, timeoutMs, preferSdk);
+        const vaults = yield* svc.listVaults();
+        const vault = vaults.find((v) => v.id === config.vaultId);
+        return new ConnectionStatus({
+          connected: true,
+          vaultName: vault?.title,
+        });
+      }),
+
+    listVaults: (auth: OnePasswordAuth) =>
+      Effect.gen(function* () {
+        const resolved = yield* resolveAuth(auth, ctx);
+        const svc = yield* makeOnePasswordService(resolved, {
+          timeoutMs,
+          preferSdk,
+        });
+        const vaults = yield* svc.listVaults();
+        return vaults
+          .map((v) => new Vault({ id: v.id, name: v.title }))
+          .sort((a, b) => a.name.localeCompare(b.name));
+      }),
+
+    resolve: (uri: string) =>
+      Effect.gen(function* () {
+        const config = yield* ctx.storage.getConfig();
+        if (!config) {
+          return yield* new OnePasswordError({
+            operation: "resolve",
+            message: "1Password is not configured",
+          });
+        }
+        const svc = yield* getServiceFromConfig(config, ctx, timeoutMs, preferSdk);
+        return yield* svc.resolveSecret(uri);
+      }),
+  };
+};
+
+export type OnePasswordExtension = ReturnType<typeof makeOnePasswordExtension>;
 
 // ---------------------------------------------------------------------------
 // Plugin factory
@@ -270,88 +282,21 @@ export interface OnePasswordPluginOptions {
   readonly preferSdk?: boolean;
 }
 
-export const onepasswordPlugin = definePlugin(
-  (options?: OnePasswordPluginOptions) => {
-    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-    const preferSdk = options?.preferSdk;
+export const onepasswordPlugin = definePlugin((options?: OnePasswordPluginOptions) => {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const preferSdk = options?.preferSdk;
 
-    return {
-      id: "onepassword" as const,
-      packageName: "@executor-js/plugin-onepassword",
-      storage: ({ blobs, scopes }) =>
-        makeOnePasswordStore(blobs, scopes.at(-1)!.id as string),
+  return {
+    id: "onepassword" as const,
+    packageName: "@executor-js/plugin-onepassword",
+    storage: ({ blobs, scopes }) => makeOnePasswordStore(blobs, scopes.at(-1)!.id),
 
-      extension: (ctx) => {
-        return {
-          configure: (config) => ctx.storage.saveConfig(config),
+    extension: (ctx) => makeOnePasswordExtension(ctx, timeoutMs, preferSdk),
 
-          getConfig: () => ctx.storage.getConfig(),
+    secretProviders: (ctx) => [makeProvider(ctx, timeoutMs, preferSdk)],
 
-          removeConfig: () => ctx.storage.deleteConfig(),
-
-          status: () =>
-            Effect.gen(function* () {
-              const config = yield* ctx.storage.getConfig();
-              if (!config) {
-                return new ConnectionStatus({
-                  connected: false,
-                  error: "Not configured",
-                });
-              }
-              const svc = yield* getServiceFromConfig(
-                config,
-                ctx,
-                timeoutMs,
-                preferSdk,
-              );
-              const vaults = yield* svc.listVaults();
-              const vault = vaults.find((v) => v.id === config.vaultId);
-              return new ConnectionStatus({
-                connected: true,
-                vaultName: vault?.title,
-              });
-            }),
-
-          listVaults: (auth) =>
-            Effect.gen(function* () {
-              const resolved = yield* resolveAuth(auth, ctx);
-              const svc = yield* makeOnePasswordService(resolved, {
-                timeoutMs,
-                preferSdk,
-              });
-              const vaults = yield* svc.listVaults();
-              return vaults
-                .map((v) => new Vault({ id: v.id, name: v.title }))
-                .sort((a, b) => a.name.localeCompare(b.name));
-            }),
-
-          resolve: (uri) =>
-            Effect.gen(function* () {
-              const config = yield* ctx.storage.getConfig();
-              if (!config) {
-                return yield* Effect.fail(
-                  new OnePasswordError({
-                    operation: "resolve",
-                    message: "1Password is not configured",
-                  }),
-                );
-              }
-              const svc = yield* getServiceFromConfig(
-                config,
-                ctx,
-                timeoutMs,
-                preferSdk,
-              );
-              return yield* svc.resolveSecret(uri);
-            }),
-        } satisfies OnePasswordExtension;
-      },
-
-      secretProviders: (ctx) => [makeProvider(ctx, timeoutMs, preferSdk)],
-
-      routes: () => OnePasswordGroup,
-      handlers: () => OnePasswordHandlers,
-      extensionService: OnePasswordExtensionService,
-    };
-  },
-);
+    routes: () => OnePasswordGroup,
+    handlers: () => OnePasswordHandlers,
+    extensionService: OnePasswordExtensionService,
+  };
+});

--- a/packages/plugins/onepassword/src/sdk/service.ts
+++ b/packages/plugins/onepassword/src/sdk/service.ts
@@ -53,10 +53,10 @@ type OnePasswordSdkModule = typeof import("@1password/sdk");
 const loadOnePasswordSdk = (): Effect.Effect<OnePasswordSdkModule, OnePasswordError> =>
   Effect.tryPromise({
     try: () => import("@1password/sdk"),
-    catch: (cause) =>
+    catch: () =>
       new OnePasswordError({
         operation: "sdk module load",
-        message: cause instanceof Error ? cause.message : String(cause),
+        message: "Failed to load 1Password SDK",
       }),
   });
 
@@ -99,22 +99,20 @@ export const makeNativeSdkService = (
           integrationName: "Executor",
           integrationVersion: "0.0.0",
         }),
-      catch: (cause) =>
+      catch: () =>
         new OnePasswordError({
           operation: "client setup",
-          message: cause instanceof Error ? cause.message : String(cause),
+          message: "Failed to set up 1Password client",
         }),
-    }).pipe(
-      timeoutWithOnePasswordError("client setup", timeoutMs),
-    );
+    }).pipe(timeoutWithOnePasswordError("client setup", timeoutMs));
 
     const wrap = <A>(fn: () => Promise<A>, operation: string): Effect.Effect<A, OnePasswordError> =>
       Effect.tryPromise({
         try: fn,
-        catch: (cause) =>
+        catch: () =>
           new OnePasswordError({
             operation,
-            message: cause instanceof Error ? cause.message : String(cause),
+            message: `1Password SDK ${operation} failed`,
           }),
       }).pipe(
         timeoutWithOnePasswordError(operation, timeoutMs),
@@ -154,10 +152,10 @@ export const makeCliService = (
     const wrapSync = <A>(fn: () => A, operation: string): Effect.Effect<A, OnePasswordError> =>
       Effect.try({
         try: fn,
-        catch: (cause) =>
+        catch: () =>
           new OnePasswordError({
             operation,
-            message: cause instanceof Error ? cause.message : String(cause),
+            message: `1Password CLI ${operation} failed`,
           }),
       }).pipe(Effect.withSpan(`onepassword.cli.${operation}`));
 


### PR DESCRIPTION
## Summary
- parse stored OnePassword config with Effect Schema JSON decoding
- derive the OnePassword extension type from the extension factory
- replace manual tag checks and unknown error message leaks with typed Effect handling and stable messages

## Verification
- bunx oxlint --format=unix packages/plugins/onepassword/src/sdk/plugin.ts packages/plugins/onepassword/src/sdk/service.ts
- bun run --cwd packages/plugins/onepassword typecheck
- bun run --cwd packages/plugins/onepassword test