### PR TITLE
Fix local MCP host boundary lint

### DIFF
--- a/apps/local/src/server/mcp.ts
+++ b/apps/local/src/server/mcp.ts
@@ -20,6 +20,24 @@ const jsonError = (status: number, code: number, message: string): Response =>
     headers: { "content-type": "application/json" },
   });
 
+const formatBoundaryError = (error: unknown): unknown => {
+  // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: MCP request handler catches unknown SDK/runtime failures for process logging
+  if (error instanceof Error) return error.stack ?? error.message;
+  return error;
+};
+
+const ignoreClose = (close: (() => Promise<void>) | undefined): Promise<void> =>
+  close
+    ? Effect.runPromise(
+        Effect.ignore(
+          Effect.tryPromise({
+            try: close,
+            catch: () => undefined,
+          }),
+        ),
+      )
+    : Promise.resolve();
+
 export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpRequestHandler => {
   const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
   const servers = new Map<string, McpServer>();
@@ -29,8 +47,8 @@ export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpReq
     const s = servers.get(id);
     transports.delete(id);
     servers.delete(id);
-    if (opts.transport) await t?.close().catch(() => undefined);
-    if (opts.server) await s?.close().catch(() => undefined);
+    if (opts.transport) await ignoreClose(t ? () => t.close() : undefined);
+    if (opts.server) await ignoreClose(s ? () => s.close() : undefined);
   };
 
   return {
@@ -59,21 +77,24 @@ export const createMcpRequestHandler = (config: ExecutorMcpServerConfig): McpReq
         if (sid) void dispose(sid, { server: true });
       };
 
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: MCP SDK handler must return JSON-RPC errors from thrown Promise APIs
       try {
         created = await Effect.runPromise(createExecutorMcpServer(config));
         await created.connect(transport);
         const response = await transport.handleRequest(request);
 
         if (!transport.sessionId) {
-          await transport.close().catch(() => undefined);
-          await created.close().catch(() => undefined);
+          await ignoreClose(() => transport.close());
+          const server = created;
+          await ignoreClose(server ? () => server.close() : undefined);
         }
         return response;
       } catch (error) {
-        console.error("[mcp] handleRequest error:", error instanceof Error ? error.stack : error);
+        console.error("[mcp] handleRequest error:", formatBoundaryError(error));
         if (!transport.sessionId) {
-          await transport.close().catch(() => undefined);
-          await created?.close().catch(() => undefined);
+          await ignoreClose(() => transport.close());
+          const server = created;
+          await ignoreClose(server ? () => server.close() : undefined);
         }
         return jsonError(500, -32603, "Internal server error");
       }
@@ -109,11 +130,12 @@ export const runMcpStdioServer = async (config: ExecutorMcpServerConfig): Promis
       process.stdin.once("close", finish);
     });
 
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: stdio server lifetime uses Promise-based SDK/process APIs and always closes resources
   try {
     await server.connect(transport);
     await waitForExit();
   } finally {
-    await transport.close().catch(() => undefined);
-    await server.close().catch(() => undefined);
+    await ignoreClose(() => transport.close());
+    await ignoreClose(() => server.close());
   }
 };

--- a/apps/local/src/server/migrate-connections.ts
+++ b/apps/local/src/server/migrate-connections.ts
@@ -32,11 +32,21 @@ const isRecord = (v: unknown): v is Record<string, unknown> =>
 const isString = (v: unknown): v is string => typeof v === "string";
 
 const JsonObject = Schema.Record(Schema.String, Schema.Unknown);
+const JsonObjectFromString = Schema.fromJsonString(JsonObject);
 
 const decodeUnknownOptionAs =
   <A>(schema: Schema.Decoder<A>) =>
   (input: unknown): Option.Option<A> =>
     Schema.decodeUnknownOption(schema)(input);
+
+const decodeJsonObjectString = Schema.decodeUnknownOption(JsonObjectFromString);
+
+const formatBoundaryError = (error: unknown): string => {
+  // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: sqlite transaction throws expose only an unknown JS error value for logging
+  if (error instanceof Error) return error.message;
+  // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: fallback log formatting for unknown sqlite transaction failures
+  return String(error);
+};
 
 /** Pre-flight: bail unless the drizzle migration that added the Connection
  *  table + `secret.owned_by_connection_id` has completed. */
