### PR TITLE
Tighten scoped storage boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ executor.jsonc
 # Warden local scan outputs
 .warden/
 .warden-runs/
+
+# Agent local notes
+MISTAKES.md
+DESIRES.md
+LEARNINGS.md

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -7,6 +7,7 @@
     "executor/no-conditional-tests": "error",
     "executor/no-double-cast": "error",
     "executor/no-cross-package-relative-imports": "error",
+    "executor/no-direct-cloud-executor-schema-import": "error",
     "executor/require-reactivity-keys": "error",
     "executor/no-effect-escape-hatch": "error",
     "executor/no-effect-internal-tags": "error",

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -2,7 +2,6 @@ import { Context, Deferred, Effect, Option, Result, Schema, Semaphore } from "ef
 import { generateKeyBetween } from "fractional-indexing";
 import {
   StorageError,
-  typedAdapter,
   type DBAdapter,
   type DBSchema,
   type DBTransactionAdapter,
@@ -88,7 +87,7 @@ import {
   type ToolListFilter,
 } from "./types";
 import { buildToolTypeScriptPreview } from "./schema-types";
-import { scopeAdapter } from "./scoped-adapter";
+import { scopedTypedAdapter, scopeAdapter, type ScopedDBAdapter } from "./scoped-adapter";
 
 // ---------------------------------------------------------------------------
 // Elicitation handler — set once at `createExecutor({ onElicitation })`
@@ -538,7 +537,7 @@ const activeAdapterRef = Context.Reference<DBTransactionAdapter | null>("executo
 // root) on every call. Stable identity for consumers (plugin storage,
 // `typedAdapter`, etc.) — they see one adapter object, but the routing is
 // decided at call time via the FiberRef above.
-const buildAdapterRouter = (root: DBAdapter): DBAdapter => {
+const buildAdapterRouter = (root: ScopedDBAdapter): ScopedDBAdapter => {
   const pick = <A, E>(
     use: (active: DBTransactionAdapter) => Effect.Effect<A, E>,
   ): Effect.Effect<A, E> =>
@@ -571,7 +570,7 @@ const buildAdapterRouter = (root: DBAdapter): DBAdapter => {
           Effect.provideService(callback(trx), activeAdapterRef, trx),
         );
       }),
-  } as DBAdapter;
+  } as ScopedDBAdapter;
 };
 
 // ---------------------------------------------------------------------------
@@ -624,7 +623,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
     const scopeIds = scopes.map((s) => s.id);
     const scopedRoot = scopeAdapter(rootAdapter, { scopes: scopeIds }, schema);
     const adapter = buildAdapterRouter(scopedRoot);
-    const core = typedAdapter<CoreSchema>(adapter);
+    const core = scopedTypedAdapter<CoreSchema>(adapter);
 
     // Populated once, never mutated after startup.
     const staticTools = new Map<string, StaticTools>();
