### PR TITLE
Keep kernel core failures typed

### DIFF
--- a/packages/kernel/core/src/code-recovery.ts
+++ b/packages/kernel/core/src/code-recovery.ts
@@ -139,6 +139,7 @@ export const recoverExecutionBody = (code: string): string => {
   const source = extractCandidateSource(code);
   if (!source) return "";
 
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Babel parser throws for malformed candidate code, then recovery falls back to heuristics
   try {
     return renderParsedBody(source);
   } catch {

--- a/packages/kernel/core/src/effect-errors.ts
+++ b/packages/kernel/core/src/effect-errors.ts
@@ -3,10 +3,8 @@ import * as Data from "effect/Data";
 export class KernelCoreEffectError extends Data.TaggedError("KernelCoreEffectError")<{
   readonly module: string;
   readonly message: string;
+  readonly cause?: unknown;
 }> {}
-
-export const kernelCoreEffectError = (module: string, message: string) =>
-  new KernelCoreEffectError({ module, message });
 
 /**
  * Default failure type for any `CodeExecutor.execute` implementation —

--- a/packages/kernel/core/src/validation.ts
+++ b/packages/kernel/core/src/validation.ts
@@ -1,7 +1,7 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
 import * as Effect from "effect/Effect";
 
-import { kernelCoreEffectError } from "./effect-errors";
+import { KernelCoreEffectError } from "./effect-errors";
 
 const getSchemaValidator = (
   schema: unknown,
@@ -55,25 +55,29 @@ export const validateInput = (input: {
   const validate = getSchemaValidator(input.schema);
   if (!validate) {
     return Effect.fail(
-      kernelCoreEffectError(
-        "validation",
-        `Tool ${input.path} has no Standard Schema validator on inputSchema`,
-      ),
+      new KernelCoreEffectError({
+        module: "validation",
+        message: `Tool ${input.path} has no Standard Schema validator on inputSchema`,
+      }),
     );
   }
 
   return Effect.tryPromise({
     try: () => Promise.resolve(validate(input.value)),
     catch: (cause) =>
-      kernelCoreEffectError("validation", `Validation error for ${input.path}: ${String(cause)}`),
+      new KernelCoreEffectError({
+        module: "validation",
+        message: `Validation error for ${input.path}`,
+        cause,
+      }),
   }).pipe(
     Effect.flatMap((result) => {
       if ("issues" in result && result.issues) {
         return Effect.fail(
-          kernelCoreEffectError(
-            "validation",
-            `Input validation failed for ${input.path}: ${formatIssues(result.issues)}`,
-          ),
+          new KernelCoreEffectError({
+            module: "validation",
+            message: `Input validation failed for ${input.path}: ${formatIssues(result.issues)}`,
+          }),
         );
       }
       return Effect.succeed(result.value);


### PR DESCRIPTION
## Summary
- remove the redundant kernel error factory
- preserve validation causes on KernelCoreEffectError instead of stringifying unknowns
- mark the Babel parser fallback as a narrow recovery boundary

## Verification
- bunx oxlint --format=unix packages/kernel/core/src/code-recovery.ts packages/kernel/core/src/effect-errors.ts packages/kernel/core/src/validation.ts
- bun run --cwd packages/kernel/core typecheck
- bun run --cwd packages/kernel/core test