### PR TITLE
ci(desktop): rewrite publish workflow + add PR smoke build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,28 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - run: bun run test
+
+  desktop-smoke:
+    name: Desktop smoke build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - run: bun install --frozen-lockfile
+
+      - name: Build web app
+        run: bun run --filter @executor-js/local build
+
+      - name: Build sidecar + stage web UI
+        env:
+          BUN_TARGET: bun-linux-x64
+        run: bun ./scripts/build-sidecar.ts
+        working-directory: apps/desktop
+
+      - name: Build Electron main/preload/renderer
+        run: bunx --bun electron-vite build
+        working-directory: apps/desktop

--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -1,6 +1,11 @@
 name: Publish Desktop App
 run-name: "${{ format('publish desktop {0}', github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name) }}"
 
+# Triggered manually or by publish-executor-package.yml after a CLI release
+# lands. Builds Electron distributables for mac/win/linux with the Bun-compiled
+# sidecar bundled in `resources/sidecar/`, then attaches them to the GitHub
+# release matching the tag so electron-updater can pick them up.
+
 on:
   workflow_dispatch:
     inputs:
@@ -27,19 +32,19 @@ jobs:
           - os: macos-latest
             arch: arm64
             platform: mac
-            cli-asset: executor-darwin-arm64.zip
+            bun-target: bun-darwin-arm64
           - os: macos-latest
             arch: x64
             platform: mac
-            cli-asset: executor-darwin-x64.zip
+            bun-target: bun-darwin-x64
           - os: ubuntu-latest
             arch: x64
             platform: linux
-            cli-asset: executor-linux-x64.tar.gz
+            bun-target: bun-linux-x64
           - os: windows-latest
             arch: x64
             platform: win
-            cli-asset: executor-windows-x64.zip
+            bun-target: bun-windows-x64
 
     runs-on: ${{ matrix.os }}
 
@@ -77,52 +82,25 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build web app
-        run: bun run build
-        working-directory: apps/local
+        run: bun run --filter @executor-js/local build
 
-      - name: Download and extract CLI sidecar (unix)
-        if: matrix.platform != 'win'
+      - name: Build sidecar binary + stage web UI
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          mkdir -p apps/desktop/resources
-          gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "${{ matrix.cli-asset }}" --dir /tmp/cli-download
-          cd /tmp/cli-download
-          if [[ "${{ matrix.cli-asset }}" == *.tar.gz ]]; then
-            tar -xzf "${{ matrix.cli-asset }}"
-          else
-            unzip -o "${{ matrix.cli-asset }}"
-          fi
-          cp executor "${{ github.workspace }}/apps/desktop/resources/executor"
-          chmod +x "${{ github.workspace }}/apps/desktop/resources/executor"
-          if [ -f emscripten-module.wasm ]; then
-            cp emscripten-module.wasm "${{ github.workspace }}/apps/desktop/resources/"
-          fi
-
-      - name: Download and extract CLI sidecar (windows)
-        if: matrix.platform == 'win'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path "apps/desktop/resources"
-          gh release download "$env:RELEASE_TAG" --repo "$env:GITHUB_REPOSITORY" --pattern "${{ matrix.cli-asset }}" --dir "$env:TEMP/cli-download"
-          Expand-Archive -Path "$env:TEMP/cli-download/${{ matrix.cli-asset }}" -DestinationPath "$env:TEMP/cli-extract" -Force
-          Copy-Item "$env:TEMP/cli-extract/executor.exe" "apps/desktop/resources/executor.exe"
-          if (Test-Path "$env:TEMP/cli-extract/emscripten-module.wasm") {
-            Copy-Item "$env:TEMP/cli-extract/emscripten-module.wasm" "apps/desktop/resources/"
-          }
-
-      - name: Build desktop app (TypeScript)
-        run: bunx tsc -p tsconfig.json
+          BUN_TARGET: ${{ matrix.bun-target }}
+        run: bun ./scripts/build-sidecar.ts
         working-directory: apps/desktop
 
-      - name: Prepare Linux package output directory
-        if: matrix.platform == 'linux'
-        run: mkdir -p apps/desktop/dist/@executor-js
+      - name: Build Electron main/preload/renderer
+        run: bunx --bun electron-vite build
+        working-directory: apps/desktop
 
       - name: Build desktop distributables
-        run: npx electron-builder --${{ matrix.platform }} --${{ matrix.arch }}
+        env:
+          # electron-builder reads GH_TOKEN for the publish step. We use
+          # --publish never here and attach assets explicitly in the release
+          # job so we don't fight electron-updater's metadata expectations.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bunx --bun electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never --config electron-builder.config.ts
         working-directory: apps/desktop
 
       - name: Upload artifacts
