### PR TITLE
Improve scope add flow

### DIFF
--- a/apps/cloud/drizzle/0015_add_credential_binding_secret_scope.sql
+++ b/apps/cloud/drizzle/0015_add_credential_binding_secret_scope.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "credential_binding" ADD COLUMN "secret_scope_id" text;--> statement-breakpoint
+CREATE INDEX "credential_binding_secret_scope_id_idx" ON "credential_binding" USING btree ("secret_scope_id");

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1778192434062,
       "tag": "0014_repair_openapi_oauth_cutover_residue",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1778192434063,
+      "tag": "0015_add_credential_binding_secret_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cloud/src/services/executor-schema.ts
+++ b/apps/cloud/src/services/executor-schema.ts
@@ -148,6 +148,7 @@ export const credential_binding = pgTable(
     kind: text("kind").notNull(),
     text_value: text("text_value"),
     secret_id: text("secret_id"),
+    secret_scope_id: text("secret_scope_id"),
     connection_id: text("connection_id"),
     created_at: timestamp("created_at").notNull(),
     updated_at: timestamp("updated_at").notNull(),
@@ -161,6 +162,7 @@ export const credential_binding = pgTable(
     index("credential_binding_slot_key_idx").on(table.slot_key),
     index("credential_binding_kind_idx").on(table.kind),
     index("credential_binding_secret_id_idx").on(table.secret_id),
+    index("credential_binding_secret_scope_id_idx").on(table.secret_scope_id),
     index("credential_binding_connection_id_idx").on(table.connection_id),
   ],
 );

--- a/apps/cloud/src/services/sources-api.node.test.ts
+++ b/apps/cloud/src/services/sources-api.node.test.ts
@@ -830,6 +830,7 @@ describe("sources api (HTTP)", () => {
           value: {
             kind: "secret",
             secretId: SecretId.make("alice_pat"),
+            secretScopeId: ScopeId.make(aliceScope),
           },
         }),
       );
@@ -858,6 +859,7 @@ describe("sources api (HTTP)", () => {
           value: {
             kind: "secret",
             secretId: SecretId.make("bob_pat"),
+            secretScopeId: ScopeId.make(bobScope),
           },
         }),
       );

--- a/apps/local/drizzle/0010_add_credential_binding_secret_scope.sql
+++ b/apps/local/drizzle/0010_add_credential_binding_secret_scope.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `credential_binding` ADD COLUMN `secret_scope_id` text;--> statement-breakpoint
+CREATE INDEX `credential_binding_secret_scope_id_idx` ON `credential_binding` (`secret_scope_id`);

--- a/apps/local/drizzle/meta/_journal.json
+++ b/apps/local/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778192434062,
       "tag": "0009_repair_openapi_oauth_cutover_residue",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1778192434063,
+      "tag": "0010_add_credential_binding_secret_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/local/src/server/executor-schema.ts
+++ b/apps/local/src/server/executor-schema.ts
@@ -137,6 +137,7 @@ export const credential_binding = sqliteTable(
     kind: text("kind").notNull(),
     text_value: text("text_value"),
     secret_id: text("secret_id"),
+    secret_scope_id: text("secret_scope_id"),
     connection_id: text("connection_id"),
     created_at: integer("created_at", { mode: "timestamp_ms" }).notNull(),
     updated_at: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
@@ -150,6 +151,7 @@ export const credential_binding = sqliteTable(
     index("credential_binding_slot_key_idx").on(table.slot_key),
     index("credential_binding_kind_idx").on(table.kind),
     index("credential_binding_secret_id_idx").on(table.secret_id),
+    index("credential_binding_secret_scope_id_idx").on(table.secret_scope_id),
     index("credential_binding_connection_id_idx").on(table.connection_id),
   ],
 );

