### PR TITLE
chore(release): sync @executor-js/desktop into the cli release flow

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,7 +10,7 @@
       "@executor-js/runtime-quickjs",
       "@executor-js/execution",
       "@executor-js/config",
-      "@executor-js/cli",
+      "executor",
       "@executor-js/plugin-file-secrets",
       "@executor-js/plugin-google-discovery",
       "@executor-js/plugin-graphql",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/desktop",
-  "version": "1.4.0-beta.0",
+  "version": "1.4.19",
   "private": true,
   "homepage": "https://github.com/RhysSullivan/executor",
   "license": "MIT",

--- a/bun.lock
+++ b/bun.lock
@@ -117,7 +117,7 @@
     },
     "apps/desktop": {
       "name": "@executor-js/desktop",
-      "version": "1.4.0-beta.0",
+      "version": "1.4.19",
       "dependencies": {
         "electron-log": "^5",
         "electron-store": "^10",


### PR DESCRIPTION
Two corrections so the next CLI release ships a consistent desktop version.

## Summary

- **Changesets fixed group**: the CLI's workspace name is \`executor\` (per \`apps/cli/package.json\`), not the \`@executor-js/cli\` stub that was sitting in the \`fixed\` array. The stub didn't match any real package, so the group's lockstep coupling didn't include the cli. Swap in \`executor\` so the cli is actually linked to the rest of the group — including the newly added \`@executor-js/desktop\`.
- **\`apps/desktop/package.json\` version**: bump from \`1.4.0-beta.0\` (a stale root-borrowed marker) to \`1.4.19\` to match the current CLI. From here on, Changesets keeps them in lockstep.

Should land before #777 merges. After this lands on main, the Version Packages PR's auto-update will detect the new linked group and bump \`apps/desktop/package.json\` alongside \`apps/cli/package.json\` (both 1.4.19 → 1.4.20).

When the next CLI release fires, \`publish-desktop.yml\` ships the desktop app with a version label matching the GitHub release tag — no drift between the CLI tag (\`v1.4.20\`) and the \`latest*.yml\` electron-updater sees.

## Test plan

- [ ] \`bun run release:check\` passes locally (no changeset orphans, fixed-group resolves).
- [ ] After landing, \`gh pr view 777\` (Version Packages) re-runs the changesets action and the diff now includes \`apps/desktop/package.json: 1.4.19 → 1.4.20\` plus the existing cli bump.
- [ ] Merging #777 produces tag \`v1.4.20\` with both the cli and desktop pinned to 1.4.20.