### PR TITLE
Bind execution continuations to callers

### DIFF
--- a/apps/cloud/src/mcp-session.ts
+++ b/apps/cloud/src/mcp-session.ts
@@ -303,6 +303,7 @@ export class McpSessionDO extends DurableObject {
         description,
         parentSpan: () => self.currentRequestSpan ?? undefined,
         debug: env.EXECUTOR_MCP_DEBUG === "true",
+        continuationOwnerId: sessionMeta.userId,
       }).pipe(Effect.withSpan("McpSessionDO.createExecutorMcpServer"));
       const transport = yield* makeMcpWorkerTransport({
         sessionIdGenerator: () => self.ctx.id.toString(),
@@ -662,6 +663,28 @@ export class McpSessionDO extends DurableObject {
         Effect.provide(DoTelemetryLive),
       ),
     );
+  }
+
+  async clearSessionForOwner(
+    token: McpSessionInit,
+    incoming?: IncomingTraceHeaders,
+  ): Promise<boolean> {
+    const self = this;
+    const program = Effect.gen(function* () {
+      const sessionMeta = yield* self.loadSessionMeta();
+      if (!sessionMeta) return false;
+      const matches =
+        sessionMeta.userId === token.userId && sessionMeta.organizationId === token.organizationId;
+      yield* Effect.annotateCurrentSpan({ "mcp.session.owner_match": matches });
+      if (!matches) return false;
+      yield* Effect.promise(() => self.cleanup());
+      return true;
+    }).pipe(
+      Effect.withSpan("McpSessionDO.clearSessionForOwner"),
+      (eff) => withIncomingParent(incoming, eff),
+      Effect.provide(DoTelemetryLive),
+    );
+    return Effect.runPromise(program);
   }
 
   private async runAlarm(): Promise<void> {

--- a/packages/core/execution/src/engine.ts
+++ b/packages/core/execution/src/engine.ts
@@ -4,10 +4,10 @@ import type * as Cause from "effect/Cause";
 import type {
   Executor,
   InvokeOptions,
-  ElicitationResponse,
   ElicitationHandler,
   ElicitationContext,
 } from "@executor-js/sdk/core";
+import { ElicitationResponse } from "@executor-js/sdk/core";
 import { CodeExecutionError } from "@executor-js/codemode-core";
 import type { CodeExecutor, ExecuteResult, SandboxToolInvoker } from "@executor-js/codemode-core";
 
@@ -27,6 +27,8 @@ import { buildExecuteDescription } from "./description";
 export type ExecutionEngineConfig<E extends Cause.YieldableError = CodeExecutionError> = {
   readonly executor: Executor;
   readonly codeExecutor: CodeExecutor<E>;
+  readonly maxPausedExecutionsPerOwner?: number;
+  readonly pausedExecutionTtlMs?: number;
 };
 
 export type ExecutionResult =
@@ -40,14 +42,20 @@ export type PausedExecution = {
 
 /** Internal representation with Effect runtime state for pause/resume. */
 type InternalPausedExecution<E> = PausedExecution & {
+  readonly ownerId: string | null;
   readonly response: Deferred.Deferred<typeof ElicitationResponse.Type>;
   readonly fiber: Fiber.Fiber<ExecuteResult, E>;
   readonly pauseSignalRef: Ref.Ref<Deferred.Deferred<InternalPausedExecution<E>>>;
+  timeoutId?: ReturnType<typeof setTimeout>;
 };
 
 export type ResumeResponse = {
   readonly action: "accept" | "decline" | "cancel";
   readonly content?: Record<string, unknown>;
+};
+
+export type ExecutionOwner = {
+  readonly ownerId?: string | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -323,7 +331,10 @@ export type ExecutionEngine<E extends Cause.YieldableError = CodeExecutionError>
    * Use this when the host doesn't support inline elicitation.
    * Returns either a completed result or a paused execution that can be resumed.
    */
-  readonly executeWithPause: (code: string) => Effect.Effect<ExecutionResult, E>;
+  readonly executeWithPause: (
+    code: string,
+    options?: ExecutionOwner,
+  ) => Effect.Effect<ExecutionResult, E>;
 
   /**
    * Resume a paused execution. Returns a completed result, a new pause, or
@@ -332,6 +343,7 @@ export type ExecutionEngine<E extends Cause.YieldableError = CodeExecutionError>
   readonly resume: (
     executionId: string,
     response: ResumeResponse,
+    options?: ExecutionOwner,
   ) => Effect.Effect<ExecutionResult | null, E>;
 
   /**
@@ -345,7 +357,20 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
 ): ExecutionEngine<E> => {
   const { executor, codeExecutor } = config;
   const pausedExecutions = new Map<string, InternalPausedExecution<E>>();
+  const maxPausedExecutionsPerOwner = Math.max(
+    1,
+    Math.floor(config.maxPausedExecutionsPerOwner ?? 32),
+  );
+  const pausedExecutionTtlMs = Math.max(1, Math.floor(config.pausedExecutionTtlMs ?? 300_000));
   let nextId = 0;
+
+  const countPausedForOwner = (ownerId: string | null): number => {
+    let count = 0;
+    for (const paused of pausedExecutions.values()) {
+      if (paused.ownerId === ownerId) count++;
+    }
+    return count;
+  };
 
   /**
    * Race a running fiber against a pause signal. Returns when either
@@ -379,7 +404,10 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
    * The sandbox is forked as a daemon because paused executions can outlive the
    * caller scope that returned the first pause, such as an HTTP request handler.
    */
-  const startPausableExecution = Effect.fn("mcp.execute")(function* (code: string) {
+  const startPausableExecution = Effect.fn("mcp.execute")(function* (
+    code: string,
+    options?: ExecutionOwner,
+  ) {
     yield* Effect.annotateCurrentSpan({
       "mcp.execute.mode": "pausable",
       "mcp.execute.code_length": code.length,
@@ -395,17 +423,36 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
 
     const elicitationHandler: ElicitationHandler = (ctx) =>
       Effect.gen(function* () {
+        const ownerId = options?.ownerId ?? null;
+        if (countPausedForOwner(ownerId) >= maxPausedExecutionsPerOwner) {
+          return new ElicitationResponse({ action: "cancel" });
+        }
+
         const responseDeferred = yield* Deferred.make<typeof ElicitationResponse.Type>();
         const id = `exec_${++nextId}`;
 
         const paused: InternalPausedExecution<E> = {
           id,
+          ownerId,
           elicitationContext: ctx,
           response: responseDeferred,
           fiber: fiber!,
           pauseSignalRef,
         };
         pausedExecutions.set(id, paused);
+        paused.timeoutId = setTimeout(() => {
+          if (pausedExecutions.get(id) !== paused) return;
+          pausedExecutions.delete(id);
+          Effect.runFork(
+            Effect.gen(function* () {
+              yield* Deferred.succeed(paused.response, {
+                action: "cancel",
+                content: undefined,
+              });
+              yield* Fiber.interrupt(fiber!);
+            }),
+          );
+        }, pausedExecutionTtlMs);
 
         const currentSignal = yield* Ref.get(pauseSignalRef);
         yield* Deferred.succeed(currentSignal, paused);
@@ -431,6 +478,7 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
   const resumeExecution = Effect.fn("mcp.execute.resume")(function* (
     executionId: string,
     response: ResumeResponse,
+    options?: ExecutionOwner,
   ) {
     yield* Effect.annotateCurrentSpan({
       "mcp.execute.resume.action": response.action,
@@ -438,7 +486,9 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
 
     const paused = pausedExecutions.get(executionId);
     if (!paused) return null;
+    if (paused.ownerId !== null && paused.ownerId !== (options?.ownerId ?? null)) return null;
     pausedExecutions.delete(executionId);
+    clearTimeout(paused.timeoutId);
 
     // Swap in a fresh pause signal BEFORE unblocking the fiber, so the
     // next elicitation handler call signals this new Deferred.

--- a/packages/core/execution/src/promise.ts
+++ b/packages/core/execution/src/promise.ts
@@ -26,6 +26,7 @@ import {
   createExecutionEngine as createEffectExecutionEngine,
   type ExecutionEngine as EffectExecutionEngine,
   type ExecutionResult,
+  type ExecutionOwner,
   type PausedExecution,
   type ResumeResponse,
 } from "./engine";
@@ -42,10 +43,11 @@ export type ExecutionEngine = {
     code: string,
     options: { readonly onElicitation: ElicitationHandler },
   ) => Promise<ExecuteResult>;
-  readonly executeWithPause: (code: string) => Promise<ExecutionResult>;
+  readonly executeWithPause: (code: string, options?: ExecutionOwner) => Promise<ExecutionResult>;
   readonly resume: (
     executionId: string,
     response: ResumeResponse,
+    options?: ExecutionOwner,
   ) => Promise<ExecutionResult | null>;
   readonly getDescription: () => Promise<string>;
 };
@@ -158,8 +160,9 @@ export const toPromiseExecutionEngine = <E extends Cause.YieldableError>(
           Effect.tryPromise(() => options.onElicitation(ctx)).pipe(Effect.orDie),
       }),
     ),
-  executeWithPause: (code) => Effect.runPromise(engine.executeWithPause(code)),
-  resume: (executionId, response) => Effect.runPromise(engine.resume(executionId, response)),
+  executeWithPause: (code, options) => Effect.runPromise(engine.executeWithPause(code, options)),
+  resume: (executionId, response, options) =>
+    Effect.runPromise(engine.resume(executionId, response, options)),
   getDescription: () => Effect.runPromise(engine.getDescription),
 });
 
@@ -179,7 +182,7 @@ export const createExecutionEngine = <E extends Cause.YieldableError = CodeExecu
 
 export { formatExecuteResult, formatPausedExecution } from "./engine";
 
-export type { ExecutionResult, PausedExecution, ResumeResponse };
+export type { ExecutionOwner, ExecutionResult, PausedExecution, ResumeResponse };
 
 export { buildExecuteDescription } from "./description";
 export { ExecutionToolError } from "./errors";

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -526,6 +526,75 @@ describe("pause/resume with multiple elicitations", () => {
     { timeout: 10000 },
   );
 
+  it.effect("resume requires the same owner when one is provided", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeElicitingExecutor();
+      const engine = createExecutionEngine({ executor, codeExecutor });
+
+      const outcome1 = yield* engine.executeWithPause(
+        "return await tools.api.singleApproval({});",
+        { ownerId: "member-a" },
+      );
+      expect(outcome1.status).toBe("paused");
+      const paused1 = outcome1 as Extract<typeof outcome1, { status: "paused" }>;
+
+      const otherOwner = yield* engine.resume(
+        paused1.execution.id,
+        { action: "accept" },
+        { ownerId: "member-b" },
+      );
+      expect(otherOwner).toBeNull();
+
+      const sameOwner = yield* engine.resume(
+        paused1.execution.id,
+        { action: "accept" },
+        { ownerId: "member-a" },
+      );
+      expect(sameOwner?.status).toBe("completed");
+    }),
+  );
+
+  it.effect("resume remains available when no owner is provided", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeElicitingExecutor();
+      const engine = createExecutionEngine({ executor, codeExecutor });
+
+      const outcome1 = yield* engine.executeWithPause("return await tools.api.singleApproval({});");
+      expect(outcome1.status).toBe("paused");
+      const paused1 = outcome1 as Extract<typeof outcome1, { status: "paused" }>;
+
+      const resumed = yield* engine.resume(paused1.execution.id, { action: "accept" });
+      expect(resumed?.status).toBe("completed");
+    }),
+  );
+
+  it.effect("paused execution expires after the configured lifetime", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeElicitingExecutor();
+      const engine = createExecutionEngine({
+        executor,
+        codeExecutor,
+        pausedExecutionTtlMs: 10,
+      });
+
+      const outcome1 = yield* engine.executeWithPause(
+        "return await tools.api.singleApproval({});",
+        { ownerId: "member-a" },
+      );
+      expect(outcome1.status).toBe("paused");
+      const paused1 = outcome1 as Extract<typeof outcome1, { status: "paused" }>;
+
+      yield* Effect.promise(() => new Promise((resolve) => setTimeout(resolve, 30)));
+
+      const resumed = yield* engine.resume(
+        paused1.execution.id,
+        { action: "accept" },
+        { ownerId: "member-a" },
+      );
+      expect(resumed).toBeNull();
+    }),
+  );
+
   // Regression: use separate top-level runPromise calls to match HTTP/CLI
   // pause/resume, and a single-elicit tool so no later pause can mask a dead
   // sandbox fiber.

--- a/packages/hosts/mcp/src/server.test.ts
+++ b/packages/hosts/mcp/src/server.test.ts
@@ -38,8 +38,12 @@ const withClient = async <E extends Cause.YieldableError>(
   engine: ExecutionEngine<E>,
   capabilities: ClientCapabilities,
   fn: (client: Client) => Promise<void>,
+  options: {
+    readonly continuationOwnerId?: string;
+    readonly enableModelVisibleResumeTool?: boolean;
+  } = {},
 ) => {
-  const mcpServer = await Effect.runPromise(createExecutorMcpServer({ engine }));
+  const mcpServer = await Effect.runPromise(createExecutorMcpServer({ engine, ...options }));
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities });
   await mcpServer.connect(serverTransport);
@@ -360,16 +364,16 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
     });
   });
 
