### PR TITLE
fix(release): publish as draft until desktop assets upload

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -170,10 +170,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          find artifacts -type f \
+          set -euo pipefail
+          while IFS= read -r file; do
+            echo "Uploading: $file"
+            gh release upload "$RELEASE_TAG" "$file" --repo "$GITHUB_REPOSITORY" --clobber
+          done < <(find artifacts -type f \
             \( -name "*.dmg" -o -name "*.zip" -o -name "*.exe" \
             -o -name "*.AppImage" -o -name "*.deb" -o -name "*.rpm" \
-            -o -name "latest*.yml" \) | while read file; do
-            echo "Uploading: $file"
-            gh release upload "$RELEASE_TAG" "$file" --repo "$GITHUB_REPOSITORY" --clobber || true
-          done
+            -o -name "latest*.yml" \))
+
+      # Flip draft → published only after every desktop asset is uploaded —
+      # this is the atomic point where the new tag becomes "latest".
+      - name: Promote release (draft → published)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --repo "$GITHUB_REPOSITORY"

--- a/apps/cli/src/release.ts
+++ b/apps/cli/src/release.ts
@@ -200,6 +200,9 @@ const syncGitHubRelease = async (input: {
   const notesPath = resolve(cliRoot, "release-notes", "next.md");
   const notesFile = existsSync(notesPath) ? notesPath : null;
 
+  // Draft until publish-desktop.yml finishes uploading installers and flips
+  // it; otherwise /releases/latest/download/<desktop-asset> 404s during the
+  // ~15-20 min desktop build window.
   const args = [
     "release",
     "create",
@@ -211,12 +214,11 @@ const syncGitHubRelease = async (input: {
     input.tag,
     ...(notesFile ? ["--notes-file", notesFile] : ["--generate-notes"]),
     "--verify-tag",
+    "--draft",
   ];
 
   if (input.channel === "beta") {
     args.push("--prerelease");
-  } else {
-    args.push("--latest");
   }
 
   await runCommand({


### PR DESCRIPTION
## Summary

The release flow promoted a tag to "latest" the moment the CLI publish step completed (via `gh release create --latest`). The desktop build then ran for another ~15-20 min before attaching DMG / zip / exe / AppImage / deb / rpm / `latest*.yml` assets, so any user hitting `/releases/latest/download/<desktop-asset>` during that window got a 404 — including the link from `apps/cli/release-notes/next.md` that points users at `releases/latest`.

## Fix

- `apps/cli/src/release.ts` — create the GitHub release with `--draft` instead of `--latest`. Beta still gets `--prerelease` on top.
- `.github/workflows/publish-desktop.yml` — final step now runs `gh release edit "$RELEASE_TAG" --draft=false` after every desktop asset has been uploaded. GitHub auto-promotes the now-undrafted release to "latest" based on semver, so no explicit `--latest` flag is needed.

While the release is still a draft, `/releases/latest/...` continues to redirect to the previous release, so `install.sh` and the download links in release notes keep working. The atomic flip happens only once the new tag actually has every asset behind it.

## Hardening

Also tightened the upload loop in `publish-desktop.yml`:
- Removed `|| true` that was silently swallowing `gh release upload` failures.
- Added `set -euo pipefail` and switched to process substitution so a failed upload aborts the job instead of leaving the release short an asset (which the old code would have happily promoted).

## Tradeoff

CLI-only users running `install.sh` (no `--version`) during the desktop build window will get the *previous* CLI version until the release is promoted. Old CLI works; broken download doesn't. Specific-version installs (`install.sh --version X.Y.Z`) already 404 during the window today since draft asset URLs aren't anonymous-accessible — same surface area as before, just no longer the default path.

## Test plan

- [ ] Merge to `main`, watch the `Version Packages` PR flow produce a release tag
- [ ] Verify `publish-executor-package.yml` creates the GitHub release as a draft (visible under Releases with the draft badge, not pinned as "Latest")
- [ ] Verify `/releases/latest/download/executor-darwin-arm64.zip` still redirects to the *previous* release during the desktop build
- [ ] Verify `publish-desktop.yml` uploads all desktop assets and the final "Promote release" step flips it to published
- [ ] Verify GitHub auto-pins the new release as "Latest" after the flip
- [ ] Verify `/releases/latest/download/executor-desktop-mac-arm64.dmg` resolves with no 404 window

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RhysSullivan/codesmith/executor/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->