### PR TITLE
fix(oauth): declare requested scopes in DCR body

### DIFF
--- a/packages/core/sdk/src/oauth-discovery.test.ts
+++ b/packages/core/sdk/src/oauth-discovery.test.ts
@@ -14,6 +14,7 @@ type Handler = (url: string, init: RequestInit) => Response | Promise<Response>;
 const DcrRequestBody = Schema.Struct({
   redirect_uris: Schema.Array(Schema.String),
   token_endpoint_auth_method: Schema.String,
+  scope: Schema.optional(Schema.String),
 });
 const decodeDcrRequestBody = Schema.decodeUnknownSync(Schema.fromJsonString(DcrRequestBody));
 
@@ -347,6 +348,62 @@ describe("beginDynamicAuthorization", () => {
     );
     expect(result.state.clientInformation.client_id).toBe("dyn-client-42");
     expect(result.state.resourceMetadata?.resource).toBe("https://backboard.railway.com");
+  });
+
+  it("declares requested scopes in the DCR body so Auth0-style servers don't reject /authorize", async () => {
+    const { calls } = installFetchRouter([
+      {
+        match: (u) => u === "https://mcp.grata.com/.well-known/oauth-protected-resource",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://mcp.grata.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://mcp.grata.com/",
+              authorization_endpoint: "https://mcp.grata.com/authorize",
+              token_endpoint: "https://mcp.grata.com/token",
+              registration_endpoint: "https://mcp.grata.com/register",
+              scopes_supported: ["openid", "profile", "email", "offline_access"],
+              response_types_supported: ["code"],
+              grant_types_supported: ["authorization_code", "refresh_token"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://mcp.grata.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "grata-client-id",
+              redirect_uris: ["https://app.example/cb"],
+              token_endpoint_auth_method: "none",
+              scope: "openid profile email offline_access",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const result = await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://mcp.grata.com/",
+        redirectUrl: "https://app.example/cb",
+        state: "state-grata",
+      }),
+    );
+
+    const dcrCall = calls.find((c) => c.url === "https://mcp.grata.com/register");
+    expect(dcrCall).toBeDefined();
+    const body = decodeDcrRequestBody(String(dcrCall!.init.body));
+    expect(body.scope).toBe("openid profile email offline_access");
+
+    const authUrl = new URL(result.authorizationUrl);
+    expect(authUrl.searchParams.get("scope")).toBe("openid profile email offline_access");
+    expect(authUrl.searchParams.get("client_id")).toBe("grata-client-id");
   });
 
   it("skips discovery + DCR when previousState is provided", async () => {

--- a/packages/core/sdk/src/oauth-discovery.ts
+++ b/packages/core/sdk/src/oauth-discovery.ts
@@ -640,11 +640,14 @@ export const beginDynamicAuthorization = (
       });
     }
 
+    const scopes = input.scopes ?? authServer.metadata.scopes_supported ?? [];
+
     const baseClientMetadata: DynamicClientMetadata = {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
       token_endpoint_auth_method: "none",
       client_name: "Executor",
+      ...(scopes.length > 0 ? { scope: scopes.join(" ") } : {}),
       ...(input.clientMetadata ?? {}),
       redirect_uris: input.clientMetadata?.redirect_uris ?? [input.redirectUrl],
     };
@@ -669,7 +672,6 @@ export const beginDynamicAuthorization = (
 
     const codeVerifier = createPkceCodeVerifier();
     const codeChallenge = yield* Effect.promise(() => createPkceCodeChallenge(codeVerifier));
-    const scopes = input.scopes ?? authServer.metadata.scopes_supported ?? [];
 
     const authorizationUrl = buildAuthorizationUrl({
       authorizationUrl: authServer.metadata.authorization_endpoint,


### PR DESCRIPTION
## Summary

When adding an MCP source backed by an Auth0-style authorization server (advertising `scopes_supported` that includes `offline_access`), the source-add flow fails after Dynamic Client Registration with:

```
/oauth/callback?error=invalid_scope&error_description=Client+was+not+registered+with+scope+offline_access
```

Trace evidence (one full attempt against an Auth0-shaped AS):

1. `GET /.well-known/oauth-protected-resource` → 200
2. `GET /.well-known/oauth-authorization-server` → 200 (advertises `scopes_supported: ["openid", "profile", "email", "offline_access"]`)
3. `POST /register` → 201 (DCR succeeds)
4. Browser redirected to `/authorize?...&scope=openid profile email offline_access`
5. Authorization server hits the configured callback with `error=invalid_scope`

## Root cause

`beginDynamicAuthorization` in `packages/core/sdk/src/oauth-discovery.ts` computed the requested scope list **after** the DCR call and passed it only to `buildAuthorizationUrl`. The DCR body had no `scope` field, so RFC 7591 servers that strictly validate "client may only request scopes it registered with" rejected the subsequent `/authorize` redirect.

## Fix

Compute `scopes` once before DCR, include it as `scope: scopes.join(" ")` in `baseClientMetadata` (only when non-empty, and still overridable by caller-supplied `clientMetadata`), and reuse the same value for the authorization URL.

## Test plan

- [x] New test `declares requested scopes in the DCR body so Auth0-style servers don't reject /authorize` asserts the DCR request body contains `scope: "openid profile email offline_access"` and that the authorization URL carries the same scopes.
- [x] `bunx vitest run packages/core/sdk/src/oauth-discovery.test.ts` — 13/13 pass.
- [x] `bun run typecheck` — green.
- [x] `bun run lint` — green.
- [x] `bun run format:check` — green.