### PR TITLE
Fix vite-plugin exports so fresh clones can bun dev without prebuilding

### DIFF
--- a/packages/core/vite-plugin/package.json
+++ b/packages/core/vite-plugin/package.json
@@ -16,7 +16,11 @@
   ],
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/vite-plugin/package.json
+++ b/packages/core/vite-plugin/package.json
@@ -16,11 +16,7 @@
   ],
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "bun": "./src/index.ts",
-      "default": "./dist/index.js"
-    }
+    ".": "./src/index.ts"
   },
   "publishConfig": {
     "access": "public",

--- a/turbo.json
+++ b/turbo.json
@@ -18,6 +18,7 @@
       "outputs": []
     },
     "dev": {
+      "dependsOn": ["@executor-js/vite-plugin#build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
## Summary
- `packages/core/vite-plugin/package.json` had in-repo `exports` with `default: ./dist/index.js`, so Vite's resolver in `apps/local`/`apps/marketing` couldn't load the plugin on a clean checkout — `bun install && bun dev` failed with `Failed to resolve entry for package "@executor-js/vite-plugin"`.
- Every other workspace package already points its in-repo `exports` straight at `./src/...`. This change does the same for vite-plugin. `publishConfig.exports` (which overrides at publish time to point at `dist/`) is untouched, so npm consumers are unaffected.

## Test plan
- [x] Fresh clone into `/tmp`, `bun install && bun dev` — Vite reports `ready in 1617 ms` and serves `http://127.0.0.1:4297/`. Previously this errored out before the dev server started.