@@ -1743,7 +1742,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const storageDeps: StorageDeps<any> = {
         scopes,
-        adapter: typedAdapter(adapter),
+        adapter: plugin.schema ? scopedTypedAdapter(adapter) : adapter,
         // Blob keys are namespaced by `<scope>/<plugin>` so two tenants
         // sharing a backing BlobStore can't collide or leak on the
         // same `(plugin, key)` pair. The store's `get`/`has` walk the

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -203,6 +203,7 @@ export {
 } from "./oauth-helpers";
 
 export { makeOAuth2Service, type OAuthServiceDeps } from "./oauth-service";
+export type { ScopedDBAdapter, ScopedTypedAdapter } from "./scoped-adapter";
 
 export {
   OAuthDiscoveryError,

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -37,7 +37,7 @@
 
 import { Effect, Option, Schema } from "effect";
 
-import type { DBAdapter, StorageFailure, TypedAdapter } from "@executor-js/storage-core";
+import type { StorageFailure, TypedAdapter } from "@executor-js/storage-core";
 
 import {
   ConnectionRefreshError,
@@ -86,6 +86,7 @@ import {
   type OAuth2Error,
   refreshAccessToken,
 } from "./oauth-helpers";
+import type { ScopedDBAdapter } from "./scoped-adapter";
 
 // ---------------------------------------------------------------------------
 // Session payload — persisted under `oauth2_session.payload` as opaque
@@ -248,9 +249,9 @@ export interface OAuthServiceDeps {
    *  fall through the scope stack; writes stamp the scope the caller
    *  named (`tokenScope` on start input). */
   readonly adapter: TypedAdapter<CoreSchema>;
-  /** Raw adapter for opening transactions — the typed one doesn't expose
-   *  `.transaction` directly. */
-  readonly rawAdapter: DBAdapter;
+  /** Scoped adapter for opening transactions — the typed one doesn't
+   *  expose `.transaction` directly. */
+  readonly rawAdapter: ScopedDBAdapter;
   /** Resolves client-id / client-secret refs at start + refresh time.
    *  A `null` return means "secret row is gone" and aborts the flow. */
   readonly secretsGet: (id: string) => Effect.Effect<string | null, StorageFailure>;

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -1,6 +1,6 @@
 import type { Context, Effect, Layer } from "effect";
 import type { HttpApiGroup } from "effect/unstable/httpapi";
-import type { DBAdapter, DBSchema, StorageFailure, TypedAdapter } from "@executor-js/storage-core";
+import type { DBSchema, StorageFailure } from "@executor-js/storage-core";
 
 import type { PluginBlobStore } from "./blob";
 import type {
@@ -29,6 +29,7 @@ import type {
 } from "./errors";
 import type { OAuthService } from "./oauth";
 import type { Scope } from "./scope";
+import type { ScopedDBAdapter, ScopedTypedAdapter } from "./scoped-adapter";
 import type { SecretProvider, SecretRef, SetSecretInput } from "./secrets";
 import type { Usage, UsagesForConnectionInput, UsagesForSecretInput } from "./usages";
 
@@ -60,7 +61,7 @@ export interface StorageDeps<TSchema extends DBSchema | undefined = undefined> {
    * `@executor-js/api` `withCapture`) is the one place that
    * translates it to the opaque `InternalError({ traceId })`.
    */
-  readonly adapter: TSchema extends DBSchema ? TypedAdapter<TSchema, StorageFailure> : DBAdapter;
+  readonly adapter: TSchema extends DBSchema ? ScopedTypedAdapter<TSchema> : ScopedDBAdapter;
   readonly blobs: PluginBlobStore;
 }
 

--- a/packages/core/sdk/src/scoped-adapter.test.ts
+++ b/packages/core/sdk/src/scoped-adapter.test.ts
@@ -4,8 +4,8 @@ import { Cause, Effect, Exit } from "effect";
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
 import { StorageError, typedAdapter } from "@executor-js/storage-core";
 
-import { defineSchema } from "./plugin";
-import { scopeAdapter } from "./scoped-adapter";
+import { defineSchema, type StorageDeps } from "./plugin";
+import { scopedTypedAdapter, scopeAdapter } from "./scoped-adapter";
 
 const schema = defineSchema({
   thing: {
@@ -28,6 +28,32 @@ const setup = (scopes: readonly string[]) => {
   const wrapped = scopeAdapter(inner, { scopes }, schema);
   return typedAdapter<typeof schema>(wrapped);
 };
+
+describe("StorageDeps type boundary", () => {
+  it("does not accept typedAdapter(rawAdapter)", () => {
+    const raw = makeMemoryAdapter({ schema });
+    const rawTyped = typedAdapter<typeof schema>(raw);
+    const scopedTyped = scopedTypedAdapter<typeof schema>(
+      scopeAdapter(raw, { scopes: ["a"] }, schema),
+    );
+
+    const accepted: StorageDeps<typeof schema> = {
+      scopes: [],
+      adapter: scopedTyped,
+      blobs: null as never,
+    };
+
+    const rejected = {
+      scopes: [],
+      // @ts-expect-error StorageDeps must not accept typedAdapter(rawAdapter).
+      adapter: rawTyped,
+      blobs: null as never,
+    } satisfies StorageDeps<typeof schema>;
+
+    expect(accepted.adapter).toBe(scopedTyped);
+    expect(rejected.adapter).toBe(rawTyped);
+  });
+});
 
 describe("scopeAdapter — write rejection on scoped tables", () => {
   it.effect("rejects create with scope_id outside the stack", () =>

--- a/packages/core/sdk/src/scoped-adapter.ts
+++ b/packages/core/sdk/src/scoped-adapter.ts
@@ -19,13 +19,16 @@
 // `scope_id: { type: "string", required: true, index: true }`. Tables
 // without it are shared across scopes by construction.
 
-import { Effect } from "effect";
+import { Effect, type Brand } from "effect";
 
 import {
   StorageError,
+  typedAdapter,
   type DBAdapter,
   type DBSchema,
   type DBTransactionAdapter,
+  type StorageFailure,
+  type TypedAdapter,
   type Where,
 } from "@executor-js/storage-core";
 
@@ -40,6 +43,25 @@ export interface ScopeContext {
    */
   readonly scopes: readonly string[];
 }
+
+/**
+ * Adapter that has already been wrapped by `scopeAdapter`. Executor/plugin
+ * internals should accept this branded type after construction, so a raw
+ * adapter cannot be threaded into scoped storage by accident.
+ */
+export type ScopedDBAdapter = DBAdapter & Brand.Brand<"ScopedDBAdapter">;
+
+/**
+ * Plugin-facing typed adapter derived from a `ScopedDBAdapter`. It has the
+ * same runtime shape as `TypedAdapter`, but the brand keeps StorageDeps from
+ * being satisfied by `typedAdapter(rawAdapter)`.
+ */
+export type ScopedTypedAdapter<TSchema extends DBSchema> = TypedAdapter<TSchema, StorageFailure> &
+  Brand.Brand<"ScopedTypedAdapter">;
+
+export const scopedTypedAdapter = <TSchema extends DBSchema>(
+  adapter: ScopedDBAdapter,
+): ScopedTypedAdapter<TSchema> => typedAdapter<TSchema>(adapter) as ScopedTypedAdapter<TSchema>;
 
 const collectScopedModels = (schema: DBSchema): Set<string> => {
   const out = new Set<string>();
@@ -190,7 +212,11 @@ const wrapTxMethods = (
   };
 };
 
-export const scopeAdapter = (inner: DBAdapter, ctx: ScopeContext, schema: DBSchema): DBAdapter => {
+export const scopeAdapter = (
+  inner: DBAdapter,
+  ctx: ScopeContext,
+  schema: DBSchema,
+): ScopedDBAdapter => {
   const scopedModels = collectScopedModels(schema);
   const tx = wrapTxMethods(inner, ctx, scopedModels);
   return {
@@ -202,7 +228,7 @@ export const scopeAdapter = (inner: DBAdapter, ctx: ScopeContext, schema: DBSche
       }),
     createSchema: inner.createSchema,
     options: inner.options,
-  };
+  } as ScopedDBAdapter;
 };
 
 export const __scopeField = SCOPE_FIELD;

--- a/scripts/oxlint-plugin-executor.js
+++ b/scripts/oxlint-plugin-executor.js
@@ -1,5 +1,6 @@
 import noConditionalTests from "./oxlint-plugin-executor/rules/no-conditional-tests.js";
 import noCrossPackageRelativeImports from "./oxlint-plugin-executor/rules/no-cross-package-relative-imports.js";
+import noDirectCloudExecutorSchemaImport from "./oxlint-plugin-executor/rules/no-direct-cloud-executor-schema-import.js";
 import noDoubleCast from "./oxlint-plugin-executor/rules/no-double-cast.js";
 import noEffectEscapeHatch from "./oxlint-plugin-executor/rules/no-effect-escape-hatch.js";
 import noEffectInternalTags from "./oxlint-plugin-executor/rules/no-effect-internal-tags.js";
@@ -36,6 +37,7 @@ export default {
     "no-conditional-tests": noConditionalTests,
     "no-double-cast": noDoubleCast,
     "no-cross-package-relative-imports": noCrossPackageRelativeImports,
+    "no-direct-cloud-executor-schema-import": noDirectCloudExecutorSchemaImport,
     "require-reactivity-keys": requireReactivityKeys,
     "no-effect-escape-hatch": noEffectEscapeHatch,
     "no-effect-internal-tags": noEffectInternalTags,

--- a/scripts/oxlint-plugin-executor/rules/no-direct-cloud-executor-schema-import.js
+++ b/scripts/oxlint-plugin-executor/rules/no-direct-cloud-executor-schema-import.js
@@ -1,0 +1,77 @@
+import { getPropertyName, isIdentifier, toRepoRelative, unwrapExpression } from "../utils.js";
+
+const message =
+  "Do not access cloud executor tables directly outside DB schema wiring. Executor-domain table access must go through the scoped SDK adapter so scope_id filtering cannot be skipped.";
+
+const allowedFiles = new Set([
+  "apps/cloud/src/services/db.ts",
+  "apps/cloud/src/services/db.schema.test.ts",
+]);
+
+const isCloudSource = (filename) => toRepoRelative(filename).startsWith("apps/cloud/src/");
+
+const isDirectExecutorSchemaImport = (specifier) =>
+  specifier === "./executor-schema" ||
+  specifier === "./executor-schema.ts" ||
+  specifier === "../services/executor-schema" ||
+  specifier === "../services/executor-schema.ts" ||
+  specifier.endsWith("/services/executor-schema") ||
+  specifier.endsWith("/services/executor-schema.ts");
+
+const coreTableNames = new Set([
+  "source",
+  "tool",
+  "definition",
+  "secret",
+  "connection",
+  "oauth2_session",
+  "tool_policy",
+]);
+
+const pluginTablePrefixes = ["openapi_", "graphql_", "mcp_"];
+
+const isExecutorTableName = (name) =>
+  coreTableNames.has(name) || pluginTablePrefixes.some((prefix) => name.startsWith(prefix));
+
+const isDbQueryExecutorTableAccess = (node) => {
+  const tableName = getPropertyName(node.property);
+  if (!tableName || !isExecutorTableName(tableName)) return false;
+
+  const object = unwrapExpression(node.object);
+  if (object?.type !== "MemberExpression") return false;
+  return getPropertyName(object.property) === "query";
+};
+
+const isCombinedSchemaExecutorTableAccess = (node) => {
+  const tableName = getPropertyName(node.property);
+  if (!tableName || !isExecutorTableName(tableName)) return false;
+  return isIdentifier(unwrapExpression(node.object), "combinedSchema");
+};
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow direct imports of cloud executor-schema outside sanctioned DB wiring.",
+    },
+  },
+  create(context) {
+    const filename = toRepoRelative(context.filename);
+    if (!isCloudSource(context.filename) || allowedFiles.has(filename)) return {};
+
+    return {
+      ImportDeclaration(node) {
+        const specifier = node.source.value;
+        if (typeof specifier !== "string") return;
+        if (!isDirectExecutorSchemaImport(specifier)) return;
+
+        context.report({ node: node.source, message });
+      },
+      MemberExpression(node) {
+        if (isDbQueryExecutorTableAccess(node) || isCombinedSchemaExecutorTableAccess(node)) {
+          context.report({ node, message });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## Summary

- add Effect-branded scoped adapter types so plugin storage deps cannot be built from a raw adapter by accident
- route executor/plugin internals through the branded scoped adapter after `createExecutor` wraps storage
- add a cloud lint guard for direct executor-table access and ignore local agent note files

## Checks

- `bun run --cwd packages/core/sdk typecheck`
- `bun run --cwd packages/core/sdk test -- scoped-adapter.test.ts`
- `bun run --cwd packages/core/sdk test -- scoped-adapter.test.ts executor.test.ts`
- `bun run --filter='@executor-js/plugin-openapi' typecheck`
- `bun run --filter='@executor-js/plugin-graphql' typecheck`
- `bun run --filter='@executor-js/plugin-mcp' typecheck`
- `bun run --filter='@executor-js/plugin-workos-vault' typecheck`
- targeted `oxlint`
- targeted `oxfmt --check`