### PR TITLE
Add cloud production deployment foundation

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,0 +1,101 @@
+name: Deploy Cloud
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_migrations:
+        description: Run production Drizzle migrations before deploy
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+  push:
+    branches:
+      - main
+    paths:
+      - apps/cloud/**
+      - packages/**
+      - patches/**
+      - package.json
+      - bun.lock
+      - turbo.json
+      - tsconfig.json
+      - .github/workflows/deploy-cloud.yml
+
+concurrency:
+  group: deploy-cloud-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy executor-cloud
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://executor.sh
+    permissions:
+      contents: read
+      deployments: write
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+      EXECUTOR_BUILD_SHA: ${{ github.sha }}
+      EXECUTOR_BUILD_VERSION: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      # apps/cloud's tests invoke `node` directly; undici 8.x needs Node 22.10+.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format check
+        run: bun run format:check
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck cloud app
+        working-directory: apps/cloud
+        run: bun run typecheck
+
+      - name: Test cloud app
+        working-directory: apps/cloud
+        run: bun run test
+
+      - name: Build cloud worker
+        working-directory: apps/cloud
+        run: bun run build
+
+      - name: Run production migrations
+        if: ${{ github.event_name == 'push' || inputs.run_migrations == 'true' }}
+        working-directory: apps/cloud
+        run: bun run db:migrate:ci
+
+      - name: Deploy Cloudflare Worker
+        working-directory: apps/cloud
+        run: bun run deploy:ci
+
+      - name: Verify health endpoint
+        run: |
+          for i in {1..12}; do
+            code=$(curl -fsS -o /tmp/health.json -w "%{http_code}" https://executor.sh/healthz || true)
+            if [ "$code" = "200" ]; then
+              cat /tmp/health.json
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "health check failed"
+          cat /tmp/health.json 2>/dev/null || true
+          exit 1

--- a/apps/cloud/.env.example
+++ b/apps/cloud/.env.example
@@ -1,0 +1,42 @@
+# Executor Cloud local/deploy environment template
+# Copy to `.dev.vars` for local Wrangler-style secrets or map these values into
+# 1Password / GitHub Environments / Cloudflare Worker secrets for production.
+
+# Public app URLs
+VITE_PUBLIC_SITE_URL=http://127.0.0.1:5394
+VITE_PUBLIC_POSTHOG_KEY=
+VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+VITE_PUBLIC_SENTRY_DSN=
+
+# Database
+# Local dev can use the PGlite socket started by `bun run dev:db`.
+# Production should set PRODUCTION_DATABASE_URL in GitHub only for migrations;
+# runtime requests should prefer the HYPERDRIVE binding from wrangler.jsonc.
+DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5433/postgres
+EXECUTOR_DIRECT_DATABASE_URL=true
+
+# WorkOS AuthKit / Organizations
+WORKOS_API_KEY=
+WORKOS_CLIENT_ID=
+WORKOS_COOKIE_PASSWORD=
+
+# Billing / plans
+AUTUMN_SECRET_KEY=
+
+# MCP OAuth/resource metadata
+MCP_AUTHKIT_DOMAIN=
+MCP_RESOURCE_ORIGIN=http://127.0.0.1:5394
+EXECUTOR_MCP_DEBUG=false
+
+# Observability
+SENTRY_DSN=
+AXIOM_TOKEN=
+AXIOM_DATASET=executor-cloud
+AXIOM_TRACES_URL=https://api.axiom.co/v1/traces
+AXIOM_TRACES_SAMPLE_RATIO=1
+
+# Deployment/readiness metadata
+EXECUTOR_BUILD_VERSION=local
+EXECUTOR_BUILD_SHA=local
+# Optional: if set, `/readyz` requires `x-readiness-token: <value>`.
+READINESS_TOKEN=

--- a/apps/cloud/DEPLOYMENT.md
+++ b/apps/cloud/DEPLOYMENT.md
@@ -1,0 +1,120 @@
+# Executor Cloud production deployment
+
+Executor Cloud is the B2B SaaS surface for Executor: Cloudflare Worker + Durable Objects, Postgres via Hyperdrive, WorkOS AuthKit/Organizations, Autumn billing, Sentry/Axiom/PostHog observability, and the MCP endpoint.
+
+## Production resources
+
+Provision these before the first production deploy:
+
+- **Cloudflare**
+  - Worker name: `executor-cloud`
+  - Route/custom domain: `executor.sh`
+  - Hyperdrive binding: `HYPERDRIVE`
+  - Durable Object binding: `MCP_SESSION`
+  - Service binding: `MARKETING` -> `executor-marketing`
+  - API token with Workers deploy permissions
+- **Postgres**
+  - Production database reachable from Cloudflare Hyperdrive
+  - Migration URL stored only in GitHub as `PRODUCTION_DATABASE_URL`
+  - Runtime requests should prefer the Hyperdrive binding, not direct `DATABASE_URL`
+- **WorkOS**
+  - AuthKit application and callback URL: `https://executor.sh/api/auth/callback`
+  - Organizations enabled
+  - Roles configured at least for `admin` and `member`
+- **Autumn**
+  - Products/features from `apps/cloud/autumn.config.ts`
+  - Secret key available to the Worker
+- **Observability**
+  - Sentry DSN for Worker and browser tunnel
+  - Axiom token/dataset/traces endpoint for OTEL
+  - PostHog public key/host for browser analytics
+
+## GitHub environment secrets
+
+Create a GitHub Environment named `production` and add:
+
+- `CLOUDFLARE_API_TOKEN`
+- `CLOUDFLARE_ACCOUNT_ID`
+- `PRODUCTION_DATABASE_URL`
+
+Recommended: require approval on the `production` environment.
+
+## Cloudflare Worker secrets
+
+Set these with `wrangler secret put` or the Cloudflare dashboard:
+
+```bash
+cd apps/cloud
+wrangler secret put WORKOS_API_KEY
+wrangler secret put WORKOS_CLIENT_ID
+wrangler secret put WORKOS_COOKIE_PASSWORD
+wrangler secret put AUTUMN_SECRET_KEY
+wrangler secret put SENTRY_DSN
+wrangler secret put AXIOM_TOKEN
+wrangler secret put AXIOM_DATASET
+wrangler secret put AXIOM_TRACES_URL
+wrangler secret put MCP_AUTHKIT_DOMAIN
+wrangler secret put MCP_RESOURCE_ORIGIN
+wrangler secret put READINESS_TOKEN
+```
+
+Non-secret public vars live in `apps/cloud/wrangler.jsonc` under `vars`.
+
+## Deployment flow
+
+The production workflow is `.github/workflows/deploy-cloud.yml`.
+
+On every push to `main` that touches cloud/package files, it:
+
+1. Installs Bun dependencies.
+2. Runs format/lint checks.
+3. Typechecks `apps/cloud`.
+4. Runs `apps/cloud` tests.
+5. Builds the Cloudflare Worker.
+6. Runs Drizzle migrations with `PRODUCTION_DATABASE_URL`.
+7. Deploys with Wrangler.
+8. Verifies `https://executor.sh/healthz`.
+
+Manual deploys can be started from GitHub Actions. The manual input `run_migrations=false` can be used for a redeploy/rollback where the database is already at the target schema.
+
+## Local smoke checks
+
+```bash
+bun install
+cd apps/cloud
+bun run typecheck
+bun run test
+bun run build
+```
+
+Never use `bun test`; repo tests are Vitest-based.
+
+## Runtime health endpoints
+
+- `GET /healthz` — public, cheap, no dependency checks. Returns service/version/commit.
+- `GET /readyz` — dependency-aware readiness. Checks required SaaS secrets and Postgres connectivity. If `READINESS_TOKEN` is set, call it with:
+
+```bash
+curl -H "x-readiness-token: $READINESS_TOKEN" https://executor.sh/readyz
+```
+
+Use `/healthz` for post-deploy smoke checks and `/readyz` for internal monitors.
+
+## First production deploy checklist
+
+- [ ] Cloudflare Worker route and service binding exist.
+- [ ] Hyperdrive binding id in `apps/cloud/wrangler.jsonc` points at production Postgres.
+- [ ] WorkOS callback URL is configured.
+- [ ] Autumn products/features are synced from `apps/cloud/autumn.config.ts`.
+- [ ] GitHub `production` environment secrets are present.
+- [ ] Worker runtime secrets are present.
+- [ ] `cd apps/cloud && bun run db:migrate:ci` succeeds against production.
+- [ ] Deploy workflow succeeds.
+- [ ] `/healthz` returns 200.
+- [ ] `/readyz` returns 200 with the readiness token.
+
+## Rollback
+
+For app-only regressions, redeploy the previous successful GitHub SHA from the Actions UI with `run_migrations=false`.
+
+For schema regressions, do not blindly roll back code. First inspect the Drizzle migration that shipped and create an explicit forward-fix migration. Production migrations are treated as irreversible unless a tested down-migration exists.

--- a/apps/cloud/PRODUCTIONIZATION_PLAN.md
+++ b/apps/cloud/PRODUCTIONIZATION_PLAN.md
@@ -1,0 +1,96 @@
+# Executor B2B SaaS productionization plan
+
+## Current foundation
+
+Executor already has a strong SaaS-shaped core in `apps/cloud`:
+
+- Cloudflare Worker + TanStack Start app shell.
+- Durable Object MCP session runtime (`MCP_SESSION`).
+- Postgres-backed storage through Hyperdrive / direct database URL fallback.
+- WorkOS AuthKit + Organizations auth model.
+- Autumn billing/usage hooks.
+- API surface for sources, secrets, policies, tools, org membership, and execution usage.
+- Sentry, Axiom/OTEL, and PostHog integrations.
+- Vitest + Miniflare tests covering tenant isolation, secrets isolation, MCP auth/session flow, organization limits, and backend APIs.
+
+## Production target architecture
+
+1. **Cloud edge**
+   - `executor-cloud` Cloudflare Worker serves app/backend/MCP.
+   - Custom domain: `executor.sh`.
+   - Durable Object binding: `MCP_SESSION` for long-lived MCP sessions.
+   - Service binding: `MARKETING` for marketing pages.
+   - Hyperdrive binding: `HYPERDRIVE` for production Postgres pooling.
+
+2. **Data layer**
+   - Managed Postgres for tenant/org/source/secret/policy/execution state.
+   - Drizzle migrations run from GitHub Actions using `PRODUCTION_DATABASE_URL`.
+   - Runtime uses Hyperdrive by default; direct `DATABASE_URL` only for CI/local.
+
+3. **Identity / tenancy**
+   - WorkOS AuthKit handles login/logout/callback/session refresh.
+   - WorkOS Organizations maps users to org tenants.
+   - App-side authorization scopes all mutable resources to organization id.
+   - Admin/member roles used for org management and billing actions.
+
+4. **Billing / metering**
+   - Autumn products/features define plan entitlements.
+   - Execution usage is tracked per organization.
+   - Limits/entitlements gate sources, members, and executions.
+
+5. **Observability / operations**
+   - `/healthz` for deployment smoke checks.
+   - `/readyz` for dependency readiness: Postgres + required secrets.
+   - Sentry tunnel for frontend/server errors.
+   - OTEL/Axiom spans for MCP/worker operations.
+   - PostHog first-party proxy for product analytics.
+
+## Implementation phases
+
+### Phase 1 — deployment foundation (implemented in this branch)
+
+- Add CI-friendly `db:migrate:ci` and `deploy:ci` scripts.
+- Add Cloudflare/GitHub production deployment workflow.
+- Add `.env.example` and `DEPLOYMENT.md` with required resources/secrets.
+- Add `/healthz` and `/readyz` middleware before app/API routing.
+- Add runtime env typings for WorkOS/build/readiness secrets.
+- Verify typecheck, tests, and production build locally.
+
+### Phase 2 — production account provisioning
+
+- Create/verify Cloudflare Worker, route, Hyperdrive id, Durable Object migration, and marketing service binding.
+- Create managed Postgres and wire Hyperdrive to it.
+- Configure WorkOS AuthKit callback/logout URLs and organization roles.
+- Configure Autumn products/features from `apps/cloud/autumn.config.ts`.
+- Configure Sentry, Axiom, and PostHog projects.
+- Add GitHub `production` environment secrets and Cloudflare Worker secrets.
+
+### Phase 3 — launch hardening
+
+- Add automated post-deploy `/readyz` monitor with `READINESS_TOKEN`.
+- Add alerting for Worker errors, DB connection failures, and elevated MCP failure rates.
+- Add rate limits / abuse controls around MCP execution and public auth endpoints.
+- Add paid-plan gates to any remaining unaudited resource creation paths.
+- Add admin audit log for source/secret/policy changes.
+- Add customer onboarding checklist: invite org, connect source, test MCP client, verify billing usage.
+
+### Phase 4 — scale / enterprise readiness
+
+- SSO/SAML enterprise setup via WorkOS organizations.
+- SCIM / directory sync if needed.
+- Per-org data export/deletion workflows.
+- More granular RBAC beyond `admin` / `member`.
+- Region-aware data placement if customers require data residency.
+- Dedicated enterprise org limits, support tooling, and incident runbooks.
+
+## Acceptance criteria for production deploy
+
+- `bun run typecheck` passes in `apps/cloud`.
+- `bun run test` passes in `apps/cloud`.
+- `bun run build` passes in `apps/cloud`.
+- GitHub Actions deployment workflow succeeds.
+- `https://executor.sh/healthz` returns 200 after deploy.
+- `https://executor.sh/readyz` returns 200 with readiness token after secrets and DB are wired.
+- WorkOS login/callback/logout works on production domain.
+- A test organization can create sources/secrets/policies and run MCP tools.
+- Autumn usage events show up for a test organization.

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -22,7 +22,9 @@
     "test": "node ../../node_modules/vitest/vitest.mjs run && node ../../node_modules/vitest/vitest.mjs run --config vitest.node.config.ts",
     "test:watch": "node ../../node_modules/vitest/vitest.mjs",
     "test:node": "node ../../node_modules/vitest/vitest.mjs run --config vitest.node.config.ts",
-    "typecheck:slow": "tsc --noEmit"
+    "typecheck:slow": "tsc --noEmit",
+    "db:migrate:ci": "bun --bun ../../node_modules/.bun/node_modules/drizzle-kit/bin.cjs migrate",
+    "deploy:ci": "bun run build && wrangler deploy"
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.31.1",

--- a/apps/cloud/src/env-augment.d.ts
+++ b/apps/cloud/src/env-augment.d.ts
@@ -20,6 +20,11 @@ declare global {
       DATABASE_URL?: string;
       EXECUTOR_DIRECT_DATABASE_URL?: string;
 
+      // WorkOS AuthKit / Organizations
+      WORKOS_API_KEY?: string;
+      WORKOS_CLIENT_ID?: string;
+      WORKOS_COOKIE_PASSWORD?: string;
+
       // Billing
       AUTUMN_SECRET_KEY?: string;
 
@@ -28,6 +33,11 @@ declare global {
       MCP_AUTHKIT_DOMAIN?: string;
       MCP_RESOURCE_ORIGIN?: string;
       NODE_ENV?: string;
+
+      // Deployment/readiness metadata
+      EXECUTOR_BUILD_VERSION?: string;
+      EXECUTOR_BUILD_SHA?: string;
+      READINESS_TOKEN?: string;
 
       // Shared with frontend
       VITE_PUBLIC_SITE_URL?: string;

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -1,9 +1,114 @@
 import { env } from "cloudflare:workers";
+import postgres from "postgres";
 import { createMiddleware, createStart } from "@tanstack/react-start";
 import { Effect } from "effect";
 import { handleApiRequest } from "./api";
 import { mcpFetch } from "./mcp";
 import { handleSentryTunnelRequest } from "./sentry-tunnel";
+import { resolveConnectionString } from "./services/db";
+
+// ---------------------------------------------------------------------------
+// Health/readiness endpoints — intentionally handled before app/API routing
+// so deploy automation and Cloudflare monitors can verify the worker without
+// booting the full React/API request path. `/healthz` is public and cheap;
+// `/readyz` is dependency-aware and may be protected by READINESS_TOKEN.
+// ---------------------------------------------------------------------------
+
+const jsonResponse = (payload: unknown, init?: ResponseInit) =>
+  new Response(JSON.stringify(payload), {
+    ...init,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+      ...init?.headers,
+    },
+  });
+
+const currentBuild = () => ({
+  service: "executor-cloud",
+  status: "ok",
+  version: env.EXECUTOR_BUILD_VERSION ?? "dev",
+  commit: env.EXECUTOR_BUILD_SHA ?? null,
+});
+
+type DatabaseCheck = { ok: true } | { ok: false; error: string };
+
+const checkDatabase = (): Effect.Effect<DatabaseCheck, never, never> => {
+  const connectionString = resolveConnectionString();
+  if (!connectionString) {
+    return Effect.succeed({ ok: false, error: "database connection string is not configured" });
+  }
+
+  const sql = postgres(connectionString, {
+    max: 1,
+    idle_timeout: 0,
+    max_lifetime: 5,
+    connect_timeout: 5,
+    fetch_types: false,
+    prepare: false,
+    onnotice: () => undefined,
+  });
+
+  return Effect.tryPromise({
+    try: () => sql`select 1`,
+    catch: (cause) => cause,
+  }).pipe(
+    Effect.as({ ok: true } as const),
+    Effect.catch((cause: unknown) =>
+      Effect.sync(() => {
+        console.error("[readyz] database check failed", cause);
+        return { ok: false, error: "database check failed" } as const;
+      }),
+    ),
+    Effect.ensuring(
+      Effect.promise(() =>
+        sql.end({ timeout: 0 }).then(
+          () => undefined,
+          () => undefined,
+        ),
+      ),
+    ),
+  );
+};
+
+const requiredSecretChecks = () => ({
+  WORKOS_API_KEY: Boolean(env.WORKOS_API_KEY),
+  WORKOS_CLIENT_ID: Boolean(env.WORKOS_CLIENT_ID),
+  WORKOS_COOKIE_PASSWORD: Boolean(env.WORKOS_COOKIE_PASSWORD),
+  AUTUMN_SECRET_KEY: Boolean(env.AUTUMN_SECRET_KEY),
+});
+
+const healthMiddleware = createMiddleware({ type: "request" }).server(
+  async ({ pathname, request, next }) => {
+    if (pathname === "/healthz") {
+      return jsonResponse(currentBuild());
+    }
+
+    if (pathname !== "/readyz") return next();
+
+    const readinessToken = env.READINESS_TOKEN;
+    if (readinessToken) {
+      const header = request.headers.get("x-readiness-token");
+      if (header !== readinessToken) {
+        return jsonResponse({ ...currentBuild(), status: "unauthorized" }, { status: 401 });
+      }
+    }
+
+    const database = await Effect.runPromise(checkDatabase());
+    const secrets = requiredSecretChecks();
+    const secretsOk = Object.values(secrets).every(Boolean);
+    const ok = database.ok && secretsOk;
+
+    return jsonResponse(
+      {
+        ...currentBuild(),
+        status: ok ? "ready" : "not_ready",
+        checks: { database, secrets },
+      },
+      { status: ok ? 200 : 503 },
+    );
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Marketing routes — proxied to the marketing worker via service binding
@@ -137,6 +242,7 @@ const apiRequestMiddleware = createMiddleware({ type: "request" }).server(
 
 export const startInstance = createStart(() => ({
   requestMiddleware: [
+    healthMiddleware,
     marketingMiddleware,
     mcpRequestMiddleware,
     sentryTunnelMiddleware,


### PR DESCRIPTION
## Summary
- add production deployment docs and productionization plan for Executor Cloud
- add CI-friendly Cloudflare deploy workflow with migrations and health smoke check
- add `/healthz` and `/readyz` endpoints for deploy/monitoring readiness
- add env typing/template for WorkOS, Autumn, observability, build metadata, readiness

## Verification
- `cd apps/cloud && bun run typecheck`
- `cd apps/cloud && bun run test`
- `cd apps/cloud && bun run build`
- `bun run format:check`
- `bun run lint`

## Production blockers before actual deploy
- Cloudflare auth is not configured locally: `bunx wrangler whoami` says not authenticated
- GitHub `production` environment secrets must be added: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, `PRODUCTION_DATABASE_URL`
- Worker runtime secrets must be set per `apps/cloud/DEPLOYMENT.md`
