### PR TITLE
Mark local app runtime boundaries

### DIFF
--- a/apps/local/src/routes/plugins.$pluginId.$.tsx
+++ b/apps/local/src/routes/plugins.$pluginId.$.tsx
@@ -30,10 +30,12 @@ function PluginRouteComponent() {
   const { pluginId, _splat: rest } = Route.useParams();
   const plugins = useClientPlugins();
   const plugin = plugins.find((p) => p.id === pluginId);
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: TanStack Router represents not-found from components by throwing notFound()
   if (!plugin) throw notFound();
 
   const target = normalizePath(rest ?? "/");
   const page = plugin.pages?.find((p) => normalizePath(p.path) === target);
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: TanStack Router represents not-found from components by throwing notFound()
   if (!page) throw notFound();
 
   const Component = page.component;

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -37,6 +37,7 @@ const hasFileExtension = (pathname: string): boolean => {
 
 function collectStaticRoutes(dir: string, prefix = ""): Record<string, StaticHandler> {
   const routes: Record<string, StaticHandler> = {};
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: filesystem route discovery is best-effort for optional built assets
   try {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       const fullPath = join(dir, entry.name);

--- a/apps/local/src/server/observability.ts
+++ b/apps/local/src/server/observability.ts
@@ -23,6 +23,7 @@ export const ErrorCaptureLive: Layer.Layer<ErrorCapture> = Layer.succeed(
         const squashed = Cause.squash(cause);
         console.error(
           `[executor ${traceId}]`,
+          // oxlint-disable-next-line executor/no-instanceof-error -- boundary: console logger preserves native Error stack output
           squashed instanceof Error ? squashed.stack ?? squashed : squashed,
         );
         console.error(`[executor ${traceId}] cause:`, Cause.pretty(cause));


### PR DESCRIPTION
## Summary
- mark optional static route filesystem discovery as a best-effort boundary
- preserve native Error stack logging at the local observability boundary
- mark TanStack Router notFound throws as route boundaries

## Verification
- bunx oxlint --format=unix apps/local/src/serve.ts apps/local/src/server/observability.ts apps/local/src/routes/plugins.$pluginId.$.tsx
- bun run --cwd apps/local typecheck
- cd apps/local && bunx --bun vitest run