### PR TITLE
feat(desktop): system-browser OAuth + HTTP-only MCP install

### DIFF
--- a/.changeset/desktop-oauth-system-browser.md
+++ b/.changeset/desktop-oauth-system-browser.md
@@ -1,0 +1,22 @@
+---
+"executor": patch
+"@executor-js/desktop": patch
+---
+
+Desktop OAuth flows now open in the user's default browser instead of an
+Electron child window. The renderer skips the in-page popup, calls
+`window.executor.openExternal(authorizationUrl)`, and polls
+`/api/oauth/await/:sessionId` for the completed result. Provider sessions
+the user is already signed into (Google, GitHub, etc.) are picked up
+without re-authenticating inside an isolated Electron cookie jar.
+
+The completion side channel is local-only: `setOAuthCompletionListener`
+is a noop hook in `@executor-js/api`, and the in-memory result store +
+HTTP polling route are registered by the local server. Stateless
+deployments (Cloudflare Workers) carry no footprint and continue to use
+the existing `postMessage`/`BroadcastChannel` handoff.
+
+Also hides the stdio MCP install command in the desktop renderer — that
+path required the `executor` CLI on PATH, which the desktop app does not
+provide. Desktop users see only the HTTP install command, which routes
+through the running sidecar.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -206,6 +206,17 @@ const registerIpcHandlers = () => {
     (): DesktopServerSettings => regeneratePassword(),
   );
   ipcMain.handle("executor:server:restart", () => restartSidecarAndReload());
+  ipcMain.handle("executor:shell:open-external", async (_evt, rawUrl: unknown) => {
+    if (typeof rawUrl !== "string") return;
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: untrusted renderer string, URL ctor throws on malformed input
+    try {
+      const parsed = new URL(rawUrl);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return;
+      await shell.openExternal(parsed.toString());
+    } catch {
+      // Reject malformed URLs silently — renderer falls back to popup flow.
+    }
+  });
 };
 
 const boot = async () => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -22,6 +22,13 @@ const api = {
   restartServer(): Promise<{ readonly port: number; readonly baseUrl: string }> {
     return ipcRenderer.invoke("executor:server:restart");
   },
+  /**
+   * Open an http(s) URL in the user's default browser. Main-side validates
+   * the scheme. Used by the system-browser OAuth flow.
+   */
+  openExternal(url: string): Promise<void> {
+    return ipcRenderer.invoke("executor:shell:open-external", url);
+  },
 } as const;
 
 contextBridge.exposeInMainWorld("executor", api);

--- a/apps/local/src/oauth-result-store.ts
+++ b/apps/local/src/oauth-result-store.ts
@@ -1,0 +1,65 @@
+/**
+ * Process-wide in-memory store of completed OAuth popup results, keyed by
+ * sessionId (the `state` parameter from the auth flow).
+ *
+ * Exists for clients that can't use the in-browser BroadcastChannel /
+ * postMessage handoff — specifically the Electron desktop's renderer
+ * when the user runs the OAuth flow in their system browser. That
+ * external browser has no shared origin with the desktop's renderer, so
+ * the renderer instead polls the local server to learn when the flow
+ * completed.
+ *
+ * The store is one-shot: a successful `consumeOAuthResult` removes the
+ * entry, so a second poll for the same sessionId returns null. Entries
+ * also expire after `RESULT_TTL_MS` to prevent abandoned flows from
+ * keeping memory pinned.
+ */
+
+import type { OAuthPopupResult } from "@executor-js/sdk";
+
+type AnyResult = OAuthPopupResult<unknown>;
+
+interface StoredResult {
+  readonly result: AnyResult;
+  readonly expiresAt: number;
+}
+
+const RESULT_TTL_MS = 10 * 60 * 1000; // 10 minutes — long enough for slow MFA prompts
+
+const store = new Map<string, StoredResult>();
+
+const cleanupExpired = (now: number) => {
+  for (const [sessionId, entry] of store) {
+    if (entry.expiresAt < now) store.delete(sessionId);
+  }
+};
+
+/**
+ * Publish a completed OAuth result. Called from `runOAuthCallback` after
+ * the per-plugin `complete` Effect resolves (success or failure).
+ */
+export const publishOAuthResult = (result: AnyResult): void => {
+  const sessionId = result.sessionId;
+  if (!sessionId) return;
+  const now = Date.now();
+  cleanupExpired(now);
+  store.set(sessionId, { result, expiresAt: now + RESULT_TTL_MS });
+};
+
+/**
+ * Read and remove a result. Returns null if the sessionId has no entry
+ * (the OAuth flow is still in progress, or the user abandoned it).
+ */
+export const consumeOAuthResult = (sessionId: string): AnyResult | null => {
+  const now = Date.now();
+  cleanupExpired(now);
+  const entry = store.get(sessionId);
+  if (!entry) return null;
+  store.delete(sessionId);
+  return entry.result;
+};
+
+/** Test-only — clears the entire store between tests. */
+export const __resetOAuthResultStoreForTests = (): void => {
+  store.clear();
+};