--- a/apps/local/src/server/migrate-oauth-connections.test.ts
+++ b/apps/local/src/server/migrate-oauth-connections.test.ts
@@ -158,9 +158,7 @@ describe("0009_repair_openapi_oauth_cutover_residue", () => {
       );
     `);
 
-    db.prepare(
-      "INSERT INTO `openapi_source` (id, scope_id, oauth2) VALUES (?, ?, ?)",
-    ).run(
+    db.prepare("INSERT INTO `openapi_source` (id, scope_id, oauth2) VALUES (?, ?, ?)").run(
       "dealcloud_api",
       "org-1",
       JSON.stringify({

--- a/notes/product-scope-language.md
+++ b/notes/product-scope-language.md
@@ -1,0 +1,47 @@
+# Product Scope Language
+
+Executor has a real scope model, but the product should mostly avoid saying
+"scope" to users. Use ownership and usage language instead.
+
+## Product Terms
+
+- **Personal**: only this user can use or update the credential/connection.
+- **Organization**: everyone with access to the source can use the shared
+  credential/connection.
+- **Source owner**: where the source definition and shared auth method live.
+  This is usually implicit from the current page/context and should not be
+  shown as debug information.
+- **Used by**: who uses a specific credential value for a shared auth slot.
+- **Saved to**: where a newly created secret or OAuth token/connection is
+  stored.
+
+## UI Rules
+
+- Communicate source auth as two separate choices:
+  - the shared authentication method for the source, such as bearer header,
+    query parameter, or OAuth;
+  - the credential/connection value used for that method.
+- Do not imply users can change the auth method per person when the backend only
+  allows credential values to vary per scope.
+- Put secret storage choices in the new-secret flow, because choosing Personal
+  or Organization there creates a reusable secret at that ownership level.
+- Put credential usage choices next to the credential picker as **Used by**,
+  because attaching a secret to a source slot is separate from where the secret
+  itself is stored.
+- Put OAuth token/connection storage next to **Connect via OAuth** as **Token
+  saved to**. This is independent from OAuth client ID/client secret storage.
+- Secret lists should show secrets from all visible ownership levels with a
+  Personal/Organization badge.
+
+## Preferred Copy
+
+- Use "Personal" and "Organization" for selectors.
+- Use "Used by" for source credential bindings.
+- Use "Save secret to" in secret creation.
+- Use "Token saved to" for OAuth sign-in results.
+- Use "Add without credentials" whenever the source can be added with missing
+  initial credential values, not only for OAuth.
+
+Avoid copy like "scope", "target scope", "source scope", "binding scope", or
+"credential target scope" in product UI unless it is explicitly a developer or
+debug surface.

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -182,6 +182,7 @@ export const coreSchema = {
       kind: { type: credentialBindingKinds, required: true, index: true },
       text_value: { type: "string", required: false },
       secret_id: { type: "string", required: false, index: true },
+      secret_scope_id: { type: "string", required: false, index: true },
       connection_id: { type: "string", required: false, index: true },
       created_at: { type: "date", required: true },
       updated_at: { type: "date", required: true },
@@ -244,7 +245,7 @@ export type ConnectionRow = InferDBFieldsOutput<CoreSchema["connection"]["fields
 type CredentialBindingRowFields = InferDBFieldsOutput<CoreSchema["credential_binding"]["fields"]>;
 type CredentialBindingRowBase = Omit<
   CredentialBindingRowFields,
-  "kind" | "text_value" | "secret_id" | "connection_id"
+  "kind" | "text_value" | "secret_id" | "secret_scope_id" | "connection_id"
 >;
 
 export type CredentialBindingRow = CredentialBindingRowBase &
@@ -256,6 +257,7 @@ export type CredentialBindingRow = CredentialBindingRowBase &
     | {
         kind: "secret";
         secret_id: string;
+        secret_scope_id?: string;
       }
     | {
         kind: "connection";

--- a/packages/core/sdk/src/credential-bindings.test.ts
+++ b/packages/core/sdk/src/credential-bindings.test.ts
@@ -437,7 +437,10 @@ describe("credential bindings", () => {
         sourceId: TEST_SOURCE_ID,
         sourceScope: harness.scopes.org.id,
         slotKey: "oauth.connection",
-        value: { kind: "connection", connectionId: ConnectionId.make("oauth-connection") },
+        value: {
+          kind: "connection",
+          connectionId: ConnectionId.make("oauth-connection"),
+        },
       });
 
       const userB = yield* harness.create([harness.scopes.userWorkspaceB, harness.scopes.org]);
@@ -606,6 +609,129 @@ describe("credential bindings", () => {
       expect(Result.isFailure(result)).toBe(true);
       if (!Result.isFailure(result)) return;
       expect(Predicate.isTagged("SecretInUseError")(result.failure)).toBe(true);
+    }),
+  );
+
+  it.effect("a personal binding can point at an organization-owned secret", () =>
+    Effect.gen(function* () {
+      const harness = makeHarness();
+      const orgExecutor = yield* harness.create([harness.scopes.org]);
+      yield* orgExecutor.credentialTest.registerSource(harness.scopes.org.id);
+      yield* setSecret(orgExecutor, harness.scopes.org.id, "shared-token-id", "sk-org");
+
+      const userExecutor = yield* harness.create([
+        harness.scopes.userWorkspaceA,
+        harness.scopes.org,
+      ]);
+
+      const binding = yield* userExecutor.credentialBindings.set({
+        targetScope: harness.scopes.userWorkspaceA.id,
+        pluginId: TEST_PLUGIN_ID,
+        sourceId: TEST_SOURCE_ID,
+        sourceScope: harness.scopes.org.id,
+        slotKey: TEST_SLOT,
+        value: {
+          kind: "secret",
+          secretId: SecretId.make("shared-token-id"),
+          secretScopeId: harness.scopes.org.id,
+        },
+      });
+
+      expect(binding.scopeId).toBe(harness.scopes.userWorkspaceA.id);
+      expect(binding.value).toMatchObject({
+        kind: "secret",
+        secretId: SecretId.make("shared-token-id"),
+        secretScopeId: harness.scopes.org.id,
+      });
+
+      const resolved = yield* userExecutor.credentialBindings.resolve({
+        pluginId: TEST_PLUGIN_ID,
+        sourceId: TEST_SOURCE_ID,
+        sourceScope: harness.scopes.org.id,
+        slotKey: TEST_SLOT,
+      });
+
+      expect(resolved.status).toBe("resolved");
+      expect(resolved.bindingScopeId).toBe(harness.scopes.userWorkspaceA.id);
+    }),
+  );
+
+  it.effect(
+    "removing an organization secret is blocked when a personal binding references it",
+    () =>
+      Effect.gen(function* () {
+        const harness = makeHarness();
+        const orgExecutor = yield* harness.create([harness.scopes.org]);
+        yield* orgExecutor.credentialTest.registerSource(harness.scopes.org.id);
+        yield* setSecret(orgExecutor, harness.scopes.org.id, "shared-token-id", "sk-org");
+
+        const userExecutor = yield* harness.create([
+          harness.scopes.userWorkspaceA,
+          harness.scopes.org,
+        ]);
+        yield* userExecutor.credentialBindings.set({
+          targetScope: harness.scopes.userWorkspaceA.id,
+          pluginId: TEST_PLUGIN_ID,
+          sourceId: TEST_SOURCE_ID,
+          sourceScope: harness.scopes.org.id,
+          slotKey: TEST_SLOT,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make("shared-token-id"),
+            secretScopeId: harness.scopes.org.id,
+          },
+        });
+
+        const result = yield* Effect.result(
+          userExecutor.secrets.remove(
+            new RemoveSecretInput({
+              id: SecretId.make("shared-token-id"),
+              targetScope: harness.scopes.org.id,
+            }),
+          ),
+        );
+
+        expect(Result.isFailure(result)).toBe(true);
+        if (!Result.isFailure(result)) return;
+        expect(Predicate.isTagged("SecretInUseError")(result.failure)).toBe(true);
+      }),
+  );
+
+  it.effect("rejects an organization binding to a personal secret", () =>
+    Effect.gen(function* () {
+      const harness = makeHarness();
+      const orgExecutor = yield* harness.create([harness.scopes.org]);
+      yield* orgExecutor.credentialTest.registerSource(harness.scopes.org.id);
+
+      const userExecutor = yield* harness.create([
+        harness.scopes.userWorkspaceA,
+        harness.scopes.org,
+      ]);
+      yield* setSecret(
+        userExecutor,
+        harness.scopes.userWorkspaceA.id,
+        "personal-token",
+        "sk-user-a",
+      );
+
+      const result = yield* Effect.result(
+        userExecutor.credentialBindings.set({
+          targetScope: harness.scopes.org.id,
+          pluginId: TEST_PLUGIN_ID,
+          sourceId: TEST_SOURCE_ID,
+          sourceScope: harness.scopes.org.id,
+          slotKey: TEST_SLOT,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make("personal-token"),
+            secretScopeId: harness.scopes.userWorkspaceA.id,
+          },
+        }),
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+      if (!Result.isFailure(result)) return;
+      expect(Predicate.isTagged("StorageError")(result.failure)).toBe(true);
     }),
   );
 });

--- a/packages/core/sdk/src/credential-bindings.ts
+++ b/packages/core/sdk/src/credential-bindings.ts
@@ -17,6 +17,7 @@ export const CredentialBindingValue = Schema.Union([
   Schema.Struct({
     kind: Schema.Literal("secret"),
     secretId: SecretId,
+    secretScopeId: Schema.optional(ScopeId),
   }),
   Schema.Struct({
     kind: Schema.Literal("connection"),
@@ -35,6 +36,14 @@ export class ConfiguredCredentialBinding extends Schema.Class<ConfiguredCredenti
 
 export const ConfiguredCredentialValue = Schema.Union([Schema.String, ConfiguredCredentialBinding]);
 export type ConfiguredCredentialValue = typeof ConfiguredCredentialValue.Type;
+
+export const ScopedSecretCredentialInput = Schema.Struct({
+  secretId: Schema.String,
+  prefix: Schema.optional(Schema.String),
+  targetScope: ScopeId,
+  secretScopeId: Schema.optional(ScopeId),
+});
+export type ScopedSecretCredentialInput = typeof ScopedSecretCredentialInput.Type;
 
 export class CredentialBindingRef extends Schema.Class<CredentialBindingRef>(
   "CredentialBindingRef",
@@ -172,9 +181,10 @@ export const credentialBindingValueFromRow = (row: CredentialBindingRow): Creden
       kind: "text" as const,
       text: text_value,
     })),
-    Match.when({ kind: "secret" }, ({ secret_id }) => ({
+    Match.when({ kind: "secret" }, ({ scope_id, secret_id, secret_scope_id }) => ({
       kind: "secret" as const,
       secretId: SecretId.make(secret_id),
+      secretScopeId: ScopeId.make(secret_scope_id ?? scope_id),
     })),
     Match.when({ kind: "connection" }, ({ connection_id }) => ({
       kind: "connection" as const,

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -900,7 +900,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
     ): Effect.Effect<string | null, SecretOwnedByConnectionError | StorageFailure> =>
       Effect.gen(function* () {
         yield* assertScopeInStack("secret get scope", scope);
-        const row = yield* findSecretRowAtScope({ secretId: id, scopeId: scope });
+        const row = yield* findSecretRowAtScope({
+          secretId: id,
+          scopeId: scope,
+        });
         if (row?.owned_by_connection_id) {
           return yield* new SecretOwnedByConnectionError({
             secretId: SecretId.make(id),
@@ -922,7 +925,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
     ): Effect.Effect<string | null, StorageFailure> =>
       Effect.gen(function* () {
         yield* assertScopeInStack("connection secret get scope", scope);
-        const row = yield* findSecretRowAtScope({ secretId: id, scopeId: scope });
+        const row = yield* findSecretRowAtScope({
+          secretId: id,
+          scopeId: scope,
+        });
         return yield* resolveSecretValueAtScope(row, id);
       });
 
@@ -1423,7 +1429,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
     ): Effect.Effect<ConnectionRef | null, StorageFailure> =>
       Effect.gen(function* () {
         yield* assertScopeInStack("connection get scope", scope);
-        const row = yield* findConnectionRowAtScope({ connectionId: id, scopeId: scope });
+        const row = yield* findConnectionRowAtScope({
+          connectionId: id,
+          scopeId: scope,
+        });
         return row ? rowToConnection(row) : null;
       });
 
@@ -1962,7 +1971,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
     ): Effect.Effect<string, AccessTokenError> =>
       Effect.gen(function* () {
         yield* assertScopeInStack("connection accessToken scope", scope);
-        const row = yield* findConnectionRowAtScope({ connectionId: id, scopeId: scope });
+        const row = yield* findConnectionRowAtScope({
+          connectionId: id,
+          scopeId: scope,
+        });
         if (!row) {
           return yield* new ConnectionNotFoundError({
             connectionId: ConnectionId.make(id),
@@ -2139,15 +2151,25 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
         }
 
         if (input.value.kind === "secret") {
+          const secretScope = input.value.secretScopeId ?? input.targetScope;
+          yield* assertScopeInStack("credential binding secretScope", secretScope);
+          if (scopePrecedence.get(secretScope)! < scopePrecedence.get(input.targetScope)!) {
+            return yield* new StorageError({
+              message:
+                `Cannot bind secret "${input.value.secretId}" from scope "${secretScope}" ` +
+                `to target scope "${input.targetScope}": shared bindings cannot reference inner-scope secrets.`,
+              cause: undefined,
+            });
+          }
           const secret = yield* findSecretRowAtScope({
             secretId: input.value.secretId,
-            scopeId: input.targetScope,
+            scopeId: secretScope,
           });
           if (!secret) {
             return yield* new StorageError({
               message:
-                `Cannot bind secret "${input.value.secretId}" at scope "${input.targetScope}": ` +
-                `the secret must be owned by the same scope as the binding.`,
+                `Cannot bind secret "${input.value.secretId}" from scope "${secretScope}": ` +
+                `the secret must be visible and owned by that scope.`,
               cause: undefined,
             });
           }
@@ -2192,6 +2214,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
             kind: input.value.kind,
             text_value: input.value.kind === "text" ? input.value.text : undefined,
             secret_id: input.value.kind === "secret" ? input.value.secretId : undefined,
+            secret_scope_id:
+              input.value.kind === "secret"
+                ? (input.value.secretScopeId ?? input.targetScope)
+                : undefined,
             connection_id: input.value.kind === "connection" ? input.value.connectionId : undefined,
             created_at: now,
             updated_at: now,
@@ -2208,6 +2234,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
           kind: input.value.kind,
           text_value: input.value.kind === "text" ? input.value.text : undefined,
           secret_id: input.value.kind === "secret" ? input.value.secretId : undefined,
+          secret_scope_id:
+            input.value.kind === "secret"
+              ? (input.value.secretScopeId ?? input.targetScope)
+              : undefined,
           connection_id: input.value.kind === "connection" ? input.value.connectionId : undefined,
           created_at: now,
           updated_at: now,
@@ -2347,7 +2377,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
           if (!row.secret_id) return "missing";
           const secret = yield* findSecretRowAtScope({
             secretId: row.secret_id,
-            scopeId: row.scope_id,
+            scopeId: row.secret_scope_id ?? row.scope_id,
           });
           if (!secret) return "missing";
           return (yield* secretRouteHasBackingValue(secret)) ? "resolved" : "missing";
@@ -2416,7 +2446,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
           (row) =>
             new Usage({
               pluginId: row.plugin_id,
-              scopeId: ScopeId.make(row.scope_id),
+              scopeId: ScopeId.make(
+                row.kind === "secret" ? (row.secret_scope_id ?? row.scope_id) : row.scope_id,
+              ),
               ownerKind: "credential-binding",
               ownerId: row.source_id,
               ownerName: names.get(`${row.source_scope_id}\u0000${row.source_id}`) ?? null,
@@ -2882,7 +2914,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
 
         const defsMap = new Map<string, unknown>(Object.entries(defs));
         const preview = yield* Effect.sync(() =>
-          buildToolTypeScriptPreview({ inputSchema, outputSchema, defs: defsMap }),
+          buildToolTypeScriptPreview({
+            inputSchema,
+            outputSchema,
+            defs: defsMap,
+          }),
         ).pipe(
           Effect.withSpan("schema.compile.preview", {
             attributes: {

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -129,6 +129,7 @@ export {
   CredentialBindingValue,
   ConfiguredCredentialBinding,
   ConfiguredCredentialValue,
+  ScopedSecretCredentialInput,
   CredentialBindingRef,
   SetCredentialBindingInput,
   CredentialBindingSourceInput,

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -16,7 +16,7 @@
 //     construction keeps the call sync and lets callers opt out of PAR
 // ---------------------------------------------------------------------------
 
-import { Data, Effect } from "effect";
+import { Data, Effect, Predicate } from "effect";
 import * as oauth from "oauth4webapi";
 
 // ---------------------------------------------------------------------------
@@ -121,11 +121,7 @@ export const buildAuthorizationUrl = (input: BuildAuthorizationUrlInput): string
 // to reauth-required) across wrappers.
 // ---------------------------------------------------------------------------
 
-const isOAuth2Error = (cause: unknown): cause is OAuth2Error =>
-  typeof cause === "object" &&
-  cause !== null &&
-  "_tag" in cause &&
-  (cause as { readonly _tag?: unknown })._tag === "OAuth2Error";
+const isOAuth2Error = Predicate.isTagged("OAuth2Error") as (cause: unknown) => cause is OAuth2Error;
 
 const responseFromOAuthErrorCause = (cause: unknown): Response | undefined => {
   if (cause instanceof Response) return cause;
@@ -200,18 +196,25 @@ const toOAuth2Error = (cause: unknown): OAuth2Error => {
   });
 };
 
-const toOAuth2ErrorWithHttpSummary = async (cause: unknown): Promise<OAuth2Error> => {
-  if (isOAuth2Error(cause)) return cause;
+const toOAuth2ErrorWithHttpSummary = (cause: unknown): Effect.Effect<OAuth2Error> => {
+  if (isOAuth2Error(cause)) return Effect.succeed(cause);
   const base = toOAuth2Error(cause);
   const response = responseFromOAuthErrorCause(cause);
-  if (!response) return base;
-  const summary = await tokenEndpointHttpSummary(response);
-  return new OAuth2Error({
-    message: `${base.message} (${summary})`,
-    error: base.error,
-    cause,
-  });
+  if (!response) return Effect.succeed(base);
+  return Effect.promise(() => tokenEndpointHttpSummary(response)).pipe(
+    Effect.map(
+      (summary) =>
+        new OAuth2Error({
+          message: `${base.message} (${summary})`,
+          error: base.error,
+          cause,
+        }),
+    ),
+  );
 };
+
+const failOAuth2WithHttpSummary = (cause: unknown): Effect.Effect<never, OAuth2Error> =>
+  toOAuth2ErrorWithHttpSummary(cause).pipe(Effect.flatMap((error) => Effect.fail(error)));
 
 // ---------------------------------------------------------------------------
 // oauth4webapi adapter helpers
@@ -348,40 +351,36 @@ export const exchangeAuthorizationCode = (
 ): Effect.Effect<OAuth2TokenResponse, OAuth2Error> =>
   Effect.tryPromise({
     try: async () => {
-      try {
-        const as = asFromTokenUrlAndIssuer(input.tokenUrl, input.issuerUrl, {
-          idTokenSigningAlgValuesSupported: input.idTokenSigningAlgValuesSupported,
-        });
-        const client: oauth.Client = { client_id: input.clientId };
-        const clientAuth = pickClientAuth(input.clientSecret, input.clientAuth ?? "body");
-        // `authorizationCodeGrantRequest` requires its `callbackParameters`
-        // to have been returned from `validateAuthResponse`. Our public API
-        // takes the `code` directly (the UI already validated `state` by
-        // looking up the session), so skip the library's state-validation
-        // rail and go through the generic grant request instead.
-        const params = new URLSearchParams({
-          code: input.code,
-          redirect_uri: input.redirectUrl,
-          code_verifier: input.codeVerifier,
-        });
-        if (input.resource) {
-          params.set("resource", input.resource);
-        }
-        const response = await oauth.genericTokenEndpointRequest(
-          as,
-          client,
-          clientAuth,
-          "authorization_code",
-          params,
-          oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs),
-        );
-        return await processTokenEndpointResponse(as, client, response);
-      } catch (cause) {
-        throw await toOAuth2ErrorWithHttpSummary(cause);
+      const as = asFromTokenUrlAndIssuer(input.tokenUrl, input.issuerUrl, {
+        idTokenSigningAlgValuesSupported: input.idTokenSigningAlgValuesSupported,
+      });
+      const client: oauth.Client = { client_id: input.clientId };
+      const clientAuth = pickClientAuth(input.clientSecret, input.clientAuth ?? "body");
+      // `authorizationCodeGrantRequest` requires its `callbackParameters`
+      // to have been returned from `validateAuthResponse`. Our public API
+      // takes the `code` directly (the UI already validated `state` by
+      // looking up the session), so skip the library's state-validation
+      // rail and go through the generic grant request instead.
+      const params = new URLSearchParams({
+        code: input.code,
+        redirect_uri: input.redirectUrl,
+        code_verifier: input.codeVerifier,
+      });
+      if (input.resource) {
+        params.set("resource", input.resource);
       }
+      const response = await oauth.genericTokenEndpointRequest(
+        as,
+        client,
+        clientAuth,
+        "authorization_code",
+        params,
+        oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs),
+      );
+      return await processTokenEndpointResponse(as, client, response);
     },
-    catch: toOAuth2Error,
-  });
+    catch: (cause) => cause,
+  }).pipe(Effect.catch(failOAuth2WithHttpSummary));
 
 // ---------------------------------------------------------------------------
 // Exchange client credentials → tokens (RFC 6749 §4.4)
@@ -402,29 +401,25 @@ export const exchangeClientCredentials = (
 ): Effect.Effect<OAuth2TokenResponse, OAuth2Error> =>
   Effect.tryPromise({
     try: async () => {
-      try {
-        const as = asFromTokenUrl(input.tokenUrl);
-        const client: oauth.Client = { client_id: input.clientId };
-        const clientAuth = pickClientAuth(input.clientSecret, input.clientAuth ?? "body");
-        const params = new URLSearchParams();
-        if (input.scopes && input.scopes.length > 0) {
-          params.set("scope", input.scopes.join(input.scopeSeparator ?? " "));
-        }
-        const response = await oauth.clientCredentialsGrantRequest(
-          as,
-          client,
-          clientAuth,
-          params,
-          oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs),
-        );
-        const result = await oauth.processClientCredentialsResponse(as, client, response);
-        return tokenResponseFrom(result);
-      } catch (cause) {
-        throw await toOAuth2ErrorWithHttpSummary(cause);
+      const as = asFromTokenUrl(input.tokenUrl);
+      const client: oauth.Client = { client_id: input.clientId };
+      const clientAuth = pickClientAuth(input.clientSecret, input.clientAuth ?? "body");
+      const params = new URLSearchParams();
+      if (input.scopes && input.scopes.length > 0) {
+        params.set("scope", input.scopes.join(input.scopeSeparator ?? " "));
       }
+      const response = await oauth.clientCredentialsGrantRequest(
+        as,
+        client,
+        clientAuth,
+        params,
+        oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs),
+      );
+      const result = await oauth.processClientCredentialsResponse(as, client, response);
+      return tokenResponseFrom(result);
     },
-    catch: toOAuth2Error,
-  });
+    catch: (cause) => cause,
+  }).pipe(Effect.catch(failOAuth2WithHttpSummary));
 
 // ---------------------------------------------------------------------------
 // Refresh access token
@@ -452,43 +447,39 @@ export const refreshAccessToken = (
 ): Effect.Effect<OAuth2TokenResponse, OAuth2Error> =>
   Effect.tryPromise({
     try: async () => {
-      try {
-        const as = asFromTokenUrlAndIssuer(input.tokenUrl, input.issuerUrl, {
-          idTokenSigningAlgValuesSupported: input.idTokenSigningAlgValuesSupported,
-        });
-        const client: oauth.Client = { client_id: input.clientId };
-        const clientAuth = pickClientAuth(input.clientSecret, input.clientAuth ?? "body");
-        const extraParams = new URLSearchParams();
-        if (input.scopes && input.scopes.length > 0) {
-          extraParams.set("scope", input.scopes.join(input.scopeSeparator ?? " "));
-        }
-        if (input.resource) {
-          extraParams.set("resource", input.resource);
-        }
-        const additionalParameters =
-          Array.from(extraParams.keys()).length > 0 ? extraParams : undefined;
-        const response = await oauth.refreshTokenGrantRequest(
-          as,
-          client,
-          clientAuth,
-          input.refreshToken,
-          {
-            ...oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs),
-            additionalParameters,
-          },
-        );
-        const result = await oauth.processRefreshTokenResponse(
-          as,
-          client,
-          await stripIdToken(response),
-        );
-        return tokenResponseFrom(result);
-      } catch (cause) {
-        throw await toOAuth2ErrorWithHttpSummary(cause);
+      const as = asFromTokenUrlAndIssuer(input.tokenUrl, input.issuerUrl, {
+        idTokenSigningAlgValuesSupported: input.idTokenSigningAlgValuesSupported,
+      });
+      const client: oauth.Client = { client_id: input.clientId };
+      const clientAuth = pickClientAuth(input.clientSecret, input.clientAuth ?? "body");
+      const extraParams = new URLSearchParams();
+      if (input.scopes && input.scopes.length > 0) {
+        extraParams.set("scope", input.scopes.join(input.scopeSeparator ?? " "));
       }
+      if (input.resource) {
+        extraParams.set("resource", input.resource);
+      }
+      const additionalParameters =
+        Array.from(extraParams.keys()).length > 0 ? extraParams : undefined;
+      const response = await oauth.refreshTokenGrantRequest(
+        as,
+        client,
+        clientAuth,
+        input.refreshToken,
+        {
+          ...oauth4webapiRequestOptions(input.tokenUrl, input.timeoutMs),
+          additionalParameters,
+        },
+      );
+      const result = await oauth.processRefreshTokenResponse(
+        as,
+        client,
+        await stripIdToken(response),
+      );
+      return tokenResponseFrom(result);
     },
-    catch: toOAuth2Error,
-  });
+    catch: (cause) => cause,
+  }).pipe(Effect.catch(failOAuth2WithHttpSummary));
 
 // ---------------------------------------------------------------------------
 // Refresh-needed predicate

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -9,11 +9,12 @@ import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import {
   HttpCredentialsEditor,
   httpCredentialsValid,
+  serializeScopedHttpCredentials,
   serializeHttpCredentials,
   type HttpCredentialsState,
 } from "@executor-js/react/plugins/http-credentials";
 import {
-  displayNameFromUrl,
+  sourceDisplayNameFromUrl,
   slugifyNamespace,
   SourceIdentityFieldRows,
   useSourceIdentity,
@@ -25,7 +26,8 @@ import {
   type OAuthCompletionPayload,
 } from "@executor-js/react/plugins/oauth-sign-in";
 import {
-  CredentialScopeSection,
+  CredentialControlField,
+  CredentialUsageRow,
   useCredentialTargetScope,
 } from "@executor-js/react/plugins/credential-target-scope";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
@@ -61,7 +63,7 @@ export default function AddGraphqlSource(props: {
 }) {
   const [endpoint, setEndpoint] = useState(props.initialUrl ?? "");
   const identity = useSourceIdentity({
-    fallbackName: displayNameFromUrl(endpoint) ?? "",
+    fallbackName: sourceDisplayNameFromUrl(endpoint, "GraphQL") ?? "",
   });
   const [credentials, setCredentials] = useState<HttpCredentialsState>(initialGraphqlCredentials);
   const [adding, setAdding] = useState(false);
@@ -70,8 +72,12 @@ export default function AddGraphqlSource(props: {
   const [tokens, setTokens] = useState<OAuthCompletionPayload | null>(null);
 
   const scopeId = useScope();
-  const { credentialTargetScope, setCredentialTargetScope, credentialScopeOptions } =
-    useCredentialTargetScope();
+  const { credentialTargetScope: requestCredentialTargetScope } = useCredentialTargetScope();
+  const {
+    credentialTargetScope: oauthCredentialTargetScope,
+    setCredentialTargetScope: setOAuthCredentialTargetScope,
+    credentialScopeOptions,
+  } = useCredentialTargetScope();
   const doAdd = useAtomSet(addGraphqlSourceOptimistic(scopeId), {
     mode: "promiseExit",
   });
@@ -91,9 +97,10 @@ export default function AddGraphqlSource(props: {
     const trimmedEndpoint = endpoint.trim();
     const namespace =
       slugifyNamespace(identity.namespace) ||
-      slugifyNamespace(displayNameFromUrl(trimmedEndpoint) ?? "") ||
+      slugifyNamespace(sourceDisplayNameFromUrl(trimmedEndpoint, "GraphQL") ?? "") ||
       "graphql";
-    const displayName = identity.name.trim() || displayNameFromUrl(trimmedEndpoint) || namespace;
+    const displayName =
+      identity.name.trim() || sourceDisplayNameFromUrl(trimmedEndpoint, "GraphQL") || namespace;
     return { trimmedEndpoint, namespace, displayName };
   }, [endpoint, identity.name, identity.namespace]);
 
@@ -109,7 +116,7 @@ export default function AddGraphqlSource(props: {
         ...(Object.keys(queryParams).length > 0 ? { queryParams } : {}),
         redirectUrl: oauthCallbackUrl(),
         connectionId: oauthConnectionId({ pluginId: "graphql", namespace }),
-        tokenScope: credentialTargetScope,
+        tokenScope: oauthCredentialTargetScope,
         strategy: { kind: "dynamic-dcr" },
         pluginId: "graphql",
         identityLabel: `${displayName} OAuth`,
@@ -123,12 +130,15 @@ export default function AddGraphqlSource(props: {
       },
       onError: setAddError,
     });
-  }, [endpoint, credentials, oauth, sourceIdentity, credentialTargetScope]);
+  }, [endpoint, credentials, oauth, sourceIdentity, oauthCredentialTargetScope]);
 
   const handleAdd = async () => {
     setAdding(true);
     setAddError(null);
-    const { headers: headerMap, queryParams } = serializeHttpCredentials(credentials);
+    const { headers: headerMap, queryParams } = serializeScopedHttpCredentials(
+      credentials,
+      requestCredentialTargetScope,
+    );
 
     const { trimmedEndpoint, namespace, displayName } = sourceIdentity();
     const exit = await doAdd({
@@ -144,7 +154,10 @@ export default function AddGraphqlSource(props: {
               queryParams: queryParams as Record<string, GraphqlCredentialInput>,
             }
           : {}),
-        credentialTargetScope,
+        credentialTargetScope:
+          authMode === "oauth2" && tokens
+            ? oauthCredentialTargetScope
+            : requestCredentialTargetScope,
         ...(authMode === "oauth2" && tokens
           ? {
               auth: {
@@ -185,24 +198,18 @@ export default function AddGraphqlSource(props: {
         </CardStackContent>
       </CardStack>
 
-      <CredentialScopeSection
-        value={credentialTargetScope}
-        options={credentialScopeOptions}
-        onChange={(targetScope) => {
-          setCredentialTargetScope(targetScope);
-          setTokens(null);
-        }}
-      >
-        <HttpCredentialsEditor
-          credentials={credentials}
-          onChange={setCredentials}
-          existingSecrets={secretList}
-          sourceName={identity.name}
-          targetScope={credentialTargetScope}
-        />
-      </CredentialScopeSection>
+      <HttpCredentialsEditor
+        credentials={credentials}
+        onChange={setCredentials}
+        existingSecrets={secretList}
+        sourceName={identity.name}
+        targetScope={requestCredentialTargetScope}
+        credentialScopeOptions={credentialScopeOptions}
+        bindingScopeOptions={credentialScopeOptions}
+      />
 
-      <section className="space-y-2.5">
+      {/* Temporarily hidden while we revisit GraphQL OAuth discovery and UX. */}
+      <section className="hidden space-y-2.5">
         <div className="flex items-center justify-between gap-3">
           <span className="text-sm font-medium text-foreground">Authentication</span>
           <FilterTabs<AuthMode>
@@ -219,27 +226,38 @@ export default function AddGraphqlSource(props: {
         </div>
 
         {authMode === "oauth2" && (
-          <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2.5">
-            {tokens ? (
-              <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                Authenticated
-              </span>
-            ) : (
-              <span className="text-xs text-muted-foreground">
-                Sign in before adding so Executor can introspect the schema.
-              </span>
-            )}
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="ml-auto h-7 px-2 text-xs"
-              onClick={() => void handleOAuth()}
-              disabled={!endpoint.trim() || !httpCredentialsValid(credentials) || oauth.busy}
-            >
-              {oauth.busy ? "Signing in..." : tokens ? "Reconnect" : "Sign in"}
-            </Button>
-          </div>
+          <CredentialUsageRow
+            value={oauthCredentialTargetScope}
+            options={credentialScopeOptions}
+            onChange={(targetScope) => {
+              setOAuthCredentialTargetScope(targetScope);
+              setTokens(null);
+            }}
+            label="Connection saved to"
+            help="Choose who can use the OAuth connection."
+          >
+            <CredentialControlField label="Connect via OAuth" help="Start the provider OAuth flow.">
+              <div className="flex min-h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+                {tokens ? (
+                  <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                    Authenticated
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">Not connected</span>
+                )}
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="ml-auto h-7 px-2 text-xs"
+                  onClick={() => void handleOAuth()}
+                  disabled={!endpoint.trim() || !httpCredentialsValid(credentials) || oauth.busy}
+                >
+                  {oauth.busy ? "Signing in..." : tokens ? "Reconnect" : "Sign in"}
+                </Button>
+              </div>
+            </CredentialControlField>
+          </CredentialUsageRow>
         )}
       </section>
 

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -222,7 +222,8 @@ function EditForm(props: {
         targetScope={credentialTargetScope}
       />
 
-      <section className="space-y-2.5">
+      {/* Temporarily hidden while we revisit GraphQL OAuth discovery and UX. */}
+      <section className="hidden space-y-2.5">
         <div className="flex items-center justify-between gap-3">
           <span className="text-sm font-medium text-foreground">Authentication</span>
           <FilterTabs<AuthMode>

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -604,6 +604,68 @@ describe("graphqlPlugin", () => {
     }),
   );
 
+  it.effect("addSource stores direct GraphQL credential bindings at each row scope", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          scopes: stackedScopes,
+          plugins: [memorySecretsPlugin(), graphqlPlugin()] as const,
+        }),
+      );
+
+      yield* executor.secrets.set({
+        id: SecretId.make("row-user-token"),
+        scope: ScopeId.make(USER_SCOPE),
+        name: "User token",
+        value: "user-secret",
+        provider: "memory",
+      });
+      yield* executor.secrets.set({
+        id: SecretId.make("row-org-query"),
+        scope: ScopeId.make(ORG_SCOPE),
+        name: "Org query",
+        value: "org-secret",
+        provider: "memory",
+      });
+
+      yield* executor.graphql.addSource({
+        endpoint: "https://example.com/graphql",
+        scope: ORG_SCOPE,
+        namespace: "row_scoped_credentials",
+        introspectionJson,
+        headers: {
+          Authorization: {
+            secretId: "row-user-token",
+            prefix: "Bearer ",
+            targetScope: USER_SCOPE,
+          },
+        },
+        queryParams: {
+          token: {
+            secretId: "row-org-query",
+            targetScope: ORG_SCOPE,
+          },
+        },
+      });
+
+      const bindings = yield* executor.graphql.listSourceBindings(
+        "row_scoped_credentials",
+        ORG_SCOPE,
+      );
+
+      expect(bindings.map((binding) => binding.slot).sort()).toEqual([
+        graphqlHeaderSlot("Authorization"),
+        graphqlQueryParamSlot("token"),
+      ]);
+      expect(
+        bindings.find((binding) => binding.slot === graphqlHeaderSlot("Authorization"))?.scopeId,
+      ).toBe(ScopeId.make(USER_SCOPE));
+      expect(
+        bindings.find((binding) => binding.slot === graphqlQueryParamSlot("token"))?.scopeId,
+      ).toBe(ScopeId.make(ORG_SCOPE));
+    }),
+  );
+
   it.effect("org header binding resolves the org secret when a user has the same secret id", () =>
     Effect.gen(function* () {
       const server = yield* serveGreetingServer;

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -424,6 +424,19 @@ const bindingTargetScope = (
   );
 };
 
+const targetScopeForBinding = (
+  fallbackTargetScope: string | undefined,
+  binding: { readonly targetScope?: string },
+): Effect.Effect<string, GraphqlIntrospectionError> => {
+  const targetScope = binding.targetScope ?? fallbackTargetScope;
+  if (targetScope) return Effect.succeed(targetScope);
+  return Effect.fail(
+    new GraphqlIntrospectionError({
+      message: "credentialTargetScope is required when adding direct GraphQL credentials",
+    }),
+  );
+};
+
 const canonicalizeCredentialMap = (
   values: Record<string, GraphqlCredentialInput> | undefined,
   slotForName: (name: string) => string,
@@ -432,10 +445,15 @@ const canonicalizeCredentialMap = (
   readonly bindings: ReadonlyArray<{
     readonly slot: string;
     readonly value: GraphqlSourceBindingValue;
+    readonly targetScope?: string;
   }>;
 } => {
   const nextValues: Record<string, ConfiguredGraphqlCredentialValue> = {};
-  const bindings: Array<{ slot: string; value: GraphqlSourceBindingValue }> = [];
+  const bindings: Array<{
+    slot: string;
+    value: GraphqlSourceBindingValue;
+    targetScope?: string;
+  }> = [];
   for (const [name, value] of Object.entries(values ?? {})) {
     if (typeof value === "string") {
       nextValues[name] = value;
@@ -453,9 +471,13 @@ const canonicalizeCredentialMap = (
     });
     bindings.push({
       slot,
+      targetScope: "targetScope" in value ? value.targetScope : undefined,
       value: {
         kind: "secret",
         secretId: SecretId.make(value.secretId),
+        ...("secretScopeId" in value && value.secretScopeId
+          ? { secretScopeId: value.secretScopeId }
+          : {}),
       },
     });
   }
@@ -469,6 +491,7 @@ const canonicalizeAuth = (
   readonly bindings: ReadonlyArray<{
     readonly slot: string;
     readonly value: GraphqlSourceBindingValue;
+    readonly targetScope?: string;
   }>;
 } => {
   if (!auth || auth.kind === "none") return { auth: { kind: "none" }, bindings: [] };
@@ -606,8 +629,12 @@ const makeGraphqlExtension = (
           if (slotResolved?.[name] !== undefined) resolved[name] = slotResolved[name];
           continue;
         }
+        const secretScope =
+          "secretScopeId" in value
+            ? (value.secretScopeId ?? value.targetScope)
+            : (params.targetScope ?? params.sourceScope);
         const secret = yield* ctx.secrets
-          .getAtScope(SecretId.make(value.secretId), params.targetScope ?? params.sourceScope)
+          .getAtScope(SecretId.make(value.secretId), secretScope)
           .pipe(
             Effect.catchTag("SecretOwnedByConnectionError", () =>
               Effect.fail(
@@ -682,14 +709,21 @@ const makeGraphqlExtension = (
           ...canonicalQueryParams.bindings,
           ...canonicalAuth.bindings,
         ];
-        const targetScope = yield* bindingTargetScope(config.credentialTargetScope, directBindings);
-        if (targetScope) {
+        for (const binding of directBindings) {
+          const bindingTargetScope = yield* targetScopeForBinding(
+            config.credentialTargetScope,
+            binding,
+          );
           yield* validateGraphqlBindingTarget(ctx, {
             sourceId: namespace,
             sourceScope: config.scope,
-            targetScope,
+            targetScope: bindingTargetScope,
           });
         }
+        const targetScope =
+          directBindings[0] !== undefined
+            ? yield* targetScopeForBinding(config.credentialTargetScope, directBindings[0])
+            : undefined;
 
         let introspectionResult: IntrospectionResult;
         if (config.introspectionJson) {
@@ -769,10 +803,14 @@ const makeGraphqlExtension = (
           });
         }
 
-        if (targetScope) {
+        if (directBindings.length > 0) {
           for (const binding of directBindings) {
+            const bindingTargetScope = yield* targetScopeForBinding(
+              config.credentialTargetScope,
+              binding,
+            );
             yield* ctx.credentialBindings.set({
-              targetScope: ScopeId.make(targetScope),
+              targetScope: ScopeId.make(bindingTargetScope),
               pluginId: GRAPHQL_PLUGIN_ID,
               sourceId: namespace,
               sourceScope: ScopeId.make(config.scope),

--- a/packages/plugins/graphql/src/sdk/types.ts
+++ b/packages/plugins/graphql/src/sdk/types.ts
@@ -3,6 +3,7 @@ import {
   ConfiguredCredentialValue as ConfiguredCredentialValueSchema,
   CredentialBindingValue,
   credentialSlotKey,
+  ScopedSecretCredentialInput,
   SecretBackedValue,
   ScopeId,
 } from "@executor-js/sdk/core";
@@ -68,7 +69,11 @@ export type QueryParamValue = typeof QueryParamValue.Type;
 
 export const ConfiguredGraphqlCredentialValue = ConfiguredCredentialValueSchema;
 export type ConfiguredGraphqlCredentialValue = typeof ConfiguredGraphqlCredentialValue.Type;
-export const GraphqlCredentialInput = Schema.Union([HeaderValue, ConfiguredGraphqlCredentialValue]);
+export const GraphqlCredentialInput = Schema.Union([
+  ScopedSecretCredentialInput,
+  HeaderValue,
+  ConfiguredGraphqlCredentialValue,
+]);
 export type GraphqlCredentialInput = typeof GraphqlCredentialInput.Type;
 
 export const graphqlHeaderSlot = (name: string): string => credentialSlotKey("header", name);

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -27,17 +27,15 @@ import { Skeleton } from "@executor-js/react/components/skeleton";
 import { SourceFavicon } from "@executor-js/react/components/source-favicon";
 import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
 import { Textarea } from "@executor-js/react/components/textarea";
-import { HeadersList } from "@executor-js/react/plugins/headers-list";
 import {
   emptyHttpCredentials,
   httpCredentialsValid,
   HttpCredentialsEditor,
+  serializeScopedHttpCredentials,
   serializeHttpCredentials,
-  type SecretBackedValue,
 } from "@executor-js/react/plugins/http-credentials";
-import { type HeaderState } from "@executor-js/react/plugins/secret-header-auth";
 import {
-  displayNameFromUrl,
+  sourceDisplayNameFromUrl,
   slugifyNamespace,
   SourceIdentityFieldRows,
   SourceIdentityFields,
@@ -51,15 +49,16 @@ import {
   type OAuthCompletionPayload,
 } from "@executor-js/react/plugins/oauth-sign-in";
 import {
-  CredentialScopeSection,
+  CredentialControlField,
+  CredentialUsageRow,
   useCredentialTargetScope,
 } from "@executor-js/react/plugins/credential-target-scope";
 
-type RemoteAuthMode = "none" | "header" | "oauth2";
+type RemoteAuthMode = "none" | "oauth2";
 import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { probeMcpEndpoint, addMcpSourceOptimistic } from "./atoms";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
-import { MCP_OAUTH_CONNECTION_SLOT } from "../sdk/types";
+import { MCP_OAUTH_CONNECTION_SLOT, type McpCredentialInput } from "../sdk/types";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
 const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
@@ -101,7 +100,7 @@ type PlainHeader = {
 
 type State =
   | { step: "url"; url: string }
-  | { step: "probing"; url: string }
+  | { step: "probing"; url: string; probe: ProbeResult | null }
   | { step: "probed"; url: string; probe: ProbeResult }
   | { step: "oauth-starting"; url: string; probe: ProbeResult }
   | {
@@ -148,7 +147,7 @@ function reducer(state: State, action: Action): State {
       return { step: "url", url: action.url };
 
     case "probe-start":
-      return { step: "probing", url: state.url };
+      return { step: "probing", url: state.url, probe: "probe" in state ? state.probe : null };
 
     case "probe-ok":
       return { step: "probed", url: state.url, probe: action.probe };
@@ -292,8 +291,12 @@ export default function AddMcpSource(props: {
   );
 
   const scopeId = useScope();
-  const { credentialTargetScope, setCredentialTargetScope, credentialScopeOptions } =
-    useCredentialTargetScope();
+  const { credentialTargetScope: requestCredentialTargetScope } = useCredentialTargetScope();
+  const {
+    credentialTargetScope: oauthCredentialTargetScope,
+    setCredentialTargetScope: setOAuthCredentialTargetScope,
+    credentialScopeOptions,
+  } = useCredentialTargetScope();
   const doProbe = useAtomSet(probeMcpEndpoint, { mode: "promiseExit" });
   const doAdd = useAtomSet(addMcpSourceOptimistic(scopeId), {
     mode: "promiseExit",
@@ -306,14 +309,6 @@ export default function AddMcpSource(props: {
   });
 
   const [remoteAuthMode, setRemoteAuthMode] = useState<RemoteAuthMode>("none");
-  const [remoteAuthHeaders, setRemoteAuthHeaders] = useState<HeaderState[]>([
-    {
-      name: "Authorization",
-      prefix: "Bearer ",
-      presetKey: "bearer",
-      secretId: null,
-    },
-  ]);
   const [remoteHeaders, setRemoteHeaders] = useState<PlainHeader[]>([]);
   const [remoteCredentials, setRemoteCredentials] = useState(() => emptyHttpCredentials());
 
@@ -321,25 +316,19 @@ export default function AddMcpSource(props: {
   const tokens = "tokens" in state ? state.tokens : null;
 
   const remoteIdentity = useSourceIdentity({
-    fallbackName: probe?.serverName ?? probe?.name ?? displayNameFromUrl(state.url) ?? "",
+    fallbackName:
+      sourceDisplayNameFromUrl(state.url, "MCP") ?? probe?.serverName ?? probe?.name ?? "",
   });
   const isProbing = state.step === "probing";
   const isAdding = state.step === "adding";
   const isOAuthBusy =
     state.step === "oauth-starting" || state.step === "oauth-waiting" || oauth.busy;
   const canUseNone = probe?.requiresOAuth !== true;
-  const remoteAuthHeader = remoteAuthHeaders[0];
-  const headerAuthComplete = Boolean(remoteAuthHeader?.name.trim() && remoteAuthHeader?.secretId);
   const remoteHeadersComplete = remoteHeaders.every(
     (header) => header.name.trim() && header.value.trim(),
   );
   const remoteCredentialsComplete = httpCredentialsValid(remoteCredentials);
-  const authReady =
-    remoteAuthMode === "none"
-      ? canUseNone
-      : remoteAuthMode === "header"
-        ? headerAuthComplete
-        : tokens !== null;
+  const authReady = remoteAuthMode === "none" ? canUseNone : tokens !== null;
   const canAdd =
     Boolean(probe) &&
     authReady &&
@@ -392,17 +381,11 @@ export default function AddMcpSource(props: {
       handleProbeRef.current();
     }, 400);
     return () => clearTimeout(handle);
-  }, [transport, state.step, state.url, remoteCredentials]);
+  }, [transport, state.step, state.url]);
 
-  const handleRemoteCredentialsChange = useCallback(
-    (next: typeof remoteCredentials) => {
-      setRemoteCredentials(next);
-      if (state.step === "error" || state.step === "probed" || state.step === "oauth-done") {
-        dispatch({ type: "set-url", url: state.url });
-      }
-    },
-    [state],
-  );
+  const handleRemoteCredentialsChange = useCallback((next: typeof remoteCredentials) => {
+    setRemoteCredentials(next);
+  }, []);
 
   const handleOAuth = useCallback(async () => {
     dispatch({ type: "oauth-start" });
@@ -421,7 +404,7 @@ export default function AddMcpSource(props: {
           pluginId: "mcp",
           namespace: namespaceSlug,
         }),
-        tokenScope: credentialTargetScope,
+        tokenScope: oauthCredentialTargetScope,
         strategy: { kind: "dynamic-dcr" },
         pluginId: "mcp",
         identityLabel: `${remoteIdentity.name.trim() || probe?.serverName || probe?.name || "MCP"} OAuth`,
@@ -440,7 +423,7 @@ export default function AddMcpSource(props: {
         dispatch({ type: "oauth-waiting", sessionId: result.sessionId }),
       onError: (error) => dispatch({ type: "oauth-fail", error }),
     });
-  }, [state.url, remoteIdentity, probe, remoteCredentials, oauth, credentialTargetScope]);
+  }, [state.url, remoteIdentity, probe, remoteCredentials, oauth, oauthCredentialTargetScope]);
 
   const handleCancelOAuth = useCallback(() => {
     oauth.cancel();
@@ -450,33 +433,28 @@ export default function AddMcpSource(props: {
   const handleAddRemote = useCallback(async () => {
     if (!probe) return;
     dispatch({ type: "add-start" });
-    const headerAuth = remoteAuthHeaders[0];
     const auth =
-      remoteAuthMode === "header" && headerAuth?.secretId
-        ? {
-            kind: "header" as const,
-            headerName: headerAuth.name.trim(),
-            secretId: headerAuth.secretId,
-            ...(headerAuth.prefix ? { prefix: headerAuth.prefix } : {}),
-          }
-        : remoteAuthMode === "oauth2"
-          ? tokens
-            ? {
-                kind: "oauth2" as const,
-                connectionId: tokens.connectionId,
-              }
-            : {
-                kind: "oauth2" as const,
-                connectionSlot: MCP_OAUTH_CONNECTION_SLOT,
-              }
-          : { kind: "none" as const };
+      remoteAuthMode === "oauth2"
+        ? tokens
+          ? {
+              kind: "oauth2" as const,
+              connectionId: tokens.connectionId,
+            }
+          : {
+              kind: "oauth2" as const,
+              connectionSlot: MCP_OAUTH_CONNECTION_SLOT,
+            }
+        : { kind: "none" as const };
     const headers = Object.fromEntries(
       remoteHeaders
         .map((header) => [header.name.trim(), header.value.trim()] as const)
         .filter(([name, value]) => name && value),
     );
-    const credentials = serializeHttpCredentials(remoteCredentials);
-    const remoteRequestHeaders: Record<string, SecretBackedValue> = {
+    const credentials = serializeScopedHttpCredentials(
+      remoteCredentials,
+      requestCredentialTargetScope,
+    );
+    const remoteRequestHeaders: Record<string, McpCredentialInput> = {
       ...headers,
       ...credentials.headers,
     };
@@ -491,7 +469,10 @@ export default function AddMcpSource(props: {
         namespace: slugNamespace || undefined,
         endpoint: state.url.trim(),
         auth,
-        credentialTargetScope,
+        credentialTargetScope:
+          remoteAuthMode === "oauth2" && tokens
+            ? oauthCredentialTargetScope
+            : requestCredentialTargetScope,
         ...(Object.keys(remoteRequestHeaders).length > 0 ? { headers: remoteRequestHeaders } : {}),
         ...(Object.keys(credentials.queryParams).length > 0
           ? { queryParams: credentials.queryParams }
@@ -510,7 +491,6 @@ export default function AddMcpSource(props: {
   }, [
     probe,
     remoteAuthMode,
-    remoteAuthHeaders,
     remoteHeaders,
     remoteCredentials,
     remoteIdentity,
@@ -519,7 +499,8 @@ export default function AddMcpSource(props: {
     doAdd,
     props,
     scopeId,
-    credentialTargetScope,
+    requestCredentialTargetScope,
+    oauthCredentialTargetScope,
   ]);
 
   // ---- Stdio actions ----
@@ -714,6 +695,7 @@ export default function AddMcpSource(props: {
                     <div className="mt-2 space-y-2">
                       <FieldError>{probeError}</FieldError>
                       <Button
+                        type="button"
                         variant="outline"
                         size="sm"
                         onClick={handleProbe}
@@ -733,7 +715,9 @@ export default function AddMcpSource(props: {
             onChange={handleRemoteCredentialsChange}
             existingSecrets={secretList}
             sourceName={remoteIdentity.name}
-            targetScope={credentialTargetScope}
+            targetScope={requestCredentialTargetScope}
+            credentialScopeOptions={credentialScopeOptions}
+            bindingScopeOptions={credentialScopeOptions}
             labels={{
               headers: "Request headers",
               queryParams: "Query parameters",
@@ -748,13 +732,10 @@ export default function AddMcpSource(props: {
                 <FilterTabs<RemoteAuthMode>
                   tabs={
                     probe.requiresOAuth
-                      ? [
-                          { value: "header", label: "Header" },
-                          { value: "oauth2", label: "OAuth" },
-                        ]
+                      ? [{ value: "oauth2", label: "OAuth" }]
                       : [
                           { value: "none", label: "None" },
-                          { value: "header", label: "Header" },
+                          { value: "oauth2", label: "OAuth" },
                         ]
                   }
                   value={remoteAuthMode}
@@ -762,88 +743,77 @@ export default function AddMcpSource(props: {
                 />
               </div>
 
-              {remoteAuthMode === "header" && (
-                <CredentialScopeSection
-                  value={credentialTargetScope}
-                  options={credentialScopeOptions}
-                  onChange={(targetScope) => {
-                    setCredentialTargetScope(targetScope);
-                    dispatch({ type: "oauth-reset" });
-                  }}
-                >
-                  <HeadersList
-                    headers={remoteAuthHeaders}
-                    onHeadersChange={setRemoteAuthHeaders}
-                    existingSecrets={secretList}
-                    singleHeader
-                    sourceName={remoteIdentity.name}
-                    targetScope={credentialTargetScope}
-                  />
-                </CredentialScopeSection>
-              )}
-
               {remoteAuthMode === "oauth2" && (
-                <CredentialScopeSection
-                  value={credentialTargetScope}
+                <CredentialUsageRow
+                  value={oauthCredentialTargetScope}
                   options={credentialScopeOptions}
                   onChange={(targetScope) => {
-                    setCredentialTargetScope(targetScope);
+                    setOAuthCredentialTargetScope(targetScope);
                     dispatch({ type: "oauth-reset" });
                   }}
-                  description="Choose who can use the OAuth connection."
+                  label="Connection saved to"
+                  help="Choose who can use the OAuth connection."
                 >
-                  {!tokens && state.step === "probed" && (
-                    <div className="flex flex-col gap-2">
-                      <Button onClick={handleOAuth} variant="outline">
+                  <CredentialControlField
+                    label="Connect via OAuth"
+                    help="Start the provider OAuth flow."
+                  >
+                    {!tokens && state.step === "probed" && (
+                      <Button
+                        type="button"
+                        onClick={handleOAuth}
+                        variant="outline"
+                        className="w-full"
+                      >
                         Sign in
                       </Button>
-                      <p className="text-[11px] text-muted-foreground">
-                        Sign in before adding so Executor can discover and save the tool catalog.
-                      </p>
-                    </div>
-                  )}
+                    )}
 
-                  {!tokens && state.step === "oauth-starting" && (
-                    <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2.5">
-                      <Spinner className="size-3.5" />
-                      <span className="text-xs text-muted-foreground">Starting authorization…</span>
-                    </div>
-                  )}
+                    {!tokens && state.step === "oauth-starting" && (
+                      <div className="flex min-h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+                        <Spinner className="size-3.5" />
+                        <span className="text-xs text-muted-foreground">
+                          Starting authorization...
+                        </span>
+                      </div>
+                    )}
 
-                  {!tokens && state.step === "oauth-waiting" && (
-                    <div className="flex items-center gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2.5">
-                      <Spinner className="size-3.5 text-blue-500" />
-                      <span className="text-xs text-blue-600 dark:text-blue-400">
-                        Waiting for authorization in popup…
-                      </span>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleCancelOAuth}
-                        className="ml-auto h-7 px-2 text-xs"
-                      >
-                        Cancel
-                      </Button>
-                    </div>
-                  )}
+                    {!tokens && state.step === "oauth-waiting" && (
+                      <div className="flex min-h-9 items-center gap-2 rounded-md border border-blue-500/30 bg-blue-500/5 px-3 py-2">
+                        <Spinner className="size-3.5 text-blue-500" />
+                        <span className="text-xs text-blue-600 dark:text-blue-400">
+                          Waiting for authorization...
+                        </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={handleCancelOAuth}
+                          className="ml-auto h-7 px-2 text-xs"
+                        >
+                          Cancel
+                        </Button>
+                      </div>
+                    )}
 
-                  {tokens && (
-                    <div className="flex items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2.5">
-                      <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
-                        <path
-                          d="M3 8.5l3 3 7-7"
-                          stroke="currentColor"
-                          strokeWidth="1.5"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
-                      </svg>
-                      <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
-                        Authenticated
-                      </span>
-                    </div>
-                  )}
-                </CredentialScopeSection>
+                    {tokens && (
+                      <div className="flex min-h-9 items-center gap-2 rounded-md border border-emerald-500/30 bg-emerald-500/5 px-3 py-2">
+                        <svg viewBox="0 0 16 16" fill="none" className="size-3.5 text-emerald-500">
+                          <path
+                            d="M3 8.5l3 3 7-7"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                        <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+                          Authenticated
+                        </span>
+                      </div>
+                    )}
+                  </CredentialControlField>
+                </CredentialUsageRow>
               )}
             </section>
           )}
@@ -854,8 +824,8 @@ export default function AddMcpSource(props: {
               <div>
                 <Label>Additional headers</Label>
                 <p className="mt-1 text-[12px] text-muted-foreground">
-                  Plaintext headers sent with every request. Use authentication for secret-backed
-                  auth headers.
+                  Plaintext headers sent with every request. Use request headers above for
+                  secret-backed values.
                 </p>
               </div>
 
@@ -957,6 +927,7 @@ export default function AddMcpSource(props: {
                 <p className="text-[12px] text-destructive">{otherError}</p>
               </div>
               <Button
+                type="button"
                 variant="outline"
                 size="sm"
                 onClick={() => dispatch({ type: "retry" })}
@@ -969,6 +940,7 @@ export default function AddMcpSource(props: {
 
           <FloatActions>
             <Button
+              type="button"
               variant="ghost"
               onClick={() => {
                 oauth.cancel();
@@ -979,7 +951,7 @@ export default function AddMcpSource(props: {
               Cancel
             </Button>
             {(probe || isProbing) && (
-              <Button onClick={handleAddRemote} disabled={!canAdd}>
+              <Button type="button" onClick={handleAddRemote} disabled={!canAdd}>
                 {isAdding ? (
                   <>
                     <Spinner className="size-3.5" /> Adding…
@@ -1046,10 +1018,14 @@ export default function AddMcpSource(props: {
           )}
 
           <FloatActions>
-            <Button variant="ghost" onClick={props.onCancel} disabled={stdioAdding}>
+            <Button type="button" variant="ghost" onClick={props.onCancel} disabled={stdioAdding}>
               Cancel
             </Button>
-            <Button onClick={handleAddStdio} disabled={!stdioCommand.trim() || stdioAdding}>
+            <Button
+              type="button"
+              onClick={handleAddStdio}
+              disabled={!stdioCommand.trim() || stdioAdding}
+            >
               {stdioAdding ? (
                 <>
                   <Spinner className="size-3.5" /> Adding…

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -308,6 +308,20 @@ const bindingTargetScope = (
   );
 };
 
+const targetScopeForBinding = (
+  fallbackTargetScope: string | undefined,
+  binding: { readonly targetScope?: string },
+): Effect.Effect<string, McpConnectionError> => {
+  const targetScope = binding.targetScope ?? fallbackTargetScope;
+  if (targetScope) return Effect.succeed(targetScope);
+  return Effect.fail(
+    new McpConnectionError({
+      transport: "remote",
+      message: "credentialTargetScope is required when adding direct MCP credentials",
+    }),
+  );
+};
+
 const canonicalizeCredentialMap = (
   values: Record<string, McpCredentialInput> | undefined,
   slotForName: (name: string) => string,
@@ -316,10 +330,11 @@ const canonicalizeCredentialMap = (
   readonly bindings: ReadonlyArray<{
     readonly slot: string;
     readonly value: McpSourceBindingValue;
+    readonly targetScope?: string;
   }>;
 } => {
   const nextValues: Record<string, ConfiguredMcpCredentialValue> = {};
-  const bindings: Array<{ slot: string; value: McpSourceBindingValue }> = [];
+  const bindings: Array<{ slot: string; value: McpSourceBindingValue; targetScope?: string }> = [];
   for (const [name, value] of Object.entries(values ?? {})) {
     if (typeof value === "string") {
       nextValues[name] = value;
@@ -337,9 +352,13 @@ const canonicalizeCredentialMap = (
     });
     bindings.push({
       slot,
+      targetScope: "targetScope" in value ? value.targetScope : undefined,
       value: {
         kind: "secret",
         secretId: SecretId.make(value.secretId),
+        ...("secretScopeId" in value && value.secretScopeId
+          ? { secretScopeId: value.secretScopeId }
+          : {}),
       },
     });
   }
@@ -353,6 +372,7 @@ const canonicalizeAuth = (
   readonly bindings: ReadonlyArray<{
     readonly slot: string;
     readonly value: McpSourceBindingValue;
+    readonly targetScope?: string;
   }>;
 } => {
   if (!auth || auth.kind === "none") return { auth: { kind: "none" }, bindings: [] };
@@ -368,13 +388,18 @@ const canonicalizeAuth = (
       bindings: [
         {
           slot: MCP_HEADER_AUTH_SLOT,
-          value: { kind: "secret", secretId: SecretId.make(auth.secretId) },
+          targetScope: auth.targetScope,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(auth.secretId),
+            ...(auth.secretScopeId ? { secretScopeId: auth.secretScopeId } : {}),
+          },
         },
       ],
     };
   }
   if ("connectionSlot" in auth) return { auth, bindings: [] };
-  const bindings: Array<{ slot: string; value: McpSourceBindingValue }> = [
+  const bindings: Array<{ slot: string; value: McpSourceBindingValue; targetScope?: string }> = [
     {
       slot: MCP_OAUTH_CONNECTION_SLOT,
       value: {
@@ -572,18 +597,20 @@ const resolveMcpCredentialInputMap = (
         if (slotResolved?.[name] !== undefined) resolved[name] = slotResolved[name];
         continue;
       }
-      const secret = yield* ctx.secrets
-        .getAtScope(SecretId.make(value.secretId), params.targetScope ?? params.sourceScope)
-        .pipe(
-          Effect.catchTag("SecretOwnedByConnectionError", () =>
-            Effect.fail(
-              new McpConnectionError({
-                transport: "remote",
-                message: `Failed to resolve secret for ${params.missingLabel} "${name}"`,
-              }),
-            ),
+      const secretScope =
+        "secretScopeId" in value
+          ? (value.secretScopeId ?? value.targetScope)
+          : (params.targetScope ?? params.sourceScope);
+      const secret = yield* ctx.secrets.getAtScope(SecretId.make(value.secretId), secretScope).pipe(
+        Effect.catchTag("SecretOwnedByConnectionError", () =>
+          Effect.fail(
+            new McpConnectionError({
+              transport: "remote",
+              message: `Failed to resolve secret for ${params.missingLabel} "${name}"`,
+            }),
           ),
-        );
+        ),
+      );
       if (secret === null) {
         return yield* new McpConnectionError({
           transport: "remote",
@@ -681,18 +708,17 @@ const resolveMcpInputAuth = (
         const headers = yield* resolveMcpHeaderAuth(ctx, sourceId, sourceScope, auth);
         return { headers };
       }
-      const secret = yield* ctx.secrets
-        .getAtScope(SecretId.make(auth.secretId), targetScope ?? sourceScope)
-        .pipe(
-          Effect.catchTag("SecretOwnedByConnectionError", () =>
-            Effect.fail(
-              new McpConnectionError({
-                transport: "remote",
-                message: `Failed to resolve secret "${auth.secretId}"`,
-              }),
-            ),
+      const secretScope = auth.secretScopeId ?? auth.targetScope ?? targetScope ?? sourceScope;
+      const secret = yield* ctx.secrets.getAtScope(SecretId.make(auth.secretId), secretScope).pipe(
+        Effect.catchTag("SecretOwnedByConnectionError", () =>
+          Effect.fail(
+            new McpConnectionError({
+              transport: "remote",
+              message: `Failed to resolve secret "${auth.secretId}"`,
+            }),
           ),
-        );
+        ),
+      );
       if (secret === null) {
         return yield* new McpConnectionError({
           transport: "remote",
@@ -1074,17 +1100,21 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
                 ...canonicalRemote.auth.bindings,
               ]
             : [];
-          const targetScope =
-            config.transport === "remote"
-              ? yield* bindingTargetScope(config.credentialTargetScope, directBindings)
-              : undefined;
-          if (targetScope) {
+          for (const binding of directBindings) {
+            const bindingTargetScope = yield* targetScopeForBinding(
+              config.transport === "remote" ? config.credentialTargetScope : undefined,
+              binding,
+            );
             yield* validateMcpBindingTarget(ctx, {
               sourceId: namespace,
               sourceScope: config.scope,
-              targetScope,
+              targetScope: bindingTargetScope,
             });
           }
+          const targetScope =
+            config.transport === "remote" && directBindings[0]
+              ? yield* targetScopeForBinding(config.credentialTargetScope, directBindings[0])
+              : undefined;
           const sd = toStoredSourceData(
             config,
             canonicalRemote
@@ -1227,10 +1257,14 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
                   })),
                 });
 
-                if (targetScope) {
+                if (directBindings.length > 0) {
                   for (const binding of directBindings) {
+                    const bindingTargetScope = yield* targetScopeForBinding(
+                      config.transport === "remote" ? config.credentialTargetScope : undefined,
+                      binding,
+                    );
                     yield* ctx.credentialBindings.set({
-                      targetScope: ScopeId.make(targetScope),
+                      targetScope: ScopeId.make(bindingTargetScope),
                       pluginId: MCP_PLUGIN_ID,
                       sourceId: namespace,
                       sourceScope: ScopeId.make(config.scope),

--- a/packages/plugins/mcp/src/sdk/types.ts
+++ b/packages/plugins/mcp/src/sdk/types.ts
@@ -3,6 +3,7 @@ import {
   ConfiguredCredentialValue as ConfiguredCredentialValueSchema,
   CredentialBindingValue,
   credentialSlotKey,
+  ScopedSecretCredentialInput,
   ScopeId,
   SecretBackedMap,
   SecretBackedValue,
@@ -24,7 +25,11 @@ export type McpTransport = typeof McpTransport.Type;
 export const ConfiguredMcpCredentialValue = ConfiguredCredentialValueSchema;
 export type ConfiguredMcpCredentialValue = typeof ConfiguredMcpCredentialValue.Type;
 
-export const McpCredentialInput = Schema.Union([SecretBackedValue, ConfiguredMcpCredentialValue]);
+export const McpCredentialInput = Schema.Union([
+  ScopedSecretCredentialInput,
+  SecretBackedValue,
+  ConfiguredMcpCredentialValue,
+]);
 export type McpCredentialInput = typeof McpCredentialInput.Type;
 
 export const mcpHeaderSlot = (name: string): string => credentialSlotKey("header", name);
@@ -69,6 +74,8 @@ export const McpConnectionAuthInput = Schema.Union([
     headerName: Schema.String,
     secretId: Schema.String,
     prefix: Schema.optional(Schema.String),
+    targetScope: Schema.optional(ScopeId),
+    secretScopeId: Schema.optional(ScopeId),
   }),
   Schema.Struct({
     kind: Schema.Literal("oauth2"),

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -1,6 +1,6 @@
 import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
 import { Schema } from "effect";
-import { ScopeId, SecretBackedValue } from "@executor-js/sdk/core";
+import { ScopeId, ScopedSecretCredentialInput, SecretBackedValue } from "@executor-js/sdk/core";
 import { InternalError } from "@executor-js/api";
 
 import { OpenApiParseError, OpenApiExtractionError, OpenApiOAuthError } from "../sdk/errors";
@@ -43,6 +43,23 @@ const SpecFetchCredentialsPayload = Schema.Struct({
   queryParams: Schema.optional(Schema.Record(Schema.String, SecretBackedValue)),
 });
 
+const ConfiguredCredentialBindingPayload = Schema.Struct({
+  kind: Schema.Literal("binding"),
+  slot: Schema.String,
+  prefix: Schema.optional(Schema.String),
+});
+
+const ConfiguredCredentialValuePayload = Schema.Union([
+  Schema.String,
+  ConfiguredCredentialBindingPayload,
+]);
+
+const OpenApiCredentialInputPayload = Schema.Union([
+  ScopedSecretCredentialInput,
+  SecretBackedValue,
+  ConfiguredCredentialValuePayload,
+]);
+
 // ---------------------------------------------------------------------------
 // Payloads
 // ---------------------------------------------------------------------------
@@ -55,8 +72,8 @@ const AddSpecPayload = Schema.Struct({
   name: Schema.optional(Schema.String),
   baseUrl: Schema.optional(Schema.String),
   namespace: Schema.optional(Schema.String),
-  headers: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
-  queryParams: Schema.optional(Schema.Record(Schema.String, SecretBackedValue)),
+  headers: Schema.optional(Schema.Record(Schema.String, OpenApiCredentialInputPayload)),
+  queryParams: Schema.optional(Schema.Record(Schema.String, OpenApiCredentialInputPayload)),
   oauth2: Schema.optional(OAuth2SourceConfig),
 });
 
@@ -69,8 +86,8 @@ const UpdateSourcePayload = Schema.Struct({
   sourceScope: ScopeId,
   name: Schema.optional(Schema.String),
   baseUrl: Schema.optional(Schema.String),
-  headers: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
-  queryParams: Schema.optional(Schema.Record(Schema.String, SecretBackedValue)),
+  headers: Schema.optional(Schema.Record(Schema.String, OpenApiCredentialInputPayload)),
+  queryParams: Schema.optional(Schema.Record(Schema.String, OpenApiCredentialInputPayload)),
   credentialTargetScope: Schema.optional(ScopeId),
   // Set after a successful re-authenticate to refresh the source's
   // stored OAuth2 metadata.

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useAtomSet } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
@@ -6,7 +6,7 @@ import * as Schema from "effect/Schema";
 
 import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk/core";
 import { startOAuth } from "@executor-js/react/api/atoms";
-import { useScope } from "@executor-js/react/api/scope-context";
+import { useScope, useScopeStack } from "@executor-js/react/api/scope-context";
 import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 
 // `addSpec` with an oauth2 payload persists a source row AND (for
@@ -28,10 +28,6 @@ import {
   useOAuthPopupFlow,
   type OAuthCompletionPayload,
 } from "@executor-js/react/plugins/oauth-sign-in";
-import {
-  CredentialScopeSection,
-  useCredentialTargetScope,
-} from "@executor-js/react/plugins/credential-target-scope";
 import {
   CreatableSecretPicker,
   matchPresetKey,
@@ -62,12 +58,20 @@ import {
 } from "@executor-js/react/components/card-stack";
 import { FieldLabel } from "@executor-js/react/components/field";
 import { FloatActions } from "@executor-js/react/components/float-actions";
+import { HelpTooltip } from "@executor-js/react/components/help-tooltip";
 import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
 import { Textarea } from "@executor-js/react/components/textarea";
 import { Checkbox } from "@executor-js/react/components/checkbox";
 import { SourceFavicon } from "@executor-js/react/components/source-favicon";
 import { RadioGroup, RadioGroupItem } from "@executor-js/react/components/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@executor-js/react/components/select";
 import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
 import { addOpenApiSpecOptimistic, previewOpenApiSpec, setOpenApiSourceBinding } from "./atoms";
 import type { SpecPreview, HeaderPreset, OAuth2Preset } from "../sdk/preview";
@@ -76,6 +80,7 @@ import {
   oauth2ClientIdSlot,
   oauth2ClientSecretSlot,
   oauth2ConnectionSlot,
+  queryParamBindingSlot,
 } from "../sdk/store";
 import {
   ConfiguredHeaderBinding,
@@ -200,6 +205,49 @@ function entriesFromSpecPreset(preset: HeaderPreset): HeaderState[] {
   });
 }
 
+const secretStorageDescription = (label: string): string =>
+  label === "Personal"
+    ? "Only you can use this secret."
+    : "Everyone in the organization can use this secret.";
+
+function CredentialScopeDropdown(props: {
+  readonly value: ScopeId;
+  readonly options: readonly {
+    readonly scopeId: ScopeId;
+    readonly label: string;
+  }[];
+  readonly onChange: (scopeId: ScopeId) => void;
+  readonly label?: string;
+  readonly help?: ReactNode;
+}) {
+  const label = props.label ?? "Used by";
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <FieldLabel className="text-[11px]">{label}</FieldLabel>
+        <HelpTooltip label={label}>
+          {props.help ?? "Choose who uses this credential value."}
+        </HelpTooltip>
+      </div>
+      <Select
+        value={String(props.value)}
+        onValueChange={(value) => props.onChange(ScopeId.make(value))}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder={label} />
+        </SelectTrigger>
+        <SelectContent>
+          {props.options.map((option) => (
+            <SelectItem key={option.scopeId} value={option.scopeId}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main component — single progressive form
 // ---------------------------------------------------------------------------
@@ -237,6 +285,8 @@ export default function AddOpenApiSource(props: {
   // OAuth2 state (only populated while an oauth2 preset is selected)
   const [oauth2ClientIdSecretId, setOauth2ClientIdSecretId] = useState<string | null>(null);
   const [oauth2ClientSecretSecretId, setOauth2ClientSecretSecretId] = useState<string | null>(null);
+  const [oauth2ClientIdScope, setOauth2ClientIdScope] = useState<ScopeId | null>(null);
+  const [oauth2ClientSecretScope, setOauth2ClientSecretScope] = useState<ScopeId | null>(null);
   const [oauth2SelectedScopes, setOauth2SelectedScopes] = useState<Set<string>>(new Set());
   const [oauth2AuthState, setOauth2AuthState] = useState<{
     readonly fingerprint: string;
@@ -250,8 +300,47 @@ export default function AddOpenApiSource(props: {
   const [addError, setAddError] = useState<string | null>(null);
 
   const scopeId = useScope();
-  const { credentialTargetScope, setCredentialTargetScope, credentialScopeOptions } =
-    useCredentialTargetScope();
+  const scopeStack = useScopeStack();
+  const credentialScopeOptions = useMemo(
+    () =>
+      scopeStack.map((entry, index) => ({
+        scopeId: entry.id,
+        label: index === 0 ? "Personal" : entry.name || "Organization",
+        description: secretStorageDescription(
+          index === 0 ? "Personal" : entry.name || "Organization",
+        ),
+      })),
+    [scopeStack],
+  );
+  const defaultCredentialTargetScope =
+    credentialScopeOptions[credentialScopeOptions.length - 1]?.scopeId ?? scopeId;
+  const defaultOAuthTokenTargetScope = credentialScopeOptions[0]?.scopeId ?? scopeId;
+  const [credentialTargetScope, setCredentialTargetScope] = useState<ScopeId>(
+    defaultCredentialTargetScope,
+  );
+  const [oauthTokenTargetScope, setOAuthTokenTargetScope] = useState<ScopeId>(
+    defaultOAuthTokenTargetScope,
+  );
+  const bindingScopeOptions = useMemo(
+    () => credentialScopeOptions.map((option) => ({ ...option })),
+    [credentialScopeOptions],
+  );
+  useEffect(() => {
+    if (!credentialScopeOptions.some((option) => option.scopeId === credentialTargetScope)) {
+      setCredentialTargetScope(defaultCredentialTargetScope);
+    }
+  }, [credentialScopeOptions, credentialTargetScope, defaultCredentialTargetScope]);
+  useEffect(() => {
+    if (!credentialScopeOptions.some((option) => option.scopeId === oauthTokenTargetScope)) {
+      setOAuthTokenTargetScope(defaultOAuthTokenTargetScope);
+    }
+  }, [credentialScopeOptions, defaultOAuthTokenTargetScope, oauthTokenTargetScope]);
+  const initialCredentialScopeOption =
+    credentialScopeOptions.find((option) => option.scopeId === credentialTargetScope) ??
+    credentialScopeOptions[0];
+  const initialCredentialScopeOptions = initialCredentialScopeOption
+    ? [initialCredentialScopeOption]
+    : [];
   const doPreview = useAtomSet(previewOpenApiSpec, { mode: "promiseExit" });
   const doAdd = useAtomSet(addOpenApiSpecOptimistic(scopeId), {
     mode: "promiseExit",
@@ -261,6 +350,10 @@ export default function AddOpenApiSource(props: {
     mode: "promiseExit",
   });
   const secretList = useSecretPickerSecrets();
+  const initialCredentialSecrets = useMemo(
+    () => secretList.filter((secret) => secret.scopeId === String(credentialTargetScope)),
+    [credentialTargetScope, secretList],
+  );
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
     popupName: OPENAPI_OAUTH_POPUP_NAME,
     popupBlockedMessage: "OAuth popup was blocked by the browser",
@@ -318,7 +411,19 @@ export default function AddOpenApiSource(props: {
   const resolvedBaseUrl = baseUrl.trim();
 
   const configuredHeaders: Record<string, ConfiguredHeaderBinding> = {};
-  const headerBindings: Array<{ slot: string; secretId: string }> = [];
+  const headerBindings: Array<{
+    slot: string;
+    secretId: string;
+    scope: ScopeId;
+    secretScope: ScopeId;
+  }> = [];
+  const configuredQueryParams: Record<string, string | ConfiguredHeaderBinding> = {};
+  const queryParamBindings: Array<{
+    slot: string;
+    secretId: string;
+    scope: ScopeId;
+    secretScope: ScopeId;
+  }> = [];
   for (const ch of customHeaders) {
     if (!ch.name.trim()) continue;
     const slot = headerBindingSlot(ch.name.trim());
@@ -328,7 +433,34 @@ export default function AddOpenApiSource(props: {
       prefix: ch.prefix,
     });
     if (ch.secretId) {
-      headerBindings.push({ slot, secretId: ch.secretId });
+      headerBindings.push({
+        slot,
+        secretId: ch.secretId,
+        scope: ch.targetScope ?? credentialTargetScope,
+        secretScope: ch.secretScope ?? ch.targetScope ?? credentialTargetScope,
+      });
+    }
+  }
+  for (const param of runtimeCredentials.queryParams) {
+    const name = param.name.trim();
+    if (!name) continue;
+    if (param.secretId) {
+      const slot = queryParamBindingSlot(name);
+      configuredQueryParams[name] = new ConfiguredHeaderBinding({
+        kind: "binding",
+        slot,
+        prefix: param.prefix,
+      });
+      queryParamBindings.push({
+        slot,
+        secretId: param.secretId,
+        scope: param.targetScope ?? credentialTargetScope,
+        secretScope: param.secretScope ?? param.targetScope ?? credentialTargetScope,
+      });
+      continue;
+    }
+    if (param.literalValue?.trim()) {
+      configuredQueryParams[name] = param.literalValue.trim();
     }
   }
 
@@ -380,6 +512,18 @@ export default function AddOpenApiSource(props: {
       : null;
   const hasHeaders = Object.keys(configuredHeaders).length > 0;
   const oauth2Busy = startingOAuth || oauth.busy;
+  const canConnectOAuth2 = Boolean(oauth2ClientIdSecretId) && resolvedBaseUrl.length > 0;
+  const hasIncompleteHeaderCredentials =
+    strategy.kind !== "none" &&
+    strategy.kind !== "oauth2" &&
+    customHeaders.some((header) => header.name.trim() && !header.secretId);
+  const hasIncompleteQueryCredentials = runtimeCredentials.queryParams.some(
+    (param) => param.name.trim() && !param.secretId && !param.literalValue?.trim(),
+  );
+  const willAddWithoutInitialCredentials =
+    Boolean(selectedOAuth2Preset && !oauth2Auth) ||
+    hasIncompleteHeaderCredentials ||
+    hasIncompleteQueryCredentials;
 
   const canAdd = preview !== null && resolvedBaseUrl.length > 0;
 
@@ -470,6 +614,24 @@ export default function AddOpenApiSource(props: {
     }
   };
 
+  const setInitialCredentialScope = (targetScope: ScopeId) => {
+    setCredentialTargetScope(targetScope);
+    setCustomHeaders((headers) =>
+      headers.map((header) => ({
+        ...header,
+        targetScope,
+        ...(header.secretScope && header.secretScope !== targetScope
+          ? { secretId: null, secretScope: undefined }
+          : {}),
+      })),
+    );
+    setOauth2ClientIdSecretId(null);
+    setOauth2ClientSecretSecretId(null);
+    setOauth2ClientIdScope(null);
+    setOauth2ClientSecretScope(null);
+    setOauth2AuthState(null);
+  };
+
   const toggleOAuth2Scope = (scope: string) => {
     setOauth2SelectedScopes((prev) => {
       const copy = new Set(prev);
@@ -505,7 +667,7 @@ export default function AddOpenApiSource(props: {
           endpoint: tokenUrl,
           redirectUrl: tokenUrl,
           connectionId,
-          tokenScope: credentialTargetScope,
+          tokenScope: oauthTokenTargetScope,
           strategy: {
             kind: "client-credentials",
             tokenEndpoint: tokenUrl,
@@ -542,14 +704,14 @@ export default function AddOpenApiSource(props: {
     const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
 
     await oauth.openAuthorization({
-      tokenScope: credentialTargetScope,
+      tokenScope: oauthTokenTargetScope,
       run: async () => {
         const exit = await doStartOAuth({
           params: { scopeId },
           payload: {
             endpoint: authorizationUrl,
             connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
-            tokenScope: credentialTargetScope,
+            tokenScope: oauthTokenTargetScope,
             redirectUrl: oauth2RedirectUrl,
             strategy: {
               kind: "authorization-code",
@@ -604,7 +766,7 @@ export default function AddOpenApiSource(props: {
     resolvedSourceId,
     selectedOAuth2Fingerprint,
     oauth,
-    credentialTargetScope,
+    oauthTokenTargetScope,
   ]);
 
   const handleCancelOAuth2 = useCallback(() => {
@@ -631,10 +793,8 @@ export default function AddOpenApiSource(props: {
         namespace,
         baseUrl: resolvedBaseUrl || undefined,
         ...(hasHeaders ? { headers: configuredHeaders } : {}),
-        ...(Object.keys(serializeHttpCredentials(runtimeCredentials).queryParams).length > 0
-          ? {
-              queryParams: serializeHttpCredentials(runtimeCredentials).queryParams,
-            }
+        ...(Object.keys(configuredQueryParams).length > 0
+          ? { queryParams: configuredQueryParams }
           : {}),
         ...(configuredOAuth2 ? { oauth2: configuredOAuth2 } : {}),
       },
@@ -649,6 +809,9 @@ export default function AddOpenApiSource(props: {
     const sourceId = exit.value.namespace;
     const sourceScope = ScopeId.make(scopeId);
     const bindingScope = ScopeId.make(credentialTargetScope);
+    const oauthTokenBindingScope = ScopeId.make(oauthTokenTargetScope);
+    const clientIdSecretScope = oauth2ClientIdScope ?? bindingScope;
+    const clientSecretSecretScope = oauth2ClientSecretScope ?? bindingScope;
 
     for (const binding of headerBindings) {
       const bindingExit = await doSetBinding({
@@ -656,11 +819,35 @@ export default function AddOpenApiSource(props: {
         payload: {
           sourceId,
           sourceScope,
-          scope: bindingScope,
+          scope: binding.scope,
           slot: binding.slot,
           value: {
             kind: "secret",
             secretId: SecretId.make(binding.secretId),
+            secretScopeId: binding.secretScope,
+          },
+        },
+        reactivityKeys: bindingWriteKeys,
+      });
+      if (Exit.isFailure(bindingExit)) {
+        setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
+        setAdding(false);
+        return;
+      }
+    }
+
+    for (const binding of queryParamBindings) {
+      const bindingExit = await doSetBinding({
+        params: { scopeId },
+        payload: {
+          sourceId,
+          sourceScope,
+          scope: binding.scope,
+          slot: binding.slot,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make(binding.secretId),
+            secretScopeId: binding.secretScope,
           },
         },
         reactivityKeys: bindingWriteKeys,
@@ -683,6 +870,7 @@ export default function AddOpenApiSource(props: {
           value: {
             kind: "secret",
             secretId: SecretId.make(oauth2ClientIdSecretId),
+            secretScopeId: clientIdSecretScope,
           },
         },
         reactivityKeys: bindingWriteKeys,
@@ -705,6 +893,7 @@ export default function AddOpenApiSource(props: {
           value: {
             kind: "secret",
             secretId: SecretId.make(oauth2ClientSecretSecretId),
+            secretScopeId: clientSecretSecretScope,
           },
         },
         reactivityKeys: bindingWriteKeys,
@@ -722,7 +911,7 @@ export default function AddOpenApiSource(props: {
         payload: {
           sourceId,
           sourceScope,
-          scope: bindingScope,
+          scope: oauthTokenBindingScope,
           slot: configuredOAuth2.connectionSlot,
           value: {
             kind: "connection",
@@ -747,10 +936,6 @@ export default function AddOpenApiSource(props: {
     <div className="flex flex-1 flex-col gap-6">
       <div>
         <h1 className="text-xl font-semibold text-foreground">Add OpenAPI Source</h1>
-        <p className="mt-1 text-[13px] text-muted-foreground">
-          Save the source now, then add personal or organization credentials where the API needs
-          them.
-        </p>
       </div>
 
       {!preview && (
@@ -880,7 +1065,7 @@ export default function AddOpenApiSource(props: {
       {preview && (
         <>
           <section className="space-y-2.5">
-            <FieldLabel>Authentication</FieldLabel>
+            <FieldLabel>Authentication method</FieldLabel>
             {/* RadioGroup always renders so the static Custom + None radios
                 stay visible for specs with no security schemes (e.g. MS Graph).
                 The preset .map() blocks below render nothing when their arrays
@@ -959,22 +1144,19 @@ export default function AddOpenApiSource(props: {
 
             {/* Header-based auth input */}
             {strategy.kind !== "none" && strategy.kind !== "oauth2" && (
-              <CredentialScopeSection
-                value={credentialTargetScope}
-                options={credentialScopeOptions}
-                onChange={(targetScope) => {
-                  setCredentialTargetScope(targetScope);
-                  setOauth2AuthState(null);
-                }}
-              >
+              <div className="space-y-3">
                 <HeadersList
                   headers={customHeaders}
                   onHeadersChange={handleHeadersChange}
                   existingSecrets={secretList}
                   sourceName={identity.name}
                   targetScope={credentialTargetScope}
+                  credentialScopeOptions={initialCredentialScopeOptions}
+                  bindingScopeOptions={bindingScopeOptions}
+                  restrictSecretsToTargetScope
+                  emptyLabel="No credentials yet. Add the header value this method should use."
                 />
-              </CredentialScopeSection>
+              </div>
             )}
 
             <HttpCredentialsEditor
@@ -983,6 +1165,9 @@ export default function AddOpenApiSource(props: {
               existingSecrets={secretList}
               sourceName={identity.name}
               targetScope={credentialTargetScope}
+              credentialScopeOptions={initialCredentialScopeOptions}
+              bindingScopeOptions={bindingScopeOptions}
+              restrictSecretsToTargetScope
               sections={{ headers: false, queryParams: true }}
               labels={{ queryParams: "Runtime query parameters" }}
             />
@@ -990,15 +1175,7 @@ export default function AddOpenApiSource(props: {
             {/* OAuth2 configuration */}
             {selectedOAuth2Preset && (
               <div className="space-y-3 rounded-lg border border-border/60 bg-muted/10 p-3">
-                <CredentialScopeSection
-                  value={credentialTargetScope}
-                  options={credentialScopeOptions}
-                  onChange={(targetScope) => {
-                    setCredentialTargetScope(targetScope);
-                    setOauth2AuthState(null);
-                  }}
-                  description="Choose who can use the OAuth client secrets and connection."
-                >
+                <div className="space-y-3">
                   <div className="space-y-1.5">
                     <FieldLabel className="text-[11px]">
                       Redirect URL{" "}
@@ -1013,17 +1190,35 @@ export default function AddOpenApiSource(props: {
                   </div>
                   <div className="space-y-1.5">
                     <FieldLabel className="text-[11px]">Client ID secret</FieldLabel>
-                    <CreatableSecretPicker
-                      value={oauth2ClientIdSecretId}
-                      onSelect={(id: string) => {
-                        setOauth2ClientIdSecretId(id);
-                        setOauth2AuthState(null);
-                      }}
-                      secrets={secretList}
-                      sourceName={identity.name}
-                      secretLabel="Client ID"
-                      targetScope={credentialTargetScope}
-                    />
+                    <div className="grid gap-2 md:grid-cols-2">
+                      <div className="space-y-1.5">
+                        <div className="flex items-center gap-1.5">
+                          <FieldLabel className="text-[11px]">Secret</FieldLabel>
+                          <HelpTooltip label="Client ID secret">
+                            Select or create the OAuth client ID secret.
+                          </HelpTooltip>
+                        </div>
+                        <CreatableSecretPicker
+                          value={oauth2ClientIdSecretId}
+                          onSelect={(id: string, secretScopeId?: ScopeId) => {
+                            setOauth2ClientIdSecretId(id);
+                            setOauth2ClientIdScope(secretScopeId ?? credentialTargetScope);
+                            setOauth2AuthState(null);
+                          }}
+                          secrets={initialCredentialSecrets}
+                          sourceName={identity.name}
+                          secretLabel="Client ID"
+                          targetScope={oauth2ClientIdScope ?? credentialTargetScope}
+                          credentialScopeOptions={initialCredentialScopeOptions}
+                          onCreatedScope={setOauth2ClientIdScope}
+                        />
+                      </div>
+                      <CredentialScopeDropdown
+                        value={credentialTargetScope}
+                        options={bindingScopeOptions}
+                        onChange={setInitialCredentialScope}
+                      />
+                    </div>
                   </div>
                   <div className="space-y-1.5">
                     <FieldLabel className="text-[11px]">
@@ -1032,17 +1227,35 @@ export default function AddOpenApiSource(props: {
                         · optional for public clients with PKCE
                       </span>
                     </FieldLabel>
-                    <CreatableSecretPicker
-                      value={oauth2ClientSecretSecretId}
-                      onSelect={(id: string) => {
-                        setOauth2ClientSecretSecretId(id);
-                        setOauth2AuthState(null);
-                      }}
-                      secrets={secretList}
-                      sourceName={identity.name}
-                      secretLabel="Client Secret"
-                      targetScope={credentialTargetScope}
-                    />
+                    <div className="grid gap-2 md:grid-cols-2">
+                      <div className="space-y-1.5">
+                        <div className="flex items-center gap-1.5">
+                          <FieldLabel className="text-[11px]">Secret</FieldLabel>
+                          <HelpTooltip label="Client secret">
+                            Select or create the OAuth client secret.
+                          </HelpTooltip>
+                        </div>
+                        <CreatableSecretPicker
+                          value={oauth2ClientSecretSecretId}
+                          onSelect={(id: string, secretScopeId?: ScopeId) => {
+                            setOauth2ClientSecretSecretId(id);
+                            setOauth2ClientSecretScope(secretScopeId ?? credentialTargetScope);
+                            setOauth2AuthState(null);
+                          }}
+                          secrets={initialCredentialSecrets}
+                          sourceName={identity.name}
+                          secretLabel="Client Secret"
+                          targetScope={oauth2ClientSecretScope ?? credentialTargetScope}
+                          credentialScopeOptions={initialCredentialScopeOptions}
+                          onCreatedScope={setOauth2ClientSecretScope}
+                        />
+                      </div>
+                      <CredentialScopeDropdown
+                        value={credentialTargetScope}
+                        options={bindingScopeOptions}
+                        onChange={setInitialCredentialScope}
+                      />
+                    </div>
                   </div>
                   <div className="space-y-1.5">
                     <FieldLabel className="text-[11px]">Scopes</FieldLabel>
@@ -1097,18 +1310,38 @@ export default function AddOpenApiSource(props: {
                     </div>
                   ) : (
                     <div className="flex flex-col gap-1.5">
-                      <Button
-                        variant="secondary"
-                        onClick={handleConnectOAuth2}
-                        disabled={!oauth2ClientIdSecretId || resolvedBaseUrl.length === 0}
-                        className="w-full"
-                      >
-                        Connect via OAuth
-                      </Button>
-                      <p className="text-[11px] text-muted-foreground">
-                        You can add the source without this OAuth connection. Secured operations
-                        will ask for credentials on the source detail page.
-                      </p>
+                      <div className="grid gap-2 md:grid-cols-2">
+                        <div className="space-y-1.5">
+                          <div className="flex items-center gap-1.5">
+                            <FieldLabel className="text-[11px]">OAuth sign-in</FieldLabel>
+                            <HelpTooltip label="OAuth sign-in">
+                              Start the provider OAuth flow.
+                            </HelpTooltip>
+                          </div>
+                          <Button
+                            variant="secondary"
+                            onClick={handleConnectOAuth2}
+                            disabled={!canConnectOAuth2}
+                            className={
+                              canConnectOAuth2
+                                ? "w-full border border-green-500/30 bg-green-600 text-white hover:bg-green-700 focus-visible:ring-green-500/30 dark:bg-green-500 dark:text-white dark:hover:bg-green-600"
+                                : "w-full"
+                            }
+                          >
+                            Connect via OAuth
+                          </Button>
+                        </div>
+                        <CredentialScopeDropdown
+                          value={oauthTokenTargetScope}
+                          options={credentialScopeOptions}
+                          onChange={(targetScope) => {
+                            setOAuthTokenTargetScope(targetScope);
+                            setOauth2AuthState(null);
+                          }}
+                          label="Token saved to"
+                          help="Choose who can use the signed-in OAuth token."
+                        />
+                      </div>
                     </div>
                   )}
 
@@ -1117,7 +1350,7 @@ export default function AddOpenApiSource(props: {
                       <p className="text-[11px] text-destructive">{oauth2Error}</p>
                     </div>
                   )}
-                </CredentialScopeSection>
+                </div>
               </div>
             )}
           </section>
@@ -1140,7 +1373,7 @@ export default function AddOpenApiSource(props: {
             {adding && <Spinner className="size-3.5" />}
             {adding
               ? "Adding…"
-              : selectedOAuth2Preset && !oauth2Auth
+              : willAddWithoutInitialCredentials
                 ? "Add without credentials"
                 : "Add source"}
           </Button>

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -170,8 +170,12 @@ export default function EditOpenApiSource(props: {
   const secretList = useSecretPickerSecrets();
 
   const doUpdate = useAtomSet(updateOpenApiSource, { mode: "promiseExit" });
-  const doSetBinding = useAtomSet(setOpenApiSourceBinding, { mode: "promiseExit" });
-  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, { mode: "promiseExit" });
+  const doSetBinding = useAtomSet(setOpenApiSourceBinding, {
+    mode: "promiseExit",
+  });
+  const doRemoveBinding = useAtomSet(removeOpenApiSourceBinding, {
+    mode: "promiseExit",
+  });
   const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
     popupName: OPENAPI_OAUTH_POPUP_NAME,
@@ -196,10 +200,14 @@ export default function EditOpenApiSource(props: {
     readonly connectionId: string;
   } | null>(null);
   const [loadedSourceKey, setLoadedSourceKey] = useState<string | null>(null);
-  const [selectedCredentialScope, setSelectedCredentialScope] = useState<string>(
+  const [selectedOAuthTokenScope, setSelectedOAuthTokenScope] = useState<string>(
     userScope !== sourceScopeId ? userScope : sourceScopeId,
   );
   const sourceSaveSeq = useRef(0);
+
+  useEffect(() => {
+    setSelectedOAuthTokenScope(userScope !== sourceScopeId ? userScope : sourceScopeId);
+  }, [sourceScopeId, userScope]);
 
   useEffect(() => {
     if (!source) return;
@@ -210,10 +218,6 @@ export default function EditOpenApiSource(props: {
     setSourceSaveState("idle");
     setLoadedSourceKey(sourceKey);
   }, [loadedSourceKey, source, sourceScopeId]);
-
-  useEffect(() => {
-    setSelectedCredentialScope(userScope !== sourceScopeId ? userScope : sourceScopeId);
-  }, [sourceScopeId, userScope]);
 
   useEffect(() => {
     if (!source) return;
@@ -313,15 +317,39 @@ export default function EditOpenApiSource(props: {
     if (userScope !== sourceScopeId) {
       entries.unshift({ scopeId: ScopeId.make(userScope), label: "Personal" });
     } else {
-      entries[0] = { scopeId: ScopeId.make(sourceScopeId), label: "Credentials" };
+      entries[0] = {
+        scopeId: ScopeId.make(sourceScopeId),
+        label: "Credentials",
+      };
     }
     return entries;
   }, [sourceScopeId, userScope]);
-  const activeCredentialScope =
-    credentialScopes.find((entry) => entry.scopeId === selectedCredentialScope) ??
+  const credentialScopeOptions = useMemo(
+    () =>
+      credentialScopes.map((entry) => ({
+        scopeId: entry.scopeId,
+        label: entry.label,
+        description:
+          entry.label === "Personal"
+            ? "Saved only for your account."
+            : "Shared with everyone who can use this source.",
+      })),
+    [credentialScopes],
+  );
+  const organizationCredentialScope =
+    credentialScopes.find((entry) => entry.label === "Organization") ?? credentialScopes[0]!;
+  const personalCredentialScope =
+    credentialScopes.find((entry) => entry.label === "Personal") ?? null;
+  const secretBindingScopes =
+    personalCredentialScope &&
+    personalCredentialScope.scopeId !== organizationCredentialScope.scopeId
+      ? [organizationCredentialScope, personalCredentialScope]
+      : [organizationCredentialScope];
+  const activeOAuthTokenScope =
+    credentialScopes.find((entry) => entry.scopeId === selectedOAuthTokenScope) ??
     credentialScopes[0]!;
-  const activeCredentialScopeId = activeCredentialScope.scopeId;
-  const activeCredentialScopeLabel = activeCredentialScope.label;
+  const activeOAuthTokenScopeId = activeOAuthTokenScope.scopeId;
+  const activeOAuthTokenScopeLabel = activeOAuthTokenScope.label;
 
   if (!source) {
     return (
@@ -332,7 +360,12 @@ export default function EditOpenApiSource(props: {
     );
   }
 
-  const setSecretBinding = async (targetScope: ScopeId, slot: string, secretId: string) => {
+  const setSecretBinding = async (
+    targetScope: ScopeId,
+    slot: string,
+    secretId: string,
+    secretScope: ScopeId,
+  ) => {
     const inputKey = `${targetScope}:${slot}`;
     const trimmed = secretId.trim();
     if (!trimmed) return;
@@ -345,7 +378,11 @@ export default function EditOpenApiSource(props: {
         sourceScope,
         scope: targetScope,
         slot,
-        value: { kind: "secret", secretId: SecretId.make(trimmed) },
+        value: {
+          kind: "secret",
+          secretId: SecretId.make(trimmed),
+          secretScopeId: secretScope,
+        },
       },
       reactivityKeys: sourceWriteKeys,
     });
@@ -562,10 +599,6 @@ export default function EditOpenApiSource(props: {
     <div className="space-y-6">
       <div>
         <h1 className="text-xl font-semibold text-foreground">OpenAPI Source</h1>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Shared source settings stay on the source. Credentials can be saved personally or shared
-          with the organization.
-        </p>
       </div>
 
       <CardStack>
@@ -612,101 +645,110 @@ export default function EditOpenApiSource(props: {
 
       <CardStack>
         <CardStackContent className="border-t-0">
-          {credentialScopes.length > 1 && (
-            <CardStackEntry>
-              <CardStackEntryContent>
-                <CardStackEntryTitle>Credentials</CardStackEntryTitle>
-                <CardStackEntryDescription>
-                  Choose whether each credential is personal or shared with the organization.
-                </CardStackEntryDescription>
-              </CardStackEntryContent>
-              <FilterTabs
-                tabs={credentialScopes.map((entry) => ({
-                  value: entry.scopeId,
-                  label: entry.label,
-                }))}
-                value={activeCredentialScopeId}
-                onChange={setSelectedCredentialScope}
-              />
-            </CardStackEntry>
-          )}
+          <CardStackEntry>
+            <CardStackEntryContent>
+              <CardStackEntryTitle>Secrets</CardStackEntryTitle>
+            </CardStackEntryContent>
+          </CardStackEntry>
 
           {secretSlots
             .filter((slot) => slot.kind === "secret")
             .map((slot) => {
-              const exact = exactBindingForScope(bindingRows, slot.slot, activeCredentialScopeId);
-              const effective = effectiveBindingForScope(
-                bindingRows,
-                slot.slot,
-                activeCredentialScopeId,
-                scopeRanks,
-              );
-              const inputKey = `${activeCredentialScopeId}:${slot.slot}`;
-              const savedHere = !!(exact && isSecretBindingValue(exact.value));
-              const inherited =
-                !savedHere &&
-                effective &&
-                effective.scopeId !== activeCredentialScopeId &&
-                isSecretBindingValue(effective.value);
-              const currentSecretId =
-                exact && isSecretBindingValue(exact.value)
-                  ? exact.value.secretId
-                  : inherited && effective && isSecretBindingValue(effective.value)
-                    ? effective.value.secretId
-                    : null;
               return (
-                <CardStackEntryField
-                  key={`${slot.slot}:${activeCredentialScopeId}`}
-                  label={slot.label}
-                >
-                  <div className="space-y-2">
-                    <CreatableSecretPicker
-                      value={currentSecretId}
-                      onSelect={(secretId) =>
-                        void setSecretBinding(activeCredentialScopeId, slot.slot, secretId)
-                      }
-                      secrets={secretList}
-                      placeholder={
-                        savedHere
-                          ? `Selected in ${activeCredentialScopeLabel.toLowerCase()}`
-                          : inherited
-                            ? "Using organization default"
-                            : "Select or create a secret"
-                      }
-                      targetScope={activeCredentialScopeId}
-                      suggestedId={bindingSecretId(
-                        props.sourceId,
+                <CardStackEntryField key={slot.slot} label={slot.label}>
+                  <div className="space-y-3">
+                    {secretBindingScopes.map((bindingScope) => {
+                      const exact = exactBindingForScope(
+                        bindingRows,
                         slot.slot,
-                        activeCredentialScopeId,
-                      )}
-                      sourceName={source.name}
-                      secretLabel={slot.label}
-                    />
-                    <div className="flex items-center gap-2">
-                      {savedHere && (
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => void clearBinding(activeCredentialScopeId, slot.slot)}
-                          disabled={busyKey === `${activeCredentialScopeId}:${slot.slot}:clear`}
+                        bindingScope.scopeId,
+                      );
+                      const exactSecretId =
+                        exact && isSecretBindingValue(exact.value) ? exact.value.secretId : null;
+                      const inherited =
+                        bindingScope.label === "Personal"
+                          ? effectiveBindingForScope(
+                              bindingRows,
+                              slot.slot,
+                              bindingScope.scopeId,
+                              scopeRanks,
+                            )
+                          : null;
+                      const inheritedSecretId =
+                        inherited &&
+                        inherited.scopeId !== bindingScope.scopeId &&
+                        isSecretBindingValue(inherited.value)
+                          ? inherited.value.secretId
+                          : null;
+                      const inputKey = `${bindingScope.scopeId}:${slot.slot}`;
+                      const clearKey = `${bindingScope.scopeId}:${slot.slot}:clear`;
+                      const rowTitle =
+                        bindingScope.label === "Personal"
+                          ? "My override"
+                          : secretBindingScopes.length === 1
+                            ? "Source credential"
+                            : "Organization default";
+
+                      return (
+                        <div
+                          key={bindingScope.scopeId}
+                          className="space-y-2 rounded-md border border-border bg-background/40 p-3"
                         >
-                          Clear
-                        </Button>
-                      )}
-                      {busyKey === inputKey && (
-                        <span className="text-xs text-muted-foreground">Saving…</span>
-                      )}
-                      {slot.hint && (
-                        <span className="text-xs text-muted-foreground">{slot.hint}</span>
-                      )}
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      {savedHere
-                        ? `Saved in ${activeCredentialScopeLabel.toLowerCase()}.`
-                        : inherited
-                          ? "No value saved here. Using the organization default."
-                          : `No ${activeCredentialScopeLabel.toLowerCase()} value saved yet.`}
-                    </p>
+                          <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                            <div>
+                              <div className="text-sm font-medium text-foreground">{rowTitle}</div>
+                            </div>
+                            {bindingScope.label === "Personal" &&
+                              !exactSecretId &&
+                              inheritedSecretId && (
+                                <span className="text-xs text-muted-foreground">
+                                  Using organization default
+                                </span>
+                              )}
+                          </div>
+                          <CreatableSecretPicker
+                            value={exactSecretId}
+                            onSelect={(secretId, secretScopeId) => {
+                              void setSecretBinding(
+                                bindingScope.scopeId,
+                                slot.slot,
+                                secretId,
+                                secretScopeId ?? bindingScope.scopeId,
+                              );
+                            }}
+                            secrets={secretList}
+                            placeholder="Select or create a secret"
+                            targetScope={bindingScope.scopeId}
+                            credentialScopeOptions={credentialScopeOptions}
+                            suggestedId={bindingSecretId(
+                              props.sourceId,
+                              slot.slot,
+                              bindingScope.scopeId,
+                            )}
+                            sourceName={source.name}
+                            secretLabel={slot.label}
+                          />
+                          <div className="flex flex-wrap items-center gap-2">
+                            {exactSecretId && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => void clearBinding(bindingScope.scopeId, slot.slot)}
+                                disabled={busyKey === clearKey}
+                              >
+                                Clear
+                              </Button>
+                            )}
+                            {busyKey === inputKey && (
+                              <span className="text-xs text-muted-foreground">Saving…</span>
+                            )}
+                            {slot.hint && (
+                              <span className="text-xs text-muted-foreground">{slot.hint}</span>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
                   </div>
                 </CardStackEntryField>
               );
@@ -725,19 +767,37 @@ export default function EditOpenApiSource(props: {
                   </p>
                 </div>
               </CardStackEntryField>
+              {credentialScopes.length > 1 && (
+                <CardStackEntry>
+                  <CardStackEntryContent>
+                    <CardStackEntryTitle>OAuth token</CardStackEntryTitle>
+                    <CardStackEntryDescription>
+                      Choose where the signed-in OAuth token is saved.
+                    </CardStackEntryDescription>
+                  </CardStackEntryContent>
+                  <FilterTabs
+                    tabs={credentialScopes.map((entry) => ({
+                      value: entry.scopeId,
+                      label: entry.label,
+                    }))}
+                    value={activeOAuthTokenScopeId}
+                    onChange={setSelectedOAuthTokenScope}
+                  />
+                </CardStackEntry>
+              )}
               <CardStackEntryField label="OAuth Connection">
                 {(() => {
                   const exact = exactBindingForScope(
                     bindingRows,
                     source.config.oauth2!.connectionSlot,
-                    activeCredentialScopeId,
+                    activeOAuthTokenScopeId,
                   );
                   const binding =
                     exact ??
                     effectiveBindingForScope(
                       bindingRows,
                       source.config.oauth2!.connectionSlot,
-                      activeCredentialScopeId,
+                      activeOAuthTokenScopeId,
                       scopeRanks,
                     );
                   const connectionBinding =
@@ -748,9 +808,10 @@ export default function EditOpenApiSource(props: {
                   const bindingScopeId = connectionBinding && binding ? binding.scopeId : null;
                   const isConnecting =
                     busyKey ===
-                    `${activeCredentialScopeId}:${source.config.oauth2.connectionSlot}:connect`;
+                    `${activeOAuthTokenScopeId}:${source.config.oauth2.connectionSlot}:connect`;
                   const isPendingOAuthConnection =
-                    pendingOAuthConnection?.scopeId === activeCredentialScopeId &&
+                    pendingOAuthConnection?.scopeId === activeOAuthTokenScopeId &&
+                    pendingOAuthConnection !== null &&
                     pendingOAuthConnection.slot === source.config.oauth2.connectionSlot;
                   const isConnected = connection !== null && connection !== undefined;
                   const statusText =
@@ -758,24 +819,24 @@ export default function EditOpenApiSource(props: {
                       ? "Saving OAuth connection..."
                       : connectionBinding && bindingScopeId
                         ? connection
-                          ? bindingScopeId === activeCredentialScopeId
-                            ? `Connected in ${activeCredentialScopeLabel.toLowerCase()} as ${
+                          ? bindingScopeId === activeOAuthTokenScopeId
+                            ? `Connected in ${activeOAuthTokenScopeLabel.toLowerCase()} as ${
                                 connection.identityLabel ?? connection.id
                               }`
                             : `Using organization connection ${
                                 connection.identityLabel ?? connection.id
                               }`
-                          : bindingScopeId === activeCredentialScopeId
-                            ? `Saved connection is missing in ${activeCredentialScopeLabel.toLowerCase()}`
+                          : bindingScopeId === activeOAuthTokenScopeId
+                            ? `Saved connection is missing in ${activeOAuthTokenScopeLabel.toLowerCase()}`
                             : "Organization connection is missing"
-                        : `No ${activeCredentialScopeLabel.toLowerCase()} connection`;
+                        : `No ${activeOAuthTokenScopeLabel.toLowerCase()} connection`;
 
                   return (
                     <div className="space-y-2">
                       <div className="text-sm text-muted-foreground">{statusText}</div>
                       <Button
                         size="sm"
-                        onClick={() => void connectOAuth(activeCredentialScopeId)}
+                        onClick={() => void connectOAuth(activeOAuthTokenScopeId)}
                         disabled={isConnecting}
                       >
                         {isConnecting ? "Connecting…" : isConnected ? "Reconnect" : "Connect"}

--- a/packages/plugins/openapi/src/sdk/multi-scope-bearer.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-bearer.test.ts
@@ -81,9 +81,10 @@ const ProjectsGroupLive = HttpApiBuilder.group(VercelApi, "projects", (handlers)
 
 const ApiLive = HttpApiBuilder.layer(VercelApi).pipe(Layer.provide(ProjectsGroupLive));
 
-const TestLayer = HttpRouter.serve(ApiLive, { disableListenLog: true, disableLogger: true }).pipe(
-  Layer.provideMerge(NodeHttpServer.layerTest),
-);
+const TestLayer = HttpRouter.serve(ApiLive, {
+  disableListenLog: true,
+  disableLogger: true,
+}).pipe(Layer.provideMerge(NodeHttpServer.layerTest));
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -296,7 +297,10 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
         "vercel.projects.list",
         {},
         autoApprove,
-      )) as { data: { authorization?: string; token?: string } | null; error: unknown };
+      )) as {
+        data: { authorization?: string; token?: string } | null;
+        error: unknown;
+      };
       expect(aliceResult.error).toBeNull();
       expect(aliceResult.data?.authorization).toBe("Bearer alice-vercel-token");
       expect(aliceResult.data?.token).toBe("alice-team");
