### PR TITLE
Refactor source credential edit surfaces

### DIFF
--- a/packages/core/sdk/src/client.ts
+++ b/packages/core/sdk/src/client.ts
@@ -122,9 +122,6 @@ export interface SourcePlugin {
     readonly variant?: "badge" | "panel";
     readonly onAction?: () => void;
   }>;
-  readonly signIn?: ComponentType<{
-    readonly sourceId: string;
-  }>;
   readonly presets?: readonly SourcePreset[];
   /** Trigger early download of the plugin's lazy component chunks (add/edit/etc.).
    *  Call from the host on intent (hover/focus) so the chunks land before the

--- a/packages/plugins/google-discovery/src/react/EditGoogleDiscoverySource.tsx
+++ b/packages/plugins/google-discovery/src/react/EditGoogleDiscoverySource.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@executor-js/react/components/badge";
 import { Button } from "@executor-js/react/components/button";
 
 import { googleDiscoverySourceAtom } from "./atoms";
+import GoogleDiscoverySignInButton from "./GoogleDiscoverySignInButton";
 
 export default function EditGoogleDiscoverySource({
   sourceId,
@@ -63,9 +64,12 @@ export default function EditGoogleDiscoverySource({
             <p className="text-xs uppercase tracking-wider text-muted-foreground mb-1">
               Authentication
             </p>
-            <p className="text-sm font-medium text-foreground capitalize">
-              {authKind === "oauth2" ? "OAuth 2.0" : authKind}
-            </p>
+            <div className="flex min-h-9 items-center justify-between gap-3">
+              <p className="text-sm font-medium text-foreground capitalize">
+                {authKind === "oauth2" ? "OAuth 2.0" : authKind}
+              </p>
+              {authKind === "oauth2" && <GoogleDiscoverySignInButton sourceId={sourceId} />}
+            </div>
           </div>
         </div>
       )}

--- a/packages/plugins/google-discovery/src/react/source-plugin.ts
+++ b/packages/plugins/google-discovery/src/react/source-plugin.ts
@@ -5,7 +5,6 @@ import { googleDiscoveryPresets } from "../sdk/presets";
 const importAdd = () => import("./AddGoogleDiscoverySource");
 const importEdit = () => import("./EditGoogleDiscoverySource");
 const importSummary = () => import("./GoogleDiscoverySourceSummary");
-const importSignIn = () => import("./GoogleDiscoverySignInButton");
 
 export const googleDiscoverySourcePlugin: SourcePlugin = {
   key: "googleDiscovery",
@@ -13,12 +12,10 @@ export const googleDiscoverySourcePlugin: SourcePlugin = {
   add: lazy(importAdd),
   edit: lazy(importEdit),
   summary: lazy(importSummary),
-  signIn: lazy(importSignIn),
   presets: googleDiscoveryPresets,
   preload: () => {
     void importAdd();
     void importEdit();
     void importSummary();
-    void importSignIn();
   },
 };

--- a/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/AddGraphqlSource.tsx
@@ -16,7 +16,6 @@ import {
 import {
   sourceDisplayNameFromUrl,
   slugifyNamespace,
-  SourceIdentityFieldRows,
   useSourceIdentity,
 } from "@executor-js/react/plugins/source-identity";
 import {
@@ -33,16 +32,11 @@ import {
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor-js/react/components/button";
 import { FilterTabs } from "@executor-js/react/components/filter-tabs";
-import {
-  CardStack,
-  CardStackContent,
-  CardStackEntryField,
-} from "@executor-js/react/components/card-stack";
 import { FloatActions } from "@executor-js/react/components/float-actions";
-import { Input } from "@executor-js/react/components/input";
 import { Spinner } from "@executor-js/react/components/spinner";
 import { addGraphqlSourceOptimistic } from "./atoms";
 import { initialGraphqlCredentials } from "./defaults";
+import { GraphqlSourceFields } from "./GraphqlSourceFields";
 import type { GraphqlCredentialInput } from "../sdk/types";
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
@@ -181,22 +175,7 @@ export default function AddGraphqlSource(props: {
     <div className="flex flex-1 flex-col gap-6">
       <h1 className="text-xl font-semibold text-foreground">Add GraphQL Source</h1>
 
-      <CardStack>
-        <CardStackContent className="border-t-0">
-          <CardStackEntryField
-            label="Endpoint"
-            hint="The endpoint will be introspected to discover available queries and mutations."
-          >
-            <Input
-              value={endpoint}
-              onChange={(e) => setEndpoint((e.target as HTMLInputElement).value)}
-              placeholder="https://api.example.com/graphql"
-              className="font-mono text-sm"
-            />
-          </CardStackEntryField>
-          <SourceIdentityFieldRows identity={identity} namePlaceholder="e.g. Shopify API" />
-        </CardStackContent>
-      </CardStack>
+      <GraphqlSourceFields endpoint={endpoint} onEndpointChange={setEndpoint} identity={identity} />
 
       <HttpCredentialsEditor
         credentials={credentials}

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -2,40 +2,42 @@ import { useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { graphqlSourceAtom, graphqlSourceBindingsAtom, updateGraphqlSource } from "./atoms";
-import { useScope } from "@executor-js/react/api/scope-context";
-import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import {
+  graphqlSourceAtom,
+  graphqlSourceBindingsAtom,
+  setGraphqlSourceBinding,
+  updateGraphqlSource,
+} from "./atoms";
+import { connectionsAtom } from "@executor-js/react/api/atoms";
+import { useScope, useScopeStack } from "@executor-js/react/api/scope-context";
+import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import {
   HttpCredentialsEditor,
+  serializeHttpCredentials,
   serializeScopedHttpCredentials,
   type HttpCredentialsState,
 } from "@executor-js/react/plugins/http-credentials";
 import {
+  effectiveCredentialBindingForScope,
   httpCredentialsFromConfiguredCredentialBindings,
   initialCredentialTargetScope,
 } from "@executor-js/react/plugins/credential-bindings";
-import {
-  SourceIdentityFields,
-  useSourceIdentity,
-} from "@executor-js/react/plugins/source-identity";
+import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
 import {
   CredentialTargetScopeSelector,
   useCredentialTargetScope,
 } from "@executor-js/react/plugins/credential-target-scope";
 import { Button } from "@executor-js/react/components/button";
 import { FilterTabs } from "@executor-js/react/components/filter-tabs";
-import {
-  CardStack,
-  CardStackContent,
-  CardStackEntryField,
-} from "@executor-js/react/components/card-stack";
-import { Input } from "@executor-js/react/components/input";
+import { SourceOAuthConnectionControl } from "@executor-js/react/plugins/source-oauth-connection";
 import { Badge } from "@executor-js/react/components/badge";
 import { ScopeId } from "@executor-js/sdk/core";
+import { GraphqlSourceFields } from "./GraphqlSourceFields";
 import {
   GRAPHQL_OAUTH_CONNECTION_SLOT,
   type GraphqlCredentialInput,
+  GraphqlSourceBindingInput,
   type GraphqlSourceBindingRef,
 } from "../sdk/types";
 import type { StoredGraphqlSource } from "../sdk/store";
@@ -54,14 +56,24 @@ function EditForm(props: {
   onSave: () => void;
 }) {
   const displayScope = useScope();
+  const scopeStack = useScopeStack();
   const sourceScope = ScopeId.make(props.initial.scope);
   const { credentialTargetScope, setCredentialTargetScope, credentialScopeOptions } =
     useCredentialTargetScope({
       sourceScope,
       initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
     });
+  const {
+    credentialTargetScope: oauthCredentialTargetScope,
+    setCredentialTargetScope: setOAuthCredentialTargetScope,
+  } = useCredentialTargetScope({
+    sourceScope,
+    initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
+  });
   const doUpdate = useAtomSet(updateGraphqlSource, { mode: "promiseExit" });
+  const setBinding = useAtomSet(setGraphqlSourceBinding, { mode: "promise" });
   const secretList = useSecretPickerSecrets();
+  const connectionsResult = useAtomValue(connectionsAtom(displayScope));
 
   const identity = useSourceIdentity({
     fallbackName: props.initial.name,
@@ -84,6 +96,23 @@ function EditForm(props: {
   const identityDirty = identity.name.trim() !== props.initial.name.trim();
   const metadataDirty = identityDirty || endpoint.trim() !== props.initial.endpoint.trim();
   const dirty = metadataDirty || credentialsDirty || authDirty;
+  const oauth2 = props.initial.auth.kind === "oauth2" ? props.initial.auth : null;
+  const connections = AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : [];
+  const scopeRanks = new Map(scopeStack.map((scope, index) => [scope.id, index] as const));
+  const connectionBinding = oauth2
+    ? effectiveCredentialBindingForScope(
+        props.bindings,
+        oauth2.connectionSlot,
+        oauthCredentialTargetScope,
+        scopeRanks,
+      )
+    : null;
+  const boundConnectionId =
+    connectionBinding?.value.kind === "connection" ? connectionBinding.value.connectionId : null;
+  const isConnected =
+    boundConnectionId !== null &&
+    connections.some((connection) => connection.id === boundConnectionId);
+  const oauthRequestCredentials = serializeHttpCredentials(credentials);
 
   const handleCredentialsChange = (next: HttpCredentialsState) => {
     setCredentials(next);
@@ -164,22 +193,12 @@ function EditForm(props: {
         </Badge>
       </div>
 
-      <SourceIdentityFields identity={identity} namespaceReadOnly />
-
-      <CardStack>
-        <CardStackContent className="border-t-0">
-          <CardStackEntryField label="Endpoint">
-            <Input
-              value={endpoint}
-              onChange={(e) => {
-                setEndpoint((e.target as HTMLInputElement).value);
-              }}
-              placeholder="https://api.example.com/graphql"
-              className="font-mono text-sm"
-            />
-          </CardStackEntryField>
-        </CardStackContent>
-      </CardStack>
+      <GraphqlSourceFields
+        endpoint={endpoint}
+        onEndpointChange={setEndpoint}
+        identity={identity}
+        namespaceReadOnly
+      />
 
       <CredentialTargetScopeSelector
         value={credentialTargetScope}
@@ -223,6 +242,37 @@ function EditForm(props: {
           </p>
         )}
       </section>
+
+      {oauth2 && (
+        <SourceOAuthConnectionControl
+          popupName="graphql-oauth"
+          pluginId="graphql"
+          namespace={slugifyNamespace(props.initial.namespace) || "graphql"}
+          fallbackNamespace="graphql"
+          endpoint={endpoint.trim()}
+          tokenScope={oauthCredentialTargetScope}
+          onTokenScopeChange={setOAuthCredentialTargetScope}
+          credentialScopeOptions={credentialScopeOptions}
+          connectionId={boundConnectionId}
+          sourceLabel={`${identity.name.trim() || props.initial.namespace || "GraphQL"} OAuth`}
+          headers={oauthRequestCredentials.headers}
+          queryParams={oauthRequestCredentials.queryParams}
+          isConnected={isConnected}
+          onConnected={async (connectionId) => {
+            await setBinding({
+              params: { scopeId: oauthCredentialTargetScope },
+              payload: new GraphqlSourceBindingInput({
+                sourceId: props.sourceId,
+                sourceScope,
+                scope: oauthCredentialTargetScope,
+                slot: oauth2.connectionSlot,
+                value: { kind: "connection", connectionId },
+              }),
+              reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
+            });
+          }}
+        />
+      )}
 
       {error && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">

--- a/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
+++ b/packages/plugins/graphql/src/react/EditGraphqlSource.tsx
@@ -24,10 +24,7 @@ import {
   initialCredentialTargetScope,
 } from "@executor-js/react/plugins/credential-bindings";
 import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
-import {
-  CredentialTargetScopeSelector,
-  useCredentialTargetScope,
-} from "@executor-js/react/plugins/credential-target-scope";
+import { useCredentialTargetScope } from "@executor-js/react/plugins/credential-target-scope";
 import { Button } from "@executor-js/react/components/button";
 import { FilterTabs } from "@executor-js/react/components/filter-tabs";
 import { SourceOAuthConnectionControl } from "@executor-js/react/plugins/source-oauth-connection";
@@ -58,11 +55,10 @@ function EditForm(props: {
   const displayScope = useScope();
   const scopeStack = useScopeStack();
   const sourceScope = ScopeId.make(props.initial.scope);
-  const { credentialTargetScope, setCredentialTargetScope, credentialScopeOptions } =
-    useCredentialTargetScope({
-      sourceScope,
-      initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
-    });
+  const { credentialTargetScope, credentialScopeOptions } = useCredentialTargetScope({
+    sourceScope,
+    initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
+  });
   const {
     credentialTargetScope: oauthCredentialTargetScope,
     setCredentialTargetScope: setOAuthCredentialTargetScope,
@@ -198,16 +194,6 @@ function EditForm(props: {
         onEndpointChange={setEndpoint}
         identity={identity}
         namespaceReadOnly
-      />
-
-      <CredentialTargetScopeSelector
-        value={credentialTargetScope}
-        options={credentialScopeOptions}
-        onChange={(targetScope) => {
-          setCredentialTargetScope(targetScope);
-          setCredentialsDirty(true);
-        }}
-        description="Choose where updated GraphQL credentials are saved."
       />
 
       <HttpCredentialsEditor

--- a/packages/plugins/graphql/src/react/GraphqlSourceFields.tsx
+++ b/packages/plugins/graphql/src/react/GraphqlSourceFields.tsx
@@ -1,0 +1,42 @@
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "@executor-js/react/components/card-stack";
+import { Input } from "@executor-js/react/components/input";
+import {
+  SourceIdentityFieldRows,
+  type SourceIdentity,
+} from "@executor-js/react/plugins/source-identity";
+
+export function GraphqlSourceFields(props: {
+  readonly endpoint: string;
+  readonly onEndpointChange: (endpoint: string) => void;
+  readonly identity: SourceIdentity;
+  readonly endpointDisabled?: boolean;
+  readonly namespaceReadOnly?: boolean;
+}) {
+  return (
+    <CardStack>
+      <CardStackContent className="border-t-0">
+        <CardStackEntryField
+          label="Endpoint"
+          hint="The endpoint will be introspected to discover available queries and mutations."
+        >
+          <Input
+            value={props.endpoint}
+            onChange={(e) => props.onEndpointChange((e.target as HTMLInputElement).value)}
+            placeholder="https://api.example.com/graphql"
+            className="font-mono text-sm"
+            disabled={props.endpointDisabled}
+          />
+        </CardStackEntryField>
+        <SourceIdentityFieldRows
+          identity={props.identity}
+          namePlaceholder="e.g. Shopify API"
+          namespaceReadOnly={props.namespaceReadOnly}
+        />
+      </CardStackContent>
+    </CardStack>
+  );
+}

--- a/packages/plugins/graphql/src/react/source-plugin.ts
+++ b/packages/plugins/graphql/src/react/source-plugin.ts
@@ -5,7 +5,6 @@ import { graphqlPresets } from "../sdk/presets";
 const importAdd = () => import("./AddGraphqlSource");
 const importEdit = () => import("./EditGraphqlSource");
 const importSummary = () => import("./GraphqlSourceSummary");
-const importSignIn = () => import("./GraphqlSignInButton");
 
 export const graphqlSourcePlugin: SourcePlugin = {
   key: "graphql",
@@ -13,12 +12,10 @@ export const graphqlSourcePlugin: SourcePlugin = {
   add: lazy(importAdd),
   edit: lazy(importEdit),
   summary: lazy(importSummary),
-  signIn: lazy(importSignIn),
   presets: graphqlPresets,
   preload: () => {
     void importAdd();
     void importEdit();
     void importSummary();
-    void importSignIn();
   },
 };

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -10,7 +10,6 @@ import {
   CardStack,
   CardStackContent,
   CardStackEntry,
-  CardStackEntryContent,
   CardStackEntryField,
 } from "@executor-js/react/components/card-stack";
 import { FieldLabel } from "@executor-js/react/components/field";
@@ -30,7 +29,6 @@ import {
 import {
   sourceDisplayNameFromUrl,
   slugifyNamespace,
-  SourceIdentityFieldRows,
   SourceIdentityFields,
   useSourceIdentity,
 } from "@executor-js/react/plugins/source-identity";

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -10,22 +10,15 @@ import {
   CardStack,
   CardStackContent,
   CardStackEntry,
-  CardStackEntryActions,
   CardStackEntryContent,
-  CardStackEntryDescription,
   CardStackEntryField,
-  CardStackEntryMedia,
-  CardStackEntryTitle,
 } from "@executor-js/react/components/card-stack";
-import { FieldError, FieldLabel } from "@executor-js/react/components/field";
+import { FieldLabel } from "@executor-js/react/components/field";
 import { FilterTabs } from "@executor-js/react/components/filter-tabs";
 import { FloatActions } from "@executor-js/react/components/float-actions";
 import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
-import { Badge } from "@executor-js/react/components/badge";
-import { Skeleton } from "@executor-js/react/components/skeleton";
-import { SourceFavicon } from "@executor-js/react/components/source-favicon";
-import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
+import { Spinner } from "@executor-js/react/components/spinner";
 import { Textarea } from "@executor-js/react/components/textarea";
 import {
   emptyHttpCredentials,
@@ -57,6 +50,7 @@ import {
 type RemoteAuthMode = "none" | "oauth2";
 import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { probeMcpEndpoint, addMcpSourceOptimistic } from "./atoms";
+import { McpRemoteSourceFields } from "./McpRemoteSourceFields";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
 import { MCP_OAUTH_CONNECTION_SLOT, type McpCredentialInput } from "../sdk/types";
 
@@ -599,116 +593,15 @@ export default function AddMcpSource(props: {
 
       {transport === "remote" ? (
         <>
-          {/* Server info card (shown above URL input after probing) */}
-          {probe ? (
-            <CardStack>
-              <CardStackContent className="border-t-0">
-                <CardStackEntry>
-                  <CardStackEntryMedia>
-                    <SourceFavicon url={state.url} size={32} />
-                  </CardStackEntryMedia>
-                  <CardStackEntryContent>
-                    <CardStackEntryTitle>{probe.serverName ?? probe.name}</CardStackEntryTitle>
-                    <CardStackEntryDescription>
-                      {probe.connected
-                        ? `${probe.toolCount} tool${probe.toolCount !== 1 ? "s" : ""} available`
-                        : "OAuth required to discover tools"}
-                    </CardStackEntryDescription>
-                  </CardStackEntryContent>
-                  <CardStackEntryActions>
-                    {probe.connected ? (
-                      <Badge
-                        variant="outline"
-                        className="border-emerald-500/20 bg-emerald-500/10 text-[10px] text-emerald-600 dark:text-emerald-400"
-                      >
-                        Connected
-                      </Badge>
-                    ) : (
-                      <Badge
-                        variant="outline"
-                        className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
-                      >
-                        OAuth required
-                      </Badge>
-                    )}
-                  </CardStackEntryActions>
-                </CardStackEntry>
-                <SourceIdentityFieldRows identity={remoteIdentity} namePlaceholder="e.g. Linear" />
-                <CardStackEntryField label="Server URL">
-                  <Input
-                    value={state.url}
-                    onChange={(e) =>
-                      dispatch({
-                        type: "set-url",
-                        url: (e.target as HTMLInputElement).value,
-                      })
-                    }
-                    placeholder="https://mcp.example.com"
-                    className="w-full font-mono text-sm"
-                  />
-                </CardStackEntryField>
-              </CardStackContent>
-            </CardStack>
-          ) : isProbing ? (
-            <CardStack>
-              <CardStackContent className="border-t-0">
-                <CardStackEntry>
-                  <CardStackEntryMedia>
-                    <Skeleton className="size-4 rounded" />
-                  </CardStackEntryMedia>
-                  <CardStackEntryContent>
-                    <Skeleton className="h-4 w-40" />
-                    <Skeleton className="mt-1 h-3 w-32" />
-                  </CardStackEntryContent>
-                  <CardStackEntryActions>
-                    <Skeleton className="h-4 w-20 rounded-full" />
-                  </CardStackEntryActions>
-                </CardStackEntry>
-              </CardStackContent>
-            </CardStack>
-          ) : null}
-
-          {!probe && (
-            <CardStack>
-              <CardStackContent className="border-t-0">
-                <CardStackEntryField label="Server URL">
-                  <div className="relative">
-                    <Input
-                      value={state.url}
-                      onChange={(e) =>
-                        dispatch({
-                          type: "set-url",
-                          url: (e.target as HTMLInputElement).value,
-                        })
-                      }
-                      placeholder="https://mcp.example.com"
-                      className="w-full pr-9 font-mono text-sm"
-                      aria-invalid={probeError ? true : undefined}
-                    />
-                    {isProbing && (
-                      <div className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
-                        <IOSSpinner className="size-4" />
-                      </div>
-                    )}
-                  </div>
-                  {probeError && (
-                    <div className="mt-2 space-y-2">
-                      <FieldError>{probeError}</FieldError>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={handleProbe}
-                        className="h-7 px-2 text-xs"
-                      >
-                        Try again
-                      </Button>
-                    </div>
-                  )}
-                </CardStackEntryField>
-              </CardStackContent>
-            </CardStack>
-          )}
+          <McpRemoteSourceFields
+            url={state.url}
+            onUrlChange={(url) => dispatch({ type: "set-url", url })}
+            identity={remoteIdentity}
+            preview={probe}
+            probing={isProbing}
+            error={probeError}
+            onRetry={handleProbe}
+          />
 
           <HttpCredentialsEditor
             credentials={remoteCredentials}

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -12,10 +12,7 @@ import { connectionsAtom } from "@executor-js/react/api/atoms";
 import { useScope, useScopeStack } from "@executor-js/react/api/scope-context";
 import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
