### PR TITLE
Default openapi.addSpec credentialTargetScope to the source's scope

### DIFF
--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -549,6 +549,57 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
     }),
   );
 
+  it.effect("addSpec without credentialTargetScope defaults to the source's scope", () =>
+    // Regression: config-sync calls addSpec without ever setting
+    // credentialTargetScope. Before the fix, any source with a
+    // header secret in executor.jsonc errored with
+    // "credentialTargetScope is required when adding direct OpenAPI
+    // credentials" the moment the daemon started.
+    Effect.gen(function* () {
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [
+            openApiPlugin({ httpClientLayer: clientLayer }),
+            memorySecretsPlugin(),
+          ] as const,
+        }),
+      );
+
+      yield* executor.secrets.set(
+        new SetSecretInput({
+          id: SecretId.make("config-sync-token"),
+          scope: ScopeId.make(TEST_SCOPE),
+          name: "Config-sync token",
+          value: "secret-from-jsonc",
+        }),
+      );
+
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: TEST_SCOPE,
+        namespace: "default_target_scope",
+        baseUrl: "",
+        headers: {
+          Authorization: { secretId: "config-sync-token", prefix: "Bearer " },
+        },
+      });
+
+      const bindings = yield* executor.openapi.listSourceBindings(
+        "default_target_scope",
+        TEST_SCOPE,
+      );
+      expect(bindings).toHaveLength(1);
+      expect(bindings[0]).toMatchObject({
+        scopeId: ScopeId.make(TEST_SCOPE),
+        slot: "header:authorization",
+        value: { kind: "secret", secretId: SecretId.make("config-sync-token") },
+      });
+    }),
+  );
+
   it.effect("fails clearly when a secret is missing", () =>
     Effect.gen(function* () {
       const httpClient = yield* HttpClient.HttpClient;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -1004,7 +1004,11 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
             queryParams: config.queryParams,
             specFetchCredentials: config.specFetchCredentials,
             oauth2: config.oauth2,
-            credentialTargetScope: config.credentialTargetScope,
+            // Default to the source's own scope. refreshSource and editSource
+            // do the same; without this, config-sync's addSpec — which never
+            // passes the field — fails with "credentialTargetScope is
+            // required" the moment the jsonc declares any header secret.
+            credentialTargetScope: config.credentialTargetScope ?? config.scope,
           });
         });
 


### PR DESCRIPTION
## Summary

`addSpecInternal` forwarded `credentialTargetScope` to `rebuildSource` unchanged. When the caller (notably config-sync, which never sets it) passed `undefined`, `targetScopeForBinding` errored with `"credentialTargetScope is required when adding direct OpenAPI credentials"` — so any OpenAPI source with a header secret in `executor.jsonc` broke the daemon at startup.

Default to `config.scope`, matching the pattern already used by:
- `refreshSource` (`packages/plugins/openapi/src/sdk/plugin.ts:972` — hardcodes `scope`)
- `editSource` (`packages/plugins/openapi/src/sdk/plugin.ts:1090` — `input.credentialTargetScope ?? scope`)

## Repro (before this PR)

```jsonc
// executor.jsonc
{
  "sources": [
    {
      "kind": "openapi",
      "spec": "https://raw.githubusercontent.com/cloudflare/api-schemas/main/openapi.json",
      "namespace": "cloudflare_api",
      "headers": {
        "Authorization": { "value": "secret-public-ref:...", "prefix": "Bearer " }
      }
    }
  ]
}
```

```
$ executor web
[config-sync] Failed to load source "cloudflare_api":
  OpenApiOAuthError: credentialTargetScope is required when adding direct OpenAPI credentials
```

## Test plan

- [x] New regression test in `plugin.test.ts`: `addSpec without credentialTargetScope defaults to the source's scope` — fails on `main`, passes after the fix
- [x] Full openapi plugin suite: 90 tests pass (was 89)
- [x] `bun run lint` clean