### PR TITLE
Keep OpenAPI credentials bound to destinations

### DIFF
--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -944,7 +944,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
     }),
   );
 
-  it.effect("updateSource on user shadow does not mutate the org row", () =>
+  it.effect("updateSource on user shadow cannot override the inherited base URL", () =>
     Effect.gen(function* () {
       const httpClient = yield* HttpClient.HttpClient;
       const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
@@ -970,22 +970,81 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
         spec: specJson,
         scope: String(USER_SCOPE),
         namespace: "shared",
-        baseUrl: "https://user.example.com",
         name: "User Source",
       });
 
-      yield* executor.openapi.updateSource("shared", String(USER_SCOPE), {
-        name: "User Renamed",
-        baseUrl: "https://user-new.example.com",
-      });
+      const updateResult = yield* executor.openapi
+        .updateSource("shared", String(USER_SCOPE), {
+          name: "User Renamed",
+          baseUrl: "https://user-new.example.com",
+        })
+        .pipe(
+          Effect.match({
+            onFailure: (error) => error,
+            onSuccess: () => null,
+          }),
+        );
 
       const userView = yield* executor.openapi.getSource("shared", String(USER_SCOPE));
       const orgView = yield* executor.openapi.getSource("shared", String(ORG_SCOPE));
 
-      expect(userView?.name).toBe("User Renamed");
-      expect(userView?.config.baseUrl).toBe("https://user-new.example.com");
+      expect(updateResult).toMatchObject({ _tag: "OpenApiOAuthError" });
+      expect(userView?.name).toBe("User Source");
+      expect(userView?.config.baseUrl).toBe("https://org.example.com");
       expect(orgView?.name).toBe("Org Source");
       expect(orgView?.config.baseUrl).toBe("https://org.example.com");
+    }),
+  );
+
+  it.effect("addSpec on user shadow cannot override the inherited base URL", () =>
+    Effect.gen(function* () {
+      const server = yield* makeOpenApiTestServer({ spec });
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          scopes: stackedScopes,
+          plugins: [
+            openApiPlugin({ httpClientLayer: server.httpClientLayer }),
+            memorySecretsPlugin(),
+          ] as const,
+        }),
+      );
+
+      yield* executor.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("org-api-token"),
+          scope: ORG_SCOPE,
+          name: "Org API token",
+          value: "org-secret",
+        }),
+      );
+
+      yield* executor.openapi.addSpec({
+        spec: server.specJson,
+        scope: String(ORG_SCOPE),
+        namespace: "shadow_auth",
+        baseUrl: "https://org.example.com",
+        credentialTargetScope: String(ORG_SCOPE),
+        headers: {
+          Authorization: { secretId: "org-api-token", prefix: "Bearer " },
+        },
+      });
+
+      const addResult = yield* executor.openapi
+        .addSpec({
+          spec: server.specJson,
+          scope: String(USER_SCOPE),
+          namespace: "shadow_auth",
+          baseUrl: server.baseUrl,
+          name: "User Shadow",
+        })
+        .pipe(
+          Effect.match({
+            onFailure: (error) => error,
+            onSuccess: () => null,
+          }),
+        );
+
+      expect(addResult).toMatchObject({ _tag: "OpenApiOAuthError" });
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -529,20 +529,29 @@ const targetScopeForBinding = (
   );
 };
 
+const findOuterSource = (
+  ctx: PluginCtx<OpenapiStore>,
+  namespace: string,
+  scope: string,
+): Effect.Effect<StoredSource | null, StorageFailure> =>
+  Effect.gen(function* () {
+    const ranks = scopeRanks(ctx);
+    const baseRank = scopeRank(ranks, scope);
+    for (let index = baseRank + 1; index < ctx.scopes.length; index++) {
+      const candidateScope = ctx.scopes[index];
+      if (!candidateScope) continue;
+      const source = yield* ctx.storage.getSource(namespace, candidateScope.id);
+      if (source) return source;
+    }
+    return null;
+  });
+
 const resolveEffectiveSourceConfig = (
   ctx: PluginCtx<OpenapiStore>,
   base: StoredSource,
 ): Effect.Effect<EffectiveSourceConfig, StorageFailure> =>
   Effect.gen(function* () {
-    const ranks = scopeRanks(ctx);
-    const baseRank = scopeRank(ranks, base.scope);
-    let fallback: StoredSource | null = null;
-    for (let index = baseRank + 1; index < ctx.scopes.length; index++) {
-      const scope = ctx.scopes[index];
-      if (!scope) continue;
-      fallback = yield* ctx.storage.getSource(base.namespace, scope.id);
-      if (fallback) break;
-    }
+    const fallback = yield* findOuterSource(ctx, base.namespace, base.scope);
 
     if (!fallback) {
       return {
@@ -561,7 +570,7 @@ const resolveEffectiveSourceConfig = (
       config: {
         ...base.config,
         sourceUrl: base.config.sourceUrl ?? fallback.config.sourceUrl,
-        baseUrl: base.config.baseUrl || fallback.config.baseUrl,
+        baseUrl: fallback.config.baseUrl,
         namespace: base.config.namespace ?? fallback.config.namespace,
         headers: hasBaseHeaders ? base.config.headers : fallback.config.headers,
         queryParams: hasBaseQueryParams ? base.config.queryParams : fallback.config.queryParams,
@@ -806,6 +815,12 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         Option.getOrElse(result.title, () => "api")
           .toLowerCase()
           .replace(/[^a-z0-9]+/g, "_");
+      const outerSource = yield* findOuterSource(ctx, namespace, input.scope);
+      if (outerSource && input.baseUrl !== undefined && input.baseUrl.trim() !== "") {
+        return yield* new OpenApiOAuthError({
+          message: "OpenAPI source shadows inherit the outer source base URL",
+        });
+      }
 
       const hoistedDefs: Record<string, unknown> = {};
       if (doc.components?.schemas) {
@@ -814,7 +829,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         }
       }
 
-      const baseUrl = input.baseUrl ?? resolveBaseUrl(result.servers);
+      const baseUrl = outerSource ? undefined : (input.baseUrl ?? resolveBaseUrl(result.servers));
       const canonicalHeaders = canonicalizeHeaders(input.headers);
       const canonicalQueryParams = canonicalizeCredentialMap(
         input.queryParams,
@@ -1073,6 +1088,14 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
               ...(input.oauth2 !== undefined ? ["oauth2:"] : []),
             ];
             const targetScope = input.credentialTargetScope ?? scope;
+            if (input.baseUrl !== undefined && input.baseUrl.trim() !== "") {
+              const outerSource = yield* findOuterSource(ctx, namespace, scope);
+              if (outerSource) {
+                return yield* new OpenApiOAuthError({
+                  message: "OpenAPI source shadows inherit the outer source base URL",
+                });
+              }
+            }
             if (affectedPrefixes.length > 0 || directBindings.length > 0) {
               yield* validateOpenApiBindingTarget(ctx, {
                 sourceId: namespace,


### PR DESCRIPTION
## Summary

- Stop OpenAPI user shadows with a changed base URL from inheriting invocation headers, query params, or OAuth configuration from an outer source.
- Require common sensitive OpenAPI headers to use credential bindings instead of raw stored header values.
- Add OpenAPI plugin tests for changed-destination shadow behavior and sensitive header binding requirements.

## Validation

- `cd packages/plugins/openapi && bunx vitest run src/sdk/plugin.test.ts`
- `cd packages/plugins/openapi && bun run typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`