### PR TITLE
Harden local server boundaries

### DIFF
--- a/apps/cli/src/daemon-state.test.ts
+++ b/apps/cli/src/daemon-state.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { BunServices } from "@effect/platform-bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as Effect from "effect/Effect";
+
+import {
+  canonicalDaemonHost,
+  currentDaemonScopeId,
+  readDaemonPointer,
+  writeDaemonPointer,
+} from "./daemon-state";
+
+const previousDataDir = process.env.EXECUTOR_DATA_DIR;
+const previousScopeDir = process.env.EXECUTOR_SCOPE_DIR;
+const originalCwd = process.cwd();
+
+afterEach(() => {
+  if (previousDataDir === undefined) {
+    delete process.env.EXECUTOR_DATA_DIR;
+  } else {
+    process.env.EXECUTOR_DATA_DIR = previousDataDir;
+  }
+
+  if (previousScopeDir === undefined) {
+    delete process.env.EXECUTOR_SCOPE_DIR;
+  } else {
+    process.env.EXECUTOR_SCOPE_DIR = previousScopeDir;
+  }
+
+  process.chdir(originalCwd);
+});
+
+describe("daemon host and scope identity", () => {
+  it("does not collapse wildcard binds into loopback pointers", () => {
+    expect(canonicalDaemonHost("127.0.0.1")).toBe("localhost");
+    expect(canonicalDaemonHost("0.0.0.0")).toBe("0.0.0.0");
+  });
+
+  it("resolves relative scope directories against the current workspace", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "executor-daemon-scope-"));
+    try {
+      process.chdir(workspace);
+      process.env.EXECUTOR_SCOPE_DIR = "executor.jsonc";
+
+      expect(currentDaemonScopeId()).toBe(`scope:${join(workspace, "executor.jsonc")}`);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it.effect("keeps daemon pointers distinct for scope ids with the same sanitized form", () =>
+    Effect.gen(function* () {
+      const dataDir = mkdtempSync(join(tmpdir(), "executor-daemon-state-"));
+      process.env.EXECUTOR_DATA_DIR = dataDir;
+
+      try {
+        const firstScope = "scope:/workspace/app";
+        const secondScope = "scope:_workspace_app";
+
+        yield* writeDaemonPointer({
+          hostname: "localhost",
+          port: 4788,
+          pid: process.pid,
+          scopeId: firstScope,
+          scopeDir: "/workspace/app",
+          token: "first-token",
+        });
+        yield* writeDaemonPointer({
+          hostname: "localhost",
+          port: 4789,
+          pid: process.pid,
+          scopeId: secondScope,
+          scopeDir: "_workspace_app",
+          token: "second-token",
+        });
+
+        const first = yield* readDaemonPointer({ hostname: "localhost", scopeId: firstScope });
+        const second = yield* readDaemonPointer({ hostname: "localhost", scopeId: secondScope });
+
+        expect(first?.port).toBe(4788);
+        expect(first?.token).toBe("first-token");
+        expect(second?.port).toBe(4789);
+        expect(second?.token).toBe("second-token");
+      } finally {
+        rmSync(dataDir, { recursive: true, force: true });
+      }
+    }).pipe(Effect.provide(BunServices.layer)),
+  );
+});

--- a/apps/cli/src/daemon-state.ts
+++ b/apps/cli/src/daemon-state.ts
@@ -1,4 +1,6 @@
+import { createHash } from "node:crypto";
 import { homedir } from "node:os";
+import { resolve } from "node:path";
 import { FileSystem, Path } from "effect";
 import type { PlatformError } from "effect/PlatformError";
 import * as Effect from "effect/Effect";
