### PR TITLE
Handle all-plugins entrypoint failures in Effect

### DIFF
--- a/examples/all-plugins/src/main.ts
+++ b/examples/all-plugins/src/main.ts
@@ -17,7 +17,7 @@
 // backends are gated behind env vars and skipped by default.
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
 
 import {
   SecretId,
@@ -448,7 +448,13 @@ const program = Effect.gen(function* () {
 // 4. Run.
 // ---------------------------------------------------------------------------
 
-Effect.runPromise(program).catch((err) => {
-  console.error("Example failed:", err);
-  process.exit(1);
-});
+Effect.runPromise(
+  program.pipe(
+    Effect.catchCause((cause) =>
+      Effect.sync(() => {
+        console.error("Example failed:", Cause.squash(cause));
+        process.exit(1);
+      }),
+    ),
+  ),
+);


### PR DESCRIPTION
## Summary
- replace the all-plugins example Promise.catch entrypoint with Effect catchCause
- preserve the existing failure log and exit behavior

## Verification
- bunx oxlint --format=unix examples/all-plugins/src/main.ts