@@ -882,8 +886,16 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
       const adapter = makeMemoryAdapter({ schema: collectSchemas(plugins) });
       const blobs = makeInMemoryBlobStore();
       const now = new Date();
-      const orgScope = new Scope({ id: ScopeId.make("org"), name: "org", createdAt: now });
-      const userScope = new Scope({ id: ScopeId.make("user"), name: "user", createdAt: now });
+      const orgScope = new Scope({
+        id: ScopeId.make("org"),
+        name: "org",
+        createdAt: now,
+      });
+      const userScope = new Scope({
+        id: ScopeId.make("user"),
+        name: "user",
+        createdAt: now,
+      });
 
       const adminExec = yield* createExecutor({
         scopes: [orgScope],
@@ -947,6 +959,108 @@ layer(TestLayer)("OpenAPI multi-scope bearer (Vercel-style)", (it) => {
 
       expect(result.error).toBeNull();
       expect(result.data?.authorization).toBe("Bearer org-token");
+    }),
+  );
+
+  it.effect("personal binding can override the source with an org-owned secret", () =>
+    Effect.gen(function* () {
+      const secretStore = new Map<string, string>();
+      const key = (scope: string, id: string) => `${scope}\u0000${id}`;
+      const memoryProvider: SecretProvider = {
+        key: "memory",
+        writable: true,
+        get: (id, scope) => Effect.sync(() => secretStore.get(key(scope, id)) ?? null),
+        set: (id, value, scope) =>
+          Effect.sync(() => {
+            secretStore.set(key(scope, id), value);
+          }),
+        delete: (id, scope) => Effect.sync(() => secretStore.delete(key(scope, id))),
+      };
+      const memorySecretsPlugin = definePlugin(() => ({
+        id: "memory-secrets" as const,
+        storage: () => ({}),
+        secretProviders: [memoryProvider],
+      }));
+
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+      const plugins = [
+        openApiPlugin({ httpClientLayer: clientLayer }),
+        memorySecretsPlugin(),
+      ] as const;
+
+      const adapter = makeMemoryAdapter({ schema: collectSchemas(plugins) });
+      const blobs = makeInMemoryBlobStore();
+      const now = new Date();
+      const orgScope = new Scope({
+        id: ScopeId.make("org"),
+        name: "org",
+        createdAt: now,
+      });
+      const userScope = new Scope({
+        id: ScopeId.make("user"),
+        name: "user",
+        createdAt: now,
+      });
+
+      const adminExec = yield* createExecutor({
+        scopes: [orgScope],
+        adapter,
+        blobs,
+        plugins,
+        onElicitation: "accept-all",
+      });
+      const userExec = yield* createExecutor({
+        scopes: [userScope, orgScope],
+        adapter,
+        blobs,
+        plugins,
+        onElicitation: "accept-all",
+      });
+
+      yield* adminExec.openapi.addSpec({
+        spec: specJson,
+        scope: String(orgScope.id),
+        namespace: "vercel",
+        baseUrl: "",
+        headers: {
+          Authorization: new ConfiguredHeaderBinding({
+            kind: "binding",
+            slot: "auth:personal-choice",
+            prefix: "Bearer ",
+          }),
+        },
+      });
+      yield* adminExec.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("org-choice-token"),
+          scope: orgScope.id,
+          name: "Org choice token",
+          value: "org-choice",
+        }),
+      );
+
+      yield* userExec.openapi.setSourceBinding(
+        new OpenApiSourceBindingInput({
+          sourceId: "vercel",
+          sourceScope: orgScope.id,
+          scope: userScope.id,
+          slot: "auth:personal-choice",
+          value: {
+            kind: "secret",
+            secretId: SecretId.make("org-choice-token"),
+            secretScopeId: orgScope.id,
+          },
+        }),
+      );
+
+      const result = (yield* userExec.tools.invoke("vercel.projects.list", {}, autoApprove)) as {
+        data: { authorization?: string } | null;
+        error: unknown;
+      };
+
+      expect(result.error).toBeNull();
+      expect(result.data?.authorization).toBe("Bearer org-choice");
     }),
   );
 });

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -1122,6 +1122,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       expect(clientIdBinding?.value).toEqual({
         kind: "secret",
         secretId: SecretId.make("acme-client-id"),
+        secretScopeId: ScopeId.make(TEST_SCOPE),
       });
 
       const connectionBinding = yield* executor.openapi

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -45,8 +45,10 @@ import {
   ConfiguredHeaderValue as ConfiguredHeaderValueSchema,
   ConfiguredHeaderBinding,
   OAuth2SourceConfig,
+  OpenApiCredentialInput as OpenApiCredentialInputSchema,
   OpenApiSourceBindingInput,
   OpenApiSourceBindingRef,
+  type OpenApiCredentialInput as OpenApiCredentialInputValue,
   type OpenApiSourceBindingValue,
   OperationBinding,
   type ConfiguredHeaderValue as ConfiguredHeaderValueValue,
@@ -60,7 +62,7 @@ import {
 export type HeaderValue = HeaderValueValue;
 export type ConfiguredHeaderValue = ConfiguredHeaderValueValue;
 export type OpenApiHeaderInput = HeaderValue | ConfiguredHeaderValue;
-export type OpenApiCredentialInput = HeaderValue | ConfiguredHeaderValue;
+export type OpenApiCredentialInput = OpenApiCredentialInputValue;
 export type OpenApiOAuthInput = OAuth2SourceConfig;
 
 export interface OpenApiSpecFetchCredentialsInput {
@@ -86,7 +88,7 @@ export interface OpenApiSpecConfig {
   readonly name?: string;
   readonly baseUrl?: string;
   readonly namespace?: string;
-  readonly headers?: Record<string, OpenApiHeaderInput>;
+  readonly headers?: Record<string, OpenApiCredentialInput>;
   readonly queryParams?: Record<string, OpenApiCredentialInput>;
   readonly oauth2?: OpenApiOAuthInput;
   readonly credentialTargetScope?: string;
@@ -95,7 +97,7 @@ export interface OpenApiSpecConfig {
 export interface OpenApiUpdateSourceInput {
   readonly name?: string;
   readonly baseUrl?: string;
-  readonly headers?: Record<string, OpenApiHeaderInput>;
+  readonly headers?: Record<string, OpenApiCredentialInput>;
   readonly queryParams?: Record<string, OpenApiCredentialInput>;
   readonly credentialTargetScope?: string;
   /** Refresh the source's stored OAuth2 metadata after a successful
@@ -173,7 +175,6 @@ const PreviewSpecInputSchema = Schema.Struct({
 type PreviewSpecInput = typeof PreviewSpecInputSchema.Type;
 
 const OpenApiHeaderInputSchema = Schema.Union([HeaderValueSchema, ConfiguredHeaderValueSchema]);
-const OpenApiCredentialInputSchema = Schema.Union([HeaderValueSchema, ConfiguredHeaderValueSchema]);
 const OpenApiOAuthInputSchema = OAuth2SourceConfig;
 
 const AddSourceInputSchema = Schema.Struct({
@@ -262,16 +263,21 @@ const specFetchQueryParamSlotFromName = (name: string): string =>
   `spec_fetch_query_param:${slotPart(name)}`;
 
 const canonicalizeHeaders = (
-  headers: Record<string, OpenApiHeaderInput> | undefined,
+  headers: Record<string, OpenApiCredentialInput> | undefined,
 ): {
   readonly headers: Record<string, ConfiguredHeaderValue>;
   readonly bindings: ReadonlyArray<{
     readonly slot: string;
     readonly value: OpenApiSourceBindingValue;
+    readonly targetScope?: string;
   }>;
 } => {
   const nextHeaders: Record<string, ConfiguredHeaderValue> = {};
-  const bindings: Array<{ slot: string; value: OpenApiSourceBindingValue }> = [];
+  const bindings: Array<{
+    slot: string;
+    value: OpenApiSourceBindingValue;
+    targetScope?: string;
+  }> = [];
   for (const [name, value] of Object.entries(headers ?? {})) {
     if (typeof value === "string") {
       nextHeaders[name] = value;
@@ -289,9 +295,13 @@ const canonicalizeHeaders = (
     });
     bindings.push({
       slot,
+      targetScope: "targetScope" in value ? value.targetScope : undefined,
       value: {
         kind: "secret",
         secretId: SecretId.make(value.secretId),
+        ...("secretScopeId" in value && value.secretScopeId
+          ? { secretScopeId: value.secretScopeId }
+          : {}),
       },
     });
   }
@@ -306,10 +316,15 @@ const canonicalizeCredentialMap = (
   readonly bindings: ReadonlyArray<{
     readonly slot: string;
     readonly value: OpenApiSourceBindingValue;
+    readonly targetScope?: string;
   }>;
 } => {
   const nextValues: Record<string, ConfiguredHeaderValue> = {};
-  const bindings: Array<{ slot: string; value: OpenApiSourceBindingValue }> = [];
+  const bindings: Array<{
+    slot: string;
+    value: OpenApiSourceBindingValue;
+    targetScope?: string;
+  }> = [];
   for (const [name, value] of Object.entries(values ?? {})) {
     if (typeof value === "string") {
       nextValues[name] = value;
@@ -327,9 +342,13 @@ const canonicalizeCredentialMap = (
     });
     bindings.push({
       slot,
+      targetScope: "targetScope" in value ? value.targetScope : undefined,
       value: {
         kind: "secret",
         secretId: SecretId.make(value.secretId),
+        ...("secretScopeId" in value && value.secretScopeId
+          ? { secretScopeId: value.secretScopeId }
+          : {}),
       },
     });
   }
@@ -348,6 +367,7 @@ const canonicalizeSpecFetchCredentials = (
   readonly bindings: ReadonlyArray<{
     readonly slot: string;
     readonly value: OpenApiSourceBindingValue;
+    readonly targetScope?: string;
   }>;
 } => {
   const headers = canonicalizeCredentialMap(credentials?.headers, specFetchHeaderSlotFromName);
@@ -496,11 +516,11 @@ const validateOpenApiBindingTarget = (
     }
   });
 
-const bindingTargetScope = (
-  targetScope: string | undefined,
-  bindings: readonly unknown[],
-): Effect.Effect<string | undefined, OpenApiOAuthError> => {
-  if (bindings.length === 0) return Effect.succeed(undefined);
+const targetScopeForBinding = (
+  fallbackTargetScope: string | undefined,
+  binding: { readonly slot: string; readonly targetScope?: string },
+): Effect.Effect<string, OpenApiOAuthError> => {
+  const targetScope = binding.targetScope ?? fallbackTargetScope;
   if (targetScope) return Effect.succeed(targetScope);
   return Effect.fail(
     new OpenApiOAuthError({
@@ -579,15 +599,17 @@ const resolveConfiguredValueMap = (
         value.slot,
       );
       if (binding?.value.kind === "secret") {
-        const secret = yield* ctx.secrets.getAtScope(binding.value.secretId, binding.scopeId).pipe(
-          Effect.catchTag("SecretOwnedByConnectionError", () =>
-            Effect.fail(
-              new OpenApiOAuthError({
-                message: `Secret not found for header "${name}"`,
-              }),
+        const secret = yield* ctx.secrets
+          .getAtScope(binding.value.secretId, binding.value.secretScopeId ?? binding.scopeId)
+          .pipe(
+            Effect.catchTag("SecretOwnedByConnectionError", () =>
+              Effect.fail(
+                new OpenApiOAuthError({
+                  message: `Secret not found for header "${name}"`,
+                }),
+              ),
             ),
-          ),
-        );
+          );
         if (secret === null) {
           return yield* new OpenApiOAuthError({
             message: `Missing secret "${binding.value.secretId}" for ${params.missingLabel} "${name}"`,
@@ -808,15 +830,17 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         ...canonicalSpecFetchCredentials.bindings,
         ...canonicalOAuth2.bindings,
       ];
-      const targetScope = yield* bindingTargetScope(input.credentialTargetScope, directBindings);
-      if (targetScope) {
+      for (const binding of directBindings) {
+        const bindingTargetScope = yield* targetScopeForBinding(
+          input.credentialTargetScope,
+          binding,
+        );
         yield* validateOpenApiBindingTarget(ctx, {
           sourceId: namespace,
           sourceScope: input.scope,
-          targetScope,
+          targetScope: bindingTargetScope,
         });
       }
-
       const definitions = compileToolDefinitions(result.operations);
       const sourceName = input.name ?? Option.getOrElse(result.title, () => namespace);
 
@@ -867,10 +891,14 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
             })),
           });
 
-          if (targetScope) {
+          if (directBindings.length > 0) {
             for (const binding of directBindings) {
+              const bindingTargetScope = yield* targetScopeForBinding(
+                input.credentialTargetScope,
+                binding,
+              );
               yield* ctx.credentialBindings.set({
-                targetScope: ScopeId.make(targetScope),
+                targetScope: ScopeId.make(bindingTargetScope),
                 pluginId: OPENAPI_PLUGIN_ID,
                 sourceId: namespace,
                 sourceScope: ScopeId.make(input.scope),
@@ -1000,7 +1028,10 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
                   sourceScope: ScopeId.make(scope),
                 });
                 yield* ctx.storage.removeSource(namespace, scope);
-                yield* ctx.core.sources.unregister({ id: namespace, targetScope: scope });
+                yield* ctx.core.sources.unregister({
+                  id: namespace,
+                  targetScope: scope,
+                });
               }),
             );
             if (configFile) {

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -304,6 +304,9 @@ const slugifySlotPart = (value: string): string =>
 export const headerBindingSlot = (headerName: string): string =>
   `header:${slugifySlotPart(headerName)}`;
 
+export const queryParamBindingSlot = (name: string): string =>
+  `query_param:${slugifySlotPart(name)}`;
+
 export const oauth2ClientIdSlot = (securitySchemeName: string): string =>
   `oauth2:${slugifySlotPart(securitySchemeName)}:client-id`;
 

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -1,5 +1,11 @@
 import { Schema } from "effect";
-import { ConnectionId, ScopeId, SecretBackedValue, SecretId } from "@executor-js/sdk/core";
+import {
+  ConnectionId,
+  ScopeId,
+  ScopedSecretCredentialInput,
+  SecretBackedValue,
+  SecretId,
+} from "@executor-js/sdk/core";
 
 // ---------------------------------------------------------------------------
 // Branded IDs
@@ -146,10 +152,18 @@ export class ConfiguredHeaderBinding extends Schema.Class<ConfiguredHeaderBindin
 export const ConfiguredHeaderValue = Schema.Union([Schema.String, ConfiguredHeaderBinding]);
 export type ConfiguredHeaderValue = typeof ConfiguredHeaderValue.Type;
 
+export const OpenApiCredentialInput = Schema.Union([
+  ScopedSecretCredentialInput,
+  HeaderValue,
+  ConfiguredHeaderValue,
+]);
+export type OpenApiCredentialInput = typeof OpenApiCredentialInput.Type;
+
 export const OpenApiSourceBindingValue = Schema.Union([
   Schema.Struct({
     kind: Schema.Literal("secret"),
     secretId: SecretId,
+    secretScopeId: Schema.optional(ScopeId),
   }),
   Schema.Struct({
     kind: Schema.Literal("connection"),

--- a/packages/react/src/components/help-tooltip.tsx
+++ b/packages/react/src/components/help-tooltip.tsx
@@ -1,0 +1,32 @@
+import { InfoIcon } from "lucide-react";
+
+import { cn } from "../lib/utils";
+import { Button } from "./button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./tooltip";
+
+export function HelpTooltip(props: {
+  readonly label: string;
+  readonly children: React.ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="inline-flex size-4 items-center justify-center rounded-full text-muted-foreground outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+            aria-label={`${props.label} help`}
+          >
+            <InfoIcon className="size-3.5" aria-hidden />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent className={cn("w-max max-w-72 text-left text-wrap", props.className)}>
+          {props.children}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -11,6 +11,7 @@ import { useSecretProviderPlugins } from "@executor-js/sdk/client";
 import { SecretId, SecretInUseError, type ScopeId } from "@executor-js/sdk";
 import { SecretForm } from "../plugins/secret-form";
 import { useScope } from "../hooks/use-scope";
+import { useScopeStack } from "../api/scope-context";
 import {
   Dialog,
   DialogContent,
@@ -169,6 +170,7 @@ function SecretRow(props: {
   usageScopeId: ScopeId;
   showProvider: boolean;
   secret: { id: string; scopeId: ScopeId; name: string; provider?: string };
+  scopeLabel: string;
   onRemove: () => void;
 }) {
   const { secret, showProvider } = props;
@@ -192,6 +194,7 @@ function SecretRow(props: {
         </Suspense>
       </CardStackEntryContent>
       <CardStackEntryActions>
+        <Badge variant="secondary">{props.scopeLabel}</Badge>
         {showProvider && secret.provider && <Badge variant="outline">{secret.provider}</Badge>}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
@@ -238,7 +241,14 @@ export function SecretsPage(props: {
   const secretProviderPlugins = useSecretProviderPlugins();
   const [addOpen, setAddOpen] = useState(false);
   const scopeId = useScope();
+  const scopeStack = useScopeStack();
   const secrets = useAtomValue(secretsOptimisticAtom(scopeId));
+  const scopeLabel = (secretScopeId: ScopeId): string => {
+    const index = scopeStack.findIndex((entry) => entry.id === secretScopeId);
+    if (index === 0) return "Personal";
+    if (index > 0) return scopeStack[index]?.name || "Organization";
+    return "Scoped";
+  };
   const existingSecretIds = useMemo(
     () =>
       AsyncResult.match(secrets, {
@@ -367,6 +377,7 @@ export function SecretsPage(props: {
                           name: s.name,
                           provider: s.provider ? String(s.provider) : undefined,
                         }}
+                        scopeLabel={scopeLabel(s.scopeId)}
                         onRemove={() => handleRemove(s)}
                       />
                     ),

--- a/packages/react/src/plugins/credential-target-scope.tsx
+++ b/packages/react/src/plugins/credential-target-scope.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
-import type { ScopeId } from "@executor-js/sdk";
+import { ScopeId } from "@executor-js/sdk";
 
 import { useScope, useUserScope } from "../api/scope-context";
 import {
@@ -13,6 +13,15 @@ import {
   CardStackEntryTitle,
 } from "../components/card-stack";
 import { FilterTabs } from "../components/filter-tabs";
+import { FieldLabel } from "../components/field";
+import { HelpTooltip } from "../components/help-tooltip";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/select";
 
 export interface CredentialTargetScopeOption {
   readonly scopeId: ScopeId;
@@ -147,10 +156,89 @@ export function CredentialScopeSection(props: {
         value={props.value}
         options={props.options}
         onChange={props.onChange}
-        title={props.title ?? "Save credentials to"}
-        description={props.description ?? "Choose who can use the credentials attached below."}
+        title={props.title ?? "Used by"}
+        description={props.description ?? "Choose who can use these credentials."}
       />
       {props.children}
+    </div>
+  );
+}
+
+export function CredentialScopeDropdown(props: {
+  readonly value: ScopeId;
+  readonly options: readonly CredentialTargetScopeOption[];
+  readonly onChange: (scope: ScopeId) => void;
+  readonly label?: string;
+  readonly help?: ReactNode;
+}) {
+  const label = props.label ?? "Used by";
+  if (props.options.length <= 1) return null;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <FieldLabel className="text-[11px]">{label}</FieldLabel>
+        <HelpTooltip label={label}>
+          {props.help ?? "Choose who can use these credentials."}
+        </HelpTooltip>
+      </div>
+      <Select
+        value={String(props.value)}
+        onValueChange={(value) => props.onChange(ScopeId.make(value))}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder={label} />
+        </SelectTrigger>
+        <SelectContent>
+          {props.options.map((option) => (
+            <SelectItem key={option.scopeId} value={option.scopeId}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+export function CredentialControlField(props: {
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly help?: ReactNode;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <FieldLabel className="text-[11px]">{props.label}</FieldLabel>
+        {props.help ? <HelpTooltip label={props.label}>{props.help}</HelpTooltip> : null}
+      </div>
+      {props.children}
+    </div>
+  );
+}
+
+export function CredentialUsageRow(props: {
+  readonly value: ScopeId;
+  readonly options: readonly CredentialTargetScopeOption[];
+  readonly onChange: (scope: ScopeId) => void;
+  readonly children: ReactNode;
+  readonly label?: string;
+  readonly help?: ReactNode;
+}) {
+  if (props.options.length <= 1) {
+    return <div className="space-y-2.5">{props.children}</div>;
+  }
+
+  return (
+    <div className="grid gap-2 md:grid-cols-2">
+      <div className="min-w-0 space-y-2.5">{props.children}</div>
+      <CredentialScopeDropdown
+        value={props.value}
+        options={props.options}
+        onChange={props.onChange}
+        label={props.label}
+        help={props.help}
+      />
     </div>
   );
 }

--- a/packages/react/src/plugins/headers-list.tsx
+++ b/packages/react/src/plugins/headers-list.tsx
@@ -14,7 +14,10 @@ import {
   type HeaderAuthPreset,
   type HeaderState,
   SecretHeaderAuthRow,
+  type SecretCredentialPreviewComponent,
+  type SecretCredentialRowCopy,
 } from "./secret-header-auth";
+import type { CredentialTargetScopeOption } from "./credential-target-scope";
 import type { SecretPickerSecret } from "./secret-picker";
 
 export interface HeadersListProps {
@@ -27,6 +30,10 @@ export interface HeadersListProps {
   readonly singleHeader?: boolean;
   /** Text shown in the empty state. */
   readonly emptyLabel?: ReactNode;
+  readonly addLabel?: ReactNode;
+  readonly addAriaLabel?: string;
+  readonly rowCopy?: Partial<SecretCredentialRowCopy>;
+  readonly rowPreviewComponent?: SecretCredentialPreviewComponent;
   /**
    * Display name of the source that owns these headers (e.g. "Axiom"). Used
    * to derive unique default secret labels/IDs like `axiom-authorization`.
@@ -34,6 +41,11 @@ export interface HeadersListProps {
   readonly sourceName?: string;
   /** Inline-created secrets are written to this explicit scope. */
   readonly targetScope: ScopeId;
+  /** Scope choices shown only inside the inline "+ New secret" form. */
+  readonly credentialScopeOptions?: readonly CredentialTargetScopeOption[];
+  /** Scope choices for where this source credential is used. */
+  readonly bindingScopeOptions?: readonly CredentialTargetScopeOption[];
+  readonly restrictSecretsToTargetScope?: boolean;
 }
 
 export function HeadersList({
@@ -43,11 +55,26 @@ export function HeadersList({
   presets = defaultHeaderAuthPresets,
   singleHeader = false,
   emptyLabel = "No headers",
+  addLabel,
+  addAriaLabel = "Add header",
+  rowCopy,
+  rowPreviewComponent,
   sourceName,
   targetScope,
+  credentialScopeOptions,
+  bindingScopeOptions,
+  restrictSecretsToTargetScope,
 }: HeadersListProps) {
   const [picking, setPicking] = useState(false);
   const canAddMore = !singleHeader || headers.length === 0;
+  const addFirstPreset = () => {
+    const preset = presets[0];
+    if (presets.length === 1 && preset) {
+      addHeaderFromPreset(preset);
+      return;
+    }
+    setPicking(true);
+  };
 
   const addHeaderFromPreset = (preset: HeaderAuthPreset) => {
     onHeadersChange([
@@ -57,6 +84,7 @@ export function HeadersList({
         prefix: preset.prefix,
         presetKey: preset.key,
         secretId: null,
+        targetScope,
       },
     ]);
     setPicking(false);
@@ -69,6 +97,8 @@ export function HeadersList({
       secretId: string | null;
       prefix?: string;
       presetKey?: string;
+      targetScope?: ScopeId;
+      secretScope?: ScopeId;
     }>,
   ) => {
     onHeadersChange(headers.map((entry, i) => (i === index ? { ...entry, ...update } : entry)));
@@ -89,7 +119,11 @@ export function HeadersList({
           />
         ) : headers.length === 0 ? (
           canAddMore ? (
-            <AddHeaderRow leading={<span>{emptyLabel}</span>} onClick={() => setPicking(true)} />
+            <AddHeaderRow
+              leading={<span>{emptyLabel}</span>}
+              onClick={addFirstPreset}
+              ariaLabel={addAriaLabel}
+            />
           ) : (
             <CardStackEmpty>
               <span>{emptyLabel}</span>
@@ -104,15 +138,28 @@ export function HeadersList({
                 prefix={header.prefix}
                 presetKey={header.presetKey}
                 secretId={header.secretId}
+                secretScope={header.secretScope}
                 onChange={(update) => updateHeader(index, update)}
-                onSelectSecret={(secretId) => updateHeader(index, { secretId })}
+                onSelectSecret={(secretId, scopeId) =>
+                  updateHeader(index, {
+                    secretId,
+                    ...(scopeId ? { secretScope: scopeId } : {}),
+                  })
+                }
                 onRemove={singleHeader ? undefined : () => removeHeader(index)}
                 existingSecrets={existingSecrets}
                 sourceName={sourceName}
-                targetScope={targetScope}
+                targetScope={header.targetScope ?? targetScope}
+                credentialScopeOptions={credentialScopeOptions}
+                bindingScopeOptions={bindingScopeOptions}
+                restrictSecretsToTargetScope={restrictSecretsToTargetScope}
+                copy={rowCopy}
+                previewComponent={rowPreviewComponent}
               />
             ))}
-            {canAddMore && <AddHeaderRow onClick={() => setPicking(true)} />}
+            {canAddMore && (
+              <AddHeaderRow leading={addLabel} onClick={addFirstPreset} ariaLabel={addAriaLabel} />
+            )}
           </>
         )}
       </CardStackContent>
@@ -123,9 +170,10 @@ export function HeadersList({
 interface AddHeaderRowProps {
   readonly onClick: () => void;
   readonly leading?: ReactNode;
+  readonly ariaLabel: string;
 }
 
-function AddHeaderRow({ onClick, leading }: AddHeaderRowProps) {
+function AddHeaderRow({ onClick, leading, ariaLabel }: AddHeaderRowProps) {
   return (
     // oxlint-disable-next-line react/forbid-elements
     <button
@@ -134,7 +182,7 @@ function AddHeaderRow({ onClick, leading }: AddHeaderRowProps) {
         event.stopPropagation();
         onClick();
       }}
-      aria-label="Add header"
+      aria-label={ariaLabel}
       className="flex w-full items-center justify-between gap-4 px-4 py-3 text-sm text-muted-foreground outline-none transition-[background-color] duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] hover:bg-accent/40 focus-visible:bg-accent/40"
     >
       <span className="min-w-0 flex-1 text-left">{leading}</span>

--- a/packages/react/src/plugins/http-credentials.tsx
+++ b/packages/react/src/plugins/http-credentials.tsx
@@ -1,18 +1,15 @@
-import { useId } from "react";
-import { PlusIcon } from "lucide-react";
-import type { ScopeId, SecretBackedValue } from "@executor-js/sdk";
+import type { ScopeId, ScopedSecretCredentialInput, SecretBackedValue } from "@executor-js/sdk";
 
-import { Button } from "../components/button";
-import { CardStack, CardStackContent, CardStackEntry } from "../components/card-stack";
-import { Field, FieldGroup, FieldLabel } from "../components/field";
-import { Input } from "../components/input";
+import { FieldLabel } from "../components/field";
 import { HeadersList } from "./headers-list";
 import {
-  CreatableSecretPicker,
   headerValueToState,
   headersFromState,
+  QueryParamCredentialValuePreview,
+  type HeaderAuthPreset,
   type HeaderState,
 } from "./secret-header-auth";
+import type { CredentialTargetScopeOption } from "./credential-target-scope";
 import type { SecretPickerSecret } from "./secret-picker";
 
 export type { SecretBackedValue };
@@ -22,7 +19,13 @@ export type QueryParamState = {
   secretId: string | null;
   prefix?: string;
   literalValue?: string;
+  targetScope?: ScopeId;
+  secretScope?: ScopeId;
 };
+
+const queryParamPresets: readonly HeaderAuthPreset[] = [
+  { key: "custom", label: "Query parameter", name: "" },
+];
 
 export type HttpCredentialsState = {
   headers: HeaderState[];
@@ -84,6 +87,58 @@ export const serializeHttpCredentials = (
   queryParams: serializeQueryCredentials(credentials.queryParams),
 });
 
+export const serializeScopedHeaderCredentials = (
+  headers: readonly HeaderState[],
+  fallbackTargetScope: ScopeId,
+): Record<string, ScopedSecretCredentialInput> => {
+  const result: Record<string, ScopedSecretCredentialInput> = {};
+  for (const header of headers) {
+    const name = header.name.trim();
+    if (!name || !header.secretId) continue;
+    const targetScope = header.targetScope ?? fallbackTargetScope;
+    result[name] = {
+      secretId: header.secretId,
+      targetScope,
+      ...(header.secretScope ? { secretScopeId: header.secretScope } : {}),
+      ...(header.prefix ? { prefix: header.prefix } : {}),
+    };
+  }
+  return result;
+};
+
+export const serializeScopedQueryCredentials = (
+  queryParams: readonly QueryParamState[],
+  fallbackTargetScope: ScopeId,
+): Record<string, string | ScopedSecretCredentialInput> => {
+  const result: Record<string, string | ScopedSecretCredentialInput> = {};
+  for (const param of queryParams) {
+    const name = param.name.trim();
+    if (!name) continue;
+    if (param.secretId) {
+      const targetScope = param.targetScope ?? fallbackTargetScope;
+      result[name] = {
+        secretId: param.secretId,
+        targetScope,
+        ...(param.secretScope ? { secretScopeId: param.secretScope } : {}),
+        ...(param.prefix ? { prefix: param.prefix } : {}),
+      };
+      continue;
+    }
+    if (param.literalValue?.trim()) {
+      result[name] = param.literalValue.trim();
+    }
+  }
+  return result;
+};
+
+export const serializeScopedHttpCredentials = (
+  credentials: HttpCredentialsState,
+  fallbackTargetScope: ScopeId,
+) => ({
+  headers: serializeScopedHeaderCredentials(credentials.headers, fallbackTargetScope),
+  queryParams: serializeScopedQueryCredentials(credentials.queryParams, fallbackTargetScope),
+});
+
 export const httpCredentialsValid = (credentials: HttpCredentialsState): boolean =>
   credentials.headers.every((header) => header.name.trim() && header.secretId) &&
   credentials.queryParams.every((param) => {
@@ -97,6 +152,9 @@ export function HttpCredentialsEditor(props: {
   readonly existingSecrets: readonly SecretPickerSecret[];
   readonly sourceName?: string;
   readonly targetScope: ScopeId;
+  readonly credentialScopeOptions?: readonly CredentialTargetScopeOption[];
+  readonly bindingScopeOptions?: readonly CredentialTargetScopeOption[];
+  readonly restrictSecretsToTargetScope?: boolean;
   readonly sections?: {
     readonly headers?: boolean;
     readonly queryParams?: boolean;
@@ -120,6 +178,9 @@ export function HttpCredentialsEditor(props: {
             existingSecrets={props.existingSecrets}
             sourceName={props.sourceName}
             targetScope={props.targetScope}
+            credentialScopeOptions={props.credentialScopeOptions}
+            bindingScopeOptions={props.bindingScopeOptions}
+            restrictSecretsToTargetScope={props.restrictSecretsToTargetScope}
           />
         </section>
       )}
@@ -127,170 +188,27 @@ export function HttpCredentialsEditor(props: {
       {showQueryParams && (
         <section className="space-y-2.5">
           <FieldLabel>{props.labels?.queryParams ?? "Query parameters"}</FieldLabel>
-          <QueryParamsList
-            queryParams={props.credentials.queryParams}
-            onQueryParamsChange={(queryParams) =>
-              props.onChange({ ...props.credentials, queryParams })
-            }
+          <HeadersList
+            headers={props.credentials.queryParams}
+            onHeadersChange={(queryParams) => props.onChange({ ...props.credentials, queryParams })}
             existingSecrets={props.existingSecrets}
             sourceName={props.sourceName}
             targetScope={props.targetScope}
+            credentialScopeOptions={props.credentialScopeOptions}
+            bindingScopeOptions={props.bindingScopeOptions}
+            restrictSecretsToTargetScope={props.restrictSecretsToTargetScope}
+            presets={queryParamPresets}
+            emptyLabel="No query parameters"
+            addLabel="Add query parameter"
+            addAriaLabel="Add query parameter"
+            rowCopy={{
+              rowLabel: "Query parameter",
+              namePlaceholder: "token",
+            }}
+            rowPreviewComponent={QueryParamCredentialValuePreview}
           />
         </section>
       )}
     </div>
-  );
-}
-
-function QueryParamsList(props: {
-  readonly queryParams: readonly QueryParamState[];
-  readonly onQueryParamsChange: (queryParams: QueryParamState[]) => void;
-  readonly existingSecrets: readonly SecretPickerSecret[];
-  readonly sourceName?: string;
-  readonly targetScope: ScopeId;
-}) {
-  const addParam = () => {
-    props.onQueryParamsChange([...props.queryParams, { name: "", secretId: null }]);
-  };
-  const updateParam = (index: number, update: Partial<QueryParamState>) => {
-    props.onQueryParamsChange(
-      props.queryParams.map((param, i) => (i === index ? { ...param, ...update } : param)),
-    );
-  };
-  const removeParam = (index: number) => {
-    props.onQueryParamsChange(props.queryParams.filter((_, i) => i !== index));
-  };
-
-  return (
-    <CardStack>
-      <CardStackContent className="[&>*+*]:before:inset-x-0">
-        {props.queryParams.length === 0 ? (
-          <AddQueryParamRow leading={<span>No query parameters</span>} onClick={addParam} />
-        ) : (
-          <>
-            {props.queryParams.map((param, index) => (
-              <QueryParamRow
-                key={index}
-                param={param}
-                existingSecrets={props.existingSecrets}
-                sourceName={props.sourceName}
-                targetScope={props.targetScope}
-                onChange={(update) => updateParam(index, update)}
-                onRemove={() => removeParam(index)}
-              />
-            ))}
-            <AddQueryParamRow onClick={addParam} />
-          </>
-        )}
-      </CardStackContent>
-    </CardStack>
-  );
-}
-
-function QueryParamRow(props: {
-  readonly param: QueryParamState;
-  readonly existingSecrets: readonly SecretPickerSecret[];
-  readonly sourceName?: string;
-  readonly targetScope: ScopeId;
-  readonly onChange: (update: Partial<QueryParamState>) => void;
-  readonly onRemove: () => void;
-}) {
-  const nameInputId = useId();
-  const prefixInputId = useId();
-  const literalInputId = useId();
-  const name = props.param.name.trim();
-  const secretLabel = name ? `${name} query parameter` : "Query parameter";
-
-  return (
-    <div className="space-y-2.5 px-4 py-3">
-      <div className="flex w-full items-center justify-between gap-4">
-        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-          Query parameter
-        </span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          className="text-muted-foreground hover:text-destructive"
-          onClick={props.onRemove}
-        >
-          Remove
-        </Button>
-      </div>
-
-      <FieldGroup className="grid grid-cols-2 gap-3">
-        <Field>
-          <FieldLabel htmlFor={nameInputId}>Name</FieldLabel>
-          <Input
-            id={nameInputId}
-            value={props.param.name}
-            onChange={(event) => props.onChange({ name: event.currentTarget.value })}
-            placeholder="token"
-            className="font-mono"
-          />
-        </Field>
-        <Field>
-          <FieldLabel htmlFor={prefixInputId}>
-            Prefix <span className="font-normal text-muted-foreground/60">(optional)</span>
-          </FieldLabel>
-          <Input
-            id={prefixInputId}
-            value={props.param.prefix ?? ""}
-            onChange={(event) => props.onChange({ prefix: event.currentTarget.value || undefined })}
-            placeholder="Bearer "
-            className="font-mono"
-          />
-        </Field>
-      </FieldGroup>
-
-      <CreatableSecretPicker
-        value={props.param.secretId}
-        onSelect={(secretId) => props.onChange({ secretId, literalValue: undefined })}
-        secrets={props.existingSecrets}
-        placeholder="Select a secret"
-        sourceName={props.sourceName}
-        secretLabel={secretLabel}
-        targetScope={props.targetScope}
-      />
-
-      {!props.param.secretId && props.param.literalValue !== undefined && (
-        <Field>
-          <FieldLabel htmlFor={literalInputId}>Literal value</FieldLabel>
-          <Input
-            id={literalInputId}
-            value={props.param.literalValue}
-            onChange={(event) => props.onChange({ literalValue: event.currentTarget.value })}
-            placeholder="value"
-            className="font-mono"
-          />
-        </Field>
-      )}
-    </div>
-  );
-}
-
-function AddQueryParamRow(props: {
-  readonly onClick: () => void;
-  readonly leading?: React.ReactNode;
-}) {
-  return (
-    <CardStackEntry
-      asChild
-      className="justify-between gap-4 px-0 py-0 text-sm text-muted-foreground"
-    >
-      <Button
-        type="button"
-        variant="ghost"
-        onClick={(event) => {
-          event.stopPropagation();
-          props.onClick();
-        }}
-        aria-label="Add query parameter"
-        className="h-auto w-full justify-between rounded-none px-4 py-3 text-left text-muted-foreground hover:bg-accent/40 focus-visible:bg-accent/40"
-      >
-        <span className="min-w-0 flex-1">{props.leading}</span>
-        <PlusIcon aria-hidden className="size-4 shrink-0" />
-      </Button>
-    </CardStackEntry>
   );
 }

--- a/packages/react/src/plugins/secret-form.tsx
+++ b/packages/react/src/plugins/secret-form.tsx
@@ -109,7 +109,7 @@ function SecretFormProvider(props: SecretFormProviderProps) {
   const doSet = useAtomSet(setSecret, { mode: "promiseExit" });
 
   const [state, setState] = useState<SecretFormState>(() => ({
-    name: "",
+    name: suggestedName,
     value: "",
     idOverride: null,
     provider: initialProvider,
@@ -215,7 +215,7 @@ function IdField(props: { placeholder?: string }) {
   );
 }
 
-function ValueField(props: { revealable?: boolean; placeholder?: string }) {
+function ValueField(props: { revealable?: boolean; placeholder?: string; autoFocus?: boolean }) {
   const { state, actions } = useSecretForm();
   const inputId = useId();
   const revealable = props.revealable ?? false;
@@ -231,6 +231,7 @@ function ValueField(props: { revealable?: boolean; placeholder?: string }) {
           value={state.value}
           onChange={(e) => actions.setValue((e.target as HTMLInputElement).value)}
           placeholder={props.placeholder ?? "ghp_xxxxxxxxxxxxxxxxxxxx"}
+          autoFocus={props.autoFocus}
           className={revealable ? "pr-9 font-mono" : "font-mono"}
           style={
             revealable && !state.revealed

--- a/packages/react/src/plugins/secret-header-auth.tsx
+++ b/packages/react/src/plugins/secret-header-auth.tsx
@@ -1,11 +1,30 @@
-import { useId, useState } from "react";
+import { useId, useState, type ReactNode } from "react";
 
-import { type ScopeId } from "@executor-js/sdk";
+import { ScopeId } from "@executor-js/sdk";
 import { Button } from "../components/button";
 import { Field, FieldGroup, FieldLabel } from "../components/field";
+import { HelpTooltip } from "../components/help-tooltip";
 import { Input } from "../components/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../components/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/select";
 import { SecretForm } from "./secret-form";
 import { SecretPicker, type SecretPickerSecret } from "./secret-picker";
+import {
+  CredentialTargetScopeSelector,
+  type CredentialTargetScopeOption,
+} from "./credential-target-scope";
 
 export const secretsForCredentialTarget = (
   secrets: readonly SecretPickerSecret[],
@@ -21,8 +40,18 @@ export interface HeaderAuthPreset {
 }
 
 export const defaultHeaderAuthPresets: readonly HeaderAuthPreset[] = [
-  { key: "bearer", label: "Bearer Token", name: "Authorization", prefix: "Bearer " },
-  { key: "basic", label: "Basic Auth", name: "Authorization", prefix: "Basic " },
+  {
+    key: "bearer",
+    label: "Bearer Token",
+    name: "Authorization",
+    prefix: "Bearer ",
+  },
+  {
+    key: "basic",
+    label: "Basic Auth",
+    name: "Authorization",
+    prefix: "Basic ",
+  },
   { key: "api-key", label: "API Key", name: "X-API-Key" },
   { key: "auth-token", label: "Auth Token", name: "X-Auth-Token" },
   { key: "access-token", label: "Access Token", name: "X-Access-Token" },
@@ -30,51 +59,141 @@ export const defaultHeaderAuthPresets: readonly HeaderAuthPreset[] = [
   { key: "custom", label: "Custom", name: "" },
 ];
 
-export function InlineCreateSecret(props: {
+function CreateSecretContent(props: {
   suggestedName: string;
   existingSecretIds: readonly string[];
-  onCreated: (secretId: string) => void;
-  onCancel: () => void;
+  onCreated: (secretId: string, scopeId: ScopeId) => void;
+  onCancel?: () => void;
   fallbackId?: string;
   targetScope: ScopeId;
+  credentialScopeOptions?: readonly CredentialTargetScopeOption[];
 }) {
+  const [scopeId, setScopeId] = useState(props.targetScope);
+  const activeScope = props.credentialScopeOptions?.find((option) => option.scopeId === scopeId);
+
   return (
     <SecretForm.Provider
       existingSecretIds={props.existingSecretIds}
       suggestedName={props.suggestedName}
       fallbackId={props.fallbackId ?? "custom-header"}
-      scopeId={props.targetScope}
-      onCreated={props.onCreated}
+      scopeId={scopeId}
+      onCreated={(secretId) => props.onCreated(secretId, scopeId)}
     >
-      <div className="bg-primary/[0.03] px-4 py-3 space-y-3">
-        <p className="text-[11px] font-semibold text-primary tracking-wide uppercase">New secret</p>
+      <div className="space-y-3">
+        {props.credentialScopeOptions && props.credentialScopeOptions.length > 1 && (
+          <CredentialTargetScopeSelector
+            value={scopeId}
+            options={props.credentialScopeOptions}
+            onChange={setScopeId}
+            title="Save secret to"
+            description={activeScope?.description ?? "Choose where this secret is saved."}
+          />
+        )}
         <FieldGroup className="gap-3">
           <div className="grid grid-cols-2 gap-3">
             <SecretForm.NameField label="Label" placeholder="API Token" />
             <SecretForm.IdField placeholder="my-api-token" />
           </div>
-          <SecretForm.ValueField revealable placeholder="paste your token or key…" />
+          <SecretForm.ValueField revealable autoFocus placeholder="paste your token or key…" />
         </FieldGroup>
-        <div className="flex justify-end gap-1.5 pt-0.5">
-          <Button variant="outline" size="xs" onClick={props.onCancel}>
-            Cancel
-          </Button>
-          <SecretForm.SubmitButton size="xs">Create and use</SecretForm.SubmitButton>
+        <div className="flex justify-end gap-2 pt-0.5">
+          {props.onCancel && (
+            <Button type="button" variant="outline" size="sm" onClick={props.onCancel}>
+              Cancel
+            </Button>
+          )}
+          <SecretForm.SubmitButton size="sm">Create and use</SecretForm.SubmitButton>
         </div>
       </div>
     </SecretForm.Provider>
   );
 }
 
-function HeaderValuePreview(props: { headerName: string; secretId: string; prefix?: string }) {
-  const { headerName, prefix } = props;
+export function InlineCreateSecret(props: {
+  suggestedName: string;
+  existingSecretIds: readonly string[];
+  onCreated: (secretId: string, scopeId: ScopeId) => void;
+  onCancel: () => void;
+  fallbackId?: string;
+  targetScope: ScopeId;
+  credentialScopeOptions?: readonly CredentialTargetScopeOption[];
+}) {
+  return (
+    <div className="bg-primary/[0.03] px-4 py-3">
+      <p className="mb-3 text-[11px] font-semibold tracking-wide text-primary uppercase">
+        New secret
+      </p>
+      <CreateSecretContent {...props} />
+    </div>
+  );
+}
+
+function CreateSecretDialog(props: {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly suggestedName: string;
+  readonly existingSecretIds: readonly string[];
+  readonly onCreated: (secretId: string, scopeId: ScopeId) => void;
+  readonly fallbackId?: string;
+  readonly targetScope: ScopeId;
+  readonly credentialScopeOptions?: readonly CredentialTargetScopeOption[];
+}) {
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New secret</DialogTitle>
+          <DialogDescription>
+            Create a reusable secret, then use it for this credential.
+          </DialogDescription>
+        </DialogHeader>
+        <CreateSecretContent
+          suggestedName={props.suggestedName}
+          existingSecretIds={props.existingSecretIds}
+          fallbackId={props.fallbackId}
+          onCreated={props.onCreated}
+          onCancel={() => props.onOpenChange(false)}
+          targetScope={props.targetScope}
+          credentialScopeOptions={props.credentialScopeOptions}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export type SecretCredentialPreviewProps = {
+  readonly name: string;
+  readonly secretId: string;
+  readonly prefix?: string;
+};
+
+export type SecretCredentialPreviewComponent = (props: SecretCredentialPreviewProps) => ReactNode;
+
+export function HeaderCredentialValuePreview(props: SecretCredentialPreviewProps) {
+  const { name, prefix } = props;
+  const maskedValue = "•".repeat(12);
 
   return (
     <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 font-mono text-xs">
-      <span className="text-muted-foreground shrink-0">{headerName}:</span>
+      <span className="text-muted-foreground shrink-0">{name}:</span>
       <span className="text-foreground truncate">
         {prefix && <span className="text-muted-foreground">{prefix}</span>}
-        {"•".repeat(12)}
+        {maskedValue}
+      </span>
+    </div>
+  );
+}
+
+export function QueryParamCredentialValuePreview(props: SecretCredentialPreviewProps) {
+  const { name, prefix } = props;
+  const maskedValue = "•".repeat(12);
+
+  return (
+    <div className="rounded-md border border-border bg-muted/30 px-2.5 py-1.5 font-mono text-xs">
+      <span className="text-muted-foreground">?{name}=</span>
+      <span className="text-foreground">
+        {prefix && <span className="text-muted-foreground">{prefix}</span>}
+        {maskedValue}
       </span>
     </div>
   );
@@ -90,6 +209,10 @@ export type HeaderState = {
   prefix?: string;
   presetKey?: string;
   fromPreset?: boolean;
+  /** Scope where this source credential value is used. */
+  targetScope?: ScopeId;
+  /** Scope that owns the selected reusable secret. */
+  secretScope?: ScopeId;
 };
 
 export function matchPresetKey(name: string, prefix?: string): string {
@@ -98,6 +221,39 @@ export function matchPresetKey(name: string, prefix?: string): string {
     defaultHeaderAuthPresets.find((p) => p.name === name && p.prefix === undefined);
   return preset?.key ?? "custom";
 }
+
+function InfoLabel(props: { readonly children: string; readonly tooltip: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <FieldLabel>{props.children}</FieldLabel>
+      <HelpTooltip label={props.children}>{props.tooltip}</HelpTooltip>
+    </div>
+  );
+}
+
+export type SecretCredentialRowCopy = {
+  readonly rowLabel: string;
+  readonly nameLabel: string;
+  readonly namePlaceholder: string;
+  readonly prefixLabel: string;
+  readonly prefixPlaceholder: string;
+  readonly secretLabel: string;
+  readonly secretHelp: string;
+  readonly usedByLabel: string;
+  readonly usedByHelp: string;
+};
+
+const defaultSecretCredentialRowCopy: SecretCredentialRowCopy = {
+  rowLabel: "Header",
+  nameLabel: "Name",
+  namePlaceholder: "Authorization",
+  prefixLabel: "Prefix",
+  prefixPlaceholder: "Bearer ",
+  secretLabel: "Secret",
+  secretHelp: "Select or create a reusable secret.",
+  usedByLabel: "Used by",
+  usedByHelp: "Choose who uses this credential value.",
+};
 
 export function headerValueToState(
   name: string,
@@ -138,12 +294,21 @@ export function SecretHeaderAuthRow(props: {
   prefix?: string;
   presetKey?: string;
   secretId: string | null;
-  onChange: (update: { name: string; prefix?: string; presetKey?: string }) => void;
-  onSelectSecret: (secretId: string) => void;
+  secretScope?: ScopeId;
+  onChange: (update: {
+    name: string;
+    secretId?: string | null;
+    prefix?: string;
+    presetKey?: string;
+    targetScope?: ScopeId;
+    secretScope?: ScopeId;
+  }) => void;
+  onSelectSecret: (secretId: string, scopeId?: ScopeId) => void;
   existingSecrets: readonly SecretPickerSecret[];
   onRemove?: () => void;
   removeLabel?: string;
-  label?: string;
+  copy?: Partial<SecretCredentialRowCopy>;
+  previewComponent?: SecretCredentialPreviewComponent;
   /**
    * Display name of the source this header belongs to (e.g. "Axiom"). Used
    * to prefix the suggested secret label and ID so tokens from different
@@ -151,6 +316,9 @@ export function SecretHeaderAuthRow(props: {
    */
   sourceName?: string;
   targetScope: ScopeId;
+  credentialScopeOptions?: readonly CredentialTargetScopeOption[];
+  bindingScopeOptions?: readonly CredentialTargetScopeOption[];
+  restrictSecretsToTargetScope?: boolean;
 }) {
   const [creating, setCreating] = useState(false);
   const nameInputId = useId();
@@ -160,42 +328,49 @@ export function SecretHeaderAuthRow(props: {
     prefix,
     presetKey,
     secretId,
+    secretScope,
     onChange,
     onSelectSecret,
     existingSecrets,
     onRemove,
     removeLabel = "Remove",
-    label = "Header",
+    copy: copyOverride,
+    previewComponent: PreviewComponent = HeaderCredentialValuePreview,
     sourceName,
     targetScope,
+    credentialScopeOptions,
+    bindingScopeOptions,
+    restrictSecretsToTargetScope = false,
   } = props;
 
   const isCustom = presetKey === "custom" || presetKey === undefined;
+  const copy = { ...defaultSecretCredentialRowCopy, ...copyOverride };
   const headerLabel = name.trim() || "Custom Header";
   const suggestedName = [sourceName?.trim(), headerLabel].filter(Boolean).join(" ");
   const scopedSecrets = secretsForCredentialTarget(existingSecrets, targetScope);
-
-  if (creating) {
-    return (
-      <InlineCreateSecret
-        suggestedName={suggestedName}
-        existingSecretIds={scopedSecrets.map((secret) => secret.id)}
-        onCreated={(id) => {
-          onSelectSecret(id);
-          setCreating(false);
-        }}
-        onCancel={() => setCreating(false)}
-        targetScope={targetScope}
-      />
-    );
-  }
+  const selectableSecrets = restrictSecretsToTargetScope ? scopedSecrets : existingSecrets;
 
   return (
     <div className="space-y-2.5 px-4 py-3">
+      <CreateSecretDialog
+        open={creating}
+        onOpenChange={setCreating}
+        suggestedName={suggestedName}
+        existingSecretIds={scopedSecrets.map((secret) => secret.id)}
+        onCreated={(id, scopeId) => {
+          onSelectSecret(id, scopeId);
+          setCreating(false);
+        }}
+        targetScope={targetScope}
+        credentialScopeOptions={credentialScopeOptions}
+      />
       <div className="flex w-full items-center justify-between gap-4">
-        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{label}</span>
+        <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+          {copy.rowLabel}
+        </span>
         {onRemove && (
           <Button
+            type="button"
             variant="ghost"
             size="xs"
             className="text-muted-foreground hover:text-destructive"
@@ -208,7 +383,7 @@ export function SecretHeaderAuthRow(props: {
 
       <FieldGroup className="grid grid-cols-2 gap-3">
         <Field>
-          <FieldLabel htmlFor={nameInputId}>Name</FieldLabel>
+          <FieldLabel htmlFor={nameInputId}>{copy.nameLabel}</FieldLabel>
           <Input
             id={nameInputId}
             value={name}
@@ -219,13 +394,14 @@ export function SecretHeaderAuthRow(props: {
                 presetKey: isCustom ? "custom" : presetKey,
               })
             }
-            placeholder="Authorization"
+            placeholder={copy.namePlaceholder}
             className="font-mono"
           />
         </Field>
         <Field>
           <FieldLabel htmlFor={prefixInputId}>
-            Prefix <span className="font-normal text-muted-foreground/60">(optional)</span>
+            {copy.prefixLabel}{" "}
+            <span className="font-normal text-muted-foreground/60">(optional)</span>
           </FieldLabel>
           <Input
             id={prefixInputId}
@@ -237,21 +413,62 @@ export function SecretHeaderAuthRow(props: {
                 presetKey: isCustom ? "custom" : presetKey,
               })
             }
-            placeholder="Bearer "
+            placeholder={copy.prefixPlaceholder}
             className="font-mono"
           />
         </Field>
       </FieldGroup>
 
-      <SecretPicker
-        value={secretId}
-        onSelect={onSelectSecret}
-        secrets={scopedSecrets}
-        onCreateNew={() => setCreating(true)}
-      />
+      <div
+        className={
+          bindingScopeOptions && bindingScopeOptions.length > 1
+            ? "grid gap-2 md:grid-cols-2"
+            : undefined
+        }
+      >
+        <div className="space-y-1.5">
+          <InfoLabel tooltip={copy.secretHelp}>{copy.secretLabel}</InfoLabel>
+          <SecretPicker
+            value={secretId}
+            valueScopeId={secretScope ? String(secretScope) : undefined}
+            onSelect={(id, scopeId) => onSelectSecret(id, ScopeId.make(scopeId))}
+            secrets={selectableSecrets}
+            onCreateNew={() => setCreating(true)}
+          />
+        </div>
+        {bindingScopeOptions && bindingScopeOptions.length > 1 && (
+          <div className="space-y-1.5">
+            <InfoLabel tooltip={copy.usedByHelp}>{copy.usedByLabel}</InfoLabel>
+            <Select
+              value={String(targetScope)}
+              onValueChange={(nextScope) =>
+                onChange({
+                  name,
+                  secretId: null,
+                  secretScope: undefined,
+                  prefix,
+                  presetKey,
+                  targetScope: ScopeId.make(nextScope),
+                })
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Used by" />
+              </SelectTrigger>
+              <SelectContent>
+                {bindingScopeOptions.map((option) => (
+                  <SelectItem key={option.scopeId} value={option.scopeId}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+      </div>
 
       {secretId && name.trim() && (
-        <HeaderValuePreview headerName={name.trim()} secretId={secretId} prefix={prefix} />
+        <PreviewComponent name={name.trim()} secretId={secretId} prefix={prefix} />
       )}
     </div>
   );
@@ -263,10 +480,12 @@ export function SecretHeaderAuthRow(props: {
 
 export function CreatableSecretPicker(props: {
   readonly value: string | null;
-  readonly onSelect: (secretId: string) => void;
+  readonly onSelect: (secretId: string, scopeId?: ScopeId) => void;
   readonly secrets: readonly SecretPickerSecret[];
   readonly placeholder?: string;
   readonly targetScope: ScopeId;
+  readonly credentialScopeOptions?: readonly CredentialTargetScopeOption[];
+  readonly onCreatedScope?: (scopeId: ScopeId) => void;
   readonly suggestedId?: string;
   /**
    * Display name of the source the secret belongs to (e.g. "Stripe").
@@ -284,6 +503,8 @@ export function CreatableSecretPicker(props: {
     sourceName,
     secretLabel,
     targetScope,
+    credentialScopeOptions,
+    onCreatedScope,
     suggestedId: suggestedIdProp,
   } = props;
   const [creating, setCreating] = useState(false);
@@ -293,16 +514,19 @@ export function CreatableSecretPicker(props: {
 
   if (creating) {
     return (
-      <InlineCreateSecret
+      <CreateSecretDialog
+        open={creating}
+        onOpenChange={setCreating}
         suggestedName={suggestedName}
         existingSecretIds={scopedSecrets.map((secret) => secret.id)}
         fallbackId={suggestedIdProp?.trim() || "secret"}
-        onCreated={(id) => {
-          onSelect(id);
+        onCreated={(id, scopeId) => {
+          onCreatedScope?.(scopeId);
+          onSelect(id, scopeId);
           setCreating(false);
         }}
-        onCancel={() => setCreating(false)}
         targetScope={targetScope}
+        credentialScopeOptions={credentialScopeOptions}
       />
     );
   }
@@ -310,8 +534,9 @@ export function CreatableSecretPicker(props: {
   return (
     <SecretPicker
       value={value}
-      onSelect={onSelect}
-      secrets={scopedSecrets}
+      valueScopeId={String(targetScope)}
+      onSelect={(id, scopeId) => onSelect(id, ScopeId.make(scopeId))}
+      secrets={secrets}
       placeholder={placeholder}
       onCreateNew={() => setCreating(true)}
     />

--- a/packages/react/src/plugins/secret-picker.tsx
+++ b/packages/react/src/plugins/secret-picker.tsx
@@ -2,6 +2,7 @@ import { useState, type ChangeEvent, type FocusEvent } from "react";
 import { PlusIcon } from "lucide-react";
 
 import { Input } from "../components/input";
+import { Badge } from "../components/badge";
 import {
   Command,
   CommandEmpty,
@@ -11,6 +12,7 @@ import {
   CommandSeparator,
 } from "../components/command";
 import { Popover, PopoverAnchor, PopoverContent } from "../components/popover";
+import { useScopeStack } from "../api/scope-context";
 
 export interface SecretPickerSecret {
   readonly id: string;
@@ -33,17 +35,38 @@ const providerLabel = (key: string | undefined): string => {
 
 export function SecretPicker(props: {
   readonly value: string | null;
-  readonly onSelect: (secretId: string) => void;
+  readonly valueScopeId?: string;
+  readonly onSelect: (secretId: string, scopeId: string) => void;
   readonly secrets: readonly SecretPickerSecret[];
   readonly placeholder?: string;
   /** When provided, renders a "+ New secret" row at the top of the dropdown. */
   readonly onCreateNew?: () => void;
 }) {
-  const { value, onSelect, secrets, placeholder = "Search secrets…", onCreateNew } = props;
+  const {
+    value,
+    valueScopeId,
+    onSelect,
+    secrets,
+    placeholder = "Search secrets…",
+    onCreateNew,
+  } = props;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const scopeStack = useScopeStack();
+  const scopeLabel = (scopeId: string): string => {
+    const index = scopeStack.findIndex((entry) => String(entry.id) === scopeId);
+    if (index === 0) return "Personal";
+    if (index > 0) return scopeStack[index]?.name || "Organization";
+    return "Scoped";
+  };
 
-  const selected = secrets.find((secret) => secret.id === value) ?? null;
+  const selected =
+    secrets.find(
+      (secret) =>
+        secret.id === value && (valueScopeId === undefined || secret.scopeId === valueScopeId),
+    ) ??
+    secrets.find((secret) => secret.id === value) ??
+    null;
 
   const grouped = new Map<string, SecretPickerSecret[]>();
   for (const secret of secrets) {
@@ -132,15 +155,18 @@ export function SecretPicker(props: {
                   <CommandGroup key={label} heading={showGroupHeadings ? label : undefined}>
                     {filtered.map((secret) => (
                       <CommandItem
-                        key={secret.id}
-                        value={`${secret.name} ${secret.id}`}
+                        key={`${secret.scopeId}:${secret.id}`}
+                        value={`${secret.name} ${secret.id} ${secret.scopeId}`}
                         onSelect={() => {
-                          onSelect(secret.id);
+                          onSelect(secret.id, secret.scopeId);
                           setOpen(false);
                           setQuery("");
                         }}
                       >
-                        <span className="truncate">{secret.name}</span>
+                        <span className="min-w-0 flex-1 truncate">{secret.name}</span>
+                        <Badge variant="outline" className="ml-2 shrink-0 text-[10px]">
+                          {scopeLabel(secret.scopeId)}
+                        </Badge>
                       </CommandItem>
                     ))}
                   </CommandGroup>

--- a/packages/react/src/plugins/source-identity.test.ts
+++ b/packages/react/src/plugins/source-identity.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  domainLabelFromUrl,
+  pascalCaseDomainLabel,
+  sourceDisplayNameFromUrl,
+} from "./source-identity";
+
+describe("source identity URL display names", () => {
+  it("uses the apex domain label without the public suffix", () => {
+    expect(domainLabelFromUrl("https://api.example.co.uk/graphql")).toBe("example");
+  });
+
+  it("normalizes domain labels to PascalCase", () => {
+    expect(pascalCaseDomainLabel("my-api")).toBe("MyApi");
+  });
+
+  it("appends the source kind to the PascalCase domain label", () => {
+    expect(sourceDisplayNameFromUrl("https://mcp.linear.app/sse", "MCP")).toBe("Linear MCP");
+    expect(sourceDisplayNameFromUrl("https://api.shopify.com/graphql", "GraphQL")).toBe(
+      "Shopify GraphQL",
+    );
+  });
+});

--- a/packages/react/src/plugins/source-identity.tsx
+++ b/packages/react/src/plugins/source-identity.tsx
@@ -20,6 +20,32 @@ export function displayNameFromUrl(url: string): string | null {
   return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
+export function domainLabelFromUrl(url: string): string | null {
+  const trimmed = url.trim();
+  if (!trimmed) return null;
+  return parse(trimmed).domainWithoutSuffix ?? null;
+}
+
+export function pascalCaseDomainLabel(label: string): string | null {
+  const words = label
+    .split(/[^a-z0-9]+/i)
+    .map((word) => word.trim())
+    .filter(Boolean);
+  if (words.length === 0) return null;
+  return words
+    .map((word) => {
+      const normalized = word.toLowerCase();
+      return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+    })
+    .join("");
+}
+
+export function sourceDisplayNameFromUrl(url: string, sourceKind: string): string | null {
+  const label = domainLabelFromUrl(url);
+  const displayLabel = label ? pascalCaseDomainLabel(label) : null;
+  return displayLabel ? `${displayLabel} ${sourceKind}` : null;
+}
+
 // ---------------------------------------------------------------------------
 // Hook — owns the name + namespace state with namespace auto-derivation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- separate secret ownership from source credential binding scope for OpenAPI credential bindings
- update Add/Edit OpenAPI source UI to make credential usage, secret creation, and OAuth token storage explicit
- add shared `ScopedSecretCredentialInput` in the core SDK and have OpenAPI, GraphQL, and MCP compose it for row-level request credentials
- align OpenAPI, GraphQL, and MCP request credential models so row-level secret scope and binding scope are real data, not just local UI state
- reuse the shared secret credential row for MCP/GraphQL request credentials so `Secret` and `Used by` render with the same 50/50 treatment as OpenAPI
- keep MCP/GraphQL OAuth connection scope independent from request credential scope, and show that dropdown only as `Connection saved to`
- default MCP and GraphQL display names from the URL apex domain label using `tldts`, normalized to PascalCase (`Linear MCP`, `Shopify GraphQL`)
- add scope badges to secret selection/pages, document product scope language, and preserve `secret_scope_id` through local/cloud schemas
- guard cross-scope secret deletion/binding edge cases
- mark MCP/shared credential action buttons as non-submit controls so adding headers cannot submit an ancestor form
- keep the last MCP probe visible during explicit refetches and stop credential edits from resetting the add flow to URL probing

## Verification
- `./node_modules/.bin/oxfmt --check <PR files>`
- `./node_modules/.bin/oxfmt --check packages/react/src/plugins/credential-target-scope.tsx packages/plugins/graphql/src/react/AddGraphqlSource.tsx packages/plugins/mcp/src/react/AddMcpSource.tsx`
- `./node_modules/.bin/oxfmt --check packages/react/src/plugins/source-identity.tsx packages/react/src/plugins/source-identity.test.ts packages/plugins/graphql/src/react/AddGraphqlSource.tsx packages/plugins/mcp/src/react/AddMcpSource.tsx`
- `./node_modules/.bin/oxfmt --check packages/core/sdk/src/credential-bindings.ts packages/core/sdk/src/index.ts packages/react/src/plugins/http-credentials.tsx packages/plugins/graphql/src/sdk/types.ts packages/plugins/mcp/src/sdk/types.ts packages/plugins/graphql/src/sdk/plugin.ts packages/plugins/graphql/src/sdk/plugin.test.ts packages/plugins/graphql/src/react/AddGraphqlSource.tsx packages/plugins/mcp/src/sdk/plugin.ts packages/plugins/mcp/src/react/AddMcpSource.tsx`
- `./node_modules/.bin/oxfmt --check packages/plugins/openapi/src/sdk/types.ts packages/plugins/openapi/src/sdk/plugin.ts packages/plugins/openapi/src/api/group.ts packages/plugins/mcp/src/react/AddMcpSource.tsx packages/react/src/plugins/secret-header-auth.tsx`
- `bun run --cwd packages/core/sdk typecheck`
- `bun run --cwd packages/react typecheck`
- `bun run --cwd packages/plugins/openapi typecheck`
- `bun run --cwd packages/plugins/graphql typecheck`
- `bun run --cwd packages/plugins/mcp typecheck`
- `bun run --cwd apps/local typecheck`
- `bun run --cwd apps/cloud typecheck`
- `/home/rhys/executor/node_modules/.bin/vitest run -c vitest.config.ts src/plugins/source-identity.test.ts` from `packages/react`
- `bun run --cwd packages/plugins/graphql test src/sdk/plugin.test.ts`
- `bun run --cwd packages/core/sdk test src/credential-bindings.test.ts`
- `bun run --cwd packages/plugins/openapi test src/sdk/multi-scope-bearer.test.ts`

Note: full `bun run format:check` still reports a pre-existing formatting issue in `apps/local/src/server/migrate-oauth-connections.test.ts`, which this PR intentionally leaves untouched.