### PR TITLE
[codex] Put typed base URL first in combobox

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -838,7 +838,6 @@ export default function AddOpenApiSource(props: {
                   onValueChange={setBaseUrl}
                   options={baseUrlOptions}
                   placeholder="https://api.example.com"
-                  emptyLabel="Use the custom URL you typed."
                   className="w-full"
                   inputClassName="font-mono text-sm"
                 />

--- a/packages/react/src/components/combobox.tsx
+++ b/packages/react/src/components/combobox.tsx
@@ -278,13 +278,16 @@ function FreeformCombobox(props: {
   readonly inputClassName?: string;
   readonly disabled?: boolean;
 }) {
-  const selectedValue = props.options.some((option) => option.value === props.value)
-    ? props.value
-    : null;
+  const valueOption = props.value.trim();
+  const options =
+    valueOption.length > 0 && !props.options.some((option) => option.value === valueOption)
+      ? [{ value: valueOption, label: valueOption }, ...props.options]
+      : props.options;
+  const selectedValue = options.some((option) => option.value === props.value) ? props.value : null;
 
   return (
     <Combobox
-      items={props.options.map((option) => option.value)}
+      items={options.map((option) => option.value)}
       inputValue={props.value}
       value={selectedValue}
       onInputValueChange={props.onValueChange}
@@ -302,7 +305,7 @@ function FreeformCombobox(props: {
       <ComboboxContent>
         <ComboboxEmpty>{props.emptyLabel ?? "No options"}</ComboboxEmpty>
         <ComboboxList>
-          {props.options.map((option) => (
+          {options.map((option) => (
             <ComboboxItem key={option.value} value={option.value}>
               <div className="min-w-0 flex-1">
                 <div className="truncate">{option.label ?? option.value}</div>


### PR DESCRIPTION
## Summary

- Show the typed freeform value as the first selectable option in the base URL combobox.
- Remove the custom empty-state copy from the OpenAPI base URL field.

## Validation

- bunx oxfmt --check packages/react/src/components/combobox.tsx packages/plugins/openapi/src/react/AddOpenApiSource.tsx
- bun run --filter @executor-js/react typecheck
- bun run --filter @executor-js/plugin-openapi typecheck
- git diff --check
