### PR TITLE
Add error handling for outdated clients running against newer DB schemas

### DIFF
--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -78,6 +78,7 @@ Tool dispatch, plugins, storage, schema, and transport are now fully instrumente
 - Upgrade: preserve legacy OAuth connection backfills after the `connection.kind` column is removed.
 - OpenAPI: refreshing or editing sources with legacy inline secret/OAuth config now materializes the new source binding rows instead of dropping credentials.
 - Keychain: skip provider registration when the OS backend is unreachable (no more startup failure when running headless on Linux without a keyring).
+- Local database: fail early with guidance when an older Executor build opens a data directory migrated by a newer build, instead of surfacing a low-level SQLite schema error.
 - Local server: return 404 for missing static assets instead of serving HTML.
 - Tests: Windows compatibility across the suite.
 

--- a/apps/local/src/server/executor-schema-compat.test.ts
+++ b/apps/local/src/server/executor-schema-compat.test.ts
@@ -20,13 +20,13 @@ const MIGRATIONS_FOLDER = join(import.meta.dirname, "../../drizzle");
 const workDirs: string[] = [];
 const openDbs: Database[] = [];
 
-const tempDb = (): { db: Database; path: string } => {
+const tempDb = (): { db: Database; path: string; dataDir: string } => {
   const dir = mkdtempSync(join(tmpdir(), "executor-schema-compat-"));
   workDirs.push(dir);
   const path = join(dir, "data.db");
   const db = new Database(path);
   openDbs.push(db);
-  return { db, path };
+  return { db, path, dataDir: dir };
 };
 
 const createMigrationTable = (db: Database): void => {
@@ -58,11 +58,12 @@ afterEach(() => {
 describe("Drizzle migration compatibility preflight", () => {
   it.effect("allows a fresh DB without __drizzle_migrations", () =>
     Effect.gen(function* () {
-      const { db, path } = tempDb();
+      const { db, path, dataDir } = tempDb();
 
       yield* checkDrizzleMigrationCompatibility({
         sqlite: db,
         dbPath: path,
+        dataDir,
         migrationsFolder: MIGRATIONS_FOLDER,
       });
     }),
@@ -70,12 +71,13 @@ describe("Drizzle migration compatibility preflight", () => {
 
   it.effect("allows an existing but empty __drizzle_migrations table", () =>
     Effect.gen(function* () {
-      const { db, path } = tempDb();
+      const { db, path, dataDir } = tempDb();
       createMigrationTable(db);
 
       yield* checkDrizzleMigrationCompatibility({
         sqlite: db,
         dbPath: path,
+        dataDir,
         migrationsFolder: MIGRATIONS_FOLDER,
       });
     }),
@@ -92,7 +94,7 @@ describe("Drizzle migration compatibility preflight", () => {
 
   it.effect("fails with LocalDatabaseSchemaTooNew when the DB has more migrations", () =>
     Effect.gen(function* () {
-      const { db, path } = tempDb();
+      const { db, path, dataDir } = tempDb();
       const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
       createMigrationTable(db);
       insertMigrationHashes(db, [...bundled, "future-migration-hash"]);
@@ -100,6 +102,7 @@ describe("Drizzle migration compatibility preflight", () => {
       const error = yield* checkDrizzleMigrationCompatibility({
         sqlite: db,
         dbPath: path,
+        dataDir,
         migrationsFolder: MIGRATIONS_FOLDER,
       }).pipe(Effect.flip);
 
@@ -115,7 +118,7 @@ describe("Drizzle migration compatibility preflight", () => {
 
   it.effect("fails with LocalDatabaseMigrationHistoryMismatch when hashes diverge", () =>
     Effect.gen(function* () {
-      const { db, path } = tempDb();
+      const { db, path, dataDir } = tempDb();
       const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
       createMigrationTable(db);
       insertMigrationHashes(db, ["different-migration-hash", ...bundled.slice(1)]);
@@ -123,6 +126,7 @@ describe("Drizzle migration compatibility preflight", () => {
       const error = yield* checkDrizzleMigrationCompatibility({
         sqlite: db,
         dbPath: path,
+        dataDir,
         migrationsFolder: MIGRATIONS_FOLDER,
       }).pipe(Effect.flip);
 
@@ -136,7 +140,7 @@ describe("Drizzle migration compatibility preflight", () => {
 
   it.effect("allows an older DB whose migration history is a bundled prefix", () =>
     Effect.gen(function* () {
-      const { db, path } = tempDb();
+      const { db, path, dataDir } = tempDb();
       const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
       createMigrationTable(db);
       insertMigrationHashes(db, bundled.slice(0, 1));
@@ -144,6 +148,7 @@ describe("Drizzle migration compatibility preflight", () => {
       yield* checkDrizzleMigrationCompatibility({
         sqlite: db,
         dbPath: path,
+        dataDir,
         migrationsFolder: MIGRATIONS_FOLDER,
       });
     }),

--- a/apps/local/src/server/executor-schema-compat.test.ts
+++ b/apps/local/src/server/executor-schema-compat.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
 
@@ -17,12 +18,15 @@ import {
 const MIGRATIONS_FOLDER = join(import.meta.dirname, "../../drizzle");
 
 const workDirs: string[] = [];
+const openDbs: Database[] = [];
 
 const tempDb = (): { db: Database; path: string } => {
   const dir = mkdtempSync(join(tmpdir(), "executor-schema-compat-"));
   workDirs.push(dir);
   const path = join(dir, "data.db");
-  return { db: new Database(path), path };
+  const db = new Database(path);
+  openDbs.push(db);
+  return { db, path };
 };
 
 const createMigrationTable = (db: Database): void => {
@@ -43,139 +47,105 @@ const insertMigrationHashes = (db: Database, hashes: ReadonlyArray<string>): voi
 };
 
 afterEach(() => {
+  for (const db of openDbs.splice(0)) {
+    db.close();
+  }
   for (const dir of workDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
 });
 
 describe("Drizzle migration compatibility preflight", () => {
-  it("allows a fresh DB without __drizzle_migrations", () => {
-    const { db, path } = tempDb();
-    try {
-      expect(() =>
-        checkDrizzleMigrationCompatibility({
-          sqlite: db,
-          dbPath: path,
-          migrationsFolder: MIGRATIONS_FOLDER,
-        }),
-      ).not.toThrow();
-    } finally {
-      db.close();
-    }
-  });
+  it.effect("allows a fresh DB without __drizzle_migrations", () =>
+    Effect.gen(function* () {
+      const { db, path } = tempDb();
 
-  it("allows an existing but empty __drizzle_migrations table", () => {
-    const { db, path } = tempDb();
-    try {
+      yield* checkDrizzleMigrationCompatibility({
+        sqlite: db,
+        dbPath: path,
+        migrationsFolder: MIGRATIONS_FOLDER,
+      });
+    }),
+  );
+
+  it.effect("allows an existing but empty __drizzle_migrations table", () =>
+    Effect.gen(function* () {
+      const { db, path } = tempDb();
       createMigrationTable(db);
 
-      expect(() =>
-        checkDrizzleMigrationCompatibility({
-          sqlite: db,
-          dbPath: path,
-          migrationsFolder: MIGRATIONS_FOLDER,
-        }),
-      ).not.toThrow();
-    } finally {
-      db.close();
-    }
-  });
+      yield* checkDrizzleMigrationCompatibility({
+        sqlite: db,
+        dbPath: path,
+        migrationsFolder: MIGRATIONS_FOLDER,
+      });
+    }),
+  );
 
   it("computes bundled hashes that exactly match hashes written by Drizzle", () => {
     const { db } = tempDb();
-    try {
-      migrate(drizzle(db), { migrationsFolder: MIGRATIONS_FOLDER });
+    migrate(drizzle(db), { migrationsFolder: MIGRATIONS_FOLDER });
 
-      expect(readAppliedDrizzleMigrationHashes(db)).toEqual(
-        readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER),
-      );
-    } finally {
-      db.close();
-    }
+    expect(readAppliedDrizzleMigrationHashes(db)).toEqual(
+      readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER),
+    );
   });
 
-  it("throws LocalDatabaseSchemaTooNew when the DB has more migrations than the binary", () => {
-    const { db, path } = tempDb();
-    try {
+  it.effect("fails with LocalDatabaseSchemaTooNew when the DB has more migrations", () =>
+    Effect.gen(function* () {
+      const { db, path } = tempDb();
       const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
       createMigrationTable(db);
       insertMigrationHashes(db, [...bundled, "future-migration-hash"]);
 
-      expect(() =>
-        checkDrizzleMigrationCompatibility({
-          sqlite: db,
-          dbPath: path,
-          migrationsFolder: MIGRATIONS_FOLDER,
-        }),
-      ).toThrow(LocalDatabaseSchemaTooNew);
+      const error = yield* checkDrizzleMigrationCompatibility({
+        sqlite: db,
+        dbPath: path,
+        migrationsFolder: MIGRATIONS_FOLDER,
+      }).pipe(Effect.flip);
 
-      try {
-        checkDrizzleMigrationCompatibility({
-          sqlite: db,
-          dbPath: path,
-          migrationsFolder: MIGRATIONS_FOLDER,
-        });
-      } catch (error) {
-        expect(error).toBeInstanceOf(LocalDatabaseSchemaTooNew);
-        expect((error as Error).message).toContain(
-          "This Executor binary is older than the schema",
-        );
-        expect((error as Error).message).toContain("Use a newer Executor binary");
-      }
-    } finally {
-      db.close();
-    }
-  });
+      expect(error).toBeInstanceOf(LocalDatabaseSchemaTooNew);
+      expect(error).toMatchObject({
+        message: expect.stringContaining("This Executor binary is older than the schema"),
+      });
+      expect(error).toMatchObject({
+        message: expect.stringContaining("Use a newer Executor binary"),
+      });
+    }),
+  );
 
-  it("throws LocalDatabaseMigrationHistoryMismatch when hashes diverge", () => {
-    const { db, path } = tempDb();
-    try {
+  it.effect("fails with LocalDatabaseMigrationHistoryMismatch when hashes diverge", () =>
+    Effect.gen(function* () {
+      const { db, path } = tempDb();
       const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
       createMigrationTable(db);
       insertMigrationHashes(db, ["different-migration-hash", ...bundled.slice(1)]);
 
-      expect(() =>
-        checkDrizzleMigrationCompatibility({
-          sqlite: db,
-          dbPath: path,
-          migrationsFolder: MIGRATIONS_FOLDER,
-        }),
-      ).toThrow(LocalDatabaseMigrationHistoryMismatch);
+      const error = yield* checkDrizzleMigrationCompatibility({
+        sqlite: db,
+        dbPath: path,
+        migrationsFolder: MIGRATIONS_FOLDER,
+      }).pipe(Effect.flip);
 
-      try {
-        checkDrizzleMigrationCompatibility({
-          sqlite: db,
-          dbPath: path,
-          migrationsFolder: MIGRATIONS_FOLDER,
-        });
-      } catch (error) {
-        expect(error).toBeInstanceOf(LocalDatabaseMigrationHistoryMismatch);
-        expect((error as Error).message).toContain(
-          "does not match this Executor build",
-        );
-        expect((error as Error).message).toContain("restore a backup");
-      }
-    } finally {
-      db.close();
-    }
-  });
+      expect(error).toBeInstanceOf(LocalDatabaseMigrationHistoryMismatch);
+      expect(error).toMatchObject({
+        message: expect.stringContaining("does not match this Executor build"),
+      });
+      expect(error).toMatchObject({ message: expect.stringContaining("restore a backup") });
+    }),
+  );
 
-  it("allows an older DB whose migration history is a bundled prefix", () => {
-    const { db, path } = tempDb();
-    try {
+  it.effect("allows an older DB whose migration history is a bundled prefix", () =>
+    Effect.gen(function* () {
+      const { db, path } = tempDb();
       const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
       createMigrationTable(db);
       insertMigrationHashes(db, bundled.slice(0, 1));
 
-      expect(() =>
-        checkDrizzleMigrationCompatibility({
-          sqlite: db,
-          dbPath: path,
-          migrationsFolder: MIGRATIONS_FOLDER,
-        }),
-      ).not.toThrow();
-    } finally {
-      db.close();
-    }
-  });
+      yield* checkDrizzleMigrationCompatibility({
+        sqlite: db,
+        dbPath: path,
+        migrationsFolder: MIGRATIONS_FOLDER,
+      });
+    }),
+  );
 });

--- a/apps/local/src/server/executor-schema-compat.test.ts
+++ b/apps/local/src/server/executor-schema-compat.test.ts
@@ -1,0 +1,181 @@
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "@effect/vitest";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { migrate } from "drizzle-orm/bun-sqlite/migrator";
+
+import {
+  LocalDatabaseMigrationHistoryMismatch,
+  LocalDatabaseSchemaTooNew,
+  checkDrizzleMigrationCompatibility,
+  readAppliedDrizzleMigrationHashes,
+  readBundledDrizzleMigrationHashes,
+} from "./executor";
+
+const MIGRATIONS_FOLDER = join(import.meta.dirname, "../../drizzle");
+
+const workDirs: string[] = [];
+
+const tempDb = (): { db: Database; path: string } => {
+  const dir = mkdtempSync(join(tmpdir(), "executor-schema-compat-"));
+  workDirs.push(dir);
+  const path = join(dir, "data.db");
+  return { db: new Database(path), path };
+};
+
+const createMigrationTable = (db: Database): void => {
+  db.exec(`
+    CREATE TABLE __drizzle_migrations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      hash TEXT NOT NULL,
+      created_at NUMERIC
+    )
+  `);
+};
+
+const insertMigrationHashes = (db: Database, hashes: ReadonlyArray<string>): void => {
+  const stmt = db.prepare("INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)");
+  for (const [index, hash] of hashes.entries()) {
+    stmt.run(hash, index + 1);
+  }
+};
+
+afterEach(() => {
+  for (const dir of workDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("Drizzle migration compatibility preflight", () => {
+  it("allows a fresh DB without __drizzle_migrations", () => {
+    const { db, path } = tempDb();
+    try {
+      expect(() =>
+        checkDrizzleMigrationCompatibility({
+          sqlite: db,
+          dbPath: path,
+          migrationsFolder: MIGRATIONS_FOLDER,
+        }),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("allows an existing but empty __drizzle_migrations table", () => {
+    const { db, path } = tempDb();
+    try {
+      createMigrationTable(db);
+
+      expect(() =>
+        checkDrizzleMigrationCompatibility({
+          sqlite: db,
+          dbPath: path,
+          migrationsFolder: MIGRATIONS_FOLDER,
+        }),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+
+  it("computes bundled hashes that exactly match hashes written by Drizzle", () => {
+    const { db } = tempDb();
+    try {
+      migrate(drizzle(db), { migrationsFolder: MIGRATIONS_FOLDER });
+
+      expect(readAppliedDrizzleMigrationHashes(db)).toEqual(
+        readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER),
+      );
+    } finally {
+      db.close();
+    }
+  });
+
+  it("throws LocalDatabaseSchemaTooNew when the DB has more migrations than the binary", () => {
+    const { db, path } = tempDb();
+    try {
+      const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
+      createMigrationTable(db);
+      insertMigrationHashes(db, [...bundled, "future-migration-hash"]);
+
+      expect(() =>
+        checkDrizzleMigrationCompatibility({
+          sqlite: db,
+          dbPath: path,
+          migrationsFolder: MIGRATIONS_FOLDER,
+        }),
+      ).toThrow(LocalDatabaseSchemaTooNew);
+
+      try {
+        checkDrizzleMigrationCompatibility({
+          sqlite: db,
+          dbPath: path,
+          migrationsFolder: MIGRATIONS_FOLDER,
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(LocalDatabaseSchemaTooNew);
+        expect((error as Error).message).toContain(
+          "This Executor binary is older than the schema",
+        );
+        expect((error as Error).message).toContain("Use a newer Executor binary");
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("throws LocalDatabaseMigrationHistoryMismatch when hashes diverge", () => {
+    const { db, path } = tempDb();
+    try {
+      const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
+      createMigrationTable(db);
+      insertMigrationHashes(db, ["different-migration-hash", ...bundled.slice(1)]);
+
+      expect(() =>
+        checkDrizzleMigrationCompatibility({
+          sqlite: db,
+          dbPath: path,
+          migrationsFolder: MIGRATIONS_FOLDER,
+        }),
+      ).toThrow(LocalDatabaseMigrationHistoryMismatch);
+
+      try {
+        checkDrizzleMigrationCompatibility({
+          sqlite: db,
+          dbPath: path,
+          migrationsFolder: MIGRATIONS_FOLDER,
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(LocalDatabaseMigrationHistoryMismatch);
+        expect((error as Error).message).toContain(
+          "does not match this Executor build",
+        );
+        expect((error as Error).message).toContain("restore a backup");
+      }
+    } finally {
+      db.close();
+    }
+  });
+
+  it("allows an older DB whose migration history is a bundled prefix", () => {
+    const { db, path } = tempDb();
+    try {
+      const bundled = readBundledDrizzleMigrationHashes(MIGRATIONS_FOLDER);
+      createMigrationTable(db);
+      insertMigrationHashes(db, bundled.slice(0, 1));
+
+      expect(() =>
+        checkDrizzleMigrationCompatibility({
+          sqlite: db,
+          dbPath: path,
+          migrationsFolder: MIGRATIONS_FOLDER,
+        }),
+      ).not.toThrow();
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -1,7 +1,7 @@
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 import { migrate } from "drizzle-orm/bun-sqlite/migrator";
-import { Context, Data, Effect, Layer, ManagedRuntime } from "effect";
+import { Context, Data, Effect, Layer, ManagedRuntime, Schema } from "effect";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
 import { homedir, tmpdir } from "node:os";
@@ -165,21 +165,25 @@ export const readAppliedDrizzleMigrationHashes = (sqlite: Database): ReadonlyArr
     .map((row) => row.hash);
 };
 
-interface DrizzleJournal {
-  readonly entries: ReadonlyArray<{
-    readonly idx: number;
-    readonly tag: string;
-  }>;
-}
+const DrizzleJournal = Schema.Struct({
+  entries: Schema.Array(
+    Schema.Struct({
+      idx: Schema.Number,
+      tag: Schema.String,
+    }),
+  ),
+});
+
+const decodeDrizzleJournal = Schema.decodeUnknownSync(Schema.fromJsonString(DrizzleJournal));
 
 export const readBundledDrizzleMigrationHashes = (
   migrationsFolder: string,
 ): ReadonlyArray<string> => {
   // Keep this in sync with drizzle-orm/src/migrator.ts: Drizzle hashes the raw
   // migration file contents before splitting on statement breakpoints.
-  const journal = JSON.parse(
+  const journal = decodeDrizzleJournal(
     fs.readFileSync(join(migrationsFolder, "meta", "_journal.json")).toString(),
-  ) as DrizzleJournal;
+  );
 
   return [...journal.entries]
     .sort((left, right) => left.idx - right.idx)
@@ -207,36 +211,37 @@ export const checkDrizzleMigrationCompatibility = (input: {
   readonly sqlite: Database;
   readonly dbPath: string;
   readonly migrationsFolder: string;
-}): void => {
-  // Before running migrations, ensure the DB history is a prefix of the
-  // migrations bundled with this binary. This catches newer or divergent schemas
-  // before startup reaches arbitrary schema-dependent queries.
-  if (!drizzleMigrationsTableExists(input.sqlite)) return;
+}): Effect.Effect<void, LocalDatabaseSchemaTooNew | LocalDatabaseMigrationHistoryMismatch> =>
+  Effect.gen(function* () {
+    // Before running migrations, ensure the DB history is a prefix of the
+    // migrations bundled with this binary. This catches newer or divergent schemas
+    // before startup reaches arbitrary schema-dependent queries.
+    if (!drizzleMigrationsTableExists(input.sqlite)) return;
 
-  const applied = readAppliedDrizzleMigrationHashes(input.sqlite);
-  const bundled = readBundledDrizzleMigrationHashes(input.migrationsFolder);
+    const applied = readAppliedDrizzleMigrationHashes(input.sqlite);
+    const bundled = readBundledDrizzleMigrationHashes(input.migrationsFolder);
 
-  if (applied.length > bundled.length) {
-    throw new LocalDatabaseSchemaTooNew({
-      message: schemaTooNewMessage(input.dbPath),
-      dbPath: input.dbPath,
-      appliedMigrationCount: applied.length,
-      knownMigrationCount: bundled.length,
-    });
-  }
-
-  for (let index = 0; index < applied.length; index += 1) {
-    if (applied[index] !== bundled[index]) {
-      throw new LocalDatabaseMigrationHistoryMismatch({
-        message: migrationHistoryMismatchMessage(input.dbPath),
+    if (applied.length > bundled.length) {
+      return yield* new LocalDatabaseSchemaTooNew({
+        message: schemaTooNewMessage(input.dbPath),
         dbPath: input.dbPath,
-        migrationIndex: index,
-        appliedHash: applied[index],
-        knownHash: bundled[index],
+        appliedMigrationCount: applied.length,
+        knownMigrationCount: bundled.length,
       });
     }
-  }
-};
+
+    for (let index = 0; index < applied.length; index += 1) {
+      if (applied[index] !== bundled[index]) {
+        return yield* new LocalDatabaseMigrationHistoryMismatch({
+          message: migrationHistoryMismatchMessage(input.dbPath),
+          dbPath: input.dbPath,
+          migrationIndex: index,
+          appliedHash: applied[index],
+          knownHash: bundled[index],
+        });
+      }
+    }
+  });
 
 const createLocalExecutorLayer = () => {
   const { path: dbPath, legacySecrets } = resolveDbPath();
@@ -247,7 +252,7 @@ const createLocalExecutorLayer = () => {
         Effect.sync(() => new Database(dbPath)),
         (conn) => Effect.sync(() => conn.close()),
       );
-      checkDrizzleMigrationCompatibility({
+      yield* checkDrizzleMigrationCompatibility({
         sqlite,
         dbPath,
         migrationsFolder: MIGRATIONS_FOLDER,

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -45,6 +45,7 @@ const MIGRATIONS_FOLDER = resolveMigrationsFolder();
 
 interface ResolvedDb {
   readonly path: string;
+  readonly dataDir: string;
   readonly legacySecrets: readonly LegacySecret[];
 }
 
@@ -67,7 +68,7 @@ const resolveDbPath = (): ResolvedDb => {
           : "."),
     );
   }
-  return { path: dbPath, legacySecrets };
+  return { path: dbPath, dataDir, legacySecrets };
 };
 
 // Hash suffix disambiguates same-basename folders so two projects with
@@ -151,7 +152,7 @@ export const drizzleMigrationsTableExists = (sqlite: Database): boolean => {
     )
     .get("__drizzle_migrations");
 
-  return row !== null;
+  return row != null;
 };
 
 export const readAppliedDrizzleMigrationHashes = (sqlite: Database): ReadonlyArray<string> => {
@@ -193,16 +194,16 @@ export const readBundledDrizzleMigrationHashes = (
     });
 };
 
-const schemaTooNewMessage = (dbPath: string): string =>
+const schemaTooNewMessage = (dataDir: string): string =>
   [
-    `This Executor binary is older than the schema in ${process.env.EXECUTOR_DATA_DIR ?? dirname(dbPath)}.`,
+    `This Executor binary is older than the schema in ${dataDir}.`,
     "The database was likely opened by a newer Executor build.",
     "Use a newer Executor binary or set EXECUTOR_DATA_DIR to a different data directory.",
   ].join("\n");
 
-const migrationHistoryMismatchMessage = (dbPath: string): string =>
+const migrationHistoryMismatchMessage = (dataDir: string): string =>
   [
-    `The migration history in ${process.env.EXECUTOR_DATA_DIR ?? dirname(dbPath)} does not match this Executor build.`,
+    `The migration history in ${dataDir} does not match this Executor build.`,
     "The database may have been created by a different development branch, manually modified, or corrupted.",
     "Use the matching Executor build, set EXECUTOR_DATA_DIR to a different data directory, or restore a backup.",
   ].join("\n");
@@ -210,6 +211,7 @@ const migrationHistoryMismatchMessage = (dbPath: string): string =>
 export const checkDrizzleMigrationCompatibility = (input: {
   readonly sqlite: Database;
   readonly dbPath: string;
+  readonly dataDir: string;
   readonly migrationsFolder: string;
 }): Effect.Effect<void, LocalDatabaseSchemaTooNew | LocalDatabaseMigrationHistoryMismatch> =>
   Effect.gen(function* () {
@@ -223,7 +225,7 @@ export const checkDrizzleMigrationCompatibility = (input: {
 
     if (applied.length > bundled.length) {
       return yield* new LocalDatabaseSchemaTooNew({
-        message: schemaTooNewMessage(input.dbPath),
+        message: schemaTooNewMessage(input.dataDir),
         dbPath: input.dbPath,
         appliedMigrationCount: applied.length,
         knownMigrationCount: bundled.length,
@@ -233,7 +235,7 @@ export const checkDrizzleMigrationCompatibility = (input: {
     for (let index = 0; index < applied.length; index += 1) {
       if (applied[index] !== bundled[index]) {
         return yield* new LocalDatabaseMigrationHistoryMismatch({
-          message: migrationHistoryMismatchMessage(input.dbPath),
+          message: migrationHistoryMismatchMessage(input.dataDir),
           dbPath: input.dbPath,
           migrationIndex: index,
           appliedHash: applied[index],
@@ -244,7 +246,7 @@ export const checkDrizzleMigrationCompatibility = (input: {
   });
 
 const createLocalExecutorLayer = () => {
-  const { path: dbPath, legacySecrets } = resolveDbPath();
+  const { path: dbPath, dataDir, legacySecrets } = resolveDbPath();
 
   return Layer.effect(LocalExecutorTag)(
     Effect.gen(function* () {
@@ -255,6 +257,7 @@ const createLocalExecutorLayer = () => {
       yield* checkDrizzleMigrationCompatibility({
         sqlite,
         dbPath,
+        dataDir,
         migrationsFolder: MIGRATIONS_FOLDER,
       });
       sqlite.exec("PRAGMA journal_mode = WAL");

--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -97,6 +97,23 @@ class LocalExecutorTag extends Context.Service<LocalExecutorTag, LocalExecutorBu
 
 export type LocalExecutor = LocalExecutorBundle["executor"];
 
+export class LocalDatabaseSchemaTooNew extends Data.TaggedError("LocalDatabaseSchemaTooNew")<{
+  readonly message: string;
+  readonly dbPath: string;
+  readonly appliedMigrationCount: number;
+  readonly knownMigrationCount: number;
+}> {}
+
+export class LocalDatabaseMigrationHistoryMismatch extends Data.TaggedError(
+  "LocalDatabaseMigrationHistoryMismatch",
+)<{
+  readonly message: string;
+  readonly dbPath: string;
+  readonly migrationIndex: number;
+  readonly appliedHash: string | undefined;
+  readonly knownHash: string | undefined;
+}> {}
+
 class LocalExecutorDisposeError extends Data.TaggedError("LocalExecutorDisposeError")<{
   readonly operation: "createHandle" | "disposeExecutor" | "disposeRuntime";
   readonly cause: unknown;
@@ -127,6 +144,100 @@ const handleOrNull = (promise: ReturnType<typeof createExecutorHandle>) =>
     ),
   );
 
+export const drizzleMigrationsTableExists = (sqlite: Database): boolean => {
+  const row = sqlite
+    .query<{ name: string }, [string]>(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+    )
+    .get("__drizzle_migrations");
+
+  return row !== null;
+};
+
+export const readAppliedDrizzleMigrationHashes = (sqlite: Database): ReadonlyArray<string> => {
+  if (!drizzleMigrationsTableExists(sqlite)) return [];
+
+  // Drizzle inserts one row per applied migration. `id` is the stable
+  // application order; `created_at` comes from migration metadata and can tie.
+  return sqlite
+    .query<{ hash: string }, []>("SELECT hash FROM __drizzle_migrations ORDER BY id ASC")
+    .all()
+    .map((row) => row.hash);
+};
+
+interface DrizzleJournal {
+  readonly entries: ReadonlyArray<{
+    readonly idx: number;
+    readonly tag: string;
+  }>;
+}
+
+export const readBundledDrizzleMigrationHashes = (
+  migrationsFolder: string,
+): ReadonlyArray<string> => {
+  // Keep this in sync with drizzle-orm/src/migrator.ts: Drizzle hashes the raw
+  // migration file contents before splitting on statement breakpoints.
+  const journal = JSON.parse(
+    fs.readFileSync(join(migrationsFolder, "meta", "_journal.json")).toString(),
+  ) as DrizzleJournal;
+
+  return [...journal.entries]
+    .sort((left, right) => left.idx - right.idx)
+    .map((entry) => {
+      const query = fs.readFileSync(join(migrationsFolder, `${entry.tag}.sql`)).toString();
+      return createHash("sha256").update(query).digest("hex");
+    });
+};
+
+const schemaTooNewMessage = (dbPath: string): string =>
+  [
+    `This Executor binary is older than the schema in ${process.env.EXECUTOR_DATA_DIR ?? dirname(dbPath)}.`,
+    "The database was likely opened by a newer Executor build.",
+    "Use a newer Executor binary or set EXECUTOR_DATA_DIR to a different data directory.",
+  ].join("\n");
+
+const migrationHistoryMismatchMessage = (dbPath: string): string =>
+  [
+    `The migration history in ${process.env.EXECUTOR_DATA_DIR ?? dirname(dbPath)} does not match this Executor build.`,
+    "The database may have been created by a different development branch, manually modified, or corrupted.",
+    "Use the matching Executor build, set EXECUTOR_DATA_DIR to a different data directory, or restore a backup.",
+  ].join("\n");
+
+export const checkDrizzleMigrationCompatibility = (input: {
+  readonly sqlite: Database;
+  readonly dbPath: string;
+  readonly migrationsFolder: string;
+}): void => {
+  // Before running migrations, ensure the DB history is a prefix of the
+  // migrations bundled with this binary. This catches newer or divergent schemas
+  // before startup reaches arbitrary schema-dependent queries.
+  if (!drizzleMigrationsTableExists(input.sqlite)) return;
+
+  const applied = readAppliedDrizzleMigrationHashes(input.sqlite);
+  const bundled = readBundledDrizzleMigrationHashes(input.migrationsFolder);
+
+  if (applied.length > bundled.length) {
+    throw new LocalDatabaseSchemaTooNew({
+      message: schemaTooNewMessage(input.dbPath),
+      dbPath: input.dbPath,
+      appliedMigrationCount: applied.length,
+      knownMigrationCount: bundled.length,
+    });
+  }
+
+  for (let index = 0; index < applied.length; index += 1) {
+    if (applied[index] !== bundled[index]) {
+      throw new LocalDatabaseMigrationHistoryMismatch({
+        message: migrationHistoryMismatchMessage(input.dbPath),
+        dbPath: input.dbPath,
+        migrationIndex: index,
+        appliedHash: applied[index],
+        knownHash: bundled[index],
+      });
+    }
+  }
+};
+
 const createLocalExecutorLayer = () => {
   const { path: dbPath, legacySecrets } = resolveDbPath();
 
@@ -136,6 +247,11 @@ const createLocalExecutorLayer = () => {
         Effect.sync(() => new Database(dbPath)),
         (conn) => Effect.sync(() => conn.close()),
       );
+      checkDrizzleMigrationCompatibility({
+        sqlite,
+        dbPath,
+        migrationsFolder: MIGRATIONS_FOLDER,
+      });
       sqlite.exec("PRAGMA journal_mode = WAL");
 
       const db = drizzle(sqlite, { schema: executorSchema });


### PR DESCRIPTION
## Context

A user can currently hit an opaque SQLite error when switching between Executor builds that know different local DB schemas:

1. Run a release `executor` binary against `EXECUTOR_DATA_DIR`.
2. Run a newer/dev build (`bun dev:cli`) against the same `EXECUTOR_DATA_DIR`, which applies newer local Drizzle migrations.
3. Run the older release binary again.
4. Startup fails later with a low-level error such as `no such column: invocation_config`.

## Changes

Add a read-only/synchronous preflight in local executor startup, immediately before `migrate(db, { migrationsFolder: MIGRATIONS_FOLDER })`.

The preflight will:

1. Check whether `__drizzle_migrations` exists.
   - If missing, treat the DB as fresh for this purpose and let Drizzle initialize/migrate it.
   - This intentionally follows the requested small-scope behavior; existing untracked legacy DB handling remains separate (`moveAsidePreScopeDb`, `readLegacySecrets`).
2. If `__drizzle_migrations` exists, read applied hashes ordered by `id ASC`.
   - `id` is autoincrement, monotonic, non-null, and avoids timestamp tie issues.
3. Compute bundled migration hashes exactly like Drizzle:
   - Read `meta/_journal.json`.
   - Sort entries by `idx`.
   - For each entry, read `${entry.tag}.sql` as raw text.
   - Hash the entire raw SQL file with SHA-256 before statement-breakpoint splitting.
4. Compare applied migration history against the bundled migration history as a prefix.
   - If applied count is greater than bundled count: throw `LocalDatabaseSchemaTooNew`.
   - If any applied hash does not equal the bundled hash at the same index: throw `LocalDatabaseMigrationHistoryMismatch`.
   - If `__drizzle_migrations` exists but is empty: pass and let Drizzle run all migrations.

Two new errors:

- `LocalDatabaseSchemaTooNew`: likely opened by a newer Executor; user action is to update Executor or choose another `EXECUTOR_DATA_DIR`.
- `LocalDatabaseMigrationHistoryMismatch`: DB history does not match this binary's migration lineage; likely different branch/corruption/manual modification; user probably cannot fix this by merely updating to the same release line.
