### PR TITLE
[codex] Share credential slot UI primitives

### DIFF
--- a/notes/credential-slot-ui-refactor.md
+++ b/notes/credential-slot-ui-refactor.md
@@ -1,0 +1,53 @@
+# Credential Slot UI Refactor Notes
+
+We want to keep the plugin model, but stop making each source UI reinvent the
+same credential concepts. OpenAPI, MCP, and GraphQL should still own their
+source-specific setup, probing, parsing, auth capabilities, and save payloads.
+The shared layer should only cover credential slots, binding values, secret
+selection, OAuth connection controls, and product language around ownership.
+
+## Product Direction
+
+- A source has a shared authentication method. Users may be able to override
+  credential values for that method, but they cannot switch the method per
+  person unless the backend model explicitly supports that.
+- Secrets are reusable values that live at a personal or organization ownership
+  level.
+- Source bindings attach a secret, literal value, or OAuth connection to a
+  source slot for a personal or organization usage level.
+- The UI should communicate these as separate choices:
+  - where a new secret is saved;
+  - who uses a source credential binding;
+  - where an OAuth connection/token is saved.
+- Avoid product copy that exposes "scope" unless it is a developer/debug
+  surface.
+
+## Refactor Direction
+
+- Do not introduce a generic HTTP source model.
+- Do introduce shared credential-slot UI primitives that plugins compose.
+- Plugins should adapt their own source config into shared slot descriptors and
+  save the result through plugin-owned atoms/API calls.
+- Add and edit flows should reuse the same credential editors where the product
+  behavior is the same.
+- OpenAPI is the largest cleanup target. MCP and GraphQL are smaller but useful
+  for extracting the lower-risk shared pieces first.
+
+## Likely Shared Concepts
+
+- Convert configured credential values plus binding refs into editor state.
+- Preserve per-row binding usage scope and selected secret ownership scope.
+- Render secret-backed headers and query params with the same picker, preview,
+  and "Used by" controls.
+- Render OAuth connect/reconnect controls with the same saved-to dropdown and
+  validity styling, while keeping plugin-specific OAuth payload construction.
+- Report effective vs explicit credential state without each plugin rendering
+  bespoke debug/product copy.
+
+## Guardrails
+
+- Do not collapse plugin-specific source models into one abstraction.
+- Do not make MCP stdio, MCP remote probing, GraphQL introspection, and OpenAPI
+  spec parsing fit a fake common lifecycle.
+- Prefer small shared adapters first, then replace bespoke OpenAPI edit pieces
+  after the shared API has proven itself in MCP/GraphQL.

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -8,10 +8,13 @@ import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import {
   HttpCredentialsEditor,
-  httpCredentialsFromValues,
-  serializeHttpCredentials,
+  serializeScopedHttpCredentials,
   type HttpCredentialsState,
 } from "@executor-js/react/plugins/http-credentials";
