### PR TITLE
Normalize cloud startup boundaries

### DIFF
--- a/apps/cloud/src/services/db.ts
+++ b/apps/cloud/src/services/db.ts
@@ -73,7 +73,14 @@ export class DbService extends Context.Service<
         // Fire-and-forget: the Terminate round-trip sometimes hangs, and
         // we don't need to block scope close waiting for it.
         Effect.sync(() => {
-          sql.end({ timeout: 0 }).catch(() => undefined);
+          void Effect.runFork(
+            Effect.ignore(
+              Effect.tryPromise({
+                try: () => sql.end({ timeout: 0 }),
+                catch: (cause) => cause,
+              }),
+            ),
+          );
         }),
     ),
   );

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -1,5 +1,6 @@
 import { env } from "cloudflare:workers";
 import { createMiddleware, createStart } from "@tanstack/react-start";
+import { Data, Effect, Schema } from "effect";
 import { handleApiRequest } from "./api";
 import { mcpFetch } from "./mcp";
 
@@ -72,7 +73,7 @@ const mcpRequestMiddleware = createMiddleware({ type: "request" }).server(
 // ---------------------------------------------------------------------------
 
 const sentryTunnelMiddleware = createMiddleware({ type: "request" }).server(
-  async ({ pathname, request, next }) => {
+  ({ pathname, request, next }) => {
     if (pathname !== "/api/sentry-tunnel" || request.method !== "POST") {
       return next();
     }
@@ -80,30 +81,61 @@ const sentryTunnelMiddleware = createMiddleware({ type: "request" }).server(
     const configuredDsn = (env as { SENTRY_DSN?: string }).SENTRY_DSN;
     if (!configuredDsn) return new Response(null, { status: 204 });
 
-    try {
-      const envelope = await request.text();
-      const firstLine = envelope.slice(0, envelope.indexOf("\n"));
-      const header = JSON.parse(firstLine) as { dsn?: string };
-      if (!header.dsn) return new Response("missing dsn", { status: 400 });
-
-      const envelopeDsn = new URL(header.dsn);
-      const ourDsn = new URL(configuredDsn);
-      if (envelopeDsn.host !== ourDsn.host || envelopeDsn.pathname !== ourDsn.pathname) {
-        return new Response("dsn mismatch", { status: 400 });
-      }
-
-      const projectId = envelopeDsn.pathname.replace(/^\//, "");
-      const ingestUrl = `https://${envelopeDsn.host}/api/${projectId}/envelope/`;
-      return fetch(ingestUrl, {
-        method: "POST",
-        body: envelope,
-        headers: { "Content-Type": "application/x-sentry-envelope" },
-      });
-    } catch {
-      return new Response("bad envelope", { status: 400 });
-    }
+    return Effect.runPromise(handleSentryTunnelRequest(request, configuredDsn));
   },
 );
+
+class SentryTunnelError extends Data.TaggedError("SentryTunnelError")<{
+  readonly cause?: unknown;
+}> {}
+
+const SentryEnvelopeHeader = Schema.Struct({
+  dsn: Schema.optional(Schema.String),
+});
+
+const decodeSentryEnvelopeHeader = Schema.decodeUnknownEffect(
+  Schema.fromJsonString(SentryEnvelopeHeader),
+);
+
+const badSentryEnvelopeResponse = () => new Response("bad envelope", { status: 400 });
+
+const handleSentryTunnelRequest = (request: Request, configuredDsn: string) =>
+  Effect.gen(function* () {
+    const envelope = yield* Effect.tryPromise({
+      try: () => request.text(),
+      catch: (cause) => new SentryTunnelError({ cause }),
+    });
+    const firstLine = envelope.slice(0, envelope.indexOf("\n"));
+    const header = yield* decodeSentryEnvelopeHeader(firstLine).pipe(
+      Effect.mapError((cause) => new SentryTunnelError({ cause })),
+    );
+    const dsn = header.dsn;
+    if (!dsn) return new Response("missing dsn", { status: 400 });
+
+    const envelopeDsn = yield* Effect.try({
+      try: () => new URL(dsn),
+      catch: (cause) => new SentryTunnelError({ cause }),
+    });
+    const ourDsn = yield* Effect.try({
+      try: () => new URL(configuredDsn),
+      catch: (cause) => new SentryTunnelError({ cause }),
+    });
+    if (envelopeDsn.host !== ourDsn.host || envelopeDsn.pathname !== ourDsn.pathname) {
+      return new Response("dsn mismatch", { status: 400 });
+    }
+
+    const projectId = envelopeDsn.pathname.replace(/^\//, "");
+    const ingestUrl = `https://${envelopeDsn.host}/api/${projectId}/envelope/`;
+    return yield* Effect.tryPromise({
+      try: () =>
+        fetch(ingestUrl, {
+          method: "POST",
+          body: envelope,
+          headers: { "Content-Type": "application/x-sentry-envelope" },
+        }),
+      catch: (cause) => new SentryTunnelError({ cause }),
+    });
+  }).pipe(Effect.catch(() => Effect.succeed(badSentryEnvelopeResponse())));
 
 // ---------------------------------------------------------------------------
 // PostHog reverse proxy — the browser SDK targets a build-randomized


### PR DESCRIPTION
## Summary
- parse the Sentry tunnel envelope header with Effect Schema
- wrap Sentry tunnel request, URL, and fetch failures into a stable bad-envelope response
- keep database shutdown fire-and-forget while avoiding Promise.catch

## Verification
- bunx oxlint --format=unix apps/cloud/src/start.ts apps/cloud/src/services/db.ts
- bun run --cwd apps/cloud typecheck