### PR TITLE
Harden hosted outbound requests and org limits

### DIFF
--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -47,6 +47,8 @@ const DELETE_COOKIE_OPTIONS = {
   secure: true,
 };
 
+const MAX_ORGANIZATIONS_PER_USER = 3;
+
 const randomState = (): string => {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
@@ -245,6 +247,11 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           const session = yield* SessionContext;
 
           const name = payload.name.trim();
+          const memberships = yield* workos.listUserMemberships(session.accountId);
+          if (memberships.data.length >= MAX_ORGANIZATIONS_PER_USER) {
+            return yield* new WorkOSError();
+          }
+
           const org = yield* workos.createOrganization(name);
           yield* workos.createMembership(org.id, session.accountId, "admin");
           yield* users.use((s) => s.upsertOrganization({ id: org.id, name: org.name }));

--- a/apps/cloud/src/org/handlers.ts
+++ b/apps/cloud/src/org/handlers.ts
@@ -8,6 +8,7 @@ import { WorkOSAuth } from "../auth/workos";
 import { AutumnService } from "../services/autumn";
 import { OrgHttpApi } from "./compose";
 import { Forbidden } from "./api";
+import { getMemberLimitForPlan, selectActiveMemberLimitPlan } from "./member-limits";
 
 const requireAdmin = Effect.gen(function* () {
   const auth = yield* AuthContext;
@@ -52,17 +53,6 @@ const assertDomainInSessionOrg = (domainId: string) =>
     }
   });
 
-// Per-plan member limits live in code, not Autumn. Members aren't billable
-// usage — they're a permission attached to the plan. We still ask Autumn
-// which plan the org is on (Autumn is the billing source of truth), but
-// the cap itself is a constant here. `null` = unlimited.
-const MEMBER_LIMITS: Record<string, number | null> = {
-  free: 3,
-  "free-pay-as-you-go": 3,
-  team: null,
-};
-const DEFAULT_MEMBER_LIMIT = 3;
-
 // Compute live seat usage from WorkOS truth (active+pending memberships +
 // pending invitations) and look up the per-plan cap from MEMBER_LIMITS.
 // Recomputed on every call — no event-counting drift.
@@ -74,8 +64,8 @@ const getMemberSeats = (organizationId: string) =>
     const customer = yield* autumn.use((client) =>
       client.customers.getOrCreate({ customerId: organizationId }),
     );
-    const planId = customer.subscriptions[0]?.planId ?? "free";
-    const limit = planId in MEMBER_LIMITS ? MEMBER_LIMITS[planId] : DEFAULT_MEMBER_LIMIT;
+    const planId = selectActiveMemberLimitPlan(customer.subscriptions);
+    const limit = getMemberLimitForPlan(planId);
 
     const memberships = yield* workos.listOrgMembers(organizationId);
     const invitations = yield* workos.listPendingInvitations(organizationId);
@@ -258,7 +248,7 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
               featureId: "domain-verification",
             }),
           )
