### PR TITLE
fix: declare effect as a peer dependency in published packages

### DIFF
--- a/.changeset/effect-peer-dependency.md
+++ b/.changeset/effect-peer-dependency.md
@@ -1,0 +1,9 @@
+---
+"executor": patch
+---
+
+Move `effect` from `dependencies` to `peerDependencies` (with a `devDependencies` mirror) in the published library packages.
+
+`effect` relies on a single module instance for `Context`/service identity and type equality. Declaring it as a hard dependency lets consumers end up with duplicated `effect` copies — e.g. an app on a newer `4.0.0-beta.x` installed alongside these packages' pinned version — which breaks service resolution and surfaces as TypeScript reporting the two `effect` copies as incompatible.
+
+Declaring `effect` as a peer dependency lets the consuming app supply the single shared `effect` version. Consumers now need `effect` as a direct dependency. Private workspace packages and the `executor` CLI keep `effect` as a regular dependency.

--- a/bun.lock
+++ b/bun.lock
@@ -338,7 +338,6 @@
       "version": "1.4.33",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
         "jiti": "^2.6.1",
         "jsonc-parser": "^3.3.1",
       },
@@ -346,9 +345,13 @@
         "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/core/execution": {
@@ -357,16 +360,19 @@
       "dependencies": {
         "@executor-js/codemode-core": "workspace:*",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@executor-js/runtime-quickjs": "workspace:*",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/core/fumadb": {
@@ -418,7 +424,6 @@
       "version": "1.4.33",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "effect": "catalog:",
         "fractional-indexing": "^3.2.0",
         "fumadb": "workspace:*",
         "oauth4webapi": "^3.8.5",
@@ -432,6 +437,7 @@
         "@types/react": "catalog:",
         "better-sqlite3": "^12.9.0",
         "drizzle-orm": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
@@ -440,6 +446,7 @@
       "peerDependencies": {
         "@effect/atom-react": "catalog:",
         "@effect/platform-node": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -511,16 +518,19 @@
         "@standard-schema/spec": "^1.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
-        "effect": "catalog:",
         "sucrase": "^3.35.1",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/kernel/ir": {
@@ -578,16 +588,19 @@
       "version": "1.4.33",
       "dependencies": {
         "@executor-js/codemode-core": "workspace:*",
-        "effect": "catalog:",
         "quickjs-emscripten": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/plugins/desktop-settings": {
@@ -631,13 +644,16 @@
       "version": "1.4.33",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/plugins/graphql": {
@@ -647,7 +663,6 @@
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
         "graphql": "^16.12.0",
         "graphql-yoga": "^5.17.0",
       },
@@ -659,6 +674,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -668,6 +684,7 @@
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@tanstack/react-router": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -684,14 +701,17 @@
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "@napi-rs/keyring": "^1.2.0",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/plugins/mcp": {
@@ -703,7 +723,6 @@
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "effect": "catalog:",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -714,6 +733,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -723,6 +743,7 @@
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@tanstack/react-router": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -741,7 +762,6 @@
         "@1password/sdk": "^0.4.1-beta.1",
         "@effect/atom-react": "catalog:",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
@@ -749,6 +769,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -757,6 +778,7 @@
         "@effect/atom-react": "catalog:",
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
+        "effect": "catalog:",
         "react": ">=18",
       },
       "optionalPeers": [
@@ -773,7 +795,6 @@
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
         "openapi-types": "^12.1.3",
         "yaml": "^2.7.1",
       },
@@ -785,6 +806,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -794,6 +816,7 @@
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@tanstack/react-router": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -810,18 +833,19 @@
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "@workos-inc/node": "^8.11.1",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "@types/react": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
       },
       "peerDependencies": {
         "@executor-js/react": "workspace:*",
+        "effect": "catalog:",
         "react": ">=18",
       },
       "optionalPeers": [

--- a/packages/core/config/package.json
+++ b/packages/core/config/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:",
     "jiti": "^2.6.1",
     "jsonc-parser": "^3.3.1"
   },
@@ -45,8 +44,12 @@
     "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -44,16 +44,19 @@
   },
   "dependencies": {
     "@executor-js/codemode-core": "workspace:*",
-    "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@executor-js/runtime-quickjs": "workspace:*",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -73,7 +73,6 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "effect": "catalog:",
     "fractional-indexing": "^3.2.0",
     "fumadb": "workspace:*",
     "oauth4webapi": "^3.8.5"
@@ -87,6 +86,7 @@
     "@types/react": "catalog:",
     "better-sqlite3": "^12.9.0",
     "drizzle-orm": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
@@ -95,6 +95,7 @@
   "peerDependencies": {
     "@effect/atom-react": "catalog:",
     "@effect/platform-node": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/kernel/core/package.json
+++ b/packages/kernel/core/package.json
@@ -41,15 +41,18 @@
     "@standard-schema/spec": "^1.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "effect": "catalog:",
     "sucrase": "^3.35.1"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/kernel/runtime-quickjs/package.json
+++ b/packages/kernel/runtime-quickjs/package.json
@@ -38,15 +38,18 @@
   },
   "dependencies": {
     "@executor-js/codemode-core": "workspace:*",
-    "effect": "catalog:",
     "quickjs-emscripten": "catalog:"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/plugins/file-secrets/package.json
+++ b/packages/plugins/file-secrets/package.json
@@ -44,13 +44,16 @@
     "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -64,7 +64,6 @@
     "@effect/platform-node": "catalog:",
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:",
     "graphql": "^16.12.0",
     "graphql-yoga": "^5.17.0"
   },
@@ -76,6 +75,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -85,6 +85,7 @@
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@tanstack/react-router": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/keychain/package.json
+++ b/packages/plugins/keychain/package.json
@@ -45,14 +45,17 @@
   },
   "dependencies": {
     "@executor-js/sdk": "workspace:*",
-    "@napi-rs/keyring": "^1.2.0",
-    "effect": "catalog:"
+    "@napi-rs/keyring": "^1.2.0"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -66,7 +66,6 @@
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "effect": "catalog:",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -77,6 +76,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -86,6 +86,7 @@
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@tanstack/react-router": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/onepassword/package.json
+++ b/packages/plugins/onepassword/package.json
@@ -56,8 +56,7 @@
     "@1password/op-js": "^0.1.13",
     "@1password/sdk": "^0.4.1-beta.1",
     "@effect/atom-react": "catalog:",
-    "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
@@ -65,6 +64,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -73,6 +73,7 @@
     "@effect/atom-react": "catalog:",
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
+    "effect": "catalog:",
     "react": ">=18"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -64,7 +64,6 @@
     "@effect/platform-node": "catalog:",
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:",
     "openapi-types": "^12.1.3",
     "yaml": "^2.7.1"
   },
@@ -76,6 +75,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -85,6 +85,7 @@
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@tanstack/react-router": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/workos-vault/package.json
+++ b/packages/plugins/workos-vault/package.json
@@ -54,19 +54,20 @@
   },
   "dependencies": {
     "@executor-js/sdk": "workspace:*",
-    "@workos-inc/node": "^8.11.1",
-    "effect": "catalog:"
+    "@workos-inc/node": "^8.11.1"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {
     "@executor-js/react": "workspace:*",
+    "effect": "catalog:",
     "react": ">=18"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Problem

The published `@executor-js/*` packages declare `effect` as a hard `dependency`. Since `effect` needs a **single module instance** for `Context`/service identity and type equality, a consumer pinning a different `4.0.0-beta.x` ends up with a duplicated `effect` — services stop resolving, and TypeScript flags the two copies as incompatible.

## Fix

Move `effect` from `dependencies` → `peerDependencies` (with a `devDependencies` mirror) in the 12 published library packages, so the consumer supplies the single shared instance. Matches how `react` / `@effect/atom-react` are already declared as peers.

The `executor` CLI (leaf binary) and private workspace packages keep `effect` as a regular dependency.

## Verification

- `bun install` → single `effect@4.0.0-beta.59`
- `turbo run typecheck` → 34/34 pass
- `bun pm pack` on `@executor-js/sdk` → `effect` under `peerDependencies`, not `dependencies`