### PR TITLE
Add real protocol testing fixtures

### DIFF
--- a/.agents/skills/wrdn-effect-raw-fetch-boundary/SKILL.md
+++ b/.agents/skills/wrdn-effect-raw-fetch-boundary/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: wrdn-effect-raw-fetch-boundary
+description: Route HTTP through Effect boundaries instead of raw fetch. Use when lint flags executor/no-raw-fetch or when adding networked protocol/provider code.
+allowed-tools: Read Grep Glob Bash
+---
+
+HTTP in core SDK and protocol plugins should go through Effect services so tests
+can replace real networks with local protocol fixtures or mock `HttpClient`
+layers.
+
+## Fix Shape
+
+- Prefer `effect/unstable/http` `HttpClient` and `HttpClientRequest` for
+  ordinary HTTP calls.
+- Accept a `Layer.Layer<HttpClient.HttpClient>` option on plugin/provider code
+  when callers need to inject a test client.
+- In tests, use real local servers plus `FetchHttpClient.layer` or a captured
+  `HttpClient` service from the test layer.
+- Do not add fetch-shaped abstractions in SDK or plugin seams. If a third-party
+  library truly only accepts `fetch`, keep the adapter in the owning package,
+  name the forced boundary explicitly, and delegate internally to Effect
+  `HttpClient`.
+- Do not type new protocol/plugin seams as `typeof globalThis.fetch`; keep the
+  ambient runtime boundary out of domain and test APIs.
+- Do not patch `globalThis.fetch`. Replace those tests with a local server,
+  `HttpClient` layer, or the approved Effect-backed adapter.
+- Do not add a broad allowlist entry unless the file is a platform entrypoint
+  or a temporary migration target.
+
+## Approved Boundaries
+
+- Worker/handler objects whose public API must expose a `fetch` method.
+- Test calls to a worker or Miniflare binding's `.fetch(...)` method.
+- Small adapters for libraries that only accept `fetch`, if the implementation
+  delegates to Effect `HttpClient`.
+- Browser UI event handlers may remain raw only until app-side boundaries are
+  classified; prefer SDK/client APIs where available.
+
+## Bad
+
+```ts
+const response = await fetch(url);
+```
+
+```ts
+const fetchImpl = options.fetch ?? globalThis.fetch;
+```
+
+## Good
+
+```ts
+const client = yield * HttpClient.HttpClient;
+const response = yield * client.execute(HttpClientRequest.get(url));
+```
+
+```ts
+const plugin = graphqlPlugin({ httpClientLayer: testHttpClientLayer });
+```

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -17,6 +17,7 @@
     "executor/no-manual-tag-check": "error",
     "executor/no-promise-catch": "error",
     "executor/no-promise-reject": "error",
+    "executor/no-raw-fetch": "error",
     "executor/no-redundant-primitive-cast": "error",
     "executor/no-redundant-error-factory": "error",
     "executor/no-ts-nocheck": "error",

