### PR TITLE
Add PostHog to marketing site

### DIFF
--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -14,7 +14,7 @@
     "db:studio:prod": "op run --env-file=.env.production -- drizzle-kit studio",
     "db:migrate:prod": "op run --env-file=.env.production -- drizzle-kit migrate",
     "db:migrate:dev": "op run --env-file=.env.op -- drizzle-kit migrate",
-    "build": "turbo run build --filter @executor-js/vite-plugin && vite build",
+    "build": "node scripts/build.mjs",
     "preview": "vite preview",
     "deploy": "op run --env-file=.env.production -- bun run build && op run --env-file=.env.production -- wrangler deploy",
     "cf-typegen": "wrangler types",

--- a/apps/cloud/scripts/build.mjs
+++ b/apps/cloud/scripts/build.mjs
@@ -1,0 +1,25 @@
+// Build wrapper that pins VITE_PUBLIC_ANALYTICS_PATH for the whole build.
+//
+// Vite reloads vite.config.ts separately for the client and SSR/Cloudflare
+// environments, so a module-scoped randomUUID() ends up running twice and
+// the two bundles bake different values. The browser SDK then targets a
+// path the worker middleware never matches, and PostHog requests 404. By
+// generating once here and putting it in process.env before vite starts,
+// every environment build sees the same value.
+
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+
+if (!process.env.VITE_PUBLIC_ANALYTICS_PATH) {
+  process.env.VITE_PUBLIC_ANALYTICS_PATH = randomBytes(4).toString("hex");
+}
+console.log(`[build] VITE_PUBLIC_ANALYTICS_PATH=${process.env.VITE_PUBLIC_ANALYTICS_PATH}`);
+
+const steps = ["turbo run build --filter @executor-js/vite-plugin", "vite build"];
+
+for (const step of steps) {
+  const result = spawnSync(step, { stdio: "inherit", shell: true });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}

--- a/apps/cloud/vite.config.ts
+++ b/apps/cloud/vite.config.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { defineConfig, loadEnv, type Plugin } from "vite";
 import { cloudflare } from "@cloudflare/vite-plugin";
@@ -42,17 +41,17 @@ const loadWranglerPublicVars = () => {
   );
 };
 
-let generatedAnalyticsPath: string | undefined;
-const getGeneratedAnalyticsPath = () => {
-  generatedAnalyticsPath ??= randomUUID().slice(0, 8);
-  return generatedAnalyticsPath;
-};
+// VITE_PUBLIC_ANALYTICS_PATH is generated once per build by `scripts/build.mjs`
+// and inherited via process.env, so the client and SSR/Cloudflare environment
+// builds bake the same value. The fallback "a" is for `vite dev`, where the
+// proxy isn't routed anyway.
+const ANALYTICS_PATH = process.env.VITE_PUBLIC_ANALYTICS_PATH ?? "a";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const publicEnv = {
     ...loadWranglerPublicVars(),
-    VITE_PUBLIC_ANALYTICS_PATH: getGeneratedAnalyticsPath(),
+    VITE_PUBLIC_ANALYTICS_PATH: ANALYTICS_PATH,
     ...env,
   };
 

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -10,8 +10,8 @@
     "preview": "astro preview",
     "deploy": "astro build && npx wrangler deploy --config dist/server/wrangler.json",
     "astro": "astro",
-    "typecheck": "astro sync && tsgo --noEmit",
-    "typecheck:slow": "astro sync && tsc --noEmit"
+    "typecheck": "tsgo --noEmit",
+    "typecheck:slow": "tsc --noEmit"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^13.0.0",

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "astro": "^6.1.3",
     "effect": "catalog:",
