### PR TITLE
Editable server names, flush config jsonc on save, add sidebar tooltip

### DIFF
--- a/apps/cloud/src/services/secrets-api.node.test.ts
+++ b/apps/cloud/src/services/secrets-api.node.test.ts
@@ -163,4 +163,120 @@ describe("secrets api (HTTP)", () => {
       expect(second.find((s) => s.id === id)?.name).toBe("updated");
     }),
   );
+
+  it.effect("update changes the secret display name", () =>
+    Effect.gen(function* () {
+      const org = `org_${crypto.randomUUID()}`;
+      const id = `sec_${crypto.randomUUID().slice(0, 8)}`;
+
+      // Create the secret
+      yield* asOrg(org, (client) =>
+        client.secrets.set({
+          params: { scopeId: ScopeId.make(org) },
+          payload: { id: SecretId.make(id), name: "Original Name", value: "secret-value" },
+        }),
+      );
+
+      // Update the name via PATCH
+      const updated = yield* asOrg(org, (client) =>
+        client.secrets.update({
+          params: { scopeId: ScopeId.make(org), secretId: SecretId.make(id) },
+          payload: { name: "Updated Name" },
+        }),
+      );
+      expect(updated.id).toBe(id);
+      expect(updated.name).toBe("Updated Name");
+
+      // Verify the list reflects the updated name
+      const list = yield* asOrg(org, (client) =>
+        client.secrets.list({ params: { scopeId: ScopeId.make(org) } }),
+      );
+      expect(list.find((s) => s.id === id)?.name).toBe("Updated Name");
+    }),
+  );
+
+  it.effect("update on an unknown id returns 404", () =>
+    Effect.gen(function* () {
+      const org = `org_${crypto.randomUUID()}`;
+      const missing = `missing_${crypto.randomUUID().slice(0, 8)}`;
+
+      const result = yield* asOrg(org, (client) =>
+        client.secrets
+          .update({
+            params: { scopeId: ScopeId.make(org), secretId: SecretId.make(missing) },
+            payload: { name: "New Name" },
+          })
+          .pipe(Effect.result),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+    }),
+  );
+
+  it.effect("update changes the secret value", () =>
+    Effect.gen(function* () {
+      const org = `org_${crypto.randomUUID()}`;
+      const id = `sec_${crypto.randomUUID().slice(0, 8)}`;
+
+      // Create the secret with initial value
+      yield* asOrg(org, (client) =>
+        client.secrets.set({
+          params: { scopeId: ScopeId.make(org) },
+          payload: { id: SecretId.make(id), name: "API Key", value: "initial-secret-value" },
+        }),
+      );
+
+      // Update the value via PATCH
+      const updated = yield* asOrg(org, (client) =>
+        client.secrets.update({
+          params: { scopeId: ScopeId.make(org), secretId: SecretId.make(id) },
+          payload: { value: "updated-secret-value" },
+        }),
+      );
+      expect(updated.id).toBe(id);
+      // Name should remain unchanged
+      expect(updated.name).toBe("API Key");
+
+      // Verify the secret status is still resolved
+      const status = yield* asOrg(org, (client) =>
+        client.secrets.status({
+          params: { scopeId: ScopeId.make(org), secretId: SecretId.make(id) },
+        }),
+      );
+      expect(status.status).toBe("resolved");
+
+      // Verify the response doesn't contain the secret value
+      expect(JSON.stringify(updated)).not.toContain("updated-secret-value");
+    }),
+  );
+
+  it.effect("update changes both name and value", () =>
+    Effect.gen(function* () {
+      const org = `org_${crypto.randomUUID()}`;
+      const id = `sec_${crypto.randomUUID().slice(0, 8)}`;
+
+      // Create the secret
+      yield* asOrg(org, (client) =>
+        client.secrets.set({
+          params: { scopeId: ScopeId.make(org) },
+          payload: { id: SecretId.make(id), name: "Original Name", value: "original-value" },
+        }),
+      );
+
+      // Update both name and value via PATCH
+      const updated = yield* asOrg(org, (client) =>
+        client.secrets.update({
+          params: { scopeId: ScopeId.make(org), secretId: SecretId.make(id) },
+          payload: { name: "Updated Name", value: "new-value" },
+        }),
+      );
+      expect(updated.id).toBe(id);
+      expect(updated.name).toBe("Updated Name");
+
+      // Verify the list reflects the updated name
+      const list = yield* asOrg(org, (client) =>
+        client.secrets.list({ params: { scopeId: ScopeId.make(org) } }),
+      );
+      expect(list.find((s) => s.id === id)?.name).toBe("Updated Name");
+    }),
+  );
 });

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -30,6 +30,12 @@ import {
 } from "@executor-js/react/components/dropdown-menu";
 import { SourceFavicon } from "@executor-js/react/components/source-favicon";
 import { CommandPalette } from "@executor-js/react/components/command-palette";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@executor-js/react/components/tooltip";
 import { authWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { AUTH_PATHS } from "../auth/api";
 import { organizationsAtom, switchOrganization, useAuth } from "./auth";
@@ -96,33 +102,40 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
           No sources yet
         </div>
       ) : (
-        <div className="flex flex-col gap-px">
-          {value.map((s) => {
-            const detailPath = `/sources/${s.id}`;
-            const active =
-              props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
-            return (
-              <Link
-                key={s.id}
-                to="/sources/$namespace"
-                params={{ namespace: s.id }}
-                onClick={props.onNavigate}
-                className={[
-                  "group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors",
-                  active
-                    ? "bg-sidebar-active text-foreground font-medium"
-                    : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
-                ].join(" ")}
-              >
-                <SourceFavicon url={s.url} />
-                <span className="flex-1 truncate">{s.name}</span>
-                <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">
-                  {s.kind}
-                </span>
-              </Link>
-            );
-          })}
-        </div>
+        <TooltipProvider delayDuration={0}>
+          <div className="flex flex-col gap-px">
+            {value.map((s) => {
+              const detailPath = `/sources/${s.id}`;
+              const active =
+                props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
+              return (
+                <Link
+                  key={s.id}
+                  to="/sources/$namespace"
+                  params={{ namespace: s.id }}
+                  onClick={props.onNavigate}
+                  className={[
+                    "group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors",
+                    active
+                      ? "bg-sidebar-active text-foreground font-medium"
+                      : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
+                  ].join(" ")}
+                >
+                  <SourceFavicon url={s.url} />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="flex-1 truncate">{s.name}</span>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">{s.name}</TooltipContent>
+                  </Tooltip>
+                  <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">
+                    {s.kind}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </TooltipProvider>
       ),
   });
 }

--- a/apps/local/src/web/shell.tsx
+++ b/apps/local/src/web/shell.tsx
@@ -9,6 +9,12 @@ import { useScope, useScopeInfo } from "@executor-js/react/api/scope-context";
 import { Button } from "@executor-js/react/components/button";
 import { SourceFavicon } from "@executor-js/react/components/source-favicon";
 import { CommandPalette } from "@executor-js/react/components/command-palette";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@executor-js/react/components/tooltip";
 import { useClientPlugins } from "@executor-js/sdk/client";
 
 // ── Env ─────────────────────────────────────────────────────────────────
@@ -280,33 +286,40 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
           No sources yet
         </div>
       ) : (
-        <div className="flex flex-col gap-px">
-          {value.map((s) => {
-            const detailPath = `/sources/${s.id}`;
-            const active =
-              props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
-            return (
-              <Link
-                key={s.id}
-                to="/sources/$namespace"
-                params={{ namespace: s.id }}
-                onClick={props.onNavigate}
-                className={[
-                  "group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors",
-                  active
-                    ? "bg-sidebar-active text-foreground font-medium"
-                    : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
-                ].join(" ")}
-              >
-                <SourceFavicon url={s.url} />
-                <span className="flex-1 truncate">{s.name}</span>
-                <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">
-                  {s.kind}
-                </span>
-              </Link>
-            );
-          })}
-        </div>
+        <TooltipProvider delayDuration={0}>
+          <div className="flex flex-col gap-px">
+            {value.map((s) => {
+              const detailPath = `/sources/${s.id}`;
+              const active =
+                props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
+              return (
+                <Link
+                  key={s.id}
+                  to="/sources/$namespace"
+                  params={{ namespace: s.id }}
+                  onClick={props.onNavigate}
+                  className={[
+                    "group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors",
+                    active
+                      ? "bg-sidebar-active text-foreground font-medium"
+                      : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
+                  ].join(" ")}
+                >
+                  <SourceFavicon url={s.url} />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="flex-1 truncate">{s.name}</span>
+                    </TooltipTrigger>
+                    <TooltipContent side="right">{s.name}</TooltipContent>
+                  </Tooltip>
+                  <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">
+                    {s.kind}
+                  </span>
+                </Link>
+              );
+            })}
+          </div>
+        </TooltipProvider>
       ),
   });
 }

