### PR TITLE
[codex] add WorkOS API key auth

### DIFF
--- a/apps/cloud/src/api/error-logging.ts
+++ b/apps/cloud/src/api/error-logging.ts
@@ -1,0 +1,83 @@
+import { Cause, Effect, Option, Predicate, Result } from "effect";
+import { HttpRouter, HttpServerRequest } from "effect/unstable/http";
+
+const MAX_LOGGED_CAUSE_CHARS = 4_000;
+
+const truncate = (value: string): string =>
+  value.length <= MAX_LOGGED_CAUSE_CHARS
+    ? value
+    : `${value.slice(0, MAX_LOGGED_CAUSE_CHARS)}\n...[truncated ${
+        value.length - MAX_LOGGED_CAUSE_CHARS
+      } chars]`;
+
+const loggedCause = (cause: Cause.Cause<unknown>): string => truncate(Cause.pretty(cause));
+
+const objectValue = (value: unknown, key: string): unknown =>
+  Predicate.hasProperty(value, key) ? value[key] : undefined;
+
+const numberValue = (value: unknown, key: string): number | undefined => {
+  const field = objectValue(value, key);
+  return typeof field === "number" ? field : undefined;
+};
+
+const stringValue = (value: unknown, key: string): string | undefined => {
+  const field = objectValue(value, key);
+  return typeof field === "string" ? field : undefined;
+};
+
+const firstFailureOrDefect = (cause: Cause.Cause<unknown>): unknown => {
+  const failure = Cause.findErrorOption(cause);
+  if (Option.isSome(failure)) return failure.value;
+
+  const defect = Cause.findDefect(cause);
+  if (Result.isSuccess(defect)) return defect.success;
+
+  return undefined;
+};
+
+const errorTag = (error: unknown): string => stringValue(error, "_tag") ?? "Unknown";
+
+const httpStatus = (error: unknown): number => {
+  const directStatus = numberValue(error, "status");
+  if (directStatus) return directStatus;
+
+  const constructor = objectValue(error, "constructor");
+  const ast = objectValue(constructor, "ast");
+  const annotations = objectValue(ast, "annotations");
+  return numberValue(annotations, "httpApiStatus") ?? 500;
+};
+
+const requestPath = (request: HttpServerRequest.HttpServerRequest): string => {
+  if (URL.canParse(request.url, "http://executor.local")) {
+    return new URL(request.url, "http://executor.local").pathname;
+  }
+
+  return request.url.split("?")[0] ?? request.url;
+};
+
+export const logApiErrorCause = (
+  request: HttpServerRequest.HttpServerRequest,
+  cause: Cause.Cause<unknown>,
+): void => {
+  const error = firstFailureOrDefect(cause);
+  console.error("[api] request failed", {
+    method: request.method,
+    path: requestPath(request),
+    status: httpStatus(error),
+    errorTag: errorTag(error),
+    cause: loggedCause(cause),
+  });
+};
+
+export const ApiErrorLoggingLive = HttpRouter.middleware()((httpEffect) =>
+  Effect.gen(function* () {
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    return yield* httpEffect.pipe(
+      Effect.tapCause((cause) =>
+        Effect.sync(() => {
+          logApiErrorCause(request, cause);
+        }),
+      ),
+    );
+  }),
+).layer;

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -3,6 +3,7 @@ import { HttpServer } from "effect/unstable/http";
 import { Layer } from "effect";
 
 import { OrgAuthLive, SessionAuthLive } from "../auth/middleware-live";