-          .pipe(Effect.orElseSucceed(() => ({ allowed: true })));
+          .pipe(Effect.orElseSucceed(() => ({ allowed: false })));
 
         if (!check.allowed) {
           return yield* new Forbidden();

--- a/apps/cloud/src/org/member-limits.node.test.ts
+++ b/apps/cloud/src/org/member-limits.node.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { getMemberLimitForPlan, selectActiveMemberLimitPlan } from "./member-limits";
+
+describe("member limits", () => {
+  it("uses an active or trialing subscription before older entries", () => {
+    expect(
+      selectActiveMemberLimitPlan([
+        { planId: "free", status: "canceled" },
+        { planId: "team", status: "trialing" },
+      ]),
+    ).toBe("team");
+
+    expect(
+      selectActiveMemberLimitPlan([
+        { planId: "free", status: "past_due" },
+        { planId: "team", status: "active" },
+      ]),
+    ).toBe("team");
+  });
+
+  it("falls back to the first subscription, then the free plan", () => {
+    expect(
+      selectActiveMemberLimitPlan([
+        { planId: "free-pay-as-you-go", status: "canceled" },
+        { planId: "team", status: "incomplete" },
+      ]),
+    ).toBe("free-pay-as-you-go");
+
+    expect(selectActiveMemberLimitPlan([])).toBe("free");
+  });
+
+  it("resolves member limits from the selected plan", () => {
+    expect(getMemberLimitForPlan("free")).toBe(3);
+    expect(getMemberLimitForPlan("team")).toBeNull();
+    expect(getMemberLimitForPlan("unknown")).toBe(3);
+  });
+});

--- a/apps/cloud/src/org/member-limits.ts
+++ b/apps/cloud/src/org/member-limits.ts
@@ -1,0 +1,25 @@
+const MEMBER_LIMITS: Record<string, number | null> = {
+  free: 3,
+  "free-pay-as-you-go": 3,
+  team: null,
+};
+
+export const DEFAULT_MEMBER_LIMIT = 3;
+
+export type AutumnSubscriptionSummary = {
+  readonly planId?: string | null;
+  readonly status?: string | null;
+};
+
+export const selectActiveMemberLimitPlan = (
+  subscriptions: ReadonlyArray<AutumnSubscriptionSummary>,
+): string => {
+  const active =
+    subscriptions.find((subscription) =>
+      ["active", "trialing"].includes(subscription.status ?? ""),
+    ) ?? subscriptions[0];
+  return active?.planId ?? "free";
+};
+
+export const getMemberLimitForPlan = (planId: string): number | null =>
+  planId in MEMBER_LIMITS ? MEMBER_LIMITS[planId] : DEFAULT_MEMBER_LIMIT;

--- a/packages/core/sdk/src/hosted-http-client.test.ts
+++ b/packages/core/sdk/src/hosted-http-client.test.ts
@@ -1,12 +1,8 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Result } from "effect";
+import { Effect, Predicate, Result } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
-import {
-  HostedOutboundRequestBlocked,
-  makeHostedHttpClientLayer,
-  validateHostedOutboundUrl,
-} from "./hosted-http-client";
+import { makeHostedHttpClientLayer, validateHostedOutboundUrl } from "./hosted-http-client";
 
 describe("hosted outbound HTTP client", () => {
   it.effect("allows public HTTP and HTTPS URLs", () =>
@@ -27,7 +23,22 @@ describe("hosted outbound HTTP client", () => {
         "http://169.254.169.254/latest/meta-data/",
       ]) {
         const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
-        expect(error).toBeInstanceOf(HostedOutboundRequestBlocked);
+        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(true);
+      }
+    }),
+  );
+
+  it.effect("rejects IPv4-mapped IPv6 URLs for local and private networks", () =>
+    Effect.gen(function* () {
+      for (const url of [
+        "http://[::ffff:127.0.0.1]:3000",
+        "http://[::ffff:10.0.0.1]/openapi.json",
+        "http://[::ffff:172.16.0.1]/graphql",
+        "http://[::ffff:192.168.1.10]/mcp",
+        "http://[::ffff:169.254.169.254]/latest/meta-data/",
+      ]) {
+        const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
+        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(true);
       }
     }),
   );
@@ -61,6 +72,71 @@ describe("hosted outbound HTTP client", () => {
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);
+    }),
+  );
+
+  it.effect("rejects cross-origin redirects before following them", () =>
+    Effect.gen(function* () {
+      let calls = 0;
+      const fakeFetch: typeof globalThis.fetch = (async (input) => {
+        calls++;
+        const url = input instanceof Request ? input.url : String(input);
+        if (url === "https://api.example/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://elsewhere.example/next" },
+          });
+        }
+        return new Response("unexpected", { status: 200 });
+      }) as typeof globalThis.fetch;
+
+      const result = yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* client.execute(HttpClientRequest.get("https://api.example/start"));
+      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })), Effect.result);
+
+      expect(Result.isFailure(result)).toBe(true);
+      expect(calls).toBe(1);
+    }),
+  );
+
+  it.effect("rejects responses with content-length beyond the configured limit", () =>
+    Effect.gen(function* () {
+      const fakeFetch: typeof globalThis.fetch = (async () =>
+        new Response("too large", {
+          status: 200,
+          headers: { "content-length": "9" },
+        })) as typeof globalThis.fetch;
+
+      const result = yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* client.execute(HttpClientRequest.get("https://public.example/spec"));
+      }).pipe(
+        Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch, maxResponseBytes: 8 })),
+        Effect.result,
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
+    }),
+  );
+
+  it.effect("rejects streamed responses that exceed the configured limit", () =>
+    Effect.gen(function* () {
+      const fakeFetch: typeof globalThis.fetch = (async () =>
+        new Response("too large", { status: 200 })) as typeof globalThis.fetch;
+
+      const result = yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        const response = yield* client.execute(
+          HttpClientRequest.get("https://public.example/spec"),
+        );
+        return yield* response.text;
+      }).pipe(
+        Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch, maxResponseBytes: 8 })),
+        Effect.result,
+      );
+
+      expect(Result.isFailure(result)).toBe(true);
     }),
   );
 });

--- a/packages/core/sdk/src/hosted-http-client.ts
+++ b/packages/core/sdk/src/hosted-http-client.ts
@@ -12,8 +12,11 @@ export class HostedOutboundRequestBlocked extends Schema.TaggedErrorClass<Hosted
 export interface HostedHttpClientOptions {
   readonly allowLocalNetwork?: boolean;
   readonly maxRedirects?: number;
+  readonly maxResponseBytes?: number;
   readonly fetch?: typeof globalThis.fetch;
 }