-  it("both execute and resume tools are visible", async () => {
+  it("resume tool is hidden by default", async () => {
     await withClient(makeStubEngine({}), NO_CAPS, async (client) => {
       const { tools } = await client.listTools();
       const names = tools.map((t) => t.name);
       expect(names).toContain("execute");
-      expect(names).toContain("resume");
+      expect(names).not.toContain("resume");
     });
   });
 
-  it("paused execution returns interaction metadata with executionId", async () => {
+  it("paused execution returns interaction metadata without a continuation handle", async () => {
     const engine = makeStubEngine({
       executeWithPause: () =>
         Effect.succeed(
@@ -391,12 +395,11 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         name: "execute",
         arguments: { code: "pause-me" },
       });
-      expect(textOf(result)).toContain("exec_42");
-      expect(textOf(result)).toContain("Need approval");
+      expect(textOf(result)).toBe("Execution paused for interaction.");
       expect(result.isError).toBeFalsy();
 
       const structured = result.structuredContent as Record<string, unknown>;
-      expect(structured?.executionId).toBe("exec_42");
+      expect(structured?.executionId).toBeUndefined();
       expect(structured?.status).toBe("waiting_for_interaction");
     });
   });
@@ -411,14 +414,53 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         ),
     });
 
-    await withClient(engine, NO_CAPS, async (client) => {
-      const result = await client.callTool({
-        name: "resume",
-        arguments: { executionId: "exec_1", action: "accept", content: "{}" },
-      });
-      expect(result.content).toEqual([{ type: "text", text: "resumed-ok" }]);
-      expect(result.isError).toBeFalsy();
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_1", action: "accept", content: "{}" },
+        });
+        expect(result.content).toEqual([{ type: "text", text: "resumed-ok" }]);
+        expect(result.isError).toBeFalsy();
+      },
+      { enableModelVisibleResumeTool: true },
+    );
+  });
+
+  it("resume tool passes continuation owner to the engine", async () => {
+    const owners: Array<string | null | undefined> = [];
+    const engine = makeStubEngine({
+      executeWithPause: (_code, options) =>
+        Effect.sync(() => {
+          owners.push(options?.ownerId);
+          return makePausedResult(
+            "exec_1",
+            new FormElicitation({ message: "Need approval", requestedSchema: {} }),
+          );
+        }),
+      resume: (_executionId, _response, options) =>
+        Effect.sync(() => {
+          owners.push(options?.ownerId);
+          return { status: "completed", result: { result: "resumed-ok" } };
+        }),
     });
+
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        await client.callTool({ name: "execute", arguments: { code: "pause-me" } });
+        await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_1", action: "accept", content: "{}" },
+        });
+      },
+      { continuationOwnerId: "member-a", enableModelVisibleResumeTool: true },
+    );
+
+    expect(owners).toEqual(["member-a", "member-a"]);
   });
 
   it("resume tool passes parsed content to engine", async () => {
@@ -431,17 +473,22 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         }),
     });
 
