### PR TITLE
fix(oauth): MCP authorization spec hardening

### DIFF
--- a/packages/core/sdk/src/oauth-discovery.test.ts
+++ b/packages/core/sdk/src/oauth-discovery.test.ts
@@ -4,6 +4,7 @@ import { Cause, Effect, Exit, Schema } from "effect";
 import {
   OAuthDiscoveryError,
   beginDynamicAuthorization,
+  canonicalResourceUrl,
   discoverAuthorizationServerMetadata,
   discoverProtectedResourceMetadata,
   registerDynamicClient,
@@ -15,6 +16,7 @@ const DcrRequestBody = Schema.Struct({
   redirect_uris: Schema.Array(Schema.String),
   token_endpoint_auth_method: Schema.String,
   scope: Schema.optional(Schema.String),
+  client_uri: Schema.optional(Schema.String),
 });
 const decodeDcrRequestBody = Schema.decodeUnknownSync(Schema.fromJsonString(DcrRequestBody));
 
@@ -33,6 +35,18 @@ const installFetchRouter = (
 };
 
 const originalFetch = globalThis.fetch;
+
+describe("canonicalResourceUrl", () => {
+  it("lowercases scheme + host, drops trailing slash, fragment, and query", () => {
+    expect(canonicalResourceUrl("https://API.Example.com/v1/mcp/")).toBe(
+      "https://api.example.com/v1/mcp",
+    );
+    expect(canonicalResourceUrl("HTTPS://api.example.com/v1/mcp?x=1#frag")).toBe(
+      "https://api.example.com/v1/mcp",
+    );
+    expect(canonicalResourceUrl("https://api.example.com/")).toBe("https://api.example.com");
+  });
+});
 
 describe("discoverProtectedResourceMetadata", () => {
   afterEach(() => {
@@ -350,7 +364,7 @@ describe("beginDynamicAuthorization", () => {
     expect(result.state.resourceMetadata?.resource).toBe("https://backboard.railway.com");
   });
 
-  it("declares requested scopes in the DCR body so Auth0-style servers don't reject /authorize", async () => {
+  it("declares requested scopes in the DCR body when caller passes them explicitly", async () => {
     const { calls } = installFetchRouter([
       {
         match: (u) => u === "https://mcp.grata.com/.well-known/oauth-protected-resource",
@@ -381,7 +395,7 @@ describe("beginDynamicAuthorization", () => {
               client_id: "grata-client-id",
               redirect_uris: ["https://app.example/cb"],
               token_endpoint_auth_method: "none",
-              scope: "openid profile email offline_access",
+              scope: "openid offline_access",
             }),
             { status: 201, headers: { "content-type": "application/json" } },
           ),
@@ -393,17 +407,500 @@ describe("beginDynamicAuthorization", () => {
         endpoint: "https://mcp.grata.com/",
         redirectUrl: "https://app.example/cb",
         state: "state-grata",
+        scopes: ["openid", "offline_access"],
       }),
     );
 
     const dcrCall = calls.find((c) => c.url === "https://mcp.grata.com/register");
     expect(dcrCall).toBeDefined();
     const body = decodeDcrRequestBody(String(dcrCall!.init.body));
-    expect(body.scope).toBe("openid profile email offline_access");
+    expect(body.scope).toBe("openid offline_access");
 
     const authUrl = new URL(result.authorizationUrl);
-    expect(authUrl.searchParams.get("scope")).toBe("openid profile email offline_access");
+    expect(authUrl.searchParams.get("scope")).toBe("openid offline_access");
     expect(authUrl.searchParams.get("client_id")).toBe("grata-client-id");
+  });
+
+  it("requests only PRM scopes_supported when advertised (RFC 9728 §2 limited scope)", async () => {
+    const { calls } = installFetchRouter([
+      {
+        match: (u) => u === "https://api.example.com/.well-known/oauth-protected-resource/v1/mcp",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              resource: "https://api.example.com/v1/mcp",
+              authorization_servers: ["https://as.example.com"],
+              scopes_supported: ["mcp:read"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://as.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://as.example.com",
+              authorization_endpoint: "https://as.example.com/authorize",
+              token_endpoint: "https://as.example.com/token",
+              registration_endpoint: "https://as.example.com/register",
+              scopes_supported: ["openid", "profile", "mcp:read", "mcp:admin", "offline_access"],
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://as.example.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "narrow-scope-client",
+              redirect_uris: ["https://app/cb"],
+              token_endpoint_auth_method: "none",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const result = await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://api.example.com/v1/mcp",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+
+    const dcrCall = calls.find((c) => c.url === "https://as.example.com/register");
+    const body = decodeDcrRequestBody(String(dcrCall!.init.body));
+    expect(body.scope).toBe("mcp:read");
+
+    const authUrl = new URL(result.authorizationUrl);
+    expect(authUrl.searchParams.get("scope")).toBe("mcp:read");
+  });
+
+  it("requests empty scope when only AS-level scopes_supported is advertised (RFC 9728 §2)", async () => {
+    const { calls } = installFetchRouter([
+      {
+        match: (u) => u === "https://only-as.example.com/.well-known/oauth-protected-resource",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://only-as.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://only-as.example.com",
+              authorization_endpoint: "https://only-as.example.com/authorize",
+              token_endpoint: "https://only-as.example.com/token",
+              registration_endpoint: "https://only-as.example.com/register",
+              scopes_supported: ["openid", "profile", "admin", "offline_access"],
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://only-as.example.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "no-scope-client",
+              redirect_uris: ["https://app/cb"],
+              token_endpoint_auth_method: "none",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const result = await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://only-as.example.com/",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+
+    const dcrCall = calls.find((c) => c.url === "https://only-as.example.com/register");
+    const body = decodeDcrRequestBody(String(dcrCall!.init.body));
+    expect(body.scope).toBeUndefined();
+
+    const authUrl = new URL(result.authorizationUrl);
+    expect(authUrl.searchParams.get("scope")).toBe("");
+  });
+
+  it("includes RFC 8707 resource parameter on the authorization URL (PRM resource claim)", async () => {
+    installFetchRouter([
+      {
+        match: (u) => u === "https://api.example.com/.well-known/oauth-protected-resource/v1/mcp",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              resource: "https://api.example.com/canonical-id",
+              authorization_servers: ["https://api.example.com"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://api.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://api.example.com",
+              authorization_endpoint: "https://api.example.com/authorize",
+              token_endpoint: "https://api.example.com/token",
+              registration_endpoint: "https://api.example.com/register",
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://api.example.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "res-client",
+              redirect_uris: ["https://app/cb"],
+              token_endpoint_auth_method: "none",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const result = await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://api.example.com/v1/mcp",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+
+    const authUrl = new URL(result.authorizationUrl);
+    expect(authUrl.searchParams.get("resource")).toBe("https://api.example.com/canonical-id");
+    expect(result.state.resource).toBe("https://api.example.com/canonical-id");
+  });
+
+  it("falls back to canonical endpoint URL for the resource parameter when PRM is absent", async () => {
+    installFetchRouter([
+      {
+        match: (u) => u === "https://api.example.com/.well-known/oauth-protected-resource/v1/mcp",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://api.example.com/.well-known/oauth-protected-resource",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://api.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://api.example.com",
+              authorization_endpoint: "https://api.example.com/authorize",
+              token_endpoint: "https://api.example.com/token",
+              registration_endpoint: "https://api.example.com/register",
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://api.example.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "ep-client",
+              redirect_uris: ["https://app/cb"],
+              token_endpoint_auth_method: "none",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const result = await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://API.example.com/v1/mcp/",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+
+    const authUrl = new URL(result.authorizationUrl);
+    expect(authUrl.searchParams.get("resource")).toBe("https://api.example.com/v1/mcp");
+  });
+
+  it("includes client_uri in the DCR body (RFC 7591 §2 RECOMMENDED)", async () => {
+    const { calls } = installFetchRouter([
+      {
+        match: (u) => u === "https://only-as.example.com/.well-known/oauth-protected-resource",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://only-as.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://only-as.example.com",
+              authorization_endpoint: "https://only-as.example.com/authorize",
+              token_endpoint: "https://only-as.example.com/token",
+              registration_endpoint: "https://only-as.example.com/register",
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://only-as.example.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "uri-client",
+              redirect_uris: ["https://app/cb"],
+              token_endpoint_auth_method: "none",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://only-as.example.com/",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+
+    const dcrCall = calls.find((c) => c.url === "https://only-as.example.com/register");
+    const body = decodeDcrRequestBody(String(dcrCall!.init.body));
+    expect(body.client_uri).toBe("https://executor.sh");
+  });
+
+  it("negotiates client_secret_post when the AS does not advertise 'none' (Clay-style)", async () => {
+    const { calls } = installFetchRouter([
+      {
+        match: (u) => u === "https://api.clay.com/.well-known/oauth-protected-resource/v3/mcp",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              resource: "https://api.clay.com/v3/mcp",
+              authorization_servers: ["https://api.clay.com"],
+              scopes_supported: ["mcp"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://api.clay.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://api.clay.com",
+              authorization_endpoint: "https://api.clay.com/authorize",
+              token_endpoint: "https://api.clay.com/token",
+              registration_endpoint: "https://api.clay.com/register",
+              token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post"],
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://api.clay.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "clay-id",
+              client_secret: "clay-secret",
+              redirect_uris: ["https://app/cb"],
+              token_endpoint_auth_method: "client_secret_post",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://api.clay.com/v3/mcp",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+
+    const dcrCall = calls.find((c) => c.url === "https://api.clay.com/register");
+    const body = decodeDcrRequestBody(String(dcrCall!.init.body));
+    expect(body.token_endpoint_auth_method).toBe("client_secret_post");
+  });
+
+  it("fails with a clear error when the AS advertises only auth methods we don't support", async () => {
+    installFetchRouter([
+      {
+        match: (u) => u === "https://jwt-only.example.com/.well-known/oauth-protected-resource",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://jwt-only.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://jwt-only.example.com",
+              authorization_endpoint: "https://jwt-only.example.com/authorize",
+              token_endpoint: "https://jwt-only.example.com/token",
+              registration_endpoint: "https://jwt-only.example.com/register",
+              token_endpoint_auth_methods_supported: ["private_key_jwt"],
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const exit = await Effect.runPromiseExit(
+      beginDynamicAuthorization({
+        endpoint: "https://jwt-only.example.com/",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const reason = exit.cause.reasons.find(Cause.isFailReason);
+    expect(reason?.error).toEqual(
+      expect.objectContaining({
+        _tag: "OAuthDiscoveryError",
+        message: expect.stringMatching(/usable token_endpoint_auth_method/),
+      }),
+    );
+  });
+
+  it("falls through to a later authorization_servers entry when the first has no metadata", async () => {
+    installFetchRouter([
+      {
+        match: (u) => u === "https://multi-as.example.com/.well-known/oauth-protected-resource/api",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              resource: "https://multi-as.example.com/api",
+              authorization_servers: ["https://primary.example.com", "https://backup.example.com"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://primary.example.com/.well-known/oauth-authorization-server",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://primary.example.com/.well-known/openid-configuration",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://backup.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://backup.example.com",
+              authorization_endpoint: "https://backup.example.com/authorize",
+              token_endpoint: "https://backup.example.com/token",
+              registration_endpoint: "https://backup.example.com/register",
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://backup.example.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              client_id: "backup-client",
+              redirect_uris: ["https://app/cb"],
+              token_endpoint_auth_method: "none",
+            }),
+            { status: 201, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const result = await Effect.runPromise(
+      beginDynamicAuthorization({
+        endpoint: "https://multi-as.example.com/api",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+
+    expect(result.state.authorizationServerUrl).toBe("https://backup.example.com");
+    expect(result.state.clientInformation.client_id).toBe("backup-client");
+  });
+
+  it("propagates AS error code + description on DCR failure (RFC 7591 §3.2.2)", async () => {
+    installFetchRouter([
+      {
+        match: (u) => u === "https://errd.example.com/.well-known/oauth-protected-resource",
+        handle: () => new Response(null, { status: 404 }),
+      },
+      {
+        match: (u) => u === "https://errd.example.com/.well-known/oauth-authorization-server",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              issuer: "https://errd.example.com",
+              authorization_endpoint: "https://errd.example.com/authorize",
+              token_endpoint: "https://errd.example.com/token",
+              registration_endpoint: "https://errd.example.com/register",
+              response_types_supported: ["code"],
+              code_challenge_methods_supported: ["S256"],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+      },
+      {
+        match: (u) => u === "https://errd.example.com/register",
+        handle: () =>
+          new Response(
+            JSON.stringify({
+              error: "invalid_redirect_uri",
+              error_description: "redirect_uri must be from an allowed domain",
+            }),
+            { status: 400, headers: { "content-type": "application/json" } },
+          ),
+      },
+    ]);
+
+    const exit = await Effect.runPromiseExit(
+      beginDynamicAuthorization({
+        endpoint: "https://errd.example.com/",
+        redirectUrl: "https://app/cb",
+        state: "s",
+      }),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (!Exit.isFailure(exit)) return;
+    const reason = exit.cause.reasons.find(Cause.isFailReason);
+    expect(reason?.error).toEqual(
+      expect.objectContaining({
+        _tag: "OAuthDiscoveryError",
+        status: 400,
+        error: "invalid_redirect_uri",
+        errorDescription: "redirect_uri must be from an allowed domain",
+      }),
+    );
   });
 
   it("skips discovery + DCR when previousState is provided", async () => {

--- a/packages/core/sdk/src/oauth-discovery.ts
+++ b/packages/core/sdk/src/oauth-discovery.ts
@@ -40,6 +40,12 @@ import {
 export class OAuthDiscoveryError extends Data.TaggedError("OAuthDiscoveryError")<{
   readonly message: string;
   readonly status?: number;
+  /** RFC 6749 §5.2 / RFC 7591 §3.2.2 error code, when the AS returned
+   *  one (`invalid_client_metadata`, `invalid_redirect_uri`, ...). Lets
+   *  the HTTP edge surface a structured error to the UI rather than
+   *  swallow the AS's response into a generic message string. */
+  readonly error?: string;
+  readonly errorDescription?: string;
   readonly cause?: unknown;
 }> {}
 
@@ -523,6 +529,8 @@ export const registerDynamicClient = (
               err.error_description ? ` — ${err.error_description}` : ""
             }`,
             status: err.status,
+            error: err.error,
+            errorDescription: err.error_description,
             cause: err,
           }),
         ),
@@ -538,6 +546,44 @@ export const registerDynamicClient = (
   );
 
 // ---------------------------------------------------------------------------
+// RFC 8707 — Resource Indicator canonicalisation
+//
+// MCP Authorization 2025-06-18 requires `resource` on /authorize and /token
+// requests. RFC 8707 §2 says the value is "an absolute URI" identifying the
+// protected resource — same scheme + host + (optional) path, no fragment,
+// no query, lowercased scheme/host.
+// ---------------------------------------------------------------------------
+
+export const canonicalResourceUrl = (value: string): string => {
+  const url = new URL(value);
+  const scheme = url.protocol.toLowerCase();
+  const host = url.host.toLowerCase();
+  const path = url.pathname.replace(/\/+$/, "");
+  return `${scheme}//${host}${path}`;
+};
+
+// ---------------------------------------------------------------------------
+// Token-endpoint auth method negotiation
+//
+// OAuth 2.1 §2.4 leaves the choice to the client; our preference order is
+// security-first: PKCE-only public client > client_secret_post >
+// client_secret_basic. Servers like Clay only advertise the secret variants;
+// servers like most MCP examples only advertise `none`.
+// ---------------------------------------------------------------------------
+
+const SUPPORTED_DCR_AUTH_METHODS = ["none", "client_secret_post", "client_secret_basic"] as const;
+
+type DcrAuthMethod = (typeof SUPPORTED_DCR_AUTH_METHODS)[number];
+
+const negotiateAuthMethod = (advertised: readonly string[] | undefined): DcrAuthMethod | null => {
+  if (!advertised || advertised.length === 0) return "none";
+  for (const candidate of SUPPORTED_DCR_AUTH_METHODS) {
+    if (advertised.includes(candidate)) return candidate;
+  }
+  return null;
+};
+
+// ---------------------------------------------------------------------------
 // Convenience: begin the full dynamic flow in one call
 // ---------------------------------------------------------------------------
 
@@ -548,6 +594,12 @@ export interface DynamicAuthorizationState {
   readonly authorizationServerMetadataUrl: string;
   readonly authorizationServerMetadata: OAuthAuthorizationServerMetadata;
   readonly clientInformation: OAuthClientInformation;
+  /** RFC 8707 canonical resource URL passed on /authorize and persisted
+   *  for the matching /token + refresh calls. */
+  readonly resource: string;
+  /** Scopes ultimately requested at /authorize. Persisted so refresh
+   *  can replay the same set. */
+  readonly scopes: readonly string[];
 }
 
 export interface DynamicAuthorizationStartResult {
@@ -604,27 +656,48 @@ export const beginDynamicAuthorization = (
         : null
       : yield* discoverProtectedResourceMetadata(input.endpoint, options);
 
-    const authorizationServerUrl = (() => {
-      if (prior.authorizationServerUrl) return prior.authorizationServerUrl;
-      const fromResource = resource && resource.metadata.authorization_servers?.[0];
-      if (fromResource) return fromResource;
+    // RFC 9728 allows multiple authorization_servers — try each in
+    // listed order. Fall back to the endpoint's origin only when no
+    // PRM is advertised.
+    const candidateAuthorizationServerUrls: readonly string[] = (() => {
+      if (prior.authorizationServerUrl) return [prior.authorizationServerUrl];
+      const fromResource = resource?.metadata.authorization_servers ?? [];
+      if (fromResource.length > 0) return fromResource;
       const u = new URL(input.endpoint);
-      return `${u.protocol}//${u.host}`;
+      return [`${u.protocol}//${u.host}`];
     })();
 
-    const authServer =
+    const priorAuthServer =
       prior.authorizationServerMetadata && prior.authorizationServerMetadataUrl
         ? {
             metadata: prior.authorizationServerMetadata,
             metadataUrl: prior.authorizationServerMetadataUrl,
+            url: prior.authorizationServerUrl ?? candidateAuthorizationServerUrls[0]!,
           }
-        : yield* discoverAuthorizationServerMetadata(authorizationServerUrl, options);
+        : null;
 
-    if (!authServer) {
-      return yield* new OAuthDiscoveryError({
-        message: `No OAuth authorization server metadata at ${authorizationServerUrl}`,
-      });
-    }
+    const discovered = priorAuthServer
+      ? priorAuthServer
+      : yield* (() => {
+          const tried: string[] = [];
+          return Effect.gen(function* () {
+            for (const candidate of candidateAuthorizationServerUrls) {
+              tried.push(candidate);
+              const md = yield* discoverAuthorizationServerMetadata(candidate, options).pipe(
+                Effect.catchTag("OAuthDiscoveryError", () => Effect.succeed(null)),
+              );
+              if (md) {
+                return { metadata: md.metadata, metadataUrl: md.metadataUrl, url: candidate };
+              }
+            }
+            return yield* new OAuthDiscoveryError({
+              message: `No OAuth authorization server metadata found (tried: ${tried.join(", ")})`,
+            });
+          });
+        })();
+
+    const authServer = { metadata: discovered.metadata, metadataUrl: discovered.metadataUrl };
+    const authorizationServerUrl = discovered.url;
 
     const pkceMethods = authServer.metadata.code_challenge_methods_supported ?? [];
     if (pkceMethods.length > 0 && !pkceMethods.includes("S256")) {
@@ -640,13 +713,36 @@ export const beginDynamicAuthorization = (
       });
     }
 
-    const scopes = input.scopes ?? authServer.metadata.scopes_supported ?? [];
+    // RFC 9728 §2: PRM `scopes_supported` is the resource-scoped list and is
+    // authoritative when present. AS-level `scopes_supported` is global and
+    // (per RFC 9728 §2) "not meant to indicate that an OAuth client should
+    // request all scopes in the list", so we don't auto-expand it. When only
+    // AS-level scopes are advertised we request none and let the AS apply
+    // its default — callers wanting refresh tokens / specific scopes pass
+    // them explicitly via `input.scopes`.
+    const scopes: readonly string[] =
+      input.scopes ??
+      (resource?.metadata.scopes_supported && resource.metadata.scopes_supported.length > 0
+        ? resource.metadata.scopes_supported
+        : []);
+
+    const negotiatedAuthMethod = negotiateAuthMethod(
+      authServer.metadata.token_endpoint_auth_methods_supported,
+    );
+    if (!negotiatedAuthMethod) {
+      return yield* new OAuthDiscoveryError({
+        message: `Authorization server does not support a usable token_endpoint_auth_method (advertised: ${(
+          authServer.metadata.token_endpoint_auth_methods_supported ?? []
+        ).join(", ")})`,
+      });
+    }
 
     const baseClientMetadata: DynamicClientMetadata = {
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
-      token_endpoint_auth_method: "none",
+      token_endpoint_auth_method: negotiatedAuthMethod,
       client_name: "Executor",
+      client_uri: "https://executor.sh",
       ...(scopes.length > 0 ? { scope: scopes.join(" ") } : {}),
       ...(input.clientMetadata ?? {}),
       redirect_uris: input.clientMetadata?.redirect_uris ?? [input.redirectUrl],
@@ -670,6 +766,8 @@ export const beginDynamicAuthorization = (
         );
       })());
 
+    const resourceValue = resource?.metadata.resource ?? canonicalResourceUrl(input.endpoint);
+
     const codeVerifier = createPkceCodeVerifier();
     const codeChallenge = yield* Effect.promise(() => createPkceCodeChallenge(codeVerifier));
 
@@ -680,6 +778,7 @@ export const beginDynamicAuthorization = (
       scopes,
       state: input.state,
       codeChallenge,
+      resource: resourceValue,
     });
 
     return {
@@ -692,6 +791,8 @@ export const beginDynamicAuthorization = (
         authorizationServerMetadataUrl: authServer.metadataUrl,
         authorizationServerMetadata: authServer.metadata,
         clientInformation,
+        resource: resourceValue,
+        scopes,
       },
     };
   });

--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -117,6 +117,21 @@ describe("buildAuthorizationUrl", () => {
     expect(url.searchParams.get("tenant")).toBe("acme");
     expect(url.searchParams.get("client_id")).toBe("client-123");
   });
+
+  it("includes RFC 8707 resource indicator when provided", () => {
+    const url = new URL(
+      buildAuthorizationUrl({
+        ...baseInput,
+        resource: "https://api.example.com/v1/mcp",
+      }),
+    );
+    expect(url.searchParams.get("resource")).toBe("https://api.example.com/v1/mcp");
+  });
+
+  it("omits resource parameter when not provided", () => {
+    const url = new URL(buildAuthorizationUrl(baseInput));
+    expect(url.searchParams.has("resource")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -182,6 +197,37 @@ describe("exchangeAuthorizationCode", () => {
     expect(body.get("redirect_uri")).toBe("https://app.example.com/cb");
     expect(body.get("code_verifier")).toBe("verifier");
     expect(body.get("code")).toBe("abc");
+  });
+
+  it("includes RFC 8707 resource parameter on the token request when provided", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+        resource: "https://api.example.com/v1/mcp",
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.get("resource")).toBe("https://api.example.com/v1/mcp");
+  });
+
+  it("omits resource parameter when not provided", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      exchangeAuthorizationCode({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        redirectUrl: "https://app.example.com/cb",
+        codeVerifier: "verifier",
+        code: "abc",
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.has("resource")).toBe(false);
   });
 
   it("omits client_secret when none is provided (public clients with PKCE)", async () => {
@@ -454,6 +500,20 @@ describe("refreshAccessToken", () => {
     );
     const body = calls[0]!.init.body as URLSearchParams;
     expect(body.has("scope")).toBe(false);
+  });
+
+  it("includes RFC 8707 resource parameter on refresh requests when provided", async () => {
+    const { calls } = captureFetch(jsonResponse(200, validBody));
+    await Effect.runPromise(
+      refreshAccessToken({
+        tokenUrl: "https://example.com/token",
+        clientId: "cid",
+        refreshToken: "old",
+        resource: "https://api.example.com/v1/mcp",
+      }),
+    );
+    const body = calls[0]!.init.body as URLSearchParams;
+    expect(body.get("resource")).toBe("https://api.example.com/v1/mcp");
   });
 
   it("strips refreshed id_tokens whose iss does not match AS metadata", async () => {

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -80,6 +80,10 @@ export type BuildAuthorizationUrlInput = {
   readonly codeChallenge: string;
   /** Separator between scopes. RFC 6749 says space; some providers use comma. */
   readonly scopeSeparator?: string;
+  /** RFC 8707 Resource Indicator. MCP Authorization 2025-06-18 §"Resource
+   *  Parameter Implementation" requires clients to send this on every
+   *  authorization request, regardless of AS support. */
+  readonly resource?: string;
   /** Provider-specific extras (e.g. Google's `access_type=offline`). */
   readonly extraParams?: Readonly<Record<string, string>>;
 };
@@ -96,6 +100,9 @@ export const buildAuthorizationUrl = (input: BuildAuthorizationUrlInput): string
   url.searchParams.set("state", input.state);
   url.searchParams.set("code_challenge_method", "S256");
   url.searchParams.set("code_challenge", input.codeChallenge);
+  if (input.resource) {
+    url.searchParams.set("resource", input.resource);
+  }
   if (input.extraParams) {
     for (const [k, v] of Object.entries(input.extraParams)) {
       url.searchParams.set(k, v);
@@ -261,6 +268,10 @@ export type ExchangeAuthorizationCodeInput = {
   readonly code: string;
   readonly clientAuth?: ClientAuthMethod;
   readonly idTokenSigningAlgValuesSupported?: readonly string[];
+  /** RFC 8707 Resource Indicator. MCP Auth spec MUST-requires this on
+   *  the token request when the client knows the resource it intends
+   *  to call. */
+  readonly resource?: string;
   readonly timeoutMs?: number;
 };
 
@@ -284,6 +295,9 @@ export const exchangeAuthorizationCode = (
         redirect_uri: input.redirectUrl,
         code_verifier: input.codeVerifier,
       });
+      if (input.resource) {
+        params.set("resource", input.resource);
+      }
       const response = await oauth.genericTokenEndpointRequest(
         as,
         client,
@@ -350,6 +364,10 @@ export type RefreshAccessTokenInput = {
   readonly scopeSeparator?: string;
   readonly clientAuth?: ClientAuthMethod;
   readonly idTokenSigningAlgValuesSupported?: readonly string[];
+  /** RFC 8707 Resource Indicator — MCP spec MUST-requires this on
+   *  refresh requests so the new access token's audience is bound to
+   *  the same resource. */
+  readonly resource?: string;
   readonly timeoutMs?: number;
 };
 
@@ -363,12 +381,15 @@ export const refreshAccessToken = (
       });
       const client: oauth.Client = { client_id: input.clientId };
       const clientAuth = pickClientAuth(input.clientSecret, input.clientAuth ?? "body");
+      const extraParams = new URLSearchParams();
+      if (input.scopes && input.scopes.length > 0) {
+        extraParams.set("scope", input.scopes.join(input.scopeSeparator ?? " "));
+      }
+      if (input.resource) {
+        extraParams.set("resource", input.resource);
+      }
       const additionalParameters =
-        input.scopes && input.scopes.length > 0
-          ? new URLSearchParams({
-              scope: input.scopes.join(input.scopeSeparator ?? " "),
-            })
-          : undefined;
+        Array.from(extraParams.keys()).length > 0 ? extraParams : undefined;
       const response = await oauth.refreshTokenGrantRequest(
         as,
         client,

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -107,6 +107,7 @@ const DynamicDcrSessionPayload = Schema.Struct({
   resourceMetadataUrl: Schema.NullOr(Schema.String),
   resourceMetadata: Schema.NullOr(Schema.Record(Schema.String, Schema.Unknown)),
   scopes: Schema.Array(Schema.String),
+  resource: Schema.NullOr(Schema.String).pipe(Schema.withDecodingDefaultType(Effect.succeed(null))),
 });
 
 const AuthorizationCodeSessionPayload = Schema.Struct({
@@ -344,9 +345,20 @@ export const makeOAuth2Service = (
           )
         : null;
 
+      // Dynamic registration is only viable when the AS advertises a
+      // registration_endpoint AND a token_endpoint_auth_method we can use
+      // (`none`, `client_secret_post`, or `client_secret_basic`). If the AS
+      // doesn't list any methods we assume `none` is acceptable per OAuth
+      // 2.1 §2.4 (server's choice).
+      const advertisedAuthMethods =
+        authServer?.metadata.token_endpoint_auth_methods_supported ?? [];
+      const hasNegotiableAuthMethod =
+        advertisedAuthMethods.length === 0 ||
+        advertisedAuthMethods.some(
+          (m) => m === "none" || m === "client_secret_post" || m === "client_secret_basic",
+        );
       const supportsDynamicRegistration = !!(
-        authServer?.metadata.registration_endpoint &&
-        (authServer.metadata.token_endpoint_auth_methods_supported ?? []).includes("none")
+        authServer?.metadata.registration_endpoint && hasNegotiableAuthMethod
       );
 
       // Bearer challenge probe — POST the endpoint unauth, look for
@@ -421,10 +433,12 @@ export const makeOAuth2Service = (
           resourceQueryParams: input.queryParams,
         },
       ).pipe(
-        Effect.catchTag("OAuthDiscoveryError", ({ message }) =>
+        Effect.catchTag("OAuthDiscoveryError", ({ message, error, errorDescription }) =>
           Effect.fail(
             new OAuthStartError({
               message: `Dynamic authorization setup failed: ${message}`,
+              error,
+              errorDescription,
             }),
           ),
         ),
@@ -444,9 +458,10 @@ export const makeOAuth2Service = (
         authorizationUrl: started.state.authorizationServerMetadata.authorization_endpoint,
         clientId: started.state.clientInformation.client_id,
         redirectUrl: input.redirectUrl,
-        scopes: strategy.scopes ?? started.state.authorizationServerMetadata.scopes_supported ?? [],
+        scopes: started.state.scopes,
         state: sessionId,
         codeChallenge,
+        resource: started.state.resource,
       });
 
       const payload: OAuthSessionPayload = {
@@ -466,9 +481,8 @@ export const makeOAuth2Service = (
         resourceMetadataUrl: started.state.resourceMetadataUrl,
         resourceMetadata:
           (started.state.resourceMetadata as Record<string, unknown> | null) ?? null,
-        scopes: [
-          ...(strategy.scopes ?? started.state.authorizationServerMetadata.scopes_supported ?? []),
-        ],
+        scopes: [...started.state.scopes],
+        resource: started.state.resource,
       };
 
       yield* writeSession({
@@ -811,6 +825,7 @@ export const makeOAuth2Service = (
                   : "body",
               scopes: [...payload.scopes],
               scope: exchangeResult.tokens.scope ?? null,
+              resource: payload.resource,
             }
           : {
               kind: "authorization-code",
@@ -922,6 +937,7 @@ export const makeOAuth2Service = (
         code,
         idTokenSigningAlgValuesSupported: md.id_token_signing_alg_values_supported,
         clientAuth: ci.token_endpoint_auth_method === "client_secret_basic" ? "basic" : "body",
+        resource: payload.resource ?? undefined,
       }).pipe(
         Effect.mapError(
           ({ message, error }: OAuth2Error) =>
@@ -1198,6 +1214,10 @@ export const makeOAuth2Service = (
                 clientAuth: state.clientAuth,
                 idTokenSigningAlgValuesSupported:
                   state.kind === "dynamic-dcr" ? state.idTokenSigningAlgValuesSupported : undefined,
+                resource:
+                  state.kind === "dynamic-dcr" || state.kind === "authorization-code"
+                    ? (state.resource ?? undefined)
+                    : undefined,
               })
         ).pipe(
           Effect.mapError(

--- a/packages/core/sdk/src/oauth.ts
+++ b/packages/core/sdk/src/oauth.ts
@@ -127,6 +127,9 @@ export const OAuthProviderState = Schema.Union([
     scopes: Schema.Array(Schema.String).pipe(Schema.withDecodingDefaultType(Effect.succeed([]))),
     scopeSeparator: Schema.optional(Schema.String),
     scope: Schema.NullOr(Schema.String),
+    /** RFC 8707 canonical resource URL. Replayed on refresh so the new
+     *  access token's audience stays bound to the same resource. */
+    resource: Schema.optional(Schema.NullOr(Schema.String)),
   }),
   Schema.Struct({
     kind: Schema.Literal("authorization-code"),
@@ -138,6 +141,7 @@ export const OAuthProviderState = Schema.Union([
     scopes: Schema.Array(Schema.String).pipe(Schema.withDecodingDefaultType(Effect.succeed([]))),
     scopeSeparator: Schema.optional(Schema.String),
     scope: Schema.NullOr(Schema.String),
+    resource: Schema.optional(Schema.NullOr(Schema.String)),
   }),
   Schema.Struct({
     kind: Schema.Literal("client-credentials"),
@@ -268,6 +272,11 @@ export class OAuthProbeError extends Schema.TaggedErrorClass<OAuthProbeError>()(
 
 export class OAuthStartError extends Schema.TaggedErrorClass<OAuthStartError>()("OAuthStartError", {
   message: Schema.String,
+  /** RFC 6749 §5.2 / RFC 7591 §3.2.2 error code propagated up from the
+   *  authorization server (e.g. `invalid_client_metadata`). UI surfaces
+   *  it as the structured "AS rejected the registration" reason. */
+  error: Schema.optional(Schema.String),
+  errorDescription: Schema.optional(Schema.String),
 }) {
   static annotations = { httpApiStatus: 400 };
 }


### PR DESCRIPTION
## Summary

Closes spec-grounded gaps surfaced by debugging two real-world MCP source-add failures (Auth0-style and Clay-style auth servers). Each item references the spec text it's grounded in.

- **MCP Auth 2025-06-18 (MUST):** Pass RFC 8707 `resource` indicator on every `/authorize` and `/token` request — including refresh — derived from PRM `resource` claim or canonicalized endpoint URL.
- **OAuth 2.1 §2.4:** Negotiate `token_endpoint_auth_method` from `token_endpoint_auth_methods_supported` instead of hardcoding `none`. Preference order: `none` > `client_secret_post` > `client_secret_basic`. Fail with a clear message when no usable method overlaps.
- **RFC 9728 §2:** Stop expanding AS-level `scopes_supported` into "request all" — the RFC explicitly says it's not meant for that. Prefer PRM `scopes_supported` (resource-scoped, authoritative) when present; otherwise request the empty set and let the AS apply its default. Callers wanting refresh tokens / specific scopes pass them explicitly.
- **RFC 7591 §2 RECOMMENDED:** Send `client_uri` (`https://executor.sh`) in the DCR body.
- **UX:** Propagate the AS's `error` + `error_description` from DCR failures up through `OAuthDiscoveryError` → `OAuthStartError` so the source-add UI can render the actionable reason instead of receiving an opaque error.
- **Probe gate:** `supportsDynamicRegistration` now reflects whether we can negotiate an auth method, not just whether the AS lists `none`.
- **Robustness:** When PRM lists multiple `authorization_servers`, try each in order rather than always picking `[0]`.

## Test plan

- [x] `canonicalResourceUrl lowercases scheme + host, drops trailing slash, fragment, and query`
- [x] `buildAuthorizationUrl includes RFC 8707 resource indicator when provided`
- [x] `buildAuthorizationUrl omits resource parameter when not provided`
- [x] `exchangeAuthorizationCode includes RFC 8707 resource parameter on the token request when provided`
- [x] `exchangeAuthorizationCode omits resource parameter when not provided`
- [x] `refreshAccessToken includes RFC 8707 resource parameter on refresh requests when provided`
- [x] `beginDynamicAuthorization declares requested scopes in the DCR body when caller passes them explicitly`
- [x] `beginDynamicAuthorization requests only PRM scopes_supported when advertised (RFC 9728 §2 limited scope)`
- [x] `beginDynamicAuthorization requests empty scope when only AS-level scopes_supported is advertised (RFC 9728 §2)`
- [x] `beginDynamicAuthorization includes RFC 8707 resource parameter on the authorization URL (PRM resource claim)`
- [x] `beginDynamicAuthorization falls back to canonical endpoint URL for the resource parameter when PRM is absent`
- [x] `beginDynamicAuthorization includes client_uri in the DCR body (RFC 7591 §2 RECOMMENDED)`
- [x] `beginDynamicAuthorization negotiates client_secret_post when the AS does not advertise 'none' (Clay-style)`
- [x] `beginDynamicAuthorization fails with a clear error when the AS advertises only auth methods we don't support`
- [x] `beginDynamicAuthorization falls through to a later authorization_servers entry when the first has no metadata`
- [x] `beginDynamicAuthorization propagates AS error code + description on DCR failure (RFC 7591 §3.2.2)`
- [x] `bun run format:check`, `bun run lint`, `bun run typecheck`, `bun run test` all green