### PR TITLE
Harden SQLite import checkpoint handling

### DIFF
--- a/apps/local/src/server/executor.ts
+++ b/apps/local/src/server/executor.ts
@@ -138,6 +138,11 @@ class LocalExecutorDisposeError extends Data.TaggedError("LocalExecutorDisposeEr
   readonly cause: unknown;
 }> {}
 
+class LocalSqliteCheckpointError extends Data.TaggedError("LocalSqliteCheckpointError")<{
+  readonly path: string;
+  readonly busy: number;
+}> {}
+
 const localExecutorCreateError = (
   operation: LocalExecutorCreateError["operation"],
   cause: unknown,
@@ -287,6 +292,32 @@ const moveSqliteFileSetToBackup = (path: string): string => {
   return backupPath;
 };
 
+const checkpointSqliteForFileMove = (input: {
+  readonly sqlite: Database;
+  readonly path: string;
+}) => {
+  const checkpoint = input.sqlite
+    .query<{ busy: number; log: number; checkpointed: number }, []>(
+      "PRAGMA wal_checkpoint(TRUNCATE)",
+    )
+    .get();
+
+  if (checkpoint && checkpoint.busy !== 0) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: SQLite file replacement is synchronous; callers wrap this native failure into LocalExecutorCreateError
+    throw new LocalSqliteCheckpointError({ path: input.path, busy: checkpoint.busy });
+  }
+
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: DELETE mode is best-effort after a successful checkpoint; an open read handle can reject the mode switch without making the file set unsafe to move
+  try {
+    input.sqlite.exec("PRAGMA journal_mode = DELETE");
+  } catch (cause) {
+    console.warn(
+      `[executor] Checkpointed SQLite WAL for ${input.path}, but could not switch journal mode to DELETE before import. Continuing with the checkpointed file set.`,
+      cause,
+    );
+  }
+};
+
 const writeSqliteImportMarker = (
   markerPath: string,
   input: {
@@ -422,8 +453,7 @@ const prepareLegacySqliteForFumaImport = (input: {
           `Skipping legacy Drizzle replay and importing the existing schema as-is.`,
       );
     }
-    sqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    sqlite.exec("PRAGMA journal_mode = DELETE");
+    checkpointSqliteForFileMove({ sqlite, path: input.storage.sqlitePath });
     return { legacySecrets: [] };
   } finally {
     sqlite.close();
@@ -469,8 +499,7 @@ const importMissingMarkedTables = async (input: {
       tables: pickedTables,
       scopeId: input.scopeId,
     });
-    target.sqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    target.sqlite.exec("PRAGMA journal_mode = DELETE");
+    checkpointSqliteForFileMove({ sqlite: target.sqlite, path: input.storage.sqlitePath });
     await target.close();
     removeSqliteSidecars(input.storage.sqlitePath);
 
@@ -534,8 +563,7 @@ export const importLegacySqliteIfNeeded = async (options: {
             await withQueryContext(target.db, {
               allowedScopeIds: new Set([scopeId]),
             }).createMany("secret", createLegacySecretRows(scopeId, prepared.legacySecrets));
-            target.sqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-            target.sqlite.exec("PRAGMA journal_mode = DELETE");
+            checkpointSqliteForFileMove({ sqlite: target.sqlite, path: storage.sqlitePath });
           } finally {
             await target.close();
             removeSqliteSidecars(storage.sqlitePath);
@@ -601,8 +629,7 @@ export const importLegacySqliteIfNeeded = async (options: {
       tables,
       scopeId,
     });
-    target.sqlite.exec("PRAGMA wal_checkpoint(TRUNCATE)");
-    target.sqlite.exec("PRAGMA journal_mode = DELETE");
+    checkpointSqliteForFileMove({ sqlite: target.sqlite, path: targetPath });
     await target.close();
     removeSqliteSidecars(targetPath);
 

--- a/apps/local/src/server/sqlite-import.test.ts
+++ b/apps/local/src/server/sqlite-import.test.ts
@@ -24,13 +24,16 @@ import { createSqliteFumaDb, type SqliteFumaDb } from "./sqlite-fumadb";
 
 let workDir: string;
 let sqlite: SqliteFumaDb | null;
+let heldReader: Database | null;
 
 beforeEach(() => {
   workDir = mkdtempSync(join(tmpdir(), "executor-sqlite-import-"));
   sqlite = null;
+  heldReader = null;
 });
 
 afterEach(async () => {
+  heldReader?.close();
   await sqlite?.close();
   rmSync(workDir, { recursive: true, force: true });
 });
@@ -435,6 +438,46 @@ describe("importSqliteDataToFuma", () => {
     expect(result.imported).toBe(true);
     expect(result.importedRows).toBe(2);
     expect(result.importedTables).toEqual(["source", "blob"]);
+    expect(existsSync(markerPath)).toBe(true);
+
+    sqlite = await createSqliteFumaDb({
+      tables,
+      namespace: "executor_local",
+      path: sqlitePath,
+    });
+    await expect(
+      withQueryContext(sqlite.db, { allowedScopeIds: new Set(["scope_a"]) }).findFirst("source", {
+        where: (b) => b("id", "=", "src_1"),
+      }),
+    ).resolves.toMatchObject({ id: "src_1", scope_id: "scope_a" });
+  });
+
+  it("imports a checkpointed legacy WAL database even when DELETE journal mode is busy", async () => {
+    const sqlitePath = join(workDir, "data.db");
+    const markerPath = join(workDir, "fumadb-sqlite-imported");
+    seedMigratedSqlite(sqlitePath);
+
+    const writer = new Database(sqlitePath);
+    writer.exec("PRAGMA journal_mode = WAL");
+    writer.close();
+
+    heldReader = new Database(sqlitePath, { readonly: true });
+    heldReader.exec("BEGIN");
+    heldReader.query("SELECT * FROM source").all();
+
+    const tables = collectTables([]);
+    const result = await importLegacySqliteIfNeeded({
+      storage: {
+        dataDir: workDir,
+        sqlitePath,
+        importMarkerPath: markerPath,
+      },
+      tables,
+      scopeId: "scope_a",
+    });
+
+    expect(result.imported).toBe(true);
+    expect(result.importedRows).toBe(2);
     expect(existsSync(markerPath)).toBe(true);
 
     sqlite = await createSqliteFumaDb({


### PR DESCRIPTION
## Summary

- Handles busy DELETE-journal cleanup after a successful WAL checkpoint during legacy SQLite import.
- Adds regression coverage for checkpoint/import cleanup behavior.

## Validation

- `bun --bun vitest run src/server/sqlite-import.test.ts` in `apps/local`
- `bun run typecheck` in `apps/local`

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#863** 👈 current
2. #864
3. #865
4. #866
5. #861
<!-- stack:links:end -->