### PR TITLE
[codex] Move control tools under executor namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Open `http://127.0.0.1:4788`, go to **Add Source**, paste a URL, and Executor wi
 ### Via the CLI
 
 ```bash
-executor call openapi addSource '{
+executor call executor openapi addSource '{
   "spec": "https://petstore3.swagger.io/api/v3/openapi.json",
   "namespace": "petstore",
   "baseUrl": "https://petstore3.swagger.io/api/v3"

--- a/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-miniflare.e2e.node.test.ts
@@ -14,7 +14,7 @@
 //
 // Elicitation coverage uses the openapi plugin: a tiny Effect HttpApi
 // upstream is stood up in-process, its generated spec is handed to
-// `tools.openapi.addSource`, and the cloud engine invokes a POST operation.
+// `tools.executor.openapi.addSource`, and the cloud engine invokes a POST operation.
 // `requiresApproval: true` fires the executor's approval elicitation, which
 // round-trips back to the SDK Client's `ElicitRequestSchema` handler.
 // ---------------------------------------------------------------------------
@@ -455,7 +455,7 @@ layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it)
             method: "POST",
             headers: {
               accept: "application/json, text/event-stream",
-              authorization: "Bearer bogus",
+              authorization: "Bearer bogus.bogus.bogus",
               "content-type": "application/json",
             },
             body: JSON.stringify({
@@ -794,7 +794,7 @@ layer(TestEnv, { timeout: 60_000 })("cloud MCP over real HTTP (miniflare)", (it)
         // `HttpApiGroup` name ("approve") becomes part of the sandbox path,
         // so the invocation reads `tools.approveapi.approve.approveThing`.
         const code = [
-          `await tools.openapi.addSource({ scope: ${JSON.stringify(orgId)}, spec: ${JSON.stringify(specJson)}, namespace: "approveapi" });`,
+          `await tools.executor.openapi.addSource({ scope: ${JSON.stringify(orgId)}, spec: ${JSON.stringify(specJson)}, namespace: "approveapi" });`,
           `return await tools.approveapi.approve.approveThing({});`,
         ].join("\n");
         const result = yield* Effect.promise(() =>

--- a/apps/cloud/src/mcp-session.e2e.node.test.ts
+++ b/apps/cloud/src/mcp-session.e2e.node.test.ts
@@ -15,7 +15,7 @@
 // before prod does.
 
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -44,11 +44,9 @@ import { DbService } from "./services/db";
 // eliciting test drive the real engine + sandbox rather than a stub engine.
 // ---------------------------------------------------------------------------
 
-const EMPTY_INPUT_SCHEMA = {
-  type: "object",
-  properties: {},
-  additionalProperties: false,
-} as const;
+const EMPTY_INPUT_SCHEMA = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(Schema.Struct({})),
+);
 
 const elicitingTestPlugin = definePlugin(() => ({
   id: "eliciting-test" as const,

--- a/apps/cloud/src/services/sources-api.node.test.ts
+++ b/apps/cloud/src/services/sources-api.node.test.ts
@@ -676,13 +676,13 @@ describe("sources api (HTTP)", () => {
   it.effect("sources.remove on a static source is rejected", () =>
     Effect.gen(function* () {
       // `canRemove: false` is reserved for static (plugin-declared)
-      // sources. The openapi plugin declares one with id "openapi"
-      // for its control tools.
+      // sources. Plugin-owned executor tools are mounted under the
+      // built-in executor source.
       const org = `org_${crypto.randomUUID()}`;
 
       const result = yield* asOrg(org, (client) =>
         client.sources
-          .remove({ params: { scopeId: ScopeId.make(org), sourceId: "openapi" } })
+          .remove({ params: { scopeId: ScopeId.make(org), sourceId: "executor" } })
           .pipe(Effect.result),
       );
       expect(Result.isFailure(result)).toBe(true);

--- a/apps/local/src/web/shell.tsx
+++ b/apps/local/src/web/shell.tsx
@@ -298,7 +298,7 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
                     : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
                 ].join(" ")}
               >
-                <SourceFavicon url={s.url} />
+                <SourceFavicon sourceId={s.id} url={s.url} />
                 <span className="flex-1 truncate">{s.name}</span>
                 <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">
                   {s.kind}

--- a/apps/local/vite.config.ts
+++ b/apps/local/vite.config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { Readable } from "node:stream";
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
@@ -38,6 +39,11 @@ function executorApiPlugin(): Plugin {
   return {
     name: "executor-api",
     configureServer(server) {
+      server.watcher.on("change", (path) => {
+        if (path.includes("/src/server/") || path.endsWith("/executor.config.ts")) {
+          handlers = null;
+        }
+      });
       server.middlewares.use(async (req, res, next) => {
         const rawUrl = req.url ?? "/";
         const isApi = rawUrl.startsWith("/api/") || rawUrl === "/api";
@@ -120,6 +126,9 @@ export default defineConfig({
       // polling is slower but reliable.
       usePolling: true,
       interval: 200,
+    },
+    fs: {
+      allow: [resolve(import.meta.dirname, "../..")],
     },
   },
   plugins: [

--- a/bun.lock
+++ b/bun.lock
@@ -316,6 +316,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@executor-js/storage-core": "workspace:*",
+        "@standard-schema/spec": "^1.1.0",
         "effect": "catalog:",
         "fractional-indexing": "^3.2.0",
         "oauth4webapi": "^3.8.5",

--- a/notes/old/mcp-testing.md
+++ b/notes/old/mcp-testing.md
@@ -90,7 +90,7 @@ Pattern used in `mcp-miniflare.e2e.node.test.ts`:
 5. SDK Client advertises `capabilities: { elicitation: { form: {} } }` and
    registers `client.setRequestHandler(ElicitRequestSchema, ...)` that returns
    `{ action: "accept", content: {} }`.
-6. Call `execute` with code that (a) calls `tools.openapi.addSource({ spec,
+6. Call `execute` with code that (a) calls `tools.executor.openapi.addSource({ spec,
 namespace })`, (b) invokes the POST operation.
 
 **Tool id format inside the `execute` sandbox.**

--- a/packages/core/execution/src/description.test.ts
+++ b/packages/core/execution/src/description.test.ts
@@ -1,15 +1,13 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Schema } from "effect";
 
 import { createExecutor, definePlugin, makeTestConfig } from "@executor-js/sdk";
 
 import { buildExecuteDescription } from "./description";
 
-const EmptyInputSchema = {
-  type: "object",
-  properties: {},
-  additionalProperties: false,
-} as const;
+const EmptyInputSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(Schema.Struct({})),
+);
 
 // Two plugins registering static sources whose ids are distinct from their
 // pluginIds/names. If `buildExecuteDescription` ever renders the wrong field

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect, Fiber } from "effect";
+import { Effect, Fiber, Schema } from "effect";
 
 import {
   ElicitationResponse,
@@ -14,30 +14,17 @@ import { describeTool, makeExecutorToolInvoker, searchTools } from "./tool-invok
 
 const codeExecutor = makeQuickJsExecutor();
 
-const RepoInputSchema = {
-  type: "object",
-  properties: {
-    owner: { type: "string" },
-    repo: { type: "string" },
-  },
-  required: ["owner", "repo"],
-  additionalProperties: false,
-} as const;
+const RepoInputSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(Schema.Struct({ owner: Schema.String, repo: Schema.String })),
+);
 
