### PR TITLE
Use schema guards for page tagged errors

### DIFF
--- a/packages/react/src/pages/connections.tsx
+++ b/packages/react/src/pages/connections.tsx
@@ -3,6 +3,7 @@ import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import { ConnectionId, ConnectionInUseError, type ScopeId } from "@executor-js/sdk";
 import { toast } from "sonner";
 
@@ -42,6 +43,8 @@ const providerDisplayNames: Record<string, string> = {
 };
 
 const displayProvider = (provider: string): string => providerDisplayNames[provider] ?? provider;
+
+const isConnectionInUseError = Schema.is(ConnectionInUseError);
 
 const connectionScopeLabel = (
   scopeId: string,
@@ -174,7 +177,7 @@ export function ConnectionsPage() {
     if (Exit.isFailure(exit)) {
       pending.undo();
       const error = Exit.findErrorOption(exit);
-      if (Option.isSome(error) && error.value instanceof ConnectionInUseError) {
+      if (Option.isSome(error) && isConnectionInUseError(error.value)) {
         const count = error.value.usageCount;
         toast.error(
           `Connection is used by ${count} ${count === 1 ? "source" : "sources"}. Detach it before removing it.`,

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -3,6 +3,7 @@ import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import { toast } from "sonner";
 import {
   removeSecretOptimistic,
@@ -52,6 +53,8 @@ const defaultStorageOptions: readonly SecretStorageOption[] = [
   { value: "keychain", label: "Keychain" },
   { value: "file", label: "File" },
 ];
+
+const isSecretInUseError = Schema.is(SecretInUseError);
 
 // ---------------------------------------------------------------------------
 // Add secret dialog
@@ -265,7 +268,7 @@ export function SecretsPage(props: {
     });
     if (Exit.isFailure(exit)) {
       const error = Exit.findErrorOption(exit);
-      if (Option.isSome(error) && error.value instanceof SecretInUseError) {
+      if (Option.isSome(error) && isSecretInUseError(error.value)) {
         const count = error.value.usageCount;
         toast.error(
           `Secret is used by ${count} ${count === 1 ? "source" : "sources"}. Detach it before removing it.`,


### PR DESCRIPTION
## Summary
- replace manual tagged-error instanceof checks with Schema.is guards
- preserve the existing connection and secret in-use messages

## Verification
- bunx oxlint --format=unix packages/react/src/pages/connections.tsx packages/react/src/pages/secrets.tsx
- bun run --cwd packages/react typecheck