### PR TITLE
Parse file secrets with schema

### DIFF
--- a/packages/plugins/file-secrets/src/index.ts
+++ b/packages/plugins/file-secrets/src/index.ts
@@ -27,11 +27,9 @@ export const xdgDataHome = (): string => {
   return path.join(process.env.HOME || "~", ".local", "share");
 };
 
-const authDir = (overrideDir?: string): string =>
-  overrideDir ?? path.join(xdgDataHome(), APP_NAME);
+const authDir = (overrideDir?: string): string => overrideDir ?? path.join(xdgDataHome(), APP_NAME);
 
-const authFilePath = (overrideDir?: string): string =>
-  path.join(authDir(overrideDir), "auth.json");
+const authFilePath = (overrideDir?: string): string => path.join(authDir(overrideDir), "auth.json");
 
 // ---------------------------------------------------------------------------
 // Schema for the auth file
@@ -40,59 +38,83 @@ const authFilePath = (overrideDir?: string): string =>
 //   { "web-a1b2c3d4": { "github-token": "ghp_xxx" } }
 // ---------------------------------------------------------------------------
 
-const ScopedAuthFile = Schema.Record(
-  Schema.String,
-  Schema.Record(Schema.String, Schema.String),
-);
-const decodeScopedAuthFile = Schema.decodeUnknownSync(ScopedAuthFile);
+const ScopedAuthFile = Schema.Record(Schema.String, Schema.Record(Schema.String, Schema.String));
+const decodeScopedAuthFile = Schema.decodeUnknownEffect(Schema.fromJsonString(ScopedAuthFile));
 
 // ---------------------------------------------------------------------------
 // File I/O with restricted permissions
 //
-// These helpers throw on real I/O or decode failures — the provider wraps
-// every call in `Effect.try` so those throws surface as typed
-// `StorageError` on the Effect error channel. Previously `readFullFile`
-// used a blanket `try { ... } catch { return {}; }` which masked JSON
-// parse errors, schema decode failures, and permission errors as
-// "empty file", making misconfigured installs silently return null from
-// every `get`.
+// These helpers keep real I/O and decode failures in the Effect error
+// channel as `StorageError`. Missing files are still treated as an empty
+// auth file, but malformed JSON, schema decode failures, and permission
+// errors no longer collapse into "empty file".
 // ---------------------------------------------------------------------------
 
