### PR TITLE
[codex] Fix tool contract shapes

### DIFF
--- a/.changeset/quiet-tools-describe.md
+++ b/.changeset/quiet-tools-describe.md
@@ -1,0 +1,7 @@
+---
+"@executor-js/execution": patch
+"@executor-js/plugin-openapi": patch
+"executor": patch
+---
+
+Expose TypeScript contracts for built-in Executor discovery tools and describe OpenAPI tool results with their transport envelope so read-only sandbox calls match their input and output shapes.

--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -551,6 +551,50 @@ describe("tool discovery", () => {
     }),
   );
 
+  it.effect("describes built-in discovery tool shapes that accept their runtime output", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeSearchExecutor();
+      const engine = createExecutionEngine({ executor, codeExecutor });
+
+      const execution = yield* engine.execute(
+        [
+          "const searchDetails = await tools.describe.tool({ path: 'search' });",
+          "const sourceDetails = await tools.describe.tool({ path: 'executor.sources.list' });",
+          "const describeDetails = await tools.describe.tool({ path: 'describe.tool' });",
+          "return {",
+          "  searchDetails,",
+          "  searchResult: await tools.search({ query: 'repo details', limit: 2 }),",
+          "  sourceDetails,",
+          "  sourceResult: await tools.executor.sources.list({ limit: 2 }),",
+          "  describeDetails,",
+          "  describeResult: await tools.describe.tool({ path: 'github.getRepositoryDetails' }),",
+          "};",
+        ].join("\n"),
+        { onElicitation: acceptAll },
+      );
+
+      expect(execution.error).toBeUndefined();
+      const observed = execution.result as {
+        readonly searchDetails: DescribedToolContract;
+        readonly searchResult: unknown;
+        readonly sourceDetails: DescribedToolContract;
+        readonly sourceResult: unknown;
+        readonly describeDetails: DescribedToolContract;
+        readonly describeResult: unknown;
+      };
+
+      expect(
+        typeCheckDescribedInvocation(observed.searchDetails, observed.searchResult, ""),
+      ).toEqual([]);
+      expect(
+        typeCheckDescribedInvocation(observed.sourceDetails, observed.sourceResult, ""),
+      ).toEqual([]);
+      expect(
+        typeCheckDescribedInvocation(observed.describeDetails, observed.describeResult, ""),
+      ).toEqual([]);
+    }),
+  );
+
   it.effect("rejects malformed discover calls inside the sandbox", () =>
     Effect.gen(function* () {
       const executor = yield* makeSearchExecutor();

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -26,6 +26,65 @@ const withToolResultDefinitions = (
   ToolError: TOOL_ERROR_TYPESCRIPT,
 });
 
+type DescribedTool = {
+  readonly path: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly inputTypeScript?: string;
+  readonly outputTypeScript?: string;
+  readonly typeScriptDefinitions?: Record<string, string>;
+};
+
+const BUILTIN_TOOL_DESCRIPTIONS: ReadonlyMap<string, DescribedTool> = new Map<
+  string,
+  DescribedTool
+>([
+  [
+    "search",
+    {
+      path: "search",
+      name: "search",
+      description: "Search available Executor tools.",
+      inputTypeScript: "{ query: string; namespace?: string; limit?: number; offset?: number; }",
+      outputTypeScript:
+        "{ items: ToolDiscoveryResult[]; total: number; hasMore: boolean; nextOffset: number | null; }",
+      typeScriptDefinitions: {
+        ToolDiscoveryResult:
+          "{ path: string; name: string; description?: string; sourceId: string; score: number; }",
+      },
+    },
+  ],
+  [
+    "executor.sources.list",
+    {
+      path: "executor.sources.list",
+      name: "executor.sources.list",
+      description: "List configured and built-in Executor sources.",
+      inputTypeScript: "{ query?: string; limit?: number; offset?: number; }",
+      outputTypeScript:
+        "{ items: ExecutorSourceListItem[]; total: number; hasMore: boolean; nextOffset: number | null; }",
+      typeScriptDefinitions: {
+        ExecutorSourceListItem:
+          "{ id: string; name: string; kind: string; runtime?: boolean; canRemove?: boolean; canRefresh?: boolean; toolCount: number; }",
+      },
+    },
+  ],
+  [
+    "describe.tool",
+    {
+      path: "describe.tool",
+      name: "describe.tool",
+      description: "Describe a tool's compact TypeScript input and output shapes.",
+      inputTypeScript: "{ path: string; }",
+      outputTypeScript: "DescribedTool",
+      typeScriptDefinitions: {
+        DescribedTool:
+          "{ path: string; name: string; description?: string; inputTypeScript?: string; outputTypeScript?: string; typeScriptDefinitions?: { [k: string]: string; }; }",
+      },
+    },
+  ],
+]);
+
 const newCorrelationId = (): string => {
   // 8-hex-char correlation id; enough entropy to disambiguate within a
   // single deployment without leaking host process info.
@@ -533,6 +592,9 @@ export const describeTool = Effect.fn("executor.tools.describe")(function* (
   path: string,
 ) {
   yield* Effect.annotateCurrentSpan({ "mcp.tool.name": path });
+
+  const builtin = BUILTIN_TOOL_DESCRIPTIONS.get(path);
+  if (builtin) return builtin;
 
   // Single tools.schema() call — it already fetches the tool row
   // internally. No need to also call tools.list() just for name/description.

--- a/packages/plugins/openapi/src/sdk/__snapshots__/real-specs.test.ts.snap
+++ b/packages/plugins/openapi/src/sdk/__snapshots__/real-specs.test.ts.snap
@@ -62,20 +62,40 @@ exports[`Real specs: Cloudflare API > preserves registered tool schema and TypeS
   },
   "inputTypeScript": "{ account_id: AccessIdentifier; body: AccessAppRequest; }",
   "outputSchema": {
-    "allOf": [
-      {
-        "$ref": "#/$defs/access_apps_components-schemas-single_response",
-      },
-      {
-        "properties": {
-          "result": {
-            "$ref": "#/$defs/access_app_response",
+    "additionalProperties": false,
+    "properties": {
+      "data": {
+        "allOf": [
+          {
+            "$ref": "#/$defs/access_apps_components-schemas-single_response",
           },
-        },
+          {
+            "properties": {
+              "result": {
+                "$ref": "#/$defs/access_app_response",
+              },
+            },
+          },
+        ],
       },
+      "headers": {
+        "additionalProperties": {
+          "type": "string",
+        },
+        "type": "object",
+      },
+      "status": {
+        "type": "integer",
+      },
+    },
+    "required": [
+      "status",
+      "headers",
+      "data",
     ],
+    "type": "object",
   },
-  "outputTypeScript": "(AccessAppsComponentsSchemasSingleResponse & { result?: AccessAppResponse; })",
+  "outputTypeScript": "{ status: number; headers: { [k: string]: string; }; data: (AccessAppsComponentsSchemasSingleResponse & { result?: AccessAppResponse; }); }",
   "schemaDefinitionCount": 157,
   "schemaDefinitionNames": [
     "access_access_group_rule",
@@ -1090,2113 +1110,1910 @@ exports[`Real specs: Vercel API > preserves registered tool schema and TypeScrip
   },
   "inputTypeScript": "{ forceNew?: "0" | "1"; skipAutoDetectionConfirmation?: "0" | "1"; teamId?: string; slug?: string; body: { customEnvironmentSlugOrId?: string; deploymentId?: string; files?: (InlinedFile | UploadedFile)[]; gitMetadata?: { remoteUrl?: string; commitAuthorName?: string; commitAuthorEmail?: string; commitMessage?: string; commitRef?: string; commitSha?: string; dirty?: boolean; ci?: boolean; ciType?: string; ciGitProviderUsername?: string; ciGitRepoVisibility?: string; }; gitSource?: { type: "vercel"; sha: string; } | { ref: string; repoId: number | string; sha?: string; type: "github"; } | { org: string; ref: string; repo: string; sha?: string; type: "github"; } | { ref: string; repoId: number | string; sha?: string; type: "github-limited"; } | { org: string; ref: string; repo: string; sha?: string; type: "github-limited"; } | { projectId: number | string; ref: string; sha?: string; type: "gitlab"; } | { ref: string; repoUuid: string; sha?: string; type: "bitbucket"; workspaceUuid?: string; } | { owner: string; ref: string; sha?: string; slug: string; type: "bitbucket"; }; meta?: { [k: string]: string; }; monorepoManager?: string | null; name: string; project?: string; projectSettings?: { buildCommand?: string | null; commandForIgnoringBuildStep?: string | null; devCommand?: string | null; framework?: null | "blitzjs" | "nextjs" | "gatsby" | "remix" | "react-router" | "astro" | "hexo" | "eleventy" | "docusaurus-2" | "docusaurus" | "preact" | "solidstart-1" | "solidstart" | "dojo" | "ember" | "vue" | "scully" | "ionic-angular" | "angular" | "polymer" | "svelte" | "sveltekit" | "sveltekit-1" | "ionic-react" | "create-react-app" | "gridsome" | "umijs" | "sapper" | "saber" | "stencil" | "nuxtjs" | "redwoodjs" | "hugo" | "jekyll" | "brunch" | "middleman" | "zola" | "hydrogen" | "vite" | "tanstack-start" | "vitepress" | "vuepress" | "parcel" | "fastapi" | "flask" | "fasthtml" | "django" | "ash" | "sanity-v3" | "sanity" | "storybook" | "nitro" | "hono" | "express" | "h3" | "koa" | "nestjs" | "elysia" | "fastify" | "xmcp" | "python" | "ruby" | "rust" | "axum" | "actix-web" | "node" | "go" | "services" | "mastra"; installCommand?: string | null; nodeVersion?: "24.x" | "22.x" | "20.x" | "18.x" | "16.x" | "14.x" | "12.x" | "10.x" | "8.10.x"; outputDirectory?: string | null; rootDirectory?: string | null; serverlessFunctionRegion?: string | null; skipGitConnectDuringLink?: boolean; sourceFilesOutsideRootDirectory?: boolean; }; target?: string; withLatestCommit?: boolean; }; }",
   "outputSchema": {
-    "description": "The successfully created deployment",
+    "additionalProperties": false,
     "properties": {
-      "alias": {
-        "description": "A list of all the aliases (default aliases, staging aliases and production aliases) that were assigned upon deployment creation",
-        "example": [],
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "aliasAssigned": {
-        "description": "A boolean that will be true when the aliases from the alias property were assigned successfully",
-        "enum": [
-          false,
-          true,
-        ],
-        "example": true,
-        "type": "boolean",
-      },
-      "aliasAssignedAt": {
-        "nullable": true,
-        "oneOf": [
-          {
-            "type": "number",
+      "data": {
+        "description": "The successfully created deployment",
+        "properties": {
+          "alias": {
+            "description": "A list of all the aliases (default aliases, staging aliases and production aliases) that were assigned upon deployment creation",
+            "example": [],
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
           },
-          {
+          "aliasAssigned": {
+            "description": "A boolean that will be true when the aliases from the alias property were assigned successfully",
             "enum": [
               false,
               true,
             ],
+            "example": true,
             "type": "boolean",
           },
-        ],
-      },
-      "aliasError": {
-        "description": "An object that will contain a \`code\` and a \`message\` when the aliasing fails, otherwise the value will be \`null\`",
-        "example": null,
-        "nullable": true,
-        "properties": {
-          "code": {
-            "type": "string",
-          },
-          "message": {
-            "type": "string",
-          },
-        },
-        "required": [
-          "code",
-          "message",
-        ],
-        "type": "object",
-      },
-      "aliasFinal": {
-        "nullable": true,
-        "type": "string",
-      },
-      "aliasWarning": {
-        "nullable": true,
-        "properties": {
-          "action": {
-            "type": "string",
-          },
-          "code": {
-            "type": "string",
-          },
-          "link": {
-            "type": "string",
-          },
-          "message": {
-            "type": "string",
-          },
-        },
-        "required": [
-          "code",
-          "message",
-        ],
-        "type": "object",
-      },
-      "alwaysRefuseToBuild": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "attribution": {
-        "description": "Attribution metadata for the deployment, linking commit author to git and Vercel users. Only populated when the \`enable-deployment-attribution\` flag is enabled.",
-        "properties": {
-          "commitMeta": {
-            "description": "Commit metadata from the git commit author",
-            "properties": {
-              "email": {
-                "description": "Email from git commit author",
-                "type": "string",
+          "aliasAssignedAt": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "type": "number",
               },
-              "isVerified": {
-                "description": "Whether the commit was signed/verified (GitHub only, others return undefined)",
+              {
                 "enum": [
                   false,
                   true,
                 ],
                 "type": "boolean",
               },
-              "name": {
-                "description": "Name from git commit author",
-                "type": "string",
-              },
-            },
-            "type": "object",
+            ],
           },
-          "gitUser": {
-            "description": "Git provider user associated with the commit author email (only set if resolved)",
+          "aliasError": {
+            "description": "An object that will contain a \`code\` and a \`message\` when the aliasing fails, otherwise the value will be \`null\`",
+            "example": null,
+            "nullable": true,
             "properties": {
-              "id": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                  },
-                  {
-                    "type": "number",
-                  },
-                ],
-              },
-              "login": {
-                "description": "Git provider username/login",
+              "code": {
                 "type": "string",
               },
-              "provider": {
-                "description": "The git provider (github, gitlab, bitbucket)",
-                "type": "string",
-              },
-              "type": {
-                "description": "User type",
+              "message": {
                 "type": "string",
               },
             },
             "required": [
-              "id",
-              "login",
+              "code",
+              "message",
             ],
             "type": "object",
           },
-          "vercelUser": {
-            "description": "Vercel user linked to the git provider account (only set if resolved)",
+          "aliasFinal": {
+            "nullable": true,
+            "type": "string",
+          },
+          "aliasWarning": {
+            "nullable": true,
             "properties": {
-              "id": {
-                "description": "Vercel user ID",
+              "action": {
                 "type": "string",
               },
-              "teamRoles": {
-                "description": "Team roles at time of deployment",
+              "code": {
+                "type": "string",
+              },
+              "link": {
+                "type": "string",
+              },
+              "message": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "code",
+              "message",
+            ],
+            "type": "object",
+          },
+          "alwaysRefuseToBuild": {
+            "enum": [
+              false,
+              true,
+            ],
+            "type": "boolean",
+          },
+          "attribution": {
+            "description": "Attribution metadata for the deployment, linking commit author to git and Vercel users. Only populated when the \`enable-deployment-attribution\` flag is enabled.",
+            "properties": {
+              "commitMeta": {
+                "description": "Commit metadata from the git commit author",
+                "properties": {
+                  "email": {
+                    "description": "Email from git commit author",
+                    "type": "string",
+                  },
+                  "isVerified": {
+                    "description": "Whether the commit was signed/verified (GitHub only, others return undefined)",
+                    "enum": [
+                      false,
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "name": {
+                    "description": "Name from git commit author",
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "gitUser": {
+                "description": "Git provider user associated with the commit author email (only set if resolved)",
+                "properties": {
+                  "id": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "number",
+                      },
+                    ],
+                  },
+                  "login": {
+                    "description": "Git provider username/login",
+                    "type": "string",
+                  },
+                  "provider": {
+                    "description": "The git provider (github, gitlab, bitbucket)",
+                    "type": "string",
+                  },
+                  "type": {
+                    "description": "User type",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                  "login",
+                ],
+                "type": "object",
+              },
+              "vercelUser": {
+                "description": "Vercel user linked to the git provider account (only set if resolved)",
+                "properties": {
+                  "id": {
+                    "description": "Vercel user ID",
+                    "type": "string",
+                  },
+                  "teamRoles": {
+                    "description": "Team roles at time of deployment",
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  "username": {
+                    "description": "Vercel username",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                  "username",
+                ],
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "autoAssignCustomDomains": {
+            "description": "applies to custom domains only, defaults to \`true\`",
+            "enum": [
+              false,
+              true,
+            ],
+            "type": "boolean",
+          },
+          "automaticAliases": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "bootedAt": {
+            "type": "number",
+          },
+          "build": {
+            "properties": {
+              "env": {
                 "items": {
                   "type": "string",
                 },
                 "type": "array",
               },
+            },
+            "required": [
+              "env",
+            ],
+            "type": "object",
+          },
+          "buildArtifactUrls": {
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "buildContainerFinishedAt": {
+            "description": "Since April 2025 it necessary for On-Demand Concurrency Minutes calculation",
+            "type": "number",
+          },
+          "buildErrorAt": {
+            "type": "number",
+          },
+          "buildSkipped": {
+            "enum": [
+              false,
+              true,
+            ],
+            "type": "boolean",
+          },
+          "buildingAt": {
+            "type": "number",
+          },
+          "builds": {
+            "items": {
+              "properties": {
+                "config": {
+                  "additionalProperties": true,
+                  "type": "object",
+                },
+                "src": {
+                  "type": "string",
+                },
+                "use": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "use",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "canceledAt": {
+            "type": "number",
+          },
+          "checks": {
+            "properties": {
+              "deployment-alias": {
+                "description": "Condensed check data. Retrieve individual check and check run data using api-checks v2 routes.",
+                "properties": {
+                  "completedAt": {
+                    "type": "number",
+                  },
+                  "startedAt": {
+                    "type": "number",
+                  },
+                  "state": {
+                    "enum": [
+                      "succeeded",
+                      "failed",
+                      "pending",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "startedAt",
+                  "state",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "deployment-alias",
+            ],
+            "type": "object",
+          },
+          "checksConclusion": {
+            "enum": [
+              "succeeded",
+              "failed",
+              "skipped",
+              "canceled",
+            ],
+            "type": "string",
+          },
+          "checksState": {
+            "enum": [
+              "registered",
+              "running",
+              "completed",
+            ],
+            "type": "string",
+          },
+          "config": {
+            "description": "Since February 2025 the configuration must include snapshot data at the time of deployment creation to capture properties for the /deployments/:id/config endpoint utilized for displaying Deployment Configuration on the frontend This is optional because older deployments may not have this data captured",
+            "properties": {
+              "functionMemoryType": {
+                "enum": [
+                  "standard",
+                  "standard_legacy",
+                  "performance",
+                ],
+                "type": "string",
+              },
+              "functionTimeout": {
+                "nullable": true,
+                "type": "number",
+              },
+              "functionType": {
+                "enum": [
+                  "standard",
+                  "fluid",
+                ],
+                "type": "string",
+              },
+              "isUsingActiveCPU": {
+                "enum": [
+                  false,
+                  true,
+                ],
+                "type": "boolean",
+              },
+              "resourceConfig": {
+                "description": "Build resource configuration snapshot for this deployment.",
+                "properties": {
+                  "buildMachine": {
+                    "properties": {
+                      "purchaseType": {
+                        "description": "Machine type that was used for the build.",
+                        "enum": [
+                          "enhanced",
+                          "turbo",
+                          "standard",
+                          null,
+                        ],
+                        "nullable": true,
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "buildQueue": {
+                    "description": "Build resource configuration snapshot for this deployment.",
+                    "properties": {
+                      "configuration": {
+                        "description": "Build resource configuration snapshot for this deployment.",
+                        "enum": [
+                          "SKIP_NAMESPACE_QUEUE",
+                          "WAIT_FOR_NAMESPACE_QUEUE",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "elasticConcurrency": {
+                    "description": "When elastic concurrency is used for this deployment, a value is set. The value tells the reason where the setting was coming from. - TEAM_SETTING: Inherited from team settings - PROJECT_SETTING: Inherited from project settings - SKIP_QUEUE: Manually triggered by user to skip the queues",
+                    "enum": [
+                      "TEAM_SETTING",
+                      "PROJECT_SETTING",
+                      "SKIP_QUEUE",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "type": "object",
+              },
+              "secureComputeFallbackRegion": {
+                "nullable": true,
+                "type": "string",
+              },
+              "secureComputePrimaryRegion": {
+                "nullable": true,
+                "type": "string",
+              },
+              "version": {
+                "type": "number",
+              },
+            },
+            "required": [
+              "functionMemoryType",
+              "functionTimeout",
+              "functionType",
+              "secureComputeFallbackRegion",
+              "secureComputePrimaryRegion",
+            ],
+            "type": "object",
+          },
+          "connectBuildsEnabled": {
+            "enum": [
+              false,
+              true,
+            ],
+            "type": "boolean",
+          },
+          "connectConfigurationId": {
+            "type": "string",
+          },
+          "createdAt": {
+            "description": "A number containing the date when the deployment was created in milliseconds",
+            "example": 1540257589405,
+            "type": "number",
+          },
+          "createdIn": {
+            "type": "string",
+          },
+          "creator": {
+            "description": "Information about the deployment creator",
+            "properties": {
+              "avatar": {
+                "description": "The avatar of the user that created the deployment",
+                "type": "string",
+              },
+              "uid": {
+                "description": "The ID of the user that created the deployment",
+                "example": "96SnxkFiMyVKsK3pnoHfx3Hz",
+                "type": "string",
+              },
               "username": {
-                "description": "Vercel username",
+                "description": "The username of the user that created the deployment",
+                "example": "john-doe",
                 "type": "string",
               },
             },
             "required": [
-              "id",
-              "username",
+              "uid",
             ],
             "type": "object",
           },
-        },
-        "type": "object",
-      },
-      "autoAssignCustomDomains": {
-        "description": "applies to custom domains only, defaults to \`true\`",
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "automaticAliases": {
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "bootedAt": {
-        "type": "number",
-      },
-      "build": {
-        "properties": {
+          "crons": {
+            "items": {
+              "properties": {
+                "path": {
+                  "type": "string",
+                },
+                "schedule": {
+                  "type": "string",
+                },
+              },
+              "required": [
+                "path",
+                "schedule",
+              ],
+              "type": "object",
+            },
+            "type": "array",
+          },
+          "customEnvironment": {
+            "oneOf": [
+              {
+                "description": "If the deployment was created using a Custom Environment, then this property contains information regarding the environment used.",
+                "properties": {
+                  "branchMatcher": {
+                    "description": "Configuration for matching git branches to this environment",
+                    "properties": {
+                      "pattern": {
+                        "description": "The pattern to match against branch names",
+                        "type": "string",
+                      },
+                      "type": {
+                        "description": "The type of matching to perform",
+                        "enum": [
+                          "endsWith",
+                          "startsWith",
+                          "equals",
+                        ],
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "pattern",
+                      "type",
+                    ],
+                    "type": "object",
+                  },
+                  "createdAt": {
+                    "description": "Timestamp when the environment was created",
+                    "type": "number",
+                  },
+                  "currentDeploymentAliases": {
+                    "description": "List of aliases for the current deployment",
+                    "items": {
+                      "type": "string",
+                    },
+                    "type": "array",
+                  },
+                  "description": {
+                    "description": "Optional description of the environment's purpose",
+                    "type": "string",
+                  },
+                  "domains": {
+                    "description": "List of domains associated with this environment",
+                    "items": {
+                      "description": "List of domains associated with this environment",
+                      "properties": {
+                        "apexName": {
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "type": "number",
+                        },
+                        "customEnvironmentId": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "gitBranch": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "projectId": {
+                          "type": "string",
+                        },
+                        "redirect": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "redirectStatusCode": {
+                          "enum": [
+                            307,
+                            301,
+                            302,
+                            308,
+                            null,
+                          ],
+                          "nullable": true,
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "type": "number",
+                        },
+                        "verification": {
+                          "description": "A list of verification challenges, one of which must be completed to verify the domain for use on the project. After the challenge is complete \`POST /projects/:idOrName/domains/:domain/verify\` to verify the domain. Possible challenges: - If \`verification.type = TXT\` the \`verification.domain\` will be checked for a TXT record matching \`verification.value\`.",
+                          "items": {
+                            "description": "A list of verification challenges, one of which must be completed to verify the domain for use on the project. After the challenge is complete \`POST /projects/:idOrName/domains/:domain/verify\` to verify the domain. Possible challenges: - If \`verification.type = TXT\` the \`verification.domain\` will be checked for a TXT record matching \`verification.value\`.",
+                            "properties": {
+                              "domain": {
+                                "type": "string",
+                              },
+                              "reason": {
+                                "type": "string",
+                              },
+                              "type": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "domain",
+                              "reason",
+                              "type",
+                              "value",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "verified": {
+                          "description": "\`true\` if the domain is verified for use with the project. If \`false\` it will not be used as an alias on this project until the challenge in \`verification\` is completed.",
+                          "enum": [
+                            false,
+                            true,
+                          ],
+                          "type": "boolean",
+                        },
+                      },
+                      "required": [
+                        "apexName",
+                        "name",
+                        "projectId",
+                        "verified",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "id": {
+                    "description": "Unique identifier for the custom environment (format: env_*)",
+                    "type": "string",
+                  },
+                  "slug": {
+                    "description": "URL-friendly name of the environment",
+                    "type": "string",
+                  },
+                  "type": {
+                    "description": "The type of environment (production, preview, or development)",
+                    "enum": [
+                      "production",
+                      "preview",
+                      "development",
+                    ],
+                    "type": "string",
+                  },
+                  "updatedAt": {
+                    "description": "Timestamp when the environment was last updated",
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "createdAt",
+                  "id",
+                  "slug",
+                  "type",
+                  "updatedAt",
+                ],
+                "type": "object",
+              },
+              {
+                "description": "If the deployment was created using a Custom Environment, then this property contains information regarding the environment used.",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          "defaultRoute": {
+            "description": "Computed field that is only available for deployments with a microfrontend configuration.",
+            "type": "string",
+          },
+          "deletedAt": {
+            "description": "A number containing the date when the deployment was deleted at milliseconds",
+            "example": 1540257589405,
+            "nullable": true,
+            "type": "number",
+          },
           "env": {
             "items": {
               "type": "string",
             },
             "type": "array",
           },
-        },
-        "required": [
-          "env",
-        ],
-        "type": "object",
-      },
-      "buildArtifactUrls": {
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "buildContainerFinishedAt": {
-        "description": "Since April 2025 it necessary for On-Demand Concurrency Minutes calculation",
-        "type": "number",
-      },
-      "buildErrorAt": {
-        "type": "number",
-      },
-      "buildSkipped": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "buildingAt": {
-        "type": "number",
-      },
-      "builds": {
-        "items": {
-          "properties": {
-            "config": {
-              "additionalProperties": true,
+          "errorCode": {
+            "type": "string",
+          },
+          "errorLink": {
+            "type": "string",
+          },
+          "errorMessage": {
+            "nullable": true,
+            "type": "string",
+          },
+          "errorStep": {
+            "type": "string",
+          },
+          "flags": {
+            "oneOf": [
+              {
+                "description": "Flags defined in the Build Output API, used by this deployment. Primarily used by the Toolbar to know about the used flags.",
+                "properties": {
+                  "definitions": {
+                    "additionalProperties": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "options": {
+                          "items": {
+                            "properties": {
+                              "label": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "$ref": "#/$defs/FlagJSONValue",
+                              },
+                            },
+                            "required": [
+                              "value",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "url": {
+                          "type": "string",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "definitions",
+                ],
+                "type": "object",
+              },
+              {
+                "description": "Flags defined in the Build Output API, used by this deployment. Primarily used by the Toolbar to know about the used flags.",
+                "items": {
+                  "description": "Flags defined in the Build Output API, used by this deployment. Primarily used by the Toolbar to know about the used flags.",
+                  "type": "object",
+                },
+                "type": "array",
+              },
+            ],
+          },
+          "functions": {
+            "additionalProperties": {
+              "properties": {
+                "architecture": {
+                  "enum": [
+                    "x86_64",
+                    "arm64",
+                  ],
+                  "type": "string",
+                },
+                "excludeFiles": {
+                  "type": "string",
+                },
+                "experimentalTriggers": {
+                  "items": {
+                    "oneOf": [
+                      {
+                        "description": "Queue trigger input event for v1beta (from vercel.json config). Requires explicit consumer name.",
+                        "properties": {
+                          "consumer": {
+                            "description": "Name of the consumer group for this trigger (REQUIRED)",
+                            "type": "string",
+                          },
+                          "initialDelaySeconds": {
+                            "description": "Initial delay in seconds before first execution attempt (OPTIONAL) Must be 0 or greater. Use 0 for no initial delay. Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "maxConcurrency": {
+                            "description": "Maximum number of concurrent executions for this consumer (OPTIONAL) Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "maxDeliveries": {
+                            "description": "Maximum number of delivery attempts for message processing (OPTIONAL) This represents the total number of times a message can be delivered, not the number of retries. Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "retryAfterSeconds": {
+                            "description": "Delay in seconds before retrying failed executions (OPTIONAL) Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "topic": {
+                            "description": "Name of the queue topic to consume from (REQUIRED)",
+                            "type": "string",
+                          },
+                          "type": {
+                            "description": "Event type - must be "queue/v1beta" (REQUIRED)",
+                            "enum": [
+                              "queue/v1beta",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "consumer",
+                          "topic",
+                          "type",
+                        ],
+                        "type": "object",
+                      },
+                      {
+                        "description": "Queue trigger input event for v2beta (from vercel.json config). Consumer name is implicitly derived from the function path. Only one trigger per function is allowed.",
+                        "properties": {
+                          "initialDelaySeconds": {
+                            "description": "Initial delay in seconds before first execution attempt (OPTIONAL) Must be 0 or greater. Use 0 for no initial delay. Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "maxConcurrency": {
+                            "description": "Maximum number of concurrent executions for this consumer (OPTIONAL) Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "maxDeliveries": {
+                            "description": "Maximum number of delivery attempts for message processing (OPTIONAL) This represents the total number of times a message can be delivered, not the number of retries. Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "retryAfterSeconds": {
+                            "description": "Delay in seconds before retrying failed executions (OPTIONAL) Behavior when not specified depends on the server's default configuration.",
+                            "type": "number",
+                          },
+                          "topic": {
+                            "description": "Name of the queue topic to consume from (REQUIRED)",
+                            "type": "string",
+                          },
+                          "type": {
+                            "description": "Event type - must be "queue/v2beta" (REQUIRED)",
+                            "enum": [
+                              "queue/v2beta",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "topic",
+                          "type",
+                        ],
+                        "type": "object",
+                      },
+                    ],
+                  },
+                  "type": "array",
+                },
+                "functionFailoverRegions": {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                "includeFiles": {
+                  "type": "string",
+                },
+                "maxDuration": {
+                  "oneOf": [
+                    {
+                      "type": "number",
+                    },
+                    {
+                      "enum": [
+                        "max",
+                      ],
+                      "type": "string",
+                    },
+                  ],
+                },
+                "memory": {
+                  "type": "number",
+                },
+                "regions": {
+                  "items": {
+                    "type": "string",
+                  },
+                  "type": "array",
+                },
+                "runtime": {
+                  "type": "string",
+                },
+                "supportsCancellation": {
+                  "enum": [
+                    false,
+                    true,
+                  ],
+                  "type": "boolean",
+                },
+              },
               "type": "object",
             },
-            "src": {
-              "type": "string",
-            },
-            "use": {
-              "type": "string",
-            },
+            "nullable": true,
+            "type": "object",
           },
-          "required": [
-            "use",
-          ],
-          "type": "object",
-        },
-        "type": "array",
-      },
-      "canceledAt": {
-        "type": "number",
-      },
-      "checks": {
-        "properties": {
-          "deployment-alias": {
-            "description": "Condensed check data. Retrieve individual check and check run data using api-checks v2 routes.",
+          "gitRepo": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "properties": {
+                  "defaultBranch": {
+                    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
+                  },
+                  "namespace": {
+                    "type": "string",
+                  },
+                  "ownerType": {
+                    "enum": [
+                      "team",
+                      "user",
+                    ],
+                    "type": "string",
+                  },
+                  "path": {
+                    "type": "string",
+                  },
+                  "private": {
+                    "enum": [
+                      false,
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "projectId": {
+                    "type": "number",
+                  },
+                  "type": {
+                    "enum": [
+                      "gitlab",
+                    ],
+                    "type": "string",
+                  },
+                  "url": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "defaultBranch",
+                  "name",
+                  "namespace",
+                  "ownerType",
+                  "path",
+                  "private",
+                  "projectId",
+                  "type",
+                  "url",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "defaultBranch": {
+                    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
+                  },
+                  "org": {
+                    "type": "string",
+                  },
+                  "ownerType": {
+                    "enum": [
+                      "team",
+                      "user",
+                    ],
+                    "type": "string",
+                  },
+                  "path": {
+                    "type": "string",
+                  },
+                  "private": {
+                    "enum": [
+                      false,
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "repoId": {
+                    "type": "number",
+                  },
+                  "repoOwnerId": {
+                    "type": "number",
+                  },
+                  "type": {
+                    "enum": [
+                      "github",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "defaultBranch",
+                  "name",
+                  "org",
+                  "ownerType",
+                  "path",
+                  "private",
+                  "repo",
+                  "repoId",
+                  "repoOwnerId",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "defaultBranch": {
+                    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
+                  },
+                  "owner": {
+                    "type": "string",
+                  },
+                  "ownerType": {
+                    "enum": [
+                      "team",
+                      "user",
+                    ],
+                    "type": "string",
+                  },
+                  "path": {
+                    "type": "string",
+                  },
+                  "private": {
+                    "enum": [
+                      false,
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "repoUuid": {
+                    "type": "string",
+                  },
+                  "slug": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "bitbucket",
+                    ],
+                    "type": "string",
+                  },
+                  "workspaceUuid": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "defaultBranch",
+                  "name",
+                  "owner",
+                  "ownerType",
+                  "path",
+                  "private",
+                  "repoUuid",
+                  "slug",
+                  "type",
+                  "workspaceUuid",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "defaultBranch": {
+                    "type": "string",
+                  },
+                  "name": {
+                    "type": "string",
+                  },
+                  "org": {
+                    "type": "string",
+                  },
+                  "ownerType": {
+                    "enum": [
+                      "team",
+                      "user",
+                    ],
+                    "type": "string",
+                  },
+                  "path": {
+                    "type": "string",
+                  },
+                  "private": {
+                    "enum": [
+                      false,
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "vercel",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "defaultBranch",
+                  "name",
+                  "org",
+                  "ownerType",
+                  "path",
+                  "private",
+                  "repo",
+                  "type",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          "gitSource": {
+            "oneOf": [
+              {
+                "properties": {
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repoId": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "number",
+                      },
+                    ],
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "repoId",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "org": {
+                    "type": "string",
+                  },
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "org",
+                  "repo",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "host": {
+                    "type": "string",
+                  },
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repoId": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "number",
+                      },
+                    ],
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github-custom-host",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "host",
+                  "repoId",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "host": {
+                    "type": "string",
+                  },
+                  "org": {
+                    "type": "string",
+                  },
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github-custom-host",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "host",
+                  "org",
+                  "repo",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repoId": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "number",
+                      },
+                    ],
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github-limited",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "repoId",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "org": {
+                    "type": "string",
+                  },
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github-limited",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "org",
+                  "repo",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "projectId": {
+                    "oneOf": [
+                      {
+                        "type": "string",
+                      },
+                      {
+                        "type": "number",
+                      },
+                    ],
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "gitlab",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "projectId",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repoUuid": {
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "bitbucket",
+                    ],
+                    "type": "string",
+                  },
+                  "workspaceUuid": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "repoUuid",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "owner": {
+                    "type": "string",
+                  },
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "slug": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "bitbucket",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "owner",
+                  "slug",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "org": {
+                    "type": "string",
+                  },
+                  "prId": {
+                    "nullable": true,
+                    "type": "number",
+                  },
+                  "ref": {
+                    "nullable": true,
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "repoPushedAt": {
+                    "type": "number",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "vercel",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "sha",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "description": "Allows custom git sources (local folder mounted to the container) in test mode",
+                "properties": {
+                  "gitUrl": {
+                    "type": "string",
+                  },
+                  "ref": {
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "custom",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "gitUrl",
+                  "ref",
+                  "sha",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "org": {
+                    "type": "string",
+                  },
+                  "ref": {
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "repoId": {
+                    "type": "number",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "ref",
+                  "repoId",
+                  "sha",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "host": {
+                    "type": "string",
+                  },
+                  "org": {
+                    "type": "string",
+                  },
+                  "ref": {
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "repoId": {
+                    "type": "number",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github-custom-host",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "host",
+                  "ref",
+                  "repoId",
+                  "sha",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "org": {
+                    "type": "string",
+                  },
+                  "ref": {
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "repoId": {
+                    "type": "number",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "github-limited",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "ref",
+                  "repoId",
+                  "sha",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "projectId": {
+                    "type": "number",
+                  },
+                  "ref": {
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "gitlab",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "projectId",
+                  "ref",
+                  "sha",
+                  "type",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "owner": {
+                    "type": "string",
+                  },
+                  "ref": {
+                    "type": "string",
+                  },
+                  "repoUuid": {
+                    "type": "string",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "slug": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "bitbucket",
+                    ],
+                    "type": "string",
+                  },
+                  "workspaceUuid": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "ref",
+                  "repoUuid",
+                  "sha",
+                  "type",
+                  "workspaceUuid",
+                ],
+                "type": "object",
+              },
+              {
+                "properties": {
+                  "org": {
+                    "type": "string",
+                  },
+                  "ref": {
+                    "type": "string",
+                  },
+                  "repo": {
+                    "type": "string",
+                  },
+                  "repoPushedAt": {
+                    "type": "number",
+                  },
+                  "sha": {
+                    "type": "string",
+                  },
+                  "type": {
+                    "enum": [
+                      "vercel",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "org",
+                  "ref",
+                  "repo",
+                  "sha",
+                  "type",
+                ],
+                "type": "object",
+              },
+            ],
+          },
+          "id": {
+            "description": "A string holding the unique ID of the deployment",
+            "example": "dpl_89qyp1cskzkLrVicDaZoDbjyHuDJ",
+            "type": "string",
+          },
+          "images": {
             "properties": {
+              "contentDispositionType": {
+                "enum": [
+                  "inline",
+                  "attachment",
+                ],
+                "type": "string",
+              },
+              "contentSecurityPolicy": {
+                "type": "string",
+              },
+              "dangerouslyAllowSVG": {
+                "enum": [
+                  false,
+                  true,
+                ],
+                "type": "boolean",
+              },
+              "domains": {
+                "items": {
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "formats": {
+                "items": {
+                  "enum": [
+                    "image/avif",
+                    "image/webp",
+                  ],
+                  "type": "string",
+                },
+                "type": "array",
+              },
+              "localPatterns": {
+                "items": {
+                  "properties": {
+                    "pathname": {
+                      "description": "Can be literal or wildcard. Single \`*\` matches a single path segment. Double \`**\` matches any number of path segments.",
+                      "type": "string",
+                    },
+                    "search": {
+                      "description": "Can be literal query string such as \`?v=1\` or empty string meaning no query string.",
+                      "type": "string",
+                    },
+                  },
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "minimumCacheTTL": {
+                "type": "number",
+              },
+              "qualities": {
+                "items": {
+                  "type": "number",
+                },
+                "type": "array",
+              },
+              "remotePatterns": {
+                "items": {
+                  "properties": {
+                    "hostname": {
+                      "description": "Can be literal or wildcard. Single \`*\` matches a single subdomain. Double \`**\` matches any number of subdomains.",
+                      "type": "string",
+                    },
+                    "pathname": {
+                      "description": "Can be literal or wildcard. Single \`*\` matches a single path segment. Double \`**\` matches any number of path segments.",
+                      "type": "string",
+                    },
+                    "port": {
+                      "description": "Can be literal port such as \`8080\` or empty string meaning no port.",
+                      "type": "string",
+                    },
+                    "protocol": {
+                      "description": "Must be \`http\` or \`https\`.",
+                      "enum": [
+                        "http",
+                        "https",
+                      ],
+                      "type": "string",
+                    },
+                    "search": {
+                      "description": "Can be literal query string such as \`?v=1\` or empty string meaning no query string.",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "hostname",
+                  ],
+                  "type": "object",
+                },
+                "type": "array",
+              },
+              "sizes": {
+                "items": {
+                  "type": "number",
+                },
+                "type": "array",
+              },
+            },
+            "type": "object",
+          },
+          "initReadyAt": {
+            "type": "number",
+          },
+          "inspectorUrl": {
+            "nullable": true,
+            "type": "string",
+          },
+          "integrations": {
+            "properties": {
+              "claimedAt": {
+                "type": "number",
+              },
               "completedAt": {
                 "type": "number",
+              },
+              "skippedAt": {
+                "type": "number",
+              },
+              "skippedBy": {
+                "type": "string",
               },
               "startedAt": {
                 "type": "number",
               },
-              "state": {
+              "status": {
                 "enum": [
-                  "succeeded",
-                  "failed",
+                  "skipped",
                   "pending",
+                  "ready",
+                  "error",
+                  "timeout",
                 ],
                 "type": "string",
               },
             },
             "required": [
               "startedAt",
-              "state",
+              "status",
             ],
             "type": "object",
           },
-        },
-        "required": [
-          "deployment-alias",
-        ],
-        "type": "object",
-      },
-      "checksConclusion": {
-        "enum": [
-          "succeeded",
-          "failed",
-          "skipped",
-          "canceled",
-        ],
-        "type": "string",
-      },
-      "checksState": {
-        "enum": [
-          "registered",
-          "running",
-          "completed",
-        ],
-        "type": "string",
-      },
-      "config": {
-        "description": "Since February 2025 the configuration must include snapshot data at the time of deployment creation to capture properties for the /deployments/:id/config endpoint utilized for displaying Deployment Configuration on the frontend This is optional because older deployments may not have this data captured",
-        "properties": {
-          "functionMemoryType": {
-            "enum": [
-              "standard",
-              "standard_legacy",
-              "performance",
-            ],
-            "type": "string",
-          },
-          "functionTimeout": {
-            "nullable": true,
-            "type": "number",
-          },
-          "functionType": {
-            "enum": [
-              "standard",
-              "fluid",
-            ],
-            "type": "string",
-          },
-          "isUsingActiveCPU": {
+          "isFirstBranchDeployment": {
             "enum": [
               false,
               true,
             ],
             "type": "boolean",
           },
-          "resourceConfig": {
-            "description": "Build resource configuration snapshot for this deployment.",
-            "properties": {
-              "buildMachine": {
-                "properties": {
-                  "purchaseType": {
-                    "description": "Machine type that was used for the build.",
-                    "enum": [
-                      "enhanced",
-                      "turbo",
-                      "standard",
-                      null,
-                    ],
-                    "nullable": true,
-                    "type": "string",
-                  },
-                },
-                "type": "object",
-              },
-              "buildQueue": {
-                "description": "Build resource configuration snapshot for this deployment.",
-                "properties": {
-                  "configuration": {
-                    "description": "Build resource configuration snapshot for this deployment.",
-                    "enum": [
-                      "SKIP_NAMESPACE_QUEUE",
-                      "WAIT_FOR_NAMESPACE_QUEUE",
-                    ],
-                    "type": "string",
-                  },
-                },
-                "type": "object",
-              },
-              "elasticConcurrency": {
-                "description": "When elastic concurrency is used for this deployment, a value is set. The value tells the reason where the setting was coming from. - TEAM_SETTING: Inherited from team settings - PROJECT_SETTING: Inherited from project settings - SKIP_QUEUE: Manually triggered by user to skip the queues",
-                "enum": [
-                  "TEAM_SETTING",
-                  "PROJECT_SETTING",
-                  "SKIP_QUEUE",
-                ],
-                "type": "string",
-              },
-            },
-            "type": "object",
-          },
-          "secureComputeFallbackRegion": {
-            "nullable": true,
-            "type": "string",
-          },
-          "secureComputePrimaryRegion": {
-            "nullable": true,
-            "type": "string",
-          },
-          "version": {
-            "type": "number",
-          },
-        },
-        "required": [
-          "functionMemoryType",
-          "functionTimeout",
-          "functionType",
-          "secureComputeFallbackRegion",
-          "secureComputePrimaryRegion",
-        ],
-        "type": "object",
-      },
-      "connectBuildsEnabled": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "connectConfigurationId": {
-        "type": "string",
-      },
-      "createdAt": {
-        "description": "A number containing the date when the deployment was created in milliseconds",
-        "example": 1540257589405,
-        "type": "number",
-      },
-      "createdIn": {
-        "type": "string",
-      },
-      "creator": {
-        "description": "Information about the deployment creator",
-        "properties": {
-          "avatar": {
-            "description": "The avatar of the user that created the deployment",
-            "type": "string",
-          },
-          "uid": {
-            "description": "The ID of the user that created the deployment",
-            "example": "96SnxkFiMyVKsK3pnoHfx3Hz",
-            "type": "string",
-          },
-          "username": {
-            "description": "The username of the user that created the deployment",
-            "example": "john-doe",
-            "type": "string",
-          },
-        },
-        "required": [
-          "uid",
-        ],
-        "type": "object",
-      },
-      "crons": {
-        "items": {
-          "properties": {
-            "path": {
-              "type": "string",
-            },
-            "schedule": {
-              "type": "string",
-            },
-          },
-          "required": [
-            "path",
-            "schedule",
-          ],
-          "type": "object",
-        },
-        "type": "array",
-      },
-      "customEnvironment": {
-        "oneOf": [
-          {
-            "description": "If the deployment was created using a Custom Environment, then this property contains information regarding the environment used.",
-            "properties": {
-              "branchMatcher": {
-                "description": "Configuration for matching git branches to this environment",
-                "properties": {
-                  "pattern": {
-                    "description": "The pattern to match against branch names",
-                    "type": "string",
-                  },
-                  "type": {
-                    "description": "The type of matching to perform",
-                    "enum": [
-                      "endsWith",
-                      "startsWith",
-                      "equals",
-                    ],
-                    "type": "string",
-                  },
-                },
-                "required": [
-                  "pattern",
-                  "type",
-                ],
-                "type": "object",
-              },
-              "createdAt": {
-                "description": "Timestamp when the environment was created",
-                "type": "number",
-              },
-              "currentDeploymentAliases": {
-                "description": "List of aliases for the current deployment",
-                "items": {
-                  "type": "string",
-                },
-                "type": "array",
-              },
-              "description": {
-                "description": "Optional description of the environment's purpose",
-                "type": "string",
-              },
-              "domains": {
-                "description": "List of domains associated with this environment",
-                "items": {
-                  "description": "List of domains associated with this environment",
-                  "properties": {
-                    "apexName": {
-                      "type": "string",
-                    },
-                    "createdAt": {
-                      "type": "number",
-                    },
-                    "customEnvironmentId": {
-                      "nullable": true,
-                      "type": "string",
-                    },
-                    "gitBranch": {
-                      "nullable": true,
-                      "type": "string",
-                    },
-                    "name": {
-                      "type": "string",
-                    },
-                    "projectId": {
-                      "type": "string",
-                    },
-                    "redirect": {
-                      "nullable": true,
-                      "type": "string",
-                    },
-                    "redirectStatusCode": {
-                      "enum": [
-                        307,
-                        301,
-                        302,
-                        308,
-                        null,
-                      ],
-                      "nullable": true,
-                      "type": "number",
-                    },
-                    "updatedAt": {
-                      "type": "number",
-                    },
-                    "verification": {
-                      "description": "A list of verification challenges, one of which must be completed to verify the domain for use on the project. After the challenge is complete \`POST /projects/:idOrName/domains/:domain/verify\` to verify the domain. Possible challenges: - If \`verification.type = TXT\` the \`verification.domain\` will be checked for a TXT record matching \`verification.value\`.",
-                      "items": {
-                        "description": "A list of verification challenges, one of which must be completed to verify the domain for use on the project. After the challenge is complete \`POST /projects/:idOrName/domains/:domain/verify\` to verify the domain. Possible challenges: - If \`verification.type = TXT\` the \`verification.domain\` will be checked for a TXT record matching \`verification.value\`.",
-                        "properties": {
-                          "domain": {
-                            "type": "string",
-                          },
-                          "reason": {
-                            "type": "string",
-                          },
-                          "type": {
-                            "type": "string",
-                          },
-                          "value": {
-                            "type": "string",
-                          },
-                        },
-                        "required": [
-                          "domain",
-                          "reason",
-                          "type",
-                          "value",
-                        ],
-                        "type": "object",
-                      },
-                      "type": "array",
-                    },
-                    "verified": {
-                      "description": "\`true\` if the domain is verified for use with the project. If \`false\` it will not be used as an alias on this project until the challenge in \`verification\` is completed.",
-                      "enum": [
-                        false,
-                        true,
-                      ],
-                      "type": "boolean",
-                    },
-                  },
-                  "required": [
-                    "apexName",
-                    "name",
-                    "projectId",
-                    "verified",
-                  ],
-                  "type": "object",
-                },
-                "type": "array",
-              },
-              "id": {
-                "description": "Unique identifier for the custom environment (format: env_*)",
-                "type": "string",
-              },
-              "slug": {
-                "description": "URL-friendly name of the environment",
-                "type": "string",
-              },
-              "type": {
-                "description": "The type of environment (production, preview, or development)",
-                "enum": [
-                  "production",
-                  "preview",
-                  "development",
-                ],
-                "type": "string",
-              },
-              "updatedAt": {
-                "description": "Timestamp when the environment was last updated",
-                "type": "number",
-              },
-            },
-            "required": [
-              "createdAt",
-              "id",
-              "slug",
-              "type",
-              "updatedAt",
+          "isInConcurrentBuildsQueue": {
+            "enum": [
+              false,
+              true,
             ],
-            "type": "object",
+            "type": "boolean",
           },
-          {
-            "description": "If the deployment was created using a Custom Environment, then this property contains information regarding the environment used.",
-            "properties": {
-              "id": {
-                "type": "string",
-              },
-            },
-            "required": [
-              "id",
+          "isInSystemBuildsQueue": {
+            "enum": [
+              false,
+              true,
             ],
-            "type": "object",
+            "type": "boolean",
           },
-        ],
-      },
-      "defaultRoute": {
-        "description": "Computed field that is only available for deployments with a microfrontend configuration.",
-        "type": "string",
-      },
-      "deletedAt": {
-        "description": "A number containing the date when the deployment was deleted at milliseconds",
-        "example": 1540257589405,
-        "nullable": true,
-        "type": "number",
-      },
-      "env": {
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "errorCode": {
-        "type": "string",
-      },
-      "errorLink": {
-        "type": "string",
-      },
-      "errorMessage": {
-        "nullable": true,
-        "type": "string",
-      },
-      "errorStep": {
-        "type": "string",
-      },
-      "flags": {
-        "oneOf": [
-          {
-            "description": "Flags defined in the Build Output API, used by this deployment. Primarily used by the Toolbar to know about the used flags.",
-            "properties": {
-              "definitions": {
-                "additionalProperties": {
-                  "properties": {
-                    "description": {
-                      "type": "string",
-                    },
-                    "options": {
-                      "items": {
-                        "properties": {
-                          "label": {
-                            "type": "string",
-                          },
-                          "value": {
-                            "$ref": "#/$defs/FlagJSONValue",
-                          },
-                        },
-                        "required": [
-                          "value",
-                        ],
-                        "type": "object",
-                      },
-                      "type": "array",
-                    },
-                    "url": {
-                      "type": "string",
-                    },
-                  },
-                  "type": "object",
-                },
-                "type": "object",
-              },
-            },
-            "required": [
-              "definitions",
-            ],
-            "type": "object",
-          },
-          {
-            "description": "Flags defined in the Build Output API, used by this deployment. Primarily used by the Toolbar to know about the used flags.",
+          "lambdas": {
             "items": {
-              "description": "Flags defined in the Build Output API, used by this deployment. Primarily used by the Toolbar to know about the used flags.",
-              "type": "object",
-            },
-            "type": "array",
-          },
-        ],
-      },
-      "functions": {
-        "additionalProperties": {
-          "properties": {
-            "architecture": {
-              "enum": [
-                "x86_64",
-                "arm64",
-              ],
-              "type": "string",
-            },
-            "excludeFiles": {
-              "type": "string",
-            },
-            "experimentalTriggers": {
-              "items": {
-                "oneOf": [
-                  {
-                    "description": "Queue trigger input event for v1beta (from vercel.json config). Requires explicit consumer name.",
-                    "properties": {
-                      "consumer": {
-                        "description": "Name of the consumer group for this trigger (REQUIRED)",
-                        "type": "string",
-                      },
-                      "initialDelaySeconds": {
-                        "description": "Initial delay in seconds before first execution attempt (OPTIONAL) Must be 0 or greater. Use 0 for no initial delay. Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "maxConcurrency": {
-                        "description": "Maximum number of concurrent executions for this consumer (OPTIONAL) Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "maxDeliveries": {
-                        "description": "Maximum number of delivery attempts for message processing (OPTIONAL) This represents the total number of times a message can be delivered, not the number of retries. Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "retryAfterSeconds": {
-                        "description": "Delay in seconds before retrying failed executions (OPTIONAL) Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "topic": {
-                        "description": "Name of the queue topic to consume from (REQUIRED)",
-                        "type": "string",
-                      },
-                      "type": {
-                        "description": "Event type - must be "queue/v1beta" (REQUIRED)",
-                        "enum": [
-                          "queue/v1beta",
-                        ],
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "consumer",
-                      "topic",
-                      "type",
-                    ],
-                    "type": "object",
-                  },
-                  {
-                    "description": "Queue trigger input event for v2beta (from vercel.json config). Consumer name is implicitly derived from the function path. Only one trigger per function is allowed.",
-                    "properties": {
-                      "initialDelaySeconds": {
-                        "description": "Initial delay in seconds before first execution attempt (OPTIONAL) Must be 0 or greater. Use 0 for no initial delay. Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "maxConcurrency": {
-                        "description": "Maximum number of concurrent executions for this consumer (OPTIONAL) Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "maxDeliveries": {
-                        "description": "Maximum number of delivery attempts for message processing (OPTIONAL) This represents the total number of times a message can be delivered, not the number of retries. Must be at least 1 if specified. Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "retryAfterSeconds": {
-                        "description": "Delay in seconds before retrying failed executions (OPTIONAL) Behavior when not specified depends on the server's default configuration.",
-                        "type": "number",
-                      },
-                      "topic": {
-                        "description": "Name of the queue topic to consume from (REQUIRED)",
-                        "type": "string",
-                      },
-                      "type": {
-                        "description": "Event type - must be "queue/v2beta" (REQUIRED)",
-                        "enum": [
-                          "queue/v2beta",
-                        ],
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "topic",
-                      "type",
-                    ],
-                    "type": "object",
-                  },
-                ],
-              },
-              "type": "array",
-            },
-            "functionFailoverRegions": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "includeFiles": {
-              "type": "string",
-            },
-            "maxDuration": {
-              "oneOf": [
-                {
+              "description": "A partial representation of a Build used by the deployment endpoint.",
+              "properties": {
+                "createdAt": {
                   "type": "number",
                 },
-                {
+                "entrypoint": {
+                  "nullable": true,
+                  "type": "string",
+                },
+                "id": {
+                  "type": "string",
+                },
+                "output": {
+                  "items": {
+                    "properties": {
+                      "functionName": {
+                        "type": "string",
+                      },
+                      "path": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "functionName",
+                      "path",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+                "readyState": {
                   "enum": [
-                    "max",
+                    "BUILDING",
+                    "ERROR",
+                    "INITIALIZING",
+                    "READY",
                   ],
                   "type": "string",
                 },
-              ],
-            },
-            "memory": {
-              "type": "number",
-            },
-            "regions": {
-              "items": {
-                "type": "string",
-              },
-              "type": "array",
-            },
-            "runtime": {
-              "type": "string",
-            },
-            "supportsCancellation": {
-              "enum": [
-                false,
-                true,
-              ],
-              "type": "boolean",
-            },
-          },
-          "type": "object",
-        },
-        "nullable": true,
-        "type": "object",
-      },
-      "gitRepo": {
-        "nullable": true,
-        "oneOf": [
-          {
-            "properties": {
-              "defaultBranch": {
-                "type": "string",
-              },
-              "name": {
-                "type": "string",
-              },
-              "namespace": {
-                "type": "string",
-              },
-              "ownerType": {
-                "enum": [
-                  "team",
-                  "user",
-                ],
-                "type": "string",
-              },
-              "path": {
-                "type": "string",
-              },
-              "private": {
-                "enum": [
-                  false,
-                  true,
-                ],
-                "type": "boolean",
-              },
-              "projectId": {
-                "type": "number",
-              },
-              "type": {
-                "enum": [
-                  "gitlab",
-                ],
-                "type": "string",
-              },
-              "url": {
-                "type": "string",
-              },
-            },
-            "required": [
-              "defaultBranch",
-              "name",
-              "namespace",
-              "ownerType",
-              "path",
-              "private",
-              "projectId",
-              "type",
-              "url",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "defaultBranch": {
-                "type": "string",
-              },
-              "name": {
-                "type": "string",
-              },
-              "org": {
-                "type": "string",
-              },
-              "ownerType": {
-                "enum": [
-                  "team",
-                  "user",
-                ],
-                "type": "string",
-              },
-              "path": {
-                "type": "string",
-              },
-              "private": {
-                "enum": [
-                  false,
-                  true,
-                ],
-                "type": "boolean",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "repoId": {
-                "type": "number",
-              },
-              "repoOwnerId": {
-                "type": "number",
-              },
-              "type": {
-                "enum": [
-                  "github",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "defaultBranch",
-              "name",
-              "org",
-              "ownerType",
-              "path",
-              "private",
-              "repo",
-              "repoId",
-              "repoOwnerId",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "defaultBranch": {
-                "type": "string",
-              },
-              "name": {
-                "type": "string",
-              },
-              "owner": {
-                "type": "string",
-              },
-              "ownerType": {
-                "enum": [
-                  "team",
-                  "user",
-                ],
-                "type": "string",
-              },
-              "path": {
-                "type": "string",
-              },
-              "private": {
-                "enum": [
-                  false,
-                  true,
-                ],
-                "type": "boolean",
-              },
-              "repoUuid": {
-                "type": "string",
-              },
-              "slug": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "bitbucket",
-                ],
-                "type": "string",
-              },
-              "workspaceUuid": {
-                "type": "string",
-              },
-            },
-            "required": [
-              "defaultBranch",
-              "name",
-              "owner",
-              "ownerType",
-              "path",
-              "private",
-              "repoUuid",
-              "slug",
-              "type",
-              "workspaceUuid",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "defaultBranch": {
-                "type": "string",
-              },
-              "name": {
-                "type": "string",
-              },
-              "org": {
-                "type": "string",
-              },
-              "ownerType": {
-                "enum": [
-                  "team",
-                  "user",
-                ],
-                "type": "string",
-              },
-              "path": {
-                "type": "string",
-              },
-              "private": {
-                "enum": [
-                  false,
-                  true,
-                ],
-                "type": "boolean",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "vercel",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "defaultBranch",
-              "name",
-              "org",
-              "ownerType",
-              "path",
-              "private",
-              "repo",
-              "type",
-            ],
-            "type": "object",
-          },
-        ],
-      },
-      "gitSource": {
-        "oneOf": [
-          {
-            "properties": {
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repoId": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                  },
-                  {
-                    "type": "number",
-                  },
-                ],
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "repoId",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "org": {
-                "type": "string",
-              },
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "org",
-              "repo",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "host": {
-                "type": "string",
-              },
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repoId": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                  },
-                  {
-                    "type": "number",
-                  },
-                ],
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github-custom-host",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "host",
-              "repoId",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "host": {
-                "type": "string",
-              },
-              "org": {
-                "type": "string",
-              },
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github-custom-host",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "host",
-              "org",
-              "repo",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repoId": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                  },
-                  {
-                    "type": "number",
-                  },
-                ],
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github-limited",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "repoId",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "org": {
-                "type": "string",
-              },
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github-limited",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "org",
-              "repo",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "projectId": {
-                "oneOf": [
-                  {
-                    "type": "string",
-                  },
-                  {
-                    "type": "number",
-                  },
-                ],
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "gitlab",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "projectId",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repoUuid": {
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "bitbucket",
-                ],
-                "type": "string",
-              },
-              "workspaceUuid": {
-                "type": "string",
-              },
-            },
-            "required": [
-              "repoUuid",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "owner": {
-                "type": "string",
-              },
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "slug": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "bitbucket",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "owner",
-              "slug",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "org": {
-                "type": "string",
-              },
-              "prId": {
-                "nullable": true,
-                "type": "number",
-              },
-              "ref": {
-                "nullable": true,
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "repoPushedAt": {
-                "type": "number",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "vercel",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "sha",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "description": "Allows custom git sources (local folder mounted to the container) in test mode",
-            "properties": {
-              "gitUrl": {
-                "type": "string",
-              },
-              "ref": {
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "custom",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "gitUrl",
-              "ref",
-              "sha",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "org": {
-                "type": "string",
-              },
-              "ref": {
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "repoId": {
-                "type": "number",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "ref",
-              "repoId",
-              "sha",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "host": {
-                "type": "string",
-              },
-              "org": {
-                "type": "string",
-              },
-              "ref": {
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "repoId": {
-                "type": "number",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github-custom-host",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "host",
-              "ref",
-              "repoId",
-              "sha",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "org": {
-                "type": "string",
-              },
-              "ref": {
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "repoId": {
-                "type": "number",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "github-limited",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "ref",
-              "repoId",
-              "sha",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "projectId": {
-                "type": "number",
-              },
-              "ref": {
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "gitlab",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "projectId",
-              "ref",
-              "sha",
-              "type",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "owner": {
-                "type": "string",
-              },
-              "ref": {
-                "type": "string",
-              },
-              "repoUuid": {
-                "type": "string",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "slug": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "bitbucket",
-                ],
-                "type": "string",
-              },
-              "workspaceUuid": {
-                "type": "string",
-              },
-            },
-            "required": [
-              "ref",
-              "repoUuid",
-              "sha",
-              "type",
-              "workspaceUuid",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "org": {
-                "type": "string",
-              },
-              "ref": {
-                "type": "string",
-              },
-              "repo": {
-                "type": "string",
-              },
-              "repoPushedAt": {
-                "type": "number",
-              },
-              "sha": {
-                "type": "string",
-              },
-              "type": {
-                "enum": [
-                  "vercel",
-                ],
-                "type": "string",
-              },
-            },
-            "required": [
-              "org",
-              "ref",
-              "repo",
-              "sha",
-              "type",
-            ],
-            "type": "object",
-          },
-        ],
-      },
-      "id": {
-        "description": "A string holding the unique ID of the deployment",
-        "example": "dpl_89qyp1cskzkLrVicDaZoDbjyHuDJ",
-        "type": "string",
-      },
-      "images": {
-        "properties": {
-          "contentDispositionType": {
-            "enum": [
-              "inline",
-              "attachment",
-            ],
-            "type": "string",
-          },
-          "contentSecurityPolicy": {
-            "type": "string",
-          },
-          "dangerouslyAllowSVG": {
-            "enum": [
-              false,
-              true,
-            ],
-            "type": "boolean",
-          },
-          "domains": {
-            "items": {
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "formats": {
-            "items": {
-              "enum": [
-                "image/avif",
-                "image/webp",
-              ],
-              "type": "string",
-            },
-            "type": "array",
-          },
-          "localPatterns": {
-            "items": {
-              "properties": {
-                "pathname": {
-                  "description": "Can be literal or wildcard. Single \`*\` matches a single path segment. Double \`**\` matches any number of path segments.",
-                  "type": "string",
-                },
-                "search": {
-                  "description": "Can be literal query string such as \`?v=1\` or empty string meaning no query string.",
-                  "type": "string",
-                },
-              },
-              "type": "object",
-            },
-            "type": "array",
-          },
-          "minimumCacheTTL": {
-            "type": "number",
-          },
-          "qualities": {
-            "items": {
-              "type": "number",
-            },
-            "type": "array",
-          },
-          "remotePatterns": {
-            "items": {
-              "properties": {
-                "hostname": {
-                  "description": "Can be literal or wildcard. Single \`*\` matches a single subdomain. Double \`**\` matches any number of subdomains.",
-                  "type": "string",
-                },
-                "pathname": {
-                  "description": "Can be literal or wildcard. Single \`*\` matches a single path segment. Double \`**\` matches any number of path segments.",
-                  "type": "string",
-                },
-                "port": {
-                  "description": "Can be literal port such as \`8080\` or empty string meaning no port.",
-                  "type": "string",
-                },
-                "protocol": {
-                  "description": "Must be \`http\` or \`https\`.",
-                  "enum": [
-                    "http",
-                    "https",
-                  ],
-                  "type": "string",
-                },
-                "search": {
-                  "description": "Can be literal query string such as \`?v=1\` or empty string meaning no query string.",
-                  "type": "string",
+                "readyStateAt": {
+                  "type": "number",
                 },
               },
               "required": [
-                "hostname",
+                "id",
+                "output",
               ],
               "type": "object",
             },
             "type": "array",
           },
-          "sizes": {
-            "items": {
-              "type": "number",
-            },
-            "type": "array",
-          },
-        },
-        "type": "object",
-      },
-      "initReadyAt": {
-        "type": "number",
-      },
-      "inspectorUrl": {
-        "nullable": true,
-        "type": "string",
-      },
-      "integrations": {
-        "properties": {
-          "claimedAt": {
-            "type": "number",
-          },
-          "completedAt": {
-            "type": "number",
-          },
-          "skippedAt": {
-            "type": "number",
-          },
-          "skippedBy": {
-            "type": "string",
-          },
-          "startedAt": {
-            "type": "number",
-          },
-          "status": {
-            "enum": [
-              "skipped",
-              "pending",
-              "ready",
-              "error",
-              "timeout",
-            ],
-            "type": "string",
-          },
-        },
-        "required": [
-          "startedAt",
-          "status",
-        ],
-        "type": "object",
-      },
-      "isFirstBranchDeployment": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "isInConcurrentBuildsQueue": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "isInSystemBuildsQueue": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "lambdas": {
-        "items": {
-          "description": "A partial representation of a Build used by the deployment endpoint.",
-          "properties": {
-            "createdAt": {
-              "type": "number",
-            },
-            "entrypoint": {
-              "nullable": true,
-              "type": "string",
-            },
-            "id": {
-              "type": "string",
-            },
-            "output": {
-              "items": {
-                "properties": {
-                  "functionName": {
-                    "type": "string",
-                  },
-                  "path": {
-                    "type": "string",
-                  },
-                },
-                "required": [
-                  "functionName",
-                  "path",
-                ],
-                "type": "object",
-              },
-              "type": "array",
-            },
-            "readyState": {
-              "enum": [
-                "BUILDING",
-                "ERROR",
-                "INITIALIZING",
-                "READY",
-              ],
-              "type": "string",
-            },
-            "readyStateAt": {
-              "type": "number",
-            },
-          },
-          "required": [
-            "id",
-            "output",
-          ],
-          "type": "object",
-        },
-        "type": "array",
-      },
-      "manualProvisioning": {
-        "description": "Present when deployment was created with manual provisioning enabled, either explicitly or via the experimental BYOC git flow. The deployment stays in INITIALIZING until /continue is called.",
-        "properties": {
-          "completedAt": {
-            "description": "Timestamp when manual provisioning completed",
-            "type": "number",
-          },
-          "state": {
-            "description": "Current provisioning state",
-            "enum": [
-              "PENDING",
-              "COMPLETE",
-              "TIMEOUT",
-            ],
-            "type": "string",
-          },
-        },
-        "required": [
-          "state",
-        ],
-        "type": "object",
-      },
-      "meta": {
-        "additionalProperties": {
-          "type": "string",
-        },
-        "type": "object",
-      },
-      "microfrontends": {
-        "oneOf": [
-          {
+          "manualProvisioning": {
+            "description": "Present when deployment was created with manual provisioning enabled, either explicitly or via the experimental BYOC git flow. The deployment stays in INITIALIZING until /continue is called.",
             "properties": {
-              "defaultAppProjectName": {
-                "description": "The project name of the default app of this deployment's microfrontends group.",
-                "type": "string",
+              "completedAt": {
+                "description": "Timestamp when manual provisioning completed",
+                "type": "number",
               },
-              "defaultRoute": {
-                "description": "A path that is used to take screenshots and as the default path in preview links when a domain for this microfrontend is shown in the UI.",
-                "type": "string",
-              },
-              "groupIds": {
-                "description": "The group of microfrontends that this project belongs to. Each microfrontend project must belong to a microfrontends group that is the set of microfrontends that are used together.",
-                "items": {
-                  "type": "string",
-                },
-                "minItems": 1,
-                "type": "array",
-              },
-              "isDefaultApp": {
+              "state": {
+                "description": "Current provisioning state",
                 "enum": [
-                  false,
-                ],
-                "type": "boolean",
-              },
-            },
-            "required": [
-              "defaultAppProjectName",
-              "groupIds",
-            ],
-            "type": "object",
-          },
-          {
-            "properties": {
-              "defaultAppProjectName": {
-                "description": "The project name of the default app of this deployment's microfrontends group.",
-                "type": "string",
-              },
-              "defaultRoute": {
-                "description": "A path that is used to take screenshots and as the default path in preview links when a domain for this microfrontend is shown in the UI.",
-                "type": "string",
-              },
-              "groupIds": {
-                "description": "The group of microfrontends that this project belongs to. Each microfrontend project must belong to a microfrontends group that is the set of microfrontends that are used together.",
-                "items": {
-                  "type": "string",
-                },
-                "minItems": 1,
-                "type": "array",
-              },
-              "isDefaultApp": {
-                "enum": [
-                  true,
-                ],
-                "type": "boolean",
-              },
-              "mfeConfigUploadState": {
-                "description": "The result of the microfrontends config upload during deployment creation / build. Only set for default app deployments. The config upload is attempted during deployment create, and then again during the build. If the config is not in the root directory, or the deployment is prebuilt, the config cannot be uploaded during deployment create. The upload during deployment build finds the config even if it's not in the root directory, as it has access to all files. Uploading the config during create is ideal, as then all child deployments are guaranteed to have access to the default app deployment config even if the default app has not yet started building. If the config is not uploaded, the child app will show as building until the config has been uploaded during the default app build. - \`success\` - The config was uploaded successfully, either when the deployment was created or during the build. - \`waiting_on_build\` - The config could not be uploaded during deployment create, will be attempted again during the build. - \`no_config\` - No config was found. Only set once the build has not found the config in any of the deployment's files. - \`undefined\` - Legacy deployments, or there was an error uploading the config during deployment create.",
-                "enum": [
-                  "success",
-                  "waiting_on_build",
-                  "no_config",
+                  "PENDING",
+                  "COMPLETE",
+                  "TIMEOUT",
                 ],
                 "type": "string",
               },
             },
             "required": [
-              "defaultAppProjectName",
-              "groupIds",
-              "isDefaultApp",
-            ],
-            "type": "object",
-          },
-        ],
-      },
-      "monorepoManager": {
-        "nullable": true,
-        "type": "string",
-      },
-      "name": {
-        "description": "The name of the project associated with the deployment at the time that the deployment was created",
-        "example": "my-project",
-        "type": "string",
-      },
-      "nodeVersion": {
-        "description": "If set it overrides the \`projectSettings.nodeVersion\` for this deployment.",
-        "enum": [
-          "24.x",
-          "22.x",
-          "20.x",
-          "18.x",
-          "16.x",
-          "14.x",
-          "12.x",
-          "10.x",
-          "8.10.x",
-        ],
-        "type": "string",
-      },
-      "oidcTokenClaims": {
-        "properties": {
-          "aud": {
-            "type": "string",
-          },
-          "custom_environment_id": {
-            "type": "string",
-          },
-          "environment": {
-            "type": "string",
-          },
-          "iss": {
-            "type": "string",
-          },
-          "owner": {
-            "type": "string",
-          },
-          "owner_id": {
-            "type": "string",
-          },
-          "plan": {
-            "type": "string",
-          },
-          "project": {
-            "type": "string",
-          },
-          "project_id": {
-            "type": "string",
-          },
-          "scope": {
-            "type": "string",
-          },
-          "sub": {
-            "type": "string",
-          },
-        },
-        "required": [
-          "aud",
-          "environment",
-          "iss",
-          "owner",
-          "owner_id",
-          "project",
-          "project_id",
-          "scope",
-          "sub",
-        ],
-        "type": "object",
-      },
-      "oomReport": {
-        "enum": [
-          "out-of-memory",
-        ],
-        "type": "string",
-      },
-      "originCacheRegion": {
-        "type": "string",
-      },
-      "ownerId": {
-        "type": "string",
-      },
-      "passiveConnectConfigurationId": {
-        "description": "Since November 2023 this field defines a Secure Compute network that will only be used to deploy passive lambdas to (as in passiveRegions)",
-        "type": "string",
-      },
-      "passiveRegions": {
-        "description": "Since November 2023 this field defines a set of regions that we will deploy the lambda to passively Lambdas will be deployed to these regions but only invoked if all of the primary \`regions\` are marked as out of service",
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "plan": {
-        "enum": [
-          "pro",
-          "enterprise",
-          "hobby",
-        ],
-        "type": "string",
-      },
-      "platform": {
-        "description": "Metadata about the source platform that triggered the deployment. Allows us to map a deployment back to a platform (e.g. the chat that created it)",
-        "properties": {
-          "creator": {
-            "description": "The user on the external platform who triggered the deployment.",
-            "properties": {
-              "avatar": {
-                "description": "URL of the platform user's avatar image.",
-                "type": "string",
-              },
-              "name": {
-                "description": "Display name of the platform user.",
-                "type": "string",
-              },
-            },
-            "required": [
-              "name",
+              "state",
             ],
             "type": "object",
           },
@@ -3204,186 +3021,95 @@ exports[`Real specs: Vercel API > preserves registered tool schema and TypeScrip
             "additionalProperties": {
               "type": "string",
             },
-            "description": "Arbitrary key-value metadata provided by the platform.",
             "type": "object",
           },
-          "origin": {
-            "description": "Reference back to the entity on the platform that initiated the deployment.",
-            "properties": {
-              "type": {
-                "description": "Whether the value is an opaque identifier or a URL.",
-                "enum": [
-                  "id",
-                  "url",
+          "microfrontends": {
+            "oneOf": [
+              {
+                "properties": {
+                  "defaultAppProjectName": {
+                    "description": "The project name of the default app of this deployment's microfrontends group.",
+                    "type": "string",
+                  },
+                  "defaultRoute": {
+                    "description": "A path that is used to take screenshots and as the default path in preview links when a domain for this microfrontend is shown in the UI.",
+                    "type": "string",
+                  },
+                  "groupIds": {
+                    "description": "The group of microfrontends that this project belongs to. Each microfrontend project must belong to a microfrontends group that is the set of microfrontends that are used together.",
+                    "items": {
+                      "type": "string",
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                  },
+                  "isDefaultApp": {
+                    "enum": [
+                      false,
+                    ],
+                    "type": "boolean",
+                  },
+                },
+                "required": [
+                  "defaultAppProjectName",
+                  "groupIds",
                 ],
-                "type": "string",
+                "type": "object",
               },
-              "value": {
-                "description": "The identifier or URL pointing to the originating entity.",
-                "type": "string",
+              {
+                "properties": {
+                  "defaultAppProjectName": {
+                    "description": "The project name of the default app of this deployment's microfrontends group.",
+                    "type": "string",
+                  },
+                  "defaultRoute": {
+                    "description": "A path that is used to take screenshots and as the default path in preview links when a domain for this microfrontend is shown in the UI.",
+                    "type": "string",
+                  },
+                  "groupIds": {
+                    "description": "The group of microfrontends that this project belongs to. Each microfrontend project must belong to a microfrontends group that is the set of microfrontends that are used together.",
+                    "items": {
+                      "type": "string",
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                  },
+                  "isDefaultApp": {
+                    "enum": [
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "mfeConfigUploadState": {
+                    "description": "The result of the microfrontends config upload during deployment creation / build. Only set for default app deployments. The config upload is attempted during deployment create, and then again during the build. If the config is not in the root directory, or the deployment is prebuilt, the config cannot be uploaded during deployment create. The upload during deployment build finds the config even if it's not in the root directory, as it has access to all files. Uploading the config during create is ideal, as then all child deployments are guaranteed to have access to the default app deployment config even if the default app has not yet started building. If the config is not uploaded, the child app will show as building until the config has been uploaded during the default app build. - \`success\` - The config was uploaded successfully, either when the deployment was created or during the build. - \`waiting_on_build\` - The config could not be uploaded during deployment create, will be attempted again during the build. - \`no_config\` - No config was found. Only set once the build has not found the config in any of the deployment's files. - \`undefined\` - Legacy deployments, or there was an error uploading the config during deployment create.",
+                    "enum": [
+                      "success",
+                      "waiting_on_build",
+                      "no_config",
+                    ],
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "defaultAppProjectName",
+                  "groupIds",
+                  "isDefaultApp",
+                ],
+                "type": "object",
               },
-            },
-            "required": [
-              "type",
-              "value",
             ],
-            "type": "object",
           },
-          "source": {
-            "description": "The external platform that created the deployment (e.g. its display name).",
-            "properties": {
-              "name": {
-                "description": "Display name of the platform.",
-                "type": "string",
-              },
-            },
-            "required": [
-              "name",
-            ],
-            "type": "object",
-          },
-        },
-        "required": [
-          "creator",
-          "origin",
-          "source",
-        ],
-        "type": "object",
-      },
-      "prebuilt": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "previewCommentsEnabled": {
-        "description": "Whether or not preview comments are enabled for the deployment",
-        "enum": [
-          false,
-          true,
-        ],
-        "example": false,
-        "type": "boolean",
-      },
-      "project": {
-        "description": "The public project information associated with the deployment.",
-        "properties": {
-          "framework": {
+          "monorepoManager": {
             "nullable": true,
-            "type": "string",
-          },
-          "id": {
             "type": "string",
           },
           "name": {
-            "type": "string",
-          },
-        },
-        "required": [
-          "id",
-          "name",
-        ],
-        "type": "object",
-      },
-      "projectId": {
-        "type": "string",
-      },
-      "projectSettings": {
-        "properties": {
-          "buildCommand": {
-            "nullable": true,
-            "type": "string",
-          },
-          "commandForIgnoringBuildStep": {
-            "nullable": true,
-            "type": "string",
-          },
-          "devCommand": {
-            "nullable": true,
-            "type": "string",
-          },
-          "framework": {
-            "enum": [
-              "blitzjs",
-              "nextjs",
-              "gatsby",
-              "remix",
-              "react-router",
-              "astro",
-              "hexo",
-              "eleventy",
-              "docusaurus-2",
-              "docusaurus",
-              "preact",
-              "solidstart-1",
-              "solidstart",
-              "dojo",
-              "ember",
-              "vue",
-              "scully",
-              "ionic-angular",
-              "angular",
-              "polymer",
-              "svelte",
-              "sveltekit",
-              "sveltekit-1",
-              "ionic-react",
-              "create-react-app",
-              "gridsome",
-              "umijs",
-              "sapper",
-              "saber",
-              "stencil",
-              "nuxtjs",
-              "redwoodjs",
-              "hugo",
-              "jekyll",
-              "brunch",
-              "middleman",
-              "zola",
-              "hydrogen",
-              "vite",
-              "tanstack-start",
-              "vitepress",
-              "vuepress",
-              "parcel",
-              "fastapi",
-              "flask",
-              "fasthtml",
-              "django",
-              "ash",
-              "sanity-v3",
-              "sanity",
-              "storybook",
-              "nitro",
-              "hono",
-              "express",
-              "h3",
-              "koa",
-              "nestjs",
-              "elysia",
-              "fastify",
-              "xmcp",
-              "python",
-              "ruby",
-              "rust",
-              "axum",
-              "actix-web",
-              "node",
-              "go",
-              "services",
-              "mastra",
-              null,
-            ],
-            "nullable": true,
-            "type": "string",
-          },
-          "installCommand": {
-            "nullable": true,
+            "description": "The name of the project associated with the deployment at the time that the deployment was created",
+            "example": "my-project",
             "type": "string",
           },
           "nodeVersion": {
+            "description": "If set it overrides the \`projectSettings.nodeVersion\` for this deployment.",
             "enum": [
               "24.x",
               "22.x",
@@ -3397,935 +3123,1249 @@ exports[`Real specs: Vercel API > preserves registered tool schema and TypeScrip
             ],
             "type": "string",
           },
-          "outputDirectory": {
-            "nullable": true,
-            "type": "string",
-          },
-          "speedInsights": {
+          "oidcTokenClaims": {
             "properties": {
-              "canceledAt": {
-                "type": "number",
-              },
-              "disabledAt": {
-                "type": "number",
-              },
-              "enabledAt": {
-                "type": "number",
-              },
-              "hasData": {
-                "enum": [
-                  false,
-                  true,
-                ],
-                "type": "boolean",
-              },
-              "id": {
+              "aud": {
                 "type": "string",
               },
-              "paidAt": {
-                "type": "number",
+              "custom_environment_id": {
+                "type": "string",
               },
-            },
-            "required": [
-              "id",
-            ],
-            "type": "object",
-          },
-          "webAnalytics": {
-            "properties": {
-              "canceledAt": {
-                "type": "number",
+              "environment": {
+                "type": "string",
               },
-              "disabledAt": {
-                "type": "number",
+              "iss": {
+                "type": "string",
               },
-              "enabledAt": {
-                "type": "number",
+              "owner": {
+                "type": "string",
               },
-              "hasData": {
-                "enum": [
-                  true,
-                ],
-                "type": "boolean",
+              "owner_id": {
+                "type": "string",
               },
-              "id": {
+              "plan": {
+                "type": "string",
+              },
+              "project": {
+                "type": "string",
+              },
+              "project_id": {
+                "type": "string",
+              },
+              "scope": {
+                "type": "string",
+              },
+              "sub": {
                 "type": "string",
               },
             },
             "required": [
-              "id",
+              "aud",
+              "environment",
+              "iss",
+              "owner",
+              "owner_id",
+              "project",
+              "project_id",
+              "scope",
+              "sub",
             ],
             "type": "object",
           },
-        },
-        "type": "object",
-      },
-      "public": {
-        "description": "A boolean representing if the deployment is public or not. By default this is \`false\`",
-        "enum": [
-          false,
-          true,
-        ],
-        "example": false,
-        "type": "boolean",
-      },
-      "ready": {
-        "type": "number",
-      },
-      "readyState": {
-        "description": "The state of the deployment depending on the process of deploying, or if it is ready or in an error state",
-        "enum": [
-          "QUEUED",
-          "BUILDING",
-          "ERROR",
-          "BLOCKED",
-          "INITIALIZING",
-          "READY",
-          "CANCELED",
-        ],
-        "example": "READY",
-        "type": "string",
-      },
-      "readyStateReason": {
-        "type": "string",
-      },
-      "readySubstate": {
-        "description": "Substate of deployment when readyState is 'READY' Tracks whether or not deployment has seen production traffic: - STAGED: never seen production traffic - ROLLING: in the process of having production traffic gradually transitioned. - PROMOTED: has seen production traffic",
-        "enum": [
-          "STAGED",
-          "ROLLING",
-          "PROMOTED",
-        ],
-        "type": "string",
-      },
-      "regions": {
-        "description": "The regions the deployment exists in",
-        "example": [
-          "sfo1",
-        ],
-        "items": {
-          "type": "string",
-        },
-        "type": "array",
-      },
-      "routes": {
-        "items": {
-          "oneOf": [
-            {
-              "properties": {
-                "caseSensitive": {
-                  "enum": [
-                    false,
-                    true,
-                  ],
-                  "type": "boolean",
-                },
-                "check": {
-                  "enum": [
-                    false,
-                    true,
-                  ],
-                  "type": "boolean",
-                },
-                "continue": {
-                  "enum": [
-                    false,
-                    true,
-                  ],
-                  "type": "boolean",
-                },
-                "dest": {
-                  "type": "string",
-                },
-                "destination": {
-                  "type": "string",
-                },
-                "env": {
-                  "items": {
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "has": {
-                  "items": {
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "type": {
-                            "enum": [
-                              "host",
-                            ],
-                            "type": "string",
-                          },
-                          "value": {
-                            "oneOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "properties": {
-                                  "eq": {
-                                    "oneOf": [
-                                      {
-                                        "type": "string",
-                                      },
-                                      {
-                                        "type": "number",
-                                      },
-                                    ],
-                                  },
-                                  "gt": {
-                                    "type": "number",
-                                  },
-                                  "gte": {
-                                    "type": "number",
-                                  },
-                                  "inc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "lt": {
-                                    "type": "number",
-                                  },
-                                  "lte": {
-                                    "type": "number",
-                                  },
-                                  "neq": {
-                                    "type": "string",
-                                  },
-                                  "ninc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "pre": {
-                                    "type": "string",
-                                  },
-                                  "re": {
-                                    "type": "string",
-                                  },
-                                  "suf": {
-                                    "type": "string",
-                                  },
-                                },
-                                "type": "object",
-                              },
-                            ],
-                          },
-                        },
-                        "required": [
-                          "type",
-                          "value",
-                        ],
-                        "type": "object",
-                      },
-                      {
-                        "properties": {
-                          "key": {
-                            "type": "string",
-                          },
-                          "type": {
-                            "enum": [
-                              "header",
-                              "cookie",
-                              "query",
-                            ],
-                            "type": "string",
-                          },
-                          "value": {
-                            "oneOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "properties": {
-                                  "eq": {
-                                    "oneOf": [
-                                      {
-                                        "type": "string",
-                                      },
-                                      {
-                                        "type": "number",
-                                      },
-                                    ],
-                                  },
-                                  "gt": {
-                                    "type": "number",
-                                  },
-                                  "gte": {
-                                    "type": "number",
-                                  },
-                                  "inc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "lt": {
-                                    "type": "number",
-                                  },
-                                  "lte": {
-                                    "type": "number",
-                                  },
-                                  "neq": {
-                                    "type": "string",
-                                  },
-                                  "ninc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "pre": {
-                                    "type": "string",
-                                  },
-                                  "re": {
-                                    "type": "string",
-                                  },
-                                  "suf": {
-                                    "type": "string",
-                                  },
-                                },
-                                "type": "object",
-                              },
-                            ],
-                          },
-                        },
-                        "required": [
-                          "key",
-                          "type",
-                        ],
-                        "type": "object",
-                      },
-                    ],
-                  },
-                  "type": "array",
-                },
-                "headers": {
-                  "additionalProperties": {
-                    "type": "string",
-                  },
-                  "type": "object",
-                },
-                "important": {
-                  "enum": [
-                    false,
-                    true,
-                  ],
-                  "type": "boolean",
-                },
-                "locale": {
-                  "properties": {
-                    "cookie": {
-                      "type": "string",
-                    },
-                    "redirect": {
-                      "additionalProperties": {
-                        "type": "string",
-                      },
-                      "type": "object",
-                    },
-                  },
-                  "type": "object",
-                },
-                "methods": {
-                  "items": {
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "middleware": {
-                  "description": "A middleware index in the \`middleware\` key under the build result",
-                  "type": "number",
-                },
-                "middlewarePath": {
-                  "description": "A middleware key within the \`output\` key under the build result. Overrides a \`middleware\` definition.",
-                  "type": "string",
-                },
-                "middlewareRawSrc": {
-                  "description": "The original middleware matchers.",
-                  "items": {
-                    "type": "string",
-                  },
-                  "type": "array",
-                },
-                "missing": {
-                  "items": {
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "type": {
-                            "enum": [
-                              "host",
-                            ],
-                            "type": "string",
-                          },
-                          "value": {
-                            "oneOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "properties": {
-                                  "eq": {
-                                    "oneOf": [
-                                      {
-                                        "type": "string",
-                                      },
-                                      {
-                                        "type": "number",
-                                      },
-                                    ],
-                                  },
-                                  "gt": {
-                                    "type": "number",
-                                  },
-                                  "gte": {
-                                    "type": "number",
-                                  },
-                                  "inc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "lt": {
-                                    "type": "number",
-                                  },
-                                  "lte": {
-                                    "type": "number",
-                                  },
-                                  "neq": {
-                                    "type": "string",
-                                  },
-                                  "ninc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "pre": {
-                                    "type": "string",
-                                  },
-                                  "re": {
-                                    "type": "string",
-                                  },
-                                  "suf": {
-                                    "type": "string",
-                                  },
-                                },
-                                "type": "object",
-                              },
-                            ],
-                          },
-                        },
-                        "required": [
-                          "type",
-                          "value",
-                        ],
-                        "type": "object",
-                      },
-                      {
-                        "properties": {
-                          "key": {
-                            "type": "string",
-                          },
-                          "type": {
-                            "enum": [
-                              "header",
-                              "cookie",
-                              "query",
-                            ],
-                            "type": "string",
-                          },
-                          "value": {
-                            "oneOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "properties": {
-                                  "eq": {
-                                    "oneOf": [
-                                      {
-                                        "type": "string",
-                                      },
-                                      {
-                                        "type": "number",
-                                      },
-                                    ],
-                                  },
-                                  "gt": {
-                                    "type": "number",
-                                  },
-                                  "gte": {
-                                    "type": "number",
-                                  },
-                                  "inc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "lt": {
-                                    "type": "number",
-                                  },
-                                  "lte": {
-                                    "type": "number",
-                                  },
-                                  "neq": {
-                                    "type": "string",
-                                  },
-                                  "ninc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "pre": {
-                                    "type": "string",
-                                  },
-                                  "re": {
-                                    "type": "string",
-                                  },
-                                  "suf": {
-                                    "type": "string",
-                                  },
-                                },
-                                "type": "object",
-                              },
-                            ],
-                          },
-                        },
-                        "required": [
-                          "key",
-                          "type",
-                        ],
-                        "type": "object",
-                      },
-                    ],
-                  },
-                  "type": "array",
-                },
-                "mitigate": {
-                  "properties": {
-                    "action": {
-                      "enum": [
-                        "challenge",
-                        "deny",
-                      ],
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "action",
-                  ],
-                  "type": "object",
-                },
-                "override": {
-                  "enum": [
-                    false,
-                    true,
-                  ],
-                  "type": "boolean",
-                },
-                "respectOriginCacheControl": {
-                  "enum": [
-                    false,
-                    true,
-                  ],
-                  "type": "boolean",
-                },
-                "source": {
-                  "description": "Aliases for \`src\`, \`dest\`, and \`status\`. These provide consistency with the \`rewrites\`, \`redirects\`, and \`headers\` fields which use \`source\`, \`destination\`, and \`statusCode\`. During normalization, these are converted to their canonical forms (\`src\`, \`dest\`, \`status\`) and stripped from the route object.",
-                  "type": "string",
-                },
-                "src": {
-                  "type": "string",
-                },
-                "status": {
-                  "type": "number",
-                },
-                "statusCode": {
-                  "type": "number",
-                },
-                "transforms": {
-                  "items": {
-                    "properties": {
-                      "args": {
-                        "oneOf": [
-                          {
-                            "type": "string",
-                          },
-                          {
-                            "items": {
-                              "type": "string",
-                            },
-                            "type": "array",
-                          },
-                        ],
-                      },
-                      "env": {
-                        "items": {
-                          "type": "string",
-                        },
-                        "type": "array",
-                      },
-                      "op": {
-                        "enum": [
-                          "append",
-                          "set",
-                          "delete",
-                        ],
-                        "type": "string",
-                      },
-                      "target": {
-                        "properties": {
-                          "key": {
-                            "oneOf": [
-                              {
-                                "type": "string",
-                              },
-                              {
-                                "properties": {
-                                  "eq": {
-                                    "oneOf": [
-                                      {
-                                        "type": "string",
-                                      },
-                                      {
-                                        "type": "number",
-                                      },
-                                    ],
-                                  },
-                                  "gt": {
-                                    "type": "number",
-                                  },
-                                  "gte": {
-                                    "type": "number",
-                                  },
-                                  "inc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "lt": {
-                                    "type": "number",
-                                  },
-                                  "lte": {
-                                    "type": "number",
-                                  },
-                                  "neq": {
-                                    "type": "string",
-                                  },
-                                  "ninc": {
-                                    "items": {
-                                      "type": "string",
-                                    },
-                                    "type": "array",
-                                  },
-                                  "pre": {
-                                    "type": "string",
-                                  },
-                                  "suf": {
-                                    "type": "string",
-                                  },
-                                },
-                                "type": "object",
-                              },
-                            ],
-                          },
-                        },
-                        "required": [
-                          "key",
-                        ],
-                        "type": "object",
-                      },
-                      "type": {
-                        "enum": [
-                          "request.headers",
-                          "request.query",
-                          "response.headers",
-                        ],
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "op",
-                      "target",
-                      "type",
-                    ],
-                    "type": "object",
-                  },
-                  "type": "array",
-                },
-              },
-              "required": [
-                "src",
-              ],
-              "type": "object",
-            },
-            {
-              "properties": {
-                "dest": {
-                  "type": "string",
-                },
-                "handle": {
-                  "enum": [
-                    "error",
-                    "filesystem",
-                    "hit",
-                    "miss",
-                    "rewrite",
-                    "resource",
-                  ],
-                  "type": "string",
-                },
-                "src": {
-                  "type": "string",
-                },
-                "status": {
-                  "type": "number",
-                },
-              },
-              "required": [
-                "handle",
-              ],
-              "type": "object",
-            },
-            {
-              "properties": {
-                "continue": {
-                  "enum": [
-                    false,
-                    true,
-                  ],
-                  "type": "boolean",
-                },
-                "middleware": {
-                  "enum": [
-                    0,
-                  ],
-                  "type": "number",
-                },
-                "src": {
-                  "type": "string",
-                },
-              },
-              "required": [
-                "continue",
-                "middleware",
-                "src",
-              ],
-              "type": "object",
-            },
-          ],
-        },
-        "nullable": true,
-        "type": "array",
-      },
-      "seatBlock": {
-        "description": "NSNB Blocked metadata",
-        "properties": {
-          "blockCode": {
-            "description": "The NSNB decision code for the seat block. TODO: We should consolidate block types.",
+          "oomReport": {
             "enum": [
-              "TEAM_ACCESS_REQUIRED",
-              "COMMIT_AUTHOR_REQUIRED",
+              "out-of-memory",
             ],
             "type": "string",
           },
-          "gitProvider": {
-            "description": "The git provider type associated with gitUserId.",
+          "originCacheRegion": {
+            "type": "string",
+          },
+          "ownerId": {
+            "type": "string",
+          },
+          "passiveConnectConfigurationId": {
+            "description": "Since November 2023 this field defines a Secure Compute network that will only be used to deploy passive lambdas to (as in passiveRegions)",
+            "type": "string",
+          },
+          "passiveRegions": {
+            "description": "Since November 2023 this field defines a set of regions that we will deploy the lambda to passively Lambdas will be deployed to these regions but only invoked if all of the primary \`regions\` are marked as out of service",
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "plan": {
             "enum": [
-              "gitlab",
-              "bitbucket",
-              "github",
+              "pro",
+              "enterprise",
+              "hobby",
             ],
             "type": "string",
           },
-          "gitUserId": {
-            "oneOf": [
-              {
-                "type": "string",
+          "platform": {
+            "description": "Metadata about the source platform that triggered the deployment. Allows us to map a deployment back to a platform (e.g. the chat that created it)",
+            "properties": {
+              "creator": {
+                "description": "The user on the external platform who triggered the deployment.",
+                "properties": {
+                  "avatar": {
+                    "description": "URL of the platform user's avatar image.",
+                    "type": "string",
+                  },
+                  "name": {
+                    "description": "Display name of the platform user.",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "name",
+                ],
+                "type": "object",
               },
-              {
-                "type": "number",
+              "meta": {
+                "additionalProperties": {
+                  "type": "string",
+                },
+                "description": "Arbitrary key-value metadata provided by the platform.",
+                "type": "object",
               },
+              "origin": {
+                "description": "Reference back to the entity on the platform that initiated the deployment.",
+                "properties": {
+                  "type": {
+                    "description": "Whether the value is an opaque identifier or a URL.",
+                    "enum": [
+                      "id",
+                      "url",
+                    ],
+                    "type": "string",
+                  },
+                  "value": {
+                    "description": "The identifier or URL pointing to the originating entity.",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "type",
+                  "value",
+                ],
+                "type": "object",
+              },
+              "source": {
+                "description": "The external platform that created the deployment (e.g. its display name).",
+                "properties": {
+                  "name": {
+                    "description": "Display name of the platform.",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "name",
+                ],
+                "type": "object",
+              },
+            },
+            "required": [
+              "creator",
+              "origin",
+              "source",
             ],
+            "type": "object",
           },
-          "isVerified": {
-            "description": "Determines if the user was verified during the block. In the git integration case, the commit sender was the author.",
+          "prebuilt": {
             "enum": [
               false,
               true,
             ],
             "type": "boolean",
           },
-          "userId": {
-            "description": "The blocked vercel user ID.",
+          "previewCommentsEnabled": {
+            "description": "Whether or not preview comments are enabled for the deployment",
+            "enum": [
+              false,
+              true,
+            ],
+            "example": false,
+            "type": "boolean",
+          },
+          "project": {
+            "description": "The public project information associated with the deployment.",
+            "properties": {
+              "framework": {
+                "nullable": true,
+                "type": "string",
+              },
+              "id": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "id",
+              "name",
+            ],
+            "type": "object",
+          },
+          "projectId": {
             "type": "string",
+          },
+          "projectSettings": {
+            "properties": {
+              "buildCommand": {
+                "nullable": true,
+                "type": "string",
+              },
+              "commandForIgnoringBuildStep": {
+                "nullable": true,
+                "type": "string",
+              },
+              "devCommand": {
+                "nullable": true,
+                "type": "string",
+              },
+              "framework": {
+                "enum": [
+                  "blitzjs",
+                  "nextjs",
+                  "gatsby",
+                  "remix",
+                  "react-router",
+                  "astro",
+                  "hexo",
+                  "eleventy",
+                  "docusaurus-2",
+                  "docusaurus",
+                  "preact",
+                  "solidstart-1",
+                  "solidstart",
+                  "dojo",
+                  "ember",
+                  "vue",
+                  "scully",
+                  "ionic-angular",
+                  "angular",
+                  "polymer",
+                  "svelte",
+                  "sveltekit",
+                  "sveltekit-1",
+                  "ionic-react",
+                  "create-react-app",
+                  "gridsome",
+                  "umijs",
+                  "sapper",
+                  "saber",
+                  "stencil",
+                  "nuxtjs",
+                  "redwoodjs",
+                  "hugo",
+                  "jekyll",
+                  "brunch",
+                  "middleman",
+                  "zola",
+                  "hydrogen",
+                  "vite",
+                  "tanstack-start",
+                  "vitepress",
+                  "vuepress",
+                  "parcel",
+                  "fastapi",
+                  "flask",
+                  "fasthtml",
+                  "django",
+                  "ash",
+                  "sanity-v3",
+                  "sanity",
+                  "storybook",
+                  "nitro",
+                  "hono",
+                  "express",
+                  "h3",
+                  "koa",
+                  "nestjs",
+                  "elysia",
+                  "fastify",
+                  "xmcp",
+                  "python",
+                  "ruby",
+                  "rust",
+                  "axum",
+                  "actix-web",
+                  "node",
+                  "go",
+                  "services",
+                  "mastra",
+                  null,
+                ],
+                "nullable": true,
+                "type": "string",
+              },
+              "installCommand": {
+                "nullable": true,
+                "type": "string",
+              },
+              "nodeVersion": {
+                "enum": [
+                  "24.x",
+                  "22.x",
+                  "20.x",
+                  "18.x",
+                  "16.x",
+                  "14.x",
+                  "12.x",
+                  "10.x",
+                  "8.10.x",
+                ],
+                "type": "string",
+              },
+              "outputDirectory": {
+                "nullable": true,
+                "type": "string",
+              },
+              "speedInsights": {
+                "properties": {
+                  "canceledAt": {
+                    "type": "number",
+                  },
+                  "disabledAt": {
+                    "type": "number",
+                  },
+                  "enabledAt": {
+                    "type": "number",
+                  },
+                  "hasData": {
+                    "enum": [
+                      false,
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "id": {
+                    "type": "string",
+                  },
+                  "paidAt": {
+                    "type": "number",
+                  },
+                },
+                "required": [
+                  "id",
+                ],
+                "type": "object",
+              },
+              "webAnalytics": {
+                "properties": {
+                  "canceledAt": {
+                    "type": "number",
+                  },
+                  "disabledAt": {
+                    "type": "number",
+                  },
+                  "enabledAt": {
+                    "type": "number",
+                  },
+                  "hasData": {
+                    "enum": [
+                      true,
+                    ],
+                    "type": "boolean",
+                  },
+                  "id": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "id",
+                ],
+                "type": "object",
+              },
+            },
+            "type": "object",
+          },
+          "public": {
+            "description": "A boolean representing if the deployment is public or not. By default this is \`false\`",
+            "enum": [
+              false,
+              true,
+            ],
+            "example": false,
+            "type": "boolean",
+          },
+          "ready": {
+            "type": "number",
+          },
+          "readyState": {
+            "description": "The state of the deployment depending on the process of deploying, or if it is ready or in an error state",
+            "enum": [
+              "QUEUED",
+              "BUILDING",
+              "ERROR",
+              "BLOCKED",
+              "INITIALIZING",
+              "READY",
+              "CANCELED",
+            ],
+            "example": "READY",
+            "type": "string",
+          },
+          "readyStateReason": {
+            "type": "string",
+          },
+          "readySubstate": {
+            "description": "Substate of deployment when readyState is 'READY' Tracks whether or not deployment has seen production traffic: - STAGED: never seen production traffic - ROLLING: in the process of having production traffic gradually transitioned. - PROMOTED: has seen production traffic",
+            "enum": [
+              "STAGED",
+              "ROLLING",
+              "PROMOTED",
+            ],
+            "type": "string",
+          },
+          "regions": {
+            "description": "The regions the deployment exists in",
+            "example": [
+              "sfo1",
+            ],
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "routes": {
+            "items": {
+              "oneOf": [
+                {
+                  "properties": {
+                    "caseSensitive": {
+                      "enum": [
+                        false,
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                    "check": {
+                      "enum": [
+                        false,
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                    "continue": {
+                      "enum": [
+                        false,
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                    "dest": {
+                      "type": "string",
+                    },
+                    "destination": {
+                      "type": "string",
+                    },
+                    "env": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "has": {
+                      "items": {
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "host",
+                                ],
+                                "type": "string",
+                              },
+                              "value": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "properties": {
+                                      "eq": {
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "number",
+                                          },
+                                        ],
+                                      },
+                                      "gt": {
+                                        "type": "number",
+                                      },
+                                      "gte": {
+                                        "type": "number",
+                                      },
+                                      "inc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "lt": {
+                                        "type": "number",
+                                      },
+                                      "lte": {
+                                        "type": "number",
+                                      },
+                                      "neq": {
+                                        "type": "string",
+                                      },
+                                      "ninc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "pre": {
+                                        "type": "string",
+                                      },
+                                      "re": {
+                                        "type": "string",
+                                      },
+                                      "suf": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                            },
+                            "required": [
+                              "type",
+                              "value",
+                            ],
+                            "type": "object",
+                          },
+                          {
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                              },
+                              "type": {
+                                "enum": [
+                                  "header",
+                                  "cookie",
+                                  "query",
+                                ],
+                                "type": "string",
+                              },
+                              "value": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "properties": {
+                                      "eq": {
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "number",
+                                          },
+                                        ],
+                                      },
+                                      "gt": {
+                                        "type": "number",
+                                      },
+                                      "gte": {
+                                        "type": "number",
+                                      },
+                                      "inc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "lt": {
+                                        "type": "number",
+                                      },
+                                      "lte": {
+                                        "type": "number",
+                                      },
+                                      "neq": {
+                                        "type": "string",
+                                      },
+                                      "ninc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "pre": {
+                                        "type": "string",
+                                      },
+                                      "re": {
+                                        "type": "string",
+                                      },
+                                      "suf": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "type",
+                            ],
+                            "type": "object",
+                          },
+                        ],
+                      },
+                      "type": "array",
+                    },
+                    "headers": {
+                      "additionalProperties": {
+                        "type": "string",
+                      },
+                      "type": "object",
+                    },
+                    "important": {
+                      "enum": [
+                        false,
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                    "locale": {
+                      "properties": {
+                        "cookie": {
+                          "type": "string",
+                        },
+                        "redirect": {
+                          "additionalProperties": {
+                            "type": "string",
+                          },
+                          "type": "object",
+                        },
+                      },
+                      "type": "object",
+                    },
+                    "methods": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "middleware": {
+                      "description": "A middleware index in the \`middleware\` key under the build result",
+                      "type": "number",
+                    },
+                    "middlewarePath": {
+                      "description": "A middleware key within the \`output\` key under the build result. Overrides a \`middleware\` definition.",
+                      "type": "string",
+                    },
+                    "middlewareRawSrc": {
+                      "description": "The original middleware matchers.",
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "missing": {
+                      "items": {
+                        "oneOf": [
+                          {
+                            "properties": {
+                              "type": {
+                                "enum": [
+                                  "host",
+                                ],
+                                "type": "string",
+                              },
+                              "value": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "properties": {
+                                      "eq": {
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "number",
+                                          },
+                                        ],
+                                      },
+                                      "gt": {
+                                        "type": "number",
+                                      },
+                                      "gte": {
+                                        "type": "number",
+                                      },
+                                      "inc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "lt": {
+                                        "type": "number",
+                                      },
+                                      "lte": {
+                                        "type": "number",
+                                      },
+                                      "neq": {
+                                        "type": "string",
+                                      },
+                                      "ninc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "pre": {
+                                        "type": "string",
+                                      },
+                                      "re": {
+                                        "type": "string",
+                                      },
+                                      "suf": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                            },
+                            "required": [
+                              "type",
+                              "value",
+                            ],
+                            "type": "object",
+                          },
+                          {
+                            "properties": {
+                              "key": {
+                                "type": "string",
+                              },
+                              "type": {
+                                "enum": [
+                                  "header",
+                                  "cookie",
+                                  "query",
+                                ],
+                                "type": "string",
+                              },
+                              "value": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "properties": {
+                                      "eq": {
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "number",
+                                          },
+                                        ],
+                                      },
+                                      "gt": {
+                                        "type": "number",
+                                      },
+                                      "gte": {
+                                        "type": "number",
+                                      },
+                                      "inc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "lt": {
+                                        "type": "number",
+                                      },
+                                      "lte": {
+                                        "type": "number",
+                                      },
+                                      "neq": {
+                                        "type": "string",
+                                      },
+                                      "ninc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "pre": {
+                                        "type": "string",
+                                      },
+                                      "re": {
+                                        "type": "string",
+                                      },
+                                      "suf": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "type",
+                            ],
+                            "type": "object",
+                          },
+                        ],
+                      },
+                      "type": "array",
+                    },
+                    "mitigate": {
+                      "properties": {
+                        "action": {
+                          "enum": [
+                            "challenge",
+                            "deny",
+                          ],
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "action",
+                      ],
+                      "type": "object",
+                    },
+                    "override": {
+                      "enum": [
+                        false,
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                    "respectOriginCacheControl": {
+                      "enum": [
+                        false,
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                    "source": {
+                      "description": "Aliases for \`src\`, \`dest\`, and \`status\`. These provide consistency with the \`rewrites\`, \`redirects\`, and \`headers\` fields which use \`source\`, \`destination\`, and \`statusCode\`. During normalization, these are converted to their canonical forms (\`src\`, \`dest\`, \`status\`) and stripped from the route object.",
+                      "type": "string",
+                    },
+                    "src": {
+                      "type": "string",
+                    },
+                    "status": {
+                      "type": "number",
+                    },
+                    "statusCode": {
+                      "type": "number",
+                    },
+                    "transforms": {
+                      "items": {
+                        "properties": {
+                          "args": {
+                            "oneOf": [
+                              {
+                                "type": "string",
+                              },
+                              {
+                                "items": {
+                                  "type": "string",
+                                },
+                                "type": "array",
+                              },
+                            ],
+                          },
+                          "env": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          "op": {
+                            "enum": [
+                              "append",
+                              "set",
+                              "delete",
+                            ],
+                            "type": "string",
+                          },
+                          "target": {
+                            "properties": {
+                              "key": {
+                                "oneOf": [
+                                  {
+                                    "type": "string",
+                                  },
+                                  {
+                                    "properties": {
+                                      "eq": {
+                                        "oneOf": [
+                                          {
+                                            "type": "string",
+                                          },
+                                          {
+                                            "type": "number",
+                                          },
+                                        ],
+                                      },
+                                      "gt": {
+                                        "type": "number",
+                                      },
+                                      "gte": {
+                                        "type": "number",
+                                      },
+                                      "inc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "lt": {
+                                        "type": "number",
+                                      },
+                                      "lte": {
+                                        "type": "number",
+                                      },
+                                      "neq": {
+                                        "type": "string",
+                                      },
+                                      "ninc": {
+                                        "items": {
+                                          "type": "string",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "pre": {
+                                        "type": "string",
+                                      },
+                                      "suf": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                ],
+                              },
+                            },
+                            "required": [
+                              "key",
+                            ],
+                            "type": "object",
+                          },
+                          "type": {
+                            "enum": [
+                              "request.headers",
+                              "request.query",
+                              "response.headers",
+                            ],
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "op",
+                          "target",
+                          "type",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "src",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "properties": {
+                    "dest": {
+                      "type": "string",
+                    },
+                    "handle": {
+                      "enum": [
+                        "error",
+                        "filesystem",
+                        "hit",
+                        "miss",
+                        "rewrite",
+                        "resource",
+                      ],
+                      "type": "string",
+                    },
+                    "src": {
+                      "type": "string",
+                    },
+                    "status": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "handle",
+                  ],
+                  "type": "object",
+                },
+                {
+                  "properties": {
+                    "continue": {
+                      "enum": [
+                        false,
+                        true,
+                      ],
+                      "type": "boolean",
+                    },
+                    "middleware": {
+                      "enum": [
+                        0,
+                      ],
+                      "type": "number",
+                    },
+                    "src": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "continue",
+                    "middleware",
+                    "src",
+                  ],
+                  "type": "object",
+                },
+              ],
+            },
+            "nullable": true,
+            "type": "array",
+          },
+          "seatBlock": {
+            "description": "NSNB Blocked metadata",
+            "properties": {
+              "blockCode": {
+                "description": "The NSNB decision code for the seat block. TODO: We should consolidate block types.",
+                "enum": [
+                  "TEAM_ACCESS_REQUIRED",
+                  "COMMIT_AUTHOR_REQUIRED",
+                ],
+                "type": "string",
+              },
+              "gitProvider": {
+                "description": "The git provider type associated with gitUserId.",
+                "enum": [
+                  "gitlab",
+                  "bitbucket",
+                  "github",
+                ],
+                "type": "string",
+              },
+              "gitUserId": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                  },
+                  {
+                    "type": "number",
+                  },
+                ],
+              },
+              "isVerified": {
+                "description": "Determines if the user was verified during the block. In the git integration case, the commit sender was the author.",
+                "enum": [
+                  false,
+                  true,
+                ],
+                "type": "boolean",
+              },
+              "userId": {
+                "description": "The blocked vercel user ID.",
+                "type": "string",
+              },
+            },
+            "required": [
+              "blockCode",
+            ],
+            "type": "object",
+          },
+          "softDeletedByRetention": {
+            "description": "flag to indicate if the deployment was deleted by retention policy",
+            "enum": [
+              false,
+              true,
+            ],
+            "example": "true",
+            "type": "boolean",
+          },
+          "source": {
+            "description": "Where was the deployment created from",
+            "enum": [
+              "api-trigger-git-deploy",
+              "cli",
+              "clone/repo",
+              "git",
+              "import",
+              "import/repo",
+              "redeploy",
+              "v0-web",
+            ],
+            "example": "cli",
+            "type": "string",
+          },
+          "status": {
+            "enum": [
+              "QUEUED",
+              "BUILDING",
+              "ERROR",
+              "BLOCKED",
+              "INITIALIZING",
+              "READY",
+              "CANCELED",
+            ],
+            "type": "string",
+          },
+          "target": {
+            "description": "If defined, either \`staging\` if a staging alias in the format \`<project>.<team>.now.sh\` was assigned upon creation, or \`production\` if the aliases from \`alias\` were assigned. \`null\` value indicates the "preview" deployment.",
+            "enum": [
+              "staging",
+              "production",
+              null,
+            ],
+            "example": null,
+            "nullable": true,
+            "type": "string",
+          },
+          "team": {
+            "description": "The team that owns the deployment if any",
+            "properties": {
+              "avatar": {
+                "type": "string",
+              },
+              "id": {
+                "type": "string",
+              },
+              "name": {
+                "type": "string",
+              },
+              "slug": {
+                "type": "string",
+              },
+            },
+            "required": [
+              "id",
+              "name",
+              "slug",
+            ],
+            "type": "object",
+          },
+          "ttyBuildLogs": {
+            "enum": [
+              false,
+              true,
+            ],
+            "type": "boolean",
+          },
+          "type": {
+            "enum": [
+              "LAMBDAS",
+            ],
+            "type": "string",
+          },
+          "undeletedAt": {
+            "description": "A number containing the date when the deployment was undeleted at milliseconds",
+            "example": 1540257589405,
+            "type": "number",
+          },
+          "url": {
+            "description": "A string with the unique URL of the deployment",
+            "example": "my-instant-deployment-3ij3cxz9qr.now.sh",
+            "type": "string",
+          },
+          "userAliases": {
+            "description": "An array of domains that were provided by the user when creating the Deployment.",
+            "example": [
+              "sub1.example.com",
+              "sub2.example.com",
+            ],
+            "items": {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "userConfiguredDeploymentId": {
+            "description": "Since January 2025 User-configured deployment ID for skew protection with pre-built deployments. This is set when users configure a custom deploymentId in their next.config.js file. This allows Next.js to use skew protection even when deployments are pre-built outside of Vercel's build system.",
+            "example": "abc123",
+            "type": "string",
+          },
+          "version": {
+            "description": "The platform version that was used to create the deployment.",
+            "enum": [
+              2,
+            ],
+            "example": 2,
+            "type": "number",
           },
         },
         "required": [
-          "blockCode",
-        ],
-        "type": "object",
-      },
-      "softDeletedByRetention": {
-        "description": "flag to indicate if the deployment was deleted by retention policy",
-        "enum": [
-          false,
-          true,
-        ],
-        "example": "true",
-        "type": "boolean",
-      },
-      "source": {
-        "description": "Where was the deployment created from",
-        "enum": [
-          "api-trigger-git-deploy",
-          "cli",
-          "clone/repo",
-          "git",
-          "import",
-          "import/repo",
-          "redeploy",
-          "v0-web",
-        ],
-        "example": "cli",
-        "type": "string",
-      },
-      "status": {
-        "enum": [
-          "QUEUED",
-          "BUILDING",
-          "ERROR",
-          "BLOCKED",
-          "INITIALIZING",
-          "READY",
-          "CANCELED",
-        ],
-        "type": "string",
-      },
-      "target": {
-        "description": "If defined, either \`staging\` if a staging alias in the format \`<project>.<team>.now.sh\` was assigned upon creation, or \`production\` if the aliases from \`alias\` were assigned. \`null\` value indicates the "preview" deployment.",
-        "enum": [
-          "staging",
-          "production",
-          null,
-        ],
-        "example": null,
-        "nullable": true,
-        "type": "string",
-      },
-      "team": {
-        "description": "The team that owns the deployment if any",
-        "properties": {
-          "avatar": {
-            "type": "string",
-          },
-          "id": {
-            "type": "string",
-          },
-          "name": {
-            "type": "string",
-          },
-          "slug": {
-            "type": "string",
-          },
-        },
-        "required": [
+          "aliasAssigned",
+          "bootedAt",
+          "build",
+          "buildSkipped",
+          "buildingAt",
+          "createdAt",
+          "createdIn",
+          "creator",
+          "env",
           "id",
+          "inspectorUrl",
+          "isInConcurrentBuildsQueue",
+          "isInSystemBuildsQueue",
+          "meta",
           "name",
-          "slug",
+          "ownerId",
+          "plan",
+          "projectId",
+          "projectSettings",
+          "public",
+          "readyState",
+          "regions",
+          "routes",
+          "status",
+          "type",
+          "url",
+          "version",
         ],
         "type": "object",
       },
-      "ttyBuildLogs": {
-        "enum": [
-          false,
-          true,
-        ],
-        "type": "boolean",
-      },
-      "type": {
-        "enum": [
-          "LAMBDAS",
-        ],
-        "type": "string",
-      },
-      "undeletedAt": {
-        "description": "A number containing the date when the deployment was undeleted at milliseconds",
-        "example": 1540257589405,
-        "type": "number",
-      },
-      "url": {
-        "description": "A string with the unique URL of the deployment",
-        "example": "my-instant-deployment-3ij3cxz9qr.now.sh",
-        "type": "string",
-      },
-      "userAliases": {
-        "description": "An array of domains that were provided by the user when creating the Deployment.",
-        "example": [
-          "sub1.example.com",
-          "sub2.example.com",
-        ],
-        "items": {
+      "headers": {
+        "additionalProperties": {
           "type": "string",
         },
-        "type": "array",
+        "type": "object",
       },
-      "userConfiguredDeploymentId": {
-        "description": "Since January 2025 User-configured deployment ID for skew protection with pre-built deployments. This is set when users configure a custom deploymentId in their next.config.js file. This allows Next.js to use skew protection even when deployments are pre-built outside of Vercel's build system.",
-        "example": "abc123",
-        "type": "string",
-      },
-      "version": {
-        "description": "The platform version that was used to create the deployment.",
-        "enum": [
-          2,
-        ],
-        "example": 2,
-        "type": "number",
+      "status": {
+        "type": "integer",
       },
     },
     "required": [
-      "aliasAssigned",
-      "bootedAt",
-      "build",
-      "buildSkipped",
-      "buildingAt",
-      "createdAt",
-      "createdIn",
-      "creator",
-      "env",
-      "id",
-      "inspectorUrl",
-      "isInConcurrentBuildsQueue",
-      "isInSystemBuildsQueue",
-      "meta",
-      "name",
-      "ownerId",
-      "plan",
-      "projectId",
-      "projectSettings",
-      "public",
-      "readyState",
-      "regions",
-      "routes",
       "status",
-      "type",
-      "url",
-      "version",
+      "headers",
+      "data",
     ],
     "type": "object",
   },
-  "outputTypeScript": "{ aliasAssignedAt?: number | false | true | null; alwaysRefuseToBuild?: false | true; build: { env: string[]; }; buildArtifactUrls?: string[]; builds?: { use: string; src?: string; config?: { [k: string]: unknown; }; }[]; env: string[]; inspectorUrl: string | null; isInConcurrentBuildsQueue: false | true; isInSystemBuildsQueue: false | true; projectSettings: { nodeVersion?: "24.x" | "22.x" | "20.x" | "18.x" | "16.x" | "14.x" | "12.x" | "10.x" | "8.10.x"; buildCommand?: string | null; devCommand?: string | null; framework?: "blitzjs" | "nextjs" | "gatsby" | "remix" | "react-router" | "astro" | "hexo" | "eleventy" | "docusaurus-2" | "docusaurus" | "preact" | "solidstart-1" | "solidstart" | "dojo" | "ember" | "vue" | "scully" | "ionic-angular" | "angular" | "polymer" | "svelte" | "sveltekit" | "sveltekit-1" | "ionic-react" | "create-react-app" | "gridsome" | "umijs" | "sapper" | "saber" | "stencil" | "nuxtjs" | "redwoodjs" | "hugo" | "jekyll" | "brunch" | "middleman" | "zola" | "hydrogen" | "vite" | "tanstack-start" | "vitepress" | "vuepress" | "parcel" | "fastapi" | "flask" | "fasthtml" | "django" | "ash" | "sanity-v3" | "sanity" | "storybook" | "nitro" | "hono" | "express" | "h3" | "koa" | "nestjs" | "elysia" | "fastify" | "xmcp" | "python" | "ruby" | "rust" | "axum" | "actix-web" | "node" | "go" | "services" | "mastra" | null; commandForIgnoringBuildStep?: string | null; installCommand?: string | null; outputDirectory?: string | null; speedInsights?: { id: string; enabledAt?: number; disabledAt?: number; canceledAt?: number; hasData?: false | true; paidAt?: number; }; webAnalytics?: { id: string; disabledAt?: number; canceledAt?: number; enabledAt?: number; hasData?: true; }; }; integrations?: { status: "skipped" | "pending" | "ready" | "error" | "timeout"; startedAt: number; claimedAt?: number; completedAt?: number; skippedAt?: number; skippedBy?: string; }; images?: { sizes?: number[]; qualities?: number[]; domains?: string[]; remotePatterns?: { protocol?: "http" | "https"; hostname: string; port?: string; pathname?: string; search?: string; }[]; localPatterns?: { pathname?: string; search?: string; }[]; minimumCacheTTL?: number; formats?: ("image/avif" | "image/webp")[]; dangerouslyAllowSVG?: false | true; contentSecurityPolicy?: string; contentDispositionType?: "inline" | "attachment"; }; alias?: string[]; aliasAssigned: false | true; bootedAt: number; buildingAt: number; buildContainerFinishedAt?: number; buildSkipped: false | true; creator: { uid: string; username?: string; avatar?: string; }; initReadyAt?: number; isFirstBranchDeployment?: false | true; lambdas?: { id: string; createdAt?: number; readyState?: "BUILDING" | "ERROR" | "INITIALIZING" | "READY"; entrypoint?: string | null; readyStateAt?: number; output: { path: string; functionName: string; }[]; }[]; public: false | true; ready?: number; status: "QUEUED" | "BUILDING" | "ERROR" | "BLOCKED" | "INITIALIZING" | "READY" | "CANCELED"; team?: { id: string; name: string; slug: string; avatar?: string; }; userAliases?: string[]; previewCommentsEnabled?: false | true; ttyBuildLogs?: false | true; customEnvironment?: { id: string; slug: string; type: "production" | "preview" | "development"; description?: string; branchMatcher?: { type: "endsWith" | "startsWith" | "equals"; pattern: string; }; domains?: { name: string; apexName: string; projectId: string; redirect?: string | null; redirectStatusCode?: 307 | 301 | 302 | 308 | null; gitBranch?: string | null; customEnvironmentId?: string | null; updatedAt?: number; createdAt?: number; verified: false | true; verification?: { type: string; domain: string; value: string; reason: string; }[]; }[]; currentDeploymentAliases?: string[]; createdAt: number; updatedAt: number; } | { id: string; }; oomReport?: "out-of-memory"; readyStateReason?: string; aliasWarning?: { code: string; message: string; link?: string; action?: string; } | null; id: string; createdAt: number; readyState: "QUEUED" | "BUILDING" | "ERROR" | "BLOCKED" | "INITIALIZING" | "READY" | "CANCELED"; name: string; type: "LAMBDAS"; aliasError?: { code: string; message: string; } | null; aliasFinal?: string | null; autoAssignCustomDomains?: false | true; automaticAliases?: string[]; buildErrorAt?: number; checksState?: "registered" | "running" | "completed"; checksConclusion?: "succeeded" | "failed" | "skipped" | "canceled"; deletedAt?: number | null; defaultRoute?: string; canceledAt?: number; errorCode?: string; errorLink?: string; errorMessage?: string | null; errorStep?: string; passiveRegions?: string[]; gitSource?: { type: "github"; repoId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github"; org: string; repo: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-custom-host"; host: string; repoId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-custom-host"; host: string; org: string; repo: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-limited"; repoId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-limited"; org: string; repo: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "gitlab"; projectId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "bitbucket"; workspaceUuid?: string; repoUuid: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "bitbucket"; owner: string; slug: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "vercel"; org?: string; repo?: string; sha: string; repoPushedAt?: number; ref?: string | null; prId?: number | null; } | { type: "custom"; ref: string; sha: string; gitUrl: string; } | { type: "github"; ref: string; sha: string; repoId: number; org?: string; repo?: string; } | { type: "github-custom-host"; host: string; ref: string; sha: string; repoId: number; org?: string; repo?: string; } | { type: "github-limited"; ref: string; sha: string; repoId: number; org?: string; repo?: string; } | { type: "gitlab"; ref: string; sha: string; projectId: number; } | { type: "bitbucket"; ref: string; sha: string; owner?: string; slug?: string; workspaceUuid: string; repoUuid: string; } | { type: "vercel"; ref: string; sha: string; org: string; repo: string; repoPushedAt?: number; }; manualProvisioning?: { state: "PENDING" | "COMPLETE" | "TIMEOUT"; completedAt?: number; }; meta: { [k: string]: string; }; originCacheRegion?: string; nodeVersion?: "24.x" | "22.x" | "20.x" | "18.x" | "16.x" | "14.x" | "12.x" | "10.x" | "8.10.x"; project?: { id: string; name: string; framework?: string | null; }; prebuilt?: false | true; readySubstate?: "STAGED" | "ROLLING" | "PROMOTED"; regions: string[]; softDeletedByRetention?: false | true; source?: "api-trigger-git-deploy" | "cli" | "clone/repo" | "git" | "import" | "import/repo" | "redeploy" | "v0-web"; target?: "staging" | "production" | null; undeletedAt?: number; url: string; userConfiguredDeploymentId?: string; version: 2; oidcTokenClaims?: { iss: string; sub: string; scope: string; aud: string; owner: string; owner_id: string; project: string; project_id: string; environment: string; custom_environment_id?: string; plan?: string; }; projectId: string; plan: "pro" | "enterprise" | "hobby"; platform?: { source: { name: string; }; origin: { type: "id" | "url"; value: string; }; creator: { name: string; avatar?: string; }; meta?: { [k: string]: string; }; }; connectBuildsEnabled?: false | true; connectConfigurationId?: string; createdIn: string; crons?: { schedule: string; path: string; }[]; functions?: { [k: string]: { architecture?: "x86_64" | "arm64"; memory?: number; maxDuration?: number | "max"; regions?: string[]; functionFailoverRegions?: string[]; runtime?: string; includeFiles?: string; excludeFiles?: string; experimentalTriggers?: ({ type: "queue/v1beta"; consumer: string; topic: string; maxDeliveries?: number; retryAfterSeconds?: number; initialDelaySeconds?: number; maxConcurrency?: number; } | { type: "queue/v2beta"; topic: string; maxDeliveries?: number; retryAfterSeconds?: number; initialDelaySeconds?: number; maxConcurrency?: number; })[]; supportsCancellation?: false | true; }; } | null; monorepoManager?: string | null; ownerId: string; passiveConnectConfigurationId?: string; routes: ({ src: string; dest?: string; headers?: { [k: string]: string; }; methods?: string[]; continue?: (false | true); override?: (false | true); caseSensitive?: (false | true); check?: (false | true); important?: (false | true); status?: number; has?: ({ type: "host"; value: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); } | { type: ("header" | "cookie" | "query"); key: string; value?: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); })[]; missing?: ({ type: "host"; value: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); } | { type: ("header" | "cookie" | "query"); key: string; value?: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); })[]; mitigate?: { action: ("challenge" | "deny"); }; transforms?: { type: ("request.headers" | "request.query" | "response.headers"); op: ("append" | "set" | "delete"); target: { key: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); }; args?: (string | string[]); env?: string[]; }[]; env?: string[]; locale?: { redirect?: { [k: string]: string; }; cookie?: string; }; source?: string; destination?: string; statusCode?: number; middlewarePath?: string; middlewareRawSrc?: string[]; middleware?: number; respectOriginCacheControl?: (false | true); } | { handle: ("error" | "filesystem" | "hit" | "miss" | "rewrite" | "resource"); src?: string; dest?: string; status?: number; } | { src: string; continue: (false | true); middleware: 0; })[] | null; gitRepo?: { namespace: string; projectId: number; type: "gitlab"; url: string; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | { org: string; repo: string; repoId: number; type: "github"; repoOwnerId: number; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | { owner: string; repoUuid: string; slug: string; type: "bitbucket"; workspaceUuid: string; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | { org: string; repo: string; type: "vercel"; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | null; flags?: { definitions: { [k: string]: { options?: { value: FlagJSONValue; label?: string; }[]; url?: string; description?: string; }; }; } | { [k: string]: unknown; }[]; microfrontends?: { isDefaultApp?: false; defaultAppProjectName: string; defaultRoute?: string; groupIds: [string, ...(string)[]]; } | { isDefaultApp: true; mfeConfigUploadState?: "success" | "waiting_on_build" | "no_config"; defaultAppProjectName: string; defaultRoute?: string; groupIds: [string, ...(string)[]]; }; config?: { version?: number; functionType: "standard" | "fluid"; functionMemoryType: "standard" | "standard_legacy" | "performance"; functionTimeout: number | null; secureComputePrimaryRegion: string | null; secureComputeFallbackRegion: string | null; isUsingActiveCPU?: false | true; resourceConfig?: { buildQueue?: { configuration?: "SKIP_NAMESPACE_QUEUE" | "WAIT_FOR_NAMESPACE_QUEUE"; }; elasticConcurrency?: "TEAM_SETTING" | "PROJECT_SETTING" | "SKIP_QUEUE"; buildMachine?: { purchaseType?: "enhanced" | "turbo" | "standard" | null; }; }; }; checks?: { "deployment-alias": { state: "succeeded" | "failed" | "pending"; startedAt: number; completedAt?: number; }; }; seatBlock?: { blockCode: "TEAM_ACCESS_REQUIRED" | "COMMIT_AUTHOR_REQUIRED"; userId?: string; isVerified?: false | true; gitUserId?: string | number; gitProvider?: "gitlab" | "bitbucket" | "github"; }; attribution?: { commitMeta?: { email?: string; name?: string; isVerified?: false | true; }; gitUser?: { id: string | number; login: string; type?: string; provider?: string; }; vercelUser?: { id: string; username: string; teamRoles?: string[]; }; }; }",
+  "outputTypeScript": "{ status: number; headers: { [k: string]: string; }; data: { aliasAssignedAt?: number | false | true | null; alwaysRefuseToBuild?: false | true; build: { env: string[]; }; buildArtifactUrls?: string[]; builds?: { use: string; src?: string; config?: { [k: string]: unknown; }; }[]; env: string[]; inspectorUrl: string | null; isInConcurrentBuildsQueue: false | true; isInSystemBuildsQueue: false | true; projectSettings: { nodeVersion?: "24.x" | "22.x" | "20.x" | "18.x" | "16.x" | "14.x" | "12.x" | "10.x" | "8.10.x"; buildCommand?: string | null; devCommand?: string | null; framework?: "blitzjs" | "nextjs" | "gatsby" | "remix" | "react-router" | "astro" | "hexo" | "eleventy" | "docusaurus-2" | "docusaurus" | "preact" | "solidstart-1" | "solidstart" | "dojo" | "ember" | "vue" | "scully" | "ionic-angular" | "angular" | "polymer" | "svelte" | "sveltekit" | "sveltekit-1" | "ionic-react" | "create-react-app" | "gridsome" | "umijs" | "sapper" | "saber" | "stencil" | "nuxtjs" | "redwoodjs" | "hugo" | "jekyll" | "brunch" | "middleman" | "zola" | "hydrogen" | "vite" | "tanstack-start" | "vitepress" | "vuepress" | "parcel" | "fastapi" | "flask" | "fasthtml" | "django" | "ash" | "sanity-v3" | "sanity" | "storybook" | "nitro" | "hono" | "express" | "h3" | "koa" | "nestjs" | "elysia" | "fastify" | "xmcp" | "python" | "ruby" | "rust" | "axum" | "actix-web" | "node" | "go" | "services" | "mastra" | null; commandForIgnoringBuildStep?: string | null; installCommand?: string | null; outputDirectory?: string | null; speedInsights?: { id: string; enabledAt?: number; disabledAt?: number; canceledAt?: number; hasData?: false | true; paidAt?: number; }; webAnalytics?: { id: string; disabledAt?: number; canceledAt?: number; enabledAt?: number; hasData?: true; }; }; integrations?: { status: "skipped" | "pending" | "ready" | "error" | "timeout"; startedAt: number; claimedAt?: number; completedAt?: number; skippedAt?: number; skippedBy?: string; }; images?: { sizes?: number[]; qualities?: number[]; domains?: string[]; remotePatterns?: { protocol?: "http" | "https"; hostname: string; port?: string; pathname?: string; search?: string; }[]; localPatterns?: { pathname?: string; search?: string; }[]; minimumCacheTTL?: number; formats?: ("image/avif" | "image/webp")[]; dangerouslyAllowSVG?: false | true; contentSecurityPolicy?: string; contentDispositionType?: "inline" | "attachment"; }; alias?: string[]; aliasAssigned: false | true; bootedAt: number; buildingAt: number; buildContainerFinishedAt?: number; buildSkipped: false | true; creator: { uid: string; username?: string; avatar?: string; }; initReadyAt?: number; isFirstBranchDeployment?: false | true; lambdas?: { id: string; createdAt?: number; readyState?: "BUILDING" | "ERROR" | "INITIALIZING" | "READY"; entrypoint?: string | null; readyStateAt?: number; output: { path: string; functionName: string; }[]; }[]; public: false | true; ready?: number; status: "QUEUED" | "BUILDING" | "ERROR" | "BLOCKED" | "INITIALIZING" | "READY" | "CANCELED"; team?: { id: string; name: string; slug: string; avatar?: string; }; userAliases?: string[]; previewCommentsEnabled?: false | true; ttyBuildLogs?: false | true; customEnvironment?: { id: string; slug: string; type: "production" | "preview" | "development"; description?: string; branchMatcher?: { type: "endsWith" | "startsWith" | "equals"; pattern: string; }; domains?: { name: string; apexName: string; projectId: string; redirect?: string | null; redirectStatusCode?: 307 | 301 | 302 | 308 | null; gitBranch?: string | null; customEnvironmentId?: string | null; updatedAt?: number; createdAt?: number; verified: false | true; verification?: { type: string; domain: string; value: string; reason: string; }[]; }[]; currentDeploymentAliases?: string[]; createdAt: number; updatedAt: number; } | { id: string; }; oomReport?: "out-of-memory"; readyStateReason?: string; aliasWarning?: { code: string; message: string; link?: string; action?: string; } | null; id: string; createdAt: number; readyState: "QUEUED" | "BUILDING" | "ERROR" | "BLOCKED" | "INITIALIZING" | "READY" | "CANCELED"; name: string; type: "LAMBDAS"; aliasError?: { code: string; message: string; } | null; aliasFinal?: string | null; autoAssignCustomDomains?: false | true; automaticAliases?: string[]; buildErrorAt?: number; checksState?: "registered" | "running" | "completed"; checksConclusion?: "succeeded" | "failed" | "skipped" | "canceled"; deletedAt?: number | null; defaultRoute?: string; canceledAt?: number; errorCode?: string; errorLink?: string; errorMessage?: string | null; errorStep?: string; passiveRegions?: string[]; gitSource?: { type: "github"; repoId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github"; org: string; repo: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-custom-host"; host: string; repoId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-custom-host"; host: string; org: string; repo: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-limited"; repoId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "github-limited"; org: string; repo: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "gitlab"; projectId: string | number; ref?: string | null; sha?: string; prId?: number | null; } | { type: "bitbucket"; workspaceUuid?: string; repoUuid: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "bitbucket"; owner: string; slug: string; ref?: string | null; sha?: string; prId?: number | null; } | { type: "vercel"; org?: string; repo?: string; sha: string; repoPushedAt?: number; ref?: string | null; prId?: number | null; } | { type: "custom"; ref: string; sha: string; gitUrl: string; } | { type: "github"; ref: string; sha: string; repoId: number; org?: string; repo?: string; } | { type: "github-custom-host"; host: string; ref: string; sha: string; repoId: number; org?: string; repo?: string; } | { type: "github-limited"; ref: string; sha: string; repoId: number; org?: string; repo?: string; } | { type: "gitlab"; ref: string; sha: string; projectId: number; } | { type: "bitbucket"; ref: string; sha: string; owner?: string; slug?: string; workspaceUuid: string; repoUuid: string; } | { type: "vercel"; ref: string; sha: string; org: string; repo: string; repoPushedAt?: number; }; manualProvisioning?: { state: "PENDING" | "COMPLETE" | "TIMEOUT"; completedAt?: number; }; meta: { [k: string]: string; }; originCacheRegion?: string; nodeVersion?: "24.x" | "22.x" | "20.x" | "18.x" | "16.x" | "14.x" | "12.x" | "10.x" | "8.10.x"; project?: { id: string; name: string; framework?: string | null; }; prebuilt?: false | true; readySubstate?: "STAGED" | "ROLLING" | "PROMOTED"; regions: string[]; softDeletedByRetention?: false | true; source?: "api-trigger-git-deploy" | "cli" | "clone/repo" | "git" | "import" | "import/repo" | "redeploy" | "v0-web"; target?: "staging" | "production" | null; undeletedAt?: number; url: string; userConfiguredDeploymentId?: string; version: 2; oidcTokenClaims?: { iss: string; sub: string; scope: string; aud: string; owner: string; owner_id: string; project: string; project_id: string; environment: string; custom_environment_id?: string; plan?: string; }; projectId: string; plan: "pro" | "enterprise" | "hobby"; platform?: { source: { name: string; }; origin: { type: "id" | "url"; value: string; }; creator: { name: string; avatar?: string; }; meta?: { [k: string]: string; }; }; connectBuildsEnabled?: false | true; connectConfigurationId?: string; createdIn: string; crons?: { schedule: string; path: string; }[]; functions?: { [k: string]: { architecture?: "x86_64" | "arm64"; memory?: number; maxDuration?: number | "max"; regions?: string[]; functionFailoverRegions?: string[]; runtime?: string; includeFiles?: string; excludeFiles?: string; experimentalTriggers?: ({ type: "queue/v1beta"; consumer: string; topic: string; maxDeliveries?: number; retryAfterSeconds?: number; initialDelaySeconds?: number; maxConcurrency?: number; } | { type: "queue/v2beta"; topic: string; maxDeliveries?: number; retryAfterSeconds?: number; initialDelaySeconds?: number; maxConcurrency?: number; })[]; supportsCancellation?: false | true; }; } | null; monorepoManager?: string | null; ownerId: string; passiveConnectConfigurationId?: string; routes: ({ src: string; dest?: string; headers?: { [k: string]: string; }; methods?: string[]; continue?: (false | true); override?: (false | true); caseSensitive?: (false | true); check?: (false | true); important?: (false | true); status?: number; has?: ({ type: "host"; value: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); } | { type: ("header" | "cookie" | "query"); key: string; value?: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); })[]; missing?: ({ type: "host"; value: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); } | { type: ("header" | "cookie" | "query"); key: string; value?: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; re?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); })[]; mitigate?: { action: ("challenge" | "deny"); }; transforms?: { type: ("request.headers" | "request.query" | "response.headers"); op: ("append" | "set" | "delete"); target: { key: (string | { eq?: (string | number); neq?: string; inc?: string[]; ninc?: string[]; pre?: string; suf?: string; gt?: number; gte?: number; lt?: number; lte?: number; }); }; args?: (string | string[]); env?: string[]; }[]; env?: string[]; locale?: { redirect?: { [k: string]: string; }; cookie?: string; }; source?: string; destination?: string; statusCode?: number; middlewarePath?: string; middlewareRawSrc?: string[]; middleware?: number; respectOriginCacheControl?: (false | true); } | { handle: ("error" | "filesystem" | "hit" | "miss" | "rewrite" | "resource"); src?: string; dest?: string; status?: number; } | { src: string; continue: (false | true); middleware: 0; })[] | null; gitRepo?: { namespace: string; projectId: number; type: "gitlab"; url: string; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | { org: string; repo: string; repoId: number; type: "github"; repoOwnerId: number; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | { owner: string; repoUuid: string; slug: string; type: "bitbucket"; workspaceUuid: string; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | { org: string; repo: string; type: "vercel"; path: string; defaultBranch: string; name: string; private: false | true; ownerType: "team" | "user"; } | null; flags?: { definitions: { [k: string]: { options?: { value: FlagJSONValue; label?: string; }[]; url?: string; description?: string; }; }; } | { [k: string]: unknown; }[]; microfrontends?: { isDefaultApp?: false; defaultAppProjectName: string; defaultRoute?: string; groupIds: [string, ...(string)[]]; } | { isDefaultApp: true; mfeConfigUploadState?: "success" | "waiting_on_build" | "no_config"; defaultAppProjectName: string; defaultRoute?: string; groupIds: [string, ...(string)[]]; }; config?: { version?: number; functionType: "standard" | "fluid"; functionMemoryType: "standard" | "standard_legacy" | "performance"; functionTimeout: number | null; secureComputePrimaryRegion: string | null; secureComputeFallbackRegion: string | null; isUsingActiveCPU?: false | true; resourceConfig?: { buildQueue?: { configuration?: "SKIP_NAMESPACE_QUEUE" | "WAIT_FOR_NAMESPACE_QUEUE"; }; elasticConcurrency?: "TEAM_SETTING" | "PROJECT_SETTING" | "SKIP_QUEUE"; buildMachine?: { purchaseType?: "enhanced" | "turbo" | "standard" | null; }; }; }; checks?: { "deployment-alias": { state: "succeeded" | "failed" | "pending"; startedAt: number; completedAt?: number; }; }; seatBlock?: { blockCode: "TEAM_ACCESS_REQUIRED" | "COMMIT_AUTHOR_REQUIRED"; userId?: string; isVerified?: false | true; gitUserId?: string | number; gitProvider?: "gitlab" | "bitbucket" | "github"; }; attribution?: { commitMeta?: { email?: string; name?: string; isVerified?: false | true; }; gitUser?: { id: string | number; login: string; type?: string; provider?: string; }; vercelUser?: { id: string; username: string; teamRoles?: string[]; }; }; }; }",
   "schemaDefinitionCount": 1,
   "schemaDefinitionNames": [
     "FlagJSONValue",

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -17,7 +17,11 @@ import {
   type InvokeOptions,
   type SecretProvider,
 } from "@executor-js/sdk";
-import { makeTestConfig, memorySecretsPlugin } from "@executor-js/sdk/testing";
+import {
+  makeTestConfig,
+  memorySecretsPlugin,
+  typeCheckOutputTypeScript,
+} from "@executor-js/sdk/testing";
 import type { ConfigFileSink } from "@executor-js/config";
 
 const TEST_SCOPE = "test-scope";
@@ -31,6 +35,8 @@ import {
 } from "../testing";
 
 const autoApprove: InvokeOptions = { onElicitation: "accept-all" };
+const TOOL_ERROR_TYPESCRIPT =
+  "{ code: string; message: string; status?: number; details?: unknown; retryable?: boolean }";
 
 type FumaQueryCall = {
   readonly method: "findFirst" | "findMany";
@@ -841,6 +847,56 @@ describe("OpenAPI Plugin", () => {
         );
         expect(result.error).toBeNull();
         expect(result.data).toEqual(ITEMS);
+      }),
+    ),
+  );
+
+  it.effect("describes OpenAPI invocation results with the transport envelope", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* servePluginTestApi();
+        const clientLayer = FetchHttpClient.layer;
+        const executor = yield* createExecutor(
+          makeTestConfig({
+            plugins: [
+              openApiPlugin({ httpClientLayer: clientLayer }),
+              memorySecretsPlugin(),
+            ] as const,
+          }),
+        );
+
+        yield* addOpenApiTestSource(executor, server, {
+          scope: TEST_SCOPE,
+          namespace: "test",
+        });
+
+        const schema = yield* executor.tools.schema("test.items.listItems");
+        expect(schema?.outputTypeScript).toContain("status: number");
+        expect(schema?.outputTypeScript).toContain("headers:");
+        expect(schema?.outputTypeScript).toContain("data:");
+
+        const result = yield* executor.tools.invoke("test.items.listItems", {}, autoApprove);
+        const diagnostics = typeCheckOutputTypeScript(
+          {
+            outputTypeScript: `{ ok: true; data: ${schema?.outputTypeScript ?? "unknown"} } | { ok: false; error: ToolError }`,
+            typeScriptDefinitions: {
+              ...(schema?.typeScriptDefinitions ?? {}),
+              ToolError: TOOL_ERROR_TYPESCRIPT,
+            },
+          },
+          result,
+          {
+            consumerSource: [
+              "if (invokedOutput.ok) {",
+              "  const status: number = invokedOutput.data.status;",
+              "  const items = invokedOutput.data.data;",
+              "  items.map((item) => item.name);",
+              "}",
+            ].join("\n"),
+          },
+        );
+
+        expect(diagnostics).toEqual([]);
       }),
     ),
   );

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -1205,6 +1205,20 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
     readonly oauth2?: OpenApiOAuthInput;
   };
 
+  const openApiTransportOutputSchema = (dataSchema: unknown): Record<string, unknown> => ({
+    type: "object",
+    additionalProperties: false,
+    required: ["status", "headers", "data"],
+    properties: {
+      status: { type: "integer" },
+      headers: {
+        type: "object",
+        additionalProperties: { type: "string" },
+      },
+      data: dataSchema ?? {},
+    },
+  });
+
   // ctx comes from the plugin runtime — the same instance is passed to
   // `extension(ctx)` and to every lifecycle hook (`refreshSource`, etc.),
   // so helpers parameterised on ctx can be called from either surface.
@@ -1284,7 +1298,9 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
               name: def.toolPath,
               description: descriptionFor(def),
               inputSchema: normalizeOpenApiRefs(Option.getOrUndefined(def.operation.inputSchema)),
-              outputSchema: normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+              outputSchema: openApiTransportOutputSchema(
+                normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+              ),
             })),
           });
 


### PR DESCRIPTION
## Summary

- Add described TypeScript contracts for built-in Executor discovery tools: `search`, `executor.sources.list`, and `describe.tool`.
- Describe OpenAPI tool success results with the runtime transport envelope: `{ status, headers, data }`.
- Add regression coverage that type-checks real read-only invocation results against their described output contracts.
- Update real-spec snapshots for the new OpenAPI envelope shape.
- Add a patch changeset for the affected release packages.

## Root Cause

Built-in discovery tools were routed outside normal registered tool schema lookup, so `tools.describe.tool` fell back to a minimal stub. OpenAPI tools registered the upstream response body schema, while invocation returns a transport envelope around that body.

## Validation

Full local gates passed on the updated branch:

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`

Targeted checks also passed while developing:

- `bunx vitest run src/tool-invoker.test.ts` from `packages/core/execution`
- `bunx vitest run src/sdk/plugin.test.ts` from `packages/plugins/openapi`
- `bunx vitest run src/sdk/real-specs.test.ts --update` from `packages/plugins/openapi`