### PR TITLE
Clean core API typed boundaries

### DIFF
--- a/packages/core/api/src/handlers/tools.ts
+++ b/packages/core/api/src/handlers/tools.ts
@@ -35,7 +35,7 @@ export const ToolsHandlers = HttpApiBuilder.group(ExecutorApi, "tools", (handler
         const executor = yield* ExecutorService;
         const schema = yield* executor.tools.schema(path.toolId);
         if (schema === null) {
-          return yield* Effect.fail(new ToolNotFoundError({ toolId: path.toolId }));
+          return yield* new ToolNotFoundError({ toolId: path.toolId });
         }
         return schema;
       })),

--- a/packages/core/api/src/oauth-popup.test.ts
+++ b/packages/core/api/src/oauth-popup.test.ts
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Data, Effect, Schema } from "effect";
 
 import {
   OAUTH_POPUP_MESSAGE_TYPE,
@@ -169,16 +169,21 @@ describe("runOAuthCallback", () => {
   });
 
   it("renders a failure popup when completeOAuth fails and uses toErrorMessage", async () => {
-    class DomainError {
-      readonly _tag = "DomainError";
-      constructor(readonly message: string) {}
-    }
+    class DomainError extends Data.TaggedError("DomainError")<{
+      readonly message: string;
+    }> {}
+    const isDomainError = Schema.is(Schema.Struct({
+      _tag: Schema.Literal("DomainError"),
+      message: Schema.String,
+    }));
     const html = await Effect.runPromise(
       runOAuthCallback<GoogleAuth, DomainError, never>({
-        complete: () => Effect.fail(new DomainError("Code expired")),
+        complete: () => Effect.fail(new DomainError({ message: "Code expired" })),
         urlParams: { state: "s1" },
-        toErrorMessage: (error) =>
-          error instanceof DomainError ? error.message : "unknown",
+        toErrorMessage: (error) => {
+          // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: schema guard narrows the unknown popup callback error to the public test message
+          return isDomainError(error) ? error.message : "unknown";
+        },
         channelName: "c",
       }),
     );


### PR DESCRIPTION
## Summary
- yield ToolNotFoundError directly from the tools handler generator
- replace OAuth popup test instanceof handling with a schema-guarded boundary

## Verification
- bunx oxlint --format=unix packages/core/api/src/handlers/tools.ts packages/core/api/src/oauth-popup.test.ts
- bun run --cwd packages/core/api typecheck
- bun run --cwd packages/core/api test -- src/oauth-popup.test.ts