### PR TITLE
feat(marketing): hero Cloud/Local toggle + desktop download surface

### DIFF
--- a/apps/marketing/src/components/self-host-contact-modal.tsx
+++ b/apps/marketing/src/components/self-host-contact-modal.tsx
@@ -7,31 +7,48 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@executor-js/react/components/dialog";
+
 const TEMPLATE = "Hi Rhys, I'm at {company} and interested in self hosting executor.";
 const EMAIL = "rhys@executor.sh";
 
-export function SelfHostContactModal() {
+type Variant = "card" | "inline";
+
+interface Props {
+  /**
+   * "card" (default) — block-level "Get in touch →" link styled like a card CTA.
+   * "inline" — accent-colored inline link sized to flow inside a paragraph.
+   */
+  readonly variant?: Variant;
+}
+
+export function SelfHostContactModal({ variant = "card" }: Props) {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button
-          variant="link"
-          className="btn-link self-start h-auto p-0 text-current hover:no-underline"
-        >
-          Get in touch →
-        </Button>
+        {variant === "inline" ? (
+          <Button variant="link" className="link-accent inline-flex h-auto items-baseline p-0">
+            Looking for self-hosted? →
+          </Button>
+        ) : (
+          <Button
+            variant="link"
+            className="btn-link self-start h-auto p-0 text-current hover:no-underline"
+          >
+            Get in touch →
+          </Button>
+        )}
       </DialogTrigger>
       <DialogContent
         showCloseButton={false}
-        className="surface-card gap-0 border-0 p-6 sm:max-w-[520px] sm:p-7"
+        className="surface-card gap-0 border-0 p-6 sm:max-w-[560px] sm:p-7"
         style={{
           background: "var(--color-surface)",
           color: "var(--color-ink)",
         }}
       >
-        <div className="mb-4 flex items-start justify-between gap-4">
+        <div className="mb-5 flex items-start justify-between gap-4">
           <DialogTitle className="text-[20px] font-semibold tracking-[-0.01em]">
-            Get in touch
+            Self-hosted Executor
           </DialogTitle>
           <DialogClose asChild>
             <Button
@@ -58,8 +75,13 @@ export function SelfHostContactModal() {
           </DialogClose>
         </div>
 
-        <p className="mb-3 text-[13.5px] leading-[1.55]" style={{ color: "var(--color-ink-2)" }}>
-          Copy the template, fill in your company, and send it to me.
+        <p className="mb-4 text-[14px] leading-[1.6]" style={{ color: "var(--color-ink-2)" }}>
+          We're looking for early adopters to give feedback and use the self hosted product. If
+          you're a company interested in self hosting get in touch.
+        </p>
+
+        <p className="mb-2 text-[13px] font-medium" style={{ color: "var(--color-ink-3)" }}>
+          Copy this and send it over:
         </p>
 
         <div

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -59,48 +59,106 @@ import { SelfHostContactModal } from "../components/self-host-contact-modal";
             >
               One gateway. Every tool. Every team.
             </p>
+
+            {/* ── Toggle: Try in Cloud / Try locally ── */}
             <div
-              class="rise-4 flex flex-wrap items-center justify-center gap-5"
+              class="rise-4 hero-toggle flex flex-col items-center gap-7"
+              data-active="cloud"
             >
-              <a href="/cloud" class="btn-primary">Try Cloud →</a>
-              <button
-                type="button"
-                class="btn-link copy-btn"
-                data-copy="npm i -g executor && executor web"
-                aria-label="Copy npm i -g executor && executor web to clipboard"
+              <div
+                class="tab-toggle"
+                data-active="cloud"
+                role="tablist"
+                aria-label="Choose how to try Executor"
               >
-                <span class="font-mono text-[13px] text-ink-3">$</span>
-                <span>npm i -g executor && executor web</span>
-                <span class="copy-icons text-ink-3" aria-hidden="true">
-                  <svg
-                    class="copy-icon-copy"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    ><rect x="9" y="9" width="13" height="13" rx="2" ry="2"
-                    ></rect><path
-                      d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-                    ></path></svg
+                <span class="tab-indicator" aria-hidden="true"></span>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected="true"
+                  data-tab="cloud"
+                >
+                  Cloud
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected="false"
+                  data-tab="local"
+                >
+                  Local
+                </button>
+              </div>
+
+              {/* Cloud pane */}
+              <div
+                class="pane flex-col items-center gap-4"
+                data-pane="cloud"
+                role="tabpanel"
+                aria-labelledby="tab-cloud"
+              >
+                <p class="pane-desc">
+                  Built for teams. Plug into any agent via MCP.
+                </p>
+                <a href="/cloud" class="btn-primary btn-primary--hero"
+                  >Try Cloud →</a
+                >
+              </div>
+
+              {/* Local pane — auto-detected download */}
+              <div
+                class="pane flex-col items-center gap-4"
+                data-pane="local"
+                role="tabpanel"
+                aria-labelledby="tab-local"
+                data-download
+              >
+                <p class="pane-desc">
+                  Everything runs on your machine locally.
+                </p>
+                <div class="flex flex-wrap items-center justify-center gap-3">
+                  <a
+                    data-os="mac-arm64"
+                    href="https://github.com/RhysSullivan/executor/releases/latest/download/executor-desktop-mac-arm64.dmg"
+                    class="btn-primary btn-primary--hero"
                   >
-                  <svg
-                    class="copy-icon-check"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    ><polyline points="20 6 9 17 4 12"></polyline></svg
+                    Download for Mac (Apple Silicon)
+                  </a>
+                  <a
+                    data-os="mac-x64"
+                    href="https://github.com/RhysSullivan/executor/releases/latest/download/executor-desktop-mac-x64.dmg"
+                    class="btn-primary btn-primary--hero"
                   >
-                </span>
-              </button>
+                    Download for Mac (Intel)
+                  </a>
+                  <a
+                    data-os="win-x64"
+                    href="https://github.com/RhysSullivan/executor/releases/latest/download/executor-desktop-win-x64.exe"
+                    class="btn-primary btn-primary--hero"
+                  >
+                    Download for Windows
+                  </a>
+                  <a
+                    data-os="linux-x64"
+                    href="https://github.com/RhysSullivan/executor/releases/latest/download/executor-desktop-linux-x64.AppImage"
+                    class="btn-primary btn-primary--hero"
+                  >
+                    Download for Linux
+                  </a>
+
+                  <details
+                    class="download-other hidden"
+                    data-download-other
+                  >
+                    <summary>Other platforms ▾</summary>
+                    <div
+                      class="download-other-list"
+                      data-download-other-list
+                    >
+                    </div>
+                  </details>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -200,7 +258,9 @@ import { SelfHostContactModal } from "../components/self-host-contact-modal";
             </h2>
           </div>
 
-          <div class="grid md:grid-cols-3 gap-6 max-w-[1100px] mx-auto">
+          <div
+            class="grid md:grid-cols-2 gap-6 max-w-[760px] mx-auto"
+          >
             {/* Cloud */}
             <div
               class="surface-card p-8 flex flex-col"
@@ -218,15 +278,18 @@ import { SelfHostContactModal } from "../components/self-host-contact-modal";
                 Cloud
               </h3>
               <p
-                class="text-[14.5px] leading-[1.55] text-ink-2 mb-6 text-pretty flex-1"
+                class="text-[14.5px] leading-[1.55] text-ink-2 mb-3 text-pretty"
               >
-                Hosted Executor. Auth, sync, policies, and the whole team online
-                in five minutes. Free tier to start.
+                Hosted Executor. Auth, sync, policies, and the whole team
+                online in five minutes. Free tier to start.
+              </p>
+              <p class="mb-6 text-[13.5px] leading-[1.55] text-ink-3 flex-1">
+                <SelfHostContactModal client:load variant="inline" />
               </p>
               <a href="/cloud" class="btn-primary self-start">Try Cloud →</a>
             </div>
 
-            {/* Local */}
+            {/* Desktop */}
             <div class="surface-card p-8 flex flex-col">
               <div class="flex items-center gap-2 mb-4">
                 <span
@@ -237,43 +300,21 @@ import { SelfHostContactModal } from "../components/self-host-contact-modal";
               <h3
                 class="text-[22px] font-semibold tracking-[-0.01em] text-ink mb-3"
               >
-                Local
+                Desktop
               </h3>
               <p
                 class="text-[14.5px] leading-[1.55] text-ink-2 mb-6 text-pretty flex-1"
               >
-                Run on your own machine. Keychain-backed secrets. Zero data
-                leaves your laptop. MIT licensed.
+                A native app for Mac, Windows, and Linux. Everything stays
+                on your machine — sources, secrets, sessions. MIT licensed.
               </p>
-              <div
-                class="font-mono text-[13px] text-ink bg-surface-2 border border-rule px-3 py-2 rounded-md self-start"
-                style="background: var(--color-surface-2)"
+              <button
+                type="button"
+                data-jump-to-local
+                class="btn-primary self-start"
               >
-                <span class="text-ink-3">$</span> npm i -g executor && executor web
-              </div>
-            </div>
-
-            {/* Self-Hosted */}
-            <div class="surface-card p-8 flex flex-col">
-              <div class="flex items-center gap-2 mb-4">
-                <span
-                  class="font-mono text-[11px] uppercase tracking-[0.18em] text-ink-3"
-                  >Bring your own infra</span
-                >
-              </div>
-              <h3
-                class="text-[22px] font-semibold tracking-[-0.01em] text-ink mb-3"
-              >
-                Self-Hosted
-              </h3>
-              <p
-                class="text-[14.5px] leading-[1.55] text-ink-2 mb-6 text-pretty flex-1"
-              >
-                We're looking for early adopters to give feedback and use the
-                self hosted product. If you're a company interested in self
-                hosting get in touch.
-              </p>
-              <SelfHostContactModal client:load />
+                Download →
+              </button>
             </div>
           </div>
         </div>
@@ -327,4 +368,124 @@ import { SelfHostContactModal } from "../components/self-host-contact-modal";
         }, 1500);
       });
     });
