### PR TITLE
Split cloud onboarding into create-org and setup-mcp routes

### DIFF
--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -10,9 +10,11 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as ToolsRouteImport } from './routes/tools'
+import { Route as SetupMcpRouteImport } from './routes/setup-mcp'
 import { Route as SecretsRouteImport } from './routes/secrets'
 import { Route as PoliciesRouteImport } from './routes/policies'
 import { Route as OrgRouteImport } from './routes/org'
+import { Route as CreateOrgRouteImport } from './routes/create-org'
 import { Route as ConnectionsRouteImport } from './routes/connections'
 import { Route as BillingRouteImport } from './routes/billing'
 import { Route as ApiKeysRouteImport } from './routes/api-keys'
@@ -24,6 +26,11 @@ import { Route as SourcesAddPluginKeyRouteImport } from './routes/sources.add.$p
 const ToolsRoute = ToolsRouteImport.update({
   id: '/tools',
   path: '/tools',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SetupMcpRoute = SetupMcpRouteImport.update({
+  id: '/setup-mcp',
+  path: '/setup-mcp',
   getParentRoute: () => rootRouteImport,
 } as any)
 const SecretsRoute = SecretsRouteImport.update({
@@ -39,6 +46,11 @@ const PoliciesRoute = PoliciesRouteImport.update({
 const OrgRoute = OrgRouteImport.update({
   id: '/org',
   path: '/org',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CreateOrgRoute = CreateOrgRouteImport.update({
+  id: '/create-org',
+  path: '/create-org',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ConnectionsRoute = ConnectionsRouteImport.update({
@@ -82,9 +94,11 @@ export interface FileRoutesByFullPath {
   '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
   '/connections': typeof ConnectionsRoute
+  '/create-org': typeof CreateOrgRoute
   '/org': typeof OrgRoute
   '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
+  '/setup-mcp': typeof SetupMcpRoute
   '/tools': typeof ToolsRoute
   '/billing/plans': typeof BillingPlansRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -95,9 +109,11 @@ export interface FileRoutesByTo {
   '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
   '/connections': typeof ConnectionsRoute
+  '/create-org': typeof CreateOrgRoute
   '/org': typeof OrgRoute
   '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
+  '/setup-mcp': typeof SetupMcpRoute
   '/tools': typeof ToolsRoute
   '/billing/plans': typeof BillingPlansRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -109,9 +125,11 @@ export interface FileRoutesById {
   '/api-keys': typeof ApiKeysRoute
   '/billing': typeof BillingRoute
   '/connections': typeof ConnectionsRoute
+  '/create-org': typeof CreateOrgRoute
   '/org': typeof OrgRoute
   '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
+  '/setup-mcp': typeof SetupMcpRoute
   '/tools': typeof ToolsRoute
   '/billing_/plans': typeof BillingPlansRoute
   '/sources/$namespace': typeof SourcesNamespaceRoute
@@ -124,9 +142,11 @@ export interface FileRouteTypes {
     | '/api-keys'
     | '/billing'
     | '/connections'
+    | '/create-org'
     | '/org'
     | '/policies'
     | '/secrets'
+    | '/setup-mcp'
     | '/tools'
     | '/billing/plans'
     | '/sources/$namespace'
@@ -137,9 +157,11 @@ export interface FileRouteTypes {
     | '/api-keys'
     | '/billing'
     | '/connections'
+    | '/create-org'
     | '/org'
     | '/policies'
     | '/secrets'
+    | '/setup-mcp'
     | '/tools'
     | '/billing/plans'
     | '/sources/$namespace'
@@ -150,9 +172,11 @@ export interface FileRouteTypes {
     | '/api-keys'
     | '/billing'
     | '/connections'
+    | '/create-org'
     | '/org'
     | '/policies'
     | '/secrets'
+    | '/setup-mcp'
     | '/tools'
     | '/billing_/plans'
     | '/sources/$namespace'
@@ -164,9 +188,11 @@ export interface RootRouteChildren {
   ApiKeysRoute: typeof ApiKeysRoute
   BillingRoute: typeof BillingRoute
   ConnectionsRoute: typeof ConnectionsRoute
+  CreateOrgRoute: typeof CreateOrgRoute
   OrgRoute: typeof OrgRoute
   PoliciesRoute: typeof PoliciesRoute
   SecretsRoute: typeof SecretsRoute
+  SetupMcpRoute: typeof SetupMcpRoute
   ToolsRoute: typeof ToolsRoute
   BillingPlansRoute: typeof BillingPlansRoute
   SourcesNamespaceRoute: typeof SourcesNamespaceRoute
@@ -180,6 +206,13 @@ declare module '@tanstack/react-router' {
       path: '/tools'
       fullPath: '/tools'
       preLoaderRoute: typeof ToolsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/setup-mcp': {
+      id: '/setup-mcp'
+      path: '/setup-mcp'
+      fullPath: '/setup-mcp'
+      preLoaderRoute: typeof SetupMcpRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/secrets': {
@@ -201,6 +234,13 @@ declare module '@tanstack/react-router' {
       path: '/org'
       fullPath: '/org'
       preLoaderRoute: typeof OrgRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/create-org': {
+      id: '/create-org'
+      path: '/create-org'
+      fullPath: '/create-org'
+      preLoaderRoute: typeof CreateOrgRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/connections': {
@@ -260,9 +300,11 @@ const rootRouteChildren: RootRouteChildren = {
   ApiKeysRoute: ApiKeysRoute,
   BillingRoute: BillingRoute,
   ConnectionsRoute: ConnectionsRoute,
+  CreateOrgRoute: CreateOrgRoute,
   OrgRoute: OrgRoute,
   PoliciesRoute: PoliciesRoute,
   SecretsRoute: SecretsRoute,
+  SetupMcpRoute: SetupMcpRoute,
   ToolsRoute: ToolsRoute,
   BillingPlansRoute: BillingPlansRoute,
   SourcesNamespaceRoute: SourcesNamespaceRoute,

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import * as Sentry from "@sentry/react";
-import { HeadContent, Scripts, createRootRoute } from "@tanstack/react-router";
+import {
+  HeadContent,
+  Outlet,
+  Scripts,
+  createRootRoute,
+  useLocation,
+  useNavigate,
+} from "@tanstack/react-router";
 import { AutumnProvider } from "autumn-js/react";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
@@ -13,9 +20,10 @@ import { plugins as clientPlugins } from "virtual:executor/plugins-client";
 import { AuthProvider, useAuth } from "../web/auth";
 import { SupportOptions } from "../web/components/support-options";
 import { LoginPage } from "../web/pages/login";
-import { OnboardingPage } from "../web/pages/onboarding";
 import { Shell } from "../web/shell";
 import appCss from "@executor-js/react/globals.css?url";
+
+const ONBOARDING_PATHS = new Set(["/create-org", "/setup-mcp"]);
 
 if (typeof window !== "undefined" && import.meta.env.VITE_PUBLIC_SENTRY_DSN) {
   Sentry.init({
@@ -198,6 +206,18 @@ function ShellErrorFallback() {
 
 function AuthGate() {
   const auth = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isOnboardingRoute = ONBOARDING_PATHS.has(location.pathname);
+
+  const needsOrgRedirect =
+    auth.status === "authenticated" && auth.organization == null && !isOnboardingRoute;
+
+  React.useEffect(() => {
+    if (needsOrgRedirect) {
+      void navigate({ to: "/create-org", replace: true });
+    }
+  }, [needsOrgRedirect, navigate]);
 
   if (auth.status === "loading") {
     return <ShellSkeleton />;
@@ -207,8 +227,12 @@ function AuthGate() {
     return <LoginPage />;
   }
 
+  if (isOnboardingRoute) {
+    return <Outlet />;
+  }
+
   if (auth.organization == null) {
-    return <OnboardingPage />;
+    return <ShellSkeleton />;
   }
 
   return (

--- a/apps/cloud/src/routes/create-org.tsx
+++ b/apps/cloud/src/routes/create-org.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CreateOrgPage } from "../web/pages/create-org";
+
+export const Route = createFileRoute("/create-org")({
+  component: CreateOrgPage,
+});

--- a/apps/cloud/src/routes/setup-mcp.tsx
+++ b/apps/cloud/src/routes/setup-mcp.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SetupMcpPage } from "../web/pages/setup-mcp";
+
+export const Route = createFileRoute("/setup-mcp")({
+  component: SetupMcpPage,
+});

--- a/apps/cloud/src/web/pages/create-org.tsx
+++ b/apps/cloud/src/web/pages/create-org.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
+import { useNavigate } from "@tanstack/react-router";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import { authWriteKeys } from "@executor-js/react/api/reactivity-keys";
@@ -39,8 +40,9 @@ const formatRelativeTime = (iso: string): string => {
   return `${Math.floor(days / 365)}y ago`;
 };
 
-export const OnboardingPage = () => {
+export const CreateOrgPage = () => {
   const auth = useAuth();
+  const navigate = useNavigate();
   const invitationsResult = useAtomValue(pendingInvitationsAtom);
   const doAccept = useAtomSet(acceptInvitation, { mode: "promiseExit" });
 
@@ -75,7 +77,9 @@ export const OnboardingPage = () => {
 
   const form = useCreateOrganizationForm({
     defaultName: suggestedName,
-    onSuccess: () => {},
+    onSuccess: () => {
+      void navigate({ to: "/setup-mcp" });
+    },
   });
 
   const isLoading =
@@ -93,6 +97,9 @@ export const OnboardingPage = () => {
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="mx-auto flex w-full max-w-sm flex-col gap-6">
         <header className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Step 1 of 2
+          </p>
           <h1 className="font-serif text-3xl">
             {isLoading
               ? "Loading"

--- a/apps/cloud/src/web/pages/setup-mcp.tsx
+++ b/apps/cloud/src/web/pages/setup-mcp.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Button } from "@executor-js/react/components/button";
+import { CodeBlock } from "@executor-js/react/components/code-block";
+import { CopyButton } from "@executor-js/react/components/copy-button";
+
+const buildInstallCommand = (endpoint: string): string =>
+  `npx add-mcp ${endpoint} --transport http --name executor`;
+
+export const SetupMcpPage = () => {
+  const navigate = useNavigate();
+  const [origin, setOrigin] = useState<string | null>(null);
+
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
+
+  const endpoint = origin ? `${origin}/mcp` : "";
+  const command = endpoint ? buildInstallCommand(endpoint) : "";
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4 py-10">
+      <div className="mx-auto flex w-full max-w-lg flex-col gap-6">
+        <header className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Step 2 of 2
+          </p>
+          <h1 className="font-serif text-3xl">Connect your MCP client</h1>
+          <p className="text-sm text-muted-foreground">
+            Executor exposes your sources, secrets, and tools to any MCP-compatible agent. Copy the
+            URL into your client, or run the install command.
+          </p>
+        </header>
+
+        <section aria-label="MCP server URL" className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            MCP server URL
+          </p>
+          <div className="flex items-center gap-2 rounded-md border border-border bg-card/60 px-3 py-2">
+            <span className="min-w-0 flex-1 truncate font-mono text-sm text-foreground/90">
+              {endpoint || "…"}
+            </span>
+            {endpoint && <CopyButton value={endpoint} />}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Paste this into your MCP client config.
+          </p>
+        </section>
+
+        <div className="relative flex items-center">
+          <div className="h-px flex-1 bg-border" />
+          <span className="px-3 text-xs uppercase tracking-wider text-muted-foreground">or</span>
+          <div className="h-px flex-1 bg-border" />
+        </div>
+
+        <section aria-label="Install command" className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Install command
+          </p>
+          <CodeBlock code={command} lang="bash" />
+          <p className="text-xs text-muted-foreground">Adds the server to a supported agent.</p>
+        </section>
+
+        <div className="flex items-center justify-between gap-3">
+          {/* oxlint-disable-next-line react/forbid-elements */}
+          <button
+            type="button"
+            onClick={() => void navigate({ to: "/" })}
+            className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Skip for now
+          </button>
+          <Button size="sm" onClick={() => void navigate({ to: "/" })}>
+            Continue to app
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/cloud/src/web/pages/setup-mcp.tsx
+++ b/apps/cloud/src/web/pages/setup-mcp.tsx
@@ -42,9 +42,7 @@ export const SetupMcpPage = () => {
             </span>
             {endpoint && <CopyButton value={endpoint} />}
           </div>
-          <p className="text-xs text-muted-foreground">
-            Paste this into your MCP client config.
-          </p>
+          <p className="text-xs text-muted-foreground">Paste this into your MCP client config.</p>
         </section>
 
         <div className="relative flex items-center">


### PR DESCRIPTION
## Summary

- Adds two onboarding routes: `/create-org` (organization creation plus any pending invitations) and `/setup-mcp` (the MCP server URL and an `npx add-mcp …` install command, presented as separate options).
- Updates `AuthGate` in the cloud app to redirect an authenticated user without an org to `/create-org` and to render these routes without the app shell, so the flow reads as a focused two-step onboarding.
- Removes the old single-page `OnboardingPage`; after creating an org the user is now sent to `/setup-mcp`, and "Continue to app" lands at `/`.

## Test plan

- [ ] As a new user with no org, visit any URL → bounced to `/create-org`.
- [ ] Create an org → land on `/setup-mcp`; URL and install command both copyable; "Continue to app" goes to `/`.
- [ ] As a user with a pending invitation, `/create-org` lists it and lets you accept without forcing the MCP step.
- [ ] As a logged-in user with an org, `/setup-mcp` is still directly reachable for testing.