-    await withClient(engine, NO_CAPS, async (client) => {
-      await client.callTool({
-        name: "resume",
-        arguments: {
-          executionId: "exec_1",
-          action: "accept",
-          content: JSON.stringify({ approved: true, name: "test" }),
-        },
-      });
-      expect(receivedContent).toEqual({ approved: true, name: "test" });
-    });
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        await client.callTool({
+          name: "resume",
+          arguments: {
+            executionId: "exec_1",
+            action: "accept",
+            content: JSON.stringify({ approved: true, name: "test" }),
+          },
+        });
+        expect(receivedContent).toEqual({ approved: true, name: "test" });
+      },
+      { enableModelVisibleResumeTool: true },
+    );
   });
 
   it("resume with empty content passes undefined", async () => {
@@ -454,33 +501,43 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         }),
     });
 
-    await withClient(engine, NO_CAPS, async (client) => {
-      await client.callTool({
-        name: "resume",
-        arguments: { executionId: "exec_1", action: "accept", content: "{}" },
-      });
-      expect(receivedContent).toBeUndefined();
-    });
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_1", action: "accept", content: "{}" },
+        });
+        expect(receivedContent).toBeUndefined();
+      },
+      { enableModelVisibleResumeTool: true },
+    );
   });
 
   it("resume with unknown executionId returns error", async () => {
     const engine = makeStubEngine({ resume: () => Effect.succeed(null) });
 
-    await withClient(engine, NO_CAPS, async (client) => {
-      const result = await client.callTool({
-        name: "resume",
-        arguments: {
-          executionId: "does-not-exist",
-          action: "accept",
-          content: "{}",
-        },
-      });
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain("does-not-exist");
-    });
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: {
+            executionId: "does-not-exist",
+            action: "accept",
+            content: "{}",
+          },
+        });
+        expect(result.isError).toBe(true);
+        expect(textOf(result)).toContain("does-not-exist");
+      },
+      { enableModelVisibleResumeTool: true },
+    );
   });
 