--- a/bun.lock
+++ b/bun.lock
@@ -601,6 +601,8 @@
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "effect": "catalog:",
+        "graphql": "^16.12.0",
+        "graphql-yoga": "^5.17.0",
       },
       "devDependencies": {
         "@effect/atom-react": "catalog:",
@@ -1157,6 +1159,12 @@
 
     "@emotion/weak-memoize": ["@emotion/weak-memoize@0.4.0", "", {}, "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="],
 
+    "@envelop/core": ["@envelop/core@5.5.1", "", { "dependencies": { "@envelop/instrumentation": "^1.0.0", "@envelop/types": "^5.2.1", "@whatwg-node/promise-helpers": "^1.2.4", "tslib": "^2.5.0" } }, "sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw=="],
+
+    "@envelop/instrumentation": ["@envelop/instrumentation@1.0.0", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.2.1", "tslib": "^2.5.0" } }, "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw=="],
+
+    "@envelop/types": ["@envelop/types@5.2.1", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.5.0" } }, "sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg=="],
+
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
     "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
@@ -1277,6 +1285,8 @@
 
     "@executor-js/vite-plugin": ["@executor-js/vite-plugin@workspace:packages/core/vite-plugin"],
 
+    "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
+
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
@@ -1288,6 +1298,22 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@giscus/react": ["@giscus/react@3.1.0", "", { "dependencies": { "giscus": "^1.6.0" }, "peerDependencies": { "react": "^16 || ^17 || ^18 || ^19", "react-dom": "^16 || ^17 || ^18 || ^19" } }, "sha512-0TCO2TvL43+oOdyVVGHDItwxD1UMKP2ZYpT6gXmhFOqfAJtZxTzJ9hkn34iAF/b6YzyJ4Um89QIt9z/ajmAEeg=="],
+
+    "@graphql-tools/executor": ["@graphql-tools/executor@1.5.3", "", { "dependencies": { "@graphql-tools/utils": "^11.1.0", "@graphql-typed-document-node/core": "^3.2.0", "@repeaterjs/repeater": "^3.0.4", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mgBFC0bsrZPZLu9EnydpMnAuQ8Iiq0CEbUcsmvXsm2/iYektGHDN/+bmb7hicA6dWZtdPfklYJmr21WD0GnOfA=="],
+
+    "@graphql-tools/merge": ["@graphql-tools/merge@9.1.9", "", { "dependencies": { "@graphql-tools/utils": "^11.1.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-iHUWNjRHeQRYdgIMIuChThOwoKzA9vrzYeslgfBo5eUYEyHGZCoDPjAavssoYXLwstYt1dZj2J22jSzc2DrN0Q=="],
+
+    "@graphql-tools/schema": ["@graphql-tools/schema@10.0.33", "", { "dependencies": { "@graphql-tools/merge": "^9.1.9", "@graphql-tools/utils": "^11.1.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-O6P3RIftO0jafnSsFAqpjurUuUxJ43s/AdPVLQsBkI6y4Ic/tKm4C1Qm1KKQsCDTOxXPJClh/v3g7k7yLKCFBQ=="],
+
+    "@graphql-tools/utils": ["@graphql-tools/utils@10.11.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q=="],
+
+    "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@graphql-yoga/logger": ["@graphql-yoga/logger@2.0.1", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA=="],
+
+    "@graphql-yoga/subscription": ["@graphql-yoga/subscription@5.0.5", "", { "dependencies": { "@graphql-yoga/typed-event-target": "^3.0.2", "@repeaterjs/repeater": "^3.0.4", "@whatwg-node/events": "^0.1.0", "tslib": "^2.8.1" } }, "sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw=="],
+
+    "@graphql-yoga/typed-event-target": ["@graphql-yoga/typed-event-target@3.0.2", "", { "dependencies": { "@repeaterjs/repeater": "^3.0.4", "tslib": "^2.8.1" } }, "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
@@ -1939,6 +1965,8 @@
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
+    "@repeaterjs/repeater": ["@repeaterjs/repeater@3.0.6", "", {}, "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="],
+
     "@rhyssul/portless": ["@rhyssul/portless@0.13.3", "", { "os": [ "linux", "win32", "darwin", ], "bin": { "portless": "dist/cli.js" } }, "sha512-oPvwXJIIkRg2i1CUEUsz8sAdFSf0Fzzv+NmaacAsi6ZZTHxDOofbO6fGInVnbESIFOu4k8a/rXOZRF0aqLAUgw=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.15", "", { "os": "android", "cpu": "arm64" }, "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA=="],
@@ -2337,6 +2365,18 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
+    "@whatwg-node/disposablestack": ["@whatwg-node/disposablestack@0.0.6", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.6.3" } }, "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw=="],
+
+    "@whatwg-node/events": ["@whatwg-node/events@0.1.2", "", { "dependencies": { "tslib": "^2.6.3" } }, "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ=="],
+
+    "@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.13", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.8.3", "urlpattern-polyfill": "^10.0.0" } }, "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q=="],
+
+    "@whatwg-node/node-fetch": ["@whatwg-node/node-fetch@0.8.5", "", { "dependencies": { "@fastify/busboy": "^3.1.1", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/promise-helpers": "^1.3.2", "tslib": "^2.6.3" } }, "sha512-4xzCl/zphPqlp9tASLVeUhB5+WJHbuWGYpfoC2q1qh5dw0AqZBW7L27V5roxYWijPxj4sspRAAoOH3d2ztaHUQ=="],
+
+    "@whatwg-node/promise-helpers": ["@whatwg-node/promise-helpers@1.3.2", "", { "dependencies": { "tslib": "^2.6.3" } }, "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA=="],
+
+    "@whatwg-node/server": ["@whatwg-node/server@0.10.18", "", { "dependencies": { "@envelop/instrumentation": "^1.0.0", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/fetch": "^0.10.13", "@whatwg-node/promise-helpers": "^1.3.2", "tslib": "^2.6.3" } }, "sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg=="],
+
     "@workos-inc/node": ["@workos-inc/node@8.13.0", "", { "dependencies": { "eventemitter3": "^5.0.4" } }, "sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.12", "", {}, "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg=="],
@@ -2636,6 +2676,8 @@
     "cron-schedule": ["cron-schedule@6.0.0", "", {}, "sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ=="],
 
     "cross-dirname": ["cross-dirname@0.1.0", "", {}, "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q=="],
+
+    "cross-inspect": ["cross-inspect@1.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -3083,6 +3125,10 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "graphql": ["graphql@16.14.0", "", {}, "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q=="],
+
+    "graphql-yoga": ["graphql-yoga@5.21.0", "", { "dependencies": { "@envelop/core": "^5.5.1", "@envelop/instrumentation": "^1.0.0", "@graphql-tools/executor": "^1.5.0", "@graphql-tools/schema": "^10.0.11", "@graphql-tools/utils": "^10.11.0", "@graphql-yoga/logger": "^2.0.1", "@graphql-yoga/subscription": "^5.0.5", "@whatwg-node/fetch": "^0.10.6", "@whatwg-node/promise-helpers": "^1.3.2", "@whatwg-node/server": "^0.10.14", "lru-cache": "^10.0.0", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^15.2.0 || ^16.0.0" } }, "sha512-PS37UoDihx8209RRl1ogttzWevNYDnGvP7beHkwHzUpUdfZTHsVRTVe1ysGXre1EjwUAePbpez302YSrq70Ngw=="],
+
     "h3": ["h3@1.15.11", "", { "dependencies": { "cookie-es": "^1.2.3", "crossws": "^0.3.5", "defu": "^6.1.6", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg=="],
 
     "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
@@ -3431,7 +3477,7 @@
 
     "lowercase-keys": ["lowercase-keys@2.0.0", "", {}, "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="],
 
-    "lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "lru_map": ["lru_map@0.4.1", "", {}, "sha512-I+lBvqMMFfqaV8CJCISjI3wbjmwVu/VyOoU7+qtu9d7ioW5klMgsTTiUOUp+DJvfTTzKXoPbyC6YfgkNcyPSOg=="],
 
@@ -4417,6 +4463,8 @@
 
     "url-join": ["url-join@5.0.0", "", {}, "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA=="],
 
+    "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
+
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
     "use-merge-value": ["use-merge-value@1.2.0", "", { "peerDependencies": { "react": ">= 16.x" } }, "sha512-DXgG0kkgJN45TcyoXL49vJnn55LehnrmoHc7MbKi+QDBvr8dsesqws8UlyIWGHMR+JXgxc1nvY+jDGMlycsUcw=="],
@@ -4645,6 +4693,12 @@
 
     "@executor-js/storage-postgres/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@graphql-tools/executor/@graphql-tools/utils": ["@graphql-tools/utils@11.1.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag=="],
+
+    "@graphql-tools/merge/@graphql-tools/utils": ["@graphql-tools/utils@11.1.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag=="],
+
+    "@graphql-tools/schema/@graphql-tools/utils": ["@graphql-tools/utils@11.1.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-PtFVG4r8Z2LEBSaPYQMusBiB3o6kjLVJyjCLbnWem/SpSuM21v6LTmgpkXfYU1qpBV2UGsFyuEnSJInl8fR1Ag=="],
+
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
@@ -4678,8 +4732,6 @@
     "@microlabs/otel-cf-workers/@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.200.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/otlp-exporter-base": "0.200.0", "@opentelemetry/otlp-transformer": "0.200.0", "@opentelemetry/resources": "2.0.0", "@opentelemetry/sdk-trace-base": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Goi//m/7ZHeUedxTGVmEzH19NgqJY+Bzr6zXo1Rni1+hwqaksEyJ44gdlEMREu6dzX1DlAaH/qSykSVzdrdafA=="],
 
     "@modelcontextprotocol/sdk/jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
-
-    "@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@opentelemetry/exporter-logs-otlp-http/@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.214.0", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/otlp-transformer": "0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-u1Gdv0/E9wP+apqWf7Wv2npXmgJtxsW2XL0TEv9FZloTZRuMBKmu8cYVXwS4Hm3q/f/3FuCnPTgiwYvIqRSpRg=="],
 
@@ -4885,8 +4937,6 @@
 
     "cacache/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
-    "cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
     "cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
     "cheerio/undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
@@ -5027,8 +5077,6 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
-    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "posthog-js/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.208.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg=="],
@@ -5100,6 +5148,8 @@
     "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "unstorage/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/notes/real-protocol-testing-plan.md
+++ b/notes/real-protocol-testing-plan.md
@@ -46,7 +46,7 @@ Testing services belong behind explicit `./testing` subpath exports:
 
 The plugin packages own the protocol details. Core SDK testing owns only boring
 Executor fixtures such as memory adapters, memory secrets, auto-accept
-elicitation, and fetch-shaped adapters that delegate to Effect HTTP.
+elicitation, and other Effect-native test primitives.
 
 Use `TestLayer` / `TestLayers` naming for realistic local test services.
 Reserve `LiveLayer` / `LiveLayers` for production wiring. These servers are
@@ -124,7 +124,6 @@ Suggested file layout:
 ```txt
 packages/core/sdk/src/testing.ts
 packages/core/sdk/src/testing/
-  fetch.ts
   memory-secrets.ts
 
 packages/plugins/openapi/src/testing/
@@ -191,9 +190,6 @@ Useful additions:
   in-test secret provider definitions.
 - `makeExecutorTestLayer(options)`, if repeated `createExecutor(makeTestConfig)`
   setup becomes noisy.
-- `makeFetchFromHttpClient` or `FetchTestAdapter`, for third-party APIs that
-  require a fetch-shaped callback while still routing requests through Effect's
-  HTTP client.
 - Small request/response capture primitives built on `Ref`, only if multiple
   plugins need the same shape.
 
@@ -243,8 +239,8 @@ Work:
 - Support a fresh `McpServer` factory per session, matching the current helper.
 - Keep malformed/non-MCP HTTP endpoints as explicit test layers for probe
   behavior.
-- Replace fetch-injected probe tests with real local HTTP servers and the
-  Effect-backed fetch adapter.
+- Replace fetch-injected probe tests with real local HTTP servers and
+  Effect-native HTTP boundaries.
 
 Representative scenarios:
 
@@ -261,10 +257,11 @@ Representative scenarios:
 GraphQL should gain a real executable schema server. This is the place where a
 new dependency may be justified.
 
-Preferred first dependency is the core `graphql` package if it is enough:
-define a schema, execute introspection and operations with `graphql(...)`, and
-serve the standard JSON-over-HTTP GraphQL endpoint through Effect/node HTTP.
-Use `graphql-yoga` only if we need a fuller server feature set later.
+Use `graphql-yoga` for the test server. The extra dependency is justified
+because the fixture needs to exercise a real JSON-over-HTTP GraphQL endpoint,
+not only direct `graphql(...)` execution. Keep Vitest configured to inline the
+Yoga/GraphQL dependency chain so executable schemas and server execution share
+one GraphQL module realm.
 
 Work:
 
@@ -292,19 +289,19 @@ Representative scenarios:
 ## Fetch Boundary
 
 The target rule is: product and plugin code should not call raw `fetch`
-directly. HTTP should go through Effect HTTP or a small approved adapter that
-turns an Effect `HttpClient` into a fetch-shaped function for libraries that
-force that API.
+directly. HTTP should go through Effect HTTP. If a third-party library truly
+forces a fetch-shaped callback, the adapter should live at that owning package's
+boundary rather than in shared SDK testing.
 
 Boundary files may exist, but they should be explicit and scarce. Examples:
 
-- a SDK adapter for `oauth4webapi` custom fetch
+- a core OAuth adapter for `oauth4webapi` custom fetch, if that library forces it
 - a MCP transport adapter if the upstream MCP SDK requires fetch-shaped input
 - platform entrypoints that must implement a `fetch(request, env, ctx)` method
 - test harnesses that intentionally call a Worker binding's `fetch` method
 
-Everything else should use Effect HTTP, Executor client APIs, or the approved
-adapter.
+Everything else should use Effect HTTP, Executor client APIs, or an explicit
+package-local boundary.
 
 Lint plan:
 
@@ -319,17 +316,17 @@ Lint plan:
 - Start with a narrow allowlist for known boundary files and remove entries as
   migrations land.
 - Include error messages that tell the author which Effect HTTP or approved
-  adapter to use.
+  package-local boundary to use.
 
-The lint rule should land after the first adapter exists. Otherwise every fix
-has to invent its own local escape hatch.
+The lint rule can land once the core test primitives and at least one real
+protocol fixture exist. Fetch-shaped adapters should be added only at forced
+library boundaries during migration.
 
 ## Migration Order
 
 1. Add `./testing` exports and SDK test primitives.
    - Expose `@executor-js/sdk/testing`.
    - Add memory secrets test support.
-   - Add the Effect HTTP to fetch-shaped adapter.
    - Keep `makeTestConfig` available from the root SDK.
 
 2. Build the GraphQL vertical slice.
@@ -344,8 +341,8 @@ has to invent its own local escape hatch.
    - Migrate current tests to import from the new public testing subpaths.
 
 4. Replace global fetch patching.
-   - Convert core OAuth discovery/helper tests to real local servers or the
-     Effect-backed fetch adapter.
+   - Convert core OAuth discovery/helper tests to real local servers or
+     package-local Effect HTTP boundaries.
    - Convert OpenAPI OAuth tests to the OAuth test server.
    - Convert MCP probe tests to real local HTTP server layers.
    - Convert Google Discovery tests using the same boundary pattern.
@@ -403,8 +400,8 @@ Turbo. Do not use `bun test`.
 
 - Should `@executor-js/sdk/testing` be a new subpath around the existing
   `src/testing.ts`, or should `src/testing.ts` become `src/testing/index.ts`?
-- Should GraphQL use only the `graphql` package, or should we adopt
-  `graphql-yoga` once tests need more HTTP behavior?
+- How much GraphQL HTTP behavior should live in the shared fixture versus
+  scenario-specific schemas in individual tests?
 - Which app-level raw fetch calls should remain approved platform boundaries
   versus being migrated to Effect HTTP?
 - Should the raw fetch lint rule become repo-wide immediately with allowlists,

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -19,7 +19,8 @@
     ".": "./src/index.ts",
     "./core": "./src/index.ts",
     "./promise": "./src/promise.ts",
-    "./client": "./src/client.ts"
+    "./client": "./src/client.ts",
+    "./testing": "./src/testing.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -40,6 +41,12 @@
         "import": {
           "types": "./dist/client.d.ts",
           "default": "./dist/client.js"
+        }
+      },
+      "./testing": {
+        "import": {
+          "types": "./dist/testing.d.ts",
+          "default": "./dist/testing.js"
         }
       }
     }

--- a/packages/core/sdk/src/testing.ts
+++ b/packages/core/sdk/src/testing.ts
@@ -1,11 +1,14 @@
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
 
+import { Effect } from "effect";
+
 import { makeInMemoryBlobStore } from "./blob";
 import type { ExecutorConfig } from "./executor";
 import { collectSchemas } from "./executor";
 import { ScopeId } from "./ids";
-import type { AnyPlugin } from "./plugin";
+import { definePlugin, type AnyPlugin } from "./plugin";
 import { Scope } from "./scope";
+import type { SecretProvider } from "./secrets";
 
 // ---------------------------------------------------------------------------
 // makeTestConfig — build an ExecutorConfig backed by in-memory adapter +
@@ -42,3 +45,31 @@ export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = []>
     onElicitation: "accept-all",
   };
 };
+
+export const memorySecretsPlugin = definePlugin(() => {
+  const store = new Map<string, string>();
+
+  const provider: SecretProvider = {
+    key: "memory",
+    writable: true,
+    get: (id, scope) => Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
+    set: (id, value, scope) =>
+      Effect.sync(() => {
+        store.set(`${scope}\u0000${id}`, value);
+      }),
+    delete: (id, scope) => Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
+    list: () =>
+      Effect.sync(() =>
+        Array.from(store.keys()).map((key) => {
+          const name = key.split("\u0000", 2)[1] ?? key;
+          return { id: name, name };
+        }),
+      ),
+  };
+
+  return {
+    id: "memory-secrets" as const,
+    storage: () => ({}),
+    secretProviders: [provider],
+  };
+});

--- a/packages/core/sdk/tsup.config.ts
+++ b/packages/core/sdk/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/promise.ts",
     core: "src/index.ts",
     client: "src/client.ts",
+    testing: "src/testing.ts",
   },
   format: ["esm"],
   dts: false,

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -21,7 +21,8 @@
     "./api": "./src/api/index.ts",
     "./react": "./src/react/index.ts",
     "./presets": "./src/sdk/presets.ts",
-    "./client": "./src/react/plugin-client.tsx"
+    "./client": "./src/react/plugin-client.tsx",
+    "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -37,6 +38,12 @@
           "types": "./dist/sdk/index.d.ts",
           "default": "./dist/core.js"
         }
+      },
+      "./testing": {
+        "import": {
+          "types": "./dist/testing/index.d.ts",
+          "default": "./dist/testing.js"
+        }
       }
     }
   },
@@ -51,7 +58,9 @@
     "@effect/platform-node": "catalog:",
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "graphql": "^16.12.0",
+    "graphql-yoga": "^5.17.0"
   },
   "devDependencies": {
     "@effect/atom-react": "catalog:",

--- a/packages/plugins/graphql/src/sdk/introspect.ts
+++ b/packages/plugins/graphql/src/sdk/introspect.ts
@@ -220,8 +220,9 @@ export const introspect = Effect.fn("GraphQL.introspect")(function* (
   );
 
   if (response.status !== 200) {
+    const body = yield* response.text.pipe(Effect.catch(() => Effect.succeed("<unreadable>")));
     return yield* new GraphqlIntrospectionError({
-      message: `Introspection failed with status ${response.status}`,
+      message: `Introspection failed with status ${response.status}: ${body.slice(0, 1_000)}`,
     });
   }
 

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -1,25 +1,23 @@
 import { describe, it, expect } from "@effect/vitest";
-import { Data, Effect } from "effect";
+import { Effect } from "effect";
 
 import {
   ConnectionId,
   CreateConnectionInput,
   createExecutor,
-  definePlugin,
   makeTestConfig,
   Scope,
   ScopeId,
   SecretId,
-  type SecretProvider,
   TokenMaterial,
 } from "@executor-js/sdk";
+import { memorySecretsPlugin } from "@executor-js/sdk/testing";
 
 import { graphqlPlugin } from "./plugin";
 import type { IntrospectionResult } from "./introspect";
+import { makeGreetingGraphqlSchema, serveGraphqlTestServer } from "../testing";
 
 const TEST_SCOPE = "test-scope";
-
-class TestServerAddressError extends Data.TaggedError("TestServerAddressError")<{}> {}
 
 // ---------------------------------------------------------------------------
 // Mock introspection response
@@ -92,31 +90,119 @@ const introspectionResult: IntrospectionResult = {
 
 const introspectionJson = JSON.stringify({ data: introspectionResult });
 
-const makeMemorySecretsPlugin = () => {
-  const store = new Map<string, string>();
-  const provider: SecretProvider = {
-    key: "memory",
-    writable: true,
-    get: (id, scope) => Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
-    set: (id, value, scope) =>
-      Effect.sync(() => {
-        store.set(`${scope}\u0000${id}`, value);
-      }),
-    delete: (id, scope) => Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
-    list: () =>
-      Effect.sync(() =>
-        Array.from(store.keys()).map((key) => {
-          const name = key.split("\u0000", 2)[1] ?? key;
-          return { id: name, name };
+describe("graphqlPlugin real protocol server", () => {
+  const serveGreetingServer = serveGraphqlTestServer({ schema: makeGreetingGraphqlSchema() });
+
+  it.effect("adds a source by introspecting the live GraphQL endpoint", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGreetingServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [graphqlPlugin()] as const }),
+      );
+
+      const result = yield* executor.graphql.addSource({
+        endpoint: server.endpoint,
+        scope: TEST_SCOPE,
+        namespace: "live_graph",
+      });
+
+      expect(result).toEqual({ toolCount: 2, namespace: "live_graph" });
+
+      const tools = yield* executor.tools.list();
+      expect(tools.map((tool) => tool.id)).toEqual(
+        expect.arrayContaining(["live_graph.query.hello", "live_graph.mutation.setGreeting"]),
+      );
+
+      const requests = yield* server.requests;
+      expect(requests.some((request) => request.payload.query?.includes("__schema"))).toBe(true);
+    }),
+  );
+
+  it.effect("invokes a live query with headers and query params", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGreetingServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [graphqlPlugin()] as const }),
+      );
+
+      yield* executor.graphql.addSource({
+        endpoint: server.endpoint,
+        scope: TEST_SCOPE,
+        namespace: "live_invoke",
+        headers: { "x-static": "abc" },
+        queryParams: { token: "qp-token" },
+      });
+      yield* server.clearRequests;
+
+      const result = yield* executor.tools.invoke("live_invoke.query.hello", {
+        name: "Ada",
+      });
+
+      expect(result).toEqual({
+        status: 200,
+        data: { hello: "Hello Ada" },
+        errors: null,
+      });
+
+      const requests = yield* server.requests;
+      expect(requests.length).toBe(1);
+      expect(requests[0]?.headers["x-static"]).toBe("abc");
+      expect(new URL(requests[0]!.url).searchParams.get("token")).toBe("qp-token");
+      expect(requests[0]?.payload.variables).toEqual({ name: "Ada" });
+    }),
+  );
+
+  it.effect("invokes OAuth-backed sources with a bearer token", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGreetingServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [memorySecretsPlugin(), graphqlPlugin()] as const,
         }),
-      ),
-  };
-  return definePlugin(() => ({
-    id: "memory-secrets" as const,
-    storage: () => ({}),
-    secretProviders: [provider],
-  }));
-};
+      );
+
+      const connectionId = ConnectionId.make("graphql-oauth2-test");
+      yield* executor.connections.create(
+        new CreateConnectionInput({
+          id: connectionId,
+          scope: ScopeId.make(TEST_SCOPE),
+          provider: "oauth2",
+          identityLabel: "GraphQL Test",
+          accessToken: new TokenMaterial({
+            secretId: SecretId.make(`${connectionId}.access_token`),
+            name: "GraphQL Access Token",
+            value: "secret-token",
+          }),
+          refreshToken: null,
+          expiresAt: null,
+          oauthScope: null,
+          providerState: null,
+        }),
+      );
+
+      yield* executor.graphql.addSource({
+        endpoint: server.endpoint,
+        scope: TEST_SCOPE,
+        namespace: "oauth_graph",
+        auth: { kind: "oauth2", connectionId },
+      });
+      yield* server.clearRequests;
+
+      const result = yield* executor.tools.invoke("oauth_graph.query.hello", {
+        name: "Ada",
+      });
+
+      expect(result).toEqual({
+        status: 200,
+        data: { hello: "Hello Ada" },
+        errors: null,
+      });
+
+      const requests = yield* server.requests;
+      expect(requests[0]?.headers.authorization).toBe("Bearer secret-token");
+    }),
+  );
+});
 
 describe("graphqlPlugin", () => {
   it.effect("registers tools from introspection JSON", () =>
@@ -253,85 +339,6 @@ describe("graphqlPlugin", () => {
       // already there from addSource and haven't been removed).
       const tools = yield* executor.tools.list();
       expect(tools.filter((t) => t.sourceId === "patched").length).toBe(2);
-    }),
-  );
-
-  it.effect("invokes OAuth-backed sources with a bearer token", () =>
-    Effect.gen(function* () {
-      const http = yield* Effect.promise(() => import("node:http"));
-      let authorizationHeader: string | null = null;
-      const server = yield* Effect.acquireRelease(
-        Effect.callback<
-          {
-            readonly server: ReturnType<typeof http.createServer>;
-            readonly port: number;
-          },
-          Error | TestServerAddressError
-        >((resume) => {
-          const server = http.createServer((req, res) => {
-            authorizationHeader = req.headers.authorization ?? null;
-            res.setHeader("content-type", "application/json");
-            res.end(JSON.stringify({ data: { hello: "Hello Ada" } }));
-          });
-          server.listen(0, "127.0.0.1", () => {
-            const address = server.address();
-            if (!address || typeof address === "string") {
-              resume(Effect.fail(new TestServerAddressError()));
-              return;
-            }
-            resume(Effect.succeed({ server, port: address.port }));
-          });
-          server.once("error", (error) => resume(Effect.fail(error)));
-        }),
-        ({ server }) =>
-          Effect.callback<void>((resume) => {
-            server.close(() => resume(Effect.void));
-          }).pipe(Effect.ignore),
-      );
-
-      const executor = yield* createExecutor(
-        makeTestConfig({
-          plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
-        }),
-      );
-
-      const connectionId = ConnectionId.make("graphql-oauth2-test");
-      yield* executor.connections.create(
-        new CreateConnectionInput({
-          id: connectionId,
-          scope: ScopeId.make(TEST_SCOPE),
-          provider: "oauth2",
-          identityLabel: "GraphQL Test",
-          accessToken: new TokenMaterial({
-            secretId: SecretId.make(`${connectionId}.access_token`),
-            name: "GraphQL Access Token",
-            value: "secret-token",
-          }),
-          refreshToken: null,
-          expiresAt: null,
-          oauthScope: null,
-          providerState: null,
-        }),
-      );
-
-      yield* executor.graphql.addSource({
-        endpoint: `http://127.0.0.1:${server.port}/graphql`,
-        scope: TEST_SCOPE,
-        introspectionJson,
-        namespace: "oauth_graph",
-        auth: { kind: "oauth2", connectionId },
-      });
-
-      const result = yield* executor.tools.invoke("oauth_graph.query.hello", {
-        name: "Ada",
-      });
-
-      expect(result).toEqual({
-        status: 200,
-        data: { hello: "Hello Ada" },
-        errors: null,
-      });
-      expect(authorizationHeader).toBe("Bearer secret-token");
     }),
   );
 
@@ -506,7 +513,7 @@ describe("graphqlPlugin", () => {
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({
-          plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
+          plugins: [memorySecretsPlugin(), graphqlPlugin()] as const,
         }),
       );
 
@@ -543,7 +550,7 @@ describe("graphqlPlugin", () => {
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({
-          plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
+          plugins: [memorySecretsPlugin(), graphqlPlugin()] as const,
         }),
       );
 
@@ -579,7 +586,7 @@ describe("graphqlPlugin", () => {
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({
-          plugins: [makeMemorySecretsPlugin()(), graphqlPlugin()] as const,
+          plugins: [memorySecretsPlugin(), graphqlPlugin()] as const,
         }),
       );
 

--- a/packages/plugins/graphql/src/testing/index.ts
+++ b/packages/plugins/graphql/src/testing/index.ts
@@ -1,0 +1,195 @@
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+
+import { Context, Data, Effect, Layer, Ref, Schema as EffectSchema, Scope } from "effect";
+import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
+import { createYoga, type GraphQLParams, type YogaInitialContext } from "graphql-yoga";
+
+const GraphqlRequestPayload = EffectSchema.Struct({
+  query: EffectSchema.optional(EffectSchema.String),
+  variables: EffectSchema.optional(EffectSchema.Record(EffectSchema.String, EffectSchema.Unknown)),
+  operationName: EffectSchema.optional(EffectSchema.NullOr(EffectSchema.String)),
+});
+
+type GraphqlRequestPayload = typeof GraphqlRequestPayload.Type;
+
+export interface GraphqlTestRequest {
+  readonly url: string;
+  readonly method: string;
+  readonly path: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly payload: GraphqlRequestPayload;
+}
+
+export interface GraphqlTestContext {
+  readonly request: GraphqlTestRequest;
+}
+
+export interface GraphqlTestServerOptions {
+  readonly schema: GraphQLSchema;
+  readonly path?: string;
+}
+
+export interface GraphqlTestServerShape {
+  readonly endpoint: string;
+  readonly schema: GraphQLSchema;
+  readonly requests: Effect.Effect<readonly GraphqlTestRequest[]>;
+  readonly clearRequests: Effect.Effect<void>;
+}
+
+class GraphqlTestServerAddressError extends Data.TaggedError("GraphqlTestServerAddressError")<{
+  readonly address: unknown;
+}> {}
+
+class GraphqlTestServerListenError extends Data.TaggedError("GraphqlTestServerListenError")<{
+  readonly cause: unknown;
+}> {}
+
+const headersFromRequest = (
+  headers: Headers | IncomingHttpHeaders,
+): Readonly<Record<string, string>> => {
+  if ("entries" in headers && typeof headers.entries === "function") {
+    return Object.fromEntries(headers.entries());
+  }
+  return Object.fromEntries(
+    Object.entries(headers).flatMap(([name, value]) => {
+      if (value === undefined) return [];
+      return [[name, Array.isArray(value) ? value.join(", ") : value]];
+    }),
+  );
+};
+
+const payloadFromParams = (params: GraphQLParams): GraphqlRequestPayload => ({
+  query: params.query,
+  variables:
+    typeof params.variables === "object" && params.variables !== null
+      ? params.variables
+      : undefined,
+  operationName: params.operationName ?? null,
+});
+
+const captureRequest = (
+  initial: YogaInitialContext,
+  requests: Ref.Ref<readonly GraphqlTestRequest[]>,
+) => {
+  const url = new URL(initial.request.url);
+  const captured: GraphqlTestRequest = {
+    url: initial.request.url,
+    method: initial.request.method,
+    path: url.pathname,
+    headers: headersFromRequest(initial.request.headers),
+    payload: payloadFromParams(initial.params),
+  };
+  return Effect.runPromise(
+    Ref.update(requests, (all) => [...all, captured]).pipe(Effect.as(captured)),
+  );
+};
+
+const closeServer = (server: Server): Effect.Effect<void> =>
+  Effect.callback<void>((resume) => {
+    server.close(() => resume(Effect.void));
+  });
+
+export const serveGraphqlTestServer = (
+  options: GraphqlTestServerOptions,
+): Effect.Effect<
+  GraphqlTestServerShape,
+  GraphqlTestServerAddressError | GraphqlTestServerListenError,
+  Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const requests = yield* Ref.make<readonly GraphqlTestRequest[]>([]);
+    const path = options.path ?? "/graphql";
+
+    const yoga = createYoga<Record<string, never>, GraphqlTestContext>({
+      schema: options.schema,
+      graphqlEndpoint: path,
+      graphiql: false,
+      landingPage: false,
+      logging: false,
+      maskedErrors: false,
+      context: (initial) =>
+        captureRequest(initial, requests).then((request) => ({
+          request,
+        })),
+    });
+    const server = createServer(yoga);
+
+    const port = yield* Effect.acquireRelease(
+      Effect.callback<number, GraphqlTestServerAddressError | GraphqlTestServerListenError>(
+        (resume) => {
+          const onError = (cause: unknown) =>
+            resume(Effect.fail(new GraphqlTestServerListenError({ cause })));
+          server.once("error", onError);
+          server.listen(0, "127.0.0.1", () => {
+            server.off("error", onError);
+            const address = server.address();
+            if (!address || typeof address === "string") {
+              resume(Effect.fail(new GraphqlTestServerAddressError({ address })));
+              return;
+            }
+            resume(Effect.succeed(address.port));
+          });
+        },
+      ),
+      () => closeServer(server),
+    );
+
+    return {
+      endpoint: `http://127.0.0.1:${port}${path}`,
+      schema: options.schema,
+      requests: Ref.get(requests),
+      clearRequests: Ref.set(requests, []),
+    };
+  });
+
+export class GraphqlTestServer extends Context.Service<GraphqlTestServer, GraphqlTestServerShape>()(
+  "@executor-js/plugin-graphql/testing/GraphqlTestServer",
+) {
+  static readonly layer = (options: GraphqlTestServerOptions) =>
+    Layer.effect(GraphqlTestServer, serveGraphqlTestServer(options));
+}
+
+const stringArgument = (
+  args: Readonly<Record<string, unknown>>,
+  key: string,
+  fallback: string,
+): string => {
+  const value = args[key];
+  return typeof value === "string" ? value : fallback;
+};
+
+export const makeGreetingGraphqlSchema = (): GraphQLSchema => {
+  const Query = new GraphQLObjectType<unknown, GraphqlTestContext>({
+    name: "Query",
+    fields: {
+      hello: {
+        type: GraphQLString,
+        description: "Say hello",
+        args: {
+          name: { type: GraphQLString },
+        },
+        resolve: (_source, args) => `Hello ${stringArgument(args, "name", "world")}`,
+      },
+    },
+  });
+
+  const Mutation = new GraphQLObjectType<unknown, GraphqlTestContext>({
+    name: "Mutation",
+    fields: {
+      setGreeting: {
+        type: GraphQLString,
+        description: "Set greeting message",
+        args: {
+          message: { type: new GraphQLNonNull(GraphQLString) },
+        },
+        resolve: (_source, args) => stringArgument(args, "message", ""),
+      },
+    },
+  });
+
+  return new GraphQLSchema({ query: Query, mutation: Mutation });
+};
+
+export const TestLayers = {
+  greeting: () => GraphqlTestServer.layer({ schema: makeGreetingGraphqlSchema() }),
+};

--- a/packages/plugins/graphql/tsup.config.ts
+++ b/packages/plugins/graphql/tsup.config.ts
@@ -4,10 +4,11 @@ export default defineConfig({
   entry: {
     index: "src/promise.ts",
     core: "src/sdk/index.ts",
+    testing: "src/testing/index.ts",
   },
   format: ["esm"],
   dts: false,
   sourcemap: true,
   clean: true,
-  external: [/^@executor-js\//, /^effect/, /^@effect\//],
+  external: [/^@executor-js\//, /^effect/, /^@effect\//, /^graphql/, /^graphql-yoga/],
 });

--- a/packages/plugins/graphql/vitest.config.ts
+++ b/packages/plugins/graphql/vitest.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
+    server: {
+      deps: {
+        inline: ["graphql", "graphql-yoga", "@graphql-tools", "@envelop", "@whatwg-node"],
+      },
+    },
   },
 });

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -21,7 +21,8 @@
     "./api": "./src/api/index.ts",
     "./react": "./src/react/index.ts",
     "./presets": "./src/sdk/presets.ts",
-    "./client": "./src/react/plugin-client.tsx"
+    "./client": "./src/react/plugin-client.tsx",
+    "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -36,6 +37,12 @@
         "import": {
           "types": "./dist/sdk/index.d.ts",
           "default": "./dist/core.js"
+        }
+      },
+      "./testing": {
+        "import": {
+          "types": "./dist/testing/index.d.ts",
+          "default": "./dist/testing.js"
         }
       }
     }

--- a/packages/plugins/mcp/src/sdk/elicitation.test.ts
+++ b/packages/plugins/mcp/src/sdk/elicitation.test.ts
@@ -12,7 +12,7 @@ import {
 } from "@executor-js/sdk";
 
 import { mcpPlugin } from "./plugin";
-import { serveMcpServer } from "./test-utils";
+import { serveMcpServer } from "../testing";
 
 // ---------------------------------------------------------------------------
 // Test MCP server on a real HTTP port

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -18,7 +18,7 @@ import {
 
 import { mcpPlugin } from "./plugin";
 import { extractManifestFromListToolsResult, deriveMcpNamespace, joinToolPath } from "./manifest";
-import { serveMcpServer } from "./test-utils";
+import { serveMcpServer } from "../testing";
 
 // ---------------------------------------------------------------------------
 // Memory secrets plugin — without a writable provider in the stack,

--- a/packages/plugins/mcp/src/testing/index.ts
+++ b/packages/plugins/mcp/src/testing/index.ts
@@ -1,0 +1,1 @@
+export { serveMcpServer, type McpTestServer } from "./server";

--- a/packages/plugins/mcp/src/testing/server.ts
+++ b/packages/plugins/mcp/src/testing/server.ts
@@ -10,12 +10,6 @@ export type McpTestServer = {
   readonly sessionCount: () => number;
 };
 
-/**
- * Spin up a real HTTP server backed by a fresh `McpServer` per session,
- * with proper session routing via `mcp-session-id`. The factory is invoked
- * once per new session, so tools registered inside it are isolated per
- * connection (matching the SDK's own server/transport coupling).
- */
 export const serveMcpServer = (factory: () => McpServer) =>
   Effect.acquireRelease(
     Effect.callback<McpTestServer, Error>((resume) => {

--- a/packages/plugins/mcp/tsup.config.ts
+++ b/packages/plugins/mcp/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/promise.ts",
     core: "src/sdk/index.ts",
+    testing: "src/testing/index.ts",
   },
   format: ["esm"],
   dts: false,

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -21,7 +21,8 @@
     "./api": "./src/api/index.ts",
     "./react": "./src/react/index.ts",
     "./client": "./src/react/plugin-client.tsx",
-    "./presets": "./src/sdk/presets.ts"
+    "./presets": "./src/sdk/presets.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -36,6 +37,12 @@
         "import": {
           "types": "./dist/sdk/index.d.ts",
           "default": "./dist/core.js"
+        }
+      },
+      "./testing": {
+        "import": {
+          "types": "./dist/testing/index.d.ts",
+          "default": "./dist/testing.js"
         }
       }
     }

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -13,20 +13,20 @@ import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import {
   createExecutor,
   type DBAdapter,
-  definePlugin,
   makeTestConfig,
   Scope,
   ScopeId,
   SecretId,
   SetSecretInput,
   type InvokeOptions,
-  type SecretProvider,
   type Where,
 } from "@executor-js/sdk";
+import { memorySecretsPlugin } from "@executor-js/sdk/testing";
 
 const TEST_SCOPE = "test-scope";
 import { openApiPlugin } from "./plugin";
 import { OAuth2Auth, OpenApiSourceBindingInput } from "./types";
+import { makeOpenApiTestServer } from "../testing";
 
 const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
 
@@ -52,38 +52,6 @@ const recordFindMany = (adapter: DBAdapter, calls: FindManyCall[]): DBAdapter =>
       }),
     ),
 });
-
-// ---------------------------------------------------------------------------
-// In-memory secrets provider plugin — registered alongside openapi so
-// executor.secrets.set/get work in tests.
-// ---------------------------------------------------------------------------
-
-const memoryProvider: SecretProvider = (() => {
-  const store = new Map<string, string>();
-  return {
-    key: "memory",
-    writable: true,
-    get: (id, scope) => Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
-    set: (id, value, scope) =>
-      Effect.sync(() => {
-        store.set(`${scope}\u0000${id}`, value);
-      }),
-    delete: (id, scope) => Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
-    list: () =>
-      Effect.sync(() =>
-        Array.from(store.keys()).map((k) => {
-          const name = k.split("\u0000", 2)[1] ?? k;
-          return { id: name, name };
-        }),
-      ),
-  };
-})();
-
-const memorySecretsPlugin = definePlugin(() => ({
-  id: "memory-secrets" as const,
-  storage: () => ({}),
-  secretProviders: [memoryProvider],
-}));
 
 // ---------------------------------------------------------------------------
 // Define a test API with Effect HttpApi
@@ -186,19 +154,18 @@ const TestLayer = HttpRouter.serve(ApiLive, { disableListenLog: true, disableLog
 layer(TestLayer)("OpenAPI Plugin", (it) => {
   it.effect("previewSpec returns metadata and header presets", () =>
     Effect.gen(function* () {
-      const httpClient = yield* HttpClient.HttpClient;
-      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+      const server = yield* makeOpenApiTestServer({ spec });
 
       const executor = yield* createExecutor(
         makeTestConfig({
           plugins: [
-            openApiPlugin({ httpClientLayer: clientLayer }),
+            openApiPlugin({ httpClientLayer: server.httpClientLayer }),
             memorySecretsPlugin(),
           ] as const,
         }),
       );
 
-      const preview = yield* executor.openapi.previewSpec(specJson);
+      const preview = yield* executor.openapi.previewSpec(server.specJson);
 
       expect(preview.operationCount).toBeGreaterThanOrEqual(2);
       expect(preview.servers).toBeDefined();

--- a/packages/plugins/openapi/src/testing/index.ts
+++ b/packages/plugins/openapi/src/testing/index.ts
@@ -1,0 +1,86 @@
+import { Context, Data, Effect, Layer, Predicate, Schema } from "effect";
+import { HttpClient, HttpServer } from "effect/unstable/http";
+
+export class OpenApiTestServerAddressError extends Data.TaggedError(
+  "OpenApiTestServerAddressError",
+)<{
+  readonly address: unknown;
+}> {}
+
+export class OpenApiTestServerSpecError extends Data.TaggedError("OpenApiTestServerSpecError")<{
+  readonly cause: unknown;
+}> {}
+
+export interface OpenApiTestServerOptions {
+  readonly spec: unknown;
+}
+
+export interface OpenApiTestServerShape {
+  readonly baseUrl: string;
+  readonly specJson: string;
+  readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>;
+}
+
+const decodeJsonSpec = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
+
+const isJsonObject = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+export const openApiSpecJsonWithServer = (
+  spec: unknown,
+  baseUrl: string,
+): Effect.Effect<string, OpenApiTestServerSpecError> =>
+  Effect.gen(function* () {
+    const parsed =
+      typeof spec === "string"
+        ? yield* decodeJsonSpec(spec).pipe(
+            Effect.mapError((cause) => new OpenApiTestServerSpecError({ cause })),
+          )
+        : spec;
+    const withServer = isJsonObject(parsed)
+      ? {
+          ...parsed,
+          servers: [{ url: baseUrl }],
+        }
+      : parsed;
+    return yield* Effect.try({
+      try: () => JSON.stringify(withServer),
+      catch: (cause) => new OpenApiTestServerSpecError({ cause }),
+    });
+  });
+
+export const makeOpenApiTestServer = (
+  options: OpenApiTestServerOptions,
+): Effect.Effect<
+  OpenApiTestServerShape,
+  OpenApiTestServerAddressError | OpenApiTestServerSpecError,
+  HttpClient.HttpClient | HttpServer.HttpServer
+> =>
+  Effect.gen(function* () {
+    const server = yield* HttpServer.HttpServer;
+    const address = server.address;
+    if (!Predicate.isTagged(address, "TcpAddress")) {
+      return yield* new OpenApiTestServerAddressError({ address });
+    }
+
+    const client = yield* HttpClient.HttpClient;
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const specJson = yield* openApiSpecJsonWithServer(options.spec, baseUrl);
+
+    return {
+      baseUrl,
+      specJson,
+      httpClientLayer: Layer.succeed(HttpClient.HttpClient, client),
+    };
+  });
+
+export class OpenApiTestServer extends Context.Service<OpenApiTestServer, OpenApiTestServerShape>()(
+  "@executor-js/plugin-openapi/testing/OpenApiTestServer",
+) {
+  static readonly layer = (options: OpenApiTestServerOptions) =>
+    Layer.effect(OpenApiTestServer, makeOpenApiTestServer(options));
+}
+
+export const TestLayers = {
+  server: OpenApiTestServer.layer,
+};

--- a/packages/plugins/openapi/tsup.config.ts
+++ b/packages/plugins/openapi/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/promise.ts",
     core: "src/sdk/index.ts",
+    testing: "src/testing/index.ts",
   },
   format: ["esm"],
   dts: false,

--- a/scripts/oxlint-plugin-executor.js
+++ b/scripts/oxlint-plugin-executor.js
@@ -12,6 +12,7 @@ import noManualTagCheck from "./oxlint-plugin-executor/rules/no-manual-tag-check
 import noPromiseCatch from "./oxlint-plugin-executor/rules/no-promise-catch.js";
 import noPromiseClientSurface from "./oxlint-plugin-executor/rules/no-promise-client-surface.js";
 import noPromiseReject from "./oxlint-plugin-executor/rules/no-promise-reject.js";
+import noRawFetch from "./oxlint-plugin-executor/rules/no-raw-fetch.js";
 import noRawErrorThrow from "./oxlint-plugin-executor/rules/no-raw-error-throw.js";
 import noRedundantPrimitiveCast from "./oxlint-plugin-executor/rules/no-redundant-primitive-cast.js";
 import noRedundantErrorFactory from "./oxlint-plugin-executor/rules/no-redundant-error-factory.js";
@@ -48,6 +49,7 @@ export default {
     "no-promise-catch": noPromiseCatch,
     "no-promise-client-surface": noPromiseClientSurface,
     "no-promise-reject": noPromiseReject,
+    "no-raw-fetch": noRawFetch,
     "no-raw-error-throw": noRawErrorThrow,
     "no-redundant-primitive-cast": noRedundantPrimitiveCast,
     "no-redundant-error-factory": noRedundantErrorFactory,

--- a/scripts/oxlint-plugin-executor/rules/no-raw-fetch.js
+++ b/scripts/oxlint-plugin-executor/rules/no-raw-fetch.js
@@ -1,0 +1,76 @@
+import {
+  getPropertyName,
+  isDeclarationFile,
+  isIdentifier,
+  toRepoRelative,
+  unwrapExpression,
+} from "../utils.js";
+
+const message =
+  "Do not call raw fetch in core/plugin code. Route HTTP through Effect HttpClient or an explicit package-local boundary. Skill: wrdn-effect-raw-fetch-boundary.";
+
+const checkedPrefixes = [
+  "packages/core/sdk/src/",
+  "packages/plugins/graphql/src/",
+  "packages/plugins/mcp/src/",
+  "packages/plugins/openapi/src/",
+];
+
+const temporaryAllowedFiles = new Set([
+  "packages/core/sdk/src/oauth-discovery.ts",
+  "packages/core/sdk/src/oauth-discovery.test.ts",
+  "packages/core/sdk/src/oauth-helpers.test.ts",
+  "packages/core/sdk/src/oauth-service.ts",
+  "packages/plugins/mcp/src/sdk/probe-shape.ts",
+  "packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts",
+  "packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts",
+  "packages/plugins/openapi/src/sdk/oauth-refresh.test.ts",
+]);
+
+const shouldCheck = (filename) => {
+  const normalized = toRepoRelative(filename);
+  if (isDeclarationFile(filename)) return false;
+  if (temporaryAllowedFiles.has(normalized)) return false;
+  return checkedPrefixes.some((prefix) => normalized.startsWith(prefix));
+};
+
+const isGlobalFetchMember = (node) => {
+  const expression = unwrapExpression(node);
+  if (expression?.type !== "MemberExpression") return false;
+  const object = unwrapExpression(expression.object);
+  const property = getPropertyName(expression.property);
+  return (
+    property === "fetch" &&
+    (isIdentifier(object, "globalThis") ||
+      isIdentifier(object, "window") ||
+      isIdentifier(object, "self"))
+  );
+};
+
+const isBareFetchCall = (node) => isIdentifier(unwrapExpression(node), "fetch");
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow raw fetch outside approved Effect HTTP boundaries.",
+    },
+  },
+  create(context) {
+    if (!shouldCheck(context.filename)) return {};
+
+    return {
+      CallExpression(node) {
+        if (isBareFetchCall(node.callee) || isGlobalFetchMember(node.callee)) {
+          context.report({ node: node.callee, message });
+        }
+      },
+      MemberExpression(node) {
+        if (node.parent?.type === "CallExpression" && node.parent.callee === node) return;
+        if (isGlobalFetchMember(node)) {
+          context.report({ node, message });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary
- add protocol-owned testing exports for GraphQL, MCP, and OpenAPI
- add a real GraphQL test server fixture and migrate representative plugin tests to live protocol coverage
- add SDK memory secrets test support and a raw fetch lint rule with an agent skill

## Verification
- bun run test -- src/sdk/plugin.test.ts (packages/plugins/graphql)
- bun run test -- src/sdk/extract.test.ts (packages/plugins/graphql)
- bun run test -- src/sdk/plugin.test.ts (packages/plugins/openapi)
- bun run lint
- bun run typecheck
- bun run format:check
- git diff --check