@@ -280,20 +290,14 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
   for (const row of rows) {
     let invocation: Record<string, unknown> = {};
     if (row.invocation_config) {
-      try {
-        const parsed = JSON.parse(row.invocation_config) as unknown;
-        if (isRecord(parsed)) invocation = parsed;
-      } catch {
-        continue;
-      }
+      const parsed = decodeJsonObjectString(row.invocation_config);
+      if (Option.isNone(parsed)) continue;
+      invocation = parsed.value;
     }
     let oauth2Col: unknown = null;
     if (row.oauth2) {
-      try {
-        oauth2Col = JSON.parse(row.oauth2) as unknown;
-      } catch {
-        // fall through
-      }
+      const parsed = decodeJsonObjectString(row.oauth2);
+      if (Option.isSome(parsed)) oauth2Col = parsed.value;
     }
     const primary = invocation.oauth2 ?? oauth2Col;
     if (primary == null) continue;
@@ -355,6 +359,7 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
         providerState,
       });
       const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: bun:sqlite transaction callback must throw to roll back
       if (err) throw new Error(err);
       if (hasInvocationConfig) {
         const nextInvocation = { ...invocation, oauth2: oauth2Pointer };
@@ -372,6 +377,7 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
         );
       }
     });
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: bun:sqlite transaction reports rollback failures by throwing
     try {
       txn();
       console.log(
@@ -379,7 +385,7 @@ const migrateOpenApi = async (sqlite: Database): Promise<void> => {
       );
     } catch (err) {
       console.warn(
-        `[migrate-connections] fail openapi ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        `[migrate-connections] fail openapi ${row.scope_id}/${row.id}: ${formatBoundaryError(err)}`,
       );
     }
   }
@@ -450,14 +456,9 @@ const migrateMcp = (sqlite: Database): void => {
     : null;
 
   for (const row of rows) {
-    let config: Record<string, unknown> = {};
-    try {
-      const parsed = JSON.parse(row.config) as unknown;
-      if (!isRecord(parsed)) continue;
-      config = parsed;
-    } catch {
-      continue;
-    }
+    const parsedConfig = decodeJsonObjectString(row.config);
+    if (Option.isNone(parsedConfig)) continue;
+    const config = parsedConfig.value;
     if (config.transport !== "remote") continue;
     const auth = config.auth;
     if (!isRecord(auth) || auth.kind !== "oauth2") continue;
@@ -514,6 +515,7 @@ const migrateMcp = (sqlite: Database): void => {
         providerState,
       });
       const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: bun:sqlite transaction callback must throw to roll back
       if (err) throw new Error(err);
       if (updateConfigAndAuth) {
         updateConfigAndAuth.run(
@@ -526,6 +528,7 @@ const migrateMcp = (sqlite: Database): void => {
         updateConfig.run(JSON.stringify(nextConfig), row.scope_id, row.id);
       }
     });
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: bun:sqlite transaction reports rollback failures by throwing
     try {
       txn();
       console.log(
@@ -533,7 +536,7 @@ const migrateMcp = (sqlite: Database): void => {
       );
     } catch (err) {
       console.warn(
-        `[migrate-connections] fail mcp ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        `[migrate-connections] fail mcp ${row.scope_id}/${row.id}: ${formatBoundaryError(err)}`,
       );
     }
   }
@@ -591,14 +594,9 @@ const migrateGoogleDiscovery = (sqlite: Database): void => {
   );
 
   for (const row of rows) {
-    let config: Record<string, unknown> = {};
-    try {
-      const parsed = JSON.parse(row.config) as unknown;
-      if (!isRecord(parsed)) continue;
-      config = parsed;
-    } catch {
-      continue;
-    }
+    const parsedConfig = decodeJsonObjectString(row.config);
+    if (Option.isNone(parsedConfig)) continue;
+    const config = parsedConfig.value;
     const auth = config.auth;
     if (!isRecord(auth) || auth.kind !== "oauth2") continue;
 
@@ -643,9 +641,11 @@ const migrateGoogleDiscovery = (sqlite: Database): void => {
         providerState,
       });
       const err = rewireSecrets(sqlite, row.scope_id, connectionId, secretIds, secretNames);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: bun:sqlite transaction callback must throw to roll back
       if (err) throw new Error(err);
       updateSource.run(JSON.stringify(nextConfig), Date.now(), row.scope_id, row.id);
     });
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: bun:sqlite transaction reports rollback failures by throwing
     try {
       txn();
       console.log(
@@ -653,7 +653,7 @@ const migrateGoogleDiscovery = (sqlite: Database): void => {
       );
     } catch (err) {
       console.warn(
-        `[migrate-connections] fail google-discovery ${row.scope_id}/${row.id}: ${err instanceof Error ? err.message : String(err)}`,
+        `[migrate-connections] fail google-discovery ${row.scope_id}/${row.id}: ${formatBoundaryError(err)}`,
       );
     }
   }