-const ContactInputSchema = {
-  type: "object",
-  properties: {
-    email: { type: "string" },
-  },
-  required: ["email"],
-  additionalProperties: false,
-} as const;
+const ContactInputSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(Schema.Struct({ email: Schema.String })),
+);
 
-const EmptyInputSchema = {
-  type: "object",
-  properties: {},
-  additionalProperties: false,
-} as const;
+const EmptyInputSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(Schema.Struct({})),
+);
 
 const acceptAll = () => Effect.succeed(new ElicitationResponse({ action: "accept" }));
 

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@executor-js/storage-core": "workspace:*",
+    "@standard-schema/spec": "^1.1.0",
     "effect": "catalog:",
     "fractional-indexing": "^3.2.0",
     "oauth4webapi": "^3.8.5"

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Data, Effect, Exit, Predicate, Result } from "effect";
+import { Data, Effect, Exit, Predicate, Result, Schema } from "effect";
 import { FetchHttpClient } from "effect/unstable/http";
 
 import { makeMemoryAdapter } from "@executor-js/storage-core/testing/memory";
@@ -9,7 +9,7 @@ import { makeInMemoryBlobStore } from "./blob";
 import { CreateConnectionInput, TokenMaterial } from "./connections";
 import { collectSchemas, createExecutor } from "./executor";
 import { ElicitationResponse, FormElicitation, UrlElicitation } from "./elicitation";
-import { defineSchema, definePlugin } from "./plugin";
+import { defineSchema, definePlugin, tool } from "./plugin";
 import { RemoveSecretInput, SetSecretInput } from "./secrets";
 import { makeTestConfig } from "./testing";
 import type { SecretProvider } from "./secrets";
@@ -45,7 +45,7 @@ const recordFindMany = (adapter: DBAdapter, calls: FindManyCall[]): DBAdapter =>
 });
 
 // ---------------------------------------------------------------------------
-// Tiny test plugin — declares a static source with two control tools, a
+// Tiny test plugin — declares a static source with two built-in tools, a
 // plugin schema for a per-row key/value table, and a dynamic invokeTool
 // handler. Exercises everything createExecutor has to wire up.
 // ---------------------------------------------------------------------------
