### PR TITLE
Add OpenAPI parse boundary tests

### DIFF
--- a/packages/plugins/openapi/src/sdk/parse.test.ts
+++ b/packages/plugins/openapi/src/sdk/parse.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { OpenApiParseError } from "./errors";
+import { parse } from "./parse";
+
+describe("OpenAPI parse", () => {
+  it.effect("parses JSON OpenAPI documents", () =>
+    Effect.gen(function* () {
+      const doc = yield* parse(
+        JSON.stringify({
+          openapi: "3.1.0",
+          info: { title: "Test", version: "1.0.0" },
+          paths: {},
+        }),
+      );
+
+      expect(doc.openapi).toBe("3.1.0");
+    }),
+  );
+
+  it.effect("parses YAML OpenAPI documents", () =>
+    Effect.gen(function* () {
+      const doc = yield* parse(`
+openapi: 3.0.0
+info:
+  title: Test
+  version: 1.0.0
+paths: {}
+`);
+
+      expect(doc.openapi).toBe("3.0.0");
+    }),
+  );
+
+  it.effect("returns a stable parse error for empty documents", () =>
+    Effect.gen(function* () {
+      const error = yield* parse("").pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(OpenApiParseError);
+      expect(error).toHaveProperty("message", "OpenAPI document is empty");
+    }),
+  );
+
+  it.effect("returns a stable parse error for non-object documents", () =>
+    Effect.gen(function* () {
+      const error = yield* parse("[]").pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(OpenApiParseError);
+      expect(error).toHaveProperty("message", "OpenAPI document must parse to an object");
+    }),
+  );
+});


### PR DESCRIPTION
## Summary
- split OpenAPI parse tests out of the older mixed parse cleanup PR
- stack them on the OpenAPI parser boundary PR because the stable parse error messages depend on that implementation
- assert error messages with toHaveProperty so the tests actually cover the Error message field

## Verification
- bunx oxlint --format=unix packages/plugins/openapi/src/sdk/parse.test.ts
- bun run --cwd packages/plugins/openapi test -- src/sdk/parse.test.ts
- bun run --cwd packages/plugins/openapi typecheck