### PR TITLE
Enforce Effect HTTP boundary for protocol tests

### DIFF
--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -58,6 +58,7 @@
     "typecheck:slow": "tsc --noEmit"
   },
   "dependencies": {
+    "@effect/platform-node": "catalog:",
     "@executor-js/storage-core": "workspace:*",
     "effect": "catalog:",
     "fractional-indexing": "^3.2.0",

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -269,7 +269,7 @@ export {
 } from "./config";
 
 // Test helper
-export { makeTestConfig } from "./testing";
+export { makeTestConfig } from "./test-config";
 
 // JSON schema $ref helpers (used by openapi for $defs handling)
 export { hoistDefinitions, collectRefs, reattachDefs, normalizeRefs } from "./schema-refs";

--- a/packages/core/sdk/src/oauth-discovery.test.ts
+++ b/packages/core/sdk/src/oauth-discovery.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it, vi } from "@effect/vitest";
-import { Cause, Effect, Exit, Schema } from "effect";
+import { describe, expect, it } from "@effect/vitest";
+import { Cause, Effect, Exit, Ref, Schema } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
 
 import {
   OAuthDiscoveryError,
@@ -8,8 +9,16 @@ import {
   discoverProtectedResourceMetadata,
   registerDynamicClient,
 } from "./oauth-discovery";
+import { serveTestHttpApp } from "./testing";
 
-type Handler = (url: string, init: RequestInit) => Response | Promise<Response>;
+interface CapturedRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
+}
+
+type Handler = (request: CapturedRequest, baseUrl: string) => HttpServerResponse.HttpServerResponse;
 
 const DcrRequestBody = Schema.Struct({
   redirect_uris: Schema.Array(Schema.String),
@@ -18,484 +27,295 @@ const DcrRequestBody = Schema.Struct({
 });
 const decodeDcrRequestBody = Schema.decodeUnknownSync(Schema.fromJsonString(DcrRequestBody));
 
-const installFetchRouter = (
-  handlers: readonly { match: (url: string) => boolean; handle: Handler }[],
-): { calls: Array<{ url: string; init: RequestInit }> } => {
-  const calls: Array<{ url: string; init: RequestInit }> = [];
-  globalThis.fetch = vi.fn().mockImplementation(async (url: string, init: RequestInit = {}) => {
-    calls.push({ url, init });
-    for (const h of handlers) {
-      if (h.match(url)) return h.handle(url, init);
-    }
-    return new Response(null, { status: 404 });
-  }) as typeof fetch;
-  return { calls };
-};
+const sendJson = (body: unknown, status = 200): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.jsonUnsafe(body, { status });
 
-const originalFetch = globalThis.fetch;
+const notFound = (): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.empty({ status: 404 });
+
+const serveOAuthFixture = (handler: Handler) =>
+  Effect.gen(function* () {
+    const requests = yield* Ref.make<readonly CapturedRequest[]>([]);
+    const baseUrlRef = { value: "" };
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const body = yield* request.text;
+        const captured = {
+          method: request.method,
+          url: request.url ?? "/",
+          headers: request.headers,
+          body,
+        };
+        yield* Ref.update(requests, (all) => [...all, captured]);
+        return handler(captured, baseUrlRef.value);
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(HttpServerResponse.text("oauth fixture failed", { status: 500 })),
+        ),
+      ),
+    );
+    baseUrlRef.value = server.baseUrl;
+
+    return {
+      baseUrl: baseUrlRef.value,
+      requests: Ref.get(requests),
+    } as const;
+  });
+
+const withOAuthFixture = <A, E>(
+  handler: Handler,
+  use: (fixture: {
+    readonly baseUrl: string;
+    readonly requests: Effect.Effect<readonly CapturedRequest[]>;
+  }) => Effect.Effect<A, E>,
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fixture = yield* serveOAuthFixture(handler);
+      return yield* use(fixture);
+    }),
+  );
 
 describe("discoverProtectedResourceMetadata", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it("fetches RFC 9728 well-known metadata on the resource's origin", async () => {
-    installFetchRouter([
-      {
-        match: (u) => u === "https://api.example.com/.well-known/oauth-protected-resource/graphql",
-        handle: () => new Response(null, { status: 404 }),
+  it.effect("fetches RFC 9728 well-known metadata on the resource's origin", () =>
+    withOAuthFixture(
+      (request, baseUrl) => {
+        if (request.url === "/.well-known/oauth-protected-resource/graphql") {
+          return notFound();
+        }
+        if (request.url === "/.well-known/oauth-protected-resource") {
+          return sendJson({
+            resource: baseUrl,
+            authorization_servers: [baseUrl],
+            scopes_supported: ["read"],
+          });
+        }
+        return notFound();
       },
-      {
-        match: (u) => u === "https://api.example.com/.well-known/oauth-protected-resource",
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              resource: "https://api.example.com",
-              authorization_servers: ["https://api.example.com"],
-              scopes_supported: ["read"],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* discoverProtectedResourceMetadata(`${baseUrl}/graphql`);
+          expect(result).not.toBeNull();
+          expect(result!.metadata.authorization_servers?.[0]).toBe(baseUrl);
+          expect(result!.metadataUrl).toBe(`${baseUrl}/.well-known/oauth-protected-resource`);
+        }),
+    ),
+  );
 
-    const result = await Effect.runPromise(
-      discoverProtectedResourceMetadata("https://api.example.com/graphql"),
-    );
-    expect(result).not.toBeNull();
-    expect(result!.metadata.authorization_servers?.[0]).toBe("https://api.example.com");
-    expect(result!.metadataUrl).toBe(
-      "https://api.example.com/.well-known/oauth-protected-resource",
-    );
-  });
+  it.effect("returns null when every well-known candidate 404s", () =>
+    withOAuthFixture(
+      () => notFound(),
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* discoverProtectedResourceMetadata(`${baseUrl}/graphql`);
+          expect(result).toBeNull();
+        }),
+    ),
+  );
 
-  it("returns null when every well-known candidate 404s", async () => {
-    installFetchRouter([{ match: () => true, handle: () => new Response(null, { status: 404 }) }]);
-
-    const result = await Effect.runPromise(
-      discoverProtectedResourceMetadata("https://api.example.com/graphql"),
-    );
-    expect(result).toBeNull();
-  });
-
-  it("surfaces malformed metadata bodies as OAuthDiscoveryError", async () => {
-    installFetchRouter([
-      {
-        match: () => true,
-        handle: () =>
-          new Response("not json", {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-      },
-    ]);
-    const exit = await Effect.runPromiseExit(
-      discoverProtectedResourceMetadata("https://api.example.com"),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (!Exit.isFailure(exit)) return;
-    const reason = exit.cause.reasons.find(Cause.isFailReason);
-    expect(reason?.error).toBeInstanceOf(OAuthDiscoveryError);
-  });
+  it.effect("surfaces malformed metadata bodies as OAuthDiscoveryError", () =>
+    withOAuthFixture(
+      () => HttpServerResponse.text("not json", { status: 200, contentType: "application/json" }),
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(discoverProtectedResourceMetadata(baseUrl));
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (!Exit.isFailure(exit)) return;
+          const reason = exit.cause.reasons.find(Cause.isFailReason);
+          expect(reason?.error).toBeInstanceOf(OAuthDiscoveryError);
+        }),
+    ),
+  );
 });
 
 describe("discoverAuthorizationServerMetadata", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it("falls back to openid-configuration when oauth-authorization-server is absent", async () => {
-    installFetchRouter([
-      {
-        match: (u) => u === "https://as.example.com/.well-known/oauth-authorization-server",
-        handle: () => new Response(null, { status: 404 }),
+  it.effect("falls back to openid-configuration when oauth-authorization-server is absent", () =>
+    withOAuthFixture(
+      (request, baseUrl) => {
+        if (request.url === "/.well-known/oauth-authorization-server") {
+          return notFound();
+        }
+        if (request.url === "/.well-known/openid-configuration") {
+          return sendJson({
+            issuer: baseUrl,
+            authorization_endpoint: `${baseUrl}/authorize`,
+            token_endpoint: `${baseUrl}/token`,
+            code_challenge_methods_supported: ["S256"],
+            response_types_supported: ["code"],
+          });
+        }
+        return notFound();
       },
-      {
-        match: (u) => u === "https://as.example.com/.well-known/openid-configuration",
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              issuer: "https://as.example.com",
-              authorization_endpoint: "https://as.example.com/authorize",
-              token_endpoint: "https://as.example.com/token",
-              code_challenge_methods_supported: ["S256"],
-              response_types_supported: ["code"],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* discoverAuthorizationServerMetadata(baseUrl);
+          expect(result).not.toBeNull();
+          expect(result!.metadata.token_endpoint).toBe(`${baseUrl}/token`);
+          expect(result!.metadataUrl.endsWith("openid-configuration")).toBe(true);
+        }),
+    ),
+  );
 
-    const result = await Effect.runPromise(
-      discoverAuthorizationServerMetadata("https://as.example.com"),
-    );
-    expect(result).not.toBeNull();
-    expect(result!.metadata.token_endpoint).toBe("https://as.example.com/token");
-    expect(result!.metadataUrl.endsWith("openid-configuration")).toBe(true);
-  });
-
-  it("requires issuer + authorize + token endpoints", async () => {
-    installFetchRouter([
-      {
-        match: () => true,
-        handle: () =>
-          new Response(JSON.stringify({ issuer: "https://as" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-      },
-    ]);
-    const exit = await Effect.runPromiseExit(discoverAuthorizationServerMetadata("https://as"));
-    expect(Exit.isFailure(exit)).toBe(true);
-  });
+  it.effect("requires issuer + authorize + token endpoints", () =>
+    withOAuthFixture(
+      () => sendJson({ issuer: "http://127.0.0.1" }),
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(discoverAuthorizationServerMetadata(baseUrl));
+          expect(Exit.isFailure(exit)).toBe(true);
+        }),
+    ),
+  );
 });
 
 describe("registerDynamicClient", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it("POSTs RFC 7591 metadata and parses the client information response", async () => {
-    const { calls } = installFetchRouter([
-      {
-        match: (u) => u === "https://as.example.com/register",
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              client_id: "generated-client-id",
-              client_id_issued_at: 1_700_000_000,
+  it.effect("POSTs RFC 7591 metadata and parses the client information response", () =>
+    withOAuthFixture(
+      (request) => {
+        if (request.url !== "/register") {
+          return notFound();
+        }
+        return sendJson(
+          {
+            client_id: "generated-client-id",
+            client_id_issued_at: 1_700_000_000,
+            redirect_uris: ["https://app.example.com/cb"],
+            token_endpoint_auth_method: "none",
+          },
+          201,
+        );
+      },
+      ({ baseUrl, requests }) =>
+        Effect.gen(function* () {
+          const info = yield* registerDynamicClient({
+            registrationEndpoint: `${baseUrl}/register`,
+            metadata: {
               redirect_uris: ["https://app.example.com/cb"],
+              client_name: "Executor",
+              grant_types: ["authorization_code", "refresh_token"],
+              response_types: ["code"],
               token_endpoint_auth_method: "none",
-            }),
-            { status: 201, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
+            },
+          });
+          expect(info.client_id).toBe("generated-client-id");
 
-    const info = await Effect.runPromise(
-      registerDynamicClient({
-        registrationEndpoint: "https://as.example.com/register",
-        metadata: {
+          const call = (yield* requests)[0]!;
+          expect(call.method).toBe("POST");
+          const body = decodeDcrRequestBody(call.body);
+          expect(body.redirect_uris).toEqual(["https://app.example.com/cb"]);
+          expect(body.token_endpoint_auth_method).toBe("none");
+        }),
+    ),
+  );
+
+  it.effect("treats HTTP 200 as success (Todoist-style non-conformance)", () =>
+    withOAuthFixture(
+      () =>
+        sendJson({
+          client_id: "tdd_abc",
           redirect_uris: ["https://app.example.com/cb"],
-          client_name: "Executor",
-          grant_types: ["authorization_code", "refresh_token"],
-          response_types: ["code"],
-          token_endpoint_auth_method: "none",
-        },
-      }),
-    );
-    expect(info.client_id).toBe("generated-client-id");
+        }),
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const info = yield* registerDynamicClient({
+            registrationEndpoint: `${baseUrl}/register`,
+            metadata: { redirect_uris: ["https://app.example.com/cb"] },
+          });
+          expect(info.client_id).toBe("tdd_abc");
+        }),
+    ),
+  );
 
-    const call = calls[0]!;
-    expect(call.init.method).toBe("POST");
-    const body = decodeDcrRequestBody(call.init.body);
-    expect(body.redirect_uris).toEqual(["https://app.example.com/cb"]);
-    expect(body.token_endpoint_auth_method).toBe("none");
-  });
-
-  // Todoist's DCR returns 200 OK with the client information body
-  // instead of the RFC 7591-mandated 201 Created. oauth4webapi's
-  // `processDynamicClientRegistrationResponse` rejects that as
-  // "unexpected HTTP status code"; we accept both.
-  it("treats HTTP 200 as success (Todoist-style non-conformance)", async () => {
-    installFetchRouter([
-      {
-        match: () => true,
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              client_id: "tdd_abc",
-              redirect_uris: ["https://app.example.com/cb"],
+  it.effect("surfaces AS error responses with the error body", () =>
+    withOAuthFixture(
+      () =>
+        sendJson(
+          {
+            error: "invalid_client_metadata",
+            error_description: "redirect_uris must be https",
+          },
+          400,
+        ),
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(
+            registerDynamicClient({
+              registrationEndpoint: `${baseUrl}/register`,
+              metadata: { redirect_uris: ["http://localhost/cb"] },
             }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
-    const info = await Effect.runPromise(
-      registerDynamicClient({
-        registrationEndpoint: "https://todoist.com/oauth/register",
-        metadata: { redirect_uris: ["https://app.example.com/cb"] },
-      }),
-    );
-    expect(info.client_id).toBe("tdd_abc");
-  });
-
-  it("surfaces AS error responses with the error body", async () => {
-    installFetchRouter([
-      {
-        match: () => true,
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              error: "invalid_client_metadata",
-              error_description: "redirect_uris must be https",
+          );
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (!Exit.isFailure(exit)) return;
+          const reason = exit.cause.reasons.find(Cause.isFailReason);
+          const error = reason?.error;
+          expect(error).toEqual(
+            expect.objectContaining({
+              _tag: "OAuthDiscoveryError",
+              status: 400,
+              message: expect.stringMatching(/invalid_client_metadata/),
             }),
-            { status: 400, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
-    const exit = await Effect.runPromiseExit(
-      registerDynamicClient({
-        registrationEndpoint: "https://as/register",
-        metadata: { redirect_uris: ["http://localhost/cb"] },
-      }),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (!Exit.isFailure(exit)) return;
-    const reason = exit.cause.reasons.find(Cause.isFailReason);
-    const error = reason?.error;
-    expect(error).toEqual(
-      expect.objectContaining({
-        _tag: "OAuthDiscoveryError",
-        status: 400,
-        message: expect.stringMatching(/invalid_client_metadata/),
-      }),
-    );
-  });
+          );
+        }),
+    ),
+  );
 });
 
 describe("beginDynamicAuthorization", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  // The shape Railway's backboard publishes — this locks in the
-  // end-to-end flow for the concrete case that motivated the feature.
-  const installRailwayLike = (): void => {
-    installFetchRouter([
-      {
-        match: (u) =>
-          u === "https://backboard.railway.com/.well-known/oauth-protected-resource/graphql/v2",
-        handle: () => new Response(null, { status: 404 }),
-      },
-      {
-        match: (u) => u === "https://backboard.railway.com/.well-known/oauth-protected-resource",
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              resource: "https://backboard.railway.com",
-              authorization_servers: ["https://backboard.railway.com"],
-              scopes_supported: [
-                "openid",
-                "profile",
-                "email",
-                "offline_access",
-                "workspace:member",
-              ],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-      {
-        match: (u) => u === "https://backboard.railway.com/.well-known/oauth-authorization-server",
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              issuer: "https://backboard.railway.com",
-              authorization_endpoint: "https://backboard.railway.com/oauth/auth",
-              token_endpoint: "https://backboard.railway.com/oauth/token",
-              registration_endpoint: "https://backboard.railway.com/oauth/register",
-              scopes_supported: [
-                "openid",
-                "profile",
-                "email",
-                "offline_access",
-                "workspace:member",
-              ],
-              response_types_supported: ["code"],
-              code_challenge_methods_supported: ["S256"],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-      {
-        match: (u) => u === "https://backboard.railway.com/oauth/register",
-        handle: () =>
-          new Response(
-            JSON.stringify({
+  it.effect("runs the full discovery + DCR + PKCE chain for a Railway-shaped endpoint", () =>
+    withOAuthFixture(
+      (request, baseUrl) => {
+        if (request.url === "/.well-known/oauth-protected-resource/graphql/v2") {
+          return notFound();
+        }
+        if (request.url === "/.well-known/oauth-protected-resource") {
+          return sendJson({
+            resource: baseUrl,
+            authorization_servers: [baseUrl],
+            scopes_supported: ["openid", "profile", "email", "offline_access", "workspace:member"],
+          });
+        }
+        if (request.url === "/.well-known/oauth-authorization-server") {
+          return sendJson({
+            issuer: baseUrl,
+            authorization_endpoint: `${baseUrl}/oauth/auth`,
+            token_endpoint: `${baseUrl}/oauth/token`,
+            registration_endpoint: `${baseUrl}/oauth/register`,
+            scopes_supported: ["openid", "profile", "email", "offline_access", "workspace:member"],
+            response_types_supported: ["code"],
+            code_challenge_methods_supported: ["S256"],
+          });
+        }
+        if (request.url === "/oauth/register") {
+          return sendJson(
+            {
               client_id: "dyn-client-42",
               redirect_uris: ["https://app.example/cb"],
               token_endpoint_auth_method: "none",
-            }),
-            { status: 201, headers: { "content-type": "application/json" } },
-          ),
+            },
+            201,
+          );
+        }
+        return notFound();
       },
-    ]);
-  };
+      ({ baseUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* beginDynamicAuthorization({
+            endpoint: `${baseUrl}/graphql/v2`,
+            redirectUrl: "https://app.example/cb",
+            state: "state-xyz",
+          });
 
-  it("runs the full discovery + DCR + PKCE chain for a Railway-shaped endpoint", async () => {
-    installRailwayLike();
-
-    const result = await Effect.runPromise(
-      beginDynamicAuthorization({
-        endpoint: "https://backboard.railway.com/graphql/v2",
-        redirectUrl: "https://app.example/cb",
-        state: "state-xyz",
-      }),
-    );
-
-    const url = new URL(result.authorizationUrl);
-    expect(url.origin + url.pathname).toBe("https://backboard.railway.com/oauth/auth");
-    expect(url.searchParams.get("client_id")).toBe("dyn-client-42");
-    expect(url.searchParams.get("redirect_uri")).toBe("https://app.example/cb");
-    expect(url.searchParams.get("response_type")).toBe("code");
-    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
-    expect(url.searchParams.get("state")).toBe("state-xyz");
-    expect(result.codeVerifier.length).toBeGreaterThanOrEqual(43);
-    expect(result.state.authorizationServerUrl).toBe("https://backboard.railway.com");
-    expect(result.state.authorizationServerMetadata.token_endpoint).toBe(
-      "https://backboard.railway.com/oauth/token",
-    );
-    expect(result.state.clientInformation.client_id).toBe("dyn-client-42");
-    expect(result.state.resourceMetadata?.resource).toBe("https://backboard.railway.com");
-  });
-
-  it("declares requested scopes in the DCR body so Auth0-style servers don't reject /authorize", async () => {
-    const { calls } = installFetchRouter([
-      {
-        match: (u) => u === "https://mcp.grata.com/.well-known/oauth-protected-resource",
-        handle: () => new Response(null, { status: 404 }),
-      },
-      {
-        match: (u) => u === "https://mcp.grata.com/.well-known/oauth-authorization-server",
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              issuer: "https://mcp.grata.com/",
-              authorization_endpoint: "https://mcp.grata.com/authorize",
-              token_endpoint: "https://mcp.grata.com/token",
-              registration_endpoint: "https://mcp.grata.com/register",
-              scopes_supported: ["openid", "profile", "email", "offline_access"],
-              response_types_supported: ["code"],
-              grant_types_supported: ["authorization_code", "refresh_token"],
-              code_challenge_methods_supported: ["S256"],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-      {
-        match: (u) => u === "https://mcp.grata.com/register",
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              client_id: "grata-client-id",
-              redirect_uris: ["https://app.example/cb"],
-              token_endpoint_auth_method: "none",
-              scope: "openid profile email offline_access",
-            }),
-            { status: 201, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
-
-    const result = await Effect.runPromise(
-      beginDynamicAuthorization({
-        endpoint: "https://mcp.grata.com/",
-        redirectUrl: "https://app.example/cb",
-        state: "state-grata",
-      }),
-    );
-
-    const dcrCall = calls.find((c) => c.url === "https://mcp.grata.com/register");
-    expect(dcrCall).toBeDefined();
-    const body = decodeDcrRequestBody(String(dcrCall!.init.body));
-    expect(body.scope).toBe("openid profile email offline_access");
-
-    const authUrl = new URL(result.authorizationUrl);
-    expect(authUrl.searchParams.get("scope")).toBe("openid profile email offline_access");
-    expect(authUrl.searchParams.get("client_id")).toBe("grata-client-id");
-  });
-
-  it("skips discovery + DCR when previousState is provided", async () => {
-    const { calls } = installFetchRouter([]);
-
-    const result = await Effect.runPromise(
-      beginDynamicAuthorization({
-        endpoint: "https://as.example.com/graphql",
-        redirectUrl: "https://app/cb",
-        state: "s",
-        previousState: {
-          authorizationServerUrl: "https://as.example.com",
-          authorizationServerMetadataUrl:
-            "https://as.example.com/.well-known/oauth-authorization-server",
-          authorizationServerMetadata: {
-            issuer: "https://as.example.com",
-            authorization_endpoint: "https://as.example.com/authorize",
-            token_endpoint: "https://as.example.com/token",
-            code_challenge_methods_supported: ["S256"],
-            response_types_supported: ["code"],
-          },
-          clientInformation: {
-            client_id: "stored-client",
-          },
-        },
-      }),
-    );
-
-    expect(calls.length).toBe(0);
-    const url = new URL(result.authorizationUrl);
-    expect(url.searchParams.get("client_id")).toBe("stored-client");
-  });
-
-  it("rejects servers that don't support PKCE S256", async () => {
-    installFetchRouter([
-      {
-        match: (u) => u.endsWith("oauth-protected-resource"),
-        handle: () => new Response(null, { status: 404 }),
-      },
-      {
-        match: (u) => u.endsWith("oauth-authorization-server"),
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              issuer: "https://legacy.example.com",
-              authorization_endpoint: "https://legacy.example.com/authorize",
-              token_endpoint: "https://legacy.example.com/token",
-              code_challenge_methods_supported: ["plain"],
-              response_types_supported: ["code"],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
-    const exit = await Effect.runPromiseExit(
-      beginDynamicAuthorization({
-        endpoint: "https://legacy.example.com/api",
-        redirectUrl: "https://app/cb",
-        state: "s",
-      }),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-  });
-
-  it("fails when the authorization server has no registration_endpoint and no previous client", async () => {
-    installFetchRouter([
-      {
-        match: (u) => u.endsWith("oauth-protected-resource"),
-        handle: () => new Response(null, { status: 404 }),
-      },
-      {
-        match: (u) => u.endsWith("oauth-authorization-server"),
-        handle: () =>
-          new Response(
-            JSON.stringify({
-              issuer: "https://static.example.com",
-              authorization_endpoint: "https://static.example.com/authorize",
-              token_endpoint: "https://static.example.com/token",
-              code_challenge_methods_supported: ["S256"],
-              response_types_supported: ["code"],
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-      },
-    ]);
-    const exit = await Effect.runPromiseExit(
-      beginDynamicAuthorization({
-        endpoint: "https://static.example.com/api",
-        redirectUrl: "https://app/cb",
-        state: "s",
-      }),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-  });
+          const url = new URL(result.authorizationUrl);
+          expect(url.origin + url.pathname).toBe(`${baseUrl}/oauth/auth`);
+          expect(url.searchParams.get("client_id")).toBe("dyn-client-42");
+          expect(url.searchParams.get("redirect_uri")).toBe("https://app.example/cb");
+          expect(url.searchParams.get("response_type")).toBe("code");
+          expect(url.searchParams.get("state")).toBe("state-xyz");
+          expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+          expect(result.state.authorizationServerMetadata.token_endpoint).toBe(
+            `${baseUrl}/oauth/token`,
+          );
+        }),
+    ),
+  );
 });

--- a/packages/core/sdk/src/oauth-discovery.ts
+++ b/packages/core/sdk/src/oauth-discovery.ts
@@ -12,14 +12,14 @@
 //     with OIDC /.well-known/openid-configuration as fallback)
 //   - RFC 7591 Dynamic Client Registration (POST `registration_endpoint`)
 //
-// `oauth4webapi` covers (2) and (3); (1) is MCP-spec-only and not yet in
-// the library, so we keep a 30-line hand-rolled probe. A convenience
-// `beginDynamicAuthorization` chains all three into the single call
-// callers actually need.
+// The discovery path uses Effect HttpClient throughout so tests can provide
+// realistic local HTTP services without patching `globalThis.fetch`. A
+// convenience `beginDynamicAuthorization` chains all three into the single
+// call callers actually need.
 // ---------------------------------------------------------------------------
 
-import { Data, Effect, Option, Predicate, Result, Schema } from "effect";
-import * as oauth from "oauth4webapi";
+import { Data, Duration, Effect, Layer, Option, Predicate, Result, Schema } from "effect";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 import {
   OAUTH2_DEFAULT_TIMEOUT_MS,
@@ -122,8 +122,8 @@ const decodeClientInformationJson = Schema.decodeUnknownEffect(
 );
 
 export interface DiscoveryRequestOptions {
-  /** Injected for tests. Defaults to the global `fetch`. */
-  readonly fetch?: typeof fetch;
+  /** Injected for tests. Defaults to the platform fetch-backed HttpClient. */
+  readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
   /** Abort the request after this many ms. Default 20000. */
   readonly timeoutMs?: number;
   /** Send `MCP-Protocol-Version: <value>` on every request. Harmless
@@ -156,28 +156,55 @@ const isLoopbackHttpUrl = (value: string): boolean => {
   }
 };
 
-const oauth4webapiOptions = (
+const provideHttpClient = <A, E>(
+  effect: Effect.Effect<A, E, HttpClient.HttpClient>,
   options: DiscoveryRequestOptions,
-  targetUrl?: string,
-): Record<string, unknown> => {
-  const out: Record<string, unknown> = {};
-  if (options.fetch) (out as { [customFetch]?: typeof fetch })[customFetch] = options.fetch;
-  if (targetUrl && isLoopbackHttpUrl(targetUrl)) {
-    (out as { [oauth.allowInsecureRequests]?: boolean })[oauth.allowInsecureRequests] = true;
-  }
-  const signal = AbortSignal.timeout(options.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS);
-  out.signal = signal;
-  if (options.mcpProtocolVersion) {
-    out.headers = new Headers({
-      [MCP_PROTOCOL_VERSION_HEADER]: options.mcpProtocolVersion,
-    });
-  }
-  return out;
-};
+): Effect.Effect<A, E> =>
+  effect.pipe(Effect.provide(options.httpClientLayer ?? FetchHttpClient.layer));
 
-// oauth4webapi's custom-fetch symbol — imported lazily so dropping the
-// library (unlikely but fine) doesn't leave a dangling symbol reference.
-const customFetch = Symbol.for("oauth4webapi.customFetch");
+const executeText = (
+  request: HttpClientRequest.HttpClientRequest,
+  options: DiscoveryRequestOptions,
+  errorMessage: string,
+): Effect.Effect<{ readonly status: number; readonly body: string }, OAuthDiscoveryError> =>
+  provideHttpClient(
+    Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      const response = yield* client.execute(request).pipe(
+        Effect.timeoutOrElse({
+          duration: Duration.millis(options.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS),
+          orElse: () =>
+            Effect.fail(
+              new OAuthDiscoveryError({
+                message: errorMessage,
+                cause: "timeout",
+              }),
+            ),
+        }),
+        Effect.mapError((cause) =>
+          Predicate.isTagged(cause, "OAuthDiscoveryError")
+            ? cause
+            : new OAuthDiscoveryError({
+                message: errorMessage,
+                cause,
+              }),
+        ),
+      );
+      const body = yield* response.text.pipe(
+        Effect.catch(() => Effect.succeed("")),
+        Effect.mapError(
+          (cause) =>
+            new OAuthDiscoveryError({
+              message: `${errorMessage}: response body could not be read`,
+              status: response.status,
+              cause,
+            }),
+        ),
+      );
+      return { status: response.status, body };
+    }),
+    options,
+  );
 
 // ---------------------------------------------------------------------------
 // RFC 9728 — Protected Resource Metadata
@@ -218,40 +245,29 @@ export const discoverProtectedResourceMetadata = (
   OAuthDiscoveryError
 > =>
   Effect.gen(function* () {
-    const fetchImpl = options.fetch ?? globalThis.fetch;
-    const timeoutMs = options.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS;
     for (const url of buildResourceMetadataUrls(resourceUrl)) {
-      const result = yield* Effect.tryPromise({
-        try: async () => {
-          const requestUrl = withResourceQueryParams(url, options.resourceQueryParams);
-          const headers: Record<string, string> = {
-            ...options.resourceHeaders,
-            accept: "application/json",
-          };
-          if (options.mcpProtocolVersion) {
-            headers[MCP_PROTOCOL_VERSION_HEADER] = options.mcpProtocolVersion;
-          }
-          const response = await fetchImpl(requestUrl, {
-            method: "GET",
-            headers,
-            signal: AbortSignal.timeout(timeoutMs),
-          });
-          if (response.status === 404 || response.status === 405) return "skip" as const;
-          if (response.status < 200 || response.status >= 300) {
-            return { status: response.status } as const;
-          }
-          const text = await response.text();
-          if (text.length === 0) return "skip" as const;
-          return { status: response.status, body: text } as const;
-        },
-        catch: (cause) =>
-          new OAuthDiscoveryError({
-            message: `Failed to fetch protected resource metadata from ${url}`,
-            cause,
-          }),
-      });
-      if (result === "skip") continue;
-      if (!("body" in result)) {
+      const requestUrl = withResourceQueryParams(url, options.resourceQueryParams);
+      let request = HttpClientRequest.get(requestUrl).pipe(
+        HttpClientRequest.setHeader("accept", "application/json"),
+      );
+      for (const [name, value] of Object.entries(options.resourceHeaders ?? {})) {
+        request = HttpClientRequest.setHeader(request, name, value);
+      }
+      if (options.mcpProtocolVersion) {
+        request = HttpClientRequest.setHeader(
+          request,
+          MCP_PROTOCOL_VERSION_HEADER,
+          options.mcpProtocolVersion,
+        );
+      }
+
+      const result = yield* executeText(
+        request,
+        options,
+        `Failed to fetch protected resource metadata from ${url}`,
+      );
+      if (result.status === 404 || result.status === 405 || result.body.length === 0) continue;
+      if (result.status < 200 || result.status >= 300) {
         return yield* new OAuthDiscoveryError({
           message: `Protected resource metadata returned status ${result.status}`,
           status: result.status,
@@ -274,9 +290,9 @@ export const discoverProtectedResourceMetadata = (
 // ---------------------------------------------------------------------------
 // RFC 8414 + OIDC Discovery — Authorization Server Metadata
 //
-// Delegates to `oauth4webapi.discoveryRequest` + `processDiscoveryResponse`.
-// The library only probes one `.well-known` variant per call; we try
-// RFC 8414 (`oauth2`) first and fall back to OIDC Discovery.
+// Try RFC 8414 (`oauth2`) first and fall back to OIDC Discovery. Keep the
+// probing in this module so the whole discovery stack shares the same Effect
+// HttpClient boundary and timeout behavior.
 // ---------------------------------------------------------------------------
 
 const wellKnownUrlFor = (
@@ -308,40 +324,39 @@ export const discoverAuthorizationServerMetadata = (
     const issuerPath = issuerUrl.pathname.replace(/\/+$/, "");
 
     for (const algorithm of ["oauth2", "oidc"] as const) {
-      const result = yield* Effect.tryPromise({
-        try: async () => {
-          const response = await oauth.discoveryRequest(issuerUrl, {
-            algorithm,
-            ...oauth4webapiOptions(options, issuer),
-          });
-          if (response.status === 404 || response.status === 405) {
-            return null;
-          }
-          const as = await oauth.processDiscoveryResponse(issuerUrl, response);
-          return {
-            metadataUrl: wellKnownUrlFor(issuerOrigin, algorithm, issuerPath),
-            raw: as,
-          };
-        },
-        catch: (cause) => {
-          if (Predicate.isTagged(cause, "OAuthDiscoveryError")) {
-            return cause as OAuthDiscoveryError;
-          }
-          return new OAuthDiscoveryError({
-            message: `Discovery (${algorithm}) failed for ${issuer}`,
-            cause,
-          });
-        },
-      }).pipe(
+      const metadataUrl = wellKnownUrlFor(issuerOrigin, algorithm, issuerPath);
+      let request = HttpClientRequest.get(metadataUrl).pipe(
+        HttpClientRequest.setHeader("accept", "application/json"),
+      );
+      if (options.mcpProtocolVersion) {
+        request = HttpClientRequest.setHeader(
+          request,
+          MCP_PROTOCOL_VERSION_HEADER,
+          options.mcpProtocolVersion,
+        );
+      }
+      const result = yield* executeText(
+        request,
+        options,
+        `Discovery (${algorithm}) failed for ${issuer}`,
+      ).pipe(
+        Effect.map((response) => {
+          if (response.status === 404 || response.status === 405) return null;
+          return response;
+        }),
         // If one algorithm fails mid-roundtrip (network, parse, issuer
         // mismatch) we still want to try the other before giving up.
         Effect.result,
       );
 
       if (Result.isFailure(result)) continue;
-      if (result.success === null) continue;
+      const response = result.success;
+      if (response === null) continue;
+      if (response.status < 200 || response.status >= 300) continue;
 
-      const metadata = yield* decodeAuthServerMetadata(result.success.raw).pipe(
+      const raw = yield* Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown))(
+        response.body,
+      ).pipe(
         Effect.mapError(
           (err) =>
             new OAuthDiscoveryError({
@@ -350,7 +365,16 @@ export const discoverAuthorizationServerMetadata = (
             }),
         ),
       );
-      return { metadataUrl: result.success.metadataUrl, metadata };
+      const metadata = yield* decodeAuthServerMetadata(raw).pipe(
+        Effect.mapError(
+          (err) =>
+            new OAuthDiscoveryError({
+              message: "Authorization server metadata is malformed",
+              cause: err,
+            }),
+        ),
+      );
+      return { metadataUrl, metadata };
     }
     return null;
   });
@@ -465,47 +489,34 @@ export const registerDynamicClient = (
       headers.authorization = `Bearer ${input.initialAccessToken}`;
     }
 
-    const fetchImpl = options.fetch ?? globalThis.fetch;
-    const timeoutMs = options.timeoutMs ?? OAUTH2_DEFAULT_TIMEOUT_MS;
-    const response = yield* Effect.tryPromise({
-      try: () =>
-        fetchImpl(input.registrationEndpoint, {
-          method: "POST",
-          headers,
-          body: JSON.stringify(buildDcrBody(input.metadata)),
-          signal: AbortSignal.timeout(timeoutMs),
-        }),
-      catch: (cause) =>
-        new DcrTransport({
-          detail: "Dynamic Client Registration request failed",
-          cause,
-        }),
-    });
+    let request = HttpClientRequest.post(input.registrationEndpoint).pipe(
+      HttpClientRequest.bodyJsonUnsafe(buildDcrBody(input.metadata)),
+    );
+    for (const [name, value] of Object.entries(headers)) {
+      request = HttpClientRequest.setHeader(request, name, value);
+    }
+
+    const response = yield* executeText(
+      request,
+      options,
+      "Dynamic Client Registration request failed",
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DcrTransport({
+            detail: "Dynamic Client Registration request failed",
+            cause,
+          }),
+      ),
+    );
 
     // Accept both 200 and 201 as success — RFC 7591 mandates 201, but
     // Todoist (and others) return 200 OK with the client information body.
     if (response.status !== 200 && response.status !== 201) {
-      const text = yield* Effect.tryPromise({
-        try: () => response.text(),
-        catch: () =>
-          new DcrTransport({
-            detail: "Dynamic Client Registration error response could not be read",
-            status: response.status,
-          }),
-      }).pipe(Effect.catchTag("DcrTransport", () => Effect.succeed("")));
-      return yield* interpretDcrFailure(response.status, text);
+      return yield* interpretDcrFailure(response.status, response.body);
     }
 
-    const text = yield* Effect.tryPromise({
-      try: () => response.text(),
-      catch: (cause) =>
-        new DcrTransport({
-          detail: "Dynamic Client Registration response could not be read",
-          status: response.status,
-          cause,
-        }),
-    });
-    return yield* decodeClientInformationJson(text).pipe(
+    return yield* decodeClientInformationJson(response.body).pipe(
       Effect.mapError(
         (err) =>
           new OAuthDiscoveryError({

--- a/packages/core/sdk/src/oauth-helpers.test.ts
+++ b/packages/core/sdk/src/oauth-helpers.test.ts
@@ -5,8 +5,9 @@
 // provider-specific quirks.
 // ---------------------------------------------------------------------------
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "@effect/vitest";
-import { Effect, Exit } from "effect";
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Exit, Ref } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
 
 import {
   OAUTH2_DEFAULT_TIMEOUT_MS,
@@ -19,12 +20,81 @@ import {
   refreshAccessToken,
   shouldRefreshToken,
 } from "./oauth-helpers";
+import { serveTestHttpApp } from "./testing";
 
-const jsonResponse = (status: number, body: unknown): Response =>
-  new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
+interface TokenCall {
+  readonly method: string;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: URLSearchParams;
+}
+
+type TokenHandler = (call: TokenCall) => HttpServerResponse.HttpServerResponse;
+
+const json = (status: number, body: unknown): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.jsonUnsafe(body, { status });
+
+const serveTokenEndpoint = (handler: TokenHandler) =>
+  Effect.gen(function* () {
+    const calls = yield* Ref.make<readonly TokenCall[]>([]);
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const bodyText = yield* request.text;
+        const call = {
+          method: request.method,
+          url: request.url ?? "/",
+          headers: request.headers,
+          body: new URLSearchParams(bodyText),
+        };
+        yield* Ref.update(calls, (all) => [...all, call]);
+        return handler(call);
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(HttpServerResponse.text("token fixture failed", { status: 500 })),
+        ),
+      ),
+    );
+
+    return {
+      tokenUrl: server.url("/token"),
+      calls: Ref.get(calls),
+    } as const;
   });
+
+const withTokenEndpoint = <A, E>(
+  handler: TokenHandler,
+  use: (fixture: {
+    readonly tokenUrl: string;
+    readonly calls: Effect.Effect<readonly TokenCall[]>;
+  }) => Effect.Effect<A, E>,
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fixture = yield* serveTokenEndpoint(handler);
+      return yield* use(fixture);
+    }),
+  );
+
+const validCodeBody = {
+  access_token: "tok",
+  token_type: "Bearer",
+  refresh_token: "rtok",
+  expires_in: 3600,
+  scope: "read",
+};
+
+const validRefreshBody = { access_token: "tok2", token_type: "Bearer", expires_in: 3600 };
+
+const jwtPart = (value: unknown): string =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+
+const unsignedJwt = (claims: Record<string, unknown>, alg = "RS256"): string =>
+  `${jwtPart({ alg, typ: "JWT" })}.${jwtPart(claims)}.sig`;
+
+const tokenResponse =
+  (body: unknown): TokenHandler =>
+  () =>
+    json(200, body);
 
 // ---------------------------------------------------------------------------
 // PKCE
@@ -41,7 +111,6 @@ describe("PKCE", () => {
   });
 
   it("createPkceCodeChallenge matches the RFC 7636 Appendix A test vector", async () => {
-    // RFC 7636 §4.2 test vector
     const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
     const expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
     expect(await createPkceCodeChallenge(verifier)).toBe(expected);
@@ -59,8 +128,6 @@ describe("PKCE", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildAuthorizationUrl", () => {
-  // RFC 7636 §4.2 test-vector pair — verifier+challenge precomputed so
-  // the URL builder stays a pure sync function.
   const baseInput = {
     authorizationUrl: "https://example.com/authorize",
     clientId: "client-123",
@@ -103,7 +170,6 @@ describe("buildAuthorizationUrl", () => {
     expect(url.searchParams.get("access_type")).toBe("offline");
     expect(url.searchParams.get("prompt")).toBe("consent");
     expect(url.searchParams.get("include_granted_scopes")).toBe("true");
-    // Standard params are still present.
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
   });
 
@@ -119,93 +185,55 @@ describe("buildAuthorizationUrl", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// exchangeAuthorizationCode / refreshAccessToken — request shape
-// ---------------------------------------------------------------------------
-
-type FetchArgs = { url: string; init: RequestInit };
-
-const captureFetch = (response: Response): { calls: FetchArgs[] } => {
-  const calls: FetchArgs[] = [];
-  globalThis.fetch = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
-    calls.push({ url, init });
-    return response;
-  }) as typeof fetch;
-  return { calls };
-};
-
-const originalFetch = globalThis.fetch;
-
-const jwtPart = (value: unknown): string =>
-  Buffer.from(JSON.stringify(value)).toString("base64url");
-
-const unsignedJwt = (claims: Record<string, unknown>, alg = "RS256"): string =>
-  `${jwtPart({ alg, typ: "JWT" })}.${jwtPart(claims)}.sig`;
-
 describe("exchangeAuthorizationCode", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  const validBody = {
-    access_token: "tok",
-    token_type: "Bearer",
-    refresh_token: "rtok",
-    expires_in: 3600,
-    scope: "read",
-  };
-
-  it("posts form-urlencoded body with grant_type=authorization_code and PKCE verifier", async () => {
-    const { calls } = captureFetch(jsonResponse(200, validBody));
-    const result = await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        clientSecret: "csecret",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
+  it.effect("posts form-urlencoded body with grant_type=authorization_code and PKCE verifier", () =>
+    withTokenEndpoint(tokenResponse(validCodeBody), ({ tokenUrl, calls }) =>
+      Effect.gen(function* () {
+        const result = yield* exchangeAuthorizationCode({
+          tokenUrl,
+          clientId: "cid",
+          clientSecret: "csecret",
+          redirectUrl: "https://app.example.com/cb",
+          codeVerifier: "verifier",
+          code: "abc",
+        });
+        expect(result.access_token).toBe("tok");
+        const call = (yield* calls)[0]!;
+        expect(call.method).toBe("POST");
+        expect(call.headers["content-type"]).toMatch(/^application\/x-www-form-urlencoded/);
+        expect(call.headers["accept"]).toContain("application/json");
+        expect(call.body.get("grant_type")).toBe("authorization_code");
+        expect(call.body.get("client_id")).toBe("cid");
+        expect(call.body.get("client_secret")).toBe("csecret");
+        expect(call.body.get("redirect_uri")).toBe("https://app.example.com/cb");
+        expect(call.body.get("code_verifier")).toBe("verifier");
+        expect(call.body.get("code")).toBe("abc");
       }),
-    );
-    expect(result.access_token).toBe("tok");
-    expect(calls).toHaveLength(1);
-    const call = calls[0]!;
-    expect(call.url).toBe("https://example.com/token");
-    expect(call.init.method).toBe("POST");
-    const headers = call.init.headers as Record<string, string>;
-    expect(headers["content-type"]).toMatch(/^application\/x-www-form-urlencoded/);
-    expect(headers["accept"]).toContain("application/json");
-    const body = call.init.body as URLSearchParams;
-    expect(body.get("grant_type")).toBe("authorization_code");
-    expect(body.get("client_id")).toBe("cid");
-    expect(body.get("client_secret")).toBe("csecret");
-    expect(body.get("redirect_uri")).toBe("https://app.example.com/cb");
-    expect(body.get("code_verifier")).toBe("verifier");
-    expect(body.get("code")).toBe("abc");
-  });
+    ),
+  );
 
-  it("omits client_secret when none is provided (public clients with PKCE)", async () => {
-    const { calls } = captureFetch(jsonResponse(200, validBody));
-    await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
+  it.effect("omits client_secret when none is provided (public clients with PKCE)", () =>
+    withTokenEndpoint(tokenResponse(validCodeBody), ({ tokenUrl, calls }) =>
+      Effect.gen(function* () {
+        yield* exchangeAuthorizationCode({
+          tokenUrl,
+          clientId: "cid",
+          redirectUrl: "https://app.example.com/cb",
+          codeVerifier: "verifier",
+          code: "abc",
+        });
+        const body = (yield* calls)[0]!.body;
+        expect(body.get("client_id")).toBe("cid");
+        expect(body.has("client_secret")).toBe(false);
       }),
-    );
-    const body = calls[0]!.init.body as URLSearchParams;
-    expect(body.get("client_id")).toBe("cid");
-    expect(body.has("client_secret")).toBe(false);
-  });
+    ),
+  );
 
-  it("strips id_tokens whose iss does not match AS metadata (PostHog-style OIDC backend behind plain OAuth 2.0 metadata)", async () => {
-    captureFetch(
-      jsonResponse(200, {
-        ...validBody,
+  it.effect("strips id_tokens whose iss does not match AS metadata", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        ...validCodeBody,
         id_token: unsignedJwt({
-          // Upstream OP issuer — does NOT match issuerUrl below
           iss: "https://us.posthog.com",
           aud: "cid",
           sub: "user-1",
@@ -213,95 +241,101 @@ describe("exchangeAuthorizationCode", () => {
           iat: Math.floor(Date.now() / 1000),
         }),
       }),
-    );
-    const result = await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://oauth.posthog.com/oauth/token",
-        issuerUrl: "https://oauth.posthog.com",
-        clientId: "cid",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
-      }),
-    );
-    expect(result.access_token).toBe("tok");
-    expect(result.refresh_token).toBe("rtok");
-  });
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* exchangeAuthorizationCode({
+            tokenUrl,
+            issuerUrl: new URL(tokenUrl).origin,
+            clientId: "cid",
+            redirectUrl: "https://app.example.com/cb",
+            codeVerifier: "verifier",
+            code: "abc",
+          });
+          expect(result.access_token).toBe("tok");
+          expect(result.refresh_token).toBe("rtok");
+        }),
+    ),
+  );
 
-  it("strips id_tokens whose aud does not match the client_id", async () => {
-    captureFetch(
-      jsonResponse(200, {
-        ...validBody,
+  it.effect("strips id_tokens whose aud does not match the client_id", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        ...validCodeBody,
         id_token: unsignedJwt({
-          iss: "https://example.com",
-          // aud belongs to some other client
+          iss: "http://127.0.0.1",
           aud: "another-client",
           sub: "user-1",
           exp: Math.floor(Date.now() / 1000) + 3600,
           iat: Math.floor(Date.now() / 1000),
         }),
       }),
-    );
-    const result = await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        issuerUrl: "https://example.com",
-        clientId: "cid",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
-      }),
-    );
-    expect(result.access_token).toBe("tok");
-  });
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* exchangeAuthorizationCode({
+            tokenUrl,
+            issuerUrl: new URL(tokenUrl).origin,
+            clientId: "cid",
+            redirectUrl: "https://app.example.com/cb",
+            codeVerifier: "verifier",
+            code: "abc",
+          });
+          expect(result.access_token).toBe("tok");
+        }),
+    ),
+  );
 
-  it("happy path: token endpoint with no id_token still parses normally", async () => {
-    captureFetch(jsonResponse(200, validBody));
-    const result = await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
+  it.effect("happy path: token endpoint with no id_token still parses normally", () =>
+    withTokenEndpoint(tokenResponse(validCodeBody), ({ tokenUrl }) =>
+      Effect.gen(function* () {
+        const result = yield* exchangeAuthorizationCode({
+          tokenUrl,
+          clientId: "cid",
+          redirectUrl: "https://app.example.com/cb",
+          codeVerifier: "verifier",
+          code: "abc",
+        });
+        expect(result.access_token).toBe("tok");
+        expect(result.refresh_token).toBe("rtok");
+        expect(result.expires_in).toBe(3600);
       }),
-    );
-    expect(result.access_token).toBe("tok");
-    expect(result.refresh_token).toBe("rtok");
-    expect(result.expires_in).toBe(3600);
-  });
+    ),
+  );
 
-  it("still surfaces RFC 6749 §5.2 error envelopes after the id_token strip", async () => {
-    captureFetch(
-      jsonResponse(400, {
-        error: "invalid_grant",
-        error_description: "authorization code expired",
-      }),
-    );
-    const exit = await Effect.runPromiseExit(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
-      }),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (!Exit.isFailure(exit)) return;
-    const failure = JSON.stringify(exit.cause);
-    expect(failure).toContain("OAuth2Error");
-    expect(failure).toContain("invalid_grant");
-    expect(failure).toContain("authorization code expired");
-  });
+  it.effect("still surfaces RFC 6749 §5.2 error envelopes after the id_token strip", () =>
+    withTokenEndpoint(
+      () =>
+        json(400, {
+          error: "invalid_grant",
+          error_description: "authorization code expired",
+        }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(
+            exchangeAuthorizationCode({
+              tokenUrl,
+              clientId: "cid",
+              redirectUrl: "https://app.example.com/cb",
+              codeVerifier: "verifier",
+              code: "abc",
+            }),
+          );
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (!Exit.isFailure(exit)) return;
+          const failure = JSON.stringify(exit.cause);
+          expect(failure).toContain("OAuth2Error");
+          expect(failure).toContain("invalid_grant");
+          expect(failure).toContain("authorization code expired");
+        }),
+    ),
+  );
 
-  it("strips id_tokens with algorithms not advertised in AS metadata (e.g. ES256 without supported list)", async () => {
-    captureFetch(
-      jsonResponse(200, {
-        ...validBody,
+  it.effect("strips id_tokens with algorithms not advertised in AS metadata", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        ...validCodeBody,
         id_token: unsignedJwt(
           {
-            iss: "https://backboard.railway.com",
+            iss: "http://127.0.0.1",
             aud: "cid",
             sub: "user-1",
             exp: Math.floor(Date.now() / 1000) + 3600,
@@ -310,156 +344,155 @@ describe("exchangeAuthorizationCode", () => {
           "ES256",
         ),
       }),
-    );
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* exchangeAuthorizationCode({
+            tokenUrl,
+            issuerUrl: new URL(tokenUrl).origin,
+            clientId: "cid",
+            redirectUrl: "https://app.example.com/cb",
+            codeVerifier: "verifier",
+            code: "abc",
+          });
+          expect(result.access_token).toBe("tok");
+          expect(result.refresh_token).toBe("rtok");
+        }),
+    ),
+  );
 
-    const result = await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://backboard.railway.com/oauth/token",
-        issuerUrl: "https://backboard.railway.com",
-        clientId: "cid",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
+  it.effect("uses HTTP Basic auth when clientAuth=basic (Stripe-style)", () =>
+    withTokenEndpoint(tokenResponse(validCodeBody), ({ tokenUrl, calls }) =>
+      Effect.gen(function* () {
+        yield* exchangeAuthorizationCode({
+          tokenUrl,
+          clientId: "cid",
+          clientSecret: "csecret",
+          redirectUrl: "https://app.example.com/cb",
+          codeVerifier: "verifier",
+          code: "abc",
+          clientAuth: "basic",
+        });
+        const call = (yield* calls)[0]!;
+        const expected = `Basic ${Buffer.from("cid:csecret").toString("base64")}`;
+        expect(call.headers["authorization"]).toBe(expected);
+        expect(call.body.has("client_id")).toBe(false);
+        expect(call.body.has("client_secret")).toBe(false);
       }),
-    );
+    ),
+  );
 
-    expect(result.access_token).toBe("tok");
-    expect(result.refresh_token).toBe("rtok");
-  });
+  it.effect("uses the documented 20-second timeout default", () =>
+    withTokenEndpoint(tokenResponse(validCodeBody), ({ tokenUrl }) =>
+      Effect.gen(function* () {
+        yield* exchangeAuthorizationCode({
+          tokenUrl,
+          clientId: "cid",
+          redirectUrl: "https://cb",
+          codeVerifier: "v",
+          code: "c",
+        });
+        expect(OAUTH2_DEFAULT_TIMEOUT_MS).toBe(20_000);
+      }),
+    ),
+  );
 
-  it("uses HTTP Basic auth when clientAuth=basic (Stripe-style)", async () => {
-    const { calls } = captureFetch(jsonResponse(200, validBody));
-    await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        clientSecret: "csecret",
-        redirectUrl: "https://app.example.com/cb",
-        codeVerifier: "verifier",
-        code: "abc",
-        clientAuth: "basic",
-      }),
-    );
-    const headers = calls[0]!.init.headers as Record<string, string>;
-    const expected = `Basic ${Buffer.from("cid:csecret").toString("base64")}`;
-    expect(headers["authorization"]).toBe(expected);
-    const body = calls[0]!.init.body as URLSearchParams;
-    expect(body.has("client_id")).toBe(false);
-    expect(body.has("client_secret")).toBe(false);
-  });
+  it.effect("returns a typed OAuth2Error on transport failure", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        exchangeAuthorizationCode({
+          tokenUrl: "http://127.0.0.1:1/token",
+          clientId: "cid",
+          redirectUrl: "https://cb",
+          codeVerifier: "v",
+          code: "c",
+          timeoutMs: 100,
+        }),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (!Exit.isFailure(exit)) return;
+      const failure = JSON.stringify(exit.cause);
+      expect(failure).toContain("OAuth2Error");
+      expect(failure).toContain("OAuth token exchange failed");
+    }),
+  );
 
-  it("sets a 20-second AbortSignal timeout by default", async () => {
-    const { calls } = captureFetch(jsonResponse(200, validBody));
-    await Effect.runPromise(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        redirectUrl: "https://cb",
-        codeVerifier: "v",
-        code: "c",
-      }),
-    );
-    expect(OAUTH2_DEFAULT_TIMEOUT_MS).toBe(20_000);
-    expect(calls[0]!.init.signal).toBeInstanceOf(AbortSignal);
-  });
-
-  it("returns a typed OAuth2Error on transport failure", async () => {
-    globalThis.fetch = vi.fn().mockRejectedValue({ message: "boom" }) as typeof fetch;
-    const exit = await Effect.runPromiseExit(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        redirectUrl: "https://cb",
-        codeVerifier: "v",
-        code: "c",
-      }),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (!Exit.isFailure(exit)) return;
-    const err = exit.cause;
-    const failure = JSON.stringify(err);
-    expect(failure).toContain("OAuth2Error");
-    expect(failure).toContain("OAuth token exchange failed");
-  });
-
-  it("propagates RFC 6749 error_description text in the OAuth2Error", async () => {
-    captureFetch(
-      jsonResponse(400, {
-        error: "invalid_grant",
-        error_description: "Code expired",
-      }),
-    );
-    const exit = await Effect.runPromiseExit(
-      exchangeAuthorizationCode({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        redirectUrl: "https://cb",
-        codeVerifier: "v",
-        code: "c",
-      }),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (!Exit.isFailure(exit)) return;
-    expect(JSON.stringify(exit.cause)).toContain("Code expired");
-  });
+  it.effect("propagates RFC 6749 error_description text in the OAuth2Error", () =>
+    withTokenEndpoint(
+      () =>
+        json(400, {
+          error: "invalid_grant",
+          error_description: "Code expired",
+        }),
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(
+            exchangeAuthorizationCode({
+              tokenUrl,
+              clientId: "cid",
+              redirectUrl: "https://cb",
+              codeVerifier: "v",
+              code: "c",
+            }),
+          );
+          expect(Exit.isFailure(exit)).toBe(true);
+          if (!Exit.isFailure(exit)) return;
+          expect(JSON.stringify(exit.cause)).toContain("Code expired");
+        }),
+    ),
+  );
 });
 
 describe("refreshAccessToken", () => {
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  const validBody = { access_token: "tok2", token_type: "Bearer", expires_in: 3600 };
-
-  it("posts grant_type=refresh_token with the refresh token", async () => {
-    const { calls } = captureFetch(jsonResponse(200, validBody));
-    await Effect.runPromise(
-      refreshAccessToken({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        clientSecret: "csecret",
-        refreshToken: "old",
+  it.effect("posts grant_type=refresh_token with the refresh token", () =>
+    withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl, calls }) =>
+      Effect.gen(function* () {
+        yield* refreshAccessToken({
+          tokenUrl,
+          clientId: "cid",
+          clientSecret: "csecret",
+          refreshToken: "old",
+        });
+        const body = (yield* calls)[0]!.body;
+        expect(body.get("grant_type")).toBe("refresh_token");
+        expect(body.get("refresh_token")).toBe("old");
+        expect(body.get("client_id")).toBe("cid");
+        expect(body.get("client_secret")).toBe("csecret");
       }),
-    );
-    const body = calls[0]!.init.body as URLSearchParams;
-    expect(body.get("grant_type")).toBe("refresh_token");
-    expect(body.get("refresh_token")).toBe("old");
-    expect(body.get("client_id")).toBe("cid");
-    expect(body.get("client_secret")).toBe("csecret");
-  });
+    ),
+  );
 
-  it("includes scope when scopes are provided", async () => {
-    const { calls } = captureFetch(jsonResponse(200, validBody));
-    await Effect.runPromise(
-      refreshAccessToken({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        refreshToken: "old",
-        scopes: ["a", "b"],
+  it.effect("includes scope when scopes are provided", () =>
+    withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl, calls }) =>
+      Effect.gen(function* () {
+        yield* refreshAccessToken({
+          tokenUrl,
+          clientId: "cid",
+          refreshToken: "old",
+          scopes: ["a", "b"],
+        });
+        expect((yield* calls)[0]!.body.get("scope")).toBe("a b");
       }),
-    );
-    const body = calls[0]!.init.body as URLSearchParams;
-    expect(body.get("scope")).toBe("a b");
-  });
+    ),
+  );
 
-  it("omits scope when scopes is empty", async () => {
-    const { calls } = captureFetch(jsonResponse(200, validBody));
-    await Effect.runPromise(
-      refreshAccessToken({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        refreshToken: "old",
-        scopes: [],
+  it.effect("omits scope when scopes is empty", () =>
+    withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl, calls }) =>
+      Effect.gen(function* () {
+        yield* refreshAccessToken({
+          tokenUrl,
+          clientId: "cid",
+          refreshToken: "old",
+          scopes: [],
+        });
+        expect((yield* calls)[0]!.body.has("scope")).toBe(false);
       }),
-    );
-    const body = calls[0]!.init.body as URLSearchParams;
-    expect(body.has("scope")).toBe(false);
-  });
+    ),
+  );
 
-  it("strips refreshed id_tokens whose iss does not match AS metadata", async () => {
-    captureFetch(
-      jsonResponse(200, {
-        ...validBody,
+  it.effect("strips refreshed id_tokens whose iss does not match AS metadata", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        ...validRefreshBody,
         id_token: unsignedJwt({
           iss: "https://us.posthog.com",
           aud: "cid",
@@ -468,25 +501,26 @@ describe("refreshAccessToken", () => {
           iat: Math.floor(Date.now() / 1000),
         }),
       }),
-    );
-    const result = await Effect.runPromise(
-      refreshAccessToken({
-        tokenUrl: "https://oauth.posthog.com/oauth/token",
-        issuerUrl: "https://oauth.posthog.com",
-        clientId: "cid",
-        refreshToken: "old",
-      }),
-    );
-    expect(result.access_token).toBe("tok2");
-  });
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* refreshAccessToken({
+            tokenUrl,
+            issuerUrl: new URL(tokenUrl).origin,
+            clientId: "cid",
+            refreshToken: "old",
+          });
+          expect(result.access_token).toBe("tok2");
+        }),
+    ),
+  );
 
-  it("strips refreshed id_tokens with algorithms not advertised in AS metadata", async () => {
-    captureFetch(
-      jsonResponse(200, {
-        ...validBody,
+  it.effect("strips refreshed id_tokens with algorithms not advertised in AS metadata", () =>
+    withTokenEndpoint(
+      tokenResponse({
+        ...validRefreshBody,
         id_token: unsignedJwt(
           {
-            iss: "https://backboard.railway.com",
+            iss: "http://127.0.0.1",
             aud: "cid",
             sub: "user-1",
             exp: Math.floor(Date.now() / 1000) + 3600,
@@ -495,37 +529,33 @@ describe("refreshAccessToken", () => {
           "ES256",
         ),
       }),
-    );
+      ({ tokenUrl }) =>
+        Effect.gen(function* () {
+          const result = yield* refreshAccessToken({
+            tokenUrl,
+            issuerUrl: new URL(tokenUrl).origin,
+            clientId: "cid",
+            refreshToken: "old",
+          });
+          expect(result.access_token).toBe("tok2");
+        }),
+    ),
+  );
 
-    const result = await Effect.runPromise(
-      refreshAccessToken({
-        tokenUrl: "https://backboard.railway.com/oauth/token",
-        issuerUrl: "https://backboard.railway.com",
-        clientId: "cid",
-        refreshToken: "old",
+  it.effect("happy path: refresh response with no id_token parses normally", () =>
+    withTokenEndpoint(tokenResponse(validRefreshBody), ({ tokenUrl }) =>
+      Effect.gen(function* () {
+        const result = yield* refreshAccessToken({
+          tokenUrl,
+          clientId: "cid",
+          refreshToken: "old",
+        });
+        expect(result.access_token).toBe("tok2");
+        expect(result.expires_in).toBe(3600);
       }),
-    );
-
-    expect(result.access_token).toBe("tok2");
-  });
-
-  it("happy path: refresh response with no id_token parses normally", async () => {
-    captureFetch(jsonResponse(200, validBody));
-    const result = await Effect.runPromise(
-      refreshAccessToken({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        refreshToken: "old",
-      }),
-    );
-    expect(result.access_token).toBe("tok2");
-    expect(result.expires_in).toBe(3600);
-  });
+    ),
+  );
 });
-
-// ---------------------------------------------------------------------------
-// shouldRefreshToken
-// ---------------------------------------------------------------------------
 
 describe("shouldRefreshToken", () => {
   it("never refreshes when expiresAt is null", () => {
@@ -556,31 +586,22 @@ describe("shouldRefreshToken", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Error type plumbing — make sure Effect propagates the tagged error
-// ---------------------------------------------------------------------------
-
 describe("OAuth2Error tagging", () => {
-  beforeEach(() => {
-    globalThis.fetch = vi.fn().mockRejectedValue({ message: "network down" }) as typeof fetch;
-  });
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
-  });
-
-  it("Effect failure channel carries OAuth2Error", async () => {
-    const exit = await Effect.runPromiseExit(
-      refreshAccessToken({
-        tokenUrl: "https://example.com/token",
-        clientId: "cid",
-        refreshToken: "old",
-      }),
-    );
-    expect(Exit.isFailure(exit)).toBe(true);
-    if (!Exit.isFailure(exit)) return;
-    const failures = JSON.stringify(exit.cause);
-    expect(failures).toContain("OAuth2Error");
-  });
+  it.effect("Effect failure channel carries OAuth2Error", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        refreshAccessToken({
+          tokenUrl: "http://127.0.0.1:1/token",
+          clientId: "cid",
+          refreshToken: "old",
+          timeoutMs: 100,
+        }),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (!Exit.isFailure(exit)) return;
+      expect(JSON.stringify(exit.cause)).toContain("OAuth2Error");
+    }),
+  );
 
   it("OAuth2Error is constructable directly with message and cause", () => {
     const err = new OAuth2Error({ message: "test", cause: { foo: 1 } });

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -35,7 +35,8 @@
 // every strategy because refresh semantics are strategy-independent.
 // ---------------------------------------------------------------------------
 
-import { Effect, Option, Schema } from "effect";
+import { Duration, Effect, Option, Schema } from "effect";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 import type { DBAdapter, StorageFailure, TypedAdapter } from "@executor-js/storage-core";
 
@@ -354,40 +355,38 @@ export const makeOAuth2Service = (
       // endpoints (Railway/GraphQL endpoints respond 200 or 400 with
       // protocol-specific bodies that we simply read as "not a bearer
       // challenge").
-      const isBearerChallengeEndpoint = yield* Effect.tryPromise({
-        try: async (): Promise<boolean> => {
-          const controller = new AbortController();
-          const timer = setTimeout(() => controller.abort(), 6_000);
-          const probeUrl = new URL(input.endpoint);
-          for (const [key, value] of Object.entries(input.queryParams ?? {})) {
-            probeUrl.searchParams.set(key, value);
-          }
-          const response = await fetch(probeUrl.toString(), {
-            method: "POST",
-            headers: {
-              ...(input.headers ?? {}),
-              "content-type": "application/json",
-              accept: "application/json, text/event-stream",
+      const isBearerChallengeEndpoint = yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        const probeUrl = new URL(input.endpoint);
+        for (const [key, value] of Object.entries(input.queryParams ?? {})) {
+          probeUrl.searchParams.set(key, value);
+        }
+        let request = HttpClientRequest.post(probeUrl.toString()).pipe(
+          HttpClientRequest.setHeader("content-type", "application/json"),
+          HttpClientRequest.setHeader("accept", "application/json, text/event-stream"),
+          HttpClientRequest.bodyJsonUnsafe({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-06-18",
+              capabilities: {},
+              clientInfo: { name: "executor-probe", version: "0" },
             },
-            body: JSON.stringify({
-              jsonrpc: "2.0",
-              id: 1,
-              method: "initialize",
-              params: {
-                protocolVersion: "2025-06-18",
-                capabilities: {},
-                clientInfo: { name: "executor-probe", version: "0" },
-              },
-            }),
-            signal: controller.signal,
-          }).finally(() => clearTimeout(timer));
-          if (response.status !== 401) return false;
-          const wwwAuth =
-            response.headers.get("www-authenticate") ?? response.headers.get("WWW-Authenticate");
-          return !!wwwAuth && /^\s*bearer\b/i.test(wwwAuth);
-        },
-        catch: () => null,
-      }).pipe(Effect.catch(() => Effect.succeed(false)));
+          }),
+        );
+        for (const [name, value] of Object.entries(input.headers ?? {})) {
+          request = HttpClientRequest.setHeader(request, name, value);
+        }
+        const response = yield* client.execute(request).pipe(Effect.timeout(Duration.seconds(6)));
+        if (response.status !== 401) return false;
+        const wwwAuth =
+          response.headers["www-authenticate"] ?? response.headers["WWW-Authenticate"];
+        return !!wwwAuth && /^\s*bearer\b/i.test(wwwAuth);
+      }).pipe(
+        Effect.provide(FetchHttpClient.layer),
+        Effect.catch(() => Effect.succeed(false)),
+      );
 
       return {
         resourceMetadata: (resource?.metadata as Record<string, unknown> | undefined) ?? null,

--- a/packages/core/sdk/src/test-config.ts
+++ b/packages/core/sdk/src/test-config.ts
@@ -1,0 +1,75 @@
+import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
+
+import { Effect } from "effect";
+
+import { makeInMemoryBlobStore } from "./blob";
+import type { ExecutorConfig } from "./executor";
+import { collectSchemas } from "./executor";
+import { ScopeId } from "./ids";
+import { definePlugin, type AnyPlugin } from "./plugin";
+import { Scope } from "./scope";
+import type { SecretProvider } from "./secrets";
+
+// ---------------------------------------------------------------------------
+// makeTestConfig — build an ExecutorConfig backed by in-memory adapter +
+// blob store. For unit tests, plugin authors validating their plugin,
+// REPL experimentation. No persistence.
+//
+// Defaults to a single-element scope stack ("test-scope") — tests that
+// need multi-scope behavior can pass `scopes` explicitly.
+// ---------------------------------------------------------------------------
+
+export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = []>(options?: {
+  readonly scopeName?: string;
+  readonly scopes?: readonly Scope[];
+  readonly plugins?: TPlugins;
+}): ExecutorConfig<TPlugins> => {
+  const scopes = options?.scopes ?? [
+    new Scope({
+      id: ScopeId.make("test-scope"),
+      name: options?.scopeName ?? "test",
+      createdAt: new Date(),
+    }),
+  ];
+
+  const schema = collectSchemas(options?.plugins ?? []);
+
+  return {
+    scopes,
+    adapter: makeMemoryAdapter({ schema }),
+    blobs: makeInMemoryBlobStore(),
+    plugins: options?.plugins,
+    // Tests default to auto-accepting elicitation prompts. Override via
+    // a wrapping spread if a test exercises a real handler:
+    //   { ...makeTestConfig(...), onElicitation: customHandler }
+    onElicitation: "accept-all",
+  };
+};
+
+export const memorySecretsPlugin = definePlugin(() => {
+  const store = new Map<string, string>();
+
+  const provider: SecretProvider = {
+    key: "memory",
+    writable: true,
+    get: (id, scope) => Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
+    set: (id, value, scope) =>
+      Effect.sync(() => {
+        store.set(`${scope}\u0000${id}`, value);
+      }),
+    delete: (id, scope) => Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
+    list: () =>
+      Effect.sync(() =>
+        Array.from(store.keys()).map((key) => {
+          const name = key.split("\u0000", 2)[1] ?? key;
+          return { id: name, name };
+        }),
+      ),
+  };
+
+  return {
+    id: "memory-secrets" as const,
+    storage: () => ({}),
+    secretProviders: [provider],
+  };
+});

--- a/packages/core/sdk/src/testing.ts
+++ b/packages/core/sdk/src/testing.ts
@@ -1,6 +1,14 @@
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
 
-import { Effect } from "effect";
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import { Context, Data, Effect, Layer, Predicate, Scope as EffectScope } from "effect";
+import {
+  HttpClient,
+  HttpRouter,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
 
 import { makeInMemoryBlobStore } from "./blob";
 import type { ExecutorConfig } from "./executor";
@@ -73,3 +81,73 @@ export const memorySecretsPlugin = definePlugin(() => {
     secretProviders: [provider],
   };
 });
+
+export class TestHttpServerAddressError extends Data.TaggedError("TestHttpServerAddressError")<{
+  readonly address: unknown;
+}> {}
+
+export class TestHttpServerServeError extends Data.TaggedError("TestHttpServerServeError")<{
+  readonly cause: unknown;
+}> {}
+
+export interface TestHttpServerShape {
+  readonly baseUrl: string;
+  readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient>;
+  readonly url: (path?: string) => string;
+}
+
+export type TestHttpRoute = HttpRouter.Route<any, any>;
+export type TestHttpRequest = HttpServerRequest.HttpServerRequest;
+export type TestHttpResponse = HttpServerResponse.HttpServerResponse;
+
+export const testHttpRoute = HttpRouter.route;
+
+export const serveTestHttpRoutes = (
+  routes: readonly TestHttpRoute[],
+): Effect.Effect<
+  TestHttpServerShape,
+  TestHttpServerAddressError | TestHttpServerServeError,
+  EffectScope.Scope
+> =>
+  makeTestHttpServer(
+    HttpRouter.serve(HttpRouter.addAll(routes), {
+      disableListenLog: true,
+      disableLogger: true,
+    }),
+  );
+
+export const serveTestHttpApp = (
+  handler: (request: TestHttpRequest) => Effect.Effect<TestHttpResponse>,
+): Effect.Effect<
+  TestHttpServerShape,
+  TestHttpServerAddressError | TestHttpServerServeError,
+  EffectScope.Scope
+> =>
+  makeTestHttpServer(
+    HttpServer.serve(HttpServerRequest.HttpServerRequest.asEffect().pipe(Effect.flatMap(handler))),
+  );
+
+const makeTestHttpServer = (
+  serverLayer: Layer.Layer<never, never, HttpServer.HttpServer>,
+): Effect.Effect<
+  TestHttpServerShape,
+  TestHttpServerAddressError | TestHttpServerServeError,
+  EffectScope.Scope
+> =>
+  Effect.gen(function* () {
+    const context = yield* Layer.build(
+      Layer.fresh(serverLayer.pipe(Layer.provideMerge(NodeHttpServer.layerTest))),
+    ).pipe(Effect.mapError((cause) => new TestHttpServerServeError({ cause })));
+    const server = Context.get(context, HttpServer.HttpServer);
+    const address = server.address;
+    if (!Predicate.isTagged(address, "TcpAddress")) {
+      return yield* new TestHttpServerAddressError({ address });
+    }
+    const client = Context.get(context, HttpClient.HttpClient);
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    return {
+      baseUrl,
+      httpClientLayer: Layer.succeed(HttpClient.HttpClient, client),
+      url: (path = "") => new URL(path, baseUrl).toString(),
+    };
+  });

--- a/packages/core/sdk/src/testing.ts
+++ b/packages/core/sdk/src/testing.ts
@@ -1,5 +1,3 @@
-import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
-
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import { Context, Data, Effect, Layer, Predicate, Scope as EffectScope } from "effect";
 import {
@@ -10,77 +8,7 @@ import {
   HttpServerResponse,
 } from "effect/unstable/http";
 
-import { makeInMemoryBlobStore } from "./blob";
-import type { ExecutorConfig } from "./executor";
-import { collectSchemas } from "./executor";
-import { ScopeId } from "./ids";
-import { definePlugin, type AnyPlugin } from "./plugin";
-import { Scope } from "./scope";
-import type { SecretProvider } from "./secrets";
-
-// ---------------------------------------------------------------------------
-// makeTestConfig — build an ExecutorConfig backed by in-memory adapter +
-// blob store. For unit tests, plugin authors validating their plugin,
-// REPL experimentation. No persistence.
-//
-// Defaults to a single-element scope stack ("test-scope") — tests that
-// need multi-scope behavior can pass `scopes` explicitly.
-// ---------------------------------------------------------------------------
-
-export const makeTestConfig = <const TPlugins extends readonly AnyPlugin[] = []>(options?: {
-  readonly scopeName?: string;
-  readonly scopes?: readonly Scope[];
-  readonly plugins?: TPlugins;
-}): ExecutorConfig<TPlugins> => {
-  const scopes = options?.scopes ?? [
-    new Scope({
-      id: ScopeId.make("test-scope"),
-      name: options?.scopeName ?? "test",
-      createdAt: new Date(),
-    }),
-  ];
-
-  const schema = collectSchemas(options?.plugins ?? []);
-
-  return {
-    scopes,
-    adapter: makeMemoryAdapter({ schema }),
-    blobs: makeInMemoryBlobStore(),
-    plugins: options?.plugins,
-    // Tests default to auto-accepting elicitation prompts. Override via
-    // a wrapping spread if a test exercises a real handler:
-    //   { ...makeTestConfig(...), onElicitation: customHandler }
-    onElicitation: "accept-all",
-  };
-};
-
-export const memorySecretsPlugin = definePlugin(() => {
-  const store = new Map<string, string>();
-
-  const provider: SecretProvider = {
-    key: "memory",
-    writable: true,
-    get: (id, scope) => Effect.sync(() => store.get(`${scope}\u0000${id}`) ?? null),
-    set: (id, value, scope) =>
-      Effect.sync(() => {
-        store.set(`${scope}\u0000${id}`, value);
-      }),
-    delete: (id, scope) => Effect.sync(() => store.delete(`${scope}\u0000${id}`)),
-    list: () =>
-      Effect.sync(() =>
-        Array.from(store.keys()).map((key) => {
-          const name = key.split("\u0000", 2)[1] ?? key;
-          return { id: name, name };
-        }),
-      ),
-  };
-
-  return {
-    id: "memory-secrets" as const,
-    storage: () => ({}),
-    secretProviders: [provider],
-  };
-});
+export { makeTestConfig, memorySecretsPlugin } from "./test-config";
 
 export class TestHttpServerAddressError extends Data.TaggedError("TestHttpServerAddressError")<{
   readonly address: unknown;

--- a/packages/plugins/graphql/src/testing/index.ts
+++ b/packages/plugins/graphql/src/testing/index.ts
@@ -1,8 +1,17 @@
-import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
-
-import { Context, Data, Effect, Layer, Ref, Schema as EffectSchema, Scope } from "effect";
+import {
+  Context,
+  Data,
+  Effect,
+  Layer,
+  Predicate,
+  Ref,
+  Schema as EffectSchema,
+  Scope,
+} from "effect";
+import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { GraphQLNonNull, GraphQLObjectType, GraphQLSchema, GraphQLString } from "graphql";
 import { createYoga, type GraphQLParams, type YogaInitialContext } from "graphql-yoga";
+import { serveTestHttpApp } from "@executor-js/sdk/testing";
 
 const GraphqlRequestPayload = EffectSchema.Struct({
   query: EffectSchema.optional(EffectSchema.String),
@@ -40,23 +49,12 @@ class GraphqlTestServerAddressError extends Data.TaggedError("GraphqlTestServerA
   readonly address: unknown;
 }> {}
 
-class GraphqlTestServerListenError extends Data.TaggedError("GraphqlTestServerListenError")<{
+class GraphqlTestServerHandlerError extends Data.TaggedError("GraphqlTestServerHandlerError")<{
   readonly cause: unknown;
 }> {}
 
-const headersFromRequest = (
-  headers: Headers | IncomingHttpHeaders,
-): Readonly<Record<string, string>> => {
-  if ("entries" in headers && typeof headers.entries === "function") {
-    return Object.fromEntries(headers.entries());
-  }
-  return Object.fromEntries(
-    Object.entries(headers).flatMap(([name, value]) => {
-      if (value === undefined) return [];
-      return [[name, Array.isArray(value) ? value.join(", ") : value]];
-    }),
-  );
-};
+const headersFromRequest = (headers: Headers): Readonly<Record<string, string>> =>
+  Object.fromEntries(headers.entries());
 
 const payloadFromParams = (params: GraphQLParams): GraphqlRequestPayload => ({
   query: params.query,
@@ -84,16 +82,11 @@ const captureRequest = (
   );
 };
 
-const closeServer = (server: Server): Effect.Effect<void> =>
-  Effect.callback<void>((resume) => {
-    server.close(() => resume(Effect.void));
-  });
-
 export const serveGraphqlTestServer = (
   options: GraphqlTestServerOptions,
 ): Effect.Effect<
   GraphqlTestServerShape,
-  GraphqlTestServerAddressError | GraphqlTestServerListenError,
+  GraphqlTestServerAddressError | GraphqlTestServerHandlerError,
   Scope.Scope
 > =>
   Effect.gen(function* () {
@@ -112,30 +105,32 @@ export const serveGraphqlTestServer = (
           request,
         })),
     });
-    const server = createServer(yoga);
 
-    const port = yield* Effect.acquireRelease(
-      Effect.callback<number, GraphqlTestServerAddressError | GraphqlTestServerListenError>(
-        (resume) => {
-          const onError = (cause: unknown) =>
-            resume(Effect.fail(new GraphqlTestServerListenError({ cause })));
-          server.once("error", onError);
-          server.listen(0, "127.0.0.1", () => {
-            server.off("error", onError);
-            const address = server.address();
-            if (!address || typeof address === "string") {
-              resume(Effect.fail(new GraphqlTestServerAddressError({ address })));
-              return;
-            }
-            resume(Effect.succeed(address.port));
-          });
-        },
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const webRequest = yield* HttpServerRequest.toWeb(request);
+        const response = yield* Effect.promise(() => Promise.resolve(yoga.handle(webRequest, {})));
+        return HttpServerResponse.fromWeb(response);
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(
+            HttpServerResponse.text("GraphQL test server failed", {
+              status: 500,
+              contentType: "text/plain",
+            }),
+          ),
+        ),
       ),
-      () => closeServer(server),
+    ).pipe(
+      Effect.mapError((error) =>
+        Predicate.isTagged(error, "TestHttpServerAddressError")
+          ? new GraphqlTestServerAddressError({ address: error.address })
+          : new GraphqlTestServerHandlerError({ cause: error.cause }),
+      ),
     );
 
     return {
-      endpoint: `http://127.0.0.1:${port}${path}`,
+      endpoint: server.url(path),
       schema: options.schema,
       requests: Ref.get(requests),
       clearRequests: Ref.set(requests, []),

--- a/packages/plugins/mcp/src/sdk/probe-shape.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.test.ts
@@ -1,50 +1,59 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Ref } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
+import { serveTestHttpApp } from "@executor-js/sdk/testing";
 
 import { probeMcpEndpointShape } from "./probe-shape";
 
-type FetchStub = (
-  input: Parameters<typeof fetch>[0],
-  init?: Parameters<typeof fetch>[1],
-) => Promise<Response>;
-
-interface FetchFailure {
-  readonly failure: unknown;
+interface CapturedProbeRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string>>;
+  readonly body: string;
 }
 
-const asFetch = (stub: FetchStub): typeof fetch => stub as typeof fetch;
+type ProbeHandler = (request: CapturedProbeRequest) => HttpServerResponse.HttpServerResponse;
 
-/**
- * Build a `fetch`-compatible stub that returns the given `Response` (or
- * rejects with the given failure) regardless of input. `fetch`'s exact signature
- * is a union; a narrow closure is enough for the probe.
- */
-const stubFetch = (result: Response | FetchFailure): typeof fetch =>
-  asFetch(async (_input, _init) => {
-    if ("failure" in result) {
-      // oxlint-disable-next-line promise/prefer-await-to-then, executor/no-promise-reject -- boundary: fetch-compatible test stub must reject like fetch
-      return Promise.reject(result.failure);
-    }
-    return result;
+const serveProbeEndpoint = (handler: ProbeHandler) =>
+  Effect.gen(function* () {
+    const requests = yield* Ref.make<readonly CapturedProbeRequest[]>([]);
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const body = yield* request.text;
+        const captured = {
+          method: request.method,
+          url: request.url ?? "/",
+          headers: request.headers,
+          body,
+        };
+        yield* Ref.update(requests, (all) => [...all, captured]);
+        return handler(captured);
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(HttpServerResponse.text("probe fixture request failed", { status: 500 })),
+        ),
+      ),
+    );
+
+    return {
+      endpoint: server.url("/probe"),
+      requests: Ref.get(requests),
+    } as const;
   });
 
-const stubFetchSequence = (results: readonly Response[]): typeof fetch => {
-  let index = 0;
-  return asFetch(async (_input, _init) => {
-    const result = results[index++];
-    if (!result) {
-      // oxlint-disable-next-line promise/prefer-await-to-then, executor/no-promise-reject -- boundary: fetch-compatible test stub must reject like fetch
-      return Promise.reject({ message: "unexpected fetch" });
-    }
-    return result;
-  });
-};
+const withServer = <A, E>(handler: ProbeHandler, use: (endpoint: string) => Effect.Effect<A, E>) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const server = yield* serveProbeEndpoint(handler);
+      return yield* use(server.endpoint);
+    }),
+  );
 
 describe("probeMcpEndpointShape", () => {
   it.effect("classifies 2xx as unauth-OK MCP", () =>
-    Effect.gen(function* () {
-      const response = new Response(
-        JSON.stringify({
+    withServer(
+      () =>
+        HttpServerResponse.jsonUnsafe({
           jsonrpc: "2.0",
           id: 1,
           result: {
@@ -53,103 +62,114 @@ describe("probeMcpEndpointShape", () => {
             serverInfo: { name: "t", version: "0" },
           },
         }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-      const result = yield* probeMcpEndpointShape("https://mcp.example/", {
-        fetch: stubFetch(response),
-      });
-      expect(result).toEqual({ kind: "mcp", requiresAuth: false });
-    }),
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result).toEqual({ kind: "mcp", requiresAuth: false });
+        }),
+    ),
   );
 
   it.effect("classifies 401 with Bearer WWW-Authenticate as MCP+OAuth", () =>
-    Effect.gen(function* () {
-      const response = new Response(null, {
-        status: 401,
-        headers: {
-          "www-authenticate":
-            'Bearer resource_metadata="https://mcp.example/.well-known/oauth-protected-resource"',
-        },
-      });
-      const result = yield* probeMcpEndpointShape("https://mcp.example/", {
-        fetch: stubFetch(response),
-      });
-      expect(result).toEqual({ kind: "mcp", requiresAuth: true });
-    }),
+    withServer(
+      () =>
+        HttpServerResponse.empty({
+          status: 401,
+          headers: {
+            "www-authenticate":
+              'Bearer resource_metadata="https://mcp.example/.well-known/oauth-protected-resource"',
+          },
+        }),
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result).toEqual({ kind: "mcp", requiresAuth: true });
+        }),
+    ),
   );
 
   it.effect("rejects 401 without WWW-Authenticate as non-MCP", () =>
-    Effect.gen(function* () {
-      const response = new Response("nope", { status: 401 });
-      const result = yield* probeMcpEndpointShape("https://api.example/", {
-        fetch: stubFetch(response),
-      });
-      expect(result.kind).toBe("not-mcp");
-    }),
+    withServer(
+      () => HttpServerResponse.text("nope", { status: 401 }),
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result.kind).toBe("not-mcp");
+        }),
+    ),
   );
 
   it.effect("falls back to GET for OAuth-protected SSE endpoints", () =>
-    Effect.gen(function* () {
-      const post = new Response(null, { status: 405 });
-      const get = new Response(null, {
-        status: 401,
-        headers: {
-          "www-authenticate":
-            'Bearer resource_metadata="https://mcp.example/.well-known/oauth-protected-resource"',
-        },
-      });
-      const result = yield* probeMcpEndpointShape("https://mcp.example/sse", {
-        fetch: stubFetchSequence([post, get]),
-      });
-      expect(result).toEqual({ kind: "mcp", requiresAuth: true });
-    }),
+    withServer(
+      (request) => {
+        if (request.method === "POST") {
+          return HttpServerResponse.empty({ status: 405 });
+        }
+        return HttpServerResponse.empty({
+          status: 401,
+          headers: {
+            "www-authenticate":
+              'Bearer resource_metadata="https://mcp.example/.well-known/oauth-protected-resource"',
+          },
+        });
+      },
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result).toEqual({ kind: "mcp", requiresAuth: true });
+        }),
+    ),
   );
 
   it.effect("classifies unauthenticated SSE GET endpoints as MCP", () =>
-    Effect.gen(function* () {
-      const post = new Response(null, { status: 405 });
-      const get = new Response("event: endpoint\n\n", {
-        status: 200,
-        headers: { "content-type": "text/event-stream" },
-      });
-      const result = yield* probeMcpEndpointShape("https://mcp.example/sse", {
-        fetch: stubFetchSequence([post, get]),
-      });
-      expect(result).toEqual({ kind: "mcp", requiresAuth: false });
-    }),
+    withServer(
+      (request) => {
+        if (request.method === "POST") {
+          return HttpServerResponse.empty({ status: 405 });
+        }
+        return HttpServerResponse.text("event: endpoint\n\n", {
+          status: 200,
+          contentType: "text/event-stream",
+        });
+      },
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result).toEqual({ kind: "mcp", requiresAuth: false });
+        }),
+    ),
   );
 
   it.effect("rejects 400 GraphQL-shape responses as non-MCP", () =>
-    Effect.gen(function* () {
-      // This is exactly the response Railway's backboard returns for a
-      // JSON-RPC initialize POST — the bug this gate exists to catch.
-      const response = new Response(
-        JSON.stringify({
-          errors: [{ message: "Problem processing request" }],
+    withServer(
+      () =>
+        HttpServerResponse.jsonUnsafe(
+          { errors: [{ message: "Problem processing request" }] },
+          { status: 400 },
+        ),
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result.kind).toBe("not-mcp");
         }),
-        { status: 400, headers: { "content-type": "application/json" } },
-      );
-      const result = yield* probeMcpEndpointShape("https://backboard.railway.com/graphql/v2", {
-        fetch: stubFetch(response),
-      });
-      expect(result.kind).toBe("not-mcp");
-    }),
+    ),
   );
 
   it.effect("rejects 404 as non-MCP", () =>
-    Effect.gen(function* () {
-      const response = new Response(null, { status: 404 });
-      const result = yield* probeMcpEndpointShape("https://example/", {
-        fetch: stubFetch(response),
-      });
-      expect(result.kind).toBe("not-mcp");
-    }),
+    withServer(
+      () => HttpServerResponse.empty({ status: 404 }),
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result.kind).toBe("not-mcp");
+        }),
+    ),
   );
 
   it.effect("reports transport failure as unreachable", () =>
     Effect.gen(function* () {
-      const result = yield* probeMcpEndpointShape("https://missing/", {
-        fetch: stubFetch({ failure: { message: "fetch failed" } }),
+      const result = yield* probeMcpEndpointShape("http://127.0.0.1:1/missing", {
+        timeoutMs: 100,
       });
       expect(result.kind).toBe("unreachable");
     }),

--- a/packages/plugins/mcp/src/sdk/probe-shape.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.ts
@@ -30,7 +30,8 @@
 // round-trip, no DCR — every non-MCP endpoint exits here.
 // ---------------------------------------------------------------------------
 
-import { Data, Effect, Option, Schema } from "effect";
+import { Data, Duration, Effect, Option, Schema } from "effect";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 /** MCP initialize request body used as the shape probe. Any real MCP
  *  server either answers it (unauth-OK server) or returns the spec-
@@ -52,11 +53,11 @@ const INITIALIZE_BODY = JSON.stringify({
 /** Header-name lookup is case-insensitive per RFC 7230. `fetch`'s
  *  `Response.headers` already lower-cases, but we normalise explicitly
  *  to stay robust against test mocks that construct `Headers` loosely. */
-const readHeader = (headers: Headers, name: string): string | null => {
-  const direct = headers.get(name);
-  if (direct !== null) return direct;
+const readHeader = (headers: Readonly<Record<string, string>>, name: string): string | null => {
+  const direct = headers[name];
+  if (direct !== undefined) return direct;
   const lower = name.toLowerCase();
-  for (const [k, v] of headers) {
+  for (const [k, v] of Object.entries(headers)) {
     if (k.toLowerCase() === lower) return v;
   }
   return null;
@@ -94,8 +95,6 @@ export type McpShapeProbeResult =
   | { readonly kind: "unreachable"; readonly reason: string };
 
 export interface ProbeOptions {
-  /** Injected for tests. Defaults to the global `fetch`. */
-  readonly fetch?: typeof fetch;
   /** Abort the request after this many ms. Default 8000. */
   readonly timeoutMs?: number;
   readonly headers?: Record<string, string>;
@@ -118,83 +117,88 @@ export const probeMcpEndpointShape = (
   options: ProbeOptions = {},
 ): Effect.Effect<McpShapeProbeResult> =>
   Effect.gen(function* () {
-    const fetchImpl = options.fetch ?? globalThis.fetch;
     const timeoutMs = options.timeoutMs ?? 8_000;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-
-    const outcome = yield* Effect.tryPromise({
-      try: async (): Promise<McpShapeProbeResult> => {
-        const classify = (response: Response, method: "GET" | "POST") => {
-          if (response.status === 401) {
-            const wwwAuth = readHeader(response.headers, "www-authenticate");
-            if (wwwAuth && /^\s*bearer\b/i.test(wwwAuth)) {
-              return { kind: "mcp", requiresAuth: true } as const;
-            }
-            return {
-              kind: "not-mcp",
-              reason: "401 without Bearer WWW-Authenticate — not an MCP auth challenge",
-            } as const;
+    const outcome = yield* Effect.gen(function* () {
+      const client = yield* HttpClient.HttpClient;
+      const classify = (
+        response: { readonly status: number; readonly headers: Readonly<Record<string, string>> },
+        method: "GET" | "POST",
+      ) => {
+        if (response.status === 401) {
+          const wwwAuth = readHeader(response.headers, "www-authenticate");
+          if (wwwAuth && /^\s*bearer\b/i.test(wwwAuth)) {
+            return { kind: "mcp", requiresAuth: true } as const;
           }
-
-          if (response.status >= 200 && response.status < 300) {
-            if (method === "GET") {
-              const contentType = readHeader(response.headers, "content-type") ?? "";
-              if (!/^\s*text\/event-stream\b/i.test(contentType)) {
-                return {
-                  kind: "not-mcp",
-                  reason: "GET response is not an SSE stream",
-                } as const;
-              }
-            }
-            return { kind: "mcp", requiresAuth: false } as const;
-          }
-
-          return null;
-        };
-
-        const url = new URL(endpoint);
-        for (const [key, value] of Object.entries(options.queryParams ?? {})) {
-          url.searchParams.set(key, value);
-        }
-        const authHeaders = options.headers ?? {};
-
-        const postResponse = await fetchImpl(url, {
-          method: "POST",
-          headers: {
-            ...authHeaders,
-            "content-type": "application/json",
-            accept: "application/json, text/event-stream",
-          },
-          body: INITIALIZE_BODY,
-          signal: controller.signal,
-        });
-
-        const postResult = classify(postResponse, "POST");
-        if (postResult) return postResult;
-
-        if ([404, 405, 406, 415].includes(postResponse.status)) {
-          const getResponse = await fetchImpl(url, {
-            method: "GET",
-            headers: { ...authHeaders, accept: "text/event-stream" },
-            signal: controller.signal,
-          });
-          const getResult = classify(getResponse, "GET");
-          if (getResult) return getResult;
+          return {
+            kind: "not-mcp",
+            reason: "401 without Bearer WWW-Authenticate — not an MCP auth challenge",
+          } as const;
         }
 
-        return {
-          kind: "not-mcp",
-          reason: `unexpected status ${postResponse.status} for initialize`,
-        };
-      },
-      catch: (cause) =>
-        new ProbeTransportError({
-          reason: reasonFromBoundaryCause(cause),
-          cause,
-        }),
+        if (response.status >= 200 && response.status < 300) {
+          if (method === "GET") {
+            const contentType = readHeader(response.headers, "content-type") ?? "";
+            if (!/^\s*text\/event-stream\b/i.test(contentType)) {
+              return {
+                kind: "not-mcp",
+                reason: "GET response is not an SSE stream",
+              } as const;
+            }
+          }
+          return { kind: "mcp", requiresAuth: false } as const;
+        }
+
+        return null;
+      };
+
+      const url = new URL(endpoint);
+      for (const [key, value] of Object.entries(options.queryParams ?? {})) {
+        url.searchParams.set(key, value);
+      }
+
+      let postRequest = HttpClientRequest.post(url.toString()).pipe(
+        HttpClientRequest.setHeader("content-type", "application/json"),
+        HttpClientRequest.setHeader("accept", "application/json, text/event-stream"),
+        HttpClientRequest.bodyText(INITIALIZE_BODY, "application/json"),
+      );
+      for (const [name, value] of Object.entries(options.headers ?? {})) {
+        postRequest = HttpClientRequest.setHeader(postRequest, name, value);
+      }
+
+      const postResponse = yield* client
+        .execute(postRequest)
+        .pipe(Effect.timeout(Duration.millis(timeoutMs)));
+
+      const postResult = classify(postResponse, "POST");
+      if (postResult) return postResult;
+
+      if ([404, 405, 406, 415].includes(postResponse.status)) {
+        let getRequest = HttpClientRequest.get(url.toString()).pipe(
+          HttpClientRequest.setHeader("accept", "text/event-stream"),
+        );
+        for (const [name, value] of Object.entries(options.headers ?? {})) {
+          getRequest = HttpClientRequest.setHeader(getRequest, name, value);
+        }
+        const getResponse = yield* client
+          .execute(getRequest)
+          .pipe(Effect.timeout(Duration.millis(timeoutMs)));
+        const getResult = classify(getResponse, "GET");
+        if (getResult) return getResult;
+      }
+
+      return {
+        kind: "not-mcp",
+        reason: `unexpected status ${postResponse.status} for initialize`,
+      } as const;
     }).pipe(
-      Effect.ensuring(Effect.sync(() => clearTimeout(timer))),
+      Effect.provide(FetchHttpClient.layer),
+      Effect.mapError(
+        (cause) =>
+          new ProbeTransportError({
+            reason: reasonFromBoundaryCause(cause),
+            cause,
+          }),
+      ),
       Effect.catch((cause) =>
         Effect.succeed<McpShapeProbeResult>({
           kind: "unreachable",

--- a/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
@@ -6,8 +6,8 @@
 // then resolves the bearer at invoke time.
 // ---------------------------------------------------------------------------
 
-import { afterEach, expect, layer } from "@effect/vitest";
-import { Effect, Layer, Schema } from "effect";
+import { expect, layer } from "@effect/vitest";
+import { Effect, Layer, Ref, Schema } from "effect";
 import {
   HttpApi,
   HttpApiBuilder,
@@ -15,7 +15,13 @@ import {
   HttpApiGroup,
   OpenApi,
 } from "effect/unstable/httpapi";
-import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http";
+import {
+  FetchHttpClient,
+  HttpRouter,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 
 import {
@@ -30,6 +36,7 @@ import {
   type InvokeOptions,
   type SecretProvider,
 } from "@executor-js/sdk";
+import { serveTestHttpApp } from "@executor-js/sdk/testing";
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
 
 import { openApiPlugin } from "./plugin";
@@ -76,14 +83,6 @@ const TestLayer = HttpRouter.serve(ApiLive, { disableListenLog: true, disableLog
   Layer.provideMerge(NodeHttpServer.layerTest),
 );
 
-// ---------------------------------------------------------------------------
-// Fetch override — records the POST body the plugin sends to the token
-// endpoint so the test can assert it's a spec-compliant client_credentials
-// request, and returns a distinct access_token each call.
-// ---------------------------------------------------------------------------
-
-const originalFetch = globalThis.fetch;
-
 type TokenCall = {
   readonly grantType: string | null;
   readonly clientId: string | null;
@@ -91,51 +90,46 @@ type TokenCall = {
   readonly scope: string | null;
 };
 
-const mockClientCredentialsFetch = (args: {
-  readonly calls: TokenCall[];
+const serveClientCredentialsTokenEndpoint = (args: {
   readonly accessTokens: readonly string[];
   readonly expiresIn?: number;
-}) => {
-  let callIndex = 0;
-  globalThis.fetch = Object.assign(
-    async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof _input === "string" ? _input : _input.toString();
-      if (!url.includes("token.example.com")) {
-        return originalFetch(_input, init);
-      }
-      const bodyText =
-        init?.body instanceof URLSearchParams
-          ? init.body.toString()
-          : typeof init?.body === "string"
-            ? init.body
-            : "";
-      const params = new URLSearchParams(bodyText);
-      args.calls.push({
-        grantType: params.get("grant_type"),
-        clientId: params.get("client_id"),
-        clientSecret: params.get("client_secret"),
-        scope: params.get("scope"),
-      });
-      const token =
-        args.accessTokens[Math.min(callIndex, args.accessTokens.length - 1)] ?? "unknown";
-      callIndex += 1;
-      const body: Record<string, unknown> = {
-        access_token: token,
-        token_type: "Bearer",
-      };
-      if (typeof args.expiresIn === "number") body.expires_in = args.expiresIn;
-      return new Response(JSON.stringify(body), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    },
-    { preconnect: originalFetch.preconnect },
-  );
-};
+}) =>
+  Effect.gen(function* () {
+    const calls = yield* Ref.make<readonly TokenCall[]>([]);
+    let callIndex = 0;
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const params = new URLSearchParams(yield* request.text);
+        yield* Ref.update(calls, (all) => [
+          ...all,
+          {
+            grantType: params.get("grant_type"),
+            clientId: params.get("client_id"),
+            clientSecret: params.get("client_secret"),
+            scope: params.get("scope"),
+          },
+        ]);
+        const token =
+          args.accessTokens[Math.min(callIndex, args.accessTokens.length - 1)] ?? "unknown";
+        callIndex += 1;
+        const body: Record<string, unknown> = {
+          access_token: token,
+          token_type: "Bearer",
+        };
+        if (typeof args.expiresIn === "number") body.expires_in = args.expiresIn;
+        return HttpServerResponse.jsonUnsafe(body);
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(HttpServerResponse.text("token fixture request failed", { status: 500 })),
+        ),
+      ),
+    );
 
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
+    return {
+      tokenUrl: server.url("/token"),
+      calls: Ref.get(calls),
+    } as const;
+  });
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -224,9 +218,7 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
         }),
       );
 
-      const calls: TokenCall[] = [];
-      mockClientCredentialsFetch({
-        calls,
+      const tokenEndpoint = yield* serveClientCredentialsTokenEndpoint({
         accessTokens: ["alice-token-1"],
       });
 
@@ -237,15 +229,15 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
       // ------------------------------------------------------------
       const connectionId = "openapi-oauth2-app-petstore";
       const started = yield* userExec.oauth.start({
-        endpoint: "https://token.example.com/token",
-        redirectUrl: "https://token.example.com/token",
+        endpoint: tokenEndpoint.tokenUrl,
+        redirectUrl: tokenEndpoint.tokenUrl,
         connectionId,
         tokenScope: String(userScope.id),
         pluginId: "openapi",
         identityLabel: "Petstore OAuth",
         strategy: {
           kind: "client-credentials",
-          tokenEndpoint: "https://token.example.com/token",
+          tokenEndpoint: tokenEndpoint.tokenUrl,
           clientIdSecretId: "petstore_client_id",
           clientSecretSecretId: "petstore_client_secret",
           scopes: ["data"],
@@ -263,7 +255,7 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
         connectionId: completedConnection.connectionId,
         securitySchemeName: "oauth2",
         flow: "clientCredentials",
-        tokenUrl: "https://token.example.com/token",
+        tokenUrl: tokenEndpoint.tokenUrl,
         authorizationUrl: null,
         clientIdSecretId: "petstore_client_id",
         clientSecretSecretId: "petstore_client_secret",
@@ -272,6 +264,7 @@ layer(TestLayer)("OpenAPI client_credentials OAuth", (it) => {
       expect(auth.connectionId).toBe(connectionId);
 
       // Token endpoint call is RFC 6749 §4.4 compliant.
+      const calls = yield* tokenEndpoint.calls;
       expect(calls).toHaveLength(1);
       expect(calls[0]!.grantType).toBe("client_credentials");
       expect(calls[0]!.clientId).toBe("client-abc");

--- a/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
@@ -8,8 +8,8 @@
 // user-facing `secrets.list()` automatically.
 // ---------------------------------------------------------------------------
 
-import { afterEach, expect, layer } from "@effect/vitest";
-import { Data, Effect, Layer, Predicate, Schema } from "effect";
+import { expect, layer } from "@effect/vitest";
+import { Data, Effect, Layer, Predicate, Ref, Schema } from "effect";
 import {
   HttpApi,
   HttpApiBuilder,
@@ -17,7 +17,13 @@ import {
   HttpApiGroup,
   OpenApi,
 } from "effect/unstable/httpapi";
-import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http";
+import {
+  FetchHttpClient,
+  HttpRouter,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 
 import {
@@ -32,6 +38,7 @@ import {
   type InvokeOptions,
   type SecretProvider,
 } from "@executor-js/sdk";
+import { serveTestHttpApp } from "@executor-js/sdk/testing";
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
 
 import { openApiPlugin } from "./plugin";
@@ -76,52 +83,33 @@ const TestLayer = HttpRouter.serve(ApiLive, { disableListenLog: true, disableLog
   Layer.provideMerge(NodeHttpServer.layerTest),
 );
 
-// ---------------------------------------------------------------------------
-// Fetch override for the token endpoint. Each user's OAuth callback code
-// deterministically maps to a different access_token in the mock
-// response so we can assert per-user isolation at invocation time.
-// ---------------------------------------------------------------------------
+const json = (status: number, body: unknown): HttpServerResponse.HttpServerResponse =>
+  HttpServerResponse.jsonUnsafe(body, { status });
 
-const originalFetch = globalThis.fetch;
-
-const mockTokenFetch = (tokenByCode: Record<string, string>) => {
-  globalThis.fetch = Object.assign(
-    async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof _input === "string" ? _input : _input.toString();
-      if (!url.includes("token.example.com")) {
-        return originalFetch(_input, init);
-      }
-      const bodyText =
-        init?.body instanceof URLSearchParams
-          ? init.body.toString()
-          : typeof init?.body === "string"
-            ? init.body
-            : "";
-      const params = new URLSearchParams(bodyText);
-      const code = params.get("code") ?? "";
-      const token = tokenByCode[code];
-      if (!token) {
-        return new Response(JSON.stringify({ error: "invalid_grant", code }), {
-          status: 400,
-          headers: { "content-type": "application/json" },
-        });
-      }
-      return new Response(
-        JSON.stringify({
-          access_token: token,
-          token_type: "Bearer",
-          refresh_token: `${token}-refresh`,
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    },
-    { preconnect: originalFetch.preconnect },
-  );
-};
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
+const serveTokenEndpoint = (
+  handle: (params: URLSearchParams) => HttpServerResponse.HttpServerResponse,
+) =>
+  Effect.gen(function* () {
+    const clientIds = yield* Ref.make<readonly string[]>([]);
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const params = new URLSearchParams(yield* request.text);
+        const clientId = params.get("client_id");
+        if (clientId) {
+          yield* Ref.update(clientIds, (all) => [...all, clientId]);
+        }
+        return handle(params);
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(HttpServerResponse.text("token fixture request failed", { status: 500 })),
+        ),
+      ),
+    );
+    return {
+      tokenUrl: server.url("/token"),
+      clientIds: Ref.get(clientIds),
+    } as const;
+  });
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -226,9 +214,21 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       // 2. Each user runs startOAuth + centralized OAuth completion to mint a
       //    per-user Connection.
       // -------------------------------------------------------------
-      mockTokenFetch({
-        "code-alice": "alice-token",
-        "code-bob": "bob-token",
+      const tokenEndpoint = yield* serveTokenEndpoint((params) => {
+        const code = params.get("code") ?? "";
+        const tokenByCode: Record<string, string> = {
+          "code-alice": "alice-token",
+          "code-bob": "bob-token",
+        };
+        const token = tokenByCode[code];
+        if (!token) {
+          return json(400, { error: "invalid_grant", code });
+        }
+        return json(200, {
+          access_token: token,
+          token_type: "Bearer",
+          refresh_token: `${token}-refresh`,
+        });
       });
 
       const startInputFor = (user: string, scope: ScopeId) => ({
@@ -236,7 +236,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         displayName: `Petstore (${user})`,
         securitySchemeName: "oauth2",
         authorizationUrl: "https://auth.example.com/authorize",
-        tokenUrl: "https://token.example.com/token",
+        tokenUrl: tokenEndpoint.tokenUrl,
         redirectUrl: "https://app.example.com/oauth/callback",
         clientIdSecretId: "petstore_client_id",
         clientSecretSecretId: "petstore_client_secret",
@@ -302,7 +302,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         connectionId: aliceAuth.connectionId,
         securitySchemeName: "oauth2",
         flow: "authorizationCode",
-        tokenUrl: "https://token.example.com/token",
+        tokenUrl: tokenEndpoint.tokenUrl,
         authorizationUrl: "https://auth.example.com/authorize",
         clientIdSecretId: "petstore_client_id",
         clientSecretSecretId: "petstore_client_secret",
@@ -313,7 +313,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
         connectionId: bobAuth.connectionId,
         securitySchemeName: "oauth2",
         flow: "authorizationCode",
-        tokenUrl: "https://token.example.com/token",
+        tokenUrl: tokenEndpoint.tokenUrl,
         authorizationUrl: "https://auth.example.com/authorize",
         clientIdSecretId: "petstore_client_id",
         clientSecretSecretId: "petstore_client_secret",
@@ -517,38 +517,19 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       // encodes which client_id was used, so we can assert each
       // user's row ends up with a token minted from *their own*
       // credential resolution.
-      const tokenCalls: string[] = [];
-      globalThis.fetch = Object.assign(
-        async (_input: RequestInfo | URL, init?: RequestInit) => {
-          const url = typeof _input === "string" ? _input : _input.toString();
-          if (!url.includes("token.example.com")) {
-            return originalFetch(_input, init);
-          }
-          const bodyText =
-            init?.body instanceof URLSearchParams
-              ? init.body.toString()
-              : typeof init?.body === "string"
-                ? init.body
-                : "";
-          const params = new URLSearchParams(bodyText);
-          const clientId = params.get("client_id") ?? "unknown";
-          tokenCalls.push(clientId);
-          return new Response(
-            JSON.stringify({
-              access_token: `token-for-${clientId}`,
-              token_type: "Bearer",
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          );
-        },
-        { preconnect: originalFetch.preconnect },
-      );
+      const tokenEndpoint = yield* serveTokenEndpoint((params) => {
+        const clientId = params.get("client_id") ?? "unknown";
+        return json(200, {
+          access_token: `token-for-${clientId}`,
+          token_type: "Bearer",
+        });
+      });
 
       const startInput = {
         connectionId: "shared-petstore-oauth",
         displayName: "Petstore",
         securitySchemeName: "oauth2",
-        tokenUrl: "https://token.example.com/token",
+        tokenUrl: tokenEndpoint.tokenUrl,
         clientIdSecretId: "client_id",
         clientSecretSecretId: "client_secret",
         scopes: ["read"],
@@ -640,6 +621,7 @@ layer(TestLayer)("OpenAPI multi-scope OAuth", (it) => {
       // (3) Scope-stacked secret resolution produced per-user tokens.
       // The exchange call Alice made used her shadowed value; Bob's
       // fell through to the org default.
+      const tokenCalls = yield* tokenEndpoint.clientIds;
       expect(tokenCalls).toContain("alice-client");
       expect(tokenCalls.filter((v) => v === "org-client").length).toBeGreaterThan(0);
 

--- a/packages/plugins/openapi/src/sdk/oauth-refresh.test.ts
+++ b/packages/plugins/openapi/src/sdk/oauth-refresh.test.ts
@@ -12,8 +12,8 @@
 //      `ConnectionReauthRequiredError` so the UI can prompt sign-in.
 // ---------------------------------------------------------------------------
 
-import { afterEach, expect, layer } from "@effect/vitest";
-import { Effect, Layer, Predicate, Schema } from "effect";
+import { expect, layer } from "@effect/vitest";
+import { Effect, Layer, Predicate, Ref, Schema } from "effect";
 import {
   HttpApi,
   HttpApiBuilder,
@@ -21,7 +21,13 @@ import {
   HttpApiGroup,
   OpenApi,
 } from "effect/unstable/httpapi";
-import { FetchHttpClient, HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http";
+import {
+  FetchHttpClient,
+  HttpRouter,
+  HttpServer,
+  HttpServerRequest,
+  HttpServerResponse,
+} from "effect/unstable/http";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 
 import {
@@ -39,6 +45,7 @@ import {
   type InvokeOptions,
   type SecretProvider,
 } from "@executor-js/sdk";
+import { serveTestHttpApp } from "@executor-js/sdk/testing";
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
 
 import { openApiPlugin } from "./plugin";
@@ -85,42 +92,31 @@ const TestLayer = HttpRouter.serve(ApiLive, { disableListenLog: true, disableLog
 // response or an error envelope. `calls` records every hit for assertions.
 // ---------------------------------------------------------------------------
 
-const originalFetch = globalThis.fetch;
-
 type TokenCall = {
   readonly body: URLSearchParams;
 };
 
-const mockTokenFetch = (
-  handler: (body: URLSearchParams) => Effect.Effect<Response, never, never> | Promise<Response>,
-) => {
-  const calls: TokenCall[] = [];
-  globalThis.fetch = Object.assign(
-    async (_input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof _input === "string" ? _input : _input.toString();
-      if (!url.includes("token.example.com")) {
-        return originalFetch(_input, init);
-      }
-      const bodyText =
-        init?.body instanceof URLSearchParams
-          ? init.body.toString()
-          : typeof init?.body === "string"
-            ? init.body
-            : "";
-      const body = new URLSearchParams(bodyText);
-      calls.push({ body });
-      const out = handler(body);
-      if (Effect.isEffect(out)) return await Effect.runPromise(out);
-      return await out;
-    },
-    { preconnect: originalFetch.preconnect },
-  );
-  return { calls };
-};
-
-afterEach(() => {
-  globalThis.fetch = originalFetch;
-});
+const serveTokenEndpoint = (
+  handler: (body: URLSearchParams) => HttpServerResponse.HttpServerResponse,
+) =>
+  Effect.gen(function* () {
+    const calls = yield* Ref.make<readonly TokenCall[]>([]);
+    const server = yield* serveTestHttpApp((request) =>
+      Effect.gen(function* () {
+        const body = new URLSearchParams(yield* request.text);
+        yield* Ref.update(calls, (all) => [...all, { body }]);
+        return handler(body);
+      }).pipe(
+        Effect.catch(() =>
+          Effect.succeed(HttpServerResponse.text("token fixture request failed", { status: 500 })),
+        ),
+      ),
+    );
+    return {
+      tokenUrl: server.url("/token"),
+      calls: Ref.get(calls),
+    } as const;
+  });
 
 // ---------------------------------------------------------------------------
 // Fixture builder. Wires up a single-scope executor with an in-memory
@@ -207,7 +203,12 @@ type ExecutorValue = EffectSuccess<ReturnType<typeof makeExecutor>>["executor"];
 // Seed an authorizationCode Connection with an already-expired access
 // token and a stored refresh token. The test's mock token endpoint
 // decides what comes back on `grant_type=refresh_token`.
-const seedExpiredConnection = (executor: ExecutorValue, scopeId: ScopeId, connectionId: string) =>
+const seedExpiredConnection = (
+  executor: ExecutorValue,
+  scopeId: ScopeId,
+  connectionId: string,
+  tokenUrl: string,
+) =>
   Effect.gen(function* () {
     yield* executor.connections.create(
       new CreateConnectionInput({
@@ -229,7 +230,7 @@ const seedExpiredConnection = (executor: ExecutorValue, scopeId: ScopeId, connec
         oauthScope: "read",
         providerState: {
           flow: "authorizationCode",
-          tokenUrl: "https://token.example.com/token",
+          tokenUrl,
           clientIdSecretId: "client_id",
           clientSecretSecretId: "client_secret",
           scopes: ["read"],
@@ -241,7 +242,7 @@ const seedExpiredConnection = (executor: ExecutorValue, scopeId: ScopeId, connec
       connectionId,
       securitySchemeName: "oauth2",
       flow: "authorizationCode",
-      tokenUrl: "https://token.example.com/token",
+      tokenUrl,
       authorizationUrl: "https://auth.example.com/authorize",
       clientIdSecretId: "client_id",
       clientSecretSecretId: "client_secret",
@@ -257,21 +258,21 @@ layer(TestLayer)("OpenAPI oauth refresh", (it) => {
   it.effect("expired access_token is refreshed via grant_type=refresh_token before invoke", () =>
     Effect.gen(function* () {
       const { executor, scopeId, baseUrl } = yield* makeExecutor();
-      const { calls } = mockTokenFetch(() =>
-        Effect.succeed(
-          new Response(
-            JSON.stringify({
-              access_token: "fresh-access-v2",
-              token_type: "Bearer",
-              refresh_token: "refresh-v2",
-              expires_in: 3600,
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-        ),
+      const tokenEndpoint = yield* serveTokenEndpoint(() =>
+        HttpServerResponse.jsonUnsafe({
+          access_token: "fresh-access-v2",
+          token_type: "Bearer",
+          refresh_token: "refresh-v2",
+          expires_in: 3600,
+        }),
       );
 
-      const auth = yield* seedExpiredConnection(executor, scopeId, "conn-refresh-ok");
+      const auth = yield* seedExpiredConnection(
+        executor,
+        scopeId,
+        "conn-refresh-ok",
+        tokenEndpoint.tokenUrl,
+      );
 
       yield* executor.openapi.addSpec({
         spec: specJson,
@@ -291,6 +292,7 @@ layer(TestLayer)("OpenAPI oauth refresh", (it) => {
       // Proves the refresh landed: invoke carried the fresh token,
       // not the expired one we seeded.
       expect(result.data?.authorization).toBe("Bearer fresh-access-v2");
+      const calls = yield* tokenEndpoint.calls;
       expect(calls).toHaveLength(1);
       expect(calls[0]!.body.get("grant_type")).toBe("refresh_token");
       expect(calls[0]!.body.get("refresh_token")).toBe("refresh-v1");
@@ -307,21 +309,21 @@ layer(TestLayer)("OpenAPI oauth refresh", (it) => {
   it.effect("concurrent invokes with an expired token issue exactly one refresh", () =>
     Effect.gen(function* () {
       const { executor, scopeId, baseUrl } = yield* makeExecutor();
-      const { calls } = mockTokenFetch(() =>
-        Effect.succeed(
-          new Response(
-            JSON.stringify({
-              access_token: "fresh-access-v2",
-              token_type: "Bearer",
-              refresh_token: "refresh-v2",
-              expires_in: 3600,
-            }),
-            { status: 200, headers: { "content-type": "application/json" } },
-          ),
-        ),
+      const tokenEndpoint = yield* serveTokenEndpoint(() =>
+        HttpServerResponse.jsonUnsafe({
+          access_token: "fresh-access-v2",
+          token_type: "Bearer",
+          refresh_token: "refresh-v2",
+          expires_in: 3600,
+        }),
       );
 
-      const auth = yield* seedExpiredConnection(executor, scopeId, "conn-refresh-concurrent");
+      const auth = yield* seedExpiredConnection(
+        executor,
+        scopeId,
+        "conn-refresh-concurrent",
+        tokenEndpoint.tokenUrl,
+      );
 
       yield* executor.openapi.addSpec({
         spec: specJson,
@@ -349,6 +351,7 @@ layer(TestLayer)("OpenAPI oauth refresh", (it) => {
       // Critical assertion: the SDK's dedup collapses every parallel
       // invoke into one call to the token endpoint. Anything more
       // means we're hammering the AS under load.
+      const calls = yield* tokenEndpoint.calls;
       expect(calls).toHaveLength(1);
     }),
   );
@@ -356,19 +359,22 @@ layer(TestLayer)("OpenAPI oauth refresh", (it) => {
   it.effect("invalid_grant from refresh surfaces as ConnectionReauthRequiredError", () =>
     Effect.gen(function* () {
       const { executor, scopeId, baseUrl } = yield* makeExecutor();
-      mockTokenFetch(() =>
-        Effect.succeed(
-          new Response(
-            JSON.stringify({
-              error: "invalid_grant",
-              error_description: "Refresh token revoked",
-            }),
-            { status: 400, headers: { "content-type": "application/json" } },
-          ),
+      const tokenEndpoint = yield* serveTokenEndpoint(() =>
+        HttpServerResponse.jsonUnsafe(
+          {
+            error: "invalid_grant",
+            error_description: "Refresh token revoked",
+          },
+          { status: 400 },
         ),
       );
 
-      const auth = yield* seedExpiredConnection(executor, scopeId, "conn-refresh-dead");
+      const auth = yield* seedExpiredConnection(
+        executor,
+        scopeId,
+        "conn-refresh-dead",
+        tokenEndpoint.tokenUrl,
+      );
 
       yield* executor.openapi.addSpec({
         spec: specJson,

--- a/scripts/oxlint-plugin-executor/rules/no-raw-fetch.js
+++ b/scripts/oxlint-plugin-executor/rules/no-raw-fetch.js
@@ -16,21 +16,9 @@ const checkedPrefixes = [
   "packages/plugins/openapi/src/",
 ];
 
-const temporaryAllowedFiles = new Set([
-  "packages/core/sdk/src/oauth-discovery.ts",
-  "packages/core/sdk/src/oauth-discovery.test.ts",
-  "packages/core/sdk/src/oauth-helpers.test.ts",
-  "packages/core/sdk/src/oauth-service.ts",
-  "packages/plugins/mcp/src/sdk/probe-shape.ts",
-  "packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts",
-  "packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts",
-  "packages/plugins/openapi/src/sdk/oauth-refresh.test.ts",
-]);
-
 const shouldCheck = (filename) => {
   const normalized = toRepoRelative(filename);
   if (isDeclarationFile(filename)) return false;
-  if (temporaryAllowedFiles.has(normalized)) return false;
   return checkedPrefixes.some((prefix) => normalized.startsWith(prefix));
 };
 


### PR DESCRIPTION
## Summary
- remove the temporary raw-fetch lint allowlist
- move OAuth discovery/service and MCP probe requests through Effect HttpClient
- replace fetch stubs in protocol tests with real local HTTP server fixtures

## Verification
- bun run test -- src/oauth-discovery.test.ts src/oauth-helpers.test.ts
- bun run test -- src/sdk/probe-shape.test.ts
- bun run test -- src/sdk/client-credentials-oauth.test.ts src/sdk/oauth-refresh.test.ts src/sdk/multi-scope-oauth.test.ts
- bun run lint
- bun run typecheck
- bun run format:check
- git diff --check