@@ -37,7 +39,7 @@ export interface DaemonStartLock {
 // Host normalization
 // ---------------------------------------------------------------------------
 
-const LOCAL_HOST_ALIASES = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0"]);
+const LOCAL_HOST_ALIASES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 export const canonicalDaemonHost = (hostname: string): string => {
   const normalized = hostname.trim().toLowerCase();
@@ -47,9 +49,9 @@ export const canonicalDaemonHost = (hostname: string): string => {
 export const currentDaemonScopeId = (): string => {
   const explicitScope = process.env.EXECUTOR_SCOPE_DIR?.trim();
   if (explicitScope && explicitScope.length > 0) {
-    return `scope:${explicitScope}`;
+    return `scope:${resolve(explicitScope)}`;
   }
-  return `cwd:${process.cwd()}`;
+  return `cwd:${resolve(process.cwd())}`;
 };
 
 // ---------------------------------------------------------------------------
@@ -61,7 +63,8 @@ const resolveDaemonDataDir = (path: Path.Path): string =>
 
 const sanitizeHostForPath = (hostname: string): string =>
   hostname.replaceAll(/[^a-z0-9.-]+/gi, "_");
-const sanitizeScopeForPath = (scopeId: string): string => scopeId.replaceAll(/[^a-z0-9.-]+/gi, "_");
+const scopeKeyForPath = (scopeId: string): string =>
+  createHash("sha256").update(scopeId).digest("hex").slice(0, 24);
 
 const daemonRecordPath = (path: Path.Path, input: { hostname: string; port: number }): string => {
   const host = sanitizeHostForPath(canonicalDaemonHost(input.hostname));
@@ -73,7 +76,7 @@ const daemonPointerPath = (
   input: { hostname: string; scopeId: string },
 ): string => {
   const host = sanitizeHostForPath(canonicalDaemonHost(input.hostname));
-  const scope = sanitizeScopeForPath(input.scopeId);
+  const scope = scopeKeyForPath(input.scopeId);
   return path.join(resolveDaemonDataDir(path), `daemon-active-${host}-${scope}.json`);
 };
 

--- a/apps/cli/src/daemon.test.ts
+++ b/apps/cli/src/daemon.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { canAutoStartLocalDaemonForHost } from "./daemon";
+
+describe("canAutoStartLocalDaemonForHost", () => {
+  it("allows loopback hosts", () => {
+    expect(canAutoStartLocalDaemonForHost("localhost")).toBe(true);
+    expect(canAutoStartLocalDaemonForHost("127.0.0.1")).toBe(true);
+    expect(canAutoStartLocalDaemonForHost("[::1]")).toBe(true);
+  });
+
+  it("does not treat wildcard binds as loopback", () => {
+    expect(canAutoStartLocalDaemonForHost("0.0.0.0")).toBe(false);
+    expect(canAutoStartLocalDaemonForHost("::")).toBe(false);
+  });
+});

--- a/apps/cli/src/daemon.ts
+++ b/apps/cli/src/daemon.ts
@@ -48,7 +48,7 @@ export const parseDaemonBaseUrl = (baseUrl: string, defaultPort: number): Parsed
 // Local-host checks
 // ---------------------------------------------------------------------------
 
-const LOCAL_DAEMON_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "0.0.0.0"]);
+const LOCAL_DAEMON_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 export const canAutoStartLocalDaemonForHost = (hostname: string): boolean =>
   LOCAL_DAEMON_HOSTNAMES.has(hostname.toLowerCase());

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -97,6 +97,8 @@ import {
   inspectToolPath,
   normalizeCliErrorText,
   parseJsonObjectInput,
+  sanitizeCliOutputText,
+  shellQuoteArg,
 } from "./tooling";
 
 // Embedded web UI — baked into compiled binaries via `with { type: "file" }`
@@ -459,8 +461,9 @@ const printExecutionOutcome = (input: { baseUrl: string; outcome: ExecuteCodeOut
             console.log(`\nRequested schema:\n${JSON.stringify(requestedSchema, null, 2)}`);
           }
           const template = buildResumeContentTemplate(requestedSchema);
+          const contentArg = shellQuoteArg(JSON.stringify(template));
           console.log("\nResume commands:");
-          console.log(`  ${commandPrefix} --action accept --content '${JSON.stringify(template)}'`);
+          console.log(`  ${commandPrefix} --action accept --content ${contentArg}`);
           console.log(`  ${commandPrefix} --action decline`);
           console.log(`  ${commandPrefix} --action cancel`);
         } else {
@@ -496,6 +499,8 @@ const runForegroundSession = (input: {
   port: number;
   hostname: string;
   allowedHosts: ReadonlyArray<string>;
+  authToken: string | undefined;
+  authPassword: string | undefined;
 }) =>
   Effect.gen(function* () {
     const server = yield* Effect.promise(() =>
@@ -503,6 +508,8 @@ const runForegroundSession = (input: {
         port: input.port,
         hostname: input.hostname,
         allowedHosts: input.allowedHosts,
+        authToken: input.authToken,
+        authPassword: input.authPassword,
         embeddedWebUI,
       }),
     );
@@ -521,6 +528,11 @@ const runForegroundSession = (input: {
       if (input.allowedHosts.length > 0) {
         console.log(`   Extra allowed Host headers: ${input.allowedHosts.join(", ")}`);
       }
+      if (input.authPassword) {
+        console.log("   Basic authentication is enabled.");
+      } else if (input.authToken) {
+        console.log("   Token authentication is enabled.");
+      }
     }
     console.log(`\nPress Ctrl+C to stop.`);
 
@@ -532,6 +544,8 @@ const runDaemonSession = (input: {
   port: number;
   hostname: string;
   allowedHosts: ReadonlyArray<string>;
+  authToken: string | undefined;
+  authPassword: string | undefined;
 }) =>
   Effect.gen(function* () {
     const daemonHost = canonicalDaemonHost(input.hostname);
@@ -559,6 +573,8 @@ const runDaemonSession = (input: {
         port: input.port,
         hostname: input.hostname,
         allowedHosts: input.allowedHosts,
+        authToken: input.authToken,
+        authPassword: input.authPassword,
         embeddedWebUI,
       }),
     );
@@ -582,6 +598,11 @@ const runDaemonSession = (input: {
     });
 
     console.log(`Daemon ready on http://${daemonHost}:${daemonPort}`);
+    if (input.authPassword) {
+      console.log("Basic authentication is enabled.");
+    } else if (input.authToken) {
+      console.log("Token authentication is enabled.");
+    }
 
     try {
       yield* waitForShutdownSignal();
@@ -871,7 +892,7 @@ const printCallBrowseHelp = (input: {
     if (input.exactTool) {
       console.log(`\nCallable path: ${input.exactTool.id}`);
       if (input.exactTool.description) {
-        console.log(input.exactTool.description);
+        console.log(sanitizeCliOutputText(input.exactTool.description));
       }
     }
 
@@ -927,13 +948,13 @@ const printCallLeafHelp = (input: {
     console.log(`Usage:\n  ${callPath}\n  ${callPath} '{"k":"v"}'`);
     console.log(`\nTool: ${input.tool.id}`);
     if (input.tool.description) {
-      console.log(input.tool.description);
+      console.log(sanitizeCliOutputText(input.tool.description));
     }
     if (input.schema?.inputTypeScript) {
-      console.log(`\nInput:\n${input.schema.inputTypeScript}`);
+      console.log(`\nInput:\n${sanitizeCliOutputText(input.schema.inputTypeScript)}`);
     }
     if (input.schema?.outputTypeScript) {
-      console.log(`\nOutput:\n${input.schema.outputTypeScript}`);
+      console.log(`\nOutput:\n${sanitizeCliOutputText(input.schema.outputTypeScript)}`);
     }
   });
 
@@ -1275,12 +1296,24 @@ const webCommand = Command.make(
           "Additional hostname permitted in the Host header (repeatable). localhost/127.0.0.1 are always allowed.",
         ),
       ),
+    authToken: Options.string("auth-token")
+      .pipe(Options.optional)
+      .pipe(Options.withDescription("Bearer token required for requests.")),
+    authPassword: Options.string("auth-password")
+      .pipe(Options.optional)
+      .pipe(Options.withDescription("Basic auth password required for requests.")),
     scope,
   },
-  ({ port, scope, hostname, allowedHost }) =>
+  ({ port, scope, hostname, allowedHost, authToken, authPassword }) =>
     Effect.gen(function* () {
       applyScope(scope);
-      yield* runForegroundSession({ port, hostname, allowedHosts: allowedHost });
+      yield* runForegroundSession({
+        port,
+        hostname,
+        allowedHosts: allowedHost,
+        authToken: Option.getOrUndefined(authToken),
+        authPassword: Option.getOrUndefined(authPassword),
+      });
     }),
 ).pipe(Command.withDescription("Start a foreground web session"));
 
@@ -1298,6 +1331,12 @@ const daemonRunCommand = Command.make(
           "Additional hostname permitted in the Host header (repeatable). localhost/127.0.0.1 are always allowed.",
         ),
       ),
+    authToken: Options.string("auth-token")
+      .pipe(Options.optional)
+      .pipe(Options.withDescription("Bearer token required for requests.")),
+    authPassword: Options.string("auth-password")
+      .pipe(Options.optional)
+      .pipe(Options.withDescription("Basic auth password required for requests.")),
     foreground: Options.boolean("foreground")
       .pipe(Options.withDefault(false))
       .pipe(
@@ -1307,11 +1346,17 @@ const daemonRunCommand = Command.make(
       ),
     scope,
   },
-  ({ port, scope, hostname, allowedHost, foreground }) =>
+  ({ port, scope, hostname, allowedHost, authToken, authPassword, foreground }) =>
     Effect.gen(function* () {
       applyScope(scope);
       if (foreground) {
-        yield* runDaemonSession({ port, hostname, allowedHosts: allowedHost });
+        yield* runDaemonSession({
+          port,
+          hostname,
+          allowedHosts: allowedHost,
+          authToken: Option.getOrUndefined(authToken),
+          authPassword: Option.getOrUndefined(authPassword),
+        });
       } else {
         yield* runBackgroundDaemonStart({ port, hostname, allowedHosts: allowedHost });
       }

--- a/apps/cli/src/tooling.test.ts
+++ b/apps/cli/src/tooling.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { sanitizeCliOutputText, shellQuoteArg } from "./tooling";
+
+describe("shellQuoteArg", () => {
+  it("quotes single quotes without breaking the shell argument", () => {
+    expect(shellQuoteArg(`{"name":"owner's repo"}`)).toBe(`'{"name":"owner'"'"'s repo"}'`);
+  });
+
+  it("leaves simple values readable", () => {
+    expect(shellQuoteArg("exec_123")).toBe("exec_123");
+  });
+});
+
+describe("sanitizeCliOutputText", () => {
+  it("removes terminal control sequences from tool metadata", () => {
+    expect(sanitizeCliOutputText("safe\u001b[2J\u001b]0;title\u0007 text\u0000")).toBe("safe text");
+  });
+
+  it("preserves readable multiline content", () => {
+    expect(sanitizeCliOutputText("type Input = {\n\tname: string\n}")).toBe(
+      "type Input = {\n\tname: string\n}",
+    );
+  });
+});

--- a/apps/cli/src/tooling.ts
+++ b/apps/cli/src/tooling.ts
@@ -11,6 +11,15 @@ const stripRepeatedErrorPrefix = (input: string): string => {
   return output;
 };
 
+export const sanitizeCliOutputText = (input: string): string =>
+  input
+    // oxlint-disable-next-line eslint/no-control-regex -- boundary: CLI output sanitizer intentionally strips OSC control sequences
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/gu, "")
+    // oxlint-disable-next-line eslint/no-control-regex -- boundary: CLI output sanitizer intentionally strips ANSI control sequences
+    .replace(/\u001b[@-_][0-?]*[ -/]*[@-~]/gu, "")
+    // oxlint-disable-next-line eslint/no-control-regex -- boundary: CLI output sanitizer intentionally strips remaining control characters
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/gu, "");
+
 const TOOL_PATH_TOKEN = /^[A-Za-z0-9._-]+$/;
 
 const toToolPathSegments = (parts: ReadonlyArray<string>): ReadonlyArray<string> =>
@@ -261,6 +270,11 @@ const schemaExample = (schema: unknown, depth = 0): unknown => {
 export const buildResumeContentTemplate = (
   requestedSchema: Record<string, unknown> | undefined,
 ): Record<string, unknown> => schemaExample(requestedSchema ?? {}) as Record<string, unknown>;
+
+export const shellQuoteArg = (value: string): string => {
+  if (/^[A-Za-z0-9_/:=@%+.,-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+};
 
 const tokenizeSegment = (input: string): ReadonlyArray<string> =>
   input

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/apps/local/src/serve.test.ts
+++ b/apps/local/src/serve.test.ts
@@ -63,3 +63,54 @@ describe("startServer static/SPA routing", () => {
     expect(await response.text()).toContain("index-shell");
   });
 });
+
+describe("startServer network bind auth", () => {
+  it("refuses non-loopback binds without a token or password", async () => {
+    await expect(
+      startServer({
+        port: 0,
+        hostname: "0.0.0.0",
+        clientDir,
+        handlers: {
+          api: {
+            handler: async () => new Response("ok"),
+            dispose: async () => {},
+          },
+          mcp: {
+            handleRequest: async () => new Response("ok"),
+            close: async () => {},
+          },
+        },
+      }),
+    ).rejects.toThrow("non-loopback host without an auth token or password");
+  });
+
+  it("requires the configured token when auth is enabled", async () => {
+    server = await startServer({
+      port: 0,
+      hostname: "127.0.0.1",
+      clientDir,
+      authToken: "test-token",
+      handlers: {
+        api: {
+          handler: async () => new Response("ok"),
+          dispose: async () => {},
+        },
+        mcp: {
+          handleRequest: async () => new Response("ok"),
+          close: async () => {},
+        },
+      },
+    });
+
+    const baseUrl = `http://127.0.0.1:${server.port}`;
+    const unauthorized = await fetch(`${baseUrl}/api/health`);
+    expect(unauthorized.status).toBe(401);
+
+    const authorized = await fetch(`${baseUrl}/api/health`, {
+      headers: { authorization: "Bearer test-token" },
+    });
+    expect(authorized.status).toBe(200);
+    expect(await authorized.text()).toBe("ok");
+  });
+});

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -7,6 +7,7 @@
  * Or import:      import { startServer } from "@executor-js/local/serve"
  */
 
+import { timingSafeEqual } from "node:crypto";
 import { resolve, join } from "node:path";
 import { readdirSync } from "node:fs";
 import { getServerHandlers } from "./server/main";
@@ -16,6 +17,21 @@ import { getServerHandlers } from "./server/main";
 // ---------------------------------------------------------------------------
 
 const DEFAULT_ALLOWED_HOSTS = ["localhost", "127.0.0.1", "[::1]", "::1"];
+const LOOPBACK_BIND_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
+
+const normalizeCredential = (value: string | undefined): string | null => {
+  const normalized = value?.trim();
+  return normalized && normalized.length > 0 ? normalized : null;
+};
+
+const safeEqual = (actual: string, expected: string): boolean => {
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+};
+
+const isLoopbackBindHost = (hostname: string): boolean =>
+  LOOPBACK_BIND_HOSTS.has(hostname.trim().toLowerCase());
 
 const makeIsAllowedHost =
   (allowed: ReadonlySet<string>) =>
@@ -25,6 +41,39 @@ const makeIsAllowedHost =
     const hostname = host.replace(/:\d+$/, "");
     return allowed.has(hostname);
   };
+
+const hasBearerToken = (request: Request, token: string): boolean => {
+  const authorization = request.headers.get("authorization");
+  const bearer = authorization?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+  return (
+    (bearer !== undefined && safeEqual(bearer, token)) ||
+    safeEqual(request.headers.get("x-executor-token") ?? "", token)
+  );
+};
+
+const hasBasicPassword = (request: Request, password: string): boolean => {
+  const authorization = request.headers.get("authorization");
+  const encoded = authorization?.match(/^Basic\s+(.+)$/i)?.[1]?.trim();
+  if (!encoded) return false;
+
+  let decoded: string;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Basic auth decoding accepts untrusted header bytes
+  try {
+    decoded = Buffer.from(encoded, "base64").toString("utf8");
+  } catch {
+    return false;
+  }
+
+  const separator = decoded.indexOf(":");
+  const actualPassword = separator >= 0 ? decoded.slice(separator + 1) : decoded;
+  return safeEqual(actualPassword, password);
+};
+
+const makeIsAuthorized =
+  (auth: { token: string | null; password: string | null }) =>
+  (request: Request): boolean =>
+    (auth.token !== null && hasBearerToken(request, auth.token)) ||
+    (auth.password !== null && hasBasicPassword(request, auth.password));
 
 // ---------------------------------------------------------------------------
 // Static files
@@ -88,6 +137,10 @@ export interface StartServerOptions {
   hostname?: string;
   /** Extra hostnames permitted in the Host header, on top of localhost/127.0.0.1. */
   allowedHosts?: ReadonlyArray<string>;
+  /** Bearer token required for requests. Required for non-loopback bind addresses. */
+  authToken?: string;
+  /** Basic auth password required for requests. Required for non-loopback bind addresses. */
+  authPassword?: string;
   /** Test hook for supplying API/MCP handlers without loading the local server graph. */
   handlers?: ServerHandlers;
 }
@@ -102,6 +155,17 @@ type ServerHandlers = Awaited<ReturnType<typeof getServerHandlers>>;
 export async function startServer(opts: StartServerOptions = {}): Promise<ServerInstance> {
   const port = opts.port ?? parseInt(process.env.PORT ?? "4788", 10);
   const hostname = opts.hostname ?? "127.0.0.1";
+  const auth = {
+    token: normalizeCredential(opts.authToken),
+    password: normalizeCredential(opts.authPassword),
+  };
+  const isNetworkBind = !isLoopbackBindHost(hostname);
+  const requiresAuth = auth.token !== null || auth.password !== null;
+  if (isNetworkBind && !requiresAuth) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: startServer is a Promise API and rejects invalid bind options
+    throw new Error("Refusing to listen on a non-loopback host without an auth token or password.");
+  }
+  const isAuthorized = makeIsAuthorized(auth);
   const allowedHostSet = new Set<string>([...DEFAULT_ALLOWED_HOSTS, ...(opts.allowedHosts ?? [])]);
   const isAllowedHost = makeIsAllowedHost(allowedHostSet);
   const clientDir = opts.clientDir ?? resolve(import.meta.dirname, "../dist");
@@ -132,6 +196,13 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
     async fetch(req) {
       if (!isAllowedHost(req)) {
         return new Response("Forbidden", { status: 403 });
+      }
+
+      if (requiresAuth && !isAuthorized(req)) {
+        return new Response("Unauthorized", {
+          status: 401,
+          headers: { "www-authenticate": 'Bearer realm="executor", Basic realm="executor"' },
+        });
       }
 
       const url = new URL(req.url);


### PR DESCRIPTION
## Summary

- Add authentication options for non-loopback local web sessions and pass them through foreground and daemon startup paths.
- Stabilize daemon pointer state and CLI output handling with regression coverage.
- Keep local runtime scratch data out of the repository.

## Validation

- `bunx --bun vitest run --config vitest.config.ts` from `apps/cli`
- `bunx --bun vitest run src/serve.test.ts src/server/mcp-oauth.test.ts` from `apps/local`
- `bun run format:check`
- `bun run lint`
