### PR TITLE
Bound source detection behavior

### DIFF
--- a/packages/core/api/src/handlers/sources.ts
+++ b/packages/core/api/src/handlers/sources.ts
@@ -76,7 +76,7 @@ export const SourcesHandlers = HttpApiBuilder.group(ExecutorApi, "sources", (han
       capture(
         Effect.gen(function* () {
           const executor = yield* ExecutorService;
-          const results = yield* executor.sources.detect(payload.url);
+          const results = yield* executor.sources.detect(payload.url.trim());
           return results.map((r) => ({
             kind: r.kind,
             confidence: r.confidence,

--- a/packages/core/api/src/sources/api.ts
+++ b/packages/core/api/src/sources/api.ts
@@ -49,7 +49,7 @@ const ToolMetadataResponse = Schema.Struct({
 });
 
 const DetectRequest = Schema.Struct({
-  url: Schema.String,
+  url: Schema.String.check(Schema.isMaxLength(2_048)),
 });
 
 const DetectResultResponse = Schema.Struct({

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Data, Effect, Exit, Predicate, Result } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
 
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
 import type { DBAdapter, Where } from "@executor-js/storage-core";
@@ -230,6 +231,75 @@ const opaqueRouteSecretsPlugin = definePlugin(() => ({
   secretProviders: [opaqueRouteProvider],
 }));
 
+const providerOnlySecretPlugin = definePlugin(() => ({
+  id: "provider-only-secret" as const,
+  storage: () => ({}),
+  secretProviders: [
+    {
+      key: "provider-only",
+      writable: false,
+      get: (id: string) => Effect.succeed(id === "provider-token" ? "provider-value" : null),
+      list: () => Effect.succeed([{ id: "provider-token", name: "Provider token" }]),
+    } satisfies SecretProvider,
+  ],
+}));
+
+const fallbackOrderingPlugin = (laterCalls: { count: number }) =>
+  definePlugin(() => ({
+    id: "fallback-ordering" as const,
+    storage: () => ({}),
+    secretProviders: [
+      {
+        key: "first-fallback",
+        writable: false,
+        get: (id: string) => Effect.succeed(id === "token" ? "first-value" : null),
+        list: () => Effect.succeed([{ id: "token", name: "token" }]),
+      },
+      {
+        key: "later-fallback",
+        writable: false,
+        get: () =>
+          Effect.sync(() => {
+            laterCalls.count += 1;
+            return "later-value";
+          }),
+        list: () => Effect.succeed([{ id: "token", name: "token" }]),
+      },
+    ] satisfies readonly SecretProvider[],
+  }));
+
+const fallbackDisabledPlugin = definePlugin(() => ({
+  id: "fallback-disabled" as const,
+  storage: () => ({}),
+  secretProviders: [
+    {
+      key: "fallback-disabled-provider",
+      writable: false,
+      allowFallback: false,
+      get: (id: string) => Effect.succeed(id === "token" ? "disabled-value" : null),
+      list: () => Effect.succeed([{ id: "token", name: "token" }]),
+    },
+  ] satisfies readonly SecretProvider[],
+}));
+
+const duplicateToolsPlugin = definePlugin(() => ({
+  id: "duplicateTools" as const,
+  storage: () => ({}),
+  extension: (ctx) => ({
+    register: () =>
+      ctx.core.sources.register({
+        id: "dup-source",
+        scope: ctx.scopes[0]!.id,
+        kind: "test",
+        name: "Duplicate source",
+        tools: [
+          { name: "same", description: "first" },
+          { name: "same", description: "last" },
+        ],
+      }),
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -310,6 +380,20 @@ describe("createExecutor", () => {
     }),
   );
 
+  it.effect("bounds annotation resolution groups", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [testPlugin()] as const }));
+      for (let index = 0; index < 70; index++) {
+        yield* executor.test.addThing(`thing${index}`, "hello");
+      }
+      testAnnotationResolveCount = 0;
+
+      yield* executor.tools.list();
+
+      expect(testAnnotationResolveCount).toBe(64);
+    }),
+  );
+
   it.effect("invokes a dynamic tool through plugin.invokeTool", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(makeTestConfig({ plugins: [testPlugin()] as const }));
@@ -328,6 +412,7 @@ describe("createExecutor", () => {
     Effect.gen(function* () {
       const executor = yield* createExecutor(makeTestConfig({ plugins: [testPlugin()] as const }));
       yield* executor.test.addThing("thing1", "hello");
+      let approvalMessage = "";
 
       // requiresApproval: true → declined → ElicitationDeclinedError
       const declined = yield* executor.tools
@@ -335,11 +420,16 @@ describe("createExecutor", () => {
           "thing1.write",
           { value: "updated" },
           {
-            onElicitation: () => Effect.succeed(new ElicitationResponse({ action: "decline" })),
+            onElicitation: (ctx) =>
+              Effect.sync(() => {
+                approvalMessage = ctx.request.message;
+                return new ElicitationResponse({ action: "decline" });
+              }),
           },
         )
         .pipe(Effect.flip);
       expect(Predicate.isTagged(declined, "ElicitationDeclinedError")).toBe(true);
+      expect(approvalMessage).toContain('"value": "updated"');
 
       // auto-accept → succeeds
       const accepted = yield* executor.tools.invoke(
@@ -409,6 +499,75 @@ describe("createExecutor", () => {
       const results = yield* executor.sources.detect("https://example.com/source");
 
       expect(results.map((result) => result.kind)).toEqual(["graphql", "mcp"]);
+    }),
+  );
+
+  it.effect("bounds source detection fan-out and results", () =>
+    Effect.gen(function* () {
+      const calls: string[] = [];
+      const detector = (id: string, confidence: "high" | "medium" | "low") =>
+        definePlugin(() => ({
+          id,
+          storage: () => ({}),
+          detect: () =>
+            Effect.sync(() => {
+              calls.push(id);
+              return new SourceDetectionResult({
+                kind: id,
+                confidence,
+                endpoint: `https://example.com/${id}`,
+                name: id,
+                namespace: id,
+              });
+            }),
+        }));
+
+      const executor = yield* createExecutor({
+        ...makeTestConfig({
+          plugins: [
+            detector("first", "low")(),
+            detector("second", "high")(),
+            detector("third", "medium")(),
+          ] as const,
+        }),
+        sourceDetection: { maxDetectors: 2, maxResults: 1 },
+      });
+
+      const results = yield* executor.sources.detect("https://example.com/source");
+
+      expect(calls).toEqual(["first", "second"]);
+      expect(results.map((result) => result.kind)).toEqual(["second"]);
+    }),
+  );
+
+  it.effect("applies hosted outbound policy before source detection plugins run", () =>
+    Effect.gen(function* () {
+      let called = false;
+      const detector = definePlugin(() => ({
+        id: "detector" as const,
+        storage: () => ({}),
+        detect: () =>
+          Effect.sync(() => {
+            called = true;
+            return new SourceDetectionResult({
+              kind: "detector",
+              confidence: "high",
+              endpoint: "http://127.0.0.1/source",
+              name: "detector",
+              namespace: "detector",
+            });
+          }),
+      }));
+
+      const executor = yield* createExecutor({
+        ...makeTestConfig({ plugins: [detector()] as const }),
+        httpClientLayer: FetchHttpClient.layer,
+      });
+
+      const results = yield* executor.sources.detect("http://127.0.0.1/source");
+
+      expect(results).toEqual([]);
+      expect(called).toBe(false);
     }),
   );
 
@@ -1265,6 +1424,62 @@ describe("tenant isolation (SDK)", () => {
 
       expect(refs.map((ref) => ref.id)).toContain("opaque-secret");
       expect(status).toBe("resolved");
+    }),
+  );
+
+  it.effect("secrets.list and status only expose routed secret rows", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [providerOnlySecretPlugin()] as const }),
+      );
+
+      const refs = yield* executor.secrets.list();
+      const status = yield* executor.secrets.status("provider-token");
+      const value = yield* executor.secrets.get("provider-token");
+
+      expect(refs.map((ref) => ref.id)).not.toContain("provider-token");
+      expect(status).toBe("missing");
+      expect(value).toBe("provider-value");
+    }),
+  );
+
+  it.effect("secrets.get short-circuits provider fallback in registration order", () =>
+    Effect.gen(function* () {
+      const laterCalls = { count: 0 };
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [fallbackOrderingPlugin(laterCalls)()] as const }),
+      );
+
+      const value = yield* executor.secrets.get("token");
+
+      expect(value).toBe("first-value");
+      expect(laterCalls.count).toBe(0);
+    }),
+  );
+
+  it.effect("secrets.get skips providers that disable fallback lookup", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [fallbackDisabledPlugin()] as const }),
+      );
+
+      const value = yield* executor.secrets.get("token");
+
+      expect(value).toBeNull();
+    }),
+  );
+
+  it.effect("source registration deduplicates duplicate tool ids before bulk insert", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [duplicateToolsPlugin()] as const }),
+      );
+
+      yield* executor.duplicateTools.register();
+
+      const tools = yield* executor.tools.list();
+      expect(tools.filter((tool) => tool.id === "dup-source.same")).toHaveLength(1);
+      expect(tools.find((tool) => tool.id === "dup-source.same")?.description).toBe("last");
     }),
   );
 });

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1,4 +1,14 @@
-import { Context, Deferred, Effect, Layer, Option, Result, Schema, Semaphore } from "effect";
+import {
+  Context,
+  Deferred,
+  Duration,
+  Effect,
+  Layer,
+  Option,
+  Result,
+  Schema,
+  Semaphore,
+} from "effect";
 import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 import type { OAuthEndpointUrlPolicy } from "./oauth-helpers";
 import { generateKeyBetween } from "fractional-indexing";
