### PR TITLE
Fix OpenAPI boundary lint

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
-import { Option } from "effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk/core";
 import { startOAuth } from "@executor-js/react/api/atoms";
@@ -81,6 +83,17 @@ import {
   type ServerVariable,
 } from "../sdk/types";
 
+const ErrorMessage = Schema.Struct({ message: Schema.String });
+
+const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
+  Option.match(
+    Option.flatMap(Exit.findErrorOption(exit), Schema.decodeUnknownOption(ErrorMessage)),
+    {
+      onNone: () => fallback,
+      onSome: ({ message }) => message,
+    },
+  );
+
 export const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
 export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/oauth/callback";
 
@@ -109,25 +122,15 @@ export const openApiOAuthConnectionId = (
  */
 export function resolveOAuthUrl(url: string, baseUrl: string): string {
   if (!url) return url;
-  try {
-    new URL(url);
+  if (URL.canParse(url)) {
     return url;
-  } catch {
-    if (!baseUrl) return url;
-    try {
-      return new URL(url, baseUrl).toString();
-    } catch {
-      return url;
-    }
   }
+  if (!baseUrl || !URL.canParse(url, baseUrl)) return url;
+  return new URL(url, baseUrl).toString();
 }
 
 export function inferOAuthIssuerUrl(authorizationUrl: string): string | null {
-  try {
-    return new URL(authorizationUrl).origin;
-  } catch {
-    return null;
-  }
+  return URL.canParse(authorizationUrl) ? new URL(authorizationUrl).origin : null;
 }
 
 type StrategySelection =
@@ -242,10 +245,10 @@ export default function AddOpenApiSource(props: {
 
   const scopeId = useScope();
   const userScope = useUserScope();
-  const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promise" });
-  const doAdd = useAtomSet(addOpenApiSpec, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
-  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promise" });
+  const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promiseExit" });
+  const doAdd = useAtomSet(addOpenApiSpec, { mode: "promiseExit" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
+  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promiseExit" });
   const { beginAdd } = usePendingSources();
   const secretList = useSecretPickerSecrets();
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
@@ -278,7 +281,7 @@ export default function AddOpenApiSource(props: {
     selectedServerIndex >= 0 ? (servers[selectedServerIndex] ?? null) : null;
 
   const serverVariables: Record<string, ServerVariable> = selectedServer
-    ? Option.getOrElse(selectedServer.variables, () => ({}) as Record<string, ServerVariable>)
+    ? Option.getOrElse(selectedServer.variables, () => ({}))
     : {};
   const serverVariableEntries: Array<[string, ServerVariable]> = Object.entries(serverVariables);
 
@@ -290,10 +293,7 @@ export default function AddOpenApiSource(props: {
   // Helper used by analyze + server selection: build a default selection map
   // from a server's variable defaults.
   const defaultSelectionsFor = (server: ServerInfo): Record<string, string> => {
-    const vars: Record<string, ServerVariable> = Option.getOrElse(
-      server.variables,
-      () => ({}) as Record<string, ServerVariable>,
-    );
+    const vars: Record<string, ServerVariable> = Option.getOrElse(server.variables, () => ({}));
     const out: Record<string, string> = {};
     for (const [name, v] of Object.entries(vars)) out[name] = v.default;
     return out;
@@ -371,45 +371,47 @@ export default function AddOpenApiSource(props: {
     setAnalyzing(true);
     setAnalyzeError(null);
     setAddError(null);
-    try {
-      const credentials = serializeHttpCredentials(specFetchCredentials);
-      const result = await doPreview({
-        params: { scopeId },
-        payload: {
-          spec: specUrl,
-          specFetchCredentials: credentials,
-        },
-      });
-      setPreview(result);
-
-      const firstServer = result.servers[0];
-      if (firstServer) {
-        setSelectedServerIndex(0);
-        setVariableSelections(defaultSelectionsFor(firstServer));
-        setCustomBaseUrl("");
-      } else {
-        setSelectedServerIndex(-1);
-        setVariableSelections({});
-        setCustomBaseUrl("");
-      }
-
-      const firstPreset = result.headerPresets[0];
-      if (firstPreset) {
-        setStrategy({ kind: "header", presetIndex: 0 });
-        setCustomHeaders(entriesFromSpecPreset(firstPreset));
-      } else {
-        // No header presets — default to "custom" so the headers editor is
-        // visible immediately. Specs with no `security` block (e.g. Microsoft
-        // Graph) would otherwise leave the user staring at just the
-        // Authentication heading with no way to add headers.
-        setStrategy({ kind: "custom" });
-        setCustomHeaders([]);
-      }
-    } catch (e) {
-      setAnalyzeError(e instanceof Error ? e.message : "Failed to parse spec");
-    } finally {
+    const credentials = serializeHttpCredentials(specFetchCredentials);
+    const exit = await doPreview({
+      params: { scopeId },
+      payload: {
+        spec: specUrl,
+        specFetchCredentials: credentials,
+      },
+    });
+    if (Exit.isFailure(exit)) {
+      setAnalyzeError(errorMessageFromExit(exit, "Failed to parse spec"));
       setAnalyzing(false);
+      return;
     }
+
+    const result = exit.value;
+    setPreview(result);
+
+    const firstServer = result.servers[0];
+    if (firstServer) {
+      setSelectedServerIndex(0);
+      setVariableSelections(defaultSelectionsFor(firstServer));
+      setCustomBaseUrl("");
+    } else {
+      setSelectedServerIndex(-1);
+      setVariableSelections({});
+      setCustomBaseUrl("");
+    }
+
+    const firstPreset = result.headerPresets[0];
+    if (firstPreset) {
+      setStrategy({ kind: "header", presetIndex: 0 });
+      setCustomHeaders(entriesFromSpecPreset(firstPreset));
+    } else {
+      // No header presets — default to "custom" so the headers editor is
+      // visible immediately. Specs with no `security` block (e.g. Microsoft
+      // Graph) would otherwise leave the user staring at just the
+      // Authentication heading with no way to add headers.
+      setStrategy({ kind: "custom" });
+      setCustomHeaders([]);
+    }
+    setAnalyzing(false);
   };
 
   handleAnalyzeRef.current = handleAnalyze;
@@ -470,122 +472,126 @@ export default function AddOpenApiSource(props: {
     if (!selectedOAuth2Preset || !oauth2ClientIdSecretId || !preview) return;
     oauth.cancel();
     setOauth2Error(null);
-    try {
-      const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
+    const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
 
-      const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
+    const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
 
-      if (selectedOAuth2Preset.flow === "clientCredentials") {
-        // RFC 6749 §4.4: no user-interactive consent step. The client_secret
-        // is mandatory; the backend exchanges tokens inline and returns a
-        // completed OAuth2Auth we can attach to the source directly.
-        if (!oauth2ClientSecretSecretId) {
-          setOauth2Error("client_credentials requires a client secret");
-          return;
-        }
-        setStartingOAuth(true);
-        const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
-        const response = await doStartOAuth({
-          params: { scopeId },
-          payload: {
-            endpoint: tokenUrl,
-            redirectUrl: tokenUrl,
-            connectionId,
-            tokenScope: scopeId as string,
-            strategy: {
-              kind: "client-credentials",
-              tokenEndpoint: tokenUrl,
-              clientIdSecretId: oauth2ClientIdSecretId,
-              clientSecretSecretId: oauth2ClientSecretSecretId,
-              scopes: [...oauth2SelectedScopes],
-            },
-            pluginId: "openapi",
-            identityLabel: `${displayName} OAuth`,
+    if (selectedOAuth2Preset.flow === "clientCredentials") {
+      // RFC 6749 §4.4: no user-interactive consent step. The client_secret
+      // is mandatory; the backend exchanges tokens inline and returns a
+      // completed OAuth2Auth we can attach to the source directly.
+      if (!oauth2ClientSecretSecretId) {
+        setOauth2Error("client_credentials requires a client secret");
+        return;
+      }
+      setStartingOAuth(true);
+      const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
+      const startOAuthExit = await doStartOAuth({
+        params: { scopeId },
+        payload: {
+          endpoint: tokenUrl,
+          redirectUrl: tokenUrl,
+          connectionId,
+          tokenScope: scopeId,
+          strategy: {
+            kind: "client-credentials",
+            tokenEndpoint: tokenUrl,
+            clientIdSecretId: oauth2ClientIdSecretId,
+            clientSecretSecretId: oauth2ClientSecretSecretId,
+            scopes: [...oauth2SelectedScopes],
           },
-        });
-        setStartingOAuth(false);
-        if (!response.completedConnection) {
-          setOauth2Error("client_credentials flow did not mint a connection");
-          return;
-        }
+          pluginId: "openapi",
+          identityLabel: `${displayName} OAuth`,
+        },
+      });
+      setStartingOAuth(false);
+      if (Exit.isFailure(startOAuthExit)) {
+        setOauth2Error(errorMessageFromExit(startOAuthExit, "Failed to start OAuth"));
+        return;
+      }
+      const response = startOAuthExit.value;
+      if (!response.completedConnection) {
+        setOauth2Error("client_credentials flow did not mint a connection");
+        return;
+      }
+      setOauth2AuthState({
+        fingerprint: selectedOAuth2Fingerprint,
+        auth: new OAuth2Auth({
+          kind: "oauth2",
+          connectionId: response.completedConnection.connectionId,
+          securitySchemeName: selectedOAuth2Preset.securitySchemeName,
+          flow: "clientCredentials",
+          tokenUrl,
+          authorizationUrl: null,
+          clientIdSecretId: oauth2ClientIdSecretId,
+          clientSecretSecretId: oauth2ClientSecretSecretId,
+          scopes: [...oauth2SelectedScopes],
+        }),
+      });
+      setOauth2Error(null);
+      return;
+    }
+
+    const authorizationUrl = resolveOAuthUrl(
+      Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
+      resolvedBaseUrl,
+    );
+    const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
+    const startOAuthExit = await doStartOAuth({
+      params: { scopeId },
+      payload: {
+        endpoint: authorizationUrl,
+        connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
+        tokenScope: scopeId,
+        redirectUrl: oauth2RedirectUrl,
+        strategy: {
+          kind: "authorization-code",
+          authorizationEndpoint: authorizationUrl,
+          tokenEndpoint: tokenUrl,
+          issuerUrl,
+          clientIdSecretId: oauth2ClientIdSecretId,
+          clientSecretSecretId: oauth2ClientSecretSecretId ?? null,
+          scopes: [...oauth2SelectedScopes],
+        },
+        pluginId: "openapi",
+        identityLabel: `${displayName} OAuth`,
+      },
+    });
+    if (Exit.isFailure(startOAuthExit)) {
+      setOauth2Error(errorMessageFromExit(startOAuthExit, "Failed to start OAuth"));
+      return;
+    }
+    const response = startOAuthExit.value;
+    if (response.authorizationUrl === null) {
+      setOauth2Error("Unexpected response flow from server");
+      return;
+    }
+
+    await oauth.openAuthorization({
+      run: async () => ({
+        sessionId: response.sessionId,
+        authorizationUrl: response.authorizationUrl,
+      }),
+      onSuccess: (result) => {
         setOauth2AuthState({
           fingerprint: selectedOAuth2Fingerprint,
           auth: new OAuth2Auth({
             kind: "oauth2",
-            connectionId: response.completedConnection.connectionId,
+            connectionId: result.connectionId,
             securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-            flow: "clientCredentials",
+            flow: "authorizationCode",
             tokenUrl,
-            authorizationUrl: null,
+            authorizationUrl,
+            issuerUrl,
             clientIdSecretId: oauth2ClientIdSecretId,
             clientSecretSecretId: oauth2ClientSecretSecretId,
             scopes: [...oauth2SelectedScopes],
           }),
         });
         setOauth2Error(null);
-        return;
-      }
-
-      const authorizationUrl = resolveOAuthUrl(
-        Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
-        resolvedBaseUrl,
-      );
-      const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
-
-      await oauth.openAuthorization({
-        run: async () => {
-          const response = await doStartOAuth({
-            params: { scopeId },
-            payload: {
-              endpoint: authorizationUrl,
-              connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
-              tokenScope: scopeId as string,
-              redirectUrl: oauth2RedirectUrl,
-              strategy: {
-                kind: "authorization-code",
-                authorizationEndpoint: authorizationUrl,
-                tokenEndpoint: tokenUrl,
-                issuerUrl,
-                clientIdSecretId: oauth2ClientIdSecretId,
-                clientSecretSecretId: oauth2ClientSecretSecretId ?? null,
-                scopes: [...oauth2SelectedScopes],
-              },
-              pluginId: "openapi",
-              identityLabel: `${displayName} OAuth`,
-            },
-          });
-          if (response.authorizationUrl === null) {
-            throw new Error("Unexpected response flow from server");
-          }
-          return {
-            sessionId: response.sessionId,
-            authorizationUrl: response.authorizationUrl,
-          };
-        },
-        onSuccess: (result) => {
-          setOauth2AuthState({
-            fingerprint: selectedOAuth2Fingerprint,
-            auth: new OAuth2Auth({
-              kind: "oauth2",
-              connectionId: result.connectionId,
-              securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-              flow: "authorizationCode",
-              tokenUrl,
-              authorizationUrl,
-              issuerUrl,
-              clientIdSecretId: oauth2ClientIdSecretId,
-              clientSecretSecretId: oauth2ClientSecretSecretId,
-              scopes: [...oauth2SelectedScopes],
-            }),
-          });
-          setOauth2Error(null);
-        },
-        onError: setOauth2Error,
-      });
-    } catch (e) {
-      setStartingOAuth(false);
-      setOauth2Error(e instanceof Error ? e.message : "Failed to start OAuth");
-    }
+      },
+      onError: setOauth2Error,
+    });
   }, [
     selectedOAuth2Preset,
     oauth2ClientIdSecretId,
@@ -621,103 +627,123 @@ export default function AddOpenApiSource(props: {
       kind: "openapi",
       url: resolvedBaseUrl || undefined,
     });
-    try {
-      const result = await doAdd({
+    const failAdd = (message: string) => {
+      setAddError(message);
+      setAdding(false);
+      placeholder.done();
+    };
+    const resultExit = await doAdd({
+      params: { scopeId },
+      payload: {
+        spec: specUrl,
+        specFetchCredentials: serializeHttpCredentials(specFetchCredentials),
+        name: identity.name.trim() || undefined,
+        namespace: slugifyNamespace(identity.namespace) || undefined,
+        baseUrl: resolvedBaseUrl || undefined,
+        ...(hasHeaders ? { headers: configuredHeaders } : {}),
+        ...(Object.keys(serializeHttpCredentials(runtimeCredentials).queryParams).length > 0
+          ? { queryParams: serializeHttpCredentials(runtimeCredentials).queryParams }
+          : {}),
+        ...(configuredOAuth2 ? { oauth2: configuredOAuth2 } : {}),
+      },
+      reactivityKeys: addSpecWriteKeys,
+    });
+
+    if (Exit.isFailure(resultExit)) {
+      failAdd(errorMessageFromExit(resultExit, "Failed to add source"));
+      return;
+    }
+
+    const sourceId = resultExit.value.namespace;
+    const sourceScope = ScopeId.make(scopeId);
+    const bindingScope = ScopeId.make(userScope);
+
+    for (const binding of headerBindings) {
+      const bindingExit = await doSetBinding({
         params: { scopeId },
         payload: {
-          spec: specUrl,
-          specFetchCredentials: serializeHttpCredentials(specFetchCredentials),
-          name: identity.name.trim() || undefined,
-          namespace: slugifyNamespace(identity.namespace) || undefined,
-          baseUrl: resolvedBaseUrl || undefined,
-          ...(hasHeaders ? { headers: configuredHeaders } : {}),
-          ...(Object.keys(serializeHttpCredentials(runtimeCredentials).queryParams).length > 0
-            ? { queryParams: serializeHttpCredentials(runtimeCredentials).queryParams }
-            : {}),
-          ...(configuredOAuth2 ? { oauth2: configuredOAuth2 } : {}),
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: binding.slot,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(binding.secretId),
+          },
         },
-        reactivityKeys: addSpecWriteKeys,
+        reactivityKeys: bindingWriteKeys,
       });
-
-      const sourceId = result.namespace;
-      const sourceScope = ScopeId.make(scopeId);
-      const bindingScope = ScopeId.make(userScope);
-
-      for (const binding of headerBindings) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: binding.slot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(binding.secretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
+      if (Exit.isFailure(bindingExit)) {
+        failAdd(errorMessageFromExit(bindingExit, "Failed to add source"));
+        return;
       }
-
-      if (configuredOAuth2 && oauth2ClientIdSecretId) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.clientIdSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientIdSecretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      if (configuredOAuth2?.clientSecretSlot && oauth2ClientSecretSecretId) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.clientSecretSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientSecretSecretId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      if (configuredOAuth2 && oauth2Auth) {
-        await doSetBinding({
-          params: { scopeId },
-          payload: {
-            sourceId,
-            sourceScope,
-            scope: bindingScope,
-            slot: configuredOAuth2.connectionSlot,
-            value: {
-              kind: "connection",
-              connectionId: ConnectionId.make(oauth2Auth.connectionId),
-            },
-          },
-          reactivityKeys: bindingWriteKeys,
-        });
-      }
-
-      props.onComplete();
-    } catch (e) {
-      setAddError(e instanceof Error ? e.message : "Failed to add source");
-      setAdding(false);
-    } finally {
-      placeholder.done();
     }
+
+    if (configuredOAuth2 && oauth2ClientIdSecretId) {
+      const clientIdBindingExit = await doSetBinding({
+        params: { scopeId },
+        payload: {
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: configuredOAuth2.clientIdSlot,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(oauth2ClientIdSecretId),
+          },
+        },
+        reactivityKeys: bindingWriteKeys,
+      });
+      if (Exit.isFailure(clientIdBindingExit)) {
+        failAdd(errorMessageFromExit(clientIdBindingExit, "Failed to add source"));
+        return;
+      }
+    }
+
+    if (configuredOAuth2?.clientSecretSlot && oauth2ClientSecretSecretId) {
+      const clientSecretBindingExit = await doSetBinding({
+        params: { scopeId },
+        payload: {
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: configuredOAuth2.clientSecretSlot,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(oauth2ClientSecretSecretId),
+          },
+        },
+        reactivityKeys: bindingWriteKeys,
+      });
+      if (Exit.isFailure(clientSecretBindingExit)) {
+        failAdd(errorMessageFromExit(clientSecretBindingExit, "Failed to add source"));
+        return;
+      }
+    }
+
+    if (configuredOAuth2 && oauth2Auth) {
+      const connectionBindingExit = await doSetBinding({
+        params: { scopeId },
+        payload: {
+          sourceId,
+          sourceScope,
+          scope: bindingScope,
+          slot: configuredOAuth2.connectionSlot,
+          value: {
+            kind: "connection",
+            connectionId: ConnectionId.make(oauth2Auth.connectionId),
+          },
+        },
+        reactivityKeys: bindingWriteKeys,
+      });
+      if (Exit.isFailure(connectionBindingExit)) {
+        failAdd(errorMessageFromExit(connectionBindingExit, "Failed to add source"));
+        return;
+      }
+    }
+
+    placeholder.done();
+    props.onComplete();
   };
 
   // ---- Render ----

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
 import { connectionsAtom, sourceAtom, startOAuth } from "@executor-js/react/api/atoms";
@@ -42,7 +45,21 @@ import {
   resolveOAuthUrl,
 } from "./AddOpenApiSource";
 import { oauth2ClientSecretSlot } from "../sdk/store";
-import type { OpenApiSourceBindingValue } from "../sdk/types";
+import {
+  OpenApiSourceBindingValue,
+  type OpenApiSourceBindingValue as OpenApiSourceBindingValueType,
+} from "../sdk/types";
+
+const ErrorMessage = Schema.Struct({ message: Schema.String });
+
+const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
+  Option.match(
+    Option.flatMap(Exit.findErrorOption(exit), Schema.decodeUnknownOption(ErrorMessage)),
+    {
+      onNone: () => fallback,
+      onSome: ({ message }) => message,
+    },
+  );
 
 type SlotDef =
   | {
@@ -79,7 +96,7 @@ const openApiOAuthConnectionId = (
   targetScope: ScopeId,
 ): ConnectionId =>
   ConnectionId.make(
-    `openapi-oauth-${slugify(sourceId)}-${slugify(securitySchemeName)}-${shortHash(targetScope as string)}`,
+    `openapi-oauth-${slugify(sourceId)}-${slugify(securitySchemeName)}-${shortHash(targetScope)}`,
   );
 
 const bindingSecretId = (sourceId: string, slot: string, scopeId: string): string =>
@@ -101,7 +118,7 @@ const exactBindingForScope = (
 ) => rows.find((row) => row.slot === slot && row.scopeId === scopeId) ?? null;
 
 const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
-  ranks.get(scopeId as string) ?? Number.MAX_SAFE_INTEGER;
+  ranks.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
 
 const effectiveBindingForScope = (
   rows: readonly {
@@ -119,21 +136,13 @@ const effectiveBindingForScope = (
 
 const isSecretBindingValue = (
   value: unknown,
-): value is Extract<OpenApiSourceBindingValue, { readonly kind: "secret" }> =>
-  typeof value === "object" &&
-  value !== null &&
-  "kind" in value &&
-  (value as { kind?: unknown }).kind === "secret" &&
-  "secretId" in value;
+): value is Extract<OpenApiSourceBindingValueType, { readonly kind: "secret" }> =>
+  Schema.is(OpenApiSourceBindingValue)(value) && value.kind === "secret";
 
 const isConnectionBindingValue = (
   value: unknown,
-): value is Extract<OpenApiSourceBindingValue, { readonly kind: "connection" }> =>
-  typeof value === "object" &&
-  value !== null &&
-  "kind" in value &&
-  (value as { kind?: unknown }).kind === "connection" &&
-  "connectionId" in value;
+): value is Extract<OpenApiSourceBindingValueType, { readonly kind: "connection" }> =>
+  Schema.is(OpenApiSourceBindingValue)(value) && value.kind === "connection";
 
 export default function EditOpenApiSource(props: {
   readonly sourceId: string;
@@ -150,7 +159,7 @@ export default function EditOpenApiSource(props: {
   const sourceScopeId = sourceSummary?.scopeId ?? displayScope;
   const sourceScope = ScopeId.make(sourceScopeId);
   const scopeRanks = useMemo(
-    () => new Map(scopeStack.map((scope, index) => [scope.id as string, index] as const)),
+    () => new Map(scopeStack.map((scope, index) => [scope.id, index] as const)),
     [scopeStack],
   );
 
@@ -161,10 +170,10 @@ export default function EditOpenApiSource(props: {
   const connectionsResult = useAtomValue(connectionsAtom(displayScope));
   const secretList = useSecretPickerSecrets();
 
-  const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promise" });
-  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promise" });
-  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, { mode: "promise" });
-  const doStartOAuth = useAtomSet(startOAuth, { mode: "promise" });
+  const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promiseExit" });
+  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promiseExit" });
+  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, { mode: "promiseExit" });
+  const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
     popupName: OPENAPI_OAUTH_POPUP_NAME,
     popupBlockedMessage: "OAuth popup was blocked by the browser",
@@ -224,28 +233,28 @@ export default function EditOpenApiSource(props: {
       const seq = ++sourceSaveSeq.current;
       setSourceSaveState("saving");
       setError(null);
-      void doUpdate({
-        params: { scopeId: ScopeId.make(sourceScopeId), namespace: props.sourceId },
-        payload: {
-          name: nextName || undefined,
-          baseUrl: nextBaseUrl || undefined,
-          headers: source.config.headers,
-          oauth2: source.config.oauth2,
-        },
-        reactivityKeys: openApiWriteKeys,
-      })
-        .then(() => {
-          if (sourceSaveSeq.current !== seq) return;
-          setSourceSaveState("saved");
-          window.setTimeout(() => {
-            if (sourceSaveSeq.current === seq) setSourceSaveState("idle");
-          }, 1600);
-        })
-        .catch((e: unknown) => {
-          if (sourceSaveSeq.current !== seq) return;
-          setSourceSaveState("idle");
-          setError(e instanceof Error ? e.message : "Failed to save source details");
+      void (async () => {
+        const exit = await doUpdate({
+          params: { scopeId: ScopeId.make(sourceScopeId), namespace: props.sourceId },
+          payload: {
+            name: nextName || undefined,
+            baseUrl: nextBaseUrl || undefined,
+            headers: source.config.headers,
+            oauth2: source.config.oauth2,
+          },
+          reactivityKeys: openApiWriteKeys,
         });
+        if (sourceSaveSeq.current !== seq) return;
+        if (Exit.isFailure(exit)) {
+          setSourceSaveState("idle");
+          setError(errorMessageFromExit(exit, "Failed to save source details"));
+          return;
+        }
+        setSourceSaveState("saved");
+        window.setTimeout(() => {
+          if (sourceSaveSeq.current === seq) setSourceSaveState("idle");
+        }, 1600);
+      })();
     }, 600);
 
     return () => window.clearTimeout(timeout);
@@ -321,44 +330,40 @@ export default function EditOpenApiSource(props: {
     if (!trimmed) return;
     setBusyKey(inputKey);
     setError(null);
-    try {
-      await doSetBinding({
-        params: { scopeId: displayScope },
-        payload: {
-          sourceId: props.sourceId,
-          sourceScope,
-          scope: targetScope,
-          slot,
-          value: { kind: "secret", secretId: SecretId.make(trimmed) },
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save credential binding");
-    } finally {
-      setBusyKey(null);
+    const exit = await doSetBinding({
+      params: { scopeId: displayScope },
+      payload: {
+        sourceId: props.sourceId,
+        sourceScope,
+        scope: targetScope,
+        slot,
+        value: { kind: "secret", secretId: SecretId.make(trimmed) },
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(errorMessageFromExit(exit, "Failed to save credential binding"));
     }
+    setBusyKey(null);
   };
 
   const clearBinding = async (targetScope: ScopeId, slot: string) => {
     setBusyKey(`${targetScope}:${slot}:clear`);
     setError(null);
-    try {
-      await doRemoveBinding({
-        params: { scopeId: displayScope },
-        payload: {
-          sourceId: props.sourceId,
-          sourceScope,
-          slot,
-          scope: targetScope,
-        },
-        reactivityKeys: sourceWriteKeys,
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to clear credential binding");
-    } finally {
-      setBusyKey(null);
+    const exit = await doRemoveBinding({
+      params: { scopeId: displayScope },
+      payload: {
+        sourceId: props.sourceId,
+        sourceScope,
+        slot,
+        scope: targetScope,
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(errorMessageFromExit(exit, "Failed to clear credential binding"));
     }
+    setBusyKey(null);
   };
 
   const connectOAuth = async (targetScope: ScopeId) => {
@@ -410,35 +415,112 @@ export default function EditOpenApiSource(props: {
     setPendingOAuthConnection({
       scopeId: targetScope,
       slot: oauth2.connectionSlot,
-      connectionId: connectionId as string,
+      connectionId: connectionId,
     });
     setError(null);
-    try {
-      const displayName = source.name;
-      const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
-      if (oauth2.flow === "clientCredentials") {
-        const response = await doStartOAuth({
-          params: { scopeId: displayScope },
-          payload: {
-            endpoint: tokenUrl,
-            redirectUrl: tokenUrl,
-            connectionId: connectionId as string,
-            tokenScope: targetScope as string,
-            strategy: {
-              kind: "client-credentials",
-              tokenEndpoint: tokenUrl,
-              clientIdSecretId,
-              clientSecretSecretId: clientSecretValue!.secretId,
-              scopes: [...oauth2.scopes],
-            },
-            pluginId: "openapi",
-            identityLabel: `${displayName} OAuth`,
+    const failConnect = (message: string) => {
+      setError(message);
+      setPendingOAuthConnection(null);
+      setBusyKey(null);
+    };
+    const displayName = source.name;
+    const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
+    if (oauth2.flow === "clientCredentials") {
+      const startOAuthExit = await doStartOAuth({
+        params: { scopeId: displayScope },
+        payload: {
+          endpoint: tokenUrl,
+          redirectUrl: tokenUrl,
+          connectionId: connectionId,
+          tokenScope: targetScope,
+          strategy: {
+            kind: "client-credentials",
+            tokenEndpoint: tokenUrl,
+            clientIdSecretId,
+            clientSecretSecretId: clientSecretValue!.secretId,
+            scopes: [...oauth2.scopes],
           },
-        });
-        if (!response.completedConnection) {
-          throw new Error("Unexpected OAuth response");
-        }
-        await doSetBinding({
+          pluginId: "openapi",
+          identityLabel: `${displayName} OAuth`,
+        },
+      });
+      if (Exit.isFailure(startOAuthExit)) {
+        failConnect(errorMessageFromExit(startOAuthExit, "Failed to connect OAuth"));
+        return;
+      }
+      const response = startOAuthExit.value;
+      if (!response.completedConnection) {
+        failConnect("Unexpected OAuth response");
+        return;
+      }
+      const setBindingExit = await doSetBinding({
+        params: { scopeId: displayScope },
+        payload: {
+          sourceId: props.sourceId,
+          sourceScope,
+          scope: targetScope,
+          slot: oauth2.connectionSlot,
+          value: {
+            kind: "connection",
+            connectionId: ConnectionId.make(response.completedConnection.connectionId),
+          },
+        },
+        reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
+      });
+      if (Exit.isFailure(setBindingExit)) {
+        failConnect(errorMessageFromExit(setBindingExit, "Failed to connect OAuth"));
+        return;
+      }
+      setPendingOAuthConnection(null);
+      setBusyKey(null);
+      return;
+    }
+
+    const authorizationUrl = resolveOAuthUrl(
+      oauth2.authorizationUrl ?? "",
+      source.config.baseUrl ?? "",
+    );
+    const issuerUrl = oauth2.issuerUrl ?? inferOAuthIssuerUrl(authorizationUrl);
+    const startOAuthExit = await doStartOAuth({
+      params: { scopeId: displayScope },
+      payload: {
+        endpoint: authorizationUrl,
+        connectionId,
+        tokenScope: targetScope,
+        redirectUrl: oauth2RedirectUrl,
+        strategy: {
+          kind: "authorization-code",
+          authorizationEndpoint: authorizationUrl,
+          tokenEndpoint: tokenUrl,
+          issuerUrl,
+          clientIdSecretId,
+          clientSecretSecretId:
+            clientSecretBinding && isSecretBindingValue(clientSecretBinding.value)
+              ? clientSecretBinding.value.secretId
+              : null,
+          scopes: [...oauth2.scopes],
+        },
+        pluginId: "openapi",
+        identityLabel: `${displayName} OAuth`,
+      },
+    });
+    if (Exit.isFailure(startOAuthExit)) {
+      failConnect(errorMessageFromExit(startOAuthExit, "Failed to connect OAuth"));
+      return;
+    }
+    const response = startOAuthExit.value;
+    if (response.authorizationUrl === null) {
+      failConnect("Unexpected OAuth response");
+      return;
+    }
+
+    await oauth.openAuthorization({
+      run: async () => ({
+        sessionId: response.sessionId,
+        authorizationUrl: response.authorizationUrl,
+      }),
+      onSuccess: async (result) => {
+        const setBindingExit = await doSetBinding({
           params: { scopeId: displayScope },
           payload: {
             sourceId: props.sourceId,
@@ -447,83 +529,24 @@ export default function EditOpenApiSource(props: {
             slot: oauth2.connectionSlot,
             value: {
               kind: "connection",
-              connectionId: ConnectionId.make(response.completedConnection.connectionId),
+              connectionId: ConnectionId.make(result.connectionId),
             },
           },
           reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
         });
+        if (Exit.isFailure(setBindingExit)) {
+          failConnect(errorMessageFromExit(setBindingExit, "Failed to connect OAuth"));
+          return;
+        }
         setPendingOAuthConnection(null);
         setBusyKey(null);
-        return;
-      }
-
-      const authorizationUrl = resolveOAuthUrl(
-        oauth2.authorizationUrl ?? "",
-        source.config.baseUrl ?? "",
-      );
-      const issuerUrl = oauth2.issuerUrl ?? inferOAuthIssuerUrl(authorizationUrl);
-      await oauth.openAuthorization({
-        run: async () => {
-          const response = await doStartOAuth({
-            params: { scopeId: displayScope },
-            payload: {
-              endpoint: authorizationUrl,
-              connectionId: connectionId as string,
-              tokenScope: targetScope as string,
-              redirectUrl: oauth2RedirectUrl,
-              strategy: {
-                kind: "authorization-code",
-                authorizationEndpoint: authorizationUrl,
-                tokenEndpoint: tokenUrl,
-                issuerUrl,
-                clientIdSecretId,
-                clientSecretSecretId:
-                  clientSecretBinding && isSecretBindingValue(clientSecretBinding.value)
-                    ? clientSecretBinding.value.secretId
-                    : null,
-                scopes: [...oauth2.scopes],
-              },
-              pluginId: "openapi",
-              identityLabel: `${displayName} OAuth`,
-            },
-          });
-          if (response.authorizationUrl === null) {
-            throw new Error("Unexpected OAuth response");
-          }
-          return {
-            sessionId: response.sessionId,
-            authorizationUrl: response.authorizationUrl,
-          };
-        },
-        onSuccess: async (result) => {
-          await doSetBinding({
-            params: { scopeId: displayScope },
-            payload: {
-              sourceId: props.sourceId,
-              sourceScope,
-              scope: targetScope,
-              slot: oauth2.connectionSlot,
-              value: {
-                kind: "connection",
-                connectionId: ConnectionId.make(result.connectionId),
-              },
-            },
-            reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
-          });
-          setPendingOAuthConnection(null);
-          setBusyKey(null);
-        },
-        onError: (message) => {
-          setError(message);
-          setPendingOAuthConnection(null);
-          setBusyKey(null);
-        },
-      });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to connect OAuth");
-      setPendingOAuthConnection(null);
-      setBusyKey(null);
-    }
+      },
+      onError: (message) => {
+        setError(message);
+        setPendingOAuthConnection(null);
+        setBusyKey(null);
+      },
+    });
   };
 
   return (
@@ -590,10 +613,10 @@ export default function EditOpenApiSource(props: {
               </CardStackEntryContent>
               <FilterTabs
                 tabs={credentialScopes.map((entry) => ({
-                  value: entry.scopeId as string,
+                  value: entry.scopeId,
                   label: entry.label,
                 }))}
-                value={activeCredentialScopeId as string}
+                value={activeCredentialScopeId}
                 onChange={setSelectedCredentialScope}
               />
             </CardStackEntry>
@@ -618,9 +641,9 @@ export default function EditOpenApiSource(props: {
                 isSecretBindingValue(effective.value);
               const currentSecretId =
                 exact && isSecretBindingValue(exact.value)
-                  ? (exact.value.secretId as string)
+                  ? exact.value.secretId
                   : inherited && effective && isSecretBindingValue(effective.value)
-                    ? (effective.value.secretId as string)
+                    ? effective.value.secretId
                     : null;
               return (
                 <CardStackEntryField

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 
 import {
   ConnectionId,
@@ -174,9 +174,7 @@ export interface StoredSource {
 // an encodable/decodable shape for HTTP responses.
 // ---------------------------------------------------------------------------
 
-export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>(
-  "OpenApiStoredSource",
-)({
+export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>("OpenApiStoredSource")({
   namespace: Schema.String,
   name: Schema.String,
   config: Schema.Struct({
@@ -184,20 +182,12 @@ export class StoredSourceSchema extends Schema.Class<StoredSourceSchema>(
     sourceUrl: Schema.optional(Schema.String),
     baseUrl: Schema.optional(Schema.String),
     namespace: Schema.optional(Schema.String),
-    headers: Schema.optional(
-      Schema.Record(Schema.String, ConfiguredHeaderValue),
-    ),
-    queryParams: Schema.optional(
-      Schema.Record(Schema.String, HeaderValue),
-    ),
+    headers: Schema.optional(Schema.Record(Schema.String, ConfiguredHeaderValue)),
+    queryParams: Schema.optional(Schema.Record(Schema.String, HeaderValue)),
     specFetchCredentials: Schema.optional(
       Schema.Struct({
-        headers: Schema.optional(
-          Schema.Record(Schema.String, HeaderValue),
-        ),
-        queryParams: Schema.optional(
-          Schema.Record(Schema.String, HeaderValue),
-        ),
+        headers: Schema.optional(Schema.Record(Schema.String, HeaderValue)),
+        queryParams: Schema.optional(Schema.Record(Schema.String, HeaderValue)),
       }),
     ),
     // Canonical source-owned OAuth config. Concrete client credentials
@@ -221,9 +211,84 @@ export interface StoredOperation {
 
 const encodeBinding = Schema.encodeSync(OperationBinding);
 const decodeBinding = Schema.decodeUnknownSync(OperationBinding);
+const decodeBindingJson = Schema.decodeUnknownSync(Schema.fromJsonString(OperationBinding));
 
 const decodeOAuth2 = Schema.decodeUnknownSync(OAuth2Auth);
+const decodeOAuth2Option = Schema.decodeUnknownOption(OAuth2Auth);
+const decodeOAuth2JsonOption = Schema.decodeUnknownOption(Schema.fromJsonString(OAuth2Auth));
+const decodeOAuth2SourceConfigOption = Schema.decodeUnknownOption(OAuth2SourceConfig);
+const decodeOAuth2SourceConfigJsonOption = Schema.decodeUnknownOption(
+  Schema.fromJsonString(OAuth2SourceConfig),
+);
 const encodeOAuth2SourceConfig = Schema.encodeSync(OAuth2SourceConfig);
+
+const decodeHeaderValueOption = Schema.decodeUnknownOption(HeaderValue);
+const UnknownRecord = Schema.Record(Schema.String, Schema.Unknown);
+const decodeUnknownRecord = Schema.decodeUnknownSync(UnknownRecord);
+const decodeUnknownRecordJson = Schema.decodeUnknownSync(Schema.fromJsonString(UnknownRecord));
+const decodeConfiguredHeaderBindingOption = Schema.decodeUnknownOption(ConfiguredHeaderBinding);
+
+const NullableString = Schema.NullOr(Schema.String);
+const OptionalNullableString = Schema.optional(NullableString);
+
+const ChildStorageRow = Schema.Struct({
+  name: Schema.String,
+  kind: Schema.Literals(["text", "secret"]),
+  text_value: OptionalNullableString,
+  secret_id: OptionalNullableString,
+  secret_prefix: OptionalNullableString,
+});
+const decodeChildStorageRowOption = Schema.decodeUnknownOption(ChildStorageRow);
+
+const SourceBindingStorageRow = Schema.Struct({
+  source_id: Schema.String,
+  source_scope_id: Schema.String,
+  target_scope_id: Schema.String,
+  slot: Schema.String,
+  kind: Schema.Literals(["secret", "connection", "text"]),
+  secret_id: OptionalNullableString,
+  connection_id: OptionalNullableString,
+  text_value: OptionalNullableString,
+  created_at: Schema.Unknown,
+  updated_at: Schema.Unknown,
+});
+const decodeSourceBindingStorageRow = Schema.decodeUnknownSync(SourceBindingStorageRow);
+
+const SourceStorageRow = Schema.Struct({
+  id: Schema.String,
+  scope_id: Schema.String,
+  name: Schema.String,
+  spec: Schema.String,
+  source_url: OptionalNullableString,
+  base_url: OptionalNullableString,
+  headers: Schema.optional(Schema.Unknown),
+  oauth2: Schema.optional(Schema.Unknown),
+});
+const decodeSourceStorageRow = Schema.decodeUnknownSync(SourceStorageRow);
+
+const OperationStorageRow = Schema.Struct({
+  id: Schema.String,
+  source_id: Schema.String,
+  binding: Schema.Unknown,
+});
+const decodeOperationStorageRow = Schema.decodeUnknownSync(OperationStorageRow);
+
+const ChildUsageStorageRow = Schema.Struct({
+  source_id: Schema.String,
+  scope_id: Schema.String,
+  name: Schema.String,
+});
+const decodeChildUsageStorageRow = Schema.decodeUnknownSync(ChildUsageStorageRow);
+
+const SourceNameStorageRow = Schema.Struct({
+  id: Schema.String,
+  scope_id: Schema.String,
+  name: Schema.String,
+});
+const decodeSourceNameStorageRow = Schema.decodeUnknownSync(SourceNameStorageRow);
+
+const decodeStorageDate = (value: unknown): Date =>
+  value instanceof Date ? value : new Date(Schema.decodeUnknownSync(Schema.String)(value));
 
 interface ChildRow {
   readonly id: string;
@@ -277,21 +342,24 @@ const childRowsToValueMap = (
 ): Record<string, HeaderValue> => {
   const out: Record<string, HeaderValue> = {};
   for (const row of rows) {
-    const name = row.name as string;
-    if (row.kind === "secret" && typeof row.secret_id === "string") {
-      const prefix = row.secret_prefix as string | undefined | null;
-      out[name] = prefix
-        ? { secretId: row.secret_id, prefix }
-        : { secretId: row.secret_id };
-    } else if (row.kind === "text" && typeof row.text_value === "string") {
-      out[name] = row.text_value;
+    const decoded = decodeChildStorageRowOption(row);
+    if (Option.isSome(decoded)) {
+      const child = decoded.value;
+      if (child.kind === "secret" && child.secret_id != null) {
+        out[child.name] =
+          child.secret_prefix != null
+            ? { secretId: child.secret_id, prefix: child.secret_prefix }
+            : { secretId: child.secret_id };
+      } else if (child.kind === "text" && child.text_value != null) {
+        out[child.name] = child.text_value;
+      }
     }
   }
   return out;
 };
 
-const toJsonRecord = (value: unknown): Record<string, unknown> =>
-  value as Record<string, unknown>;
+// oxlint-disable-next-line executor/no-explicit-unknown-record -- boundary: storage adapter accepts JSON object columns
+const toJsonRecord = (value: unknown): Record<string, unknown> => value as Record<string, unknown>;
 
 const toConfiguredHeaderBinding = (value: {
   readonly slot?: unknown;
@@ -303,11 +371,10 @@ const toConfiguredHeaderBinding = (value: {
     ...(typeof value.prefix === "string" ? { prefix: value.prefix } : {}),
   });
 
-const decodeHeaders = (value: unknown): Record<string, HeaderValue> => {
+const decodeHeaders = (value: unknown): Record<string, unknown> => {
   if (value == null) return {};
-  if (typeof value === "string")
-    return JSON.parse(value) as Record<string, HeaderValue>;
-  return value as Record<string, HeaderValue>;
+  if (typeof value === "string") return decodeUnknownRecordJson(value);
+  return decodeUnknownRecord(value);
 };
 
 const slugifySlotPart = (value: string): string =>
@@ -344,20 +411,18 @@ const normalizeStoredHeaders = (
       legacy[name] = header;
       continue;
     }
-    if (
-      header &&
-      typeof header === "object" &&
-      "kind" in header &&
-      (header as { kind?: unknown }).kind === "binding"
-    ) {
-      headers[name] = toConfiguredHeaderBinding(header);
+    const binding = decodeConfiguredHeaderBindingOption(header);
+    if (Option.isSome(binding)) {
+      headers[name] = toConfiguredHeaderBinding(binding.value);
       continue;
     }
-    legacy[name] = header;
+    const legacyHeader = decodeHeaderValueOption(header);
+    if (Option.isNone(legacyHeader)) continue;
+    legacy[name] = legacyHeader.value;
     headers[name] = new ConfiguredHeaderBinding({
       kind: "binding",
       slot: headerBindingSlot(name),
-      prefix: header.prefix,
+      prefix: typeof legacyHeader.value === "string" ? undefined : legacyHeader.value.prefix,
     });
   }
   return { headers, legacy };
@@ -370,13 +435,16 @@ const normalizeStoredOAuth2 = (
   readonly legacy?: OAuth2Auth;
 } => {
   if (value == null) return {};
-  const parsed = typeof value === "string" ? JSON.parse(value) : value;
-  if (parsed && typeof parsed === "object" && "connectionSlot" in parsed) {
-    return {
-      oauth2: Schema.decodeUnknownSync(OAuth2SourceConfig)(parsed),
-    };
+  const sourceConfig =
+    typeof value === "string"
+      ? decodeOAuth2SourceConfigJsonOption(value)
+      : decodeOAuth2SourceConfigOption(value);
+  if (Option.isSome(sourceConfig)) {
+    return { oauth2: sourceConfig.value };
   }
-  const legacy = decodeOAuth2(parsed);
+  const legacyOption =
+    typeof value === "string" ? decodeOAuth2JsonOption(value) : decodeOAuth2Option(value);
+  const legacy = Option.isSome(legacyOption) ? legacyOption.value : decodeOAuth2(value);
   return {
     legacy,
     oauth2: new OAuth2SourceConfig({
@@ -438,10 +506,7 @@ export interface OpenapiStore {
     scope: string,
   ) => Effect.Effect<StoredSource | null, StorageFailure>;
 
-  readonly listSources: () => Effect.Effect<
-    readonly StoredSource[],
-    StorageFailure
-  >;
+  readonly listSources: () => Effect.Effect<readonly StoredSource[], StorageFailure>;
 
   readonly getOperationByToolId: (
     toolId: string,
@@ -453,10 +518,7 @@ export interface OpenapiStore {
     scope: string,
   ) => Effect.Effect<readonly StoredOperation[], StorageFailure>;
 
-  readonly removeSource: (
-    namespace: string,
-    scope: string,
-  ) => Effect.Effect<void, StorageFailure>;
+  readonly removeSource: (namespace: string, scope: string) => Effect.Effect<void, StorageFailure>;
 
   readonly listSourceBindings: (
     sourceId: string,
@@ -501,10 +563,7 @@ export interface OpenapiStore {
    *  `query_param:foo` or `spec_fetch_header:Authorization`. */
   readonly findChildRowsBySecret: (secretId: string) => Effect.Effect<
     readonly {
-      readonly kind:
-        | "query_param"
-        | "spec_fetch_header"
-        | "spec_fetch_query_param";
+      readonly kind: "query_param" | "spec_fetch_header" | "spec_fetch_query_param";
       readonly source_id: string;
       readonly scope_id: string;
       readonly name: string;
@@ -527,14 +586,12 @@ export const makeDefaultOpenapiStore = ({
   adapter,
   scopes,
 }: StorageDeps<OpenapiSchema>): OpenapiStore => {
-  const scopeIds = scopes.map((scope) => scope.id as string);
+  const scopeIds = scopes.map((scope) => String(scope.id));
   const scopePrecedence = new Map<string, number>();
   scopeIds.forEach((scope, index) => scopePrecedence.set(scope, index));
-  const scopeRank = (scopeId: string): number =>
-    scopePrecedence.get(scopeId) ?? Infinity;
+  const scopeRank = (scopeId: string): number => scopePrecedence.get(scopeId) ?? Infinity;
 
-  const encodeSyntheticRowIdPart = (value: string): string =>
-    encodeURIComponent(value);
+  const encodeSyntheticRowIdPart = (value: string): string => encodeURIComponent(value);
 
   const sourceBindingRowId = (
     sourceId: string,
@@ -550,47 +607,47 @@ export const makeDefaultOpenapiStore = ({
       encodeSyntheticRowIdPart(scopeId),
     ].join("::");
 
-  const rowToSourceBindingValue = (
-    row: Record<string, unknown>,
-  ): OpenApiSourceBindingValue => {
-    const kind = row.kind as string;
-    if (kind === "secret" && typeof row.secret_id === "string") {
-      return { kind: "secret", secretId: SecretId.make(row.secret_id) };
+  const rowToSourceBindingValue = (row: Record<string, unknown>): OpenApiSourceBindingValue => {
+    const decoded = decodeSourceBindingStorageRow(row);
+    if (decoded.kind === "secret" && decoded.secret_id != null) {
+      return { kind: "secret", secretId: SecretId.make(decoded.secret_id) };
     }
-    if (kind === "connection" && typeof row.connection_id === "string") {
+    if (decoded.kind === "connection" && decoded.connection_id != null) {
       return {
         kind: "connection",
-        connectionId: ConnectionId.make(row.connection_id),
+        connectionId: ConnectionId.make(decoded.connection_id),
       };
     }
     // text fallback covers both well-formed text rows and any
     // partial/null row that survived a malformed write — `text_value`
     // defaults to "" so the type stays satisfied without a throw.
-    return { kind: "text", text: (row.text_value as string | null) ?? "" };
+    return { kind: "text", text: decoded.text_value ?? "" };
   };
 
-  const rowToSourceBinding = (
-    row: Record<string, unknown>,
-  ): OpenApiSourceBindingRef =>
-    new OpenApiSourceBindingRef({
-      sourceId: row.source_id as string,
-      sourceScopeId: ScopeId.make(row.source_scope_id as string),
-      scopeId: ScopeId.make(row.target_scope_id as string),
-      slot: row.slot as string,
+  const rowToSourceBinding = (row: Record<string, unknown>): OpenApiSourceBindingRef => {
+    const decoded = decodeSourceBindingStorageRow(row);
+    return new OpenApiSourceBindingRef({
+      sourceId: decoded.source_id,
+      sourceScopeId: ScopeId.make(decoded.source_scope_id),
+      scopeId: ScopeId.make(decoded.target_scope_id),
+      slot: decoded.slot,
       value: rowToSourceBindingValue(row),
-      createdAt:
-        row.created_at instanceof Date
-          ? row.created_at
-          : new Date(row.created_at as string),
-      updatedAt:
-        row.updated_at instanceof Date
-          ? row.updated_at
-          : new Date(row.updated_at as string),
+      createdAt: decodeStorageDate(decoded.created_at),
+      updatedAt: decodeStorageDate(decoded.updated_at),
     });
+  };
+
+  const sourceBindingTargetScope = (row: Record<string, unknown>): string =>
+    decodeSourceBindingStorageRow(row).target_scope_id;
 
   const sourceBindingValueColumns = (
     value: OpenApiSourceBindingValue,
-  ): { kind: string; secret_id?: string; connection_id?: string; text_value?: string } => {
+  ): {
+    kind: string;
+    secret_id?: string;
+    connection_id?: string;
+    text_value?: string;
+  } => {
     if (value.kind === "secret") {
       return { kind: "secret", secret_id: value.secretId };
     }
@@ -606,24 +663,20 @@ export const makeDefaultOpenapiStore = ({
   }) =>
     Effect.gen(function* () {
       if (!scopeIds.includes(params.sourceScope)) {
-        return yield* Effect.fail(
-          new StorageError({
-            message:
-              `OpenAPI source binding references source scope "${params.sourceScope}" ` +
-              `which is not in the executor's scope stack [${scopeIds.join(", ")}].`,
-            cause: undefined,
-          }),
-        );
+        return yield* new StorageError({
+          message:
+            `OpenAPI source binding references source scope "${params.sourceScope}" ` +
+            `which is not in the executor's scope stack [${scopeIds.join(", ")}].`,
+          cause: undefined,
+        });
       }
       if (!scopeIds.includes(params.targetScope)) {
-        return yield* Effect.fail(
-          new StorageError({
-            message:
-              `OpenAPI source binding targets scope "${params.targetScope}" which is not ` +
-              `in the executor's scope stack [${scopeIds.join(", ")}].`,
-            cause: undefined,
-          }),
-        );
+        return yield* new StorageError({
+          message:
+            `OpenAPI source binding targets scope "${params.targetScope}" which is not ` +
+            `in the executor's scope stack [${scopeIds.join(", ")}].`,
+          cause: undefined,
+        });
       }
     });
 
@@ -645,23 +698,19 @@ export const makeDefaultOpenapiStore = ({
         ],
       });
       if (!source) {
-        return yield* Effect.fail(
-          new StorageError({
-            message: `OpenAPI source "${params.sourceId}" does not exist at scope "${params.sourceScope}"`,
-            cause: undefined,
-          }),
-        );
+        return yield* new StorageError({
+          message: `OpenAPI source "${params.sourceId}" does not exist at scope "${params.sourceScope}"`,
+          cause: undefined,
+        });
       }
       if (scopeRank(params.targetScope) > scopeRank(params.sourceScope)) {
-        return yield* Effect.fail(
-          new StorageError({
-            message:
-              `OpenAPI source bindings for "${params.sourceId}" cannot be written at ` +
-              `outer scope "${params.targetScope}" because the base source lives at ` +
-              `"${params.sourceScope}"`,
-            cause: undefined,
-          }),
-        );
+        return yield* new StorageError({
+          message:
+            `OpenAPI source bindings for "${params.sourceId}" cannot be written at ` +
+            `outer scope "${params.targetScope}" because the base source lives at ` +
+            `"${params.sourceScope}"`,
+          cause: undefined,
+        });
       }
       return source;
     });
@@ -684,20 +733,15 @@ export const makeDefaultOpenapiStore = ({
       })
       .pipe(Effect.map(childRowsToValueMap));
 
-  const rowToSource = (
-    row: Record<string, unknown>,
-  ): Effect.Effect<StoredSource, StorageFailure> =>
+  const rowToSource = (row: Record<string, unknown>): Effect.Effect<StoredSource, StorageFailure> =>
     Effect.gen(function* () {
-      const sourceId = row.id as string;
-      const scope = row.scope_id as string;
-      const normalizedHeaders = normalizeStoredHeaders(row.headers);
-      const normalizedOAuth2 = normalizeStoredOAuth2(row.oauth2);
+      const sourceRow = decodeSourceStorageRow(row);
+      const sourceId = sourceRow.id;
+      const scope = sourceRow.scope_id;
+      const normalizedHeaders = normalizeStoredHeaders(sourceRow.headers);
+      const normalizedOAuth2 = normalizeStoredOAuth2(sourceRow.oauth2);
 
-      const queryParams = yield* loadChildValueMap(
-        "openapi_source_query_param",
-        sourceId,
-        scope,
-      );
+      const queryParams = yield* loadChildValueMap("openapi_source_query_param", sourceId, scope);
       const specFetchHeaders = yield* loadChildValueMap(
         "openapi_source_spec_fetch_header",
         sourceId,
@@ -709,13 +753,10 @@ export const makeDefaultOpenapiStore = ({
         scope,
       );
       const specFetchCredentials: OpenApiSpecFetchCredentials | undefined =
-        Object.keys(specFetchHeaders).length === 0 &&
-        Object.keys(specFetchQueryParams).length === 0
+        Object.keys(specFetchHeaders).length === 0 && Object.keys(specFetchQueryParams).length === 0
           ? undefined
           : {
-              ...(Object.keys(specFetchHeaders).length > 0
-                ? { headers: specFetchHeaders }
-                : {}),
+              ...(Object.keys(specFetchHeaders).length > 0 ? { headers: specFetchHeaders } : {}),
               ...(Object.keys(specFetchQueryParams).length > 0
                 ? { queryParams: specFetchQueryParams }
                 : {}),
@@ -724,38 +765,40 @@ export const makeDefaultOpenapiStore = ({
       return {
         namespace: sourceId,
         scope,
-        name: row.name as string,
+        name: sourceRow.name,
         config: {
-          spec: row.spec as string,
-          sourceUrl: (row.source_url as string | null | undefined) ?? undefined,
-          baseUrl: (row.base_url as string | null | undefined) ?? undefined,
+          spec: sourceRow.spec,
+          sourceUrl: sourceRow.source_url ?? undefined,
+          baseUrl: sourceRow.base_url ?? undefined,
           headers: normalizedHeaders.headers,
           queryParams,
           specFetchCredentials,
           oauth2: normalizedOAuth2.oauth2,
         },
         legacy:
-          Object.keys(normalizedHeaders.legacy).length > 0 ||
-          normalizedOAuth2.legacy
+          Object.keys(normalizedHeaders.legacy).length > 0 || normalizedOAuth2.legacy
             ? {
                 ...(Object.keys(normalizedHeaders.legacy).length > 0
                   ? { headers: normalizedHeaders.legacy }
                   : {}),
-                ...(normalizedOAuth2.legacy
-                  ? { oauth2: normalizedOAuth2.legacy }
-                  : {}),
+                ...(normalizedOAuth2.legacy ? { oauth2: normalizedOAuth2.legacy } : {}),
               }
             : undefined,
       };
     });
 
-  const rowToOperation = (row: Record<string, unknown>): StoredOperation => ({
-    toolId: row.id as string,
-    sourceId: row.source_id as string,
-    binding: decodeBinding(
-      typeof row.binding === "string" ? JSON.parse(row.binding) : row.binding,
-    ),
-  });
+  const rowToOperation = (row: Record<string, unknown>): StoredOperation => {
+    const operationRow = decodeOperationStorageRow(row);
+    return {
+      toolId: operationRow.id,
+      sourceId: operationRow.source_id,
+      binding: decodeBinding(
+        typeof operationRow.binding === "string"
+          ? decodeBindingJson(operationRow.binding)
+          : operationRow.binding,
+      ),
+    };
+  };
 
   // Replace the rows of one child table for a source: delete then bulk
   // insert. Single helper so upsertSource and updateSourceMeta both
@@ -845,20 +888,18 @@ export const makeDefaultOpenapiStore = ({
             source_url: input.config.sourceUrl ?? undefined,
             base_url: input.config.baseUrl ?? undefined,
             headers: Object.fromEntries(
-              Object.entries(input.config.headers ?? {}).map(
-                ([name, value]) => [
-                  name,
-                  typeof value === "string"
-                    ? value
-                    : value.kind === "binding"
-                      ? {
-                          kind: value.kind,
-                          slot: value.slot,
-                          ...(value.prefix ? { prefix: value.prefix } : {}),
-                        }
-                      : value,
-                ],
-              ),
+              Object.entries(input.config.headers ?? {}).map(([name, value]) => [
+                name,
+                typeof value === "string"
+                  ? value
+                  : value.kind === "binding"
+                    ? {
+                        kind: value.kind,
+                        slot: value.slot,
+                        ...(value.prefix ? { prefix: value.prefix } : {}),
+                      }
+                    : value,
+              ]),
             ) as Record<string, unknown>,
             oauth2: input.config.oauth2
               ? toJsonRecord(encodeOAuth2SourceConfig(input.config.oauth2))
@@ -911,14 +952,10 @@ export const makeDefaultOpenapiStore = ({
         const existing = yield* rowToSource(existingRow);
 
         const nextName = patch.name?.trim() || existing.name;
-        const nextBaseUrl =
-          patch.baseUrl !== undefined ? patch.baseUrl : existing.config.baseUrl;
+        const nextBaseUrl = patch.baseUrl !== undefined ? patch.baseUrl : existing.config.baseUrl;
         const nextHeaders =
-          patch.headers !== undefined
-            ? patch.headers
-            : (existing.config.headers ?? {});
-        const nextOAuth2 =
-          patch.oauth2 !== undefined ? patch.oauth2 : existing.config.oauth2;
+          patch.headers !== undefined ? patch.headers : (existing.config.headers ?? {});
+        const nextOAuth2 = patch.oauth2 !== undefined ? patch.oauth2 : existing.config.oauth2;
 
         yield* adapter.update({
           model: "openapi_source",
@@ -941,9 +978,7 @@ export const makeDefaultOpenapiStore = ({
                     },
               ]),
             ) as Record<string, unknown>,
-            oauth2: nextOAuth2
-              ? toJsonRecord(encodeOAuth2SourceConfig(nextOAuth2))
-              : undefined,
+            oauth2: nextOAuth2 ? toJsonRecord(encodeOAuth2SourceConfig(nextOAuth2)) : undefined,
           },
         });
         if (patch.queryParams !== undefined) {
@@ -999,8 +1034,7 @@ export const makeDefaultOpenapiStore = ({
         })
         .pipe(Effect.map((rows) => rows.map(rowToOperation))),
 
-    removeSource: (namespace, scope) =>
-      deleteSource(namespace, scope, { includeBindings: true }),
+    removeSource: (namespace, scope) => deleteSource(namespace, scope, { includeBindings: true }),
 
     listSourceBindings: (sourceId, sourceScope) =>
       Effect.gen(function* () {
@@ -1017,14 +1051,10 @@ export const makeDefaultOpenapiStore = ({
           ],
         });
         return rows
-          .filter(
-            (row) =>
-              scopeRank(row.target_scope_id as string) <= sourceScopeRank,
-          )
+          .filter((row) => scopeRank(sourceBindingTargetScope(row)) <= sourceScopeRank)
           .sort(
             (a, b) =>
-              scopeRank(a.target_scope_id as string) -
-              scopeRank(b.target_scope_id as string),
+              scopeRank(sourceBindingTargetScope(a)) - scopeRank(sourceBindingTargetScope(b)),
           )
           .map(rowToSourceBinding);
       }),
@@ -1045,31 +1075,24 @@ export const makeDefaultOpenapiStore = ({
         });
         const sourceScopeRank = scopeRank(sourceScope);
         const row = rows
-          .filter(
-            (candidate) =>
-              scopeRank(candidate.target_scope_id as string) <= sourceScopeRank,
-          )
+          .filter((candidate) => scopeRank(sourceBindingTargetScope(candidate)) <= sourceScopeRank)
           .sort(
             (a, b) =>
-              scopeRank(a.target_scope_id as string) -
-              scopeRank(b.target_scope_id as string),
+              scopeRank(sourceBindingTargetScope(a)) - scopeRank(sourceBindingTargetScope(b)),
           )[0];
         return row ? rowToSourceBinding(row) : null;
       }),
 
     setSourceBinding: (input) =>
       Effect.gen(function* () {
+        const sourceScope = String(input.sourceScope);
+        const targetScope = String(input.scope);
         yield* validateBindingTarget({
           sourceId: input.sourceId,
-          sourceScope: input.sourceScope as string,
-          targetScope: input.scope as string,
+          sourceScope,
+          targetScope,
         });
-        const id = sourceBindingRowId(
-          input.sourceId,
-          input.sourceScope as string,
-          input.slot,
-          input.scope as string,
-        );
+        const id = sourceBindingRowId(input.sourceId, sourceScope, input.slot, targetScope);
         const now = new Date();
         const valueColumns = sourceBindingValueColumns(input.value);
         yield* adapter.delete({
@@ -1081,8 +1104,8 @@ export const makeDefaultOpenapiStore = ({
           data: {
             id,
             source_id: input.sourceId,
-            source_scope_id: input.sourceScope as string,
-            target_scope_id: input.scope as string,
+            source_scope_id: sourceScope,
+            target_scope_id: targetScope,
             slot: input.slot,
             ...valueColumns,
             created_at: now,
@@ -1139,8 +1162,14 @@ export const makeDefaultOpenapiStore = ({
       Effect.gen(function* () {
         const tables = [
           { model: "openapi_source_query_param" as const, kind: "query_param" as const },
-          { model: "openapi_source_spec_fetch_header" as const, kind: "spec_fetch_header" as const },
-          { model: "openapi_source_spec_fetch_query_param" as const, kind: "spec_fetch_query_param" as const },
+          {
+            model: "openapi_source_spec_fetch_header" as const,
+            kind: "spec_fetch_header" as const,
+          },
+          {
+            model: "openapi_source_spec_fetch_query_param" as const,
+            kind: "spec_fetch_query_param" as const,
+          },
         ];
         const perTable = yield* Effect.forEach(
           tables,
@@ -1152,12 +1181,15 @@ export const makeDefaultOpenapiStore = ({
               })
               .pipe(
                 Effect.map((rows) =>
-                  rows.map((r) => ({
-                    kind: t.kind,
-                    source_id: r.source_id as string,
-                    scope_id: r.scope_id as string,
-                    name: r.name as string,
-                  })),
+                  rows.map((r) => {
+                    const row = decodeChildUsageStorageRow(r);
+                    return {
+                      kind: t.kind,
+                      source_id: row.source_id,
+                      scope_id: row.scope_id,
+                      name: row.name,
+                    };
+                  }),
                 ),
               ),
           { concurrency: "unbounded" },
@@ -1172,8 +1204,9 @@ export const makeDefaultOpenapiStore = ({
         const requested = new Set(keys);
         const out = new Map<string, string>();
         for (const r of rows) {
-          const key = `${r.scope_id as string}:${r.id as string}`;
-          if (requested.has(key)) out.set(key, r.name as string);
+          const row = decodeSourceNameStorageRow(r);
+          const key = `${row.scope_id}:${row.id}`;
+          if (requested.has(key)) out.set(key, row.name);
         }
         return out;
       }),


### PR DESCRIPTION
## Summary
- decode OpenAPI store JSON and row shapes with Effect Schema at storage boundaries
- convert OpenAPI React mutation handlers to promiseExit/Exit handling
- remove redundant casts while preserving multi-scope bearer/OAuth behavior

## Verification
- bunx oxlint --format=unix packages/plugins/openapi/src/sdk/store.ts packages/plugins/openapi/src/react/AddOpenApiSource.tsx packages/plugins/openapi/src/react/EditOpenApiSource.tsx
- bun run --cwd packages/plugins/openapi typecheck
- bun run --cwd packages/plugins/openapi test src/sdk/plugin.test.ts src/sdk/multi-scope-bearer.test.ts src/sdk/multi-scope-oauth.test.ts