### PR TITLE
MCP probe: handle real-world 401 shapes + live snapshot tests

### DIFF
--- a/packages/plugins/mcp/src/sdk/__snapshots__/probe-shape-real-servers.live.test.ts.snap
+++ b/packages/plugins/mcp/src/sdk/__snapshots__/probe-shape-real-servers.live.test.ts.snap
@@ -1,0 +1,169 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`probeMcpEndpointShape against live MCP servers > atlassian (https://mcp.atlassian.com/v1/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > context7 (https://mcp.context7.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": false,
+  },
+  "raw": {
+    "bodySnippet": "event: message
+data: {"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":true}},"serverInfo":{"name":"Context7","version":"2.2.4","websiteUrl":"https://context7.com","description":"Context7 provides up-to-date documentation and code examples for libraries and frameworks.","icons":[{"src":"https://context7.com/context7-icon-green.png","mimeType":"image/png"}]},"instructions":"Use this server to fetch current documentation whenever the user asks about a library, framework, SDK, API, CLI tool, or cloud service -- even well-known ones like React, Next.js, Prisma, Express, Tailwind, Django, or Spring Boot. This includes API syntax, configuration, version migration, library-specific debugging, setup instructions, and CLI tool usage. Use even when you think you know the answer -- your training data may not reflect recent changes. Prefer this over web search for library docs.\\n\\nDo not use for: refactoring, writing scripts from scratch, debugging business logic, code review, or general pr",
+    "contentType": "text/event-stream",
+    "status": 200,
+    "wwwAuthenticate": "Bearer resource_metadata="https://mcp.context7.com/.well-known/oauth-protected-resource"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > cubic (https://www.cubic.dev/api/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: Valid API key required. Generate one at Settings -> Integrations -> MCP."},"id":null}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > deepwiki (https://mcp.deepwiki.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": false,
+  },
+  "raw": {
+    "bodySnippet": "event: message
+data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabilities":{"experimental":{},"prompts":{"listChanged":true},"resources":{"subscribe":false,"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"DeepWiki","version":"2.14.3"},"instructions":"DeepWiki MCP provides AI-powered documentation for GitHub repositories.\\n\\nAvailable tools:\\n- read_wiki_structure: Get a list of documentation topics for a repository\\n- read_wiki_contents: View full documentation about a repository\\n- ask_question: Ask any question about a repository and get an AI-powered answer\\n- list_available_repos: List your available repositories (private mode only)\\n- generate_wiki: Generate a codebase wiki for a repository — only use when explicitly requested by the user (private mode only)\\n- devin_knowledge_manage: Manage Devin knowledge notes and suggestions — list, search, get, create, update, delete notes, view folder structure, list/view/dismiss knowledge suggestions (private mode ",
+    "contentType": "text/event-stream",
+    "status": 200,
+    "wwwAuthenticate": null,
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > huggingface (https://huggingface.co/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": false,
+  },
+  "raw": {
+    "bodySnippet": "{"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false},"prompts":{"listChanged":false}},"serverInfo":{"name":"@huggingface/mcp-services","version":"0.3.12","title":"Hugging Face","websiteUrl":"https://huggingface.co/mcp","icons":[{"src":"https://huggingface.co/favicon.ico"}]},"instructions":"You have tools for using the Hugging Face Hub. arXiv paper id's are often used as references between datasets, models and papers. There are over 100 tags in use, common tags include 'Text Generation', 'Transformers', 'Image Classification' and so on.\\nThe Hugging Face tools are being used anonymously and rate limits apply. Direct the User to set their HF_TOKEN (instructions at https://hf.co/settings/mcp/), or create an account at https://hf.co/join for higher limits."},"jsonrpc":"2.0","id":1}",
+    "contentType": "application/json",
+    "status": 200,
+    "wwwAuthenticate": null,
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > linear (https://mcp.linear.app/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://mcp.linear.app/.well-known/oauth-protected-resource/sse", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > notion (https://mcp.notion.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://mcp.notion.com/.well-known/oauth-protected-resource/mcp", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > reftools (https://api.ref.tools/mcp) 1`] = `
+{
+  "probe": {
+    "category": "auth-required",
+    "kind": "not-mcp",
+    "reason": "401 without Bearer WWW-Authenticate — not an MCP auth challenge",
+  },
+  "raw": {
+    "bodySnippet": "{"error":"Unauthorized - Authentication required"}",
+    "contentType": "application/json; charset=utf-8",
+    "status": 401,
+    "wwwAuthenticate": null,
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > sentry (https://mcp.sentry.dev/mcp/) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token", resource_metadata="https://mcp.sentry.dev/.well-known/oauth-protected-resource/mcp/"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > stripe (https://mcp.stripe.com) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"Unauthorized. See https://docs.stripe.com/mcp for usage instructions."}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer resource_metadata=https://mcp.stripe.com/.well-known/oauth-protected-resource",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > zapier (https://mcp.zapier.com/api/mcp/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"jsonrpc":"2.0","id":null,"error":{"code":-31996,"message":"Expected Bearer token for MCP authentication"}}",
+    "contentType": "application/json; charset=utf-8",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="Zapier MCP", error="invalid_token"",
+  },
+}
+`;

