### PR TITLE
Route OpenAPI OAuth starts through token scope

### DIFF
--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -597,7 +597,7 @@ export default function AddOpenApiSource(props: {
       setStartingOAuth(true);
       const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
       const exit = await doStartOAuth({
-        params: { scopeId },
+        params: { scopeId: oauthTokenTargetScope },
         payload: {
           endpoint: tokenUrl,
           redirectUrl: tokenUrl,
@@ -642,7 +642,7 @@ export default function AddOpenApiSource(props: {
       tokenScope: oauthTokenTargetScope,
       run: async () => {
         const exit = await doStartOAuth({
-          params: { scopeId },
+          params: { scopeId: oauthTokenTargetScope },
           payload: {
             endpoint: authorizationUrl,
             connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
@@ -696,7 +696,6 @@ export default function AddOpenApiSource(props: {
     resolvedBaseUrl,
     preview,
     doStartOAuth,
-    scopeId,
     identity.name,
     resolvedSourceId,
     selectedOAuth2Fingerprint,

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -447,7 +447,7 @@ export default function EditOpenApiSource(props: {
     const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
     if (oauth2.flow === "clientCredentials") {
       const startOAuthExit = await doStartOAuth({
-        params: { scopeId: displayScope },
+        params: { scopeId: targetScope },
         payload: {
           endpoint: tokenUrl,
           redirectUrl: tokenUrl,
@@ -502,7 +502,7 @@ export default function EditOpenApiSource(props: {
     );
     const issuerUrl = oauth2.issuerUrl ?? inferOAuthIssuerUrl(authorizationUrl);
     const startOAuthExit = await doStartOAuth({
-      params: { scopeId: displayScope },
+      params: { scopeId: targetScope },
       payload: {
         endpoint: authorizationUrl,
         connectionId,


### PR DESCRIPTION
## Summary
- route OpenAPI direct OAuth starts through the selected token scope
- keep add/edit OpenAPI OAuth flows aligned with the OAuth route/token scope invariant

## Verification
- bun run typecheck (packages/plugins/openapi)
- bunx oxlint -c ../../../.oxlintrc.jsonc src/react/AddOpenApiSource.tsx src/react/EditOpenApiSource.tsx --deny-warnings
