### PR TITLE
fix(marketing): correct download link for Linux (Desktop AppImage)

### DIFF
--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -140,7 +140,7 @@ import { SelfHostContactModal } from "../components/self-host-contact-modal";
                   </a>
                   <a
                     data-os="linux-x64"
-                    href="https://github.com/RhysSullivan/executor/releases/latest/download/executor-desktop-linux-x64.AppImage"
+                    href="https://github.com/RhysSullivan/executor/releases/latest/download/executor-desktop-linux-x86_64.AppImage"
                     class="btn-primary btn-primary--hero"
                   >
                     Download for Linux


### PR DESCRIPTION
The link to the GitHub release for the Linux Desktop app is malformed and 404s through GitHub, this PR ensures the correct download link is used