### PR TITLE
Improve OpenAPI OAuth account reuse

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -774,6 +774,7 @@
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "effect": "catalog:",
+        "lucide-react": "^1.7.0",
         "openapi-types": "^12.1.3",
         "yaml": "^2.7.1",
       },

--- a/packages/core/sdk/src/http-source.ts
+++ b/packages/core/sdk/src/http-source.ts
@@ -46,6 +46,14 @@ export const OAuth2Flow = Schema.Literals(["authorizationCode", "clientCredentia
 export type OAuth2Flow = typeof OAuth2Flow.Type;
 export type OAuth2FlowType = OAuth2Flow;
 
+export const OAuth2IdentityScopes = Schema.Union([
+  Schema.Literal("auto"),
+  Schema.Literal(false),
+  Schema.Array(Schema.String),
+]);
+export type OAuth2IdentityScopes = typeof OAuth2IdentityScopes.Type;
+export type OAuth2IdentityScopesType = OAuth2IdentityScopes;
+
 export const OAuth2SourceConfig = Schema.Struct({
   kind: Schema.Literal("oauth2"),
   securitySchemeName: Schema.String,
@@ -60,6 +68,10 @@ export const OAuth2SourceConfig = Schema.Struct({
   clientSecretSlot: Schema.NullOr(Schema.String),
   connectionSlot: Schema.String,
   scopes: Schema.Array(Schema.String),
+  identityScopes: OAuth2IdentityScopes.pipe(
+    Schema.optional,
+    Schema.withDecodingDefault(Effect.succeed("auto" as const)),
+  ),
 }).annotate({ identifier: "OAuth2SourceConfig" });
 export type OAuth2SourceConfig = typeof OAuth2SourceConfig.Type;
 export type OAuth2SourceConfigType = OAuth2SourceConfig;

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -142,6 +142,7 @@ const AuthorizationCodeSessionPayload = Schema.Struct({
     Schema.withDecodingDefaultType(Effect.succeed(null)),
   ),
   scopes: Schema.Array(Schema.String),
+  authorizationScopes: Schema.optional(Schema.Array(Schema.String)),
   storedScope: Schema.optional(Schema.String),
   scopeSeparator: Schema.optional(Schema.String),
   clientAuth: Schema.Literals(["body", "basic"]),
@@ -615,12 +616,19 @@ export const makeOAuth2Service = (
       const sessionId = scopedSessionId(input.tokenScope, newSessionId());
       const codeVerifier = createPkceCodeVerifier();
       const codeChallenge = yield* Effect.promise(() => createPkceCodeChallenge(codeVerifier));
+      const authorizationScopes =
+        options?.authorizationScopes ?? strategy.authorizationScopes ?? strategy.scopes;
+      const storedScope =
+        options?.storedScope ??
+        (strategy.authorizationScopes
+          ? strategy.scopes.join(strategy.scopeSeparator ?? " ")
+          : undefined);
 
       const authorizationUrl = buildAuthorizationUrl({
         authorizationUrl: strategy.authorizationEndpoint,
         clientId: clientIdRef.value,
         redirectUrl: input.redirectUrl,
-        scopes: options?.authorizationScopes ?? strategy.scopes,
+        scopes: authorizationScopes,
         state: sessionId,
         codeChallenge,
         scopeSeparator: strategy.scopeSeparator,
@@ -645,7 +653,8 @@ export const makeOAuth2Service = (
             }))?.scopeId ?? null)
           : null,
         scopes: [...strategy.scopes],
-        storedScope: options?.storedScope,
+        authorizationScopes: [...authorizationScopes],
+        storedScope,
         scopeSeparator: strategy.scopeSeparator,
         clientAuth: strategy.clientAuth ?? "body",
       };
@@ -1011,7 +1020,7 @@ export const makeOAuth2Service = (
               clientSecretSecretId: payload.clientSecretSecretId,
               clientSecretSecretScopeId: payload.clientSecretSecretScopeId,
               clientAuth: payload.clientAuth,
-              scopes: [...payload.scopes],
+              scopes: [...(payload.authorizationScopes ?? payload.scopes)],
               scopeSeparator: payload.scopeSeparator,
               scope: effectiveOAuthScope,
             };

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -61,6 +61,7 @@ import {
   OAuthSessionNotFoundError,
   OAuthStartError,
   type OAuthAuthorizationCodeStrategy,
+  type OAuthAuthorizationCodeExistingClientStrategy,
   type OAuthClientCredentialsStrategy,
   type OAuthCompleteInput,
   type OAuthCompleteResult,
@@ -657,6 +658,42 @@ export const makeOAuth2Service = (
       };
     });
 
+  const startAuthorizationCodeWithExistingClient = (
+    input: OAuthStartInput,
+    strategy: OAuthAuthorizationCodeExistingClientStrategy,
+  ): Effect.Effect<OAuthStartResult, OAuthStartError | StorageFailure> =>
+    Effect.gen(function* () {
+      const existing = yield* connectionsGet(input.connectionId);
+      if (!existing || existing.scopeId !== input.tokenScope) {
+        return yield* new OAuthStartError({
+          message: "Existing OAuth connection was not found at the selected scope",
+        });
+      }
+      const state = existing.providerState
+        ? Option.getOrNull(decodeProviderStateOption(coerceJson(existing.providerState)))
+        : null;
+      if (!state || state.kind !== "authorization-code") {
+        return yield* new OAuthStartError({
+          message: "Existing OAuth connection cannot be reused for authorization-code sign-in",
+        });
+      }
+
+      return yield* startAuthorizationCode(input, {
+        kind: "authorization-code",
+        authorizationEndpoint: strategy.authorizationEndpoint,
+        tokenEndpoint: strategy.tokenEndpoint ?? state.tokenEndpoint,
+        issuerUrl: strategy.issuerUrl ?? state.issuerUrl,
+        clientIdSecretId: state.clientIdSecretId,
+        clientIdSecretScopeId: state.clientIdSecretScopeId,
+        clientSecretSecretId: state.clientSecretSecretId,
+        clientSecretSecretScopeId: state.clientSecretSecretScopeId,
+        scopes: [...strategy.scopes],
+        scopeSeparator: strategy.scopeSeparator ?? state.scopeSeparator,
+        extraAuthorizationParams: strategy.extraAuthorizationParams,
+        clientAuth: state.clientAuth,
+      });
+    });
+
   const startClientCredentials = (
     input: OAuthStartInput,
     strategy: OAuthClientCredentialsStrategy,
@@ -764,6 +801,9 @@ export const makeOAuth2Service = (
       Match.when({ kind: "dynamic-dcr" }, (strategy) => startDynamicDcr(input, strategy)),
       Match.when({ kind: "authorization-code" }, (strategy) =>
         startAuthorizationCode(input, strategy),
+      ),
+      Match.when({ kind: "authorization-code-existing-client" }, (strategy) =>
+        startAuthorizationCodeWithExistingClient(input, strategy),
       ),
       Match.when({ kind: "client-credentials" }, (strategy) =>
         startClientCredentials(input, strategy),

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -142,6 +142,7 @@ const AuthorizationCodeSessionPayload = Schema.Struct({
     Schema.withDecodingDefaultType(Effect.succeed(null)),
   ),
   scopes: Schema.Array(Schema.String),
+  storedScope: Schema.optional(Schema.String),
   scopeSeparator: Schema.optional(Schema.String),
   clientAuth: Schema.Literals(["body", "basic"]),
 });
@@ -588,6 +589,10 @@ export const makeOAuth2Service = (
   const startAuthorizationCode = (
     input: OAuthStartInput,
     strategy: OAuthAuthorizationCodeStrategy,
+    options?: {
+      readonly authorizationScopes?: readonly string[];
+      readonly storedScope?: string;
+    },
   ): Effect.Effect<OAuthStartResult, OAuthStartError | StorageFailure> =>
     Effect.gen(function* () {
       const clientIdRef = yield* secretsGetResolvedAtScope({
@@ -615,7 +620,7 @@ export const makeOAuth2Service = (
         authorizationUrl: strategy.authorizationEndpoint,
         clientId: clientIdRef.value,
         redirectUrl: input.redirectUrl,
-        scopes: strategy.scopes,
+        scopes: options?.authorizationScopes ?? strategy.scopes,
         state: sessionId,
         codeChallenge,
         scopeSeparator: strategy.scopeSeparator,
@@ -640,6 +645,7 @@ export const makeOAuth2Service = (
             }))?.scopeId ?? null)
           : null,
         scopes: [...strategy.scopes],
+        storedScope: options?.storedScope,
         scopeSeparator: strategy.scopeSeparator,
         clientAuth: strategy.clientAuth ?? "body",
       };
@@ -678,20 +684,31 @@ export const makeOAuth2Service = (
         });
       }
 
-      return yield* startAuthorizationCode(input, {
-        kind: "authorization-code",
-        authorizationEndpoint: strategy.authorizationEndpoint,
-        tokenEndpoint: strategy.tokenEndpoint ?? state.tokenEndpoint,
-        issuerUrl: strategy.issuerUrl ?? state.issuerUrl,
-        clientIdSecretId: state.clientIdSecretId,
-        clientIdSecretScopeId: state.clientIdSecretScopeId,
-        clientSecretSecretId: state.clientSecretSecretId,
-        clientSecretSecretScopeId: state.clientSecretSecretScopeId,
-        scopes: [...strategy.scopes],
-        scopeSeparator: strategy.scopeSeparator ?? state.scopeSeparator,
-        extraAuthorizationParams: strategy.extraAuthorizationParams,
-        clientAuth: state.clientAuth,
-      });
+      const scopeSeparator = strategy.scopeSeparator ?? state.scopeSeparator;
+
+      return yield* startAuthorizationCode(
+        input,
+        {
+          kind: "authorization-code",
+          authorizationEndpoint: strategy.authorizationEndpoint,
+          tokenEndpoint: strategy.tokenEndpoint ?? state.tokenEndpoint,
+          issuerUrl: strategy.issuerUrl ?? state.issuerUrl,
+          clientIdSecretId: state.clientIdSecretId,
+          clientIdSecretScopeId: state.clientIdSecretScopeId,
+          clientSecretSecretId: state.clientSecretSecretId,
+          clientSecretSecretScopeId: state.clientSecretSecretScopeId,
+          scopes: [...strategy.scopes],
+          scopeSeparator,
+          extraAuthorizationParams: strategy.extraAuthorizationParams,
+          clientAuth: state.clientAuth,
+        },
+        strategy.authorizationScopes
+          ? {
+              authorizationScopes: strategy.authorizationScopes,
+              storedScope: strategy.scopes.join(scopeSeparator ?? " "),
+            }
+          : undefined,
+      );
     });
 
   const startClientCredentials = (
@@ -915,6 +932,10 @@ export const makeOAuth2Service = (
         typeof exchangeResult.tokens.expires_in === "number"
           ? now() + exchangeResult.tokens.expires_in * 1000
           : null;
+      const effectiveOAuthScope =
+        payload.kind === "authorization-code" && payload.storedScope
+          ? payload.storedScope
+          : (exchangeResult.tokens.scope ?? null);
 
       const dynamicClientSecretSecretId = yield* (() => {
         if (payload.kind !== "dynamic-dcr") return Effect.succeed(null);
@@ -978,7 +999,7 @@ export const makeOAuth2Service = (
                   : "body",
               clientSecretSecretScopeId: dynamicClientSecretSecretId ? tokenScope : null,
               scopes: [...payload.scopes],
-              scope: exchangeResult.tokens.scope ?? null,
+              scope: effectiveOAuthScope,
               resource: payload.resource,
             }
           : {
@@ -992,7 +1013,7 @@ export const makeOAuth2Service = (
               clientAuth: payload.clientAuth,
               scopes: [...payload.scopes],
               scopeSeparator: payload.scopeSeparator,
-              scope: exchangeResult.tokens.scope ?? null,
+              scope: effectiveOAuthScope,
             };
 
       yield* deps
@@ -1017,7 +1038,7 @@ export const makeOAuth2Service = (
                 })
               : null,
             expiresAt: connectionExpiresAt,
-            oauthScope: exchangeResult.tokens.scope ?? null,
+            oauthScope: effectiveOAuthScope,
             providerState: encodeProviderStateSync(providerState) as Record<string, unknown>,
           }),
         )
@@ -1049,7 +1070,7 @@ export const makeOAuth2Service = (
       return {
         connectionId,
         expiresAt: connectionExpiresAt,
-        scope: exchangeResult.tokens.scope ?? null,
+        scope: effectiveOAuthScope,
       };
     });
 

--- a/packages/core/sdk/src/oauth.ts
+++ b/packages/core/sdk/src/oauth.ts
@@ -64,7 +64,11 @@ export const OAuthAuthorizationCodeStrategy = Schema.Struct({
    *  PKCE without a confidential secret. */
   clientSecretSecretId: Schema.NullOr(Schema.String),
   clientSecretSecretScopeId: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Final scope set Executor should remember for this connection. */
   scopes: Schema.Array(Schema.String),
+  /** Optional smaller scope set to send to the authorization server. This is
+   *  useful when one provider scope covers many source-level operation scopes. */
+  authorizationScopes: Schema.optional(Schema.Array(Schema.String)),
   /** Separator between scopes. RFC 6749 says space; some providers
    *  (GitHub classic) use comma. */
   scopeSeparator: Schema.optional(Schema.String),
@@ -88,9 +92,7 @@ export const OAuthAuthorizationCodeExistingClientStrategy = Schema.Struct({
   /** Final scope set Executor should remember for this connection. */
   scopes: Schema.Array(Schema.String),
   /** Optional smaller scope set to send to the authorization server. This is
-   *  for providers such as Google that support incremental authorization via
-   *  `include_granted_scopes=true`: request only newly-missing scopes, but
-   *  keep the connection's full granted-scope model for refresh/source reuse. */
+   *  useful when one provider scope covers many source-level operation scopes. */
   authorizationScopes: Schema.optional(Schema.Array(Schema.String)),
   scopeSeparator: Schema.optional(Schema.String),
   extraAuthorizationParams: Schema.optional(Schema.Record(Schema.String, Schema.String)),

--- a/packages/core/sdk/src/oauth.ts
+++ b/packages/core/sdk/src/oauth.ts
@@ -77,6 +77,21 @@ export const OAuthAuthorizationCodeStrategy = Schema.Struct({
 });
 export type OAuthAuthorizationCodeStrategy = typeof OAuthAuthorizationCodeStrategy.Type;
 
+/** Authorization-code flow that reuses the client credentials recorded on
+ *  an existing OAuth connection. Used for incremental authorization where
+ *  the user is granting more scopes to the same account/provider. */
+export const OAuthAuthorizationCodeExistingClientStrategy = Schema.Struct({
+  kind: Schema.Literal("authorization-code-existing-client"),
+  authorizationEndpoint: Schema.String,
+  tokenEndpoint: Schema.optional(Schema.String),
+  issuerUrl: Schema.optional(Schema.NullOr(Schema.String)),
+  scopes: Schema.Array(Schema.String),
+  scopeSeparator: Schema.optional(Schema.String),
+  extraAuthorizationParams: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+});
+export type OAuthAuthorizationCodeExistingClientStrategy =
+  typeof OAuthAuthorizationCodeExistingClientStrategy.Type;
+
 /** RFC 6749 §4.4 client credentials — no user redirect, no PKCE. Used
  *  for server-to-server integrations where the plugin has both
  *  `client_id` and `client_secret` and the server will mint tokens
@@ -100,6 +115,7 @@ export type OAuthClientCredentialsStrategy = typeof OAuthClientCredentialsStrate
 export const OAuthStrategy = Schema.Union([
   OAuthDynamicDcrStrategy,
   OAuthAuthorizationCodeStrategy,
+  OAuthAuthorizationCodeExistingClientStrategy,
   OAuthClientCredentialsStrategy,
 ]);
 export type OAuthStrategy = typeof OAuthStrategy.Type;

--- a/packages/core/sdk/src/oauth.ts
+++ b/packages/core/sdk/src/oauth.ts
@@ -85,7 +85,13 @@ export const OAuthAuthorizationCodeExistingClientStrategy = Schema.Struct({
   authorizationEndpoint: Schema.String,
   tokenEndpoint: Schema.optional(Schema.String),
   issuerUrl: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Final scope set Executor should remember for this connection. */
   scopes: Schema.Array(Schema.String),
+  /** Optional smaller scope set to send to the authorization server. This is
+   *  for providers such as Google that support incremental authorization via
+   *  `include_granted_scopes=true`: request only newly-missing scopes, but
+   *  keep the connection's full granted-scope model for refresh/source reuse. */
+  authorizationScopes: Schema.optional(Schema.Array(Schema.String)),
   scopeSeparator: Schema.optional(Schema.String),
   extraAuthorizationParams: Schema.optional(Schema.Record(Schema.String, Schema.String)),
 });

--- a/packages/core/sdk/src/testing.test.ts
+++ b/packages/core/sdk/src/testing.test.ts
@@ -61,12 +61,14 @@ layer(TestLayer, { timeout: "15 seconds" })("testing fixtures", (it) => {
           tokenEndpoint: oauth.tokenEndpoint,
           clientIdSecretId: "oauth-client-id",
           clientSecretSecretId: "oauth-client-secret",
-          scopes: ["read"],
+          scopes: ["read", "write"],
+          authorizationScopes: ["read"],
         },
       });
 
       expect(started.authorizationUrl).not.toBeNull();
       const authorizationUrl = started.authorizationUrl ?? "";
+      expect(new URL(authorizationUrl).searchParams.get("scope")).toBe("read");
       const callback = yield* oauth.completeAuthorizationCodeFlow({ authorizationUrl });
       const completed = yield* workspace.executor.oauth.complete({
         state: callback.state,
@@ -75,6 +77,7 @@ layer(TestLayer, { timeout: "15 seconds" })("testing fixtures", (it) => {
       });
 
       expect(completed.connectionId).toBe("test-oauth-authorization-code");
+      expect(completed.scope).toBe("read write");
       const accessToken = yield* workspace.executor.connections.accessToken(completed.connectionId);
       expect(yield* oauth.acceptsAccessToken(accessToken)).toBe(true);
     }),

--- a/packages/core/sdk/src/testing.test.ts
+++ b/packages/core/sdk/src/testing.test.ts
@@ -140,13 +140,14 @@ layer(TestLayer, { timeout: "15 seconds" })("testing fixtures", (it) => {
           authorizationEndpoint: oauth.authorizationEndpoint,
           tokenEndpoint: oauth.tokenEndpoint,
           scopes: ["gmail.read", "calendar.read"],
+          authorizationScopes: ["calendar.read"],
           extraAuthorizationParams: { include_granted_scopes: "true" },
         },
       });
 
       const authorizationUrl = new URL(incremental.authorizationUrl ?? "");
       expect(authorizationUrl.searchParams.get("client_id")).toBe("test-client");
-      expect(authorizationUrl.searchParams.get("scope")).toBe("gmail.read calendar.read");
+      expect(authorizationUrl.searchParams.get("scope")).toBe("calendar.read");
       expect(authorizationUrl.searchParams.get("include_granted_scopes")).toBe("true");
 
       const incrementalCallback = yield* oauth.completeAuthorizationCodeFlow({

--- a/packages/core/sdk/src/testing.test.ts
+++ b/packages/core/sdk/src/testing.test.ts
@@ -80,6 +80,91 @@ layer(TestLayer, { timeout: "15 seconds" })("testing fixtures", (it) => {
     }),
   );
 
+  it.effect("authorization-code OAuth can reuse an existing connection client", () =>
+    Effect.gen(function* () {
+      const workspace = yield* TestWorkspace.current<typeof plugins>();
+      const oauth = yield* OAuthTestServer;
+      const scope = workspace.scopes[0]!;
+
+      yield* workspace.executor.secrets.set(
+        SetSecretInput.make({
+          id: SecretId.make("oauth-client-id"),
+          scope: scope.id,
+          name: "OAuth Client ID",
+          value: "test-client",
+        }),
+      );
+      yield* workspace.executor.secrets.set(
+        SetSecretInput.make({
+          id: SecretId.make("oauth-client-secret"),
+          scope: scope.id,
+          name: "OAuth Client Secret",
+          value: "test-secret",
+        }),
+      );
+
+      const started = yield* workspace.executor.oauth.start({
+        endpoint: oauth.resourceUrl,
+        connectionId: "test-oauth-existing-client",
+        tokenScope: String(scope.id),
+        redirectUrl: "http://127.0.0.1/callback",
+        pluginId: "test",
+        identityLabel: "OAuth Test",
+        strategy: {
+          kind: "authorization-code",
+          authorizationEndpoint: oauth.authorizationEndpoint,
+          tokenEndpoint: oauth.tokenEndpoint,
+          clientIdSecretId: "oauth-client-id",
+          clientSecretSecretId: "oauth-client-secret",
+          scopes: ["gmail.read"],
+        },
+      });
+      const callback = yield* oauth.completeAuthorizationCodeFlow({
+        authorizationUrl: started.authorizationUrl ?? "",
+      });
+      yield* workspace.executor.oauth.complete({
+        state: callback.state,
+        code: callback.code,
+        tokenScope: String(scope.id),
+      });
+
+      const incremental = yield* workspace.executor.oauth.start({
+        endpoint: oauth.resourceUrl,
+        connectionId: "test-oauth-existing-client",
+        tokenScope: String(scope.id),
+        redirectUrl: "http://127.0.0.1/callback",
+        pluginId: "test",
+        identityLabel: "OAuth Test",
+        strategy: {
+          kind: "authorization-code-existing-client",
+          authorizationEndpoint: oauth.authorizationEndpoint,
+          tokenEndpoint: oauth.tokenEndpoint,
+          scopes: ["gmail.read", "calendar.read"],
+          extraAuthorizationParams: { include_granted_scopes: "true" },
+        },
+      });
+
+      const authorizationUrl = new URL(incremental.authorizationUrl ?? "");
+      expect(authorizationUrl.searchParams.get("client_id")).toBe("test-client");
+      expect(authorizationUrl.searchParams.get("scope")).toBe("gmail.read calendar.read");
+      expect(authorizationUrl.searchParams.get("include_granted_scopes")).toBe("true");
+
+      const incrementalCallback = yield* oauth.completeAuthorizationCodeFlow({
+        authorizationUrl: incremental.authorizationUrl ?? "",
+      });
+      const completed = yield* workspace.executor.oauth.complete({
+        state: incrementalCallback.state,
+        code: incrementalCallback.code,
+        tokenScope: String(scope.id),
+      });
+
+      expect(completed.connectionId).toBe("test-oauth-existing-client");
+      expect(completed.scope).toBe("gmail.read calendar.read");
+      const accessToken = yield* workspace.executor.connections.accessToken(completed.connectionId);
+      expect(yield* oauth.acceptsAccessToken(accessToken)).toBe(true);
+    }),
+  );
+
   it.effect("OAuthTestServer supports MCP-style dynamic client registration", () =>
     Effect.gen(function* () {
       const workspace = yield* TestWorkspace.current<typeof plugins>();

--- a/packages/core/sdk/src/testing/oauth-test-server.ts
+++ b/packages/core/sdk/src/testing/oauth-test-server.ts
@@ -40,6 +40,7 @@ export interface OAuthTestServerRequest {
   readonly path: string;
   readonly headers: Readonly<Record<string, string>>;
   readonly body: string;
+  readonly query: Readonly<Record<string, string>>;
 }
 
 export interface OAuthTestServerOptions {
@@ -435,6 +436,7 @@ export const serveOAuthTestServer = (
             path: requestUrl.pathname,
             headers,
             body,
+            query: Object.fromEntries(requestUrl.searchParams.entries()),
           },
         ]);
 

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -65,6 +65,7 @@
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
     "effect": "catalog:",
+    "lucide-react": "^1.7.0",
     "openapi-types": "^12.1.3",
     "yaml": "^2.7.1"
   },

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -204,9 +204,48 @@ const googleAuthorizationParams = (enabled: boolean): Record<string, string> | u
   enabled
     ? {
         access_type: "offline",
-        include_granted_scopes: "true",
       }
     : undefined;
+
+const googleBroadScopeGroups: readonly {
+  readonly broad: string;
+  readonly prefixes: readonly string[];
+}[] = [
+  {
+    broad: "https://mail.google.com/",
+    prefixes: ["https://www.googleapis.com/auth/gmail."],
+  },
+  {
+    broad: "https://www.googleapis.com/auth/calendar",
+    prefixes: ["https://www.googleapis.com/auth/calendar."],
+  },
+  {
+    broad: "https://www.googleapis.com/auth/drive",
+    prefixes: ["https://www.googleapis.com/auth/drive."],
+  },
+];
+
+const compactGoogleOAuthScopes = (scopes: Iterable<string>): string[] => {
+  const ordered = mergeOAuthScopes(
+    [...scopes].map((scope) =>
+      scope === "https://www.googleapis.com/auth/userinfo.email"
+        ? "email"
+        : scope === "https://www.googleapis.com/auth/userinfo.profile"
+          ? "profile"
+          : scope,
+    ),
+  );
+  const present = new Set(ordered);
+  return ordered.filter(
+    (scope) =>
+      !googleBroadScopeGroups.some(
+        (group) =>
+          scope !== group.broad &&
+          present.has(group.broad) &&
+          group.prefixes.some((prefix) => scope.startsWith(prefix)),
+      ),
+  );
+};
 
 type OAuthConnectionChoice = {
   readonly id: ConnectionId;
@@ -890,10 +929,9 @@ export default function AddOpenApiSource(props: {
             selectedOAuth2IsGoogle ? oauth2SelectedScopes : selectedOAuth2Scopes,
           )
         : selectedOAuth2Scopes;
-      const incrementalAuthorizationScopes =
-        existingConnection && selectedOAuth2IsGoogle
-          ? [...existingConnection.missingApiScopes]
-          : undefined;
+      const scopesForProviderAuthorization = selectedOAuth2IsGoogle
+        ? compactGoogleOAuthScopes(scopesForAuthorization)
+        : undefined;
       const extraAuthorizationParams = googleAuthorizationParams(selectedOAuth2IsGoogle);
 
       const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
@@ -962,8 +1000,8 @@ export default function AddOpenApiSource(props: {
             tokenEndpoint: tokenUrl,
             issuerUrl,
             scopes: scopesForAuthorization,
-            ...(incrementalAuthorizationScopes && incrementalAuthorizationScopes.length > 0
-              ? { authorizationScopes: incrementalAuthorizationScopes }
+            ...(scopesForProviderAuthorization && scopesForProviderAuthorization.length > 0
+              ? { authorizationScopes: scopesForProviderAuthorization }
               : {}),
             extraAuthorizationParams,
           }
@@ -980,6 +1018,9 @@ export default function AddOpenApiSource(props: {
                 ? String(clientSecretSecretScope)
                 : null,
               scopes: scopesForAuthorization,
+              ...(scopesForProviderAuthorization && scopesForProviderAuthorization.length > 0
+                ? { authorizationScopes: scopesForProviderAuthorization }
+                : {}),
               extraAuthorizationParams,
             }
           : null;
@@ -1678,7 +1719,7 @@ export default function AddOpenApiSource(props: {
                             </FieldLabel>
                             <div className="text-[10px] leading-tight text-muted-foreground">
                               Continue with an account you already connected. If permissions are
-                              missing, only the missing access is requested.
+                              missing, Google will confirm access for this source.
                             </div>
                           </div>
                           <div className="space-y-1.5">

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -351,22 +351,21 @@ function entriesFromSpecPreset(preset: HeaderPreset): HeaderState[] {
 function OAuthConnectedAccount(props: {
   readonly scopeId: ScopeId;
   readonly connectionId: string;
-  readonly fallbackLabel: string;
+  readonly scopeSummary: string;
   readonly sourceName: string;
   readonly onSetSourceName: (name: string) => void;
 }) {
   const identityResult = useAtomValue(
     connectionIdentityAtom(props.scopeId, ConnectionId.make(props.connectionId)),
   );
-  const identity =
-    AsyncResult.isSuccess(identityResult) && identityResult.value.status === "available"
-      ? identityResult.value
-      : null;
-  const label = identity?.email ?? identity?.name ?? props.fallbackLabel;
-  const sourceNameWithAccount = props.sourceName.includes(label)
-    ? props.sourceName
-    : `${props.sourceName} - ${label}`;
-  const accountIsInSourceName = props.sourceName === sourceNameWithAccount;
+  const identityResponse = AsyncResult.isSuccess(identityResult) ? identityResult.value : null;
+  const identity = identityResponse?.status === "available" ? identityResponse : null;
+  const accountLabel = identity?.email ?? identity?.name ?? identity?.username ?? null;
+  const sourceNameWithAccount =
+    accountLabel && !props.sourceName.includes(accountLabel)
+      ? `${props.sourceName} - ${accountLabel}`
+      : props.sourceName;
+  const accountIsInSourceName = accountLabel !== null && props.sourceName === sourceNameWithAccount;
   return (
     <div className="flex min-w-0 flex-1 items-center gap-3">
       <div className="min-w-0 flex-1">
@@ -379,15 +378,18 @@ function OAuthConnectedAccount(props: {
               className="size-5 shrink-0 rounded-full"
             />
           ) : null}
-          <span className="min-w-0 truncate text-foreground">Connected as {label}</span>
+          <span className="min-w-0 truncate text-foreground">
+            {accountLabel ? `Connected as ${accountLabel}` : "Connected"}
+            <span className="text-muted-foreground"> · {props.scopeSummary}</span>
+          </span>
         </div>
-        {identity ? (
+        {accountLabel ? (
           <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
             Source name: {sourceNameWithAccount}
           </div>
         ) : null}
       </div>
-      {identity ? (
+      {accountLabel ? (
         <Button
           variant="secondary"
           size="sm"
@@ -1681,7 +1683,7 @@ export default function AddOpenApiSource(props: {
                         <OAuthConnectedAccount
                           scopeId={oauthTokenTargetScope}
                           connectionId={oauth2Auth.connectionId}
-                          fallbackLabel={`${selectedOAuth2Scopes.length} scope${
+                          scopeSummary={`${selectedOAuth2Scopes.length} scope${
                             selectedOAuth2Scopes.length === 1 ? "" : "s"
                           } granted`}
                           sourceName={resolvedDisplayName}

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAtomSet } from "@effect/atom-react";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
+import { ChevronDownIcon } from "lucide-react";
 
 import {
   ConnectionId,
@@ -12,7 +14,12 @@ import {
   SecretId,
   SetSourceCredentialBindingInput,
 } from "@executor-js/sdk/shared";
-import { setSourceCredentialBinding, startOAuth } from "@executor-js/react/api/atoms";
+import {
+  connectionIdentityAtom,
+  connectionsAtom,
+  setSourceCredentialBinding,
+  startOAuth,
+} from "@executor-js/react/api/atoms";
 import { useScope, useScopeStack } from "@executor-js/react/api/scope-context";
 import { connectionWriteKeys, sourceWriteKeys } from "@executor-js/react/api/reactivity-keys";
 
@@ -65,6 +72,7 @@ import { RadioGroup, RadioGroupItem } from "@executor-js/react/components/radio-
 import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
 import { addOpenApiSpecOptimistic, previewOpenApiSpec } from "./atoms";
 import { OpenApiSourceDetailsFields } from "./OpenApiSourceDetailsFields";
+import { openApiPresets } from "../sdk/presets";
 import type { SpecPreview, HeaderPreset, OAuth2Preset } from "../sdk/preview";
 import {
   headerBindingSlot,
@@ -131,6 +139,46 @@ export function inferOAuthIssuerUrl(authorizationUrl: string): string | null {
   }
 }
 
+const standardOidcIdentityScopes = ["openid", "email", "profile"] as const;
+
+const identityScopesForPreset = (
+  identityScopes: OAuth2Preset["identityScopes"],
+): readonly string[] => {
+  if (identityScopes === false) return [];
+  return identityScopes === "auto" ? standardOidcIdentityScopes : identityScopes;
+};
+
+const resolvedOAuthScopes = (
+  apiScopes: Iterable<string>,
+  identityScopes: OAuth2Preset["identityScopes"],
+): string[] => {
+  const merged = new Set(apiScopes);
+  for (const scope of identityScopesForPreset(identityScopes)) merged.add(scope);
+  return [...merged];
+};
+
+const splitOAuthScopes = (value: string | null): Set<string> =>
+  new Set(value?.split(/\s+/).filter(Boolean) ?? []);
+
+type OAuthConnectionChoice = {
+  readonly id: ConnectionId;
+  readonly scopeId: ScopeId;
+  readonly provider: string;
+  readonly identityLabel: string | null;
+  readonly oauthScope: string | null;
+};
+
+const hasRequiredApiScopes = (
+  connection: OAuthConnectionChoice,
+  requiredApiScopes: Iterable<string>,
+): boolean => {
+  const granted = splitOAuthScopes(connection.oauthScope);
+  for (const scope of requiredApiScopes) {
+    if (!granted.has(scope)) return false;
+  }
+  return true;
+};
+
 const specInputForAdd = (input: string) => {
   const value = input.trim();
   const parsed = Effect.runSyncExit(
@@ -153,6 +201,15 @@ const isGoogleDiscoveryUrl = (url: string): boolean => {
   const host = parsed.hostname.toLowerCase();
   if (!host.endsWith("googleapis.com")) return false;
   return parsed.pathname.includes("/discovery/") || parsed.pathname.includes("$discovery");
+};
+
+const normalizePresetUrl = (url: string): string => {
+  const trimmed = url.trim();
+  if (!URL.canParse(trimmed)) return trimmed.replace(/\/$/, "");
+  const parsed = new URL(trimmed);
+  parsed.hash = "";
+  parsed.searchParams.sort();
+  return parsed.toString().replace(/\/$/, "");
 };
 
 type StrategySelection =
@@ -214,6 +271,113 @@ function entriesFromSpecPreset(preset: HeaderPreset): HeaderState[] {
   });
 }
 
+function OAuthConnectedAccount(props: {
+  readonly scopeId: ScopeId;
+  readonly connectionId: string;
+  readonly fallbackLabel: string;
+  readonly sourceName: string;
+  readonly onSetSourceName: (name: string) => void;
+}) {
+  const identityResult = useAtomValue(
+    connectionIdentityAtom(props.scopeId, ConnectionId.make(props.connectionId)),
+  );
+  const identity =
+    AsyncResult.isSuccess(identityResult) && identityResult.value.status === "available"
+      ? identityResult.value
+      : null;
+  const label = identity?.email ?? identity?.name ?? props.fallbackLabel;
+  const sourceNameWithAccount = props.sourceName.includes(label)
+    ? props.sourceName
+    : `${props.sourceName} - ${label}`;
+  const accountIsInSourceName = props.sourceName === sourceNameWithAccount;
+  return (
+    <div className="flex min-w-0 flex-1 items-center gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          {identity?.picture ? (
+            <img
+              src={identity.picture}
+              alt=""
+              referrerPolicy="no-referrer"
+              className="size-5 shrink-0 rounded-full"
+            />
+          ) : null}
+          <span className="min-w-0 truncate text-foreground">Connected as {label}</span>
+        </div>
+        {identity ? (
+          <div className="mt-0.5 truncate text-[11px] text-muted-foreground">
+            Source name: {sourceNameWithAccount}
+          </div>
+        ) : null}
+      </div>
+      {identity ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-6 shrink-0 px-2 text-[11px]"
+          disabled={accountIsInSourceName}
+          onClick={() => props.onSetSourceName(sourceNameWithAccount)}
+        >
+          {accountIsInSourceName ? "Name includes account" : "Add account name to source name"}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+function ExistingOAuthConnectionOption(props: {
+  readonly connection: OAuthConnectionChoice;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+}) {
+  const identityResult = useAtomValue(
+    connectionIdentityAtom(props.connection.scopeId, props.connection.id),
+  );
+  const identity =
+    AsyncResult.isSuccess(identityResult) && identityResult.value.status === "available"
+      ? identityResult.value
+      : null;
+  const label =
+    identity?.email ?? identity?.name ?? props.connection.identityLabel ?? props.connection.id;
+  const picture = identity?.picture;
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      onClick={props.onSelect}
+      className={`h-auto w-full justify-between gap-3 rounded-md border px-3 py-2 text-left transition-colors ${
+        props.selected
+          ? "border-primary/40 bg-primary/10"
+          : "border-border/60 bg-background hover:border-border hover:bg-muted/30"
+      }`}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        {picture ? (
+          <img
+            src={picture}
+            alt=""
+            referrerPolicy="no-referrer"
+            className="size-5 shrink-0 rounded-full"
+          />
+        ) : (
+          <span className="grid size-5 shrink-0 place-items-center rounded-full bg-muted text-[10px] text-muted-foreground">
+            {label.slice(0, 1).toUpperCase()}
+          </span>
+        )}
+        <span className="min-w-0">
+          <span className="block truncate text-[12px] text-foreground">{label}</span>
+          <span className="block truncate text-[10px] text-muted-foreground">
+            {props.connection.identityLabel ?? "OAuth connection"}
+          </span>
+        </span>
+      </span>
+      <span className="shrink-0 text-[11px] font-medium text-foreground">
+        {props.selected ? "Selected" : "Use account"}
+      </span>
+    </Button>
+  );
+}
+
 const secretStorageDescription = (label: string): string =>
   label === "Personal"
     ? "Only you can use this secret."
@@ -259,6 +423,8 @@ export default function AddOpenApiSource(props: {
   const [oauth2ClientIdScope, setOauth2ClientIdScope] = useState<ScopeId | null>(null);
   const [oauth2ClientSecretScope, setOauth2ClientSecretScope] = useState<ScopeId | null>(null);
   const [oauth2SelectedScopes, setOauth2SelectedScopes] = useState<Set<string>>(new Set());
+  const [includeOAuth2IdentityScopes, setIncludeOAuth2IdentityScopes] = useState(true);
+  const [oauth2ScopesOpen, setOauth2ScopesOpen] = useState(false);
   const [oauth2AuthState, setOauth2AuthState] = useState<{
     readonly fingerprint: string;
     readonly auth: { readonly connectionId: string };
@@ -318,6 +484,7 @@ export default function AddOpenApiSource(props: {
   const doSetBinding = useAtomSet(setSourceCredentialBinding, {
     mode: "promiseExit",
   });
+  const connectionsResult = useAtomValue(connectionsAtom(scopeId));
   const secretList = useSecretPickerSecrets();
   const oauth = useOAuthPopupFlow<OAuthCompletionPayload>({
     popupName: OPENAPI_OAUTH_POPUP_NAME,
@@ -355,6 +522,9 @@ export default function AddOpenApiSource(props: {
   const baseUrlOptions = Array.from(
     new Map(servers.flatMap(expandServerOptions).map((option) => [option.value, option])).values(),
   );
+  const previewPresetIcon =
+    openApiPresets.find((preset) => normalizePresetUrl(preset.url) === normalizePresetUrl(specUrl))
+      ?.icon ?? null;
 
   const resolvedBaseUrl = baseUrl.trim();
   const sourceScope = ScopeId.make(scopeId);
@@ -460,11 +630,13 @@ export default function AddOpenApiSource(props: {
   const resolvedSourceId =
     slugifyNamespace(identity.namespace) ||
     (preview ? Option.getOrElse(preview.title, () => "openapi") : "openapi");
+  const resolvedDisplayName =
+    identity.name.trim() ||
+    (preview ? Option.getOrElse(preview.title, () => resolvedSourceId) : resolvedSourceId);
   const selectedOAuth2Preset: OAuth2Preset | null =
     strategy.kind === "oauth2" ? (oauth2Presets[strategy.presetIndex] ?? null) : null;
   const selectedOAuth2Fingerprint = selectedOAuth2Preset
     ? [
-        resolvedSourceId,
         resolvedBaseUrl,
         selectedOAuth2Preset.securitySchemeName,
         selectedOAuth2Preset.flow,
@@ -474,6 +646,33 @@ export default function AddOpenApiSource(props: {
     : "";
   const oauth2Auth =
     oauth2AuthState?.fingerprint === selectedOAuth2Fingerprint ? oauth2AuthState.auth : null;
+  const selectedOAuth2AvailableIdentityScopes = selectedOAuth2Preset
+    ? identityScopesForPreset(selectedOAuth2Preset.identityScopes)
+    : [];
+  const configuredOAuth2IdentityScopes =
+    selectedOAuth2Preset && includeOAuth2IdentityScopes
+      ? selectedOAuth2Preset.identityScopes
+      : false;
+  const selectedOAuth2Scopes = useMemo(
+    () =>
+      selectedOAuth2Preset
+        ? resolvedOAuthScopes(oauth2SelectedScopes, configuredOAuth2IdentityScopes)
+        : [...oauth2SelectedScopes],
+    [configuredOAuth2IdentityScopes, oauth2SelectedScopes, selectedOAuth2Preset],
+  );
+  const existingOAuthConnections = useMemo(() => {
+    if (
+      !selectedOAuth2Preset ||
+      selectedOAuth2Preset.flow !== "authorizationCode" ||
+      !AsyncResult.isSuccess(connectionsResult)
+    ) {
+      return [];
+    }
+    return connectionsResult.value.filter(
+      (connection) =>
+        connection.provider === "oauth2" && hasRequiredApiScopes(connection, oauth2SelectedScopes),
+    );
+  }, [connectionsResult, oauth2SelectedScopes, selectedOAuth2Preset]);
 
   const configuredOAuth2 =
     strategy.kind === "oauth2" && selectedOAuth2Preset
@@ -496,6 +695,7 @@ export default function AddOpenApiSource(props: {
           clientSecretSlot: oauth2ClientSecretSlot(selectedOAuth2Preset.securitySchemeName),
           connectionSlot: oauth2ConnectionSlot(selectedOAuth2Preset.securitySchemeName),
           scopes: [...oauth2SelectedScopes],
+          identityScopes: configuredOAuth2IdentityScopes,
         })
       : null;
   const hasHeaders = Object.keys(configuredHeaders).length > 0;
@@ -554,6 +754,7 @@ export default function AddOpenApiSource(props: {
       setStrategy({ kind: "oauth2", presetIndex: 0 });
       setCustomHeaders([]);
       setOauth2SelectedScopes(new Set(Object.keys(result.oauth2Presets[0].scopes)));
+      setIncludeOAuth2IdentityScopes(result.oauth2Presets[0].identityScopes !== false);
     } else {
       // No header presets — default to "custom" so the headers editor is
       // visible immediately. Specs with no `security` block (e.g. Microsoft
@@ -593,6 +794,7 @@ export default function AddOpenApiSource(props: {
         const preset = preview?.oauth2Presets[n.presetIndex];
         if (preset) {
           setOauth2SelectedScopes(new Set(Object.keys(preset.scopes)));
+          setIncludeOAuth2IdentityScopes(preset.identityScopes !== false);
         }
       }),
       Match.exhaustive,
@@ -651,7 +853,7 @@ export default function AddOpenApiSource(props: {
             clientIdSecretScopeId: String(clientIdSecretScope),
             clientSecretSecretId: oauth2ClientSecretSecretId,
             clientSecretSecretScopeId: String(clientSecretSecretScope),
-            scopes: [...oauth2SelectedScopes],
+            scopes: selectedOAuth2Scopes,
           },
           pluginId: "openapi",
           identityLabel: `${displayName} OAuth`,
@@ -702,7 +904,7 @@ export default function AddOpenApiSource(props: {
               clientSecretSecretScopeId: oauth2ClientSecretSecretId
                 ? String(clientSecretSecretScope)
                 : null,
-              scopes: [...oauth2SelectedScopes],
+              scopes: selectedOAuth2Scopes,
             },
             pluginId: "openapi",
             identityLabel: `${displayName} OAuth`,
@@ -738,7 +940,7 @@ export default function AddOpenApiSource(props: {
     selectedOAuth2Preset,
     oauth2ClientIdSecretId,
     oauth2ClientSecretSecretId,
-    oauth2SelectedScopes,
+    selectedOAuth2Scopes,
     oauth2RedirectUrl,
     resolvedBaseUrl,
     preview,
@@ -759,18 +961,29 @@ export default function AddOpenApiSource(props: {
     setOauth2Error(null);
   }, [oauth]);
 
+  const handleReuseOAuthConnection = useCallback(
+    (connection: OAuthConnectionChoice) => {
+      oauth.cancel();
+      setStartingOAuth(false);
+      setOAuthTokenTargetScope(connection.scopeId);
+      setOauth2AuthState({
+        fingerprint: selectedOAuth2Fingerprint,
+        auth: { connectionId: connection.id },
+      });
+      setOauth2Error(null);
+    },
+    [oauth, selectedOAuth2Fingerprint],
+  );
+
   const handleAdd = async () => {
     setAdding(true);
     setAddError(null);
     const namespace = resolvedSourceId;
-    const displayName =
-      identity.name.trim() ||
-      (preview ? Option.getOrElse(preview.title, () => namespace) : namespace);
     const exit = await doAdd({
       params: { scopeId },
       payload: {
         spec: specInputForAdd(specUrl),
-        name: displayName,
+        name: resolvedDisplayName,
         namespace,
         baseUrl: resolvedBaseUrl,
         ...(configuredSpecFetchCredentials
@@ -1021,6 +1234,7 @@ export default function AddOpenApiSource(props: {
             setOauth2AuthState(null);
             setOauth2Error(null);
           }}
+          faviconIcon={previewPresetIcon}
           faviconUrl={resolvedBaseUrl}
           baseUrlMissingMessage="A base URL is required to make requests."
         />
@@ -1157,15 +1371,22 @@ export default function AddOpenApiSource(props: {
                       <CopyButton value={oauth2RedirectUrl} />
                     </div>
                   </div>
-                  <div className="space-y-1.5">
-                    <FieldLabel className="text-[11px]">Client ID secret</FieldLabel>
-                    <div className="grid gap-2 md:grid-cols-2">
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <div className="space-y-2">
                       <div className="space-y-1.5">
-                        <div className="flex items-center gap-1.5">
-                          <FieldLabel className="text-[11px]">Secret</FieldLabel>
-                          <HelpTooltip label="Client ID secret">
-                            Select or create the OAuth client ID secret.
-                          </HelpTooltip>
+                        <div className="space-y-0.5">
+                          <div className="flex items-center gap-1.5">
+                            <FieldLabel className="text-[11px]">Client ID</FieldLabel>
+                            <HelpTooltip label="Client ID secret">
+                              Select or create the OAuth client ID secret.
+                            </HelpTooltip>
+                          </div>
+                          <div
+                            aria-hidden
+                            className="invisible text-[10px] leading-tight text-muted-foreground"
+                          >
+                            Required OAuth client identifier.
+                          </div>
                         </div>
                         <CreatableSecretPicker
                           value={oauth2ClientIdSecretId}
@@ -1194,21 +1415,18 @@ export default function AddOpenApiSource(props: {
                         help="Choose where this OAuth client ID credential lives."
                       />
                     </div>
-                  </div>
-                  <div className="space-y-1.5">
-                    <FieldLabel className="text-[11px]">
-                      Client secret{" "}
-                      <span className="text-muted-foreground">
-                        · optional for public clients with PKCE
-                      </span>
-                    </FieldLabel>
-                    <div className="grid gap-2 md:grid-cols-2">
+                    <div className="space-y-2">
                       <div className="space-y-1.5">
-                        <div className="flex items-center gap-1.5">
-                          <FieldLabel className="text-[11px]">Secret</FieldLabel>
-                          <HelpTooltip label="Client secret">
-                            Select or create the OAuth client secret.
-                          </HelpTooltip>
+                        <div className="space-y-0.5">
+                          <div className="flex items-center gap-1.5">
+                            <FieldLabel className="text-[11px]">Client Secret</FieldLabel>
+                            <HelpTooltip label="Client secret">
+                              Select or create the OAuth client secret.
+                            </HelpTooltip>
+                          </div>
+                          <div className="text-[10px] leading-tight text-muted-foreground">
+                            Optional for public clients with PKCE.
+                          </div>
                         </div>
                         <CreatableSecretPicker
                           value={oauth2ClientSecretSecretId}
@@ -1238,39 +1456,101 @@ export default function AddOpenApiSource(props: {
                       />
                     </div>
                   </div>
-                  <div className="space-y-1.5">
-                    <FieldLabel className="text-[11px]">Scopes</FieldLabel>
-                    <div className="space-y-1 rounded-md border border-border/50 bg-background/50 p-2">
-                      {Object.keys(selectedOAuth2Preset.scopes).length === 0 ? (
-                        <div className="text-[11px] italic text-muted-foreground">
-                          No scopes declared by the spec.
-                        </div>
-                      ) : (
-                        Object.entries(selectedOAuth2Preset.scopes).map(([scope, description]) => (
-                          <Label key={scope} className="flex items-start gap-2 cursor-pointer py-1">
+                  <Collapsible
+                    open={oauth2ScopesOpen}
+                    onOpenChange={setOauth2ScopesOpen}
+                    className="space-y-1.5"
+                  >
+                    <CollapsibleTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-full justify-between !px-0 text-[11px] hover:bg-transparent hover:text-foreground dark:hover:bg-transparent"
+                      >
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          <span className="font-medium text-foreground">Scopes</span>
+                          <span className="text-muted-foreground">
+                            {selectedOAuth2Scopes.length} selected
+                          </span>
+                        </span>
+                        <span className="flex size-3 shrink-0 items-center justify-center">
+                          <ChevronDownIcon
+                            className={`size-3 text-muted-foreground transition-transform ${
+                              oauth2ScopesOpen ? "" : "-rotate-90"
+                            }`}
+                          />
+                        </span>
+                      </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent>
+                      <div className="space-y-1 rounded-md border border-border/50 bg-background/50 p-2">
+                        {Object.keys(selectedOAuth2Preset.scopes).length === 0 ? (
+                          <div className="text-[11px] italic text-muted-foreground">
+                            No scopes declared by the spec.
+                          </div>
+                        ) : (
+                          Object.entries(selectedOAuth2Preset.scopes).map(
+                            ([scope, description]) => (
+                              <Label
+                                key={scope}
+                                className="flex items-start gap-2 cursor-pointer py-1"
+                              >
+                                <Checkbox
+                                  checked={oauth2SelectedScopes.has(scope)}
+                                  onCheckedChange={() => toggleOAuth2Scope(scope)}
+                                />
+                                <div className="min-w-0 flex-1">
+                                  <div className="font-mono text-[11px] text-foreground">
+                                    {scope}
+                                  </div>
+                                  {description && (
+                                    <div className="text-[10px] text-muted-foreground">
+                                      {description}
+                                    </div>
+                                  )}
+                                </div>
+                              </Label>
+                            ),
+                          )
+                        )}
+                        {selectedOAuth2AvailableIdentityScopes.length > 0 && (
+                          <Label className="mt-2 flex cursor-pointer items-start gap-2 border-t border-border/50 pt-2">
                             <Checkbox
-                              checked={oauth2SelectedScopes.has(scope)}
-                              onCheckedChange={() => toggleOAuth2Scope(scope)}
+                              checked={includeOAuth2IdentityScopes}
+                              onCheckedChange={(checked) => {
+                                setIncludeOAuth2IdentityScopes(checked === true);
+                                setOauth2AuthState(null);
+                              }}
                             />
                             <div className="min-w-0 flex-1">
-                              <div className="font-mono text-[11px] text-foreground">{scope}</div>
-                              {description && (
-                                <div className="text-[10px] text-muted-foreground">
-                                  {description}
-                                </div>
-                              )}
+                              <div className="text-[11px] font-medium text-foreground">
+                                Account identity
+                              </div>
+                              <div className="font-mono text-[10px] text-muted-foreground">
+                                {selectedOAuth2AvailableIdentityScopes.join(" · ")}
+                              </div>
+                              <div className="text-[10px] text-muted-foreground">
+                                Lets the connections page show the signed-in account.
+                              </div>
                             </div>
                           </Label>
-                        ))
-                      )}
-                    </div>
-                  </div>
+                        )}
+                      </div>
+                    </CollapsibleContent>
+                  </Collapsible>
 
                   {oauth2Auth ? (
-                    <div className="flex items-center justify-between rounded-md border border-green-500/30 bg-green-500/5 px-3 py-2">
-                      <div className="text-[11px] text-green-700 dark:text-green-400">
-                        Connected · {oauth2SelectedScopes.size} scope
-                        {oauth2SelectedScopes.size === 1 ? "" : "s"} granted
+                    <div className="flex items-center justify-between rounded-md border border-border/60 bg-background/50 px-3 py-2">
+                      <div className="min-w-0 text-[12px]">
+                        <OAuthConnectedAccount
+                          scopeId={oauthTokenTargetScope}
+                          connectionId={oauth2Auth.connectionId}
+                          fallbackLabel={`${selectedOAuth2Scopes.length} scope${
+                            selectedOAuth2Scopes.length === 1 ? "" : "s"
+                          } granted`}
+                          sourceName={resolvedDisplayName}
+                          onSetSourceName={identity.setName}
+                        />
                       </div>
                       <Button variant="ghost" size="sm" onClick={() => setOauth2AuthState(null)}>
                         Disconnect
@@ -1291,10 +1571,36 @@ export default function AddOpenApiSource(props: {
                     </div>
                   ) : (
                     <div className="flex flex-col gap-1.5">
+                      {existingOAuthConnections.length > 0 && (
+                        <div className="space-y-2">
+                          <div className="space-y-0.5">
+                            <FieldLabel className="text-[11px]">
+                              Reuse a signed-in account
+                            </FieldLabel>
+                            <div className="text-[10px] leading-tight text-muted-foreground">
+                              Skip OAuth and connect this source with an existing account.
+                            </div>
+                          </div>
+                          <div className="space-y-1.5">
+                            {existingOAuthConnections.map((connection) => (
+                              <ExistingOAuthConnectionOption
+                                key={`${connection.scopeId}:${connection.id}`}
+                                connection={connection}
+                                selected={false}
+                                onSelect={() => handleReuseOAuthConnection(connection)}
+                              />
+                            ))}
+                          </div>
+                        </div>
+                      )}
                       <div className="grid gap-2 md:grid-cols-2">
                         <div className="space-y-1.5">
                           <div className="flex items-center gap-1.5">
-                            <FieldLabel className="text-[11px]">OAuth sign-in</FieldLabel>
+                            <FieldLabel className="text-[11px]">
+                              {existingOAuthConnections.length > 0
+                                ? "Sign in with another account"
+                                : "OAuth sign-in"}
+                            </FieldLabel>
                             <HelpTooltip label="OAuth sign-in">
                               Start the provider OAuth flow.
                             </HelpTooltip>

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -885,8 +885,15 @@ export default function AddOpenApiSource(props: {
         existingConnection?.id ??
         openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
       const scopesForAuthorization = existingConnection
-        ? mergeOAuthScopes(splitOAuthScopes(existingConnection.oauthScope), selectedOAuth2Scopes)
+        ? mergeOAuthScopes(
+            splitOAuthScopes(existingConnection.oauthScope),
+            selectedOAuth2IsGoogle ? oauth2SelectedScopes : selectedOAuth2Scopes,
+          )
         : selectedOAuth2Scopes;
+      const incrementalAuthorizationScopes =
+        existingConnection && selectedOAuth2IsGoogle
+          ? [...existingConnection.missingApiScopes]
+          : undefined;
       const extraAuthorizationParams = googleAuthorizationParams(selectedOAuth2IsGoogle);
 
       const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
@@ -955,6 +962,9 @@ export default function AddOpenApiSource(props: {
             tokenEndpoint: tokenUrl,
             issuerUrl,
             scopes: scopesForAuthorization,
+            ...(incrementalAuthorizationScopes && incrementalAuthorizationScopes.length > 0
+              ? { authorizationScopes: incrementalAuthorizationScopes }
+              : {}),
             extraAuthorizationParams,
           }
         : oauth2ClientIdSecretId
@@ -1022,6 +1032,7 @@ export default function AddOpenApiSource(props: {
       selectedOAuth2Preset,
       oauth2ClientIdSecretId,
       oauth2ClientSecretSecretId,
+      oauth2SelectedScopes,
       selectedOAuth2Scopes,
       selectedOAuth2IsGoogle,
       oauth2RedirectUrl,

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -160,23 +160,61 @@ const resolvedOAuthScopes = (
 const splitOAuthScopes = (value: string | null): Set<string> =>
   new Set(value?.split(/\s+/).filter(Boolean) ?? []);
 
+const mergeOAuthScopes = (...values: readonly Iterable<string>[]): string[] => {
+  const merged = new Set<string>();
+  for (const scopes of values) {
+    for (const scope of scopes) {
+      if (scope.trim()) merged.add(scope);
+    }
+  }
+  return [...merged];
+};
+
+const missingOAuthScopes = (
+  connection: { readonly oauthScope: string | null },
+  requiredApiScopes: Iterable<string>,
+): readonly string[] => {
+  const granted = splitOAuthScopes(connection.oauthScope);
+  return [...requiredApiScopes].filter((scope) => !granted.has(scope));
+};
+
+const isGoogleOAuthScope = (scope: string): boolean =>
+  scope === "https://mail.google.com/" ||
+  scope.startsWith("https://www.googleapis.com/auth/") ||
+  scope.startsWith("https://www.google.com/m8/feeds/");
+
+const hasGoogleOAuthScope = (connection: { readonly oauthScope: string | null }): boolean =>
+  [...splitOAuthScopes(connection.oauthScope)].some(isGoogleOAuthScope);
+
+const isGoogleOAuthUrl = (url: string): boolean => {
+  if (!URL.canParse(url)) return false;
+  const host = new URL(url).hostname.toLowerCase();
+  return host === "accounts.google.com" || host === "oauth2.googleapis.com";
+};
+
+const isGoogleOAuthTarget = (preset: OAuth2Preset, baseUrl: string, specUrl: string): boolean => {
+  if (isGoogleDiscoveryUrl(specUrl)) return true;
+  if (Object.keys(preset.scopes).some(isGoogleOAuthScope)) return true;
+  if (isGoogleOAuthUrl(resolveOAuthUrl(preset.tokenUrl, baseUrl))) return true;
+  const authorizationUrl = Option.getOrElse(preset.authorizationUrl, () => "");
+  return authorizationUrl ? isGoogleOAuthUrl(resolveOAuthUrl(authorizationUrl, baseUrl)) : false;
+};
+
+const googleAuthorizationParams = (enabled: boolean): Record<string, string> | undefined =>
+  enabled
+    ? {
+        access_type: "offline",
+        include_granted_scopes: "true",
+      }
+    : undefined;
+
 type OAuthConnectionChoice = {
   readonly id: ConnectionId;
   readonly scopeId: ScopeId;
   readonly provider: string;
   readonly identityLabel: string | null;
   readonly oauthScope: string | null;
-};
-
-const hasRequiredApiScopes = (
-  connection: OAuthConnectionChoice,
-  requiredApiScopes: Iterable<string>,
-): boolean => {
-  const granted = splitOAuthScopes(connection.oauthScope);
-  for (const scope of requiredApiScopes) {
-    if (!granted.has(scope)) return false;
-  }
-  return true;
+  readonly missingApiScopes: readonly string[];
 };
 
 const specInputForAdd = (input: string) => {
@@ -329,6 +367,7 @@ function ExistingOAuthConnectionOption(props: {
   readonly connection: OAuthConnectionChoice;
   readonly selected: boolean;
   readonly onSelect: () => void;
+  readonly providerLabel: string;
 }) {
   const identityResult = useAtomValue(
     connectionIdentityAtom(props.connection.scopeId, props.connection.id),
@@ -340,6 +379,7 @@ function ExistingOAuthConnectionOption(props: {
   const label =
     identity?.email ?? identity?.name ?? props.connection.identityLabel ?? props.connection.id;
   const picture = identity?.picture;
+  const needsPermission = props.connection.missingApiScopes.length > 0;
   return (
     <Button
       type="button"
@@ -367,12 +407,14 @@ function ExistingOAuthConnectionOption(props: {
         <span className="min-w-0">
           <span className="block truncate text-[12px] text-foreground">{label}</span>
           <span className="block truncate text-[10px] text-muted-foreground">
-            {props.connection.identityLabel ?? "OAuth connection"}
+            {needsPermission
+              ? `Needs ${props.providerLabel} permission`
+              : (props.connection.identityLabel ?? "Already connected")}
           </span>
         </span>
       </span>
       <span className="shrink-0 text-[11px] font-medium text-foreground">
-        {props.selected ? "Selected" : "Use account"}
+        {props.selected ? "Selected" : needsPermission ? "Continue" : "Use account"}
       </span>
     </Button>
   );
@@ -649,6 +691,10 @@ export default function AddOpenApiSource(props: {
   const selectedOAuth2AvailableIdentityScopes = selectedOAuth2Preset
     ? identityScopesForPreset(selectedOAuth2Preset.identityScopes)
     : [];
+  const selectedOAuth2IsGoogle = selectedOAuth2Preset
+    ? isGoogleOAuthTarget(selectedOAuth2Preset, resolvedBaseUrl, specUrl)
+    : false;
+  const selectedOAuth2ProviderLabel = selectedOAuth2IsGoogle ? "Google" : "OAuth";
   const configuredOAuth2IdentityScopes =
     selectedOAuth2Preset && includeOAuth2IdentityScopes
       ? selectedOAuth2Preset.identityScopes
@@ -668,11 +714,20 @@ export default function AddOpenApiSource(props: {
     ) {
       return [];
     }
-    return connectionsResult.value.filter(
-      (connection) =>
-        connection.provider === "oauth2" && hasRequiredApiScopes(connection, oauth2SelectedScopes),
-    );
-  }, [connectionsResult, oauth2SelectedScopes, selectedOAuth2Preset]);
+    return connectionsResult.value
+      .flatMap((connection) => {
+        if (connection.provider !== "oauth2") return [];
+        const missingApiScopes = missingOAuthScopes(connection, oauth2SelectedScopes);
+        if (missingApiScopes.length === 0) {
+          return [{ ...connection, missingApiScopes }];
+        }
+        if (selectedOAuth2IsGoogle && hasGoogleOAuthScope(connection)) {
+          return [{ ...connection, missingApiScopes }];
+        }
+        return [];
+      })
+      .sort((a, b) => a.missingApiScopes.length - b.missingApiScopes.length);
+  }, [connectionsResult, oauth2SelectedScopes, selectedOAuth2IsGoogle, selectedOAuth2Preset]);
 
   const configuredOAuth2 =
     strategy.kind === "oauth2" && selectedOAuth2Preset
@@ -819,82 +874,92 @@ export default function AddOpenApiSource(props: {
     setOauth2AuthState(null);
   };
 
-  const handleConnectOAuth2 = useCallback(async () => {
-    if (!selectedOAuth2Preset || !oauth2ClientIdSecretId || !preview) return;
-    oauth.cancel();
-    setOauth2Error(null);
-    const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
-
-    const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
-    const clientIdSecretScope = oauth2ClientIdScope ?? sourceScope;
-    const clientSecretSecretScope = oauth2ClientSecretScope ?? sourceScope;
-
-    if (selectedOAuth2Preset.flow === "clientCredentials") {
-      // RFC 6749 §4.4: no user-interactive consent step. The client_secret
-      // is mandatory; the backend exchanges tokens inline and returns a
-      // completed Connection we bind to the source's connection slot.
-      if (!oauth2ClientSecretSecretId) {
-        setOauth2Error("client_credentials requires a client secret");
-        return;
-      }
-      setStartingOAuth(true);
-      const connectionId = openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
-      const exit = await doStartOAuth({
-        params: { scopeId: oauthTokenTargetScope },
-        payload: {
-          endpoint: tokenUrl,
-          redirectUrl: tokenUrl,
-          connectionId,
-          tokenScope: oauthTokenTargetScope,
-          strategy: {
-            kind: "client-credentials",
-            tokenEndpoint: tokenUrl,
-            clientIdSecretId: oauth2ClientIdSecretId,
-            clientIdSecretScopeId: String(clientIdSecretScope),
-            clientSecretSecretId: oauth2ClientSecretSecretId,
-            clientSecretSecretScopeId: String(clientSecretSecretScope),
-            scopes: selectedOAuth2Scopes,
-          },
-          pluginId: "openapi",
-          identityLabel: `${displayName} OAuth`,
-        },
-      });
-      setStartingOAuth(false);
-      if (Exit.isFailure(exit)) {
-        setOauth2Error(errorMessageFromExit(exit, "Failed to start OAuth"));
-        return;
-      }
-      const response = exit.value;
-      if (!response.completedConnection) {
-        setOauth2Error("client_credentials flow did not mint a connection");
-        return;
-      }
-      setOauth2AuthState({
-        fingerprint: selectedOAuth2Fingerprint,
-        auth: { connectionId: response.completedConnection.connectionId },
-      });
+  const handleConnectOAuth2 = useCallback(
+    async (existingConnection?: OAuthConnectionChoice) => {
+      if (!selectedOAuth2Preset || !preview) return;
+      oauth.cancel();
       setOauth2Error(null);
-      return;
-    }
+      const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
+      const tokenTargetScope = existingConnection?.scopeId ?? oauthTokenTargetScope;
+      const connectionId =
+        existingConnection?.id ??
+        openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
+      const scopesForAuthorization = existingConnection
+        ? mergeOAuthScopes(splitOAuthScopes(existingConnection.oauthScope), selectedOAuth2Scopes)
+        : selectedOAuth2Scopes;
+      const extraAuthorizationParams = googleAuthorizationParams(selectedOAuth2IsGoogle);
 
-    const authorizationUrl = resolveOAuthUrl(
-      Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
-      resolvedBaseUrl,
-    );
-    const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
+      const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
+      const clientIdSecretScope = oauth2ClientIdScope ?? sourceScope;
+      const clientSecretSecretScope = oauth2ClientSecretScope ?? sourceScope;
 
-    await oauth.openAuthorization({
-      tokenScope: oauthTokenTargetScope,
-      run: async () => {
+      if (selectedOAuth2Preset.flow === "clientCredentials") {
+        if (!oauth2ClientIdSecretId) return;
+        // RFC 6749 §4.4: no user-interactive consent step. The client_secret
+        // is mandatory; the backend exchanges tokens inline and returns a
+        // completed Connection we bind to the source's connection slot.
+        if (!oauth2ClientSecretSecretId) {
+          setOauth2Error("client_credentials requires a client secret");
+          return;
+        }
+        setStartingOAuth(true);
         const exit = await doStartOAuth({
-          params: { scopeId: oauthTokenTargetScope },
+          params: { scopeId: tokenTargetScope },
           payload: {
-            endpoint: authorizationUrl,
-            connectionId: openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow),
-            tokenScope: oauthTokenTargetScope,
-            redirectUrl: oauth2RedirectUrl,
+            endpoint: tokenUrl,
+            redirectUrl: tokenUrl,
+            connectionId,
+            tokenScope: tokenTargetScope,
             strategy: {
-              kind: "authorization-code",
+              kind: "client-credentials",
+              tokenEndpoint: tokenUrl,
+              clientIdSecretId: oauth2ClientIdSecretId,
+              clientIdSecretScopeId: String(clientIdSecretScope),
+              clientSecretSecretId: oauth2ClientSecretSecretId,
+              clientSecretSecretScopeId: String(clientSecretSecretScope),
+              scopes: scopesForAuthorization,
+            },
+            pluginId: "openapi",
+            identityLabel: `${displayName} OAuth`,
+          },
+        });
+        setStartingOAuth(false);
+        if (Exit.isFailure(exit)) {
+          setOauth2Error(errorMessageFromExit(exit, "Failed to start OAuth"));
+          return;
+        }
+        const response = exit.value;
+        if (!response.completedConnection) {
+          setOauth2Error("client_credentials flow did not mint a connection");
+          return;
+        }
+        setOAuthTokenTargetScope(tokenTargetScope);
+        setOauth2AuthState({
+          fingerprint: selectedOAuth2Fingerprint,
+          auth: { connectionId: response.completedConnection.connectionId },
+        });
+        setOauth2Error(null);
+        return;
+      }
+      if (!existingConnection && !oauth2ClientIdSecretId) return;
+
+      const authorizationUrl = resolveOAuthUrl(
+        Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
+        resolvedBaseUrl,
+      );
+      const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
+      const authorizationStrategy = existingConnection
+        ? {
+            kind: "authorization-code-existing-client" as const,
+            authorizationEndpoint: authorizationUrl,
+            tokenEndpoint: tokenUrl,
+            issuerUrl,
+            scopes: scopesForAuthorization,
+            extraAuthorizationParams,
+          }
+        : oauth2ClientIdSecretId
+          ? {
+              kind: "authorization-code" as const,
               authorizationEndpoint: authorizationUrl,
               tokenEndpoint: tokenUrl,
               issuerUrl,
@@ -904,56 +969,75 @@ export default function AddOpenApiSource(props: {
               clientSecretSecretScopeId: oauth2ClientSecretSecretId
                 ? String(clientSecretSecretScope)
                 : null,
-              scopes: selectedOAuth2Scopes,
+              scopes: scopesForAuthorization,
+              extraAuthorizationParams,
+            }
+          : null;
+      if (!authorizationStrategy) return;
+
+      await oauth.openAuthorization({
+        tokenScope: tokenTargetScope,
+        run: async () => {
+          const exit = await doStartOAuth({
+            params: { scopeId: tokenTargetScope },
+            payload: {
+              endpoint: authorizationUrl,
+              connectionId,
+              tokenScope: tokenTargetScope,
+              redirectUrl: oauth2RedirectUrl,
+              strategy: authorizationStrategy,
+              pluginId: "openapi",
+              identityLabel: existingConnection?.identityLabel ?? `${displayName} OAuth`,
             },
-            pluginId: "openapi",
-            identityLabel: `${displayName} OAuth`,
-          },
-        });
-        if (Exit.isFailure(exit)) {
-          // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: OAuth popup API represents start failure by rejecting run()
-          throw new Error(errorMessageFromExit(exit, "Failed to start OAuth"));
-        }
-        const response = exit.value;
-        if (response.authorizationUrl === null) {
-          // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: OAuth popup API represents start failure by rejecting run()
-          throw new Error("Unexpected response flow from server");
-        }
-        return {
-          sessionId: response.sessionId,
-          authorizationUrl: response.authorizationUrl,
-        };
-      },
-      onSuccess: (result) => {
-        setOauth2AuthState({
-          fingerprint: selectedOAuth2Fingerprint,
-          auth: { connectionId: result.connectionId },
-        });
-        setOauth2Error(null);
-      },
-      onError: (message) => {
-        setStartingOAuth(false);
-        setOauth2Error(message);
-      },
-    });
-  }, [
-    selectedOAuth2Preset,
-    oauth2ClientIdSecretId,
-    oauth2ClientSecretSecretId,
-    selectedOAuth2Scopes,
-    oauth2RedirectUrl,
-    resolvedBaseUrl,
-    preview,
-    doStartOAuth,
-    identity.name,
-    resolvedSourceId,
-    selectedOAuth2Fingerprint,
-    oauth,
-    oauthTokenTargetScope,
-    oauth2ClientIdScope,
-    oauth2ClientSecretScope,
-    sourceScope,
-  ]);
+          });
+          if (Exit.isFailure(exit)) {
+            // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: OAuth popup API represents start failure by rejecting run()
+            throw new Error(errorMessageFromExit(exit, "Failed to start OAuth"));
+          }
+          const response = exit.value;
+          if (response.authorizationUrl === null) {
+            // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: OAuth popup API represents start failure by rejecting run()
+            throw new Error("Unexpected response flow from server");
+          }
+          return {
+            sessionId: response.sessionId,
+            authorizationUrl: response.authorizationUrl,
+          };
+        },
+        onSuccess: (result) => {
+          setOAuthTokenTargetScope(tokenTargetScope);
+          setOauth2AuthState({
+            fingerprint: selectedOAuth2Fingerprint,
+            auth: { connectionId: result.connectionId },
+          });
+          setOauth2Error(null);
+        },
+        onError: (message) => {
+          setStartingOAuth(false);
+          setOauth2Error(message);
+        },
+      });
+    },
+    [
+      selectedOAuth2Preset,
+      oauth2ClientIdSecretId,
+      oauth2ClientSecretSecretId,
+      selectedOAuth2Scopes,
+      selectedOAuth2IsGoogle,
+      oauth2RedirectUrl,
+      resolvedBaseUrl,
+      preview,
+      doStartOAuth,
+      identity.name,
+      resolvedSourceId,
+      selectedOAuth2Fingerprint,
+      oauth,
+      oauthTokenTargetScope,
+      oauth2ClientIdScope,
+      oauth2ClientSecretScope,
+      sourceScope,
+    ],
+  );
 
   const handleCancelOAuth2 = useCallback(() => {
     oauth.cancel();
@@ -1565,7 +1649,11 @@ export default function AddOpenApiSource(props: {
                       <Button variant="ghost" size="sm" onClick={handleCancelOAuth2}>
                         Cancel
                       </Button>
-                      <Button variant="secondary" size="sm" onClick={handleConnectOAuth2}>
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => void handleConnectOAuth2()}
+                      >
                         Retry
                       </Button>
                     </div>
@@ -1575,10 +1663,11 @@ export default function AddOpenApiSource(props: {
                         <div className="space-y-2">
                           <div className="space-y-0.5">
                             <FieldLabel className="text-[11px]">
-                              Reuse a signed-in account
+                              Use {selectedOAuth2ProviderLabel} account
                             </FieldLabel>
                             <div className="text-[10px] leading-tight text-muted-foreground">
-                              Skip OAuth and connect this source with an existing account.
+                              Continue with an account you already connected. If permissions are
+                              missing, only the missing access is requested.
                             </div>
                           </div>
                           <div className="space-y-1.5">
@@ -1587,7 +1676,12 @@ export default function AddOpenApiSource(props: {
                                 key={`${connection.scopeId}:${connection.id}`}
                                 connection={connection}
                                 selected={false}
-                                onSelect={() => handleReuseOAuthConnection(connection)}
+                                providerLabel={selectedOAuth2ProviderLabel}
+                                onSelect={() =>
+                                  connection.missingApiScopes.length > 0
+                                    ? void handleConnectOAuth2(connection)
+                                    : handleReuseOAuthConnection(connection)
+                                }
                               />
                             ))}
                           </div>
@@ -1607,7 +1701,7 @@ export default function AddOpenApiSource(props: {
                           </div>
                           <Button
                             variant="secondary"
-                            onClick={handleConnectOAuth2}
+                            onClick={() => void handleConnectOAuth2()}
                             disabled={!canConnectOAuth2}
                             className={
                               canConnectOAuth2

--- a/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/EditOpenApiSource.tsx
@@ -73,6 +73,19 @@ import { OAuth2SourceConfig } from "../sdk/types";
 const ErrorMessage = Schema.Struct({ message: Schema.String });
 const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
 
+const standardOidcIdentityScopes = ["openid", "email", "profile"] as const;
+
+const resolvedOAuthScopes = (oauth2: OAuth2SourceConfig): string[] => {
+  const merged = new Set(oauth2.scopes);
+  if (oauth2.identityScopes === false) return [...merged];
+  const extras =
+    oauth2.identityScopes === undefined || oauth2.identityScopes === "auto"
+      ? standardOidcIdentityScopes
+      : oauth2.identityScopes;
+  for (const scope of extras) merged.add(scope);
+  return [...merged];
+};
+
 const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: string): string =>
   Option.match(Option.flatMap(Exit.findErrorOption(exit), decodeErrorMessage), {
     onNone: () => fallback,
@@ -422,6 +435,7 @@ export default function EditOpenApiSource(props: {
     };
     const displayName = source.name;
     const tokenUrl = resolveOAuthUrl(oauth2.tokenUrl, source.config.baseUrl ?? "");
+    const scopes = resolvedOAuthScopes(oauth2);
     if (oauth2.flow === "clientCredentials") {
       const startOAuthExit = await doStartOAuth({
         params: { scopeId: targetScope },
@@ -439,7 +453,7 @@ export default function EditOpenApiSource(props: {
             clientSecretSecretScopeId: clientSecretSecretScopeId
               ? String(clientSecretSecretScopeId)
               : null,
-            scopes: [...oauth2.scopes],
+            scopes,
           },
           pluginId: "openapi",
           identityLabel: `${displayName} OAuth`,
@@ -502,7 +516,7 @@ export default function EditOpenApiSource(props: {
           clientSecretSecretScopeId: clientSecretSecretScopeId
             ? String(clientSecretSecretScopeId)
             : null,
-          scopes: [...oauth2.scopes],
+          scopes,
         },
         pluginId: "openapi",
         identityLabel: `${displayName} OAuth`,
@@ -648,6 +662,7 @@ export default function EditOpenApiSource(props: {
                         clientSecretSlot: oauth2.clientSecretSlot,
                         connectionSlot: oauth2.connectionSlot,
                         scopes: [...oauth2.scopes],
+                        identityScopes: oauth2.identityScopes,
                       }),
                     },
                   },

--- a/packages/plugins/openapi/src/react/OpenApiSourceDetailsFields.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceDetailsFields.tsx
@@ -27,6 +27,7 @@ export function OpenApiSourceDetailsFields(props: {
   readonly baseUrlOptions?: readonly FreeformComboboxOption[];
   readonly specUrl?: string;
   readonly onSpecUrlChange?: (value: string) => void;
+  readonly faviconIcon?: string | null;
   readonly faviconUrl?: string;
   readonly namespaceReadOnly?: boolean;
   readonly specUrlDisabled?: boolean;
@@ -40,7 +41,9 @@ export function OpenApiSourceDetailsFields(props: {
     <CardStack>
       <CardStackContent className="border-t-0">
         <CardStackEntry>
-          {props.faviconUrl && <SourceFavicon url={props.faviconUrl} size={16} />}
+          {(props.faviconIcon || props.faviconUrl) && (
+            <SourceFavicon icon={props.faviconIcon} url={props.faviconUrl} size={16} />
+          )}
           <CardStackEntryContent>
             <CardStackEntryTitle>{props.title}</CardStackEntryTitle>
             {props.description && (

--- a/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
+++ b/packages/plugins/openapi/src/react/OpenApiSourceSummary.tsx
@@ -1,10 +1,11 @@
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
-import { connectionsAtom, sourceAtom } from "@executor-js/react/api/atoms";
+import { connectionIdentityAtom, connectionsAtom, sourceAtom } from "@executor-js/react/api/atoms";
 import { Badge } from "@executor-js/react/components/badge";
+import { Button } from "@executor-js/react/components/button";
 import { useScope, useScopeStack, useUserScope } from "@executor-js/react/api/scope-context";
-import { ScopeId } from "@executor-js/sdk/shared";
+import { ConnectionId, ScopeId } from "@executor-js/sdk/shared";
 import {
   SourceCredentialLoadingBadge,
   SourceCredentialNotice,
@@ -21,12 +22,65 @@ function OAuthBadge() {
   return <Badge variant="secondary">OAuth</Badge>;
 }
 
+function SourceAccountNotice(props: {
+  readonly connection: {
+    readonly id: string;
+    readonly scopeId: string;
+    readonly identityLabel: string | null;
+  };
+  readonly onAction?: () => void;
+}) {
+  const identityResult = useAtomValue(
+    connectionIdentityAtom(
+      ScopeId.make(props.connection.scopeId),
+      ConnectionId.make(props.connection.id),
+    ),
+  );
+  const identity =
+    AsyncResult.isSuccess(identityResult) && identityResult.value.status === "available"
+      ? identityResult.value
+      : null;
+  const label = identity?.email ?? identity?.name ?? props.connection.identityLabel ?? "Connected";
+  return (
+    <div className="shrink-0 border-b border-border bg-muted/20 px-4 py-3">
+      <div className="mx-auto flex max-w-4xl items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2">
+          {identity?.picture ? (
+            <img
+              src={identity.picture}
+              alt=""
+              referrerPolicy="no-referrer"
+              className="size-6 shrink-0 rounded-full"
+            />
+          ) : (
+            <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-[11px] font-medium text-muted-foreground">
+              {label.slice(0, 1).toUpperCase()}
+            </div>
+          )}
+          <div className="min-w-0">
+            <div className="truncate text-sm font-medium text-foreground">{label}</div>
+            <div className="text-xs text-muted-foreground">OAuth account for this source</div>
+          </div>
+        </div>
+        {props.onAction ? (
+          <Button variant="ghost" size="sm" onClick={props.onAction} className="shrink-0">
+            Configure
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 const effectiveClientSecretSlot = (oauth2: {
   readonly securitySchemeName: string;
   readonly clientSecretSlot: string | null;
 }): string => oauth2.clientSecretSlot ?? oauth2ClientSecretSlot(oauth2.securitySchemeName);
 
-const sourceCredentialSlots = (source: StoredSourceSchemaType): readonly SourceCredentialSlot[] => {
+const sourceCredentialSlots = (
+  source: StoredSourceSchemaType,
+  options?: { readonly hasLiveOAuthConnection?: boolean },
+): readonly SourceCredentialSlot[] => {
   const slots: SourceCredentialSlot[] = [];
   for (const [name, value] of Object.entries(source.config.headers ?? {})) {
     if (typeof value !== "string") slots.push({ kind: "secret", slot: value.slot, label: name });
@@ -36,12 +90,14 @@ const sourceCredentialSlots = (source: StoredSourceSchemaType): readonly SourceC
   }
   const oauth2 = source.config.oauth2;
   if (oauth2) {
-    slots.push({ kind: "secret", slot: oauth2.clientIdSlot, label: "Client ID" });
-    slots.push({
-      kind: "secret",
-      slot: effectiveClientSecretSlot(oauth2),
-      label: "Client Secret",
-    });
+    if (!options?.hasLiveOAuthConnection) {
+      slots.push({ kind: "secret", slot: oauth2.clientIdSlot, label: "Client ID" });
+      slots.push({
+        kind: "secret",
+        slot: effectiveClientSecretSlot(oauth2),
+        label: "Client Secret",
+      });
+    }
     slots.push({
       kind: "connection",
       slot: oauth2.connectionSlot,
@@ -93,24 +149,9 @@ export default function OpenApiSourceSummary(props: {
   const liveConnectionIds = new Set(connections.map((connection) => connection.id));
   const scopeRanks = new Map(scopeStack.map((scope, index) => [scope.id, index] as const));
   const credentialTargetScope = userScope;
-  const missing = missingSourceCredentialLabels({
-    slots: sourceCredentialSlots(source),
-    bindings,
-    targetScope: credentialTargetScope,
-    scopeRanks,
-    liveConnectionIds,
-  });
-
-  if (props.variant === "panel") {
-    return <SourceCredentialNotice missing={missing} onAction={props.onAction} />;
-  }
-
-  if (missing.length > 0) return <SourceCredentialStatusBadge missing={missing} />;
-
-  if (!oauth2) return null;
   const connectionBinding = effectiveBindingForScope(
     bindings,
-    oauth2.connectionSlot,
+    oauth2?.connectionSlot ?? "",
     credentialTargetScope,
     scopeRanks,
   );
@@ -118,8 +159,30 @@ export default function OpenApiSourceSummary(props: {
     connectionBinding && connectionBinding.value.kind === "connection"
       ? connectionBinding.value.connectionId
       : null;
+  const connection = connectionId
+    ? (connections.find((candidate) => candidate.id === connectionId) ?? null)
+    : null;
+  const missing = missingSourceCredentialLabels({
+    slots: sourceCredentialSlots(source, { hasLiveOAuthConnection: connection !== null }),
+    bindings,
+    targetScope: credentialTargetScope,
+    scopeRanks,
+    liveConnectionIds,
+  });
 
-  if (connectionId && connections.some((connection) => connection.id === connectionId)) {
+  if (props.variant === "panel") {
+    if (missing.length > 0)
+      return <SourceCredentialNotice missing={missing} onAction={props.onAction} />;
+    return connection ? (
+      <SourceAccountNotice connection={connection} onAction={props.onAction} />
+    ) : null;
+  }
+
+  if (missing.length > 0) return <SourceCredentialStatusBadge missing={missing} />;
+
+  if (!oauth2) return null;
+
+  if (connection) {
     return <SourceCredentialStatusBadge missing={[]} />;
   }
 

--- a/packages/plugins/openapi/src/sdk/credential-status.test.ts
+++ b/packages/plugins/openapi/src/sdk/credential-status.test.ts
@@ -30,6 +30,18 @@ const source: SourceForCredentialStatus = {
   },
 };
 
+const authorizationCodeSource: SourceForCredentialStatus = {
+  config: {
+    oauth2: {
+      securitySchemeName: "oauth2",
+      flow: "authorizationCode",
+      clientIdSlot: "oauth2:oauth2:client-id",
+      clientSecretSlot: "oauth2:oauth2:client-secret",
+      connectionSlot: "oauth2:oauth2:connection",
+    },
+  },
+};
+
 const bindings = (
   scopeId: ScopeId,
   slots: readonly string[],
@@ -79,6 +91,28 @@ describe("OpenAPI credential status", () => {
         liveConnectionIds: [],
       }),
     ).toEqual(["OAuth client connection"]);
+  });
+
+  it("treats a live authorization-code connection as ready without source client credentials", () => {
+    expect(
+      missingCredentialLabels(
+        authorizationCodeSource,
+        bindings(userScope, ["oauth2:oauth2:connection"]),
+        userScope,
+        scopeRanks,
+        {
+          liveConnectionIds: [ConnectionId.make("user-connection")],
+        },
+      ),
+    ).toEqual([]);
+  });
+
+  it("requires client credentials before starting authorization-code OAuth when no connection is bound", () => {
+    expect(
+      missingCredentialLabels(authorizationCodeSource, [], userScope, scopeRanks, {
+        liveConnectionIds: [],
+      }),
+    ).toEqual(["Client ID", "Client Secret", "OAuth sign-in"]);
   });
 
   it("does not treat personal bindings as satisfying org-level credential status", () => {

--- a/packages/plugins/openapi/src/sdk/credential-status.ts
+++ b/packages/plugins/openapi/src/sdk/credential-status.ts
@@ -88,18 +88,23 @@ export function missingCredentialLabels(
   const oauth2 = source.config.oauth2;
   if (!oauth2) return missing;
 
-  if (!hasSecretBinding(bindings, oauth2.clientIdSlot, targetScope, ranks)) {
-    missing.push("Client ID");
-  }
+  const hasLiveConnection = hasConnectionBinding(
+    bindings,
+    oauth2.connectionSlot,
+    targetScope,
+    ranks,
+    liveConnectionIds,
+  );
+  if (!hasLiveConnection) {
+    if (!hasSecretBinding(bindings, oauth2.clientIdSlot, targetScope, ranks)) {
+      missing.push("Client ID");
+    }
 
-  const clientSecretSlot = effectiveClientSecretSlot(oauth2);
-  if (!hasSecretBinding(bindings, clientSecretSlot, targetScope, ranks)) {
-    missing.push("Client Secret");
-  }
+    const clientSecretSlot = effectiveClientSecretSlot(oauth2);
+    if (!hasSecretBinding(bindings, clientSecretSlot, targetScope, ranks)) {
+      missing.push("Client Secret");
+    }
 
-  if (
-    !hasConnectionBinding(bindings, oauth2.connectionSlot, targetScope, ranks, liveConnectionIds)
-  ) {
     missing.push(oauth2.flow === "clientCredentials" ? "OAuth client connection" : "OAuth sign-in");
   }
 

--- a/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
+++ b/packages/plugins/openapi/src/sdk/multi-scope-oauth.test.ts
@@ -46,6 +46,7 @@ const makeOauth2SourceConfig = (params: {
   readonly tokenUrl: string;
   readonly authorizationUrl: string | null;
   readonly scopes: readonly string[];
+  readonly identityScopes?: OAuth2SourceConfig["identityScopes"];
 }): OAuth2SourceConfig =>
   OAuth2SourceConfig.make({
     kind: "oauth2",
@@ -57,7 +58,19 @@ const makeOauth2SourceConfig = (params: {
     clientSecretSlot: "oauth2:oauth2:client-secret",
     connectionSlot: "oauth2:oauth2:connection",
     scopes: [...params.scopes],
+    ...(params.identityScopes !== undefined ? { identityScopes: params.identityScopes } : {}),
   });
+
+const resolvedOAuthScopes = (oauth2: OAuth2SourceConfig): string[] => {
+  const merged = new Set(oauth2.scopes);
+  if (oauth2.identityScopes === false) return [...merged];
+  const extras =
+    oauth2.identityScopes === undefined || oauth2.identityScopes === "auto"
+      ? ["openid", "email", "profile"]
+      : oauth2.identityScopes;
+  for (const scope of extras) merged.add(scope);
+  return [...merged];
+};
 
 // ---------------------------------------------------------------------------
 // Test API — a single endpoint that echoes the Authorization header so the
@@ -357,6 +370,87 @@ describe("OpenAPI multi-scope OAuth", () => {
       expect(aliceSecretIds).toContain("petstore_client_secret");
       expect(aliceSecretIds).not.toContain(`${aliceAuth.connectionId}.access_token`);
       expect(aliceSecretIds).not.toContain(`${aliceAuth.connectionId}.refresh_token`);
+    }),
+  );
+
+  it.effect("authorization-code OpenAPI sources request identity scopes by default", () =>
+    Effect.gen(function* () {
+      const secretStore = new Map<string, string>();
+      const key = (scope: string, id: string) => `${scope} ${id}`;
+      const memoryProvider: SecretProvider = {
+        key: "memory",
+        writable: true,
+        get: (id, scope) => Effect.sync(() => secretStore.get(key(scope, id)) ?? null),
+        set: (id, value, scope) =>
+          Effect.sync(() => {
+            secretStore.set(key(scope, id), value);
+          }),
+        delete: (id, scope) => Effect.sync(() => secretStore.delete(key(scope, id))),
+      };
+      const memorySecretsPlugin = definePlugin(() => ({
+        id: "memory-secrets" as const,
+        storage: () => ({}),
+        secretProviders: [memoryProvider],
+      }));
+      const userScope = Scope.make({
+        id: ScopeId.make("user-alice"),
+        name: "Alice",
+        createdAt: new Date(),
+      });
+      const executor = yield* createExecutor(
+        makeTestConfig({
+          plugins: [openApiPlugin(), memorySecretsPlugin()] as const,
+          scopes: [userScope],
+        }),
+      );
+      yield* executor.secrets.set(
+        SetSecretInput.make({
+          id: SecretId.make("petstore_client_id"),
+          scope: userScope.id,
+          name: "Petstore Client ID",
+          value: "client-abc",
+        }),
+      );
+      yield* executor.secrets.set(
+        SetSecretInput.make({
+          id: SecretId.make("petstore_client_secret"),
+          scope: userScope.id,
+          name: "Petstore Client Secret",
+          value: "secret-xyz",
+        }),
+      );
+      const oauth = yield* serveOAuthTestServer({
+        defaultClientId: "client-abc",
+        defaultClientSecret: "secret-xyz",
+      });
+      const oauth2 = makeOauth2SourceConfig({
+        flow: "authorizationCode",
+        authorizationUrl: oauth.authorizationEndpoint,
+        tokenUrl: oauth.tokenEndpoint,
+        scopes: ["read"],
+      });
+
+      const start = yield* executor.oauth.start({
+        endpoint: oauth.authorizationEndpoint,
+        redirectUrl: "https://app.example.com/oauth/callback",
+        connectionId: "openapi-oauth2-user-petstore",
+        tokenScope: String(userScope.id),
+        pluginId: "openapi",
+        identityLabel: "Petstore OAuth",
+        strategy: {
+          kind: "authorization-code",
+          authorizationEndpoint: oauth.authorizationEndpoint,
+          tokenEndpoint: oauth.tokenEndpoint,
+          issuerUrl: oauth.issuerUrl,
+          clientIdSecretId: "petstore_client_id",
+          clientSecretSecretId: "petstore_client_secret",
+          scopes: resolvedOAuthScopes(oauth2),
+        },
+      });
+
+      expect(start.authorizationUrl).not.toBeNull();
+      const authorizationUrl = new URL(start.authorizationUrl ?? "");
+      expect(authorizationUrl.searchParams.get("scope")).toBe("read openid email profile");
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -303,6 +303,11 @@ const StaticPreviewOAuth2PresetSchema = Schema.Struct({
   tokenUrl: Schema.String,
   refreshUrl: Schema.NullOr(Schema.String),
   scopes: Schema.Record(Schema.String, Schema.String),
+  identityScopes: Schema.Union([
+    Schema.Literal("auto"),
+    Schema.Literal(false),
+    Schema.Array(Schema.String),
+  ]),
 });
 const StaticPreviewSpecOutputSchema = Schema.Struct({
   title: Schema.NullOr(Schema.String),
@@ -535,6 +540,7 @@ const staticPreviewOutput = (preview: SpecPreview): StaticPreviewSpecOutput => (
     tokenUrl: preset.tokenUrl,
     refreshUrl: Option.getOrNull(preset.refreshUrl),
     scopes: preset.scopes,
+    identityScopes: preset.identityScopes,
   })),
 });
 

--- a/packages/plugins/openapi/src/sdk/preview-oauth2.test.ts
+++ b/packages/plugins/openapi/src/sdk/preview-oauth2.test.ts
@@ -96,6 +96,7 @@ describe("previewSpec OAuth2 extraction", () => {
         read: "Read access",
         write: "Write access",
       });
+      expect(preset.identityScopes).toBe("auto");
     }),
   );
 
@@ -126,6 +127,7 @@ describe("previewSpec OAuth2 extraction", () => {
       const cc = preview.oauth2Presets.find((p) => p.flow === "clientCredentials")!;
       expect(Option.isNone(cc.authorizationUrl)).toBe(true);
       expect(cc.scopes).toEqual({ "admin:read": "Admin read" });
+      expect(cc.identityScopes).toBe(false);
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -106,6 +106,12 @@ export const OAuth2Preset = Schema.Struct({
   refreshUrl: Schema.OptionFromOptional(Schema.String),
   /** Declared scopes for this flow: `{ scope: description }`. */
   scopes: Schema.Record(Schema.String, Schema.String),
+  /** Identity scopes to request alongside API scopes. `"auto"` discovers standard OIDC scopes. */
+  identityScopes: Schema.Union([
+    Schema.Literal("auto"),
+    Schema.Literal(false),
+    Schema.Array(Schema.String),
+  ]),
 });
 export type OAuth2Preset = typeof OAuth2Preset.Type;
 
@@ -328,6 +334,7 @@ const buildOAuth2Presets = (schemes: readonly SecurityScheme[]): OAuth2Preset[] 
           tokenUrl: flow.tokenUrl,
           refreshUrl: flow.refreshUrl,
           scopes: flow.scopes,
+          identityScopes: "auto",
         }),
       );
     }
@@ -343,6 +350,7 @@ const buildOAuth2Presets = (schemes: readonly SecurityScheme[]): OAuth2Preset[] 
           tokenUrl: flow.tokenUrl,
           refreshUrl: flow.refreshUrl,
           scopes: flow.scopes,
+          identityScopes: false,
         }),
       );
     }

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -181,6 +181,7 @@ export const cancelOAuth = ExecutorApiClient.mutation("oauth", "cancel");
 
 export const oauthConnectionCompleted = ExecutorApiClient.runtime.fn<{
   readonly tokenScope: string;
+  readonly reactivityKeys: typeof connectionWriteKeys;
 }>()(() => Effect.void, {
   reactivityKeys: connectionWriteKeys,
 });

--- a/packages/react/src/api/atoms.tsx
+++ b/packages/react/src/api/atoms.tsx
@@ -7,9 +7,10 @@ import {
 } from "@executor-js/sdk/shared";
 import * as Atom from "effect/unstable/reactivity/Atom";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import * as Effect from "effect/Effect";
 
 import { ExecutorApiClient } from "./client";
-import { ReactivityKey } from "./reactivity-keys";
+import { connectionWriteKeys, ReactivityKey } from "./reactivity-keys";
 
 // ---------------------------------------------------------------------------
 // Scope — fetched from the server
@@ -177,6 +178,12 @@ export const startOAuth = ExecutorApiClient.mutation("oauth", "start");
 export const completeOAuth = ExecutorApiClient.mutation("oauth", "complete");
 
 export const cancelOAuth = ExecutorApiClient.mutation("oauth", "cancel");
+
+export const oauthConnectionCompleted = ExecutorApiClient.runtime.fn<{
+  readonly tokenScope: string;
+}>()(() => Effect.void, {
+  reactivityKeys: connectionWriteKeys,
+});
 
 export const createPolicy = ExecutorApiClient.mutation("policies", "create");
 

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -12,6 +12,7 @@ import {
   reserveOAuthPopup,
   type OAuthPopupResult,
 } from "../api/oauth-popup";
+import { connectionWriteKeys } from "../api/reactivity-keys";
 
 type DesktopBridge = {
   readonly openExternal: (url: string) => Promise<void>;
@@ -227,7 +228,10 @@ export function useOAuthPopupFlow<
           return;
         }
 
-        const refreshExit = await doOAuthConnectionCompleted({ tokenScope: input.tokenScope });
+        const refreshExit = await doOAuthConnectionCompleted({
+          tokenScope: input.tokenScope,
+          reactivityKeys: connectionWriteKeys,
+        });
         if (Exit.isFailure(refreshExit)) {
           const message = messageFromExit(refreshExit, "Failed to refresh connection");
           reportHandledError(refreshExit.cause, {

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -4,7 +4,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 
-import { cancelOAuth, startOAuth } from "../api/atoms";
+import { cancelOAuth, oauthConnectionCompleted, startOAuth } from "../api/atoms";
 import { messageFromExit, messageFromUnknown, useReportHandledError } from "../api/error-reporting";
 import {
   openOAuthPopup,
@@ -73,7 +73,7 @@ export type StartOAuthAuthorizationInput<TPayload extends OAuthCompletionPayload
   readonly tokenScope: string;
   readonly run: () => Promise<OAuthAuthorizationStartResult>;
   readonly onSuccess: (payload: TPayload) => void | Promise<void>;
-  readonly onError?: (error: string) => void;
+  readonly onError?: (error: string, details?: string) => void;
   readonly onAuthorizationStarted?: (result: OAuthAuthorizationStartResult) => void;
   readonly reportMetadata?: Record<string, string | number | boolean | null | undefined>;
 };
@@ -119,6 +119,7 @@ export function useOAuthPopupFlow<
   } = options;
   const doStartOAuth = useAtomSet(startOAuth, { mode: "promiseExit" });
   const doCancelOAuth = useAtomSet(cancelOAuth, { mode: "promiseExit" });
+  const doOAuthConnectionCompleted = useAtomSet(oauthConnectionCompleted, { mode: "promiseExit" });
   const reportHandledError = useReportHandledError();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -222,7 +223,22 @@ export function useOAuthPopupFlow<
         if (!result.ok) {
           setBusy(false);
           setError(result.error);
-          input.onError?.(result.error);
+          input.onError?.(result.error, result.errorDetails);
+          return;
+        }
+
+        const refreshExit = await doOAuthConnectionCompleted({ tokenScope: input.tokenScope });
+        if (Exit.isFailure(refreshExit)) {
+          const message = messageFromExit(refreshExit, "Failed to refresh connection");
+          reportHandledError(refreshExit.cause, {
+            surface: "oauth",
+            action: "refresh_connection",
+            message,
+            metadata: input.reportMetadata,
+          });
+          setBusy(false);
+          setError(message);
+          input.onError?.(message);
           return;
         }
 
@@ -292,6 +308,7 @@ export function useOAuthPopupFlow<
       cancel,
       cancelSession,
       detectPopupClosed,
+      doOAuthConnectionCompleted,
       noAuthorizationUrlMessage,
       popupBlockedMessage,
       popupClosedMessage,


### PR DESCRIPTION
## Summary
- request account identity scopes by default for authorization-code OAuth sources with opt-out support
- let OpenAPI add-source reuse existing OAuth connections with matching API scopes
- polish add-source OAuth credentials, scopes, and connected-account UX

## Tests
- bun run --cwd packages/plugins/openapi test -- src/sdk/google-discovery.test.ts src/sdk/multi-scope-oauth.test.ts src/sdk/preview-oauth2.test.ts
- bun run --cwd packages/plugins/openapi typecheck
- bun run --cwd packages/react typecheck

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #871
2. #872
3. **#873** 👈 current
4. #874
5. #875
<!-- stack:links:end -->