### PR TITLE
Use RELEASE_PAT for changesets/action so Version Packages PRs trigger CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,13 @@ jobs:
           title: Version Packages
           createGithubReleases: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT (RELEASE_PAT) so the auto-opened Version Packages PR
+          # triggers downstream workflows (pkg-pr-new, CI). PRs authored
+          # by the default GITHUB_TOKEN do not trigger other workflows by
+          # GitHub design. Falls back to GITHUB_TOKEN when the secret is
+          # not set, so the workflow keeps working in forks / before the
+          # secret is configured.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Publish @executor-js library packages
         if: steps.changesets.outputs.hasChangesets == 'false'


### PR DESCRIPTION
## Summary

Swap `GITHUB_TOKEN` for `secrets.RELEASE_PAT` (with fallback) in the `changesets/action` step of `release.yml`. Falls back to `GITHUB_TOKEN` when the secret is unset, so forks and pre-secret states keep working.

## Why

GitHub does not trigger downstream workflow runs from events caused by the default `GITHUB_TOKEN`. The Version Packages PR auto-opened by `changesets/action` was being authored by `github-actions[bot]` via that token, so neither `pkg-pr-new` nor `CI` ran on it. Reviewers couldn't preview-install the bundle that was about to publish.

With a PAT, the PR is authored by a real user and downstream workflows fire normally.

## Setup needed (one-time)

Repo secret `RELEASE_PAT` must be set to a PAT (fine-grained or classic) with at minimum:

- `Contents: Read and write`
- `Pull requests: Read and write`

Scoped to this repo only (for fine-grained PATs). Already set in this repo.

## Test plan

- [ ] After merge, push a no-op changeset commit to `main` and confirm the resulting Version Packages PR has `pkg-pr-new` + `CI` runs without manual close/reopen