### PR TITLE
Keep cloud API errors typed

### DIFF
--- a/apps/cloud/src/api/error-response.ts
+++ b/apps/cloud/src/api/error-response.ts
@@ -1,4 +1,4 @@
-import { Cause, Data, Effect, Result } from "effect";
+import { Cause, Data, Effect, Predicate, Result } from "effect";
 import {
   HttpServerRespondable,
   HttpServerResponse,
@@ -38,9 +38,12 @@ const unwrapCause = (error: unknown): unknown => {
   return error;
 };
 
+const isHttpResponseError = (error: unknown): error is HttpResponseError =>
+  Predicate.isTagged(error, "HttpResponseError");
+
 const toHttpResponseError = (error: unknown): HttpResponseError => {
   const unwrapped = unwrapCause(error);
-  return unwrapped instanceof HttpResponseError
+  return isHttpResponseError(unwrapped)
     ? unwrapped
     : new HttpResponseError({
         status: 500,
@@ -62,7 +65,7 @@ export const toErrorServerResponse = (error: unknown): HttpServerResponse.HttpSe
   if (mapped.status >= 500) {
     console.error(
       "[api] toErrorServerResponse error:",
-      Cause.isCause(error) ? Cause.pretty(error) : error instanceof Error ? error.stack : error,
+      Cause.isCause(error) ? Cause.pretty(error) : error,
     );
     captureCause(error);
   }

--- a/apps/cloud/src/api/slack.ts
+++ b/apps/cloud/src/api/slack.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:workers";
-import { Effect } from "effect";
+import { Cause, Effect } from "effect";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 
 import { SlackService } from "../services/slack";
@@ -31,20 +31,18 @@ const verifyTurnstile = (token: string, remoteIp: string | null) =>
       const json = (await res.json()) as { success: boolean; "error-codes"?: string[] };
       return { success: json.success, errorCodes: json["error-codes"] ?? [] };
     },
-    catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
+    catch: (cause) => ({ success: false as const, fetchError: cause }),
   });
 
 const handler = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
 
   if (request.method !== "POST") {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 405,
-        code: "method_not_allowed",
-        message: "Method not allowed",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 405,
+      code: "method_not_allowed",
+      message: "Method not allowed",
+    });
   }
 
   const body = (yield* Effect.mapError(
@@ -73,36 +71,30 @@ const handler = Effect.gen(function* () {
   const turnstileToken = typeof body.turnstileToken === "string" ? body.turnstileToken : "";
 
   if (!isValidEmail(email)) {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 400,
-        code: "invalid_email",
-        message: "A valid email is required",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 400,
+      code: "invalid_email",
+      message: "A valid email is required",
+    });
   }
 
   if (!turnstileToken) {
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 400,
-        code: "captcha_required",
-        message: "Captcha verification is required.",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 400,
+      code: "captcha_required",
+      message: "Captcha verification is required.",
+    });
   }
 
   const remoteIp = request.headers["cf-connecting-ip"] ?? null;
   const verification = yield* verifyTurnstile(turnstileToken, remoteIp);
   if (!verification.success) {
     console.error("[slack] turnstile verification failed:", verification);
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 403,
-        code: "captcha_failed",
-        message: "Captcha verification failed. Please try again.",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 403,
+      code: "captcha_failed",
+      message: "Captcha verification failed. Please try again.",
+    });
   }
 
   // Global daily channel-creation cap — bounds the worst case if Turnstile is
@@ -110,17 +102,15 @@ const handler = Effect.gen(function* () {
   // this binding is a single shared bucket keyed at "global".
   const limit = yield* Effect.tryPromise({
     try: () => env.SLACK_INVITE_LIMITER.limit({ key: "global" }),
-    catch: (cause) => ({ success: false as const, fetchError: String(cause) }),
+    catch: (cause) => ({ success: false as const, fetchError: cause }),
   });
   if (!limit.success) {
     console.error("[slack] global rate limit hit");
-    return yield* Effect.fail(
-      new HttpResponseError({
-        status: 429,
-        code: "rate_limited",
-        message: "We're getting more contact requests than usual. Please try again later.",
-      }),
-    );
+    return yield* new HttpResponseError({
+      status: 429,
+      code: "rate_limited",
+      message: "We're getting more contact requests than usual. Please try again later.",
+    });
   }
 
   const slack = yield* SlackService;
@@ -144,7 +134,7 @@ const handler = Effect.gen(function* () {
 }).pipe(
   Effect.catchCause((err) => {
     if (isServerError(err)) {
-      console.error("[slack] request failed:", err instanceof Error ? err.stack : err);
+      console.error("[slack] request failed:", Cause.pretty(err));
     }
     return Effect.succeed(toErrorServerResponse(err));
   }),


### PR DESCRIPTION
## Summary
- replace cloud API instanceof/tag checks with typed Effect predicates
- yield HttpResponseError directly from Effect generators
- preserve unknown causes instead of stringifying them in Slack request handling

## Verification
- bunx oxlint --format=unix apps/cloud/src/api/error-response.ts apps/cloud/src/api/slack.ts
- bun run --cwd apps/cloud typecheck
- bun run --cwd apps/cloud test