### PR TITLE
perf(schema): hoist Schema compilers and add lint rule

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -11,6 +11,7 @@
     "executor/no-effect-escape-hatch": "error",
     "executor/no-effect-internal-tags": "error",
     "executor/no-error-constructor": "error",
+    "executor/no-inline-schema-compile": "error",
     "executor/no-instanceof-error": "error",
     "executor/no-instanceof-tagged-error": "error",
     "executor/no-json-parse": "error",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,7 @@ inspect it there.
 - `packages/kernel/*`: execution runtimes and code execution substrate.
 - `apps/local`, `apps/cloud`, `apps/cli`, and `apps/desktop`: product entry
   points that compose the packages.
+
+## Other
+
+Please make note of mistakes you make in MISTAKES.md. If you find you wish you had more context or tools, write that down in DESIRES.md. If you learn anything about your env write that down in LEARNINGS.md.

--- a/apps/cloud/src/jwks-cache.ts
+++ b/apps/cloud/src/jwks-cache.ts
@@ -61,8 +61,11 @@ const JsonWebKeySetPayload = Schema.Struct({
 });
 const decodeJsonWebKeySetPayload = Schema.decodeUnknownPromise(JsonWebKeySetPayload);
 
+const ErrorWithCode = Schema.Struct({ code: Schema.String });
+const isErrorWithCode = Schema.is(ErrorWithCode);
+
 const isJwksNoMatchingKey = (cause: unknown): boolean =>
-  Schema.is(Schema.Struct({ code: Schema.String }))(cause) && cause.code === JWKSNoMatchingKey.code;
+  isErrorWithCode(cause) && cause.code === JWKSNoMatchingKey.code;
 
 interface CacheEntry {
   jwks: JSONWebKeySet;

--- a/apps/cloud/src/mcp-auth.ts
+++ b/apps/cloud/src/mcp-auth.ts
@@ -15,9 +15,10 @@ export class McpJwtVerificationError extends Data.TaggedError("McpJwtVerificatio
 }> {}
 
 const JoseErrorCode = Schema.Struct({ code: Schema.String });
+const isJoseErrorCodeShape = Schema.is(JoseErrorCode);
 
 const getJoseErrorCode = (cause: unknown): string | null =>
-  Schema.is(JoseErrorCode)(cause) ? cause.code : null;
+  isJoseErrorCodeShape(cause) ? cause.code : null;
 
 const isJoseErrorCode = (code: string): boolean => code.startsWith("ERR_J");
 

--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -186,6 +186,8 @@ const OtlpPayloadFromJson = Schema.fromJsonString(
   }),
 );
 
