### PR TITLE
Document React scope context boundaries

### DIFF
--- a/packages/react/src/api/scope-context.tsx
+++ b/packages/react/src/api/scope-context.tsx
@@ -41,6 +41,7 @@ export function ScopeProvider(props: React.PropsWithChildren<{ fallback?: React.
 export function useScope(): ScopeId {
   const scope = React.useContext(ScopeContext);
   if (scope === null) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: React hook invariant
     throw new Error("useScope must be used inside a ScopeProvider");
   }
   return scope.id;
@@ -53,6 +54,7 @@ export function useScope(): ScopeId {
 export function useScopeInfo(): ScopeInfo {
   const scope = React.useContext(ScopeContext);
   if (scope === null) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: React hook invariant
     throw new Error("useScopeInfo must be used inside a ScopeProvider");
   }
   return scope;
@@ -66,6 +68,7 @@ export function useUserScope(): ScopeId {
   const stack = useScopeStack();
   const innermost = stack[0];
   if (!innermost) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: React hook invariant
     throw new Error("useUserScope requires a non-empty scope stack");
   }
   return innermost.id;


### PR DESCRIPTION
## Summary
- split the scope-context hook boundary suppressions out of the older mixed React UI PR
- leave source-form promiseExit work to the newer focused source UI PRs

## Verification
- bunx oxlint --format=unix packages/react/src/api/scope-context.tsx
- bun run --cwd packages/react typecheck