### PR TITLE
Harden release workflow refs

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -3,6 +3,9 @@ name: Publish (pkg.pr.new)
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   # Per-platform matrix: build the executor binary, tar it, upload to R2.
   # The wrapper npm package is built later by the `publish` job which just
@@ -24,6 +27,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -60,8 +65,13 @@ jobs:
     name: Publish
     needs: build-preview-binary
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -10,7 +10,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: publish-desktop-${{ github.ref }}
@@ -18,6 +18,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -45,12 +47,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: refs/tags/${{ inputs.tag }}
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Validate release tag
+        env:
+          RAW_RELEASE_TAG: ${{ inputs.tag }}
+        run: bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG
+
+      - name: Checkout release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" fetch --force --tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          git checkout --detach "$RELEASE_TAG"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -70,7 +84,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p apps/desktop/resources
-          gh release download "${{ inputs.tag }}" --repo "${{ github.repository }}" --pattern "${{ matrix.cli-asset }}" --dir /tmp/cli-download
+          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "${{ matrix.cli-asset }}" --dir /tmp/cli-download
           cd /tmp/cli-download
           if [[ "${{ matrix.cli-asset }}" == *.tar.gz ]]; then
             tar -xzf "${{ matrix.cli-asset }}"
@@ -90,7 +104,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path "apps/desktop/resources"
-          gh release download "${{ inputs.tag }}" --repo "${{ github.repository }}" --pattern "${{ matrix.cli-asset }}" --dir "$env:TEMP/cli-download"
+          gh release download "$env:RELEASE_TAG" --repo "$env:GITHUB_REPOSITORY" --pattern "${{ matrix.cli-asset }}" --dir "$env:TEMP/cli-download"
           Expand-Archive -Path "$env:TEMP/cli-download/${{ matrix.cli-asset }}" -DestinationPath "$env:TEMP/cli-extract" -Force
           Copy-Item "$env:TEMP/cli-extract/executor.exe" "apps/desktop/resources/executor.exe"
           if (Test-Path "$env:TEMP/cli-extract/emscripten-module.wasm") {
@@ -119,8 +133,25 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
+      - name: Checkout validation script
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Validate release tag
+        env:
+          RAW_RELEASE_TAG: ${{ inputs.tag }}
+        run: bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
@@ -133,5 +164,5 @@ jobs:
         run: |
           find artifacts -type f \( -name "*.dmg" -o -name "*.exe" -o -name "*.AppImage" -o -name "*.deb" \) | while read file; do
             echo "Uploading: $file"
-            gh release upload "${{ inputs.tag }}" "$file" --repo "${{ github.repository }}" --clobber || true
+            gh release upload "$RELEASE_TAG" "$file" --repo "$GITHUB_REPOSITORY" --clobber || true
           done

--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -13,9 +13,7 @@ on:
         type: string
 
 permissions:
-  actions: write
-  contents: write
-  id-token: write
+  contents: read
 
 concurrency:
   group: publish-executor-package-${{ github.ref }}
@@ -24,18 +22,34 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
+
+      - name: Validate release tag
+        env:
+          RAW_RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG
+
+      - name: Checkout release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" fetch --force --tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          git checkout --detach "$RELEASE_TAG"
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -57,7 +71,6 @@ jobs:
       - name: Publish package and create release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: |
           export GITHUB_REF_TYPE=tag
           export GITHUB_REF_NAME="$RELEASE_TAG"
@@ -67,5 +80,4 @@ jobs:
       - name: Trigger desktop build
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
         run: gh workflow run publish-desktop.yml -f tag="$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,7 @@ on:
       - main
 
 permissions:
-  actions: write
-  contents: write
-  id-token: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -19,12 +16,18 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      id-token: write
+      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -84,27 +87,36 @@ jobs:
 
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Validate release tag
+        if: steps.changesets.outputs.hasChangesets == 'false' && steps.detect_release.outputs.changed == 'true'
+        id: validate_release
+        env:
+          RELEASE_VERSION: ${{ steps.detect_release.outputs.version }}
+        run: bun run scripts/validate-release-ref.ts --version-env RELEASE_VERSION --output tag
+
       - name: Create and push release tag
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.detect_release.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.validate_release.outputs.tag }}
         run: |
-          tag="v${{ steps.detect_release.outputs.version }}"
-          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "Tag $tag already exists."
+          if git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Tag $RELEASE_TAG already exists."
             exit 0
           fi
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "$tag"
-          git push origin "$tag"
+          git tag "$RELEASE_TAG"
+          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" push origin "$RELEASE_TAG"
 
       - name: Trigger CLI publish
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.detect_release.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.validate_release.outputs.tag }}
         run: |
-          tag="v${{ steps.detect_release.outputs.version }}"
-          gh workflow run publish-executor-package.yml --ref "$tag" -f tag="$tag"
+          gh workflow run publish-executor-package.yml --ref "$RELEASE_TAG" -f tag="$RELEASE_TAG"
 
       # Desktop build downloads CLI binaries from the release, so it must
       # run after CLI publish completes. Trigger it from the CLI workflow

