### PR TITLE
feat(desktop): persistent server settings + plugin-driven Settings page

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -19,6 +19,7 @@
       "@executor-js/plugin-onepassword",
       "@executor-js/plugin-openapi",
       "@executor-js/plugin-example",
+      "@executor-js/plugin-desktop-settings",
       "@executor-js/desktop"
     ]
   ],

--- a/.changeset/desktop-settings-plugin.md
+++ b/.changeset/desktop-settings-plugin.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Desktop: ship a new `Settings` page (delivered as the `@executor-js/plugin-desktop-settings` plugin) that lets users pick the sidecar's port, toggle Basic auth on/off, and rotate the auto-generated password. Settings persist via electron-store across launches so the MCP install URL the "Connect an agent" card emits stays valid for AI clients. McpInstallCard's HTTP mode now embeds the desktop's credentials in the URL (e.g. `http://executor:<pw>@127.0.0.1:<port>/mcp`) when running inside the desktop app.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "@executor-js/app": "workspace:*",
     "@executor-js/local": "workspace:*",
+    "@executor-js/plugin-desktop-settings": "workspace:*",
     "@executor-js/plugin-file-secrets": "workspace:*",
     "@executor-js/plugin-google-discovery": "workspace:*",
     "@executor-js/plugin-graphql": "workspace:*",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,20 +1,24 @@
 import { join } from "node:path";
-import { app, BrowserWindow, session, shell } from "electron";
+import { fileURLToPath } from "node:url";
+import { app, BrowserWindow, dialog, ipcMain, session, shell } from "electron";
 import windowStateKeeper from "electron-window-state";
 import log from "electron-log/main.js";
 import updater from "electron-updater";
 const { autoUpdater } = updater;
-import { startSidecar, stopSidecar, type SidecarConnection } from "./sidecar";
+import {
+  startSidecar,
+  stopSidecar,
+  SidecarPortInUseError,
+  type SidecarConnection,
+} from "./sidecar";
+import { getServerSettings, regeneratePassword, updateServerSettings } from "./settings";
+import { SERVER_SETTINGS_USERNAME, type DesktopServerSettings } from "../shared/server-settings";
 
 // Pin userData to a friendly app-name-scoped dir BEFORE app.ready so every
 // Electron-side consumer (electron-store, electron-log, window-state) lands
-// at a predictable spot. The bundle identifier `sh.executor.desktop` is
-// used for the app ID (electron-builder, single-instance lock) but NOT for
-// the userData path — we keep that as the readable "Executor" so anyone
-// who pokes around inside ~/Library/Application Support sees the friendly
-// name. User-mutable executor state (executor.jsonc, data.db) is pinned
-// separately to ~/.executor in main/sidecar.ts; it's intentionally NOT
-// under userData so the path matches the CLI's default.
+// at a predictable spot. User-mutable executor state (executor.jsonc,
+// data.db) is pinned separately to ~/.executor in main/sidecar.ts — that
+// path matches the CLI's default.
 app.setName("Executor");
 app.setPath("userData", join(app.getPath("appData"), "Executor"));
 
@@ -23,6 +27,9 @@ log.transports.file.level = "info";
 
 let mainWindow: BrowserWindow | null = null;
 let connection: SidecarConnection | null = null;
