### PR TITLE
Fix Google Discovery boundary lint

### DIFF
--- a/packages/plugins/google-discovery/src/sdk/binding-store.ts
+++ b/packages/plugins/google-discovery/src/sdk/binding-store.ts
@@ -13,13 +13,9 @@
 // survive adapter serialization.
 // ---------------------------------------------------------------------------
 
-import { Effect, Schema } from "effect";
+import { Effect, Option, Schema } from "effect";
 
-import {
-  defineSchema,
-  type StorageDeps,
-  type StorageFailure,
-} from "@executor-js/sdk/core";
+import { defineSchema, type StorageDeps, type StorageFailure } from "@executor-js/sdk/core";
 
 import {
   GoogleDiscoveryMethodBinding,
@@ -135,15 +131,14 @@ const encodeBinding = Schema.encodeSync(GoogleDiscoveryMethodBinding);
 const decodeBinding = Schema.decodeUnknownSync(GoogleDiscoveryMethodBinding);
 
 const toJsonRecord = (value: unknown): Record<string, unknown> => value as Record<string, unknown>;
+const decodeString = Schema.decodeUnknownSync(Schema.String);
+const decodeJsonObject = Schema.decodeUnknownSync(Schema.Record(Schema.String, Schema.Unknown));
+const decodeJsonString = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown));
 
 const decodeJson = (value: unknown): unknown => {
   if (value === null || value === undefined) return value;
   if (typeof value !== "string") return value;
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
+  return Option.getOrElse(decodeJsonString(value), () => value);
 };
 
 // --- auth column packing/unpacking ------------------------------------------
@@ -239,12 +234,10 @@ const rowsToValueMap = (
 ): Record<string, GoogleDiscoveryCredentialValue> => {
   const out: Record<string, GoogleDiscoveryCredentialValue> = {};
   for (const row of rows) {
-    const name = row.name as string;
+    const name = decodeString(row.name);
     if (row.kind === "secret" && typeof row.secret_id === "string") {
       const prefix = row.secret_prefix as string | undefined | null;
-      out[name] = prefix
-        ? { secretId: row.secret_id, prefix }
-        : { secretId: row.secret_id };
+      out[name] = prefix ? { secretId: row.secret_id, prefix } : { secretId: row.secret_id };
     } else if (row.kind === "text" && typeof row.text_value === "string") {
       out[name] = row.text_value;
     }
@@ -320,9 +313,7 @@ export interface GoogleDiscoveryStore {
 
   /** Source rows whose oauth2 auth columns reference the given secret id.
    *  `slot` distinguishes client_id vs client_secret. */
-  readonly findSourcesBySecret: (
-    secretId: string,
-  ) => Effect.Effect<
+  readonly findSourcesBySecret: (secretId: string) => Effect.Effect<
     readonly {
       readonly namespace: string;
       readonly scope_id: string;
@@ -333,9 +324,7 @@ export interface GoogleDiscoveryStore {
   >;
 
   /** Source rows whose oauth2 auth points at the given connection id. */
-  readonly findSourcesByConnection: (
-    connectionId: string,
-  ) => Effect.Effect<
+  readonly findSourcesByConnection: (connectionId: string) => Effect.Effect<
     readonly {
       readonly namespace: string;
       readonly scope_id: string;
@@ -382,7 +371,7 @@ export const makeGoogleDiscoveryStore = (
         });
         if (!row) return null;
         const decoded = decodeBinding(decodeJson(row.binding));
-        return { namespace: row.source_id as string, binding: decoded };
+        return { namespace: decodeString(row.source_id), binding: decoded };
       }),
 
     putBinding: (toolId, sourceId, scope, binding) =>
@@ -420,7 +409,7 @@ export const makeGoogleDiscoveryStore = (
             { field: "scope_id", value: scope },
           ],
         });
-        const ids = rows.map((r) => r.id as string);
+        const ids = rows.map((r) => decodeString(r.id));
         yield* db.deleteMany({
           model: "google_discovery_binding",
           where: [
@@ -442,7 +431,7 @@ export const makeGoogleDiscoveryStore = (
         });
         const out = new Map<string, GoogleDiscoveryMethodBinding>();
         for (const row of rows) {
-          out.set(row.id as string, decodeBinding(decodeJson(row.binding)));
+          out.set(decodeString(row.id), decodeBinding(decodeJson(row.binding)));
         }
         return out;
       }),
@@ -462,7 +451,7 @@ export const makeGoogleDiscoveryStore = (
         yield* deleteSourceChildren(source.namespace, source.scope);
 
         const encoded = stripExtractedFields(
-          encodeStoredSourceData(source.config) as Record<string, unknown>,
+          decodeJsonObject(encodeStoredSourceData(source.config)),
         );
         yield* db.create({
           model: "google_discovery_source",
@@ -477,11 +466,7 @@ export const makeGoogleDiscoveryStore = (
           },
           forceAllowId: true,
         });
-        yield* writeCredentialRows(
-          source.namespace,
-          source.scope,
-          source.config.credentials,
-        );
+        yield* writeCredentialRows(source.namespace, source.scope, source.config.credentials);
       }),
 
     updateSourceMeta: (sourceId, scope, update) =>
