### PR TITLE
[codex] Fix OpenAPI OAuth config compatibility

### DIFF
--- a/apps/cloud/drizzle/0018_repair_openapi_oauth_authorization_url.sql
+++ b/apps/cloud/drizzle/0018_repair_openapi_oauth_authorization_url.sql
@@ -1,0 +1,9 @@
+UPDATE "plugin_storage"
+SET
+  "data" = jsonb_set("data"::jsonb, '{config,oauth2,authorizationUrl}', 'null'::jsonb, true)::json,
+  "updated_at" = now()
+WHERE
+  "plugin_id" = 'openapi'
+  AND "collection" = 'source'
+  AND "data" #> '{config,oauth2}' IS NOT NULL
+  AND NOT ("data"::jsonb #> '{config,oauth2}' ? 'authorizationUrl');

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1779087600000,
       "tag": "0017_plugin_storage_sources",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1779199200000,
+      "tag": "0018_repair_openapi_oauth_authorization_url",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/plugins/http-source/src/sdk/types.ts
+++ b/packages/plugins/http-source/src/sdk/types.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect";
+import { Effect, Schema } from "effect";
 
 export const HttpCredentialInput = Schema.Union([
   Schema.String,
@@ -37,7 +37,10 @@ export const OAuth2SourceConfig = Schema.Struct({
   securitySchemeName: Schema.String,
   flow: OAuth2Flow,
   tokenUrl: Schema.String,
-  authorizationUrl: Schema.NullOr(Schema.String),
+  authorizationUrl: Schema.NullOr(Schema.String).pipe(
+    Schema.optional,
+    Schema.withDecodingDefault(Effect.succeed(null)),
+  ),
   issuerUrl: Schema.optional(Schema.NullOr(Schema.String)),
   clientIdSlot: Schema.String,
   clientSecretSlot: Schema.NullOr(Schema.String),

--- a/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/client-credentials-oauth.test.ts
@@ -108,7 +108,6 @@ describe("OpenAPI client_credentials OAuth", () => {
         openApiPlugin({ httpClientLayer: clientLayer }),
         memorySecretsPlugin(),
       ] as const;
-      const config = makeTestConfig({ plugins });
 
       const now = new Date();
       const orgScope = Scope.make({
@@ -121,6 +120,7 @@ describe("OpenAPI client_credentials OAuth", () => {
         name: "alice",
         createdAt: now,
       });
+      const config = makeTestConfig({ plugins, scopes: [userScope, orgScope] });
 
       const adminExec = yield* createExecutor({
         ...config,
@@ -214,6 +214,62 @@ describe("OpenAPI client_credentials OAuth", () => {
         namespace: "petstore",
         oauth2,
       });
+      const storedSourceRow = yield* Effect.promise(() =>
+        config.db.findFirst("plugin_storage", {
+          where: (b) =>
+            b.and(
+              b("scope_id", "=", String(userScope.id)),
+              b("plugin_id", "=", "openapi"),
+              b("collection", "=", "source"),
+              b("key", "=", "petstore"),
+            ),
+        }),
+      );
+      const storedData = storedSourceRow?.data as
+        | {
+            readonly config?: Record<string, unknown>;
+          }
+        | undefined;
+      const storedOAuth2 = storedData?.config?.oauth2;
+      if (
+        !storedSourceRow ||
+        !storedData?.config ||
+        typeof storedOAuth2 !== "object" ||
+        storedOAuth2 === null ||
+        Array.isArray(storedOAuth2)
+      ) {
+        return yield* new OpenApiClientCredentialsTestSetupError({
+          message: "Expected stored OpenAPI source OAuth config",
+        });
+      }
+      const { authorizationUrl: _authorizationUrl, ...oauth2WithoutAuthorizationUrl } =
+        storedOAuth2 as Record<string, unknown>;
+      yield* Effect.promise(() =>
+        config.db.updateMany("plugin_storage", {
+          where: (b) =>
+            b.and(
+              b("scope_id", "=", String(userScope.id)),
+              b("plugin_id", "=", "openapi"),
+              b("collection", "=", "source"),
+              b("key", "=", "petstore"),
+            ),
+          set: {
+            data: {
+              ...storedData,
+              config: {
+                ...storedData.config,
+                oauth2: oauth2WithoutAuthorizationUrl,
+              },
+            },
+          },
+        }),
+      );
+      const sourceAfterLegacyShape = yield* userExec.openapi.getSource(
+        "petstore",
+        String(userScope.id),
+      );
+      expect(sourceAfterLegacyShape?.config.oauth2?.authorizationUrl).toBeNull();
+
       yield* userExec.sources.setBinding(
         SetSourceCredentialBindingInput.make({
           source: { id: "petstore", scope: userScope.id },


### PR DESCRIPTION
## Summary

- Treat missing OpenAPI OAuth `authorizationUrl` as `null` when decoding source config.
- Add a migration to backfill `authorizationUrl: null` for stored OpenAPI OAuth configs missing the key.
- Add a client-credentials regression test that exercises the migrated stored shape.