+import { ApiKeyService } from "../auth/api-keys";
 import { UserStoreService } from "../auth/context";
 import {
   CloudAuthPublicHandlers,
@@ -50,6 +51,7 @@ export const BootSharedServices = Layer.mergeAll(
 export const makeNonProtectedApiLive = (rsLive: Layer.Layer<DbService | UserStoreService>) =>
   HttpApiBuilder.layer(NonProtectedApi).pipe(
     Layer.provide(Layer.mergeAll(CloudAuthPublicHandlers, CloudSessionAuthHandlers)),
+    Layer.provideMerge(ApiKeyService.WorkOS),
     Layer.provide(requestScopedMiddleware(rsLive).layer),
     Layer.provideMerge(SessionAuthLive),
   );

--- a/apps/cloud/src/api/protected-api-key-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-api-key-auth.node.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { ApiKeyService } from "../auth/api-keys";
+import { UserStoreService } from "../auth/context";
+import { WorkOSAuth, type WorkOSAuthService } from "../auth/workos";
+import { resolveProtectedIdentity } from "./protected";
+
+const createdAt = new Date("2026-01-01T00:00:00.000Z");
+
+const stubApiKeys = Layer.succeed(ApiKeyService)({
+  validate: (value: string) =>
+    Effect.succeed(
+      value === "valid_user_key"
+        ? {
+            accountId: "user_123",
+            organizationId: "org_123",
+            keyId: "api_key_123",
+          }
+        : null,
+    ),
+  listUserKeys: () => Effect.succeed([]),
+  createUserKey: () => Effect.die("protected API auth test does not create API keys"),
+  revokeUserKey: () => Effect.void,
+});
+
+const stubWorkOS = Layer.succeed(
+  WorkOSAuth,
+  new Proxy({} as WorkOSAuthService, {
+    get: (_target, prop) => {
+      if (prop === "listUserMemberships") {
+        return (userId: string) =>
+          Effect.succeed({
+            data:
+              userId === "user_123"
+                ? [{ userId, organizationId: "org_123", status: "active" }]
+                : [],
+          });
+      }
+      return () => Effect.die(`unexpected WorkOSAuth.${String(prop)} call`);
+    },
+  }),
+);
+
+const stubUsers = Layer.succeed(UserStoreService)({
+  use: (fn) =>
+    Effect.promise(() =>
+      fn({
+        ensureAccount: async (id: string) => ({ id, createdAt }),
+        getAccount: async (id: string) => ({ id, createdAt }),
+        upsertOrganization: async (org: { id: string; name: string }) => ({
+          ...org,
+          createdAt,
+        }),
+        getOrganization: async (id: string) => ({ id, name: `Org ${id}`, createdAt }),
+      }),
+    ),
+});
+
+const run = (request: Request) =>
+  resolveProtectedIdentity(request).pipe(
+    Effect.provide(Layer.mergeAll(stubApiKeys, stubWorkOS, stubUsers)),
+  );
+
+describe("protected API key auth", () => {
+  it.effect("resolves a valid bearer API key into protected identity", () =>
+    Effect.gen(function* () {
+      const identity = yield* run(
+        new Request("https://executor.test/api/tools", {
+          headers: { authorization: "Bearer valid_user_key" },
+        }),
+      );
+
+      expect(identity).toEqual({
+        accountId: "user_123",
+        organizationId: "org_123",
+        organizationName: "Org org_123",
+        email: "",
+        name: null,
+        avatarUrl: null,
+      });
+    }),
+  );
+
+  it.effect("rejects invalid bearer API keys", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        run(
+          new Request("https://executor.test/api/tools", {
+            headers: { authorization: "Bearer invalid_user_key" },
+          }),
+        ),
+      );
+
+      expect(error).toMatchObject({
+        status: 401,
+        code: "invalid_api_key",
+      });
+    }),
+  );
+});

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -15,6 +15,7 @@ import {
 
 import { cloudPlugins, type CloudPlugins } from "./cloud-plugins";
 import { AuthContext } from "../auth/middleware";
+import { ApiKeyService } from "../auth/api-keys";
 import { authorizeOrganization } from "../auth/authorize-organization";
 import { UserStoreService } from "../auth/context";
 import { WorkOSAuth } from "../auth/workos";
@@ -30,6 +31,105 @@ import { requestScopedMiddleware } from "./request-scoped";
 // executor[id])` chain. The plugin spec carries the Service tag so
 // this file doesn't import each plugin's `*/api` directly.
 const provideExecutorExtensions = providePluginExtensions(cloudPlugins);
+const BEARER_PREFIX = "Bearer ";
+
+export const resolveApiKeyIdentity = (request: Request) =>
+  Effect.gen(function* () {
+    const authHeader = request.headers.get("authorization");
+    if (!authHeader) return null;
+
+    if (!authHeader.startsWith(BEARER_PREFIX)) {
+      return yield* new HttpResponseError({
+        status: 401,
+        code: "invalid_authorization_header",
+        message: "Authorization header must use Bearer authentication",
+      });
+    }
+
+    const value = authHeader.slice(BEARER_PREFIX.length).trim();
+    if (!value) {
+      return yield* new HttpResponseError({
+        status: 401,
+        code: "invalid_api_key",
+        message: "Invalid API key",
+      });
+    }
+
+    const apiKeys = yield* ApiKeyService;
+    const principal = yield* apiKeys.validate(value).pipe(
+      Effect.catchTag("ApiKeyValidationError", () =>
+        Effect.fail(
+          new HttpResponseError({
+            status: 503,
+            code: "api_key_validation_unavailable",
+            message: "API key validation is temporarily unavailable",
+          }),
+        ),
+      ),
+    );
+
+    if (!principal) {
+      return yield* new HttpResponseError({
+        status: 401,
+        code: "invalid_api_key",
+        message: "Invalid API key",
+      });
+    }
+
+    const org = yield* authorizeOrganization(principal.accountId, principal.organizationId);
+    if (!org) {
+      return yield* new HttpResponseError({
+        status: 403,
+        code: "no_organization",
+        message: "No organization in API key",
+      });
+    }
+
+    return {
+      accountId: principal.accountId,
+      organizationId: org.id,
+      organizationName: org.name,
+      email: "",
+      name: null,
+      avatarUrl: null,
+    };
+  });
+
+export const resolveSessionIdentity = (request: Request) =>
+  Effect.gen(function* () {
+    const workos = yield* WorkOSAuth;
+    const session = yield* workos.authenticateRequest(request);
+    if (!session || !session.organizationId) {
+      return yield* new HttpResponseError({
+        status: 403,
+        code: "no_organization",
+        message: "No organization in session",
+      });
+    }
+    const org = yield* authorizeOrganization(session.userId, session.organizationId);
+    if (!org) {
+      return yield* new HttpResponseError({
+        status: 403,
+        code: "no_organization",
+        message: "No organization in session",
+      });
+    }
+    return {
+      accountId: session.userId,
+      organizationId: org.id,
+      organizationName: org.name,
+      email: session.email,
+      name: `${session.firstName ?? ""} ${session.lastName ?? ""}`.trim() || null,
+      avatarUrl: session.avatarUrl ?? null,
+    };
+  });
+
+export const resolveProtectedIdentity = (request: Request) =>
+  Effect.gen(function* () {
+    const apiKeyIdentity = yield* resolveApiKeyIdentity(request);
+    if (apiKeyIdentity) return apiKeyIdentity;
+    return yield* resolveSessionIdentity(request);
+  });
 
 // One `HttpRouter` middleware that:
 //   1. authenticates the WorkOS sealed session,
@@ -65,36 +165,24 @@ const ExecutionStackMiddleware = HttpRouter.middleware<{
     | PluginExtensionServices<CloudPlugins>;
 }>()(
   Effect.gen(function* () {
-    const longLived = yield* Effect.context<WorkOSAuth | AutumnService>();
+    const longLived = yield* Effect.context<WorkOSAuth | AutumnService | ApiKeyService>();
     return (httpEffect) =>
       Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest;
         const webRequest = yield* HttpServerRequest.toWeb(request);
-        const workos = yield* WorkOSAuth;
-        const session = yield* workos.authenticateRequest(webRequest);
-        if (!session || !session.organizationId) {
-          return yield* new HttpResponseError({
-            status: 403,
-            code: "no_organization",
-            message: "No organization in session",
-          });
-        }
-        const org = yield* authorizeOrganization(session.userId, session.organizationId);
-        if (!org) {
-          return yield* new HttpResponseError({
-            status: 403,
-            code: "no_organization",
-            message: "No organization in session",
-          });
-        }
+        const identity = yield* resolveProtectedIdentity(webRequest);
         const auth = AuthContext.of({
-          accountId: session.userId,
-          organizationId: org.id,
-          email: session.email,
-          name: `${session.firstName ?? ""} ${session.lastName ?? ""}`.trim() || null,
-          avatarUrl: session.avatarUrl ?? null,
+          accountId: identity.accountId,
+          organizationId: identity.organizationId,
+          email: identity.email,
+          name: identity.name,
+          avatarUrl: identity.avatarUrl,
         });
-        const { executor, engine } = yield* makeExecutionStack(auth.accountId, org.id, org.name);
+        const { executor, engine } = yield* makeExecutionStack(
+          auth.accountId,
+          identity.organizationId,
+          identity.organizationName,
+        );
         return yield* httpEffect.pipe(
           Effect.provideService(AuthContext, auth),
           Effect.provideService(ExecutorService, executor),
@@ -118,6 +206,7 @@ export const makeProtectedApiLive = (rsLive: Layer.Layer<DbService | UserStoreSe
   ).layer;
   return ProtectedCloudApiLive.pipe(
     Layer.provide(protectedMiddleware),
+    Layer.provideMerge(ApiKeyService.WorkOS),
     Layer.provideMerge(HttpApiSwagger.layer(ProtectedCloudApi, { path: "/docs" })),
     Layer.provideMerge(RouterConfig),
   );

--- a/apps/cloud/src/api/router.ts
+++ b/apps/cloud/src/api/router.ts
@@ -4,6 +4,7 @@ import { UserStoreService } from "../auth/context";
 import { DbService } from "../services/db";
 
 import { AutumnRoutesLive } from "./autumn";
+import { ApiErrorLoggingLive } from "./error-logging";
 import {
   BootSharedServices,
   RequestScopedServicesLive,
@@ -30,6 +31,7 @@ export const makeApiLive = (requestScopedLive: Layer.Layer<DbService | UserStore
     makeOrgApiLive(requestScopedLive),
     makeProtectedApiLive(requestScopedLive),
     AutumnRoutesLive,
+    ApiErrorLoggingLive,
   ).pipe(Layer.provideMerge(RouterConfig), Layer.provideMerge(BootSharedServices));
 
 export const ApiLive = makeApiLive(RequestScopedServicesLive);

--- a/apps/cloud/src/auth/api-key-errors.ts
+++ b/apps/cloud/src/auth/api-key-errors.ts
@@ -1,0 +1,7 @@
+import { Schema } from "effect";
+
+export class ApiKeyManagementError extends Schema.TaggedErrorClass<ApiKeyManagementError>()(
+  "ApiKeyManagementError",
+  { cause: Schema.Unknown },
+  { httpApiStatus: 500 },
+) {}

--- a/apps/cloud/src/auth/api-keys.node.test.ts
+++ b/apps/cloud/src/auth/api-keys.node.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+
+import { ApiKeyService } from "./api-keys";
+import { WorkOSAuth, type WorkOSAuthService } from "./workos";
+
+const stubWorkOS = (overrides: Partial<WorkOSAuthService>) =>
+  Layer.succeed(
+    WorkOSAuth,
+    new Proxy({} as WorkOSAuthService, {
+      get: (_target, prop) => {
+        if (prop in overrides) return overrides[prop as keyof WorkOSAuthService];
+        return () => Effect.die(`unexpected WorkOSAuth.${String(prop)} call`);
+      },
+    }),
+  );
+
+const validate = (response: unknown) =>
+  Effect.gen(function* () {
+    const apiKeys = yield* ApiKeyService;
+    return yield* apiKeys.validate("test_key");
+  }).pipe(
+    Effect.provide(
+      ApiKeyService.WorkOS.pipe(
+        Layer.provide(stubWorkOS({ validateApiKey: () => Effect.succeed(response) })),
+      ),
+    ),
+  );
+
+describe("ApiKeyService.WorkOS", () => {
+  it.effect("accepts user-owned keys with camel-case organization id", () =>
+    Effect.gen(function* () {
+      const principal = yield* validate({
+        apiKey: {
+          id: "api_key_123",
+          owner: {
+            type: "user",
+            id: "user_123",
+            organizationId: "org_123",
+          },
+        },
+      });
+
+      expect(principal).toEqual({
+        accountId: "user_123",
+        organizationId: "org_123",
+        keyId: "api_key_123",
+      });
+    }),
+  );
+
+  it.effect("accepts user-owned keys with snake-case organization id", () =>
+    Effect.gen(function* () {
+      const principal = yield* validate({
+        apiKey: {
+          id: "api_key_456",
+          owner: {
+            type: "user",
+            id: "user_456",
+            organization_id: "org_456",
+          },
+        },
+      });
+
+      expect(principal?.organizationId).toBe("org_456");
+    }),
+  );
+
+  it.effect("rejects missing, organization-owned, and org-less keys", () =>
+    Effect.gen(function* () {
+      const missing = yield* validate({ apiKey: null });
+      const orgOwned = yield* validate({
+        apiKey: {
+          id: "api_key_org",
+          owner: { type: "organization", id: "org_123" },
+        },
+      });
+      const orgLess = yield* validate({
+        apiKey: {
+          id: "api_key_no_org",
+          owner: { type: "user", id: "user_123" },
+        },
+      });
+
+      expect(missing).toBeNull();
+      expect(orgOwned).toBeNull();
+      expect(orgLess).toBeNull();
+    }),
+  );
+
+  it.effect("lists and creates user-owned keys", () =>
+    Effect.gen(function* () {
+      const program = Effect.gen(function* () {
+        const apiKeys = yield* ApiKeyService;
+        const listed = yield* apiKeys.listUserKeys({
+          accountId: "user_123",
+          organizationId: "org_123",
+        });
+        const created = yield* apiKeys.createUserKey({
+          accountId: "user_123",
+          organizationId: "org_123",
+          name: "Local CLI",
+        });
+        return { listed, created };
+      }).pipe(
+        Effect.provide(
+          ApiKeyService.WorkOS.pipe(
+            Layer.provide(
+              stubWorkOS({
+                listUserApiKeys: () =>
+                  Effect.succeed({
+                    data: [
+                      {
+                        id: "api_key_listed",
+                        name: "Listed",
+                        obfuscated_value: "sk_...1234",
+                        created_at: "2026-01-01T00:00:00.000Z",
+                        updated_at: "2026-01-01T00:00:00.000Z",
+                        last_used_at: null,
+                        owner: {
+                          type: "user",
+                          id: "user_123",
+                          organization_id: "org_123",
+                        },
+                      },
+                    ],
+                  }),
+                createUserApiKey: () =>
+                  Effect.succeed({
+                    id: "api_key_created",
+                    name: "Local CLI",
+                    value: "sk_created",
+                    obfuscated_value: "sk_...ated",
+                    created_at: "2026-01-01T00:00:00.000Z",
+                    updated_at: "2026-01-01T00:00:00.000Z",
+                    last_used_at: null,
+                    owner: {
+                      type: "user",
+                      id: "user_123",
+                      organization_id: "org_123",
+                    },
+                  }),
+              }),
+            ),
+          ),
+        ),
+      );
+
+      const result = yield* program;
+      expect(result.listed).toEqual([
+        {
+          id: "api_key_listed",
+          name: "Listed",
+          obfuscatedValue: "sk_...1234",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+          lastUsedAt: null,
+        },
+      ]);
+      expect(result.created.value).toBe("sk_created");
+    }),
+  );
+});

--- a/apps/cloud/src/auth/api-keys.ts
+++ b/apps/cloud/src/auth/api-keys.ts
@@ -1,0 +1,183 @@
+import { Context, Data, Effect, Layer, Option, Schema } from "effect";
+
+import { ApiKeyManagementError } from "./api-key-errors";
+import { WorkOSAuth } from "./workos";
+
+export type ApiKeyPrincipal = {
+  readonly accountId: string;
+  readonly organizationId: string;
+  readonly keyId: string;
+};
+
+export type ApiKeySummary = {
+  readonly id: string;
+  readonly name: string;
+  readonly obfuscatedValue: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly lastUsedAt: string | null;
+};
+
+export type CreatedApiKey = ApiKeySummary & {
+  readonly value: string;
+};
+
+export class ApiKeyValidationError extends Data.TaggedError("ApiKeyValidationError")<{
+  readonly cause: unknown;
+}> {}
+
+const UserApiKeyOwner = Schema.Struct({
+  type: Schema.Literal("user"),
+  id: Schema.String,
+  organizationId: Schema.optional(Schema.String),
+  organization_id: Schema.optional(Schema.String),
+});
+
+const ApiKey = Schema.Struct({
+  id: Schema.String,
+  owner: UserApiKeyOwner,
+  name: Schema.optional(Schema.String),
+  obfuscatedValue: Schema.optional(Schema.String),
+  obfuscated_value: Schema.optional(Schema.String),
+  createdAt: Schema.optional(Schema.String),
+  created_at: Schema.optional(Schema.String),
+  updatedAt: Schema.optional(Schema.String),
+  updated_at: Schema.optional(Schema.String),
+  lastUsedAt: Schema.optional(Schema.NullOr(Schema.String)),
+  last_used_at: Schema.optional(Schema.NullOr(Schema.String)),
+});
+
+const ValidateApiKeyResponse = Schema.Struct({
+  apiKey: Schema.NullOr(ApiKey),
+});
+
+const RawCreatedApiKey = Schema.Struct({
+  id: Schema.String,
+  owner: UserApiKeyOwner,
+  name: Schema.optional(Schema.String),
+  obfuscatedValue: Schema.optional(Schema.String),
+  obfuscated_value: Schema.optional(Schema.String),
+  createdAt: Schema.optional(Schema.String),
+  created_at: Schema.optional(Schema.String),
+  updatedAt: Schema.optional(Schema.String),
+  updated_at: Schema.optional(Schema.String),
+  lastUsedAt: Schema.optional(Schema.NullOr(Schema.String)),
+  last_used_at: Schema.optional(Schema.NullOr(Schema.String)),
+  value: Schema.String,
+});
+
+const ListApiKeysResponse = Schema.Struct({
+  data: Schema.Array(ApiKey),
+});
+
+const CreateApiKeyResponse = Schema.Union([
+  RawCreatedApiKey,
+  Schema.Struct({ apiKey: RawCreatedApiKey }),
+  Schema.Struct({ api_key: RawCreatedApiKey }),
+]);
+
+const decodeValidateApiKeyResponse = Schema.decodeUnknownOption(ValidateApiKeyResponse);
+const decodeListApiKeysResponse = Schema.decodeUnknownOption(ListApiKeysResponse);
+const decodeCreateApiKeyResponse = Schema.decodeUnknownOption(CreateApiKeyResponse);
+
+const principalFromResponse = (value: unknown): ApiKeyPrincipal | null =>
+  Option.match(decodeValidateApiKeyResponse(value), {
+    onNone: () => null,
+    onSome: ({ apiKey }) => {
+      if (!apiKey) return null;
+      const organizationId = apiKey.owner.organizationId ?? apiKey.owner.organization_id;
+      if (!organizationId) return null;
+      return {
+        accountId: apiKey.owner.id,
+        organizationId,
+        keyId: apiKey.id,
+      };
+    },
+  });
+
+const summaryFromApiKey = (apiKey: typeof ApiKey.Type): ApiKeySummary | null => {
+  const organizationId = apiKey.owner.organizationId ?? apiKey.owner.organization_id;
+  if (!organizationId) return null;
+  return {
+    id: apiKey.id,
+    name: apiKey.name ?? "API key",
+    obfuscatedValue: apiKey.obfuscatedValue ?? apiKey.obfuscated_value ?? "",
+    createdAt: apiKey.createdAt ?? apiKey.created_at ?? "",
+    updatedAt: apiKey.updatedAt ?? apiKey.updated_at ?? "",
+    lastUsedAt: apiKey.lastUsedAt ?? apiKey.last_used_at ?? null,
+  };
+};
+
+const listFromResponse = (value: unknown): readonly ApiKeySummary[] =>
+  Option.match(decodeListApiKeysResponse(value), {
+    onNone: () => [],
+    onSome: ({ data }) =>
+      data.flatMap((apiKey) => {
+        const summary = summaryFromApiKey(apiKey);
+        return summary ? [summary] : [];
+      }),
+  });
+
+const createdFromResponse = (value: unknown): CreatedApiKey | null =>
+  Option.match(decodeCreateApiKeyResponse(value), {
+    onNone: () => null,
+    onSome: (response) => {
+      const apiKey =
+        "value" in response ? response : "apiKey" in response ? response.apiKey : response.api_key;
+      const summary = summaryFromApiKey(apiKey);
+      return summary ? { ...summary, value: apiKey.value } : null;
+    },
+  });
+
+export class ApiKeyService extends Context.Service<
+  ApiKeyService,
+  {
+    readonly validate: (
+      value: string,
+    ) => Effect.Effect<ApiKeyPrincipal | null, ApiKeyValidationError>;
+    readonly listUserKeys: (input: {
+      readonly accountId: string;
+      readonly organizationId: string;
+    }) => Effect.Effect<readonly ApiKeySummary[], ApiKeyManagementError>;
+    readonly createUserKey: (input: {
+      readonly accountId: string;
+      readonly organizationId: string;
+      readonly name: string;
+    }) => Effect.Effect<CreatedApiKey, ApiKeyManagementError>;
+    readonly revokeUserKey: (input: {
+      readonly keyId: string;
+    }) => Effect.Effect<void, ApiKeyManagementError>;
+  }
+>()("@executor-js/cloud/ApiKeyService") {
+  static WorkOS = Layer.effect(this)(
+    Effect.gen(function* () {
+      const workos = yield* WorkOSAuth;
+      return {
+        validate: (value: string) =>
+          workos.validateApiKey(value).pipe(
+            Effect.map(principalFromResponse),
+            Effect.mapError((cause) => new ApiKeyValidationError({ cause })),
+          ),
+        listUserKeys: ({ accountId, organizationId }) =>
+          workos.listUserApiKeys(accountId, organizationId).pipe(
+            Effect.map(listFromResponse),
+            Effect.mapError((cause) => new ApiKeyManagementError({ cause })),
+          ),
+        createUserKey: ({ accountId, organizationId, name }) =>
+          workos.createUserApiKey({ userId: accountId, organizationId, name }).pipe(
+            Effect.mapError((cause) => new ApiKeyManagementError({ cause })),
+            Effect.flatMap((response) => {
+              const created = createdFromResponse(response);
+              return created
+                ? Effect.succeed(created)
+                : Effect.fail(new ApiKeyManagementError({ cause: "invalid_create_response" }));
+            }),
+          ),
+        revokeUserKey: ({ keyId }) =>
+          workos
+            .deleteApiKey(keyId)
+            .pipe(Effect.mapError((cause) => new ApiKeyManagementError({ cause }))),
+      };
+    }),
+  );
+}

--- a/apps/cloud/src/auth/api.ts
+++ b/apps/cloud/src/auth/api.ts
@@ -1,7 +1,8 @@
 import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
 import { Schema } from "effect";
+import { ApiKeyManagementError } from "./api-key-errors";
 import { UserStoreError, WorkOSError } from "./errors";
-import { SessionAuth } from "./middleware";
+import { NoOrganization, SessionAuth } from "./middleware";
 
 const AuthUser = Schema.Struct({
   id: Schema.String,
@@ -77,6 +78,35 @@ const AcceptInvitationResponse = Schema.Struct({
   name: Schema.String,
 });
 
+const ApiKeySummary = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  obfuscatedValue: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  lastUsedAt: Schema.NullOr(Schema.String),
+});
+
+const ApiKeysResponse = Schema.Struct({
+  apiKeys: Schema.Array(ApiKeySummary),
+});
+
+const CreateApiKeyBody = Schema.Struct({
+  name: Schema.String,
+});
+
+const CreatedApiKeyResponse = Schema.Struct({
+  id: Schema.String,
+  name: Schema.String,
+  obfuscatedValue: Schema.String,
+  createdAt: Schema.String,
+  updatedAt: Schema.String,
+  lastUsedAt: Schema.NullOr(Schema.String),
+  value: Schema.String,
+});
+
+const ApiKeyParams = { apiKeyId: Schema.String };
+
 export const AUTH_PATHS = {
   login: "/api/auth/login",
   logout: "/api/auth/logout",
@@ -85,6 +115,7 @@ export const AUTH_PATHS = {
 } as const;
 
 const AuthErrors = [UserStoreError, WorkOSError] as const;
+const ApiKeyErrors = [ApiKeyManagementError, NoOrganization, UserStoreError, WorkOSError] as const;
 
 /** Public auth endpoints — no authentication required */
 export class CloudAuthPublicApi extends HttpApiGroup.make("cloudAuthPublic")
@@ -135,6 +166,25 @@ export class CloudAuthApi extends HttpApiGroup.make("cloudAuth")
       payload: AcceptInvitationBody,
       success: AcceptInvitationResponse,
       error: AuthErrors,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("listApiKeys", "/auth/api-keys", {
+      success: ApiKeysResponse,
+      error: ApiKeyErrors,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.post("createApiKey", "/auth/api-keys", {
+      payload: CreateApiKeyBody,
+      success: CreatedApiKeyResponse,
+      error: ApiKeyErrors,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.delete("revokeApiKey", "/auth/api-keys/:apiKeyId", {
+      params: ApiKeyParams,
+      error: ApiKeyErrors,
     }),
   )
   .middleware(SessionAuth) {}

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -4,12 +4,14 @@ import { Duration, Effect } from "effect";
 import { setCookie, deleteCookie } from "@tanstack/react-start/server";
 
 import { AUTH_PATHS, CloudAuthApi, CloudAuthPublicApi } from "./api";
-import { SessionContext } from "./middleware";
+import { NoOrganization, SessionContext } from "./middleware";
 import { UserStoreService } from "./context";
 import { authorizeOrganization } from "./authorize-organization";
 import { env } from "cloudflare:workers";
+import { ApiKeyManagementError } from "./api-key-errors";
 import { WorkOSError } from "./errors";
 import { WorkOSAuth } from "./workos";
+import { ApiKeyService } from "./api-keys";
 
 const COOKIE_OPTIONS = {
   path: "/",
@@ -48,6 +50,7 @@ const DELETE_COOKIE_OPTIONS = {
 };
 
 const MAX_ORGANIZATIONS_PER_USER = 3;
+const MAX_API_KEY_NAME_LENGTH = 80;
 
 const randomState = (): string => {
   const bytes = new Uint8Array(32);
@@ -63,6 +66,16 @@ const timingSafeEqual = (a: string, b: string): boolean => {
   }
   return diff === 0;
 };
+
+const requireSessionOrganization = Effect.gen(function* () {
+  const session = yield* SessionContext;
+  if (!session.organizationId) {
+    return yield* new NoOrganization();
+  }
+  const org = yield* authorizeOrganization(session.accountId, session.organizationId);
+  if (!org) return yield* new NoOrganization();
+  return { session, org };
+});
 
 const setResponseCookie = (
   response: HttpServerResponse.HttpServerResponse,
@@ -375,6 +388,47 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
 
           setCookie("wos-session", refreshed, COOKIE_OPTIONS);
           return { id: org.id, name: org.name };
+        }),
+      )
+      .handle("listApiKeys", () =>
+        Effect.gen(function* () {
+          const { session, org } = yield* requireSessionOrganization;
+          const apiKeys = yield* ApiKeyService;
+          const keys = yield* apiKeys.listUserKeys({
+            accountId: session.accountId,
+            organizationId: org.id,
+          });
+          return { apiKeys: keys };
+        }),
+      )
+      .handle("createApiKey", ({ payload }) =>
+        Effect.gen(function* () {
+          const { session, org } = yield* requireSessionOrganization;
+          const name = payload.name.trim().slice(0, MAX_API_KEY_NAME_LENGTH);
+          if (!name) {
+            return yield* new ApiKeyManagementError({ cause: "missing_name" });
+          }
+
+          const apiKeys = yield* ApiKeyService;
+          return yield* apiKeys.createUserKey({
+            accountId: session.accountId,
+            organizationId: org.id,
+            name,
+          });
+        }),
+      )
+      .handle("revokeApiKey", ({ params }) =>
+        Effect.gen(function* () {
+          const { session, org } = yield* requireSessionOrganization;
+          const apiKeys = yield* ApiKeyService;
+          const ownedKeys = yield* apiKeys.listUserKeys({
+            accountId: session.accountId,
+            organizationId: org.id,
+          });
+          if (!ownedKeys.some((key) => key.id === params.apiKeyId)) {
+            return yield* new ApiKeyManagementError({ cause: "api_key_not_found" });
+          }
+          yield* apiKeys.revokeUserKey({ keyId: params.apiKeyId });
         }),
       ),
 );

--- a/apps/cloud/src/auth/workos.ts
+++ b/apps/cloud/src/auth/workos.ts
@@ -10,6 +10,20 @@ import { WorkOSError, tryPromiseService, withServiceLogging } from "./errors";
 const COOKIE_NAME = "wos-session";
 const INVALID_COOKIE_PASSWORD_MESSAGE = "WORKOS_COOKIE_PASSWORD must be at least 32 characters";
 
+type RawWorkOS = WorkOS & {
+  readonly get: (
+    path: string,
+    options?: { readonly query?: Record<string, unknown> },
+  ) => Promise<{
+    readonly data: unknown;
+  }>;
+  readonly post: (
+    path: string,
+    entity: unknown,
+    options?: { readonly idempotencyKey?: string },
+  ) => Promise<{ readonly data: unknown }>;
+};
+
 class WorkOSAuthConfigurationError extends Data.TaggedError("WorkOSAuthConfigurationError")<{
   readonly message: string;
 }> {}
@@ -156,6 +170,36 @@ const make = Effect.gen(function* () {
         if (!sessionData) return null;
         return yield* authenticateSealedSession(sessionData);
       }),
+
+    /**
+     * Validate an AuthKit API key. The SDK version installed here exposes
+     * organization-owned key types, while WorkOS's API also returns user-owned
+     * keys. Keep this boundary unknown and decode the precise app shape in
+     * auth/api-keys.ts.
+     */
+    validateApiKey: (value: string) =>
+      use((wos) => wos.apiKeys.validateApiKey({ value }) as Promise<unknown>),
+
+    listUserApiKeys: (userId: string, organizationId: string) =>
+      use(async (wos) => {
+        const raw = wos as RawWorkOS;
+        const response = await raw.get(`/user_management/users/${userId}/api_keys`, {
+          query: { organization_id: organizationId },
+        });
+        return response.data;
+      }),
+
+    createUserApiKey: (params: { userId: string; organizationId: string; name: string }) =>
+      use(async (wos) => {
+        const raw = wos as RawWorkOS;
+        const response = await raw.post(`/user_management/users/${params.userId}/api_keys`, {
+          name: params.name,
+          organization_id: params.organizationId,
+        });
+        return response.data;
+      }),
+
+    deleteApiKey: (id: string) => use((wos) => wos.apiKeys.deleteApiKey(id)),
 
     /** List organization memberships with user details. */
     listOrgMembers: (organizationId: string) =>

--- a/apps/cloud/src/mcp.ts
+++ b/apps/cloud/src/mcp.ts
@@ -26,6 +26,7 @@ import {
   verifyWorkOSMcpAccessToken,
   type VerifiedToken,
 } from "./mcp-auth";
+import { ApiKeyService } from "./auth/api-keys";
 import { authorizeOrganization } from "./auth/authorize-organization";
 import { UserStoreService } from "./auth/context";
 import { CoreSharedServices } from "./api/core-shared-services";
@@ -148,41 +149,89 @@ export const McpOrganizationAuthLive = Layer.succeed(McpOrganizationAuth)({
     ),
 });
 
-export const McpAuthLive = Layer.succeed(McpAuth)({
-  verifyBearer: Effect.fn("mcp.auth.verify_bearer")(function* (request) {
-    const authHeader = request.headers.get("authorization");
-    if (!authHeader?.startsWith(BEARER_PREFIX)) {
-      yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_bearer" });
-      return mcpUnauthorized("missing_bearer");
-    }
-    const verified = yield* verifyJwt(authHeader.slice(BEARER_PREFIX.length)).pipe(
-      Effect.catchTag("McpJwtVerificationError", (error) => {
-        if (error.reason === "system") return Effect.fail(error);
-        return Effect.gen(function* () {
-          yield* Effect.annotateCurrentSpan({
-            "mcp.auth.outcome": "invalid",
-            "mcp.auth.invalid_reason": error.reason,
-          });
-          return mcpUnauthorized(
-            "invalid_token",
-            error.reason === "expired" ? "The access token expired" : "The access token is invalid",
-          );
+const looksLikeJwt = (token: string): boolean => token.split(".").length === 3;
+
+export const McpAuthLive = Layer.effect(
+  McpAuth,
+  Effect.gen(function* () {
+    const apiKeys = yield* ApiKeyService;
+
+    const verifyApiKey = Effect.fn("mcp.auth.verify_api_key")(function* (token: string) {
+      const principal = yield* apiKeys.validate(token).pipe(
+        Effect.catchTag("ApiKeyValidationError", (error) =>
+          Effect.fail(
+            new McpJwtVerificationError({
+              cause: error.cause,
+              reason: "system",
+            }),
+          ),
+        ),
+      );
+      if (!principal) {
+        yield* Effect.annotateCurrentSpan({
+          "mcp.auth.outcome": "invalid",
+          "mcp.auth.invalid_reason": "api_key",
         });
-      }),
-    );
-    if (!verified) return mcpUnauthorized("invalid_token", "The access token is invalid");
-    if (Predicate.isTagged(verified, "Unauthorized")) return verified;
-    if (!verified.accountId) {
-      yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
-      return mcpUnauthorized("invalid_token", "The access token is invalid");
-    }
-    yield* Effect.annotateCurrentSpan({
-      "mcp.auth.outcome": "verified",
-      "mcp.auth.has_organization": !!verified.organizationId,
+        return mcpUnauthorized("invalid_token", "The API key is invalid");
+      }
+
+      yield* Effect.annotateCurrentSpan({
+        "mcp.auth.outcome": "verified",
+        "mcp.auth.credential_type": "api_key",
+        "mcp.auth.has_organization": true,
+      });
+      return mcpAuthorized({
+        accountId: principal.accountId,
+        organizationId: principal.organizationId,
+      });
     });
-    return mcpAuthorized(verified);
+
+    const verifyJwtBearer = Effect.fn("mcp.auth.verify_jwt_bearer")(function* (token: string) {
+      const verified = yield* verifyJwt(token).pipe(
+        Effect.catchTag("McpJwtVerificationError", (error) => {
+          if (error.reason === "system") return Effect.fail(error);
+          return Effect.gen(function* () {
+            yield* Effect.annotateCurrentSpan({
+              "mcp.auth.outcome": "invalid",
+              "mcp.auth.invalid_reason": error.reason,
+            });
+            return mcpUnauthorized(
+              "invalid_token",
+              error.reason === "expired"
+                ? "The access token expired"
+                : "The access token is invalid",
+            );
+          });
+        }),
+      );
+      if (!verified) return mcpUnauthorized("invalid_token", "The access token is invalid");
+      if (Predicate.isTagged(verified, "Unauthorized")) return verified;
+      if (!verified.accountId) {
+        yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_subject" });
+        return mcpUnauthorized("invalid_token", "The access token is invalid");
+      }
+      yield* Effect.annotateCurrentSpan({
+        "mcp.auth.outcome": "verified",
+        "mcp.auth.credential_type": "jwt",
+        "mcp.auth.has_organization": !!verified.organizationId,
+      });
+      return mcpAuthorized(verified);
+    });
+
+    return {
+      verifyBearer: Effect.fn("mcp.auth.verify_bearer")(function* (request) {
+        const authHeader = request.headers.get("authorization");
+        if (!authHeader?.startsWith(BEARER_PREFIX)) {
+          yield* Effect.annotateCurrentSpan({ "mcp.auth.outcome": "missing_bearer" });
+          return mcpUnauthorized("missing_bearer");
+        }
+        const token = authHeader.slice(BEARER_PREFIX.length).trim();
+        if (!token) return mcpUnauthorized("invalid_token", "The bearer token is invalid");
+        return yield* looksLikeJwt(token) ? verifyJwtBearer(token) : verifyApiKey(token);
+      }),
+    };
   }),
-});
+);
 
 // ---------------------------------------------------------------------------
 // Client fingerprint capture
@@ -708,7 +757,17 @@ export const mcpApp: Effect.Effect<
 );
 
 const rawMcpFetch = HttpEffect.toWebHandler(
-  mcpApp.pipe(Effect.provide(Layer.mergeAll(McpAuthLive, McpOrganizationAuthLive, TelemetryLive))),
+  mcpApp.pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        McpAuthLive.pipe(
+          Layer.provide(ApiKeyService.WorkOS.pipe(Layer.provide(CoreSharedServices))),
+        ),
+        McpOrganizationAuthLive,
+        TelemetryLive,
+      ),
+    ),
+  ),
 );
 
 /**

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as PoliciesRouteImport } from './routes/policies'
 import { Route as OrgRouteImport } from './routes/org'
 import { Route as ConnectionsRouteImport } from './routes/connections'
 import { Route as BillingRouteImport } from './routes/billing'
+import { Route as ApiKeysRouteImport } from './routes/api-keys'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SourcesNamespaceRouteImport } from './routes/sources.$namespace'
 import { Route as BillingPlansRouteImport } from './routes/billing_.plans'
@@ -50,6 +51,11 @@ const BillingRoute = BillingRouteImport.update({
   path: '/billing',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiKeysRoute = ApiKeysRouteImport.update({
+  id: '/api-keys',
+  path: '/api-keys',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -73,6 +79,7 @@ const SourcesAddPluginKeyRoute = SourcesAddPluginKeyRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
   '/connections': typeof ConnectionsRoute
   '/org': typeof OrgRoute
@@ -85,6 +92,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
   '/connections': typeof ConnectionsRoute
   '/org': typeof OrgRoute
@@ -98,6 +106,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
   '/connections': typeof ConnectionsRoute
   '/org': typeof OrgRoute
@@ -112,6 +121,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/api-keys'
     | '/billing'
     | '/connections'
     | '/org'
@@ -124,6 +134,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/api-keys'
     | '/billing'
     | '/connections'
     | '/org'
@@ -136,6 +147,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/api-keys'
     | '/billing'
     | '/connections'
     | '/org'
@@ -149,6 +161,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ApiKeysRoute: typeof ApiKeysRoute
   BillingRoute: typeof BillingRoute
   ConnectionsRoute: typeof ConnectionsRoute
   OrgRoute: typeof OrgRoute
@@ -204,6 +217,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BillingRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api-keys': {
+      id: '/api-keys'
+      path: '/api-keys'
+      fullPath: '/api-keys'
+      preLoaderRoute: typeof ApiKeysRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -237,6 +257,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ApiKeysRoute: ApiKeysRoute,
   BillingRoute: BillingRoute,
   ConnectionsRoute: ConnectionsRoute,
   OrgRoute: OrgRoute,

--- a/apps/cloud/src/routes/api-keys.tsx
+++ b/apps/cloud/src/routes/api-keys.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import { Exit } from "effect";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { createFileRoute } from "@tanstack/react-router";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { toast } from "sonner";
+import { apiKeyWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import { Button } from "@executor-js/react/components/button";
+import { CopyButton } from "@executor-js/react/components/copy-button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@executor-js/react/components/dialog";
+import { Input } from "@executor-js/react/components/input";
+import { Label } from "@executor-js/react/components/label";
+import { apiKeysAtom, createApiKey, revokeApiKey } from "../web/api-key-atoms";
+
+export const Route = createFileRoute("/api-keys")({
+  component: ApiKeysPage,
+});
+
+type ApiKeySummary = {
+  readonly id: string;
+  readonly name: string;
+  readonly obfuscatedValue: string;
+  readonly createdAt: string;
+  readonly lastUsedAt: string | null;
+};
+
+type CreatedKey = ApiKeySummary & {
+  readonly value: string;
+};
+
+const formatDate = (value: string | null): string => {
+  if (!value) return "Never";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? value
+    : new Intl.DateTimeFormat(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      }).format(date);
+};
+
+const defaultApiKeyName = (): string =>
+  `API key ${new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date())}`;
+
+function ApiKeysPage() {
+  const result = useAtomValue(apiKeysAtom);
+  const doCreate = useAtomSet(createApiKey, { mode: "promiseExit" });
+  const doRevoke = useAtomSet(revokeApiKey, { mode: "promiseExit" });
+  const [createOpen, setCreateOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [createdKey, setCreatedKey] = useState<CreatedKey | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setCreating(true);
+    const exit = await doCreate({
+      payload: { name: trimmed },
+      reactivityKeys: apiKeyWriteKeys,
+    });
+    setCreating(false);
+    if (Exit.isSuccess(exit)) {
+      setCreatedKey(exit.value);
+      setName("");
+      toast.success("API key created");
+      return;
+    }
+    toast.error("Failed to create API key");
+  };
+
+  const handleRevoke = async (key: ApiKeySummary) => {
+    setRevokingId(key.id);
+    const exit = await doRevoke({
+      params: { apiKeyId: key.id },
+      reactivityKeys: apiKeyWriteKeys,
+    });
+    setRevokingId(null);
+    if (Exit.isSuccess(exit)) {
+      toast.success(`Revoked ${key.name}`);
+      return;
+    }
+    toast.error("Failed to revoke API key");
+  };
+
+  const closeCreate = (open: boolean) => {
+    setCreateOpen(open);
+    if (!open) {
+      setName("");
+      setCreatedKey(null);
+      setCreating(false);
+    }
+  };
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto flex max-w-4xl flex-col gap-8 px-6 py-10 lg:px-8 lg:py-14">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0">
+            <h1 className="font-display text-3xl tracking-tight text-foreground">API keys</h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+              User keys for accessing the Executor API and MCP endpoint from scripts and tools.
+            </p>
+            <div className="mt-4 flex max-w-2xl items-center gap-2 rounded-md border border-border bg-card px-3 py-2">
+              <code className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
+                Authorization: Bearer &lt;api-key&gt;
+              </code>
+              <CopyButton value="Authorization: Bearer <api-key>" />
+            </div>
+            <p className="mt-2 max-w-2xl text-xs leading-5 text-muted-foreground">
+              API keys work as PATs and have full access to your account.
+            </p>
+          </div>
+          <Button
+            onClick={() => {
+              setName(defaultApiKeyName());
+              setCreateOpen(true);
+            }}
+            className="shrink-0"
+          >
+            <span aria-hidden="true">+</span>
+            New key
+          </Button>
+        </div>
+
+        {AsyncResult.match(result, {
+          onInitial: () => (
+            <div className="rounded-md border border-border bg-card p-6 text-sm text-muted-foreground">
+              Loading API keys...
+            </div>
+          ),
+          onFailure: () => (
+            <div className="rounded-md border border-border bg-card p-6 text-sm text-destructive">
+              Failed to load API keys
+            </div>
+          ),
+          onSuccess: ({ value }) =>
+            value.apiKeys.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border bg-card p-8">
+                <h2 className="text-base font-semibold text-foreground">No API keys</h2>
+                <p className="mt-2 max-w-xl text-sm leading-6 text-muted-foreground">
+                  Create a key and send it in the Authorization Bearer header.
+                </p>
+              </div>
+            ) : (
+              <div className="overflow-hidden rounded-md border border-border bg-card">
+                <div className="grid grid-cols-[1fr_auto] gap-4 border-b border-border px-4 py-3 text-xs font-medium uppercase tracking-wider text-muted-foreground md:grid-cols-[1.4fr_1fr_1fr_auto]">
+                  <span>Name</span>
+                  <span className="hidden md:block">Created</span>
+                  <span className="hidden md:block">Last used</span>
+                  <span className="text-right">Actions</span>
+                </div>
+                {value.apiKeys.map((key: ApiKeySummary) => (
+                  <div
+                    key={key.id}
+                    className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-border px-4 py-4 last:border-b-0 md:grid-cols-[1.4fr_1fr_1fr_auto]"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-foreground">{key.name}</p>
+                      <p className="mt-1 font-mono text-xs text-muted-foreground">
+                        {key.obfuscatedValue}
+                      </p>
+                    </div>
+                    <p className="hidden text-sm text-muted-foreground md:block">
+                      {formatDate(key.createdAt)}
+                    </p>
+                    <p className="hidden text-sm text-muted-foreground md:block">
+                      {formatDate(key.lastUsedAt)}
+                    </p>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => handleRevoke(key)}
+                      disabled={revokingId === key.id}
+                      title={`Revoke ${key.name}`}
+                      className="text-muted-foreground hover:text-destructive"
+                    >
+                      <span aria-hidden="true">×</span>
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            ),
+        })}
+      </div>
+
+      <Dialog open={createOpen} onOpenChange={closeCreate}>
+        <DialogContent className="sm:max-w-[480px]">
+          <DialogHeader>
+            <DialogTitle className="font-display text-xl">Create API key</DialogTitle>
+            <DialogDescription className="text-sm leading-relaxed">
+              The key will act as your user in the current organization.
+            </DialogDescription>
+          </DialogHeader>
+
+          {createdKey ? (
+            <div className="grid gap-4 py-3">
+              <div className="grid gap-1.5">
+                <Label className="text-sm font-medium text-foreground">New key</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={createdKey.value}
+                    readOnly
+                    className="font-mono text-xs"
+                    data-ph-mask
+                  />
+                  <CopyButton value={createdKey.value} />
+                </div>
+              </div>
+              <div className="grid gap-1.5">
+                <Label className="text-sm font-medium text-foreground">Bearer header</Label>
+                <div className="flex items-center gap-2">
+                  <Input
+                    value={`Authorization: Bearer ${createdKey.value}`}
+                    readOnly
+                    className="font-mono text-xs"
+                    data-ph-mask
+                  />
+                  <CopyButton value={`Authorization: Bearer ${createdKey.value}`} />
+                </div>
+              </div>
+              <p className="text-sm leading-6 text-muted-foreground">
+                Send this value as a Bearer token. It is only shown once.
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 py-3">
+              <div className="grid gap-1.5">
+                <Label htmlFor="api-key-name" className="text-sm font-medium text-foreground">
+                  Name
+                </Label>
+                <Input
+                  id="api-key-name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="Local CLI"
+                  maxLength={80}
+                  autoFocus
+                />
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost">Close</Button>
+            </DialogClose>
+            {!createdKey && (
+              <Button onClick={handleCreate} disabled={creating || !name.trim()}>
+                {creating ? "Creating..." : "Create key"}
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/cloud/src/test-worker.ts
+++ b/apps/cloud/src/test-worker.ts
@@ -28,10 +28,12 @@ import {
   mcpApp,
   mcpUnauthorized,
 } from "./mcp";
+import { ApiKeyService } from "./auth/api-keys";
 import { McpJwtVerificationError } from "./mcp-auth";
 import { organizations } from "./services/schema";
 import { parseTestBearer } from "./test-bearer";
 import { DoTelemetryLive } from "./services/telemetry";
+import { CoreSharedServices } from "./api/core-shared-services";
 
 export { McpSessionDO } from "./mcp-session";
 
@@ -115,7 +117,15 @@ const testMcpFetch = HttpEffect.toWebHandler(
 
 const realAuthMcpFetch = HttpEffect.toWebHandler(
   mcpApp.pipe(
-    Effect.provide(Layer.mergeAll(McpAuthLive, McpOrganizationAuthLive, DoTelemetryLive)),
+    Effect.provide(
+      Layer.mergeAll(
+        McpAuthLive.pipe(
+          Layer.provide(ApiKeyService.WorkOS.pipe(Layer.provide(CoreSharedServices))),
+        ),
+        McpOrganizationAuthLive,
+        DoTelemetryLive,
+      ),
+    ),
   ),
 );
 

--- a/apps/cloud/src/web/api-key-atoms.ts
+++ b/apps/cloud/src/web/api-key-atoms.ts
@@ -1,0 +1,9 @@
+import { ReactivityKey } from "@executor-js/react/api/reactivity-keys";
+import { CloudApiClient } from "./client";
+
+export const apiKeysAtom = CloudApiClient.query("cloudAuth", "listApiKeys", {
+  reactivityKeys: [ReactivityKey.apiKeys],
+});
+
+export const createApiKey = CloudApiClient.mutation("cloudAuth", "createApiKey");
+export const revokeApiKey = CloudApiClient.mutation("cloudAuth", "revokeApiKey");

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -301,6 +301,10 @@ function UserFooter() {
               </DropdownMenuSubContent>
             </DropdownMenuSub>
             <DropdownMenuSeparator />
+            <DropdownMenuItem asChild className="text-xs">
+              <Link to="/api-keys">API keys</Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
             <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
               Signed in as
             </DropdownMenuLabel>

--- a/packages/core/sdk/src/credential-bindings.test.ts
+++ b/packages/core/sdk/src/credential-bindings.test.ts
@@ -767,6 +767,7 @@ describe("credential bindings", () => {
           adapter,
           blobs,
           plugins,
+          onElicitation: "accept-all",
         });
         yield* orgExecutor.credentialTest.registerSource(scopes.org.id);
 
@@ -775,6 +776,7 @@ describe("credential bindings", () => {
           adapter,
           blobs,
           plugins,
+          onElicitation: "accept-all",
         });
 
         const binding = yield* userExecutor.credentialBindings.set({

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -2134,18 +2134,19 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
         }
 
         if (input.value.kind === "secret") {
+          const secretId = input.value.secretId;
           const secretScope = input.value.secretScopeId ?? input.targetScope;
           yield* assertScopeInStack("credential binding secretScope", secretScope);
           if (scopePrecedence.get(secretScope)! < scopePrecedence.get(input.targetScope)!) {
             return yield* new StorageError({
               message:
-                `Cannot bind secret "${input.value.secretId}" from scope "${secretScope}" ` +
+                `Cannot bind secret "${secretId}" from scope "${secretScope}" ` +
                 `to target scope "${input.targetScope}": shared bindings cannot reference inner-scope secrets.`,
               cause: undefined,
             });
           }
           const secret = yield* findSecretRowAtScope({
-            secretId: input.value.secretId,
+            secretId,
             scopeId: secretScope,
           });
           if (!secret) {
@@ -2162,7 +2163,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
                 const entries = yield* provider
                   .list()
                   .pipe(Effect.catch(() => Effect.succeed([] as const)));
-                const found = entries.find((e) => e.id === input.value.secretId);
+                const found = entries.find((e) => e.id === secretId);
                 if (found) name = found.name;
               }
               if (name === undefined) {
@@ -2170,16 +2171,16 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
                 // or no list() at all). Probe with get() — cheap for most
                 // backends — and use the id as the display name.
                 const value = yield* provider
-                  .get(input.value.secretId, secretScope)
+                  .get(secretId, secretScope)
                   .pipe(Effect.catch(() => Effect.succeed(null as string | null)));
-                if (value !== null) name = input.value.secretId;
+                if (value !== null) name = secretId;
               }
               if (name === undefined) continue;
               const now = new Date();
               yield* core.create({
                 model: "secret",
                 data: {
-                  id: input.value.secretId,
+                  id: secretId,
                   scope_id: secretScope,
                   name,
                   provider: key,
@@ -2194,7 +2195,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
               const providerKeys = [...secretProviders.keys()];
               return yield* new StorageError({
                 message:
-                  `Cannot bind secret "${input.value.secretId}" at scope "${secretScope}": ` +
+                  `Cannot bind secret "${secretId}" at scope "${secretScope}": ` +
                   `no registered secret provider has an item with this id ` +
                   `(checked: ${providerKeys.join(", ") || "none"}). ` +
                   `If this id points to a 1Password item, the item may have been deleted, ` +

--- a/packages/react/src/api/reactivity-keys.tsx
+++ b/packages/react/src/api/reactivity-keys.tsx
@@ -28,6 +28,7 @@ export const ReactivityKey = {
   orgMembers: "org:members",
   orgDomains: "org:domains",
   orgInfo: "org:info",
+  apiKeys: "api-keys",
   auth: "auth",
 } as const;
 
@@ -59,6 +60,9 @@ export const orgDomainWriteKeys = [ReactivityKey.orgDomains] as const;
 
 /** Cloud-only: org info mutations (name, etc.) — also touches scope/auth. */
 export const orgInfoWriteKeys = [ReactivityKey.orgInfo, ReactivityKey.auth] as const;
+
+/** Cloud-only: user API key mutations. */
+export const apiKeyWriteKeys = [ReactivityKey.apiKeys] as const;
 
 /** Cloud-only: auth mutations (org switch/create) — invalidate everything user-visible. */
 export const authWriteKeys = [


### PR DESCRIPTION
## Summary

- Adds a WorkOS-backed API key service for user-owned personal access tokens.
- Allows protected API routes and the MCP endpoint to authenticate `Authorization: Bearer <api key>`.
- Adds session-authenticated create/list/revoke API key endpoints plus an `/api-keys` page.
- Adds sanitized API error logging so typed failures surface in server logs.

## Validation

- `node ../../node_modules/vitest/vitest.mjs run src/auth/api-keys.node.test.ts src/api/protected-api-key-auth.node.test.ts --config vitest.node.config.ts`
- `node ../../node_modules/vitest/vitest.mjs run src/mcp-flow.test.ts --config vitest.config.ts --reporter verbose`
- `bun run --cwd apps/cloud typecheck`