--- a/scripts/validate-release-ref.ts
+++ b/scripts/validate-release-ref.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+import { appendFileSync } from "node:fs";
+
+const RELEASE_VERSION_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
+
+export const validateReleaseVersion = (value: string): string => {
+  if (!RELEASE_VERSION_PATTERN.test(value)) {
+    throw new Error(`Invalid release version: ${value}`);
+  }
+  return value;
+};
+
+export const validateReleaseTag = (value: string): string => {
+  if (!value.startsWith("v")) {
+    throw new Error(`Invalid release tag: ${value}`);
+  }
+  validateReleaseVersion(value.slice(1));
+  return value;
+};
+
+const readEnv = (name: string): string => {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+  return value;
+};
+
+const appendGitHubFile = (path: string | undefined, line: string): void => {
+  if (!path || !line) return;
+  appendFileSync(path, `${line}\n`, "utf8");
+};
+
+const run = (): void => {
+  const args = process.argv.slice(2);
+  const tagEnv = readOption(args, "--tag-env");
+  const versionEnv = readOption(args, "--version-env");
+  const writeEnv = readOption(args, "--write-env");
+  const outputName = readOption(args, "--output");
+
+  if (tagEnv && versionEnv) {
+    throw new Error("Use either --tag-env or --version-env, not both");
+  }
+  if (!tagEnv && !versionEnv) {
+    throw new Error("Expected --tag-env or --version-env");
+  }
+
+  const tag = tagEnv
+    ? validateReleaseTag(readEnv(tagEnv))
+    : `v${validateReleaseVersion(readEnv(versionEnv!))}`;
+
+  appendGitHubFile(process.env.GITHUB_ENV, writeEnv ? `${writeEnv}=${tag}` : "");
+  appendGitHubFile(process.env.GITHUB_OUTPUT, outputName ? `${outputName}=${tag}` : "");
+  console.log(`Validated release tag ${tag}`);
+};
+
+const readOption = (args: ReadonlyArray<string>, name: string): string | undefined => {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`Missing value for ${name}`);
+  }
+  return value;
+};
+
+if (import.meta.main) {
+  run();
+}

--- a/tests/release-workflows.test.ts
+++ b/tests/release-workflows.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "@effect/vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { validateReleaseTag, validateReleaseVersion } from "../scripts/validate-release-ref";
+
+const workflow = (name: string): string =>
+  readFileSync(resolve(import.meta.dirname, "..", ".github/workflows", name), "utf8");
+
+describe("release workflow hardening", () => {
+  it("accepts only semver release versions and v-prefixed semver tags", () => {
+    expect(validateReleaseVersion("1.2.3")).toBe("1.2.3");
+    expect(validateReleaseVersion("1.2.3-beta.4")).toBe("1.2.3-beta.4");
+    expect(validateReleaseTag("v1.2.3")).toBe("v1.2.3");
+    expect(validateReleaseTag("v1.2.3-beta.4+build.5")).toBe("v1.2.3-beta.4+build.5");
+
+    expect(() => validateReleaseVersion("v1.2.3")).toThrow();
+    expect(() => validateReleaseVersion("1.2")).toThrow();
+    expect(() => validateReleaseTag("1.2.3")).toThrow();
+    expect(() => validateReleaseTag("v1.2.3; echo unsafe")).toThrow();
+    expect(() => validateReleaseTag("v01.2.3")).toThrow();
+  });
+
+  it("validates release values through environment variables before shell use", () => {
+    const publishExecutor = workflow("publish-executor-package.yml");
+    const release = workflow("release.yml");
+    const publishDesktop = workflow("publish-desktop.yml");
+
+    expect(publishExecutor).toContain(
+      "bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG",
+    );
+    expect(release).toContain(
+      "bun run scripts/validate-release-ref.ts --version-env RELEASE_VERSION --output tag",
+    );
+    expect(publishDesktop).toContain(
+      "bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG",
+    );
+
+    expect(release).not.toContain('tag="v${{ steps.detect_release.outputs.version }}"');
+    expect(publishDesktop).not.toContain("ref: refs/tags/${{ inputs.tag }}");
+    expect(publishDesktop).not.toContain('gh release download "${{ inputs.tag }}"');
+    expect(publishExecutor).not.toMatch(/\n\s+RELEASE_TAG: \$\{\{ github\.event_name/u);
+  });
+
+  it("does not persist checkout credentials in release workflows", () => {
+    for (const name of [
+      "publish-executor-package.yml",
+      "release.yml",
+      "publish-desktop.yml",
+      "pkg-pr-new.yml",
+    ]) {
+      expect(workflow(name)).toContain("persist-credentials: false");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Validate release tag inputs before checkout, release upload, and package publishing steps.
- Reduce default workflow token scope and disable persisted checkout credentials where the jobs do not need them.
- Add static regression coverage for the release workflow tag handling.

## Validation

- `bunx vitest run tests/release-workflows.test.ts`
- `bun run format:check`
- `bun run lint`