+const decodeOtlpPayload = Schema.decodeUnknownOption(OtlpPayloadFromJson);
+
 const unwrapAttrValue = (v?: OtlpAttributeValue): unknown => {
   if (!v) return undefined;
   if (v.stringValue !== undefined) return v.stringValue;
@@ -218,7 +220,7 @@ const TelemetryReceiverLive = Layer.effect(TelemetryReceiver)(
           body += chunk;
         });
         req.on("end", () => {
-          const maybePayload = Schema.decodeUnknownOption(OtlpPayloadFromJson)(body);
+          const maybePayload = decodeOtlpPayload(body);
           if (Option.isSome(maybePayload)) {
             const payload = maybePayload.value;
             for (const rs of payload.resourceSpans ?? []) {

--- a/apps/cloud/src/services/sources-api.node.test.ts
+++ b/apps/cloud/src/services/sources-api.node.test.ts
@@ -177,6 +177,9 @@ const GraphqlRequestSchema = Schema.Struct({
   variables: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
 });
 
+const GraphqlRequestFromJson = Schema.fromJsonString(GraphqlRequestSchema);
+const decodeGraphqlRequest = Schema.decodeUnknownPromise(GraphqlRequestFromJson);
+
 const startGraphqlServer = () => {
   const requests: Array<{ readonly query: string; readonly variables: unknown }> = [];
   const server = http.createServer(async (req, res) => {
@@ -186,9 +189,7 @@ const startGraphqlServer = () => {
       return;
     }
 
-    const parsed = await Schema.decodeUnknownPromise(Schema.fromJsonString(GraphqlRequestSchema))(
-      await readBody(req),
-    );
+    const parsed = await decodeGraphqlRequest(await readBody(req));
     const query = parsed.query ?? "";
     requests.push({ query, variables: parsed.variables ?? null });
 

--- a/apps/local/src/server/migrate-connections.ts
+++ b/apps/local/src/server/migrate-connections.ts
@@ -30,10 +30,11 @@ const isString = (v: unknown): v is string => typeof v === "string";
 const JsonObject = Schema.Record(Schema.String, Schema.Unknown);
 const JsonObjectFromString = Schema.fromJsonString(JsonObject);
 
-const decodeUnknownOptionAs =
-  <A>(schema: Schema.Decoder<A>) =>
-  (input: unknown): Option.Option<A> =>
-    Schema.decodeUnknownOption(schema)(input);
+const decodeUnknownOptionAs = <A>(schema: Schema.Decoder<A>) => {
+  // oxlint-disable-next-line executor/no-inline-schema-compile -- schema bound by parameter; compiler hoisted into closure
+  const decode = Schema.decodeUnknownOption(schema);
+  return (input: unknown): Option.Option<A> => decode(input);
+};
 
 const decodeJsonObjectString = Schema.decodeUnknownOption(JsonObjectFromString);
 

--- a/apps/local/src/server/migrate-mcp-bindings.test.ts
+++ b/apps/local/src/server/migrate-mcp-bindings.test.ts
@@ -26,6 +26,8 @@ const ConfigJson = Schema.fromJsonString(
   }),
 );
 
+const decodeConfigJson = Schema.decodeUnknownSync(ConfigJson);
+
 const tempDirs: Array<string> = [];
 
 const makeDbPath = () => {
@@ -87,7 +89,7 @@ describe("0007_normalize_plugin_secret_refs (mcp)", () => {
     expect(row.auth_secret_id).toBe("tok-secret");
     expect(row.auth_secret_prefix).toBe("Bearer ");
     // The auth key should be stripped from config json after migration.
-    const config = Schema.decodeUnknownSync(ConfigJson)(row.config);
+    const config = decodeConfigJson(row.config);
     expect(config.auth).toBeUndefined();
     expect(config.transport).toBe("remote");
     expect(config.endpoint).toBe("https://example.com/mcp");
@@ -200,7 +202,7 @@ describe("0007_normalize_plugin_secret_refs (mcp)", () => {
     };
     expect(row.auth_kind).toBe("none");
     expect(row.auth_secret_id).toBeNull();
-    const config = Schema.decodeUnknownSync(ConfigJson)(row.config);
+    const config = decodeConfigJson(row.config);
     expect(config.transport).toBe("stdio");
     expect(config.command).toBe("/usr/bin/server");
     after.close();

--- a/apps/local/src/server/migrate-openapi-bindings.test.ts
+++ b/apps/local/src/server/migrate-openapi-bindings.test.ts
@@ -53,6 +53,13 @@ const CountRow = Schema.Struct({
   n: Schema.Number,
 });
 
+const decodeBindingRows = Schema.decodeUnknownSync(Schema.Array(BindingRow));
+const decodeQueryParamRows = Schema.decodeUnknownSync(Schema.Array(QueryParamRow));
+const decodeFetchHeaderRows = Schema.decodeUnknownSync(Schema.Array(FetchHeaderRow));
+const decodeFetchQueryParamRows = Schema.decodeUnknownSync(Schema.Array(FetchQueryParamRow));
+const decodeTableInfoRows = Schema.decodeUnknownSync(Schema.Array(TableInfoRow));
+const decodeCountRow = Schema.decodeUnknownSync(CountRow);
+
 describe("0007_normalize_plugin_secret_refs (openapi)", () => {
   let dir: string;
   let dbPath: string;
@@ -139,7 +146,7 @@ describe("0007_normalize_plugin_secret_refs (openapi)", () => {
     closeDatabase(drizzleSqlite);
 
     const after = openDatabase(dbPath, { readonly: true });
-    const rows = Schema.decodeUnknownSync(Schema.Array(BindingRow))(
+    const rows = decodeBindingRows(
       after
         .prepare(
           "SELECT id, kind, secret_id, connection_id, text_value FROM openapi_source_binding ORDER BY id",
@@ -169,7 +176,7 @@ describe("0007_normalize_plugin_secret_refs (openapi)", () => {
       text_value: "literal",
     });
     // value json column dropped.
-    const cols = Schema.decodeUnknownSync(Schema.Array(TableInfoRow))(
+    const cols = decodeTableInfoRows(
       after.prepare("PRAGMA table_info('openapi_source_binding')").all(),
     );
     expect(cols.some((c) => c.name === "value")).toBe(false);
@@ -213,7 +220,7 @@ describe("0007_normalize_plugin_secret_refs (openapi)", () => {
 
     const after = openDatabase(dbPath, { readonly: true });
 
-    const qpRows = Schema.decodeUnknownSync(Schema.Array(QueryParamRow))(
+    const qpRows = decodeQueryParamRows(
       after
         .prepare(
           "SELECT name, kind, text_value, secret_id FROM openapi_source_query_param WHERE source_id = ? ORDER BY name",
@@ -231,7 +238,7 @@ describe("0007_normalize_plugin_secret_refs (openapi)", () => {
       text_value: "true",
     });
 
-    const fetchHeaders = Schema.decodeUnknownSync(Schema.Array(FetchHeaderRow))(
+    const fetchHeaders = decodeFetchHeaderRows(
       after
         .prepare(
           "SELECT name, kind, secret_id, secret_prefix FROM openapi_source_spec_fetch_header WHERE source_id = ?",
@@ -246,7 +253,7 @@ describe("0007_normalize_plugin_secret_refs (openapi)", () => {
       secret_prefix: "Bearer ",
     });
 
-    const fetchQp = Schema.decodeUnknownSync(Schema.Array(FetchQueryParamRow))(
+    const fetchQp = decodeFetchQueryParamRows(
       after
         .prepare(
           "SELECT name, secret_id FROM openapi_source_spec_fetch_query_param WHERE source_id = ?",
@@ -257,9 +264,7 @@ describe("0007_normalize_plugin_secret_refs (openapi)", () => {
     expect(fetchQp[0]).toMatchObject({ name: "token", secret_id: "fetch-qp" });
 
     // Old json columns dropped.
-    const cols = Schema.decodeUnknownSync(Schema.Array(TableInfoRow))(
-      after.prepare("PRAGMA table_info('openapi_source')").all(),
-    );
+    const cols = decodeTableInfoRows(after.prepare("PRAGMA table_info('openapi_source')").all());
     expect(cols.some((c) => c.name === "query_params")).toBe(false);
     expect(cols.some((c) => c.name === "invocation_config")).toBe(false);
   });
@@ -281,7 +286,7 @@ describe("0007_normalize_plugin_secret_refs (openapi)", () => {
     closeDatabase(drizzleSqlite);
 
     const after = openDatabase(dbPath, { readonly: true });
-    const qpCount = Schema.decodeUnknownSync(CountRow)(
+    const qpCount = decodeCountRow(
       after
         .prepare("SELECT count(*) as n FROM openapi_source_query_param WHERE source_id = ?")
         .get("bare"),

--- a/notes/livestore-effect-testing-porting.md
+++ b/notes/livestore-effect-testing-porting.md
@@ -1,0 +1,196 @@
+# LiveStore Effect Testing Patterns Worth Porting
+
+LiveStore is useful as a reference repo for Effect-heavy test ergonomics, not
+as a wholesale tooling model. Executor already has the stricter Effect lint
+posture and a simpler Bun/Turbo toolchain. The part worth copying is the small
+test harness shape that makes scoped Effect tests easier to write and easier to
+debug when they hang.
+
+Reference checkout:
+
+```txt
+.reference/livestore
+```
+
+## What to Port
+
+### Effect test context helper
+
+LiveStore's `packages/@livestore/utils-dev/src/node-vitest/Vitest.ts` wraps
+`@effect/vitest` with:
+
+- `withTestCtx(test)` for per-test Effect setup.
+- `makeWithTestCtx(...)` for reusable layer/timeout config.
+- A default timeout, longer in CI.
+- `Effect.logWarnIfTakesLongerThan` before the timeout trips.
+- `Effect.timeout(...)`.
+- `Effect.provide(...)` for per-test layers.
+- `Effect.scoped` so finalizers and spans close predictably.
+- Optional tracing/log layer wiring.
+
+Executor should port the shape, not the exact implementation. LiveStore is on
+Effect 3, while Executor is on Effect 4 beta. The local helper should be tiny
+and typed against the current `@effect/vitest` and `effect` APIs.
+
+Likely home:
+
+```txt
+packages/core/sdk/src/testing.ts
+```
+
+If the helper starts pulling in cloud-specific, Node-server, or plugin-specific
+dependencies, stop and keep those helpers package-local instead.
+
+### Timeout diagnostics for slow Effect tests
+
+Several Executor tests already have manual sleeps, `Promise.race`, test-level
+timeouts, or long-running fixtures. A `withTestCtx`-style helper would make
+failures more readable by logging before timeout rather than only surfacing a
+late Vitest timeout.
+
+Good initial targets:
+
+- `apps/cloud/src/mcp-miniflare.e2e.node.test.ts`
+- `apps/cloud/src/mcp-session.e2e.node.test.ts`
+- `packages/plugins/openapi/src/sdk/oauth-refresh.test.ts`
+- `packages/plugins/mcp/src/sdk/connection-pool.test.ts`
+- `packages/core/execution/src/tool-invoker.test.ts`
+
+The first slice should convert only one painful test cluster. If it makes the
+test body clearer and failure output better, then expand.
+
+### Scoped fixture/runtime pattern
+
+LiveStore's `tests/sync-provider/src/sync-provider.test.ts` builds a shared
+`ManagedRuntime` in `beforeAll`, disposes it in `afterAll`, then creates
+per-test providers with isolated ids. That pattern is a good fit for expensive
+Executor integration fixtures:
+
+- local HTTP protocol servers,
+- MCP servers,
+- OAuth mock servers,
+- Miniflare environments,
+- database-backed cloud services,
+- plugin SDK tests that need realistic server behavior.
+
+Executor already uses `layer(TestLayer)(...)` in some OpenAPI and cloud tests.
+Keep that where it works. Use the LiveStore runtime pattern only where the
+fixture is expensive enough that rebuilding it per test is wasteful or flaky.
+
+### Property-test wrapper later
+
+LiveStore's `asProp` wrapper normalizes FastCheck options and makes shrinking
+progress clearer. Do not port it preemptively.
+
+It becomes useful if Executor adds property tests for:
+
+- OpenAPI parameter encoding,
+- form/multipart request bodies,
+- schema round-trips,
+- scope ordering and shadowing,
+- tool/source dedupe,
+- storage adapter conformance.
+
+Until then, direct `@effect/vitest` property tests are enough.
+
+### Possibly scoped React perf lint
+
+LiveStore enables `react-perf` oxlint rules for JSX props:
+
+- no new functions as props,
+- no new objects as props,
+- no JSX as props,
+- no new arrays as props.
+
+This might be useful in `packages/react`, but it should start as a scoped
+experiment. Do not enable it repo-wide. The risk is turning useful UI work into
+memoization churn.
+
+## What Not to Port
+
+### Biome
+
+LiveStore uses Biome for formatting/import organization plus oxlint for linting.
+Executor already uses `oxfmt` and oxlint:
+
+```txt
+bun run format
+bun run format:check
+bun run lint
+```
+
+Adding Biome would split formatter ownership without solving an Executor
+problem.
+
+### devenv / genie / effect-utils repo generation
+
+LiveStore's config generation and `devenv` task setup are substantial
+infrastructure. Executor's Bun/Turbo setup is smaller and easier to reason
+about. Do not port that unless there is a concrete repo-management problem that
+cannot be solved locally.
+
+### LiveStore's lint rules wholesale
+
+Executor's lint posture is already stronger and more domain-specific. Executor
+currently bans or guides:
+
+- raw Vitest imports,
+- conditional tests,
+- double casts,
+- cross-package relative imports,
+- missing effect-atom reactivity keys,
+- Effect escape hatches,
+- unsupported Effect APIs,
+- `new Error`,
+- `try`/`catch` and raw `throw`,
+- `Promise.catch` / `Promise.reject`,
+- raw fetch outside approved boundaries,
+- manual tagged-error checks,
+- duplicated schema/value-derived types.
+
+LiveStore disables several things Executor intentionally cares about, including
+some broad TypeScript strictness. Their rule set should stay reference-only.
+
+### An Effect barrel module
+
+LiveStore centralizes Effect exports through `@livestore/utils/effect`.
+Executor mostly imports from `effect` directly. Do not introduce a broad
+`@executor-js/.../effect` barrel just for symmetry. It would add another import
+surface without a concrete need.
+
+## First Implementation Slice
+
+Add a tiny test helper, then use it in one test cluster.
+
+Possible local API:
+
+```ts
+export const withTestCtx =
+  (test: TestContext, options?: TestContextOptions) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    effect.pipe(
+      Effect.logWarnIfTakesLongerThan({
+        duration: "...",
+        label: "...",
+      }),
+      Effect.timeout("..."),
+      Effect.provide(options?.layer ?? Layer.empty),
+      Effect.scoped,
+    );
+```
+
+Keep the helper small:
+
+- no tracing dependency in the first pass,
+- no generic framework package,
+- no large fixture registry,
+- no migration of every test.
+
+Validation should be narrow:
+
+```txt
+vitest run <converted test file> --testNamePattern "<converted test>"
+```
+
+If the first conversion produces clearer test bodies and better failure output,
+then expand it to the other long-running Effect integration tests.

--- a/packages/core/api/src/oauth-popup.test.ts
+++ b/packages/core/api/src/oauth-popup.test.ts
@@ -21,6 +21,12 @@ type GoogleAuth = {
   refreshTokenSecretId: string | null;
 };
 
+const DomainErrorShape = Schema.Struct({
+  _tag: Schema.Literal("DomainError"),
+  message: Schema.String,
+});
+const isDomainError = Schema.is(DomainErrorShape);
+
 // ---------------------------------------------------------------------------
 // popupDocument
 // ---------------------------------------------------------------------------
@@ -172,12 +178,6 @@ describe("runOAuthCallback", () => {
     class DomainError extends Data.TaggedError("DomainError")<{
       readonly message: string;
     }> {}
-    const isDomainError = Schema.is(
-      Schema.Struct({
-        _tag: Schema.Literal("DomainError"),
-        message: Schema.String,
-      }),
-    );
     const html = await Effect.runPromise(
       runOAuthCallback<GoogleAuth, DomainError, never>({
         complete: () => Effect.fail(new DomainError({ message: "Code expired" })),

--- a/packages/core/api/src/observability.ts
+++ b/packages/core/api/src/observability.ts
@@ -115,12 +115,14 @@ export const capture = <A, E, R>(
  * widened `YieldableError` channel on `ExecutionEngineService` is
  * narrowed to `InternalError` before leaving the handler body.
  */
+const isInternalError = Schema.is(InternalError);
+
 export const captureEngineError = <A, R>(
   eff: Effect.Effect<A, Cause.YieldableError, R>,
 ): Effect.Effect<A, InternalError, R> =>
   eff.pipe(
     Effect.catch((err) =>
-      Schema.is(InternalError)(err)
+      isInternalError(err)
         ? Effect.fail(err)
         : resolveCapture.pipe(
             Effect.flatMap((c) => c.captureException(Cause.fail(err))),

--- a/packages/core/config/src/config.test.ts
+++ b/packages/core/config/src/config.test.ts
@@ -14,6 +14,8 @@ import {
   removeSecretFromConfig,
 } from "./write";
 
+const decodeExecutorFileConfig = Schema.decodeUnknownSync(ExecutorFileConfig);
+
 const withTmpDir = <A, E>(fn: (dir: string) => Effect.Effect<A, E, FileSystem.FileSystem>) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
@@ -26,7 +28,7 @@ const withTmpDir = <A, E>(fn: (dir: string) => Effect.Effect<A, E, FileSystem.Fi
 describe("ExecutorFileConfig schema", () => {
   it("decodes a minimal config", () => {
     const raw = { sources: [] };
-    const result = Schema.decodeUnknownSync(ExecutorFileConfig)(raw);
+    const result = decodeExecutorFileConfig(raw);
     expect(result.sources).toEqual([]);
   });
 
@@ -70,7 +72,7 @@ describe("ExecutorFileConfig schema", () => {
       },
     };
 
-    const result = Schema.decodeUnknownSync(ExecutorFileConfig)(raw);
+    const result = decodeExecutorFileConfig(raw);
     expect(result.sources).toHaveLength(4);
     expect(result.name).toBe("test");
     expect(result.secrets!["my-token"]!.name).toBe("My Token");
@@ -80,7 +82,7 @@ describe("ExecutorFileConfig schema", () => {
     const raw = {
       sources: [{ kind: "invalid", endpoint: "http://example.com" }],
     };
-    expect(() => Schema.decodeUnknownSync(ExecutorFileConfig)(raw)).toThrow();
+    expect(() => decodeExecutorFileConfig(raw)).toThrow();
   });
 });
 

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -347,13 +347,15 @@ const staticDeclToSource = (decl: StaticSourceDecl, pluginId: string): Source =>
   runtime: true,
 });
 
+const decodeJsonFromString = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
+
 const decodeJsonColumn = (value: unknown): unknown => {
   if (value === null || value === undefined) return undefined;
   if (typeof value !== "string") return value;
-  return Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(value).pipe(
-    Option.getOrElse(() => value),
-  );
+  return decodeJsonFromString(value).pipe(Option.getOrElse(() => value));
 };
+
+const decodeProviderState = Schema.decodeUnknownOption(ConnectionProviderState);
 
 const rowToTool = (row: ToolRow, annotations?: ToolAnnotations): Tool => ({
   id: row.id,
@@ -1176,8 +1178,6 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
     // Matches the value the old per-plugin refresh code used, so
     // behavior under the new SDK orchestration stays identical.
     const CONNECTION_REFRESH_SKEW_MS = 60_000;
-
-    const decodeProviderState = Schema.decodeUnknownOption(ConnectionProviderState);
 
     const rowToConnection = (row: ConnectionRow): ConnectionRef =>
       new ConnectionRef({

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -137,11 +137,15 @@ type OAuthSessionPayload = typeof OAuthSessionPayload.Type;
 const decodeSessionPayload = Schema.decodeUnknownSync(OAuthSessionPayload);
 const encodeSessionPayload = Schema.encodeSync(OAuthSessionPayload);
 
+const UnknownFromJsonString = Schema.fromJsonString(Schema.Unknown);
+const decodeUnknownJsonOption = Schema.decodeUnknownOption(UnknownFromJsonString);
+
+const decodeProviderStateSync = Schema.decodeUnknownSync(OAuthProviderStateSchema);
+const encodeProviderStateSync = Schema.encodeSync(OAuthProviderStateSchema);
+
 const coerceJson = (value: unknown): unknown => {
   if (typeof value !== "string") return value;
-  return Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown))(value).pipe(
-    Option.getOrElse(() => value),
-  );
+  return decodeUnknownJsonOption(value).pipe(Option.getOrElse(() => value));
 };
 
 const stringArray = (value: unknown): readonly string[] =>
@@ -167,7 +171,7 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
   if (record && !("kind" in record) && "flow" in record && "tokenUrl" in record) {
     const flow = record.flow;
     if (flow === "authorizationCode") {
-      return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
+      return decodeProviderStateSync({
         kind: "authorization-code",
         tokenEndpoint: record.tokenUrl,
         issuerUrl: originOrNull(record.authorizationEndpoint),
@@ -178,7 +182,7 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
       });
     }
     if (flow === "clientCredentials") {
-      return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
+      return decodeProviderStateSync({
         kind: "client-credentials",
         tokenEndpoint: record.tokenUrl,
         clientIdSecretId: record.clientIdSecretId,
@@ -192,7 +196,7 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
 
   if (record && !("kind" in record) && "clientIdSecretId" in record && "scopes" in record) {
     const scopes = stringArray(record.scopes);
-    return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
+    return decodeProviderStateSync({
       kind: "authorization-code",
       tokenEndpoint: "https://oauth2.googleapis.com/token",
       issuerUrl: "https://accounts.google.com",
@@ -208,7 +212,7 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
     const authorizationServerMetadata = isRecord(record.authorizationServerMetadata)
       ? record.authorizationServerMetadata
       : null;
-    return Schema.decodeUnknownSync(OAuthProviderStateSchema)({
+    return decodeProviderStateSync({
       kind: "dynamic-dcr",
       tokenEndpoint:
         typeof record.tokenEndpoint === "string"
@@ -233,7 +237,7 @@ const decodeProviderState = (value: unknown): OAuthProviderState => {
     });
   }
 
-  return Schema.decodeUnknownSync(OAuthProviderStateSchema)(raw);
+  return decodeProviderStateSync(raw);
 };
 
 // ---------------------------------------------------------------------------
@@ -605,10 +609,7 @@ export const makeOAuth2Service = (
             refreshToken: null,
             expiresAt,
             oauthScope: tokens.scope ?? null,
-            providerState: Schema.encodeSync(OAuthProviderStateSchema)(providerState) as Record<
-              string,
-              unknown
-            >,
+            providerState: encodeProviderStateSync(providerState) as Record<string, unknown>,
           }),
         )
         .pipe(
@@ -847,10 +848,7 @@ export const makeOAuth2Service = (
               : null,
             expiresAt: connectionExpiresAt,
             oauthScope: exchangeResult.tokens.scope ?? null,
-            providerState: Schema.encodeSync(OAuthProviderStateSchema)(providerState) as Record<
-              string,
-              unknown
-            >,
+            providerState: encodeProviderStateSync(providerState) as Record<string, unknown>,
           }),
         )
         .pipe(
@@ -1219,7 +1217,7 @@ export const makeOAuth2Service = (
           refreshToken: tokens.refresh_token,
           expiresAt,
           oauthScope: tokens.scope ?? input.oauthScope,
-          providerState: Schema.encodeSync(OAuthProviderStateSchema)({
+          providerState: encodeProviderStateSync({
             ...state,
             tokenEndpoint,
             scope: tokens.scope ?? state.scope,

--- a/packages/core/storage-core/src/factory.ts
+++ b/packages/core/storage-core/src/factory.ts
@@ -81,6 +81,8 @@ const withApplyDefault = (
   return value;
 };
 
+const decodeJsonFromString = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -199,9 +201,7 @@ export const createAdapter = (options: CreateAdapterOptions): DBAdapter => {
   };
 
   const decodeJsonFallback = (value: string): unknown =>
-    Schema.decodeUnknownOption(Schema.UnknownFromJsonString)(value).pipe(
-      Option.getOrElse((): unknown => value),
-    );
+    decodeJsonFromString(value).pipe(Option.getOrElse((): unknown => value));
 
   const decodeValue = (attr: DBFieldAttribute | undefined, value: unknown): unknown => {
     if (value === undefined || value === null) return value;

--- a/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/AddGoogleDiscoverySource.tsx
@@ -51,15 +51,13 @@ import { GOOGLE_DISCOVERY_OAUTH_POPUP_NAME, googleDiscoveryOAuthStrategy } from 
 import { googleDiscoveryPresets, type GoogleDiscoveryPreset } from "../sdk/presets";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
+const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
 
 const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
-  Option.match(
-    Option.flatMap(Exit.findErrorOption(exit), Schema.decodeUnknownOption(ErrorMessage)),
-    {
-      onNone: () => fallback,
-      onSome: ({ message }) => message,
-    },
-  );
+  Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
+    onNone: () => fallback,
+    onSome: ({ message }) => message,
+  });
 
 type GoogleAuthKind = "none" | "oauth2";
 

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -40,15 +40,13 @@ import { initialGraphqlCredentials } from "./defaults";
 import type { HeaderValue } from "../sdk/types";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
+const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
 
 const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
-  Option.match(
-    Option.flatMap(Exit.findErrorOption(exit), Schema.decodeUnknownOption(ErrorMessage)),
-    {
-      onNone: () => fallback,
-      onSome: ({ message }) => message,
-    },
-  );
+  Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
+    onNone: () => fallback,
+    onSome: ({ message }) => message,
+  });
 
 type AuthMode = "none" | "oauth2";
 

--- a/packages/plugins/graphql/src/sdk/store.ts
+++ b/packages/plugins/graphql/src/sdk/store.ts
@@ -110,11 +110,17 @@ export interface StoredOperation {
   readonly binding: OperationBinding;
 }
 
+const OperationBindingFromJsonString = Schema.fromJsonString(OperationBinding);
+const decodeOperationBindingFromJsonString = Schema.decodeUnknownSync(
+  OperationBindingFromJsonString,
+);
+const decodeOperationBinding = Schema.decodeUnknownSync(OperationBinding);
+
 const decodeBinding = (value: unknown): OperationBinding => {
   if (typeof value === "string") {
-    return Schema.decodeUnknownSync(Schema.fromJsonString(OperationBinding))(value);
+    return decodeOperationBindingFromJsonString(value);
   }
-  return Schema.decodeUnknownSync(OperationBinding)(value);
+  return decodeOperationBinding(value);
 };
 
 const encodeBinding = Schema.encodeSync(OperationBinding);

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -56,15 +56,13 @@ import { probeMcpEndpoint, addMcpSourceOptimistic } from "./atoms";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
+const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
 
 const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
-  Option.match(
-    Option.flatMap(Exit.findErrorOption(exit), Schema.decodeUnknownOption(ErrorMessage)),
-    {
-      onNone: () => fallback,
-      onSome: ({ message }) => message,
-    },
-  );
+  Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
+    onNone: () => fallback,
+    onSome: ({ message }) => message,
+  });
 
 // ---------------------------------------------------------------------------
 // Preset lookup

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -86,15 +86,13 @@ export const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
 export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/oauth/callback";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
+const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
 
 const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
-  Option.match(
-    Option.flatMap(Exit.findErrorOption(exit), Schema.decodeUnknownOption(ErrorMessage)),
-    {
-      onNone: () => fallback,
-      onSome: ({ message }) => message,
-    },
-  );
+  Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
+    onNone: () => fallback,
+    onSome: ({ message }) => message,
+  });
 
 const substituteUrlVariables = (url: string, values: Record<string, string>): string => {
   let out = url;

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -51,15 +51,14 @@ import {
 } from "../sdk/types";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
+const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
+const isOpenApiSourceBindingValue = Schema.is(OpenApiSourceBindingValue);
 
 const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
-  Option.match(
-    Option.flatMap(Exit.findErrorOption(exit), Schema.decodeUnknownOption(ErrorMessage)),
-    {
-      onNone: () => fallback,
-      onSome: ({ message }) => message,
-    },
-  );
+  Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
+    onNone: () => fallback,
+    onSome: ({ message }) => message,
+  });
 
 type SlotDef =
   | {
@@ -137,12 +136,12 @@ const effectiveBindingForScope = (
 const isSecretBindingValue = (
   value: unknown,
 ): value is Extract<OpenApiSourceBindingValueType, { readonly kind: "secret" }> =>
-  Schema.is(OpenApiSourceBindingValue)(value) && value.kind === "secret";
+  isOpenApiSourceBindingValue(value) && value.kind === "secret";
 
 const isConnectionBindingValue = (
   value: unknown,
 ): value is Extract<OpenApiSourceBindingValueType, { readonly kind: "connection" }> =>
-  Schema.is(OpenApiSourceBindingValue)(value) && value.kind === "connection";
+  isOpenApiSourceBindingValue(value) && value.kind === "connection";
 
 export default function EditOpenApiSource(props: {
   readonly sourceId: string;

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -33,6 +33,7 @@ const JsonNameBody = Schema.fromJsonString(
     name: Schema.String,
   }),
 );
+const decodeJsonNameBody = Schema.decodeUnknownSync(JsonNameBody);
 
 const memoryProvider: SecretProvider = (() => {
   const store = new Map<string, string>();
@@ -216,7 +217,7 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       expect(captured.contentType).toBe("text/xml");
       const body = captured.body.toString("utf8");
       expect(body).not.toBe("[object Object]");
-      expect(Schema.decodeUnknownSync(JsonNameBody)(body)).toEqual({ name: "Acme" });
+      expect(decodeJsonNameBody(body)).toEqual({ name: "Acme" });
     }),
   );
 
@@ -364,7 +365,7 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       );
 
       expect(captured.contentType).toBe("application/json");
-      expect(Schema.decodeUnknownSync(JsonNameBody)(captured.body.toString("utf8"))).toEqual({
+      expect(decodeJsonNameBody(captured.body.toString("utf8"))).toEqual({
         name: "Acme",
       });
     }),

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -287,8 +287,10 @@ const SourceNameStorageRow = Schema.Struct({
 });
 const decodeSourceNameStorageRow = Schema.decodeUnknownSync(SourceNameStorageRow);
 
+const decodeStorageString = Schema.decodeUnknownSync(Schema.String);
+
 const decodeStorageDate = (value: unknown): Date =>
-  value instanceof Date ? value : new Date(Schema.decodeUnknownSync(Schema.String)(value));
+  value instanceof Date ? value : new Date(decodeStorageString(value));
 
 interface ChildRow {
   readonly id: string;

--- a/packages/plugins/workos-vault/src/sdk/client.ts
+++ b/packages/plugins/workos-vault/src/sdk/client.ts
@@ -26,12 +26,13 @@ const WORKOS_KEK_NOT_READY_MESSAGE =
 const CauseWithStatusSchema = Schema.Struct({
   status: Schema.Number,
 });
+const decodeCauseWithStatusOption = Schema.decodeUnknownOption(CauseWithStatusSchema);
 
 const statusFromWorkOSCause = (cause: unknown): number | undefined => {
   if (cause instanceof GenericServerException || cause instanceof NotFoundException) {
     return cause.status;
   }
-  return Option.match(Schema.decodeUnknownOption(CauseWithStatusSchema)(cause), {
+  return Option.match(decodeCauseWithStatusOption(cause), {
     onNone: () => undefined,
     onSome: (decoded) => decoded.status,
   });

--- a/scripts/oxlint-plugin-executor.js
+++ b/scripts/oxlint-plugin-executor.js
@@ -5,6 +5,7 @@ import noEffectEscapeHatch from "./oxlint-plugin-executor/rules/no-effect-escape
 import noEffectInternalTags from "./oxlint-plugin-executor/rules/no-effect-internal-tags.js";
 import noErrorConstructor from "./oxlint-plugin-executor/rules/no-error-constructor.js";
 import noInlineObjectTypeAssertion from "./oxlint-plugin-executor/rules/no-inline-object-type-assertion.js";
+import noInlineSchemaCompile from "./oxlint-plugin-executor/rules/no-inline-schema-compile.js";
 import noInstanceofError from "./oxlint-plugin-executor/rules/no-instanceof-error.js";
 import noInstanceofTaggedError from "./oxlint-plugin-executor/rules/no-instanceof-tagged-error.js";
 import noJsonParse from "./oxlint-plugin-executor/rules/no-json-parse.js";
@@ -42,6 +43,7 @@ export default {
     "no-error-constructor": noErrorConstructor,
     "no-ts-nocheck": noTsNocheck,
     "no-inline-object-type-assertion": noInlineObjectTypeAssertion,
+    "no-inline-schema-compile": noInlineSchemaCompile,
     "no-instanceof-error": noInstanceofError,
     "no-instanceof-tagged-error": noInstanceofTaggedError,
     "no-json-parse": noJsonParse,

--- a/scripts/oxlint-plugin-executor/rules/no-inline-schema-compile.js
+++ b/scripts/oxlint-plugin-executor/rules/no-inline-schema-compile.js
@@ -1,0 +1,104 @@
+import { getPropertyName, isIdentifier, unwrapExpression } from "../utils.js";
+
+// Schema methods that compile a parser/guard from a schema. Calling these
+// allocates a new function per invocation; the result should be hoisted to
+// module (or at least closure) scope.
+const COMPILER_METHODS = new Set([
+  "is",
+  "asserts",
+  "decode",
+  "decodeSync",
+  "decodePromise",
+  "decodeOption",
+  "decodeEither",
+  "decodeUnknown",
+  "decodeUnknownSync",
+  "decodeUnknownPromise",
+  "decodeUnknownOption",
+  "decodeUnknownEither",
+  "encode",
+  "encodeSync",
+  "encodePromise",
+  "encodeOption",
+  "encodeEither",
+  "encodeUnknown",
+  "encodeUnknownSync",
+  "encodeUnknownPromise",
+  "encodeUnknownOption",
+  "encodeUnknownEither",
+  "validate",
+  "validateSync",
+  "validatePromise",
+  "validateOption",
+  "validateEither",
+  "parse",
+  "parseSync",
+  "parsePromise",
+  "parseOption",
+  "parseEither",
+]);
+
+const getSchemaCompilerMethod = (callee) => {
+  const expression = unwrapExpression(callee);
+  if (expression?.type !== "MemberExpression") return undefined;
+  const object = unwrapExpression(expression.object);
+  if (!isIdentifier(object, "Schema")) return undefined;
+  const method = getPropertyName(expression.property);
+  return method && COMPILER_METHODS.has(method) ? method : undefined;
+};
+
+const isNestedSchemaCall = (node) => {
+  const expression = unwrapExpression(node);
+  if (expression?.type !== "CallExpression") return false;
+  const callee = unwrapExpression(expression.callee);
+  if (callee?.type !== "MemberExpression") return false;
+  const object = unwrapExpression(callee.object);
+  return isIdentifier(object, "Schema");
+};
+
+const messageHigh = (method) =>
+  `Hoist Schema.${method}(...) to module scope: both the inline schema literal and the compiled function are rebuilt on every call. Move the compiled function to a module-level const.`;
+
+const messageMedium = (method) =>
+  `Hoist Schema.${method}(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.`;
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow Schema compiler calls (Schema.is/decode*/encode*/validate*/parse*) inside function bodies; hoist them to module scope.",
+    },
+  },
+  create(context) {
+    let functionDepth = 0;
+
+    const enterFunction = () => {
+      functionDepth++;
+    };
+    const exitFunction = () => {
+      functionDepth--;
+    };
+
+    return {
+      FunctionDeclaration: enterFunction,
+      "FunctionDeclaration:exit": exitFunction,
+      FunctionExpression: enterFunction,
+      "FunctionExpression:exit": exitFunction,
+      ArrowFunctionExpression: enterFunction,
+      "ArrowFunctionExpression:exit": exitFunction,
+
+      CallExpression(node) {
+        if (functionDepth === 0) return;
+        const method = getSchemaCompilerMethod(node.callee);
+        if (!method) return;
+        const firstArg = node.arguments[0];
+        const high = firstArg && isNestedSchemaCall(firstArg);
+        context.report({
+          node: node.callee,
+          message: high ? messageHigh(method) : messageMedium(method),
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

- New oxlint rule `executor/no-inline-schema-compile` flags `Schema.is` / `Schema.decode*` / `Schema.encode*` / `Schema.validate*` / `Schema.parse*` calls inside function bodies, since each call rebuilds the parser/guard. Two severities — HIGH when the schema argument is itself an inline `Schema.X(...)` literal (AST + compile rebuilt), MEDIUM when only the compiler is re-called.
- Fixes the 44 existing violations across 22 files by hoisting the compiled function (and where applicable, its schema literal) to module scope.
- Notable consolidations: `oauth-service.ts` (8 sites collapse into two hoisted helpers), `jwks-cache.ts` / `mcp-auth.ts` (JWT verify error path), and the React `Add*Source` / `EditOpenApiSource` components (shared `decodeErrorMessage` / `isOpenApiSourceBindingValue`).

One targeted `oxlint-disable` in `migrate-connections.ts` for a higher-order helper whose schema is a function parameter — the compile is moved into the outer closure but the rule still flags any Schema compiler call inside any function body.

## Test plan

- [x] `bun run lint` — 0 warnings, 0 errors (rule active at `error`)
- [x] `bun run typecheck` — 33 packages pass
- [x] `bun run format:check` — clean
- [x] `bun run test` — 27 turbo tasks pass, including the most-affected (`jwks-cache.node.test.ts`, `mcp-auth.node.test.ts`, oauth-service tests, migration tests)