### PR TITLE
feat(desktop): sign + notarize macOS builds

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -94,12 +94,33 @@ jobs:
         run: bunx --bun electron-vite build
         working-directory: apps/desktop
 
+      - name: Stage Apple API key (mac signing + notarization)
+        if: matrix.platform == 'mac' && env.APPLE_API_KEY != ''
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/private_keys"
+          printf '%s' "$APPLE_API_KEY" > "${RUNNER_TEMP}/private_keys/AuthKey.p8"
+          echo "APPLE_API_KEY_PATH=${RUNNER_TEMP}/private_keys/AuthKey.p8" >> "$GITHUB_ENV"
+
       - name: Build desktop distributables
         env:
           # electron-builder reads GH_TOKEN for the publish step. We use
           # --publish never here and attach assets explicitly in the release
           # job so we don't fight electron-updater's metadata expectations.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Apple signing + notarization. electron-builder picks these up:
+          #   CSC_LINK / CSC_KEY_PASSWORD → import the Developer ID Application
+          #     cert (.p12, base64) into a temp keychain for codesign
+          #   APPLE_API_KEY (file path) / APPLE_API_KEY_ID / APPLE_API_ISSUER
+          #     → notarytool authentication for the notarization upload
+          # When the secrets aren't set (forks, local), electron-builder
+          # silently produces an unsigned build.
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: bunx --bun electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never --config electron-builder.config.ts
         working-directory: apps/desktop
 

--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Electron's V8 / Chromium needs JIT pages writable+executable -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Electron reads NODE_OPTIONS / NODE_PATH at startup; the sidecar
+         reads EXECUTOR_* env vars. Hardened runtime would strip them
+         without this entitlement. -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <!-- The Bun-compiled executor-sidecar binary inside Resources/sidecar/
+         loads dylibs Apple's library validator doesn't recognize as part
+         of the Electron bundle's signing chain. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -29,6 +29,14 @@ const config: Configuration = {
     ],
     hardenedRuntime: true,
     gatekeeperAssess: false,
+    // electron-builder reads CSC_LINK / CSC_KEY_PASSWORD for the signing
+    // identity and APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER
+    // (set in publish-desktop.yml from repo secrets) to upload to Apple
+    // for notarization. Locally, with none of those env vars set,
+    // electron-builder skips signing and produces an unsigned build.
+    entitlements: "build/entitlements.mac.plist",
+    entitlementsInherit: "build/entitlements.mac.plist",
+    notarize: true,
   },
   win: {
     target: [{ target: "nsis", arch: ["x64", "arm64"] }],


### PR DESCRIPTION
Wires the five Apple signing secrets (\`CSC_LINK\`, \`CSC_KEY_PASSWORD\`, \`APPLE_API_KEY\`, \`APPLE_API_KEY_ID\`, \`APPLE_API_ISSUER\` — all already provisioned in repo settings) into the desktop build so macOS artifacts ship signed and notarized.

## Summary

**New file: \`apps/desktop/build/entitlements.mac.plist\`** — hardened runtime entitlements:
- \`allow-jit\` + \`allow-unsigned-executable-memory\` — Electron's V8 JIT needs writable+executable pages.
- \`allow-dyld-environment-variables\` — the Bun sidecar reads \`EXECUTOR_*\` and Electron reads \`NODE_OPTIONS\` at boot; hardened runtime would strip these without the entitlement.
- \`disable-library-validation\` — the bundled \`executor-sidecar\` Bun binary in \`Resources/sidecar/\` loads dylibs that aren't part of the Electron bundle's signing chain.

**\`apps/desktop/electron-builder.config.ts\`** — mac block picks up:
\`\`\`ts
entitlements: "build/entitlements.mac.plist",
entitlementsInherit: "build/entitlements.mac.plist",
notarize: true,
\`\`\`

**\`.github/workflows/publish-desktop.yml\`** — adds a mac-only "Stage Apple API key" step that writes the \`.p8\` to \`\${RUNNER_TEMP}/private_keys/AuthKey.p8\` (notarytool wants a file path, not the key body). The "Build desktop distributables" step then receives \`CSC_LINK\` / \`CSC_KEY_PASSWORD\` (for codesign import) and \`APPLE_API_KEY\` (path) / \`APPLE_API_KEY_ID\` / \`APPLE_API_ISSUER\` (for notarization).

Forks without the secrets still produce unsigned builds — the \`if: ... && env.APPLE_API_KEY != ''\` gate on the staging step keeps it from failing, and electron-builder skips signing when \`CSC_LINK\` is empty.

## Test plan

- [ ] Repo's \`gh secret list\` shows all five secrets (verified pre-PR).
- [ ] Local cert verification: \`security import\` of the \`.p12\` produces \`1 identity imported\` and \`Developer ID Application: Rhys Sullivan (A7SQ9BT93Y)\` (verified pre-PR).
- [ ] After this PR lands on main, dispatch \`publish-desktop.yml -f tag=v1.4.20\` against the existing tag → matrix succeeds → re-uploaded \`.dmg\`/\`.zip\` are signed + notarized.
- [ ] Verify a downloaded \`.dmg\` from the re-uploaded v1.4.20:
  \`\`\`
  hdiutil attach <path>
  spctl --assess --type execute /Volumes/.../Executor.app    # expect: accepted: Notarized Developer ID
  codesign -dv --verbose=4 /Volumes/.../Executor.app          # expect: hardened runtime flag, Developer ID identifier
  xcrun stapler validate /Volumes/.../Executor.app           # expect: validate action worked
  \`\`\`
- [ ] No regression on linux/windows builds (no signing wired up for those yet).

## Out of scope

- Windows code-signing (Azure Trusted Signing) — separate follow-up if/when desired.