### PR TITLE
Bind OAuth sessions to route scopes

### DIFF
--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -72,6 +72,14 @@ const toPopupErrorMessage = (error: unknown): string => {
   return "Authentication failed";
 };
 
+const requireMatchingTokenScope = (
+  routeScope: string,
+  tokenScope: string,
+): Effect.Effect<void, OAuthStartError> =>
+  routeScope === tokenScope
+    ? Effect.void
+    : Effect.fail(new OAuthStartError({ message: "OAuth token scope must match route scope" }));
+
 export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handlers) =>
   handlers
     .handle("probe", ({ payload }) =>
@@ -96,9 +104,10 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
         }),
       ),
     )
-    .handle("start", ({ payload }) =>
+    .handle("start", ({ params: path, payload }) =>
       capture(
         Effect.gen(function* () {
+          yield* requireMatchingTokenScope(path.scopeId, payload.tokenScope);
           const executor = yield* ExecutorService;
           const headers = yield* resolveOAuthSecretBackedMap(
             executor,
@@ -124,21 +133,25 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
         }),
       ),
     )
-    .handle("complete", ({ payload }) =>
+    .handle("complete", ({ params: path, payload }) =>
       capture(
         Effect.gen(function* () {
           const executor = yield* ExecutorService;
           return yield* executor.oauth.complete({
             state: payload.state,
+            tokenScope: path.scopeId,
             code: payload.code,
             error: payload.error,
           });
         }),
       ),
     )
-    .handle("cancel", ({ payload }) =>
+    .handle("cancel", ({ params: path, payload }) =>
       capture(
         Effect.gen(function* () {
+          if (path.scopeId !== payload.tokenScope) {
+            return yield* new OAuthSessionNotFoundError({ sessionId: payload.sessionId });
+          }
           const executor = yield* ExecutorService;
           yield* executor.oauth.cancel(payload.sessionId, payload.tokenScope);
           return { cancelled: true };

--- a/packages/core/api/src/scoped-targets.test.ts
+++ b/packages/core/api/src/scoped-targets.test.ts
@@ -9,6 +9,7 @@ import {
   Scope,
   ScopeId,
   SecretId,
+  SetSecretInput,
   TokenMaterial,
   createExecutor,
   definePlugin,
@@ -174,6 +175,114 @@ describe("core API explicit target scopes", () => {
         where: [{ field: "id", value: connectionId }],
       })) as ReadonlyArray<{ readonly scope_id: string }>;
       expect(rows.map((row) => row.scope_id).sort()).toEqual([String(userScope)]);
+    }),
+  );
+
+  it.effect("OAuth start requires the route scope to match the requested token scope", () =>
+    Effect.gen(function* () {
+      const userScope = ScopeId.make("api-user");
+      const orgScope = ScopeId.make("api-org");
+      const config = makeTestConfig({
+        scopes: [scope(userScope, "user"), scope(orgScope, "org")],
+        plugins: [memorySecretsPlugin(), connectionProviderPlugin()] as const,
+      });
+      const executor = yield* createExecutor(config);
+      const web = yield* webHandlerFor(executor);
+      const context = handlerContextFor(executor);
+
+      const response = yield* Effect.promise(() =>
+        web.handler(
+          new Request(`http://localhost/scopes/${userScope}/oauth/start`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              endpoint: "https://api.example.com",
+              redirectUrl: "https://app.example.com/oauth/callback",
+              connectionId: "example-oauth",
+              tokenScope: orgScope,
+              pluginId: "test-connection-provider",
+              strategy: {
+                kind: "authorization-code",
+                authorizationEndpoint: "https://auth.example.com/oauth/authorize",
+                tokenEndpoint: "https://auth.example.com/oauth/token",
+                clientIdSecretId: "client-id",
+                clientSecretSecretId: null,
+                scopes: [],
+              },
+            }),
+          }),
+          context,
+        ),
+      );
+
+      expect(response.status).toBe(400);
+      const sessions = yield* config.adapter.findMany({ model: "oauth2_session" });
+      expect(sessions).toEqual([]);
+    }),
+  );
+
+  it.effect("OAuth complete requires the route scope to match the pending session scope", () =>
+    Effect.gen(function* () {
+      const userScope = ScopeId.make("api-user");
+      const orgScope = ScopeId.make("api-org");
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          scopes: [scope(userScope, "user"), scope(orgScope, "org")],
+          plugins: [memorySecretsPlugin(), connectionProviderPlugin()] as const,
+        }),
+      );
+      const web = yield* webHandlerFor(executor);
+      const context = handlerContextFor(executor);
+
+      yield* executor.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("client-id"),
+          scope: userScope,
+          name: "Client ID",
+          value: "client-id-value",
+        }),
+      );
+      const started = yield* executor.oauth.start({
+        endpoint: "https://api.example.com",
+        redirectUrl: "https://app.example.com/oauth/callback",
+        connectionId: "example-oauth",
+        tokenScope: String(userScope),
+        pluginId: "test-connection-provider",
+        strategy: {
+          kind: "authorization-code",
+          authorizationEndpoint: "https://auth.example.com/oauth/authorize",
+          tokenEndpoint: "https://auth.example.com/oauth/token",
+          clientIdSecretId: "client-id",
+          clientSecretSecretId: null,
+          scopes: [],
+        },
+      });
+
+      const response = yield* Effect.promise(() =>
+        web.handler(
+          new Request(`http://localhost/scopes/${orgScope}/oauth/complete`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ state: started.sessionId, code: "code" }),
+          }),
+          context,
+        ),
+      );
+
+      expect(response.status).toBe(404);
+      const row = yield* executor.oauth
+        .complete({
+          state: started.sessionId,
+          tokenScope: String(orgScope),
+          error: "cancelled",
+        })
+        .pipe(
+          Effect.match({
+            onFailure: (error) => error,
+            onSuccess: () => null,
+          }),
+        );
+      expect(row).toMatchObject({ _tag: "OAuthSessionNotFoundError" });
     }),
   );
 });

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -497,7 +497,7 @@ export const makeOAuth2Service = (
         issuerUrl: strategy.issuerUrl ?? new URL(strategy.authorizationEndpoint).origin,
         clientIdSecretId: strategy.clientIdSecretId,
         clientIdSecretScopeId: clientIdRef.scopeId,
-        clientSecretSecretId: strategy.clientSecretSecretId,
+        clientSecretSecretId: strategy.clientSecretSecretId ?? null,
         clientSecretSecretScopeId: strategy.clientSecretSecretId
           ? ((yield* secretsGetResolved(strategy.clientSecretSecretId))?.scopeId ?? null)
           : null,
@@ -667,6 +667,9 @@ export const makeOAuth2Service = (
         where: [{ field: "id", value: input.state }],
       });
       if (!row) {
+        return yield* new OAuthSessionNotFoundError({ sessionId: input.state });
+      }
+      if (input.tokenScope !== undefined && row.token_scope !== input.tokenScope) {
         return yield* new OAuthSessionNotFoundError({ sessionId: input.state });
       }
 

