### PR TITLE
Clean typed test boundary assertions

### DIFF
--- a/packages/core/sdk/src/promise.test.ts
+++ b/packages/core/sdk/src/promise.test.ts
@@ -102,24 +102,21 @@ describe("promise/createExecutor", () => {
     const ran = await executor.tools.invoke("ap.ctl.go", {});
     expect(ran).toBe("ran");
 
-    // Override with a declining handler → rejects with ElicitationDeclinedError.
-    // Effect.runPromise rejects with a FiberFailure that wraps the typed
-    // error; both `name` and `message` carry the tag.
-    let caught: unknown;
-    try {
-      await executor.tools.invoke(
+    // Override with a declining handler -> rejects with ElicitationDeclinedError.
+    // Effect.runPromise rejects with a FiberFailure that carries the tag in
+    // the error name.
+    await expect(
+      executor.tools.invoke(
         "ap.ctl.go",
         {},
         {
           onElicitation: () =>
             Effect.succeed({ action: "decline" as const }) as any,
         },
-      );
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).toBeDefined();
-    expect((caught as Error).name).toMatch(/ElicitationDeclinedError/);
+      ),
+    ).rejects.toMatchObject({
+      name: expect.stringMatching(/ElicitationDeclinedError/),
+    });
 
     await executor.close();
   });

--- a/packages/core/sdk/src/scoped-adapter.test.ts
+++ b/packages/core/sdk/src/scoped-adapter.test.ts
@@ -45,7 +45,11 @@ describe("scopeAdapter — write rejection on scoped tables", () => {
       const reason = result.cause.reasons.find(Cause.isFailReason);
       const err = reason?.error ?? null;
       expect(err).toBeInstanceOf(StorageError);
-      expect((err as StorageError).message).toContain("not in the executor");
+      expect(err).toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("not in the executor"),
+        }),
+      );
     }),
   );
 
@@ -70,7 +74,11 @@ describe("scopeAdapter — write rejection on scoped tables", () => {
       const reason = result.cause.reasons.find(Cause.isFailReason);
       const err = reason?.error ?? null;
       expect(err).toBeInstanceOf(StorageError);
-      expect((err as StorageError).message).toContain("missing required");
+      expect(err).toEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("missing required"),
+        }),
+      );
     }),
   );
 

--- a/tests/daemon-bootstrap.test.ts
+++ b/tests/daemon-bootstrap.test.ts
@@ -116,26 +116,30 @@ describe("daemon bootstrap helpers", () => {
 
   it("falls back when preferred daemon port is occupied", async () => {
     const blocker = createServer();
-    await new Promise<void>((resolve, reject) => {
-      blocker.once("error", reject);
-      blocker.listen({ port: 0, host: "127.0.0.1" }, () => resolve());
-    });
+    await Effect.runPromise(Effect.scoped(Effect.gen(function*() {
+      yield* Effect.acquireRelease(
+        Effect.callback<void, Error>((resume) => {
+          blocker.once("error", (error) => resume(Effect.fail(error)));
+          blocker.listen({ port: 0, host: "127.0.0.1" }, () =>
+            resume(Effect.succeed(undefined)));
+        }),
+        () => Effect.promise(() => new Promise<void>((resolve) => {
+          blocker.close(() => resolve());
+        })),
+      );
 
-    const occupied = (() => {
-      const address = blocker.address();
-      return typeof address === "object" && address !== null ? address.port : 0;
-    })();
+      const occupied = (() => {
+        const address = blocker.address();
+        return typeof address === "object" && address !== null ? address.port : 0;
+      })();
 
-    try {
-      const picked = await Effect.runPromise(
+      const picked = yield* (
         chooseDaemonPort({
           preferredPort: occupied,
           hostname: "127.0.0.1",
-        }),
+        })
       );
       expect(picked).not.toBe(occupied);
-    } finally {
-      await new Promise<void>((resolve) => blocker.close(() => resolve()));
-    }
+    })));
   });
 });


### PR DESCRIPTION
## Summary
- assert rejected promise failures without try/catch or unknown message reads
- assert scoped adapter typed failures by object shape
- manage daemon test server lifecycle with Effect acquire/release

## Verification
- bunx oxlint --format=unix packages/core/sdk/src/promise.test.ts packages/core/sdk/src/scoped-adapter.test.ts tests/daemon-bootstrap.test.ts
- bun run --cwd packages/core/sdk test -- promise.test.ts scoped-adapter.test.ts
- bunx vitest run tests/daemon-bootstrap.test.ts