### PR TITLE
fix(vite-plugin): emit absolute paths for plugin client imports

### DIFF
--- a/.changeset/vite-plugin-absolute-paths.md
+++ b/.changeset/vite-plugin-absolute-paths.md
@@ -1,0 +1,17 @@
+---
+"@executor-js/vite-plugin": patch
+---
+
+`virtual:executor/plugins-client` now emits absolute `file://` URLs for each
+plugin's `./client` subpath instead of bare specifiers like
+`@executor-js/plugin-openapi/client`. The plugin already resolved those
+imports against the consumer's `executor.config` directory to validate
+them; it now uses the resolved path directly.
+
+Fixes a resolution failure for hosts where Vite's `root` differs from the
+package that depends on the plugins. For example, `apps/local`'s Vite
+config sets `root: packages/app/`, so Vite walked node_modules upward from
+`packages/app/` — which doesn't see the plugin packages installed under
+`apps/local/node_modules/`. Node's resolver still honors each plugin's
+`exports./client` conditions when we resolve, so behavior is unchanged
+for hosts that previously worked.

--- a/packages/core/vite-plugin/src/index.ts
+++ b/packages/core/vite-plugin/src/index.ts
@@ -185,7 +185,15 @@ export default function executorVitePlugin(options: ExecutorVitePluginOptions = 
         continue;
       }
       const ident = `__executor_plugin_${exportExpressions.length}`;
-      lines.push(`import ${ident} from ${JSON.stringify(`${entry.pkg}/client`)};`);
+      // Emit the absolute file path rather than `${pkg}/client`. Vite
+      // resolves bare specifiers from its `root`, which for hosts like
+      // apps/local is `packages/app/` — a location that doesn't see
+      // plugin packages installed under the consumer's node_modules.
+      // Resolving here (from the consumer's executor.config dir) and
+      // emitting the absolute path bypasses Vite's node_modules walk
+      // entirely while still honoring each plugin's `exports./client`
+      // conditions (Node's resolver handles those above).
+      lines.push(`import ${ident} from ${JSON.stringify(pathToFileURL(resolved).href)};`);
       // Plugins that surface a `clientConfig` default-export a factory
       // `(config?) => ClientPluginSpec`; everyone else default-exports
       // a bare `ClientPluginSpec` value. We emit a call only when we


### PR DESCRIPTION
## Summary

- `virtual:executor/plugins-client` now emits absolute `file://` URLs for each plugin's `./client` subpath instead of bare specifiers like `@executor-js/plugin-openapi/client`.
- The plugin already resolved each entry via `createRequire` from the consumer's `executor.config` directory to validate it. Now it uses that resolved path directly when emitting the import.

## Why

Vite resolves bare specifiers from its configured `root`. Hosts where the Vite root differs from the package depending on the plugins fail to resolve plugin client modules. Concretely: `apps/local`'s Vite config sets `root: packages/app/`, so Vite walked node_modules upward from `packages/app/` — but the plugin packages are only symlinked under `apps/local/node_modules/`, outside that walk. Result: `Failed to resolve import "@executor-js/plugin-openapi/client" from "virtual:executor/plugins-client"`.

Resolving in the plugin (where we know the consumer's cwd) and emitting the absolute path bypasses Vite's node_modules walk entirely. Each plugin's `exports./client` conditions are still honored — Node's resolver applies them before we hand the path to Vite.

## Test plan

- [x] `bun run --filter=@executor-js/vite-plugin typecheck`
- [ ] `apps/local` boot via `bun dev` resolves the plugins-client virtual module