### PR TITLE
Clean small package lint boundaries

### DIFF
--- a/packages/core/cli/src/generators/index.ts
+++ b/packages/core/cli/src/generators/index.ts
@@ -13,6 +13,7 @@ export const generateSchema = (
 ) => {
   const generator = generators[adapter];
   if (!generator) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: synchronous CLI generator registry rejects unsupported adapter names
     throw new Error(
       `Generator "${adapter}" is not supported. Available: ${Object.keys(generators).join(", ")}`,
     );

--- a/packages/core/storage-file/src/index.test.ts
+++ b/packages/core/storage-file/src/index.test.ts
@@ -81,6 +81,7 @@ const bootstrapTables = (
 ): void => {
   for (const table of Object.values(tables)) {
     // Skip relations — they aren't tables
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: drizzle getTableConfig throws for relation helpers in this test bootstrap
     try {
       const config = getTableConfig(table);
       const cols = config.columns.map((col) => {

--- a/packages/plugins/example/src/server.ts
+++ b/packages/plugins/example/src/server.ts
@@ -26,11 +26,18 @@ import { ExampleApi } from "./shared";
 // FullApi, so this bundle never touches the host's wiring.
 const ExampleApiBundle = HttpApi.make("example").add(ExampleApi);
 
-interface ExampleExtension {
-  readonly greet: (
-    name: string,
-  ) => Effect.Effect<{ readonly message: string; readonly count: number }>;
-}
+const makeExampleExtension = (ctx: { readonly storage: { count: number } }) => ({
+  greet: (name: string) =>
+    Effect.sync(() => {
+      ctx.storage.count += 1;
+      return {
+        message: `hello ${name}`,
+        count: ctx.storage.count,
+      };
+    }),
+});
+
+type ExampleExtension = ReturnType<typeof makeExampleExtension>;
 
 export class ExampleExtensionService extends Context.Service<
   ExampleExtensionService,
@@ -56,16 +63,7 @@ export const examplePlugin = definePlugin(() => ({
 
   // Canonical implementation. CLI/tests/embedded callers and the HTTP
   // handler all hit this same code path.
-  extension: (ctx): ExampleExtension => ({
-    greet: (name: string) =>
-      Effect.sync(() => {
-        ctx.storage.count += 1;
-        return {
-          message: `hello ${name}`,
-          count: ctx.storage.count,
-        };
-      }),
-  }),
+  extension: makeExampleExtension,
 
   routes: () => ExampleApi,
   handlers: () => ExampleHandlers,

--- a/packages/plugins/google-discovery/src/sdk/document.ts
+++ b/packages/plugins/google-discovery/src/sdk/document.ts
@@ -135,13 +135,6 @@ const DiscoveryDocumentModel = Schema.Struct({
 });
 type DiscoveryDocument = typeof DiscoveryDocumentModel.Type;
 
-// The Schema.TaggedError version of GoogleDiscoveryParseError no longer
-// carries a `cause` field — it would leak raw decoder internals over the
-// wire. The decoder failure still shows up on the Effect cause chain for
-// server-side logging; the client only sees the user-facing `message`.
-const toParseError = (message: string, _cause: unknown) =>
-  new GoogleDiscoveryParseError({ message });
-
 const decodeUnknownWith =
   <A>(
     message: string,
@@ -150,7 +143,10 @@ const decodeUnknownWith =
   (value) =>
     Effect.try({
       try: () => decode(value),
-      catch: (error) => toParseError(message, error),
+      // The Schema.TaggedError version of GoogleDiscoveryParseError no
+      // longer carries a `cause` field because the client only sees the
+      // user-facing message.
+      catch: () => new GoogleDiscoveryParseError({ message }),
     });
 
 const decodeDiscoveryDocument = decodeUnknownWith(


### PR DESCRIPTION
## Summary
- mark the synchronous CLI generator registry throw boundary
- inline Google Discovery parse error construction
- derive the example plugin extension type from its factory
- mark the storage-file Drizzle table bootstrap as a test boundary

## Verification
- bunx oxlint --format=unix packages/core/cli/src/generators/index.ts packages/plugins/google-discovery/src/sdk/document.ts packages/plugins/example/src/server.ts packages/core/storage-file/src/index.test.ts
- bun run --cwd packages/core/cli typecheck
- bun run --cwd packages/plugins/google-discovery typecheck
- bun run --cwd packages/plugins/example typecheck
- bun run --cwd packages/core/storage-file typecheck
- bun run --cwd packages/core/storage-file test