### PR TITLE
Fix two published-bundle imports the smoke test catches

### DIFF
--- a/.changeset/fix-published-bundle-imports.md
+++ b/.changeset/fix-published-bundle-imports.md
@@ -1,0 +1,21 @@
+---
+"@executor-js/codemode-core": patch
+"@executor-js/plugin-example": patch
+---
+
+Fix two published-bundle bugs surfaced by `release:smoke:packages`:
+
+- `@executor-js/codemode-core`: import `ajv/dist/2020.js` instead of
+  `ajv/dist/2020`. Strict ESM resolvers (Node) reject extension-less
+  subpath imports, so the published bundle failed at load with
+  `Cannot find module '.../ajv/dist/2020'`. Bun's loose resolver hid
+  the bug in dev.
+- `@executor-js/plugin-example`: switch `HttpApiEndpoint` /
+  `HttpApiGroup` / `HttpApi` / `HttpApiBuilder` imports in
+  `./shared` and `./server` from `@executor-js/sdk` to
+  `@executor-js/sdk/core`. The slim `.` entry (built from
+  `src/promise.ts`) doesn't re-export the HttpApi primitives — only
+  the `/core` entry (built from `src/index.ts`) does. In dev both
+  subpaths resolve to the same source file, so typecheck never caught
+  the mismatch; consumers installing the published tarball got
+  `SyntaxError: ... does not provide an export named 'HttpApiEndpoint'`.

--- a/packages/kernel/core/src/json-schema.ts
+++ b/packages/kernel/core/src/json-schema.ts
@@ -1,5 +1,5 @@
 import type { ErrorObject } from "ajv";
-import Ajv2020 from "ajv/dist/2020";
+import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
 
 import type { StandardSchema } from "./types";

--- a/packages/plugins/example/src/server.ts
+++ b/packages/plugins/example/src/server.ts
@@ -11,7 +11,7 @@
 // React and other browser-only deps live in `./client` — never here.
 // ---------------------------------------------------------------------------
 
-import { Context, definePlugin, Effect, HttpApi, HttpApiBuilder } from "@executor-js/sdk";
+import { Context, definePlugin, Effect, HttpApi, HttpApiBuilder } from "@executor-js/sdk/core";
 
 import { ExampleApi } from "./shared";
 

--- a/packages/plugins/example/src/shared.ts
+++ b/packages/plugins/example/src/shared.ts
@@ -9,7 +9,7 @@
 // No React or Node imports here — server and client both import this.
 // ---------------------------------------------------------------------------
 
-import { HttpApiEndpoint, HttpApiGroup, Schema } from "@executor-js/sdk";
+import { HttpApiEndpoint, HttpApiGroup, Schema } from "@executor-js/sdk/core";
 
 export const Greeting = Schema.Struct({
   message: Schema.String,


### PR DESCRIPTION
## Summary

Two pre-existing published-bundle bugs surfaced by the first run of `bun run release:smoke:packages` against current main. Both reproduce in a clean Node consumer install but were hidden in dev by Bun's loose resolver / shared dev-time export paths.

- **`@executor-js/codemode-core`**: `packages/kernel/core/src/json-schema.ts:2` imports `ajv/dist/2020` without a `.js` extension. Strict ESM resolvers (Node) reject extension-less subpath imports, so the published bundle fails at load with `Cannot find module '.../ajv/dist/2020'`. Fix: add the `.js`.

- **`@executor-js/plugin-example`**: `./shared` and `./server` imported `HttpApiEndpoint` / `HttpApiGroup` / `HttpApi` / `HttpApiBuilder` from `@executor-js/sdk`. The slim `.` entry (`src/promise.ts`) doesn't re-export the HttpApi primitives — only the `/core` entry (`src/index.ts`) does. In dev both subpaths resolve to the same source file, so typecheck never caught it; consumers installing the published tarball got `SyntaxError: ... does not provide an export named 'HttpApiEndpoint'`. Fix: import from `@executor-js/sdk/core`.

Both packages are in the `fixed` changeset group, so the included `patch` changeset bumps the whole group together.

## Test plan

- [x] `bun run typecheck` — only the pre-existing `option-json-repro.test.ts` `@effect/platform-node/NodeFileSystem` error reproduces on main without these changes
- [x] `bun run lint` — 0 errors
- [x] `bun run format:check` — clean
- [x] `bun run release:smoke:packages` — every previously-skipped non-peer entry now reports `ok` (`codemode-core`, `runtime-quickjs`, `execution`, `execution/core`, `plugin-example/server`, `plugin-example/shared`)