@@ -837,21 +837,19 @@ describe("createExecutor", () => {
             kind: "control",
             name: "Preview Ctl",
             tools: [
-              {
+              tool({
                 name: "createContact",
                 description: "create",
-                inputSchema: {
-                  type: "object",
-                  properties: {
-                    name: { type: "string" },
-                    age: { type: "number" },
-                  },
-                  required: ["name", "age"],
-                  additionalProperties: false,
-                },
-                outputSchema: { type: "string" },
-                handler: ({ args }) => Effect.succeed(args),
-              },
+                inputSchema: Schema.toStandardSchemaV1(
+                  Schema.toStandardJSONSchemaV1(
+                    Schema.Struct({ name: Schema.String, age: Schema.Finite }),
+                  ),
+                ),
+                outputSchema: Schema.toStandardSchemaV1(
+                  Schema.toStandardJSONSchemaV1(Schema.String),
+                ),
+                execute: (input) => Effect.succeed(input),
+              }),
             ],
           },
         ],
@@ -1147,12 +1145,12 @@ const tenantPlugin = definePlugin(() => ({
       kind: "control" as const,
       name: "Tenant Ctl",
       tools: [
-        {
+        tool({
           name: "noop",
           description: "noop",
-          inputSchema: { type: "object", additionalProperties: false },
-          handler: () => Effect.succeed(null),
-        },
+          inputSchema: Schema.toStandardSchemaV1(Schema.toStandardJSONSchemaV1(Schema.Struct({}))),
+          execute: () => Effect.succeed(null),
+        }),
       ],
     },
   ],

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -103,6 +103,7 @@ import type {
   PluginExtensions,
   StaticSourceDecl,
   StaticToolDecl,
+  StaticToolSchema,
   StorageDeps,
 } from "./plugin";
 import type { Scope } from "./scope";
@@ -457,10 +458,31 @@ const staticDeclToTool = (
   pluginId,
   name: tool.name,
   description: tool.description,
-  inputSchema: tool.inputSchema,
-  outputSchema: tool.outputSchema,
+  inputSchema: toToolJsonSchema(tool.inputSchema),
+  outputSchema: toToolJsonSchema(tool.outputSchema, "output"),
   annotations: tool.annotations,
 });
+
+const toToolJsonSchema = (
+  schema: StaticToolSchema | undefined,
+  direction: "input" | "output" = "input",
+): unknown => {
+  if (schema == null) return undefined;
+  return schema["~standard"].jsonSchema[direction]({
+    target: "draft-2020-12",
+  });
+};
+
+const EXECUTOR_SOURCE_ID = "executor";
+const EXECUTOR_SOURCE: StaticSourceDecl = {
+  id: EXECUTOR_SOURCE_ID,
+  kind: "built-in",
+  name: "Executor",
+  canRemove: false,
+  canRefresh: false,
+  canEdit: false,
+  tools: [],
+};
 
 // ---------------------------------------------------------------------------
 // Dynamic-row writers — used by ctx.core.sources.register. Static sources
@@ -2719,18 +2741,40 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
       }
 
       // Resolve static declarations to the in-memory pools. NO DB WRITES.
+      // Plugin-owned executor tools are intentionally mounted under the
+      // single `executor` namespace so source inventory is about configured
+      // integrations, not plugin management surfaces:
+      //   openapi.addSource -> executor.openapi.addSource
       const decls = plugin.staticSources ? plugin.staticSources(extension) : [];
       for (const source of decls) {
-        if (staticSources.has(source.id)) {
-          return yield* new StorageError({
-            message: `Duplicate static source id: ${source.id} (plugin ${plugin.id})`,
-            cause: undefined,
-          });
+        const mountUnderExecutor = source.kind === "executor" && source.id === plugin.id;
+        const mountedSource = mountUnderExecutor ? EXECUTOR_SOURCE : source;
+
+        if (mountUnderExecutor) {
+          if (!staticSources.has(EXECUTOR_SOURCE_ID)) {
+            staticSources.set(EXECUTOR_SOURCE_ID, {
+              source: EXECUTOR_SOURCE,
+              pluginId: EXECUTOR_SOURCE_ID,
+            });
+          }
+        } else {
+          if (staticSources.has(source.id)) {
+            return yield* new StorageError({
+              message: `Duplicate static source id: ${source.id} (plugin ${plugin.id})`,
+              cause: undefined,
+            });
+          }
+          staticSources.set(source.id, { source, pluginId: plugin.id });
         }
-        staticSources.set(source.id, { source, pluginId: plugin.id });
 
         for (const tool of source.tools) {
-          const fqid = `${source.id}.${tool.name}`;
+          const mountedTool = mountUnderExecutor
+            ? {
+                ...tool,
+                name: `${plugin.id}.${tool.name}`,
+              }
+            : tool;
+          const fqid = `${mountedSource.id}.${mountedTool.name}`;
           if (staticTools.has(fqid)) {
             return yield* new StorageError({
               message: `Duplicate static tool id: ${fqid} (plugin ${plugin.id})`,
@@ -2738,8 +2782,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
             });
           }
           staticTools.set(fqid, {
-            source,
-            tool,
+            source: mountedSource,
+            tool: mountedTool,
             pluginId: plugin.id,
             ctx,
           });
@@ -3028,8 +3072,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = []>
             name: staticEntry.tool.name,
             description: staticEntry.tool.description,
             sourceId: undefined,
-            rawInput: staticEntry.tool.inputSchema,
-            rawOutput: staticEntry.tool.outputSchema,
+            rawInput: toToolJsonSchema(staticEntry.tool.inputSchema),
+            rawOutput: toToolJsonSchema(staticEntry.tool.outputSchema, "output"),
           });
         }
         // Innermost-wins lookup: the scope-wrapped adapter returns rows

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -280,13 +280,16 @@ export {
   type StorageDeps,
   type StaticSourceDecl,
   type StaticToolDecl,
+  type StaticToolExecuteContext,
   type StaticToolHandlerInput,
+  type StaticToolInput,
   type InvokeToolInput,
   type SourceLifecycleInput,
   type SecretListEntry,
   type Elicit,
   definePlugin,
   defineSchema,
+  tool,
 } from "./plugin";
 
 // Executor

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -1,6 +1,8 @@
-import type { Context, Effect, Layer } from "effect";
+import { Effect } from "effect";
+import type { Context, Layer } from "effect";
 import type { HttpClient } from "effect/unstable/http";
 import type { HttpApiGroup } from "effect/unstable/httpapi";
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
 import type { DBSchema, StorageFailure } from "@executor-js/storage-core";
 
 import type { PluginBlobStore } from "./blob";