@@ -131,9 +109,12 @@ jobs:
           name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
             apps/desktop/dist/*.dmg
+            apps/desktop/dist/*.zip
             apps/desktop/dist/*.exe
             apps/desktop/dist/*.AppImage
             apps/desktop/dist/*.deb
+            apps/desktop/dist/*.rpm
+            apps/desktop/dist/latest*.yml
           if-no-files-found: warn
 
   release:
@@ -168,7 +149,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          find artifacts -type f \( -name "*.dmg" -o -name "*.exe" -o -name "*.AppImage" -o -name "*.deb" \) | while read file; do
+          find artifacts -type f \
+            \( -name "*.dmg" -o -name "*.zip" -o -name "*.exe" \
+            -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
+            -o -name "latest*.yml" \) | while read file; do
             echo "Uploading: $file"
             gh release upload "$RELEASE_TAG" "$file" --repo "$GITHUB_REPOSITORY" --clobber || true
           done

--- a/apps/desktop/scripts/build-sidecar.ts
+++ b/apps/desktop/scripts/build-sidecar.ts
@@ -31,7 +31,15 @@ const APPS_LOCAL_DIST = resolve(APPS_LOCAL, "dist");
 const EMBEDDED_MIGRATIONS_PATH = join(APPS_LOCAL, "src/server/embedded-migrations.gen.ts");
 const EMBEDDED_MIGRATIONS_STUB = `const migrations: Record<string, string> | null = null;\n\nexport default migrations;\n`;
 
-const binaryName = process.platform === "win32" ? "executor-sidecar.exe" : "executor-sidecar";
+/**
+ * Cross-compile target for `bun build --compile`. When unset we use Bun's
+ * default `bun` target (the runner's own platform). CI passes a specific
+ * value like `bun-darwin-x64` to produce binaries for other platforms from
+ * a single matrix entry.
+ */
+const BUN_TARGET = process.env.BUN_TARGET ?? "bun";
+const targetIsWindows = BUN_TARGET.includes("windows") || process.platform === "win32";
+const binaryName = targetIsWindows ? "executor-sidecar.exe" : "executor-sidecar";
 const sidecarBinary = resolve(SIDECAR_OUT_DIR, binaryName);
 
 const createEmbeddedMigrationsSource = async (): Promise<string> => {
@@ -74,8 +82,10 @@ await writeFile(EMBEDDED_MIGRATIONS_PATH, `${embeddedMigrations}\n`);
 
 // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: ensure the gen stub is restored even if compile fails
 try {
-  console.log(`[build-sidecar] bun build --compile ${SIDECAR_ENTRY} → ${sidecarBinary}`);
-  await $`bun build --compile --minify --sourcemap --target=bun --outfile ${sidecarBinary} ${SIDECAR_ENTRY}`.cwd(
+  console.log(
+    `[build-sidecar] bun build --compile --target=${BUN_TARGET} ${SIDECAR_ENTRY} → ${sidecarBinary}`,
+  );
+  await $`bun build --compile --minify --sourcemap --target=${BUN_TARGET} --outfile ${sidecarBinary} ${SIDECAR_ENTRY}`.cwd(
     REPO_ROOT,
   );
 } finally {


### PR DESCRIPTION
Replaces #779 (closed when the parent #778 squash-merged and deleted its head branch). Same diff, rebased onto main.

## Summary

- Rewrites \`publish-desktop.yml\` for the new desktop architecture. Drops the old CLI-asset-download path and instead builds the Bun-compiled sidecar in-job via \`apps/desktop/scripts/build-sidecar.ts\` with \`BUN_TARGET\` set per matrix entry, then runs \`electron-vite build\` + \`electron-builder --<platform> --<arch> --publish never\`. Artifacts (\`.dmg\` / \`.zip\` / \`.exe\` / \`.AppImage\` / \`.deb\` / \`.rpm\` + \`latest*.yml\` metadata) get attached to the release in a separate \`release\` job, where \`electron-updater\` can find them.
- Adds a \`Desktop smoke build\` job to \`ci.yml\` that runs the same sidecar + electron-vite pipeline on Linux for every PR.
- \`apps/desktop/scripts/build-sidecar.ts\` now honors \`BUN_TARGET\`. Local dev uses the runner-native target; CI cross-compiles to \`bun-darwin-arm64\` / \`bun-darwin-x64\` / \`bun-linux-x64\` / \`bun-windows-x64\`.

## Test plan

- [ ] \`Desktop smoke build\` passes (web app + sidecar + electron-vite build).
- [ ] Existing Format / Lint / Typecheck / Test stay green.
- [ ] Manual dispatch of \`Publish Desktop App\` against a tag produces installable artifacts for mac arm64/x64, linux x64, win x64.
- [ ] After artifacts upload, \`electron-updater\` in a running desktop install detects the new version.