### PR TITLE
fix(oauth): surface real callback error in popup with collapsible details

### DIFF
--- a/.changeset/oauth-popup-error-details.md
+++ b/.changeset/oauth-popup-error-details.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Surface the real OAuth callback error in the popup with a collapsible details disclosure. See `apps/cli/release-notes/next.md`.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -11,3 +11,7 @@ Two regressions kept `executor.jsonc` and the runtime DB from agreeing on which 
 ### Variadic tool path arguments no longer crash
 
 Calling a tool with multiple positional path arguments (`executor <tool> path/a path/b ...`) no longer panics in the CLI argument parser. Thanks @grfwings (#761)
+
+### OAuth popup surfaces the real callback error
+
+OAuth callback failures previously rendered a hardcoded `"Authentication failed"`, hiding the actual cause behind a generic placeholder. The popup now shows a short tag-derived headline plus the full technical message inside a collapsible `<details>` disclosure, and skips auto-close on failure so users can read and act on the error. Thanks @Mark-Life (#774)

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -8,7 +8,7 @@ import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { HttpServerResponse } from "effect/unstable/http";
 import { Effect, Option, Predicate, Schema } from "effect";
 
-import { runOAuthCallback } from "../oauth-popup";
+import { runOAuthCallback, type PopupErrorMessage } from "../oauth-popup";
 import {
   OAUTH_POPUP_MESSAGE_TYPE,
   OAuthCompleteError,
@@ -50,26 +50,36 @@ const decodeOAuthCompleteError = Schema.decodeUnknownOption(OAuthCompleteError);
 const decodeOAuthProbeError = Schema.decodeUnknownOption(OAuthProbeError);
 const decodeOAuthSessionNotFoundError = Schema.decodeUnknownOption(OAuthSessionNotFoundError);
 
-const getOAuthErrorMessage = <A extends { readonly message: string }>(
-  error: unknown,
-  decode: (input: unknown) => Option.Option<A>,
-): string | undefined =>
-  Option.match(decode(error), {
-    onNone: () => undefined,
-    onSome: (oauthError) => oauthError.message,
-  });
+const toPopupErrorMessage = (error: unknown): PopupErrorMessage => {
+  const completeError = decodeOAuthCompleteError(error);
+  if (Option.isSome(completeError))
+    return {
+      short: "Could not complete authentication",
+      details: completeError.value.message,
+    };
 
-const toPopupErrorMessage = (error: unknown): string => {
-  const message =
-    getOAuthErrorMessage(error, decodeOAuthStartError) ??
-    getOAuthErrorMessage(error, decodeOAuthCompleteError) ??
-    getOAuthErrorMessage(error, decodeOAuthProbeError);
-  if (message) return message;
+  const startError = decodeOAuthStartError(error);
+  if (Option.isSome(startError))
+    return {
+      short: "Could not start authentication",
+      details: startError.value.message,
+    };
+
+  const probeError = decodeOAuthProbeError(error);
+  if (Option.isSome(probeError))
+    return {
+      short: "Could not discover authentication endpoint",
+      details: probeError.value.message,
+    };
 
   const sessionNotFound = decodeOAuthSessionNotFoundError(error);
   if (Option.isSome(sessionNotFound))
-    return `OAuth session not found: ${sessionNotFound.value.sessionId}`;
-  return "Authentication failed";
+    return {
+      short: "OAuth session expired or not found",
+      details: `Session id: ${sessionNotFound.value.sessionId}`,
+    };
+
+  return { short: "Authentication failed" };
 };
 
 const requireMatchingTokenScope = (
@@ -78,7 +88,11 @@ const requireMatchingTokenScope = (
 ): Effect.Effect<void, OAuthStartError> =>
   routeScope === tokenScope
     ? Effect.void
-    : Effect.fail(new OAuthStartError({ message: "OAuth token scope must match route scope" }));
+    : Effect.fail(
+        new OAuthStartError({
+          message: "OAuth token scope must match route scope",
+        }),
+      );
 
 export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handlers) =>
   handlers
@@ -150,7 +164,9 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
       capture(
         Effect.gen(function* () {
           if (path.scopeId !== payload.tokenScope) {
-            return yield* new OAuthSessionNotFoundError({ sessionId: payload.sessionId });
+            return yield* new OAuthSessionNotFoundError({
+              sessionId: payload.sessionId,
+            });
           }
           const executor = yield* ExecutorService;
           yield* executor.oauth.cancel(payload.sessionId, payload.tokenScope);
@@ -175,9 +191,6 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
                 .pipe(
                   Effect.tapError((cause) =>
                     Effect.logError("OAuth callback completion failed", cause),
-                  ),
-                  Effect.catchCause(() =>
-                    Effect.fail(new OAuthCompleteError({ message: "Authentication failed" })),
                   ),
                 ),
             urlParams,

--- a/packages/core/api/src/oauth-popup.test.ts
+++ b/packages/core/api/src/oauth-popup.test.ts
@@ -64,6 +64,56 @@ describe("popupDocument", () => {
     expect(html).not.toContain("<script>alert(1)</script>");
   });
 
+  it("renders a collapsible details disclosure when errorDetails is present", () => {
+    const html = popupDocument(
+      {
+        type: OAUTH_POPUP_MESSAGE_TYPE,
+        ok: false,
+        sessionId: null,
+        error: "Could not complete authentication",
+        errorDetails: "HTTP 201 Created from https://api.supabase.com/v1/oauth/token",
+      },
+      "channel-x",
+    );
+    expect(html).toContain("Could not complete authentication");
+    expect(html).toContain("<details");
+    expect(html).toContain("<summary");
+    expect(html).toContain("Details</summary>");
+    expect(html).toContain("HTTP 201 Created from https://api.supabase.com/v1/oauth/token");
+  });
+
+  it("escapes HTML inside errorDetails", () => {
+    const html = popupDocument(
+      {
+        type: OAUTH_POPUP_MESSAGE_TYPE,
+        ok: false,
+        sessionId: null,
+        error: "Failed",
+        errorDetails: "<script>alert('xss')</script>",
+      },
+      "channel-x",
+    );
+    expect(html).toContain("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;");
+    // Ensure the raw script tag does not appear inside the rendered <pre>.
+    const preMatch = /<pre[^>]*>([^<]*)<\/pre>/.exec(html);
+    expect(preMatch).not.toBeNull();
+    expect(preMatch![1]).not.toContain("<script>");
+  });
+
+  it("omits the details disclosure when errorDetails matches error", () => {
+    const html = popupDocument(
+      {
+        type: OAUTH_POPUP_MESSAGE_TYPE,
+        ok: false,
+        sessionId: null,
+        error: "Failed",
+        errorDetails: "Failed",
+      },
+      "channel-x",
+    );
+    expect(html).not.toContain("<details");
+  });
+
   it("HTML-escapes the BroadcastChannel name so attacker-controlled names cannot break out", () => {
     const html = popupDocument(successPayload, 'evil"name');
     expect(html).toContain('new BroadcastChannel("evil&quot;name")');
@@ -115,7 +165,7 @@ describe("runOAuthCallback", () => {
             refreshTokenSecretId: "s2",
           }),
         urlParams: { state: "session-xyz", code: "abc" },
-        toErrorMessage: () => "should not reach",
+        toErrorMessage: () => ({ short: "should not reach" }),
         channelName: "channel-x",
       }),
     );
@@ -137,7 +187,7 @@ describe("runOAuthCallback", () => {
           });
         },
         urlParams: { state: "s1", code: "code1", error: null },
-        toErrorMessage: () => "",
+        toErrorMessage: () => ({ short: "" }),
         channelName: "c",
       }),
     );
@@ -158,7 +208,7 @@ describe("runOAuthCallback", () => {
       runOAuthCallback<GoogleAuth, never, never>({
         complete,
         urlParams: { state: "s1", error: "access_denied" },
-        toErrorMessage: () => "",
+        toErrorMessage: () => ({ short: "" }),
         channelName: "c",
       }),
     );
@@ -166,7 +216,7 @@ describe("runOAuthCallback", () => {
       runOAuthCallback<GoogleAuth, never, never>({
         complete,
         urlParams: { state: "s2", error_description: "user cancelled" },
-        toErrorMessage: () => "",
+        toErrorMessage: () => ({ short: "" }),
         channelName: "c",
       }),
     );
@@ -183,14 +233,33 @@ describe("runOAuthCallback", () => {
         complete: () => Effect.fail(new DomainError({ message: "Code expired" })),
         urlParams: { state: "s1" },
         toErrorMessage: (error) => {
+          if (!isDomainError(error)) return { short: "unknown" };
           // oxlint-disable-next-line executor/no-unknown-error-message -- boundary: schema guard narrows the unknown popup callback error to the public test message
-          return isDomainError(error) ? error.message : "unknown";
+          return { short: "Auth failed", details: error.message };
         },
         channelName: "c",
       }),
     );
     expect(html).toContain("<title>Connection failed</title>");
+    expect(html).toContain("Auth failed");
+    expect(html).toContain("<summary");
     expect(html).toContain("Code expired");
+  });
+
+  it("omits the details disclosure when details match the short message", async () => {
+    class DomainError extends Data.TaggedError("DomainError")<{
+      readonly message: string;
+    }> {}
+    const html = await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, DomainError, never>({
+        complete: () => Effect.fail(new DomainError({ message: "boom" })),
+        urlParams: { state: "s1" },
+        toErrorMessage: () => ({ short: "Same", details: "Same" }),
+        channelName: "c",
+      }),
+    );
+    expect(html).toContain("Same");
+    expect(html).not.toContain("<details");
   });
 
   it("never rejects — even defects are rendered as a failure popup", async () => {
@@ -198,7 +267,7 @@ describe("runOAuthCallback", () => {
       runOAuthCallback<GoogleAuth, never, never>({
         complete: () => Effect.die("boom"),
         urlParams: { state: "s1" },
-        toErrorMessage: () => "transport error",
+        toErrorMessage: () => ({ short: "transport error" }),
         channelName: "c",
       }),
     );

--- a/packages/core/api/src/oauth-popup.ts
+++ b/packages/core/api/src/oauth-popup.ts
@@ -56,26 +56,34 @@ export const popupDocument = <TAuth>(
   const message = payload.ok
     ? "Authentication complete. This window will close automatically."
     : payload.error;
+  const details =
+    !payload.ok && payload.errorDetails && payload.errorDetails !== payload.error
+      ? payload.errorDetails
+      : undefined;
   const statusColor = payload.ok ? "#22c55e" : "#ef4444";
   const icon = payload.ok
     ? '<path d="M6 10l3 3 5-6" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>'
     : '<path d="M7 7l6 6M13 7l-6 6" stroke="white" stroke-width="2" stroke-linecap="round"/>';
   const escapedChannel = escapeHtml(channelName);
+  const detailsHtml = details
+    ? `<details style="margin-top:16px;text-align:left"><summary style="cursor:pointer;font-size:12px;color:#888;user-select:none">Details</summary><pre style="white-space:pre-wrap;word-break:break-word;font-size:11px;line-height:1.5;color:#52525b;background:#f4f4f5;padding:8px;border-radius:4px;margin:8px 0 0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace">${escapeHtml(details)}</pre></details>`
+    : "";
 
   return `<!doctype html>
 <html lang="en">
 <head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${escapeHtml(title)}</title></head>
-<body style="font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#fafafa;color:#111">
-<style>@media(prefers-color-scheme:dark){body{background:#09090b!important;color:#fafafa!important}p{color:#a1a1aa!important}}</style>
-<main style="text-align:center;max-width:360px;padding:24px">
+<body style="font-family:system-ui,-apple-system,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;background:#fafafa;color:#111">
+<style>@media(prefers-color-scheme:dark){body{background:#09090b!important;color:#fafafa!important}p{color:#a1a1aa!important}pre{background:#18181b!important;color:#a1a1aa!important}}</style>
+<main style="text-align:center;max-width:420px;padding:24px">
 <div style="width:40px;height:40px;border-radius:50%;background:${statusColor};margin:0 auto 16px;display:flex;align-items:center;justify-content:center">
 <svg width="20" height="20" viewBox="0 0 20 20" fill="none">${icon}</svg>
 </div>
 <h1 style="margin:0 0 8px;font-size:18px;font-weight:600">${escapeHtml(title)}</h1>
 <p style="margin:0;font-size:14px;color:#666;line-height:1.5">${escapeHtml(message)}</p>
+${detailsHtml}
 </main>
 <script>
-(()=>{const p=${serialized};try{if(window.opener)window.opener.postMessage(p,window.location.origin);if("BroadcastChannel"in window){const c=new BroadcastChannel("${escapedChannel}");c.postMessage(p);setTimeout(()=>c.close(),100)}}finally{setTimeout(()=>window.close(),150)}})();
+(()=>{const p=${serialized};try{if(window.opener)window.opener.postMessage(p,window.location.origin);if("BroadcastChannel"in window){const c=new BroadcastChannel("${escapedChannel}");c.postMessage(p);setTimeout(()=>c.close(),100)}}finally{if(p.ok)setTimeout(()=>window.close(),150)}})();
 </script>
 </body></html>`;
 };
@@ -91,6 +99,12 @@ export type OAuthCallbackUrlParams = {
   readonly error_description?: string | null;
 };
 
+/** Short summary + optional full technical detail. */
+export type PopupErrorMessage = {
+  readonly short: string;
+  readonly details?: string;
+};
+
 export type RunOAuthCallbackInput<TAuth, E, R> = {
   /** The plugin's `completeOAuth` — resolves to the auth descriptor on success. */
   readonly complete: (params: {
@@ -99,8 +113,8 @@ export type RunOAuthCallbackInput<TAuth, E, R> = {
     readonly error: string | null;
   }) => Effect.Effect<TAuth, E, R>;
   readonly urlParams: OAuthCallbackUrlParams;
-  /** Map a plugin-specific error into a user-facing message. */
-  readonly toErrorMessage: (error: unknown) => string;
+  /** Map a plugin-specific error into a short summary and optional details. */
+  readonly toErrorMessage: (error: unknown) => PopupErrorMessage;
   readonly channelName: string;
 };
 
@@ -130,13 +144,15 @@ export const runOAuthCallback = <TAuth, E, R>(
           ...auth,
         }),
       ),
-      Effect.catchCause((cause) =>
-        Effect.succeed<OAuthPopupResult<TAuth>>({
+      Effect.catchCause((cause) => {
+        const { short, details } = input.toErrorMessage(Cause.squash(cause));
+        return Effect.succeed<OAuthPopupResult<TAuth>>({
           type: OAUTH_POPUP_MESSAGE_TYPE,
           ok: false,
           sessionId: input.urlParams.state ?? null,
-          error: input.toErrorMessage(Cause.squash(cause)),
-        }),
-      ),
+          error: short,
+          ...(details && details !== short ? { errorDetails: details } : {}),
+        });
+      }),
       Effect.map((result) => popupDocument(result, input.channelName)),
     );

--- a/packages/core/sdk/src/oauth-popup-types.ts
+++ b/packages/core/sdk/src/oauth-popup-types.ts
@@ -19,7 +19,10 @@ export type OAuthPopupResult<TAuth> =
       readonly type: typeof OAUTH_POPUP_MESSAGE_TYPE;
       readonly ok: false;
       readonly sessionId: string | null;
+      /** Short user-facing summary. */
       readonly error: string;
+      /** Full technical detail. Omitted when identical to `error`. */
+      readonly errorDetails?: string;
     };
 
 export const isOAuthPopupResult = <TAuth>(value: unknown): value is OAuthPopupResult<TAuth> =>


### PR DESCRIPTION
## Summary
- Drop the `Effect.catchCause` wrapper in the OAuth callback handler so the original tagged error propagates with its real message instead of a hardcoded "Authentication failed" placeholder.
- Popup now renders a short, tag-derived headline plus the full technical message inside a collapsible `<details>` disclosure.
- Skip auto-close on failure so users can read and act on the error.
- Backwards-compatible: existing consumers reading `result.error` keep working.

Closes #773

## Test plan
- [ ] `bun run test` for `packages/core/api` (new `oauth-popup.test.ts` cases)
- [ ] Manual: trigger an OAuth callback failure; verify headline + collapsible details render and popup stays open
- [ ] Manual: trigger an OAuth success; verify existing flow/auto-close unchanged