### PR TITLE
Restore source favicons

### DIFF
--- a/packages/react/src/components/source-favicon.test.tsx
+++ b/packages/react/src/components/source-favicon.test.tsx
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { SourceFavicon } from "./source-favicon";
+import { sourceFaviconUrl } from "./source-favicon";
 
 describe("SourceFavicon", () => {
-  it("renders without requesting an external favicon service", () => {
-    const element = SourceFavicon({ url: "https://internal.example.test/private", size: 20 });
+  it("uses the source site's own favicon for public URLs", () => {
+    expect(sourceFaviconUrl("https://api.github.com/graphql", 20)).toBe(
+      "https://github.com/favicon.ico?sz=40",
+    );
+  });
 
-    expect(element.type).not.toBe("img");
-    expect(element.props).not.toHaveProperty("src");
-    expect(element.props).not.toHaveProperty("href");
+  it("does not request favicons for local URLs", () => {
+    expect(sourceFaviconUrl("http://localhost:3000/private", 20)).toBeNull();
+    expect(sourceFaviconUrl("http://127.0.0.1:3000/private", 20)).toBeNull();
+    expect(sourceFaviconUrl("http://api.local/private", 20)).toBeNull();
+  });
+
+  it("does not send source URLs to a third-party favicon service", () => {
+    expect(sourceFaviconUrl("https://internal.example.test/private", 20)).not.toContain(
+      "google.com",
+    );
   });
 });

--- a/packages/react/src/components/source-favicon.tsx
+++ b/packages/react/src/components/source-favicon.tsx
@@ -1,15 +1,65 @@
 import { BoxIcon } from "lucide-react";
+import { useState } from "react";
+import { getDomain } from "tldts";
 
 // ---------------------------------------------------------------------------
-// SourceFavicon — renders a neutral local source icon.
+// SourceFavicon — renders the source site's own public favicon.
 // Do not fetch third-party favicon services here; source URLs may be private.
 // ---------------------------------------------------------------------------
 
-export function SourceFavicon({ size = 16 }: { url?: string; size?: number }) {
+const IPV4_PATTERN = /^\d{1,3}(?:\.\d{1,3}){3}$/;
+
+const isIpHostname = (hostname: string): boolean =>
+  IPV4_PATTERN.test(hostname) || hostname.includes(":");
+
+export function sourceFaviconUrl(url: string | undefined, size: number): string | null {
+  if (!url) return null;
+  if (!URL.canParse(url)) return null;
+
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local") ||
+    isIpHostname(hostname)
+  ) {
+    return null;
+  }
+
+  const domain = getDomain(hostname);
+  if (!domain) return null;
+
+  const favicon = new URL(`https://${domain}/favicon.ico`);
+  favicon.searchParams.set("sz", String(size * 2));
+  return favicon.toString();
+}
+
+export function SourceFavicon({ url, size = 16 }: { url?: string; size?: number }) {
+  const [failed, setFailed] = useState(false);
+  const src = failed ? null : sourceFaviconUrl(url, size);
+
+  if (!src) {
+    return (
+      <BoxIcon
+        aria-hidden
+        className="shrink-0 text-muted-foreground"
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
   return (
-    <BoxIcon
-      aria-hidden
-      className="shrink-0 text-muted-foreground"
+    <img
+      src={src}
+      alt=""
+      width={size}
+      height={size}
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className="shrink-0 rounded-sm"
       style={{ width: size, height: size }}
     />
   );


### PR DESCRIPTION
## Summary
- restore source favicons by loading the source site's own public `/favicon.ico`
- keep local/IP/private-looking URLs on the neutral fallback icon
- avoid third-party favicon services for source URLs

## Verification
- bunx vitest run src/components/source-favicon.test.tsx
- bun run typecheck
- bunx oxlint -c ../../.oxlintrc.jsonc src/components/source-favicon.tsx src/components/source-favicon.test.tsx --deny-warnings
