### PR TITLE
fix(desktop): allow JS popups so OAuth sign-in works

### DIFF
--- a/.changeset/desktop-oauth-popups.md
+++ b/.changeset/desktop-oauth-popups.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Desktop: allow JS-initiated popups so OAuth sign-in works. The previous `setWindowOpenHandler` routed every `window.open` to `shell.openExternal`, which broke the renderer's OAuth popup pattern (`window.open("about:blank", name, "popup=1,...")`) — `window.open` returned `null` and the UI reported "popup was blocked." Popups now open as sandboxed Electron child windows; `<a target="_blank">` link clicks still open in the user's default browser.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -144,7 +144,33 @@ const createWindow = async (conn: SidecarConnection) => {
 
   mainWindow.once("ready-to-show", () => mainWindow?.show());
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+  mainWindow.webContents.setWindowOpenHandler(({ url, disposition }) => {
+    // JS-initiated `window.open(url, name, "popup=1,...")` calls (OAuth
+    // sign-in flow in packages/react/src/api/oauth-popup.ts:73) come in
+    // with disposition "new-window" — allow them as Electron child
+    // windows so the renderer's popup tracking (closed polling +
+    // BroadcastChannel handoff) works. Plain `<a target="_blank">`
+    // link clicks come in as "foreground-tab" / "background-tab" /
+    // "other" and route to the user's default browser.
+    if (disposition === "new-window") {
+      return {
+        action: "allow",
+        overrideBrowserWindowOptions: {
+          autoHideMenuBar: true,
+          webPreferences: {
+            // No preload, no nodeIntegration — popup loads third-party
+            // OAuth provider pages, then a final navigation back to
+            // 127.0.0.1:<port>/oauth/callback which the session-level
+            // Basic auth header injection (installBasicAuthHeader)
+            // catches automatically. The popup never needs the
+            // executor IPC bridge.
+            contextIsolation: true,
+            nodeIntegration: false,
+            sandbox: true,
+          },
+        },
+      };
+    }
     void shell.openExternal(url);
     return { action: "deny" };
   });


### PR DESCRIPTION
## Bug

OAuth sign-in in the desktop app surfaces "OAuth popup was blocked." Root cause: the \`mainWindow.webContents.setWindowOpenHandler\` denies every \`window.open\` and routes the URL to \`shell.openExternal\`. The renderer's popup reservation step (\`packages/react/src/api/oauth-popup.ts:73\`) does:

\`\`\`ts
window.open("about:blank", popupName, "width=...,popup=1");
\`\`\`

— which returns \`null\` under our handler, and the renderer surfaces the error.

## Fix

Discriminate on the handler's \`disposition\`:

- **\`"new-window"\`** (JS \`window.open\`) → allow as an Electron child window. Used by the OAuth popup pattern.
- Anything else (\`"foreground-tab"\` / \`"background-tab"\` / \`"other"\`, i.e. \`<a target="_blank">\` clicks) → still routes to \`shell.openExternal\` for the user's default browser.

Popup \`webPreferences\` keep \`contextIsolation: true, nodeIntegration: false, sandbox: true\` — the popup loads third-party OAuth provider pages and should not have access to the executor IPC bridge.

## What about the callback URL + Basic auth?

When the provider redirects the popup to \`http://127.0.0.1:<port>/oauth/callback?code=...\`, our session-level \`installBasicAuthHeader\` (which uses \`session.defaultSession.webRequest.onBeforeSendHeaders\`) automatically attaches \`Authorization: Basic\` to that request — child popup BrowserWindows inherit the default session. So the callback isn't blocked by the sidecar's auth requirement. Verified by reading \`apps/desktop/src/main/index.ts:installBasicAuthHeader\` — the URL filter is \`http://127.0.0.1:<port>/*\` which covers \`/oauth/callback\`.

## Test plan

- [ ] In dev, click Connect on a Google source. Popup opens (no "popup was blocked" error).
- [ ] User completes OAuth, popup redirects to \`/oauth/callback?...\`. Callback page loads (auth header injected, no 401).
- [ ] BroadcastChannel handoff completes; the renderer's source list updates with the new connection.
- [ ] \`<a target="_blank">\` link clicks (e.g. README link in About dialog if any) still open in the user's default browser, not in a popup.
- [ ] \`bun run typecheck\` / \`lint\` / \`format\` clean (verified locally).