@@ -114,6 +124,10 @@ import {
   type ScopeContext,
   type ScopedDBAdapter,
 } from "./scoped-adapter";
+import { validateHostedOutboundUrl } from "./hosted-http-client";
+
+const MAX_ANNOTATION_GROUPS = 64;
+const MAX_APPROVAL_ARGUMENT_PREVIEW_CHARS = 4_000;
 
 // ---------------------------------------------------------------------------
 // Elicitation handler — set once at `createExecutor({ onElicitation })`
@@ -345,6 +359,13 @@ export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = []> {
   readonly onElicitation: OnElicitation;
   readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
   readonly oauthEndpointUrlPolicy?: OAuthEndpointUrlPolicy;
+  readonly sourceDetection?: {
+    readonly maxUrlLength?: number;
+    readonly maxDetectors?: number;
+    readonly maxResults?: number;
+    readonly timeout?: Duration.Input;
+    readonly hostedOutboundPolicy?: boolean;
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -476,11 +497,17 @@ const writeSourceInput = (
       forceAllowId: true,
     });
 
-    if (input.tools.length > 0) {
+    const toolsById = new Map<string, (typeof input.tools)[number]>();
+    for (const tool of input.tools) {
+      toolsById.set(`${input.id}.${tool.name}`, tool);
+    }
+    const tools = [...toolsById.entries()];
+
+    if (tools.length > 0) {
       yield* core.createMany({
         model: "tool",
-        data: input.tools.map((tool) => ({
-          id: `${input.id}.${tool.name}`,
+        data: tools.map(([id, tool]) => ({
+          id,
           scope_id: input.scope,
           source_id: input.id,
           plugin_id: pluginId,
@@ -598,6 +625,13 @@ const activeRawAdapterRef = Context.Reference<DBTransactionAdapter | null>(
     defaultValue: () => null,
   },
 );
+
+const approvalArgumentPreview = (args: unknown): string => {
+  const text = JSON.stringify(args ?? {}, null, 2) ?? "null";
+  return text.length > MAX_APPROVAL_ARGUMENT_PREVIEW_CHARS
+    ? `${text.slice(0, MAX_APPROVAL_ARGUMENT_PREVIEW_CHARS)}...`
+    : text;
+};
 
 // A `DBAdapter` whose methods dispatch to the active adapter (tx handle or
 // root) on every call. Stable identity for consumers (plugin storage,
@@ -846,22 +880,23 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
           if (value !== null) return value;
         }
 
-        // Fallback: ask every enumerating provider in parallel. First
-        // non-null in registration order wins. Providers that throw
+        // Fallback: ask enumerating providers in registration order. First
+        // non-null wins. Providers that throw
         // are treated as "don't have it" so one flaky provider can't
         // block resolution via others. Scope-partitioning providers
         // get asked at the innermost scope as a display default — the
         // enumeration fallback doesn't know which scope the value
         // lives in; flat providers ignore the arg.
         const fallbackScope = scopeIds[0]!;
-        const candidates = [...secretProviders.values()].filter((p) => p.list);
-        const values = yield* Effect.all(
-          candidates.map((p) =>
-            p.get(id, fallbackScope).pipe(Effect.catch(() => Effect.succeed(null))),
-          ),
-          { concurrency: "unbounded" },
+        const candidates = [...secretProviders.values()].filter(
+          (p) => p.list && p.allowFallback !== false,
         );
-        for (const value of values) if (value !== null) return value;
+        for (const provider of candidates) {
+          const value = yield* provider
+            .get(id, fallbackScope)
+            .pipe(Effect.catch(() => Effect.succeed(null)));
+          if (value !== null) return value;
+        }
         return null;
       });
 
@@ -1253,9 +1288,6 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
         // deny-set so provider `list()` results for the same id can't
         // leak them back in below.
         const allRows = yield* core.findMany({ model: "secret" });
-        const connectionOwnedIds = new Set(
-          allRows.filter((r) => r.owned_by_connection_id).map((r) => r.id),
-        );
         const rows = allRows.filter((r) => !r.owned_by_connection_id);
         const pick = (row: (typeof rows)[number]) => {
           const existing = byId.get(row.id);
@@ -1281,48 +1313,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
           if (hasBackingValue) pick(row);
         }
 
-        // Then every provider that can enumerate itself, in parallel.
-        // If a provider fails to list (unlocked vault, network error),
-        // swallow the failure so one flaky provider can't block the
-        // whole list. Merge in registration order afterwards so the
-        // "first provider wins" precedence stays deterministic.
-        const attribution = scopes[0]!.id;
-        const listers = [...secretProviders.entries()].filter(([, p]) => p.list);
-        const lists = yield* Effect.all(
-          listers.map(([key, p]) =>
-            p.list!().pipe(
-              Effect.catch(() => Effect.succeed([] as const)),
-              Effect.map((entries) => ({ key, entries })),
-            ),
-          ),
-          { concurrency: "unbounded" },
-        );
-        for (const { key, entries } of lists) {
-          for (const entry of entries) {
-            if (byId.has(entry.id)) continue; // core row wins
-            if (connectionOwnedIds.has(entry.id)) continue; // hidden by connection
-            byId.set(
-              entry.id,
-              new SecretRef({
-                id: SecretId.make(entry.id),
-                scopeId: attribution,
-                name: entry.name,
-                provider: key,
-                createdAt: new Date(),
-              }),
-            );
-          }
-        }
-
         return Array.from(byId.values());
       });
 
     const secretsListAll = (): Effect.Effect<readonly SecretRef[], StorageFailure> =>
       Effect.gen(function* () {
         const allRows = yield* core.findMany({ model: "secret" });
-        const connectionOwnedIds = new Set(
-          allRows.filter((r) => r.owned_by_connection_id).map((r) => r.id),
-        );
         const coreIds = new Set<string>();
         const refs: SecretRef[] = [];
 
@@ -1340,33 +1336,6 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
               createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
             }),
           );
-        }
-
-        const attribution = scopes[0]!.id;
-        const listers = [...secretProviders.entries()].filter(([, p]) => p.list);
-        const lists = yield* Effect.all(
-          listers.map(([key, p]) =>
-            p.list!().pipe(
-              Effect.catch(() => Effect.succeed([] as const)),
-              Effect.map((entries) => ({ key, entries })),
-            ),
-          ),
-          { concurrency: "unbounded" },
-        );
-        for (const { key, entries } of lists) {
-          for (const entry of entries) {
-            if (coreIds.has(entry.id)) continue;
-            if (connectionOwnedIds.has(entry.id)) continue;
-            refs.push(
-              new SecretRef({
-                id: SecretId.make(entry.id),
-                scopeId: attribution,
-                name: entry.name,
-                provider: key,
-                createdAt: new Date(),
-              }),
-            );
-          }
         }
 
         return refs.sort((a, b) => {
@@ -2791,7 +2760,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
         // ~200-300ms storage round-trips end-to-end and dominates the
         // `executor.tools.list.annotations` span.
         const maps = yield* Effect.forEach(
-          [...groups],
+          [...groups].slice(0, MAX_ANNOTATION_GROUPS),
           ([key, groupRows]) =>
             Effect.gen(function* () {
               const [pluginId, sourceId] = key.split("\u0000") as [string, string];
@@ -3110,8 +3079,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
             ? `Approve ${toolId}? (matched policy: ${policy.pattern})`
             : `Approve ${toolId}?`;
         const request = new FormElicitation({
-          message,
-          requestedSchema: {},
+          message: `${message}\n\nArguments:\n${approvalArgumentPreview(args)}`,
+          requestedSchema: {
+            type: "object",
+            properties: {},
+          },
         });
         const response = yield* handler({ toolId: tid, args, request });
         if (response.action !== "accept") {
@@ -3312,10 +3284,18 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
         }
       });
 
-    // URL autodetection — fan out across every plugin that declared a
-    // `detect` hook. Collect all non-null results. Plugin-level detect
-    // implementations should swallow fetch errors and return null, so
-    // one flaky plugin doesn't block the whole dispatch.
+    const sourceDetectionMaxUrlLength = config.sourceDetection?.maxUrlLength ?? 2_048;
+    const sourceDetectionMaxDetectors = config.sourceDetection?.maxDetectors ?? 6;
+    const sourceDetectionMaxResults = config.sourceDetection?.maxResults ?? 4;
+    const sourceDetectionTimeout = config.sourceDetection?.timeout ?? "5 seconds";
+    const sourceDetectionHostedOutboundPolicy =
+      config.sourceDetection?.hostedOutboundPolicy ?? config.httpClientLayer !== undefined;
+
+    // URL autodetection — fan out across a bounded set of plugins that
+    // declared a `detect` hook. Collect non-null results up to the
+    // configured cap. Plugin-level detect implementations should
+    // swallow fetch errors and return null, so one flaky plugin doesn't
+    // block the whole dispatch.
     const detectionConfidenceScore = (confidence: SourceDetectionResult["confidence"]) => {
       switch (confidence) {
         case "high":
@@ -3329,17 +3309,40 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
 
     const detectSource = (url: string) =>
       Effect.gen(function* () {
+        const trimmed = url.trim();
+        if (trimmed.length === 0 || trimmed.length > sourceDetectionMaxUrlLength) return [];
+        const parsed = yield* Effect.try({
+          try: () => new URL(trimmed),
+          catch: (error) => error,
+        }).pipe(Effect.option);
+        if (Option.isNone(parsed)) return [];
+        if (parsed.value.protocol !== "http:" && parsed.value.protocol !== "https:") return [];
+        if (sourceDetectionHostedOutboundPolicy) {
+          const allowed = yield* validateHostedOutboundUrl(trimmed).pipe(
+            Effect.as(true),
+            Effect.catch(() => Effect.succeed(false)),
+          );
+          if (!allowed) return [];
+        }
+
         const results: SourceDetectionResult[] = [];
+        let detectorCount = 0;
         for (const runtime of runtimes.values()) {
           if (!runtime.plugin.detect) continue;
+          if (detectorCount >= sourceDetectionMaxDetectors) break;
+          detectorCount++;
           const result = yield* runtime.plugin
-            .detect({ ctx: runtime.ctx, url })
+            .detect({ ctx: runtime.ctx, url: trimmed })
+            .pipe(Effect.timeout(sourceDetectionTimeout))
             .pipe(Effect.catch(() => Effect.succeed(null)));
           if (result) results.push(result);
         }
-        return results.sort(
-          (a, b) => detectionConfidenceScore(b.confidence) - detectionConfidenceScore(a.confidence),
-        );
+        return results
+          .sort(
+            (a, b) =>
+              detectionConfidenceScore(b.confidence) - detectionConfidenceScore(a.confidence),
+          )
+          .slice(0, sourceDetectionMaxResults);
       });
 
     // Per-source definitions accessor — one query, one mapping pass.
@@ -3358,13 +3361,6 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
           if (yield* secretRouteHasBackingValue(row)) return "resolved";
         }
 
-        for (const provider of secretProviders.values()) {
-          if (!provider.list) continue;
-          const entries = yield* provider
-            .list()
-            .pipe(Effect.catch(() => Effect.succeed([] as const)));
-          if (entries.some((e) => e.id === id)) return "resolved";
-        }
         return "missing";
       });
 

--- a/packages/core/sdk/src/secrets.ts
+++ b/packages/core/sdk/src/secrets.ts
@@ -48,6 +48,9 @@ export interface SecretProvider {
     readonly { readonly id: string; readonly name: string }[],
     StorageFailure
   >;
+  /** If false, `get` only runs for routed secret rows owned by this
+   *  provider and is skipped by provider-enumeration fallback lookup. */
+  readonly allowFallback?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/graphql/src/sdk/introspect.ts
+++ b/packages/plugins/graphql/src/sdk/introspect.ts
@@ -220,9 +220,8 @@ export const introspect = Effect.fn("GraphQL.introspect")(function* (
   );
 
   if (response.status !== 200) {
-    const body = yield* response.text.pipe(Effect.catch(() => Effect.succeed("<unreadable>")));
     return yield* new GraphqlIntrospectionError({
-      message: `Introspection failed with status ${response.status}: ${body.slice(0, 1_000)}`,
+      message: `Introspection failed with status ${response.status}`,
     });
   }
 

--- a/packages/plugins/graphql/src/sdk/invoke.ts
+++ b/packages/plugins/graphql/src/sdk/invoke.ts
@@ -48,6 +48,14 @@ const endpointWithQueryParams = (endpoint: string, queryParams: Record<string, s
   return url.toString();
 };
 
+export const endpointForTelemetry = (endpoint: string): string => {
+  if (!URL.canParse(endpoint)) return endpoint;
+  const url = new URL(endpoint);
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+};
+
 // ---------------------------------------------------------------------------
 // Response helpers
 // ---------------------------------------------------------------------------
@@ -73,11 +81,12 @@ export const invoke = Effect.fn("GraphQL.invoke")(function* (
 ) {
   const client = yield* HttpClient.HttpClient;
   const requestEndpoint = endpointWithQueryParams(endpoint, resolvedQueryParams);
+  const telemetryEndpoint = endpointForTelemetry(endpoint);
 
   yield* Effect.annotateCurrentSpan({
     "http.method": "POST",
-    "http.url": requestEndpoint,
-    "plugin.graphql.endpoint": endpoint,
+    "http.url": telemetryEndpoint,
+    "plugin.graphql.endpoint": telemetryEndpoint,
     "plugin.graphql.operation_kind": operation.kind,
     "plugin.graphql.field_name": operation.fieldName,
     "plugin.graphql.headers.resolved_count": Object.keys(resolvedHeaders).length,
@@ -160,7 +169,7 @@ export const invokeWithLayer = (
     Effect.provide(httpClientLayer),
     Effect.withSpan("plugin.graphql.invoke", {
       attributes: {
-        "plugin.graphql.endpoint": endpoint,
+        "plugin.graphql.endpoint": endpointForTelemetry(endpoint),
         "plugin.graphql.operation_kind": operation.kind,
         "plugin.graphql.field_name": operation.fieldName,
       },

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "@effect/vitest";
 import { Effect, Predicate } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
 
 import {
   ConnectionId,
@@ -14,9 +15,11 @@ import {
   SecretId,
   TokenMaterial,
 } from "@executor-js/sdk";
-import { memorySecretsPlugin } from "@executor-js/sdk/testing";
+import { memorySecretsPlugin, serveTestHttpApp } from "@executor-js/sdk/testing";
 
 import { graphqlPlugin } from "./plugin";
+import { endpointForTelemetry } from "./invoke";
+import { introspect } from "./introspect";
 import { GraphqlSourceBindingInput, graphqlHeaderSlot, graphqlQueryParamSlot } from "./types";
 import type { IntrospectionResult } from "./introspect";
 import { makeGreetingGraphqlSchema, serveGraphqlTestServer } from "../testing";
@@ -121,6 +124,33 @@ const sampleDataPlugin = definePlugin(() => ({
 }));
 
 describe("graphqlPlugin real protocol server", () => {
+  it("uses query-free endpoints for invocation attributes", () => {
+    expect(endpointForTelemetry("https://api.example.test/graphql?token=secret#section")).toBe(
+      "https://api.example.test/graphql",
+    );
+  });
+
+  it.effect("does not include upstream response bodies in introspection status errors", () =>
+    Effect.gen(function* () {
+      const server = yield* serveTestHttpApp(() =>
+        Effect.succeed(
+          HttpServerResponse.text("internal token value", {
+            status: 500,
+            contentType: "text/plain",
+          }),
+        ),
+      );
+
+      const error = yield* introspect(server.url("/graphql")).pipe(
+        Effect.provide(server.httpClientLayer),
+        Effect.flip,
+      );
+
+      expect(error).toHaveProperty("message", "Introspection failed with status 500");
+      expect(error).not.toHaveProperty("message", expect.stringContaining("internal token value"));
+    }),
+  );
+
   it.effect("adds a source by introspecting the live GraphQL endpoint", () =>
     Effect.gen(function* () {
       const server = yield* serveGreetingServer;


### PR DESCRIPTION
## Summary

- Bound source detection URL input, detector fan-out, result count, and hosted outbound policy usage.
- Trim source-detection API input before dispatching to the SDK.
- Keep GraphQL invocation telemetry and introspection status errors concise.

## Validation

- `bunx vitest run src/executor.test.ts` from `packages/core/sdk`
- `bunx vitest run src/sdk/plugin.test.ts` from `packages/plugins/graphql`
- `bun run format:check`
- `bun run lint`
