### PR TITLE
Keep keychain boundaries typed

### DIFF
--- a/packages/plugins/keychain/src/index.test.ts
+++ b/packages/plugins/keychain/src/index.test.ts
@@ -42,7 +42,7 @@ describe("keychain plugin", () => {
         return;
       }
 
-      try {
+      yield* Effect.gen(function* () {
         // Store through SDK, pinned to keychain provider
         yield* executor.secrets.set(
           new SetSecretInput({
@@ -61,9 +61,9 @@ describe("keychain plugin", () => {
         // SDK routes through the core secret table → pinned provider
         const resolved = yield* executor.secrets.get(testId);
         expect(resolved).toBe("keychain-test-value");
-      } finally {
-        yield* executor.secrets.remove(testId).pipe(Effect.orElseSucceed(() => undefined));
-      }
+      }).pipe(
+        Effect.ensuring(executor.secrets.remove(testId).pipe(Effect.orElseSucceed(() => undefined))),
+      );
     }),
   );
 

--- a/packages/plugins/keychain/src/provider.ts
+++ b/packages/plugins/keychain/src/provider.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect";
 
 import { StorageError, type SecretProvider } from "@executor-js/sdk/core";
 
+import type { KeychainError } from "./errors";
 import { getPassword, setPassword, deletePassword } from "./keyring";
 
 // ---------------------------------------------------------------------------
@@ -18,8 +19,11 @@ import { getPassword, setPassword, deletePassword } from "./keyring";
 // impossible to debug why secrets weren't resolving.
 // ---------------------------------------------------------------------------
 
-const toStorageError = (cause: { readonly message: string; readonly cause?: unknown }) =>
-  new StorageError({ message: cause.message, cause: cause.cause ?? cause });
+const toStorageError = (cause: KeychainError) => {
+  const { cause: underlyingCause } = cause;
+  // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: typed KeychainError message becomes StorageError message
+  return new StorageError({ message: cause.message, cause: underlyingCause ?? cause });
+};
 
 // Scope arg is ignored — keychain partitions by `serviceName`, which the
 // host fixes per executor at construction time. A future refactor could


### PR DESCRIPTION
## Summary
- map typed KeychainError into StorageError without unknown message probing
- replace test cleanup try/finally with Effect.ensuring

## Verification
- bunx oxlint --format=unix packages/plugins/keychain/src/provider.ts packages/plugins/keychain/src/index.test.ts
- bun run --cwd packages/plugins/keychain typecheck
- bun run --cwd packages/plugins/keychain test