### PR TITLE
Add bundled Google source flow

### DIFF
--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -37,6 +37,10 @@ const OpenApiSpecInputPayload = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("url"), url: Schema.String }),
   Schema.Struct({ kind: Schema.Literal("blob"), value: Schema.String }),
   Schema.Struct({ kind: Schema.Literal("googleDiscovery"), url: Schema.String }),
+  Schema.Struct({
+    kind: Schema.Literal("googleDiscoveryBundle"),
+    urls: Schema.Array(Schema.String),
+  }),
 ]);
 
 const PreviewSpecFetchCredentialsPayload = Schema.Struct({

--- a/packages/plugins/openapi/src/api/handlers.ts
+++ b/packages/plugins/openapi/src/api/handlers.ts
@@ -97,6 +97,7 @@ export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "ope
                 name: source.name,
                 config: {
                   sourceUrl: source.config.sourceUrl,
+                  googleDiscoveryUrls: source.config.googleDiscoveryUrls,
                   baseUrl: source.config.baseUrl,
                   namespace: source.config.namespace,
                   headers: source.config.headers,

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -117,11 +117,7 @@ const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: strin
 const googleOAuthErrorMessage =
   "Google did not approve this permission request. Try selecting fewer services, or add sensitive services as separate Google sources.";
 
-const oauthErrorMessage = (
-  providerLabel: string,
-  message: string,
-  details?: string,
-): string => {
+const oauthErrorMessage = (providerLabel: string, message: string, details?: string): string => {
   if (providerLabel !== "Google") return details ? `${message}: ${details}` : message;
   const combined = `${message}\n${details ?? ""}`;
   if (
@@ -1584,7 +1580,10 @@ export default function AddOpenApiSource(props: {
       selectedOAuth2IsGoogle,
       oauth2RedirectUrl,
       effectiveResolvedBaseUrl,
+      configuredOAuth2IdentityScopes,
+      googleBatchAddItems,
       googleConsentBatches,
+      googleServicePickerEnabled,
       preview,
       doStartOAuth,
       identity.name,

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -48,7 +48,12 @@ import {
   type HeaderState,
 } from "@executor-js/react/plugins/secret-header-auth";
 import { CredentialScopeDropdown } from "@executor-js/react/plugins/credential-target-scope";
-import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
+import {
+  normalizeNamespaceInput,
+  slugifyNamespace,
+  useSourceIdentity,
+  type SourceIdentity,
+} from "@executor-js/react/plugins/source-identity";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor-js/react/components/button";
 import { CopyButton } from "@executor-js/react/components/copy-button";
@@ -70,9 +75,10 @@ import { Textarea } from "@executor-js/react/components/textarea";
 import { Checkbox } from "@executor-js/react/components/checkbox";
 import { RadioGroup, RadioGroupItem } from "@executor-js/react/components/radio-group";
 import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@executor-js/react/components/tabs";
 import { addOpenApiSpecOptimistic, previewOpenApiSpec } from "./atoms";
 import { OpenApiSourceDetailsFields } from "./OpenApiSourceDetailsFields";
-import { openApiPresets } from "../sdk/presets";
+import { googleOpenApiPresets, openApiPresets } from "../sdk/presets";
 import type { SpecPreview, HeaderPreset, OAuth2Preset } from "../sdk/preview";
 import {
   headerBindingSlot,
@@ -256,6 +262,29 @@ type OAuthConnectionChoice = {
   readonly missingApiScopes: readonly string[];
 };
 
+type GoogleServicePreviewState =
+  | { readonly status: "loading" }
+  | {
+      readonly status: "success";
+      readonly preview: SpecPreview;
+      readonly baseUrl: string;
+    }
+  | { readonly status: "error"; readonly message: string };
+
+type GoogleServiceAddItem = {
+  readonly preset: (typeof googleOpenApiPresets)[number];
+  readonly preview: SpecPreview;
+  readonly baseUrl: string;
+  readonly isPrimary: boolean;
+};
+
+type GoogleServiceSettings = {
+  readonly name?: string;
+  readonly namespace?: string;
+  readonly baseUrl?: string;
+  readonly specUrl?: string;
+};
+
 const specInputForAdd = (input: string) => {
   const value = input.trim();
   const parsed = Effect.runSyncExit(
@@ -288,6 +317,35 @@ const normalizePresetUrl = (url: string): string => {
   parsed.searchParams.sort();
   return parsed.toString().replace(/\/$/, "");
 };
+
+const googlePresetForSpec = (
+  presetId: string | undefined,
+  specUrl: string,
+): (typeof googleOpenApiPresets)[number] | null => {
+  const normalizedSpecUrl = normalizePresetUrl(specUrl);
+  const byUrl = googleOpenApiPresets.find(
+    (preset) => normalizePresetUrl(preset.url) === normalizedSpecUrl,
+  );
+  if (byUrl) return byUrl;
+  const byId = presetId ? googleOpenApiPresets.find((preset) => preset.id === presetId) : undefined;
+  if (byId) return byId;
+  return null;
+};
+
+const firstBaseUrlForPreview = (preview: SpecPreview): string => {
+  const firstServer = preview.servers[0];
+  return firstServer ? (expandServerUrlOptions(firstServer)[0] ?? "") : "";
+};
+
+const defaultGoogleSourceName = (
+  preset: (typeof googleOpenApiPresets)[number],
+  preview: SpecPreview,
+): string => Option.getOrElse(preview.title, () => preset.name);
+
+const defaultGoogleSourceNamespace = (
+  preset: (typeof googleOpenApiPresets)[number],
+  preview: SpecPreview,
+): string => slugifyNamespace(defaultGoogleSourceName(preset, preview)) || preset.id;
 
 type StrategySelection =
   | { readonly kind: "none" }
@@ -347,6 +405,31 @@ function entriesFromSpecPreset(preset: HeaderPreset): HeaderState[] {
     };
   });
 }
+
+const oauth2ConfigForPreset = (input: {
+  readonly preset: OAuth2Preset;
+  readonly baseUrl: string;
+  readonly scopes: Iterable<string>;
+  readonly identityScopes: OAuth2Preset["identityScopes"];
+}): OAuth2SourceConfig =>
+  OAuth2SourceConfig.make({
+    kind: "oauth2",
+    securitySchemeName: input.preset.securitySchemeName,
+    flow: input.preset.flow,
+    tokenUrl: resolveOAuthUrl(input.preset.tokenUrl, input.baseUrl),
+    authorizationUrl:
+      input.preset.flow === "authorizationCode"
+        ? resolveOAuthUrl(
+            Option.getOrElse(input.preset.authorizationUrl, () => ""),
+            input.baseUrl,
+          ) || null
+        : null,
+    clientIdSlot: oauth2ClientIdSlot(input.preset.securitySchemeName),
+    clientSecretSlot: oauth2ClientSecretSlot(input.preset.securitySchemeName),
+    connectionSlot: oauth2ConnectionSlot(input.preset.securitySchemeName),
+    scopes: [...input.scopes],
+    identityScopes: input.identityScopes,
+  });
 
 function OAuthConnectedAccount(props: {
   readonly scopeId: ScopeId;
@@ -474,6 +557,7 @@ export default function AddOpenApiSource(props: {
   onComplete: () => void;
   onCancel: () => void;
   initialUrl?: string;
+  initialPreset?: string;
   initialNamespace?: string;
 }) {
   // Spec input
@@ -514,6 +598,16 @@ export default function AddOpenApiSource(props: {
   } | null>(null);
   const [startingOAuth, setStartingOAuth] = useState(false);
   const [oauth2Error, setOauth2Error] = useState<string | null>(null);
+  const [selectedGoogleServiceIds, setSelectedGoogleServiceIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const [googleServicePreviews, setGoogleServicePreviews] = useState<
+    Record<string, GoogleServicePreviewState>
+  >({});
+  const [googleServiceSettings, setGoogleServiceSettings] = useState<
+    Record<string, GoogleServiceSettings>
+  >({});
+  const [activeGoogleServiceId, setActiveGoogleServiceId] = useState<string | null>(null);
 
   // Submit
   const [adding, setAdding] = useState(false);
@@ -608,6 +702,19 @@ export default function AddOpenApiSource(props: {
   const previewPresetIcon =
     openApiPresets.find((preset) => normalizePresetUrl(preset.url) === normalizePresetUrl(specUrl))
       ?.icon ?? null;
+  const primaryGooglePreset = preview ? googlePresetForSpec(props.initialPreset, specUrl) : null;
+  const selectedGoogleServiceIdList = useMemo(
+    () => [...selectedGoogleServiceIds],
+    [selectedGoogleServiceIds],
+  );
+  const selectedGooglePresets = useMemo(
+    () =>
+      selectedGoogleServiceIdList.flatMap((presetId) => {
+        const preset = googleOpenApiPresets.find((candidate) => candidate.id === presetId);
+        return preset ? [preset] : [];
+      }),
+    [selectedGoogleServiceIdList],
+  );
 
   const resolvedBaseUrl = baseUrl.trim();
   const sourceScope = ScopeId.make(scopeId);
@@ -736,6 +843,60 @@ export default function AddOpenApiSource(props: {
     ? isGoogleOAuthTarget(selectedOAuth2Preset, resolvedBaseUrl, specUrl)
     : false;
   const selectedOAuth2ProviderLabel = selectedOAuth2IsGoogle ? "Google" : "OAuth";
+  const googleServicePickerEnabled = Boolean(
+    preview && primaryGooglePreset && selectedOAuth2IsGoogle,
+  );
+  const googleBatchAddItems = useMemo((): readonly GoogleServiceAddItem[] => {
+    if (!preview || !primaryGooglePreset || !googleServicePickerEnabled) return [];
+    const items: GoogleServiceAddItem[] = [];
+    for (const presetId of selectedGoogleServiceIdList) {
+      const preset = googleOpenApiPresets.find((candidate) => candidate.id === presetId);
+      if (!preset) continue;
+      if (preset.id === primaryGooglePreset.id) {
+        items.push({
+          preset,
+          preview,
+          baseUrl: resolvedBaseUrl,
+          isPrimary: true,
+        });
+        continue;
+      }
+      const previewState = googleServicePreviews[preset.id];
+      if (previewState?.status === "success") {
+        items.push({
+          preset,
+          preview: previewState.preview,
+          baseUrl: previewState.baseUrl,
+          isPrimary: false,
+        });
+      }
+    }
+    return items;
+  }, [
+    googleServicePickerEnabled,
+    googleServicePreviews,
+    preview,
+    primaryGooglePreset,
+    resolvedBaseUrl,
+    selectedGoogleServiceIdList,
+  ]);
+  const googleBatchPendingCount = googleServicePickerEnabled
+    ? selectedGoogleServiceIdList.length - googleBatchAddItems.length
+    : 0;
+  const googleBatchError = googleServicePickerEnabled
+    ? selectedGoogleServiceIdList
+        .map((presetId) => googleServicePreviews[presetId])
+        .find((state) => state?.status === "error")
+    : undefined;
+  const effectiveOAuth2SelectedApiScopes = useMemo(() => {
+    if (!googleServicePickerEnabled) return oauth2SelectedScopes;
+    const scopes = new Set<string>();
+    for (const item of googleBatchAddItems) {
+      const preset = item.preview.oauth2Presets[0];
+      for (const scope of Object.keys(preset?.scopes ?? {})) scopes.add(scope);
+    }
+    return scopes.size > 0 ? scopes : oauth2SelectedScopes;
+  }, [googleBatchAddItems, googleServicePickerEnabled, oauth2SelectedScopes]);
   const configuredOAuth2IdentityScopes =
     selectedOAuth2Preset && includeOAuth2IdentityScopes
       ? selectedOAuth2Preset.identityScopes
@@ -743,10 +904,157 @@ export default function AddOpenApiSource(props: {
   const selectedOAuth2Scopes = useMemo(
     () =>
       selectedOAuth2Preset
-        ? resolvedOAuthScopes(oauth2SelectedScopes, configuredOAuth2IdentityScopes)
-        : [...oauth2SelectedScopes],
-    [configuredOAuth2IdentityScopes, oauth2SelectedScopes, selectedOAuth2Preset],
+        ? resolvedOAuthScopes(effectiveOAuth2SelectedApiScopes, configuredOAuth2IdentityScopes)
+        : [...effectiveOAuth2SelectedApiScopes],
+    [configuredOAuth2IdentityScopes, effectiveOAuth2SelectedApiScopes, selectedOAuth2Preset],
   );
+  useEffect(() => {
+    if (!googleServicePickerEnabled || !primaryGooglePreset) {
+      setSelectedGoogleServiceIds((previous) =>
+        previous.size === 0 ? previous : new Set<string>(),
+      );
+      setGoogleServicePreviews((previous) => (Object.keys(previous).length === 0 ? previous : {}));
+      setGoogleServiceSettings((previous) => (Object.keys(previous).length === 0 ? previous : {}));
+      setActiveGoogleServiceId(null);
+      return;
+    }
+    setSelectedGoogleServiceIds((previous) => {
+      if (previous.has(primaryGooglePreset.id)) return previous;
+      const next = new Set(previous);
+      next.add(primaryGooglePreset.id);
+      return next;
+    });
+  }, [googleServicePickerEnabled, primaryGooglePreset]);
+
+  useEffect(() => {
+    if (!googleServicePickerEnabled || !primaryGooglePreset) return;
+    setActiveGoogleServiceId((previous) =>
+      previous && selectedGoogleServiceIds.has(previous) ? previous : primaryGooglePreset.id,
+    );
+  }, [googleServicePickerEnabled, primaryGooglePreset, selectedGoogleServiceIds]);
+
+  useEffect(() => {
+    if (!googleServicePickerEnabled || !primaryGooglePreset) return;
+    const missingPresetIds = selectedGoogleServiceIdList.filter(
+      (presetId) => presetId !== primaryGooglePreset.id && !googleServicePreviews[presetId],
+    );
+    if (missingPresetIds.length === 0) return;
+    setGoogleServicePreviews((previous) => {
+      const next = { ...previous };
+      for (const presetId of missingPresetIds) next[presetId] = { status: "loading" };
+      return next;
+    });
+    void (async () => {
+      for (const presetId of missingPresetIds) {
+        const preset = googleOpenApiPresets.find((candidate) => candidate.id === presetId);
+        if (!preset) continue;
+        const exit = await doPreview({
+          params: { scopeId },
+          payload: {
+            spec: preset.url,
+          },
+        });
+        setGoogleServicePreviews((previous) => ({
+          ...previous,
+          [preset.id]: Exit.isSuccess(exit)
+            ? {
+                status: "success",
+                preview: exit.value,
+                baseUrl: firstBaseUrlForPreview(exit.value),
+              }
+            : {
+                status: "error",
+                message: errorMessageFromExit(exit, `Failed to preview ${preset.name}`),
+              },
+        }));
+      }
+    })();
+  }, [
+    doPreview,
+    googleServicePickerEnabled,
+    googleServicePreviews,
+    primaryGooglePreset,
+    scopeId,
+    selectedGoogleServiceIdList,
+  ]);
+
+  const setGoogleServiceSetting = (presetId: string, patch: Partial<GoogleServiceSettings>) => {
+    setGoogleServiceSettings((previous) => ({
+      ...previous,
+      [presetId]: {
+        ...previous[presetId],
+        ...patch,
+      },
+    }));
+  };
+
+  const googleServicePreviewStateFor = (
+    preset: (typeof googleOpenApiPresets)[number],
+  ): GoogleServicePreviewState | null => {
+    if (preset.id === primaryGooglePreset?.id && preview) {
+      return {
+        status: "success",
+        preview,
+        baseUrl: resolvedBaseUrl,
+      };
+    }
+    return googleServicePreviews[preset.id] ?? null;
+  };
+
+  const googleServiceNameFor = (
+    preset: (typeof googleOpenApiPresets)[number],
+    servicePreview: SpecPreview,
+  ): string => {
+    const settings = googleServiceSettings[preset.id];
+    return settings?.name ?? defaultGoogleSourceName(preset, servicePreview);
+  };
+
+  const googleServiceNamespaceFor = (
+    preset: (typeof googleOpenApiPresets)[number],
+    servicePreview: SpecPreview,
+  ): string => {
+    const settings = googleServiceSettings[preset.id];
+    const name = googleServiceNameFor(preset, servicePreview);
+    return (
+      settings?.namespace ??
+      slugifyNamespace(name) ??
+      defaultGoogleSourceNamespace(preset, servicePreview)
+    );
+  };
+
+  const googleServiceBaseUrlFor = (
+    preset: (typeof googleOpenApiPresets)[number],
+    fallbackBaseUrl: string,
+  ): string => googleServiceSettings[preset.id]?.baseUrl ?? fallbackBaseUrl;
+
+  const googleServiceSpecUrlFor = (preset: (typeof googleOpenApiPresets)[number]): string =>
+    googleServiceSettings[preset.id]?.specUrl ?? preset.url;
+
+  const googleServiceIdentityFor = (
+    preset: (typeof googleOpenApiPresets)[number],
+    servicePreview: SpecPreview,
+  ): SourceIdentity => ({
+    name: googleServiceNameFor(preset, servicePreview),
+    namespace: googleServiceNamespaceFor(preset, servicePreview),
+    setName: (name) => setGoogleServiceSetting(preset.id, { name }),
+    setNamespace: (namespace) =>
+      setGoogleServiceSetting(preset.id, {
+        namespace: normalizeNamespaceInput(namespace),
+      }),
+    reset: () =>
+      setGoogleServiceSettings((previous) => {
+        const next = { ...previous };
+        delete next[preset.id];
+        return next;
+      }),
+  });
+
+  const googleServiceBaseUrlsReady =
+    !googleServicePickerEnabled ||
+    googleBatchAddItems.every(
+      (item) => googleServiceBaseUrlFor(item.preset, item.baseUrl).trim().length > 0,
+    );
+
   const existingOAuthConnections = useMemo(() => {
     if (
       !selectedOAuth2Preset ||
@@ -758,7 +1066,7 @@ export default function AddOpenApiSource(props: {
     return connectionsResult.value
       .flatMap((connection) => {
         if (connection.provider !== "oauth2") return [];
-        const missingApiScopes = missingOAuthScopes(connection, oauth2SelectedScopes);
+        const missingApiScopes = missingOAuthScopes(connection, effectiveOAuth2SelectedApiScopes);
         if (missingApiScopes.length === 0) {
           return [{ ...connection, missingApiScopes }];
         }
@@ -768,35 +1076,29 @@ export default function AddOpenApiSource(props: {
         return [];
       })
       .sort((a, b) => a.missingApiScopes.length - b.missingApiScopes.length);
-  }, [connectionsResult, oauth2SelectedScopes, selectedOAuth2IsGoogle, selectedOAuth2Preset]);
+  }, [
+    connectionsResult,
+    effectiveOAuth2SelectedApiScopes,
+    selectedOAuth2IsGoogle,
+    selectedOAuth2Preset,
+  ]);
 
   const configuredOAuth2 =
     strategy.kind === "oauth2" && selectedOAuth2Preset
-      ? OAuth2SourceConfig.make({
-          kind: "oauth2",
-          securitySchemeName: selectedOAuth2Preset.securitySchemeName,
-          flow: selectedOAuth2Preset.flow,
-          tokenUrl: resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl),
-          authorizationUrl:
-            selectedOAuth2Preset.flow === "authorizationCode"
-              ? resolveOAuthUrl(
-                  Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
-                  resolvedBaseUrl,
-                ) || null
-              : null,
-          clientIdSlot: oauth2ClientIdSlot(selectedOAuth2Preset.securitySchemeName),
-          // Authorization-code specs can still be confidential clients
-          // (Spotify is one example). Persist the slot even when the value is
-          // deferred so the edit screen can collect the secret later.
-          clientSecretSlot: oauth2ClientSecretSlot(selectedOAuth2Preset.securitySchemeName),
-          connectionSlot: oauth2ConnectionSlot(selectedOAuth2Preset.securitySchemeName),
-          scopes: [...oauth2SelectedScopes],
+      ? oauth2ConfigForPreset({
+          preset: selectedOAuth2Preset,
+          baseUrl: resolvedBaseUrl,
+          scopes: effectiveOAuth2SelectedApiScopes,
           identityScopes: configuredOAuth2IdentityScopes,
         })
       : null;
   const hasHeaders = Object.keys(configuredHeaders).length > 0;
   const oauth2Busy = startingOAuth || oauth.busy;
-  const canConnectOAuth2 = Boolean(oauth2ClientIdSecretId) && resolvedBaseUrl.length > 0;
+  const canConnectOAuth2 =
+    Boolean(oauth2ClientIdSecretId) &&
+    resolvedBaseUrl.length > 0 &&
+    googleServiceBaseUrlsReady &&
+    (!googleServicePickerEnabled || (googleBatchPendingCount === 0 && !googleBatchError));
   const hasIncompleteHeaderCredentials =
     strategy.kind !== "none" &&
     strategy.kind !== "oauth2" &&
@@ -815,7 +1117,11 @@ export default function AddOpenApiSource(props: {
     hasIncompleteHeaderCredentials ||
     hasIncompleteQueryCredentials;
 
-  const canAdd = preview !== null && resolvedBaseUrl.length > 0;
+  const canAdd =
+    preview !== null &&
+    resolvedBaseUrl.length > 0 &&
+    googleServiceBaseUrlsReady &&
+    (!googleServicePickerEnabled || (googleBatchPendingCount === 0 && !googleBatchError));
 
   // ---- Handlers ----
 
@@ -928,7 +1234,7 @@ export default function AddOpenApiSource(props: {
       const scopesForAuthorization = existingConnection
         ? mergeOAuthScopes(
             splitOAuthScopes(existingConnection.oauthScope),
-            selectedOAuth2IsGoogle ? oauth2SelectedScopes : selectedOAuth2Scopes,
+            selectedOAuth2IsGoogle ? effectiveOAuth2SelectedApiScopes : selectedOAuth2Scopes,
           )
         : selectedOAuth2Scopes;
       const scopesForProviderAuthorization = selectedOAuth2IsGoogle
@@ -1075,7 +1381,7 @@ export default function AddOpenApiSource(props: {
       selectedOAuth2Preset,
       oauth2ClientIdSecretId,
       oauth2ClientSecretSecretId,
-      oauth2SelectedScopes,
+      effectiveOAuth2SelectedApiScopes,
       selectedOAuth2Scopes,
       selectedOAuth2IsGoogle,
       oauth2RedirectUrl,
@@ -1116,6 +1422,144 @@ export default function AddOpenApiSource(props: {
   const handleAdd = async () => {
     setAdding(true);
     setAddError(null);
+    const oauthTokenBindingScope = ScopeId.make(oauthTokenTargetScope);
+    const clientIdBindingScope = oauth2ClientIdScope ?? sourceScope;
+    const clientSecretBindingScope = oauth2ClientSecretScope ?? sourceScope;
+
+    const bindOAuth2Credentials = async (
+      sourceId: string,
+      oauth2Config: OAuth2SourceConfig,
+    ): Promise<boolean> => {
+      if (oauth2ClientIdSecretId) {
+        const bindingExit = await doSetBinding({
+          params: { scopeId },
+          payload: SetSourceCredentialBindingInput.make({
+            source: { id: sourceId, scope: sourceScope },
+            scope: clientIdBindingScope,
+            slotKey: oauth2Config.clientIdSlot,
+            value: {
+              kind: "secret",
+              secretId: SecretId.make(oauth2ClientIdSecretId),
+              secretScopeId: clientIdBindingScope,
+            },
+          }),
+          reactivityKeys: bindingWriteKeys,
+        });
+        if (Exit.isFailure(bindingExit)) {
+          setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
+          setAdding(false);
+          return false;
+        }
+      }
+
+      if (oauth2Config.clientSecretSlot && oauth2ClientSecretSecretId) {
+        const bindingExit = await doSetBinding({
+          params: { scopeId },
+          payload: SetSourceCredentialBindingInput.make({
+            source: { id: sourceId, scope: sourceScope },
+            scope: clientSecretBindingScope,
+            slotKey: oauth2Config.clientSecretSlot,
+            value: {
+              kind: "secret",
+              secretId: SecretId.make(oauth2ClientSecretSecretId),
+              secretScopeId: clientSecretBindingScope,
+            },
+          }),
+          reactivityKeys: bindingWriteKeys,
+        });
+        if (Exit.isFailure(bindingExit)) {
+          setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
+          setAdding(false);
+          return false;
+        }
+      }
+
+      if (oauth2Auth) {
+        const bindingExit = await doSetBinding({
+          params: { scopeId },
+          payload: SetSourceCredentialBindingInput.make({
+            source: { id: sourceId, scope: sourceScope },
+            scope: oauthTokenBindingScope,
+            slotKey: oauth2Config.connectionSlot,
+            value: {
+              kind: "connection",
+              connectionId: ConnectionId.make(oauth2Auth.connectionId),
+            },
+          }),
+          reactivityKeys: bindingWriteKeys,
+        });
+        if (Exit.isFailure(bindingExit)) {
+          setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
+          setAdding(false);
+          return false;
+        }
+      }
+
+      return true;
+    };
+
+    if (googleServicePickerEnabled && googleBatchAddItems.length > 1) {
+      if (googleBatchPendingCount > 0 || googleBatchError) {
+        setAddError(
+          googleBatchError?.status === "error"
+            ? googleBatchError.message
+            : "Still loading selected Google services",
+        );
+        setAdding(false);
+        return;
+      }
+
+      for (const item of googleBatchAddItems) {
+        const itemBaseUrl = googleServiceBaseUrlFor(item.preset, item.baseUrl).trim();
+        if (!itemBaseUrl) {
+          setAddError(`Base URL is required for ${item.preset.name}`);
+          setAdding(false);
+          return;
+        }
+        const fallbackName = defaultGoogleSourceName(item.preset, item.preview);
+        const sourceName = item.isPrimary
+          ? resolvedDisplayName
+          : googleServiceNameFor(item.preset, item.preview).trim() || fallbackName;
+        const sourceNamespace = item.isPrimary
+          ? resolvedSourceId
+          : slugifyNamespace(googleServiceNamespaceFor(item.preset, item.preview)) ||
+            defaultGoogleSourceNamespace(item.preset, item.preview);
+        const oauth2Preset = item.preview.oauth2Presets[0];
+        const oauth2Config = oauth2Preset
+          ? oauth2ConfigForPreset({
+              preset: oauth2Preset,
+              baseUrl: itemBaseUrl,
+              scopes: Object.keys(oauth2Preset.scopes),
+              identityScopes: configuredOAuth2IdentityScopes,
+            })
+          : null;
+        const exit = await doAdd({
+          params: { scopeId },
+          payload: {
+            spec: item.isPrimary
+              ? specInputForAdd(specUrl)
+              : { kind: "googleDiscovery", url: googleServiceSpecUrlFor(item.preset) },
+            name: sourceName,
+            namespace: sourceNamespace,
+            baseUrl: itemBaseUrl,
+            ...(oauth2Config ? { oauth2: oauth2Config } : {}),
+          },
+          reactivityKeys: addSpecWriteKeys,
+        });
+        if (Exit.isFailure(exit)) {
+          setAddError(errorMessageFromExit(exit, `Failed to add ${item.preset.name}`));
+          setAdding(false);
+          return;
+        }
+        if (oauth2Config && !(await bindOAuth2Credentials(exit.value.namespace, oauth2Config))) {
+          return;
+        }
+      }
+
+      props.onComplete();
+      return;
+    }
+
     const namespace = resolvedSourceId;
     const exit = await doAdd({
       params: { scopeId },
@@ -1142,9 +1586,6 @@ export default function AddOpenApiSource(props: {
     }
 
     const sourceId = exit.value.namespace;
-    const oauthTokenBindingScope = ScopeId.make(oauthTokenTargetScope);
-    const clientIdBindingScope = oauth2ClientIdScope ?? sourceScope;
-    const clientSecretBindingScope = oauth2ClientSecretScope ?? sourceScope;
 
     for (const binding of headerBindings) {
       const bindingExit = await doSetBinding({
@@ -1349,33 +1790,227 @@ export default function AddOpenApiSource(props: {
 
       {/* ── Source information card (shown after analysis) ── */}
       {preview ? (
-        <OpenApiSourceDetailsFields
-          title={Option.getOrElse(preview.title, () => "API")}
-          description={`${Option.getOrElse(preview.version, () => "")}${
-            Option.isSome(preview.version) ? " · " : ""
-          }${preview.operationCount} operation${preview.operationCount !== 1 ? "s" : ""}${
-            preview.tags.length > 0
-              ? ` · ${preview.tags.length} tag${preview.tags.length !== 1 ? "s" : ""}`
-              : ""
-          }`}
-          identity={identity}
-          baseUrl={resolvedBaseUrl}
-          onBaseUrlChange={setBaseUrl}
-          baseUrlOptions={baseUrlOptions}
-          specUrl={specUrl}
-          onSpecUrlChange={(value) => {
-            setSpecUrl(value);
-            setPreview(null);
-            setBaseUrl("");
-            setCustomHeaders([]);
-            setStrategy({ kind: "none" });
-            setOauth2AuthState(null);
-            setOauth2Error(null);
-          }}
-          faviconIcon={previewPresetIcon}
-          faviconUrl={resolvedBaseUrl}
-          baseUrlMissingMessage="A base URL is required to make requests."
-        />
+        googleServicePickerEnabled && primaryGooglePreset ? (
+          <Tabs
+            value={activeGoogleServiceId ?? primaryGooglePreset.id}
+            onValueChange={setActiveGoogleServiceId}
+            className="gap-3"
+          >
+            <TabsList className="max-w-full justify-start overflow-x-auto">
+              {(selectedGooglePresets.length > 0
+                ? selectedGooglePresets
+                : [primaryGooglePreset]
+              ).map((preset) => (
+                <TabsTrigger key={preset.id} value={preset.id} className="shrink-0">
+                  {preset.icon ? (
+                    <img src={preset.icon} alt="" className="size-3.5 object-contain" />
+                  ) : null}
+                  <span>{preset.name.replace(/^Google /, "")}</span>
+                </TabsTrigger>
+              ))}
+            </TabsList>
+            {(selectedGooglePresets.length > 0 ? selectedGooglePresets : [primaryGooglePreset]).map(
+              (preset) => {
+                const serviceState = googleServicePreviewStateFor(preset);
+                if (serviceState?.status !== "success") {
+                  return (
+                    <TabsContent key={preset.id} value={preset.id}>
+                      <CardStack>
+                        <CardStackContent className="border-t-0">
+                          <CardStackEntryField label={preset.name}>
+                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                              {serviceState?.status === "loading" ? (
+                                <>
+                                  <IOSSpinner className="size-3.5" />
+                                  Loading service details…
+                                </>
+                              ) : (
+                                (serviceState?.message ?? "Service details are unavailable.")
+                              )}
+                            </div>
+                          </CardStackEntryField>
+                        </CardStackContent>
+                      </CardStack>
+                    </TabsContent>
+                  );
+                }
+
+                const servicePreview = serviceState.preview;
+                const serviceBaseUrl = googleServiceBaseUrlFor(preset, serviceState.baseUrl);
+                const serviceBaseUrlOptions = Array.from(
+                  new Map(
+                    servicePreview.servers
+                      .flatMap(expandServerOptions)
+                      .map((option) => [option.value, option]),
+                  ).values(),
+                );
+                const serviceIdentity =
+                  preset.id === primaryGooglePreset.id
+                    ? identity
+                    : googleServiceIdentityFor(preset, servicePreview);
+                return (
+                  <TabsContent key={preset.id} value={preset.id}>
+                    <OpenApiSourceDetailsFields
+                      title={defaultGoogleSourceName(preset, servicePreview)}
+                      description={`${Option.getOrElse(servicePreview.version, () => "")}${
+                        Option.isSome(servicePreview.version) ? " · " : ""
+                      }${servicePreview.operationCount} operation${
+                        servicePreview.operationCount !== 1 ? "s" : ""
+                      }${
+                        servicePreview.tags.length > 0
+                          ? ` · ${servicePreview.tags.length} tag${
+                              servicePreview.tags.length !== 1 ? "s" : ""
+                            }`
+                          : ""
+                      }`}
+                      identity={serviceIdentity}
+                      baseUrl={serviceBaseUrl}
+                      onBaseUrlChange={(value) =>
+                        preset.id === primaryGooglePreset.id
+                          ? setBaseUrl(value)
+                          : setGoogleServiceSetting(preset.id, { baseUrl: value })
+                      }
+                      baseUrlOptions={serviceBaseUrlOptions}
+                      specUrl={
+                        preset.id === primaryGooglePreset.id
+                          ? specUrl
+                          : googleServiceSpecUrlFor(preset)
+                      }
+                      onSpecUrlChange={(value) => {
+                        if (preset.id !== primaryGooglePreset.id) {
+                          setGoogleServiceSetting(preset.id, { specUrl: value });
+                          return;
+                        }
+                        setSpecUrl(value);
+                        setPreview(null);
+                        setBaseUrl("");
+                        setCustomHeaders([]);
+                        setStrategy({ kind: "none" });
+                        setOauth2AuthState(null);
+                        setOauth2Error(null);
+                      }}
+                      faviconIcon={preset.icon}
+                      faviconUrl={serviceBaseUrl}
+                      specUrlDisabled={preset.id !== primaryGooglePreset.id}
+                      baseUrlMissingMessage="A base URL is required to make requests."
+                    />
+                  </TabsContent>
+                );
+              },
+            )}
+          </Tabs>
+        ) : (
+          <OpenApiSourceDetailsFields
+            title={Option.getOrElse(preview.title, () => "API")}
+            description={`${Option.getOrElse(preview.version, () => "")}${
+              Option.isSome(preview.version) ? " · " : ""
+            }${preview.operationCount} operation${preview.operationCount !== 1 ? "s" : ""}${
+              preview.tags.length > 0
+                ? ` · ${preview.tags.length} tag${preview.tags.length !== 1 ? "s" : ""}`
+                : ""
+            }`}
+            identity={identity}
+            baseUrl={resolvedBaseUrl}
+            onBaseUrlChange={setBaseUrl}
+            baseUrlOptions={baseUrlOptions}
+            specUrl={specUrl}
+            onSpecUrlChange={(value) => {
+              setSpecUrl(value);
+              setPreview(null);
+              setBaseUrl("");
+              setCustomHeaders([]);
+              setStrategy({ kind: "none" });
+              setOauth2AuthState(null);
+              setOauth2Error(null);
+            }}
+            faviconIcon={previewPresetIcon}
+            faviconUrl={resolvedBaseUrl}
+            baseUrlMissingMessage="A base URL is required to make requests."
+          />
+        )
+      ) : null}
+
+      {googleServicePickerEnabled && primaryGooglePreset ? (
+        <section className="space-y-2.5">
+          <div className="flex items-center justify-between gap-3">
+            <FieldLabel>Google services</FieldLabel>
+            <span className="text-[11px] text-muted-foreground">
+              {selectedGoogleServiceIds.size} selected
+            </span>
+          </div>
+          <div className="max-h-72 overflow-y-auto rounded-lg border border-border/60 bg-muted/10 p-2">
+            <div className="grid gap-1.5 sm:grid-cols-2">
+              {googleOpenApiPresets.map((preset) => {
+                const selected = selectedGoogleServiceIds.has(preset.id);
+                const locked = preset.id === primaryGooglePreset.id;
+                const previewState = locked
+                  ? ({ status: "success", preview: preview as SpecPreview } as const)
+                  : googleServicePreviews[preset.id];
+                return (
+                  <Label
+                    key={preset.id}
+                    className={`flex cursor-pointer items-start gap-2 rounded-md border px-2.5 py-2 transition-colors ${
+                      selected
+                        ? "border-primary/35 bg-primary/[0.04]"
+                        : "border-border/50 bg-background/40 hover:bg-accent/40"
+                    }`}
+                  >
+                    <Checkbox
+                      checked={selected}
+                      disabled={locked}
+                      onCheckedChange={(checked) => {
+                        if (checked !== true && activeGoogleServiceId === preset.id) {
+                          setActiveGoogleServiceId(primaryGooglePreset.id);
+                        }
+                        setSelectedGoogleServiceIds((previous) => {
+                          const next = new Set(previous);
+                          if (checked === true) {
+                            next.add(preset.id);
+                          } else if (!locked) {
+                            next.delete(preset.id);
+                          }
+                          return next;
+                        });
+                        setOauth2AuthState(null);
+                      }}
+                      className="mt-0.5"
+                    />
+                    {preset.icon ? (
+                      <img
+                        src={preset.icon}
+                        alt=""
+                        className="mt-0.5 size-4 shrink-0 object-contain"
+                        loading="lazy"
+                      />
+                    ) : null}
+                    <span className="min-w-0 flex-1">
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <span className="truncate text-[12px] font-medium text-foreground">
+                          {preset.name}
+                        </span>
+                        {selected && previewState?.status === "loading" ? (
+                          <IOSSpinner className="size-3 shrink-0" />
+                        ) : null}
+                      </span>
+                      <span className="mt-0.5 block truncate text-[10px] text-muted-foreground">
+                        {previewState?.status === "success"
+                          ? `${previewState.preview.operationCount} operations`
+                          : previewState?.status === "error"
+                            ? "Could not preview"
+                            : preset.summary}
+                      </span>
+                    </span>
+                  </Label>
+                );
+              })}
+            </div>
+          </div>
+          {googleBatchError?.status === "error" ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2">
+              <p className="text-[11px] text-destructive">{googleBatchError.message}</p>
+            </div>
+          ) : null}
+        </section>
       ) : null}
 
       {analyzeError && (
@@ -1423,7 +2058,10 @@ export default function AddOpenApiSource(props: {
               })}
               {oauth2Presets.map((preset, i) => {
                 const selected = strategy.kind === "oauth2" && strategy.presetIndex === i;
-                const scopeCount = Object.keys(preset.scopes).length;
+                const scopeCount =
+                  selected && googleServicePickerEnabled
+                    ? selectedOAuth2Scopes.length
+                    : Object.keys(preset.scopes).length;
                 return (
                   <Label
                     key={`oauth2-${i}`}
@@ -1622,7 +2260,44 @@ export default function AddOpenApiSource(props: {
                     </CollapsibleTrigger>
                     <CollapsibleContent>
                       <div className="space-y-1 rounded-md border border-border/50 bg-background/50 p-2">
-                        {Object.keys(selectedOAuth2Preset.scopes).length === 0 ? (
+                        {googleServicePickerEnabled ? (
+                          <div className="space-y-2">
+                            {googleBatchAddItems.map((item) => {
+                              const oauth2Preset = item.preview.oauth2Presets[0];
+                              const scopes = Object.keys(oauth2Preset?.scopes ?? {});
+                              return (
+                                <div key={item.preset.id} className="space-y-1">
+                                  <div className="text-[11px] font-medium text-foreground">
+                                    {item.preset.name}
+                                  </div>
+                                  {scopes.length === 0 ? (
+                                    <div className="text-[10px] text-muted-foreground">
+                                      No scopes declared by this service.
+                                    </div>
+                                  ) : (
+                                    <div className="flex flex-wrap gap-1.5">
+                                      {scopes.map((scope) => (
+                                        <span
+                                          key={scope}
+                                          title={scope}
+                                          className="max-w-full truncate rounded border border-border/60 bg-muted/30 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground"
+                                        >
+                                          {scope}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })}
+                            {googleBatchPendingCount > 0 ? (
+                              <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                                <IOSSpinner className="size-3" />
+                                Loading selected services…
+                              </div>
+                            ) : null}
+                          </div>
+                        ) : Object.keys(selectedOAuth2Preset.scopes).length === 0 ? (
                           <div className="text-[11px] italic text-muted-foreground">
                             No scopes declared by the spec.
                           </div>
@@ -1808,9 +2483,13 @@ export default function AddOpenApiSource(props: {
             {adding && <Spinner className="size-3.5" />}
             {adding
               ? "Adding…"
-              : willAddWithoutInitialCredentials
-                ? "Add without credentials"
-                : "Add source"}
+              : googleServicePickerEnabled && googleBatchAddItems.length > 1
+                ? willAddWithoutInitialCredentials
+                  ? `Add ${googleBatchAddItems.length} sources without credentials`
+                  : `Add ${googleBatchAddItems.length} sources`
+                : willAddWithoutInitialCredentials
+                  ? "Add without credentials"
+                  : "Add source"}
           </Button>
         )}
       </FloatActions>

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -48,12 +48,7 @@ import {
   type HeaderState,
 } from "@executor-js/react/plugins/secret-header-auth";
 import { CredentialScopeDropdown } from "@executor-js/react/plugins/credential-target-scope";
-import {
-  normalizeNamespaceInput,
-  slugifyNamespace,
-  useSourceIdentity,
-  type SourceIdentity,
-} from "@executor-js/react/plugins/source-identity";
+import { slugifyNamespace, useSourceIdentity } from "@executor-js/react/plugins/source-identity";
 import { useSecretPickerSecrets } from "@executor-js/react/plugins/use-secret-picker-secrets";
 import { Button } from "@executor-js/react/components/button";
 import { CopyButton } from "@executor-js/react/components/copy-button";
@@ -70,15 +65,20 @@ import {
 import { FieldLabel } from "@executor-js/react/components/field";
 import { FloatActions } from "@executor-js/react/components/float-actions";
 import { HelpTooltip } from "@executor-js/react/components/help-tooltip";
+import { Info, InfoDescription, InfoTitle } from "@executor-js/react/components/info";
 import { Label } from "@executor-js/react/components/label";
 import { Textarea } from "@executor-js/react/components/textarea";
 import { Checkbox } from "@executor-js/react/components/checkbox";
 import { RadioGroup, RadioGroupItem } from "@executor-js/react/components/radio-group";
 import { IOSSpinner, Spinner } from "@executor-js/react/components/spinner";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@executor-js/react/components/tabs";
 import { addOpenApiSpecOptimistic, previewOpenApiSpec } from "./atoms";
 import { OpenApiSourceDetailsFields } from "./OpenApiSourceDetailsFields";
-import { googleOpenApiPresets, openApiPresets } from "../sdk/presets";
+import {
+  googleOpenApiPresets,
+  googleStandardUserOAuthPresets,
+  openApiPresets,
+} from "../sdk/presets";
+import { GOOGLE_BUNDLE_PRESET_ID } from "../sdk/google-presets";
 import type { SpecPreview, HeaderPreset, OAuth2Preset } from "../sdk/preview";
 import {
   headerBindingSlot,
@@ -91,9 +91,19 @@ import {
 } from "../sdk/source-contracts";
 import { OAuth2SourceConfig, type ServerInfo } from "../sdk/types";
 import { expandServerUrlOptions } from "../sdk/openapi-utils";
+import {
+  compactGoogleOAuthScopes,
+  filterGoogleUserConsentOAuthScopes,
+} from "../sdk/google-oauth-scopes";
+import { googleOAuthConsentBatches } from "../sdk/google-oauth-batches";
 
 export const OPENAPI_OAUTH_POPUP_NAME = "openapi-oauth";
 export const OPENAPI_OAUTH_CALLBACK_PATH = "/api/oauth/callback";
+const GOOGLE_BUNDLE_BASE_URL = "https://www.googleapis.com/";
+const GOOGLE_ICON = "https://fonts.gstatic.com/s/i/productlogos/googleg/v6/192px.svg";
+const GOOGLE_BUNDLE_DEFAULT_PRESET = googleOpenApiPresets[0]!;
+const GOOGLE_STANDARD_SERVICE_IDS = googleStandardUserOAuthPresets.map((preset) => preset.id);
+const GOOGLE_BROAD_SELECTION_WARNING_THRESHOLD = 6;
 
 const ErrorMessage = Schema.Struct({ message: Schema.String });
 const decodeErrorMessage = Schema.decodeUnknownOption(ErrorMessage);
@@ -103,6 +113,26 @@ const errorMessageFromExit = (exit: Exit.Exit<unknown, unknown>, fallback: strin
     onNone: () => fallback,
     onSome: ({ message }) => message,
   });
+
+const googleOAuthErrorMessage =
+  "Google did not approve this permission request. Try selecting fewer services, or add sensitive services as separate Google sources.";
+
+const oauthErrorMessage = (
+  providerLabel: string,
+  message: string,
+  details?: string,
+): string => {
+  if (providerLabel !== "Google") return details ? `${message}: ${details}` : message;
+  const combined = `${message}\n${details ?? ""}`;
+  if (
+    /Authorization server returned error|Token exchange failed|invalid_grant|access_denied|Something went wrong|unknownerror/i.test(
+      combined,
+    )
+  ) {
+    return googleOAuthErrorMessage;
+  }
+  return details ? `${message}: ${details}` : message;
+};
 
 export const openApiOAuthConnectionId = (
   namespaceSlug: string,
@@ -176,11 +206,10 @@ const mergeOAuthScopes = (...values: readonly Iterable<string>[]): string[] => {
   return [...merged];
 };
 
-const missingOAuthScopes = (
-  connection: { readonly oauthScope: string | null },
+const missingOAuthScopesFromGranted = (
+  granted: ReadonlySet<string>,
   requiredApiScopes: Iterable<string>,
 ): readonly string[] => {
-  const granted = splitOAuthScopes(connection.oauthScope);
   return [...requiredApiScopes].filter((scope) => !granted.has(scope));
 };
 
@@ -213,46 +242,6 @@ const googleAuthorizationParams = (enabled: boolean): Record<string, string> | u
       }
     : undefined;
 
-const googleBroadScopeGroups: readonly {
-  readonly broad: string;
-  readonly prefixes: readonly string[];
-}[] = [
-  {
-    broad: "https://mail.google.com/",
-    prefixes: ["https://www.googleapis.com/auth/gmail."],
-  },
-  {
-    broad: "https://www.googleapis.com/auth/calendar",
-    prefixes: ["https://www.googleapis.com/auth/calendar."],
-  },
-  {
-    broad: "https://www.googleapis.com/auth/drive",
-    prefixes: ["https://www.googleapis.com/auth/drive."],
-  },
-];
-
-const compactGoogleOAuthScopes = (scopes: Iterable<string>): string[] => {
-  const ordered = mergeOAuthScopes(
-    [...scopes].map((scope) =>
-      scope === "https://www.googleapis.com/auth/userinfo.email"
-        ? "email"
-        : scope === "https://www.googleapis.com/auth/userinfo.profile"
-          ? "profile"
-          : scope,
-    ),
-  );
-  const present = new Set(ordered);
-  return ordered.filter(
-    (scope) =>
-      !googleBroadScopeGroups.some(
-        (group) =>
-          scope !== group.broad &&
-          present.has(group.broad) &&
-          group.prefixes.some((prefix) => scope.startsWith(prefix)),
-      ),
-  );
-};
-
 type OAuthConnectionChoice = {
   readonly id: ConnectionId;
   readonly scopeId: ScopeId;
@@ -274,15 +263,11 @@ type GoogleServicePreviewState =
 type GoogleServiceAddItem = {
   readonly preset: (typeof googleOpenApiPresets)[number];
   readonly preview: SpecPreview;
-  readonly baseUrl: string;
-  readonly isPrimary: boolean;
 };
 
-type GoogleServiceSettings = {
-  readonly name?: string;
-  readonly namespace?: string;
-  readonly baseUrl?: string;
-  readonly specUrl?: string;
+const scopesForGoogleServiceItem = (item: GoogleServiceAddItem): readonly string[] => {
+  const oauth2Preset = item.preview.oauth2Presets[0];
+  return filterGoogleUserConsentOAuthScopes(Object.keys(oauth2Preset?.scopes ?? {}));
 };
 
 const specInputForAdd = (input: string) => {
@@ -324,7 +309,7 @@ const googlePresetForSpec = (
 ): (typeof googleOpenApiPresets)[number] | null => {
   const normalizedSpecUrl = normalizePresetUrl(specUrl);
   const byUrl = googleOpenApiPresets.find(
-    (preset) => normalizePresetUrl(preset.url) === normalizedSpecUrl,
+    (preset) => preset.url && normalizePresetUrl(preset.url) === normalizedSpecUrl,
   );
   if (byUrl) return byUrl;
   const byId = presetId ? googleOpenApiPresets.find((preset) => preset.id === presetId) : undefined;
@@ -336,16 +321,6 @@ const firstBaseUrlForPreview = (preview: SpecPreview): string => {
   const firstServer = preview.servers[0];
   return firstServer ? (expandServerUrlOptions(firstServer)[0] ?? "") : "";
 };
-
-const defaultGoogleSourceName = (
-  preset: (typeof googleOpenApiPresets)[number],
-  preview: SpecPreview,
-): string => Option.getOrElse(preview.title, () => preset.name);
-
-const defaultGoogleSourceNamespace = (
-  preset: (typeof googleOpenApiPresets)[number],
-  preview: SpecPreview,
-): string => slugifyNamespace(defaultGoogleSourceName(preset, preview)) || preset.id;
 
 type StrategySelection =
   | { readonly kind: "none" }
@@ -561,16 +536,26 @@ export default function AddOpenApiSource(props: {
   initialNamespace?: string;
 }) {
   // Spec input
-  const [specUrl, setSpecUrl] = useState(props.initialUrl ?? "");
+  const isGoogleBundlePreset = props.initialPreset === GOOGLE_BUNDLE_PRESET_ID;
+  const [specUrl, setSpecUrl] = useState(
+    props.initialUrl ?? (isGoogleBundlePreset ? (GOOGLE_BUNDLE_DEFAULT_PRESET.url ?? "") : ""),
+  );
   const [analyzing, setAnalyzing] = useState(false);
   const [analyzeError, setAnalyzeError] = useState<string | null>(null);
 
   // After analysis
   const [preview, setPreview] = useState<SpecPreview | null>(null);
   const [baseUrl, setBaseUrl] = useState("");
+  const initialGooglePreset =
+    preview && isGoogleBundlePreset ? googlePresetForSpec(undefined, specUrl) : null;
+  const identityFallbackName = preview
+    ? isGoogleBundlePreset
+      ? "Google"
+      : Option.getOrElse(preview.title, () => "")
+    : "";
   const identity = useSourceIdentity({
-    fallbackName: preview ? Option.getOrElse(preview.title, () => "") : "",
-    fallbackNamespace: props.initialNamespace,
+    fallbackName: identityFallbackName,
+    fallbackNamespace: props.initialNamespace ?? (isGoogleBundlePreset ? "google" : undefined),
   });
 
   // Auth
@@ -594,9 +579,14 @@ export default function AddOpenApiSource(props: {
   const [oauth2ScopesOpen, setOauth2ScopesOpen] = useState(false);
   const [oauth2AuthState, setOauth2AuthState] = useState<{
     readonly fingerprint: string;
-    readonly auth: { readonly connectionId: string };
+    readonly auth: {
+      readonly connectionId: string;
+      readonly grantedScopes: readonly string[];
+      readonly scopeId: ScopeId;
+    };
   } | null>(null);
   const [startingOAuth, setStartingOAuth] = useState(false);
+  const [oauth2ProgressLabel, setOauth2ProgressLabel] = useState<string | null>(null);
   const [oauth2Error, setOauth2Error] = useState<string | null>(null);
   const [selectedGoogleServiceIds, setSelectedGoogleServiceIds] = useState<Set<string>>(
     () => new Set(),
@@ -604,10 +594,6 @@ export default function AddOpenApiSource(props: {
   const [googleServicePreviews, setGoogleServicePreviews] = useState<
     Record<string, GoogleServicePreviewState>
   >({});
-  const [googleServiceSettings, setGoogleServiceSettings] = useState<
-    Record<string, GoogleServiceSettings>
-  >({});
-  const [activeGoogleServiceId, setActiveGoogleServiceId] = useState<string | null>(null);
 
   // Submit
   const [adding, setAdding] = useState(false);
@@ -673,6 +659,7 @@ export default function AddOpenApiSource(props: {
   // Keep the latest handleAnalyze in a ref so the debounced effect doesn't
   // need it as a dependency (it closes over fresh state).
   const handleAnalyzeRef = useRef<() => void>(() => {});
+  const googleBundleSelectionSeeded = useRef(false);
 
   // Auto-analyze whenever the spec input changes, with a short debounce so
   // typing/pasting doesn't fire a request on every keystroke.
@@ -700,13 +687,30 @@ export default function AddOpenApiSource(props: {
     new Map(servers.flatMap(expandServerOptions).map((option) => [option.value, option])).values(),
   );
   const previewPresetIcon =
-    openApiPresets.find((preset) => normalizePresetUrl(preset.url) === normalizePresetUrl(specUrl))
-      ?.icon ?? null;
-  const primaryGooglePreset = preview ? googlePresetForSpec(props.initialPreset, specUrl) : null;
-  const selectedGoogleServiceIdList = useMemo(
-    () => [...selectedGoogleServiceIds],
-    [selectedGoogleServiceIds],
+    openApiPresets.find(
+      (preset) => preset.url && normalizePresetUrl(preset.url) === normalizePresetUrl(specUrl),
+    )?.icon ?? null;
+  const primaryGooglePreset = initialGooglePreset;
+  const selectedGoogleServiceIdList = useMemo(() => {
+    return [...selectedGoogleServiceIds];
+  }, [selectedGoogleServiceIds]);
+  const allStandardGoogleServicesSelected = GOOGLE_STANDARD_SERVICE_IDS.every((presetId) =>
+    selectedGoogleServiceIds.has(presetId),
   );
+  const selectedGoogleWorkspaceAdminServiceCount = selectedGoogleServiceIdList.filter((presetId) =>
+    googleOpenApiPresets.some(
+      (preset) => preset.id === presetId && preset.oauthAudience === "workspace-admin",
+    ),
+  ).length;
+  const selectedGoogleAdvancedServiceCount = selectedGoogleServiceIdList.filter((presetId) =>
+    googleOpenApiPresets.some(
+      (preset) => preset.id === presetId && preset.oauthAudience === "advanced-user",
+    ),
+  ).length;
+  const showGoogleSelectionWarning =
+    selectedGoogleServiceIdList.length >= GOOGLE_BROAD_SELECTION_WARNING_THRESHOLD ||
+    selectedGoogleWorkspaceAdminServiceCount > 0 ||
+    selectedGoogleAdvancedServiceCount > 0;
   const selectedGooglePresets = useMemo(
     () =>
       selectedGoogleServiceIdList.flatMap((presetId) => {
@@ -834,18 +838,35 @@ export default function AddOpenApiSource(props: {
         Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
       ].join("\n")
     : "";
-  const oauth2Auth =
+  const activeOAuth2AuthState =
     oauth2AuthState?.fingerprint === selectedOAuth2Fingerprint ? oauth2AuthState.auth : null;
   const selectedOAuth2AvailableIdentityScopes = selectedOAuth2Preset
     ? identityScopesForPreset(selectedOAuth2Preset.identityScopes)
     : [];
   const selectedOAuth2IsGoogle = selectedOAuth2Preset
-    ? isGoogleOAuthTarget(selectedOAuth2Preset, resolvedBaseUrl, specUrl)
+    ? isGoogleBundlePreset || isGoogleOAuthTarget(selectedOAuth2Preset, resolvedBaseUrl, specUrl)
     : false;
   const selectedOAuth2ProviderLabel = selectedOAuth2IsGoogle ? "Google" : "OAuth";
   const googleServicePickerEnabled = Boolean(
-    preview && primaryGooglePreset && selectedOAuth2IsGoogle,
+    preview && isGoogleBundlePreset && selectedOAuth2IsGoogle,
   );
+  useEffect(() => {
+    if (!selectedOAuth2IsGoogle) return;
+    if (!oauth2ClientIdSecretId) {
+      const clientIdSecret = secretList.find((secret) => secret.id === "google-client-id");
+      if (clientIdSecret) {
+        setOauth2ClientIdSecretId(clientIdSecret.id);
+        setOauth2ClientIdScope(ScopeId.make(clientIdSecret.scopeId));
+      }
+    }
+    if (!oauth2ClientSecretSecretId) {
+      const clientSecretSecret = secretList.find((secret) => secret.id === "google-client-secret");
+      if (clientSecretSecret) {
+        setOauth2ClientSecretSecretId(clientSecretSecret.id);
+        setOauth2ClientSecretScope(ScopeId.make(clientSecretSecret.scopeId));
+      }
+    }
+  }, [oauth2ClientIdSecretId, oauth2ClientSecretSecretId, secretList, selectedOAuth2IsGoogle]);
   const googleBatchAddItems = useMemo((): readonly GoogleServiceAddItem[] => {
     if (!preview || !primaryGooglePreset || !googleServicePickerEnabled) return [];
     const items: GoogleServiceAddItem[] = [];
@@ -856,8 +877,6 @@ export default function AddOpenApiSource(props: {
         items.push({
           preset,
           preview,
-          baseUrl: resolvedBaseUrl,
-          isPrimary: true,
         });
         continue;
       }
@@ -866,8 +885,6 @@ export default function AddOpenApiSource(props: {
         items.push({
           preset,
           preview: previewState.preview,
-          baseUrl: previewState.baseUrl,
-          isPrimary: false,
         });
       }
     }
@@ -877,7 +894,6 @@ export default function AddOpenApiSource(props: {
     googleServicePreviews,
     preview,
     primaryGooglePreset,
-    resolvedBaseUrl,
     selectedGoogleServiceIdList,
   ]);
   const googleBatchPendingCount = googleServicePickerEnabled
@@ -889,14 +905,27 @@ export default function AddOpenApiSource(props: {
         .find((state) => state?.status === "error")
     : undefined;
   const effectiveOAuth2SelectedApiScopes = useMemo(() => {
-    if (!googleServicePickerEnabled) return oauth2SelectedScopes;
+    if (!googleServicePickerEnabled) {
+      return new Set(
+        selectedOAuth2IsGoogle
+          ? filterGoogleUserConsentOAuthScopes(oauth2SelectedScopes)
+          : oauth2SelectedScopes,
+      );
+    }
     const scopes = new Set<string>();
     for (const item of googleBatchAddItems) {
       const preset = item.preview.oauth2Presets[0];
-      for (const scope of Object.keys(preset?.scopes ?? {})) scopes.add(scope);
+      for (const scope of filterGoogleUserConsentOAuthScopes(Object.keys(preset?.scopes ?? {}))) {
+        scopes.add(scope);
+      }
     }
-    return scopes.size > 0 ? scopes : oauth2SelectedScopes;
-  }, [googleBatchAddItems, googleServicePickerEnabled, oauth2SelectedScopes]);
+    return scopes;
+  }, [
+    googleBatchAddItems,
+    googleServicePickerEnabled,
+    oauth2SelectedScopes,
+    selectedOAuth2IsGoogle,
+  ]);
   const configuredOAuth2IdentityScopes =
     selectedOAuth2Preset && includeOAuth2IdentityScopes
       ? selectedOAuth2Preset.identityScopes
@@ -908,30 +937,58 @@ export default function AddOpenApiSource(props: {
         : [...effectiveOAuth2SelectedApiScopes],
     [configuredOAuth2IdentityScopes, effectiveOAuth2SelectedApiScopes, selectedOAuth2Preset],
   );
+  const oauth2Auth = useMemo(() => {
+    if (!activeOAuth2AuthState) return null;
+    const granted = new Set(activeOAuth2AuthState.grantedScopes);
+    return selectedOAuth2Scopes.every((scope) => granted.has(scope)) ? activeOAuth2AuthState : null;
+  }, [activeOAuth2AuthState, selectedOAuth2Scopes]);
+  const grantedScopesForConnection = useCallback(
+    (connection: {
+      readonly id: ConnectionId;
+      readonly oauthScope: string | null;
+    }): Set<string> => {
+      const granted = splitOAuthScopes(connection.oauthScope);
+      if (activeOAuth2AuthState?.connectionId === connection.id) {
+        for (const scope of activeOAuth2AuthState.grantedScopes) granted.add(scope);
+      }
+      return granted;
+    },
+    [activeOAuth2AuthState],
+  );
+  const googleConsentBatches = useMemo(
+    () =>
+      googleServicePickerEnabled
+        ? googleOAuthConsentBatches(
+            googleBatchAddItems.map((item) => ({
+              id: item.preset.id,
+              name: item.preset.name,
+              oauthAudience: item.preset.oauthAudience,
+              scopes: scopesForGoogleServiceItem(item),
+            })),
+          )
+        : [],
+    [googleBatchAddItems, googleServicePickerEnabled],
+  );
   useEffect(() => {
     if (!googleServicePickerEnabled || !primaryGooglePreset) {
+      googleBundleSelectionSeeded.current = false;
       setSelectedGoogleServiceIds((previous) =>
         previous.size === 0 ? previous : new Set<string>(),
       );
       setGoogleServicePreviews((previous) => (Object.keys(previous).length === 0 ? previous : {}));
-      setGoogleServiceSettings((previous) => (Object.keys(previous).length === 0 ? previous : {}));
-      setActiveGoogleServiceId(null);
       return;
     }
-    setSelectedGoogleServiceIds((previous) => {
-      if (previous.has(primaryGooglePreset.id)) return previous;
-      const next = new Set(previous);
-      next.add(primaryGooglePreset.id);
-      return next;
-    });
-  }, [googleServicePickerEnabled, primaryGooglePreset]);
-
-  useEffect(() => {
-    if (!googleServicePickerEnabled || !primaryGooglePreset) return;
-    setActiveGoogleServiceId((previous) =>
-      previous && selectedGoogleServiceIds.has(previous) ? previous : primaryGooglePreset.id,
+    setBaseUrl((previous) =>
+      previous === GOOGLE_BUNDLE_BASE_URL ? previous : GOOGLE_BUNDLE_BASE_URL,
     );
-  }, [googleServicePickerEnabled, primaryGooglePreset, selectedGoogleServiceIds]);
+    if (!googleBundleSelectionSeeded.current) {
+      googleBundleSelectionSeeded.current = true;
+      setSelectedGoogleServiceIds((previous) => {
+        if (previous.size > 0 || previous.has(primaryGooglePreset.id)) return previous;
+        return new Set([primaryGooglePreset.id]);
+      });
+    }
+  }, [googleServicePickerEnabled, primaryGooglePreset]);
 
   useEffect(() => {
     if (!googleServicePickerEnabled || !primaryGooglePreset) return;
@@ -948,6 +1005,7 @@ export default function AddOpenApiSource(props: {
       for (const presetId of missingPresetIds) {
         const preset = googleOpenApiPresets.find((candidate) => candidate.id === presetId);
         if (!preset) continue;
+        if (!preset.url) continue;
         const exit = await doPreview({
           params: { scopeId },
           payload: {
@@ -978,95 +1036,27 @@ export default function AddOpenApiSource(props: {
     selectedGoogleServiceIdList,
   ]);
 
-  const setGoogleServiceSetting = (presetId: string, patch: Partial<GoogleServiceSettings>) => {
-    setGoogleServiceSettings((previous) => ({
-      ...previous,
-      [presetId]: {
-        ...previous[presetId],
-        ...patch,
-      },
-    }));
-  };
-
-  const googleServicePreviewStateFor = (
-    preset: (typeof googleOpenApiPresets)[number],
-  ): GoogleServicePreviewState | null => {
-    if (preset.id === primaryGooglePreset?.id && preview) {
-      return {
-        status: "success",
-        preview,
-        baseUrl: resolvedBaseUrl,
-      };
-    }
-    return googleServicePreviews[preset.id] ?? null;
-  };
-
-  const googleServiceNameFor = (
-    preset: (typeof googleOpenApiPresets)[number],
-    servicePreview: SpecPreview,
-  ): string => {
-    const settings = googleServiceSettings[preset.id];
-    return settings?.name ?? defaultGoogleSourceName(preset, servicePreview);
-  };
-
-  const googleServiceNamespaceFor = (
-    preset: (typeof googleOpenApiPresets)[number],
-    servicePreview: SpecPreview,
-  ): string => {
-    const settings = googleServiceSettings[preset.id];
-    const name = googleServiceNameFor(preset, servicePreview);
-    return (
-      settings?.namespace ??
-      slugifyNamespace(name) ??
-      defaultGoogleSourceNamespace(preset, servicePreview)
-    );
-  };
-
-  const googleServiceBaseUrlFor = (
-    preset: (typeof googleOpenApiPresets)[number],
-    fallbackBaseUrl: string,
-  ): string => googleServiceSettings[preset.id]?.baseUrl ?? fallbackBaseUrl;
-
-  const googleServiceSpecUrlFor = (preset: (typeof googleOpenApiPresets)[number]): string =>
-    googleServiceSettings[preset.id]?.specUrl ?? preset.url;
-
-  const googleServiceIdentityFor = (
-    preset: (typeof googleOpenApiPresets)[number],
-    servicePreview: SpecPreview,
-  ): SourceIdentity => ({
-    name: googleServiceNameFor(preset, servicePreview),
-    namespace: googleServiceNamespaceFor(preset, servicePreview),
-    setName: (name) => setGoogleServiceSetting(preset.id, { name }),
-    setNamespace: (namespace) =>
-      setGoogleServiceSetting(preset.id, {
-        namespace: normalizeNamespaceInput(namespace),
-      }),
-    reset: () =>
-      setGoogleServiceSettings((previous) => {
-        const next = { ...previous };
-        delete next[preset.id];
-        return next;
-      }),
-  });
-
-  const googleServiceBaseUrlsReady =
-    !googleServicePickerEnabled ||
-    googleBatchAddItems.every(
-      (item) => googleServiceBaseUrlFor(item.preset, item.baseUrl).trim().length > 0,
-    );
+  const googleBundleOperationCount = googleBatchAddItems.reduce(
+    (count, item) => count + item.preview.operationCount,
+    0,
+  );
 
   const existingOAuthConnections = useMemo(() => {
     if (
       !selectedOAuth2Preset ||
       selectedOAuth2Preset.flow !== "authorizationCode" ||
-      !AsyncResult.isSuccess(connectionsResult)
+      !AsyncResult.isSuccess(connectionsResult) ||
+      (googleServicePickerEnabled && selectedGoogleServiceIdList.length === 0)
     ) {
       return [];
     }
     return connectionsResult.value
       .flatMap((connection) => {
         if (connection.provider !== "oauth2") return [];
-        const missingApiScopes = missingOAuthScopes(connection, effectiveOAuth2SelectedApiScopes);
+        const missingApiScopes = missingOAuthScopesFromGranted(
+          grantedScopesForConnection(connection),
+          effectiveOAuth2SelectedApiScopes,
+        );
         if (missingApiScopes.length === 0) {
           return [{ ...connection, missingApiScopes }];
         }
@@ -1079,15 +1069,19 @@ export default function AddOpenApiSource(props: {
   }, [
     connectionsResult,
     effectiveOAuth2SelectedApiScopes,
+    grantedScopesForConnection,
+    googleServicePickerEnabled,
     selectedOAuth2IsGoogle,
     selectedOAuth2Preset,
+    selectedGoogleServiceIdList.length,
   ]);
 
+  const effectiveResolvedBaseUrl = resolvedBaseUrl;
   const configuredOAuth2 =
     strategy.kind === "oauth2" && selectedOAuth2Preset
       ? oauth2ConfigForPreset({
           preset: selectedOAuth2Preset,
-          baseUrl: resolvedBaseUrl,
+          baseUrl: effectiveResolvedBaseUrl,
           scopes: effectiveOAuth2SelectedApiScopes,
           identityScopes: configuredOAuth2IdentityScopes,
         })
@@ -1096,9 +1090,11 @@ export default function AddOpenApiSource(props: {
   const oauth2Busy = startingOAuth || oauth.busy;
   const canConnectOAuth2 =
     Boolean(oauth2ClientIdSecretId) &&
-    resolvedBaseUrl.length > 0 &&
-    googleServiceBaseUrlsReady &&
-    (!googleServicePickerEnabled || (googleBatchPendingCount === 0 && !googleBatchError));
+    effectiveResolvedBaseUrl.length > 0 &&
+    (!googleServicePickerEnabled ||
+      (selectedGoogleServiceIdList.length > 0 &&
+        googleBatchPendingCount === 0 &&
+        !googleBatchError));
   const hasIncompleteHeaderCredentials =
     strategy.kind !== "none" &&
     strategy.kind !== "oauth2" &&
@@ -1119,9 +1115,11 @@ export default function AddOpenApiSource(props: {
 
   const canAdd =
     preview !== null &&
-    resolvedBaseUrl.length > 0 &&
-    googleServiceBaseUrlsReady &&
-    (!googleServicePickerEnabled || (googleBatchPendingCount === 0 && !googleBatchError));
+    effectiveResolvedBaseUrl.length > 0 &&
+    (!googleServicePickerEnabled ||
+      (selectedGoogleServiceIdList.length > 0 &&
+        googleBatchPendingCount === 0 &&
+        !googleBatchError));
 
   // ---- Handlers ----
 
@@ -1226,23 +1224,46 @@ export default function AddOpenApiSource(props: {
       if (!selectedOAuth2Preset || !preview) return;
       oauth.cancel();
       setOauth2Error(null);
+      setOauth2ProgressLabel(null);
       const displayName = identity.name.trim() || selectedOAuth2Preset.securitySchemeName;
       const tokenTargetScope = existingConnection?.scopeId ?? oauthTokenTargetScope;
       const connectionId =
         existingConnection?.id ??
         openApiOAuthConnectionId(resolvedSourceId, selectedOAuth2Preset.flow);
-      const scopesForAuthorization = existingConnection
-        ? mergeOAuthScopes(
-            splitOAuthScopes(existingConnection.oauthScope),
-            selectedOAuth2IsGoogle ? effectiveOAuth2SelectedApiScopes : selectedOAuth2Scopes,
-          )
-        : selectedOAuth2Scopes;
+      const existingGrantedScopes = existingConnection
+        ? grantedScopesForConnection(existingConnection)
+        : null;
+      const selectedGoogleConnectionScopes =
+        selectedOAuth2IsGoogle && googleServicePickerEnabled
+          ? resolvedOAuthScopes(
+              new Set(googleBatchAddItems.flatMap((item) => scopesForGoogleServiceItem(item))),
+              configuredOAuth2IdentityScopes,
+            )
+          : selectedOAuth2Scopes;
+      const scopesForConnection = existingConnection
+        ? mergeOAuthScopes(existingGrantedScopes ?? [], selectedGoogleConnectionScopes)
+        : selectedGoogleConnectionScopes;
+      const providerAuthorizationInput =
+        selectedOAuth2IsGoogle && googleServicePickerEnabled
+          ? [
+              ...googleConsentBatches.flatMap((batch) => batch.apiScopes),
+              ...identityScopesForPreset(configuredOAuth2IdentityScopes),
+            ]
+          : existingConnection && selectedOAuth2IsGoogle
+            ? resolvedOAuthScopes(
+                missingOAuthScopesFromGranted(
+                  existingGrantedScopes ?? new Set<string>(),
+                  effectiveOAuth2SelectedApiScopes,
+                ),
+                configuredOAuth2IdentityScopes,
+              )
+            : scopesForConnection;
       const scopesForProviderAuthorization = selectedOAuth2IsGoogle
-        ? compactGoogleOAuthScopes(scopesForAuthorization)
+        ? compactGoogleOAuthScopes(providerAuthorizationInput)
         : undefined;
       const extraAuthorizationParams = googleAuthorizationParams(selectedOAuth2IsGoogle);
 
-      const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, resolvedBaseUrl);
+      const tokenUrl = resolveOAuthUrl(selectedOAuth2Preset.tokenUrl, effectiveResolvedBaseUrl);
       const clientIdSecretScope = oauth2ClientIdScope ?? sourceScope;
       const clientSecretSecretScope = oauth2ClientSecretScope ?? sourceScope;
 
@@ -1270,7 +1291,7 @@ export default function AddOpenApiSource(props: {
               clientIdSecretScopeId: String(clientIdSecretScope),
               clientSecretSecretId: oauth2ClientSecretSecretId,
               clientSecretSecretScopeId: String(clientSecretSecretScope),
-              scopes: scopesForAuthorization,
+              scopes: scopesForConnection,
             },
             pluginId: "openapi",
             identityLabel: `${displayName} OAuth`,
@@ -1289,7 +1310,11 @@ export default function AddOpenApiSource(props: {
         setOAuthTokenTargetScope(tokenTargetScope);
         setOauth2AuthState({
           fingerprint: selectedOAuth2Fingerprint,
-          auth: { connectionId: response.completedConnection.connectionId },
+          auth: {
+            connectionId: response.completedConnection.connectionId,
+            grantedScopes: scopesForConnection,
+            scopeId: tokenTargetScope,
+          },
         });
         setOauth2Error(null);
         return;
@@ -1298,16 +1323,181 @@ export default function AddOpenApiSource(props: {
 
       const authorizationUrl = resolveOAuthUrl(
         Option.getOrElse(selectedOAuth2Preset.authorizationUrl, () => ""),
-        resolvedBaseUrl,
+        effectiveResolvedBaseUrl,
       );
       const issuerUrl = inferOAuthIssuerUrl(authorizationUrl);
+
+      const startAuthorizationCodeFlow = async (input: {
+        readonly connectionId: string;
+        readonly scopesForConnection: readonly string[];
+        readonly authorizationScopes: readonly string[] | undefined;
+        readonly identityLabel: string;
+        readonly onSuccess: (result: OAuthCompletionPayload) => void | Promise<void>;
+      }) => {
+        const authorizationStrategy = existingConnection
+          ? {
+              kind: "authorization-code-existing-client" as const,
+              authorizationEndpoint: authorizationUrl,
+              tokenEndpoint: tokenUrl,
+              issuerUrl,
+              scopes: input.scopesForConnection,
+              ...(input.authorizationScopes && input.authorizationScopes.length > 0
+                ? { authorizationScopes: input.authorizationScopes }
+                : {}),
+              extraAuthorizationParams,
+            }
+          : oauth2ClientIdSecretId
+            ? {
+                kind: "authorization-code" as const,
+                authorizationEndpoint: authorizationUrl,
+                tokenEndpoint: tokenUrl,
+                issuerUrl,
+                clientIdSecretId: oauth2ClientIdSecretId,
+                clientIdSecretScopeId: String(clientIdSecretScope),
+                clientSecretSecretId: oauth2ClientSecretSecretId ?? null,
+                clientSecretSecretScopeId: oauth2ClientSecretSecretId
+                  ? String(clientSecretSecretScope)
+                  : null,
+                scopes: input.scopesForConnection,
+                ...(input.authorizationScopes && input.authorizationScopes.length > 0
+                  ? { authorizationScopes: input.authorizationScopes }
+                  : {}),
+                extraAuthorizationParams,
+              }
+            : null;
+        if (!authorizationStrategy) return;
+
+        await oauth.openAuthorization({
+          tokenScope: tokenTargetScope,
+          run: async () => {
+            const exit = await doStartOAuth({
+              params: { scopeId: tokenTargetScope },
+              payload: {
+                endpoint: authorizationUrl,
+                connectionId: input.connectionId,
+                tokenScope: tokenTargetScope,
+                redirectUrl: oauth2RedirectUrl,
+                strategy: authorizationStrategy,
+                pluginId: "openapi",
+                identityLabel: input.identityLabel,
+              },
+            });
+            if (Exit.isFailure(exit)) {
+              // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: OAuth popup API represents start failure by rejecting run()
+              throw new Error(errorMessageFromExit(exit, "Failed to start OAuth"));
+            }
+            const response = exit.value;
+            if (response.authorizationUrl === null) {
+              // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: OAuth popup API represents start failure by rejecting run()
+              throw new Error("Unexpected response flow from server");
+            }
+            return {
+              sessionId: response.sessionId,
+              authorizationUrl: response.authorizationUrl,
+            };
+          },
+          onSuccess: input.onSuccess,
+          onError: (message, details) => {
+            setStartingOAuth(false);
+            setOauth2ProgressLabel(null);
+            setOauth2Error(oauthErrorMessage(selectedOAuth2ProviderLabel, message, details));
+          },
+        });
+      };
+
+      if (selectedOAuth2IsGoogle && googleConsentBatches.length > 2) {
+        const currentStoredScopes = existingConnection
+          ? (existingGrantedScopes ?? splitOAuthScopes(existingConnection.oauthScope))
+          : activeOAuth2AuthState?.connectionId === connectionId
+            ? new Set(activeOAuth2AuthState.grantedScopes)
+            : new Set<string>();
+        const hasStoredConnection = Boolean(existingConnection) || currentStoredScopes.size > 0;
+        const identityScopes = identityScopesForPreset(configuredOAuth2IdentityScopes);
+        const missingBatches = googleConsentBatches
+          .map((batch) => {
+            const missingApiScopes = batch.apiScopes.filter(
+              (scope) => !currentStoredScopes.has(scope),
+            );
+            return { ...batch, apiScopes: missingApiScopes };
+          })
+          .filter((batch) => batch.apiScopes.length > 0);
+        if (missingBatches.length === 0 && existingConnection) {
+          setOAuthTokenTargetScope(existingConnection.scopeId);
+          setOauth2AuthState({
+            fingerprint: selectedOAuth2Fingerprint,
+            auth: {
+              connectionId: existingConnection.id,
+              grantedScopes: [...currentStoredScopes],
+              scopeId: existingConnection.scopeId,
+            },
+          });
+          setOauth2Error(null);
+          return;
+        }
+
+        const runBatch = async (
+          batchIndex: number,
+          accumulatedScopes: readonly string[],
+          currentConnectionId: string,
+        ): Promise<void> => {
+          const batch = missingBatches[batchIndex];
+          if (!batch) {
+            setOAuthTokenTargetScope(tokenTargetScope);
+            setOauth2AuthState({
+              fingerprint: selectedOAuth2Fingerprint,
+              auth: {
+                connectionId: currentConnectionId,
+                grantedScopes: accumulatedScopes,
+                scopeId: tokenTargetScope,
+              },
+            });
+            setOauth2ProgressLabel(null);
+            setOauth2Error(null);
+            return;
+          }
+
+          const batchAuthorizationScopes = compactGoogleOAuthScopes([
+            ...accumulatedScopes,
+            ...batch.apiScopes,
+            ...identityScopes,
+          ]);
+          const scopesForBatchConnection =
+            batchIndex === missingBatches.length - 1
+              ? scopesForConnection
+              : batchIndex === 0 && !hasStoredConnection
+                ? batchAuthorizationScopes
+                : mergeOAuthScopes(accumulatedScopes, batchAuthorizationScopes);
+          setOauth2ProgressLabel(
+            `Connect ${batch.label} (${batchIndex + 1} of ${missingBatches.length})`,
+          );
+
+          await startAuthorizationCodeFlow({
+            connectionId: currentConnectionId,
+            scopesForConnection: scopesForBatchConnection,
+            authorizationScopes: batchAuthorizationScopes,
+            identityLabel: existingConnection?.identityLabel ?? `${displayName} OAuth`,
+            onSuccess: (result) => {
+              const nextAccumulatedScopes = result.scope
+                ? mergeOAuthScopes(accumulatedScopes, splitOAuthScopes(result.scope))
+                : scopesForBatchConnection;
+              window.setTimeout(() => {
+                void runBatch(batchIndex + 1, nextAccumulatedScopes, result.connectionId);
+              }, 0);
+            },
+          });
+        };
+
+        await runBatch(0, [...currentStoredScopes], connectionId);
+        return;
+      }
+
       const authorizationStrategy = existingConnection
         ? {
             kind: "authorization-code-existing-client" as const,
             authorizationEndpoint: authorizationUrl,
             tokenEndpoint: tokenUrl,
             issuerUrl,
-            scopes: scopesForAuthorization,
+            scopes: scopesForConnection,
             ...(scopesForProviderAuthorization && scopesForProviderAuthorization.length > 0
               ? { authorizationScopes: scopesForProviderAuthorization }
               : {}),
@@ -1325,7 +1515,7 @@ export default function AddOpenApiSource(props: {
               clientSecretSecretScopeId: oauth2ClientSecretSecretId
                 ? String(clientSecretSecretScope)
                 : null,
-              scopes: scopesForAuthorization,
+              scopes: scopesForConnection,
               ...(scopesForProviderAuthorization && scopesForProviderAuthorization.length > 0
                 ? { authorizationScopes: scopesForProviderAuthorization }
                 : {}),
@@ -1367,13 +1557,21 @@ export default function AddOpenApiSource(props: {
           setOAuthTokenTargetScope(tokenTargetScope);
           setOauth2AuthState({
             fingerprint: selectedOAuth2Fingerprint,
-            auth: { connectionId: result.connectionId },
+            auth: {
+              connectionId: result.connectionId,
+              grantedScopes: result.scope
+                ? [...splitOAuthScopes(result.scope)]
+                : scopesForConnection,
+              scopeId: tokenTargetScope,
+            },
           });
+          setOauth2ProgressLabel(null);
           setOauth2Error(null);
         },
-        onError: (message) => {
+        onError: (message, details) => {
           setStartingOAuth(false);
-          setOauth2Error(message);
+          setOauth2ProgressLabel(null);
+          setOauth2Error(oauthErrorMessage(selectedOAuth2ProviderLabel, message, details));
         },
       });
     },
@@ -1385,7 +1583,8 @@ export default function AddOpenApiSource(props: {
       selectedOAuth2Scopes,
       selectedOAuth2IsGoogle,
       oauth2RedirectUrl,
-      resolvedBaseUrl,
+      effectiveResolvedBaseUrl,
+      googleConsentBatches,
       preview,
       doStartOAuth,
       identity.name,
@@ -1395,7 +1594,10 @@ export default function AddOpenApiSource(props: {
       oauthTokenTargetScope,
       oauth2ClientIdScope,
       oauth2ClientSecretScope,
+      activeOAuth2AuthState,
+      grantedScopesForConnection,
       sourceScope,
+      selectedOAuth2ProviderLabel,
     ],
   );
 
@@ -1412,7 +1614,11 @@ export default function AddOpenApiSource(props: {
       setOAuthTokenTargetScope(connection.scopeId);
       setOauth2AuthState({
         fingerprint: selectedOAuth2Fingerprint,
-        auth: { connectionId: connection.id },
+        auth: {
+          connectionId: connection.id,
+          grantedScopes: [...splitOAuthScopes(connection.oauthScope)],
+          scopeId: connection.scopeId,
+        },
       });
       setOauth2Error(null);
     },
@@ -1426,148 +1632,31 @@ export default function AddOpenApiSource(props: {
     const clientIdBindingScope = oauth2ClientIdScope ?? sourceScope;
     const clientSecretBindingScope = oauth2ClientSecretScope ?? sourceScope;
 
-    const bindOAuth2Credentials = async (
-      sourceId: string,
-      oauth2Config: OAuth2SourceConfig,
-    ): Promise<boolean> => {
-      if (oauth2ClientIdSecretId) {
-        const bindingExit = await doSetBinding({
-          params: { scopeId },
-          payload: SetSourceCredentialBindingInput.make({
-            source: { id: sourceId, scope: sourceScope },
-            scope: clientIdBindingScope,
-            slotKey: oauth2Config.clientIdSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientIdSecretId),
-              secretScopeId: clientIdBindingScope,
-            },
-          }),
-          reactivityKeys: bindingWriteKeys,
-        });
-        if (Exit.isFailure(bindingExit)) {
-          setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
-          setAdding(false);
-          return false;
-        }
-      }
-
-      if (oauth2Config.clientSecretSlot && oauth2ClientSecretSecretId) {
-        const bindingExit = await doSetBinding({
-          params: { scopeId },
-          payload: SetSourceCredentialBindingInput.make({
-            source: { id: sourceId, scope: sourceScope },
-            scope: clientSecretBindingScope,
-            slotKey: oauth2Config.clientSecretSlot,
-            value: {
-              kind: "secret",
-              secretId: SecretId.make(oauth2ClientSecretSecretId),
-              secretScopeId: clientSecretBindingScope,
-            },
-          }),
-          reactivityKeys: bindingWriteKeys,
-        });
-        if (Exit.isFailure(bindingExit)) {
-          setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
-          setAdding(false);
-          return false;
-        }
-      }
-
-      if (oauth2Auth) {
-        const bindingExit = await doSetBinding({
-          params: { scopeId },
-          payload: SetSourceCredentialBindingInput.make({
-            source: { id: sourceId, scope: sourceScope },
-            scope: oauthTokenBindingScope,
-            slotKey: oauth2Config.connectionSlot,
-            value: {
-              kind: "connection",
-              connectionId: ConnectionId.make(oauth2Auth.connectionId),
-            },
-          }),
-          reactivityKeys: bindingWriteKeys,
-        });
-        if (Exit.isFailure(bindingExit)) {
-          setAddError(errorMessageFromExit(bindingExit, "Failed to add source"));
-          setAdding(false);
-          return false;
-        }
-      }
-
-      return true;
-    };
-
-    if (googleServicePickerEnabled && googleBatchAddItems.length > 1) {
-      if (googleBatchPendingCount > 0 || googleBatchError) {
-        setAddError(
-          googleBatchError?.status === "error"
-            ? googleBatchError.message
-            : "Still loading selected Google services",
-        );
-        setAdding(false);
-        return;
-      }
-
-      for (const item of googleBatchAddItems) {
-        const itemBaseUrl = googleServiceBaseUrlFor(item.preset, item.baseUrl).trim();
-        if (!itemBaseUrl) {
-          setAddError(`Base URL is required for ${item.preset.name}`);
-          setAdding(false);
-          return;
-        }
-        const fallbackName = defaultGoogleSourceName(item.preset, item.preview);
-        const sourceName = item.isPrimary
-          ? resolvedDisplayName
-          : googleServiceNameFor(item.preset, item.preview).trim() || fallbackName;
-        const sourceNamespace = item.isPrimary
-          ? resolvedSourceId
-          : slugifyNamespace(googleServiceNamespaceFor(item.preset, item.preview)) ||
-            defaultGoogleSourceNamespace(item.preset, item.preview);
-        const oauth2Preset = item.preview.oauth2Presets[0];
-        const oauth2Config = oauth2Preset
-          ? oauth2ConfigForPreset({
-              preset: oauth2Preset,
-              baseUrl: itemBaseUrl,
-              scopes: Object.keys(oauth2Preset.scopes),
-              identityScopes: configuredOAuth2IdentityScopes,
-            })
-          : null;
-        const exit = await doAdd({
-          params: { scopeId },
-          payload: {
-            spec: item.isPrimary
-              ? specInputForAdd(specUrl)
-              : { kind: "googleDiscovery", url: googleServiceSpecUrlFor(item.preset) },
-            name: sourceName,
-            namespace: sourceNamespace,
-            baseUrl: itemBaseUrl,
-            ...(oauth2Config ? { oauth2: oauth2Config } : {}),
-          },
-          reactivityKeys: addSpecWriteKeys,
-        });
-        if (Exit.isFailure(exit)) {
-          setAddError(errorMessageFromExit(exit, `Failed to add ${item.preset.name}`));
-          setAdding(false);
-          return;
-        }
-        if (oauth2Config && !(await bindOAuth2Credentials(exit.value.namespace, oauth2Config))) {
-          return;
-        }
-      }
-
-      props.onComplete();
+    if (googleServicePickerEnabled && (googleBatchPendingCount > 0 || googleBatchError)) {
+      setAddError(
+        googleBatchError?.status === "error"
+          ? googleBatchError.message
+          : "Still loading selected Google services",
+      );
+      setAdding(false);
       return;
     }
 
     const namespace = resolvedSourceId;
+    const specForAdd =
+      googleServicePickerEnabled && selectedGooglePresets.length > 0
+        ? {
+            kind: "googleDiscoveryBundle" as const,
+            urls: selectedGooglePresets.flatMap((preset) => (preset.url ? [preset.url] : [])),
+          }
+        : specInputForAdd(specUrl);
     const exit = await doAdd({
       params: { scopeId },
       payload: {
-        spec: specInputForAdd(specUrl),
+        spec: specForAdd,
         name: resolvedDisplayName,
         namespace,
-        baseUrl: resolvedBaseUrl,
+        baseUrl: effectiveResolvedBaseUrl,
         ...(configuredSpecFetchCredentials
           ? { specFetchCredentials: configuredSpecFetchCredentials }
           : {}),
@@ -1721,6 +1810,19 @@ export default function AddOpenApiSource(props: {
     props.onComplete();
   };
 
+  const handleToggleAllGoogleServices = () => {
+    setSelectedGoogleServiceIds((previous) => {
+      const next = new Set(previous);
+      if (allStandardGoogleServicesSelected) {
+        for (const presetId of GOOGLE_STANDARD_SERVICE_IDS) next.delete(presetId);
+        return next;
+      }
+      for (const presetId of GOOGLE_STANDARD_SERVICE_IDS) next.add(presetId);
+      return next;
+    });
+    setOauth2AuthState(null);
+  };
+
   // ---- Render ----
 
   return (
@@ -1791,114 +1893,24 @@ export default function AddOpenApiSource(props: {
       {/* ── Source information card (shown after analysis) ── */}
       {preview ? (
         googleServicePickerEnabled && primaryGooglePreset ? (
-          <Tabs
-            value={activeGoogleServiceId ?? primaryGooglePreset.id}
-            onValueChange={setActiveGoogleServiceId}
-            className="gap-3"
-          >
-            <TabsList className="max-w-full justify-start overflow-x-auto">
-              {(selectedGooglePresets.length > 0
-                ? selectedGooglePresets
-                : [primaryGooglePreset]
-              ).map((preset) => (
-                <TabsTrigger key={preset.id} value={preset.id} className="shrink-0">
-                  {preset.icon ? (
-                    <img src={preset.icon} alt="" className="size-3.5 object-contain" />
-                  ) : null}
-                  <span>{preset.name.replace(/^Google /, "")}</span>
-                </TabsTrigger>
-              ))}
-            </TabsList>
-            {(selectedGooglePresets.length > 0 ? selectedGooglePresets : [primaryGooglePreset]).map(
-              (preset) => {
-                const serviceState = googleServicePreviewStateFor(preset);
-                if (serviceState?.status !== "success") {
-                  return (
-                    <TabsContent key={preset.id} value={preset.id}>
-                      <CardStack>
-                        <CardStackContent className="border-t-0">
-                          <CardStackEntryField label={preset.name}>
-                            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                              {serviceState?.status === "loading" ? (
-                                <>
-                                  <IOSSpinner className="size-3.5" />
-                                  Loading service details…
-                                </>
-                              ) : (
-                                (serviceState?.message ?? "Service details are unavailable.")
-                              )}
-                            </div>
-                          </CardStackEntryField>
-                        </CardStackContent>
-                      </CardStack>
-                    </TabsContent>
-                  );
-                }
-
-                const servicePreview = serviceState.preview;
-                const serviceBaseUrl = googleServiceBaseUrlFor(preset, serviceState.baseUrl);
-                const serviceBaseUrlOptions = Array.from(
-                  new Map(
-                    servicePreview.servers
-                      .flatMap(expandServerOptions)
-                      .map((option) => [option.value, option]),
-                  ).values(),
-                );
-                const serviceIdentity =
-                  preset.id === primaryGooglePreset.id
-                    ? identity
-                    : googleServiceIdentityFor(preset, servicePreview);
-                return (
-                  <TabsContent key={preset.id} value={preset.id}>
-                    <OpenApiSourceDetailsFields
-                      title={defaultGoogleSourceName(preset, servicePreview)}
-                      description={`${Option.getOrElse(servicePreview.version, () => "")}${
-                        Option.isSome(servicePreview.version) ? " · " : ""
-                      }${servicePreview.operationCount} operation${
-                        servicePreview.operationCount !== 1 ? "s" : ""
-                      }${
-                        servicePreview.tags.length > 0
-                          ? ` · ${servicePreview.tags.length} tag${
-                              servicePreview.tags.length !== 1 ? "s" : ""
-                            }`
-                          : ""
-                      }`}
-                      identity={serviceIdentity}
-                      baseUrl={serviceBaseUrl}
-                      onBaseUrlChange={(value) =>
-                        preset.id === primaryGooglePreset.id
-                          ? setBaseUrl(value)
-                          : setGoogleServiceSetting(preset.id, { baseUrl: value })
-                      }
-                      baseUrlOptions={serviceBaseUrlOptions}
-                      specUrl={
-                        preset.id === primaryGooglePreset.id
-                          ? specUrl
-                          : googleServiceSpecUrlFor(preset)
-                      }
-                      onSpecUrlChange={(value) => {
-                        if (preset.id !== primaryGooglePreset.id) {
-                          setGoogleServiceSetting(preset.id, { specUrl: value });
-                          return;
-                        }
-                        setSpecUrl(value);
-                        setPreview(null);
-                        setBaseUrl("");
-                        setCustomHeaders([]);
-                        setStrategy({ kind: "none" });
-                        setOauth2AuthState(null);
-                        setOauth2Error(null);
-                      }}
-                      faviconIcon={preset.icon}
-                      faviconUrl={serviceBaseUrl}
-                      specUrlDisabled={preset.id !== primaryGooglePreset.id}
-                      baseUrlMissingMessage="A base URL is required to make requests."
-                    />
-                  </TabsContent>
-                );
-              },
-            )}
-          </Tabs>
+          <OpenApiSourceDetailsFields
+            title="Google"
+            description={`${selectedGoogleServiceIdList.length} service${
+              selectedGoogleServiceIdList.length !== 1 ? "s" : ""
+            }${
+              googleBundleOperationCount > 0
+                ? ` · ${googleBundleOperationCount} operation${
+                    googleBundleOperationCount !== 1 ? "s" : ""
+                  }`
+                : ""
+            }`}
+            identity={identity}
+            baseUrl={effectiveResolvedBaseUrl}
+            onBaseUrlChange={setBaseUrl}
+            faviconIcon={GOOGLE_ICON}
+            faviconUrl={GOOGLE_BUNDLE_BASE_URL}
+            baseUrlMissingMessage="A base URL is required to make requests."
+          />
         ) : (
           <OpenApiSourceDetailsFields
             title={Option.getOrElse(preview.title, () => "API")}
@@ -1934,44 +1946,56 @@ export default function AddOpenApiSource(props: {
         <section className="space-y-2.5">
           <div className="flex items-center justify-between gap-3">
             <FieldLabel>Google services</FieldLabel>
-            <span className="text-[11px] text-muted-foreground">
-              {selectedGoogleServiceIds.size} selected
-            </span>
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] text-muted-foreground">
+                {selectedGoogleServiceIdList.length} selected
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="xs"
+                onClick={handleToggleAllGoogleServices}
+                className="-mr-2 h-6 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+              >
+                {allStandardGoogleServicesSelected ? "Clear all" : "Select all"}
+              </Button>
+            </div>
           </div>
           <div className="max-h-72 overflow-y-auto rounded-lg border border-border/60 bg-muted/10 p-2">
             <div className="grid gap-1.5 sm:grid-cols-2">
               {googleOpenApiPresets.map((preset) => {
-                const selected = selectedGoogleServiceIds.has(preset.id);
-                const locked = preset.id === primaryGooglePreset.id;
-                const previewState = locked
-                  ? ({ status: "success", preview: preview as SpecPreview } as const)
-                  : googleServicePreviews[preset.id];
+                const selected = selectedGoogleServiceIdList.includes(preset.id);
+                const userOAuthUnsupported = preset.oauthAudience === "unsupported-user";
+                const previewState =
+                  preset.id === primaryGooglePreset.id
+                    ? ({ status: "success", preview: preview as SpecPreview } as const)
+                    : googleServicePreviews[preset.id];
                 return (
                   <Label
                     key={preset.id}
-                    className={`flex cursor-pointer items-start gap-2 rounded-md border px-2.5 py-2 transition-colors ${
-                      selected
-                        ? "border-primary/35 bg-primary/[0.04]"
-                        : "border-border/50 bg-background/40 hover:bg-accent/40"
+                    className={`flex items-start gap-2 rounded-md border px-2.5 py-2 transition-colors ${
+                      userOAuthUnsupported
+                        ? "cursor-not-allowed border-border/30 bg-background/20 opacity-60"
+                        : selected
+                          ? "cursor-pointer border-primary/35 bg-primary/[0.04]"
+                          : "cursor-pointer border-border/50 bg-background/40 hover:bg-accent/40"
                     }`}
                   >
                     <Checkbox
                       checked={selected}
-                      disabled={locked}
+                      disabled={userOAuthUnsupported}
                       onCheckedChange={(checked) => {
-                        if (checked !== true && activeGoogleServiceId === preset.id) {
-                          setActiveGoogleServiceId(primaryGooglePreset.id);
-                        }
+                        if (userOAuthUnsupported) return;
                         setSelectedGoogleServiceIds((previous) => {
                           const next = new Set(previous);
                           if (checked === true) {
                             next.add(preset.id);
-                          } else if (!locked) {
+                          } else {
                             next.delete(preset.id);
                           }
                           return next;
                         });
-                        setOauth2AuthState(null);
+                        if (!googleServicePickerEnabled) setOauth2AuthState(null);
                       }}
                       className="mt-0.5"
                     />
@@ -1988,6 +2012,11 @@ export default function AddOpenApiSource(props: {
                         <span className="truncate text-[12px] font-medium text-foreground">
                           {preset.name}
                         </span>
+                        {userOAuthUnsupported ? (
+                          <span className="shrink-0 rounded-full border border-border/60 px-1.5 py-0.5 text-[9px] uppercase tracking-normal text-muted-foreground">
+                            Unavailable
+                          </span>
+                        ) : null}
                         {selected && previewState?.status === "loading" ? (
                           <IOSSpinner className="size-3 shrink-0" />
                         ) : null}
@@ -2009,6 +2038,16 @@ export default function AddOpenApiSource(props: {
             <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2">
               <p className="text-[11px] text-destructive">{googleBatchError.message}</p>
             </div>
+          ) : null}
+          {showGoogleSelectionWarning ? (
+            <Info variant="warning">
+              <InfoTitle>Google may reject broad permission requests</InfoTitle>
+              <InfoDescription>
+                Large Google selections and admin or developer APIs can ask for permission
+                combinations Google will not approve in one sign-in. If OAuth fails, select fewer
+                services or add sensitive services as separate Google sources.
+              </InfoDescription>
+            </Info>
           ) : null}
         </section>
       ) : null}
@@ -2264,7 +2303,9 @@ export default function AddOpenApiSource(props: {
                           <div className="space-y-2">
                             {googleBatchAddItems.map((item) => {
                               const oauth2Preset = item.preview.oauth2Presets[0];
-                              const scopes = Object.keys(oauth2Preset?.scopes ?? {});
+                              const rawScopes = Object.keys(oauth2Preset?.scopes ?? {});
+                              const scopes = filterGoogleUserConsentOAuthScopes(rawScopes);
+                              const unavailableScopeCount = rawScopes.length - scopes.length;
                               return (
                                 <div key={item.preset.id} className="space-y-1">
                                   <div className="text-[11px] font-medium text-foreground">
@@ -2272,7 +2313,7 @@ export default function AddOpenApiSource(props: {
                                   </div>
                                   {scopes.length === 0 ? (
                                     <div className="text-[10px] text-muted-foreground">
-                                      No scopes declared by this service.
+                                      No user OAuth scopes requested for this service.
                                     </div>
                                   ) : (
                                     <div className="flex flex-wrap gap-1.5">
@@ -2287,6 +2328,13 @@ export default function AddOpenApiSource(props: {
                                       ))}
                                     </div>
                                   )}
+                                  {unavailableScopeCount > 0 ? (
+                                    <div className="text-[10px] text-muted-foreground">
+                                      {unavailableScopeCount} scope
+                                      {unavailableScopeCount === 1 ? "" : "s"} unavailable for
+                                      Google user sign-in.
+                                    </div>
+                                  ) : null}
                                 </div>
                               );
                             })}
@@ -2358,8 +2406,8 @@ export default function AddOpenApiSource(props: {
                         <OAuthConnectedAccount
                           scopeId={oauthTokenTargetScope}
                           connectionId={oauth2Auth.connectionId}
-                          scopeSummary={`${selectedOAuth2Scopes.length} scope${
-                            selectedOAuth2Scopes.length === 1 ? "" : "s"
+                          scopeSummary={`${oauth2Auth.grantedScopes.length} scope${
+                            oauth2Auth.grantedScopes.length === 1 ? "" : "s"
                           } granted`}
                           sourceName={resolvedDisplayName}
                           onSetSourceName={identity.setName}
@@ -2373,7 +2421,9 @@ export default function AddOpenApiSource(props: {
                     <div className="flex items-center gap-2">
                       <div className="flex flex-1 items-center gap-2 rounded-md border border-border/60 bg-background/50 px-3 py-2 text-[11px] text-muted-foreground">
                         <Spinner className="size-3.5" />
-                        Waiting for OAuth… complete the flow in the popup, or cancel to retry.
+                        {oauth2ProgressLabel
+                          ? `${oauth2ProgressLabel} in the browser.`
+                          : "Waiting for OAuth… complete the flow in the popup, or cancel to retry."}
                       </div>
                       <Button variant="ghost" size="sm" onClick={handleCancelOAuth2}>
                         Cancel
@@ -2483,13 +2533,15 @@ export default function AddOpenApiSource(props: {
             {adding && <Spinner className="size-3.5" />}
             {adding
               ? "Adding…"
-              : googleServicePickerEnabled && googleBatchAddItems.length > 1
-                ? willAddWithoutInitialCredentials
-                  ? `Add ${googleBatchAddItems.length} sources without credentials`
-                  : `Add ${googleBatchAddItems.length} sources`
-                : willAddWithoutInitialCredentials
-                  ? "Add without credentials"
-                  : "Add source"}
+              : googleServicePickerEnabled && selectedGoogleServiceIdList.length === 0
+                ? "Select services"
+                : googleServicePickerEnabled
+                  ? willAddWithoutInitialCredentials
+                    ? "Add Google without credentials"
+                    : "Add Google"
+                  : willAddWithoutInitialCredentials
+                    ? "Add without credentials"
+                    : "Add source"}
           </Button>
         )}
       </FloatActions>

--- a/packages/plugins/openapi/src/sdk/__snapshots__/google-presets.test.ts.snap
+++ b/packages/plugins/openapi/src/sdk/__snapshots__/google-presets.test.ts.snap
@@ -1,0 +1,82 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`classifies every Google service for bundle OAuth UX 1`] = `
+[
+  {
+    "id": "google-calendar",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-gmail",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-sheets",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-drive",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-docs",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-slides",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-forms",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-tasks",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-people",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-chat",
+    "oauthAudience": "workspace-admin",
+  },
+  {
+    "id": "google-keep",
+    "oauthAudience": "unsupported-user",
+  },
+  {
+    "id": "google-youtube-data",
+    "oauthAudience": "advanced-user",
+  },
+  {
+    "id": "google-search-console",
+    "oauthAudience": "standard-user",
+  },
+  {
+    "id": "google-classroom",
+    "oauthAudience": "advanced-user",
+  },
+  {
+    "id": "google-admin-directory",
+    "oauthAudience": "workspace-admin",
+  },
+  {
+    "id": "google-admin-reports",
+    "oauthAudience": "workspace-admin",
+  },
+  {
+    "id": "google-apps-script",
+    "oauthAudience": "advanced-user",
+  },
+  {
+    "id": "google-bigquery",
+    "oauthAudience": "advanced-user",
+  },
+  {
+    "id": "google-cloud-resource-manager",
+    "oauthAudience": "advanced-user",
+  },
+]
+`;

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -241,17 +241,16 @@ const explicitPathTemplate = (operation: OperationObject): string | undefined =>
 const extractServerList = (servers: readonly ServerObject[] | undefined): ServerInfo[] =>
   (servers ?? []).flatMap((server) => {
     if (!server.url) return [];
-    const serverVariables =
-      server.variables as
-        | Record<
-            string,
-            {
-              readonly default?: string;
-              readonly enum?: readonly string[];
-              readonly description?: string;
-            }
-          >
-        | undefined;
+    const serverVariables = server.variables as
+      | Record<
+          string,
+          {
+            readonly default?: string;
+            readonly enum?: readonly string[];
+            readonly description?: string;
+          }
+        >
+      | undefined;
     const vars = serverVariables
       ? Object.fromEntries(
           Object.entries(serverVariables).flatMap(([name, v]) => {

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -12,6 +12,7 @@ import {
   type PathItemObject,
   type RequestBodyObject,
   type ResponseObject,
+  type ServerObject,
 } from "./openapi-utils";
 import {
   EncodingObject,
@@ -237,22 +238,20 @@ const explicitPathTemplate = (operation: OperationObject): string | undefined =>
 // Server extraction
 // ---------------------------------------------------------------------------
 
-const extractServerList = (servers: unknown): ServerInfo[] =>
-  (Array.isArray(servers) ? servers : []).flatMap((server) => {
-    if (typeof server !== "object" || server === null) return [];
-    const raw = server as {
-      url?: unknown;
-      description?: unknown;
-      variables?: unknown;
-    };
-    if (typeof raw.url !== "string") return [];
+const extractServerList = (servers: readonly ServerObject[] | undefined): ServerInfo[] =>
+  (servers ?? []).flatMap((server) => {
+    if (!server.url) return [];
     const serverVariables =
-      typeof raw.variables === "object" && raw.variables !== null
-        ? (raw.variables as Record<
+      server.variables as
+        | Record<
             string,
-            { default?: unknown; enum?: unknown; description?: unknown }
-          >)
-        : undefined;
+            {
+              readonly default?: string;
+              readonly enum?: readonly string[];
+              readonly description?: string;
+            }
+          >
+        | undefined;
     const vars = serverVariables
       ? Object.fromEntries(
           Object.entries(serverVariables).flatMap(([name, v]) => {
@@ -267,9 +266,7 @@ const extractServerList = (servers: unknown): ServerInfo[] =>
                   default: String(v.default),
                   enum:
                     enumValues && enumValues.length > 0 ? Option.some(enumValues) : Option.none(),
-                  description: Option.fromNullishOr(
-                    typeof v.description === "string" ? v.description : undefined,
-                  ),
+                  description: Option.fromNullishOr(v.description),
                 }),
               ],
             ];
@@ -278,10 +275,8 @@ const extractServerList = (servers: unknown): ServerInfo[] =>
       : undefined;
     return [
       ServerInfo.make({
-        url: raw.url,
-        description: Option.fromNullishOr(
-          typeof raw.description === "string" ? raw.description : undefined,
-        ),
+        url: server.url,
+        description: Option.fromNullishOr(server.description),
         variables: vars && Object.keys(vars).length > 0 ? Option.some(vars) : Option.none(),
       }),
     ];
@@ -293,10 +288,10 @@ const extractOperationBaseUrl = (
   pathItem: PathItemObject,
   operation: OperationObject,
 ): string | undefined => {
-  const operationServers = extractServerList((operation as Record<string, unknown>).servers);
+  const operationServers = extractServerList(operation.servers);
   if (operationServers.length > 0) return resolveBaseUrl(operationServers);
 
-  const pathServers = extractServerList((pathItem as Record<string, unknown>).servers);
+  const pathServers = extractServerList(pathItem.servers);
   if (pathServers.length > 0) return resolveBaseUrl(pathServers);
 
   return undefined;

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -6,6 +6,7 @@ import {
   declaredContents,
   DocResolver,
   preferredResponseContent,
+  resolveBaseUrl,
   type OperationObject,
   type ParameterObject,
   type PathItemObject,
@@ -227,16 +228,34 @@ const explicitToolPath = (operation: OperationObject): string | undefined => {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 };
 
+const explicitPathTemplate = (operation: OperationObject): string | undefined => {
+  const value = (operation as Record<string, unknown>)["x-executor-pathTemplate"];
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+};
+
 // ---------------------------------------------------------------------------
 // Server extraction
 // ---------------------------------------------------------------------------
 
-const extractServers = (doc: ParsedDocument): ServerInfo[] =>
-  (doc.servers ?? []).flatMap((server) => {
-    if (!server.url) return [];
-    const vars = server.variables
+const extractServerList = (servers: unknown): ServerInfo[] =>
+  (Array.isArray(servers) ? servers : []).flatMap((server) => {
+    if (typeof server !== "object" || server === null) return [];
+    const raw = server as {
+      url?: unknown;
+      description?: unknown;
+      variables?: unknown;
+    };
+    if (typeof raw.url !== "string") return [];
+    const serverVariables =
+      typeof raw.variables === "object" && raw.variables !== null
+        ? (raw.variables as Record<
+            string,
+            { default?: unknown; enum?: unknown; description?: unknown }
+          >)
+        : undefined;
+    const vars = serverVariables
       ? Object.fromEntries(
-          Object.entries(server.variables).flatMap(([name, v]) => {
+          Object.entries(serverVariables).flatMap(([name, v]) => {
             if (v.default === undefined || v.default === null) return [];
             const enumValues = Array.isArray(v.enum)
               ? v.enum.filter((x): x is string => typeof x === "string")
@@ -248,7 +267,9 @@ const extractServers = (doc: ParsedDocument): ServerInfo[] =>
                   default: String(v.default),
                   enum:
                     enumValues && enumValues.length > 0 ? Option.some(enumValues) : Option.none(),
-                  description: Option.fromNullishOr(v.description),
+                  description: Option.fromNullishOr(
+                    typeof v.description === "string" ? v.description : undefined,
+                  ),
                 }),
               ],
             ];
@@ -257,12 +278,29 @@ const extractServers = (doc: ParsedDocument): ServerInfo[] =>
       : undefined;
     return [
       ServerInfo.make({
-        url: server.url,
-        description: Option.fromNullishOr(server.description),
+        url: raw.url,
+        description: Option.fromNullishOr(
+          typeof raw.description === "string" ? raw.description : undefined,
+        ),
         variables: vars && Object.keys(vars).length > 0 ? Option.some(vars) : Option.none(),
       }),
     ];
   });
+
+const extractServers = (doc: ParsedDocument): ServerInfo[] => extractServerList(doc.servers);
+
+const extractOperationBaseUrl = (
+  pathItem: PathItemObject,
+  operation: OperationObject,
+): string | undefined => {
+  const operationServers = extractServerList((operation as Record<string, unknown>).servers);
+  if (operationServers.length > 0) return resolveBaseUrl(operationServers);
+
+  const pathServers = extractServerList((pathItem as Record<string, unknown>).servers);
+  if (pathServers.length > 0) return resolveBaseUrl(pathServers);
+
+  return undefined;
+};
 
 // ---------------------------------------------------------------------------
 // Main extraction
@@ -294,13 +332,15 @@ export const extract = Effect.fn("OpenApi.extract")(function* (doc: ParsedDocume
       const inputSchema = buildInputSchema(parameters, requestBody);
       const outputSchema = extractOutputSchema(operation, r);
       const tags = (operation.tags ?? []).filter((t) => t.trim().length > 0);
+      const operationPathTemplate = explicitPathTemplate(operation) ?? pathTemplate;
 
       operations.push(
         ExtractedOperation.make({
           operationId: OperationId.make(deriveOperationId(method, pathTemplate, operation)),
           toolPath: Option.fromNullishOr(explicitToolPath(operation)),
           method,
-          pathTemplate,
+          baseUrl: extractOperationBaseUrl(pathItem, operation),
+          pathTemplate: operationPathTemplate,
           summary: Option.fromNullishOr(operation.summary),
           description: Option.fromNullishOr(operation.description),
           tags,

--- a/packages/plugins/openapi/src/sdk/google-discovery.test.ts
+++ b/packages/plugins/openapi/src/sdk/google-discovery.test.ts
@@ -2,7 +2,10 @@ import { expect, it } from "@effect/vitest";
 import { Effect, Option, Schema } from "effect";
 import { buildToolTypeScriptPreview } from "@executor-js/sdk/core";
 
-import { convertGoogleDiscoveryToOpenApi } from "./google-discovery";
+import {
+  convertGoogleDiscoveryBundleToOpenApi,
+  convertGoogleDiscoveryToOpenApi,
+} from "./google-discovery";
 import { extract } from "./extract";
 import { parse } from "./parse";
 
@@ -18,11 +21,14 @@ const ConvertedOperation = Schema.Struct({
       schema: Schema.Unknown,
       style: Schema.optional(Schema.String),
       explode: Schema.optional(Schema.Boolean),
+      allowReserved: Schema.optional(Schema.Boolean),
     }),
   ),
+  servers: Schema.optional(Schema.Array(Schema.Struct({ url: Schema.String }))),
   security: Schema.optional(
     Schema.Array(Schema.Record(Schema.String, Schema.Array(Schema.String))),
   ),
+  "x-executor-pathTemplate": Schema.optional(Schema.String),
   requestBody: Schema.optional(Schema.Unknown),
   responses: Schema.Unknown,
   "x-google-scopes": Schema.Array(Schema.String),
@@ -234,5 +240,203 @@ it.effect("converts Google Discovery documents into Executor-preserving OpenAPI 
       Message: "{ id?: string; labelIds?: string[]; }",
     });
     expect(result.oauth2?.identityScopes).toEqual(["openid", "email", "profile"]);
+  }),
+);
+
+it.effect("bundles Google Discovery documents into one Google OpenAPI source", () =>
+  Effect.gen(function* () {
+    const result = yield* convertGoogleDiscoveryBundleToOpenApi({
+      documents: [
+        {
+          discoveryUrl: "https://www.googleapis.com/discovery/v1/apis/gmail/v1/rest",
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
+          documentText: JSON.stringify({
+            name: "gmail",
+            version: "v1",
+            title: "Gmail API",
+            rootUrl: "https://gmail.googleapis.com/",
+            servicePath: "",
+            auth: {
+              oauth2: {
+                scopes: {
+                  "https://www.googleapis.com/auth/gmail.metadata": {
+                    description: "Read metadata",
+                  },
+                },
+              },
+            },
+            resources: {
+              users: {
+                resources: {
+                  messages: {
+                    methods: {
+                      list: {
+                        id: "gmail.users.messages.list",
+                        httpMethod: "GET",
+                        path: "gmail/v1/users/{userId}/messages",
+                        response: { $ref: "Message" },
+                        scopes: ["https://www.googleapis.com/auth/gmail.metadata"],
+                        parameters: {
+                          userId: {
+                            location: "path",
+                            required: true,
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            schemas: {
+              Message: {
+                type: "object",
+                properties: {
+                  id: { type: "string" },
+                },
+              },
+            },
+          }),
+        },
+        {
+          discoveryUrl: "https://chat.googleapis.com/$discovery/rest?version=v1",
+          // @effect-diagnostics-next-line preferSchemaOverJson:off
+          documentText: JSON.stringify({
+            name: "chat",
+            version: "v1",
+            title: "Google Chat API",
+            rootUrl: "https://chat.googleapis.com/",
+            servicePath: "",
+            auth: {
+              oauth2: {
+                scopes: {
+                  "https://www.googleapis.com/auth/chat.spaces.readonly": {
+                    description: "Read spaces",
+                  },
+                },
+              },
+            },
+            resources: {
+              spaces: {
+                methods: {
+                  get: {
+                    id: "chat.spaces.get",
+                    httpMethod: "GET",
+                    path: "v1/{+name}",
+                    response: { $ref: "Space" },
+                    scopes: ["https://www.googleapis.com/auth/chat.spaces.readonly"],
+                    parameters: {
+                      name: {
+                        location: "path",
+                        required: true,
+                        type: "string",
+                      },
+                    },
+                  },
+                },
+                resources: {
+                  messages: {
+                    methods: {
+                      get: {
+                        id: "chat.spaces.messages.get",
+                        httpMethod: "GET",
+                        path: "v1/{+name}",
+                        response: { $ref: "Message" },
+                        scopes: ["https://www.googleapis.com/auth/chat.spaces.readonly"],
+                        parameters: {
+                          name: {
+                            location: "path",
+                            required: true,
+                            type: "string",
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            schemas: {
+              Space: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                },
+              },
+              Message: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                },
+              },
+            },
+          }),
+        },
+      ],
+    });
+
+    const spec = decodeConvertedSpec(result.specText);
+    expect(result.title).toBe("Google");
+    expect(result.baseUrl).toBe("https://www.googleapis.com/");
+    expect(result.discoveryUrls).toEqual([
+      "https://www.googleapis.com/discovery/v1/apis/gmail/v1/rest",
+      "https://www.googleapis.com/discovery/v1/apis/chat/v1/rest",
+    ]);
+    expect(spec.servers).toEqual([{ url: "https://www.googleapis.com/" }]);
+    expect(spec.components.schemas).toHaveProperty("gmail_v1_Message");
+    expect(spec.components.schemas).toHaveProperty("chat_v1_Message");
+
+    const gmailList = spec.paths["/gmail/v1/users/{userId}/messages"]?.get;
+    expect(gmailList).toMatchObject({
+      operationId: "gmail.users.messages.list",
+      "x-executor-toolPath": "gmail.users.messages.list",
+      servers: [{ url: "https://gmail.googleapis.com/" }],
+    });
+    expect(gmailList?.responses).toMatchObject({
+      "200": {
+        content: {
+          "application/json": {
+            schema: { $ref: "#/components/schemas/gmail_v1_Message" },
+          },
+        },
+      },
+    });
+
+    const chatSpaceGet = spec.paths["/v1/{name}"]?.get;
+    const chatMessageGet = spec.paths["/chat.spaces.messages.get"]?.get;
+    expect(chatSpaceGet).toMatchObject({
+      operationId: "chat.spaces.get",
+      "x-executor-pathTemplate": "/v1/{+name}",
+      servers: [{ url: "https://chat.googleapis.com/" }],
+    });
+    expect(chatMessageGet).toMatchObject({
+      operationId: "chat.spaces.messages.get",
+      "x-executor-pathTemplate": "/v1/{+name}",
+      servers: [{ url: "https://chat.googleapis.com/" }],
+    });
+    expect(chatSpaceGet?.parameters).toContainEqual(
+      expect.objectContaining({
+        name: "name",
+        in: "path",
+        allowReserved: true,
+      }),
+    );
+
+    const parsed = yield* parse(result.specText);
+    const extracted = yield* extract(parsed);
+    const extractedGmail = extracted.operations.find(
+      (candidate) => candidate.operationId === "gmail.users.messages.list",
+    );
+    const extractedChatMessage = extracted.operations.find(
+      (candidate) => candidate.operationId === "chat.spaces.messages.get",
+    );
+    expect(extractedGmail?.baseUrl).toBe("https://gmail.googleapis.com/");
+    expect(extractedChatMessage?.pathTemplate).toBe("/v1/{+name}");
+    expect(extractedChatMessage?.baseUrl).toBe("https://chat.googleapis.com/");
+    expect(result.oauth2?.scopes).toEqual([
+      "https://www.googleapis.com/auth/gmail.metadata",
+      "https://www.googleapis.com/auth/chat.spaces.readonly",
+    ]);
   }),
 );

--- a/packages/plugins/openapi/src/sdk/google-discovery.ts
+++ b/packages/plugins/openapi/src/sdk/google-discovery.ts
@@ -15,6 +15,7 @@ import type { OAuth2SourceConfig } from "./types";
 import type { SpecFetchCredentials } from "./parse";
 
 const DISCOVERY_SERVICE_HOST = "https://www.googleapis.com/discovery/v1/apis";
+const GOOGLE_BUNDLE_BASE_URL = "https://www.googleapis.com/";
 const GOOGLE_OAUTH_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 const GOOGLE_OAUTH_ISSUER_URL = "https://accounts.google.com";
 const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -54,12 +55,16 @@ type OpenApiParameterObject = {
   readonly schema: OpenApiSchemaObject;
   readonly style?: "form";
   readonly explode?: boolean;
+  readonly allowReserved?: boolean;
 };
 
 type OpenApiOperationObject = {
   readonly operationId: string;
   readonly "x-executor-toolPath": string;
+  readonly "x-executor-pathTemplate"?: string;
+  readonly tags?: readonly string[];
   readonly description?: string;
+  readonly servers?: readonly { readonly url: string }[];
   readonly parameters: readonly OpenApiParameterObject[];
   readonly requestBody?: {
     readonly required: false;
@@ -108,12 +113,21 @@ type OpenApiDocument = {
     >;
   };
   readonly security?: readonly Record<string, readonly string[]>[];
-  readonly "x-executor-origin": {
-    readonly kind: "googleDiscovery";
-    readonly discoveryUrl: string;
-    readonly service: string;
-    readonly version: string;
-  };
+  readonly "x-executor-origin":
+    | {
+        readonly kind: "googleDiscovery";
+        readonly discoveryUrl: string;
+        readonly service: string;
+        readonly version: string;
+      }
+    | {
+        readonly kind: "googleDiscoveryBundle";
+        readonly services: readonly {
+          readonly discoveryUrl: string;
+          readonly service: string;
+          readonly version: string;
+        }[];
+      };
 };
 
 const TextOption = Schema.OptionFromOptional(Schema.Trim).pipe(
@@ -206,6 +220,7 @@ export interface GoogleDiscoveryOpenApiConversion {
   readonly title: string;
   readonly service: string;
   readonly version: string;
+  readonly discoveryUrls?: readonly string[];
   readonly oauth2?: OAuth2SourceConfig;
 }
 
@@ -282,6 +297,34 @@ export const fetchGoogleDiscoveryDocument = Effect.fn("OpenApi.fetchGoogleDiscov
 
 const schemaRef = (name: string) => `#/components/schemas/${name}`;
 
+const identitySchemaName = (name: string): string => name;
+
+const schemaComponentPart = (value: string): string =>
+  value
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "_")
+    .replace(/^_+|_+$/g, "") || "schema";
+
+const normalizeDiscoveryPathTemplate = (pathTemplate: string): string =>
+  pathTemplate.replaceAll(/\{\+([^{}]+)\}/g, "{$1}");
+
+const pathUsesReservedExpansion = (pathTemplate: string, parameterName: string): boolean =>
+  pathTemplate.includes(`{+${parameterName}}`);
+
+const uniquePathKey = (
+  paths: Record<string, Record<string, OpenApiOperationObject>>,
+  preferredPath: string,
+  method: string,
+  toolPath: string,
+): string => {
+  if (!paths[preferredPath]?.[method]) return preferredPath;
+  const disambiguated = `/${toolPath.replace(/[^A-Za-z0-9._~-]+/g, "/")}`;
+  if (!paths[disambiguated]?.[method]) return disambiguated;
+  let index = 2;
+  while (paths[`${disambiguated}/${index}`]?.[method]) index += 1;
+  return `${disambiguated}/${index}`;
+};
+
 const discoveryDescription = (value: unknown): string | undefined =>
   typeof value === "string"
     ? value
@@ -326,10 +369,13 @@ const schemaType = (value: unknown): OpenApiSchemaObject["type"] | undefined =>
     ? (value as OpenApiSchemaObject["type"])
     : undefined;
 
-const discoverySchemaToOpenApiSchema = (raw: unknown): OpenApiSchemaObject => {
+const discoverySchemaToOpenApiSchema = (
+  raw: unknown,
+  schemaNameForRef: (name: string) => string = identitySchemaName,
+): OpenApiSchemaObject => {
   if (!isRecord(raw)) return {};
   const schema = raw;
-  if (typeof schema.$ref === "string") return { $ref: schemaRef(schema.$ref) };
+  if (typeof schema.$ref === "string") return { $ref: schemaRef(schemaNameForRef(schema.$ref)) };
 
   const description = discoveryDescription(schema.description);
   const title = discoveryDescription(schema.title);
@@ -351,7 +397,11 @@ const discoverySchemaToOpenApiSchema = (raw: unknown): OpenApiSchemaObject => {
   } satisfies OpenApiSchemaObject;
 
   if (type === "array") {
-    return { ...base, type: "array", items: discoverySchemaToOpenApiSchema(schema.items) };
+    return {
+      ...base,
+      type: "array",
+      items: discoverySchemaToOpenApiSchema(schema.items, schemaNameForRef),
+    };
   }
 
   const properties = schema.properties;
@@ -364,7 +414,7 @@ const discoverySchemaToOpenApiSchema = (raw: unknown): OpenApiSchemaObject => {
       ? Object.fromEntries(
           Object.entries(properties).map(([name, value]) => [
             name,
-            discoverySchemaToOpenApiSchema(value),
+            discoverySchemaToOpenApiSchema(value, schemaNameForRef),
           ]),
         )
       : undefined;
@@ -374,7 +424,7 @@ const discoverySchemaToOpenApiSchema = (raw: unknown): OpenApiSchemaObject => {
         ? undefined
         : typeof schema.additionalProperties === "boolean"
           ? schema.additionalProperties
-          : discoverySchemaToOpenApiSchema(schema.additionalProperties);
+          : discoverySchemaToOpenApiSchema(schema.additionalProperties, schemaNameForRef);
     return {
       ...base,
       type: "object",
@@ -389,8 +439,11 @@ const discoverySchemaToOpenApiSchema = (raw: unknown): OpenApiSchemaObject => {
   return type !== undefined ? { ...base, type } : base;
 };
 
-const parameterSchema = (parameter: DiscoveryParameter): OpenApiSchemaObject => {
-  const base = discoverySchemaToOpenApiSchema(parameter);
+const parameterSchema = (
+  parameter: DiscoveryParameter,
+  schemaNameForRef: (name: string) => string = identitySchemaName,
+): OpenApiSchemaObject => {
+  const base = discoverySchemaToOpenApiSchema(parameter, schemaNameForRef);
   return parameter.repeated
     ? {
         type: "array",
@@ -417,6 +470,144 @@ const discoveryScopes = (document: DiscoveryDocument): Record<string, string> =>
     ]),
   );
 
+const allDiscoveryMethods = (document: DiscoveryDocument): DiscoveryMethod[] => [
+  ...Object.values(document.methods ?? {}).map((raw) => decodeDiscoveryMethod(raw)),
+  ...Object.values(document.resources ?? {}).flatMap(collectMethods),
+];
+
+type DiscoveryDocumentInfo = {
+  readonly discoveryUrl: string;
+  readonly document: DiscoveryDocument;
+  readonly service: string;
+  readonly version: string;
+  readonly rootUrl: string;
+  readonly baseUrl: string;
+  readonly title: string;
+};
+
+const discoveryDocumentInfo = (
+  document: DiscoveryDocument,
+  discoveryUrl: string,
+): Effect.Effect<DiscoveryDocumentInfo, OpenApiParseError> =>
+  Effect.gen(function* () {
+    const service = Option.getOrUndefined(document.name);
+    const version = Option.getOrUndefined(document.version);
+    const rootUrl = Option.getOrUndefined(document.rootUrl);
+    if (!service || !version || !rootUrl) {
+      return yield* new OpenApiParseError({
+        message: "Google Discovery document is missing one of: name, version, rootUrl",
+      });
+    }
+
+    return {
+      discoveryUrl,
+      document,
+      service,
+      version,
+      rootUrl,
+      baseUrl: new URL(document.servicePath || "", rootUrl).toString(),
+      title: Option.getOrElse(document.title, () => `${service} ${version}`),
+    };
+  });
+
+const buildDiscoveryOperation = (input: {
+  readonly document: DiscoveryDocument;
+  readonly method: DiscoveryMethod;
+  readonly toolPath: string;
+  readonly pathTemplate: string;
+  readonly schemaNameForRef?: (name: string) => string;
+  readonly serverUrl?: string;
+  readonly tags?: readonly string[];
+}): OpenApiOperationObject => {
+  const mergedParameters = new Map<string, DiscoveryParameter>();
+  for (const [name, raw] of Object.entries(input.document.parameters ?? {})) {
+    const parameter = decodeDiscoveryParameter(raw);
+    if (parameter.location) mergedParameters.set(name, parameter);
+  }
+  for (const [name, raw] of Object.entries(input.method.parameters ?? {})) {
+    const parameter = decodeDiscoveryParameter(raw);
+    if (parameter.location) mergedParameters.set(name, parameter);
+  }
+
+  const methodScopes = input.method.scopes ?? [];
+  const methodDescription = Option.getOrUndefined(input.method.description);
+  const schemaNameForRef = input.schemaNameForRef ?? identitySchemaName;
+
+  return {
+    operationId: input.toolPath,
+    "x-executor-toolPath": input.toolPath,
+    "x-executor-pathTemplate": input.pathTemplate,
+    ...(input.tags && input.tags.length > 0 ? { tags: input.tags } : {}),
+    ...(methodDescription !== undefined ? { description: methodDescription } : {}),
+    ...(input.serverUrl ? { servers: [{ url: input.serverUrl }] } : {}),
+    parameters: [...mergedParameters.entries()].flatMap(([name, parameter]) => {
+      const location = parameter.location;
+      if (!location) return [];
+      const description = Option.getOrUndefined(parameter.description);
+      const allowReserved =
+        location === "path" && pathUsesReservedExpansion(input.pathTemplate, name);
+      return [
+        {
+          name,
+          in: location,
+          required: location === "path" ? true : parameter.required === true,
+          ...(description !== undefined ? { description } : {}),
+          schema: parameterSchema(parameter, schemaNameForRef),
+          ...(location === "query"
+            ? { style: "form" as const, explode: parameter.repeated === true }
+            : {}),
+          ...(allowReserved ? { allowReserved: true } : {}),
+        },
+      ];
+    }),
+    ...(input.method.request?.$ref
+      ? {
+          requestBody: {
+            required: false,
+            content: {
+              "application/json": {
+                schema: { $ref: schemaRef(schemaNameForRef(input.method.request.$ref)) },
+              },
+            },
+          },
+        }
+      : {}),
+    responses: {
+      "200": {
+        description: "Successful response",
+        content: {
+          "application/json": {
+            schema: input.method.response?.$ref
+              ? { $ref: schemaRef(schemaNameForRef(input.method.response.$ref)) }
+              : {},
+          },
+        },
+      },
+    },
+    ...(methodScopes.length > 0 ? { security: [{ googleOAuth2: methodScopes }] } : {}),
+    "x-google-scopes": methodScopes,
+  };
+};
+
+const googleOauth2Config = (scopes: Record<string, string>): OAuth2SourceConfig | undefined => {
+  const securitySchemeName = "googleOAuth2";
+  return Object.keys(scopes).length > 0
+    ? {
+        kind: "oauth2",
+        securitySchemeName,
+        flow: "authorizationCode",
+        authorizationUrl: GOOGLE_OAUTH_AUTHORIZATION_URL,
+        issuerUrl: GOOGLE_OAUTH_ISSUER_URL,
+        tokenUrl: GOOGLE_OAUTH_TOKEN_URL,
+        clientIdSlot: oauth2ClientIdSlot(securitySchemeName),
+        clientSecretSlot: oauth2ClientSecretSlot(securitySchemeName),
+        connectionSlot: oauth2ConnectionSlot(securitySchemeName),
+        scopes: Object.keys(scopes),
+        identityScopes: ["openid", "email", "profile"],
+      }
+    : undefined;
+};
+
 export const convertGoogleDiscoveryToOpenApi = Effect.fn("OpenApi.convertGoogleDiscovery")(
   function* (input: { readonly discoveryUrl: string; readonly documentText: string }) {
     const parsed = yield* parseJson(input.documentText).pipe(
@@ -435,109 +626,33 @@ export const convertGoogleDiscoveryToOpenApi = Effect.fn("OpenApi.convertGoogleD
         }),
     });
 
-    const service = Option.getOrUndefined(document.name);
-    const version = Option.getOrUndefined(document.version);
-    const rootUrl = Option.getOrUndefined(document.rootUrl);
-    if (!service || !version || !rootUrl) {
-      return yield* new OpenApiParseError({
-        message: "Google Discovery document is missing one of: name, version, rootUrl",
-      });
-    }
-
-    const baseUrl = new URL(document.servicePath || "", rootUrl).toString();
-    const title = Option.getOrElse(document.title, () => `${service} ${version}`);
+    const info = yield* discoveryDocumentInfo(document, input.discoveryUrl);
+    const { service, version, baseUrl, title } = info;
     const paths: Record<string, Record<string, OpenApiOperationObject>> = {};
-    const allMethods = [
-      ...Object.values(document.methods ?? {}).map((raw) => decodeDiscoveryMethod(raw)),
-      ...Object.values(document.resources ?? {}).flatMap(collectMethods),
-    ];
 
-    for (const method of allMethods) {
+    for (const method of allDiscoveryMethods(document)) {
       const methodId = Option.getOrUndefined(method.id);
       const pathTemplate = Option.getOrUndefined(method.path);
       if (!methodId || !pathTemplate || !method.httpMethod) continue;
 
       const toolPath = methodToolPath(service, methodId);
-      const path = pathTemplate.startsWith("/") ? pathTemplate : `/${pathTemplate}`;
-      const mergedParameters = new Map<string, DiscoveryParameter>();
-      for (const [name, raw] of Object.entries(document.parameters ?? {})) {
-        const parameter = decodeDiscoveryParameter(raw);
-        if (parameter.location) mergedParameters.set(name, parameter);
-      }
-      for (const [name, raw] of Object.entries(method.parameters ?? {})) {
-        const parameter = decodeDiscoveryParameter(raw);
-        if (parameter.location) mergedParameters.set(name, parameter);
-      }
-      const methodScopes = method.scopes ?? [];
-      const methodDescription = Option.getOrUndefined(method.description);
+      const path = normalizeDiscoveryPathTemplate(
+        pathTemplate.startsWith("/") ? pathTemplate : `/${pathTemplate}`,
+      );
+      const methodKey = method.httpMethod.toLowerCase();
+      const pathKey = uniquePathKey(paths, path, methodKey, toolPath);
 
-      paths[path] ??= {};
-      paths[path]![method.httpMethod.toLowerCase()] = {
-        operationId: toolPath,
-        "x-executor-toolPath": toolPath,
-        ...(methodDescription !== undefined ? { description: methodDescription } : {}),
-        parameters: [...mergedParameters.entries()].flatMap(([name, parameter]) => {
-          const location = parameter.location;
-          if (!location) return [];
-          const description = Option.getOrUndefined(parameter.description);
-          return [
-            {
-              name,
-              in: location,
-              required: location === "path" ? true : parameter.required === true,
-              ...(description !== undefined ? { description } : {}),
-              schema: parameterSchema(parameter),
-              ...(location === "query"
-                ? { style: "form" as const, explode: parameter.repeated === true }
-                : {}),
-            },
-          ];
-        }),
-        ...(method.request?.$ref
-          ? {
-              requestBody: {
-                required: false,
-                content: {
-                  "application/json": {
-                    schema: { $ref: schemaRef(method.request.$ref) },
-                  },
-                },
-              },
-            }
-          : {}),
-        responses: {
-          "200": {
-            description: "Successful response",
-            content: {
-              "application/json": {
-                schema: method.response?.$ref ? { $ref: schemaRef(method.response.$ref) } : {},
-              },
-            },
-          },
-        },
-        ...(methodScopes.length > 0 ? { security: [{ googleOAuth2: methodScopes }] } : {}),
-        "x-google-scopes": methodScopes,
-      };
+      paths[pathKey] ??= {};
+      paths[pathKey]![methodKey] = buildDiscoveryOperation({
+        document,
+        method,
+        toolPath,
+        pathTemplate: pathTemplate.startsWith("/") ? pathTemplate : `/${pathTemplate}`,
+      });
     }
 
     const scopes = discoveryScopes(document);
-    const securitySchemeName = "googleOAuth2";
-    const oauth2: OAuth2SourceConfig | undefined =
-      Object.keys(scopes).length > 0
-        ? {
-            kind: "oauth2",
-            securitySchemeName,
-            flow: "authorizationCode",
-            authorizationUrl: GOOGLE_OAUTH_AUTHORIZATION_URL,
-            issuerUrl: GOOGLE_OAUTH_ISSUER_URL,
-            tokenUrl: GOOGLE_OAUTH_TOKEN_URL,
-            clientIdSlot: oauth2ClientIdSlot(securitySchemeName),
-            clientSecretSlot: oauth2ClientSecretSlot(securitySchemeName),
-            connectionSlot: oauth2ConnectionSlot(securitySchemeName),
-            scopes: Object.keys(scopes),
-            identityScopes: ["openid", "email", "profile"],
-          }
-        : undefined;
+    const oauth2 = googleOauth2Config(scopes);
 
     const spec: OpenApiDocument = {
       openapi: "3.1.0",
@@ -591,3 +706,126 @@ export const convertGoogleDiscoveryToOpenApi = Effect.fn("OpenApi.convertGoogleD
     };
   },
 );
+
+export const convertGoogleDiscoveryBundleToOpenApi = Effect.fn(
+  "OpenApi.convertGoogleDiscoveryBundle",
+)(function* (input: {
+  readonly documents: readonly { readonly discoveryUrl: string; readonly documentText: string }[];
+}) {
+  if (input.documents.length === 0) {
+    return yield* new OpenApiParseError({
+      message: "Google Discovery bundle requires at least one document",
+    });
+  }
+
+  const infos = yield* Effect.forEach(input.documents, ({ discoveryUrl, documentText }) =>
+    Effect.gen(function* () {
+      const parsed = yield* parseJson(documentText).pipe(
+        Effect.mapError(
+          () =>
+            new OpenApiParseError({
+              message: "Failed to parse Google Discovery document",
+            }),
+        ),
+      );
+      const document = yield* Effect.try({
+        try: () => decodeDiscoveryDocument(parsed),
+        catch: () =>
+          new OpenApiParseError({
+            message: "Failed to decode Google Discovery document",
+          }),
+      });
+      return yield* discoveryDocumentInfo(document, discoveryUrl);
+    }),
+  );
+
+  const paths: Record<string, Record<string, OpenApiOperationObject>> = {};
+  const schemas: Record<string, OpenApiSchemaObject> = {};
+  const scopes: Record<string, string> = {};
+
+  for (const info of infos) {
+    const schemaPrefix = schemaComponentPart(`${info.service}_${info.version}`);
+    const schemaNameForRef = (name: string) => `${schemaPrefix}_${schemaComponentPart(name)}`;
+
+    for (const [scope, description] of Object.entries(discoveryScopes(info.document))) {
+      scopes[scope] ??= description;
+    }
+
+    for (const [name, schema] of Object.entries(info.document.schemas ?? {})) {
+      schemas[schemaNameForRef(name)] = discoverySchemaToOpenApiSchema(schema, schemaNameForRef);
+    }
+
+    for (const method of allDiscoveryMethods(info.document)) {
+      const methodId = Option.getOrUndefined(method.id);
+      const rawPathTemplate = Option.getOrUndefined(method.path);
+      if (!methodId || !rawPathTemplate || !method.httpMethod) continue;
+
+      const toolPath = methodId;
+      const wirePath = rawPathTemplate.startsWith("/") ? rawPathTemplate : `/${rawPathTemplate}`;
+      const openApiPath = normalizeDiscoveryPathTemplate(wirePath);
+      const methodKey = method.httpMethod.toLowerCase();
+      const pathKey = uniquePathKey(paths, openApiPath, methodKey, toolPath);
+
+      paths[pathKey] ??= {};
+      paths[pathKey]![methodKey] = buildDiscoveryOperation({
+        document: info.document,
+        method,
+        toolPath,
+        pathTemplate: wirePath,
+        schemaNameForRef,
+        serverUrl: info.baseUrl,
+        tags: [info.title],
+      });
+    }
+  }
+
+  const oauth2 = googleOauth2Config(scopes);
+  const spec: OpenApiDocument = {
+    openapi: "3.1.0",
+    info: {
+      title: "Google",
+      version: "google-discovery-bundle",
+    },
+    servers: [{ url: GOOGLE_BUNDLE_BASE_URL }],
+    paths,
+    components: {
+      schemas,
+      ...(oauth2
+        ? {
+            securitySchemes: {
+              googleOAuth2: {
+                type: "oauth2",
+                flows: {
+                  authorizationCode: {
+                    authorizationUrl: GOOGLE_OAUTH_AUTHORIZATION_URL,
+                    tokenUrl: GOOGLE_OAUTH_TOKEN_URL,
+                    scopes,
+                  },
+                },
+              },
+            },
+          }
+        : {}),
+    },
+    ...(oauth2 ? { security: [{ googleOAuth2: oauth2.scopes }] } : {}),
+    "x-executor-origin": {
+      kind: "googleDiscoveryBundle",
+      services: infos.map((info) => ({
+        discoveryUrl: normalizeDiscoveryUrl(info.discoveryUrl),
+        service: info.service,
+        version: info.version,
+      })),
+    },
+  };
+
+  return {
+    // @effect-diagnostics-next-line preferSchemaOverJson:off
+    specText: JSON.stringify(spec),
+    baseUrl: GOOGLE_BUNDLE_BASE_URL,
+    title: "Google",
+    service: "google",
+    version: "google-discovery-bundle",
+    discoveryUrls: infos.map((info) => normalizeDiscoveryUrl(info.discoveryUrl)),
+    oauth2,
+  };
+});

--- a/packages/plugins/openapi/src/sdk/google-oauth-batches.test.ts
+++ b/packages/plugins/openapi/src/sdk/google-oauth-batches.test.ts
@@ -1,0 +1,98 @@
+import { expect, it } from "@effect/vitest";
+
+import { googleOAuthConsentBatches } from "./google-oauth-batches";
+
+it("keeps core Google OAuth in one consent batch", () => {
+  expect(
+    googleOAuthConsentBatches([
+      {
+        id: "google-gmail",
+        name: "Gmail",
+        oauthAudience: "standard-user",
+        scopes: ["https://mail.google.com/", "https://www.googleapis.com/auth/gmail.send"],
+      },
+      {
+        id: "google-calendar",
+        name: "Google Calendar",
+        oauthAudience: "standard-user",
+        scopes: [
+          "https://www.googleapis.com/auth/calendar",
+          "https://www.googleapis.com/auth/calendar.readonly",
+        ],
+      },
+    ]),
+  ).toEqual([
+    {
+      id: "google-core",
+      label: "Core Google services",
+      apiScopes: ["https://mail.google.com/", "https://www.googleapis.com/auth/calendar"],
+    },
+  ]);
+});
+
+it("splits advanced Google OAuth into smaller known-good consent batches", () => {
+  expect(
+    googleOAuthConsentBatches([
+      {
+        id: "google-youtube-data",
+        name: "YouTube Data",
+        oauthAudience: "advanced-user",
+        scopes: ["https://www.googleapis.com/auth/youtube"],
+      },
+      {
+        id: "google-classroom",
+        name: "Google Classroom",
+        oauthAudience: "advanced-user",
+        scopes: ["https://www.googleapis.com/auth/classroom.courses"],
+      },
+      {
+        id: "google-apps-script",
+        name: "Google Apps Script",
+        oauthAudience: "advanced-user",
+        scopes: [
+          "https://www.googleapis.com/auth/script.projects",
+          "https://www.googleapis.com/auth/drive",
+        ],
+      },
+      {
+        id: "google-bigquery",
+        name: "Google BigQuery",
+        oauthAudience: "advanced-user",
+        scopes: ["https://www.googleapis.com/auth/bigquery"],
+      },
+      {
+        id: "google-cloud-resource-manager",
+        name: "Google Cloud Resource Manager",
+        oauthAudience: "advanced-user",
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      },
+    ]).map((batch) => ({ id: batch.id, label: batch.label, apiScopes: batch.apiScopes })),
+  ).toEqual([
+    {
+      id: "google-youtube-data",
+      label: "YouTube Data",
+      apiScopes: ["https://www.googleapis.com/auth/youtube"],
+    },
+    {
+      id: "google-classroom",
+      label: "Google Classroom",
+      apiScopes: ["https://www.googleapis.com/auth/classroom.courses"],
+    },
+    {
+      id: "google-apps-script",
+      label: "Google Apps Script",
+      apiScopes: [
+        "https://www.googleapis.com/auth/script.projects",
+        "https://www.googleapis.com/auth/drive",
+      ],
+    },
+    {
+      id: "google-cloud",
+      label: "Google Cloud services",
+      apiScopes: [
+        "https://www.googleapis.com/auth/bigquery",
+        "https://www.googleapis.com/auth/cloud-platform",
+      ],
+    },
+  ]);
+});

--- a/packages/plugins/openapi/src/sdk/google-oauth-batches.ts
+++ b/packages/plugins/openapi/src/sdk/google-oauth-batches.ts
@@ -1,0 +1,69 @@
+import type { GoogleOpenApiOAuthAudience } from "./google-presets";
+import { compactGoogleOAuthScopes } from "./google-oauth-scopes";
+
+export type GoogleOAuthBatchInput = {
+  readonly id: string;
+  readonly name: string;
+  readonly oauthAudience: GoogleOpenApiOAuthAudience;
+  readonly scopes: readonly string[];
+};
+
+export type GoogleOAuthConsentBatch = {
+  readonly id: string;
+  readonly label: string;
+  readonly apiScopes: readonly string[];
+};
+
+const GOOGLE_CLOUD_BATCH_IDS = new Set(["google-bigquery", "google-cloud-resource-manager"]);
+
+export const googleOAuthConsentBatches = (
+  items: readonly GoogleOAuthBatchInput[],
+): readonly GoogleOAuthConsentBatch[] => {
+  const standardScopes: string[] = [];
+  const cloudScopes: string[] = [];
+  const batches: GoogleOAuthConsentBatch[] = [];
+
+  for (const item of items) {
+    if (item.scopes.length === 0) continue;
+    if (item.oauthAudience === "standard-user") {
+      standardScopes.push(...item.scopes);
+      continue;
+    }
+    if (GOOGLE_CLOUD_BATCH_IDS.has(item.id)) {
+      cloudScopes.push(...item.scopes);
+      continue;
+    }
+    batches.push({
+      id: item.id,
+      label: item.name,
+      apiScopes: item.scopes,
+    });
+  }
+
+  const compactedStandardScopes = compactGoogleOAuthScopes(standardScopes);
+  const compactedCloudScopes = compactGoogleOAuthScopes(cloudScopes);
+  return [
+    ...(compactedStandardScopes.length > 0
+      ? [
+          {
+            id: "google-core",
+            label: "Core Google services",
+            apiScopes: compactedStandardScopes,
+          },
+        ]
+      : []),
+    ...batches.map((batch) => ({
+      ...batch,
+      apiScopes: compactGoogleOAuthScopes(batch.apiScopes),
+    })),
+    ...(compactedCloudScopes.length > 0
+      ? [
+          {
+            id: "google-cloud",
+            label: "Google Cloud services",
+            apiScopes: compactedCloudScopes,
+          },
+        ]
+      : []),
+  ].filter((batch) => batch.apiScopes.length > 0);
+};

--- a/packages/plugins/openapi/src/sdk/google-oauth-scopes.test.ts
+++ b/packages/plugins/openapi/src/sdk/google-oauth-scopes.test.ts
@@ -1,0 +1,37 @@
+import { expect, it } from "@effect/vitest";
+
+import {
+  compactGoogleOAuthScopes,
+  filterGoogleUserConsentOAuthScopes,
+} from "./google-oauth-scopes";
+
+it("filters Google scopes that cannot be shown on a user OAuth consent screen", () => {
+  expect(
+    filterGoogleUserConsentOAuthScopes([
+      "https://www.googleapis.com/auth/calendar",
+      "https://www.googleapis.com/auth/chat.app.messages.readonly",
+      "https://www.googleapis.com/auth/chat.bot",
+      "https://www.googleapis.com/auth/chat.import",
+      "https://www.googleapis.com/auth/chat.messages.readonly",
+      "https://www.googleapis.com/auth/keep",
+      "https://www.googleapis.com/auth/keep.readonly",
+    ]),
+  ).toEqual([
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/chat.messages.readonly",
+  ]);
+});
+
+it("compacts Google OAuth scopes after filtering user-consent-incompatible scopes", () => {
+  expect(
+    compactGoogleOAuthScopes([
+      "https://mail.google.com/",
+      "https://www.googleapis.com/auth/gmail.send",
+      "https://www.googleapis.com/auth/userinfo.email",
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "openid",
+      "https://www.googleapis.com/auth/chat.app.spaces",
+      "https://www.googleapis.com/auth/keep.readonly",
+    ]),
+  ).toEqual(["https://mail.google.com/", "email", "profile", "openid"]);
+});

--- a/packages/plugins/openapi/src/sdk/google-oauth-scopes.ts
+++ b/packages/plugins/openapi/src/sdk/google-oauth-scopes.ts
@@ -1,0 +1,66 @@
+const googleUserConsentBlockedScopes = new Set([
+  "https://www.googleapis.com/auth/chat.bot",
+  "https://www.googleapis.com/auth/chat.import",
+  "https://www.googleapis.com/auth/keep",
+  "https://www.googleapis.com/auth/keep.readonly",
+]);
+
+const googleUserConsentBlockedScopePrefixes = ["https://www.googleapis.com/auth/chat.app."];
+
+const googleBroadScopeGroups: readonly {
+  readonly broad: string;
+  readonly prefixes: readonly string[];
+}[] = [
+  {
+    broad: "https://mail.google.com/",
+    prefixes: ["https://www.googleapis.com/auth/gmail."],
+  },
+  {
+    broad: "https://www.googleapis.com/auth/calendar",
+    prefixes: ["https://www.googleapis.com/auth/calendar."],
+  },
+  {
+    broad: "https://www.googleapis.com/auth/drive",
+    prefixes: ["https://www.googleapis.com/auth/drive."],
+  },
+];
+
+const normalizeGoogleIdentityScope = (scope: string): string =>
+  scope === "https://www.googleapis.com/auth/userinfo.email"
+    ? "email"
+    : scope === "https://www.googleapis.com/auth/userinfo.profile"
+      ? "profile"
+      : scope;
+
+const orderedUniqueScopes = (scopes: Iterable<string>): string[] => {
+  const ordered: string[] = [];
+  const seen = new Set<string>();
+  for (const scope of scopes) {
+    const trimmed = scope.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    ordered.push(trimmed);
+  }
+  return ordered;
+};
+
+export const isGoogleUserConsentOAuthScope = (scope: string): boolean =>
+  !googleUserConsentBlockedScopes.has(scope) &&
+  !googleUserConsentBlockedScopePrefixes.some((prefix) => scope.startsWith(prefix));
+
+export const filterGoogleUserConsentOAuthScopes = (scopes: Iterable<string>): string[] =>
+  orderedUniqueScopes(scopes).filter(isGoogleUserConsentOAuthScope);
+
+export const compactGoogleOAuthScopes = (scopes: Iterable<string>): string[] => {
+  const ordered = filterGoogleUserConsentOAuthScopes([...scopes].map(normalizeGoogleIdentityScope));
+  const present = new Set(ordered);
+  return ordered.filter(
+    (scope) =>
+      !googleBroadScopeGroups.some(
+        (group) =>
+          scope !== group.broad &&
+          present.has(group.broad) &&
+          group.prefixes.some((prefix) => scope.startsWith(prefix)),
+      ),
+  );
+};

--- a/packages/plugins/openapi/src/sdk/google-presets.test.ts
+++ b/packages/plugins/openapi/src/sdk/google-presets.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from "@effect/vitest";
+
+import { googleOpenApiPresets, googleStandardUserOAuthPresets } from "./google-presets";
+
+it("keeps Select all limited to Google services that can use normal user OAuth", () => {
+  const standardIds = new Set(googleStandardUserOAuthPresets.map((preset) => preset.id));
+
+  expect(standardIds).toContain("google-calendar");
+  expect(standardIds).toContain("google-gmail");
+  expect(standardIds).toContain("google-tasks");
+  expect(standardIds).toContain("google-people");
+  expect(standardIds).toContain("google-search-console");
+
+  expect(standardIds).not.toContain("google-youtube-data");
+  expect(standardIds).not.toContain("google-cloud-resource-manager");
+  expect(standardIds).not.toContain("google-chat");
+  expect(standardIds).not.toContain("google-keep");
+  expect(standardIds).not.toContain("google-admin-directory");
+  expect(standardIds).not.toContain("google-admin-reports");
+});
+
+it("classifies every Google service for bundle OAuth UX", () => {
+  expect(
+    googleOpenApiPresets.map((preset) => ({
+      id: preset.id,
+      oauthAudience: preset.oauthAudience,
+    })),
+  ).toMatchSnapshot();
+});

--- a/packages/plugins/openapi/src/sdk/google-presets.ts
+++ b/packages/plugins/openapi/src/sdk/google-presets.ts
@@ -1,11 +1,30 @@
 import type { OpenApiPreset } from "./presets";
 
+export type GoogleOpenApiOAuthAudience =
+  | "standard-user"
+  | "advanced-user"
+  | "workspace-admin"
+  | "unsupported-user";
+
+export type GoogleOpenApiPreset = OpenApiPreset & {
+  readonly oauthAudience: GoogleOpenApiOAuthAudience;
+};
+
 const gd = (service: string, version: string) =>
   `https://www.googleapis.com/discovery/v1/apis/${service}/${version}/rest`;
 
 const GOOGLE_G = "https://fonts.gstatic.com/s/i/productlogos/googleg/v6/192px.svg";
+export const GOOGLE_BUNDLE_PRESET_ID = "google";
 
-export const googleOpenApiPresets: readonly OpenApiPreset[] = [
+export const googleOpenApiBundlePreset: OpenApiPreset = {
+  id: GOOGLE_BUNDLE_PRESET_ID,
+  name: "Google",
+  summary: "Bundle Gmail, Calendar, Drive, Docs, and other Google APIs into one source.",
+  icon: GOOGLE_G,
+  featured: true,
+};
+
+export const googleOpenApiPresets: readonly GoogleOpenApiPreset[] = [
   {
     id: "google-calendar",
     name: "Google Calendar",
@@ -13,6 +32,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     url: gd("calendar", "v3"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/calendar_2020q4/v8/192px.svg",
     featured: true,
+    oauthAudience: "standard-user",
   },
   {
     id: "google-gmail",
@@ -21,6 +41,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     url: gd("gmail", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/gmail_2020q4/v8/web-96dp/logo_gmail_2020q4_color_2x_web_96dp.png",
     featured: true,
+    oauthAudience: "standard-user",
   },
   {
     id: "google-sheets",
@@ -29,6 +50,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     url: gd("sheets", "v4"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/sheets_2020q4/v8/192px.svg",
     featured: true,
+    oauthAudience: "standard-user",
   },
   {
     id: "google-drive",
@@ -37,6 +59,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     url: gd("drive", "v3"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/drive_2020q4/v8/192px.svg",
     featured: true,
+    oauthAudience: "standard-user",
   },
   {
     id: "google-docs",
@@ -45,6 +68,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     url: gd("docs", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/docs_2020q4/v12/192px.svg",
     featured: true,
+    oauthAudience: "standard-user",
   },
   {
     id: "google-slides",
@@ -52,6 +76,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Presentations, slides, page elements, and deck updates.",
     url: gd("slides", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/slides_2020q4/v12/192px.svg",
+    oauthAudience: "standard-user",
   },
   {
     id: "google-forms",
@@ -59,6 +84,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Forms, questions, responses, and quizzes.",
     url: "https://forms.googleapis.com/$discovery/rest?version=v1",
     icon: "https://fonts.gstatic.com/s/i/productlogos/forms_2020q4/v6/192px.svg",
+    oauthAudience: "standard-user",
   },
   {
     id: "google-tasks",
@@ -66,6 +92,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Task lists, task items, notes, and due dates.",
     url: gd("tasks", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/tasks/v5/192px.svg",
+    oauthAudience: "standard-user",
   },
   {
     id: "google-people",
@@ -73,6 +100,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Contacts, profiles, directory people, and contact groups.",
     url: gd("people", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/contacts_2022/v2/192px.svg",
+    oauthAudience: "standard-user",
   },
   {
     id: "google-chat",
@@ -80,6 +108,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Spaces, messages, members, reactions, and chat workflows.",
     url: gd("chat", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/chat_2020q4/v8/192px.svg",
+    oauthAudience: "workspace-admin",
   },
   {
     id: "google-keep",
@@ -87,6 +116,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Notes, lists, attachments, and annotations.",
     url: "https://keep.googleapis.com/$discovery/rest?version=v1",
     icon: "https://fonts.gstatic.com/s/i/productlogos/keep_2020q4/v8/192px.svg",
+    oauthAudience: "unsupported-user",
   },
   {
     id: "google-youtube-data",
@@ -94,6 +124,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Channels, playlists, videos, comments, and uploads.",
     url: gd("youtube", "v3"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/youtube/v9/192px.svg",
+    oauthAudience: "advanced-user",
   },
   {
     id: "google-search-console",
@@ -101,6 +132,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Sites, sitemaps, URL inspection, and search performance.",
     url: gd("searchconsole", "v1"),
     icon: GOOGLE_G,
+    oauthAudience: "standard-user",
   },
   {
     id: "google-classroom",
@@ -108,6 +140,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Courses, rosters, coursework, and grading.",
     url: gd("classroom", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/classroom/v7/192px.svg",
+    oauthAudience: "advanced-user",
   },
   {
     id: "google-admin-directory",
@@ -115,6 +148,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Users, groups, org units, roles, and domain resources.",
     url: "https://admin.googleapis.com/$discovery/rest?version=directory_v1",
     icon: "https://fonts.gstatic.com/s/i/productlogos/admin_2020q4/v6/192px.svg",
+    oauthAudience: "workspace-admin",
   },
   {
     id: "google-admin-reports",
@@ -122,6 +156,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Audit events, usage reports, and admin activity logs.",
     url: "https://admin.googleapis.com/$discovery/rest?version=reports_v1",
     icon: "https://fonts.gstatic.com/s/i/productlogos/admin_2020q4/v6/192px.svg",
+    oauthAudience: "workspace-admin",
   },
   {
     id: "google-apps-script",
@@ -129,6 +164,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Projects, deployments, and script execution.",
     url: gd("script", "v1"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/apps_script/v10/192px.svg",
+    oauthAudience: "advanced-user",
   },
   {
     id: "google-bigquery",
@@ -136,6 +172,7 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Datasets, tables, jobs, and analytical queries.",
     url: gd("bigquery", "v2"),
     icon: "https://fonts.gstatic.com/s/i/productlogos/google_cloud/v6/192px.svg",
+    oauthAudience: "advanced-user",
   },
   {
     id: "google-cloud-resource-manager",
@@ -143,5 +180,10 @@ export const googleOpenApiPresets: readonly OpenApiPreset[] = [
     summary: "Projects, folders, organizations, and IAM hierarchy.",
     url: "https://cloudresourcemanager.googleapis.com/$discovery/rest?version=v3",
     icon: "https://fonts.gstatic.com/s/i/productlogos/google_cloud/v6/192px.svg",
+    oauthAudience: "advanced-user",
   },
 ];
+
+export const googleStandardUserOAuthPresets = googleOpenApiPresets.filter(
+  (preset) => preset.oauthAudience === "standard-user",
+);

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -1,5 +1,6 @@
 export { parse, resolveSpecText, fetchSpecText } from "./parse";
 export {
+  convertGoogleDiscoveryBundleToOpenApi,
   convertGoogleDiscoveryToOpenApi,
   fetchGoogleDiscoveryDocument,
   isGoogleDiscoveryUrl,

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -42,6 +42,20 @@ const readParamValue = (args: Record<string, unknown>, param: OperationParameter
 const primitiveToString = (value: unknown): string =>
   typeof value === "object" && value !== null ? JSON.stringify(value) : String(value);
 
+// RFC 3986 §2.2 reserved chars. `allowReserved: true` leaves these
+// unencoded; default OAS behavior encodes everything non-unreserved.
+const RESERVED_UNENCODED_RE = /[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=]/;
+
+const encodeReservedAware = (raw: string, allowReserved: boolean): string => {
+  if (!allowReserved) return encodeURIComponent(raw);
+  // Walk char-by-char so the reserved set passes through as-is.
+  let out = "";
+  for (const ch of raw) {
+    out += RESERVED_UNENCODED_RE.test(ch) ? ch : encodeURIComponent(ch);
+  }
+  return out;
+};
+
 const queryParamValues = (value: unknown, param: OperationParameter): string[] => {
   if (value === undefined || value === null) return [];
   if (!Array.isArray(value)) return [primitiveToString(value)];
@@ -78,7 +92,12 @@ const resolvePath = Effect.fn("OpenApi.resolvePath")(function* (
       }
       continue;
     }
-    resolved = resolved.replaceAll(`{${param.name}}`, encodeURIComponent(String(value)));
+    const encoded = encodeReservedAware(
+      String(value),
+      Option.getOrElse(param.allowReserved, () => false),
+    );
+    resolved = resolved.replaceAll(`{${param.name}}`, encoded);
+    resolved = resolved.replaceAll(`{+${param.name}}`, encoded);
   }
 
   const remaining = [...resolved.matchAll(/\{([^{}]+)\}/g)]
@@ -269,19 +288,9 @@ const resolveStyleExplode = (e: EncodingObject | undefined): StyleExplode => {
   };
 };
 
-// RFC 3986 §2.2 reserved chars. `allowReserved: true` leaves these
-// unencoded; default OAS behavior encodes everything non-unreserved.
-const RESERVED_UNENCODED_RE = /[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=]/;
-
 const encodeFormValue = (v: unknown, allowReserved: boolean): string => {
   const raw = typeof v === "object" && v !== null ? JSON.stringify(v) : String(v);
-  if (!allowReserved) return encodeURIComponent(raw);
-  // Walk char-by-char so the reserved set passes through as-is.
-  let out = "";
-  for (const ch of raw) {
-    out += RESERVED_UNENCODED_RE.test(ch) ? ch : encodeURIComponent(ch);
-  }
-  return out;
+  return encodeReservedAware(raw, allowReserved);
 };
 
 /**
@@ -643,12 +652,14 @@ export const invokeWithLayer = (
   sourceQueryParams: Record<string, string>,
   httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>,
 ) => {
-  const clientWithBaseUrl = baseUrl
+  const operationBaseUrl = operation.baseUrl;
+  const effectiveBaseUrl = operationBaseUrl ?? baseUrl;
+  const clientWithBaseUrl = effectiveBaseUrl
     ? Layer.effect(
         HttpClient.HttpClient,
         Effect.map(
           Effect.service(HttpClient.HttpClient),
-          HttpClient.mapRequest(HttpClientRequest.prependUrl(baseUrl)),
+          HttpClient.mapRequest(HttpClientRequest.prependUrl(effectiveBaseUrl)),
         ),
       ).pipe(Layer.provide(httpClientLayer))
     : httpClientLayer;
@@ -659,7 +670,7 @@ export const invokeWithLayer = (
       attributes: {
         "plugin.openapi.method": operation.method.toUpperCase(),
         "plugin.openapi.path_template": operation.pathTemplate,
-        "plugin.openapi.base_url": baseUrl,
+        "plugin.openapi.base_url": effectiveBaseUrl,
       },
     }),
   );

--- a/packages/plugins/openapi/src/sdk/openapi-utils.ts
+++ b/packages/plugins/openapi/src/sdk/openapi-utils.ts
@@ -19,6 +19,7 @@ export type PathItemObject = OpenAPIV3.PathItemObject | OpenAPIV3_1.PathItemObje
 export type RequestBodyObject = OpenAPIV3.RequestBodyObject | OpenAPIV3_1.RequestBodyObject;
 export type ResponseObject = OpenAPIV3.ResponseObject | OpenAPIV3_1.ResponseObject;
 export type MediaTypeObject = OpenAPIV3.MediaTypeObject | OpenAPIV3_1.MediaTypeObject;
+export type ServerObject = OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject;
 
 // ---------------------------------------------------------------------------
 // DocResolver — wraps a parsed document for clean $ref resolution

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -120,7 +120,9 @@ const testApiSourceConfig = (options: TestApiSourceOptions = {}) =>
 
 const testApiSpec = () => {
   const spec = testApiSourceConfig().spec;
-  return spec.kind === "blob" ? spec.value : spec.url;
+  if (spec.kind === "blob") return spec.value;
+  if (spec.kind === "googleDiscoveryBundle") return spec.urls[0] ?? "";
+  return spec.url;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -34,8 +34,9 @@ import {
   OpenApiOAuthError,
   OpenApiParseError,
 } from "./errors";
-import { parse, resolveSpecText } from "./parse";
+import { parse, resolveSpecText, type SpecFetchCredentials } from "./parse";
 import {
+  convertGoogleDiscoveryBundleToOpenApi,
   convertGoogleDiscoveryToOpenApi,
   fetchGoogleDiscoveryDocument,
   isGoogleDiscoveryUrl,
@@ -332,6 +333,10 @@ const OpenApiSpecInputSchema = Schema.Union([
   Schema.Struct({ kind: Schema.Literal("url"), url: Schema.String }),
   Schema.Struct({ kind: Schema.Literal("blob"), value: Schema.String }),
   Schema.Struct({ kind: Schema.Literal("googleDiscovery"), url: Schema.String }),
+  Schema.Struct({
+    kind: Schema.Literal("googleDiscoveryBundle"),
+    urls: Schema.Array(Schema.String),
+  }),
 ]);
 const OpenApiSecretShapeInputSchema = Schema.Struct({
   kind: Schema.Literal("secret"),
@@ -590,6 +595,7 @@ const normalizeOpenApiRefs = (node: unknown): unknown => {
 const toBinding = (def: ToolDefinition): OperationBinding =>
   OperationBinding.make({
     method: def.operation.method,
+    baseUrl: def.operation.baseUrl,
     pathTemplate: def.operation.pathTemplate,
     parameters: [...def.operation.parameters],
     requestBody: def.operation.requestBody,
@@ -959,6 +965,7 @@ const resolveEffectiveSourceConfig = (
       config: {
         ...base.config,
         sourceUrl: base.config.sourceUrl ?? fallback.config.sourceUrl,
+        googleDiscoveryUrls: base.config.googleDiscoveryUrls ?? fallback.config.googleDiscoveryUrls,
         baseUrl: fallback.config.baseUrl,
         namespace: base.config.namespace ?? fallback.config.namespace,
         headers: hasBaseHeaders ? base.config.headers : fallback.config.headers,
@@ -1157,6 +1164,21 @@ const resolveStoredSpecFetchCredentials = (
     ),
   );
 
+const fetchGoogleDiscoveryBundleConversion = (
+  urls: readonly string[],
+  credentials: SpecFetchCredentials | undefined,
+  httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>,
+) =>
+  Effect.forEach(
+    urls,
+    (url) =>
+      fetchGoogleDiscoveryDocument(url, credentials).pipe(
+        Effect.provide(httpClientLayer),
+        Effect.map((documentText) => ({ discoveryUrl: url, documentText })),
+      ),
+    { concurrency: 4 },
+  ).pipe(Effect.flatMap((documents) => convertGoogleDiscoveryBundleToOpenApi({ documents })));
+
 // ---------------------------------------------------------------------------
 // OAuth2 token exchange / refresh is owned by `ctx.oauth`, which registers
 // the canonical core `"oauth2"` ConnectionProvider. OpenAPI owns only the
@@ -1197,13 +1219,18 @@ const toOpenApiSourceConfig = (
 };
 
 const specInputToConfigString = (spec: OpenApiSpecInput): string =>
-  spec.kind === "url" || spec.kind === "googleDiscovery" ? spec.url : spec.value;
+  spec.kind === "url" || spec.kind === "googleDiscovery"
+    ? spec.url
+    : spec.kind === "googleDiscoveryBundle"
+      ? spec.urls.join("\n")
+      : spec.value;
 
 export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
   type RebuildInput = {
     readonly specText: string;
     readonly scope: string;
     readonly sourceUrl?: string;
+    readonly googleDiscoveryUrls?: readonly string[];
     readonly name: string;
     readonly baseUrl: string | undefined;
     readonly namespace: string;
@@ -1269,6 +1296,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
       const sourceConfig: SourceConfig = {
         spec: input.specText,
         sourceUrl: input.sourceUrl,
+        googleDiscoveryUrls: input.googleDiscoveryUrls,
         baseUrl,
         namespace: input.namespace,
         headers: canonicalHeaders.headers,
@@ -1303,7 +1331,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
             // `canRefresh` reflects whether we still know the
             // origin URL — sources added from raw spec text have
             // nothing to re-fetch, so refresh stays disabled.
-            canRefresh: input.sourceUrl != null,
+            canRefresh: input.sourceUrl != null || input.googleDiscoveryUrls != null,
             canEdit: true,
             tools: definitions.map((def) => ({
               name: def.toolPath,
@@ -1341,25 +1369,38 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
       const effective = yield* resolveEffectiveSourceConfig(ctx, existing);
       const resolvedConfig = effective.config;
       const sourceUrl = resolvedConfig.sourceUrl;
-      if (!sourceUrl) return;
+      const googleDiscoveryUrls = resolvedConfig.googleDiscoveryUrls;
+      if (!sourceUrl && !googleDiscoveryUrls) return;
       const credentials = yield* resolveStoredSpecFetchCredentials(ctx, {
         sourceId: existing.namespace,
         sourceScope: effective.specFetchCredentialsSource.scope,
         credentials: resolvedConfig.specFetchCredentials,
       });
-      const specText = isGoogleDiscoveryUrl(sourceUrl)
-        ? yield* fetchGoogleDiscoveryDocument(sourceUrl, credentials).pipe(
-            Effect.provide(httpClientLayer),
-            Effect.flatMap((documentText) =>
-              convertGoogleDiscoveryToOpenApi({ discoveryUrl: sourceUrl, documentText }),
-            ),
-            Effect.map((conversion) => conversion.specText),
+      const conversion = googleDiscoveryUrls
+        ? yield* fetchGoogleDiscoveryBundleConversion(
+            googleDiscoveryUrls,
+            credentials,
+            httpClientLayer,
           )
-        : yield* resolveSpecText(sourceUrl, credentials).pipe(Effect.provide(httpClientLayer));
+        : undefined;
+      const specText = conversion
+        ? conversion.specText
+        : sourceUrl && isGoogleDiscoveryUrl(sourceUrl)
+          ? yield* fetchGoogleDiscoveryDocument(sourceUrl, credentials).pipe(
+              Effect.provide(httpClientLayer),
+              Effect.flatMap((documentText) =>
+                convertGoogleDiscoveryToOpenApi({ discoveryUrl: sourceUrl, documentText }),
+              ),
+              Effect.map((singleConversion) => singleConversion.specText),
+            )
+          : sourceUrl
+            ? yield* resolveSpecText(sourceUrl, credentials).pipe(Effect.provide(httpClientLayer))
+            : existing.config.spec;
       yield* rebuildSource(ctx, {
         specText,
         scope,
         sourceUrl,
+        googleDiscoveryUrls,
         name: existing.name,
         baseUrl: existing.config.baseUrl,
         namespace: existing.namespace,
@@ -1394,16 +1435,22 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
                     }),
                   ),
                 )
-              : {
-                  specText:
-                    config.spec.kind === "url"
-                      ? yield* resolveSpecText(config.spec.url).pipe(
-                          Effect.provide(httpClientLayer),
-                        )
-                      : config.spec.value,
-                  baseUrl: config.baseUrl,
-                  oauth2: config.oauth2,
-                };
+              : config.spec.kind === "googleDiscoveryBundle"
+                ? yield* fetchGoogleDiscoveryBundleConversion(
+                    config.spec.urls,
+                    undefined,
+                    httpClientLayer,
+                  )
+                : {
+                    specText:
+                      config.spec.kind === "url"
+                        ? yield* resolveSpecText(config.spec.url).pipe(
+                            Effect.provide(httpClientLayer),
+                          )
+                        : config.spec.value,
+                    baseUrl: config.baseUrl,
+                    oauth2: config.oauth2,
+                  };
           return yield* rebuildSource(ctx, {
             specText: resolvedSpec.specText,
             scope: config.scope,
@@ -1411,6 +1458,8 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
               config.spec.kind === "url" || config.spec.kind === "googleDiscovery"
                 ? config.spec.url
                 : undefined,
+            googleDiscoveryUrls:
+              config.spec.kind === "googleDiscoveryBundle" ? config.spec.urls : undefined,
             name: config.name,
             baseUrl: resolvedSpec.baseUrl || config.baseUrl,
             namespace: config.namespace,

--- a/packages/plugins/openapi/src/sdk/presets.ts
+++ b/packages/plugins/openapi/src/sdk/presets.ts
@@ -1,10 +1,10 @@
-import { googleOpenApiPresets } from "./google-presets";
+import { googleOpenApiBundlePreset, googleOpenApiPresets } from "./google-presets";
 
 export interface OpenApiPreset {
   readonly id: string;
   readonly name: string;
   readonly summary: string;
-  readonly url: string;
+  readonly url?: string;
   readonly icon?: string;
   readonly featured?: boolean;
 }
@@ -140,9 +140,10 @@ const openApiOnlyPresets: readonly OpenApiPreset[] = [
   },
 ];
 
-export { googleOpenApiPresets } from "./google-presets";
+export { googleOpenApiPresets, googleStandardUserOAuthPresets } from "./google-presets";
 
 export const openApiPresets: readonly OpenApiPreset[] = [
+  googleOpenApiBundlePreset,
   ...openApiOnlyPresets,
   ...googleOpenApiPresets,
 ];

--- a/packages/plugins/openapi/src/sdk/query-serialization.test.ts
+++ b/packages/plugins/openapi/src/sdk/query-serialization.test.ts
@@ -95,3 +95,44 @@ it.effect("serializes form-exploded query arrays as repeated parameters", () =>
     }),
   ),
 );
+
+it.effect("uses operation base URL and preserves reserved path expansion when allowed", () =>
+  Effect.promise(() =>
+    withServer(async ({ baseUrl, requests }) => {
+      const operation = OperationBinding.make({
+        method: "get",
+        baseUrl,
+        pathTemplate: "/v1/{+name}",
+        requestBody: Option.none(),
+        parameters: [
+          OperationParameter.make({
+            name: "name",
+            location: "path",
+            required: true,
+            schema: Option.some({ type: "string" }),
+            style: Option.none(),
+            explode: Option.none(),
+            allowReserved: Option.some(true),
+            description: Option.none(),
+          }),
+        ],
+      });
+
+      await Effect.runPromise(
+        invokeWithLayer(
+          operation,
+          {
+            name: "spaces/AAA/messages/BBB",
+          },
+          "https://unused.example",
+          {},
+          {},
+          FetchHttpClient.layer,
+        ),
+      );
+
+      const url = new URL(requests[0]!, "http://executor.test");
+      expect(url.pathname).toBe("/v1/spaces/AAA/messages/BBB");
+    }),
+  ),
+);

--- a/packages/plugins/openapi/src/sdk/source-contracts.ts
+++ b/packages/plugins/openapi/src/sdk/source-contracts.ts
@@ -9,6 +9,7 @@ export const StoredSourceSchema = Schema.Struct({
   config: Schema.Struct({
     spec: Schema.optional(Schema.String),
     sourceUrl: Schema.optional(Schema.String),
+    googleDiscoveryUrls: Schema.optional(Schema.Array(Schema.String)),
     baseUrl: Schema.optional(Schema.String),
     namespace: Schema.optional(Schema.String),
     headers: Schema.optional(Schema.Record(Schema.String, ConfiguredHeaderValue)),

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -25,6 +25,7 @@ export {
 export interface SourceConfig {
   readonly spec: string;
   readonly sourceUrl?: string;
+  readonly googleDiscoveryUrls?: readonly string[];
   readonly baseUrl?: string;
   readonly namespace?: string;
   readonly headers?: Record<string, ConfiguredHeaderValue>;
@@ -80,6 +81,7 @@ const SpecFetchCredentialsStorage = Schema.Struct({
 const SourceConfigStorage = Schema.Struct({
   spec: Schema.String,
   sourceUrl: Schema.optional(Schema.String),
+  googleDiscoveryUrls: Schema.optional(Schema.Array(Schema.String)),
   baseUrl: Schema.optional(Schema.String),
   namespace: Schema.optional(Schema.String),
   headers: Schema.optional(ConfiguredHeaderMapStorage),
@@ -141,6 +143,7 @@ const normalizeConfiguredMap = (
 const encodeSourceConfig = (config: SourceConfig): Record<string, unknown> => ({
   spec: config.spec,
   ...(config.sourceUrl ? { sourceUrl: config.sourceUrl } : {}),
+  ...(config.googleDiscoveryUrls ? { googleDiscoveryUrls: config.googleDiscoveryUrls } : {}),
   ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
   ...(config.namespace ? { namespace: config.namespace } : {}),
   ...(config.headers ? { headers: config.headers } : {}),
@@ -161,6 +164,7 @@ const rowToSource = (row: PluginStorageEntry): StoredSource | null => {
     config: {
       spec: stored.config.spec,
       sourceUrl: stored.config.sourceUrl,
+      googleDiscoveryUrls: stored.config.googleDiscoveryUrls,
       baseUrl: stored.config.baseUrl,
       namespace: stored.config.namespace,
       headers: normalizeConfiguredMap(stored.config.headers),

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -97,6 +97,7 @@ export const ExtractedOperation = Schema.Struct({
   operationId: OperationId,
   toolPath: Schema.OptionFromOptional(Schema.String),
   method: HttpMethod,
+  baseUrl: Schema.optional(Schema.String),
   pathTemplate: Schema.String,
   summary: Schema.OptionFromOptional(Schema.String),
   description: Schema.OptionFromOptional(Schema.String),
@@ -137,6 +138,7 @@ export type ExtractionResult = typeof ExtractionResult.Type;
 
 export const OperationBinding = Schema.Struct({
   method: HttpMethod,
+  baseUrl: Schema.optional(Schema.String),
   pathTemplate: Schema.String,
   parameters: Schema.Array(OperationParameter),
   requestBody: Schema.OptionFromOptional(OperationRequestBody),

--- a/packages/react/src/components/info.tsx
+++ b/packages/react/src/components/info.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { InfoIcon, TriangleAlertIcon } from "lucide-react";
+
+import { cn } from "../lib/utils";
+
+type InfoVariant = "default" | "warning";
+
+const variantClassName: Record<
+  InfoVariant,
+  {
+    readonly root: string;
+    readonly icon: string;
+  }
+> = {
+  default: {
+    root: "border-border/70 bg-card/50 text-foreground",
+    icon: "text-muted-foreground",
+  },
+  warning: {
+    root: "border-border/70 border-l-amber-500 bg-card text-foreground shadow-xs dark:border-border/70 dark:border-l-amber-400 dark:bg-card/70",
+    icon: "text-amber-600 dark:text-amber-400",
+  },
+};
+
+function Info({
+  className,
+  variant = "default",
+  children,
+  ...props
+}: React.ComponentProps<"section"> & {
+  readonly variant?: InfoVariant;
+}) {
+  const Icon = variant === "warning" ? TriangleAlertIcon : InfoIcon;
+  const variantClass = variantClassName[variant];
+  return (
+    <section
+      data-slot="info"
+      className={cn(
+        "grid grid-cols-[auto_1fr] gap-x-2.5 gap-y-1 rounded-md border px-3 py-2.5 text-sm",
+        variant === "warning" ? "border-l-[3px]" : null,
+        variantClass.root,
+        className,
+      )}
+      {...props}
+    >
+      <Icon className={cn("mt-0.5 size-4", variantClass.icon)} aria-hidden />
+      <div className="min-w-0 space-y-1.5">{children}</div>
+    </section>
+  );
+}
+
+function InfoTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="info-title"
+      className={cn("text-[13px] font-medium leading-5 text-current", className)}
+      {...props}
+    />
+  );
+}
+
+function InfoDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="info-description"
+      className={cn("text-[12px] leading-5 text-muted-foreground", className)}
+      {...props}
+    />
+  );
+}
+
+export { Info, InfoTitle, InfoDescription };


### PR DESCRIPTION
## Summary
- add a bundled Google OpenAPI source flow for selecting multiple Google services into one source
- convert Google Discovery bundles into a single OpenAPI document with per-operation service base URLs
- add Google OAuth scope filtering, batching, and user-facing consent warnings

## Test plan
- bun run --cwd packages/plugins/openapi test -- src/sdk/credential-status.test.ts src/sdk/google-discovery.test.ts src/sdk/google-oauth-batches.test.ts src/sdk/google-oauth-scopes.test.ts src/sdk/google-presets.test.ts src/sdk/query-serialization.test.ts
- node ../../node_modules/vitest/vitest.mjs run src/services/db.schema.test.ts
- bun run --cwd packages/plugins/openapi typecheck
- bun run --cwd apps/cloud typecheck

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #871
2. #872
3. #873
4. #874
5. **#875** 👈 current
<!-- stack:links:end -->