### PR TITLE
[codex] Fix MCP OAuth and OpenAPI JSON parsing

### DIFF
--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -88,6 +88,7 @@ const ProbeEndpointPayload = Schema.Struct({
 const ProbeEndpointResponse = Schema.Struct({
   connected: Schema.Boolean,
   requiresOAuth: Schema.Boolean,
+  supportsDynamicRegistration: Schema.Boolean,
   name: Schema.String,
   namespace: Schema.String,
   toolCount: Schema.NullOr(Schema.Number),

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -79,6 +79,7 @@ type OAuthTokens = OAuthCompletionPayload;
 type ProbeResult = {
   connected: boolean;
   requiresOAuth: boolean;
+  supportsDynamicRegistration: boolean;
   name: string;
   namespace: string;
   toolCount: number | null;
@@ -315,7 +316,7 @@ export default function AddMcpSource(props: {
   const isAdding = state.step === "adding";
   const isOAuthBusy =
     state.step === "oauth-starting" || state.step === "oauth-waiting" || oauth.busy;
-  const canUseNone = probe?.requiresOAuth !== true;
+  const canUseNone = probe?.requiresOAuth !== true || probe.supportsDynamicRegistration === false;
   const remoteHeadersComplete = remoteHeaders.every(
     (header) => header.name.trim() && header.value.trim(),
   );
@@ -622,7 +623,7 @@ export default function AddMcpSource(props: {
                 <FieldLabel>Authentication</FieldLabel>
                 <FilterTabs<RemoteAuthMode>
                   tabs={
-                    probe.requiresOAuth
+                    probe.requiresOAuth && probe.supportsDynamicRegistration
                       ? [{ value: "oauth2", label: "OAuth" }]
                       : [
                           { value: "none", label: "None" },
@@ -649,16 +650,24 @@ export default function AddMcpSource(props: {
                     label="Connect via OAuth"
                     help="Start the provider OAuth flow."
                   >
-                    {!tokens && state.step === "probed" && (
-                      <Button
-                        type="button"
-                        onClick={handleOAuth}
-                        variant="outline"
-                        className="w-full"
-                      >
-                        Sign in
-                      </Button>
-                    )}
+                    {!tokens &&
+                      state.step === "probed" &&
+                      (probe.supportsDynamicRegistration ? (
+                        <Button
+                          type="button"
+                          onClick={handleOAuth}
+                          variant="outline"
+                          className="w-full"
+                        >
+                          Sign in
+                        </Button>
+                      ) : (
+                        <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+                          This server requires OAuth, but its authorization server does not support
+                          dynamic client registration. Use request headers with a bearer token, or
+                          save the source and connect a supported OAuth connection later.
+                        </div>
+                      ))}
 
                     {!tokens && state.step === "oauth-starting" && (
                       <div className="flex min-h-9 items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2">

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -122,6 +122,7 @@ export type McpSourceConfig = McpRemoteSourceConfig | McpStdioSourceConfig;
 export interface McpProbeResult {
   readonly connected: boolean;
   readonly requiresOAuth: boolean;
+  readonly supportsDynamicRegistration: boolean;
   readonly name: string;
   readonly namespace: string;
   readonly toolCount: number | null;
@@ -1019,6 +1020,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             return {
               connected: true,
               requiresOAuth: false,
+              supportsDynamicRegistration: false,
               name: result.manifest.server?.name ?? name,
               namespace,
               toolCount: result.manifest.tools.length,
@@ -1054,15 +1056,16 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
               queryParams: probeQueryParams,
             })
             .pipe(
-              Effect.map(() => true),
-              Effect.catch(() => Effect.succeed(false)),
+              Effect.map((oauth) => ({ ok: true as const, oauth })),
+              Effect.catch(() => Effect.succeed({ ok: false as const, oauth: null })),
               Effect.withSpan("mcp.plugin.probe_oauth"),
             );
 
-          if (probeResult) {
+          if (probeResult.ok) {
             return {
               connected: false,
               requiresOAuth: true,
+              supportsDynamicRegistration: probeResult.oauth.supportsDynamicRegistration,
               name,
               namespace,
               toolCount: null,

--- a/packages/plugins/openapi/src/sdk/parse.test.ts
+++ b/packages/plugins/openapi/src/sdk/parse.test.ts
@@ -33,6 +33,20 @@ paths: {}
     }),
   );
 
+  it.effect("falls back to YAML for flow-style YAML documents", () =>
+    Effect.gen(function* () {
+      const doc = yield* parse(`
+{
+  openapi: 3.0.0,
+  info: { title: Test, version: 1.0.0 },
+  paths: {}
+}
+`);
+
+      expect(doc.openapi).toBe("3.0.0");
+    }),
+  );
+
   it.effect("returns a stable parse error for empty documents", () =>
     Effect.gen(function* () {
       const error = yield* parse("").pipe(Effect.flip);

--- a/packages/plugins/openapi/src/sdk/parse.ts
+++ b/packages/plugins/openapi/src/sdk/parse.ts
@@ -1,5 +1,5 @@
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
-import { Duration, Effect } from "effect";
+import { Duration, Effect, Schema } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 import YAML from "yaml";
 
@@ -107,13 +107,14 @@ const parseTextToObject = (text: string): Effect.Effect<OpenAPI.Document, OpenAp
       });
     }
 
-    const parsed = yield* Effect.try({
-      try: () => YAML.parse(trimmed) as unknown,
-      catch: () =>
-        new OpenApiParseError({
-          message: "Failed to parse OpenAPI document",
-        }),
-    });
+    const parsed = yield* parseJsonLike(trimmed).pipe(
+      Effect.mapError(
+        () =>
+          new OpenApiParseError({
+            message: "Failed to parse OpenAPI document",
+          }),
+      ),
+    );
 
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
       return yield* new OpenApiParseError({
@@ -123,3 +124,14 @@ const parseTextToObject = (text: string): Effect.Effect<OpenAPI.Document, OpenAp
 
     return parsed as OpenAPI.Document;
   });
+
+const parseJsonText = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown));
+
+const parseJsonLike = (text: string): Effect.Effect<unknown, unknown> => {
+  const parseYaml = Effect.try({
+    try: () => YAML.parse(text) as unknown,
+    catch: () => "YamlParseFailed" as const,
+  });
+  if (!text.startsWith("{") && !text.startsWith("[")) return parseYaml;
+  return parseJsonText(text).pipe(Effect.catch(() => parseYaml));
+};

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -5,7 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 
 import { cancelOAuth, startOAuth } from "../api/atoms";
-import { messageFromUnknown, useReportHandledError } from "../api/error-reporting";
+import { messageFromExit, messageFromUnknown, useReportHandledError } from "../api/error-reporting";
 import { openOAuthPopup, reserveOAuthPopup, type OAuthPopupResult } from "../api/oauth-popup";
 import { Button } from "../components/button";
 import {
@@ -48,6 +48,7 @@ export type OAuthAuthorizationStartResult = {
 
 class OAuthAuthorizationStartError extends Data.TaggedError("OAuthAuthorizationStartError")<{
   readonly cause: unknown;
+  readonly message: string;
 }> {}
 
 export type StartOAuthAuthorizationInput<TPayload extends OAuthCompletionPayload> = {
@@ -153,11 +154,15 @@ export function useOAuthPopupFlow<
       const startExit = await Effect.runPromiseExit(
         Effect.tryPromise({
           try: input.run,
-          catch: (cause) => new OAuthAuthorizationStartError({ cause }),
+          catch: (cause) =>
+            new OAuthAuthorizationStartError({
+              cause,
+              message: messageFromUnknown(cause, startErrorMessage ?? "Failed to start sign-in"),
+            }),
         }),
       );
       if (Exit.isFailure(startExit)) {
-        const message = startErrorMessage ?? "Failed to start sign-in";
+        const message = messageFromExit(startExit, startErrorMessage ?? "Failed to start sign-in");
         reportHandledError(startExit.cause, {
           surface: "oauth",
           action: "start",
@@ -278,7 +283,11 @@ export function useOAuthPopupFlow<
           }).then((exit) =>
             Exit.isSuccess(exit)
               ? exit.value
-              : Effect.runPromise(Effect.fail(startErrorMessage ?? "Failed to start sign-in")),
+              : Effect.runPromise(
+                  Effect.fail({
+                    message: messageFromExit(exit, startErrorMessage ?? "Failed to start sign-in"),
+                  }),
+                ),
           ),
       });
     },


### PR DESCRIPTION
## Summary

- surface whether an MCP server that requires OAuth supports dynamic client registration
- when MCP OAuth cannot use DCR, avoid trapping the add-source form in OAuth-only mode so PAT/header auth and deferred source saves remain available
- preserve the backend start error in OAuth UI flows
- parse JSON-shaped OpenAPI specs with JSON.parse first, falling back to YAML for YAML/flow-style YAML documents

## Root Cause

- GitHub Copilot MCP advertises OAuth protected-resource metadata, but the advertised GitHub authorization server does not publish RFC 8414 metadata or dynamic client registration. Treating this as a DCR-capable OAuth flow produced a vague start failure, and the first UI fix still left the form stuck in an unusable OAuth-only state.
- The GitHub REST OpenAPI description is valid JSON, but Cloudflare Workers hit resource limits when the 12.5 MB document is parsed through the YAML parser. A deployed Wrangler probe confirmed fetch, buffering, and JSON.parse succeed while YAML.parse returns Cloudflare 1102.

## Validation

- bun run --cwd packages/react test -- src/api/error-reporting.test.ts src/api/oauth-popup.test.ts
- bun run --cwd packages/plugins/mcp test -- src/api/handlers.test.ts src/sdk/plugin.test.ts
- bun run --cwd packages/core/sdk test -- src/oauth-discovery.test.ts
- bun run --cwd packages/plugins/openapi test -- src/sdk/parse.test.ts src/sdk/real-specs.test.ts
- bun run --cwd packages/react typecheck
- bun run --cwd packages/plugins/mcp typecheck
- bun run --cwd packages/plugins/openapi typecheck
- bun run --cwd packages/core/sdk typecheck
- ./node_modules/.bin/oxfmt --check packages/plugins/mcp/src/api/group.ts packages/plugins/mcp/src/sdk/plugin.ts packages/plugins/mcp/src/react/AddMcpSource.tsx packages/react/src/plugins/oauth-sign-in.tsx packages/plugins/openapi/src/sdk/parse.ts packages/plugins/openapi/src/sdk/parse.test.ts