### PR TITLE
Include source identity in MCP connection state

### DIFF
--- a/packages/plugins/mcp/src/sdk/connection-pool.test.ts
+++ b/packages/plugins/mcp/src/sdk/connection-pool.test.ts
@@ -123,7 +123,7 @@ const serveMcpServer = Effect.acquireRelease(
 // Helper — one executor, one mcp source pointed at the test server
 // ---------------------------------------------------------------------------
 
-const makeTestExecutor = (serverUrl: string) =>
+const makeTestExecutor = (serverUrl: string, namespace = "pool-test") =>
   createExecutor(
     makeTestConfig({
       plugins: [mcpPlugin()] as const,
@@ -133,7 +133,8 @@ const makeTestExecutor = (serverUrl: string) =>
       executor.mcp.addSource({
         transport: "remote",
         scope: "test-scope",
-        name: "pool-test",
+        name: namespace,
+        namespace,
         endpoint: serverUrl,
       }),
     ),
@@ -205,6 +206,52 @@ describe("MCP connection pooling (regression)", () => {
       // Back to the first tool — still pooled.
       yield* executor.tools.invoke(echo.id, { value: "c" }, { onElicitation: "accept-all" });
       expect(server.sessionCount()).toBe(baseline);
+    }),
+  );
+
+  it.effect("different sources with the same endpoint use separate cached connections", () =>
+    Effect.gen(function* () {
+      const server = yield* serveMcpServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [mcpPlugin()] as const,
+        }),
+      );
+      yield* executor.mcp.addSource({
+        transport: "remote",
+        scope: "test-scope",
+        name: "pool-a",
+        namespace: "pool_a",
+        endpoint: server.url,
+      });
+      yield* executor.mcp.addSource({
+        transport: "remote",
+        scope: "test-scope",
+        name: "pool-b",
+        namespace: "pool_b",
+        endpoint: server.url,
+      });
+
+      const tools = yield* executor.tools.list();
+      const echoTools = tools.filter((t) => t.name === "echo");
+      expect(echoTools).toHaveLength(2);
+
+      const sessionsAfterAddSource = server.sessionCount();
+
+      yield* executor.tools.invoke(
+        echoTools[0]!.id,
+        { value: "a" },
+        { onElicitation: "accept-all" },
+      );
+      const afterFirstInvoke = server.sessionCount();
+      expect(afterFirstInvoke).toBe(sessionsAfterAddSource + 1);
+
+      yield* executor.tools.invoke(
+        echoTools[1]!.id,
+        { value: "b" },
+        { onElicitation: "accept-all" },
+      );
+      expect(server.sessionCount()).toBe(afterFirstInvoke + 1);
     }),
   );
 });

--- a/packages/plugins/mcp/src/sdk/invoke.ts
+++ b/packages/plugins/mcp/src/sdk/invoke.ts
@@ -35,16 +35,54 @@ const decodeArgsRecord = Schema.decodeUnknownOption(ArgsRecord);
 const argsRecord = (value: unknown): Record<string, unknown> =>
   Option.getOrElse(decodeArgsRecord(value), () => ({}));
 
-const connectionCacheKey = (sd: McpStoredSourceData, invokerScope: string): string =>
-  sd.transport === "stdio"
-    ? `stdio:${sd.command}`
-    : // Remote sources may resolve per-user secrets (OAuth tokens, header
-      // auth) via scope shadowing, so two users invoking the same source
-      // get different Authorization headers. The connection caches that
-      // header in transport state, so the cache key must include the
-      // invoking scope — otherwise user B re-uses user A's connection
-      // (and user A's tokens).
-      `remote:${invokerScope}:${sd.endpoint}`;
+const stableJson = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+};
+
+const fingerprint = (value: unknown): string => {
+  const input = stableJson(value);
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+};
+
+const connectionCacheKey = (input: {
+  readonly sourceData: McpStoredSourceData;
+  readonly invokerScope: string;
+  readonly sourceId: string;
+  readonly sourceScope: string;
+}): string => {
+  const sd = input.sourceData;
+  return sd.transport === "stdio"
+    ? `stdio:${fingerprint({
+        sourceId: input.sourceId,
+        sourceScope: input.sourceScope,
+        command: sd.command,
+        args: sd.args ?? [],
+        env: sd.env ?? {},
+        cwd: sd.cwd ?? null,
+      })}`
+    : `remote:${fingerprint({
+        sourceId: input.sourceId,
+        sourceScope: input.sourceScope,
+        invokerScope: input.invokerScope,
+        endpoint: sd.endpoint,
+        remoteTransport: sd.remoteTransport ?? "auto",
+        headers: sd.headers ?? {},
+        queryParams: sd.queryParams ?? {},
+        auth: sd.auth,
+      })}`;
+};
 
 // ---------------------------------------------------------------------------
 // Elicitation bridge — decode incoming MCP ElicitRequest, route through
@@ -146,6 +184,8 @@ export interface InvokeMcpToolInput {
   readonly toolName: string;
   readonly args: unknown;
   readonly sourceData: McpStoredSourceData;
+  readonly sourceId: string;
+  readonly sourceScope: string;
   /** Innermost executor scope id at invoke time. Mixed into the
    *  connection cache key so per-user OAuth/secret resolution doesn't
    *  collapse multiple users onto one shared connection. */
@@ -162,7 +202,7 @@ export const invokeMcpTool = (
   const transport: string =
     input.sourceData.transport === "stdio" ? "stdio" : (input.sourceData.remoteTransport ?? "auto");
   return Effect.gen(function* () {
-    const cacheKey = connectionCacheKey(input.sourceData, input.invokerScope);
+    const cacheKey = connectionCacheKey(input);
     const args = argsRecord(input.args);
 
     // Register the connector for the cache lookup (side-channel pattern

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1581,6 +1581,8 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           toolName: entry.binding.toolName,
           args,
           sourceData: sd,
+          sourceId: entry.namespace,
+          sourceScope: toolScope,
           invokerScope: ctx.scopes[0]!.id,
           resolveConnector: () =>
             resolveConnectorInput(entry.namespace, toolScope, sd, ctx, allowStdio).pipe(


### PR DESCRIPTION
## Summary
- include source id and source scope in MCP connection cache identity
- fingerprint endpoint, transport, invoker scope, and auth-affecting source configuration for cached transports
- add regression coverage for two sources sharing an endpoint while keeping separate cached connections

## Verification
- cd packages/plugins/mcp && bunx vitest run src/sdk/connection-pool.test.ts src/sdk/per-user-auth-isolation.test.ts
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test