### PR TITLE
Clean SDK typed test boundaries

### DIFF
--- a/packages/core/sdk/src/blob.test.ts
+++ b/packages/core/sdk/src/blob.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Cause, Effect, Exit } from "effect";
+import { Effect } from "effect";
 
 import { StorageError } from "@executor-js/storage-core";
 
@@ -75,15 +75,13 @@ describe("pluginBlobStore", () => {
     Effect.gen(function* () {
       const store = makeInMemoryBlobStore();
       const plugin = pluginBlobStore(store, ["inner", "outer"], "my-plugin");
-      const result = yield* Effect.exit(
-        plugin.put("k", "v", { scope: "not-in-stack" }),
-      );
-      expect(Exit.isFailure(result)).toBe(true);
-      if (!Exit.isFailure(result)) return;
-      const reason = result.cause.reasons.find(Cause.isFailReason);
-      const err = reason?.error ?? null;
+      const err = yield* plugin
+        .put("k", "v", { scope: "not-in-stack" })
+        .pipe(Effect.flip);
       expect(err).toBeInstanceOf(StorageError);
-      expect((err as StorageError).message).toContain("not in the");
+      expect(err).toMatchObject({
+        message: expect.stringContaining("not in the"),
+      });
       // Write must not have reached the store.
       expect(yield* store.get("not-in-stack/my-plugin", "k")).toBeNull();
     }),
@@ -93,10 +91,10 @@ describe("pluginBlobStore", () => {
     Effect.gen(function* () {
       const store = makeInMemoryBlobStore();
       const plugin = pluginBlobStore(store, ["inner"], "my-plugin");
-      const result = yield* Effect.exit(
-        plugin.delete("k", { scope: "not-in-stack" }),
-      );
-      expect(Exit.isFailure(result)).toBe(true);
+      const err = yield* plugin
+        .delete("k", { scope: "not-in-stack" })
+        .pipe(Effect.flip);
+      expect(err).toBeInstanceOf(StorageError);
     }),
   );
 });

--- a/packages/core/sdk/src/error-handling.test.ts
+++ b/packages/core/sdk/src/error-handling.test.ts
@@ -22,7 +22,7 @@
 // ---------------------------------------------------------------------------
 
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Predicate } from "effect";
 
 import {
   StorageError,
@@ -83,9 +83,13 @@ const baseConfig = (adapter: DBAdapter) => ({
 describe("typed-error edge model — SDK", () => {
   it.effect("StorageError propagates raw through the executor surface", () =>
     Effect.gen(function* () {
+      const driverCause = new StorageError({
+        message: "driver kaboom",
+        cause: undefined,
+      });
       const failure = new StorageError({
         message: "backend lost its mind",
-        cause: new Error("driver kaboom"),
+        cause: driverCause,
       });
       const executor = yield* createExecutor(
         baseConfig(makeFailingAdapter(failure)),
@@ -93,12 +97,12 @@ describe("typed-error edge model — SDK", () => {
 
       const result = yield* executor.tools.list().pipe(Effect.flip);
       expect(result).toBeInstanceOf(StorageError);
-      expect(result._tag).toBe("StorageError");
+      expect(Predicate.isTagged(result, "StorageError")).toBe(true);
       // Original cause preserved end-to-end.
       const storageErr = result as StorageError;
       expect(storageErr.message).toBe("backend lost its mind");
-      expect(storageErr.cause).toBeInstanceOf(Error);
-      expect((storageErr.cause as Error).message).toBe("driver kaboom");
+      expect(storageErr.cause).toBe(driverCause);
+      expect(driverCause.message).toBe("driver kaboom");
     }),
   );
 

--- a/packages/core/sdk/src/schema-types.test.ts
+++ b/packages/core/sdk/src/schema-types.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
 import { describe, expect, it } from "@effect/vitest";
+import { Schema } from "effect";
 
 import {
   buildToolTypeScriptPreview,
@@ -7,15 +8,19 @@ import {
   schemaToTypeScriptPreviewWithDefs,
 } from "./schema-types";
 
-const stripeBalanceTransactionsFixture = JSON.parse(
+const StripeBalanceTransactionsFixture = Schema.Struct({
+  schema: Schema.Unknown,
+  defs: Schema.Record(Schema.String, Schema.Unknown),
+});
+
+const stripeBalanceTransactionsFixture = Schema.decodeUnknownSync(
+  Schema.fromJsonString(StripeBalanceTransactionsFixture),
+)(
   readFileSync(
     new URL("./__fixtures__/stripe-get-balance-transactions-id.json", import.meta.url),
     "utf8",
   ),
-) as {
-  schema: unknown;
-  defs: Record<string, unknown>;
-};
+);
 
 describe("schema-types", () => {
   it("reuses referenced definitions instead of inlining them", () => {


### PR DESCRIPTION
## Summary
- parse schema fixture JSON with Effect Schema
- assert typed blob/storage failures directly with Effect.flip
- avoid manual tag and unknown message checks in SDK error tests

## Verification
- bunx oxlint --format=unix packages/core/sdk/src/error-handling.test.ts packages/core/sdk/src/schema-types.test.ts packages/core/sdk/src/blob.test.ts
- bun run --cwd packages/core/sdk test -- src/error-handling.test.ts src/schema-types.test.ts src/blob.test.ts