### PR TITLE
Fix MCP source refresh lifecycle

### DIFF
--- a/apps/cloud/src/services/sources-api.node.test.ts
+++ b/apps/cloud/src/services/sources-api.node.test.ts
@@ -457,6 +457,54 @@ describe("sources api (HTTP)", () => {
     }),
   );
 
+  it.effect("generic source refresh updates MCP source tool rows", () =>
+    Effect.gen(function* () {
+      let toolName = "before_refresh";
+      const server = yield* serveMcpServer(() =>
+        makeGreetingMcpServer({
+          name: "cloud-refresh-mcp",
+          toolName,
+          text: "refresh-ok",
+        }),
+      );
+      const org = `org_${crypto.randomUUID()}`;
+      const namespace = `mcp_${crypto.randomUUID().replace(/-/g, "_")}`;
+      const scopeId = ScopeId.make(org);
+
+      const added = yield* asOrg(org, (client) =>
+        client.mcp.addSource({
+          params: { scopeId },
+          payload: {
+            transport: "remote",
+            name: "Cloud Refresh MCP",
+            endpoint: server.endpoint,
+            remoteTransport: "streamable-http",
+            namespace,
+          },
+        }),
+      );
+      expect(added).toEqual({ namespace, toolCount: 1 });
+
+      const beforeTools = yield* asOrg(org, (client) =>
+        client.sources.tools({ params: { scopeId, sourceId: namespace } }),
+      );
+      expect(beforeTools.map((tool) => tool.id)).toContain(`${namespace}.before_refresh`);
+      expect(beforeTools.map((tool) => tool.id)).not.toContain(`${namespace}.after_refresh`);
+
+      toolName = "after_refresh";
+      const refreshResult = yield* asOrg(org, (client) =>
+        client.sources.refresh({ params: { scopeId, sourceId: namespace } }),
+      );
+      expect(refreshResult.refreshed).toBe(true);
+
+      const afterTools = yield* asOrg(org, (client) =>
+        client.sources.tools({ params: { scopeId, sourceId: namespace } }),
+      );
+      expect(afterTools.map((tool) => tool.id)).not.toContain(`${namespace}.before_refresh`);
+      expect(afterTools.map((tool) => tool.id)).toContain(`${namespace}.after_refresh`);
+    }),
+  );
+
   it.effect("sources.remove deletes the source and it drops off sources.list", () =>
     Effect.gen(function* () {
       const org = `org_${crypto.randomUUID()}`;

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -1265,6 +1265,100 @@ const toMcpConfigEntry = (
   return entry;
 };
 
+const refreshSourceInternal = (
+  ctx: PluginCtx<McpBindingStore>,
+  sourceId: string,
+  scope: string,
+  allowStdio: boolean,
+) =>
+  Effect.gen(function* () {
+    const sd = yield* ctx.storage.getSourceConfig(sourceId, scope).pipe(
+      Effect.withSpan("mcp.plugin.load_source_config", {
+        attributes: { "mcp.source.namespace": sourceId },
+      }),
+    );
+    if (!sd) {
+      return yield* new McpConnectionError({
+        transport: "remote",
+        message: `No stored config for MCP source "${sourceId}"`,
+      });
+    }
+
+    const ci = yield* resolveConnectorInput(sourceId, scope, sd, ctx, allowStdio).pipe(
+      Effect.catchTag("McpAuthRequiredError", ({ message }) =>
+        Effect.fail(new McpConnectionError({ transport: sd.transport, message })),
+      ),
+      Effect.withSpan("mcp.plugin.resolve_connector", {
+        attributes: {
+          "mcp.source.namespace": sourceId,
+          "mcp.source.transport": sd.transport,
+        },
+      }),
+    );
+    const manifest = yield* discoverTools(createMcpConnector(ci)).pipe(
+      Effect.mapError(
+        ({ message }) =>
+          new McpToolDiscoveryError({
+            stage: "list_tools",
+            message: `MCP refresh failed: ${message}`,
+          }),
+      ),
+      Effect.withSpan("mcp.plugin.discover_tools", {
+        attributes: { "mcp.source.namespace": sourceId },
+      }),
+    );
+
+    const existing = yield* ctx.storage.getSource(sourceId, scope);
+    const sourceName = manifest.server?.name ?? existing?.name ?? sourceId;
+
+    yield* ctx
+      .transaction(
+        Effect.gen(function* () {
+          yield* ctx.storage.removeBindingsByNamespace(sourceId, scope);
+          yield* ctx.core.sources.unregister({ id: sourceId, targetScope: scope });
+
+          yield* ctx.storage.putBindings(
+            sourceId,
+            scope,
+            manifest.tools.map((e) => ({
+              toolId: `${sourceId}.${e.toolId}`,
+              binding: toBinding(e),
+            })),
+          );
+          yield* ctx.core.sources.register({
+            id: sourceId,
+            scope,
+            kind: "mcp",
+            name: sourceName,
+            url: sd.transport === "remote" ? sd.endpoint : undefined,
+            canRemove: true,
+            canRefresh: true,
+            canEdit: sd.transport === "remote",
+            tools: manifest.tools.map((e) => ({
+              name: e.toolId,
+              description: e.description ?? `MCP tool: ${e.toolName}`,
+              inputSchema: e.inputSchema,
+              outputSchema: mcpCallToolResultOutputSchema(e.outputSchema),
+            })),
+          });
+        }),
+      )
+      .pipe(
+        Effect.withSpan("mcp.plugin.persist_source", {
+          attributes: {
+            "mcp.source.namespace": sourceId,
+            "mcp.source.tool_count": manifest.tools.length,
+          },
+        }),
+      );
+
+    return { toolCount: manifest.tools.length };
+  }).pipe(
+    Effect.withSpan("mcp.plugin.refresh_source", {
+      attributes: { "mcp.source.namespace": sourceId },
+    }),
+  );
+
 export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
   const allowStdio = options?.dangerouslyAllowStdioMCP ?? false;
   // Per-plugin-instance runtime holder. Captured by closures in
@@ -1701,93 +1795,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
         );
 
       const refreshSource = (namespace: string, scope: string) =>
-        Effect.gen(function* () {
-          const sd = yield* ctx.storage.getSourceConfig(namespace, scope).pipe(
-            Effect.withSpan("mcp.plugin.load_source_config", {
-              attributes: { "mcp.source.namespace": namespace },
-            }),
-          );
-          if (!sd) {
-            return yield* new McpConnectionError({
-              transport: "remote",
-              message: `No stored config for MCP source "${namespace}"`,
-            });
-          }
-
-          const ci = yield* resolveConnectorInput(namespace, scope, sd, ctx, allowStdio).pipe(
-            Effect.catchTag("McpAuthRequiredError", ({ message }) =>
-              Effect.fail(new McpConnectionError({ transport: sd.transport, message })),
-            ),
-            Effect.withSpan("mcp.plugin.resolve_connector", {
-              attributes: {
-                "mcp.source.namespace": namespace,
-                "mcp.source.transport": sd.transport,
-              },
-            }),
-          );
-          const manifest = yield* discoverTools(createMcpConnector(ci)).pipe(
-            Effect.mapError(
-              ({ message }) =>
-                new McpToolDiscoveryError({
-                  stage: "list_tools",
-                  message: `MCP refresh failed: ${message}`,
-                }),
-            ),
-            Effect.withSpan("mcp.plugin.discover_tools", {
-              attributes: { "mcp.source.namespace": namespace },
-            }),
-          );
-
-          const existing = yield* ctx.storage.getSource(namespace, scope);
-          const sourceName = manifest.server?.name ?? existing?.name ?? namespace;
-
-          yield* ctx
-            .transaction(
-              Effect.gen(function* () {
-                yield* ctx.storage.removeBindingsByNamespace(namespace, scope);
-                yield* ctx.core.sources.unregister({ id: namespace, targetScope: scope });
-
-                yield* ctx.storage.putBindings(
-                  namespace,
-                  scope,
-                  manifest.tools.map((e) => ({
-                    toolId: `${namespace}.${e.toolId}`,
-                    binding: toBinding(e),
-                  })),
-                );
-                yield* ctx.core.sources.register({
-                  id: namespace,
-                  scope,
-                  kind: "mcp",
-                  name: sourceName,
-                  url: sd.transport === "remote" ? sd.endpoint : undefined,
-                  canRemove: true,
-                  canRefresh: true,
-                  canEdit: sd.transport === "remote",
-                  tools: manifest.tools.map((e) => ({
-                    name: e.toolId,
-                    description: e.description ?? `MCP tool: ${e.toolName}`,
-                    inputSchema: e.inputSchema,
-                    outputSchema: mcpCallToolResultOutputSchema(e.outputSchema),
-                  })),
-                });
-              }),
-            )
-            .pipe(
-              Effect.withSpan("mcp.plugin.persist_source", {
-                attributes: {
-                  "mcp.source.namespace": namespace,
-                  "mcp.source.tool_count": manifest.tools.length,
-                },
-              }),
-            );
-
-          return { toolCount: manifest.tools.length };
-        }).pipe(
-          Effect.withSpan("mcp.plugin.refresh_source", {
-            attributes: { "mcp.source.namespace": namespace },
-          }),
-        );
+        refreshSourceInternal(ctx, namespace, scope, allowStdio);
 
       const getSource = (namespace: string, scope: string) =>
         ctx.storage.getSource(namespace, scope).pipe(
@@ -2292,7 +2300,8 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
 
     usagesForConnection: () => Effect.succeed([]),
 
-    refreshSource: () => Effect.void,
+    refreshSource: ({ ctx, sourceId, scope }) =>
+      refreshSourceInternal(ctx, sourceId, scope, allowStdio).pipe(Effect.asVoid),
 
     // Connection refresh for oauth2-minted sources is owned by the
     // canonical `"oauth2"` ConnectionProvider that core registers via


### PR DESCRIPTION
## Summary
- Wire the MCP plugin into the generic source refresh lifecycle instead of leaving `Plugin.refreshSource` as a no-op.
- Reuse the same MCP discovery/persistence flow as the MCP-specific refresh path: load the stored source config, reconnect to the MCP server, list tools, replace stale tool bindings, and re-register the source/tool rows.
- Add a regression test that changes a test MCP server manifest and verifies `sources.refresh` replaces the old tool row with the new one.

## What this resolves
Executor exposes a generic source refresh endpoint used by the web UI Refresh button (`sources.refresh` / `POST /sources/:sourceId/refresh`). MCP sources displayed `canRefresh: true`, so the UI allowed refresh, but the MCP plugin lifecycle implementation was `refreshSource: () => Effect.void`. That meant the HTTP request could return success while the tool manifest stayed stale.

This showed up with hosted MCP sources after their backing server gained new tools: refreshing the source appeared successful, but agents still only saw the previous tool list until the source was deleted and re-added. The fix makes the generic refresh path actually re-discover MCP tools and persist the updated manifest.

## Test plan
- [x] `bun --filter @executor-js/cloud test:node -- sources-api.node.test.ts`