+import {
+  httpCredentialsFromConfiguredCredentialBindings,
+  initialCredentialTargetScope,
+} from "@executor-js/react/plugins/credential-bindings";
 import {
   SourceIdentityFields,
   useSourceIdentity,
@@ -32,43 +35,13 @@ import { Badge } from "@executor-js/react/components/badge";
 import { ScopeId } from "@executor-js/sdk/core";
 import {
   GRAPHQL_OAUTH_CONNECTION_SLOT,
-  type ConfiguredGraphqlCredentialValue,
   type GraphqlCredentialInput,
   type GraphqlSourceBindingRef,
-  type HeaderValue,
 } from "../sdk/types";
 import type { StoredGraphqlSource } from "../sdk/store";
 
 type EditableSource = StoredGraphqlSource;
 type AuthMode = "none" | "oauth2";
-
-const valuesForEditor = (
-  values: Record<string, ConfiguredGraphqlCredentialValue>,
-  bindings: readonly GraphqlSourceBindingRef[],
-): Record<string, HeaderValue> => {
-  const bySlot = new Map(bindings.map((binding) => [binding.slot, binding]));
-  const out: Record<string, HeaderValue> = {};
-  for (const [name, value] of Object.entries(values)) {
-    if (typeof value === "string") {
-      out[name] = value;
-      continue;
-    }
-    const binding = bySlot.get(value.slot);
-    if (binding?.value.kind === "secret") {
-      out[name] = value.prefix
-        ? { secretId: binding.value.secretId, prefix: value.prefix }
-        : { secretId: binding.value.secretId };
-    } else if (binding?.value.kind === "text") {
-      out[name] = binding.value.text;
-    }
-  }
-  return out;
-};
-
-const initialCredentialTargetScope = (
-  sourceScope: ScopeId,
-  bindings: readonly GraphqlSourceBindingRef[],
-): ScopeId => bindings[0]?.scopeId ?? sourceScope;
 
 // ---------------------------------------------------------------------------
 // Edit form
@@ -96,9 +69,10 @@ function EditForm(props: {
   });
   const [endpoint, setEndpoint] = useState(props.initial.endpoint);
   const [credentials, setCredentials] = useState<HttpCredentialsState>(() =>
-    httpCredentialsFromValues({
-      headers: valuesForEditor(props.initial.headers, props.bindings),
-      queryParams: valuesForEditor(props.initial.queryParams, props.bindings),
+    httpCredentialsFromConfiguredCredentialBindings({
+      headers: props.initial.headers,
+      queryParams: props.initial.queryParams,
+      bindings: props.bindings,
     }),
   );
   const [authMode, setAuthMode] = useState<AuthMode>(props.initial.auth.kind);
@@ -119,7 +93,10 @@ function EditForm(props: {
   const handleSave = async () => {
     setSaving(true);
     setError(null);
-    const { headers, queryParams } = serializeHttpCredentials(credentials);
+    const { headers, queryParams } = serializeScopedHttpCredentials(
+      credentials,
+      credentialTargetScope,
+    );
     const payload: {
       sourceScope: ScopeId;
       name?: string;
@@ -220,6 +197,8 @@ function EditForm(props: {
         existingSecrets={secretList}
         sourceName={identity.name}
         targetScope={credentialTargetScope}
+        credentialScopeOptions={credentialScopeOptions}
+        bindingScopeOptions={credentialScopeOptions}
       />
 
       {/* Temporarily hidden while we revisit GraphQL OAuth discovery and UX. */}

--- a/packages/plugins/graphql/src/react/GraphqlSignInButton.tsx
+++ b/packages/plugins/graphql/src/react/GraphqlSignInButton.tsx
@@ -1,49 +1,15 @@
-import { useCallback } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
 import { connectionsAtom } from "@executor-js/react/api/atoms";
 import { useScope, useUserScope } from "@executor-js/react/api/scope-context";
 import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
-import {
-  OAuthSignInButton,
-  oauthCallbackUrl,
-  oauthConnectionId,
-  useOAuthPopupFlow,
-  type OAuthCompletionPayload,
-} from "@executor-js/react/plugins/oauth-sign-in";
+import { SourceOAuthSignInButton } from "@executor-js/react/plugins/oauth-sign-in";
 import { slugifyNamespace } from "@executor-js/react/plugins/source-identity";
-import { ConnectionId, ScopeId } from "@executor-js/sdk/core";
+import { secretBackedValuesFromConfiguredCredentialBindings } from "@executor-js/react/plugins/credential-bindings";
+import { ScopeId } from "@executor-js/sdk/core";
 
 import { graphqlSourceAtom, graphqlSourceBindingsAtom, setGraphqlSourceBinding } from "./atoms";
-import type {
-  ConfiguredGraphqlCredentialValue,
-  GraphqlSourceBindingRef,
-  HeaderValue,
-} from "../sdk/types";
-
-const valuesForOAuth = (
-  values: Record<string, ConfiguredGraphqlCredentialValue>,
-  bindings: readonly GraphqlSourceBindingRef[],
-): Record<string, HeaderValue> | undefined => {
-  const bySlot = new Map(bindings.map((binding) => [binding.slot, binding]));
-  const out: Record<string, HeaderValue> = {};
-  for (const [name, value] of Object.entries(values)) {
-    if (typeof value === "string") {
-      out[name] = value;
-      continue;
-    }
-    const binding = bySlot.get(value.slot);
-    if (binding?.value.kind === "secret") {
-      out[name] = value.prefix
-        ? { secretId: binding.value.secretId, prefix: value.prefix }
-        : { secretId: binding.value.secretId };
-    } else if (binding?.value.kind === "text") {
-      out[name] = binding.value.text;
-    }
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
-};
 
 export default function GraphqlSignInButton(props: { sourceId: string }) {
   const scopeId = useScope();
@@ -57,9 +23,6 @@ export default function GraphqlSignInButton(props: { sourceId: string }) {
   );
   const connectionsResult = useAtomValue(connectionsAtom(scopeId));
   const setBinding = useAtomSet(setGraphqlSourceBinding, { mode: "promise" });
-  const oauth = useOAuthPopupFlow({
-    popupName: "graphql-oauth",
-  });
 
   const oauth2 = source?.auth.kind === "oauth2" ? source.auth : null;
   const bindings = AsyncResult.isSuccess(bindingsResult) ? bindingsResult.value : null;
@@ -74,25 +37,26 @@ export default function GraphqlSignInButton(props: { sourceId: string }) {
     connections !== null &&
     connections.some((c: { readonly id: string }) => c.id === boundConnectionId);
 
-  const handleSignIn = useCallback(async () => {
-    if (!source || !oauth2) return;
-    const namespaceSlug = slugifyNamespace(source.namespace) || "graphql";
-    await oauth.start({
-      payload: {
-        endpoint: source.endpoint,
-        redirectUrl: oauthCallbackUrl(),
-        connectionId: oauthConnectionId({
-          pluginId: "graphql",
-          namespace: namespaceSlug,
-        }),
-        headers: valuesForOAuth(source.headers, bindings ?? []),
-        queryParams: valuesForOAuth(source.queryParams, bindings ?? []),
-        tokenScope: userScopeId,
-        strategy: { kind: "dynamic-dcr" },
-        pluginId: "graphql",
-        identityLabel: `${source.name.trim() || source.namespace || "GraphQL"} OAuth`,
-      },
-      onSuccess: async (result: OAuthCompletionPayload) => {
+  if (!source || !oauth2) return null;
+  const namespaceSlug = slugifyNamespace(source.namespace) || "graphql";
+
+  return (
+    <SourceOAuthSignInButton
+      popupName="graphql-oauth"
+      pluginId="graphql"
+      namespace={namespaceSlug}
+      fallbackNamespace="graphql"
+      endpoint={source.endpoint}
+      tokenScope={userScopeId}
+      connectionId={boundConnectionId}
+      sourceLabel={`${source.name.trim() || source.namespace || "GraphQL"} OAuth`}
+      headers={secretBackedValuesFromConfiguredCredentialBindings(source.headers, bindings ?? [])}
+      queryParams={secretBackedValuesFromConfiguredCredentialBindings(
+        source.queryParams,
+        bindings ?? [],
+      )}
+      isConnected={isConnected}
+      onConnected={async (connectionId) => {
         await setBinding({
           params: { scopeId },
           payload: {
@@ -100,32 +64,11 @@ export default function GraphqlSignInButton(props: { sourceId: string }) {
             sourceScope,
             scope: userScopeId,
             slot: oauth2.connectionSlot,
-            value: { kind: "connection", connectionId: ConnectionId.make(result.connectionId) },
+            value: { kind: "connection", connectionId },
           },
           reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
         });
-      },
-    });
-  }, [
-    source,
-    oauth2,
-    bindings,
-    scopeId,
-    props.sourceId,
-    sourceScope,
-    setBinding,
-    oauth,
-    userScopeId,
-  ]);
-
-  if (!oauth2) return null;
-
-  return (
-    <OAuthSignInButton
-      busy={oauth.busy}
-      error={oauth.error}
-      isConnected={isConnected}
-      onSignIn={() => void handleSignIn()}
+      }}
     />
   );
 }

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -16,10 +16,13 @@ import {
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import {
   HttpCredentialsEditor,
-  httpCredentialsFromValues,
-  serializeHttpCredentials,
+  serializeScopedHttpCredentials,
   type HttpCredentialsState,
 } from "@executor-js/react/plugins/http-credentials";
+import {
+  httpCredentialsFromConfiguredCredentialBindings,
+  initialCredentialTargetScope,
+} from "@executor-js/react/plugins/credential-bindings";
 import { Button } from "@executor-js/react/components/button";
 import {
   CardStack,
@@ -29,41 +32,8 @@ import {
 import { Input } from "@executor-js/react/components/input";
 import { Badge } from "@executor-js/react/components/badge";
 import { ScopeId } from "@executor-js/sdk/core";
-import type {
-  ConfiguredMcpCredentialValue,
-  McpCredentialInput,
-  McpSourceBindingRef,
-  SecretBackedValue,
-} from "../sdk/types";
+import type { McpCredentialInput, McpSourceBindingRef } from "../sdk/types";
 import type { McpStoredSourceSchemaType } from "../sdk/stored-source";
-
-const valuesForEditor = (
-  values: Record<string, ConfiguredMcpCredentialValue> | undefined,
-  bindings: readonly McpSourceBindingRef[],
-): Record<string, SecretBackedValue> => {
-  const bySlot = new Map(bindings.map((binding) => [binding.slot, binding]));
-  const out: Record<string, SecretBackedValue> = {};
-  for (const [name, value] of Object.entries(values ?? {})) {
-    if (typeof value === "string") {
-      out[name] = value;
-      continue;
-    }
-    const binding = bySlot.get(value.slot);
-    if (binding?.value.kind === "secret") {
-      out[name] = value.prefix
-        ? { secretId: binding.value.secretId, prefix: value.prefix }
-        : { secretId: binding.value.secretId };
-    } else if (binding?.value.kind === "text") {
-      out[name] = binding.value.text;
-    }
-  }
-  return out;
-};
-
-const initialCredentialTargetScope = (
-  sourceScope: ScopeId,
-  bindings: readonly McpSourceBindingRef[],
-): ScopeId => bindings[0]?.scopeId ?? sourceScope;
 
 // ---------------------------------------------------------------------------
 // Remote edit form
@@ -91,9 +61,10 @@ function RemoteEditForm(props: {
   });
   const [endpoint, setEndpoint] = useState(props.initial.config.endpoint);
   const [credentials, setCredentials] = useState<HttpCredentialsState>(() =>
-    httpCredentialsFromValues({
-      headers: valuesForEditor(props.initial.config.headers, props.bindings),
-      queryParams: valuesForEditor(props.initial.config.queryParams, props.bindings),
+    httpCredentialsFromConfiguredCredentialBindings({
+      headers: props.initial.config.headers,
+      queryParams: props.initial.config.queryParams,
+      bindings: props.bindings,
     }),
   );
   const [saving, setSaving] = useState(false);
@@ -112,7 +83,10 @@ function RemoteEditForm(props: {
   const handleSave = async () => {
     setSaving(true);
     setError(null);
-    const { headers, queryParams } = serializeHttpCredentials(credentials);
+    const { headers, queryParams } = serializeScopedHttpCredentials(
+      credentials,
+      credentialTargetScope,
+    );
     const payload: {
       sourceScope: ScopeId;
       name?: string;
@@ -197,6 +171,8 @@ function RemoteEditForm(props: {
         existingSecrets={secretList}
         sourceName={identity.name}
         targetScope={credentialTargetScope}
+        credentialScopeOptions={credentialScopeOptions}
+        bindingScopeOptions={credentialScopeOptions}
       />
 
       {error && (

--- a/packages/plugins/mcp/src/react/McpSignInButton.tsx
+++ b/packages/plugins/mcp/src/react/McpSignInButton.tsx
@@ -1,50 +1,16 @@
-import { useCallback } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
-import { ConnectionId, ScopeId } from "@executor-js/sdk/core";
+import { ScopeId } from "@executor-js/sdk/core";
 import { useScope, useUserScope } from "@executor-js/react/api/scope-context";
 import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { connectionsAtom } from "@executor-js/react/api/atoms";
-import {
-  OAuthSignInButton,
-  oauthCallbackUrl,
-  oauthConnectionId,
-  useOAuthPopupFlow,
-  type OAuthCompletionPayload,
-} from "@executor-js/react/plugins/oauth-sign-in";
+import { SourceOAuthSignInButton } from "@executor-js/react/plugins/oauth-sign-in";
 import { slugifyNamespace } from "@executor-js/react/plugins/source-identity";
+import { secretBackedValuesFromConfiguredCredentialBindings } from "@executor-js/react/plugins/credential-bindings";
 
 import { mcpSourceAtom, mcpSourceBindingsAtom, setMcpSourceBinding } from "./atoms";
 import type { McpStoredSourceSchemaType } from "../sdk/stored-source";
-import type {
-  ConfiguredMcpCredentialValue,
-  McpSourceBindingRef,
-  SecretBackedValue,
-} from "../sdk/types";
-
-const valuesForOAuth = (
-  values: Record<string, ConfiguredMcpCredentialValue> | undefined,
-  bindings: readonly McpSourceBindingRef[],
-): Record<string, SecretBackedValue> | undefined => {
-  const bySlot = new Map(bindings.map((binding) => [binding.slot, binding]));
-  const out: Record<string, SecretBackedValue> = {};
-  for (const [name, value] of Object.entries(values ?? {})) {
-    if (typeof value === "string") {
-      out[name] = value;
-      continue;
-    }
-    const binding = bySlot.get(value.slot);
-    if (binding?.value.kind === "secret") {
-      out[name] = value.prefix
-        ? { secretId: binding.value.secretId, prefix: value.prefix }
-        : { secretId: binding.value.secretId };
-    } else if (binding?.value.kind === "text") {
-      out[name] = binding.value.text;
-    }
-  }
-  return Object.keys(out).length > 0 ? out : undefined;
-};
 
 // ---------------------------------------------------------------------------
 // McpSignInButton — top-bar action on the source detail page.
@@ -66,9 +32,6 @@ export default function McpSignInButton(props: { sourceId: string }) {
   const bindingsResult = useAtomValue(mcpSourceBindingsAtom(scopeId, props.sourceId, sourceScope));
   const connectionsResult = useAtomValue(connectionsAtom(scopeId));
   const setBinding = useAtomSet(setMcpSourceBinding, { mode: "promise" });
-  const oauth = useOAuthPopupFlow({
-    popupName: "mcp-oauth",
-  });
 
   const remote = source && source.config.transport === "remote" ? source.config : null;
   const oauth2 = remote && remote.auth.kind === "oauth2" ? remote.auth : null;
@@ -87,25 +50,26 @@ export default function McpSignInButton(props: { sourceId: string }) {
     connectionId !== null &&
     connections.some((c) => c.id === connectionId);
 
-  const handleSignIn = useCallback(async () => {
-    if (!remote || !oauth2 || !source) return;
-    const namespaceSlug = slugifyNamespace(source.namespace) || "mcp";
-    await oauth.start({
-      payload: {
-        endpoint: remote.endpoint,
-        redirectUrl: oauthCallbackUrl(),
-        connectionId: oauthConnectionId({
-          pluginId: "mcp",
-          namespace: namespaceSlug,
-        }),
-        headers: valuesForOAuth(remote.headers, bindings ?? []),
-        queryParams: valuesForOAuth(remote.queryParams, bindings ?? []),
-        tokenScope: userScopeId,
-        strategy: { kind: "dynamic-dcr" },
-        pluginId: "mcp",
-        identityLabel: `${source.name.trim() || source.namespace || "MCP"} OAuth`,
-      },
-      onSuccess: async (result: OAuthCompletionPayload) => {
+  if (!remote || !oauth2 || !source) return null;
+  const namespaceSlug = slugifyNamespace(source.namespace) || "mcp";
+
+  return (
+    <SourceOAuthSignInButton
+      popupName="mcp-oauth"
+      pluginId="mcp"
+      namespace={namespaceSlug}
+      fallbackNamespace="mcp"
+      endpoint={remote.endpoint}
+      tokenScope={userScopeId}
+      connectionId={connectionId}
+      sourceLabel={`${source.name.trim() || source.namespace || "MCP"} OAuth`}
+      headers={secretBackedValuesFromConfiguredCredentialBindings(remote.headers, bindings ?? [])}
+      queryParams={secretBackedValuesFromConfiguredCredentialBindings(
+        remote.queryParams,
+        bindings ?? [],
+      )}
+      isConnected={isConnected}
+      onConnected={async (nextConnectionId) => {
         await setBinding({
           params: { scopeId },
           payload: {
@@ -113,33 +77,11 @@ export default function McpSignInButton(props: { sourceId: string }) {
             sourceScope,
             scope: userScopeId,
             slot: oauth2.connectionSlot,
-            value: { kind: "connection", connectionId: ConnectionId.make(result.connectionId) },
+            value: { kind: "connection", connectionId: nextConnectionId },
           },
           reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
         });
-      },
-    });
-  }, [
-    remote,
-    oauth2,
-    source,
-    bindings,
-    scopeId,
-    props.sourceId,
-    sourceScope,
-    setBinding,
-    oauth,
-    userScopeId,
-  ]);
-
-  if (!oauth2) return null;
-
-  return (
-    <OAuthSignInButton
-      busy={oauth.busy}
-      error={oauth.error}
-      isConnected={isConnected}
-      onSignIn={() => void handleSignIn()}
+      }}
       reconnectingLabel="Reconnecting…"
       signingInLabel="Signing in…"
     />

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
@@ -33,6 +33,7 @@ import {
   matchPresetKey,
   type HeaderState,
 } from "@executor-js/react/plugins/secret-header-auth";
+import { CredentialScopeDropdown } from "@executor-js/react/plugins/credential-target-scope";
 import {
   slugifyNamespace,
   SourceIdentityFieldRows,
@@ -65,13 +66,6 @@ import { Textarea } from "@executor-js/react/components/textarea";
 import { Checkbox } from "@executor-js/react/components/checkbox";
 import { SourceFavicon } from "@executor-js/react/components/source-favicon";
 import { RadioGroup, RadioGroupItem } from "@executor-js/react/components/radio-group";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@executor-js/react/components/select";
 import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
 import { addOpenApiSpecOptimistic, previewOpenApiSpec, setOpenApiSourceBinding } from "./atoms";
 import type { SpecPreview, HeaderPreset, OAuth2Preset } from "../sdk/preview";
@@ -209,44 +203,6 @@ const secretStorageDescription = (label: string): string =>
   label === "Personal"
     ? "Only you can use this secret."
     : "Everyone in the organization can use this secret.";
-
-function CredentialScopeDropdown(props: {
-  readonly value: ScopeId;
-  readonly options: readonly {
-    readonly scopeId: ScopeId;
-    readonly label: string;
-  }[];
-  readonly onChange: (scopeId: ScopeId) => void;
-  readonly label?: string;
-  readonly help?: ReactNode;
-}) {
-  const label = props.label ?? "Used by";
-  return (
-    <div className="space-y-1.5">
-      <div className="flex items-center gap-1.5">
-        <FieldLabel className="text-[11px]">{label}</FieldLabel>
-        <HelpTooltip label={label}>
-          {props.help ?? "Choose who uses this credential value."}
-        </HelpTooltip>
-      </div>
-      <Select
-        value={String(props.value)}
-        onValueChange={(value) => props.onChange(ScopeId.make(value))}
-      >
-        <SelectTrigger className="w-full">
-          <SelectValue placeholder={label} />
-        </SelectTrigger>
-        <SelectContent>
-          {props.options.map((option) => (
-            <SelectItem key={option.scopeId} value={option.scopeId}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Main component — single progressive form

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -23,13 +23,19 @@ import { FilterTabs } from "@executor-js/react/components/filter-tabs";
 import { Input } from "@executor-js/react/components/input";
 import { sourceWriteKeys as openApiWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk/core";
-import { CreatableSecretPicker } from "@executor-js/react/plugins/secret-header-auth";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import {
   oauthCallbackUrl,
   useOAuthPopupFlow,
   type OAuthCompletionPayload,
 } from "@executor-js/react/plugins/oauth-sign-in";
+import {
+  effectiveCredentialBindingForScope,
+  exactCredentialBindingForScope,
+  isConnectionCredentialBindingValue,
+  isSecretCredentialBindingValue,
+} from "@executor-js/react/plugins/credential-bindings";
+import { SecretCredentialSlotBindings } from "@executor-js/react/plugins/credential-slot-bindings";
 
 import {
   openApiSourceAtom,
@@ -45,14 +51,10 @@ import {
   resolveOAuthUrl,
 } from "./AddOpenApiSource";
 import { oauth2ClientSecretSlot } from "../sdk/store";
-import {
-  OpenApiSourceBindingValue,
-  type OpenApiSourceBindingValue as OpenApiSourceBindingValueType,
-} from "../sdk/types";
+import { type OpenApiSourceBindingRef } from "../sdk/types";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
 const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
-const isOpenApiSourceBindingValue = Schema.is(OpenApiSourceBindingValue);
 
 const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
   Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
@@ -98,50 +100,10 @@ const openApiOAuthConnectionId = (
     `openapi-oauth-${slugify(sourceId)}-${slugify(securitySchemeName)}-${shortHash(targetScope)}`,
   );
 
-const bindingSecretId = (sourceId: string, slot: string, scopeId: string): string =>
-  `source-binding-${slugify(sourceId)}-${slugify(slot)}-${slugify(scopeId)}`;
-
 const effectiveClientSecretSlot = (oauth2: {
   readonly securitySchemeName: string;
   readonly clientSecretSlot: string | null;
 }): string => oauth2.clientSecretSlot ?? oauth2ClientSecretSlot(oauth2.securitySchemeName);
-
-const exactBindingForScope = (
-  rows: readonly {
-    readonly slot: string;
-    readonly scopeId: ScopeId;
-    readonly value: unknown;
-  }[],
-  slot: string,
-  scopeId: ScopeId,
-) => rows.find((row) => row.slot === slot && row.scopeId === scopeId) ?? null;
-
-const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
-  ranks.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
-
-const effectiveBindingForScope = (
-  rows: readonly {
-    readonly slot: string;
-    readonly scopeId: ScopeId;
-    readonly value: unknown;
-  }[],
-  slot: string,
-  targetScope: ScopeId,
-  ranks: ReadonlyMap<string, number>,
-) =>
-  rows.find(
-    (row) => row.slot === slot && scopeRank(ranks, row.scopeId) >= scopeRank(ranks, targetScope),
-  ) ?? null;
-
-const isSecretBindingValue = (
-  value: unknown,
-): value is Extract<OpenApiSourceBindingValueType, { readonly kind: "secret" }> =>
-  isOpenApiSourceBindingValue(value) && value.kind === "secret";
-
-const isConnectionBindingValue = (
-  value: unknown,
-): value is Extract<OpenApiSourceBindingValueType, { readonly kind: "connection" }> =>
-  isOpenApiSourceBindingValue(value) && value.kind === "connection";
 
 export default function EditOpenApiSource(props: {
   readonly sourceId: string;
@@ -185,7 +147,9 @@ export default function EditOpenApiSource(props: {
 
   const source =
     AsyncResult.isSuccess(sourceResult) && sourceResult.value ? sourceResult.value : null;
-  const bindingRows = AsyncResult.isSuccess(bindingsResult) ? bindingsResult.value : [];
+  const bindingRows: readonly OpenApiSourceBindingRef[] = AsyncResult.isSuccess(bindingsResult)
+    ? bindingsResult.value
+    : [];
   const connections = AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : [];
   const oauth2RedirectUrl = oauthCallbackUrl(OPENAPI_OAUTH_CALLBACK_PATH);
 
@@ -414,27 +378,27 @@ export default function EditOpenApiSource(props: {
   const connectOAuth = async (targetScope: ScopeId) => {
     const oauth2 = source.config.oauth2;
     if (!oauth2) return;
-    const clientIdBinding = effectiveBindingForScope(
+    const clientIdBinding = effectiveCredentialBindingForScope(
       bindingRows,
       oauth2.clientIdSlot,
       targetScope,
       scopeRanks,
     );
     const clientSecretSlot = effectiveClientSecretSlot(oauth2);
-    const clientSecretBinding = effectiveBindingForScope(
+    const clientSecretBinding = effectiveCredentialBindingForScope(
       bindingRows,
       clientSecretSlot,
       targetScope,
       scopeRanks,
     );
-    if (!clientIdBinding || !isSecretBindingValue(clientIdBinding.value)) {
+    if (!clientIdBinding || !isSecretCredentialBindingValue(clientIdBinding.value)) {
       setError("Client ID must be bound before connecting");
       return;
     }
     const clientIdSecretId = clientIdBinding.value.secretId;
     if (
       oauth2.flow === "clientCredentials" &&
-      (!clientSecretBinding || !isSecretBindingValue(clientSecretBinding.value))
+      (!clientSecretBinding || !isSecretCredentialBindingValue(clientSecretBinding.value))
     ) {
       setError("Client secret must be bound before connecting");
       return;
@@ -442,17 +406,17 @@ export default function EditOpenApiSource(props: {
     const clientSecretValue =
       oauth2.flow === "clientCredentials" &&
       clientSecretBinding &&
-      isSecretBindingValue(clientSecretBinding.value)
+      isSecretCredentialBindingValue(clientSecretBinding.value)
         ? clientSecretBinding.value
         : null;
 
-    const existingConnection = exactBindingForScope(
+    const existingConnection = exactCredentialBindingForScope(
       bindingRows,
       oauth2.connectionSlot,
       targetScope,
     );
     const connectionId =
-      existingConnection && isConnectionBindingValue(existingConnection.value)
+      existingConnection && isConnectionCredentialBindingValue(existingConnection.value)
         ? existingConnection.value.connectionId
         : openApiOAuthConnectionId(props.sourceId, oauth2.securitySchemeName, targetScope);
 
@@ -540,7 +504,7 @@ export default function EditOpenApiSource(props: {
           issuerUrl,
           clientIdSecretId,
           clientSecretSecretId:
-            clientSecretBinding && isSecretBindingValue(clientSecretBinding.value)
+            clientSecretBinding && isSecretCredentialBindingValue(clientSecretBinding.value)
               ? clientSecretBinding.value.secretId
               : null,
           scopes: [...oauth2.scopes],
@@ -651,108 +615,19 @@ export default function EditOpenApiSource(props: {
             </CardStackEntryContent>
           </CardStackEntry>
 
-          {secretSlots
-            .filter((slot) => slot.kind === "secret")
-            .map((slot) => {
-              return (
-                <CardStackEntryField key={slot.slot} label={slot.label}>
-                  <div className="space-y-3">
-                    {secretBindingScopes.map((bindingScope) => {
-                      const exact = exactBindingForScope(
-                        bindingRows,
-                        slot.slot,
-                        bindingScope.scopeId,
-                      );
-                      const exactSecretId =
-                        exact && isSecretBindingValue(exact.value) ? exact.value.secretId : null;
-                      const inherited =
-                        bindingScope.label === "Personal"
-                          ? effectiveBindingForScope(
-                              bindingRows,
-                              slot.slot,
-                              bindingScope.scopeId,
-                              scopeRanks,
-                            )
-                          : null;
-                      const inheritedSecretId =
-                        inherited &&
-                        inherited.scopeId !== bindingScope.scopeId &&
-                        isSecretBindingValue(inherited.value)
-                          ? inherited.value.secretId
-                          : null;
-                      const inputKey = `${bindingScope.scopeId}:${slot.slot}`;
-                      const clearKey = `${bindingScope.scopeId}:${slot.slot}:clear`;
-                      const rowTitle =
-                        bindingScope.label === "Personal"
-                          ? "My override"
-                          : secretBindingScopes.length === 1
-                            ? "Source credential"
-                            : "Organization default";
-
-                      return (
-                        <div
-                          key={bindingScope.scopeId}
-                          className="space-y-2 rounded-md border border-border bg-background/40 p-3"
-                        >
-                          <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
-                            <div>
-                              <div className="text-sm font-medium text-foreground">{rowTitle}</div>
-                            </div>
-                            {bindingScope.label === "Personal" &&
-                              !exactSecretId &&
-                              inheritedSecretId && (
-                                <span className="text-xs text-muted-foreground">
-                                  Using organization default
-                                </span>
-                              )}
-                          </div>
-                          <CreatableSecretPicker
-                            value={exactSecretId}
-                            onSelect={(secretId, secretScopeId) => {
-                              void setSecretBinding(
-                                bindingScope.scopeId,
-                                slot.slot,
-                                secretId,
-                                secretScopeId ?? bindingScope.scopeId,
-                              );
-                            }}
-                            secrets={secretList}
-                            placeholder="Select or create a secret"
-                            targetScope={bindingScope.scopeId}
-                            credentialScopeOptions={credentialScopeOptions}
-                            suggestedId={bindingSecretId(
-                              props.sourceId,
-                              slot.slot,
-                              bindingScope.scopeId,
-                            )}
-                            sourceName={source.name}
-                            secretLabel={slot.label}
-                          />
-                          <div className="flex flex-wrap items-center gap-2">
-                            {exactSecretId && (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => void clearBinding(bindingScope.scopeId, slot.slot)}
-                                disabled={busyKey === clearKey}
-                              >
-                                Clear
-                              </Button>
-                            )}
-                            {busyKey === inputKey && (
-                              <span className="text-xs text-muted-foreground">Saving…</span>
-                            )}
-                            {slot.hint && (
-                              <span className="text-xs text-muted-foreground">{slot.hint}</span>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                </CardStackEntryField>
-              );
-            })}
+          <SecretCredentialSlotBindings
+            slots={secretSlots.filter((slot) => slot.kind === "secret")}
+            bindingScopes={secretBindingScopes}
+            bindingRows={bindingRows}
+            scopeRanks={scopeRanks}
+            secrets={secretList}
+            sourceId={props.sourceId}
+            sourceName={source.name}
+            credentialScopeOptions={credentialScopeOptions}
+            busyKey={busyKey}
+            onSetSecretBinding={setSecretBinding}
+            onClearBinding={clearBinding}
+          />
 
           {source.config.oauth2 && (
             <>
@@ -787,21 +662,23 @@ export default function EditOpenApiSource(props: {
               )}
               <CardStackEntryField label="OAuth Connection">
                 {(() => {
-                  const exact = exactBindingForScope(
+                  const exact = exactCredentialBindingForScope(
                     bindingRows,
                     source.config.oauth2!.connectionSlot,
                     activeOAuthTokenScopeId,
                   );
                   const binding =
                     exact ??
-                    effectiveBindingForScope(
+                    effectiveCredentialBindingForScope(
                       bindingRows,
                       source.config.oauth2!.connectionSlot,
                       activeOAuthTokenScopeId,
                       scopeRanks,
                     );
                   const connectionBinding =
-                    binding && isConnectionBindingValue(binding.value) ? binding.value : null;
+                    binding && isConnectionCredentialBindingValue(binding.value)
+                      ? binding.value
+                      : null;
                   const connection = connectionBinding
                     ? connections.find((entry) => entry.id === connectionBinding.connectionId)
                     : null;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,6 +14,8 @@
     "./globals.css": "./src/styles/globals.css"
   },
   "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsgo --noEmit",
     "typecheck:slow": "tsc --noEmit"
   },
@@ -49,6 +51,7 @@
     "vaul": "^1.1.2"
   },
   "devDependencies": {
+    "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "hast-util-to-jsx-runtime": "^2.3.6",

--- a/packages/react/src/plugins/credential-bindings.test.ts
+++ b/packages/react/src/plugins/credential-bindings.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ScopeId, SecretId } from "@executor-js/sdk";
+
+import {
+  httpCredentialsFromConfiguredCredentialBindings,
+  initialCredentialTargetScope,
+  secretBackedValuesFromConfiguredCredentialBindings,
+} from "./credential-bindings";
+
+describe("credential binding editor helpers", () => {
+  it("hydrates configured credentials with binding and secret scopes", () => {
+    const personalScope = ScopeId.make("user_1");
+    const organizationScope = ScopeId.make("org_1");
+
+    const credentials = httpCredentialsFromConfiguredCredentialBindings({
+      headers: {
+        Authorization: {
+          slot: "header:authorization",
+          prefix: "Bearer ",
+        },
+      },
+      queryParams: {
+        token: {
+          slot: "query_param:token",
+        },
+      },
+      bindings: [
+        {
+          slot: "header:authorization",
+          scopeId: personalScope,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make("personal-api-token"),
+            secretScopeId: organizationScope,
+          },
+        },
+        {
+          slot: "query_param:token",
+          scopeId: organizationScope,
+          value: {
+            kind: "text",
+            text: "literal-token",
+          },
+        },
+      ],
+    });
+
+    expect(credentials.headers).toEqual([
+      {
+        name: "Authorization",
+        secretId: "personal-api-token",
+        prefix: "Bearer ",
+        presetKey: "bearer",
+        targetScope: personalScope,
+        secretScope: organizationScope,
+      },
+    ]);
+    expect(credentials.queryParams).toEqual([
+      {
+        name: "token",
+        secretId: null,
+        literalValue: "literal-token",
+      },
+    ]);
+  });
+
+  it("uses the first binding as the initial target scope", () => {
+    const sourceScope = ScopeId.make("org_1");
+    const personalScope = ScopeId.make("user_1");
+
+    expect(
+      initialCredentialTargetScope(sourceScope, [
+        {
+          slot: "header:authorization",
+          scopeId: personalScope,
+          value: {
+            kind: "secret",
+            secretId: SecretId.make("personal-api-token"),
+          },
+        },
+      ]),
+    ).toBe(personalScope);
+    expect(initialCredentialTargetScope(sourceScope, [])).toBe(sourceScope);
+  });
+
+  it("hydrates configured credentials to secret-backed OAuth payload values", () => {
+    expect(
+      secretBackedValuesFromConfiguredCredentialBindings(
+        {
+          Authorization: {
+            slot: "header:authorization",
+            prefix: "Bearer ",
+          },
+          "X-Literal": "literal",
+        },
+        [
+          {
+            slot: "header:authorization",
+            scopeId: ScopeId.make("user_1"),
+            value: {
+              kind: "secret",
+              secretId: SecretId.make("api-token"),
+            },
+          },
+        ],
+      ),
+    ).toEqual({
+      Authorization: {
+        secretId: "api-token",
+        prefix: "Bearer ",
+      },
+      "X-Literal": "literal",
+    });
+  });
+});

--- a/packages/react/src/plugins/credential-bindings.tsx
+++ b/packages/react/src/plugins/credential-bindings.tsx
@@ -1,0 +1,157 @@
+import { ScopeId, type CredentialBindingValue, type SecretBackedValue } from "@executor-js/sdk";
+
+import type { HttpCredentialsState, QueryParamState } from "./http-credentials";
+import { headerValueToState, type HeaderState } from "./secret-header-auth";
+
+type ConfiguredCredentialValueLike =
+  | string
+  | {
+      readonly slot: string;
+      readonly prefix?: string;
+    };
+
+type CredentialBindingRefLike = {
+  readonly slot: string;
+  readonly scopeId: ScopeId;
+  readonly value: CredentialBindingValue;
+};
+
+const bindingBySlot = (
+  bindings: readonly CredentialBindingRefLike[],
+): ReadonlyMap<string, CredentialBindingRefLike> =>
+  new Map(bindings.map((binding) => [binding.slot, binding]));
+
+export const initialCredentialTargetScope = (
+  sourceScope: ScopeId,
+  bindings: readonly CredentialBindingRefLike[],
+): ScopeId => bindings[0]?.scopeId ?? sourceScope;
+
+export const exactCredentialBindingForScope = (
+  rows: readonly CredentialBindingRefLike[],
+  slot: string,
+  scopeId: ScopeId,
+): CredentialBindingRefLike | null =>
+  rows.find((row) => row.slot === slot && row.scopeId === scopeId) ?? null;
+
+const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
+  ranks.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
+
+export const effectiveCredentialBindingForScope = (
+  rows: readonly CredentialBindingRefLike[],
+  slot: string,
+  targetScope: ScopeId,
+  ranks: ReadonlyMap<string, number>,
+): CredentialBindingRefLike | null =>
+  rows.find(
+    (row) => row.slot === slot && scopeRank(ranks, row.scopeId) >= scopeRank(ranks, targetScope),
+  ) ?? null;
+
+export const isSecretCredentialBindingValue = (
+  value: CredentialBindingValue,
+): value is Extract<CredentialBindingValue, { readonly kind: "secret" }> => value.kind === "secret";
+
+export const isConnectionCredentialBindingValue = (
+  value: CredentialBindingValue,
+): value is Extract<CredentialBindingValue, { readonly kind: "connection" }> =>
+  value.kind === "connection";
+
+const headerFromConfiguredCredential = (
+  name: string,
+  value: ConfiguredCredentialValueLike,
+  bindings: ReadonlyMap<string, CredentialBindingRefLike>,
+): HeaderState | null => {
+  if (typeof value === "string") {
+    return headerValueToState(name, value);
+  }
+
+  const binding = bindings.get(value.slot);
+  if (binding?.value.kind === "secret") {
+    return {
+      ...headerValueToState(name, {
+        secretId: binding.value.secretId,
+        prefix: value.prefix,
+      }),
+      targetScope: binding.scopeId,
+      secretScope: binding.value.secretScopeId,
+    };
+  }
+
+  if (binding?.value.kind === "text") {
+    return headerValueToState(name, binding.value.text);
+  }
+
+  return null;
+};
+
+const queryParamFromConfiguredCredential = (
+  name: string,
+  value: ConfiguredCredentialValueLike,
+  bindings: ReadonlyMap<string, CredentialBindingRefLike>,
+): QueryParamState | null => {
+  if (typeof value === "string") {
+    return { name, secretId: null, literalValue: value };
+  }
+
+  const binding = bindings.get(value.slot);
+  if (binding?.value.kind === "secret") {
+    return {
+      name,
+      secretId: binding.value.secretId,
+      prefix: value.prefix,
+      targetScope: binding.scopeId,
+      secretScope: binding.value.secretScopeId,
+    };
+  }
+
+  if (binding?.value.kind === "text") {
+    return { name, secretId: null, literalValue: binding.value.text };
+  }
+
+  return null;
+};
+
+export const secretBackedValuesFromConfiguredCredentialBindings = (
+  values: Record<string, ConfiguredCredentialValueLike> | undefined | null,
+  bindingsInput: readonly CredentialBindingRefLike[],
+): Record<string, SecretBackedValue> | undefined => {
+  const bindings = bindingBySlot(bindingsInput);
+  const out: Record<string, SecretBackedValue> = {};
+
+  for (const [name, value] of Object.entries(values ?? {})) {
+    if (typeof value === "string") {
+      out[name] = value;
+      continue;
+    }
+
+    const binding = bindings.get(value.slot);
+    if (binding?.value.kind === "secret") {
+      out[name] = {
+        secretId: binding.value.secretId,
+        ...(value.prefix ? { prefix: value.prefix } : {}),
+      };
+    } else if (binding?.value.kind === "text") {
+      out[name] = binding.value.text;
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+
+export const httpCredentialsFromConfiguredCredentialBindings = (input: {
+  readonly headers?: Record<string, ConfiguredCredentialValueLike> | null;
+  readonly queryParams?: Record<string, ConfiguredCredentialValueLike> | null;
+  readonly bindings: readonly CredentialBindingRefLike[];
+}): HttpCredentialsState => {
+  const bindings = bindingBySlot(input.bindings);
+
+  return {
+    headers: Object.entries(input.headers ?? {}).flatMap(([name, value]) => {
+      const state = headerFromConfiguredCredential(name, value, bindings);
+      return state ? [state] : [];
+    }),
+    queryParams: Object.entries(input.queryParams ?? {}).flatMap(([name, value]) => {
+      const state = queryParamFromConfiguredCredential(name, value, bindings);
+      return state ? [state] : [];
+    }),
+  };
+};

--- a/packages/react/src/plugins/credential-slot-bindings.tsx
+++ b/packages/react/src/plugins/credential-slot-bindings.tsx
@@ -1,0 +1,158 @@
+import { ScopeId, type CredentialBindingValue } from "@executor-js/sdk";
+
+import { Button } from "../components/button";
+import { CardStackEntryField } from "../components/card-stack";
+import type { CredentialTargetScopeOption } from "./credential-target-scope";
+import {
+  effectiveCredentialBindingForScope,
+  exactCredentialBindingForScope,
+  isSecretCredentialBindingValue,
+} from "./credential-bindings";
+import { CreatableSecretPicker } from "./secret-header-auth";
+import type { SecretPickerSecret } from "./secret-picker";
+
+export type SecretCredentialSlot = {
+  readonly slot: string;
+  readonly label: string;
+  readonly hint?: string;
+};
+
+export type CredentialBindingScope = {
+  readonly scopeId: ScopeId;
+  readonly label: string;
+};
+
+type CredentialSlotBindingRef = {
+  readonly slot: string;
+  readonly scopeId: ScopeId;
+  readonly value: CredentialBindingValue;
+};
+
+const slugify = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "default";
+
+const bindingSecretId = (sourceId: string, slot: string, scopeId: string): string =>
+  `source-binding-${slugify(sourceId)}-${slugify(slot)}-${slugify(scopeId)}`;
+
+const rowTitle = (bindingScope: CredentialBindingScope, bindingScopeCount: number): string =>
+  bindingScope.label === "Personal"
+    ? "My override"
+    : bindingScopeCount === 1
+      ? "Source credential"
+      : "Organization default";
+
+export function SecretCredentialSlotBindings(props: {
+  readonly slots: readonly SecretCredentialSlot[];
+  readonly bindingScopes: readonly CredentialBindingScope[];
+  readonly bindingRows: readonly CredentialSlotBindingRef[];
+  readonly scopeRanks: ReadonlyMap<string, number>;
+  readonly secrets: readonly SecretPickerSecret[];
+  readonly sourceId: string;
+  readonly sourceName: string;
+  readonly credentialScopeOptions: readonly CredentialTargetScopeOption[];
+  readonly busyKey: string | null;
+  readonly onSetSecretBinding: (
+    targetScope: ScopeId,
+    slot: string,
+    secretId: string,
+    secretScope: ScopeId,
+  ) => void | Promise<void>;
+  readonly onClearBinding: (targetScope: ScopeId, slot: string) => void | Promise<void>;
+}) {
+  return (
+    <>
+      {props.slots.map((slot) => (
+        <CardStackEntryField key={slot.slot} label={slot.label}>
+          <div className="space-y-3">
+            {props.bindingScopes.map((bindingScope) => {
+              const exact = exactCredentialBindingForScope(
+                props.bindingRows,
+                slot.slot,
+                bindingScope.scopeId,
+              );
+              const exactSecretId =
+                exact && isSecretCredentialBindingValue(exact.value) ? exact.value.secretId : null;
+              const inherited =
+                bindingScope.label === "Personal"
+                  ? effectiveCredentialBindingForScope(
+                      props.bindingRows,
+                      slot.slot,
+                      bindingScope.scopeId,
+                      props.scopeRanks,
+                    )
+                  : null;
+              const inheritedSecretId =
+                inherited &&
+                inherited.scopeId !== bindingScope.scopeId &&
+                isSecretCredentialBindingValue(inherited.value)
+                  ? inherited.value.secretId
+                  : null;
+              const inputKey = `${bindingScope.scopeId}:${slot.slot}`;
+              const clearKey = `${bindingScope.scopeId}:${slot.slot}:clear`;
+
+              return (
+                <div
+                  key={bindingScope.scopeId}
+                  className="space-y-2 rounded-md border border-border bg-background/40 p-3"
+                >
+                  <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <div className="text-sm font-medium text-foreground">
+                        {rowTitle(bindingScope, props.bindingScopes.length)}
+                      </div>
+                    </div>
+                    {bindingScope.label === "Personal" && !exactSecretId && inheritedSecretId && (
+                      <span className="text-xs text-muted-foreground">
+                        Using organization default
+                      </span>
+                    )}
+                  </div>
+                  <CreatableSecretPicker
+                    value={exactSecretId}
+                    onSelect={(secretId, secretScopeId) => {
+                      void props.onSetSecretBinding(
+                        bindingScope.scopeId,
+                        slot.slot,
+                        secretId,
+                        secretScopeId ?? bindingScope.scopeId,
+                      );
+                    }}
+                    secrets={props.secrets}
+                    placeholder="Select or create a secret"
+                    targetScope={bindingScope.scopeId}
+                    credentialScopeOptions={props.credentialScopeOptions}
+                    suggestedId={bindingSecretId(props.sourceId, slot.slot, bindingScope.scopeId)}
+                    sourceName={props.sourceName}
+                    secretLabel={slot.label}
+                  />
+                  <div className="flex flex-wrap items-center gap-2">
+                    {exactSecretId && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void props.onClearBinding(bindingScope.scopeId, slot.slot)}
+                        disabled={props.busyKey === clearKey}
+                      >
+                        Clear
+                      </Button>
+                    )}
+                    {props.busyKey === inputKey && (
+                      <span className="text-xs text-muted-foreground">Saving…</span>
+                    )}
+                    {slot.hint && (
+                      <span className="text-xs text-muted-foreground">{slot.hint}</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </CardStackEntryField>
+      ))}
+    </>
+  );
+}

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -9,6 +9,8 @@ import { useScope } from "../api/scope-context";
 import { Button } from "../components/button";
 import {
   OAUTH_POPUP_MESSAGE_TYPE,
+  ConnectionId,
+  ScopeId,
   type OAuthStrategy,
   type SecretBackedValue,
 } from "@executor-js/sdk";
@@ -271,5 +273,90 @@ export function OAuthSignInButton(props: {
             : (props.signInLabel ?? "Sign in")}
       </Button>
     </div>
+  );
+}
+
+export function SourceOAuthSignInButton(props: {
+  readonly popupName: string;
+  readonly pluginId: string;
+  readonly namespace: string;
+  readonly fallbackNamespace: string;
+  readonly endpoint: string;
+  readonly tokenScope: ScopeId;
+  readonly connectionId: string | null;
+  readonly sourceLabel: string;
+  readonly headers?: Record<string, SecretBackedValue>;
+  readonly queryParams?: Record<string, SecretBackedValue>;
+  readonly isConnected: boolean;
+  readonly onConnected: (connectionId: ConnectionId) => void | Promise<void>;
+  readonly reconnectingLabel?: string;
+  readonly signingInLabel?: string;
+}) {
+  const {
+    connectionId,
+    endpoint,
+    fallbackNamespace,
+    headers,
+    isConnected,
+    namespace,
+    onConnected,
+    pluginId,
+    popupName,
+    queryParams,
+    reconnectingLabel,
+    signingInLabel,
+    sourceLabel,
+    tokenScope,
+  } = props;
+  const oauth = useOAuthPopupFlow({
+    popupName,
+  });
+
+  const handleSignIn = useCallback(async () => {
+    await oauth.start({
+      payload: {
+        endpoint,
+        redirectUrl: oauthCallbackUrl(),
+        connectionId:
+          connectionId ??
+          oauthConnectionId({
+            pluginId,
+            namespace,
+            fallback: fallbackNamespace,
+          }),
+        headers,
+        queryParams,
+        tokenScope,
+        strategy: { kind: "dynamic-dcr" },
+        pluginId,
+        identityLabel: sourceLabel,
+      },
+      onSuccess: async (result: OAuthCompletionPayload) => {
+        await onConnected(ConnectionId.make(result.connectionId));
+      },
+    });
+  }, [
+    connectionId,
+    endpoint,
+    fallbackNamespace,
+    headers,
+    namespace,
+    oauth,
+    onConnected,
+    pluginId,
+    queryParams,
+    sourceLabel,
+    tokenScope,
+  ]);
+
+  return (
+    <OAuthSignInButton
+      busy={oauth.busy}
+      error={oauth.error}
+      isConnected={isConnected}
+      onSignIn={() => void handleSignIn()}
+      reconnectingLabel={reconnectingLabel}
+      signingInLabel={signingInLabel}
+    />
   );
 }


### PR DESCRIPTION
## Summary

- Add shared React helpers for credential binding hydration, effective binding lookup, and OAuth payload values.
- Add shared credential slot binding UI and reuse it from OpenAPI edit.
- Reuse shared OAuth sign-in and scope dropdown primitives across MCP, GraphQL, and OpenAPI flows.
- Document the credential slot UI refactor direction in notes.

## Validation

- bun run format:check
- bun run lint
- bun run typecheck
- bun run test
