### PR TITLE
feat/mcp-edit-stdio-sources

### DIFF
--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -72,6 +72,10 @@ const UpdateSourcePayload = Schema.Struct({
   queryParams: Schema.optional(Schema.Record(Schema.String, McpCredentialInput)),
   credentialTargetScope: Schema.optional(ScopeId),
   auth: Schema.optional(AuthPayload),
+  command: Schema.optional(Schema.String),
+  args: Schema.optional(Schema.Array(Schema.String)),
+  env: Schema.optional(StringMap),
+  cwd: Schema.optional(Schema.String),
 });
 
 const UpdateSourceResponse = Schema.Struct({

--- a/packages/plugins/mcp/src/api/handlers.ts
+++ b/packages/plugins/mcp/src/api/handlers.ts
@@ -164,6 +164,10 @@ export const McpHandlers = HttpApiBuilder.group(ExecutorApiWithMcp, "mcp", (hand
             queryParams: payload.queryParams,
             credentialTargetScope: payload.credentialTargetScope,
             auth: payload.auth as McpUpdateSourceInput["auth"],
+            command: payload.command,
+            args: payload.args,
+            env: payload.env,
+            cwd: payload.cwd,
           });
           return { updated: true };
         }),

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -2,16 +2,14 @@ import { useReducer, useCallback, useEffect, useRef, useState, type ReactNode } 
 import { useAtomSet } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import * as Match from "effect/Match";
-import * as Option from "effect/Option";
-import * as Schema from "effect/Schema";
 
+import { messageFromExit } from "@executor-js/react/api/error-reporting";
 import { useScope } from "@executor-js/react/api/scope-context";
 import { Button } from "@executor-js/react/components/button";
 import {
   CardStack,
   CardStackContent,
   CardStackEntry,
-  CardStackEntryField,
 } from "@executor-js/react/components/card-stack";
 import { FieldLabel } from "@executor-js/react/components/field";
 import { FilterTabs } from "@executor-js/react/components/filter-tabs";
@@ -19,7 +17,6 @@ import { FloatActions } from "@executor-js/react/components/float-actions";
 import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
 import { Spinner } from "@executor-js/react/components/spinner";
-import { Textarea } from "@executor-js/react/components/textarea";
 import {
   emptyHttpCredentials,
   httpCredentialsValid,
@@ -50,24 +47,10 @@ type RemoteAuthMode = "none" | "oauth2";
 import { sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { probeMcpEndpoint, addMcpSourceOptimistic } from "./atoms";
 import { McpRemoteSourceFields } from "./McpRemoteSourceFields";
+import { McpStdioSourceFields } from "./McpStdioSourceFields";
+import { parseStdioArgs, parseStdioEnv } from "./stdio-form-helpers";
 import { mcpPresets, type McpPreset } from "../sdk/presets";
 import { MCP_OAUTH_CONNECTION_SLOT, type McpCredentialInput } from "../sdk/types";
-
-const ErrorMessage = Schema.Struct({ message: Schema.String });
-const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
-const STDIO_ENV_ESCAPE_REPLACEMENTS: Readonly<Record<string, string>> = {
-  "\\": "\\",
-  n: "\n",
-  r: "\r",
-  t: "\t",
-  '"': '"',
-};
-
-const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
-  Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
-    onNone: () => fallback,
-    onSome: ({ message }) => message,
-  });
 
 // ---------------------------------------------------------------------------
 // Preset lookup