-  it("paused UrlElicitation includes url and kind in structured output", async () => {
+  it("paused UrlElicitation includes kind in structured output", async () => {
     const engine = makeStubEngine({
       executeWithPause: () =>
         Effect.succeed(
@@ -500,13 +557,13 @@ describe("MCP host server — client without elicitation (pause/resume)", () => 
         name: "execute",
         arguments: { code: "oauth" },
       });
-      expect(textOf(result)).toContain("https://auth.example.com/callback");
-      expect(textOf(result)).toContain("exec_99");
+      expect(textOf(result)).toBe("Execution paused for interaction.");
 
       const structured = result.structuredContent as Record<string, unknown>;
       const interaction = structured?.interaction as Record<string, unknown>;
       expect(interaction?.kind).toBe("url");
       expect(interaction?.url).toBe("https://auth.example.com/callback");
+      expect(structured?.executionId).toBeUndefined();
     });
   });
 });
@@ -563,30 +620,40 @@ describe("MCP host server — resume content parsing", () => {
   it("array JSON is rejected (not passed as content)", async () => {
     const { engine, getContent } = makeResumeEngine();
 
-    await withClient(engine, NO_CAPS, async (client) => {
-      await client.callTool({
-        name: "resume",
-        arguments: { executionId: "exec_1", action: "accept", content: "[1,2,3]" },
-      });
-      expect(getContent()).toBeUndefined();
-    });
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        await client.callTool({
+          name: "resume",
+          arguments: { executionId: "exec_1", action: "accept", content: "[1,2,3]" },
+        });
+        expect(getContent()).toBeUndefined();
+      },
+      { enableModelVisibleResumeTool: true },
+    );
   });
 
   it("invalid JSON is handled gracefully (not thrown)", async () => {
     const { engine, getContent } = makeResumeEngine();
 
-    await withClient(engine, NO_CAPS, async (client) => {
-      const result = await client.callTool({
-        name: "resume",
-        arguments: {
-          executionId: "exec_1",
-          action: "accept",
-          content: "not-valid-json",
-        },
-      });
-      expect(getContent()).toBeUndefined();
-      expect(result.isError).toBeFalsy();
-    });
+    await withClient(
+      engine,
+      NO_CAPS,
+      async (client) => {
+        const result = await client.callTool({
+          name: "resume",
+          arguments: {
+            executionId: "exec_1",
+            action: "accept",
+            content: "not-valid-json",
+          },
+        });
+        expect(getContent()).toBeUndefined();
+        expect(result.isError).toBeFalsy();
+      },
+      { enableModelVisibleResumeTool: true },
+    );
   });
 });
 