+    "posthog-js": "^1.372.5",
     "tailwindcss": "^4.2.2"
   },
   "devDependencies": {

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -10,8 +10,8 @@
     "preview": "astro preview",
     "deploy": "astro build && npx wrangler deploy --config dist/server/wrangler.json",
     "astro": "astro",
-    "typecheck": "tsgo --noEmit",
-    "typecheck:slow": "tsc --noEmit"
+    "typecheck": "astro sync && tsgo --noEmit",
+    "typecheck:slow": "astro sync && tsc --noEmit"
   },
   "dependencies": {
     "@astrojs/cloudflare": "^13.0.0",

--- a/apps/marketing/src/env.d.ts
+++ b/apps/marketing/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  readonly PUBLIC_POSTHOG_KEY?: string;
+  readonly PUBLIC_POSTHOG_HOST?: string;
+  readonly PUBLIC_ANALYTICS_PATH?: string;
+}

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -33,6 +33,22 @@ const {
     <slot />
 
     <script>
+      import posthog from 'posthog-js'
+
+      const key = import.meta.env.PUBLIC_POSTHOG_KEY
+      if (key) {
+        const analyticsPath = (import.meta.env.PUBLIC_ANALYTICS_PATH ?? 'a').replace(/^\/+|\/+$/g, '')
+        posthog.init(key, {
+          api_host:
+            import.meta.env.PUBLIC_POSTHOG_HOST ?? `${window.location.origin}/api/${analyticsPath}`,
+          ui_host: 'https://us.posthog.com',
+          defaults: '2025-05-24',
+          person_profiles: 'identified_only',
+        })
+      }
+    </script>
+
+    <script>
       // Scroll-triggered reveals
       const observer = new IntersectionObserver(
         (entries) => {

--- a/apps/marketing/src/middleware.ts
+++ b/apps/marketing/src/middleware.ts
@@ -1,4 +1,4 @@
-import { defineMiddleware } from "astro:middleware";
+import type { MiddlewareHandler } from "astro";
 
 // PostHog reverse proxy — the browser SDK targets a build-randomized
 // first-party path and we forward to PostHog's ingest + asset hosts. Keeps
@@ -12,7 +12,7 @@ const POSTHOG_PROXY_PATH = `/api/${(import.meta.env.PUBLIC_ANALYTICS_PATH ?? "a"
   "",
 )}`;
 
-export const onRequest = defineMiddleware(async (context, next) => {
+export const onRequest: MiddlewareHandler = async (context, next) => {
   const { pathname } = new URL(context.request.url);
   if (pathname !== POSTHOG_PROXY_PATH && !pathname.startsWith(`${POSTHOG_PROXY_PATH}/`)) {
     return next();
@@ -29,4 +29,4 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const upstream = new Request(url, context.request);
   upstream.headers.delete("cookie");
   return fetch(upstream);
-});
+};

--- a/apps/marketing/src/middleware.ts
+++ b/apps/marketing/src/middleware.ts
@@ -1,0 +1,32 @@
+import { defineMiddleware } from "astro:middleware";
+
+// PostHog reverse proxy — the browser SDK targets a build-randomized
+// first-party path and we forward to PostHog's ingest + asset hosts. Keeps
+// events flowing past adblockers that match *.posthog.com. See
+// https://posthog.com/docs/advanced/proxy/cloudflare
+
+const POSTHOG_INGEST_HOST = "us.i.posthog.com";
+const POSTHOG_ASSETS_HOST = "us-assets.i.posthog.com";
+const POSTHOG_PROXY_PATH = `/api/${(import.meta.env.PUBLIC_ANALYTICS_PATH ?? "a").replace(
+  /^\/+|\/+$/g,
+  "",
+)}`;
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const { pathname } = new URL(context.request.url);
+  if (pathname !== POSTHOG_PROXY_PATH && !pathname.startsWith(`${POSTHOG_PROXY_PATH}/`)) {
+    return next();
+  }
+
+  const url = new URL(context.request.url);
+  url.hostname = pathname.startsWith(`${POSTHOG_PROXY_PATH}/static/`)
+    ? POSTHOG_ASSETS_HOST
+    : POSTHOG_INGEST_HOST;
+  url.protocol = "https:";
+  url.port = "";
+  url.pathname = pathname.slice(POSTHOG_PROXY_PATH.length) || "/";
+
+  const upstream = new Request(url, context.request);
+  upstream.headers.delete("cookie");
+  return fetch(upstream);
+});

--- a/bun.lock
+++ b/bun.lock
@@ -185,6 +185,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "astro": "^6.1.3",
         "effect": "catalog:",
+        "posthog-js": "^1.372.5",
         "tailwindcss": "^4.2.2",
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary
- Mirrors the cloud app's PostHog setup on the marketing site
- Client init in `Layout.astro` behind `PUBLIC_POSTHOG_KEY` (no-op when unset)
- New Astro middleware reverse-proxies `/api/${PUBLIC_ANALYTICS_PATH ?? "a"}` to `us.i.posthog.com` / `us-assets.i.posthog.com` so events flow past adblockers, matching the cloud middleware

## Env vars to set on the Cloudflare deploy
Astro uses the `PUBLIC_*` prefix (not `VITE_PUBLIC_*` like the cloud app):
- `PUBLIC_POSTHOG_KEY` — required to enable
- `PUBLIC_ANALYTICS_PATH` — optional, defaults to `a`. Set to the same value used in cloud if you want consistent first-party paths across origins.
- `PUBLIC_POSTHOG_HOST` — optional override

## Test plan
- [x] `bun run typecheck` (apps/marketing)
- [x] `bun run build` (apps/marketing) — `posthog` lands in the client `Layout` script chunk; proxy host strings land in the server middleware bundle
- [ ] Smoke test in deploy: confirm events show up in PostHog with `PUBLIC_POSTHOG_KEY` set, and that `/api/a/...` requests return 200 from the proxy