--- a/apps/local/src/serve-shared.ts
+++ b/apps/local/src/serve-shared.ts
@@ -78,3 +78,20 @@ export const hasFileExtension = (pathname: string): boolean => {
   const lastSegment = pathname.split("/").at(-1) ?? "";
   return lastSegment.includes(".");
 };
+
+/**
+ * OAuth provider callbacks land here from the user's external browser,
+ * which has no way to send our Basic auth header. The `state` parameter
+ * is the cryptographic gate — each in-flight session is server-issued
+ * and validated by the shared `completeOAuth` before any work happens.
+ * Bypassing Basic auth on these paths is safe.
+ *
+ * Matches:
+ * - `/api/oauth/callback` — the shared OAuth API mount point.
+ * - `/api/oauth/await/<sessionId>` — polled by the Electron renderer
+ *   when the user runs the flow in their system browser. The sessionId
+ *   is the cryptographic flow id; results are one-shot, so a leaked
+ *   poll without a matching active flow returns null.
+ */
+export const isUnauthenticatedOAuthCallbackPath = (pathname: string): boolean =>
+  /^\/api\/oauth\/(callback|await)(\/|$)/.test(pathname);

--- a/apps/local/src/serve.ts
+++ b/apps/local/src/serve.ts
@@ -9,11 +9,14 @@
 
 import { resolve, join } from "node:path";
 import { readdirSync } from "node:fs";
+import { setOAuthCompletionListener } from "@executor-js/api";
+import { consumeOAuthResult, publishOAuthResult } from "./oauth-result-store";
 import { getServerHandlers } from "./server/main";
 import {
   DEFAULT_ALLOWED_HOSTS,
   hasFileExtension,
   isLoopbackBindHost,
+  isUnauthenticatedOAuthCallbackPath,
   makeIsAllowedHost,
   makeIsAuthorized,
   normalizeCredential,
@@ -111,6 +114,13 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
 
   const handlers = opts.handlers ?? (await getServerHandlers());
 
+  // Mirror every OAuth callback completion into the local in-memory result
+  // store. The Electron desktop renderer polls /api/oauth/await/:sessionId
+  // for these when the user runs the flow in their system browser (no
+  // shared origin → no postMessage). Cloud doesn't register a listener;
+  // its same-origin web SPA receives results via postMessage directly.
+  setOAuthCompletionListener((result) => publishOAuthResult(result));
+
   // Build static routes from either embedded assets or disk
   let staticRoutes: Record<string, StaticHandler>;
   let serveIndex: StaticHandler;
@@ -137,17 +147,33 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
         return new Response("Forbidden", { status: 403 });
       }
 
