### PR TITLE
Release notes + changeset for 1.4.19

### DIFF
--- a/.changeset/executor-1.4.19.md
+++ b/.changeset/executor-1.4.19.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Source state stays in sync between executor.jsonc and the runtime DB; variadic tool path arguments no longer crash. See `apps/cli/release-notes/next.md`.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -1,3 +1,13 @@
 ## Fixes
 
-- 1Password vault items now appear in the secrets list without first being bound. `executor.secrets.list()` fans out to each provider's `list()` after collecting core routing rows, so read-only providers (1Password, file-secrets, workos-vault) surface their inventory directly. Core rows still win on id collisions; connection-owned ids stay hidden.
+### Source state stays in sync between `executor.jsonc` and the runtime DB
+
+Two regressions kept `executor.jsonc` and the runtime DB from agreeing on which sources exist and how they authenticate. Together they caused deleted sources to come back after a restart and authenticated MCP sources to silently lose their credentials on boot.
+
+- Removing a source from the UI (or via `executor.{openapi,mcp,graphql}.removeSource`) now writes the deletion through to `executor.jsonc`, so the source stays gone after a reboot. Thanks @RyanNg1403 (#408)
+- Boot-time replay of remote MCP sources now threads the `auth` block from `executor.jsonc` into `executor.mcp.addSource`, so header-auth and OAuth2 sources connect with credentials on the first request after startup instead of failing the SSE handshake unauthenticated. Thanks @RyanNg1403 (#408)
+- Updating an MCP source's auth from the UI (e.g. re-linking an OAuth connection) now writes the change back to `executor.jsonc`, so the new binding survives the next restart instead of being overwritten by stale file state. Thanks @aryasaatvik (#709)
+
+### Variadic tool path arguments no longer crash
+
+Calling a tool with multiple positional path arguments (`executor <tool> path/a path/b ...`) no longer panics in the CLI argument parser. Thanks @grfwings (#761)


### PR DESCRIPTION
## Summary

- Adds `.changeset/executor-1.4.19.md` (`patch`) so the next Version Packages PR cuts CLI v1.4.19.
- Replaces the stale 1Password content in `apps/cli/release-notes/next.md` (already shipped in v1.4.18) with curated notes for the three PRs landed since:
  - #408 — `removeSource` write-back to `executor.jsonc` for openapi/mcp/graphql, plus boot-replay auth threading for remote MCP sources (@RyanNg1403)
  - #709 — MCP `updateSource` write-back so UI auth changes survive a restart, plus `credentialTargetScope` threading on boot replay (@aryasaatvik)
  - #761 — CLI no longer crashes on variadic positional path args (@grfwings)

## Test plan

- [x] `bun run lint:release-notes`
- [x] `bun run lint:changelog-stubs`
- [x] `oxfmt --check` on touched files
- [ ] Reviewer: confirm release notes copy matches user-visible behavior of #408, #709, #761