### PR TITLE
feat: Show loading badge while credentials resolve

### DIFF
--- a/packages/plugins/graphql/src/react/GraphqlSourceSummary.tsx
+++ b/packages/plugins/graphql/src/react/GraphqlSourceSummary.tsx
@@ -4,6 +4,7 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { connectionsAtom } from "@executor-js/react/api/atoms";
 import { useScope, useScopeStack, useUserScope } from "@executor-js/react/api/scope-context";
 import {
+  SourceCredentialLoadingBadge,
   SourceCredentialNotice,
   SourceCredentialStatusBadge,
   missingSourceCredentialLabels,
@@ -53,9 +54,7 @@ export default function GraphqlSourceSummary(props: {
   const slots = sourceCredentialSlots(source as StoredGraphqlSource);
   if (slots.length === 0) return null;
   if (!AsyncResult.isSuccess(bindingsResult) || !AsyncResult.isSuccess(connectionsResult)) {
-    return props.variant === "panel" ? null : (
-      <SourceCredentialStatusBadge missing={["credentials"]} />
-    );
+    return props.variant === "panel" ? null : <SourceCredentialLoadingBadge />;
   }
 
   const scopeRanks = new Map(scopeStack.map((scope, index) => [scope.id, index] as const));

--- a/packages/plugins/mcp/src/react/McpSourceSummary.tsx
+++ b/packages/plugins/mcp/src/react/McpSourceSummary.tsx
@@ -4,6 +4,7 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { connectionsAtom } from "@executor-js/react/api/atoms";
 import { useScope, useScopeStack, useUserScope } from "@executor-js/react/api/scope-context";
 import {
+  SourceCredentialLoadingBadge,
   SourceCredentialNotice,
   SourceCredentialStatusBadge,
   missingSourceCredentialLabels,
@@ -70,9 +71,7 @@ export default function McpSourceSummary(props: {
   const slots = sourceCredentialSlots(source as McpStoredSourceSchemaType);
   if (slots.length === 0) return null;
   if (!AsyncResult.isSuccess(bindingsResult) || !AsyncResult.isSuccess(connectionsResult)) {
-    return props.variant === "panel" ? null : (
-      <SourceCredentialStatusBadge missing={["credentials"]} />
-    );
+    return props.variant === "panel" ? null : <SourceCredentialLoadingBadge />;
   }
 
   const scopeRanks = new Map(scopeStack.map((scope, index) => [scope.id, index] as const));

--- a/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@executor-js/react/components/badge";
 import { useScope, useScopeStack, useUserScope } from "@executor-js/react/api/scope-context";
 import { ScopeId } from "@executor-js/sdk/core";
 import {
+  SourceCredentialLoadingBadge,
   SourceCredentialNotice,
   SourceCredentialStatusBadge,
   missingSourceCredentialLabels,
@@ -18,17 +19,6 @@ import { oauth2ClientSecretSlot, type StoredSourceSchemaType } from "../sdk/stor
 
 function OAuthBadge() {
   return <Badge variant="secondary">OAuth</Badge>;
-}
-
-function CheckingCredentialsBadge() {
-  return (
-    <Badge
-      variant="outline"
-      className="border-border bg-muted/50 text-[10px] text-muted-foreground"
-    >
-      Checking credentials
-    </Badge>
-  );
 }
 
 const effectiveClientSecretSlot = (oauth2: {
@@ -92,12 +82,12 @@ export default function OpenApiSourceSummary(props: {
   const bindingsLoaded = AsyncResult.isSuccess(bindingsResult);
   const connectionsLoaded = AsyncResult.isSuccess(connectionsResult);
   if (!bindingsLoaded) {
-    return props.variant === "panel" ? null : <CheckingCredentialsBadge />;
+    return props.variant === "panel" ? null : <SourceCredentialLoadingBadge />;
   }
 
   const bindings = AsyncResult.isSuccess(bindingsResult) ? bindingsResult.value : [];
   if (oauth2 && !connectionsLoaded) {
-    return props.variant === "panel" ? null : <CheckingCredentialsBadge />;
+    return props.variant === "panel" ? null : <SourceCredentialLoadingBadge />;
   }
   const connections = AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : [];
   const liveConnectionIds = new Set(connections.map((connection) => connection.id));

--- a/packages/react/src/plugins/source-credential-status.tsx
+++ b/packages/react/src/plugins/source-credential-status.tsx
@@ -7,6 +7,17 @@ export {
   type SourceCredentialSlot,
 } from "./source-credential-status-core";
 
+export function SourceCredentialLoadingBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="animate-pulse border-border bg-muted/40 text-[10px] text-muted-foreground"
+    >
+      loading
+    </Badge>
+  );
+}
+
 export function SourceCredentialStatusBadge(props: { readonly missing: readonly string[] }) {
   if (props.missing.length === 0) {
     return (


### PR DESCRIPTION
## Summary

- Add a shared credential loading badge with a subtle pulsing style.
- Use the loading badge while MCP, GraphQL, and OpenAPI credential bindings/connections are still resolving.
- Preserve the final credential-ready and credential-needed statuses once credential state has loaded.

## Validation

- `bunx vitest run src/plugins/source-credential-status.test.ts` from `packages/react`
- `bun run --filter='@executor-js/react' typecheck`
- `bun run --filter='@executor-js/plugin-mcp' typecheck`
- `bun run --filter='@executor-js/plugin-openapi' typecheck`
- `bun run --filter='@executor-js/plugin-graphql' typecheck`
- `bunx oxfmt --check packages/react/src/plugins/source-credential-status.tsx packages/plugins/mcp/src/react/McpSourceSummary.tsx packages/plugins/graphql/src/react/GraphqlSourceSummary.tsx packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx`
- `bun run lint`

Screenshot captured with agent-browser: `/tmp/source-credential-loading-badge-clean.png`.