@@ -361,7 +344,7 @@ export default function AddMcpSource(props: {
     if (Exit.isFailure(exit)) {
       dispatch({
         type: "probe-fail",
-        error: errorMessageFromExit(exit, "Failed to connect"),
+        error: messageFromExit(exit, "Failed to connect"),
       });
       return;
     }
@@ -487,7 +470,7 @@ export default function AddMcpSource(props: {
     if (Exit.isFailure(exit)) {
       dispatch({
         type: "add-fail",
-        error: errorMessageFromExit(exit, "Failed to add source"),
+        error: messageFromExit(exit, "Failed to add source"),
       });
       return;
     }
@@ -508,47 +491,6 @@ export default function AddMcpSource(props: {
   ]);
 
   // ---- Stdio actions ----
-
-  const parseStdioArgs = (raw: string): string[] => {
-    if (!raw.trim()) return [];
-    const args: string[] = [];
-    const regex = /[^\s"]+|"([^"]*)"/g;
-    let match;
-    while ((match = regex.exec(raw)) !== null) {
-      args.push(match[1] ?? match[0]);
-    }
-    return args;
-  };
-
-  const parseStdioEnvValue = (raw: string): string => {
-    const value = raw.trim();
-    if (value.length < 2) return value;
-
-    const quote = value[0];
-    if ((quote !== '"' && quote !== "'") || value[value.length - 1] !== quote) {
-      return value;
-    }
-
-    const inner = value.slice(1, -1);
-    if (quote === "'") return inner;
-
-    return inner.replace(
-      /\\([\\nrt"])/g,
-      (_, escaped: string) => STDIO_ENV_ESCAPE_REPLACEMENTS[escaped] ?? escaped,
-    );
-  };
-
-  const parseStdioEnv = (raw: string): Record<string, string> | undefined => {
-    if (!raw.trim()) return undefined;
-    const env: Record<string, string> = {};
-    for (const line of raw.split("\n")) {
-      const eq = line.indexOf("=");
-      if (eq > 0) {
-        env[line.slice(0, eq).trim()] = parseStdioEnvValue(line.slice(eq + 1));
-      }
-    }
-    return Object.keys(env).length > 0 ? env : undefined;
-  };
 
   const handleAddStdio = useCallback(async () => {
     const cmd = stdioCommand.trim();
@@ -571,7 +513,7 @@ export default function AddMcpSource(props: {
       reactivityKeys: sourceWriteKeys,
     });
     if (Exit.isFailure(exit)) {
-      setStdioError(errorMessageFromExit(exit, "Failed to add source"));
+      setStdioError(messageFromExit(exit, "Failed to add source"));
       setStdioAdding(false);
       return;
     }
@@ -894,48 +836,14 @@ export default function AddMcpSource(props: {
         </>
       ) : (
         <>
-          {/* Stdio form */}
-          <CardStack>
-            <CardStackContent className="border-t-0">
-              <CardStackEntryField
-                label="Command"
-                description="- The executable to run (e.g. npx, uvx, node)."
-              >
-                <Input
-                  value={stdioCommand}
-                  onChange={(e) => setStdioCommand((e.target as HTMLInputElement).value)}
-                  placeholder="npx"
-                  className="font-mono text-sm"
-                />
-              </CardStackEntryField>
-
-              <CardStackEntryField
-                label="Arguments"
-                description="- Space-separated arguments passed to the command."
-              >
-                <Input
-                  value={stdioArgs}
-                  onChange={(e) => setStdioArgs((e.target as HTMLInputElement).value)}
-                  placeholder="-y chrome-devtools-mcp@latest"
-                  className="font-mono text-sm"
-                />
-              </CardStackEntryField>
-
-              <CardStackEntryField
-                label="Environment variables"
-                description="- One per line, KEY=value format."
-              >
-                <Textarea
-                  value={stdioEnv}
-                  onChange={(e) => setStdioEnv((e.target as HTMLTextAreaElement).value)}
-                  placeholder={"KEY=value\nANOTHER=value"}
-                  rows={3}
-                  maxRows={10}
-                  className="font-mono text-sm"
-                />
-              </CardStackEntryField>
-            </CardStackContent>
-          </CardStack>
+          <McpStdioSourceFields
+            command={stdioCommand}
+            onCommandChange={setStdioCommand}
+            args={stdioArgs}
+            onArgsChange={setStdioArgs}
+            env={stdioEnv}
+            onEnvChange={setStdioEnv}
+          />
 
           <SourceIdentityFields identity={stdioIdentity} namePlaceholder="My MCP Server" />
 

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -9,6 +9,7 @@ import {
   updateMcpSource,
 } from "./atoms";
 import { connectionsAtom } from "@executor-js/react/api/atoms";
+import { messageFromExit } from "@executor-js/react/api/error-reporting";
 import { useScope, useScopeStack } from "@executor-js/react/api/scope-context";
 import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
@@ -30,6 +31,13 @@ import { Button } from "@executor-js/react/components/button";
 import { Badge } from "@executor-js/react/components/badge";
 import { ScopeId } from "@executor-js/sdk/shared";
 import { McpRemoteSourceFields } from "./McpRemoteSourceFields";
+import { McpStdioSourceFields } from "./McpStdioSourceFields";
+import {
+  formatStdioArgs,
+  formatStdioEnv,
+  parseStdioArgs,
+  parseStdioEnv,
+} from "./stdio-form-helpers";
 import {
   McpSourceBindingInput,
   type McpCredentialInput,
@@ -240,39 +248,104 @@ function RemoteEditForm(props: {
 }
 
 // ---------------------------------------------------------------------------
-// Stdio read-only view
+// Stdio edit form
 // ---------------------------------------------------------------------------
 
-function StdioReadOnly(props: {
+function StdioEditForm(props: {
   sourceId: string;
   initial: McpStoredSourceSchemaType & { config: { transport: "stdio" } };
   onSave: () => void;
 }) {
-  const { command, args } = props.initial.config;
+  const displayScope = useScope();
+  const doUpdate = useAtomSet(updateMcpSource, { mode: "promiseExit" });
+  const sourceScope = ScopeId.make(props.initial.scope);
+
+  const initialArgs = formatStdioArgs(props.initial.config.args);
+  const initialEnv = formatStdioEnv(props.initial.config.env);
+  const initialCwd = props.initial.config.cwd ?? "";
+
+  const [command, setCommand] = useState(props.initial.config.command);
+  const [args, setArgs] = useState(initialArgs);
+  const [env, setEnv] = useState(initialEnv);
+  const [cwd, setCwd] = useState(initialCwd);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedCommand = command.trim();
+  const commandChanged = trimmedCommand !== props.initial.config.command.trim();
+  const argsChanged = args !== initialArgs;
+  const envChanged = env !== initialEnv;
+  const cwdChanged = cwd !== initialCwd;
+  const dirty = commandChanged || argsChanged || envChanged || cwdChanged;
+  const canSave = Boolean(trimmedCommand) && dirty && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    setError(null);
+    const exit = await doUpdate({
+      params: { scopeId: displayScope, namespace: props.sourceId },
+      payload: {
+        sourceScope,
+        ...(commandChanged ? { command: trimmedCommand } : {}),
+        ...(argsChanged ? { args: parseStdioArgs(args) } : {}),
+        ...(envChanged ? { env: parseStdioEnv(env) ?? {} } : {}),
+        ...(cwdChanged ? { cwd: cwd.trim() } : {}),
+      },
+      reactivityKeys: sourceWriteKeys,
+    });
+    if (Exit.isFailure(exit)) {
+      setError(messageFromExit(exit, "Failed to update source"));
+      setSaving(false);
+      return;
+    }
+    setSaving(false);
+    props.onSave();
+  };
+
   return (
     <div className="space-y-6">
       <div>
         <h1 className="text-xl font-semibold text-foreground">Edit MCP Source</h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Stdio MCP sources cannot be edited in the UI. Remove and recreate the source with the
-          updated command.
+          Update the command, arguments, and environment for this MCP server. Saving re-discovers
+          the available tools.
         </p>
       </div>
 
       <div className="flex items-center gap-3 rounded-lg border border-border bg-card px-4 py-3">
         <div className="min-w-0 flex-1">
           <p className="truncate text-sm font-semibold text-card-foreground">{props.sourceId}</p>
-          <p className="mt-0.5 text-xs text-muted-foreground font-mono">
-            {command} {(args ?? []).join(" ")}
-          </p>
         </div>
         <Badge variant="secondary" className="text-xs">
           stdio
         </Badge>
       </div>
 
-      <div className="flex items-center justify-end border-t border-border pt-4">
-        <Button onClick={props.onSave}>Done</Button>
+      <McpStdioSourceFields
+        command={command}
+        onCommandChange={setCommand}
+        args={args}
+        onArgsChange={setArgs}
+        env={env}
+        onEnvChange={setEnv}
+        cwd={cwd}
+        onCwdChange={setCwd}
+      />
+
+      {error && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-3 py-2">
+          <p className="text-sm text-destructive">{error}</p>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between border-t border-border pt-4">
+        <Button variant="ghost" onClick={props.onSave} disabled={saving}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} disabled={!canSave}>
+          {saving ? "Saving…" : "Save changes"}
+        </Button>
       </div>
     </div>
   );
@@ -312,7 +385,7 @@ export default function EditMcpSource({
 
   if (source.config.transport === "stdio") {
     return (
-      <StdioReadOnly
+      <StdioEditForm
         sourceId={sourceId}
         initial={source as McpStoredSourceSchemaType & { config: { transport: "stdio" } }}
         onSave={onSave}

--- a/packages/plugins/mcp/src/react/McpStdioSourceFields.tsx
+++ b/packages/plugins/mcp/src/react/McpStdioSourceFields.tsx
@@ -1,0 +1,77 @@
+import {
+  CardStack,
+  CardStackContent,
+  CardStackEntryField,
+} from "@executor-js/react/components/card-stack";
+import { Input } from "@executor-js/react/components/input";
+import { Textarea } from "@executor-js/react/components/textarea";
+
+export function McpStdioSourceFields(props: {
+  readonly command: string;
+  readonly onCommandChange: (value: string) => void;
+  readonly args: string;
+  readonly onArgsChange: (value: string) => void;
+  readonly env: string;
+  readonly onEnvChange: (value: string) => void;
+  readonly cwd?: string;
+  readonly onCwdChange?: (value: string) => void;
+}) {
+  const showCwd = props.onCwdChange !== undefined;
+  return (
+    <CardStack>
+      <CardStackContent className="border-t-0">
+        <CardStackEntryField
+          label="Command"
+          description="- The executable to run (e.g. npx, uvx, node)."
+        >
+          <Input
+            value={props.command}
+            onChange={(e) => props.onCommandChange((e.target as HTMLInputElement).value)}
+            placeholder="npx"
+            className="font-mono text-sm"
+          />
+        </CardStackEntryField>
+
+        <CardStackEntryField
+          label="Arguments"
+          description="- Space-separated arguments passed to the command."
+        >
+          <Input
+            value={props.args}
+            onChange={(e) => props.onArgsChange((e.target as HTMLInputElement).value)}
+            placeholder="-y chrome-devtools-mcp@latest"
+            className="font-mono text-sm"
+          />
+        </CardStackEntryField>
+
+        <CardStackEntryField
+          label="Environment variables"
+          description="- One per line, KEY=value format."
+        >
+          <Textarea
+            value={props.env}
+            onChange={(e) => props.onEnvChange((e.target as HTMLTextAreaElement).value)}
+            placeholder={"KEY=value\nANOTHER=value"}
+            rows={3}
+            maxRows={10}
+            className="font-mono text-sm"
+          />
+        </CardStackEntryField>
+
+        {showCwd && (
+          <CardStackEntryField
+            label="Working directory"
+            description="- Optional. Absolute path the command runs in."
+          >
+            <Input
+              value={props.cwd ?? ""}
+              onChange={(e) => props.onCwdChange?.((e.target as HTMLInputElement).value)}
+              placeholder="/path/to/dir"
+              className="font-mono text-sm"
+            />
+          </CardStackEntryField>
+        )}
+      </CardStackContent>
+    </CardStack>
+  );
+}

--- a/packages/plugins/mcp/src/react/stdio-form-helpers.ts
+++ b/packages/plugins/mcp/src/react/stdio-form-helpers.ts
@@ -1,0 +1,72 @@
+// Add and edit must serialize stdio args/env identically — otherwise
+// round-tripping a saved source through edit would silently change its
+// shape.
+
+const STDIO_ENV_ESCAPE_REPLACEMENTS: Readonly<Record<string, string>> = {
+  "\\": "\\",
+  n: "\n",
+  r: "\r",
+  t: "\t",
+  '"': '"',
+};
+
+const ARG_TOKEN_PATTERN = /[^\s"]+|"([^"]*)"/g;
+
+export const parseStdioArgs = (raw: string): string[] => {
+  if (!raw.trim()) return [];
+  const args: string[] = [];
+  for (const match of raw.matchAll(ARG_TOKEN_PATTERN)) {
+    args.push(match[1] ?? match[0]);
+  }
+  return args;
+};
+
+const parseStdioEnvValue = (raw: string): string => {
+  const value = raw.trim();
+  if (value.length < 2) return value;
+
+  const quote = value[0];
+  if ((quote !== '"' && quote !== "'") || value[value.length - 1] !== quote) {
+    return value;
+  }
+
+  const inner = value.slice(1, -1);
+  if (quote === "'") return inner;
+
+  return inner.replace(
+    /\\([\\nrt"])/g,
+    (_, escaped: string) => STDIO_ENV_ESCAPE_REPLACEMENTS[escaped] ?? escaped,
+  );
+};
+
+export const parseStdioEnv = (raw: string): Record<string, string> | undefined => {
+  if (!raw.trim()) return undefined;
+  const env: Record<string, string> = {};
+  for (const line of raw.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq > 0) {
+      env[line.slice(0, eq).trim()] = parseStdioEnvValue(line.slice(eq + 1));
+    }
+  }
+  return Object.keys(env).length > 0 ? env : undefined;
+};
+
+// Quote args containing whitespace so the round-trip parse yields the
+// same array.
+export const formatStdioArgs = (args: readonly string[] | undefined): string => {
+  if (!args || args.length === 0) return "";
+  return args.map((a) => (/\s/.test(a) ? `"${a}"` : a)).join(" ");
+};
+
+// Double-quote values that would otherwise be reshaped by parseStdioEnv
+// (leading/trailing whitespace, newlines, embedded quotes/backslashes).
+// Plain values pass through unquoted to match what users typed.
+export const formatStdioEnv = (env: Record<string, string> | undefined): string => {
+  if (!env) return "";
+  const needsQuoting = (value: string) => value !== value.trim() || /[\n\r"\\]/.test(value);
+  const escape = (value: string) =>
+    value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+  return Object.entries(env)
+    .map(([key, value]) => `${key}=${needsQuoting(value) ? `"${escape(value)}"` : value}`)
+    .join("\n");
+};

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -535,6 +535,125 @@ describe("mcpPlugin", () => {
   );
 
   // -------------------------------------------------------------------------
+  // Stdio updateSource — the fixture server reads FIXTURE_TOOLS from env
+  // so we can vary its tool list between addSource and updateSource and
+  // assert that re-discovery actually happens.
+  // -------------------------------------------------------------------------
+
+  const stdioFixturePath = new URL("../testing/stdio-fixture-server.ts", import.meta.url).pathname;
+
+  it.effect("updateSource on stdio re-discovers tools when args/env change", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [mcpPlugin({ dangerouslyAllowStdioMCP: true })] as const,
+        }),
+      );
+
+      yield* executor.mcp.addSource({
+        transport: "stdio",
+        scope: "test-scope",
+        name: "Stdio fixture",
+        namespace: "stdio_fixture",
+        command: "bun",
+        args: ["run", stdioFixturePath],
+        env: { FIXTURE_TOOLS: "alpha,beta" },
+      });
+
+      const initialTools = yield* executor.tools.list();
+      const initialIds = initialTools
+        .filter((t) => t.id.startsWith("stdio_fixture."))
+        .map((t) => t.id)
+        .sort();
+      expect(initialIds).toEqual(["stdio_fixture.alpha", "stdio_fixture.beta"]);
+
+      yield* executor.mcp.updateSource("stdio_fixture", "test-scope", {
+        env: { FIXTURE_TOOLS: "gamma" },
+      });
+
+      const updatedTools = yield* executor.tools.list();
+      const updatedIds = updatedTools
+        .filter((t) => t.id.startsWith("stdio_fixture."))
+        .map((t) => t.id)
+        .sort();
+      expect(updatedIds).toEqual(["stdio_fixture.gamma"]);
+
+      const stored = yield* executor.mcp.getSource("stdio_fixture", "test-scope");
+      expect(stored?.config.transport).toBe("stdio");
+      if (stored?.config.transport !== "stdio") return;
+      expect(stored.config.env).toEqual({ FIXTURE_TOOLS: "gamma" });
+    }),
+  );
+
+  // Discovery against a bad command must fail loudly and must not mutate
+  // the stored source — otherwise a typo in the edit form would leave
+  // the user with a half-broken row pointing at a nonexistent process.
+  it.effect("updateSource on stdio leaves config intact when discovery fails", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [mcpPlugin({ dangerouslyAllowStdioMCP: true })] as const,
+        }),
+      );
+
+      yield* executor.mcp.addSource({
+        transport: "stdio",
+        scope: "test-scope",
+        name: "Stdio fixture",
+        namespace: "stdio_intact",
+        command: "bun",
+        args: ["run", stdioFixturePath],
+        env: { FIXTURE_TOOLS: "alpha" },
+      });
+
+      const failure = yield* executor.mcp
+        .updateSource("stdio_intact", "test-scope", {
+          command: "/definitely/not/a/real/binary",
+        })
+        .pipe(Effect.result);
+
+      expect(Result.isFailure(failure)).toBe(true);
+
+      const stored = yield* executor.mcp.getSource("stdio_intact", "test-scope");
+      expect(stored?.config.transport).toBe("stdio");
+      if (stored?.config.transport !== "stdio") return;
+      expect(stored.config.command).toBe("bun");
+      expect(stored.config.args).toEqual(["run", stdioFixturePath]);
+    }),
+  );
+
+  // Stdio fields passed on a remote source must be ignored — the
+  // transport branch in updateSource keys off the existing config, not
+  // the input. This is the regression test for the SDK type extension.
+  it.effect("updateSource ignores stdio fields on a remote source", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [mcpPlugin()] as const }));
+
+      yield* executor.mcp
+        .addSource({
+          transport: "remote",
+          scope: "test-scope",
+          name: "Remote",
+          endpoint: "http://127.0.0.1:1/remote-mcp",
+          namespace: "remote_ignored",
+        })
+        .pipe(Effect.result);
+
+      yield* executor.mcp.updateSource("remote_ignored", "test-scope", {
+        name: "Remote renamed",
+        command: "should-be-ignored",
+        args: ["nope"],
+        env: { IGNORED: "yes" },
+        cwd: "/tmp",
+      });
+
+      const stored = yield* executor.mcp.getSource("remote_ignored", "test-scope");
+      expect(stored?.name).toBe("Remote renamed");
+      expect(stored?.config.transport).toBe("remote");
+    }),
+  );
+
+  // -------------------------------------------------------------------------
   // Deferred OAuth — admin saves a source with `{kind: "oauth2",
   // connectionId}` before any user has signed in, so the row lands in
   // a "needs sign-in" state. Each user's McpSignInButton later mints a

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -130,6 +130,8 @@ export interface McpProbeResult {
   readonly serverName: string | null;
 }
 
+// Fields are transport-specific: the SDK keys off the existing source's
+// transport and ignores fields that don't apply.
 export interface McpUpdateSourceInput {
   readonly name?: string;
   readonly endpoint?: string;
@@ -137,6 +139,10 @@ export interface McpUpdateSourceInput {
   readonly queryParams?: Record<string, McpCredentialInput>;
   readonly credentialTargetScope?: string;
   readonly auth?: McpConnectionAuthInput;
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly env?: Record<string, string>;
+  readonly cwd?: string;
 }
 
 export interface McpProbeEndpointInput {
@@ -193,6 +199,28 @@ const toBinding = (entry: McpToolManifestEntry): McpToolBinding =>
     outputSchema: entry.outputSchema,
     annotations: entry.annotations,
   });
+
+const stringArraysEqual = (
+  a: readonly string[] | undefined,
+  b: readonly string[] | undefined,
+): boolean => {
+  const la = a?.length ?? 0;
+  const lb = b?.length ?? 0;
+  if (la !== lb) return false;
+  for (let i = 0; i < la; i++) if (a![i] !== b![i]) return false;
+  return true;
+};
+
+const stringRecordsEqual = (
+  a: Record<string, string> | undefined,
+  b: Record<string, string> | undefined,
+): boolean => {
+  const ka = a ? Object.keys(a) : [];
+  const kb = b ? Object.keys(b) : [];
+  if (ka.length !== kb.length) return false;
+  for (const k of ka) if (a![k] !== b?.[k]) return false;
+  return true;
+};
 
 const MCP_PLUGIN_ID = "mcp";
 const McpTextContent = Schema.Struct({ type: Schema.Literal("text"), text: Schema.String });
@@ -1097,6 +1125,11 @@ const toMcpConfigEntry = (
 
 export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
   const allowStdio = options?.dangerouslyAllowStdioMCP ?? false;
+  // Stdio sources are only editable when the host has stdio enabled —
+  // otherwise the Edit form's save would fail discovery on every attempt.
+  // Remote sources don't depend on the flag.
+  const canEditFor = (transport: "remote" | "stdio"): boolean =>
+    transport === "stdio" ? allowStdio : true;
   // Per-plugin-instance runtime holder. Captured by closures in
   // `extension`, `invokeTool`, and `close`, so all three see the same
   // connection cache across a single createExecutor lifecycle.
@@ -1399,7 +1432,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
                   url: sd.transport === "remote" ? sd.endpoint : undefined,
                   canRemove: true,
                   canRefresh: true,
-                  canEdit: sd.transport === "remote",
+                  canEdit: canEditFor(sd.transport),
                   tools: manifest.tools.map((e) => ({
                     name: e.toolId,
                     description: e.description ?? `MCP tool: ${e.toolName}`,
@@ -1541,7 +1574,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
                   url: sd.transport === "remote" ? sd.endpoint : undefined,
                   canRemove: true,
                   canRefresh: true,
-                  canEdit: sd.transport === "remote",
+                  canEdit: canEditFor(sd.transport),
                   tools: manifest.tools.map((e) => ({
                     name: e.toolId,
                     description: e.description ?? `MCP tool: ${e.toolName}`,
@@ -1567,10 +1600,14 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           }),
         );
 
-      const updateSource = (namespace: string, scope: string, input: McpUpdateSourceInput) =>
+      const updateRemoteSource = (
+        namespace: string,
+        scope: string,
+        existing: McpStoredSource,
+        input: McpUpdateSourceInput,
+      ) =>
         Effect.gen(function* () {
-          const existing = yield* ctx.storage.getSource(namespace, scope);
-          if (!existing || existing.config.transport !== "remote") return;
+          if (existing.config.transport !== "remote") return;
 
           const canonicalHeaders =
             input.headers !== undefined
@@ -1655,6 +1692,148 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
               .upsertSource(toMcpConfigEntry(namespace, sourceName, inputForm))
               .pipe(Effect.withSpan("mcp.plugin.config_file.upsert"));
           }
+        });
+
+      // Stdio updates change the spawned process, so tool shape can drift.
+      // We re-discover with the new command *before* persisting anything —
+      // a discovery failure must leave the existing source intact rather
+      // than landing stale tool bindings pointing at a broken process.
+      const updateStdioSource = (
+        namespace: string,
+        scope: string,
+        existing: McpStoredSource,
+        input: McpUpdateSourceInput,
+      ) =>
+        Effect.gen(function* () {
+          if (existing.config.transport !== "stdio") return;
+          const stdio = existing.config;
+          // `undefined` on the input means "no change". An empty array,
+          // empty object, or empty/whitespace cwd clears the field.
+          const nextArgs =
+            input.args === undefined
+              ? stdio.args
+              : input.args.length > 0
+                ? [...input.args]
+                : undefined;
+          const nextEnv =
+            input.env === undefined
+              ? stdio.env
+              : Object.keys(input.env).length > 0
+                ? input.env
+                : undefined;
+          const nextCwd = input.cwd === undefined ? stdio.cwd : input.cwd.trim() || undefined;
+          const updatedConfig: McpStoredSourceData = {
+            transport: "stdio",
+            command: input.command?.trim() || stdio.command,
+            args: nextArgs,
+            env: nextEnv,
+            cwd: nextCwd,
+          };
+          const sourceName = input.name?.trim() || existing.name;
+
+          // Discovery spawns the configured process — skip it entirely
+          // when the caller's payload would produce no change. Otherwise
+          // an HTTP PATCH with a stale snapshot would spawn unnecessarily.
+          if (
+            updatedConfig.command === stdio.command &&
+            stringArraysEqual(updatedConfig.args, stdio.args) &&
+            stringRecordsEqual(updatedConfig.env, stdio.env) &&
+            updatedConfig.cwd === stdio.cwd &&
+            sourceName === existing.name
+          ) {
+            return;
+          }
+
+          const ci = yield* resolveConnectorInput(
+            namespace,
+            scope,
+            updatedConfig,
+            ctx,
+            allowStdio,
+          ).pipe(
+            Effect.withSpan("mcp.plugin.resolve_connector", {
+              attributes: {
+                "mcp.source.namespace": namespace,
+                "mcp.source.transport": "stdio",
+              },
+            }),
+          );
+          const manifest = yield* discoverTools(createMcpConnector(ci)).pipe(
+            Effect.mapError(
+              ({ message }) =>
+                new McpToolDiscoveryError({
+                  stage: "list_tools",
+                  message: `MCP update failed: ${message}`,
+                }),
+            ),
+            Effect.withSpan("mcp.plugin.discover_tools", {
+              attributes: { "mcp.source.namespace": namespace },
+            }),
+          );
+
+          yield* ctx
+            .transaction(
+              Effect.gen(function* () {
+                yield* ctx.storage.removeBindingsByNamespace(namespace, scope);
+                yield* ctx.core.sources.unregister({ id: namespace, targetScope: scope });
+                yield* ctx.storage.putSource({
+                  namespace,
+                  scope,
+                  name: sourceName,
+                  config: updatedConfig,
+                });
+                yield* ctx.storage.putBindings(
+                  namespace,
+                  scope,
+                  manifest.tools.map((e) => ({
+                    toolId: `${namespace}.${e.toolId}`,
+                    binding: toBinding(e),
+                  })),
+                );
+                yield* ctx.core.sources.register({
+                  id: namespace,
+                  scope,
+                  kind: "mcp",
+                  name: sourceName,
+                  url: undefined,
+                  canRemove: true,
+                  canRefresh: true,
+                  canEdit: canEditFor("stdio"),
+                  tools: manifest.tools.map((e) => ({
+                    name: e.toolId,
+                    description: e.description ?? `MCP tool: ${e.toolName}`,
+                    inputSchema: e.inputSchema,
+                    outputSchema: e.outputSchema,
+                  })),
+                });
+              }),
+            )
+            .pipe(
+              Effect.withSpan("mcp.plugin.persist_source", {
+                attributes: {
+                  "mcp.source.namespace": namespace,
+                  "mcp.source.tool_count": manifest.tools.length,
+                },
+              }),
+            );
+
+          if (configFile) {
+            const inputForm = inputFormFromStored([], updatedConfig, scope, sourceName, namespace);
+            yield* configFile
+              .upsertSource(toMcpConfigEntry(namespace, sourceName, inputForm))
+              .pipe(Effect.withSpan("mcp.plugin.config_file.upsert"));
+          }
+        });
+
+      const updateSource = (namespace: string, scope: string, input: McpUpdateSourceInput) =>
+        Effect.gen(function* () {
+          const existing = yield* ctx.storage.getSource(namespace, scope);
+          if (!existing) return;
+          if (existing.config.transport === "stdio") {
+            yield* updateStdioSource(namespace, scope, existing, input);
+            return;
+          }
+          yield* updateRemoteSource(namespace, scope, existing, input);
         }).pipe(
           Effect.withSpan("mcp.plugin.update_source", {
             attributes: { "mcp.source.namespace": namespace },

--- a/packages/plugins/mcp/src/testing/stdio-fixture-server.ts
+++ b/packages/plugins/mcp/src/testing/stdio-fixture-server.ts
@@ -1,0 +1,38 @@
+// Minimal stdio MCP server used by the stdio updateSource tests.
+//
+// Reads `FIXTURE_TOOLS` from env (comma-separated tool names) and exposes
+// each as a no-op tool. Reads `FIXTURE_NAME` (default "stdio-fixture") as
+// the advertised server name. The test spawns this via:
+//
+//   command: "bun", args: ["run", <path-to-this-file>],
+//   env: { FIXTURE_TOOLS: "alpha,beta", FIXTURE_NAME: "fixture-a" }
+//
+// Changing env or args between addSource and updateSource gives us a
+// deterministic way to assert tool re-discovery on update.
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import z from "zod";
+
+const toolNames = (process.env.FIXTURE_TOOLS ?? "alpha")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+const server = new McpServer({
+  name: process.env.FIXTURE_NAME ?? "stdio-fixture",
+  version: "0.0.0",
+});
+
+for (const name of toolNames) {
+  server.registerTool(
+    name,
+    {
+      description: `Fixture tool ${name}`,
+      inputSchema: { value: z.string().optional() },
+    },
+    async () => ({ content: [{ type: "text", text: `ok:${name}` }] }),
+  );
+}
+
+await server.connect(new StdioServerTransport());


### PR DESCRIPTION
- Stdio MCP sources can now be edited from the UI — previously the edit screen only displayed the saved command and told users to delete and recreate the source.
- The edit form supports updating the command, arguments, environment variables, and a new working directory field, and re-discovers the server's tools on save.
- A failed save (e.g. a typo'd command) leaves the existing source intact instead of corrupting it, and an unchanged save is a no-op so the underlying process isn't restarted needlessly.
- The Add and Edit screens now share one component for stdio fields, so the two forms stay visually and behaviorally in sync.