### PR TITLE
Validate cloud JWT boundaries with schema

### DIFF
--- a/apps/cloud/src/jwks-cache.ts
+++ b/apps/cloud/src/jwks-cache.ts
@@ -29,6 +29,7 @@ import {
   type JWTVerifyGetKey,
   type KeyLike,
 } from "jose";
+import { Schema } from "effect";
 import { JWKSNoMatchingKey } from "jose/errors";
 
 export interface CachedRemoteJWKSetOptions {
@@ -54,13 +55,19 @@ export interface CachedRemoteJWKSet extends JWTVerifyGetKey {
 const DEFAULT_TTL_MS = 60 * 60 * 1000;
 const DEFAULT_TIMEOUT_MS = 5000;
 
+const JsonWebKey = Schema.Record(Schema.String, Schema.Unknown);
+const JsonWebKeySetPayload = Schema.Struct({
+  keys: Schema.Array(JsonWebKey),
+});
+const decodeJsonWebKeySetPayload = Schema.decodeUnknownPromise(JsonWebKeySetPayload);
+
+const isJwksNoMatchingKey = (cause: unknown): boolean =>
+  Schema.is(Schema.Struct({ code: Schema.String }))(cause) && cause.code === JWKSNoMatchingKey.code;
+
 interface CacheEntry {
   jwks: JSONWebKeySet;
   fetchedAt: number;
-  resolver: (
-    protectedHeader: JWTHeaderParameters,
-    token?: FlattenedJWSInput,
-  ) => Promise<KeyLike>;
+  resolver: (protectedHeader: JWTHeaderParameters, token?: FlattenedJWSInput) => Promise<KeyLike>;
 }
 
 const fetchJwksOnce = async (
@@ -70,20 +77,28 @@ const fetchJwksOnce = async (
 ): Promise<JSONWebKeySet> => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: fetch adapter must clear abort timer while preserving promise rejection behavior
   try {
     const response = await fetchImpl(url.toString(), {
       method: "GET",
       headers: { accept: "application/json" },
       signal: controller.signal,
     });
+
     if (!response.ok) {
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: fetch-backed JWT key resolver must reject with the existing Error cause shape
       throw new Error(`JWKS fetch failed: ${response.status} ${response.statusText}`);
     }
-    const body = (await response.json()) as JSONWebKeySet;
-    if (!body || !Array.isArray((body as JSONWebKeySet).keys)) {
+
+    const body = await response.json();
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: fetch JSON validation maps Schema failures to the existing malformed JWKS rejection
+    try {
+      await decodeJsonWebKeySetPayload(body);
+      return body as JSONWebKeySet;
+    } catch {
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: fetch JSON validation preserves the existing malformed JWKS rejection
       throw new Error("JWKS fetch returned malformed payload");
     }
-    return body;
   } finally {
     clearTimeout(timer);
   }
@@ -111,19 +126,17 @@ export const createCachedRemoteJWKSet = (
   const refresh = (): Promise<CacheEntry> => {
     if (inflight) return inflight;
     inflight = (async () => {
-      try {
-        const jwks = await fetchJwksOnce(url, fetchImpl(), timeoutMs);
-        const next: CacheEntry = {
-          jwks,
-          fetchedAt: Date.now(),
-          resolver: createLocalJWKSet(jwks),
-        };
-        entry = next;
-        return next;
-      } finally {
-        inflight = null;
-      }
-    })();
+      const jwks = await fetchJwksOnce(url, fetchImpl(), timeoutMs);
+      const next: CacheEntry = {
+        jwks,
+        fetchedAt: Date.now(),
+        resolver: createLocalJWKSet(jwks),
+      };
+      entry = next;
+      return next;
+    })().finally(() => {
+      inflight = null;
+    });
     return inflight;
   };
 
@@ -135,15 +148,19 @@ export const createCachedRemoteJWKSet = (
 
   const get: JWTVerifyGetKey = async (protectedHeader, token) => {
     const current = await ensureFresh(false);
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: jose JWTVerifyGetKey retry path is defined by thrown resolver failures
     try {
       return await current.resolver(protectedHeader, token);
     } catch (error) {
       // Likely cause: keys rotated upstream after our TTL window started.
       // Refetch once and try again. Anything still failing bubbles up so
       // jose can classify it (we do not silently swallow real failures).
-      if (!(error instanceof JWKSNoMatchingKey)) throw error;
+      if (!isJwksNoMatchingKey(error)) {
+        // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: jose JWTVerifyGetKey requires preserving upstream resolver rejection
+        throw error;
+      }
       const refreshed = await ensureFresh(true);
-      return await refreshed.resolver(protectedHeader, token);
+      return refreshed.resolver(protectedHeader, token);
     }
   };
 

--- a/apps/cloud/src/mcp-auth.ts
+++ b/apps/cloud/src/mcp-auth.ts
@@ -1,6 +1,6 @@
-import { Data, Effect, Result } from "effect";
+import { Data, Effect, Result, Schema } from "effect";
 import { jwtVerify, type JWTVerifyGetKey } from "jose";
-import { JOSEError, JWKSInvalid, JWKSTimeout, JWTExpired } from "jose/errors";
+import { JWKSInvalid, JWKSTimeout, JWTExpired } from "jose/errors";
 
 export type VerifiedToken = {
   /** The WorkOS account ID (user ID). */
@@ -14,17 +14,29 @@ export class McpJwtVerificationError extends Data.TaggedError("McpJwtVerificatio
   readonly reason: "expired" | "invalid" | "system";
 }> {}
 
+const JoseErrorCode = Schema.Struct({ code: Schema.String });
+
+const getJoseErrorCode = (cause: unknown): string | null =>
+  Schema.is(JoseErrorCode)(cause) ? cause.code : null;
+
+const isJoseErrorCode = (code: string): boolean => code.startsWith("ERR_J");
+
 const classifyJwtVerificationError = (cause: unknown): McpJwtVerificationError =>
   new McpJwtVerificationError({
     cause,
-    reason:
-      cause instanceof JWTExpired
-        ? "expired"
-        : cause instanceof JWKSTimeout ||
-            cause instanceof JWKSInvalid ||
-            !(cause instanceof JOSEError)
-          ? "system"
-          : "invalid",
+    reason: (() => {
+      const code = getJoseErrorCode(cause);
+      if (code === JWTExpired.code) return "expired";
+      if (
+        code === JWKSTimeout.code ||
+        code === JWKSInvalid.code ||
+        code === null ||
+        !isJoseErrorCode(code)
+      ) {
+        return "system";
+      }
+      return "invalid";
+    })(),
   });
 
 const isExpectedJwtVerificationError = (error: McpJwtVerificationError): boolean =>


### PR DESCRIPTION
## Summary
- classify JOSE errors through schema-backed error codes instead of instanceof
- validate fetched JWKS payloads with Effect Schema before creating local resolvers
- keep narrow boundary suppressions where jose fetch/key resolver APIs are Promise/throw-shaped

## Verification
- bunx oxlint --format=unix apps/cloud/src/jwks-cache.ts apps/cloud/src/mcp-auth.ts
- bun run --cwd apps/cloud typecheck
- bun run --cwd apps/cloud test:node -- src/jwks-cache.node.test.ts src/mcp-auth.node.test.ts