### PR TITLE
feat(desktop): in-app dialog when an update is downloaded

### DIFF
--- a/.changeset/desktop-update-dialog.md
+++ b/.changeset/desktop-update-dialog.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Desktop: surface available updates with a native dialog instead of swapping silently on quit. When a new version finishes downloading in the background, a "Restart now / Later" dialog fires so users actually know there's an update ready. Adds a `Check for Updates…` item to the app menu for manual checks. `electron-updater`'s `autoInstallOnAppQuit` is now off — the only way the new version applies is when the user chooses Restart now.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,11 +1,22 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { app, BrowserWindow, dialog, ipcMain, nativeImage, session, shell } from "electron";
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  Menu,
+  type MenuItemConstructorOptions,
+  nativeImage,
+  session,
+  shell,
+} from "electron";
 import windowStateKeeper from "electron-window-state";
 import log from "electron-log/main.js";
 import updater from "electron-updater";
 const { autoUpdater } = updater;
+type UpdateInfo = { readonly version: string };
 import {
   startSidecar,
   stopSidecar,
@@ -208,8 +219,144 @@ const registerIpcHandlers = () => {
   ipcMain.handle("executor:server:restart", () => restartSidecarAndReload());
 };
 
+// ──────────────────────────────────────────────────────────────────────
+// Auto-updates — opencode-style dialog flow.
+//
+// electron-updater's `checkForUpdatesAndNotify()` default swaps the app
+// silently on quit, so users have no signal an update is ready until
+// they relaunch and notice the version changed. We replace it with:
+//
+//   - autoDownload: true   — pull the next version in the background
+//   - autoInstallOnAppQuit: false — never swap silently
+//   - on 'update-downloaded' → native dialog with Restart now / Later
+//   - "Check for Updates…" app menu item runs the same flow manually
+//
+// Auto-checks at boot stay quiet on failure / no-op. The manual menu
+// invocation surfaces both outcomes explicitly via `alertOnFail`.
+// ──────────────────────────────────────────────────────────────────────
+
+let downloadedUpdateVersion: string | null = null;
+let updateDialogOpen = false;
+
+const promptInstallUpdate = async (version: string) => {
+  if (updateDialogOpen) return;
+  updateDialogOpen = true;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: dialog wrapper guarantees the open flag clears
+  try {
+    const response = await dialog.showMessageBox({
+      type: "info",
+      title: "Update ready",
+      message: `Executor ${version} is ready to install.`,
+      detail: "Restart now to apply the update, or keep working — we'll prompt again later.",
+      buttons: ["Restart now", "Later"],
+      defaultId: 0,
+      cancelId: 1,
+    });
+    if (response.response === 0) {
+      // Stop the sidecar cleanly before Squirrel.Mac swaps the bundle.
+      if (connection) {
+        await stopSidecar(connection.child);
+        connection = null;
+      }
+      autoUpdater.quitAndInstall(false, true);
+    }
+  } finally {
+    updateDialogOpen = false;
+  }
+};
+
+const setupAutoUpdater = () => {
+  if (!app.isPackaged) return;
+  autoUpdater.logger = log;
+  autoUpdater.autoDownload = true;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on("update-downloaded", (info: UpdateInfo) => {
+    downloadedUpdateVersion = info.version;
+    void promptInstallUpdate(info.version);
+  });
+  autoUpdater.on("error", (err: Error) => {
+    log.warn("[updater] error", err);
+  });
+};
+
+interface UpdateCheckOptions {
+  readonly alertOnFail: boolean;
+}
+
+const runUpdateCheck = async ({ alertOnFail }: UpdateCheckOptions) => {
+  if (!app.isPackaged) {
+    if (alertOnFail) {
+      await dialog.showMessageBox({
+        type: "info",
+        title: "Updates unavailable",
+        message: "Auto-update is only enabled in packaged builds.",
+      });
+    }
+    return;
+  }
+  if (downloadedUpdateVersion) {
+    await promptInstallUpdate(downloadedUpdateVersion);
+    return;
+  }
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: surface network/update failures only when the user asked
+  try {
+    const result = await autoUpdater.checkForUpdates();
+    const newer = result?.isUpdateAvailable === true;
+    if (!alertOnFail) return;
+    if (newer) return; // 'update-downloaded' handler will fire the install dialog
+    await dialog.showMessageBox({
+      type: "info",
+      title: "No updates",
+      message: `You're on the latest version (${app.getVersion()}).`,
+    });
+  } catch (error) {
+    log.warn("[updater] check failed", error);
+    if (!alertOnFail) return;
+    await dialog.showMessageBox({
+      type: "error",
+      title: "Update check failed",
+      message: "Couldn't reach the update server.",
+      detail: "Check your network and try again from the menu.",
+    });
+  }
+};
+
+const installApplicationMenu = () => {
+  const isMac = process.platform === "darwin";
+  const appMenu: MenuItemConstructorOptions = {
+    label: app.name,
+    submenu: [
+      { role: "about" },
+      { label: "Check for Updates…", click: () => void runUpdateCheck({ alertOnFail: true }) },
+      { type: "separator" },
+      ...(isMac
+        ? ([
+            { role: "services" },
+            { type: "separator" },
+            { role: "hide" },
+            { role: "hideOthers" },
+            { role: "unhide" },
+            { type: "separator" },
+          ] as MenuItemConstructorOptions[])
+        : []),
+      { role: "quit" },
+    ],
+  };
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate([
+      appMenu,
+      { role: "editMenu" },
+      { role: "viewMenu" },
+      { role: "windowMenu" },
+    ]),
+  );
+};
+
 const boot = async () => {
   installDockIcon();
+  installApplicationMenu();
+  setupAutoUpdater();
   registerIpcHandlers();
   connection = await startWithCurrentSettings();
   if (!connection) {
@@ -221,10 +368,10 @@ const boot = async () => {
     return;
   }
   await createWindow(connection);
-  if (app.isPackaged) {
-    autoUpdater.logger = log;
-    void autoUpdater.checkForUpdatesAndNotify();
-  }
+  // Check at boot. If an update is available, autoDownload pulls it and
+  // the 'update-downloaded' handler fires the install dialog. Silent on
+  // no-update / failure so we don't bother users on every launch.
+  void runUpdateCheck({ alertOnFail: false });
 };
 
 if (ensureSingleInstance()) {


### PR DESCRIPTION
Closes the "users have no idea an update is ready" gap. Before this, \`autoUpdater.checkForUpdatesAndNotify()\` silently downloaded the new version and swapped the bundle on quit — users only knew an update happened when they saw the version label change on next launch.

Now the flow matches opencode's UX:

## Boot
- \`autoDownload: true\` — new version still pulls in the background, no waiting once the user acts
- \`autoInstallOnAppQuit: false\` — never swap silently
- Background check at boot stays quiet on no-update / failure

## When an update finishes downloading
Native dialog fires:

\`\`\`
                    [icon]
   Executor 1.4.22 is ready to install.
   Restart now to apply the update, or keep working —
   we'll prompt again later.

                [Restart now] [Later]
\`\`\`

- **Restart now** → clean sidecar shutdown → \`autoUpdater.quitAndInstall(false, true)\`
- **Later** → no-op. Next launch re-checks; if the downloaded version is still relevant, the dialog re-fires.

## Manual control
New **\`Check for Updates…\`** item in the app menu (mac: under "Executor", elsewhere: under "Executor" submenu via the standard application-menu template). Same flow as the auto-check but surfaces "you're up to date" / "update failed" dialogs since the user explicitly asked.

## What this means for current installs

The first time a user with this version sees a newer release, they'll see the dialog before relaunching. Today's auto-update-on-quit behavior (which surprises them) goes away.

## Test plan

- [ ] \`bun run --filter @executor-js/desktop typecheck\` clean.
- [ ] \`bun run format:check\` / \`bun run lint\` clean.
- [ ] Dev launch: \`Check for Updates…\` from app menu shows "Auto-update is only enabled in packaged builds" — doesn't crash.
- [ ] Packaged: on a tag where a newer version exists, the dialog fires after the background download finishes. Restart now → installs. Later → app continues running normally.
- [ ] Manual \`Check for Updates…\` when already up-to-date shows the "you're on the latest version" dialog.