-const readFullFile = (filePath: string): Record<string, Record<string, string>> => {
-  if (!fs.existsSync(filePath)) return {};
-  let raw: string;
-  try {
-    raw = fs.readFileSync(filePath, "utf-8");
-  } catch (cause) {
-    // Treat "file disappeared between existsSync and readFileSync" as
-    // absence — anything else (EACCES, EISDIR, …) propagates.
-    if ((cause as NodeJS.ErrnoException).code === "ENOENT") return {};
-    throw cause;
-  }
-  return decodeScopedAuthFile(JSON.parse(raw));
+const isFileNotFoundCause = (cause: unknown): cause is NodeJS.ErrnoException =>
+  typeof cause === "object" && cause !== null && "code" in cause && cause.code === "ENOENT";
+
+const toStorageError =
+  (message: string) =>
+  (cause: unknown): StorageError =>
+    new StorageError({ message, cause });
+
+const readFullFile = (
+  filePath: string,
+): Effect.Effect<Record<string, Record<string, string>>, StorageError> => {
+  if (!fs.existsSync(filePath)) return Effect.succeed({});
+  return Effect.try({
+    try: () => fs.readFileSync(filePath, "utf-8"),
+    catch: toStorageError("Failed to read auth file"),
+  }).pipe(
+    Effect.catchIf(
+      (error) => isFileNotFoundCause(error.cause),
+      () => Effect.succeed(""),
+    ),
+    Effect.flatMap((raw) =>
+      raw === ""
+        ? Effect.succeed({})
+        : decodeScopedAuthFile(raw).pipe(
+            Effect.mapError(toStorageError("Failed to parse auth file")),
+          ),
+    ),
+  );
 };
 
-const readScopeSecrets = (filePath: string, scopeId: string): Record<string, string> =>
-  readFullFile(filePath)[scopeId] ?? {};
+const readScopeSecrets = (
+  filePath: string,
+  scopeId: string,
+): Effect.Effect<Record<string, string>, StorageError> =>
+  readFullFile(filePath).pipe(Effect.map((file) => file[scopeId] ?? {}));
 
 const writeScopeSecrets = (
   filePath: string,
   scopeId: string,
   secrets: Record<string, string>,
-): void => {
+): Effect.Effect<void, StorageError> => {
   const dir = path.dirname(filePath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
-  }
-  const full = readFullFile(filePath);
-  if (Object.keys(secrets).length === 0) {
-    delete full[scopeId];
-  } else {
-    full[scopeId] = secrets;
-  }
   const tmp = `${filePath}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(full, null, 2), { mode: 0o600 });
-  fs.renameSync(tmp, filePath);
+  return Effect.gen(function* () {
+    if (!fs.existsSync(dir)) {
+      yield* Effect.try({
+        try: () => fs.mkdirSync(dir, { recursive: true, mode: 0o700 }),
+        catch: toStorageError("Failed to create auth directory"),
+      });
+    }
+    const full = yield* readFullFile(filePath);
+    if (Object.keys(secrets).length === 0) {
+      delete full[scopeId];
+    } else {
+      full[scopeId] = secrets;
+    }
+    yield* Effect.try({
+      try: () => fs.writeFileSync(tmp, JSON.stringify(full, null, 2), { mode: 0o600 }),
+      catch: toStorageError("Failed to write temporary auth file"),
+    });
+    yield* Effect.try({
+      try: () => fs.renameSync(tmp, filePath),
+      catch: toStorageError("Failed to replace auth file"),
+    });
+  });
 };
 
 // ---------------------------------------------------------------------------
@@ -108,20 +130,15 @@ export interface FileSecretsPluginConfig {
 // Plugin extension — public API on executor.fileSecrets
 // ---------------------------------------------------------------------------
 
-export interface FileSecretsExtension {
-  /** Path to the auth file */
-  readonly filePath: string;
-}
+const makeFileSecretsExtension = (options: FileSecretsPluginConfig | undefined) => ({
+  filePath: resolveFilePath(options),
+});
+
+export type FileSecretsExtension = ReturnType<typeof makeFileSecretsExtension>;
 
 // ---------------------------------------------------------------------------
 // Provider factory (internal)
 // ---------------------------------------------------------------------------
-
-const toStorageError = (cause: unknown) =>
-  new StorageError({
-    message: cause instanceof Error ? cause.message : String(cause),
-    cause,
-  });
 
 // Scope arg is honored at every call: the auth.json is partitioned by
 // scope id, so read/write/delete route to `file[scope][secretId]`. The
@@ -133,61 +150,36 @@ const toStorageError = (cause: unknown) =>
 // the SecretProvider.list signature is scope-agnostic. That's fine for
 // the current use: `list` feeds `secrets.list()` which already walks
 // the stack at the caller layer. Innermost-first is the display default.
-const makeScopedProvider = (
-  filePath: string,
-  listScope: string,
-): SecretProvider => ({
+const makeScopedProvider = (filePath: string, listScope: string): SecretProvider => ({
   key: "file",
   writable: true,
 
   get: (secretId, scope) =>
-    Effect.try({
-      try: () => {
-        const data = readScopeSecrets(filePath, scope);
-        return data[secretId] ?? null;
-      },
-      catch: toStorageError,
-    }),
+    readScopeSecrets(filePath, scope).pipe(Effect.map((data) => data[secretId] ?? null)),
 
   has: (secretId, scope) =>
-    Effect.try({
-      try: () => {
-        const data = readScopeSecrets(filePath, scope);
-        return secretId in data;
-      },
-      catch: toStorageError,
-    }),
+    readScopeSecrets(filePath, scope).pipe(Effect.map((data) => secretId in data)),
 
   set: (secretId, value, scope) =>
-    Effect.try({
-      try: () => {
-        const data = readScopeSecrets(filePath, scope);
-        data[secretId] = value;
-        writeScopeSecrets(filePath, scope, data);
-      },
-      catch: toStorageError,
+    Effect.gen(function* () {
+      const data = yield* readScopeSecrets(filePath, scope);
+      data[secretId] = value;
+      yield* writeScopeSecrets(filePath, scope, data);
     }),
 
   delete: (secretId, scope) =>
-    Effect.try({
-      try: () => {
-        const data = readScopeSecrets(filePath, scope);
-        const had = secretId in data;
-        delete data[secretId];
-        if (had) writeScopeSecrets(filePath, scope, data);
-        return had;
-      },
-      catch: toStorageError,
+    Effect.gen(function* () {
+      const data = yield* readScopeSecrets(filePath, scope);
+      const had = secretId in data;
+      delete data[secretId];
+      if (had) yield* writeScopeSecrets(filePath, scope, data);
+      return had;
     }),
 
   list: () =>
-    Effect.try({
-      try: () => {
-        const data = readScopeSecrets(filePath, listScope);
-        return Object.keys(data).map((k) => ({ id: k, name: k }));
-      },
-      catch: toStorageError,
-    }),
+    readScopeSecrets(filePath, listScope).pipe(
+      Effect.map((data) => Object.keys(data).map((k) => ({ id: k, name: k }))),
+    ),
 });
 
 // ---------------------------------------------------------------------------
@@ -201,19 +193,15 @@ const makeScopedProvider = (
 const resolveFilePath = (config: FileSecretsPluginConfig | undefined): string =>
   authFilePath(config?.directory);
 
-export const fileSecretsPlugin = definePlugin(
-  (options?: FileSecretsPluginConfig) => ({
-    id: "fileSecrets" as const,
-    storage: () => ({}),
+export const fileSecretsPlugin = definePlugin((options?: FileSecretsPluginConfig) => ({
+  id: "fileSecrets" as const,
+  storage: () => ({}),
 
-    extension: (_ctx): FileSecretsExtension => ({
-      filePath: resolveFilePath(options),
-    }),
+  extension: () => makeFileSecretsExtension(options),
 
-    secretProviders: (ctx: PluginCtx<unknown>) => [
-      // list() falls back to the innermost scope for display; per-call
-      // get/set/delete honor the scope arg threaded from the secrets facade.
-      makeScopedProvider(resolveFilePath(options), ctx.scopes[0]!.id as string),
-    ],
-  }),
-);
+  secretProviders: (ctx: PluginCtx<unknown>) => [
+    // list() falls back to the innermost scope for display; per-call
+    // get/set/delete honor the scope arg threaded from the secrets facade.
+    makeScopedProvider(resolveFilePath(options), ctx.scopes[0]!.id),
+  ],
+}));


### PR DESCRIPTION
## Summary
- parse auth.json with Effect Schema instead of JSON.parse
- keep missing auth files as empty while preserving read/write/parse failures as StorageError
- derive the file secrets extension type from its factory

## Verification
- bunx oxlint --format=unix packages/plugins/file-secrets/src/index.ts
- bun run --cwd packages/plugins/file-secrets typecheck
- bun run --cwd packages/plugins/file-secrets test