-      if (requiresAuth && !isAuthorized(req)) {
+      const url = new URL(req.url);
+
+      // OAuth provider callbacks are hit by the user's external browser
+      // and can't carry our Basic auth header. The OAuth `state`
+      // parameter is the security gate — see isUnauthenticatedOAuthCallbackPath.
+      const skipAuth = isUnauthenticatedOAuthCallbackPath(url.pathname);
+
+      if (requiresAuth && !skipAuth && !isAuthorized(req)) {
         return new Response("Unauthorized", {
           status: 401,
           headers: { "www-authenticate": 'Bearer realm="executor", Basic realm="executor"' },
         });
       }
 
-      const url = new URL(req.url);
-
       if (url.pathname.startsWith("/mcp")) {
         return handlers.mcp.handleRequest(req);
+      }
+
+      // OAuth result polling — local-only, served outside the typed API
+      // because cloud (Cloudflare Workers, stateless) can't back the
+      // in-memory store. See setOAuthCompletionListener above.
+      const awaitMatch = /^\/api\/oauth\/await\/([^/?#]+)$/.exec(url.pathname);
+      if (awaitMatch && req.method === "GET") {
+        const result = consumeOAuthResult(awaitMatch[1]);
+        return new Response(JSON.stringify(result), {
+          headers: { "content-type": "application/json" },
+        });
       }
 
       if (url.pathname.startsWith("/api/") || url.pathname === "/api") {
@@ -174,6 +200,7 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Server
   return {
     port: server.port!,
     async stop() {
+      setOAuthCompletionListener(null);
       server.stop(true);
       await handlers.mcp.close();
       await handlers.api.dispose();

--- a/packages/core/api/src/index.ts
+++ b/packages/core/api/src/index.ts
@@ -18,7 +18,9 @@ export {
   isOAuthPopupResult,
   popupDocument,
   runOAuthCallback,
+  setOAuthCompletionListener,
   type OAuthCallbackUrlParams,
+  type OAuthCompletionListener,
   type OAuthPopupResult,
   type RunOAuthCallbackInput,
 } from "./oauth-popup";

--- a/packages/core/api/src/oauth-popup.ts
+++ b/packages/core/api/src/oauth-popup.ts
@@ -33,6 +33,7 @@ export type { OAuthPopupResult } from "@executor-js/sdk";
 
 export type OAuthCompletionListener = (result: OAuthPopupResult<unknown>) => void;
 
+// TODO: replace with plugin notify framework
 let completionListener: OAuthCompletionListener | null = null;
 
 export const setOAuthCompletionListener = (listener: OAuthCompletionListener | null): void => {

--- a/packages/core/api/src/oauth-popup.ts
+++ b/packages/core/api/src/oauth-popup.ts
@@ -18,6 +18,28 @@ export { OAUTH_POPUP_MESSAGE_TYPE, isOAuthPopupResult } from "@executor-js/sdk";
 export type { OAuthPopupResult } from "@executor-js/sdk";
 
 // ---------------------------------------------------------------------------
+// Completion listener — optional process-wide hook called every time an
+// OAuth flow finishes (success or failure). Lets hosts that can't use the
+// in-browser postMessage/BroadcastChannel handoff observe results another
+// way (e.g. the local server registers an in-memory registry so the
+// Electron renderer can poll over HTTP when the user signed in via the
+// system browser).
+//
+// Default: no listener. Cloud hosts (Cloudflare Workers — stateless,
+// multi-isolate) intentionally don't register one; an in-memory side
+// channel can't bridge isolates and the same-origin web SPA already
+// receives results via postMessage, so the listener is a no-op there.
+// ---------------------------------------------------------------------------
+
+export type OAuthCompletionListener = (result: OAuthPopupResult<unknown>) => void;
+
+let completionListener: OAuthCompletionListener | null = null;
+
+export const setOAuthCompletionListener = (listener: OAuthCompletionListener | null): void => {
+  completionListener = listener;
+};
+
+// ---------------------------------------------------------------------------
 // HTML generation
 // ---------------------------------------------------------------------------
 
@@ -154,5 +176,8 @@ export const runOAuthCallback = <TAuth, E, R>(
           ...(details && details !== short ? { errorDetails: details } : {}),
         });
       }),
+      Effect.tap((result) =>
+        Effect.sync(() => completionListener?.(result as OAuthPopupResult<unknown>)),
+      ),
       Effect.map((result) => popupDocument(result, input.channelName)),
     );

--- a/packages/react/src/api/oauth-popup.ts
+++ b/packages/react/src/api/oauth-popup.ts
@@ -202,3 +202,81 @@ export const openOAuthPopup = <TAuth>(input: OpenOAuthPopupInput<TAuth>): (() =>
     closePopup(popup);
   };
 };
+
+// ---------------------------------------------------------------------------
+// System-browser flow — used when a desktop host (Electron) opens the auth
+// URL in the user's real browser. There's no shared origin, so the
+// renderer polls `/api/oauth/await/:sessionId` for the result. The local
+// server publishes there via `setOAuthCompletionListener` (see
+// apps/local/src/serve.ts).
+// ---------------------------------------------------------------------------
+
+export type OpenOAuthSystemBrowserInput<TAuth> = {
+  readonly url: string;
+  readonly sessionId: string;
+  readonly openExternal: (url: string) => Promise<void>;
+  readonly onResult: (data: OAuthPopupResult<TAuth>) => void;
+  /** Called once if the external open itself fails (URL rejected, IPC error). */
+  readonly onOpenFailed?: (cause: unknown) => void;
+  /** Poll cadence. Default 1000ms. */
+  readonly pollMs?: number;
+  /** Stop polling after this many ms with no result. Default 10 minutes. */
+  readonly timeoutMs?: number;
+  readonly onTimeout?: () => void;
+};
+
+const OAUTH_AWAIT_DEFAULT_POLL_MS = 1000;
+const OAUTH_AWAIT_DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+export const openOAuthSystemBrowser = <TAuth>(
+  input: OpenOAuthSystemBrowserInput<TAuth>,
+): (() => void) => {
+  let settled = false;
+  let pollHandle: ReturnType<typeof setInterval> | null = null;
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  const controller = new AbortController();
+
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    if (pollHandle !== null) clearInterval(pollHandle);
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+    controller.abort();
+  };
+
+  const poll = async () => {
+    if (settled) return;
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: fetch can reject for transient network errors during polling
+    try {
+      const response = await fetch(`/api/oauth/await/${encodeURIComponent(input.sessionId)}`, {
+        signal: controller.signal,
+        cache: "no-store",
+      });
+      if (!response.ok) return;
+      const body = (await response.json()) as unknown;
+      if (body === null || settled) return;
+      if (!isOAuthPopupResult<TAuth>(body)) return;
+      settle();
+      input.onResult(body);
+    } catch {
+      // Transient — next tick will retry. AbortError after settle is also caught here.
+    }
+  };
+
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: openExternal is host-provided and may reject
+  input.openExternal(input.url).catch((cause: unknown) => {
+    if (settled) return;
+    settle();
+    input.onOpenFailed?.(cause);
+  });
+
+  pollHandle = setInterval(() => void poll(), input.pollMs ?? OAUTH_AWAIT_DEFAULT_POLL_MS);
+  void poll();
+  timeoutHandle = setTimeout(() => {
+    if (settled) return;
+    settle();
+    input.onTimeout?.();
+  }, input.timeoutMs ?? OAUTH_AWAIT_DEFAULT_TIMEOUT_MS);
+
+  return () => settle();
+};

--- a/packages/react/src/components/mcp-install-card.tsx
+++ b/packages/react/src/components/mcp-install-card.tsx
@@ -99,7 +99,11 @@ export const buildMcpInstallCommand = (input: {
 };
 
 export function McpInstallCard(props: { className?: string }) {
-  const showStdio = isLocal;
+  // Desktop hosts ship Electron without putting an `executor` binary on
+  // PATH, and the bundled sidecar is locked to the running app. Force the
+  // HTTP path there — it routes through the running sidecar with the
+  // Basic auth header injected by the renderer.
+  const showStdio = isLocal && readDesktopBridge() === null;
   const [mode, setMode] = useState<TransportMode>(showStdio ? "stdio" : "http");
   const [origin, setOrigin] = useState<string | null>(null);
   const [desktop, setDesktop] = useState<{

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -6,7 +6,24 @@ import * as Exit from "effect/Exit";
 
 import { cancelOAuth, startOAuth } from "../api/atoms";
 import { messageFromExit, messageFromUnknown, useReportHandledError } from "../api/error-reporting";
-import { openOAuthPopup, reserveOAuthPopup, type OAuthPopupResult } from "../api/oauth-popup";
+import {
+  openOAuthPopup,
+  openOAuthSystemBrowser,
+  reserveOAuthPopup,
+  type OAuthPopupResult,
+} from "../api/oauth-popup";
+
+type DesktopBridge = {
+  readonly openExternal: (url: string) => Promise<void>;
+};
+
+const getDesktopBridge = (): DesktopBridge | null => {
+  if (typeof window === "undefined") return null;
+  const bridge = (window as unknown as { executor?: Partial<DesktopBridge> }).executor;
+  return bridge && typeof bridge.openExternal === "function"
+    ? (bridge as DesktopBridge)
+    : null;
+};
 import { Button } from "../components/button";
 import {
   OAUTH_POPUP_MESSAGE_TYPE,
@@ -145,8 +162,12 @@ export function useOAuthPopupFlow<
       cancel();
       setBusy(true);
       setError(null);
-      const reservedPopup = reserveOAuthPopup({ popupName });
-      if (!reservedPopup) {
+      const desktopBridge = getDesktopBridge();
+      // Desktop hosts open the auth URL in the user's real browser, so
+      // we skip the in-page popup reservation entirely and rely on the
+      // /api/oauth/await/:sessionId polling channel for the result.
+      const reservedPopup = desktopBridge ? null : reserveOAuthPopup({ popupName });
+      if (!desktopBridge && !reservedPopup) {
         const message = popupBlockedMessage ?? "Sign-in popup was blocked by the browser";
         setBusy(false);
         setError(message);
@@ -171,7 +192,7 @@ export function useOAuthPopupFlow<
           message,
           metadata: input.reportMetadata,
         });
-        reservedPopup.popup.close();
+        reservedPopup?.popup.close();
         setBusy(false);
         setError(message);
         input.onError?.(message);
@@ -181,7 +202,7 @@ export function useOAuthPopupFlow<
       if (response.authorizationUrl === null) {
         const message =
           noAuthorizationUrlMessage ?? "OAuth start did not produce an authorization URL";
-        reservedPopup.popup.close();
+        reservedPopup?.popup.close();
         setBusy(false);
         setError(message);
         input.onError?.(message);
@@ -193,66 +214,79 @@ export function useOAuthPopupFlow<
         tokenScope: input.tokenScope,
       };
       input.onAuthorizationStarted?.(response);
-      cleanupRef.current = openOAuthPopup<TPayload>({
-        url: response.authorizationUrl,
-        popupName,
-        channelName: OAUTH_POPUP_MESSAGE_TYPE,
-        expectedSessionId: response.sessionId,
-        reservedPopup,
-        closedPollMs: detectPopupClosed ? undefined : null,
-        onResult: async (result: OAuthPopupResult<TPayload>) => {
-          cleanupRef.current = null;
-          sessionRef.current = null;
+      const handleResult = async (result: OAuthPopupResult<TPayload>) => {
+        cleanupRef.current = null;
+        sessionRef.current = null;
 
-          if (!result.ok) {
-            setBusy(false);
-            setError(result.error);
-            input.onError?.(result.error);
-            return;
-          }
-
-          const persistenceError = await Promise.resolve(input.onSuccess(result)).then(
-            () => null,
-            (cause: unknown) => cause,
-          );
-          if (persistenceError !== null) {
-            const message = messageFromUnknown(persistenceError, "Failed to save connection");
-            reportHandledError(persistenceError, {
-              surface: "oauth",
-              action: "persist_connection",
-              message,
-              metadata: input.reportMetadata,
-            });
-            setBusy(false);
-            setError(message);
-            input.onError?.(message);
-            return;
-          }
+        if (!result.ok) {
           setBusy(false);
-        },
-        onClosed: () => {
-          cleanupRef.current = null;
-          sessionRef.current = null;
-          // `popup.closed` is advisory: COOP redirects can make a live popup
-          // appear closed to the opener. Keep server OAuth state alive for a
-          // callback or TTL cleanup; only explicit cancel deletes the session.
-          const message =
-            popupClosedMessage ??
-            "Sign-in cancelled - popup was closed before completing the flow.";
+          setError(result.error);
+          input.onError?.(result.error);
+          return;
+        }
+
+        const persistenceError = await Promise.resolve(input.onSuccess(result)).then(
+          () => null,
+          (cause: unknown) => cause,
+        );
+        if (persistenceError !== null) {
+          const message = messageFromUnknown(persistenceError, "Failed to save connection");
+          reportHandledError(persistenceError, {
+            surface: "oauth",
+            action: "persist_connection",
+            message,
+            metadata: input.reportMetadata,
+          });
           setBusy(false);
           setError(message);
           input.onError?.(message);
-        },
-        onOpenFailed: () => {
-          cleanupRef.current = null;
-          sessionRef.current = null;
-          cancelSession(response.sessionId, input.tokenScope);
-          const message = popupBlockedMessage ?? "Sign-in popup was blocked by the browser";
-          setBusy(false);
-          setError(message);
-          input.onError?.(message);
-        },
-      });
+          return;
+        }
+        setBusy(false);
+      };
+      const handleClosed = () => {
+        cleanupRef.current = null;
+        sessionRef.current = null;
+        // `popup.closed` is advisory: COOP redirects can make a live popup
+        // appear closed to the opener. Keep server OAuth state alive for a
+        // callback or TTL cleanup; only explicit cancel deletes the session.
+        const message =
+          popupClosedMessage ??
+          "Sign-in cancelled - popup was closed before completing the flow.";
+        setBusy(false);
+        setError(message);
+        input.onError?.(message);
+      };
+      const handleOpenFailed = () => {
+        cleanupRef.current = null;
+        sessionRef.current = null;
+        cancelSession(response.sessionId, input.tokenScope);
+        const message = popupBlockedMessage ?? "Sign-in popup was blocked by the browser";
+        setBusy(false);
+        setError(message);
+        input.onError?.(message);
+      };
+
+      cleanupRef.current = desktopBridge
+        ? openOAuthSystemBrowser<TPayload>({
+            url: response.authorizationUrl,
+            sessionId: response.sessionId,
+            openExternal: desktopBridge.openExternal,
+            onResult: (result) => void handleResult(result),
+            onOpenFailed: handleOpenFailed,
+            onTimeout: handleClosed,
+          })
+        : openOAuthPopup<TPayload>({
+            url: response.authorizationUrl,
+            popupName,
+            channelName: OAUTH_POPUP_MESSAGE_TYPE,
+            expectedSessionId: response.sessionId,
+            reservedPopup: reservedPopup ?? undefined,
+            closedPollMs: detectPopupClosed ? undefined : null,
+            onResult: (result) => void handleResult(result),
+            onClosed: handleClosed,
+            onOpenFailed: handleOpenFailed,
+          });
     },
     [
       cancel,


### PR DESCRIPTION
## Summary

- OAuth in the desktop app now opens in the user's default browser via `shell.openExternal`. The renderer polls `/api/oauth/await/:sessionId` for the completed result instead of relying on an Electron child window. Existing provider sessions (Google, GitHub, etc.) come along — no fresh sign-in inside an isolated cookie jar.
- Side channel is local-only. Core exposes a `setOAuthCompletionListener` hook (noop by default); the in-memory result store and polling route live in `apps/local`. Stateless cloud hosts get nothing — same-origin web SPAs keep using `postMessage`/`BroadcastChannel`.
- Hides the stdio MCP install command in the desktop renderer. The packaged app doesn't put `executor` on PATH, and spawning a separate stdio sidecar would fight the running one for the DB. Desktop users see only the HTTP install command, which routes through the running sidecar with the Basic auth header.

## Test plan

- [x] `bun run --filter=@executor-js/api typecheck`
- [x] `bun run --filter=@executor-js/local typecheck`
- [x] `bun run --filter=@executor-js/react typecheck`
- [x] `bun run --filter=@executor-js/desktop typecheck`
- [x] Verified MCP HTTP transport against the running desktop sidecar end-to-end: `initialize`, session lifecycle, `tools/list`, and a real `execute` call all succeed with the Basic auth header.
- [ ] Manual OAuth round-trip in the packaged desktop app