### PR TITLE
Show connection identities in the UI

### DIFF
--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -4,10 +4,16 @@ import { useAtomRefresh, useAtomValue } from "@effect/atom-react";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
-import { sourcesAtom, sourcesOptimisticAtom, toolsAtom } from "@executor-js/react/api/atoms";
+import {
+  connectionsAtom,
+  sourcesAtom,
+  sourcesOptimisticAtom,
+  toolsAtom,
+} from "@executor-js/react/api/atoms";
 import { useScope, useScopeInfo } from "@executor-js/react/api/scope-context";
 import { Button } from "@executor-js/react/components/button";
-import { SourceFavicon, sourcePresetIconUrl } from "@executor-js/react/components/source-favicon";
+import { sourcePresetIconUrl } from "@executor-js/react/components/source-favicon";
+import { SourceIconWithAccount } from "@executor-js/react/components/source-icon-with-account";
 import { CommandPalette } from "@executor-js/react/components/command-palette";
 import { useClientPlugins, useSourcePlugins } from "@executor-js/sdk/client";
 import { ServerConnectionMenu } from "./server-connection-menu";
@@ -269,6 +275,8 @@ function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
 function SourceList(props: { pathname: string; onNavigate?: () => void }) {
   const scopeId = useScope();
   const sources = useAtomValue(sourcesOptimisticAtom(scopeId));
+  const connectionsResult = useAtomValue(connectionsAtom(scopeId));
+  const connections = AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : [];
   const sourcePlugins = useSourcePlugins();
 
   return AsyncResult.match(sources, {
@@ -287,6 +295,9 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
             const detailPath = `/sources/${s.id}`;
             const active =
               props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
+            const connection = connections.find((candidate) =>
+              s.connectionIds?.includes(candidate.id),
+            );
             return (
               <Link
                 key={s.id}
@@ -300,10 +311,12 @@ function SourceList(props: { pathname: string; onNavigate?: () => void }) {
                     : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
                 ].join(" ")}
               >
-                <SourceFavicon
+                <SourceIconWithAccount
                   icon={sourcePresetIconUrl(s, sourcePlugins)}
                   sourceId={s.id}
                   url={s.url}
+                  connection={connection}
+                  size="sm"
                 />
                 <span className="flex-1 truncate">{s.name}</span>
                 <span className="rounded bg-secondary/50 px-1 py-px text-xs font-medium text-muted-foreground">

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -88,6 +88,13 @@ export const connectionsAtom = (scopeId: ScopeId) =>
     reactivityKeys: [ReactivityKey.connections],
   });
 
+export const connectionIdentityAtom = (scopeId: ScopeId, connectionId: ConnectionId) =>
+  ExecutorApiClient.query("connections", "identity", {
+    params: { scopeId, connectionId },
+    timeToLive: "1 minute",
+    reactivityKeys: [ReactivityKey.connections],
+  });
+
 export const secretUsagesAtom = (scopeId: ScopeId, secretId: SecretId) =>
   ExecutorApiClient.query("secrets", "usages", {
     params: { scopeId, secretId },
@@ -129,6 +136,8 @@ export const setSecret = ExecutorApiClient.mutation("secrets", "set");
 export const removeSecret = ExecutorApiClient.mutation("secrets", "remove");
 
 export const removeConnection = ExecutorApiClient.mutation("connections", "remove");
+
+export const updateConnectionIdentity = ExecutorApiClient.mutation("connections", "updateIdentity");
 
 export const removeSource = ExecutorApiClient.mutation("sources", "remove");
 

--- a/packages/react/src/components/source-account-badge.tsx
+++ b/packages/react/src/components/source-account-badge.tsx
@@ -1,0 +1,40 @@
+import { useAtomValue } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import { ConnectionId, ScopeId } from "@executor-js/sdk/shared";
+
+import { connectionIdentityAtom } from "../api/atoms";
+
+export function SourceAccountBadge(props: {
+  readonly connection: {
+    readonly id: string;
+    readonly scopeId: string;
+    readonly identityLabel: string | null;
+  };
+  readonly size?: "sm" | "md";
+}) {
+  const identityResult = useAtomValue(
+    connectionIdentityAtom(
+      ScopeId.make(props.connection.scopeId),
+      ConnectionId.make(props.connection.id),
+    ),
+  );
+  const identity =
+    AsyncResult.isSuccess(identityResult) && identityResult.value.status === "available"
+      ? identityResult.value
+      : null;
+  const label = identity?.email ?? identity?.name ?? props.connection.identityLabel ?? "Connected";
+  const sizeClass = props.size === "sm" ? "size-3 text-[7px]" : "size-4 text-[9px]";
+  const badgeClass = `absolute -bottom-1 -right-1 z-10 flex ${sizeClass} items-center justify-center rounded-full border-2 border-card bg-background font-medium leading-none text-muted-foreground shadow-sm`;
+
+  return identity?.picture ? (
+    <span
+      title={label}
+      className={`${badgeClass} bg-cover bg-center`}
+      style={{ backgroundImage: `url("${identity.picture.replaceAll('"', "%22")}")` }}
+    />
+  ) : (
+    <span title={label} className={badgeClass}>
+      {label.slice(0, 1).toUpperCase()}
+    </span>
+  );
+}

--- a/packages/react/src/components/source-icon-with-account.tsx
+++ b/packages/react/src/components/source-icon-with-account.tsx
@@ -1,0 +1,27 @@
+import { SourceAccountBadge } from "./source-account-badge";
+import { SourceFavicon } from "./source-favicon";
+
+export function SourceIconWithAccount(props: {
+  readonly icon?: string | null;
+  readonly sourceId: string;
+  readonly url?: string;
+  readonly connection?: {
+    readonly id: string;
+    readonly scopeId: string;
+    readonly identityLabel: string | null;
+  } | null;
+  readonly size?: "sm" | "md";
+}) {
+  const iconSize = props.size === "sm" ? 16 : 32;
+  return (
+    <span className={props.size === "sm" ? "relative size-4 shrink-0" : "relative size-8 shrink-0"}>
+      <SourceFavicon icon={props.icon} sourceId={props.sourceId} url={props.url} size={iconSize} />
+      {props.connection ? (
+        <SourceAccountBadge
+          connection={props.connection}
+          size={props.size === "sm" ? "sm" : "md"}
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/packages/react/src/pages/connections.tsx
+++ b/packages/react/src/pages/connections.tsx
@@ -1,4 +1,5 @@
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
@@ -6,11 +7,15 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { ConnectionId, ConnectionInUseError, ScopeId } from "@executor-js/sdk/shared";
 import { toast } from "sonner";
+import { ChevronDownIcon } from "lucide-react";
 
 import {
+  connectionIdentityAtom,
   connectionUsagesAtom,
   connectionsOptimisticAtom,
   removeConnectionOptimistic,
+  sourcesOptimisticAtom,
+  updateConnectionIdentity,
 } from "../api/atoms";
 import { connectionWriteKeys } from "../api/reactivity-keys";
 import { useScope, useScopeStack } from "../hooks/use-scope";
@@ -32,6 +37,19 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "../components/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../components/dialog";
+import { Input } from "../components/input";
+import { FieldLabel } from "../components/field";
+import { SourceIconWithAccount } from "../components/source-icon-with-account";
+import { sourcePresetIconUrl } from "../components/source-favicon";
+import { useSourcePlugins } from "@executor-js/sdk/client";
 
 // ---------------------------------------------------------------------------
 // Provider display
@@ -47,6 +65,22 @@ const displayProvider = (provider: string): string => providerDisplayNames[provi
 
 const isConnectionInUseError = Schema.is(ConnectionInUseError);
 
+type ConnectionListItem = {
+  readonly id: string;
+  readonly scopeId: string;
+  readonly provider: string;
+  readonly identityLabel: string | null;
+  readonly expiresAt: number | null;
+  readonly oauthScope: string | null;
+  readonly identityOverride: {
+    readonly displayName: string | null;
+    readonly email: string | null;
+    readonly avatarUrl: string | null;
+  } | null;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+};
+
 const connectionScopeLabel = (
   scopeId: string,
   stack: readonly { readonly id: string; readonly name: string }[],
@@ -57,29 +91,125 @@ const connectionScopeLabel = (
   return "Scoped";
 };
 
+const splitScopes = (oauthScope: string | null): readonly string[] =>
+  oauthScope?.split(/\s+/).filter((scope) => scope.length > 0) ?? [];
+
+const compactScope = (scope: string): string => {
+  if (!URL.canParse(scope)) return scope;
+  const url = new URL(scope);
+  const last = url.pathname.split("/").filter(Boolean).at(-1);
+  return last ?? scope;
+};
+
+type LinkedSource = {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: string;
+  readonly url?: string;
+  readonly connectionIds?: readonly string[];
+};
+
 // ---------------------------------------------------------------------------
 // Used-by footer — same shape as the secrets page. Returns null when a
 // connection isn't referenced anywhere so newly-created connections
 // don't get a stray "Used by 0" line before any source binds to them.
 // ---------------------------------------------------------------------------
 
-function ConnectionUsageFooter(props: { scopeId: ScopeId; connectionId: ConnectionId }) {
-  const usages = useAtomValue(connectionUsagesAtom(props.scopeId, props.connectionId));
+function ConnectionDetails(props: {
+  scopeId: ScopeId;
+  connection: ConnectionListItem;
+  open: boolean;
+}) {
+  const sourcePlugins = useSourcePlugins();
+  const usages = useAtomValue(
+    connectionUsagesAtom(props.scopeId, ConnectionId.make(props.connection.id)),
+  );
+  const sourcesResult = useAtomValue(sourcesOptimisticAtom(props.scopeId));
+  const sources = AsyncResult.isSuccess(sourcesResult)
+    ? (sourcesResult.value as readonly LinkedSource[])
+    : [];
+  const allScopes = splitScopes(props.connection.oauthScope);
+  const connectionShape = {
+    id: props.connection.id,
+    scopeId: props.connection.scopeId,
+    identityLabel: props.connection.identityLabel,
+  };
   return AsyncResult.match(usages, {
     onInitial: () => null,
     onFailure: () => null,
     onSuccess: ({ value }) => {
-      if (value.length === 0) return null;
-      const labels = value
-        .map((u) => u.ownerName ?? u.ownerId)
-        .filter((s, i, a) => a.indexOf(s) === i);
-      const visible = labels.slice(0, 3);
-      const hidden = labels.length - visible.length;
+      const linkedSources = value
+        .map((usage) => {
+          const source = sources.find((candidate) => candidate.id === usage.ownerId);
+          return {
+            id: usage.ownerId,
+            name: source?.name ?? usage.ownerName ?? usage.ownerId,
+            kind: source?.kind ?? usage.pluginId,
+            url: source?.url,
+            connectionIds: source?.connectionIds,
+          };
+        })
+        .filter((source, index, all) => all.findIndex((item) => item.id === source.id) === index);
+      if (!props.open) {
+        if (linkedSources.length === 0) return null;
+        const visible = linkedSources.slice(0, 2).map((source) => source.name);
+        const hidden = linkedSources.length - visible.length;
+        return (
+          <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
+            Used by {visible.join(", ")}
+            {hidden > 0 ? ` +${hidden} more` : ""}
+          </CardStackEntryDescription>
+        );
+      }
       return (
-        <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
-          Used by {visible.join(", ")}
-          {hidden > 0 ? ` +${hidden} more` : ""}
-        </CardStackEntryDescription>
+        <div className="mt-3 space-y-3 rounded-md border border-border/50 bg-muted/10 p-3">
+          <div className="space-y-2">
+            <div className="text-[11px] font-medium text-muted-foreground">Linked sources</div>
+            {linkedSources.length === 0 ? (
+              <div className="text-xs text-muted-foreground">No sources are using this yet.</div>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {linkedSources.map((source) => (
+                  <Link
+                    key={source.id}
+                    to="/sources/$namespace"
+                    params={{ namespace: source.id }}
+                    className="flex max-w-full items-center gap-2 rounded-md border border-border/60 bg-background/70 px-2 py-1.5 transition-colors hover:bg-accent/60 focus-visible:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  >
+                    <SourceIconWithAccount
+                      icon={sourcePresetIconUrl(source, sourcePlugins)}
+                      sourceId={source.id}
+                      url={source.url}
+                      connection={connectionShape}
+                      size="sm"
+                    />
+                    <span className="truncate text-xs font-medium text-foreground">
+                      {source.name}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+          {allScopes.length > 0 ? (
+            <div className="space-y-2">
+              <div className="text-[11px] font-medium text-muted-foreground">Granted scopes</div>
+              <div className="max-h-24 overflow-y-auto pr-1">
+                <div className="flex flex-wrap gap-1.5">
+                  {allScopes.map((scope) => (
+                    <span
+                      key={scope}
+                      title={scope}
+                      className="max-w-full truncate rounded border border-border/60 bg-background/70 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                    >
+                      {compactScope(scope)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
       );
     },
   });
@@ -91,65 +221,187 @@ function ConnectionUsageFooter(props: { scopeId: ScopeId; connectionId: Connecti
 
 function ConnectionRow(props: {
   scopeId: ScopeId;
-  connection: {
-    id: string;
-    scopeId: string;
-    provider: string;
-    identityLabel: string | null;
-  };
+  connection: ConnectionListItem;
   scopeStack: readonly { readonly id: string; readonly name: string }[];
   onRemove: () => void;
 }) {
   const { connection } = props;
+  const doUpdateIdentity = useAtomSet(updateConnectionIdentity, { mode: "promiseExit" });
+  const [editingIdentity, setEditingIdentity] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const [savingIdentity, setSavingIdentity] = useState(false);
+  const [displayName, setDisplayName] = useState(connection.identityOverride?.displayName ?? "");
+  const [email, setEmail] = useState(connection.identityOverride?.email ?? "");
+  const [avatarUrl, setAvatarUrl] = useState(connection.identityOverride?.avatarUrl ?? "");
+  const identityResult = useAtomValue(
+    connectionIdentityAtom(ScopeId.make(connection.scopeId), ConnectionId.make(connection.id)),
+  );
+  const identity =
+    AsyncResult.isSuccess(identityResult) && identityResult.value.status === "available"
+      ? identityResult.value
+      : null;
+  const identityStatus =
+    AsyncResult.isSuccess(identityResult) && identityResult.value.status !== "available"
+      ? identityResult.value
+      : null;
   const scopeLabel = connectionScopeLabel(connection.scopeId, props.scopeStack);
   const displayLabel =
-    connection.identityLabel && connection.identityLabel.length > 0
+    identity?.email ??
+    identity?.name ??
+    (connection.identityLabel && connection.identityLabel.length > 0
       ? connection.identityLabel
-      : connection.id;
+      : connection.id);
+  const details = [displayProvider(connection.provider), scopeLabel];
+
+  useEffect(() => {
+    if (editingIdentity) return;
+    setDisplayName(connection.identityOverride?.displayName ?? "");
+    setEmail(connection.identityOverride?.email ?? "");
+    setAvatarUrl(connection.identityOverride?.avatarUrl ?? "");
+  }, [connection.identityOverride, editingIdentity]);
+
+  const handleSaveIdentity = async () => {
+    setSavingIdentity(true);
+    const cleanDisplayName = displayName.trim();
+    const cleanEmail = email.trim();
+    const cleanAvatarUrl = avatarUrl.trim();
+    const identityOverride =
+      cleanDisplayName || cleanEmail || cleanAvatarUrl
+        ? {
+            displayName: cleanDisplayName || null,
+            email: cleanEmail || null,
+            avatarUrl: cleanAvatarUrl || null,
+          }
+        : null;
+    const exit = await doUpdateIdentity({
+      params: {
+        scopeId: ScopeId.make(connection.scopeId),
+        connectionId: ConnectionId.make(connection.id),
+      },
+      payload: { identityOverride },
+      reactivityKeys: connectionWriteKeys,
+    });
+    setSavingIdentity(false);
+    if (Exit.isFailure(exit)) {
+      toast.error("Failed to update account info");
+      return;
+    }
+    setEditingIdentity(false);
+  };
 
   return (
-    <CardStackEntry>
-      <CardStackEntryContent>
-        <CardStackEntryTitle className="flex items-center gap-2">
-          <span className="truncate">{displayLabel}</span>
-        </CardStackEntryTitle>
-        <CardStackEntryDescription className="text-xs text-muted-foreground">
-          {displayProvider(connection.provider)}
-        </CardStackEntryDescription>
-        <Suspense fallback={null}>
-          <ConnectionUsageFooter
-            scopeId={props.scopeId}
-            connectionId={ConnectionId.make(connection.id)}
-          />
-        </Suspense>
-      </CardStackEntryContent>
-      <CardStackEntryActions>
-        <Badge variant="outline">{scopeLabel}</Badge>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-7 opacity-0 transition-opacity group-hover/card-stack-entry:opacity-100 group-focus-within/card-stack-entry:opacity-100 data-[state=open]:opacity-100"
-            >
-              <svg viewBox="0 0 16 16" className="size-3">
-                <circle cx="8" cy="3" r="1.2" fill="currentColor" />
-                <circle cx="8" cy="8" r="1.2" fill="currentColor" />
-                <circle cx="8" cy="13" r="1.2" fill="currentColor" />
-              </svg>
+    <>
+      <CardStackEntry>
+        <CardStackEntryContent>
+          <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
+            {identity?.picture ? (
+              <img
+                src={identity.picture}
+                alt=""
+                referrerPolicy="no-referrer"
+                className="size-5 shrink-0 rounded-full"
+              />
+            ) : null}
+            <span className="truncate">{displayLabel}</span>
+          </CardStackEntryTitle>
+          <CardStackEntryDescription className="text-xs text-muted-foreground">
+            {details.join(" · ")}
+          </CardStackEntryDescription>
+          {identityStatus?.status === "reauth_required" ? (
+            <CardStackEntryDescription className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+              {identityStatus.message ?? "Connection needs re-authentication"}
+            </CardStackEntryDescription>
+          ) : null}
+          <Suspense fallback={null}>
+            <ConnectionDetails scopeId={props.scopeId} connection={connection} open={expanded} />
+          </Suspense>
+        </CardStackEntryContent>
+        <CardStackEntryActions>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 px-2 text-xs text-muted-foreground"
+            onClick={() => setExpanded((value) => !value)}
+          >
+            Details
+            <ChevronDownIcon
+              className={`size-3 transition-transform ${expanded ? "rotate-180" : ""}`}
+            />
+          </Button>
+          <Badge variant="outline">{scopeLabel}</Badge>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7 opacity-0 transition-opacity group-hover/card-stack-entry:opacity-100 group-focus-within/card-stack-entry:opacity-100 data-[state=open]:opacity-100"
+              >
+                <svg viewBox="0 0 16 16" className="size-3">
+                  <circle cx="8" cy="3" r="1.2" fill="currentColor" />
+                  <circle cx="8" cy="8" r="1.2" fill="currentColor" />
+                  <circle cx="8" cy="13" r="1.2" fill="currentColor" />
+                </svg>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              <DropdownMenuItem className="text-sm" onClick={() => setEditingIdentity(true)}>
+                Edit account info
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive text-sm"
+                onClick={props.onRemove}
+              >
+                Remove
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </CardStackEntryActions>
+      </CardStackEntry>
+      <Dialog open={editingIdentity} onOpenChange={setEditingIdentity}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Account info</DialogTitle>
+            <DialogDescription>
+              Override the account details shown for this connection.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-3">
+            <div className="space-y-1.5">
+              <FieldLabel>Display name</FieldLabel>
+              <Input
+                value={displayName}
+                onChange={(event) => setDisplayName((event.target as HTMLInputElement).value)}
+                placeholder={identity?.name ?? connection.identityLabel ?? "Rhys Sullivan"}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>Email</FieldLabel>
+              <Input
+                value={email}
+                onChange={(event) => setEmail((event.target as HTMLInputElement).value)}
+                placeholder={identity?.email ?? "rhys@example.com"}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <FieldLabel>Avatar URL</FieldLabel>
+              <Input
+                value={avatarUrl}
+                onChange={(event) => setAvatarUrl((event.target as HTMLInputElement).value)}
+                placeholder={identity?.picture ?? "https://example.com/avatar.png"}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setEditingIdentity(false)}>
+              Cancel
             </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-40">
-            <DropdownMenuItem
-              className="text-destructive focus:text-destructive text-sm"
-              onClick={props.onRemove}
-            >
-              Remove
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </CardStackEntryActions>
-    </CardStackEntry>
+            <Button onClick={() => void handleSaveIdentity()} disabled={savingIdentity}>
+              {savingIdentity ? "Saving..." : "Save"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 
@@ -222,29 +474,15 @@ export function ConnectionsPage() {
                     </CardStackEntryContent>
                   </CardStackEntry>
                 ) : (
-                  value.map(
-                    (c: {
-                      readonly id: string;
-                      readonly scopeId: string;
-                      readonly provider: string;
-                      readonly identityLabel: string | null;
-                    }) => (
-                      <ConnectionRow
-                        key={c.id}
-                        scopeId={scopeId}
-                        connection={{
-                          id: c.id,
-                          scopeId: c.scopeId,
-                          provider: c.provider,
-                          identityLabel: c.identityLabel,
-                        }}
-                        scopeStack={scopeStack}
-                        onRemove={() =>
-                          handleRemove({ id: c.id, scopeId: ScopeId.make(c.scopeId) })
-                        }
-                      />
-                    ),
-                  )
+                  value.map((c: ConnectionListItem) => (
+                    <ConnectionRow
+                      key={c.id}
+                      scopeId={scopeId}
+                      connection={c}
+                      scopeStack={scopeStack}
+                      onRemove={() => handleRemove({ id: c.id, scopeId: ScopeId.make(c.scopeId) })}
+                    />
+                  ))
                 )}
               </CardStackContent>
             </CardStack>

--- a/packages/react/src/pages/connections.tsx
+++ b/packages/react/src/pages/connections.tsx
@@ -162,7 +162,7 @@ function ConnectionDetails(props: {
         );
       }
       return (
-        <div className="mt-3 space-y-3 rounded-md border border-border/50 bg-muted/10 p-3">
+        <div className="w-full space-y-4">
           <div className="space-y-2">
             <div className="text-[11px] font-medium text-muted-foreground">Linked sources</div>
             {linkedSources.length === 0 ? (
@@ -291,7 +291,7 @@ function ConnectionRow(props: {
 
   return (
     <>
-      <CardStackEntry>
+      <CardStackEntry className="flex-wrap items-start">
         <CardStackEntryContent>
           <CardStackEntryTitle className="flex min-w-0 items-center gap-2">
             {identity?.picture ? (
@@ -312,11 +312,8 @@ function ConnectionRow(props: {
               {identityStatus.message ?? "Connection needs re-authentication"}
             </CardStackEntryDescription>
           ) : null}
-          <Suspense fallback={null}>
-            <ConnectionDetails scopeId={props.scopeId} connection={connection} open={expanded} />
-          </Suspense>
         </CardStackEntryContent>
-        <CardStackEntryActions>
+        <CardStackEntryActions className="self-start pt-0.5">
           <Button
             variant="ghost"
             size="sm"
@@ -356,6 +353,9 @@ function ConnectionRow(props: {
             </DropdownMenuContent>
           </DropdownMenu>
         </CardStackEntryActions>
+        <Suspense fallback={null}>
+          <ConnectionDetails scopeId={props.scopeId} connection={connection} open={expanded} />
+        </Suspense>
       </CardStackEntry>
       <Dialog open={editingIdentity} onOpenChange={setEditingIdentity}>
         <DialogContent>

--- a/packages/react/src/pages/sources.tsx
+++ b/packages/react/src/pages/sources.tsx
@@ -6,7 +6,7 @@ import * as Exit from "effect/Exit";
 import { PlusIcon } from "lucide-react";
 import type { SourceDetectionResult } from "@executor-js/sdk/shared";
 import { useSourcePlugins, type SourcePlugin, type SourcePreset } from "@executor-js/sdk/client";
-import { detectSource, sourcesOptimisticAtom } from "../api/atoms";
+import { connectionsAtom, detectSource, sourcesOptimisticAtom } from "../api/atoms";
 import { useScope } from "../hooks/use-scope";
 import { McpInstallCard } from "../components/mcp-install-card";
 import { Button } from "../components/button";
@@ -29,7 +29,8 @@ import {
   CardStackEntryMedia,
   CardStackEntryTitle,
 } from "../components/card-stack";
-import { SourceFavicon, sourcePresetIconUrl } from "../components/source-favicon";
+import { sourcePresetIconUrl } from "../components/source-favicon";
+import { SourceIconWithAccount } from "../components/source-icon-with-account";
 import { Skeleton } from "../components/skeleton";
 
 const KIND_TO_PLUGIN_KEY: Record<string, string> = {
@@ -94,6 +95,7 @@ export function SourcesPage() {
                 readonly kind: string;
                 readonly url?: string;
                 readonly runtime?: boolean;
+                readonly connectionIds?: readonly string[];
               }>
             ).filter((source) => !source.runtime);
 
@@ -391,9 +393,13 @@ function SourceGrid(props: {
     kind: string;
     url?: string;
     runtime?: boolean;
+    connectionIds?: readonly string[];
   }[];
 }) {
   const sourcePlugins = useSourcePlugins();
+  const scopeId = useScope();
+  const connectionsResult = useAtomValue(connectionsAtom(scopeId));
+  const connections = AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : [];
   const pluginByKind = useMemo(() => {
     const out = new Map<string, SourcePlugin>();
     for (const p of sourcePlugins) out.set(p.key, p);
@@ -407,17 +413,18 @@ function SourceGrid(props: {
           const pluginKey = KIND_TO_PLUGIN_KEY[s.kind] ?? s.kind;
           const plugin = pluginByKind.get(pluginKey);
           const SummaryComponent = plugin?.summary;
+          const connection = connections.find((candidate) =>
+            s.connectionIds?.includes(candidate.id),
+          );
           return (
             <CardStackEntry key={s.id} asChild searchText={`${s.name} ${s.id} ${s.kind}`}>
               <Link to="/sources/$namespace" params={{ namespace: s.id }}>
-                <CardStackEntryMedia>
-                  <SourceFavicon
-                    icon={sourcePresetIconUrl(s, sourcePlugins)}
-                    sourceId={s.id}
-                    url={s.url}
-                    size={32}
-                  />
-                </CardStackEntryMedia>
+                <SourceIconWithAccount
+                  icon={sourcePresetIconUrl(s, sourcePlugins)}
+                  sourceId={s.id}
+                  url={s.url}
+                  connection={connection}
+                />
                 <CardStackEntryContent>
                   <CardStackEntryTitle>{s.name}</CardStackEntryTitle>
                   <CardStackEntryDescription>{s.id}</CardStackEntryDescription>


### PR DESCRIPTION
## Summary
- show detected or manually-entered account info on the connections page
- add linked source badges and expandable scopes/source details
- reuse the same account-badged source icon in the sidebar and sources page

## Tests
- bun run --cwd packages/react typecheck
- bun run --cwd packages/core/api test -- src/handlers/connection-identity.test.ts

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #871
2. **#872** 👈 current
3. #873
4. #874
5. #875
<!-- stack:links:end -->