### PR TITLE
fix(cli): invoke Args.variadic() so executor call parses positional args

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1144,7 +1144,7 @@ const resolveToolInvocation = (input: {
 const callCommand = Command.make(
   "call",
   {
-    pathParts: Args.variadic(Args.string("tool-path-segment")),
+    pathParts: Args.string("tool-path-segment").pipe(Args.variadic()),
     baseUrl: Options.string("base-url").pipe(Options.withDefault(DEFAULT_BASE_URL)),
     scope,
   },


### PR DESCRIPTION
executor call <path...> always crashes with rawPathParts.at is not a function.

Args.variadic is dual function and otherwise needs second (e.g. undefined) option.