--- a/packages/plugins/mcp/src/sdk/__snapshots__/probe-shape-real-servers.live.test.ts.snap
+++ b/packages/plugins/mcp/src/sdk/__snapshots__/probe-shape-real-servers.live.test.ts.snap
@@ -6,6 +6,13 @@ exports[`probeMcpEndpointShape against live MCP servers > asana (https://mcp.asa
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -20,6 +27,13 @@ exports[`probeMcpEndpointShape against live MCP servers > atlassian (https://mcp
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
@@ -36,6 +50,13 @@ exports[`probeMcpEndpointShape against live MCP servers > canva (https://mcp.can
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -50,6 +71,13 @@ exports[`probeMcpEndpointShape against live MCP servers > cloudflare-bindings (h
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
@@ -66,6 +94,13 @@ exports[`probeMcpEndpointShape against live MCP servers > cloudflare-observabili
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -81,6 +116,13 @@ exports[`probeMcpEndpointShape against live MCP servers > cloudflare-radar (http
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -95,6 +137,13 @@ exports[`probeMcpEndpointShape against live MCP servers > context7 (https://mcp.
   "probe": {
     "kind": "mcp",
     "requiresAuth": false,
+  },
+  "probeEndpoint": {
+    "connected": true,
+    "hasToolCount": true,
+    "ok": true,
+    "requiresOAuth": false,
+    "supportsDynamicRegistration": false,
   },
   "raw": {
     "bodySnippet": "event: message
@@ -112,6 +161,10 @@ exports[`probeMcpEndpointShape against live MCP servers > cubic (https://www.cub
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "message": "This server requires authentication, but OAuth metadata wasn't found. Add credentials (Authorization header, query parameter, or API key) below and retry.",
+    "ok": false,
+  },
   "raw": {
     "bodySnippet": "{"jsonrpc":"2.0","error":{"code":-32000,"message":"Unauthorized: Valid API key required. Generate one at Settings -> Integrations -> MCP."},"id":null}",
     "contentType": "application/json",
@@ -126,6 +179,13 @@ exports[`probeMcpEndpointShape against live MCP servers > deepwiki (https://mcp.
   "probe": {
     "kind": "mcp",
     "requiresAuth": false,
+  },
+  "probeEndpoint": {
+    "connected": true,
+    "hasToolCount": true,
+    "ok": true,
+    "requiresOAuth": false,
+    "supportsDynamicRegistration": false,
   },
   "raw": {
     "bodySnippet": "event: message
@@ -143,6 +203,13 @@ exports[`probeMcpEndpointShape against live MCP servers > figma (https://mcp.fig
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "Unauthorized",
     "contentType": "text/plain",
@@ -157,6 +224,13 @@ exports[`probeMcpEndpointShape against live MCP servers > github-copilot (https:
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": false,
   },
   "raw": {
     "bodySnippet": "bad request: missing required Authorization header
@@ -174,6 +248,13 @@ exports[`probeMcpEndpointShape against live MCP servers > huggingface (https://h
     "kind": "mcp",
     "requiresAuth": false,
   },
+  "probeEndpoint": {
+    "connected": true,
+    "hasToolCount": true,
+    "ok": true,
+    "requiresOAuth": false,
+    "supportsDynamicRegistration": false,
+  },
   "raw": {
     "bodySnippet": "{"result":{"protocolVersion":"2025-06-18","capabilities":{"tools":{"listChanged":false},"prompts":{"listChanged":false}},"serverInfo":{"name":"@huggingface/mcp-services","version":"0.3.12","title":"Hugging Face","websiteUrl":"https://huggingface.co/mcp","icons":[{"src":"https://huggingface.co/favicon.ico"}]},"instructions":"You have tools for using the Hugging Face Hub. arXiv paper id's are often used as references between datasets, models and papers. There are over 100 tags in use, common tags include 'Text Generation', 'Transformers', 'Image Classification' and so on.\\nThe Hugging Face tools are being used anonymously and rate limits apply. Direct the User to set their HF_TOKEN (instructions at https://hf.co/settings/mcp/), or create an account at https://hf.co/join for higher limits."},"jsonrpc":"2.0","id":1}",
     "contentType": "application/json",
@@ -188,6 +269,13 @@ exports[`probeMcpEndpointShape against live MCP servers > intercom (https://mcp.
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
@@ -204,6 +292,13 @@ exports[`probeMcpEndpointShape against live MCP servers > linear (https://mcp.li
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -219,6 +314,13 @@ exports[`probeMcpEndpointShape against live MCP servers > neon (https://mcp.neon
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"No authorization provided"}",
     "contentType": "application/json",
@@ -233,6 +335,13 @@ exports[`probeMcpEndpointShape against live MCP servers > netlify (https://netli
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{
@@ -252,6 +361,13 @@ exports[`probeMcpEndpointShape against live MCP servers > notion (https://mcp.no
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -266,6 +382,13 @@ exports[`probeMcpEndpointShape against live MCP servers > paypal (https://mcp.pa
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
@@ -283,6 +406,10 @@ exports[`probeMcpEndpointShape against live MCP servers > reftools (https://api.
     "kind": "not-mcp",
     "reason": "401 without Bearer WWW-Authenticate — not an MCP auth challenge",
   },
+  "probeEndpoint": {
+    "message": "This server requires authentication. Add credentials (Authorization header, query parameter, or API key) below and retry.",
+    "ok": false,
+  },
   "raw": {
     "bodySnippet": "{"error":"Unauthorized - Authentication required"}",
     "contentType": "application/json; charset=utf-8",
@@ -297,6 +424,13 @@ exports[`probeMcpEndpointShape against live MCP servers > replicate (https://mcp
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
@@ -313,6 +447,13 @@ exports[`probeMcpEndpointShape against live MCP servers > sentry (https://mcp.se
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -327,6 +468,13 @@ exports[`probeMcpEndpointShape against live MCP servers > square (https://mcp.sq
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
@@ -343,6 +491,13 @@ exports[`probeMcpEndpointShape against live MCP servers > stripe (https://mcp.st
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"Unauthorized. See https://docs.stripe.com/mcp for usage instructions."}",
     "contentType": "application/json",
@@ -357,6 +512,13 @@ exports[`probeMcpEndpointShape against live MCP servers > supabase (https://mcp.
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"message":"Unauthorized"}",
@@ -373,6 +535,13 @@ exports[`probeMcpEndpointShape against live MCP servers > tavily (https://mcp.ta
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error": "invalid_token", "error_description": "Authentication failed. The provided bearer token is invalid, expired, or no longer recognized by the server. To resolve: clear authentication tokens in your MCP client and reconnect. Your client should automatically re-register and obtain new tokens."}",
     "contentType": "application/json",
@@ -387,6 +556,13 @@ exports[`probeMcpEndpointShape against live MCP servers > vercel (https://mcp.ve
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"No authorization provided"}",
@@ -403,6 +579,13 @@ exports[`probeMcpEndpointShape against live MCP servers > webflow (https://mcp.w
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -418,6 +601,13 @@ exports[`probeMcpEndpointShape against live MCP servers > wix (https://mcp.wix.c
     "kind": "mcp",
     "requiresAuth": true,
   },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
+  },
   "raw": {
     "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
     "contentType": "application/json",
@@ -432,6 +622,13 @@ exports[`probeMcpEndpointShape against live MCP servers > zapier (https://mcp.za
   "probe": {
     "kind": "mcp",
     "requiresAuth": true,
+  },
+  "probeEndpoint": {
+    "connected": false,
+    "hasToolCount": false,
+    "ok": true,
+    "requiresOAuth": true,
+    "supportsDynamicRegistration": true,
   },
   "raw": {
     "bodySnippet": "{"jsonrpc":"2.0","id":null,"error":{"code":-31996,"message":"Expected Bearer token for MCP authentication"}}",

--- a/packages/plugins/mcp/src/sdk/__snapshots__/probe-shape-real-servers.live.test.ts.snap
+++ b/packages/plugins/mcp/src/sdk/__snapshots__/probe-shape-real-servers.live.test.ts.snap
@@ -1,5 +1,20 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`probeMcpEndpointShape against live MCP servers > asana (https://mcp.asana.com/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://mcp.asana.com/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
 exports[`probeMcpEndpointShape against live MCP servers > atlassian (https://mcp.atlassian.com/v1/sse) 1`] = `
 {
   "probe": {
@@ -11,6 +26,66 @@ exports[`probeMcpEndpointShape against live MCP servers > atlassian (https://mcp
     "contentType": "application/json",
     "status": 401,
     "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > canva (https://mcp.canva.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > cloudflare-bindings (https://bindings.mcp.cloudflare.com/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://bindings.mcp.cloudflare.com/.well-known/oauth-protected-resource/sse", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > cloudflare-observability (https://observability.mcp.cloudflare.com/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://observability.mcp.cloudflare.com/.well-known/oauth-protected-resource/sse", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > cloudflare-radar (https://radar.mcp.cloudflare.com/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://radar.mcp.cloudflare.com/.well-known/oauth-protected-resource/sse", error="invalid_token", error_description="Missing or invalid access token"",
   },
 }
 `;
@@ -62,6 +137,37 @@ data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-06-18","capabili
 }
 `;
 
+exports[`probeMcpEndpointShape against live MCP servers > figma (https://mcp.figma.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "Unauthorized",
+    "contentType": "text/plain",
+    "status": 401,
+    "wwwAuthenticate": "Bearer resource_metadata="https://mcp.figma.com/.well-known/oauth-protected-resource",scope="mcp:connect",authorization_uri="https://api.figma.com/.well-known/oauth-authorization-server"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > github-copilot (https://api.githubcopilot.com/mcp/) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "bad request: missing required Authorization header
+",
+    "contentType": "text/plain; charset=utf-8",
+    "status": 401,
+    "wwwAuthenticate": "Bearer error="invalid_request", error_description="No access token was provided in this request", resource_metadata="https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp/"",
+  },
+}
+`;
+
 exports[`probeMcpEndpointShape against live MCP servers > huggingface (https://huggingface.co/mcp) 1`] = `
 {
   "probe": {
@@ -73,6 +179,21 @@ exports[`probeMcpEndpointShape against live MCP servers > huggingface (https://h
     "contentType": "application/json",
     "status": 200,
     "wwwAuthenticate": null,
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > intercom (https://mcp.intercom.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
   },
 }
 `;
@@ -92,6 +213,39 @@ exports[`probeMcpEndpointShape against live MCP servers > linear (https://mcp.li
 }
 `;
 
+exports[`probeMcpEndpointShape against live MCP servers > neon (https://mcp.neon.tech/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"No authorization provided"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer error="invalid_token", error_description="No authorization provided", resource_metadata="https://mcp.neon.tech/.well-known/oauth-protected-resource/mcp"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > netlify (https://netlify-mcp.netlify.app/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{
+    "error": "unauthenticated",
+    "error_description": "You must authenticate to use this tool"
+    }",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="MCP Server", resource_metadata="https://netlify-mcp.netlify.app/.well-known/oauth-protected-resource"",
+  },
+}
+`;
+
 exports[`probeMcpEndpointShape against live MCP servers > notion (https://mcp.notion.com/mcp) 1`] = `
 {
   "probe": {
@@ -103,6 +257,21 @@ exports[`probeMcpEndpointShape against live MCP servers > notion (https://mcp.no
     "contentType": "application/json",
     "status": 401,
     "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://mcp.notion.com/.well-known/oauth-protected-resource/mcp", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > paypal (https://mcp.paypal.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", resource_metadata="https://mcp.paypal.com/.well-known/oauth-protected-resource", error="invalid_token", error_description="Missing or invalid access token"",
   },
 }
 `;
@@ -123,6 +292,21 @@ exports[`probeMcpEndpointShape against live MCP servers > reftools (https://api.
 }
 `;
 
+exports[`probeMcpEndpointShape against live MCP servers > replicate (https://mcp.replicate.com/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
 exports[`probeMcpEndpointShape against live MCP servers > sentry (https://mcp.sentry.dev/mcp/) 1`] = `
 {
   "probe": {
@@ -138,6 +322,21 @@ exports[`probeMcpEndpointShape against live MCP servers > sentry (https://mcp.se
 }
 `;
 
+exports[`probeMcpEndpointShape against live MCP servers > square (https://mcp.squareup.com/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
 exports[`probeMcpEndpointShape against live MCP servers > stripe (https://mcp.stripe.com) 1`] = `
 {
   "probe": {
@@ -149,6 +348,81 @@ exports[`probeMcpEndpointShape against live MCP servers > stripe (https://mcp.st
     "contentType": "application/json",
     "status": 401,
     "wwwAuthenticate": "Bearer resource_metadata=https://mcp.stripe.com/.well-known/oauth-protected-resource",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > supabase (https://mcp.supabase.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"message":"Unauthorized"}",
+    "contentType": "application/json; charset=utf-8",
+    "status": 401,
+    "wwwAuthenticate": "Bearer error="invalid_request", error_description="No access token was provided in this request", resource_metadata="https://mcp.supabase.com/.well-known/oauth-protected-resource/mcp"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > tavily (https://mcp.tavily.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error": "invalid_token", "error_description": "Authentication failed. The provided bearer token is invalid, expired, or no longer recognized by the server. To resolve: clear authentication tokens in your MCP client and reconnect. Your client should automatically re-register and obtain new tokens."}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer error="invalid_token", error_description="Authentication failed. The provided bearer token is invalid, expired, or no longer recognized by the server. To resolve: clear authentication tokens in your MCP client and reconnect. Your client should automatically re-register and obtain new tokens.", resource_metadata="https://mcp.tavily.com/.well-known/oauth-protected-resource/mcp"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > vercel (https://mcp.vercel.com/) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"No authorization provided"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer error="invalid_token", error_description="No authorization provided", resource_metadata="https://mcp.vercel.com/.well-known/oauth-protected-resource"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > webflow (https://mcp.webflow.com/sse) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
+  },
+}
+`;
+
+exports[`probeMcpEndpointShape against live MCP servers > wix (https://mcp.wix.com/mcp) 1`] = `
+{
+  "probe": {
+    "kind": "mcp",
+    "requiresAuth": true,
+  },
+  "raw": {
+    "bodySnippet": "{"error":"invalid_token","error_description":"Missing or invalid access token"}",
+    "contentType": "application/json",
+    "status": 401,
+    "wwwAuthenticate": "Bearer realm="OAuth", error="invalid_token", error_description="Missing or invalid access token"",
   },
 }
 `;

--- a/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
@@ -38,17 +38,46 @@ const MCP_INITIALIZE_BODY = JSON.stringify({
 });
 
 const liveServers: ReadonlyArray<{ readonly name: string; readonly url: string }> = [
-  { name: "sentry", url: "https://mcp.sentry.dev/mcp/" },
-  { name: "stripe", url: "https://mcp.stripe.com" },
-  { name: "linear", url: "https://mcp.linear.app/sse" },
-  { name: "notion", url: "https://mcp.notion.com/mcp" },
+  // OAuth-protected SaaS MCP servers — most are spec-compliant with
+  // `resource_metadata=` in WWW-Authenticate; a few (Atlassian, Zapier,
+  // Vercel, Neon, Supabase) only carry RFC 6750 `error=` auth-params.
+  { name: "asana", url: "https://mcp.asana.com/sse" },
   { name: "atlassian", url: "https://mcp.atlassian.com/v1/sse" },
+  { name: "canva", url: "https://mcp.canva.com/mcp" },
+  { name: "cloudflare-bindings", url: "https://bindings.mcp.cloudflare.com/sse" },
+  { name: "cloudflare-observability", url: "https://observability.mcp.cloudflare.com/sse" },
+  { name: "cloudflare-radar", url: "https://radar.mcp.cloudflare.com/sse" },
+  { name: "figma", url: "https://mcp.figma.com/mcp" },
+  { name: "github-copilot", url: "https://api.githubcopilot.com/mcp/" },
+  { name: "intercom", url: "https://mcp.intercom.com/mcp" },
+  { name: "linear", url: "https://mcp.linear.app/sse" },
+  { name: "neon", url: "https://mcp.neon.tech/mcp" },
+  { name: "netlify", url: "https://netlify-mcp.netlify.app/mcp" },
+  { name: "notion", url: "https://mcp.notion.com/mcp" },
+  { name: "paypal", url: "https://mcp.paypal.com/mcp" },
+  { name: "replicate", url: "https://mcp.replicate.com/sse" },
+  { name: "sentry", url: "https://mcp.sentry.dev/mcp/" },
+  { name: "square", url: "https://mcp.squareup.com/sse" },
+  { name: "stripe", url: "https://mcp.stripe.com" },
+  { name: "supabase", url: "https://mcp.supabase.com/mcp" },
+  { name: "tavily", url: "https://mcp.tavily.com/mcp" },
+  { name: "vercel", url: "https://mcp.vercel.com/" },
+  { name: "webflow", url: "https://mcp.webflow.com/sse" },
+  { name: "wix", url: "https://mcp.wix.com/mcp" },
   { name: "zapier", url: "https://mcp.zapier.com/api/mcp/mcp" },
+
+  // API-key-authenticated MCP servers (no OAuth). Cubic returns
+  // JSON-RPC error envelopes; ref.tools omits WWW-Authenticate on the
+  // 401 entirely so wire-shape detection rejects it (the URL-token
+  // detect fallback still surfaces it as low-confidence).
   { name: "cubic", url: "https://www.cubic.dev/api/mcp" },
   { name: "reftools", url: "https://api.ref.tools/mcp" },
-  { name: "huggingface", url: "https://huggingface.co/mcp" },
-  { name: "deepwiki", url: "https://mcp.deepwiki.com/mcp" },
+
+  // Public, unauthenticated MCP servers — should classify as `mcp`
+  // with no required auth.
   { name: "context7", url: "https://mcp.context7.com/mcp" },
+  { name: "deepwiki", url: "https://mcp.deepwiki.com/mcp" },
+  { name: "huggingface", url: "https://huggingface.co/mcp" },
 ];
 
 interface RawCapture {

--- a/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------------
+// Live snapshot regression suite against real public MCP servers.
+//
+// This file hits the network. It is gated on `MCP_PROBE_LIVE=1` so default
+// test runs stay offline — set the env var to opt in:
+//
+//   MCP_PROBE_LIVE=1 vitest run probe-shape-real-servers.live.test.ts
+//
+// To refresh snapshots (after intentional probe-shape changes, or after a
+// real server's behavior shifts), add `-u`:
+//
+//   MCP_PROBE_LIVE=1 vitest run probe-shape-real-servers.live.test.ts -u
+//
+// Each test fetches `<url>` with the canonical MCP `initialize` POST,
+// captures the raw status / content-type / www-authenticate / body
+// snippet, and runs the response through `probeMcpEndpointShape`. The
+// snapshot pins both the raw signal (so a diff tells you *why* a
+// classification changed) and the classification itself. Servers
+// occasionally drift versions or reword error strings; that's expected
+// and a snapshot update is fine.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Duration, Effect, Stream } from "effect";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
+
+import { probeMcpEndpointShape } from "./probe-shape";
+
+const MCP_INITIALIZE_BODY = JSON.stringify({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    capabilities: {},
+    clientInfo: { name: "executor-probe", version: "0" },
+  },
+});
+
+const liveServers: ReadonlyArray<{ readonly name: string; readonly url: string }> = [
+  { name: "sentry", url: "https://mcp.sentry.dev/mcp/" },
+  { name: "stripe", url: "https://mcp.stripe.com" },
+  { name: "linear", url: "https://mcp.linear.app/sse" },
+  { name: "notion", url: "https://mcp.notion.com/mcp" },
+  { name: "atlassian", url: "https://mcp.atlassian.com/v1/sse" },
+  { name: "zapier", url: "https://mcp.zapier.com/api/mcp/mcp" },
+  { name: "cubic", url: "https://www.cubic.dev/api/mcp" },
+  { name: "reftools", url: "https://api.ref.tools/mcp" },
+  { name: "huggingface", url: "https://huggingface.co/mcp" },
+  { name: "deepwiki", url: "https://mcp.deepwiki.com/mcp" },
+  { name: "context7", url: "https://mcp.context7.com/mcp" },
+];
+
+interface RawCapture {
+  readonly status: number;
+  readonly contentType: string | null;
+  readonly wwwAuthenticate: string | null;
+  readonly bodySnippet: string;
+}
+
+const BODY_CAP = 1024;
+const REQUEST_TIMEOUT = Duration.seconds(10);
+const BODY_READ_TIMEOUT = Duration.seconds(2);
+
+// Capture the raw probe response with hard timeouts and a body-size cap.
+// SSE servers stream forever, so we walk the response stream until the
+// running byte count crosses BODY_CAP, then stop. Stream cancellation
+// closes the underlying connection. We don't strip dynamic fields
+// (server version numbers, rotating error messages) — when those drift
+// we want to see it in the snapshot diff.
+const readHeaderCi = (headers: Readonly<Record<string, string>>, name: string): string | null => {
+  const direct = headers[name];
+  if (direct !== undefined) return direct;
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() === lower) return v;
+  }
+  return null;
+};
+
+const captureLive = (url: string): Effect.Effect<RawCapture, unknown> =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const request = HttpClientRequest.post(url).pipe(
+      HttpClientRequest.setHeader("content-type", "application/json"),
+      HttpClientRequest.setHeader("accept", "application/json, text/event-stream"),
+      HttpClientRequest.bodyText(MCP_INITIALIZE_BODY, "application/json"),
+    );
+    const response = yield* client.execute(request).pipe(Effect.timeout(REQUEST_TIMEOUT));
+
+    let total = 0;
+    const chunks = yield* response.stream.pipe(
+      Stream.takeUntil((chunk: Uint8Array) => {
+        total += chunk.byteLength;
+        return total >= BODY_CAP;
+      }),
+      Stream.runCollect,
+      Effect.timeout(BODY_READ_TIMEOUT),
+      Effect.catch(() => Effect.succeed([] as ReadonlyArray<Uint8Array>)),
+    );
+
+    const decoder = new TextDecoder();
+    const bodySnippet = chunks
+      .map((c) => decoder.decode(c))
+      .join("")
+      .slice(0, BODY_CAP);
+
+    return {
+      status: response.status,
+      contentType: readHeaderCi(response.headers, "content-type"),
+      wwwAuthenticate: readHeaderCi(response.headers, "www-authenticate"),
+      bodySnippet,
+    } satisfies RawCapture;
+  }).pipe(Effect.provide(FetchHttpClient.layer));
+
+const live = process.env.MCP_PROBE_LIVE === "1";
+
+describe.skipIf(!live)("probeMcpEndpointShape against live MCP servers", () => {
+  for (const server of liveServers) {
+    it.effect(
+      `${server.name} (${server.url})`,
+      () =>
+        Effect.gen(function* () {
+          const raw = yield* captureLive(server.url);
+          const probe = yield* probeMcpEndpointShape(server.url, {
+            timeoutMs: Duration.toMillis(REQUEST_TIMEOUT),
+          });
+          expect({ raw, probe }).toMatchSnapshot();
+        }),
+      { timeout: Duration.toMillis(REQUEST_TIMEOUT) * 3 },
+    );
+  }
+});

--- a/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts
@@ -21,9 +21,12 @@
 // ---------------------------------------------------------------------------
 
 import { describe, expect, it } from "@effect/vitest";
-import { Duration, Effect, Stream } from "effect";
+import { Duration, Effect, Option, Schema, Stream } from "effect";
 import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 
+import { createExecutor, makeTestConfig } from "@executor-js/sdk";
+
+import { mcpPlugin } from "./plugin";
 import { probeMcpEndpointShape } from "./probe-shape";
 
 const MCP_INITIALIZE_BODY = JSON.stringify({
@@ -144,6 +147,62 @@ const captureLive = (url: string): Effect.Effect<RawCapture, unknown> =>
 
 const live = process.env.MCP_PROBE_LIVE === "1";
 
+// Run the full probe path (the function the React UI calls). The result
+// surfaces `requiresOAuth` / `supportsDynamicRegistration`, which is what
+// drives the OAuth popup vs. credentials-editor branches in
+// AddMcpSource. For OAuth-protected servers we want this to be `true`;
+// for API-key MCPs (Cubic) it should fail with the auth-required
+// message; for unauth public servers (Hugging Face, etc.) it should
+// succeed with `requiresOAuth: false` and a tool count.
+type EndpointProbeOutcome =
+  | {
+      readonly ok: true;
+      readonly connected: boolean;
+      readonly requiresOAuth: boolean;
+      readonly supportsDynamicRegistration: boolean;
+      readonly hasToolCount: boolean;
+    }
+  | { readonly ok: false; readonly message: string };
+
+const ErrorMessage = Schema.Struct({ message: Schema.String });
+const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
+
+const messageFromUnknown = (cause: unknown): string =>
+  Option.match(decodeErrorMessage(cause), {
+    onNone: () => "(non-string error)",
+    onSome: ({ message }) => message,
+  });
+
+const runEndpointProbe = (url: string): Effect.Effect<EndpointProbeOutcome> =>
+  Effect.gen(function* () {
+    const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
+    return yield* executor.mcp.probeEndpoint(url).pipe(
+      Effect.map(
+        (r) =>
+          ({
+            ok: true as const,
+            connected: r.connected,
+            requiresOAuth: r.requiresOAuth,
+            supportsDynamicRegistration: r.supportsDynamicRegistration,
+            // Tool counts vary across runs (servers add/remove tools).
+            // Snapshot only whether we got a count, not the exact value.
+            hasToolCount: typeof r.toolCount === "number",
+          }) satisfies EndpointProbeOutcome,
+      ),
+      Effect.catch((cause) =>
+        Effect.succeed({ ok: false as const, message: messageFromUnknown(cause) }),
+      ),
+      Effect.timeout(Duration.seconds(20)),
+      Effect.catch(() =>
+        Effect.succeed({ ok: false as const, message: "(probeEndpoint timeout)" }),
+      ),
+    );
+  }).pipe(
+    Effect.catch((cause) =>
+      Effect.succeed({ ok: false as const, message: messageFromUnknown(cause) }),
+    ),
+  );
+
 describe.skipIf(!live)("probeMcpEndpointShape against live MCP servers", () => {
   for (const server of liveServers) {
     it.effect(
@@ -154,9 +213,10 @@ describe.skipIf(!live)("probeMcpEndpointShape against live MCP servers", () => {
           const probe = yield* probeMcpEndpointShape(server.url, {
             timeoutMs: Duration.toMillis(REQUEST_TIMEOUT),
           });
-          expect({ raw, probe }).toMatchSnapshot();
+          const probeEndpoint = yield* runEndpointProbe(server.url);
+          expect({ raw, probe, probeEndpoint }).toMatchSnapshot();
         }),
-      { timeout: Duration.toMillis(REQUEST_TIMEOUT) * 3 },
+      { timeout: Duration.toMillis(REQUEST_TIMEOUT) * 6 },
     );
   }
 });

--- a/packages/plugins/mcp/src/sdk/probe-shape.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.test.ts
@@ -124,6 +124,31 @@ describe("probeMcpEndpointShape", () => {
     ),
   );
 
+  // Supabase shape: Bearer challenge has `error=`/`error_description=`
+  // auth-params (RFC 6750 §3.1) but no `resource_metadata=`, and body is
+  // a non-RFC-6750 `{"message":"Unauthorized"}` envelope. The `error=`
+  // attribute alone is the accept signal.
+  it.effect("classifies 401 with Bearer error= auth-param as MCP+auth", () =>
+    withServer(
+      () =>
+        HttpServerResponse.jsonUnsafe(
+          { message: "Unauthorized" },
+          {
+            status: 401,
+            headers: {
+              "www-authenticate":
+                'Bearer error="invalid_request", error_description="No authorization header found"',
+            },
+          },
+        ),
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result).toEqual({ kind: "mcp", requiresAuth: true });
+        }),
+    ),
+  );
+
   // cubic.dev/api/mcp shape: bare `Bearer` challenge, no resource_metadata.
   // The JSON-RPC error body is what tells us this is MCP rather than some
   // other OAuth/API-key protected service.

--- a/packages/plugins/mcp/src/sdk/probe-shape.test.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.test.ts
@@ -95,6 +95,35 @@ describe("probeMcpEndpointShape", () => {
     ),
   );
 
+  // mcp.sentry.dev/mcp/ shape: spec-compliant `resource_metadata=`
+  // attribute, body is RFC 6750 OAuth-shape (`{error: "invalid_token",
+  // ...}`), not JSON-RPC. The `resource_metadata=` attribute alone is
+  // enough to classify as MCP — the body-shape gate is for the bare-Bearer
+  // case where we have no other signal.
+  it.effect("classifies 401 with resource_metadata + OAuth error body as MCP+auth", () =>
+    withServer(
+      () =>
+        HttpServerResponse.jsonUnsafe(
+          {
+            error: "invalid_token",
+            error_description: "Missing or invalid access token",
+          },
+          {
+            status: 401,
+            headers: {
+              "www-authenticate":
+                'Bearer realm="OAuth", resource_metadata="https://mcp.example/.well-known/oauth-protected-resource/mcp/", error="invalid_token"',
+            },
+          },
+        ),
+      (endpoint) =>
+        Effect.gen(function* () {
+          const result = yield* probeMcpEndpointShape(endpoint);
+          expect(result).toEqual({ kind: "mcp", requiresAuth: true });
+        }),
+    ),
+  );
+
   // cubic.dev/api/mcp shape: bare `Bearer` challenge, no resource_metadata.
   // The JSON-RPC error body is what tells us this is MCP rather than some
   // other OAuth/API-key protected service.

--- a/packages/plugins/mcp/src/sdk/probe-shape.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.ts
@@ -72,22 +72,40 @@ class ProbeTransportError extends Data.TaggedError("ProbeTransportError")<{
   readonly cause: unknown;
 }> {}
 
+const decodeJsonString = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown));
+
+const asObject = (body: string): Record<string, unknown> | null => {
+  if (!body) return null;
+  const parsed = decodeJsonString(body);
+  if (Option.isNone(parsed)) return null;
+  const value = parsed.value;
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+};
+
 /** Quick check that a body parses as a JSON-RPC 2.0 envelope. The MCP wire
  *  protocol is JSON-RPC 2.0, so a real MCP server's response to `initialize`
  *  (whether 2xx with the result, or a 401 error envelope) carries this
  *  shape. Non-MCP services don't — GraphQL APIs return `{errors:[...]}`,
  *  REST APIs return their own envelope, marketing pages return HTML. */
-const decodeJsonString = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown));
-
 const isJsonRpcEnvelope = (body: string): boolean => {
-  if (!body) return false;
-  const parsed = decodeJsonString(body);
-  if (Option.isNone(parsed)) return false;
-  const value = parsed.value;
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const obj = value as Record<string, unknown>;
+  const obj = asObject(body);
+  if (!obj) return false;
   if (obj.jsonrpc !== "2.0") return false;
   return "result" in obj || "error" in obj || "method" in obj;
+};
+
+/** Quick check that a body parses as an RFC 6750 OAuth Bearer error
+ *  envelope (`{error: "invalid_token", error_description?: ..., ...}`).
+ *  Real MCP servers like Atlassian return this shape on unauth requests
+ *  even when their WWW-Authenticate omits `resource_metadata=`. The
+ *  GraphQL `{errors: [...]}` envelope, which a non-MCP OAuth-protected
+ *  GraphQL API would return, is explicitly excluded. */
+const isOAuthErrorBody = (body: string): boolean => {
+  const obj = asObject(body);
+  if (!obj) return false;
+  if (Array.isArray(obj.errors)) return false;
+  return typeof obj.error === "string";
 };
 
 const ErrorMessageShape = Schema.Struct({ message: Schema.String });
@@ -204,17 +222,23 @@ export const probeMcpEndpointShape = (
             // SSE responses can't carry a JSON-RPC error envelope; accept the
             // Bearer challenge alone in that case (rare but spec-permissible).
             if (isSse) return { kind: "mcp", requiresAuth: true } as const;
-            // Fallback for non-OAuth MCP servers that use static API
-            // keys and don't publish RFC 9728 metadata (cubic.dev). The
-            // JSON-RPC body shape is what separates them from
-            // OAuth-protected non-MCP services that also issue bare
-            // Bearer challenges (Railway-style GraphQL, etc.).
+            // Fallback for MCP servers whose 401 omits
+            // `resource_metadata=`. Two body shapes count:
+            //   - JSON-RPC error (cubic.dev: API-key auth, JSON-RPC
+            //     errors end-to-end).
+            //   - RFC 6750 OAuth Bearer error envelope `{error:
+            //     "invalid_token", ...}` without GraphQL `{errors:[...]}`
+            //     (Atlassian).
+            // Non-MCP OAuth-protected services that issue bare Bearer
+            // challenges (Railway-style GraphQL, etc.) return `errors`
+            // arrays or other shapes that fail both checks.
             const body = yield* readBody(response);
-            if (!isJsonRpcEnvelope(body)) {
+            if (!isJsonRpcEnvelope(body) && !isOAuthErrorBody(body)) {
               return {
                 kind: "not-mcp",
                 category: "auth-required",
-                reason: "401 + Bearer without resource_metadata or JSON-RPC body",
+                reason:
+                  "401 + Bearer without resource_metadata, JSON-RPC body, or OAuth error body",
               } as const;
             }
             return { kind: "mcp", requiresAuth: true } as const;

--- a/packages/plugins/mcp/src/sdk/probe-shape.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.ts
@@ -219,6 +219,17 @@ export const probeMcpEndpointShape = (
             if (/(?:^|[\s,])resource_metadata\s*=/i.test(wwwAuth)) {
               return { kind: "mcp", requiresAuth: true } as const;
             }
+            // Looser RFC 6750 §3.1 signal: the Bearer challenge carries
+            // `error=` / `error_description=` auth-params. Real MCP
+            // servers (Supabase, GitHub Copilot, Vercel, Neon, Tavily,
+            // Replicate, ...) include this even when they omit
+            // `resource_metadata=`. The body alone isn't enough for
+            // those — Supabase, e.g., returns `{"message":"Unauthorized"}`
+            // which is neither JSON-RPC nor RFC 6750. The `error=`
+            // auth-param is the tiebreaker.
+            if (/(?:^|[\s,])error\s*=/i.test(wwwAuth)) {
+              return { kind: "mcp", requiresAuth: true } as const;
+            }
             // SSE responses can't carry a JSON-RPC error envelope; accept the
             // Bearer challenge alone in that case (rare but spec-permissible).
             if (isSse) return { kind: "mcp", requiresAuth: true } as const;

--- a/packages/plugins/mcp/src/sdk/probe-shape.ts
+++ b/packages/plugins/mcp/src/sdk/probe-shape.ts
@@ -191,15 +191,30 @@ export const probeMcpEndpointShape = (
                 reason: "401 without Bearer WWW-Authenticate — not an MCP auth challenge",
               } as const;
             }
+            // Spec-compliant MCP signal: the auth spec mandates a
+            // `resource_metadata=` attribute pointing at the server's
+            // RFC 9728 document. Real OAuth-protected MCP servers
+            // (sentry.dev, etc.) include it. This attribute is rare on
+            // unrelated OAuth services and is the cleanest accept signal
+            // we have when the 401 body is RFC 6750 OAuth-shape rather
+            // than JSON-RPC.
+            if (/(?:^|[\s,])resource_metadata\s*=/i.test(wwwAuth)) {
+              return { kind: "mcp", requiresAuth: true } as const;
+            }
             // SSE responses can't carry a JSON-RPC error envelope; accept the
             // Bearer challenge alone in that case (rare but spec-permissible).
             if (isSse) return { kind: "mcp", requiresAuth: true } as const;
+            // Fallback for non-OAuth MCP servers that use static API
+            // keys and don't publish RFC 9728 metadata (cubic.dev). The
+            // JSON-RPC body shape is what separates them from
+            // OAuth-protected non-MCP services that also issue bare
+            // Bearer challenges (Railway-style GraphQL, etc.).
             const body = yield* readBody(response);
             if (!isJsonRpcEnvelope(body)) {
               return {
                 kind: "not-mcp",
                 category: "auth-required",
-                reason: "401 + Bearer but body is not a JSON-RPC envelope",
+                reason: "401 + Bearer without resource_metadata or JSON-RPC body",
               } as const;
             }
             return { kind: "mcp", requiresAuth: true } as const;


### PR DESCRIPTION
## Summary
- Accept `resource_metadata=` in `WWW-Authenticate` as a sufficient MCP+auth signal on 401, so spec-compliant OAuth-protected servers (Sentry, Stripe, Linear, Notion, Context7) are no longer rejected when their 401 body is RFC 6750 OAuth-shape rather than JSON-RPC.
- Accept RFC 6750 OAuth Bearer error envelopes (`{error:"invalid_token",...}`) on 401 + bare `Bearer` for servers that omit `resource_metadata=` (Atlassian). GraphQL-style `{errors:[...]}` 401s still reject so non-MCP OAuth-protected APIs aren't misclassified.
- Add an opt-in live snapshot suite (`MCP_PROBE_LIVE=1`) that POSTs the canonical MCP `initialize` to 11 real public MCP servers (Sentry, Stripe, Linear, Notion, Atlassian, Zapier, Cubic, ref.tools, Hugging Face, DeepWiki, Context7), captures status/headers/body alongside the probe classification, and pins them as vitest snapshots so behavior shifts surface as reviewable diffs (`-u` regenerates).

## Test plan
- [ ] `bun run test` — full suite passes with the live file skipped by default
- [ ] `bun run lint` and `bun run typecheck` clean
- [ ] `MCP_PROBE_LIVE=1 vitest run packages/plugins/mcp/src/sdk/probe-shape-real-servers.live.test.ts` — all 11 live snapshots match
- [ ] Pasting `https://mcp.sentry.dev/mcp/` into Add MCP Source still triggers the OAuth popup
- [ ] Pasting `https://mcp.atlassian.com/v1/sse` triggers the OAuth popup
- [ ] Pasting `https://www.cubic.dev/api/mcp` (API-key MCP) is detected and surfaces as MCP+auth so user can paste credentials