-import {
-  CredentialTargetScopeSelector,
-  useCredentialTargetScope,
-} from "@executor-js/react/plugins/credential-target-scope";
+import { useCredentialTargetScope } from "@executor-js/react/plugins/credential-target-scope";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import {
   HttpCredentialsEditor,
@@ -53,11 +50,10 @@ function RemoteEditForm(props: {
   const displayScope = useScope();
   const scopeStack = useScopeStack();
   const sourceScope = ScopeId.make(props.initial.scope);
-  const { credentialTargetScope, setCredentialTargetScope, credentialScopeOptions } =
-    useCredentialTargetScope({
-      sourceScope,
-      initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
-    });
+  const { credentialTargetScope, credentialScopeOptions } = useCredentialTargetScope({
+    sourceScope,
+    initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
+  });
   const {
     credentialTargetScope: oauthCredentialTargetScope,
     setCredentialTargetScope: setOAuthCredentialTargetScope,
@@ -180,16 +176,6 @@ function RemoteEditForm(props: {
           toolCount: null,
         }}
         namespaceReadOnly
-      />
-
-      <CredentialTargetScopeSelector
-        value={credentialTargetScope}
-        options={credentialScopeOptions}
-        onChange={(targetScope) => {
-          setCredentialTargetScope(targetScope);
-          setCredentialsDirty(true);
-        }}
-        description="Choose where updated MCP credentials are saved."
       />
 
       <HttpCredentialsEditor

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -2,13 +2,16 @@ import { useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
-import { mcpSourceAtom, mcpSourceBindingsAtom, updateMcpSource } from "./atoms";
-import { useScope } from "@executor-js/react/api/scope-context";
-import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import {
-  SourceIdentityFields,
-  useSourceIdentity,
-} from "@executor-js/react/plugins/source-identity";
+  mcpSourceAtom,
+  mcpSourceBindingsAtom,
+  setMcpSourceBinding,
+  updateMcpSource,
+} from "./atoms";
+import { connectionsAtom } from "@executor-js/react/api/atoms";
+import { useScope, useScopeStack } from "@executor-js/react/api/scope-context";
+import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
 import {
   CredentialTargetScopeSelector,
   useCredentialTargetScope,
@@ -16,23 +19,25 @@ import {
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import {
   HttpCredentialsEditor,
+  serializeHttpCredentials,
   serializeScopedHttpCredentials,
   type HttpCredentialsState,
 } from "@executor-js/react/plugins/http-credentials";
 import {
+  effectiveCredentialBindingForScope,
   httpCredentialsFromConfiguredCredentialBindings,
   initialCredentialTargetScope,
 } from "@executor-js/react/plugins/credential-bindings";
+import { SourceOAuthConnectionControl } from "@executor-js/react/plugins/source-oauth-connection";
 import { Button } from "@executor-js/react/components/button";
-import {
-  CardStack,
-  CardStackContent,
-  CardStackEntryField,
-} from "@executor-js/react/components/card-stack";
-import { Input } from "@executor-js/react/components/input";
 import { Badge } from "@executor-js/react/components/badge";
 import { ScopeId } from "@executor-js/sdk/core";
-import type { McpCredentialInput, McpSourceBindingRef } from "../sdk/types";
+import { McpRemoteSourceFields } from "./McpRemoteSourceFields";
+import {
+  McpSourceBindingInput,
+  type McpCredentialInput,
+  type McpSourceBindingRef,
+} from "../sdk/types";
 import type { McpStoredSourceSchemaType } from "../sdk/stored-source";
 
 // ---------------------------------------------------------------------------
@@ -46,14 +51,24 @@ function RemoteEditForm(props: {
   onSave: () => void;
 }) {
   const displayScope = useScope();
+  const scopeStack = useScopeStack();
   const sourceScope = ScopeId.make(props.initial.scope);
   const { credentialTargetScope, setCredentialTargetScope, credentialScopeOptions } =
     useCredentialTargetScope({
       sourceScope,
       initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
     });
+  const {
+    credentialTargetScope: oauthCredentialTargetScope,
+    setCredentialTargetScope: setOAuthCredentialTargetScope,
+  } = useCredentialTargetScope({
+    sourceScope,
+    initialTargetScope: initialCredentialTargetScope(sourceScope, props.bindings),
+  });
   const doUpdate = useAtomSet(updateMcpSource, { mode: "promiseExit" });
+  const setBinding = useAtomSet(setMcpSourceBinding, { mode: "promise" });
   const secretList = useSecretPickerSecrets();
+  const connectionsResult = useAtomValue(connectionsAtom(displayScope));
 
   const identity = useSourceIdentity({
     fallbackName: props.initial.name,
@@ -74,6 +89,23 @@ function RemoteEditForm(props: {
   const identityDirty = identity.name.trim() !== props.initial.name.trim();
   const metadataDirty = identityDirty || endpoint.trim() !== props.initial.config.endpoint.trim();
   const dirty = metadataDirty || credentialsDirty;
+  const oauth2 = props.initial.config.auth.kind === "oauth2" ? props.initial.config.auth : null;
+  const connections = AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : [];
+  const scopeRanks = new Map(scopeStack.map((scope, index) => [scope.id, index] as const));
+  const connectionBinding = oauth2
+    ? effectiveCredentialBindingForScope(
+        props.bindings,
+        oauth2.connectionSlot,
+        oauthCredentialTargetScope,
+        scopeRanks,
+      )
+    : null;
+  const boundConnectionId =
+    connectionBinding?.value.kind === "connection" ? connectionBinding.value.connectionId : null;
+  const isConnected =
+    boundConnectionId !== null &&
+    connections.some((connection) => connection.id === boundConnectionId);
+  const oauthRequestCredentials = serializeHttpCredentials(credentials);
 
   const handleCredentialsChange = (next: HttpCredentialsState) => {
     setCredentials(next);
@@ -137,23 +169,18 @@ function RemoteEditForm(props: {
         </Badge>
       </div>
 
-      <SourceIdentityFields identity={identity} namespaceReadOnly />
-
-      {/* Endpoint */}
-      <CardStack>
-        <CardStackContent className="border-t-0">
-          <CardStackEntryField label="Endpoint">
-            <Input
-              value={endpoint}
-              onChange={(e) => {
-                setEndpoint((e.target as HTMLInputElement).value);
-              }}
-              placeholder="https://mcp.example.com"
-              className="font-mono text-sm"
-            />
-          </CardStackEntryField>
-        </CardStackContent>
-      </CardStack>
+      <McpRemoteSourceFields
+        url={endpoint}
+        onUrlChange={setEndpoint}
+        identity={identity}
+        preview={{
+          name: props.initial.name,
+          serverName: props.initial.name,
+          connected: true,
+          toolCount: null,
+        }}
+        namespaceReadOnly
+      />
 
       <CredentialTargetScopeSelector
         value={credentialTargetScope}
@@ -174,6 +201,39 @@ function RemoteEditForm(props: {
         credentialScopeOptions={credentialScopeOptions}
         bindingScopeOptions={credentialScopeOptions}
       />
+
+      {oauth2 && (
+        <SourceOAuthConnectionControl
+          popupName="mcp-oauth"
+          pluginId="mcp"
+          namespace={slugifyNamespace(props.initial.namespace) || "mcp"}
+          fallbackNamespace="mcp"
+          endpoint={endpoint.trim()}
+          tokenScope={oauthCredentialTargetScope}
+          onTokenScopeChange={setOAuthCredentialTargetScope}
+          credentialScopeOptions={credentialScopeOptions}
+          connectionId={boundConnectionId}
+          sourceLabel={`${identity.name.trim() || props.initial.namespace || "MCP"} OAuth`}
+          headers={oauthRequestCredentials.headers}
+          queryParams={oauthRequestCredentials.queryParams}
+          isConnected={isConnected}
+          onConnected={async (connectionId) => {
+            await setBinding({
+              params: { scopeId: oauthCredentialTargetScope },
+              payload: new McpSourceBindingInput({
+                sourceId: props.sourceId,
+                sourceScope,
+                scope: oauthCredentialTargetScope,
+                slot: oauth2.connectionSlot,
+                value: { kind: "connection", connectionId },
+              }),
+              reactivityKeys: [...sourceWriteKeys, ...connectionWriteKeys],
+            });
+          }}
+          reconnectingLabel="Reconnecting…"
+          signingInLabel="Signing in…"
+        />
+      )}
 
       {error && (
         <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">

--- a/packages/plugins/mcp/src/react/McpRemoteSourceFields.tsx
+++ b/packages/plugins/mcp/src/react/McpRemoteSourceFields.tsx
@@ -1,0 +1,157 @@
+import { Badge } from "@executor-js/react/components/badge";
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntry,
+  CardStackEntryActions,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+  CardStackEntryField,
+  CardStackEntryMedia,
+  CardStackEntryTitle,
+} from "@executor-js/react/components/card-stack";
+import { FieldError } from "@executor-js/react/components/field";
+import { Input } from "@executor-js/react/components/input";
+import { Skeleton } from "@executor-js/react/components/skeleton";
+import { SourceFavicon } from "@executor-js/react/components/source-favicon";
+import { IOSSpinner } from "@executor-js/react/components/spinner";
+import { Button } from "@executor-js/react/components/button";
+import {
+  SourceIdentityFieldRows,
+  type SourceIdentity,
+} from "@executor-js/react/plugins/source-identity";
+
+export type McpRemoteSourcePreview = {
+  readonly name: string;
+  readonly serverName: string | null;
+  readonly connected: boolean;
+  readonly toolCount: number | null;
+};
+
+export function McpRemoteSourceFields(props: {
+  readonly url: string;
+  readonly onUrlChange: (url: string) => void;
+  readonly identity: SourceIdentity;
+  readonly preview: McpRemoteSourcePreview | null;
+  readonly probing?: boolean;
+  readonly error?: string | null;
+  readonly onRetry?: () => void;
+  readonly namespaceReadOnly?: boolean;
+  readonly urlDisabled?: boolean;
+}) {
+  if (props.preview) {
+    return (
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntry>
+            <CardStackEntryMedia>
+              <SourceFavicon url={props.url} size={32} />
+            </CardStackEntryMedia>
+            <CardStackEntryContent>
+              <CardStackEntryTitle>
+                {props.preview.serverName ?? props.preview.name}
+              </CardStackEntryTitle>
+              <CardStackEntryDescription>
+                {props.preview.connected
+                  ? `${props.preview.toolCount} tool${props.preview.toolCount !== 1 ? "s" : ""} available`
+                  : "OAuth required to discover tools"}
+              </CardStackEntryDescription>
+            </CardStackEntryContent>
+            <CardStackEntryActions>
+              {props.preview.connected ? (
+                <Badge
+                  variant="outline"
+                  className="border-emerald-500/20 bg-emerald-500/10 text-[10px] text-emerald-600 dark:text-emerald-400"
+                >
+                  Connected
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
+                >
+                  OAuth required
+                </Badge>
+              )}
+            </CardStackEntryActions>
+          </CardStackEntry>
+          <SourceIdentityFieldRows
+            identity={props.identity}
+            namePlaceholder="e.g. Linear"
+            namespaceReadOnly={props.namespaceReadOnly}
+          />
+          <CardStackEntryField label="Server URL">
+            <Input
+              value={props.url}
+              onChange={(e) => props.onUrlChange((e.target as HTMLInputElement).value)}
+              placeholder="https://mcp.example.com"
+              className="w-full font-mono text-sm"
+              disabled={props.urlDisabled}
+            />
+          </CardStackEntryField>
+        </CardStackContent>
+      </CardStack>
+    );
+  }
+
+  if (props.probing) {
+    return (
+      <CardStack>
+        <CardStackContent className="border-t-0">
+          <CardStackEntry>
+            <CardStackEntryMedia>
+              <Skeleton className="size-4 rounded" />
+            </CardStackEntryMedia>
+            <CardStackEntryContent>
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="mt-1 h-3 w-32" />
+            </CardStackEntryContent>
+            <CardStackEntryActions>
+              <Skeleton className="h-4 w-20 rounded-full" />
+            </CardStackEntryActions>
+          </CardStackEntry>
+        </CardStackContent>
+      </CardStack>
+    );
+  }
+
+  return (
+    <CardStack>
+      <CardStackContent className="border-t-0">
+        <CardStackEntryField label="Server URL">
+          <div className="relative">
+            <Input
+              value={props.url}
+              onChange={(e) => props.onUrlChange((e.target as HTMLInputElement).value)}
+              placeholder="https://mcp.example.com"
+              className="w-full pr-9 font-mono text-sm"
+              aria-invalid={props.error ? true : undefined}
+              disabled={props.urlDisabled}
+            />
+            {props.probing && (
+              <div className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2">
+                <IOSSpinner className="size-4" />
+              </div>
+            )}
+          </div>
+          {props.error && (
+            <div className="mt-2 space-y-2">
+              <FieldError>{props.error}</FieldError>
+              {props.onRetry && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={props.onRetry}
+                  className="h-7 px-2 text-xs"
+                >
+                  Try again
+                </Button>
+              )}
+            </div>
+          )}
+        </CardStackEntryField>
+      </CardStackContent>
+    </CardStack>
+  );
+}

--- a/packages/plugins/mcp/src/react/McpRemoteSourceFields.tsx
+++ b/packages/plugins/mcp/src/react/McpRemoteSourceFields.tsx
@@ -39,6 +39,14 @@ export function McpRemoteSourceFields(props: {
   readonly namespaceReadOnly?: boolean;
   readonly urlDisabled?: boolean;
 }) {
+  const previewDescription = props.preview
+    ? props.preview.connected
+      ? props.preview.toolCount === null
+        ? null
+        : `${props.preview.toolCount} tool${props.preview.toolCount !== 1 ? "s" : ""} available`
+      : "OAuth required to discover tools"
+    : null;
+
   if (props.preview) {
     return (
       <CardStack>
@@ -51,11 +59,9 @@ export function McpRemoteSourceFields(props: {
               <CardStackEntryTitle>
                 {props.preview.serverName ?? props.preview.name}
               </CardStackEntryTitle>
-              <CardStackEntryDescription>
-                {props.preview.connected
-                  ? `${props.preview.toolCount} tool${props.preview.toolCount !== 1 ? "s" : ""} available`
-                  : "OAuth required to discover tools"}
-              </CardStackEntryDescription>
+              {previewDescription ? (
+                <CardStackEntryDescription>{previewDescription}</CardStackEntryDescription>
+              ) : null}
             </CardStackEntryContent>
             <CardStackEntryActions>
               {props.preview.connected ? (

--- a/packages/plugins/mcp/src/react/McpSourceSummary.tsx
+++ b/packages/plugins/mcp/src/react/McpSourceSummary.tsx
@@ -11,46 +11,63 @@ import {
 } from "@executor-js/react/plugins/source-credential-status";
 import { ScopeId } from "@executor-js/sdk/core";
 
-import { graphqlSourceAtom, graphqlSourceBindingsAtom } from "./atoms";
-import type { StoredGraphqlSource } from "../sdk/store";
+import { mcpSourceAtom, mcpSourceBindingsAtom } from "./atoms";
+import type { McpStoredSourceSchemaType } from "../sdk/stored-source";
 
-const sourceCredentialSlots = (source: StoredGraphqlSource): readonly SourceCredentialSlot[] => {
+const sourceCredentialSlots = (
+  source: McpStoredSourceSchemaType,
+): readonly SourceCredentialSlot[] => {
+  if (source.config.transport !== "remote") return [];
   const slots: SourceCredentialSlot[] = [];
-  for (const [name, value] of Object.entries(source.headers)) {
+  for (const [name, value] of Object.entries(source.config.headers ?? {})) {
     if (typeof value !== "string") slots.push({ kind: "secret", slot: value.slot, label: name });
   }
-  for (const [name, value] of Object.entries(source.queryParams)) {
+  for (const [name, value] of Object.entries(source.config.queryParams ?? {})) {
     if (typeof value !== "string") slots.push({ kind: "secret", slot: value.slot, label: name });
   }
-  if (source.auth.kind === "oauth2") {
+  const auth = source.config.auth;
+  if (auth.kind === "header") {
+    slots.push({
+      kind: "secret",
+      slot: auth.secretSlot,
+      label: auth.headerName,
+    });
+  }
+  if (auth.kind === "oauth2") {
+    if (auth.clientIdSlot) {
+      slots.push({ kind: "secret", slot: auth.clientIdSlot, label: "Client ID" });
+    }
+    if (auth.clientSecretSlot) {
+      slots.push({ kind: "secret", slot: auth.clientSecretSlot, label: "Client Secret" });
+    }
     slots.push({
       kind: "connection",
-      slot: source.auth.connectionSlot,
+      slot: auth.connectionSlot,
       label: "OAuth sign-in",
     });
   }
   return slots;
 };
 
-export default function GraphqlSourceSummary(props: {
-  sourceId: string;
-  variant?: "badge" | "panel";
-  onAction?: () => void;
+export default function McpSourceSummary(props: {
+  readonly sourceId: string;
+  readonly variant?: "badge" | "panel";
+  readonly onAction?: () => void;
 }) {
   const displayScope = useScope();
   const userScope = useUserScope();
   const scopeStack = useScopeStack();
-  const sourceResult = useAtomValue(graphqlSourceAtom(displayScope, props.sourceId));
+  const sourceResult = useAtomValue(mcpSourceAtom(displayScope, props.sourceId));
   const source =
     AsyncResult.isSuccess(sourceResult) && sourceResult.value ? sourceResult.value : null;
   const sourceScope = source ? ScopeId.make(source.scope) : displayScope;
   const bindingsResult = useAtomValue(
-    graphqlSourceBindingsAtom(displayScope, props.sourceId, sourceScope),
+    mcpSourceBindingsAtom(displayScope, props.sourceId, sourceScope),
   );
   const connectionsResult = useAtomValue(connectionsAtom(displayScope));
 
   if (!source) return null;
-  const slots = sourceCredentialSlots(source as StoredGraphqlSource);
+  const slots = sourceCredentialSlots(source as McpStoredSourceSchemaType);
   if (slots.length === 0) return null;
   if (!AsyncResult.isSuccess(bindingsResult) || !AsyncResult.isSuccess(connectionsResult)) {
     return props.variant === "panel" ? null : (

--- a/packages/plugins/mcp/src/react/source-plugin.tsx
+++ b/packages/plugins/mcp/src/react/source-plugin.tsx
@@ -4,11 +4,11 @@ import { mcpPresets } from "../sdk/presets";
 
 const importAdd = () => import("./AddMcpSource");
 const importEdit = () => import("./EditMcpSource");
-const importSignIn = () => import("./McpSignInButton");
+const importSummary = () => import("./McpSourceSummary");
 
 const LazyAddMcpSource = lazy(importAdd);
 const LazyEditMcpSource = lazy(importEdit);
-const LazyMcpSignInButton = lazy(importSignIn);
+const LazyMcpSourceSummary = lazy(importSummary);
 
 type AddProps = ComponentProps<SourcePlugin["add"]>;
 
@@ -41,12 +41,12 @@ export const createMcpSourcePlugin = (options?: McpSourcePluginOptions): SourceP
     label: "MCP",
     add: AddWithFlag,
     edit: LazyEditMcpSource,
-    signIn: LazyMcpSignInButton,
+    summary: LazyMcpSourceSummary,
     presets,
     preload: () => {
       void importAdd();
       void importEdit();
-      void importSignIn();
+      void importSummary();
     },
   };
 };

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -51,7 +51,6 @@ import {
 import { FieldLabel } from "@executor-js/react/components/field";
 import { FloatActions } from "@executor-js/react/components/float-actions";
 import { HelpTooltip } from "@executor-js/react/components/help-tooltip";
-import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
 import { Textarea } from "@executor-js/react/components/textarea";
 import { Checkbox } from "@executor-js/react/components/checkbox";

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -34,11 +34,7 @@ import {
   type HeaderState,
 } from "@executor-js/react/plugins/secret-header-auth";
 import { CredentialScopeDropdown } from "@executor-js/react/plugins/credential-target-scope";
-import {
-  slugifyNamespace,
-  SourceIdentityFieldRows,
-  useSourceIdentity,
-} from "@executor-js/react/plugins/source-identity";
+import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor-js/react/components/button";
 import { CopyButton } from "@executor-js/react/components/copy-button";
@@ -47,15 +43,10 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@executor-js/react/components/collapsible";
-import { FreeformCombobox } from "@executor-js/react/components/combobox";
 import {
   CardStack,
   CardStackContent,
-  CardStackEntry,
-  CardStackEntryContent,
-  CardStackEntryDescription,
   CardStackEntryField,
-  CardStackEntryTitle,
 } from "@executor-js/react/components/card-stack";
 import { FieldLabel } from "@executor-js/react/components/field";
 import { FloatActions } from "@executor-js/react/components/float-actions";
@@ -64,10 +55,10 @@ import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
 import { Textarea } from "@executor-js/react/components/textarea";
 import { Checkbox } from "@executor-js/react/components/checkbox";
-import { SourceFavicon } from "@executor-js/react/components/source-favicon";
 import { RadioGroup, RadioGroupItem } from "@executor-js/react/components/radio-group";
 import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
 import { addOpenApiSpecOptimistic, previewOpenApiSpec, setOpenApiSourceBinding } from "./atoms";
+import { OpenApiSourceDetailsFields } from "./OpenApiSourceDetailsFields";
 import type { SpecPreview, HeaderPreset, OAuth2Preset } from "../sdk/preview";
 import {
   headerBindingSlot,
@@ -936,61 +927,32 @@ export default function AddOpenApiSource(props: {
 
       {/* ── Source information card (shown after analysis) ── */}
       {preview ? (
-        <CardStack>
-          <CardStackContent className="border-t-0">
-            <CardStackEntry>
-              {resolvedBaseUrl && <SourceFavicon url={resolvedBaseUrl} size={16} />}
-              <CardStackEntryContent>
-                <CardStackEntryTitle>
-                  {Option.getOrElse(preview.title, () => "API")}
-                </CardStackEntryTitle>
-                <CardStackEntryDescription>
-                  {Option.getOrElse(preview.version, () => "")}
-                  {Option.isSome(preview.version) && " · "}
-                  {preview.operationCount} operation
-                  {preview.operationCount !== 1 ? "s" : ""}
-                  {preview.tags.length > 0 &&
-                    ` · ${preview.tags.length} tag${preview.tags.length !== 1 ? "s" : ""}`}
-                </CardStackEntryDescription>
-              </CardStackEntryContent>
-            </CardStackEntry>
-            <SourceIdentityFieldRows identity={identity} />
-            <div className="grid grid-cols-1 md:grid-cols-2">
-              <CardStackEntryField label="Base URL">
-                <FreeformCombobox
-                  value={resolvedBaseUrl}
-                  onValueChange={setBaseUrl}
-                  options={baseUrlOptions}
-                  placeholder="https://api.example.com"
-                  className="w-full"
-                  inputClassName="font-mono text-sm"
-                />
-
-                {!resolvedBaseUrl && (
-                  <p className="text-[11px] text-amber-600 dark:text-amber-400">
-                    A base URL is required to make requests.
-                  </p>
-                )}
-              </CardStackEntryField>
-              <CardStackEntryField label="Spec URL">
-                <Input
-                  value={specUrl}
-                  onChange={(e) => {
-                    setSpecUrl((e.target as HTMLInputElement).value);
-                    setPreview(null);
-                    setBaseUrl("");
-                    setCustomHeaders([]);
-                    setStrategy({ kind: "none" });
-                    setOauth2AuthState(null);
-                    setOauth2Error(null);
-                  }}
-                  placeholder="https://api.example.com/openapi.json"
-                  className="font-mono text-sm"
-                />
-              </CardStackEntryField>
-            </div>
-          </CardStackContent>
-        </CardStack>
+        <OpenApiSourceDetailsFields
+          title={Option.getOrElse(preview.title, () => "API")}
+          description={`${Option.getOrElse(preview.version, () => "")}${
+            Option.isSome(preview.version) ? " · " : ""
+          }${preview.operationCount} operation${preview.operationCount !== 1 ? "s" : ""}${
+            preview.tags.length > 0
+              ? ` · ${preview.tags.length} tag${preview.tags.length !== 1 ? "s" : ""}`
+              : ""
+          }`}
+          identity={identity}
+          baseUrl={resolvedBaseUrl}
+          onBaseUrlChange={setBaseUrl}
+          baseUrlOptions={baseUrlOptions}
+          specUrl={specUrl}
+          onSpecUrlChange={(value) => {
+            setSpecUrl(value);
+            setPreview(null);
+            setBaseUrl("");
+            setCustomHeaders([]);
+            setStrategy({ kind: "none" });
+            setOauth2AuthState(null);
+            setOauth2Error(null);
+          }}
+          faviconUrl={resolvedBaseUrl}
+          baseUrlMissingMessage="A base URL is required to make requests."
+        />
       ) : null}
 
       {analyzeError && (

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -44,6 +44,7 @@ import {
   setOpenApiSourceBinding,
   updateOpenApiSource,
 } from "./atoms";
+import { OpenApiSourceDetailsFields } from "./OpenApiSourceDetailsFields";
 import {
   OPENAPI_OAUTH_CALLBACK_PATH,
   OPENAPI_OAUTH_POPUP_NAME,
@@ -178,6 +179,16 @@ export default function EditOpenApiSource(props: {
   const [oauth2EndpointsSaveState, setOAuth2EndpointsSaveState] = useState<
     "idle" | "saving" | "saved"
   >("idle");
+  const editIdentity = useMemo(
+    () => ({
+      name,
+      namespace: props.sourceId,
+      setName,
+      setNamespace: () => {},
+      reset: () => {},
+    }),
+    [name, props.sourceId],
+  );
   const sourceSaveSeq = useRef(0);
   const oauth2EndpointsSaveSeq = useRef(0);
 
@@ -580,47 +591,27 @@ export default function EditOpenApiSource(props: {
         <h1 className="text-xl font-semibold text-foreground">OpenAPI Source</h1>
       </div>
 
-      <CardStack>
-        <CardStackContent className="border-t-0">
-          <CardStackEntry>
-            <CardStackEntryContent>
-              <CardStackEntryTitle>Source Details</CardStackEntryTitle>
-              <CardStackEntryDescription>
-                Name and base URL save automatically.
-              </CardStackEntryDescription>
-            </CardStackEntryContent>
-            {sourceSaveState !== "idle" && (
-              <span className="text-xs text-muted-foreground">
-                {sourceSaveState === "saving" ? "Saving…" : "Saved"}
-              </span>
-            )}
-          </CardStackEntry>
-          <CardStackEntryField label="Name">
-            <Input value={name} onChange={(e) => setName((e.target as HTMLInputElement).value)} />
-          </CardStackEntryField>
-          <CardStackEntryField label="Base URL">
-            <Input
-              value={baseUrl}
-              onChange={(e) => setBaseUrl((e.target as HTMLInputElement).value)}
-              className="font-mono text-sm"
-            />
-          </CardStackEntryField>
-          <CardStackEntry>
-            <CardStackEntryContent>
-              <CardStackEntryTitle>Authentication Template</CardStackEntryTitle>
-              <CardStackEntryDescription>
-                {source.config.oauth2
-                  ? `OAuth2 ${source.config.oauth2.flow}`
-                  : Object.keys(source.config.headers ?? {}).length > 0
-                    ? `${Object.keys(source.config.headers ?? {}).length} header binding${
-                        Object.keys(source.config.headers ?? {}).length === 1 ? "" : "s"
-                      }`
-                    : "None"}
-              </CardStackEntryDescription>
-            </CardStackEntryContent>
-          </CardStackEntry>
-        </CardStackContent>
-      </CardStack>
+      <OpenApiSourceDetailsFields
+        title="Source Details"
+        description="Name and base URL save automatically."
+        identity={editIdentity}
+        baseUrl={baseUrl}
+        onBaseUrlChange={setBaseUrl}
+        specUrl={source.config.sourceUrl ?? ""}
+        onSpecUrlChange={() => {}}
+        specUrlDisabled
+        namespaceReadOnly
+        saveState={sourceSaveState}
+        footer={
+          source.config.oauth2
+            ? `Authentication Template: OAuth2 ${source.config.oauth2.flow}`
+            : Object.keys(source.config.headers ?? {}).length > 0
+              ? `Authentication Template: ${Object.keys(source.config.headers ?? {}).length} header binding${
+                  Object.keys(source.config.headers ?? {}).length === 1 ? "" : "s"
+                }`
+              : "Authentication Template: None"
+        }
+      />
 
       <CardStack>
         <CardStackContent className="border-t-0">

--- a/packages/plugins/openapi/src/react/OpenApiSourceDetailsFields.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceDetailsFields.tsx
@@ -1,0 +1,105 @@
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntry,
+  CardStackEntryContent,
+  CardStackEntryDescription,
+  CardStackEntryField,
+  CardStackEntryTitle,
+} from "@executor-js/react/components/card-stack";
+import { FreeformCombobox } from "@executor-js/react/components/combobox";
+import { Input } from "@executor-js/react/components/input";
+import { SourceFavicon } from "@executor-js/react/components/source-favicon";
+import {
+  SourceIdentityFieldRows,
+  type SourceIdentity,
+} from "@executor-js/react/plugins/source-identity";
+
+export function OpenApiSourceDetailsFields(props: {
+  readonly title: string;
+  readonly description?: string;
+  readonly identity: SourceIdentity;
+  readonly baseUrl: string;
+  readonly onBaseUrlChange: (value: string) => void;
+  readonly baseUrlOptions?: readonly string[];
+  readonly specUrl?: string;
+  readonly onSpecUrlChange?: (value: string) => void;
+  readonly faviconUrl?: string;
+  readonly namespaceReadOnly?: boolean;
+  readonly specUrlDisabled?: boolean;
+  readonly saveState?: "idle" | "saving" | "saved";
+  readonly baseUrlMissingMessage?: string;
+  readonly footer?: string;
+}) {
+  const baseUrlOptions = props.baseUrlOptions ?? [];
+
+  return (
+    <CardStack>
+      <CardStackContent className="border-t-0">
+        <CardStackEntry>
+          {props.faviconUrl && <SourceFavicon url={props.faviconUrl} size={16} />}
+          <CardStackEntryContent>
+            <CardStackEntryTitle>{props.title}</CardStackEntryTitle>
+            {props.description && (
+              <CardStackEntryDescription>{props.description}</CardStackEntryDescription>
+            )}
+          </CardStackEntryContent>
+          {props.saveState && props.saveState !== "idle" && (
+            <span className="text-xs text-muted-foreground">
+              {props.saveState === "saving" ? "Saving…" : "Saved"}
+            </span>
+          )}
+        </CardStackEntry>
+        <SourceIdentityFieldRows
+          identity={props.identity}
+          namespaceReadOnly={props.namespaceReadOnly}
+        />
+        <div className="grid grid-cols-1 md:grid-cols-2">
+          <CardStackEntryField label="Base URL">
+            {baseUrlOptions.length > 0 ? (
+              <FreeformCombobox
+                value={props.baseUrl}
+                onValueChange={props.onBaseUrlChange}
+                options={baseUrlOptions}
+                placeholder="https://api.example.com"
+                className="w-full"
+                inputClassName="font-mono text-sm"
+              />
+            ) : (
+              <Input
+                value={props.baseUrl}
+                onChange={(e) => props.onBaseUrlChange((e.target as HTMLInputElement).value)}
+                placeholder="https://api.example.com"
+                className="font-mono text-sm"
+              />
+            )}
+
+            {props.baseUrlMissingMessage && !props.baseUrl && (
+              <p className="text-[11px] text-amber-600 dark:text-amber-400">
+                {props.baseUrlMissingMessage}
+              </p>
+            )}
+          </CardStackEntryField>
+          {props.specUrl !== undefined && props.onSpecUrlChange && (
+            <CardStackEntryField label="Spec URL">
+              <Input
+                value={props.specUrl}
+                onChange={(e) => props.onSpecUrlChange?.((e.target as HTMLInputElement).value)}
+                placeholder="https://api.example.com/openapi.json"
+                className="font-mono text-sm"
+                disabled={props.specUrlDisabled}
+              />
+            </CardStackEntryField>
+          )}
+        </div>
+        {props.footer && (
+          <CardStackEntry>
+            <CardStackEntryContent>
+              <CardStackEntryTitle>{props.footer}</CardStackEntryTitle>
+            </CardStackEntryContent>
+          </CardStackEntry>
+        )}
+      </CardStackContent>
+    </CardStack>
+  );
+}

--- a/packages/plugins/openapi/src/react/OpenApiSourceDetailsFields.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceDetailsFields.tsx
@@ -7,7 +7,10 @@ import {
   CardStackEntryField,
   CardStackEntryTitle,
 } from "@executor-js/react/components/card-stack";
-import { FreeformCombobox } from "@executor-js/react/components/combobox";
+import {
+  FreeformCombobox,
+  type FreeformComboboxOption,
+} from "@executor-js/react/components/combobox";
 import { Input } from "@executor-js/react/components/input";
 import { SourceFavicon } from "@executor-js/react/components/source-favicon";
 import {
@@ -21,7 +24,7 @@ export function OpenApiSourceDetailsFields(props: {
   readonly identity: SourceIdentity;
   readonly baseUrl: string;
   readonly onBaseUrlChange: (value: string) => void;
-  readonly baseUrlOptions?: readonly string[];
+  readonly baseUrlOptions?: readonly FreeformComboboxOption[];
   readonly specUrl?: string;
   readonly onSpecUrlChange?: (value: string) => void;
   readonly faviconUrl?: string;

--- a/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
@@ -3,37 +3,21 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
 import { connectionsAtom, sourceAtom } from "@executor-js/react/api/atoms";
 import { Badge } from "@executor-js/react/components/badge";
-import { Button } from "@executor-js/react/components/button";
 import { useScope, useScopeStack, useUserScope } from "@executor-js/react/api/scope-context";
 import { ScopeId } from "@executor-js/sdk/core";
+import {
+  SourceCredentialNotice,
+  SourceCredentialStatusBadge,
+  missingSourceCredentialLabels,
+  type SourceCredentialSlot,
+} from "@executor-js/react/plugins/source-credential-status";
 
 import { openApiSourceAtom, openApiSourceBindingsAtom } from "./atoms";
-import { effectiveBindingForScope, missingCredentialLabels } from "../sdk/credential-status";
-
-function ConnectedBadge() {
-  return (
-    <Badge
-      variant="outline"
-      className="border-green-500/30 bg-green-500/5 text-[10px] text-green-700 dark:text-green-400"
-    >
-      Connected
-    </Badge>
-  );
-}
+import { effectiveBindingForScope } from "../sdk/credential-status";
+import { oauth2ClientSecretSlot, type StoredSourceSchemaType } from "../sdk/store";
 
 function OAuthBadge() {
   return <Badge variant="secondary">OAuth</Badge>;
-}
-
-function NeedsCredentialsBadge() {
-  return (
-    <Badge
-      variant="outline"
-      className="border-amber-500/40 bg-amber-500/10 text-[10px] text-amber-700 dark:text-amber-300"
-    >
-      Needs credentials
-    </Badge>
-  );
 }
 
 function CheckingCredentialsBadge() {
@@ -46,6 +30,36 @@ function CheckingCredentialsBadge() {
     </Badge>
   );
 }
+
+const effectiveClientSecretSlot = (oauth2: {
+  readonly securitySchemeName: string;
+  readonly clientSecretSlot: string | null;
+}): string => oauth2.clientSecretSlot ?? oauth2ClientSecretSlot(oauth2.securitySchemeName);
+
+const sourceCredentialSlots = (source: StoredSourceSchemaType): readonly SourceCredentialSlot[] => {
+  const slots: SourceCredentialSlot[] = [];
+  for (const [name, value] of Object.entries(source.config.headers ?? {})) {
+    if (typeof value !== "string") slots.push({ kind: "secret", slot: value.slot, label: name });
+  }
+  for (const [name, value] of Object.entries(source.config.queryParams ?? {})) {
+    if (typeof value !== "string") slots.push({ kind: "secret", slot: value.slot, label: name });
+  }
+  const oauth2 = source.config.oauth2;
+  if (oauth2) {
+    slots.push({ kind: "secret", slot: oauth2.clientIdSlot, label: "Client ID" });
+    slots.push({
+      kind: "secret",
+      slot: effectiveClientSecretSlot(oauth2),
+      label: "Client Secret",
+    });
+    slots.push({
+      kind: "connection",
+      slot: oauth2.connectionSlot,
+      label: oauth2.flow === "clientCredentials" ? "OAuth client connection" : "OAuth sign-in",
+    });
+  }
+  return slots;
+};
 
 // The entry row already renders name + id + kind, so this summary
 // component only contributes extras — specifically, an OAuth status
@@ -89,34 +103,19 @@ export default function OpenApiSourceSummary(props: {
   const liveConnectionIds = new Set(connections.map((connection) => connection.id));
   const scopeRanks = new Map(scopeStack.map((scope, index) => [scope.id, index] as const));
   const credentialTargetScope = userScope;
-  const missing = missingCredentialLabels(source, bindings, credentialTargetScope, scopeRanks, {
+  const missing = missingSourceCredentialLabels({
+    slots: sourceCredentialSlots(source),
+    bindings,
+    targetScope: credentialTargetScope,
+    scopeRanks,
     liveConnectionIds,
   });
 
   if (props.variant === "panel") {
-    if (missing.length === 0) return null;
-    return (
-      <div className="shrink-0 border-b border-amber-500/20 bg-amber-500/[0.06] px-4 py-3">
-        <div className="mx-auto flex max-w-4xl items-center justify-between gap-4">
-          <div className="min-w-0">
-            <div className="text-sm font-medium text-foreground">
-              This source needs your credentials before tools can run.
-            </div>
-            <div className="mt-0.5 truncate text-xs text-muted-foreground">
-              Missing: {missing.join(", ")}
-            </div>
-          </div>
-          {props.onAction && (
-            <Button size="sm" onClick={props.onAction}>
-              Add credentials
-            </Button>
-          )}
-        </div>
-      </div>
-    );
+    return <SourceCredentialNotice missing={missing} onAction={props.onAction} />;
   }
 
-  if (missing.length > 0) return <NeedsCredentialsBadge />;
+  if (missing.length > 0) return <SourceCredentialStatusBadge missing={missing} />;
 
   if (!oauth2) return null;
   const connectionBinding = effectiveBindingForScope(
@@ -131,7 +130,7 @@ export default function OpenApiSourceSummary(props: {
       : null;
 
   if (connectionId && connections.some((connection) => connection.id === connectionId)) {
-    return <ConnectedBadge />;
+    return <SourceCredentialStatusBadge missing={[]} />;
   }
 
   return <OAuthBadge />;

--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -166,12 +166,6 @@ export function SourceDetailPage(props: { namespace: string }) {
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
-          {editPlugin?.signIn && !editing && !confirmDelete && (
-            <Suspense fallback={null}>
-              <editPlugin.signIn sourceId={namespace} />
-            </Suspense>
-          )}
-
           {canEdit && editPlugin && !editing && !confirmDelete && (
             <Button variant="outline" size="sm" onClick={() => setEditing(true)}>
               Edit

--- a/packages/react/src/plugins/credential-target-scope.tsx
+++ b/packages/react/src/plugins/credential-target-scope.tsx
@@ -170,6 +170,7 @@ export function CredentialScopeDropdown(props: {
   readonly onChange: (scope: ScopeId) => void;
   readonly label?: string;
   readonly help?: ReactNode;
+  readonly className?: string;
   readonly triggerClassName?: string;
   readonly size?: "sm" | "default";
 }) {
@@ -177,7 +178,7 @@ export function CredentialScopeDropdown(props: {
   if (props.options.length <= 1) return null;
 
   return (
-    <div className="space-y-1.5">
+    <div className={props.className ?? "space-y-1.5"}>
       <div className="flex items-center gap-1.5">
         <FieldLabel className="text-[11px]">{label}</FieldLabel>
         <HelpTooltip label={label}>
@@ -232,7 +233,7 @@ export function CredentialUsageRow(props: {
   }
 
   return (
-    <div className="grid gap-2 md:grid-cols-2">
+    <div className="grid items-stretch gap-2 md:grid-cols-2">
       <div className="min-w-0 space-y-2.5">{props.children}</div>
       <CredentialScopeDropdown
         value={props.value}
@@ -240,8 +241,8 @@ export function CredentialUsageRow(props: {
         onChange={props.onChange}
         label={props.label}
         help={props.help}
-        triggerClassName="w-fit min-w-28"
-        size="sm"
+        className="flex h-full flex-col space-y-1.5"
+        triggerClassName="w-full min-h-9 flex-1 data-[size=default]:h-full"
       />
     </div>
   );

--- a/packages/react/src/plugins/credential-target-scope.tsx
+++ b/packages/react/src/plugins/credential-target-scope.tsx
@@ -170,6 +170,8 @@ export function CredentialScopeDropdown(props: {
   readonly onChange: (scope: ScopeId) => void;
   readonly label?: string;
   readonly help?: ReactNode;
+  readonly triggerClassName?: string;
+  readonly size?: "sm" | "default";
 }) {
   const label = props.label ?? "Used by";
   if (props.options.length <= 1) return null;
@@ -186,7 +188,7 @@ export function CredentialScopeDropdown(props: {
         value={String(props.value)}
         onValueChange={(value) => props.onChange(ScopeId.make(value))}
       >
-        <SelectTrigger className="w-full">
+        <SelectTrigger className={props.triggerClassName ?? "w-full"} size={props.size}>
           <SelectValue placeholder={label} />
         </SelectTrigger>
         <SelectContent>
@@ -238,6 +240,8 @@ export function CredentialUsageRow(props: {
         onChange={props.onChange}
         label={props.label}
         help={props.help}
+        triggerClassName="w-fit min-w-28"
+        size="sm"
       />
     </div>
   );

--- a/packages/react/src/plugins/source-credential-status-core.ts
+++ b/packages/react/src/plugins/source-credential-status-core.ts
@@ -37,8 +37,7 @@ export const effectiveSourceCredentialBinding = (
 
 const liveConnectionSet = (
   values?: ReadonlySet<string> | readonly ConnectionId[],
-): ReadonlySet<string> | undefined =>
-  !values ? undefined : Array.isArray(values) ? new Set(values.map(String)) : values;
+): ReadonlySet<string> | undefined => (values ? new Set(Array.from(values, String)) : undefined);
 
 export const missingSourceCredentialLabels = (input: {
   readonly slots: readonly SourceCredentialSlot[];

--- a/packages/react/src/plugins/source-credential-status-core.ts
+++ b/packages/react/src/plugins/source-credential-status-core.ts
@@ -1,0 +1,79 @@
+import type { ConnectionId, CredentialBindingValue, ScopeId } from "@executor-js/sdk";
+
+export type SourceCredentialSlot =
+  | {
+      readonly kind: "secret";
+      readonly slot: string;
+      readonly label: string;
+      readonly optional?: boolean;
+    }
+  | {
+      readonly kind: "connection";
+      readonly slot: string;
+      readonly label: string;
+      readonly optional?: boolean;
+    };
+
+export type SourceCredentialBindingRef = {
+  readonly slot: string;
+  readonly scopeId: ScopeId;
+  readonly value: CredentialBindingValue;
+};
+
+const scopeRank = (ranks: ReadonlyMap<string, number>, scopeId: ScopeId): number =>
+  ranks.get(scopeId) ?? Number.MAX_SAFE_INTEGER;
+
+export const effectiveSourceCredentialBinding = (
+  rows: readonly SourceCredentialBindingRef[],
+  slot: string,
+  targetScope: ScopeId,
+  ranks: ReadonlyMap<string, number>,
+): SourceCredentialBindingRef | null =>
+  rows
+    .filter(
+      (row) => row.slot === slot && scopeRank(ranks, row.scopeId) >= scopeRank(ranks, targetScope),
+    )
+    .sort((a, b) => scopeRank(ranks, a.scopeId) - scopeRank(ranks, b.scopeId))[0] ?? null;
+
+const liveConnectionSet = (
+  values?: ReadonlySet<string> | readonly ConnectionId[],
+): ReadonlySet<string> | undefined =>
+  !values ? undefined : Array.isArray(values) ? new Set(values.map(String)) : values;
+
+export const missingSourceCredentialLabels = (input: {
+  readonly slots: readonly SourceCredentialSlot[];
+  readonly bindings: readonly SourceCredentialBindingRef[];
+  readonly targetScope: ScopeId;
+  readonly scopeRanks: ReadonlyMap<string, number>;
+  readonly liveConnectionIds?: ReadonlySet<string> | readonly ConnectionId[];
+}): string[] => {
+  const liveConnections = liveConnectionSet(input.liveConnectionIds);
+  const missing: string[] = [];
+
+  for (const slot of input.slots) {
+    if (slot.optional) continue;
+    const binding = effectiveSourceCredentialBinding(
+      input.bindings,
+      slot.slot,
+      input.targetScope,
+      input.scopeRanks,
+    );
+
+    if (slot.kind === "secret" && binding?.value.kind !== "secret") {
+      missing.push(slot.label);
+      continue;
+    }
+
+    if (slot.kind === "connection") {
+      if (binding?.value.kind !== "connection") {
+        missing.push(slot.label);
+        continue;
+      }
+      if (liveConnections && !liveConnections.has(binding.value.connectionId)) {
+        missing.push(slot.label);
+      }
+    }
+  }
+
+  return missing;
+};

--- a/packages/react/src/plugins/source-credential-status.test.ts
+++ b/packages/react/src/plugins/source-credential-status.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ConnectionId, ScopeId, SecretId } from "@executor-js/sdk";
+
+import {
+  effectiveSourceCredentialBinding,
+  missingSourceCredentialLabels,
+  type SourceCredentialBindingRef,
+  type SourceCredentialSlot,
+} from "./source-credential-status-core";
+
+const userScope = ScopeId.make("user");
+const orgScope = ScopeId.make("org");
+const scopeRanks = new Map([
+  [userScope, 0],
+  [orgScope, 1],
+]);
+
+const slots: readonly SourceCredentialSlot[] = [
+  { kind: "secret", slot: "header:authorization", label: "Authorization" },
+  { kind: "connection", slot: "auth:oauth2:connection", label: "OAuth sign-in" },
+];
+
+const bindings = (scopeId: ScopeId): readonly SourceCredentialBindingRef[] => [
+  {
+    slot: "header:authorization",
+    scopeId,
+    value: {
+      kind: "secret",
+      secretId: SecretId.make(`${scopeId}-token`),
+    },
+  },
+  {
+    slot: "auth:oauth2:connection",
+    scopeId,
+    value: {
+      kind: "connection",
+      connectionId: ConnectionId.make(`${scopeId}-connection`),
+    },
+  },
+];
+
+describe("source credential status", () => {
+  it("treats inherited source-scope credentials as satisfying a user target", () => {
+    expect(
+      missingSourceCredentialLabels({
+        slots,
+        bindings: bindings(orgScope),
+        targetScope: userScope,
+        scopeRanks,
+        liveConnectionIds: [ConnectionId.make("org-connection")],
+      }),
+    ).toEqual([]);
+  });
+
+  it("does not let inner-scope credentials satisfy an outer target", () => {
+    expect(
+      missingSourceCredentialLabels({
+        slots,
+        bindings: bindings(userScope),
+        targetScope: orgScope,
+        scopeRanks,
+      }),
+    ).toEqual(["Authorization", "OAuth sign-in"]);
+  });
+
+  it("treats stale connection bindings as missing", () => {
+    expect(
+      missingSourceCredentialLabels({
+        slots,
+        bindings: bindings(userScope),
+        targetScope: userScope,
+        scopeRanks,
+        liveConnectionIds: [],
+      }),
+    ).toEqual(["OAuth sign-in"]);
+  });
+
+  it("prefers the inner exact binding over inherited credentials", () => {
+    const binding = effectiveSourceCredentialBinding(
+      [...bindings(orgScope), ...bindings(userScope)],
+      "header:authorization",
+      userScope,
+      scopeRanks,
+    );
+
+    expect(binding?.scopeId).toEqual(userScope);
+  });
+});

--- a/packages/react/src/plugins/source-credential-status.tsx
+++ b/packages/react/src/plugins/source-credential-status.tsx
@@ -1,0 +1,55 @@
+import { Badge } from "../components/badge";
+import { Button } from "../components/button";
+export {
+  effectiveSourceCredentialBinding,
+  missingSourceCredentialLabels,
+  type SourceCredentialBindingRef,
+  type SourceCredentialSlot,
+} from "./source-credential-status-core";
+
+export function SourceCredentialStatusBadge(props: { readonly missing: readonly string[] }) {
+  if (props.missing.length === 0) {
+    return (
+      <Badge
+        variant="outline"
+        className="border-green-500/30 bg-green-500/5 text-[10px] text-green-700 dark:text-green-400"
+      >
+        Credentials ready
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge
+      variant="outline"
+      className="border-amber-500/40 bg-amber-500/10 text-[10px] text-amber-700 dark:text-amber-300"
+    >
+      Credentials needed
+    </Badge>
+  );
+}
+
+export function SourceCredentialNotice(props: {
+  readonly missing: readonly string[];
+  readonly onAction?: () => void;
+}) {
+  if (props.missing.length === 0) return null;
+
+  return (
+    <div className="shrink-0 border-b border-border bg-muted/30 px-4 py-3">
+      <div className="mx-auto flex max-w-4xl items-center justify-between gap-4">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">Credentials need attention</div>
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            Missing {props.missing.join(", ")}
+          </div>
+        </div>
+        {props.onAction && (
+          <Button size="sm" variant="outline" onClick={props.onAction}>
+            Configure
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/react/src/plugins/source-oauth-connection.tsx
+++ b/packages/react/src/plugins/source-oauth-connection.tsx
@@ -1,0 +1,68 @@
+import type { ConnectionId, ScopeId, SecretBackedValue } from "@executor-js/sdk";
+
+import {
+  CredentialControlField,
+  CredentialUsageRow,
+  type CredentialTargetScopeOption,
+} from "./credential-target-scope";
+import { SourceOAuthSignInButton } from "./oauth-sign-in";
+
+export function SourceOAuthConnectionControl(props: {
+  readonly popupName: string;
+  readonly pluginId: string;
+  readonly namespace: string;
+  readonly fallbackNamespace: string;
+  readonly endpoint: string;
+  readonly tokenScope: ScopeId;
+  readonly onTokenScopeChange: (scope: ScopeId) => void;
+  readonly credentialScopeOptions: readonly CredentialTargetScopeOption[];
+  readonly connectionId: string | null;
+  readonly sourceLabel: string;
+  readonly headers?: Record<string, SecretBackedValue>;
+  readonly queryParams?: Record<string, SecretBackedValue>;
+  readonly isConnected: boolean;
+  readonly onConnected: (connectionId: ConnectionId) => void | Promise<void>;
+  readonly disabled?: boolean;
+  readonly reconnectingLabel?: string;
+  readonly signingInLabel?: string;
+}) {
+  return (
+    <CredentialUsageRow
+      value={props.tokenScope}
+      options={props.credentialScopeOptions}
+      onChange={props.onTokenScopeChange}
+      label="Connection saved to"
+      help="Choose who can use the OAuth connection."
+    >
+      <CredentialControlField label="OAuth connection" help="Start the provider OAuth flow.">
+        <div className="flex min-h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">
+          {props.isConnected ? (
+            <span className="text-xs font-medium text-emerald-600 dark:text-emerald-400">
+              Connected
+            </span>
+          ) : (
+            <span className="text-xs text-muted-foreground">Not connected</span>
+          )}
+          <div className="ml-auto">
+            <SourceOAuthSignInButton
+              popupName={props.popupName}
+              pluginId={props.pluginId}
+              namespace={props.namespace}
+              fallbackNamespace={props.fallbackNamespace}
+              endpoint={props.endpoint}
+              tokenScope={props.tokenScope}
+              connectionId={props.connectionId}
+              sourceLabel={props.sourceLabel}
+              headers={props.headers}
+              queryParams={props.queryParams}
+              isConnected={props.isConnected}
+              onConnected={props.onConnected}
+              reconnectingLabel={props.reconnectingLabel}
+              signingInLabel={props.signingInLabel}
+            />
+          </div>
+        </div>
+      </CredentialControlField>
+    </CredentialUsageRow>
+  );
+}


### PR DESCRIPTION
## Summary
- remove plugin-level top-bar sign-in actions and move reconnect controls into edit surfaces
- add shared credential status primitives for OpenAPI, GraphQL, and MCP source summaries
- share add/edit field UI for OpenAPI, GraphQL, and MCP while disabling immutable edit fields

## Validation
- `PATH=/home/rhys/executor/node_modules/.bin:$PATH bun run --cwd apps/local typecheck`
- `PATH=/home/rhys/executor/node_modules/.bin:$PATH bunx --bun vitest run src/plugins/source-credential-status.test.ts`