--- a/packages/hosts/mcp/src/server.ts
+++ b/packages/hosts/mcp/src/server.ts
@@ -70,6 +70,8 @@ type SharedMcpServerConfig = {
    * Enable verbose MCP capability / elicitation debug logging.
    */
   readonly debug?: boolean;
+  readonly continuationOwnerId?: string | (() => string | null | undefined);
+  readonly enableModelVisibleResumeTool?: boolean;
 };
 
 export type ExecutorMcpServerConfig<E extends Cause.YieldableError = Cause.YieldableError> =
@@ -255,6 +257,19 @@ const toMcpPausedResult = (formatted: ReturnType<typeof formatPausedExecution>):
   structuredContent: formatted.structured,
 });
 
+const toMcpPendingInteractionResult = (
+  formatted: ReturnType<typeof formatPausedExecution>,
+): McpToolResult => {
+  const structured = formatted.structured;
+  return {
+    content: [{ type: "text", text: "Execution paused for interaction." }],
+    structuredContent: {
+      status: "waiting_for_interaction",
+      interaction: structured.interaction,
+    },
+  };
+};
+
 const formatFailureMessage = (value: unknown): string | null => {
   if (typeof value === "object" && value !== null && "message" in value) {
     const message = (value as { readonly message?: unknown }).message;
@@ -317,6 +332,11 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
       const ps = config.parentSpan;
       return typeof ps === "function" ? ps() : ps;
     };
+    const resolveContinuationOwner = (): string | null => {
+      const owner = config.continuationOwnerId;
+      const value = typeof owner === "function" ? owner() : owner;
+      return value ?? null;
+    };
     const anchor = <A, EffE>(effect: Effect.Effect<A, EffE>): Effect.Effect<A, EffE> => {
       const parent = resolveParentSpan();
       return parent ? Effect.withParentSpan(effect, parent) : effect;
@@ -353,10 +373,11 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           });
           return toMcpResult(formatExecuteResult(result));
         }
