### PR TITLE
Require approval for source registration tools

### DIFF
--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Predicate } from "effect";
 
 import {
   ConnectionId,
   CreateConnectionInput,
   createExecutor,
+  definePlugin,
+  ElicitationResponse,
   makeTestConfig,
   RemoveSecretInput,
   Scope,
@@ -92,6 +94,31 @@ const introspectionResult: IntrospectionResult = {
 
 const introspectionJson = JSON.stringify({ data: introspectionResult });
 const serveGreetingServer = serveGraphqlTestServer({ schema: makeGreetingGraphqlSchema() });
+const declineAll = () => Effect.succeed(new ElicitationResponse({ action: "decline" }));
+
+const sampleDataPlugin = definePlugin(() => ({
+  id: "sample-read-test" as const,
+  storage: () => ({}),
+  staticSources: () => [
+    {
+      id: "sample",
+      kind: "in-memory",
+      name: "Sample",
+      tools: [
+        {
+          name: "read",
+          description: "Read sample data",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            additionalProperties: false,
+          },
+          handler: () => Effect.succeed("sample-value"),
+        },
+      ],
+    },
+  ],
+}));
 
 describe("graphqlPlugin real protocol server", () => {
   it.effect("adds a source by introspecting the live GraphQL endpoint", () =>
@@ -376,6 +403,67 @@ describe("graphqlPlugin", () => {
 
       const tools = yield* executor.tools.list();
       expect(tools.filter((t) => t.sourceId === "via_static").length).toBe(2);
+    }),
+  );
+
+  it.effect("requires approval before a runtime-added query sends prior tool output", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGreetingServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [sampleDataPlugin(), graphqlPlugin()] as const }),
+      );
+
+      const trusted = yield* executor.tools.invoke(
+        "sample.read",
+        {},
+        { onElicitation: declineAll },
+      );
+      expect(trusted).toBe("sample-value");
+      const declined = yield* executor.tools
+        .invoke(
+          "graphql.addSource",
+          {
+            endpoint: server.endpoint,
+            scope: TEST_SCOPE,
+            introspectionJson,
+            namespace: "runtime_graphql",
+          },
+          { onElicitation: declineAll },
+        )
+        .pipe(Effect.flip);
+      expect(Predicate.isTagged(declined, "ElicitationDeclinedError")).toBe(true);
+
+      const requests = yield* server.requests;
+      expect(
+        requests.some((request) => request.payload.variables?.name === "sample-value"),
+      ).toBe(false);
+    }),
+  );
+
+  it.effect("applies source headers to the introspection request after approval", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGreetingServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [graphqlPlugin()] as const }),
+      );
+
+      yield* executor.tools.invoke(
+        "graphql.addSource",
+        {
+          endpoint: server.endpoint,
+          scope: TEST_SCOPE,
+          namespace: "header_materialization",
+          headers: {
+            authorization: "Bearer sample-token",
+          },
+        },
+        { onElicitation: "accept-all" },
+      );
+
+      const requests = yield* server.requests;
+      expect(
+        requests.some((request) => request.headers.authorization === "Bearer sample-token"),
+      ).toBe(true);
     }),
   );
 

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -976,6 +976,10 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
           {
             name: "addSource",
             description: "Add a GraphQL endpoint and register its operations as tools",
+            annotations: {
+              requiresApproval: true,
+              approvalDescription: "Add a GraphQL source",
+            },
             inputSchema: {
               type: "object",
               properties: {

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -314,6 +314,28 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
     }),
   );
 
+  it.effect("requires approval before adding a source through the runtime tool", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [openApiPlugin()] as const }),
+      );
+
+      const declined = yield* executor.tools
+        .invoke(
+          "openapi.addSource",
+          { scope: TEST_SCOPE, spec: specJson, namespace: "runtime_declined" },
+          { onElicitation: () => Effect.succeed({ action: "decline" as const }) },
+        )
+        .pipe(Effect.flip);
+
+      expect(Predicate.isTagged(declined, "ElicitationDeclinedError")).toBe(true);
+      expect(yield* executor.openapi.getSource("runtime_declined", TEST_SCOPE)).toBeNull();
+      expect((yield* executor.tools.list()).map((t) => t.id)).not.toContain(
+        "runtime_declined.items.listItems",
+      );
+    }),
+  );
+
   it.effect("adds an org source whose direct credentials are owned by the user scope", () =>
     Effect.gen(function* () {
       const httpClient = yield* HttpClient.HttpClient;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -1167,6 +1167,10 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
           {
             name: "addSource",
             description: "Add an OpenAPI source and register its operations as tools",
+            annotations: {
+              requiresApproval: true,
+              approvalDescription: "Add an OpenAPI source",
+            },
             inputSchema: {
               type: "object",
               properties: {


### PR DESCRIPTION
## Summary

- Require approval before adding GraphQL sources through the runtime tool
- Require approval before adding OpenAPI sources through the runtime tool
- Add regression coverage for declined runtime source creation while preserving credentialed GraphQL introspection after approval

## Verification

- `bun run --cwd packages/plugins/graphql test src/sdk/plugin.test.ts`
- `bun run --cwd packages/plugins/graphql typecheck`
- `bun run --cwd packages/plugins/openapi test src/sdk/plugin.test.ts`
- `bun run --cwd packages/plugins/openapi typecheck`