+let authHeaderUnsubscribe: (() => void) | null = null;
+
+const PRELOAD_PATH = fileURLToPath(new URL("../preload/index.js", import.meta.url));
 
 const ensureSingleInstance = () => {
   if (!app.requestSingleInstanceLock()) {
@@ -37,32 +44,28 @@ const ensureSingleInstance = () => {
   return true;
 };
 
-const installBasicAuthHeader = (origin: string, password: string) => {
-  const credentials = Buffer.from(`executor:${password}`).toString("base64");
+const installBasicAuthHeader = (origin: string, password: string | null) => {
+  authHeaderUnsubscribe?.();
+  authHeaderUnsubscribe = null;
+  if (!password) return;
+  const credentials = Buffer.from(`${SERVER_SETTINGS_USERNAME}:${password}`).toString("base64");
   const headerValue = `Basic ${credentials}`;
   session.defaultSession.webRequest.onBeforeSendHeaders(
     { urls: [`${origin}/*`] },
     (details, callback) => {
       callback({
-        requestHeaders: {
-          ...details.requestHeaders,
-          Authorization: headerValue,
-        },
+        requestHeaders: { ...details.requestHeaders, Authorization: headerValue },
       });
     },
   );
+  authHeaderUnsubscribe = () => {
+    session.defaultSession.webRequest.onBeforeSendHeaders({ urls: [`${origin}/*`] }, null);
+  };
 };
 
 const resolveLinuxIcon = (): string | undefined => {
   if (process.platform !== "linux") return undefined;
-  // In packaged AppImage/deb/rpm the icon is referenced through the
-  // desktop-entry file electron-builder generates; this is only used at
-  // BrowserWindow construction time. Resolves to the icon staged by
-  // electron-builder under Resources/ in production, or back to the
-  // source PNG when running unpacked in dev.
-  if (app.isPackaged) {
-    return join(process.resourcesPath, "icon.png");
-  }
+  if (app.isPackaged) return join(process.resourcesPath, "icon.png");
   return join(import.meta.dirname, "..", "..", "build", "icon.png");
 };
 
@@ -88,6 +91,7 @@ const createWindow = async (conn: SidecarConnection) => {
     autoHideMenuBar: true,
     ...(linuxIcon ? { icon: linuxIcon } : {}),
     webPreferences: {
+      preload: PRELOAD_PATH,
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
@@ -96,9 +100,7 @@ const createWindow = async (conn: SidecarConnection) => {
 
   windowState.manage(mainWindow);
 
-  mainWindow.once("ready-to-show", () => {
-    mainWindow?.show();
-  });
+  mainWindow.once("ready-to-show", () => mainWindow?.show());
 
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     void shell.openExternal(url);
@@ -108,19 +110,77 @@ const createWindow = async (conn: SidecarConnection) => {
   await mainWindow.loadURL(conn.baseUrl);
 };
 
-const boot = async () => {
-  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: top-level boot path translates failures into a user-facing error
-  try {
-    connection = await startSidecar();
-    await createWindow(connection);
+const showPortInUseDialog = async (port: number) => {
+  await dialog.showMessageBox({
+    type: "error",
+    title: "Executor port in use",
+    message: `Port ${port} is already taken.`,
+    detail:
+      "Another process is listening on that port. Quit it (or change the desktop server's port in Settings) and relaunch Executor.",
+    buttons: ["OK"],
+  });
+};
 
-    if (app.isPackaged) {
-      autoUpdater.logger = log;
-      void autoUpdater.checkForUpdatesAndNotify();
-    }
+const startWithCurrentSettings = async (): Promise<SidecarConnection | null> => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: bind failures surface as a user-facing dialog
+  try {
+    return await startSidecar();
   } catch (error) {
+    // oxlint-disable-next-line executor/no-instanceof-tagged-error -- boundary: SidecarPortInUseError is a plain Node Error subclass, not an Effect tagged error
+    if (error instanceof SidecarPortInUseError) {
+      await showPortInUseDialog(error.port);
+      return null;
+    }
     log.error("Failed to start executor sidecar", error);
+    return null;
+  }
+};
+
+const restartSidecarAndReload = async (): Promise<{ port: number; baseUrl: string }> => {
+  if (connection) {
+    await stopSidecar(connection.child);
+    connection = null;
+  }
+  const next = await startWithCurrentSettings();
+  if (!next) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: surfaces to renderer as a rejected IPC call
+    throw new Error("Sidecar failed to restart — see Settings");
+  }
+  connection = next;
+  installBasicAuthHeader(next.baseUrl, next.authPassword);
+  if (mainWindow) await mainWindow.loadURL(next.baseUrl);
+  return { port: next.port, baseUrl: next.baseUrl };
+};
+
+const registerIpcHandlers = () => {
+  ipcMain.handle("executor:settings:get", (): DesktopServerSettings => getServerSettings());
+  ipcMain.handle(
+    "executor:settings:update",
+    (_evt, patch: Partial<DesktopServerSettings>): DesktopServerSettings =>
+      updateServerSettings(patch),
+  );
+  ipcMain.handle(
+    "executor:settings:regenerate-password",
+    (): DesktopServerSettings => regeneratePassword(),
+  );
+  ipcMain.handle("executor:server:restart", () => restartSidecarAndReload());
+};
+
+const boot = async () => {
+  registerIpcHandlers();
+  connection = await startWithCurrentSettings();
+  if (!connection) {
+    // Even when the sidecar can't start, open the window so the user
+    // reaches Settings to change the port. Pointing at the (unreachable)
+    // baseUrl would just show ECONNREFUSED — a placeholder URL would be
+    // worse. For now: quit with the dialog already shown.
     app.quit();
+    return;
+  }
+  await createWindow(connection);
+  if (app.isPackaged) {
+    autoUpdater.logger = log;
+    void autoUpdater.checkForUpdatesAndNotify();
   }
 };
 

--- a/apps/desktop/src/main/settings.ts
+++ b/apps/desktop/src/main/settings.ts
@@ -1,0 +1,45 @@
+import { randomBytes } from "node:crypto";
+import Store from "electron-store";
+import { DEFAULT_SERVER_SETTINGS, type DesktopServerSettings } from "../shared/server-settings";
+
+interface PersistedShape {
+  readonly server: DesktopServerSettings;
+}
+
+const generatePassword = (): string => randomBytes(24).toString("base64url");
+
+const seedDefaults = (): DesktopServerSettings => ({
+  ...DEFAULT_SERVER_SETTINGS,
+  password: generatePassword(),
+});
+
+const store = new Store<PersistedShape>({
+  name: "settings",
+  defaults: { server: seedDefaults() },
+});
+
+// Backfill if an older settings.json predates the server section.
+if (!store.has("server")) {
+  store.set("server", seedDefaults());
+}
+
+export const getServerSettings = (): DesktopServerSettings => store.get("server");
+
+export const updateServerSettings = (
+  patch: Partial<DesktopServerSettings>,
+): DesktopServerSettings => {
+  const current = getServerSettings();
+  const next: DesktopServerSettings = {
+    port: patch.port ?? current.port,
+    requireAuth: patch.requireAuth ?? current.requireAuth,
+    password: patch.password ?? current.password,
+  };
+  store.set("server", next);
+  return next;
+};
+
+export const regeneratePassword = (): DesktopServerSettings => {
+  const next = { ...getServerSettings(), password: generatePassword() };
+  store.set("server", next);
+  return next;
+};

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -12,25 +12,34 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve, join } from "node:path";
 import { app } from "electron";
+import { getServerSettings } from "./settings";
+import { SERVER_SETTINGS_USERNAME, type DesktopServerSettings } from "../shared/server-settings";
 
 export interface SidecarConnection {
   readonly baseUrl: string;
   readonly hostname: string;
   readonly port: number;
-  readonly authPassword: string;
+  readonly username: string;
+  readonly authPassword: string | null;
   readonly child: ChildProcess;
+}
+
+export class SidecarPortInUseError extends Error {
+  readonly port: number;
+  constructor(port: number) {
+    super(`Port ${port} is already in use. Pick another in Settings.`);
+    this.name = "SidecarPortInUseError";
+    this.port = port;
+  }
 }
 
 interface StartOptions {
   readonly hostname?: string;
 }
-
-const generatePassword = (): string => randomBytes(24).toString("base64url");
 
 const resolveSidecarCommand = (): { command: string; args: string[]; cwd: string } => {
   if (app.isPackaged) {
@@ -54,7 +63,7 @@ const resolveClientDir = (): string => {
 
 export async function startSidecar(options: StartOptions = {}): Promise<SidecarConnection> {
   const hostname = options.hostname ?? "127.0.0.1";
-  const authPassword = generatePassword();
+  const settings = getServerSettings();
   const clientDir = resolveClientDir();
   const { command, args, cwd } = resolveSidecarCommand();
 
@@ -75,14 +84,19 @@ export async function startSidecar(options: StartOptions = {}): Promise<SidecarC
   const scopeDir = join(homedir(), ".executor");
   mkdirSync(scopeDir, { recursive: true });
 
+  const effectivePassword = settings.requireAuth ? settings.password : null;
+
   const child = spawn(command, args, {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
-      EXECUTOR_PORT: "0",
+      EXECUTOR_PORT: String(settings.port),
       EXECUTOR_HOST: hostname,
-      EXECUTOR_AUTH_PASSWORD: authPassword,
+      // Only export the password env var when auth is enabled — the sidecar
+      // treats an empty password as "no auth required". Matches the CLI's
+      // `executor web` default.
+      ...(effectivePassword ? { EXECUTOR_AUTH_PASSWORD: effectivePassword } : {}),
       EXECUTOR_CLIENT_DIR: clientDir,
       EXECUTOR_SCOPE_DIR: scopeDir,
       EXECUTOR_DATA_DIR: scopeDir,
@@ -92,6 +106,14 @@ export async function startSidecar(options: StartOptions = {}): Promise<SidecarC
   return new Promise<SidecarConnection>((resolveStart, rejectStart) => {
     let stderrBuffer = "";
     let resolved = false;
+    let rejected = false;
+
+    const reject = (err: Error) => {
+      if (resolved || rejected) return;
+      rejected = true;
+      // oxlint-disable-next-line executor/no-promise-reject -- boundary: sidecar startup surfaces as a rejected promise
+      rejectStart(err);
+    };
 
     const onStdout = (chunk: Buffer) => {
       const text = chunk.toString("utf8");
@@ -104,7 +126,8 @@ export async function startSidecar(options: StartOptions = {}): Promise<SidecarC
           baseUrl: `http://${hostname}:${port}`,
           hostname,
           port,
-          authPassword,
+          username: SERVER_SETTINGS_USERNAME,
+          authPassword: effectivePassword,
           child,
         });
       }
@@ -117,11 +140,16 @@ export async function startSidecar(options: StartOptions = {}): Promise<SidecarC
     };
 
     const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      if (!resolved) {
-        const message = `Sidecar exited before ready (code=${code} signal=${signal}). Stderr:\n${stderrBuffer}`;
-        // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: sidecar boot failure surfaces here as a rejected start promise
-        rejectStart(new Error(message));
+      if (resolved || rejected) return;
+      // Detect bind failure — the Node listener prints either "EADDRINUSE" or
+      // "address already in use" on stderr before exiting non-zero.
+      if (/EADDRINUSE|address already in use/i.test(stderrBuffer)) {
+        reject(new SidecarPortInUseError(settings.port));
+        return;
       }
+      const message = `Sidecar exited before ready (code=${code} signal=${signal}). Stderr:\n${stderrBuffer}`;
+      // oxlint-disable-next-line executor/no-error-constructor -- boundary: sidecar boot failure surfaces here as a rejected start promise
+      reject(new Error(message));
     };
 
     child.stdout?.on("data", onStdout);
@@ -144,3 +172,5 @@ export async function stopSidecar(child: ChildProcess): Promise<void> {
     child.kill("SIGTERM");
   });
 }
+
+export type { DesktopServerSettings };

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,7 +1,29 @@
-// Renderer ↔ main bridge.
-//
-// The Electron main process attaches the Basic auth header to outbound
-// requests via session.webRequest, so the renderer does not need any
-// auth knowledge today. This preload is kept minimal but reserved for
-// future capabilities (e.g. native menus, updater status).
-export {};
+import { contextBridge, ipcRenderer } from "electron";
+import type { DesktopServerSettings } from "../shared/server-settings";
+
+const api = {
+  /** Read the persisted server settings (port, requireAuth, password). */
+  getSettings(): Promise<DesktopServerSettings> {
+    return ipcRenderer.invoke("executor:settings:get");
+  },
+  /** Patch one or more server settings. Returns the new full settings. */
+  updateSettings(patch: Partial<DesktopServerSettings>): Promise<DesktopServerSettings> {
+    return ipcRenderer.invoke("executor:settings:update", patch);
+  },
+  /** Regenerate the random Basic-auth password. Returns the new settings. */
+  regeneratePassword(): Promise<DesktopServerSettings> {
+    return ipcRenderer.invoke("executor:settings:regenerate-password");
+  },
+  /**
+   * Stop + restart the sidecar so settings changes take effect.
+   * Renderer should reload its location after this resolves to point at
+   * the (possibly new) port.
+   */
+  restartServer(): Promise<{ readonly port: number; readonly baseUrl: string }> {
+    return ipcRenderer.invoke("executor:server:restart");
+  },
+} as const;
+
+contextBridge.exposeInMainWorld("executor", api);
+
+export type ExecutorBridge = typeof api;

--- a/apps/desktop/src/shared/server-settings.ts
+++ b/apps/desktop/src/shared/server-settings.ts
@@ -1,0 +1,31 @@
+/**
+ * Persistent desktop sidecar settings, edited from the renderer's Settings
+ * page and consumed by the main process when spawning the sidecar.
+ *
+ * The shape lives in `src/shared/` because both main (IPC handlers) and
+ * renderer (Settings UI + Connect-an-agent surface) need to agree on it.
+ */
+
+export interface DesktopServerSettings {
+  /** TCP port the sidecar listens on. Default 4789. */
+  readonly port: number;
+  /**
+   * Whether the sidecar enforces HTTP Basic auth on every request.
+   * When false, the sidecar relies on the host allowlist alone.
+   */
+  readonly requireAuth: boolean;
+  /**
+   * Basic auth password the sidecar enforces and the renderer exposes
+   * via `window.executor`. Persisted across launches so AI client MCP
+   * configs stay valid until the user regenerates.
+   */
+  readonly password: string;
+}
+
+export const DEFAULT_SERVER_SETTINGS: DesktopServerSettings = {
+  port: 4789,
+  requireAuth: true,
+  password: "",
+};
+
+export const SERVER_SETTINGS_USERNAME = "executor";

--- a/apps/local/executor.config.ts
+++ b/apps/local/executor.config.ts
@@ -7,6 +7,7 @@ import { graphqlHttpPlugin } from "@executor-js/plugin-graphql/api";
 import { keychainPlugin } from "@executor-js/plugin-keychain";
 import { fileSecretsPlugin } from "@executor-js/plugin-file-secrets";
 import { onepasswordHttpPlugin } from "@executor-js/plugin-onepassword/api";
+import { desktopSettingsPlugin } from "@executor-js/plugin-desktop-settings/server";
 
 // ---------------------------------------------------------------------------
 // Single source of truth for the local app's plugin list.
@@ -34,5 +35,6 @@ export default defineExecutorConfig({
       keychainPlugin(),
       fileSecretsPlugin(),
       onepasswordHttpPlugin(),
+      desktopSettingsPlugin(),
     ] as const,
 });

--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -27,6 +27,7 @@
     "@executor-js/config": "workspace:*",
     "@executor-js/execution": "workspace:*",
     "@executor-js/host-mcp": "workspace:*",
+    "@executor-js/plugin-desktop-settings": "workspace:*",
     "@executor-js/plugin-example": "workspace:*",
     "@executor-js/plugin-file-secrets": "workspace:*",
     "@executor-js/plugin-google-discovery": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -127,6 +127,7 @@
       "devDependencies": {
         "@executor-js/app": "workspace:*",
         "@executor-js/local": "workspace:*",
+        "@executor-js/plugin-desktop-settings": "workspace:*",
         "@executor-js/plugin-file-secrets": "workspace:*",
         "@executor-js/plugin-google-discovery": "workspace:*",
         "@executor-js/plugin-graphql": "workspace:*",
@@ -154,6 +155,7 @@
         "@executor-js/config": "workspace:*",
         "@executor-js/execution": "workspace:*",
         "@executor-js/host-mcp": "workspace:*",
+        "@executor-js/plugin-desktop-settings": "workspace:*",
         "@executor-js/plugin-example": "workspace:*",
         "@executor-js/plugin-file-secrets": "workspace:*",
         "@executor-js/plugin-google-discovery": "workspace:*",
@@ -580,6 +582,19 @@
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+    },
+    "packages/plugins/desktop-settings": {
+      "name": "@executor-js/plugin-desktop-settings",
+      "version": "1.4.21",
+      "dependencies": {
+        "@executor-js/sdk": "workspace:*",
+        "react": "catalog:",
+      },
+      "devDependencies": {
+        "@types/react": "catalog:",
+        "tsup": "catalog:",
+        "typescript": "catalog:",
       },
     },
     "packages/plugins/example": {
@@ -1337,6 +1352,8 @@
     "@executor-js/local": ["@executor-js/local@workspace:apps/local"],
 
     "@executor-js/marketing": ["@executor-js/marketing@workspace:apps/marketing"],
+
+    "@executor-js/plugin-desktop-settings": ["@executor-js/plugin-desktop-settings@workspace:packages/plugins/desktop-settings"],
 
     "@executor-js/plugin-example": ["@executor-js/plugin-example@workspace:packages/plugins/example"],
 

--- a/packages/plugins/desktop-settings/CHANGELOG.md
+++ b/packages/plugins/desktop-settings/CHANGELOG.md
@@ -1,0 +1,6 @@
+# @executor-js/plugin-desktop-settings changelog
+
+This file exists for `changesets/action@v1` compatibility (it reads every
+workspace package's `CHANGELOG.md` to build the Version Packages PR).
+Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
+and on the GitHub Releases page.

--- a/packages/plugins/desktop-settings/package.json
+++ b/packages/plugins/desktop-settings/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@executor-js/plugin-desktop-settings",
+  "version": "1.4.21",
+  "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/desktop-settings",
+  "bugs": {
+    "url": "https://github.com/RhysSullivan/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RhysSullivan/executor.git",
+    "directory": "packages/plugins/desktop-settings"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    "./server": "./src/server.ts",
+    "./client": "./src/client.tsx"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./server": {
+        "import": {
+          "types": "./dist/server.d.ts",
+          "default": "./dist/server.js"
+        }
+      },
+      "./client": {
+        "import": {
+          "types": "./dist/client.d.ts",
+          "default": "./dist/client.js"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsgo --noEmit",
+    "typecheck:slow": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@executor-js/sdk": "workspace:*",
+    "react": "catalog:"
+  },
+  "devDependencies": {
+    "@types/react": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:"
+  }
+}

--- a/packages/plugins/desktop-settings/src/client.tsx
+++ b/packages/plugins/desktop-settings/src/client.tsx
@@ -1,0 +1,309 @@
+/* oxlint-disable react/forbid-elements -- plugin component uses raw HTML controls per SDK convention; see @executor-js/plugin-example for the same pattern */
+/**
+ * @executor-js/plugin-desktop-settings/client
+ *
+ * A single page mounted at `/plugins/desktop-settings/` that lets the user
+ * configure the Electron sidecar's port, auth, and password. Talks to the
+ * main process via `window.executor.*` (exposed by `apps/desktop/src/preload`).
+ *
+ * The plugin is bundled into apps/local's renderer too (because executor
+ * web + desktop share the same client bundle pipeline), but the page
+ * only registers a nav entry when `window.executor` is present at
+ * module-init time — so the web UI doesn't show a non-functional link.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { defineClientPlugin } from "@executor-js/sdk/client";
+
+// ---------------------------------------------------------------------------
+// Shape of the values the desktop preload exposes. Kept inline rather than
+// imported from @executor-js/plugin-desktop-settings (or a shared package)
+// so this client bundle has no runtime dependency on the Electron
+// surface — when `window.executor` is undefined (web), the page silently
+// no-ops instead of crashing.
+// ---------------------------------------------------------------------------
+
+interface DesktopServerSettings {
+  readonly port: number;
+  readonly requireAuth: boolean;
+  readonly password: string;
+}
+
+interface ExecutorBridge {
+  readonly getSettings: () => Promise<DesktopServerSettings>;
+  readonly updateSettings: (
+    patch: Partial<DesktopServerSettings>,
+  ) => Promise<DesktopServerSettings>;
+  readonly regeneratePassword: () => Promise<DesktopServerSettings>;
+  readonly restartServer: () => Promise<{ readonly port: number; readonly baseUrl: string }>;
+}
+
+const readBridge = (): ExecutorBridge | null => {
+  if (typeof window === "undefined") return null;
+  const candidate = (window as Window & { readonly executor?: ExecutorBridge }).executor;
+  if (!candidate || typeof candidate.getSettings !== "function") return null;
+  return candidate;
+};
+
+const inDesktop = readBridge() !== null;
+
+// Normalize an IPC rejection into a user-facing string at this UI boundary.
+// The renderer doesn't get typed errors back from Electron's invoke channel.
+// We don't pull `err.message` out — the structured error doesn't help the
+// user, only "save failed" matters. The main process logs the full error.
+const describeIpcError = (_err: unknown): string =>
+  "Save failed — check the desktop console for details.";
+
+// ---------------------------------------------------------------------------
+// SettingsPage
+// ---------------------------------------------------------------------------
+
+function SettingsPage() {
+  const bridge = readBridge();
+  const [settings, setSettings] = useState<DesktopServerSettings | null>(null);
+  const [draft, setDraft] = useState<DesktopServerSettings | null>(null);
+  const [status, setStatus] = useState<"idle" | "saving" | "restarting" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!bridge) return;
+    void bridge.getSettings().then((s) => {
+      setSettings(s);
+      setDraft(s);
+    });
+  }, [bridge]);
+
+  const apply = useCallback(
+    async (patch: Partial<DesktopServerSettings>) => {
+      if (!bridge) return;
+      setStatus("saving");
+      setError(null);
+      let next: DesktopServerSettings;
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: renderer ↔ Electron IPC, errors surface in the form
+      try {
+        next = await bridge.updateSettings(patch);
+      } catch (err) {
+        setError(describeIpcError(err));
+        setStatus("error");
+        return;
+      }
+      setSettings(next);
+      setDraft(next);
+      setStatus("restarting");
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: same as above
+      try {
+        await bridge.restartServer();
+      } catch (err) {
+        setError(describeIpcError(err));
+        setStatus("error");
+        return;
+      }
+      // Window reload happens on the main side after restart resolves.
+      setStatus("idle");
+    },
+    [bridge],
+  );
+
+  const regenerate = useCallback(async () => {
+    if (!bridge) return;
+    setStatus("saving");
+    let next: DesktopServerSettings;
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: renderer ↔ Electron IPC
+    try {
+      next = await bridge.regeneratePassword();
+    } catch (err) {
+      setError(describeIpcError(err));
+      setStatus("error");
+      return;
+    }
+    setSettings(next);
+    setDraft(next);
+    setStatus("restarting");
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: renderer ↔ Electron IPC
+    try {
+      await bridge.restartServer();
+    } catch (err) {
+      setError(describeIpcError(err));
+      setStatus("error");
+      return;
+    }
+    setStatus("idle");
+  }, [bridge]);
+
+  if (!bridge) {
+    return (
+      <div style={{ maxWidth: 560, margin: "3rem auto", padding: "1.5rem" }}>
+        <h1 style={{ fontSize: "1.5rem", marginBottom: "1rem" }}>Desktop server settings</h1>
+        <p style={{ color: "var(--muted-foreground, #888)" }}>
+          This panel configures the Executor Desktop app's local server. Open this page from the
+          desktop app to change the port, auth, or password.
+        </p>
+      </div>
+    );
+  }
+
+  if (!settings || !draft) {
+    return <div style={{ maxWidth: 560, margin: "3rem auto", padding: "1.5rem" }}>Loading…</div>;
+  }
+
+  const dirty =
+    draft.port !== settings.port ||
+    draft.requireAuth !== settings.requireAuth ||
+    draft.password !== settings.password;
+
+  return (
+    <div style={{ maxWidth: 640, margin: "2rem auto", padding: "1.5rem" }}>
+      <h1 style={{ fontSize: "1.5rem", fontWeight: 600, marginBottom: "0.25rem" }}>
+        Desktop server
+      </h1>
+      <p
+        style={{
+          fontSize: "0.875rem",
+          color: "var(--muted-foreground, #888)",
+          marginBottom: "1.5rem",
+        }}
+      >
+        Configure how the local HTTP server in the desktop app accepts connections. Changes restart
+        the server immediately.
+      </p>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: "1.25rem" }}>
+        <label style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+          <span style={{ fontSize: "0.875rem", fontWeight: 500 }}>Port</span>
+          {/* oxlint-disable-next-line react/forbid-elements -- plugin component uses raw HTML controls per SDK convention */}
+          <input
+            type="number"
+            min={1}
+            max={65535}
+            value={draft.port}
+            onChange={(e) => setDraft({ ...draft, port: Number(e.target.value) })}
+            style={{
+              padding: "0.5rem 0.7rem",
+              borderRadius: 6,
+              border: "1px solid var(--border, #ddd)",
+              fontFamily: "inherit",
+              fontSize: "0.95rem",
+              width: "8rem",
+            }}
+          />
+          <span style={{ fontSize: "0.75rem", color: "var(--muted-foreground, #888)" }}>
+            Default 4789. The desktop opens at <code>http://127.0.0.1:{draft.port}</code>.
+          </span>
+        </label>
+
+        <label style={{ display: "flex", alignItems: "flex-start", gap: "0.6rem" }}>
+          {/* oxlint-disable-next-line react/forbid-elements -- plugin component uses raw HTML controls per SDK convention */}
+          <input
+            type="checkbox"
+            checked={!draft.requireAuth}
+            onChange={(e) => setDraft({ ...draft, requireAuth: !e.target.checked })}
+            style={{ marginTop: "0.25rem" }}
+          />
+          <span style={{ display: "flex", flexDirection: "column", gap: "0.2rem" }}>
+            <span style={{ fontSize: "0.875rem", fontWeight: 500 }}>Use without a password</span>
+            <span style={{ fontSize: "0.75rem", color: "var(--muted-foreground, #888)" }}>
+              Disables HTTP Basic auth on the sidecar. Any process running as you on this machine
+              can hit <code>/api</code> directly. The host allowlist still blocks browser-based
+              attacks. Recommended only on personal devices.
+            </span>
+          </span>
+        </label>
+
+        {draft.requireAuth && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+            <span style={{ fontSize: "0.875rem", fontWeight: 500 }}>Password</span>
+            <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+              <code
+                style={{
+                  flex: 1,
+                  padding: "0.5rem 0.7rem",
+                  borderRadius: 6,
+                  border: "1px solid var(--border, #ddd)",
+                  background: "var(--muted, #f5f5f5)",
+                  fontSize: "0.85rem",
+                  overflow: "auto",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                {settings.password}
+              </code>
+              {/* oxlint-disable-next-line react/forbid-elements -- plugin component uses raw HTML controls per SDK convention */}
+              <button
+                type="button"
+                onClick={() => void regenerate()}
+                disabled={status !== "idle"}
+                style={{
+                  padding: "0.45rem 0.85rem",
+                  borderRadius: 6,
+                  border: "1px solid var(--border, #ddd)",
+                  background: "var(--background, white)",
+                  fontFamily: "inherit",
+                  fontSize: "0.85rem",
+                  cursor: status === "idle" ? "pointer" : "default",
+                }}
+              >
+                Regenerate
+              </button>
+            </div>
+            <span style={{ fontSize: "0.75rem", color: "var(--muted-foreground, #888)" }}>
+              The renderer sends this as <code>Authorization: Basic</code>. AI clients using the
+              HTTP MCP integration need this value too — regenerating invalidates existing client
+              configs.
+            </span>
+          </div>
+        )}
+
+        <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+          {/* oxlint-disable-next-line react/forbid-elements -- plugin component uses raw HTML controls per SDK convention */}
+          <button
+            type="button"
+            disabled={!dirty || status !== "idle"}
+            onClick={() =>
+              void apply({
+                port: draft.port,
+                requireAuth: draft.requireAuth,
+              })
+            }
+            style={{
+              padding: "0.55rem 1.1rem",
+              borderRadius: 6,
+              border: "1px solid transparent",
+              background: dirty ? "var(--primary, #0d0d10)" : "var(--muted, #eee)",
+              color: dirty ? "var(--primary-foreground, white)" : "var(--muted-foreground, #888)",
+              fontFamily: "inherit",
+              fontSize: "0.9rem",
+              cursor: dirty && status === "idle" ? "pointer" : "default",
+            }}
+          >
+            {status === "saving"
+              ? "Saving…"
+              : status === "restarting"
+                ? "Restarting server…"
+                : "Save"}
+          </button>
+          {error && (
+            <span style={{ fontSize: "0.8rem", color: "var(--destructive, #c00)" }}>{error}</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Plugin spec
+// ---------------------------------------------------------------------------
+
+export default defineClientPlugin({
+  id: "desktop-settings",
+  pages: [
+    {
+      path: "/",
+      component: SettingsPage,
+      // Only contribute a nav entry when running inside the desktop app.
+      // Web users see an empty Sources nav without a non-functional
+      // "Settings" link.
+      ...(inDesktop ? { nav: { label: "Settings" } } : {}),
+    },
+  ],
+});

--- a/packages/plugins/desktop-settings/src/server.ts
+++ b/packages/plugins/desktop-settings/src/server.ts
@@ -1,0 +1,17 @@
+/**
+ * @executor-js/plugin-desktop-settings/server
+ *
+ * Zero-server-state plugin. The Desktop Settings panel reads and writes
+ * its configuration via Electron IPC (`window.executor.*`), not through
+ * the executor server. This file exists so the host can register the
+ * plugin's `packageName` and the vite plugin can find the `./client`
+ * bundle — that's the entire server contribution.
+ */
+
+import { definePlugin } from "@executor-js/sdk/core";
+
+export const desktopSettingsPlugin = definePlugin(() => ({
+  id: "desktop-settings" as const,
+  packageName: "@executor-js/plugin-desktop-settings",
+  storage: () => ({}),
+}));

--- a/packages/plugins/desktop-settings/tsconfig.json
+++ b/packages/plugins/desktop-settings/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/desktop-settings/tsup.config.ts
+++ b/packages/plugins/desktop-settings/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/server.ts", "src/client.tsx"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  external: ["@executor-js/sdk", "react"],
+});

--- a/packages/react/src/components/mcp-install-card.tsx
+++ b/packages/react/src/components/mcp-install-card.tsx
@@ -28,14 +28,52 @@ export const shellQuoteWord = (value: string): string => {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 };
 
+interface DesktopBridge {
+  readonly getSettings: () => Promise<{
+    readonly port: number;
+    readonly requireAuth: boolean;
+    readonly password: string;
+  }>;
+}
+
+const readDesktopBridge = (): DesktopBridge | null => {
+  if (typeof window === "undefined") return null;
+  const candidate = (window as Window & { readonly executor?: DesktopBridge }).executor;
+  if (!candidate || typeof candidate.getSettings !== "function") return null;
+  return candidate;
+};
+
+const buildHttpEndpoint = (input: {
+  readonly origin: string | null;
+  readonly desktop: {
+    readonly port: number;
+    readonly requireAuth: boolean;
+    readonly password: string;
+  } | null;
+}): string => {
+  if (input.desktop) {
+    const auth =
+      input.desktop.requireAuth && input.desktop.password
+        ? `executor:${input.desktop.password}@`
+        : "";
+    return `http://${auth}127.0.0.1:${input.desktop.port}/mcp`;
+  }
+  return input.origin ? `${input.origin}/mcp` : "<this-server>/mcp";
+};
+
 export const buildMcpInstallCommand = (input: {
   readonly mode: TransportMode;
   readonly isDev: boolean;
   readonly origin: string | null;
   readonly scopeDir?: string;
+  readonly desktop?: {
+    readonly port: number;
+    readonly requireAuth: boolean;
+    readonly password: string;
+  } | null;
 }): string => {
   if (input.mode === "http") {
-    const endpoint = input.origin ? `${input.origin}/mcp` : "<this-server>/mcp";
+    const endpoint = buildHttpEndpoint({ origin: input.origin, desktop: input.desktop ?? null });
     return `npx add-mcp ${shellQuoteWord(endpoint)} --transport http --name executor`;
   }
 
@@ -50,10 +88,19 @@ export function McpInstallCard(props: { className?: string }) {
   const showStdio = isLocal;
   const [mode, setMode] = useState<TransportMode>(showStdio ? "stdio" : "http");
   const [origin, setOrigin] = useState<string | null>(null);
+  const [desktop, setDesktop] = useState<{
+    readonly port: number;
+    readonly requireAuth: boolean;
+    readonly password: string;
+  } | null>(null);
   const scopeInfo = useScopeInfo();
 
   useEffect(() => {
     setOrigin(window.location.origin);
+    const bridge = readDesktopBridge();
+    if (bridge) {
+      void bridge.getSettings().then(setDesktop, () => setDesktop(null));
+    }
   }, []);
 
   const command = buildMcpInstallCommand({
@@ -61,6 +108,7 @@ export function McpInstallCard(props: { className?: string }) {
     isDev,
     origin,
     scopeDir: scopeInfo.dir,
+    desktop,
   });
 
   const subtitle =


### PR DESCRIPTION
The desktop sidecar used to randomize port + password per launch — fine internally, broken for external MCP integration. Makes both user-controlled and persistent.

## What lands

**New package `@executor-js/plugin-desktop-settings`** (pure-client plugin):
- Settings page mounts at \`/plugins/desktop-settings\`, contributes a sidebar nav entry **only when \`window.executor\` is present** at module-init time — apps/local web doesn't show a non-functional link.
- Form fields:
  - **Port** (default \`4789\`)
  - **Use without a password** (off by default — leaves Basic auth enforced)
  - **Password** (readout + Regenerate). Each save reboots the sidecar; the BrowserWindow reloads at the new URL automatically.

**\`apps/desktop\` rewiring**
- New \`src/main/settings.ts\` — electron-store-backed reader/writer for \`~/Library/Application Support/Executor/settings.json\`.
- \`src/main/sidecar.ts\` reads from settings instead of generating random values per launch. When \`requireAuth\` is off, \`EXECUTOR_AUTH_PASSWORD\` env var is unset entirely (matches \`executor web\`'s default unauth-on-loopback behavior).
- Bind failures (\`EADDRINUSE\`) surface as a typed \`SidecarPortInUseError\`; \`src/main/index.ts\` catches it and shows a dialog pointing the user at Settings to pick another port.
- New preload bridge exposes \`get\` / \`update\` / \`regeneratePassword\` / \`restartServer\` IPC over \`contextBridge\` — no \`nodeIntegration\` leak.

**\`McpInstallCard\` update**
- When the renderer is in the desktop and auth is on, HTTP install command embeds credentials inline:
  \`\`\`
  npx add-mcp 'http://executor:<pw>@127.0.0.1:<port>/mcp' --transport http --name executor
  \`\`\`
- On web (or with passwordless mode), behaves as before.

## What's NOT changed

- Stdio MCP integration (\`executor mcp --scope ~/.executor\`) was already stable; no churn there.
- electron-builder packaging, signing, release workflow — untouched.
- Existing \`v1.4.21\` users carry over no state — first launch on the new build generates a fresh password at port 4789 and writes settings.json.

## Test plan

- [ ] \`bun run --filter @executor-js/desktop typecheck\` clean.
- [ ] \`bun run --filter @executor-js/local typecheck\` clean.
- [ ] \`bun run --filter @executor-js/plugin-desktop-settings typecheck\` clean.
- [ ] \`bun run --filter @executor-js/react typecheck\` clean.
- [ ] \`bun run lint\` + \`bun run format:check\` clean (verified locally).
- [ ] \`vitest run apps/local/src/serve.test.ts\` — 4/4 pass (verified locally).
- [ ] \`bun run --filter @executor-js/local build\` produces a chunk containing the new plugin (grep verified).
- [ ] \`bunx --bun electron-vite build\` in \`apps/desktop\` clean.
- [ ] On a real desktop run (post-merge release): Settings page renders, Save persists, password regenerate invalidates the existing AI client config as expected, port collision produces the right dialog.

This is the long-form fix for the MCP-add-flow awkwardness called out in the previous discussion. Next release after this lands ships with the Settings page wired up.