### PR TITLE
Fix core OAuth boundary lint

### DIFF
--- a/packages/core/sdk/src/oauth-discovery.ts
+++ b/packages/core/sdk/src/oauth-discovery.ts
@@ -18,7 +18,7 @@
 // callers actually need.
 // ---------------------------------------------------------------------------
 
-import { Data, Effect, Result, Schema } from "effect";
+import { Data, Effect, Option, Predicate, Result, Schema } from "effect";
 import * as oauth from "oauth4webapi";
 
 import {
@@ -37,23 +37,11 @@ import {
  *  token-endpoint failures. A plugin's refresh path should never have
  *  to inspect error messages to tell "metadata drifted, re-discover"
  *  apart from "refresh token is no longer honoured". */
-export class OAuthDiscoveryError extends Data.TaggedError(
-  "OAuthDiscoveryError",
-)<{
+export class OAuthDiscoveryError extends Data.TaggedError("OAuthDiscoveryError")<{
   readonly message: string;
   readonly status?: number;
   readonly cause?: unknown;
 }> {}
-
-const discoveryError = (
-  message: string,
-  options: { status?: number; cause?: unknown } = {},
-): OAuthDiscoveryError =>
-  new OAuthDiscoveryError({
-    message,
-    status: options.status,
-    cause: options.cause,
-  });
 
 // ---------------------------------------------------------------------------
 // Schemas (narrow structural parsing — the RFCs leave many fields
@@ -69,8 +57,7 @@ export const OAuthProtectedResourceMetadataSchema = Schema.Struct({
   bearer_methods_supported: Schema.optional(StringArray),
   resource_documentation: Schema.optional(Schema.String),
 }).annotate({ identifier: "OAuthProtectedResourceMetadata" });
-export type OAuthProtectedResourceMetadata =
-  typeof OAuthProtectedResourceMetadataSchema.Type;
+export type OAuthProtectedResourceMetadata = typeof OAuthProtectedResourceMetadataSchema.Type;
 
 export const OAuthAuthorizationServerMetadataSchema = Schema.Struct({
   issuer: Schema.String,
@@ -87,8 +74,7 @@ export const OAuthAuthorizationServerMetadataSchema = Schema.Struct({
   userinfo_endpoint: Schema.optional(Schema.String),
   id_token_signing_alg_values_supported: Schema.optional(StringArray),
 }).annotate({ identifier: "OAuthAuthorizationServerMetadata" });
-export type OAuthAuthorizationServerMetadata =
-  typeof OAuthAuthorizationServerMetadataSchema.Type;
+export type OAuthAuthorizationServerMetadata = typeof OAuthAuthorizationServerMetadataSchema.Type;
 
 export type DynamicClientMetadata = {
   readonly client_name?: string;
@@ -127,14 +113,12 @@ export const OAuthClientInformationSchema = Schema.Struct({
 }).annotate({ identifier: "OAuthClientInformation" });
 export type OAuthClientInformation = typeof OAuthClientInformationSchema.Type;
 
-const decodeResourceMetadata = Schema.decodeUnknownEffect(
-  OAuthProtectedResourceMetadataSchema,
+const decodeResourceMetadataJson = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(OAuthProtectedResourceMetadataSchema),
 );
-const decodeAuthServerMetadata = Schema.decodeUnknownEffect(
-  OAuthAuthorizationServerMetadataSchema,
-);
-const decodeClientInformation = Schema.decodeUnknownEffect(
-  OAuthClientInformationSchema,
+const decodeAuthServerMetadata = Schema.decodeUnknownEffect(OAuthAuthorizationServerMetadataSchema);
+const decodeClientInformationJson = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(OAuthClientInformationSchema),
 );
 
 export interface DiscoveryRequestOptions {
@@ -155,6 +139,7 @@ export interface DiscoveryRequestOptions {
 const MCP_PROTOCOL_VERSION_HEADER = "mcp-protocol-version";
 
 const isLoopbackHttpUrl = (value: string): boolean => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform parser; invalid URLs are not loopback HTTP
   try {
     const url = new URL(value);
     if (url.protocol !== "http:") return false;
@@ -178,9 +163,7 @@ const oauth4webapiOptions = (
   const out: Record<string, unknown> = {};
   if (options.fetch) (out as { [customFetch]?: typeof fetch })[customFetch] = options.fetch;
   if (targetUrl && isLoopbackHttpUrl(targetUrl)) {
-    (out as { [oauth.allowInsecureRequests]?: boolean })[
-      oauth.allowInsecureRequests
-    ] = true;
+    (out as { [oauth.allowInsecureRequests]?: boolean })[oauth.allowInsecureRequests] = true;
   }
   const signal = AbortSignal.timeout(options.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS);
   out.signal = signal;
@@ -231,8 +214,7 @@ export const discoverProtectedResourceMetadata = (
   resourceUrl: string,
   options: DiscoveryRequestOptions = {},
 ): Effect.Effect<
-  | { readonly metadataUrl: string; readonly metadata: OAuthProtectedResourceMetadata }
-  | null,
+  { readonly metadataUrl: string; readonly metadata: OAuthProtectedResourceMetadata } | null,
   OAuthDiscoveryError
 > =>
   Effect.gen(function* () {
@@ -260,30 +242,26 @@ export const discoverProtectedResourceMetadata = (
           }
           const text = await response.text();
           if (text.length === 0) return "skip" as const;
-          return { status: response.status, body: JSON.parse(text) } as const;
+          return { status: response.status, body: text } as const;
         },
         catch: (cause) =>
-          discoveryError(
-            `Failed to fetch ${url}: ${cause instanceof Error ? cause.message : String(cause)}`,
-            { cause },
-          ),
+          new OAuthDiscoveryError({
+            message: `Failed to fetch protected resource metadata from ${url}`,
+            cause,
+          }),
       });
       if (result === "skip") continue;
       if (!("body" in result)) {
-        return yield* Effect.fail(
-          discoveryError(
-            `Protected resource metadata returned status ${result.status}`,
-            { status: result.status },
-          ),
-        );
+        return yield* new OAuthDiscoveryError({
+          message: `Protected resource metadata returned status ${result.status}`,
+          status: result.status,
+        });
       }
-      const metadata = yield* decodeResourceMetadata(result.body).pipe(
+      const metadata = yield* decodeResourceMetadataJson(result.body).pipe(
         Effect.mapError(
           (err) =>
             new OAuthDiscoveryError({
-              message: `Protected resource metadata is malformed: ${
-                Schema.isSchemaError(err) ? err.message : String(err)
-              }`,
+              message: "Protected resource metadata is malformed",
               cause: err,
             }),
         ),
@@ -308,9 +286,7 @@ const wellKnownUrlFor = (
 ): string => {
   // Mirrors the library's own well-known composition so the URL we
   // surface matches what was actually fetched.
-  const suffix = algorithm === "oauth2"
-    ? "oauth-authorization-server"
-    : "openid-configuration";
+  const suffix = algorithm === "oauth2" ? "oauth-authorization-server" : "openid-configuration";
   return issuerPath && issuerPath !== "/"
     ? `${issuerOrigin}/.well-known/${suffix}${issuerPath}`
     : `${issuerOrigin}/.well-known/${suffix}`;
@@ -320,11 +296,10 @@ export const discoverAuthorizationServerMetadata = (
   issuer: string,
   options: DiscoveryRequestOptions = {},
 ): Effect.Effect<
-  | {
-      readonly metadataUrl: string;
-      readonly metadata: OAuthAuthorizationServerMetadata;
-    }
-  | null,
+  {
+    readonly metadataUrl: string;
+    readonly metadata: OAuthAuthorizationServerMetadata;
+  } | null,
   OAuthDiscoveryError
 > =>
   Effect.gen(function* () {
@@ -349,13 +324,13 @@ export const discoverAuthorizationServerMetadata = (
           };
         },
         catch: (cause) => {
-          if (cause instanceof OAuthDiscoveryError) return cause;
-          return discoveryError(
-            `Discovery (${algorithm}) failed for ${issuer}: ${
-              cause instanceof Error ? cause.message : String(cause)
-            }`,
-            { cause },
-          );
+          if (Predicate.isTagged(cause, "OAuthDiscoveryError")) {
+            return cause as OAuthDiscoveryError;
+          }
+          return new OAuthDiscoveryError({
+            message: `Discovery (${algorithm}) failed for ${issuer}`,
+            cause,
+          });
         },
       }).pipe(
         // If one algorithm fails mid-roundtrip (network, parse, issuer
@@ -370,9 +345,7 @@ export const discoverAuthorizationServerMetadata = (
         Effect.mapError(
           (err) =>
             new OAuthDiscoveryError({
-              message: `Authorization server metadata is malformed: ${
-                Schema.isSchemaError(err) ? err.message : String(err)
-              }`,
+              message: "Authorization server metadata is malformed",
               cause: err,
             }),
         ),
@@ -407,10 +380,16 @@ class DcrErrorBody extends Data.TaggedError("DcrErrorBody")<{
 }> {}
 
 class DcrTransport extends Data.TaggedError("DcrTransport")<{
-  readonly message: string;
+  readonly detail: string;
   readonly status?: number;
   readonly cause?: unknown;
 }> {}
+
+const DcrErrorBodyJson = Schema.Struct({
+  error: Schema.String,
+  error_description: Schema.optional(Schema.String),
+});
+const decodeDcrErrorBodyJson = Schema.decodeUnknownOption(Schema.fromJsonString(DcrErrorBodyJson));
 
 const buildDcrBody = (m: DynamicClientMetadata): Record<string, unknown> => {
   const body: Record<string, unknown> = { redirect_uris: [...m.redirect_uris] };
@@ -431,33 +410,37 @@ const buildDcrBody = (m: DynamicClientMetadata): Record<string, unknown> => {
   return body;
 };
 
-const interpretDcrFailure = (
-  status: number,
-  text: string,
-): DcrErrorBody | DcrTransport => {
+const interpretDcrFailure = (status: number, text: string): DcrErrorBody | DcrTransport => {
   // RFC 6749 error envelope: `{error, error_description?}` with 4xx.
   if (status >= 400 && status < 500) {
-    const parsed = Result.try({
-      try: () => (text ? (JSON.parse(text) as unknown) : null),
-      catch: () => null,
+    const body = text ? decodeDcrErrorBodyJson(text) : null;
+    return Option.match(body ?? Option.none(), {
+      onNone: () =>
+        new DcrTransport({
+          detail: `Dynamic Client Registration endpoint returned status ${status}${
+            text ? ` — ${text.slice(0, 200)}` : ""
+          }`,
+          status,
+        }),
+      onSome: (parsed) =>
+        parsed.error.length > 0
+          ? new DcrErrorBody({
+              status,
+              error: parsed.error,
+              error_description: parsed.error_description,
+            })
+          : new DcrTransport({
+              detail: `Dynamic Client Registration endpoint returned status ${status}${
+                text ? ` — ${text.slice(0, 200)}` : ""
+              }`,
+              status,
+            }),
     });
-    const body = Result.isSuccess(parsed) ? parsed.success : null;
-    if (
-      body &&
-      typeof body === "object" &&
-      "error" in body &&
-      typeof body.error === "string" &&
-      body.error.length > 0
-    ) {
-      const desc =
-        "error_description" in body && typeof body.error_description === "string"
-          ? body.error_description
-          : undefined;
-      return new DcrErrorBody({ status, error: body.error, error_description: desc });
-    }
   }
   return new DcrTransport({
-    message: `Dynamic Client Registration endpoint returned status ${status}${text ? ` — ${text.slice(0, 200)}` : ""}`,
+    detail: `Dynamic Client Registration endpoint returned status ${status}${
+      text ? ` — ${text.slice(0, 200)}` : ""
+    }`,
     status,
   });
 };
@@ -468,12 +451,9 @@ export const registerDynamicClient = (
 ): Effect.Effect<OAuthClientInformation, OAuthDiscoveryError> =>
   Effect.gen(function* () {
     const url = new URL(input.registrationEndpoint);
-    if (
-      url.protocol !== "https:" &&
-      !isLoopbackHttpUrl(input.registrationEndpoint)
-    ) {
+    if (url.protocol !== "https:" && !isLoopbackHttpUrl(input.registrationEndpoint)) {
       return yield* new DcrTransport({
-        message: `registration_endpoint must be HTTPS or a loopback HTTP URL (got ${url.protocol}//${url.host})`,
+        detail: `registration_endpoint must be HTTPS or a loopback HTTP URL (got ${url.protocol}//${url.host})`,
       });
     }
 
@@ -497,7 +477,7 @@ export const registerDynamicClient = (
         }),
       catch: (cause) =>
         new DcrTransport({
-          message: `Dynamic Client Registration request failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+          detail: "Dynamic Client Registration request failed",
           cause,
         }),
     });
@@ -505,9 +485,14 @@ export const registerDynamicClient = (
     // Accept both 200 and 201 as success — RFC 7591 mandates 201, but
     // Todoist (and others) return 200 OK with the client information body.
     if (response.status !== 200 && response.status !== 201) {
-      const text = yield* Effect.promise(() =>
-        response.text().catch(() => ""),
-      );
+      const text = yield* Effect.tryPromise({
+        try: () => response.text(),
+        catch: () =>
+          new DcrTransport({
+            detail: "Dynamic Client Registration error response could not be read",
+            status: response.status,
+          }),
+      }).pipe(Effect.catchTag("DcrTransport", () => Effect.succeed("")));
       return yield* interpretDcrFailure(response.status, text);
     }
 
@@ -515,27 +500,16 @@ export const registerDynamicClient = (
       try: () => response.text(),
       catch: (cause) =>
         new DcrTransport({
-          message: "Dynamic Client Registration response could not be read",
+          detail: "Dynamic Client Registration response could not be read",
           status: response.status,
           cause,
         }),
     });
-    const json = yield* Effect.try({
-      try: () => JSON.parse(text) as unknown,
-      catch: (cause) =>
-        new DcrTransport({
-          message: "Dynamic Client Registration response was not valid JSON",
-          status: response.status,
-          cause,
-        }),
-    });
-    return yield* decodeClientInformation(json).pipe(
+    return yield* decodeClientInformationJson(text).pipe(
       Effect.mapError(
         (err) =>
           new OAuthDiscoveryError({
-            message: `Dynamic Client Registration response is malformed: ${
-              Schema.isSchemaError(err) ? err.message : String(err)
-            }`,
+            message: "Dynamic Client Registration response is malformed",
             cause: err,
           }),
       ),
@@ -544,16 +518,18 @@ export const registerDynamicClient = (
     Effect.catchTags({
       DcrErrorBody: (err) =>
         Effect.fail(
-          discoveryError(
-            `Dynamic Client Registration failed: ${err.error}${
+          new OAuthDiscoveryError({
+            message: `Dynamic Client Registration failed: ${err.error}${
               err.error_description ? ` — ${err.error_description}` : ""
             }`,
-            { status: err.status, cause: err },
-          ),
+            status: err.status,
+            cause: err,
+          }),
         ),
       DcrTransport: (err) =>
         Effect.fail(
-          discoveryError(`Dynamic Client Registration failed: ${err.message}`, {
+          new OAuthDiscoveryError({
+            message: `Dynamic Client Registration failed: ${err.detail}`,
             status: err.status,
             cause: err.cause ?? err,
           }),
@@ -630,8 +606,7 @@ export const beginDynamicAuthorization = (
 
     const authorizationServerUrl = (() => {
       if (prior.authorizationServerUrl) return prior.authorizationServerUrl;
-      const fromResource =
-        resource && resource.metadata.authorization_servers?.[0];
+      const fromResource = resource && resource.metadata.authorization_servers?.[0];
       if (fromResource) return fromResource;
       const u = new URL(input.endpoint);
       return `${u.protocol}//${u.host}`;
@@ -643,35 +618,26 @@ export const beginDynamicAuthorization = (
             metadata: prior.authorizationServerMetadata,
             metadataUrl: prior.authorizationServerMetadataUrl,
           }
-        : yield* discoverAuthorizationServerMetadata(
-            authorizationServerUrl,
-            options,
-          );
+        : yield* discoverAuthorizationServerMetadata(authorizationServerUrl, options);
 
     if (!authServer) {
-      return yield* Effect.fail(
-        discoveryError(
-          `No OAuth authorization server metadata at ${authorizationServerUrl}`,
-        ),
-      );
+      return yield* new OAuthDiscoveryError({
+        message: `No OAuth authorization server metadata at ${authorizationServerUrl}`,
+      });
     }
 
     const pkceMethods = authServer.metadata.code_challenge_methods_supported ?? [];
     if (pkceMethods.length > 0 && !pkceMethods.includes("S256")) {
-      return yield* Effect.fail(
-        discoveryError(
-          `Authorization server does not support PKCE S256 (advertised: ${pkceMethods.join(", ")})`,
-        ),
-      );
+      return yield* new OAuthDiscoveryError({
+        message: `Authorization server does not support PKCE S256 (advertised: ${pkceMethods.join(", ")})`,
+      });
     }
 
     const responseTypes = authServer.metadata.response_types_supported ?? [];
     if (responseTypes.length > 0 && !responseTypes.includes("code")) {
-      return yield* Effect.fail(
-        discoveryError(
-          `Authorization server does not support response_type=code (advertised: ${responseTypes.join(", ")})`,
-        ),
-      );
+      return yield* new OAuthDiscoveryError({
+        message: `Authorization server does not support response_type=code (advertised: ${responseTypes.join(", ")})`,
+      });
     }
 
     const baseClientMetadata: DynamicClientMetadata = {
@@ -689,9 +655,10 @@ export const beginDynamicAuthorization = (
         const reg = authServer.metadata.registration_endpoint;
         if (!reg) {
           return Effect.fail(
-            discoveryError(
-              "Authorization server does not advertise registration_endpoint — cannot auto-register a client",
-            ),
+            new OAuthDiscoveryError({
+              message:
+                "Authorization server does not advertise registration_endpoint — cannot auto-register a client",
+            }),
           );
         }
         return registerDynamicClient(
@@ -701,9 +668,7 @@ export const beginDynamicAuthorization = (
       })());
 
     const codeVerifier = createPkceCodeVerifier();
-    const codeChallenge = yield* Effect.promise(() =>
-      createPkceCodeChallenge(codeVerifier),
-    );
+    const codeChallenge = yield* Effect.promise(() => createPkceCodeChallenge(codeVerifier));
     const scopes = input.scopes ?? authServer.metadata.scopes_supported ?? [];
 
     const authorizationUrl = buildAuthorizationUrl({

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -35,13 +35,9 @@
 // every strategy because refresh semantics are strategy-independent.
 // ---------------------------------------------------------------------------
 
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 
-import type {
-  DBAdapter,
-  StorageFailure,
-  TypedAdapter,
-} from "@executor-js/storage-core";
+import type { DBAdapter, StorageFailure, TypedAdapter } from "@executor-js/storage-core";
 
 import {
   ConnectionRefreshError,
@@ -52,9 +48,7 @@ import {
   type ConnectionRefreshResult,
   type ConnectionRef,
 } from "./connections";
-import type {
-  ConnectionProviderNotRegisteredError,
-} from "./errors";
+import type { ConnectionProviderNotRegisteredError } from "./errors";
 import type { CoreSchema } from "./core-schema";
 import { ConnectionId, ScopeId, SecretId } from "./ids";
 import { SetSecretInput, type SecretRef } from "./secrets";
@@ -89,6 +83,7 @@ import {
   createPkceCodeVerifier,
   exchangeAuthorizationCode,
   exchangeClientCredentials,
+  type OAuth2Error,
   refreshAccessToken,
 } from "./oauth-helpers";
 
@@ -110,9 +105,7 @@ const DynamicDcrSessionPayload = Schema.Struct({
   authorizationServerMetadata: OAuthAuthorizationServerMetadataJson,
   clientInformation: OAuthClientInformationJson,
   resourceMetadataUrl: Schema.NullOr(Schema.String),
-  resourceMetadata: Schema.NullOr(
-    Schema.Record(Schema.String, Schema.Unknown),
-  ),
+  resourceMetadata: Schema.NullOr(Schema.Record(Schema.String, Schema.Unknown)),
   scopes: Schema.Array(Schema.String),
 });
 
@@ -122,7 +115,9 @@ const AuthorizationCodeSessionPayload = Schema.Struct({
   codeVerifier: Schema.String,
   authorizationEndpoint: Schema.String,
   tokenEndpoint: Schema.String,
-  issuerUrl: Schema.NullOr(Schema.String).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
+  issuerUrl: Schema.NullOr(Schema.String).pipe(
+    Schema.withDecodingDefaultType(Effect.succeed(null)),
+  ),
   clientIdSecretId: Schema.String,
   clientSecretSecretId: Schema.NullOr(Schema.String),
   scopes: Schema.Array(Schema.String),
@@ -144,20 +139,20 @@ const encodeSessionPayload = Schema.encodeSync(OAuthSessionPayload);
 
 const coerceJson = (value: unknown): unknown => {
   if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
+  return Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown))(value).pipe(
+    Option.getOrElse(() => value),
+  );
 };
 
 const stringArray = (value: unknown): readonly string[] =>
-  Array.isArray(value)
-    ? value.filter((scope): scope is string => typeof scope === "string")
-    : [];
+  Array.isArray(value) ? value.filter((scope): scope is string => typeof scope === "string") : [];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object";
 
 const originOrNull = (value: unknown): string | null => {
   if (typeof value !== "string") return null;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform parser; invalid legacy issuer values decode to null
   try {
     return new URL(value).origin;
   } catch {
@@ -167,8 +162,7 @@ const originOrNull = (value: unknown): string | null => {
 
 const decodeProviderState = (value: unknown): OAuthProviderState => {
   const raw = coerceJson(value);
-  const record =
-    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : null;
+  const record = isRecord(raw) ? raw : null;
 
   if (record && !("kind" in record) && "flow" in record && "tokenUrl" in record) {
     const flow = record.flow;
@@ -196,12 +190,7 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
     }
   }
 
-  if (
-    record &&
-    !("kind" in record) &&
-    "clientIdSecretId" in record &&
-    "scopes" in record
-  ) {
+  if (record && !("kind" in record) && "clientIdSecretId" in record && "scopes" in record) {
     const scopes = stringArray(record.scopes);
     return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
       kind: "authorization-code",
@@ -214,48 +203,30 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
     });
   }
 
-  if (
-    record &&
-    !("kind" in record) &&
-    "clientInformation" in record &&
-    "endpoint" in record
-  ) {
-    const clientInformation =
-      record.clientInformation && typeof record.clientInformation === "object"
-        ? (record.clientInformation as Record<string, unknown>)
-        : null;
+  if (record && !("kind" in record) && "clientInformation" in record && "endpoint" in record) {
+    const clientInformation = isRecord(record.clientInformation) ? record.clientInformation : null;
+    const authorizationServerMetadata = isRecord(record.authorizationServerMetadata)
+      ? record.authorizationServerMetadata
+      : null;
     return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
       kind: "dynamic-dcr",
       tokenEndpoint:
         typeof record.tokenEndpoint === "string"
           ? record.tokenEndpoint
-          : record.authorizationServerMetadata &&
-              typeof record.authorizationServerMetadata === "object" &&
-              typeof (record.authorizationServerMetadata as Record<string, unknown>)
-                .token_endpoint === "string"
-            ? ((record.authorizationServerMetadata as Record<string, unknown>)
-                .token_endpoint as string)
+          : typeof authorizationServerMetadata?.token_endpoint === "string"
+            ? authorizationServerMetadata.token_endpoint
             : "",
       issuerUrl:
-        record.authorizationServerMetadata &&
-        typeof record.authorizationServerMetadata === "object" &&
-        typeof (record.authorizationServerMetadata as Record<string, unknown>).issuer ===
-          "string"
-          ? ((record.authorizationServerMetadata as Record<string, unknown>)
-              .issuer as string)
+        typeof authorizationServerMetadata?.issuer === "string"
+          ? authorizationServerMetadata.issuer
           : null,
       authorizationServerUrl:
-        typeof record.authorizationServerUrl === "string"
-          ? record.authorizationServerUrl
-          : null,
+        typeof record.authorizationServerUrl === "string" ? record.authorizationServerUrl : null,
       authorizationServerMetadataUrl:
         typeof record.authorizationServerMetadataUrl === "string"
           ? record.authorizationServerMetadataUrl
           : null,
-      clientId:
-        typeof clientInformation?.client_id === "string"
-          ? clientInformation.client_id
-          : "",
+      clientId: typeof clientInformation?.client_id === "string" ? clientInformation.client_id : "",
       clientSecretSecretId: null,
       clientAuth: "body",
       scope: null,
@@ -288,10 +259,7 @@ export interface OAuthServiceDeps {
    *  `complete` (and from `start` for `client-credentials`). */
   readonly connectionsCreate: (
     input: CreateConnectionInput,
-  ) => Effect.Effect<
-    ConnectionRef,
-    ConnectionProviderNotRegisteredError | StorageFailure
-  >;
+  ) => Effect.Effect<ConnectionRef, ConnectionProviderNotRegisteredError | StorageFailure>;
   /** Random session id generator. Tests override to make outputs
    *  deterministic. */
   readonly newSessionId?: () => string;
@@ -304,9 +272,9 @@ const defaultSessionId = (): string => {
   if (crypto?.randomUUID) return `oauth2_session_${crypto.randomUUID()}`;
   const bytes = new Uint8Array(16);
   crypto.getRandomValues(bytes);
-  return `oauth2_session_${Array.from(bytes, (byte) =>
-    byte.toString(16).padStart(2, "0"),
-  ).join("")}`;
+  return `oauth2_session_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )}`;
 };
 
 const secretIdPart = (value: string): string =>
@@ -328,11 +296,7 @@ const oauthSecretId = (
 const scopedSessionId = (scopeId: string, sessionId: string): string =>
   `${sessionId}_${secretIdPart(scopeId).slice(0, 24)}`;
 
-const terminalRefreshErrors = new Set([
-  "invalid_grant",
-  "invalid_client",
-  "unauthorized_client",
-]);
+const terminalRefreshErrors = new Set(["invalid_grant", "invalid_client", "unauthorized_client"]);
 
 // ---------------------------------------------------------------------------
 // Service factory
@@ -347,50 +311,42 @@ export const makeOAuth2Service = (
   // -------------------------------------------------------------------
   // probe
   // -------------------------------------------------------------------
-  const probe = (
-    input: OAuthProbeInput,
-  ): Effect.Effect<OAuthProbeResult, OAuthProbeError> =>
+  const probe = (input: OAuthProbeInput): Effect.Effect<OAuthProbeResult, OAuthProbeError> =>
     Effect.gen(function* () {
-      const resource = yield* discoverProtectedResourceMetadata(
-        input.endpoint,
-        { resourceHeaders: input.headers, resourceQueryParams: input.queryParams },
-      ).pipe(
-        Effect.catchTag("OAuthDiscoveryError", (err) =>
+      const resource = yield* discoverProtectedResourceMetadata(input.endpoint, {
+        resourceHeaders: input.headers,
+        resourceQueryParams: input.queryParams,
+      }).pipe(
+        Effect.catchTag("OAuthDiscoveryError", ({ message }) =>
           Effect.fail(
             new OAuthProbeError({
-              message: `Protected resource metadata probe failed: ${err.message}`,
-
+              message: `Protected resource metadata probe failed: ${message}`,
             }),
           ),
         ),
       );
 
-      const authorizationServerUrl = (() => {
+      const authorizationServerUrl = yield* (() => {
         const fromResource = resource?.metadata.authorization_servers?.[0];
-        if (fromResource) return fromResource;
-        try {
-          const u = new URL(input.endpoint);
-          return `${u.protocol}//${u.host}`;
-        } catch {
-          return null;
-        }
+        if (fromResource) return Effect.succeed(fromResource);
+        return Effect.try({
+          try: () => {
+            const u = new URL(input.endpoint);
+            return `${u.protocol}//${u.host}`;
+          },
+          catch: () => null,
+        }).pipe(Effect.catch(() => Effect.succeed(null)));
       })();
 
       const authServer = authorizationServerUrl
-        ? yield* discoverAuthorizationServerMetadata(
-            authorizationServerUrl,
-          ).pipe(
-            Effect.catchTag("OAuthDiscoveryError", () =>
-              Effect.succeed(null),
-            ),
+        ? yield* discoverAuthorizationServerMetadata(authorizationServerUrl).pipe(
+            Effect.catchTag("OAuthDiscoveryError", () => Effect.succeed(null)),
           )
         : null;
 
       const supportsDynamicRegistration = !!(
         authServer?.metadata.registration_endpoint &&
-        (authServer.metadata.token_endpoint_auth_methods_supported ?? []).includes(
-          "none",
-        )
+        (authServer.metadata.token_endpoint_auth_methods_supported ?? []).includes("none")
       );
 
       // Bearer challenge probe — POST the endpoint unauth, look for
@@ -402,45 +358,39 @@ export const makeOAuth2Service = (
         try: async (): Promise<boolean> => {
           const controller = new AbortController();
           const timer = setTimeout(() => controller.abort(), 6_000);
-          try {
-            const probeUrl = new URL(input.endpoint);
-            for (const [key, value] of Object.entries(input.queryParams ?? {})) {
-              probeUrl.searchParams.set(key, value);
-            }
-            const response = await fetch(probeUrl.toString(), {
-              method: "POST",
-              headers: {
-                ...(input.headers ?? {}),
-                "content-type": "application/json",
-                accept: "application/json, text/event-stream",
-              },
-              body: JSON.stringify({
-                jsonrpc: "2.0",
-                id: 1,
-                method: "initialize",
-                params: {
-                  protocolVersion: "2025-06-18",
-                  capabilities: {},
-                  clientInfo: { name: "executor-probe", version: "0" },
-                },
-              }),
-              signal: controller.signal,
-            });
-            if (response.status !== 401) return false;
-            const wwwAuth =
-              response.headers.get("www-authenticate") ??
-              response.headers.get("WWW-Authenticate");
-            return !!wwwAuth && /^\s*bearer\b/i.test(wwwAuth);
-          } finally {
-            clearTimeout(timer);
+          const probeUrl = new URL(input.endpoint);
+          for (const [key, value] of Object.entries(input.queryParams ?? {})) {
+            probeUrl.searchParams.set(key, value);
           }
+          const response = await fetch(probeUrl.toString(), {
+            method: "POST",
+            headers: {
+              ...(input.headers ?? {}),
+              "content-type": "application/json",
+              accept: "application/json, text/event-stream",
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "initialize",
+              params: {
+                protocolVersion: "2025-06-18",
+                capabilities: {},
+                clientInfo: { name: "executor-probe", version: "0" },
+              },
+            }),
+            signal: controller.signal,
+          }).finally(() => clearTimeout(timer));
+          if (response.status !== 401) return false;
+          const wwwAuth =
+            response.headers.get("www-authenticate") ?? response.headers.get("WWW-Authenticate");
+          return !!wwwAuth && /^\s*bearer\b/i.test(wwwAuth);
         },
         catch: () => null,
       }).pipe(Effect.catch(() => Effect.succeed(false)));
 
       return {
-        resourceMetadata:
-          (resource?.metadata as Record<string, unknown> | undefined) ?? null,
+        resourceMetadata: (resource?.metadata as Record<string, unknown> | undefined) ?? null,
         resourceMetadataUrl: resource?.metadataUrl ?? null,
         authorizationServerMetadata:
           (authServer?.metadata as Record<string, unknown> | undefined) ?? null,
@@ -459,20 +409,22 @@ export const makeOAuth2Service = (
     strategy: OAuthDynamicDcrStrategy,
   ): Effect.Effect<OAuthStartResult, OAuthStartError | StorageFailure> =>
     Effect.gen(function* () {
-      const started = yield* beginDynamicAuthorization({
-        endpoint: input.endpoint,
-        redirectUrl: input.redirectUrl,
-        state: "",
-        scopes: strategy.scopes,
-      }, {
-        resourceHeaders: input.headers,
-        resourceQueryParams: input.queryParams,
-      }).pipe(
-        Effect.catchTag("OAuthDiscoveryError", (err) =>
+      const started = yield* beginDynamicAuthorization(
+        {
+          endpoint: input.endpoint,
+          redirectUrl: input.redirectUrl,
+          state: "",
+          scopes: strategy.scopes,
+        },
+        {
+          resourceHeaders: input.headers,
+          resourceQueryParams: input.queryParams,
+        },
+      ).pipe(
+        Effect.catchTag("OAuthDiscoveryError", ({ message }) =>
           Effect.fail(
             new OAuthStartError({
-              message: `Dynamic authorization setup failed: ${err.message}`,
-
+              message: `Dynamic authorization setup failed: ${message}`,
             }),
           ),
         ),
@@ -492,10 +444,7 @@ export const makeOAuth2Service = (
         authorizationUrl: started.state.authorizationServerMetadata.authorization_endpoint,
         clientId: started.state.clientInformation.client_id,
         redirectUrl: input.redirectUrl,
-        scopes:
-          strategy.scopes ??
-          started.state.authorizationServerMetadata.scopes_supported ??
-          [],
+        scopes: strategy.scopes ?? started.state.authorizationServerMetadata.scopes_supported ?? [],
         state: sessionId,
         codeChallenge,
       });
@@ -505,22 +454,20 @@ export const makeOAuth2Service = (
         identityLabel: input.identityLabel ?? null,
         codeVerifier: started.codeVerifier,
         authorizationServerUrl: started.state.authorizationServerUrl,
-        authorizationServerMetadataUrl:
-          started.state.authorizationServerMetadataUrl,
-        authorizationServerMetadata:
-          started.state.authorizationServerMetadata as Record<string, unknown>,
+        authorizationServerMetadataUrl: started.state.authorizationServerMetadataUrl,
+        authorizationServerMetadata: started.state.authorizationServerMetadata as Record<
+          string,
+          unknown
+        >,
         clientInformation: (() => {
           const value: unknown = started.state.clientInformation;
           return value as Record<string, unknown>;
         })(),
         resourceMetadataUrl: started.state.resourceMetadataUrl,
         resourceMetadata:
-          (started.state.resourceMetadata as Record<string, unknown> | null) ??
-          null,
+          (started.state.resourceMetadata as Record<string, unknown> | null) ?? null,
         scopes: [
-          ...(strategy.scopes ??
-            started.state.authorizationServerMetadata.scopes_supported ??
-            []),
+          ...(strategy.scopes ?? started.state.authorizationServerMetadata.scopes_supported ?? []),
         ],
       };
 
@@ -544,25 +491,22 @@ export const makeOAuth2Service = (
   ): Effect.Effect<OAuthStartResult, OAuthStartError | StorageFailure> =>
     Effect.gen(function* () {
       const clientId = yield* deps.secretsGet(strategy.clientIdSecretId).pipe(
-        Effect.mapError((err) =>
-          // Storage failure propagates; null returns aren't errors — the
-          // branch below handles them.
-          err,
+        Effect.mapError(
+          (err) =>
+            // Storage failure propagates; null returns aren't errors — the
+            // branch below handles them.
+            err,
         ),
       );
       if (clientId === null) {
-        return yield* Effect.fail(
-          new OAuthStartError({
-            message: `client_id secret "${strategy.clientIdSecretId}" not found`,
-          }),
-        );
+        return yield* new OAuthStartError({
+          message: `client_id secret "${strategy.clientIdSecretId}" not found`,
+        });
       }
 
       const sessionId = scopedSessionId(input.tokenScope, newSessionId());
       const codeVerifier = createPkceCodeVerifier();
-      const codeChallenge = yield* Effect.promise(() =>
-        createPkceCodeChallenge(codeVerifier),
-      );
+      const codeChallenge = yield* Effect.promise(() => createPkceCodeChallenge(codeVerifier));
 
       const authorizationUrl = buildAuthorizationUrl({
         authorizationUrl: strategy.authorizationEndpoint,
@@ -611,11 +555,9 @@ export const makeOAuth2Service = (
       const clientId = yield* deps.secretsGet(strategy.clientIdSecretId);
       const clientSecret = yield* deps.secretsGet(strategy.clientSecretSecretId);
       if (clientId === null || clientSecret === null) {
-        return yield* Effect.fail(
-          new OAuthStartError({
-            message: "client_id / client_secret secret not found",
-          }),
-        );
+        return yield* new OAuthStartError({
+          message: "client_id / client_secret secret not found",
+        });
       }
 
       const tokens = yield* exchangeClientCredentials({
@@ -627,18 +569,15 @@ export const makeOAuth2Service = (
         clientAuth: strategy.clientAuth ?? "body",
       }).pipe(
         Effect.mapError(
-          (err) =>
+          ({ message }: OAuth2Error) =>
             new OAuthStartError({
-              message: `Client credentials exchange failed: ${err.message}`,
-
+              message: `Client credentials exchange failed: ${message}`,
             }),
         ),
       );
 
       const expiresAt =
-        typeof tokens.expires_in === "number"
-          ? now() + tokens.expires_in * 1000
-          : null;
+        typeof tokens.expires_in === "number" ? now() + tokens.expires_in * 1000 : null;
 
       const providerState: OAuthProviderState = {
         kind: "client-credentials",
@@ -666,21 +605,33 @@ export const makeOAuth2Service = (
             refreshToken: null,
             expiresAt,
             oauthScope: tokens.scope ?? null,
-            providerState: Schema.encodeSync(OAuthProviderStateSchema)(
-              providerState,
-            ) as Record<string, unknown>,
+            providerState: Schema.encodeSync(OAuthProviderStateSchema)(providerState) as Record<
+              string,
+              unknown
+            >,
           }),
         )
         .pipe(
-          Effect.mapError(
-            (err) =>
-              new OAuthStartError({
-                message: `Failed to mint connection: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-
-              }),
-          ),
+          Effect.catchTags({
+            ConnectionProviderNotRegisteredError: () =>
+              Effect.fail(
+                new OAuthStartError({
+                  message: "Failed to mint connection: ConnectionProviderNotRegisteredError",
+                }),
+              ),
+            StorageError: ({ message }) =>
+              Effect.fail(
+                new OAuthStartError({
+                  message: `Failed to mint connection: ${message}`,
+                }),
+              ),
+            UniqueViolationError: () =>
+              Effect.fail(
+                new OAuthStartError({
+                  message: "Failed to mint connection: UniqueViolationError",
+                }),
+              ),
+          }),
         );
 
       return {
@@ -709,22 +660,24 @@ export const makeOAuth2Service = (
     payload: OAuthSessionPayload;
     strategyKind: string;
   }): Effect.Effect<void, StorageFailure> =>
-    deps.adapter.create({
-      model: "oauth2_session",
-      data: {
-        id: args.sessionId,
-        scope_id: args.input.tokenScope,
-        plugin_id: args.input.pluginId,
-        strategy: args.strategyKind,
-        connection_id: args.input.connectionId,
-        token_scope: args.input.tokenScope,
-        redirect_url: args.input.redirectUrl,
-        payload: encodeSessionPayload(args.payload) as Record<string, unknown>,
-        expires_at: now() + OAUTH2_SESSION_TTL_MS,
-        created_at: new Date(),
-      },
-      forceAllowId: true,
-    }).pipe(Effect.asVoid);
+    deps.adapter
+      .create({
+        model: "oauth2_session",
+        data: {
+          id: args.sessionId,
+          scope_id: args.input.tokenScope,
+          plugin_id: args.input.pluginId,
+          strategy: args.strategyKind,
+          connection_id: args.input.connectionId,
+          token_scope: args.input.tokenScope,
+          redirect_url: args.input.redirectUrl,
+          payload: encodeSessionPayload(args.payload) as Record<string, unknown>,
+          expires_at: now() + OAUTH2_SESSION_TTL_MS,
+          created_at: new Date(),
+        },
+        forceAllowId: true,
+      })
+      .pipe(Effect.asVoid);
 
   // -------------------------------------------------------------------
   // complete — exchange the code, mint the Connection, delete the session
@@ -741,53 +694,45 @@ export const makeOAuth2Service = (
         where: [{ field: "id", value: input.state }],
       });
       if (!row) {
-        return yield* Effect.fail(
-          new OAuthSessionNotFoundError({ sessionId: input.state }),
-        );
+        return yield* new OAuthSessionNotFoundError({ sessionId: input.state });
       }
 
       const deleteSession = deps.adapter.delete({
         model: "oauth2_session",
         where: [
           { field: "id", value: input.state },
-          { field: "scope_id", value: row.scope_id as string },
+          { field: "scope_id", value: row.scope_id },
         ],
       });
 
       if (input.error) {
         yield* deleteSession;
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: `Authorization server returned error: ${input.error}`,
-            code: input.error,
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: `Authorization server returned error: ${input.error}`,
+          code: input.error,
+        });
       }
       if (!input.code) {
         yield* deleteSession;
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: "Missing authorization code",
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: "Missing authorization code",
+        });
       }
       const expiresAt = Number(row.expires_at as number | bigint);
       if (expiresAt <= now()) {
         yield* deleteSession;
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: "OAuth session expired",
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: "OAuth session expired",
+        });
       }
 
       const payload = decodeSessionPayload(coerceJson(row.payload));
       const endpoint = ""; // not stored on the row — the payload's own
-                          // endpoint fields drive exchange; we just need
-                          // a display string for the identity label.
-      const connectionId = row.connection_id as string;
-      const tokenScope = row.token_scope as string;
-      const redirectUrl = row.redirect_url as string;
+      // endpoint fields drive exchange; we just need
+      // a display string for the identity label.
+      const connectionId = row.connection_id;
+      const tokenScope = row.token_scope;
+      const redirectUrl = row.redirect_url;
 
       // Dispatch to the strategy-specific exchange.
       const exchangeResult = yield* (() => {
@@ -795,11 +740,7 @@ export const makeOAuth2Service = (
           case "dynamic-dcr":
             return exchangeDynamicDcr(payload, input.code, redirectUrl);
           case "authorization-code":
-            return exchangeAuthorizationCodeStrategy(
-              payload,
-              input.code,
-              redirectUrl,
-            );
+            return exchangeAuthorizationCodeStrategy(payload, input.code, redirectUrl);
         }
       })().pipe(Effect.tapError(() => deleteSession));
 
@@ -810,8 +751,7 @@ export const makeOAuth2Service = (
 
       const dynamicClientSecretSecretId = yield* (() => {
         if (payload.kind !== "dynamic-dcr") return Effect.succeed(null);
-        const clientSecret = (payload.clientInformation as { client_secret?: unknown })
-          .client_secret;
+        const clientSecret = payload.clientInformation.client_secret;
         if (typeof clientSecret !== "string" || clientSecret.length === 0) {
           return Effect.succeed(null);
         }
@@ -827,14 +767,20 @@ export const makeOAuth2Service = (
           )
           .pipe(
             Effect.as(secretId),
-            Effect.mapError(
-              (err) =>
-                new OAuthCompleteError({
-                  message: `Failed to persist DCR client_secret: ${
-                    err instanceof Error ? err.message : String(err)
-                  }`,
-                }),
-            ),
+            Effect.catchTags({
+              StorageError: ({ message }) =>
+                Effect.fail(
+                  new OAuthCompleteError({
+                    message: `Failed to persist DCR client_secret: ${message}`,
+                  }),
+                ),
+              UniqueViolationError: () =>
+                Effect.fail(
+                  new OAuthCompleteError({
+                    message: "Failed to persist DCR client_secret: UniqueViolationError",
+                  }),
+                ),
+            }),
           );
       })();
 
@@ -842,21 +788,21 @@ export const makeOAuth2Service = (
         payload.kind === "dynamic-dcr"
           ? {
               kind: "dynamic-dcr",
-              tokenEndpoint: (payload.authorizationServerMetadata as {
-                token_endpoint: string;
-              }).token_endpoint,
+              tokenEndpoint: (
+                payload.authorizationServerMetadata as {
+                  token_endpoint: string;
+                }
+              ).token_endpoint,
               issuerUrl:
-                (payload.authorizationServerMetadata as { issuer?: string }).issuer ??
-                null,
+                (payload.authorizationServerMetadata as { issuer?: string }).issuer ?? null,
               authorizationServerUrl: payload.authorizationServerUrl,
-              authorizationServerMetadataUrl:
-                payload.authorizationServerMetadataUrl,
-              idTokenSigningAlgValuesSupported:
-                (payload.authorizationServerMetadata as {
+              authorizationServerMetadataUrl: payload.authorizationServerMetadataUrl,
+              idTokenSigningAlgValuesSupported: (
+                payload.authorizationServerMetadata as {
                   id_token_signing_alg_values_supported?: string[];
-                }).id_token_signing_alg_values_supported,
-              clientId: (payload.clientInformation as { client_id: string })
-                .client_id,
+                }
+              ).id_token_signing_alg_values_supported,
+              clientId: (payload.clientInformation as { client_id: string }).client_id,
               clientSecretSecretId: dynamicClientSecretSecretId,
               clientAuth:
                 (payload.clientInformation as { token_endpoint_auth_method?: string })
@@ -901,21 +847,33 @@ export const makeOAuth2Service = (
               : null,
             expiresAt: connectionExpiresAt,
             oauthScope: exchangeResult.tokens.scope ?? null,
-            providerState: Schema.encodeSync(OAuthProviderStateSchema)(
-              providerState,
-            ) as Record<string, unknown>,
+            providerState: Schema.encodeSync(OAuthProviderStateSchema)(providerState) as Record<
+              string,
+              unknown
+            >,
           }),
         )
         .pipe(
-          Effect.mapError(
-            (err) =>
-              new OAuthCompleteError({
-                message: `Failed to mint connection: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-
-              }),
-          ),
+          Effect.catchTags({
+            ConnectionProviderNotRegisteredError: () =>
+              Effect.fail(
+                new OAuthCompleteError({
+                  message: "Failed to mint connection: ConnectionProviderNotRegisteredError",
+                }),
+              ),
+            StorageError: ({ message }) =>
+              Effect.fail(
+                new OAuthCompleteError({
+                  message: `Failed to mint connection: ${message}`,
+                }),
+              ),
+            UniqueViolationError: () =>
+              Effect.fail(
+                new OAuthCompleteError({
+                  message: "Failed to mint connection: UniqueViolationError",
+                }),
+              ),
+          }),
         );
 
       yield* deleteSession;
@@ -962,19 +920,14 @@ export const makeOAuth2Service = (
         redirectUrl,
         codeVerifier: payload.codeVerifier,
         code,
-        idTokenSigningAlgValuesSupported:
-          md.id_token_signing_alg_values_supported,
-        clientAuth:
-          ci.token_endpoint_auth_method === "client_secret_basic"
-            ? "basic"
-            : "body",
+        idTokenSigningAlgValuesSupported: md.id_token_signing_alg_values_supported,
+        clientAuth: ci.token_endpoint_auth_method === "client_secret_basic" ? "basic" : "body",
       }).pipe(
         Effect.mapError(
-          (err) =>
+          ({ message, error }: OAuth2Error) =>
             new OAuthCompleteError({
-              message: `Token exchange failed: ${err.message}`,
-              code: err.error,
-
+              message: `Token exchange failed: ${message}`,
+              code: error,
             }),
         ),
       );
@@ -988,28 +941,21 @@ export const makeOAuth2Service = (
     payload: Extract<OAuthSessionPayload, { kind: "authorization-code" }>,
     code: string,
     redirectUrl: string,
-  ): Effect.Effect<
-    ExchangeResult,
-    OAuthCompleteError | StorageFailure
-  > =>
+  ): Effect.Effect<ExchangeResult, OAuthCompleteError | StorageFailure> =>
     Effect.gen(function* () {
       const clientId = yield* deps.secretsGet(payload.clientIdSecretId);
       if (clientId === null) {
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: `client_id secret "${payload.clientIdSecretId}" not found`,
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: `client_id secret "${payload.clientIdSecretId}" not found`,
+        });
       }
       const clientSecret = payload.clientSecretSecretId
         ? yield* deps.secretsGet(payload.clientSecretSecretId)
         : null;
       if (payload.clientSecretSecretId && clientSecret === null) {
-        return yield* Effect.fail(
-          new OAuthCompleteError({
-            message: `client_secret secret "${payload.clientSecretSecretId}" not found`,
-          }),
-        );
+        return yield* new OAuthCompleteError({
+          message: `client_secret secret "${payload.clientSecretSecretId}" not found`,
+        });
       }
 
       const tokens = yield* exchangeAuthorizationCode({
@@ -1023,11 +969,10 @@ export const makeOAuth2Service = (
         clientAuth: payload.clientAuth,
       }).pipe(
         Effect.mapError(
-          (err) =>
+          ({ message, error }: OAuth2Error) =>
             new OAuthCompleteError({
-              message: `Token exchange failed: ${err.message}`,
-              code: err.error,
-
+              message: `Token exchange failed: ${message}`,
+              code: error,
             }),
         ),
       );
@@ -1048,7 +993,7 @@ export const makeOAuth2Service = (
         model: "oauth2_session",
         where: [
           { field: "id", value: sessionId },
-          { field: "scope_id", value: row.scope_id as string },
+          { field: "scope_id", value: row.scope_id },
         ],
       });
     });
@@ -1071,9 +1016,7 @@ export const makeOAuth2Service = (
           catch: (cause) =>
             new ConnectionRefreshError({
               connectionId: input.connectionId,
-              message: `oauth2 providerState is malformed: ${
-                cause instanceof Error ? cause.message : String(cause)
-              }`,
+              message: "oauth2 providerState is malformed",
               cause,
             }),
         });
@@ -1095,22 +1038,26 @@ export const makeOAuth2Service = (
             case "dynamic-dcr":
               return Effect.gen(function* () {
                 const csec = state.clientSecretSecretId
-                  ? yield* deps
-                      .secretsGet(state.clientSecretSecretId)
-                      .pipe(
-                        Effect.mapError(
-                          (cause) =>
+                  ? yield* deps.secretsGet(state.clientSecretSecretId).pipe(
+                      Effect.catchTags({
+                        StorageError: ({ message, cause }) =>
+                          Effect.fail(
                             new ConnectionRefreshError({
                               connectionId: input.connectionId,
-                              message: `Failed to resolve DCR client_secret: ${
-                                cause instanceof Error
-                                  ? cause.message
-                                  : String(cause)
-                              }`,
+                              message: `Failed to resolve DCR client_secret: ${message}`,
                               cause,
                             }),
-                        ),
-                      )
+                          ),
+                        UniqueViolationError: (cause) =>
+                          Effect.fail(
+                            new ConnectionRefreshError({
+                              connectionId: input.connectionId,
+                              message: "Failed to resolve DCR client_secret: UniqueViolationError",
+                              cause,
+                            }),
+                          ),
+                      }),
+                    )
                   : null;
                 if (state.clientSecretSecretId && csec === null) {
                   return yield* new ConnectionRefreshError({
@@ -1124,22 +1071,26 @@ export const makeOAuth2Service = (
             case "authorization-code":
             case "client-credentials":
               return Effect.gen(function* () {
-                const cid = yield* deps
-                  .secretsGet(state.clientIdSecretId)
-                  .pipe(
-                    Effect.mapError(
-                      (cause) =>
+                const cid = yield* deps.secretsGet(state.clientIdSecretId).pipe(
+                  Effect.catchTags({
+                    StorageError: ({ message, cause }) =>
+                      Effect.fail(
                         new ConnectionRefreshError({
                           connectionId: input.connectionId,
-                          message: `Failed to resolve client_id secret: ${
-                            cause instanceof Error
-                              ? cause.message
-                              : String(cause)
-                          }`,
+                          message: `Failed to resolve client_id secret: ${message}`,
                           cause,
                         }),
-                    ),
-                  );
+                      ),
+                    UniqueViolationError: (cause) =>
+                      Effect.fail(
+                        new ConnectionRefreshError({
+                          connectionId: input.connectionId,
+                          message: "Failed to resolve client_id secret: UniqueViolationError",
+                          cause,
+                        }),
+                      ),
+                  }),
+                );
                 if (cid === null) {
                   return yield* new ConnectionRefreshError({
                     connectionId: input.connectionId,
@@ -1148,22 +1099,26 @@ export const makeOAuth2Service = (
                   });
                 }
                 const csec = state.clientSecretSecretId
-                  ? yield* deps
-                      .secretsGet(state.clientSecretSecretId)
-                      .pipe(
-                        Effect.mapError(
-                          (cause) =>
+                  ? yield* deps.secretsGet(state.clientSecretSecretId).pipe(
+                      Effect.catchTags({
+                        StorageError: ({ message, cause }) =>
+                          Effect.fail(
                             new ConnectionRefreshError({
                               connectionId: input.connectionId,
-                              message: `Failed to resolve client_secret: ${
-                                cause instanceof Error
-                                  ? cause.message
-                                  : String(cause)
-                              }`,
+                              message: `Failed to resolve client_secret: ${message}`,
                               cause,
                             }),
-                        ),
-                      )
+                          ),
+                        UniqueViolationError: (cause) =>
+                          Effect.fail(
+                            new ConnectionRefreshError({
+                              connectionId: input.connectionId,
+                              message: "Failed to resolve client_secret: UniqueViolationError",
+                              cause,
+                            }),
+                          ),
+                      }),
+                    )
                   : null;
                 if (state.clientSecretSecretId && csec === null) {
                   return yield* new ConnectionRefreshError({
@@ -1179,35 +1134,28 @@ export const makeOAuth2Service = (
 
         const tokenEndpoint = yield* (() => {
           if (state.tokenEndpoint) return Effect.succeed(state.tokenEndpoint);
-          if (
-            state.kind === "dynamic-dcr" &&
-            state.authorizationServerUrl
-          ) {
-            return discoverAuthorizationServerMetadata(
-              state.authorizationServerUrl,
-            ).pipe(
+          if (state.kind === "dynamic-dcr" && state.authorizationServerUrl) {
+            return discoverAuthorizationServerMetadata(state.authorizationServerUrl).pipe(
               Effect.flatMap((metadata) =>
                 metadata?.metadata.token_endpoint
                   ? Effect.succeed(metadata.metadata.token_endpoint)
                   : Effect.fail(
                       new ConnectionRefreshError({
                         connectionId: input.connectionId,
-                        message:
-                          "oauth2 legacy MCP providerState is missing token endpoint",
+                        message: "oauth2 legacy MCP providerState is missing token endpoint",
                         reauthRequired: true,
                       }),
                     ),
               ),
-              Effect.mapError((cause) =>
-                cause instanceof ConnectionRefreshError
-                  ? cause
-                  : new ConnectionRefreshError({
-                      connectionId: input.connectionId,
-                      message:
-                        "Failed to discover token endpoint for legacy MCP OAuth connection",
-                      reauthRequired: true,
-                      cause,
-                    }),
+              Effect.catchTag("OAuthDiscoveryError", (cause) =>
+                Effect.fail(
+                  new ConnectionRefreshError({
+                    connectionId: input.connectionId,
+                    message: "Failed to discover token endpoint for legacy MCP OAuth connection",
+                    reauthRequired: true,
+                    cause,
+                  }),
+                ),
               ),
             );
           }
@@ -1220,56 +1168,51 @@ export const makeOAuth2Service = (
           );
         })();
 
-        const tokens = yield* (state.kind === "client-credentials"
-          ? exchangeClientCredentials({
-              tokenUrl: tokenEndpoint,
-              clientId,
-              clientSecret: clientSecret ?? "",
-              scopes: state.scopes,
-              scopeSeparator: state.scopeSeparator,
-              clientAuth: state.clientAuth,
-            })
-          : refreshAccessToken({
-              tokenUrl: tokenEndpoint,
-              issuerUrl:
-                state.kind === "dynamic-dcr" || state.kind === "authorization-code"
-                  ? (state.issuerUrl ?? undefined)
-                  : undefined,
-              clientId,
-              clientSecret: clientSecret ?? undefined,
-              refreshToken: input.refreshToken!,
-              scopes:
-                state.kind === "dynamic-dcr" || state.kind === "authorization-code"
-                  ? state.scopes
-                  : undefined,
-              scopeSeparator:
-                state.kind === "dynamic-dcr" || state.kind === "authorization-code"
-                  ? state.scopeSeparator
-                  : undefined,
-              clientAuth: state.clientAuth,
-              idTokenSigningAlgValuesSupported:
-                state.kind === "dynamic-dcr"
-                  ? state.idTokenSigningAlgValuesSupported
-                  : undefined,
-            })).pipe(
+        const tokens = yield* (
+          state.kind === "client-credentials"
+            ? exchangeClientCredentials({
+                tokenUrl: tokenEndpoint,
+                clientId,
+                clientSecret: clientSecret ?? "",
+                scopes: state.scopes,
+                scopeSeparator: state.scopeSeparator,
+                clientAuth: state.clientAuth,
+              })
+            : refreshAccessToken({
+                tokenUrl: tokenEndpoint,
+                issuerUrl:
+                  state.kind === "dynamic-dcr" || state.kind === "authorization-code"
+                    ? (state.issuerUrl ?? undefined)
+                    : undefined,
+                clientId,
+                clientSecret: clientSecret ?? undefined,
+                refreshToken: input.refreshToken!,
+                scopes:
+                  state.kind === "dynamic-dcr" || state.kind === "authorization-code"
+                    ? state.scopes
+                    : undefined,
+                scopeSeparator:
+                  state.kind === "dynamic-dcr" || state.kind === "authorization-code"
+                    ? state.scopeSeparator
+                    : undefined,
+                clientAuth: state.clientAuth,
+                idTokenSigningAlgValuesSupported:
+                  state.kind === "dynamic-dcr" ? state.idTokenSigningAlgValuesSupported : undefined,
+              })
+        ).pipe(
           Effect.mapError(
-            (err) =>
+            ({ message, error }: OAuth2Error) =>
               new ConnectionRefreshError({
                 connectionId: input.connectionId,
-                message: `OAuth refresh failed: ${err.message}`,
+                message: `OAuth refresh failed: ${message}`,
                 // Terminal RFC 6749 §5.2 errors mean retrying won't heal it.
-                reauthRequired: err.error
-                  ? terminalRefreshErrors.has(err.error)
-                  : false,
-
+                reauthRequired: error ? terminalRefreshErrors.has(error) : false,
               }),
           ),
         );
 
         const expiresAt =
-          typeof tokens.expires_in === "number"
-            ? now() + tokens.expires_in * 1000
-            : null;
+          typeof tokens.expires_in === "number" ? now() + tokens.expires_in * 1000 : null;
 
         const result: ConnectionRefreshResult = {
           accessToken: tokens.access_token,
@@ -1293,6 +1236,7 @@ export const makeOAuth2Service = (
 
 const safeHostname = (value: string | null): string | null => {
   if (!value) return null;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: URL constructor is the platform parser; non-URL labels remain display labels
   try {
     return new URL(value).host;
   } catch {


### PR DESCRIPTION
## Summary
- parse OAuth discovery and session JSON through Effect Schema
- preserve typed OAuth failures without generic unknown error message plumbing
- keep URL constructor fallback behavior at narrow synchronous boundaries

## Verification
- bunx oxlint --format=unix packages/core/sdk/src/oauth-service.ts packages/core/sdk/src/oauth-discovery.ts
- bun run --cwd packages/core/sdk typecheck
- bun run --cwd packages/core/sdk test src/oauth-helpers.test.ts src/oauth-discovery.test.ts src/connections.test.ts