+
+const DEFAULT_MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
 
 const parseIpv4 = (hostname: string): readonly [number, number, number, number] | null => {
   const parts = hostname.split(".");
@@ -26,6 +29,36 @@ const parseIpv4 = (hostname: string): readonly [number, number, number, number] 
     parsed.push(value);
   }
   return parsed as [number, number, number, number];
+};
+
+const parseIpv4MappedIpv6 = (
+  hostname: string,
+): readonly [number, number, number, number] | null => {
+  const prefix = "::ffff:";
+  if (!hostname.startsWith(prefix)) return null;
+  const embedded = hostname.slice(prefix.length);
+  const dotted = parseIpv4(embedded);
+  if (dotted) return dotted;
+
+  const parts = embedded.split(":");
+  if (parts.length !== 2) return null;
+
+  const words = parts.map((part) => Number.parseInt(part, 16));
+  if (
+    words.some(
+      (word, index) =>
+        parts[index] === "" ||
+        !/^[0-9a-f]+$/i.test(parts[index]) ||
+        !Number.isInteger(word) ||
+        word < 0 ||
+        word > 0xffff,
+    )
+  ) {
+    return null;
+  }
+
+  const [high, low] = words;
+  return [high >> 8, high & 0xff, low >> 8, low & 0xff];
 };
 
 const isPrivateIpv4 = ([a, b]: readonly [number, number, number, number]): boolean =>
@@ -51,6 +84,8 @@ const isLocalOrPrivateHostname = (hostname: string): boolean => {
   if (normalized === "localhost" || normalized.endsWith(".localhost")) return true;
   const ipv4 = parseIpv4(normalized);
   if (ipv4) return isPrivateIpv4(ipv4);
+  const mappedIpv4 = parseIpv4MappedIpv6(normalized);
+  if (mappedIpv4) return isPrivateIpv4(mappedIpv4);
   return (
     normalized === "::1" ||
     normalized.startsWith("fe80:") ||
@@ -112,13 +147,79 @@ const guardFetch = (
         response.headers.has("location") &&
         redirects < maxRedirects
       ) {
-        current = new URL(response.headers.get("location")!, url).toString();
+        const next = new URL(response.headers.get("location")!, url);
+        if (next.origin !== new URL(url).origin) {
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: fetch-compatible adapter must reject blocked requests
+          throw new HostedOutboundRequestBlocked({
+            url: next.toString(),
+            reason: "Cross-origin redirects are not allowed",
+          });
+        }
+        current = next.toString();
         continue;
       }
-      return response;
+      return guardResponseBody(
+        response,
+        url,
+        options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES,
+      );
     }
-    return underlying(current, { ...init, redirect: "manual" });
+    const url = current instanceof Request ? current.url : String(current);
+    const response = await underlying(current, { ...init, redirect: "manual" });
+    return guardResponseBody(response, url, options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES);
   }) as typeof globalThis.fetch;
+
+const guardResponseBody = (response: Response, url: string, maxResponseBytes: number): Response => {
+  if (!Number.isFinite(maxResponseBytes) || maxResponseBytes <= 0 || !response.body) {
+    return response;
+  }
+
+  const contentLength = response.headers.get("content-length");
+  if (contentLength !== null) {
+    const parsed = Number(contentLength);
+    if (Number.isFinite(parsed) && parsed > maxResponseBytes) {
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: fetch-compatible response adapter must reject oversized responses
+      throw new HostedOutboundRequestBlocked({
+        url,
+        reason: "Response body is too large",
+      });
+    }
+  }
+
+  let total = 0;
+  const reader = response.body.getReader();
+  const limitedBody = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const next = await reader.read();
+      if (next.done) {
+        controller.close();
+        return;
+      }
+
+      total += next.value.byteLength;
+      if (total > maxResponseBytes) {
+        controller.error(
+          new HostedOutboundRequestBlocked({
+            url,
+            reason: "Response body is too large",
+          }),
+        );
+        return;
+      }
+
+      controller.enqueue(next.value);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+
+  return new Response(limitedBody, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+};
 
 export const makeHostedHttpClientLayer = (
   options: HostedHttpClientOptions = {},


### PR DESCRIPTION
## Summary

- Tighten hosted outbound request handling for private IPv4-mapped IPv6 addresses, cross-origin redirects, and oversized response bodies.
- Select active or trialing Autumn subscriptions when applying member limits, and fail closed for domain-verification availability checks.
- Add a per-user organization creation cap before creating another WorkOS organization.

## Validation

- `bunx vitest run src/hosted-http-client.test.ts` from `packages/core/sdk`
- `bunx vitest run --config ./member-limits-vitest.*.ts` from `apps/cloud` for the node-only member-limit test
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
