### PR TITLE
mount Toaster in local app

### DIFF
--- a/apps/local/src/routes/__root.tsx
+++ b/apps/local/src/routes/__root.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRootRoute } from "@tanstack/react-router";
 import { ExecutorProvider } from "@executor-js/react/api/provider";
 import { ExecutorPluginsProvider } from "@executor-js/sdk/client";
+import { Toaster } from "@executor-js/react/components/sonner";
 import { plugins as clientPlugins } from "virtual:executor/plugins-client";
 import { Shell } from "../web/shell";
 
@@ -14,6 +15,7 @@ function RootComponent() {
     <ExecutorProvider>
       <ExecutorPluginsProvider plugins={clientPlugins}>
         <Shell />
+        <Toaster />
       </ExecutorPluginsProvider>
     </ExecutorProvider>
   );


### PR DESCRIPTION
## Summary

- Toast notifications (e.g. error when removing an in-use secret) were silently swallowed in the local app because the `<Toaster />` component was never mounted in the React tree
- Added `<Toaster />` from `@executor-js/react/components/sonner` to the local app root layout, matching the cloud app

Closes #760

## Test plan

- [ ] Open the local app, create a secret, attach it to a source, then try to remove the secret — verify the "Secret is used by N sources" error toast appears
- [ ] Verify other toast calls (e.g. connection removal errors) also surface correctly