+</script>
+
+<script>
+  // ── Hero tab toggle: Try in Cloud / Try locally ────────────────────
+  // Drives the sliding pill indicator + pane visibility via a single
+  // `data-active` attribute on the wrapper. Default "cloud" so no-JS
+  // visitors still see the recommended path.
+  const heroToggle = document.querySelector<HTMLElement>(".hero-toggle");
+  const tabToggle = heroToggle?.querySelector<HTMLElement>(".tab-toggle");
+  const setActiveTab = (tab: "cloud" | "local") => {
+    if (!heroToggle || !tabToggle) return;
+    heroToggle.dataset.active = tab;
+    tabToggle.dataset.active = tab;
+    tabToggle.querySelectorAll<HTMLButtonElement>("button[data-tab]").forEach(
+      (btn) => {
+        btn.setAttribute(
+          "aria-selected",
+          btn.dataset.tab === tab ? "true" : "false",
+        );
+      },
+    );
+  };
+  if (heroToggle && tabToggle) {
+    tabToggle.querySelectorAll<HTMLButtonElement>("button[data-tab]").forEach(
+      (btn) => {
+        btn.addEventListener("click", () => {
+          const tab = btn.dataset.tab as "cloud" | "local" | undefined;
+          if (tab) setActiveTab(tab);
+        });
+      },
+    );
+  }
+
+  // Desktop card "Download →" CTA jumps to the hero, switches to Local,
+  // and lets the auto-detect script there pick the right OS button.
+  document
+    .querySelectorAll<HTMLButtonElement>("button[data-jump-to-local]")
+    .forEach((btn) => {
+      btn.addEventListener("click", () => {
+        setActiveTab("local");
+        heroToggle?.scrollIntoView({ behavior: "smooth", block: "center" });
+      });
+    });
+
+  // ── Auto-detect download platform ──────────────────────────────────
+  // Shows ONE primary button matching the visitor's OS in the "Try
+  // locally" pane; tucks the others behind an "Other platforms"
+  // popover. No-JS / unrecognised UA: all four buttons visible (still
+  // functional, just less polished).
+  type DownloadOs = "mac-arm64" | "mac-x64" | "win-x64" | "linux-x64";
+
+  type UserAgentData = {
+    readonly platform: string;
+    readonly getHighEntropyValues?: (
+      hints: ReadonlyArray<string>,
+    ) => Promise<{ readonly architecture?: string; readonly bitness?: string }>;
+  };
+
+  const detectOs = async (): Promise<DownloadOs | null> => {
+    const navAny = navigator as Navigator & {
+      readonly userAgentData?: UserAgentData;
+    };
+    const uad = navAny.userAgentData;
+    const platformRaw =
+      uad?.platform ?? navigator.platform ?? navigator.userAgent ?? "";
+    const platform = platformRaw.toLowerCase();
+    const ua = navigator.userAgent.toLowerCase();
+
+    if (platform.includes("win") || ua.includes("windows")) return "win-x64";
+    if (platform.includes("linux") || ua.includes("linux")) return "linux-x64";
+    if (platform.includes("mac") || ua.includes("mac")) {
+      // Apple Silicon vs Intel: ask client hints first, then fall back to
+      // a heuristic. Most modern Macs are arm64.
+      if (uad?.getHighEntropyValues) {
+        try {
+          const hints = await uad.getHighEntropyValues([
+            "architecture",
+            "bitness",
+          ]);
+          if (hints.architecture === "arm") return "mac-arm64";
+          if (hints.architecture === "x86") return "mac-x64";
+        } catch {}
+      }
+      return "mac-arm64";
+    }
+    return null;
+  };
+
+  void (async () => {
+    const root = document.querySelector<HTMLElement>("[data-download]");
+    if (!root) return;
+    const buttons = Array.from(
+      root.querySelectorAll<HTMLAnchorElement>("a[data-os]"),
+    );
+    const other = root.querySelector<HTMLDetailsElement>(
+      "[data-download-other]",
+    );
+    const otherList = root.querySelector<HTMLDivElement>(
+      "[data-download-other-list]",
+    );
+    if (buttons.length === 0 || !other || !otherList) return;
+
+    const detected = await detectOs();
+    if (!detected) return;
+
+    for (const btn of buttons) {
+      const os = btn.dataset.os as DownloadOs | undefined;
+      if (os && os !== detected) {
+        btn.classList.add("hidden");
+        const clone = btn.cloneNode(true) as HTMLAnchorElement;
+        clone.classList.remove(
+          "btn-primary",
+          "btn-primary--hero",
+          "hidden",
+        );
+        otherList.appendChild(clone);
+      }
+    }
+    other.classList.remove("hidden");
+  })();
 </script>