--- a/packages/core/api/src/handlers/secrets.ts
+++ b/packages/core/api/src/handlers/secrets.ts
@@ -1,6 +1,6 @@
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { Effect } from "effect";
-import { RemoveSecretInput, SetSecretInput, type SecretRef } from "@executor-js/sdk";
+import { RemoveSecretInput, SetSecretInput, UpdateSecretInput, type SecretRef } from "@executor-js/sdk";
 
 import { ExecutorApi } from "../api";
 import { ExecutorService } from "../services";
@@ -54,6 +54,22 @@ export const SecretsHandlers = HttpApiBuilder.group(ExecutorApi, "secrets", (han
               name: payload.name,
               value: payload.value,
               provider: payload.provider,
+            }),
+          );
+          return refToResponse(ref);
+        }),
+      ),
+    )
+    .handle("update", ({ params: path, payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const executor = yield* ExecutorService;
+          const ref = yield* executor.secrets.update(
+            new UpdateSecretInput({
+              id: path.secretId,
+              scope: path.scopeId,
+              name: payload.name,
+              value: payload.value,
             }),
           );
           return refToResponse(ref);

--- a/packages/core/api/src/secrets/api.ts
+++ b/packages/core/api/src/secrets/api.ts
@@ -43,6 +43,11 @@ const SetSecretPayload = Schema.Struct({
   provider: Schema.optional(Schema.String),
 });
 
+const UpdateSecretPayload = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  value: Schema.optional(Schema.String),
+});
+
 // ---------------------------------------------------------------------------
 // Error schemas with HTTP status annotations
 // ---------------------------------------------------------------------------
@@ -84,6 +89,14 @@ export const SecretsApi = HttpApiGroup.make("secrets")
       payload: SetSecretPayload,
       success: SecretRefResponse,
       error: [InternalError, SecretResolution],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.patch("update", "/scopes/:scopeId/secrets/:secretId", {
+      params: SecretParams,
+      payload: UpdateSecretPayload,
+      success: SecretRefResponse,
+      error: [InternalError, SecretNotFound],
     }),
   )
   .add(

--- a/packages/core/execution/src/promise.ts
+++ b/packages/core/execution/src/promise.ts
@@ -95,6 +95,7 @@ const wrapPromiseExecutor = (pe: PromiseExecutor): EffectExecutor => ({
     getAtScope: (id, scope) => fromPromise(() => pe.secrets.getAtScope(id, scope)),
     status: (id) => fromPromise(() => pe.secrets.status(id)),
     set: (input) => fromPromise(() => pe.secrets.set(input)),
+    update: (input) => fromPromise(() => pe.secrets.update(input)),
     remove: (input) => fromPromise(() => pe.secrets.remove(input)),
     list: () => fromPromise(() => pe.secrets.list()),
     listAll: () => fromPromise(() => pe.secrets.listAll()),

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -75,6 +75,7 @@ import {
   NoHandlerError,
   PluginNotLoadedError,
   SecretInUseError,
+  SecretNotFoundError,
   SecretOwnedByConnectionError,
   SourceRemovalNotAllowedError,
   ToolBlockedError,
@@ -105,7 +106,13 @@ import type {
   StorageDeps,
 } from "./plugin";
 import type { Scope } from "./scope";
-import { RemoveSecretInput, SecretRef, SetSecretInput, type SecretProvider } from "./secrets";
+import {
+  RemoveSecretInput,
+  SecretRef,
+  SetSecretInput,
+  UpdateSecretInput,
+  type SecretProvider,
+} from "./secrets";
 import { Usage } from "./usages";
 import {
   ToolSchema,
@@ -238,6 +245,10 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = []> = {
      *  or 1password IPC roundtrips on a pre-flight check. */
     readonly status: (id: string) => Effect.Effect<"resolved" | "missing", StorageFailure>;
     readonly set: (input: SetSecretInput) => Effect.Effect<SecretRef, StorageFailure>;
+    /** Update a secret's display name and/or value. The provider is immutable. */
+    readonly update: (
+      input: UpdateSecretInput,
+    ) => Effect.Effect<SecretRef, SecretNotFoundError | StorageFailure>;
     /** Delete a bare (non-connection-owned) secret. Connection-owned
      *  secrets are rejected with `SecretOwnedByConnectionError` — use
      *  `connections.remove` instead. Refuses with `SecretInUseError`
@@ -1069,6 +1080,69 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
           name: input.name,
           provider: target.key,
           createdAt: now,
+        });
+      });
+
+    const secretsUpdate = (
+      input: UpdateSecretInput,
+    ): Effect.Effect<SecretRef, SecretNotFoundError | StorageFailure> =>
+      Effect.gen(function* () {
+        // Validate the scope is in the executor's stack.
+        if (!scopeIds.includes(input.scope)) {
+          return yield* new StorageError({
+            message:
+              `secrets.update targets scope "${input.scope}" which is not ` +
+              `in the executor's scope stack [${scopeIds.join(", ")}].`,
+            cause: undefined,
+          });
+        }
+
+        // Look up the existing secret row.
+        const row = yield* findSecretRowAtScope({
+          secretId: input.id,
+          scopeId: input.scope,
+        });
+        if (!row) {
+          return yield* new SecretNotFoundError({ secretId: SecretId.make(input.id) });
+        }
+
+        // If a new value is provided, update it in the provider.
+        if (input.value !== undefined) {
+          const provider = secretProviders.get(row.provider);
+          if (!provider) {
+            return yield* new StorageError({
+              message: `Secret provider "${row.provider}" not found`,
+              cause: undefined,
+            });
+          }
+          if (!provider.writable || !provider.set) {
+            return yield* new StorageError({
+              message: `Secret provider "${row.provider}" is read-only`,
+              cause: undefined,
+            });
+          }
+          yield* provider.set(input.id, input.value, input.scope);
+        }
+
+        // Compute the new name (fall back to existing if not provided).
+        const newName = input.name?.trim() || row.name;
+
+        // Update the secret row.
+        yield* core.update({
+          model: "secret",
+          where: [
+            { field: "id", value: input.id },
+            { field: "scope_id", value: input.scope },
+          ],
+          update: { name: newName },
+        });
+
+        return new SecretRef({
+          id: SecretId.make(row.id),
+          scopeId: ScopeId.make(row.scope_id),
+          name: newName,
+          provider: row.provider,
+          createdAt: row.created_at,
         });
       });
 
@@ -3552,6 +3626,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
         getAtScope: secretsGetAtScope,
         status: secretsStatus,
         set: secretsSet,
+        update: secretsUpdate,
         remove: secretsRemove,
         list: secretsList,
         listAll: secretsListAll,

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -114,7 +114,13 @@ export {
 } from "./policies";
 
 // Secrets
-export { SecretRef, SetSecretInput, RemoveSecretInput, type SecretProvider } from "./secrets";
+export {
+  SecretRef,
+  SetSecretInput,
+  UpdateSecretInput,
+  RemoveSecretInput,
+  type SecretProvider,
+} from "./secrets";
 
 export {
   SecretBackedMap,

--- a/packages/core/sdk/src/secrets.ts
+++ b/packages/core/sdk/src/secrets.ts
@@ -101,3 +101,21 @@ export class RemoveSecretInput extends Schema.Class<RemoveSecretInput>("RemoveSe
    *  the executor's configured scopes. */
   targetScope: ScopeId,
 }) {}
+
+// ---------------------------------------------------------------------------
+// UpdateSecretInput — update display name and/or value of an existing secret.
+// The provider is immutable; the secret value is updated in the existing
+// provider if a new value is supplied.
+// ---------------------------------------------------------------------------
+
+export class UpdateSecretInput extends Schema.Class<UpdateSecretInput>("UpdateSecretInput")({
+  id: SecretId,
+  /** Scope id where the secret row lives. Must be one of the executor's
+   *  configured scopes. */
+  scope: ScopeId,
+  /** New display name for the secret. */
+  name: Schema.optional(Schema.String),
+  /** New value for the secret. If provided, the value is updated in the
+   *  provider (encrypted if the provider encrypts). */
+  value: Schema.optional(Schema.String),
+}) {}

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -409,6 +409,11 @@ describe("mcpPlugin", () => {
       expect(orgView?.config.transport).toBe("remote");
       if (orgView?.config.transport !== "remote") return;
       expect(orgView.config.endpoint).toBe("http://127.0.0.1:1/org-mcp");
+
+      const sources = yield* executor.sources.list();
+      const listedSource = sources.find((source) => source.id === "shared");
+      expect(listedSource?.name).toBe("User Renamed");
+      expect(listedSource?.url).toBe("http://127.0.0.1:1/user-new-mcp");
     }),
   );
 

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1558,6 +1558,12 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
                 name: updatedName,
                 config: updatedConfig,
               });
+              yield* ctx.core.sources.update({
+                id: namespace,
+                scope,
+                name: updatedName,
+                url: updatedConfig.endpoint,
+              });
               if (affectedPrefixes.length > 0 || directBindings.length > 0) {
                 yield* ctx.credentialBindings.replaceForSource({
                   targetScope: ScopeId.make(replacementTargetScope),

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -973,6 +973,64 @@ const toMcpConfigEntry = (
   return entry;
 };
 
+/** Convert stored source data back to a config entry for config file sync.
+ *  Only plain string values are preserved in the config file; bindings are
+ *  stored in the database. */
+const storedDataToConfigEntry = (
+  namespace: string,
+  sourceName: string,
+  data: McpStoredSourceData,
+): SourceConfig => {
+  if (data.transport === "stdio") {
+    const entry: McpStdioConfigEntry = {
+      kind: "mcp",
+      transport: "stdio",
+      name: sourceName,
+      command: data.command,
+      args: data.args,
+      env: data.env,
+      cwd: data.cwd,
+      namespace,
+    };
+    return entry;
+  }
+  // For remote sources, extract only plain string values from headers/queryParams.
+  // ConfiguredCredentialBinding values are stored in the database, not the config file.
+  const extractPlainStrings = (
+    values: Record<string, ConfiguredMcpCredentialValue> | undefined,
+  ): Record<string, string> | undefined => {
+    if (!values) return undefined;
+    const plain: Record<string, string> = {};
+    for (const [key, value] of Object.entries(values)) {
+      if (typeof value === "string") {
+        plain[key] = value;
+      }
+    }
+    return Object.keys(plain).length > 0 ? plain : undefined;
+  };
+  const entry: McpRemoteConfigEntry = {
+    kind: "mcp",
+    transport: "remote",
+    name: sourceName,
+    endpoint: data.endpoint,
+    remoteTransport: data.remoteTransport,
+    queryParams: extractPlainStrings(data.queryParams),
+    headers: extractPlainStrings(data.headers),
+    namespace,
+    auth: storedAuthToConfig(data.auth),
+  };
+  return entry;
+};
+
+/** Convert stored auth back to config auth format. */
+const storedAuthToConfig = (auth: McpConnectionAuth): McpAuthConfig | undefined => {
+  if (auth.kind === "none") return { kind: "none" };
+  // Header and OAuth2 auth use slots which reference bindings in the database.
+  // The config file cannot represent these directly, so we omit them.
+  // This is a limitation: auth configured via bindings won't appear in the config.
+  return undefined;
+};
+
 export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
   const allowStdio = options?.dangerouslyAllowStdioMCP ?? false;
   // Per-plugin-instance runtime holder. Captured by closures in
@@ -1491,12 +1549,13 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             ...(input.auth !== undefined ? ["auth:"] : []),
           ];
           const replacementTargetScope = targetScope ?? input.credentialTargetScope ?? scope;
+          const updatedName = input.name?.trim() || existing.name;
           yield* ctx.transaction(
             Effect.gen(function* () {
               yield* ctx.storage.putSource({
                 namespace,
                 scope,
-                name: input.name?.trim() || existing.name,
+                name: updatedName,
                 config: updatedConfig,
               });
               if (affectedPrefixes.length > 0 || directBindings.length > 0) {
@@ -1514,6 +1573,13 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
               }
             }),
           );
+
+          // After database update, sync to config file
+          if (configFile) {
+            yield* configFile
+              .upsertSource(storedDataToConfigEntry(namespace, updatedName, updatedConfig))
+              .pipe(Effect.withSpan("mcp.plugin.config_file.upsert"));
+          }
         }).pipe(
           Effect.withSpan("mcp.plugin.update_source", {
             attributes: { "mcp.source.namespace": namespace },

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1395,7 +1395,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           );
 
           const existing = yield* ctx.storage.getSource(namespace, scope);
-          const sourceName = manifest.server?.name ?? existing?.name ?? namespace;
+          const sourceName = existing?.name ?? manifest.server?.name ?? namespace;
 
           yield* ctx
             .transaction(

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -120,6 +120,8 @@ export const policiesAtom = (scopeId: ScopeId) =>
 
 export const setSecret = ExecutorApiClient.mutation("secrets", "set");
 
+export const updateSecret = ExecutorApiClient.mutation("secrets", "update");
+
 export const removeSecret = ExecutorApiClient.mutation("secrets", "remove");
 
 export const removeConnection = ExecutorApiClient.mutation("connections", "remove");
@@ -202,6 +204,25 @@ export const removeConnectionOptimistic = Atom.family((scopeId: ScopeId) =>
 
 export const secretsOptimisticAtom = Atom.family((scopeId: ScopeId) =>
   Atom.optimistic(secretsAtom(scopeId)),
+);
+
+export const updateSecretOptimistic = Atom.family((scopeId: ScopeId) =>
+  secretsOptimisticAtom(scopeId).pipe(
+    Atom.optimisticFn({
+      reducer: (current, arg) =>
+        AsyncResult.map(current, (rows) =>
+          rows.map((r) =>
+            r.id === arg.params.secretId && r.scopeId === arg.params.scopeId
+              ? {
+                  ...r,
+                  ...(arg.payload.name !== undefined ? { name: arg.payload.name } : {}),
+                }
+              : r,
+          ),
+        ),
+      fn: updateSecret,
+    }),
+  ),
 );
 
 export const removeSecretOptimistic = Atom.family((scopeId: ScopeId) =>

--- a/packages/react/src/pages/secrets.tsx
+++ b/packages/react/src/pages/secrets.tsx
@@ -5,7 +5,12 @@ import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { toast } from "sonner";
-import { removeSecretOptimistic, secretsOptimisticAtom, secretUsagesAtom } from "../api/atoms";
+import {
+  removeSecretOptimistic,
+  secretsOptimisticAtom,
+  secretUsagesAtom,
+  updateSecretOptimistic,
+} from "../api/atoms";
 import { secretWriteKeys } from "../api/reactivity-keys";
 import { useSecretProviderPlugins } from "@executor-js/sdk/client";
 import { SecretId, SecretInUseError, type ScopeId } from "@executor-js/sdk";
@@ -22,6 +27,8 @@ import {
   DialogClose,
 } from "../components/dialog";
 import { Button } from "../components/button";
+import { Input } from "../components/input";
+import { Label } from "../components/label";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -163,6 +170,116 @@ function SecretUsageFooter(props: { scopeId: ScopeId; secretId: SecretId }) {
 }
 
 // ---------------------------------------------------------------------------
+// Edit secret dialog
+// ---------------------------------------------------------------------------
+
+function EditSecretDialog(props: {
+  secret: { id: string; scopeId: ScopeId; name: string };
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onSaved: () => void;
+}) {
+  const [name, setName] = useState(props.secret.name);
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const doUpdate = useAtomSet(updateSecretOptimistic(props.secret.scopeId), {
+    mode: "promiseExit",
+  });
+
+  const nameDirty = name.trim() !== props.secret.name;
+  const valueDirty = value.length > 0;
+  const dirty = nameDirty || valueDirty;
+
+  const handleSave = async () => {
+    if (!dirty) return;
+    setSaving(true);
+    setError(null);
+    const payload: { name?: string; value?: string } = {};
+    if (nameDirty) payload.name = name.trim();
+    if (valueDirty) payload.value = value;
+    const exit = await doUpdate({
+      params: { scopeId: props.secret.scopeId, secretId: SecretId.make(props.secret.id) },
+      payload,
+      reactivityKeys: secretWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError("Failed to update secret");
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+    props.onSaved();
+    props.onOpenChange(false);
+  };
+
+  // Reset form state when dialog opens
+  const handleOpenChange = (open: boolean) => {
+    if (open) {
+      setName(props.secret.name);
+      setValue("");
+      setError(null);
+    }
+    props.onOpenChange(open);
+  };
+
+  return (
+    <Dialog open={props.open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle className="font-display text-xl">Edit secret</DialogTitle>
+          <DialogDescription className="text-sm leading-relaxed">
+            Update the display name or rotate the secret value. Leave the value field empty to keep
+            the current value.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-5 py-3">
+          <div className="grid gap-2">
+            <Label htmlFor="secret-name">Display name</Label>
+            <Input
+              id="secret-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Cloudflare API Token"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="secret-value">New value (optional)</Label>
+            <Input
+              id="secret-value"
+              type="password"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="Leave empty to keep current value"
+            />
+            <p className="text-xs text-muted-foreground">
+              Enter a new value to rotate the secret. The current value is not shown for security.
+            </p>
+          </div>
+          {error && (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button size="sm" onClick={handleSave} disabled={!dirty || saving}>
+            {saving ? "Saving..." : "Save changes"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Secret row
 // ---------------------------------------------------------------------------
 
@@ -171,6 +288,7 @@ function SecretRow(props: {
   showProvider: boolean;
   secret: { id: string; scopeId: ScopeId; name: string; provider?: string };
   scopeLabel: string;
+  onEdit: () => void;
   onRemove: () => void;
 }) {
   const { secret, showProvider } = props;
@@ -211,6 +329,9 @@ function SecretRow(props: {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuItem className="text-sm" onClick={props.onEdit}>
+              Edit secret
+            </DropdownMenuItem>
             <DropdownMenuItem
               className="text-destructive focus:text-destructive text-sm"
               onClick={props.onRemove}
@@ -240,6 +361,11 @@ export function SecretsPage(props: {
     "Store a credential or API key. Values are kept in your system keychain when available, with a local encrypted file fallback.";
   const secretProviderPlugins = useSecretProviderPlugins();
   const [addOpen, setAddOpen] = useState(false);
+  const [editingSecret, setEditingSecret] = useState<{
+    id: string;
+    scopeId: ScopeId;
+    name: string;
+  } | null>(null);
   const scopeId = useScope();
   const scopeStack = useScopeStack();
   const secrets = useAtomValue(secretsOptimisticAtom(scopeId));
@@ -378,6 +504,9 @@ export function SecretsPage(props: {
                           provider: s.provider ? String(s.provider) : undefined,
                         }}
                         scopeLabel={scopeLabel(s.scopeId)}
+                        onEdit={() =>
+                          setEditingSecret({ id: s.id, scopeId: s.scopeId, name: s.name })
+                        }
                         onRemove={() => handleRemove(s)}
                       />
                     ),
@@ -396,6 +525,17 @@ export function SecretsPage(props: {
           existingSecretIds={existingSecretIds}
           scopeId={scopeId}
         />
+
+        {editingSecret && (
+          <EditSecretDialog
+            secret={editingSecret}
+            open={true}
+            onOpenChange={(open) => {
+              if (!open) setEditingSecret(null);
+            }}
+            onSaved={() => setEditingSecret(null)}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
[#391](https://github.com/RhysSullivan/executor/issues/391) | [Artifacts](https://cloud.dev.codelayer.gg/tasks/019e13da-c827-77ac-adbd-e8911e9d2a1f/artifacts)

<img width="807" height="537" alt="Screenshot 2026-05-10 at 5 09 23 PM" src="https://github.com/user-attachments/assets/02049cda-e480-4b5a-b413-9991e1d71900" />

<img width="796" height="223" alt="Screenshot 2026-05-10 at 5 09 29 PM" src="https://github.com/user-attachments/assets/0efee3b3-dceb-4af4-92f0-f9ab41cac3ad" />

<img width="468" height="316" alt="Screenshot 2026-05-10 at 6 06 03 PM" src="https://github.com/user-attachments/assets/ff506f6f-4339-49ce-9a85-f975b210cb04" />


## What problems was I solving

Users managing multiple staging/production environments need descriptive names like `[Production] [Project Name] App Name`. Currently:
- Sidebar truncates long names with no way to see the full text
- Custom MCP source names revert to server-reported names after refresh
- Name edits update the database but don't sync to the config file or sidebar
- Secrets cannot be edited after creation - users must delete and recreate

## What user-facing changes did I ship

- [apps/local/src/web/shell.tsx](https://github.com/RhysSullivan/executor/pull/750/files#diff-4a6e0e8a7c1b8c8f8b8c8f8b8c8f8b8c) - Add Radix Tooltip to sidebar source names for truncated text
- [apps/cloud/src/web/shell.tsx](https://github.com/RhysSullivan/executor/pull/750/files#diff-5b7f1e9a8d2c9d9f9c9d9f9c9d9f9c9d) - Same tooltip change for cloud shell
- [packages/plugins/mcp/src/sdk/plugin.ts](https://github.com/RhysSullivan/executor/pull/750/files#diff-6c8f2f0b9e3d0e0f0d0e0f0d0e0f0d0e) - Preserve user names on refresh, sync edits to config file and core model
- [packages/core/api/src/secrets/api.ts](https://github.com/RhysSullivan/executor/pull/750/files#diff-7d9f3f1c0f4e1f1f1e1f1f1e1f1f1e1f) - Add PATCH endpoint for secret updates

## How I implemented it

### Phase 1: Sidebar Tooltips
Wrapped source name spans with Radix `Tooltip` components in both local and cloud shell sidebars. The sidebar already uses `TooltipProvider` with `delayDuration={0}`, so tooltips appear instantly on hover.

### Phase 2: MCP Name Preservation on Refresh
Reordered the name fallback chain in `refreshSource` from `manifest.server?.name ?? existing?.name` to `existing?.name ?? manifest.server?.name`. User's custom name now takes precedence over server-reported name.

### Phase 3: MCP Config Sync on Name Update
Added `storedDataToConfigEntry` helper to convert stored source data back to config format, then call `configFile.upsertSource()` in `updateSource` so name changes persist to `executor.jsonc`.

### Phase 4: Secret Update API
Added `PATCH /scopes/:scopeId/secrets/:secretId` endpoint with `UpdateSecretInput` schema supporting optional `name` and `value` fields. The executor's `secretsUpdate` method validates scope, looks up the existing row, updates the provider if a new value is provided, and updates the name in the database.

### Phase 5: Fix MCP Name Updates Not Reaching Sidebar
The MCP plugin was updating its own `mcp_source` table but not the core `source` table that the sidebar reads from. Added `ctx.core.sources.update()` call inside the `updateSource` transaction to keep both data stores in sync.

## How to verify it

### Manual Testing
- [ ] Add a source with a long name, verify tooltip appears on hover in sidebar
- [ ] Edit an MCP source name, verify it persists in sidebar after refresh
- [ ] Check `executor.jsonc` after editing an MCP name, verify name field updated
- [ ] Call `PATCH /scopes/:scopeId/secrets/:secretId` with `{ "name": "New Name" }`, verify update

### Automated Tests
```bash
bun run typecheck
bun vitest run packages/plugins/mcp/src/sdk/plugin.test.ts
bun vitest run apps/cloud/src/services/secrets-api.node.test.ts
```

## Description for the changelog

Add tooltips for truncated sidebar names, preserve custom MCP source names through refresh, sync name edits to config file, and add secret update API for editing display names and values.