--- a/packages/hosts/mcp/src/server.ts
+++ b/packages/hosts/mcp/src/server.ts
@@ -1,4 +1,4 @@
-import { Effect, Match } from "effect";
+import { Effect, Match, Option, Schema } from "effect";
 import * as Cause from "effect/Cause";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type {
@@ -112,6 +112,28 @@ type ElicitInputParams =
     }
   | { mode: "url"; message: string; url: string; elicitationId: string };
 
+const elicitationRequestTag = (request: ElicitationRequest): ElicitationRequest["_tag"] =>
+  Match.value(request).pipe(
+    Match.tag("UrlElicitation", () => "UrlElicitation" as const),
+    Match.tag("FormElicitation", () => "FormElicitation" as const),
+    Match.exhaustive,
+  );
+
+const requestedSchemaIsNonEmpty = (request: ElicitationRequest): boolean =>
+  Match.value(request).pipe(
+    Match.tag("FormElicitation", (req) => Object.keys(req.requestedSchema).length > 0),
+    Match.orElse(() => false),
+  );
+
+const elicitationRequestUrl = (request: ElicitationRequest): string | undefined =>
+  Match.value(request).pipe(
+    Match.tag("UrlElicitation", (req) => req.url),
+    Match.orElse(() => undefined),
+  );
+
+const pausedInteractionKind = (request: ElicitationRequest): ElicitationRequest["_tag"] =>
+  elicitationRequestTag(request);
+
 const elicitationRequestToParams: (request: ElicitationRequest) => ElicitInputParams =
   Match.type<ElicitationRequest>().pipe(
     Match.tag("UrlElicitation", (req) => ({
@@ -143,33 +165,37 @@ const makeMcpElicitationHandler =
 
     // If client doesn't support url mode, fall back to a form asking the user
     // to visit the URL manually and confirm when done.
-    const params =
-      ctx.request._tag === "UrlElicitation" && !supportsUrl
-        ? {
-            message: `${ctx.request.message}\n\nPlease visit this URL:\n${ctx.request.url}\n\nClick accept once you have completed the flow.`,
-            requestedSchema: { type: "object" as const, properties: {} },
-          }
-        : elicitationRequestToParams(ctx.request);
+    const params = Match.value(ctx.request).pipe(
+      Match.tag("UrlElicitation", (req) =>
+        !supportsUrl
+          ? {
+              message: `${req.message}\n\nPlease visit this URL:\n${req.url}\n\nClick accept once you have completed the flow.`,
+              requestedSchema: { type: "object" as const, properties: {} },
+            }
+          : elicitationRequestToParams(req),
+      ),
+      Match.orElse((req) => elicitationRequestToParams(req)),
+    );
 
     return Effect.promise(async (): Promise<typeof ElicitationResponse.Type> => {
+      const requestTag = elicitationRequestTag(ctx.request);
       debugLog?.("elicitation.request", {
-        requestTag: ctx.request._tag,
+        requestTag,
         supportsUrl,
         message: ctx.request.message,
-        hasRequestedSchema:
-          ctx.request._tag === "FormElicitation"
-            ? Object.keys(ctx.request.requestedSchema).length > 0
-            : false,
-        url: ctx.request._tag === "UrlElicitation" ? ctx.request.url : undefined,
+        hasRequestedSchema: requestedSchemaIsNonEmpty(ctx.request),
+        url: elicitationRequestUrl(ctx.request),
         clientCapabilities: server.server.getClientCapabilities() ?? null,
       });
+
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: MCP SDK elicitInput is a Promise API; failures become a cancel response
       try {
         const response = await server.server.elicitInput(
           params as Parameters<typeof server.server.elicitInput>[0],
         );
 
         debugLog?.("elicitation.response", {
-          requestTag: ctx.request._tag,
+          requestTag,
           action: response.action,
           hasContent:
             typeof response.content === "object" &&
@@ -182,19 +208,17 @@ const makeMcpElicitationHandler =
           content: response.content,
         };
       } catch (err) {
+        const error = formatBoundaryError(err);
         debugLog?.("elicitation.error", {
-          requestTag: ctx.request._tag,
-          error:
-            err instanceof Error
-              ? { name: err.name, message: err.message, stack: err.stack }
-              : { message: String(err) },
+          requestTag,
+          error,
           clientCapabilities: server.server.getClientCapabilities() ?? null,
         });
         console.error(
-          "[executor] elicitInput failed — falling back to cancel.",
+          "[executor] elicitInput failed - falling back to cancel.",
           JSON.stringify({
-            error: err instanceof Error ? err.message : String(err),
-            requestTag: ctx.request._tag,
+            error,
+            requestTag,
             ...capabilitySnapshot(server),
           }),
         );
@@ -202,6 +226,13 @@ const makeMcpElicitationHandler =
       }
     });
   };
+
+const formatBoundaryError = (err: unknown): { name?: string; message: string; stack?: string } => {
+  // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: SDK Promise rejection supplies unknown JS errors for logging only
+  if (err instanceof Error) return { name: err.name, message: err.message, stack: err.stack };
+  // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: fallback log formatting for unknown SDK Promise rejection values
+  return { message: String(err) };
+};
 
 // ---------------------------------------------------------------------------
 // MCP result formatting
@@ -225,7 +256,6 @@ const toMcpPausedResult = (formatted: ReturnType<typeof formatPausedExecution>):
 });
 
 const formatFailureMessage = (value: unknown): string | null => {
-  if (value instanceof Error) return value.message;
   if (typeof value === "object" && value !== null && "message" in value) {
     const message = (value as { readonly message?: unknown }).message;
     if (typeof message === "string" && message.length > 0) return message;
@@ -246,17 +276,13 @@ const toMcpFailureResult = (cause: Cause.Cause<unknown>): McpToolResult => {
   };
 };
 
+const JsonObjectFromString = Schema.fromJsonString(Schema.Record(Schema.String, Schema.Unknown));
+const decodeJsonObjectString = Schema.decodeUnknownOption(JsonObjectFromString);
+
 const parseJsonContent = (raw: string): Record<string, unknown> | undefined => {
   if (raw === "{}") return undefined;
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return undefined;
-  }
-  return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
-    ? (parsed as Record<string, unknown>)
-    : undefined;
+  const parsed = decodeJsonObjectString(raw);
+  return Option.isSome(parsed) ? parsed.value : undefined;
 };
 
 // ---------------------------------------------------------------------------
@@ -270,9 +296,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     const engine = "engine" in config ? config.engine : createExecutionEngine(config);
     const description =
       config.description ??
-      (yield* engine.getDescription.pipe(
-        Effect.withSpan("mcp.host.get_description"),
-      ));
+      (yield* engine.getDescription.pipe(Effect.withSpan("mcp.host.get_description")));
 
     // Captured at construction time. SDK callbacks fire later (often
     // deferred past the outer Effect's await), so we use the runtime to
@@ -281,6 +305,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     const debugEnabled = config.debug ?? readDebugDefault();
     const debugLog = (event: string, data: Record<string, unknown>) => {
       if (!debugEnabled) return;
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: debug logging must tolerate non-serializable SDK capability snapshots
       try {
         console.error(`[executor:mcp] ${event} ${JSON.stringify(data)}`);
       } catch {
@@ -299,9 +324,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     const runToolEffect = <EffE>(effect: Effect.Effect<McpToolResult, EffE>) =>
       Effect.runPromiseWith(context)(
         anchor(effect).pipe(
-          Effect.catchCause((cause) =>
-            Effect.succeed(toMcpFailureResult(cause)),
-          ),
+          Effect.catchCause((cause) => Effect.succeed(toMcpFailureResult(cause))),
         ),
       );
 
@@ -336,7 +359,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           executionId: outcome.status === "paused" ? outcome.execution.id : undefined,
           interactionKind:
             outcome.status === "paused"
-              ? outcome.execution.elicitationContext.request._tag
+              ? pausedInteractionKind(outcome.execution.elicitationContext.request)
               : undefined,
         });
         return outcome.status === "completed"
@@ -367,9 +390,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         if (!outcome) {
           debugLog("resume.missing_execution", { executionId });
           return {
-            content: [
-              { type: "text" as const, text: `No paused execution: ${executionId}` },
-            ],
+            content: [{ type: "text" as const, text: `No paused execution: ${executionId}` }],
             isError: true,
           } satisfies McpToolResult;
         }
@@ -379,7 +400,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           nextExecutionId: outcome.status === "paused" ? outcome.execution.id : undefined,
           interactionKind:
             outcome.status === "paused"
-              ? outcome.execution.elicitationContext.request._tag
+              ? pausedInteractionKind(outcome.execution.elicitationContext.request)
               : undefined,
         });
         return outcome.status === "completed"


### PR DESCRIPTION
## Summary
- parse local/host MCP JSON content with Effect Schema
- preserve host SDK Promise and stdio lifecycle boundaries with narrow suppressions
- replace manual elicitation tag reads with typed Match helpers

## Verification
- bunx oxlint --format=unix apps/local/src/server/migrate-connections.ts apps/local/src/server/mcp.ts packages/hosts/mcp/src/server.ts
- bun run --cwd apps/local typecheck
- bun run --cwd packages/hosts/mcp typecheck
- bun run --cwd apps/local test -- src/server/migrate-connections.test.ts
- bun run --cwd packages/hosts/mcp test -- src/server.test.ts