@@ -502,7 +487,7 @@ export const makeGoogleDiscoveryStore = (
             { field: "scope_id", value: scope },
           ],
           update: {
-            name: update.name ?? (row.name as string),
+            name: update.name ?? decodeString(row.name),
             updated_at: new Date(),
             ...authToColumns(auth),
           },
@@ -532,9 +517,9 @@ export const makeGoogleDiscoveryStore = (
         });
         if (!row) return null;
         return {
-          namespace: row.id as string,
-          scope: row.scope_id as string,
-          name: row.name as string,
+          namespace: decodeString(row.id),
+          scope: decodeString(row.scope_id),
+          name: decodeString(row.name),
           config: yield* hydrateStoredSourceData(row, sourceId, scope),
         };
       }),
@@ -558,15 +543,11 @@ export const makeGoogleDiscoveryStore = (
           [
             db.findMany({
               model: "google_discovery_source",
-              where: [
-                { field: "auth_client_id_secret_id", value: secretId },
-              ],
+              where: [{ field: "auth_client_id_secret_id", value: secretId }],
             }),
             db.findMany({
               model: "google_discovery_source",
-              where: [
-                { field: "auth_client_secret_secret_id", value: secretId },
-              ],
+              where: [{ field: "auth_client_secret_secret_id", value: secretId }],
             }),
           ],
           { concurrency: "unbounded" },
@@ -579,17 +560,17 @@ export const makeGoogleDiscoveryStore = (
         }[] = [];
         for (const r of byClientId) {
           out.push({
-            namespace: r.id as string,
-            scope_id: r.scope_id as string,
-            name: r.name as string,
+            namespace: decodeString(r.id),
+            scope_id: decodeString(r.scope_id),
+            name: decodeString(r.name),
             slot: "auth.oauth2.client_id",
           });
         }
         for (const r of byClientSecret) {
           out.push({
-            namespace: r.id as string,
-            scope_id: r.scope_id as string,
-            name: r.name as string,
+            namespace: decodeString(r.id),
+            scope_id: decodeString(r.scope_id),
+            name: decodeString(r.name),
             slot: "auth.oauth2.client_secret",
           });
         }
@@ -605,9 +586,9 @@ export const makeGoogleDiscoveryStore = (
         .pipe(
           Effect.map((rows) =>
             rows.map((r) => ({
-              namespace: r.id as string,
-              scope_id: r.scope_id as string,
-              name: r.name as string,
+              namespace: decodeString(r.id),
+              scope_id: decodeString(r.scope_id),
+              name: decodeString(r.name),
               slot: "auth.oauth2.connection",
             })),
           ),
@@ -631,15 +612,15 @@ export const makeGoogleDiscoveryStore = (
         return [
           ...headers.map((r) => ({
             kind: "credential_header" as const,
-            source_id: r.source_id as string,
-            scope_id: r.scope_id as string,
-            name: r.name as string,
+            source_id: decodeString(r.source_id),
+            scope_id: decodeString(r.scope_id),
+            name: decodeString(r.name),
           })),
           ...params.map((r) => ({
             kind: "credential_query_param" as const,
-            source_id: r.source_id as string,
-            scope_id: r.scope_id as string,
-            name: r.name as string,
+            source_id: decodeString(r.source_id),
+            scope_id: decodeString(r.scope_id),
+            name: decodeString(r.name),
           })),
         ];
       }),
@@ -651,8 +632,8 @@ export const makeGoogleDiscoveryStore = (
         const requested = new Set(keys);
         const out = new Map<string, string>();
         for (const r of rows) {
-          const key = `${r.scope_id as string}:${r.id as string}`;
-          if (requested.has(key)) out.set(key, r.name as string);
+          const key = `${decodeString(r.scope_id)}:${decodeString(r.id)}`;
+          if (requested.has(key)) out.set(key, decodeString(r.name));
         }
         return out;
       }),
@@ -698,11 +679,7 @@ export const makeGoogleDiscoveryStore = (
           forceAllowId: true,
         });
       }