-        const outcome = yield* engine.executeWithPause(code);
+        const outcome = yield* engine.executeWithPause(code, {
+          ownerId: resolveContinuationOwner(),
+        });
         debugLog("execute.paused_flow_result", {
           status: outcome.status,
-          executionId: outcome.status === "paused" ? outcome.execution.id : undefined,
           interactionKind:
             outcome.status === "paused"
               ? pausedInteractionKind(outcome.execution.elicitationContext.request)
@@ -364,7 +385,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
         });
         return outcome.status === "completed"
           ? toMcpResult(formatExecuteResult(outcome.result))
-          : toMcpPausedResult(formatPausedExecution(outcome.execution));
+          : toMcpPendingInteractionResult(formatPausedExecution(outcome.execution));
       }).pipe(
         Effect.withSpan("mcp.host.tool.execute", {
           attributes: {
@@ -381,23 +402,24 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
     ): Effect.Effect<McpToolResult, E> =>
       Effect.gen(function* () {
         debugLog("resume.call", {
-          executionId,
           action,
           hasContent: content !== undefined,
           clientCapabilities: server.server.getClientCapabilities() ?? null,
         });
-        const outcome = yield* engine.resume(executionId, { action, content });
+        const outcome = yield* engine.resume(
+          executionId,
+          { action, content },
+          { ownerId: resolveContinuationOwner() },
+        );
         if (!outcome) {
-          debugLog("resume.missing_execution", { executionId });
+          debugLog("resume.missing_execution", {});
           return {
             content: [{ type: "text" as const, text: `No paused execution: ${executionId}` }],
             isError: true,
           } satisfies McpToolResult;
         }
         debugLog("resume.result", {
-          executionId,
           status: outcome.status,
-          nextExecutionId: outcome.status === "paused" ? outcome.execution.id : undefined,
           interactionKind:
             outcome.status === "paused"
               ? pausedInteractionKind(outcome.execution.elicitationContext.request)
@@ -411,7 +433,6 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           attributes: {
             "mcp.tool.name": "resume",
             "mcp.execute.resume.action": action,
-            "mcp.execute.execution_id": executionId,
           },
         }),
       );
@@ -465,23 +486,25 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
 
     const syncToolAvailability = () => {
       executeTool.enable();
-      if (supportsManagedElicitation(server)) {
-        resumeTool.disable();
-      } else {
+      if (!supportsManagedElicitation(server) && config.enableModelVisibleResumeTool === true) {
         resumeTool.enable();
+      } else {
+        resumeTool.disable();
       }
       console.error(
         "[executor] MCP capability snapshot",
         JSON.stringify({
           ...capabilitySnapshot(server),
-          resumeEnabled: !supportsManagedElicitation(server),
+          resumeEnabled:
+            !supportsManagedElicitation(server) && config.enableModelVisibleResumeTool === true,
         }),
       );
       debugLog("tool.visibility", {
         clientCapabilities: server.server.getClientCapabilities() ?? null,
         elicitationSupport: getElicitationSupport(server),
         managedElicitation: supportsManagedElicitation(server),
-        resumeEnabled: !supportsManagedElicitation(server),
+        resumeEnabled:
+          !supportsManagedElicitation(server) && config.enableModelVisibleResumeTool === true,
       });
     };
 


### PR DESCRIPTION
## Summary
- add optional owner ids and lifetime limits for paused executions
- pass continuation ownership through the MCP host and cloud MCP session setup
- keep the model-visible resume tool disabled by default while preserving explicit host configuration

## Verification
- cd packages/core/execution && bunx vitest run src/tool-invoker.test.ts
- cd packages/hosts/mcp && bunx vitest run src/server.test.ts
- cd apps/cloud && bunx vitest run src/mcp-flow.test.ts
- bun run format:check
- bun run lint
- bun run typecheck
- bun run test