### PR TITLE
Version Packages

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "executor",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "private": true,
   "bin": {
     "executor": "./bin/executor.ts"

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -14,3 +14,7 @@ Downloads land on each [GitHub release](https://github.com/RhysSullivan/executor
 ## UI
 
 - Sidebar now shows a "Beta" pill next to the executor wordmark.
+
+## Fixes
+
+- Source configuration is no longer replayed from or written back to `executor.jsonc`; local source state stays in the shared Executor database while `executor.jsonc` continues to load plugin entries.

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/cloud",
-  "version": "1.4.13",
+  "version": "1.4.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/desktop",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "private": true,
   "homepage": "https://github.com/RhysSullivan/executor",
   "license": "MIT",

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "apps/cli": {
       "name": "executor",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "bin": {
         "executor": "./bin/executor.ts",
       },
@@ -50,7 +50,7 @@
     },
     "apps/cloud": {
       "name": "@executor-js/cloud",
-      "version": "1.4.13",
+      "version": "1.4.14",
       "dependencies": {
         "@cloudflare/vite-plugin": "^1.31.1",
         "@effect/atom-react": "catalog:",
@@ -118,7 +118,7 @@
     },
     "apps/desktop": {
       "name": "@executor-js/desktop",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "electron-log": "^5",
         "electron-store": "^10",
@@ -232,7 +232,7 @@
     },
     "examples/all-plugins": {
       "name": "@executor-js/example-all-plugins",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@executor-js/plugin-file-secrets": "workspace:*",
         "@executor-js/plugin-google-discovery": "workspace:*",
@@ -291,7 +291,7 @@
     },
     "packages/core/api": {
       "name": "@executor-js/api",
-      "version": "1.4.15",
+      "version": "1.4.16",
       "dependencies": {
         "@executor-js/execution": "workspace:*",
         "@executor-js/sdk": "workspace:*",
@@ -328,7 +328,7 @@
     },
     "packages/core/config": {
       "name": "@executor-js/config",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "effect": "catalog:",
@@ -346,7 +346,7 @@
     },
     "packages/core/execution": {
       "name": "@executor-js/execution",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/codemode-core": "workspace:*",
         "@executor-js/sdk": "workspace:*",
@@ -378,7 +378,7 @@
     },
     "packages/core/sdk": {
       "name": "@executor-js/sdk",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/storage-core": "workspace:*",
         "@standard-schema/spec": "^1.1.0",
@@ -410,7 +410,7 @@
     },
     "packages/core/storage-core": {
       "name": "@executor-js/storage-core",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "effect": "catalog:",
@@ -432,7 +432,7 @@
     },
     "packages/core/storage-drizzle": {
       "name": "@executor-js/storage-drizzle",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@executor-js/storage-core": "workspace:*",
         "drizzle-orm": "catalog:",
@@ -486,7 +486,7 @@
     },
     "packages/core/vite-plugin": {
       "name": "@executor-js/vite-plugin",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "jiti": "^2.6.1",
@@ -524,7 +524,7 @@
     },
     "packages/kernel/core": {
       "name": "@executor-js/codemode-core",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@babel/parser": "^7.29.2",
         "@standard-schema/spec": "^1.0.0",
@@ -589,7 +589,7 @@
     },
     "packages/kernel/runtime-quickjs": {
       "name": "@executor-js/runtime-quickjs",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/codemode-core": "workspace:*",
         "effect": "catalog:",
@@ -606,7 +606,7 @@
     },
     "packages/plugins/desktop-settings": {
       "name": "@executor-js/plugin-desktop-settings",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "react": "catalog:",
@@ -619,7 +619,7 @@
     },
     "packages/plugins/example": {
       "name": "@executor-js/plugin-example",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
       },
@@ -642,7 +642,7 @@
     },
     "packages/plugins/file-secrets": {
       "name": "@executor-js/plugin-file-secrets",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "effect": "catalog:",
@@ -656,7 +656,7 @@
     },
     "packages/plugins/google-discovery": {
       "name": "@executor-js/plugin-google-discovery",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "effect": "catalog:",
@@ -691,7 +691,7 @@
     },
     "packages/plugins/graphql": {
       "name": "@executor-js/plugin-graphql",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
@@ -729,7 +729,7 @@
     },
     "packages/plugins/keychain": {
       "name": "@executor-js/plugin-keychain",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "@napi-rs/keyring": "^1.2.0",
@@ -745,7 +745,7 @@
     },
     "packages/plugins/mcp": {
       "name": "@executor-js/plugin-mcp",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@effect/platform-node": "catalog:",
@@ -785,7 +785,7 @@
     },
     "packages/plugins/onepassword": {
       "name": "@executor-js/plugin-onepassword",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@1password/op-js": "^0.1.13",
         "@1password/sdk": "^0.4.1-beta.1",
@@ -818,7 +818,7 @@
     },
     "packages/plugins/openapi": {
       "name": "@executor-js/plugin-openapi",
-      "version": "1.4.27",
+      "version": "1.4.28",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
@@ -882,7 +882,7 @@
     },
     "packages/react": {
       "name": "@executor-js/react",
-      "version": "1.4.15",
+      "version": "1.4.16",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@effect/atom-react": "catalog:",

--- a/examples/all-plugins/package.json
+++ b/examples/all-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/example-all-plugins",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/api/package.json
+++ b/packages/core/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/api",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/config/package.json
+++ b/packages/core/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/config",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/config",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/execution",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/execution",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/sdk",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/sdk",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/core/storage-core/package.json
+++ b/packages/core/storage-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/storage-core",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/storage-core",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/core/storage-drizzle/package.json
+++ b/packages/core/storage-drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/storage-drizzle",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "type": "module",
   "exports": {

--- a/packages/core/vite-plugin/package.json
+++ b/packages/core/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/vite-plugin",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/vite-plugin",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/kernel/core/package.json
+++ b/packages/kernel/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/codemode-core",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/kernel/core",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/kernel/runtime-quickjs/package.json
+++ b/packages/kernel/runtime-quickjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/runtime-quickjs",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/kernel/runtime-quickjs",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/desktop-settings/package.json
+++ b/packages/plugins/desktop-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-desktop-settings",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/desktop-settings",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/example/package.json
+++ b/packages/plugins/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-example",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/example",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/file-secrets/package.json
+++ b/packages/plugins/file-secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-file-secrets",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/file-secrets",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/google-discovery/package.json
+++ b/packages/plugins/google-discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-google-discovery",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/google-discovery",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-graphql",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/graphql",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/keychain/package.json
+++ b/packages/plugins/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-keychain",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/keychain",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-mcp",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/mcp",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/onepassword/package.json
+++ b/packages/plugins/onepassword/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-onepassword",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/onepassword",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-openapi",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/openapi",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/react",
-  "version": "1.4.15",
+  "version": "1.4.16",
   "private": true,
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary

Prepare the 1.4.28 CLI and desktop release containing the executor.jsonc source-sync fix.

## Changes

- Bump the Changesets-managed fixed release set from 1.4.27 to 1.4.28.
- Add release notes for the source-state fix.
- Update bun.lock for the new package versions.

## Validation

- bun run lint:release-notes
- bun run release:check