-      const paramRows = valueMapToRows(
-        sourceId,
-        scope,
-        credentials.queryParams,
-      );
+      const paramRows = valueMapToRows(sourceId, scope, credentials.queryParams);
       if (paramRows.length > 0) {
         yield* db.createMany({
           model: "google_discovery_source_credential_query_param",
@@ -719,7 +696,7 @@ export const makeGoogleDiscoveryStore = (
     scope: string,
   ): Effect.Effect<GoogleDiscoveryStoredSourceData, StorageFailure> {
     return Effect.gen(function* () {
-      const partial = decodeJson(row.config) as Record<string, unknown>;
+      const partial = decodeJsonObject(decodeJson(row.config));
       const headerRows = yield* db.findMany({
         model: "google_discovery_source_credential_header",
         where: [
@@ -737,8 +714,7 @@ export const makeGoogleDiscoveryStore = (
       const headers = rowsToValueMap(headerRows);
       const queryParams = rowsToValueMap(paramRows);
       const credentials =
-        Object.keys(headers).length === 0 &&
-        Object.keys(queryParams).length === 0
+        Object.keys(headers).length === 0 && Object.keys(queryParams).length === 0
           ? undefined
           : {
               ...(Object.keys(headers).length > 0 ? { headers } : {}),
@@ -757,9 +733,7 @@ export const makeGoogleDiscoveryStore = (
 // Strip auth/credentials from the encoded source-data shape. Those
 // moved to columns and child tables; the remaining structural fields
 // live in the `config` JSON.
-const stripExtractedFields = (
-  encoded: Record<string, unknown>,
-): Record<string, unknown> => {
+const stripExtractedFields = (encoded: Record<string, unknown>): Record<string, unknown> => {
   const { auth, credentials, ...rest } = encoded;
   void auth;
   void credentials;

--- a/packages/plugins/google-discovery/src/sdk/plugin.ts
+++ b/packages/plugins/google-discovery/src/sdk/plugin.ts
@@ -1,4 +1,4 @@
-import { Effect, Option } from "effect";
+import { Effect, Option, Predicate, Schema } from "effect";
 
 import {
   ScopeId,
@@ -12,16 +12,12 @@ import {
 } from "@executor-js/sdk/core";
 
 import { GoogleDiscoveryGroup } from "../api/group";
-import {
-  GoogleDiscoveryExtensionService,
-  GoogleDiscoveryHandlers,
-} from "../api/handlers";
+import { GoogleDiscoveryExtensionService, GoogleDiscoveryHandlers } from "../api/handlers";
 
 import {
   googleDiscoverySchema,
   makeGoogleDiscoveryStore,
   type GoogleDiscoveryStore,
-  type GoogleDiscoveryStoredSource,
 } from "./binding-store";
 import { extractGoogleDiscoveryManifest } from "./document";
 import { annotationsForOperation, invokeGoogleDiscoveryTool } from "./invoke";
@@ -86,46 +82,20 @@ export type GoogleDiscoveryExtensionFailure =
   | GoogleDiscoverySourceError
   | StorageFailure;
 
-export interface GoogleDiscoveryPluginExtension {
-  readonly probeDiscovery: (
-    input: string | GoogleDiscoveryProbeInput,
-  ) => Effect.Effect<
-    GoogleDiscoveryProbeResult,
-    GoogleDiscoveryParseError | GoogleDiscoverySourceError
-  >;
-  readonly addSource: (
-    input: GoogleDiscoveryAddSourceInput,
-  ) => Effect.Effect<
-    { readonly toolCount: number; readonly namespace: string },
-    GoogleDiscoveryParseError | GoogleDiscoverySourceError | StorageFailure
-  >;
-  readonly removeSource: (namespace: string, scope: string) => Effect.Effect<void, StorageFailure>;
-  readonly getSource: (
-    namespace: string,
-    scope: string,
-  ) => Effect.Effect<GoogleDiscoveryStoredSource | null, StorageFailure>;
-  readonly updateSource: (
-    namespace: string,
-    scope: string,
-    input: GoogleDiscoveryUpdateSourceInput,
-  ) => Effect.Effect<void, StorageFailure>;
-}
-
 // ---------------------------------------------------------------------------
 // URL normalization + slug helpers (unchanged)
 // ---------------------------------------------------------------------------
 
 const DISCOVERY_SERVICE_HOST = "https://www.googleapis.com/discovery/v1/apis";
+const decodeString = Schema.decodeUnknownSync(Schema.String);
+const isGoogleDiscoverySourceError = (error: unknown): error is GoogleDiscoverySourceError =>
+  Predicate.isTagged("GoogleDiscoverySourceError")(error);
 
 const normalizeDiscoveryUrl = (discoveryUrl: string): string => {
   const trimmed = discoveryUrl.trim();
   if (trimmed.length === 0) return trimmed;
-  let parsed: URL;
-  try {
-    parsed = new URL(trimmed);
-  } catch {
-    return trimmed;
-  }
+  if (!URL.canParse(trimmed)) return trimmed;
+  const parsed = new URL(trimmed);
   if (parsed.pathname !== "/$discovery/rest") return trimmed;
   const version = parsed.searchParams.get("version")?.trim();
   if (!version) return trimmed;
@@ -164,7 +134,7 @@ const resolveGoogleDiscoveryCredentials = (
         }),
     }).pipe(
       Effect.mapError((err) =>
-        err instanceof GoogleDiscoverySourceError
+        isGoogleDiscoverySourceError(err)
           ? err
           : new GoogleDiscoverySourceError({ message: "Secret resolution failed" }),
       ),
@@ -182,7 +152,7 @@ const resolveGoogleDiscoveryCredentials = (
         }),
     }).pipe(
       Effect.mapError((err) =>
-        err instanceof GoogleDiscoverySourceError
+        isGoogleDiscoverySourceError(err)
           ? err
           : new GoogleDiscoverySourceError({ message: "Secret resolution failed" }),
       ),
@@ -200,29 +170,35 @@ const fetchDiscoveryDocument = (
     readonly queryParams?: Record<string, string>;
   },
 ) =>
-  Effect.tryPromise({
-    try: async () => {
-      const url = new URL(normalizeDiscoveryUrl(discoveryUrl));
-      for (const [key, value] of Object.entries(credentials?.queryParams ?? {})) {
-        url.searchParams.set(key, value);
-      }
-      const response = await fetch(url.toString(), {
-        headers: credentials?.headers,
-        signal: AbortSignal.timeout(20_000),
-      });
-      if (!response.ok) {
-        throw new GoogleDiscoverySourceError({
-          message: `Google Discovery fetch failed with status ${response.status}`,
+  Effect.gen(function* () {
+    const response = yield* Effect.tryPromise({
+      try: () => {
+        const url = new URL(normalizeDiscoveryUrl(discoveryUrl));
+        for (const [key, value] of Object.entries(credentials?.queryParams ?? {})) {
+          url.searchParams.set(key, value);
+        }
+        return fetch(url.toString(), {
+          headers: credentials?.headers,
+          signal: AbortSignal.timeout(20_000),
         });
-      }
-      return response.text();
-    },
-    catch: (cause) =>
-      cause instanceof GoogleDiscoverySourceError
-        ? cause
-        : new GoogleDiscoverySourceError({
-            message: cause instanceof Error ? cause.message : String(cause),
-          }),
+      },
+      catch: () =>
+        new GoogleDiscoverySourceError({
+          message: "Google Discovery fetch failed",
+        }),
+    });
+    if (!response.ok) {
+      return yield* new GoogleDiscoverySourceError({
+        message: `Google Discovery fetch failed with status ${response.status}`,
+      });
+    }
+    return yield* Effect.tryPromise({
+      try: () => response.text(),
+      catch: () =>
+        new GoogleDiscoverySourceError({
+          message: "Google Discovery response body read failed",
+        }),
+    });
   });
 
 const normalizeSlug = (value: string): string =>
@@ -302,6 +278,97 @@ const registerManifest = (
     return manifest.methods.length;
   });
 
+const makeGoogleDiscoveryPluginExtension = (ctx: PluginCtx<GoogleDiscoveryStore>) => ({
+  probeDiscovery: (input: string | GoogleDiscoveryProbeInput) =>
+    Effect.gen(function* () {
+      const discoveryUrl = typeof input === "string" ? input : input.discoveryUrl;
+      const credentials =
+        typeof input === "string"
+          ? undefined
+          : yield* resolveGoogleDiscoveryCredentials(input.credentials, ctx);
+      const text = yield* fetchDiscoveryDocument(discoveryUrl, credentials);
+      const manifest = yield* extractGoogleDiscoveryManifest(text);
+      const scopes = Object.keys(
+        Option.isSome(manifest.oauthScopes) ? manifest.oauthScopes.value : {},
+      ).sort();
+      const operations = manifest.methods.map((method) => ({
+        toolPath: method.toolPath,
+        method: method.binding.method,
+        pathTemplate: method.binding.pathTemplate,
+        description: Option.isSome(method.description) ? method.description.value : null,
+      }));
+      return {
+        name: Option.isSome(manifest.title)
+          ? manifest.title.value
+          : `${manifest.service} ${manifest.version}`,
+        title: Option.isSome(manifest.title) ? manifest.title.value : null,
+        service: manifest.service,
+        version: manifest.version,
+        toolCount: manifest.methods.length,
+        scopes,
+        operations,
+      };
+    }),
+
+  addSource: (input: GoogleDiscoveryAddSourceInput) =>
+    ctx.transaction(
+      Effect.gen(function* () {
+        const credentials = yield* resolveGoogleDiscoveryCredentials(input.credentials, ctx);
+        const text = yield* fetchDiscoveryDocument(input.discoveryUrl, credentials);
+        const manifest = yield* extractGoogleDiscoveryManifest(text);
+        const namespace =
+          input.namespace ??
+          deriveNamespace({
+            name: input.name,
+            service: manifest.service,
+            version: manifest.version,
+          });
+        const sourceData = new GoogleDiscoveryStoredSourceDataSchema({
+          name: input.name,
+          discoveryUrl: normalizeDiscoveryUrl(input.discoveryUrl),
+          credentials: input.credentials,
+          service: manifest.service,
+          version: manifest.version,
+          rootUrl: manifest.rootUrl,
+          servicePath: manifest.servicePath,
+          auth: input.auth,
+        });
+        const toolCount = yield* registerManifest(
+          ctx,
+          namespace,
+          input.scope,
+          manifest,
+          sourceData,
+        );
+        return { toolCount, namespace };
+      }),
+    ),
+
+  removeSource: (namespace: string, scope: string) =>
+    ctx.transaction(
+      Effect.gen(function* () {
+        yield* ctx.storage.removeBindingsBySource(namespace, scope);
+        yield* ctx.storage.removeSource(namespace, scope);
+        yield* ctx.core.sources.unregister(namespace).pipe(Effect.ignore);
+      }),
+    ),
+
+  // OAuth start/complete live on `ctx.oauth` now — the UI calls
+  // the shared `/scopes/:scopeId/oauth/*` endpoints directly with a
+  // Google-specific `authorization-code` strategy and writes the
+  // resulting connection back via `updateSource`.
+
+  getSource: (namespace: string, scope: string) => ctx.storage.getSource(namespace, scope),
+
+  updateSource: (namespace: string, scope: string, input: GoogleDiscoveryUpdateSourceInput) =>
+    ctx.storage.updateSourceMeta(namespace, scope, {
+      name: input.name?.trim() || undefined,
+      auth: input.auth,
+    }),
+});
+
+export type GoogleDiscoveryPluginExtension = ReturnType<typeof makeGoogleDiscoveryPluginExtension>;
+
 // ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
@@ -312,101 +379,13 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
   schema: googleDiscoverySchema,
   storage: (deps) => makeGoogleDiscoveryStore(deps),
 
-  extension: (ctx) =>
-    ({
-      probeDiscovery: (input) =>
-        Effect.gen(function* () {
-          const discoveryUrl = typeof input === "string" ? input : input.discoveryUrl;
-          const credentials =
-            typeof input === "string"
-              ? undefined
-              : yield* resolveGoogleDiscoveryCredentials(input.credentials, ctx);
-          const text = yield* fetchDiscoveryDocument(discoveryUrl, credentials);
-          const manifest = yield* extractGoogleDiscoveryManifest(text);
-          const scopes = Object.keys(
-            Option.isSome(manifest.oauthScopes) ? manifest.oauthScopes.value : {},
-          ).sort();
-          const operations = manifest.methods.map((method) => ({
-            toolPath: method.toolPath,
-            method: method.binding.method,
-            pathTemplate: method.binding.pathTemplate,
-            description: Option.isSome(method.description) ? method.description.value : null,
-          }));
-          return {
-            name: Option.isSome(manifest.title)
-              ? manifest.title.value
-              : `${manifest.service} ${manifest.version}`,
-            title: Option.isSome(manifest.title) ? manifest.title.value : null,
-            service: manifest.service,
-            version: manifest.version,
-            toolCount: manifest.methods.length,
-            scopes,
-            operations,
-          };
-        }),
-
-      addSource: (input) =>
-        ctx.transaction(
-          Effect.gen(function* () {
-            const credentials = yield* resolveGoogleDiscoveryCredentials(input.credentials, ctx);
-            const text = yield* fetchDiscoveryDocument(input.discoveryUrl, credentials);
-            const manifest = yield* extractGoogleDiscoveryManifest(text);
-            const namespace =
-              input.namespace ??
-              deriveNamespace({
-                name: input.name,
-                service: manifest.service,
-                version: manifest.version,
-              });
-            const sourceData = new GoogleDiscoveryStoredSourceDataSchema({
-              name: input.name,
-              discoveryUrl: normalizeDiscoveryUrl(input.discoveryUrl),
-              credentials: input.credentials,
-              service: manifest.service,
-              version: manifest.version,
-              rootUrl: manifest.rootUrl,
-              servicePath: manifest.servicePath,
-              auth: input.auth,
-            });
-            const toolCount = yield* registerManifest(
-              ctx,
-              namespace,
-              input.scope,
-              manifest,
-              sourceData,
-            );
-            return { toolCount, namespace };
-          }),
-        ),
-
-      removeSource: (namespace, scope) =>
-        ctx.transaction(
-          Effect.gen(function* () {
-            yield* ctx.storage.removeBindingsBySource(namespace, scope);
-            yield* ctx.storage.removeSource(namespace, scope);
-            yield* ctx.core.sources.unregister(namespace).pipe(Effect.ignore);
-          }),
-        ),
-
-      // OAuth start/complete live on `ctx.oauth` now — the UI calls
-      // the shared `/scopes/:scopeId/oauth/*` endpoints directly with a
-      // Google-specific `authorization-code` strategy and writes the
-      // resulting connection back via `updateSource`.
-
-      getSource: (namespace, scope) => ctx.storage.getSource(namespace, scope),
-
-      updateSource: (namespace, scope, input) =>
-        ctx.storage.updateSourceMeta(namespace, scope, {
-          name: input.name?.trim() || undefined,
-          auth: input.auth,
-        }),
-    }) satisfies GoogleDiscoveryPluginExtension,
+  extension: makeGoogleDiscoveryPluginExtension,
 
   invokeTool: ({ ctx, toolRow, args }) =>
     invokeGoogleDiscoveryTool({
       ctx: ctx as PluginCtx<GoogleDiscoveryStore>,
       toolId: toolRow.id,
-      toolScope: toolRow.scope_id as string,
+      toolScope: decodeString(toolRow.scope_id),
       args,
     }),
 
@@ -414,7 +393,7 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
     Effect.gen(function* () {
       const typedCtx = ctx as PluginCtx<GoogleDiscoveryStore>;
       const scopes = new Set<string>();
-      for (const row of toolRows) scopes.add(row.scope_id as string);
+      for (const row of toolRows) scopes.add(decodeString(row.scope_id));
       const byScope = new Map<string, ReadonlyMap<string, GoogleDiscoveryMethodBinding>>();
       for (const scope of scopes) {
         const bindings = yield* typedCtx.storage.getBindingsForSource(sourceId, scope);
@@ -422,7 +401,7 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
       }
       const out: Record<string, ToolAnnotations> = {};
       for (const row of toolRows) {
-        const binding = byScope.get(row.scope_id as string)?.get(row.id);
+        const binding = byScope.get(decodeString(row.scope_id))?.get(row.id);
         if (binding) {
           out[row.id] = annotationsForOperation(binding.method, binding.pathTemplate);
         }
@@ -443,16 +422,11 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
   usagesForSecret: ({ ctx, args }) =>
     Effect.gen(function* () {
       const typedCtx = ctx as PluginCtx<GoogleDiscoveryStore>;
-      const sources = yield* typedCtx.storage.findSourcesBySecret(
-        args.secretId,
-      );
-      const childRows = yield* typedCtx.storage.findCredentialRowsBySecret(
-        args.secretId,
-      );
+      const sources = yield* typedCtx.storage.findSourcesBySecret(args.secretId);
+      const childRows = yield* typedCtx.storage.findCredentialRowsBySecret(args.secretId);
       const sourceKeys = new Set<string>();
       for (const s of sources) sourceKeys.add(`${s.scope_id}:${s.namespace}`);
-      for (const r of childRows)
-        sourceKeys.add(`${r.scope_id}:${r.source_id}`);
+      for (const r of childRows) sourceKeys.add(`${r.scope_id}:${r.source_id}`);
       const names = yield* typedCtx.storage.lookupSourceNames([...sourceKeys]);
 
       const out: Usage[] = [];
@@ -486,9 +460,7 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
   usagesForConnection: ({ ctx, args }) =>
     Effect.gen(function* () {
       const typedCtx = ctx as PluginCtx<GoogleDiscoveryStore>;
-      const sources = yield* typedCtx.storage.findSourcesByConnection(
-        args.connectionId,
-      );
+      const sources = yield* typedCtx.storage.findSourcesByConnection(args.connectionId);
       return sources.map(
         (s) =>
           new Usage({
@@ -563,7 +535,7 @@ export const googleDiscoveryPlugin = definePlugin(() => ({
         servicePath: manifest.servicePath,
       });
       yield* registerManifest(typedCtx, sourceId, scope, manifest, next);
-    }).pipe(Effect.mapError((err) => (err instanceof Error ? err : new Error(String(err))))),
+    }),
 
   // Connection refresh is owned by the canonical `"oauth2"`
   // ConnectionProvider registered by core — no plugin-specific handler


### PR DESCRIPTION
## Summary
- decode Google Discovery store JSON and row fields through schema-backed adapters
- preserve typed source and invocation failures without built-in Error remapping
- derive the plugin extension type from its extension factory

## Verification
- bunx oxlint --format=unix packages/plugins/google-discovery/src/sdk/binding-store.ts packages/plugins/google-discovery/src/sdk/plugin.ts
- bun run --cwd packages/plugins/google-discovery typecheck
- bun run --cwd packages/plugins/google-discovery test -- src/sdk/plugin.test.ts src/sdk/document.test.ts src/api/handlers.test.ts