### PR TITLE
Fix crash on variadic tool path arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ MISTAKES.md
 DESIRES.md
 LEARNINGS.md
 .alchemy/
+
+# Pi coding agent
+.pi/

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1115,6 +1115,12 @@ const resolveToolInvocation = (input: {
   rawPathParts: ReadonlyArray<string>;
 }): Effect.Effect<{ path: string; args: Record<string, unknown> }, Error> =>
   Effect.gen(function* () {
+    if (!Array.isArray(input.rawPathParts)) {
+      return yield* Effect.fail(
+        new Error("Invalid tool invocation: path parts were not parsed as an array"),
+      );
+    }
+
     const maybeJsonArg = input.rawPathParts.at(-1)?.trim();
     const hasInlineJsonArg = maybeJsonArg !== undefined && maybeJsonArg.startsWith("{");
     const pathParts = hasInlineJsonArg ? input.rawPathParts.slice(0, -1) : input.rawPathParts;
@@ -1144,7 +1150,7 @@ const resolveToolInvocation = (input: {
 const callCommand = Command.make(
   "call",
   {
-    pathParts: Args.variadic(Args.string("tool-path-segment")),
+    pathParts: Args.string("tool-path-segment").pipe(Args.variadic({})),
     baseUrl: Options.string("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
     scope,
   },


### PR DESCRIPTION
Fixes #738

Effect CLI currently requires an explicit options object for `Argument.variadic`; without it, the parsed `pathParts` value
 becomes `{}` instead of an array. That made `executor call ...` crash before invoking the tool.

 This updates the call command to parse path segments with:
 ```ts
   Args.string("tool-path-segment").pipe(Args.variadic({}))
 ```
 and adds an explicit failure if the parser ever returns a non-array value.
 
 Upstream issue: Effect-TS/effect#6228

Also, added `.pi/` to .gitignore.