@@ -249,11 +251,21 @@ export interface StaticToolHandlerInput<TStore = unknown> {
   readonly elicit: Elicit;
 }
 
+export interface StaticToolExecuteContext<TStore = unknown> {
+  readonly ctx: PluginCtx<TStore>;
+  /** Suspend the fiber to request user input. The handler passed to
+   *  `createExecutor({ onElicitation })` is called. */
+  readonly elicit: Elicit;
+}
+
+export type StaticToolSchema<Input = unknown, Output = Input> = StandardSchemaV1<Input, Output> &
+  StandardJSONSchemaV1<Input, Output>;
+
 export interface StaticToolDecl<TStore = unknown> {
   readonly name: string;
   readonly description: string;
-  readonly inputSchema?: unknown;
-  readonly outputSchema?: unknown;
+  readonly inputSchema?: StaticToolSchema;
+  readonly outputSchema?: StaticToolSchema;
   /** Default-policy annotations — `requiresApproval`, `approvalDescription`,
    *  `mayElicit`. Enforced by the executor before the handler runs.
    *  Inline because static tools have no plugin storage to resolve from;
@@ -262,13 +274,68 @@ export interface StaticToolDecl<TStore = unknown> {
   readonly handler: (input: StaticToolHandlerInput<TStore>) => Effect.Effect<unknown, unknown>;
 }
 
+const decodeStaticToolArgs = (
+  schema: StaticToolSchema | undefined,
+  args: unknown,
+): Effect.Effect<unknown, unknown> => {
+  if (schema == null) return Effect.succeed(args);
+  return Effect.promise(() => Promise.resolve(schema["~standard"].validate(args))).pipe(
+    Effect.flatMap((result) =>
+      "value" in result ? Effect.succeed(result.value) : Effect.fail(result),
+    ),
+  );
+};
+
+export interface StaticToolInput<
+  TStore = unknown,
+  TInputSchema extends StaticToolSchema | undefined = StaticToolSchema | undefined,
+> {
+  readonly name: string;
+  readonly description: string;
+  readonly inputSchema?: TInputSchema;
+  readonly outputSchema?: StaticToolSchema;
+  /** Default-policy annotations — `requiresApproval`, `approvalDescription`,
+   *  `mayElicit`. Enforced by the executor before the handler runs. */
+  readonly annotations?: ToolAnnotations;
+  readonly execute: (
+    args: TInputSchema extends StaticToolSchema
+      ? StandardSchemaV1.InferOutput<TInputSchema>
+      : unknown,
+    context: StaticToolExecuteContext<TStore>,
+  ) => Effect.Effect<unknown, unknown>;
+}
+
+export const tool = <
+  TStore = unknown,
+  TInputSchema extends StaticToolSchema | undefined = StaticToolSchema | undefined,
+>(
+  input: StaticToolInput<TStore, TInputSchema>,
+): StaticToolDecl<TStore> => ({
+  name: input.name,
+  description: input.description,
+  inputSchema: input.inputSchema,
+  outputSchema: input.outputSchema,
+  annotations: input.annotations,
+  handler: ({ args, ctx, elicit }) =>
+    decodeStaticToolArgs(input.inputSchema, args).pipe(
+      Effect.flatMap((decoded) =>
+        input.execute(
+          decoded as TInputSchema extends StaticToolSchema
+            ? StandardSchemaV1.InferOutput<TInputSchema>
+            : unknown,
+          { ctx, elicit },
+        ),
+      ),
+    ),
+});
+
 export interface StaticSourceDecl<TStore = unknown> {
   readonly id: string;
   readonly kind: string;
   readonly name: string;
   readonly url?: string;
-  /** Static sources default to `canRemove: false` — they represent
-   *  plugin-provided control surfaces and shouldn't be user-removable.
+  /** Static sources default to `canRemove: false` because they are
+   *  plugin-provided surfaces and shouldn't usually be user-removable.
    *  Override only if you really want that. */
   readonly canRemove?: boolean;
   readonly canRefresh?: boolean;

--- a/packages/core/sdk/src/promise.test.ts
+++ b/packages/core/sdk/src/promise.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "@effect/vitest";
 
 import { createExecutor } from "./promise";
-import { definePlugin, defineSchema } from "./plugin";
-import { Effect } from "effect";
+import { definePlugin, defineSchema, tool } from "./plugin";
+import { Effect, Schema } from "effect";
 
 // A minimal static-tool plugin built on the Effect surface, consumed
 // through the Promise façade. Exercises the proxy's ability to promisify
@@ -17,18 +17,14 @@ const echoPlugin = definePlugin(() => ({
       kind: "control" as const,
       name: "Echo Ctl",
       tools: [
-        {
+        tool({
           name: "say",
           description: "Echo the input",
-          inputSchema: {
-            type: "object",
-            properties: { message: { type: "string" } },
-            required: ["message"],
-            additionalProperties: false,
-          },
-          handler: ({ args }: { args: unknown }) =>
-            Effect.succeed((args as { message: string }).message),
-        },
+          inputSchema: Schema.toStandardSchemaV1(
+            Schema.toStandardJSONSchemaV1(Schema.Struct({ message: Schema.String })),
+          ),
+          execute: (input) => Effect.succeed(input.message),
+        }),
       ],
     },
   ],
@@ -80,13 +76,15 @@ describe("promise/createExecutor", () => {
           kind: "control" as const,
           name: "Ap Ctl",
           tools: [
-            {
+            tool({
               name: "go",
               description: "Requires approval",
               annotations: { requiresApproval: true } as const,
-              inputSchema: { type: "object", additionalProperties: false },
-              handler: () => Effect.succeed("ran"),
-            },
+              inputSchema: Schema.toStandardSchemaV1(
+                Schema.toStandardJSONSchemaV1(Schema.Struct({})),
+              ),
+              execute: () => Effect.succeed("ran"),
+            }),
           ],
         },
       ],

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -283,8 +283,8 @@ describe("graphqlPlugin", () => {
       const ids = tools.map((t) => t.id);
       expect(ids).toContain("test_api.query.hello");
       expect(ids).toContain("test_api.mutation.setGreeting");
-      // static control tool also present
-      expect(ids).toContain("graphql.addSource");
+      // static executor tool also present under the executor namespace
+      expect(ids).toContain("executor.graphql.addSource");
 
       const queryTool = tools.find((t) => t.id === "test_api.query.hello");
       expect(queryTool?.description).toBe("Say hello");
@@ -320,7 +320,7 @@ describe("graphqlPlugin", () => {
     }),
   );
 
-  it.effect("lists sources with the static control source", () =>
+  it.effect("lists sources with the executor built-in source", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(
         makeTestConfig({ plugins: [graphqlPlugin()] as const }),
@@ -341,7 +341,8 @@ describe("graphqlPlugin", () => {
       expect(dynamic!.canEdit).toBe(true);
       expect(dynamic!.runtime).toBe(false);
 
-      const control = sources.find((s) => s.id === "graphql");
+      expect(sources.find((s) => s.id === "graphql")).toBeUndefined();
+      const control = sources.find((s) => s.id === "executor");
       expect(control).toBeDefined();
       expect(control!.runtime).toBe(true);
     }),
@@ -401,7 +402,7 @@ describe("graphqlPlugin", () => {
     }),
   );
 
-  it.effect("static graphql.addSource delegates to extension", () =>
+  it.effect("static executor.graphql.addSource delegates to extension", () =>
     Effect.gen(function* () {
       const userScope = ScopeId.make("static-user");
       const orgScope = ScopeId.make("static-org");
@@ -416,7 +417,7 @@ describe("graphqlPlugin", () => {
       );
 
       const result = yield* executor.tools.invoke(
-        "graphql.addSource",
+        "executor.graphql.addSource",
         {
           scope: String(orgScope),
           endpoint: "http://localhost:4000/graphql",
@@ -436,6 +437,22 @@ describe("graphqlPlugin", () => {
     }),
   );
 
+  it.effect("describes static addSource parameters from Standard Schema", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [graphqlPlugin()] }));
+
+      const schema = yield* executor.tools.schema("executor.graphql.addSource");
+
+      expect(schema).not.toBeNull();
+      expect(schema!.inputTypeScript).toContain("scope: string");
+      expect(schema!.inputTypeScript).toContain("endpoint: string");
+      expect(
+        (schema!.inputSchema as { properties?: Record<string, unknown> }).properties,
+      ).toHaveProperty("credentialTargetScope");
+      expect(schema!.inputTypeScript).not.toBe("Record<string, unknown>");
+    }),
+  );
+
   it.effect("requires approval before a runtime-added query sends prior tool output", () =>
     Effect.gen(function* () {
       const server = yield* serveGreetingServer;
@@ -451,7 +468,7 @@ describe("graphqlPlugin", () => {
       expect(trusted).toBe("sample-value");
       const declined = yield* executor.tools
         .invoke(
-          "graphql.addSource",
+          "executor.graphql.addSource",
           {
             endpoint: server.endpoint,
             scope: TEST_SCOPE,
@@ -478,7 +495,7 @@ describe("graphqlPlugin", () => {
       );
 
       yield* executor.tools.invoke(
-        "graphql.addSource",
+        "executor.graphql.addSource",
         {
           endpoint: server.endpoint,
           scope: TEST_SCOPE,

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -10,6 +10,7 @@ import {
   ConfiguredCredentialBinding,
   type CredentialBindingRef,
   definePlugin,
+  tool,
   ScopeId,
   SecretId,
   SourceDetectionResult,
@@ -110,6 +111,13 @@ const StaticAddSourceInputSchema = Schema.Struct({
   credentialTargetScope: Schema.optional(Schema.String),
   auth: Schema.optional(GraphqlSourceAuthInputSchema),
 });
+
+const StaticAddSourceInputStandardSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(StaticAddSourceInputSchema),
+);
+const StaticAddSourceOutputStandardSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(Schema.Struct({ toolCount: Schema.Number })),
+);
 
 // ---------------------------------------------------------------------------
 // Plugin extension
@@ -977,44 +985,20 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
     staticSources: (self) => [
       {
         id: "graphql",
-        kind: "control",
+        kind: "executor",
         name: "GraphQL",
         tools: [
-          {
+          tool({
             name: "addSource",
             description: "Add a GraphQL endpoint and register its operations as tools",
             annotations: {
               requiresApproval: true,
               approvalDescription: "Add a GraphQL source",
             },
-            inputSchema: {
-              type: "object",
-              properties: {
-                scope: { type: "string" },
-                endpoint: { type: "string" },
-                name: { type: "string" },
-                introspectionJson: { type: "string" },
-                namespace: { type: "string" },
-                headers: { type: "object" },
-                queryParams: { type: "object" },
-                credentialTargetScope: { type: "string" },
-                auth: { type: "object" },
-              },
-              required: ["scope", "endpoint"],
-            },
-            outputSchema: {
-              type: "object",
-              properties: {
-                toolCount: { type: "number" },
-              },
-              required: ["toolCount"],
-            },
-            handler: ({ args }) =>
-              Effect.gen(function* () {
-                const input = yield* Schema.decodeUnknownEffect(StaticAddSourceInputSchema)(args);
-                return yield* self.addSource(input);
-              }),
-          },
+            inputSchema: StaticAddSourceInputStandardSchema,
+            outputSchema: StaticAddSourceOutputStandardSchema,
+            execute: (input) => self.addSource(input),
+          }),
         ],
       },
     ],

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -212,7 +212,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
     }),
   );
 
-  it.effect("registers static openapi control tools", () =>
+  it.effect("registers static openapi executor tools", () =>
     Effect.gen(function* () {
       const httpClient = yield* HttpClient.HttpClient;
       const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
@@ -228,12 +228,12 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       const tools = yield* executor.tools.list();
       const ids = tools.map((t) => t.id);
-      expect(ids).toContain("openapi.previewSpec");
-      expect(ids).toContain("openapi.addSource");
+      expect(ids).toContain("executor.openapi.previewSpec");
+      expect(ids).toContain("executor.openapi.addSource");
     }),
   );
 
-  it.effect("lists openapi as a static runtime source", () =>
+  it.effect("lists executor as the static runtime source", () =>
     Effect.gen(function* () {
       const httpClient = yield* HttpClient.HttpClient;
       const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
@@ -248,7 +248,8 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       );
 
       const sources = yield* executor.sources.list();
-      const control = sources.find((s) => s.id === "openapi");
+      expect(sources.find((s) => s.id === "openapi")).toBeUndefined();
+      const control = sources.find((s) => s.id === "executor");
       expect(control).toBeDefined();
       expect(control!.runtime).toBe(true);
       expect(control!.canRemove).toBe(false);
@@ -270,12 +271,32 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       );
 
       const result = (yield* executor.tools.invoke(
-        "openapi.previewSpec",
+        "executor.openapi.previewSpec",
         { spec: specJson },
         autoApprove,
       )) as { operationCount: number };
 
       expect(result.operationCount).toBeGreaterThanOrEqual(2);
+    }),
+  );
+
+  it.effect("describes static addSource parameters from Standard Schema", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [openApiPlugin(), memorySecretsPlugin()] as const,
+        }),
+      );
+
+      const schema = yield* executor.tools.schema("executor.openapi.addSource");
+
+      expect(schema).not.toBeNull();
+      expect(schema!.inputTypeScript).toContain("scope: string");
+      expect(schema!.inputTypeScript).toContain("spec: string");
+      expect(
+        (schema!.inputSchema as { properties?: Record<string, unknown> }).properties,
+      ).toHaveProperty("credentialTargetScope");
+      expect(schema!.inputTypeScript).not.toBe("Record<string, unknown>");
     }),
   );
 
@@ -300,7 +321,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
       );
 
       const result = (yield* executor.tools.invoke(
-        "openapi.addSource",
+        "executor.openapi.addSource",
         { scope: String(orgScope), spec: specJson, namespace: "runtime" },
         autoApprove,
       )) as { sourceId: string; toolCount: number };
@@ -322,7 +343,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       const declined = yield* executor.tools
         .invoke(
-          "openapi.addSource",
+          "executor.openapi.addSource",
           { scope: TEST_SCOPE, spec: specJson, namespace: "runtime_declined" },
           { onElicitation: () => Effect.succeed({ action: "decline" as const }) },
         )
@@ -825,7 +846,7 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
 
       const remaining = yield* executor.tools.list();
       const ids = remaining.map((t) => t.id).sort();
-      expect(ids).toEqual(["openapi.addSource", "openapi.previewSpec"]);
+      expect(ids).toEqual(["executor.openapi.addSource", "executor.openapi.previewSpec"]);
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -11,6 +11,7 @@ import {
   SourceDetectionResult,
   StorageError,
   definePlugin,
+  tool,
   resolveSecretBackedMap,
   type CredentialBindingRef,
   type PluginCtx,
@@ -172,7 +173,6 @@ const PreviewSpecInputSchema = Schema.Struct({
     }),
   ),
 });
-type PreviewSpecInput = typeof PreviewSpecInputSchema.Type;
 
 const OpenApiHeaderInputSchema = Schema.Union([HeaderValueSchema, ConfiguredHeaderValueSchema]);
 const OpenApiOAuthInputSchema = OAuth2SourceConfig;
@@ -194,7 +194,21 @@ const AddSourceInputSchema = Schema.Struct({
     }),
   ),
 });
-type AddSourceInput = typeof AddSourceInputSchema.Type;
+
+const AddSourceOutputSchema = Schema.Struct({
+  sourceId: Schema.String,
+  toolCount: Schema.Number,
+});
+
+const PreviewSpecInputStandardSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(PreviewSpecInputSchema),
+);
+const AddSourceInputStandardSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(AddSourceInputSchema),
+);
+const AddSourceOutputStandardSchema = Schema.toStandardSchemaV1(
+  Schema.toStandardJSONSchemaV1(AddSourceOutputSchema),
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1175,60 +1189,26 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
     staticSources: (self) => [
       {
         id: "openapi",
-        kind: "control",
+        kind: "executor",
         name: "OpenAPI",
         tools: [
-          {
+          tool({
             name: "previewSpec",
             description: "Preview an OpenAPI document before adding it as a source",
-            inputSchema: {
-              type: "object",
-              properties: {
-                spec: { type: "string" },
-                specFetchCredentials: { type: "object" },
-              },
-              required: ["spec"],
-            },
-            handler: ({ args }) => self.previewSpec(args as PreviewSpecInput),
-          },
-          {
+            inputSchema: PreviewSpecInputStandardSchema,
+            execute: (input) => self.previewSpec(input),
+          }),
+          tool({
             name: "addSource",
             description: "Add an OpenAPI source and register its operations as tools",
             annotations: {
               requiresApproval: true,
               approvalDescription: "Add an OpenAPI source",
             },
-            inputSchema: {
-              type: "object",
-              properties: {
-                scope: { type: "string" },
-                spec: { type: "string" },
-                name: { type: "string" },
-                baseUrl: { type: "string" },
-                namespace: { type: "string" },
-                headers: { type: "object" },
-                queryParams: { type: "object" },
-                oauth2: { type: "object" },
-                credentialTargetScope: { type: "string" },
-                specFetchCredentials: { type: "object" },
-              },
-              required: ["scope", "spec"],
-            },
-            outputSchema: {
-              type: "object",
-              properties: {
-                sourceId: { type: "string" },
-                toolCount: { type: "number" },
-              },
-              required: ["sourceId", "toolCount"],
-            },
-            handler: ({ args }) =>
-              Effect.gen(function* () {
-                const input: AddSourceInput =
-                  yield* Schema.decodeUnknownEffect(AddSourceInputSchema)(args);
-                return yield* self.addSpec(input);
-              }),
-          },
+            inputSchema: AddSourceInputStandardSchema,
+            outputSchema: AddSourceOutputStandardSchema,
+            execute: (input) => self.addSpec(input),
+          }),
         ],
       },
     ],

--- a/packages/react/src/components/source-favicon.test.tsx
+++ b/packages/react/src/components/source-favicon.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 
-import { sourceFaviconUrl } from "./source-favicon";
+import { sourceFaviconUrl, sourceLocalIconUrl } from "./source-favicon";
 
 describe("SourceFavicon", () => {
   it("uses the favicon service that handles provider-specific icon locations", () => {
@@ -18,5 +18,10 @@ describe("SourceFavicon", () => {
     expect(sourceFaviconUrl("https://api.github.com/private", 20)).toBe(
       "https://www.google.com/s2/favicons?domain=github.com&sz=40",
     );
+  });
+
+  it("uses the Executor favicon for the built-in executor source", () => {
+    expect(sourceLocalIconUrl("executor")).toBe("/favicon-32.png");
+    expect(sourceLocalIconUrl("openapi")).toBeNull();
   });
 });

--- a/packages/react/src/components/source-favicon.tsx
+++ b/packages/react/src/components/source-favicon.tsx
@@ -14,9 +14,22 @@ export function sourceFaviconUrl(url: string | undefined, size: number): string 
   return `https://www.google.com/s2/favicons?domain=${domain}&sz=${size * 2}`;
 }
 
-export function SourceFavicon({ url, size = 16 }: { url?: string; size?: number }) {
+export function sourceLocalIconUrl(sourceId: string | undefined): string | null {
+  if (sourceId !== "executor") return null;
+  return "/favicon-32.png";
+}
+
+export function SourceFavicon({
+  sourceId,
+  url,
+  size = 16,
+}: {
+  sourceId?: string;
+  url?: string;
+  size?: number;
+}) {
   const [failed, setFailed] = useState(false);
-  const src = failed ? null : sourceFaviconUrl(url, size);
+  const src = failed ? null : (sourceLocalIconUrl(sourceId) ?? sourceFaviconUrl(url, size));
 
   if (!src) {
     return (

--- a/packages/react/src/pages/source-detail.tsx
+++ b/packages/react/src/pages/source-detail.tsx
@@ -157,7 +157,9 @@ export function SourceDetailPage(props: { namespace: string }) {
           {sourceData?.runtime && (
             <Badge className="bg-muted text-muted-foreground">built-in</Badge>
           )}
-          <Badge variant="secondary">{sourceData?.kind ?? "source"}</Badge>
+          {(!sourceData?.runtime || sourceData.kind !== "built-in") && (
+            <Badge variant="secondary">{sourceData?.kind ?? "source"}</Badge>
+          )}
           {AsyncResult.isSuccess(tools) && !editing && (
             <span className="hidden text-xs tabular-nums text-muted-foreground sm:block">
               {sourceTools.length} {sourceTools.length === 1 ? "tool" : "tools"}

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -411,7 +411,7 @@ function SourceGrid(props: {
             <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
               <Link to="/sources/$namespace" params={{ namespace: s.id }}>
                 <CardStackEntryMedia>
-                  <SourceFavicon url={s.url} size={32} />
+                  <SourceFavicon sourceId={s.id} url={s.url} size={32} />
                 </CardStackEntryMedia>
                 <CardStackEntryContent>
                   <CardStackEntryTitle>{s.name}</CardStackEntryTitle>
@@ -423,8 +423,11 @@ function SourceGrid(props: {
                       <SummaryComponent sourceId={s.id} />
                     </Suspense>
                   )}
-                  {s.runtime && <Badge className="bg-muted text-muted-foreground">built-in</Badge>}
-                  <Badge variant="secondary">{s.kind}</Badge>
+                  {s.runtime ? (
+                    <Badge className="bg-muted text-muted-foreground">built-in</Badge>
+                  ) : (
+                    <Badge variant="secondary">{s.kind}</Badge>
+                  )}
                 </CardStackEntryActions>
               </Link>
             </CardStackEntry>


### PR DESCRIPTION
## Summary

- Mount plugin control tools under `executor.*` so OpenAPI and GraphQL management flows are prompt-callable without exposing separate control sources.
- Add an AI SDK-style `tool(...)` helper for static internal tools and support Standard Schema / Effect Schema projection to JSON Schema for tool listing and schema previews.
- Update OpenAPI and GraphQL control tools to use Standard Schema-backed Effect schemas, fixing `Record<string, unknown>` parameter previews.
- Polish the local UI for the built-in executor source: executor favicon, single built-in badge, and HMR watcher invalidation.

## Validation

- `bun run format:check`
- `packages/react`: `bunx vitest run src/components/source-favicon.test.tsx`
- `packages/plugins/openapi`: `bunx vitest run src/sdk/plugin.test.ts`
- `packages/plugins/graphql`: `bunx vitest run src/sdk/plugin.test.ts`
- `packages/core/sdk`: `bunx vitest run src/executor.test.ts`
- `packages/plugins/openapi`: `bun run typecheck`
- `packages/plugins/graphql`: `bun run typecheck`

OpenAPI and GraphQL package typechecks completed with existing Effect suggestions/warnings only.