### PR TITLE
feat(react): emit MCP Basic auth via --header on add-mcp

### DIFF
--- a/.changeset/mcp-install-header-auth.md
+++ b/.changeset/mcp-install-header-auth.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+`McpInstallCard` emits Basic auth via a `--header 'Authorization: Basic …'` flag on the generated `npx add-mcp` command instead of embedding `executor:<password>@` credentials in the URL. The desktop's local HTTP MCP endpoint is no longer a wall of base64 stuck into a hostname; the install command reads as a plain `http://127.0.0.1:<port>/mcp` URL with a separate header line.

--- a/packages/react/src/components/mcp-install-card.tsx
+++ b/packages/react/src/components/mcp-install-card.tsx
@@ -47,18 +47,21 @@ const buildHttpEndpoint = (input: {
   readonly origin: string | null;
   readonly desktop: {
     readonly port: number;
-    readonly requireAuth: boolean;
-    readonly password: string;
   } | null;
 }): string => {
   if (input.desktop) {
-    const auth =
-      input.desktop.requireAuth && input.desktop.password
-        ? `executor:${input.desktop.password}@`
-        : "";
-    return `http://${auth}127.0.0.1:${input.desktop.port}/mcp`;
+    return `http://127.0.0.1:${input.desktop.port}/mcp`;
   }
   return input.origin ? `${input.origin}/mcp` : "<this-server>/mcp";
+};
+
+const buildBasicAuthHeader = (password: string): string => {
+  // Renderer-only — every browser/Electron renderer has btoa. SSR doesn't
+  // render this card, so we don't need a Node fallback here.
+  if (typeof globalThis.btoa !== "function") {
+    return `Authorization: Basic executor:${password}`;
+  }
+  return `Authorization: Basic ${globalThis.btoa(`executor:${password}`)}`;
 };
 
 export const buildMcpInstallCommand = (input: {
@@ -73,8 +76,19 @@ export const buildMcpInstallCommand = (input: {
   } | null;
 }): string => {
   if (input.mode === "http") {
-    const endpoint = buildHttpEndpoint({ origin: input.origin, desktop: input.desktop ?? null });
-    return `npx add-mcp ${shellQuoteWord(endpoint)} --transport http --name executor`;
+    const endpoint = buildHttpEndpoint({
+      origin: input.origin,
+      desktop: input.desktop ? { port: input.desktop.port } : null,
+    });
+    const headerFlags: string[] = [];
+    if (input.desktop?.requireAuth && input.desktop.password) {
+      headerFlags.push(`--header ${shellQuoteWord(buildBasicAuthHeader(input.desktop.password))}`);
+    }
+    const parts = [
+      `npx add-mcp ${shellQuoteWord(endpoint)} --transport http --name executor`,
+      ...headerFlags,
+    ];
+    return parts.join(" ");
   }
 
   const innerArgs = input.isDev ? ["bun", "run", "dev:cli", "mcp"] : ["executor", "mcp"];


### PR DESCRIPTION
URL-embedded credentials read awkwardly and don't survive paste in places that strip userinfo. \`add-mcp\` 1.8+ supports a repeatable \`--header\` flag — cleaner shape, same wire result.

## Before / after

\`\`\`diff
- npx add-mcp http://executor:CQJanp0rv9xN_LbqFVDADznkyjw2fK1e@127.0.0.1:4789/mcp --transport http --name executor
+ npx add-mcp http://127.0.0.1:4789/mcp --transport http --name executor --header 'Authorization: Basic ZXhlY3V0b3I6Q1FK...'
\`\`\`

The URL is now plain; auth lives next to it as a flag. Same Basic credentials, just rendered separately. Passwordless mode emits the URL with no header (same as before).

## Test plan

- [ ] \`bun run --filter @executor-js/react typecheck\` clean.
- [ ] \`bun run format:check\` / \`bun run lint\` clean.
- [ ] Renderer build picks up the new command shape.
- [ ] In a desktop run, the Connect-an-agent card's HTTP tab shows the \`--header\` flag instead of the URL-credential form.