--- a/apps/marketing/src/styles/global.css
+++ b/apps/marketing/src/styles/global.css
@@ -183,6 +183,211 @@ body {
   transform: scale(1);
 }
 
+/* ──────────────────────────────────────────────────────────────
+   Hero toggle — segmented "Try in Cloud / Try locally" control.
+   A sliding white pill animates between two equal-width tabs.
+   The active pane is revealed below; inactive panes hide.
+   ─────────────────────────────────────────────────────────── */
+.tab-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-rule);
+  border-radius: 999px;
+  padding: 4px;
+  isolation: isolate;
+}
+.tab-toggle > button {
+  position: relative;
+  z-index: 1;
+  min-width: 7.5rem;
+  padding: 0.5rem 1.1rem;
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  font-weight: 500;
+  letter-spacing: -0.005em;
+  color: var(--color-ink-3);
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+.tab-toggle > button:hover {
+  color: var(--color-ink-2);
+}
+.tab-toggle > button[aria-selected="true"] {
+  color: var(--color-ink);
+}
+.tab-toggle .tab-indicator {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  left: 4px;
+  width: calc(50% - 4px);
+  background: white;
+  border-radius: 999px;
+  box-shadow:
+    0 1px 2px rgba(13, 13, 16, 0.04),
+    0 0 0 1px var(--color-rule);
+  transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+  z-index: 0;
+}
+.tab-toggle[data-active="local"] .tab-indicator {
+  transform: translateX(100%);
+}
+
+.hero-toggle .pane {
+  display: none;
+}
+.hero-toggle[data-active="cloud"] .pane[data-pane="cloud"],
+.hero-toggle[data-active="local"] .pane[data-pane="local"] {
+  display: flex;
+}
+
+/* Per-pane description — sits above the CTA. Smaller than the hero tagline,
+   tight max-width so two lines wrap naturally on narrow widths. */
+.pane-desc {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: var(--color-ink-2);
+  letter-spacing: -0.005em;
+  max-width: 36ch;
+  text-align: center;
+  text-wrap: balance;
+  margin: 0;
+}
+
+/* Subtle metadata strip under each pane's CTA — uppercase mono dots */
+.pane-meta {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-ink-3);
+}
+.pane-meta .dot {
+  width: 3px;
+  height: 3px;
+  background: var(--color-ink-3);
+  border-radius: 999px;
+  opacity: 0.45;
+  flex-shrink: 0;
+}
+.pane-meta .meta-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  text-transform: none;
+  letter-spacing: -0.005em;
+  font-family: var(--font-mono);
+  color: var(--color-ink-2);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+.pane-meta .meta-copy:hover {
+  color: var(--color-ink);
+}
+
+/* "Other platforms" popover so the layout doesn't shift when it opens */
+.download-other {
+  position: relative;
+}
+.download-other > summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  font-size: 13px;
+  color: var(--color-ink-3);
+  padding: 0.4rem 0.6rem;
+  border-radius: 8px;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+.download-other > summary::-webkit-details-marker {
+  display: none;
+}
+.download-other > summary:hover {
+  color: var(--color-ink-2);
+  background: var(--color-surface-2);
+}
+.download-other[open] > summary {
+  color: var(--color-ink);
+}
+.download-other .download-other-list {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  background: white;
+  border: 1px solid var(--color-rule);
+  border-radius: 12px;
+  padding: 0.45rem;
+  min-width: 16rem;
+  box-shadow:
+    0 4px 16px -6px rgba(13, 13, 16, 0.12),
+    0 1px 3px rgba(13, 13, 16, 0.04);
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.download-other .download-other-list a {
+  display: block;
+  padding: 0.55rem 0.8rem;
+  border-radius: 8px;
+  font-size: 13.5px;
+  color: var(--color-ink-2);
+  text-align: left;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+.download-other .download-other-list a:hover {
+  color: var(--color-ink);
+  background: var(--color-surface-2);
+}
+
+/* Larger primary button for the hero pane — keeps btn-primary base sizing
+   for nav/cards but bumps the hero's CTA to a more confident scale */
+.btn-primary--hero {
+  padding: 0.7rem 1.25rem;
+  font-size: 14.5px;
+}
+
+/* Accent-colored inline link — for secondary callouts inside card bodies */
+.link-accent {
+  color: var(--color-accent);
+  font-weight: 500;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--color-accent) 30%, transparent);
+  text-underline-offset: 3px;
+  transition:
+    color 0.15s ease,
+    text-decoration-color 0.15s ease;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+}
+.link-accent:hover {
+  color: var(--color-accent-hover);
+  text-decoration-color: var(--color-accent-hover);
+}
+
 /* Legal pages */
 .legal-prose {
   color: color-mix(in srgb, var(--color-ink) 85%, transparent);


### PR DESCRIPTION
Replaces #780 (closed when the parent branch was deleted on merge). Same diff, rebased onto main.

Holding open per request — not merging until the first desktop release lands so the download links resolve.

## Summary

- Hero CTA row becomes a sliding segmented pill toggle (\`Cloud\` / \`Local\`).
- Cloud pane: \`Try Cloud →\` to /cloud + one-line tagline.
- Local pane: auto-detected primary download button (UA-CH + \`navigator.platform\` heuristic) + \`Other platforms ▾\` popover.
- "Pick your path" grid drops the Self-Hosted card; Cloud card body picks up a small inline accent link "Looking for self-hosted? →" that opens the existing modal. New Desktop card with \`Download →\` that switches the hero toggle to Local and scrolls up.
- Self-host modal accepts a \`variant\` prop (card / inline) and gets a fresh title; body unchanged from original framing.

## Test plan

- [ ] \`bun run --filter @executor-js/marketing dev\` — toggle between Cloud and Local, confirm pill slides, panes swap, descriptions render, both CTAs (Cloud \`Try Cloud →\` and Desktop card \`Download →\`) work.
- [ ] OS auto-detection: Mac (mac-arm64 expected primary), Windows (win-x64), Linux (linux-x64). Other platforms collapse into the popover; no-JS shows all four.
- [ ] \`bun run --filter @executor-js/marketing typecheck\` + \`build\` clean.
- [ ] Self-hosted modal opens from the Cloud card inline link; template + email copy work.
- [ ] Download links (\`/releases/latest/download/executor-desktop-*\`) will 404 until the first signed release ships; merge this PR after the first release is published.