### PR TITLE
fix(openapi): wrap wire-shape OAuth2 config before storage encode

### DIFF
--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -523,6 +523,59 @@ layer(TestLayer)("OpenAPI Plugin", (it) => {
     }),
   );
 
+  // Regression: the HTTP edge validates `oauth2` against the Struct shape of
+  // `OAuth2SourceConfigSchema` and hands the plugin a plain object — not an
+  // `OAuth2SourceConfig` instance. Storage encodes via the Class schema, which
+  // does an `instanceof` check, so without `canonicalizeOAuth2` wrapping the
+  // input the request crashed with "Expected OpenApiOAuth2SourceConfig, got
+  // {...}", the txn rolled back as `StorageError: pg transaction failed`, and
+  // the user saw an opaque `InternalError({ traceId })`.
+  it.effect("addSpec accepts plain wire-shape oauth2 config", () =>
+    Effect.gen(function* () {
+      const httpClient = yield* HttpClient.HttpClient;
+      const clientLayer = Layer.succeed(HttpClient.HttpClient, httpClient);
+
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [
+            openApiPlugin({ httpClientLayer: clientLayer }),
+            memorySecretsPlugin(),
+          ] as const,
+        }),
+      );
+
+      // Construct the exact shape the API endpoint validates and forwards:
+      // a plain object, not `new OAuth2SourceConfig(...)`.
+      const wireOAuth2 = {
+        kind: "oauth2",
+        securitySchemeName: "oauth2",
+        flow: "authorizationCode",
+        tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+        authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+        clientIdSlot: "oauth2:oauth2:client-id",
+        clientSecretSlot: "oauth2:oauth2:client-secret",
+        connectionSlot: "oauth2:oauth2:connection",
+        scopes: [],
+      } as const;
+
+      yield* executor.openapi.addSpec({
+        spec: specJson,
+        scope: TEST_SCOPE,
+        namespace: "wire_oauth",
+        baseUrl: "",
+        // Simulating the API boundary on purpose: the HTTP layer hands the
+        // plugin a plain object that satisfies the Struct shape but is not
+        // a Class instance, which is what regressed in production.
+        // oxlint-disable-next-line executor/no-double-cast
+        oauth2: wireOAuth2 as unknown as OAuth2SourceConfig,
+      });
+
+      const stored = yield* executor.openapi.getSource("wire_oauth", TEST_SCOPE);
+      expect(stored?.config.oauth2?.tokenUrl).toBe(wireOAuth2.tokenUrl);
+      expect(stored?.config.oauth2?.authorizationUrl).toBe(wireOAuth2.authorizationUrl);
+    }),
+  );
+
   it.effect("resolves secret-backed headers at invocation time", () =>
     Effect.gen(function* () {
       const httpClient = yield* HttpClient.HttpClient;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -411,8 +411,15 @@ const canonicalizeOAuth2 = (
   }>;
 } => {
   if (!oauth2) return { bindings: [] };
+  // The HTTP edge validates the OAuth2 payload against the Struct shape of
+  // `OAuth2SourceConfigSchema`, so what arrives here is a plain object —
+  // not an `OAuth2SourceConfig` instance. Storage encodes via the Class
+  // schema, which does an `instanceof` check and rejects plain objects with
+  // "Expected OpenApiOAuth2SourceConfig, got ...". Wrap here so every
+  // caller (addSpec/updateSource, both the API and in-process SDK paths)
+  // hands a real instance to storage.
   return {
-    oauth2,
+    oauth2: oauth2 instanceof OAuth2SourceConfig ? oauth2 : new OAuth2SourceConfig(oauth2),
     bindings: [],
   };
 };


### PR DESCRIPTION
## Summary

- `addSpec`/`updateSource` crashed whenever the request carried an `oauth2` block, surfacing to users as an opaque `{"_tag":"InternalError","traceId":"…"}` after OAuth.
- Root cause: the HTTP edge validates the OAuth2 payload against the Struct shape of `OAuth2SourceConfigSchema`, so the plugin received a plain object. Storage encodes via the Class schema, whose `instanceof` check rejected it with `Expected OpenApiOAuth2SourceConfig, got {…}`. The Postgres txn aborted as `StorageError: pg transaction failed`, observability translated to `InternalError({ traceId })`.
- Fix: `canonicalizeOAuth2` is the single funnel both `addSpec` (via `rebuildSource`) and `updateSource` go through, so wrapping any non-instance input as `new OAuth2SourceConfig(...)` there fixes both callers without touching the public API surface. SDK callers that already pass a class instance short-circuit through the instanceof check.
- Reproduced in Sentry as `NODE-CLOUDFLARE-WORKERS-3N` (Google + Vercel users this week, and reported again today for Microsoft SharePoint). Existing tests didn't catch it because every test constructed `new OAuth2SourceConfig({...})` directly and never exercised the wire path.

## Test plan

- [x] New regression test in `plugin.test.ts` simulates the API boundary by handing `addSpec` a plain object that satisfies the Struct shape, then asserts the source round-trips back through `getSource`. On `main` it fails with the exact production message at `store.ts:553`; with the fix it passes.
- [x] `bun run vitest run` for the openapi plugin (93 tests pass).
- [x] `bun run lint`, `bun run format:check`, `bun run typecheck` clean.