--- a/packages/core/sdk/src/oauth.ts
+++ b/packages/core/sdk/src/oauth.ts
@@ -246,6 +246,9 @@ export interface OAuthStartResult {
 export interface OAuthCompleteInput {
   /** RFC 6749 `state` parameter — maps to a session row id. */
   readonly state: string;
+  /** Optional scope check for route-scoped completions. Browser callback
+   *  completions omit this because the callback URL has no scope path. */
+  readonly tokenScope?: string;
   readonly code?: string;
   /** RFC 6749 `error` parameter — set when the AS redirected back with
    *  a failure. The service surfaces this as a tagged error. */
@@ -267,22 +270,26 @@ export interface OAuthCompleteResult {
 // capable plugin group `.addError(OAuthStartError)` etc. and the HTTP
 // edge renders them with the annotated status.
 
-export class OAuthProbeError extends Schema.TaggedErrorClass<OAuthProbeError>()("OAuthProbeError", {
-  message: Schema.String,
-}) {
-  static annotations = { httpApiStatus: 400 };
-}
+export class OAuthProbeError extends Schema.TaggedErrorClass<OAuthProbeError>()(
+  "OAuthProbeError",
+  {
+    message: Schema.String,
+  },
+  { httpApiStatus: 400 },
+) {}
 
-export class OAuthStartError extends Schema.TaggedErrorClass<OAuthStartError>()("OAuthStartError", {
-  message: Schema.String,
-  /** RFC 6749 §5.2 / RFC 7591 §3.2.2 error code propagated up from the
-   *  authorization server (e.g. `invalid_client_metadata`). UI surfaces
-   *  it as the structured "AS rejected the registration" reason. */
-  error: Schema.optional(Schema.String),
-  errorDescription: Schema.optional(Schema.String),
-}) {
-  static annotations = { httpApiStatus: 400 };
-}
+export class OAuthStartError extends Schema.TaggedErrorClass<OAuthStartError>()(
+  "OAuthStartError",
+  {
+    message: Schema.String,
+    /** RFC 6749 §5.2 / RFC 7591 §3.2.2 error code propagated up from the
+     *  authorization server (e.g. `invalid_client_metadata`). UI surfaces
+     *  it as the structured "AS rejected the registration" reason. */
+    error: Schema.optional(Schema.String),
+    errorDescription: Schema.optional(Schema.String),
+  },
+  { httpApiStatus: 400 },
+) {}
 
 export class OAuthCompleteError extends Schema.TaggedErrorClass<OAuthCompleteError>()(
   "OAuthCompleteError",
@@ -293,18 +300,16 @@ export class OAuthCompleteError extends Schema.TaggedErrorClass<OAuthCompleteErr
      *  re-auth required) from transient ones. */
     code: Schema.optional(Schema.String),
   },
-) {
-  static annotations = { httpApiStatus: 400 };
-}
+  { httpApiStatus: 400 },
+) {}
 
 export class OAuthSessionNotFoundError extends Schema.TaggedErrorClass<OAuthSessionNotFoundError>()(
   "OAuthSessionNotFoundError",
   {
     sessionId: Schema.String,
   },
-) {
-  static annotations = { httpApiStatus: 404 };
-}
+  { httpApiStatus: 404 },
+) {}
 
 // ---------------------------------------------------------------------------
 // Contract — what `ctx.oauth` exposes. Implementation lives in


### PR DESCRIPTION
## Summary

- Require OAuth start and cancel requests to use the same route scope as the requested token scope.
- Let route-scoped OAuth complete calls check the pending session scope before exchanging a code.
- Use HTTP-encoded OAuth errors consistently and cover the route-scope behavior with core API tests.

## Validation

- `cd packages/core/api && bunx vitest run src/scoped-targets.test.ts`
- `cd packages/core/api && bun run typecheck`
- `cd packages/core/sdk && bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`