### PR TITLE
Keep config write failures typed

### DIFF
--- a/packages/core/config/src/config.test.ts
+++ b/packages/core/config/src/config.test.ts
@@ -5,7 +5,7 @@ import { FileSystem } from "effect";
 import { join } from "node:path";
 
 import { ExecutorFileConfig } from "./schema";
-import { loadConfig } from "./load";
+import { ConfigParseError, loadConfig } from "./load";
 import {
   addSourceToConfig,
   removeSourceFromConfig,
@@ -128,8 +128,10 @@ describe("loadConfig", () => {
         const path = join(dir, "executor.jsonc");
         yield* fs.writeFileString(path, "{ invalid json }");
 
-        const result = yield* loadConfig(path).pipe(Effect.flip);
-        expect(result._tag).toBe("ConfigParseError");
+        const result = yield* loadConfig(path).pipe(
+          Effect.catchTag("ConfigParseError", (error) => Effect.succeed(error)),
+        );
+        expect(result).toBeInstanceOf(ConfigParseError);
       }),
     ),
   );

--- a/packages/core/config/src/write.ts
+++ b/packages/core/config/src/write.ts
@@ -4,6 +4,14 @@ import type { PlatformError } from "effect/PlatformError";
 import * as jsonc from "jsonc-parser";
 import type { SourceConfig, ExecutorFileConfig } from "./schema";
 
+export class ConfigWriteError {
+  readonly _tag = "ConfigWriteError";
+  constructor(
+    readonly path: string,
+    readonly cause: unknown,
+  ) {}
+}
+
 const FORMATTING: jsonc.FormattingOptions = {
   tabSize: 2,
   insertSpaces: true,
@@ -118,13 +126,13 @@ export const removeSourceFromConfig = (
 export const writeConfig = (
   path: string,
   config: ExecutorFileConfig,
-): Effect.Effect<void, PlatformError, FileSystem.FileSystem> =>
+): Effect.Effect<void, ConfigWriteError | PlatformError, FileSystem.FileSystem> =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const text = yield* Effect.try({
       try: () => JSON.stringify(config, null, 2) + "\n",
-      catch: (cause) => cause,
-    }).pipe(Effect.orDie);
+      catch: (cause) => new ConfigWriteError(path, cause),
+    });
     yield* fs.writeFileString(path, text);
   });
 


### PR DESCRIPTION
## Summary
- replace config write orDie usage with a typed ConfigWriteError
- replace a manual config parse tag assertion with catchTag

## Verification
- bunx oxlint --format=unix packages/core/config/src/write.ts packages/core/config/src/config.test.ts
- bun run --cwd packages/core/config typecheck
- bun run --cwd packages/core/config test