### PR TITLE
chore(deps): bump effect to 4.0.0-beta.66

### DIFF
--- a/apps/cli/src/integrations.ts
+++ b/apps/cli/src/integrations.ts
@@ -9,7 +9,7 @@ import {
 
 import { USER_AGENT } from "./installation";
 
-const refreshRegistry = IntegrationsRegistry.asEffect().pipe(
+const refreshRegistry = IntegrationsRegistry.pipe(
   Effect.flatMap((service) => service.refresh()),
   Effect.asVoid,
 );

--- a/apps/cloud/src/account/account-api.ts
+++ b/apps/cloud/src/account/account-api.ts
@@ -74,7 +74,7 @@ const AccountProviderMiddleware = HttpRouter.middleware<{ provides: AccountProvi
         // over the per-request `UserStoreService` (postgres socket) supplied by
         // the combined request-scoped layer.
         const accountProvider = yield* Effect.provide(
-          AccountProvider.asEffect(),
+          AccountProvider,
           workosAccountProvider.pipe(
             Layer.provide(ApiKeyService.WorkOS),
             Layer.provide(Layer.succeed(AccountCaller)({ session })),

--- a/apps/cloud/src/api/protected.ts
+++ b/apps/cloud/src/api/protected.ts
@@ -71,7 +71,7 @@ const ExecutionStackMiddleware = makeExecutionStackMiddleware<
 >({
   plugins: cloudPlugins,
   authenticate: (request) =>
-    IdentityProvider.asEffect().pipe(Effect.flatMap((provider) => provider.authenticate(request))),
+    IdentityProvider.pipe(Effect.flatMap((provider) => provider.authenticate(request))),
   strategy: cloudIdentityFailureStrategy,
   stackLayer: CloudMeteredExecutionStackLayer,
 });

--- a/apps/cloud/src/auth/context.ts
+++ b/apps/cloud/src/auth/context.ts
@@ -24,6 +24,6 @@ export class UserStoreService extends Context.Service<UserStoreService, UserStor
   "@executor-js/cloud/UserStoreService",
 ) {
   static Live = Layer.effect(this)(
-    Effect.map(DbService.asEffect(), ({ db }) => makeService(makeUserStore(db))),
+    Effect.map(DbService, ({ db }) => makeService(makeUserStore(db))),
   );
 }

--- a/apps/cloud/src/db/fuma.ts
+++ b/apps/cloud/src/db/fuma.ts
@@ -55,7 +55,7 @@ export const cloudDbProviderLayer = (
   tables: FumaTables,
 ): Layer.Layer<DbProvider, never, DbService> =>
   Layer.effect(DbProvider)(
-    Effect.map(DbService.asEffect(), ({ db }): ExecutorDbHandle => {
+    Effect.map(DbService, ({ db }): ExecutorDbHandle => {
       const fuma = createDrizzleFumaDb({
         db,
         tables,

--- a/apps/cloud/src/engine/execution-stack-metered.ts
+++ b/apps/cloud/src/engine/execution-stack-metered.ts
@@ -33,7 +33,7 @@ import { withExecutionUsageTracking } from "./execution-usage";
 // user-facing execution.
 export const CloudMeteringEngineDecorator: Layer.Layer<EngineDecorator, never, AutumnService> =
   Layer.effect(EngineDecorator)(
-    Effect.map(AutumnService.asEffect(), (autumn): EngineDecorator["Service"] => ({
+    Effect.map(AutumnService, (autumn): EngineDecorator["Service"] => ({
       decorate: (engine, identity: EngineStackIdentity) =>
         withExecutionUsageTracking(identity.organizationId, engine, (organizationId) =>
           Effect.runFork(autumn.trackExecution(organizationId)),

--- a/apps/cloud/src/extensions/routes.ts
+++ b/apps/cloud/src/extensions/routes.ts
@@ -47,7 +47,7 @@ import { ApiErrorLoggingLive } from "../observability/error-logging";
 // plane). Derived from the ambient router, exactly as `ExecutorApp.make` builds
 // its own internal prefixed view for the protected API.
 const apiPrefixedRouter = Layer.effect(HttpRouter.HttpRouter)(
-  Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed("/api")),
+  Effect.map(HttpRouter.HttpRouter, (router) => router.prefixed("/api")),
 );
 
 // The full cloud OpenAPI spec, prefixed so the served paths match `/api/*`.

--- a/apps/host-selfhost/src/admin/handlers.ts
+++ b/apps/host-selfhost/src/admin/handlers.ts
@@ -28,7 +28,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const requestHeaders = Effect.map(
-  HttpServerRequest.HttpServerRequest.asEffect(),
+  HttpServerRequest.HttpServerRequest,
   (request): Headers => new Headers({ ...request.headers }),
 );
 
@@ -127,7 +127,7 @@ export const makeSelfHostAdminApiLayer = ({
   mountPrefix,
 }: SelfHostAdminApiDeps) => {
   const prefixedRouter = Layer.effect(HttpRouter.HttpRouter)(
-    Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed(mountPrefix)),
+    Effect.map(HttpRouter.HttpRouter, (router) => router.prefixed(mountPrefix)),
   );
   return HttpApiBuilder.layer(AdminHttpApi).pipe(
     Layer.provide(AdminHandlers),

--- a/apps/host-selfhost/src/db/self-host-db.ts
+++ b/apps/host-selfhost/src/db/self-host-db.ts
@@ -168,7 +168,7 @@ export const SelfHostDbProvider: Layer.Layer<DbProvider, never, SelfHostDb> = La
   DbProvider,
 )(
   Effect.map(
-    SelfHostDb.asEffect(),
+    SelfHostDb,
     (handle): ExecutorDbHandle => ({
       db: handle.db,
       fuma: handle.fuma,

--- a/apps/host-selfhost/src/system/handlers.ts
+++ b/apps/host-selfhost/src/system/handlers.ts
@@ -54,7 +54,7 @@ export const makeSelfHostSystemApiLayer = ({
   mountPrefix,
 }: SelfHostSystemApiDeps) => {
   const prefixedRouter = Layer.effect(HttpRouter.HttpRouter)(
-    Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed(mountPrefix)),
+    Effect.map(HttpRouter.HttpRouter, (router) => router.prefixed(mountPrefix)),
   );
   return HttpApiBuilder.layer(SystemHttpApi).pipe(
     Layer.provide(SystemHandlers),

--- a/apps/local/src/executor.ts
+++ b/apps/local/src/executor.ts
@@ -750,7 +750,7 @@ const createLocalExecutorLayer = () => {
 export const createExecutorHandle = async () => {
   const layer = createLocalExecutorLayer();
   const runtime = ManagedRuntime.make(layer);
-  const bundle = await runtime.runPromise(LocalExecutorTag.asEffect());
+  const bundle = await runtime.runPromise(LocalExecutorTag);
 
   return {
     executor: bundle.executor,

--- a/apps/local/src/integrations.ts
+++ b/apps/local/src/integrations.ts
@@ -28,5 +28,5 @@ const integrationsRuntime = ManagedRuntime.make(
  * absorbed inside the forked fiber and the layer's catchCause handlers.
  */
 export const startIntegrationsRefresh = (): void => {
-  integrationsRuntime.runFork(IntegrationsRegistry.asEffect());
+  integrationsRuntime.runFork(IntegrationsRegistry);
 };

--- a/apps/local/src/main.ts
+++ b/apps/local/src/main.ts
@@ -85,7 +85,7 @@ const ServerHandlersLive = Layer.effect(ServerHandlersService)(
 const serverHandlersRuntime = ManagedRuntime.make(ServerHandlersLive);
 
 export const getServerHandlers = (): Promise<ServerHandlers> =>
-  serverHandlersRuntime.runPromise(ServerHandlersService.asEffect());
+  serverHandlersRuntime.runPromise(ServerHandlersService);
 
 export const disposeServerHandlers = async (): Promise<void> => {
   await Effect.runPromise(

--- a/bun.lock
+++ b/bun.lock
@@ -1006,11 +1006,11 @@
     "postgres@3.4.9": "patches/postgres@3.4.9.patch",
   },
   "catalog": {
-    "@effect/atom-react": "4.0.0-beta.59",
-    "@effect/opentelemetry": "4.0.0-beta.59",
-    "@effect/platform-bun": "4.0.0-beta.59",
-    "@effect/platform-node": "4.0.0-beta.59",
-    "@effect/vitest": "4.0.0-beta.59",
+    "@effect/atom-react": "4.0.0-beta.66",
+    "@effect/opentelemetry": "4.0.0-beta.66",
+    "@effect/platform-bun": "4.0.0-beta.66",
+    "@effect/platform-node": "4.0.0-beta.66",
+    "@effect/vitest": "4.0.0-beta.66",
     "@jitl/quickjs-wasmfile-release-sync": "0.31.0",
     "@libsql/client": "^0.17.3",
     "@libsql/kysely-libsql": "^0.4.1",
@@ -1031,7 +1031,7 @@
     "bun-types": "^1.2.22",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.0",
-    "effect": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.66",
     "quickjs-emscripten": "^0.31.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -1296,17 +1296,17 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
-    "@effect/atom-react": ["@effect/atom-react@4.0.0-beta.59", "", { "peerDependencies": { "effect": "^4.0.0-beta.59", "react": "^19.2.4", "scheduler": "*" } }, "sha512-VkznQz5c+Z/BLxX+hQNPzPOyUnLQjnbppFSNP7tbPru7HKR4ihzCDC6Xjbx87156MOrZ+JOa6shTMbmvGT5W0w=="],
+    "@effect/atom-react": ["@effect/atom-react@4.0.0-beta.66", "", { "peerDependencies": { "effect": "^4.0.0-beta.66", "react": "^19.2.4", "scheduler": "*" } }, "sha512-YEUbGXBZsb9dmgQ/FMTsqU6IYp/2rRVqloySSXFzhXlIbRT6b28SvNyTpK3x+HLGavURYfTUjjZ/Y2wEj/7A9g=="],
 
     "@effect/language-service": ["@effect/language-service@0.85.1", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-EXnJjIy6zQ3nUO/MZ+ynWUb8B895KZPotd1++oTs9JjDkplwM7cb6zo8Zq2zU6piwq+KflO7amXbEfj1UMpHkw=="],
 
-    "@effect/opentelemetry": ["@effect/opentelemetry@4.0.0-beta.59", "", { "peerDependencies": { "@opentelemetry/api": "^1.9", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": "^2.0.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.0", "@opentelemetry/sdk-trace-web": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.33.0", "effect": "^4.0.0-beta.59" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/resources", "@opentelemetry/sdk-logs", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-trace-base", "@opentelemetry/sdk-trace-node", "@opentelemetry/sdk-trace-web"] }, "sha512-nUpfzGvi0yhYAL1UgN6rB34qEFw5VPYgBZH2vymUDitvMyDnqSFXmfq5Zv4FuRMjRKfpV6YKqtw/sq+GupCk5w=="],
+    "@effect/opentelemetry": ["@effect/opentelemetry@4.0.0-beta.66", "", { "peerDependencies": { "@opentelemetry/api": "^1.9", "@opentelemetry/api-logs": ">=0.203.0 <0.300.0", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": "^2.0.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.0", "@opentelemetry/sdk-trace-web": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.33.0", "effect": "^4.0.0-beta.66" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/api-logs", "@opentelemetry/resources", "@opentelemetry/sdk-logs", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-trace-base", "@opentelemetry/sdk-trace-node", "@opentelemetry/sdk-trace-web"] }, "sha512-LU3ejAzJS+4P+Qtfn9ULnsGcIPmx1tUUB2ZswFRL+EolD8US7zMljHTwGuQRUBJOjDwt7wFCMN5AR512vdY8FQ=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-1jXCIx34X80ojiK9ACO9Q7RST9CXudRmlAbsP4kPqjUo6aqOuGSWXq9ueBO4LbaIZiioRxtTciom35U9ldfTkQ=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.66", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.66" }, "peerDependencies": { "effect": "^4.0.0-beta.66" } }, "sha512-egxbmAEtJZ8FYTaPMrYu3VwjgVuzHj3VdUyPyZ/QhSFP/DW2Yunlk/ouChi1JzX/m+Gj8tdMma7NiqO59J9d5Q=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.59", "ioredis": "^5.7.0" } }, "sha512-jHRW0l953FjYNhQHexr48jFiBu5iGEZH5nmKD6Ha+lPtm1MrKG2V4njfWA3Fv0nUmd3VN87eBJ557wU0twN1Hg=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.66", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.66", "mime": "^4.1.0", "undici": "^8.0.2" }, "peerDependencies": { "effect": "^4.0.0-beta.66", "ioredis": "^5.7.0" } }, "sha512-s/0RgaQFuszzdorRnX1PwEQNnSOi+JgMJo3zEe9O2NR3sosMhTr0Uk+1AF6bUOI9uJ2CPT3KpTIIU7q5/TpOkg=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.59", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-fGwFJuG0Te9U/ZeqeDZ2HcSKZBhX5wLjX2/Rxb5+yaOkvvFAN9MvIh05R0QQK5DCcERvnbhHSl1CjSIAN4aEwQ=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.74", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.20.0" }, "peerDependencies": { "effect": "^4.0.0-beta.74" } }, "sha512-C6C2hXixNcZXLaFF2u7B/FtOsqpdY7luaPuiGFBJza0P7EnYDkwaT3kB6lv7l/qctmkADc24qOsSCWIKRbC4jg=="],
 
     "@effect/tsgo": ["@effect/tsgo@0.5.2", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.5.2", "@effect/tsgo-darwin-x64": "0.5.2", "@effect/tsgo-linux-arm": "0.5.2", "@effect/tsgo-linux-arm64": "0.5.2", "@effect/tsgo-linux-x64": "0.5.2", "@effect/tsgo-win32-arm64": "0.5.2", "@effect/tsgo-win32-x64": "0.5.2" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-LEKmx1rwP1j3l9mPW6Bx8VIdGKW+uEvvML89z4xiWnPC+h/uFm3y6FGHULop9Kl09Ybwn2TVuZzVPSZLj+ydmg=="],
 
@@ -1324,7 +1324,7 @@
 
     "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-MCFRUI54cHuvZmnn//rOqu+ShrVSqgr2gIctPfa3L40GNUnAZ2fx/3diGZV7uSysZRMKnrz+zgGtcSM/36W6Og=="],
 
-    "@effect/vitest": ["@effect/vitest@4.0.0-beta.59", "", { "peerDependencies": { "effect": "^4.0.0-beta.59", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-jhpJbpDs1ED58SmFzcfmqLXxle84fiexaMEhV8SBl8WC2GM3FT5DW0WJYFjbZIH5/735brp3iGdjY5/uAxS7Bg=="],
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.66", "", { "peerDependencies": { "effect": "^4.0.0-beta.66", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-UHPNtU0xXkKtNgyRQEh2c8jh4nIIm8Mzp3xc4j2ZdFU4nq5ZSySnpovjPMdoWbVClg1ki8UbpNGEZUfxEJo+6Q=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.4.4", "", {}, "sha512-g/6CWAJ4XOkObWCWAQ2IReZD8VvsDy3poRHSKvpRR2F96F8WJ3HVbjpso3gN7l0q6QPPgvxSSpl/qo5k8a7mkQ=="],
 
@@ -1802,7 +1802,7 @@
 
     "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-zf6acnScjhsaBUU22zXZ/sLWim1dfhUAbGXdMmHmNG3LfBnQ3DKsOCITb2IZwoUsNNMTogqFKBnlIPPftUgGwA=="],
 
-    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/resources": "2.0.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-Bvy8QDjO05umd0+j+gDeWcTaVa1/R2lDj/eOvjzpm8VQj1K1vVZJuyjThpV5/lSHyYW2JaHF2IQ7Z8twJFAhjA=="],
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ=="],
 
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw=="],
 
@@ -3162,7 +3162,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
+    "effect": ["effect@4.0.0-beta.66", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-4arEr62cziFa8BBVDUwJCJJmaVepXf/kRg7KtC0h8+bufngscrHbwWFhr9c+HonwOF+31U3iD3xUJmw9KzX7Dw=="],
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
@@ -5012,7 +5012,7 @@
 
     "@develar/schema-utils/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
-    "@effect/platform-node-shared/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "@effect/platform-node-shared/ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "@electron/asar/commander": ["commander@5.1.0", "", {}, "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="],
 
@@ -5107,12 +5107,6 @@
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
     "@modelcontextprotocol/sdk/jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
-
-    "@opentelemetry/otlp-transformer/@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ=="],
-
-    "@opentelemetry/sdk-metrics/@opentelemetry/core": ["@opentelemetry/core@2.0.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ=="],
-
-    "@opentelemetry/sdk-metrics/@opentelemetry/resources": ["@opentelemetry/resources@2.0.0", "", { "dependencies": { "@opentelemetry/core": "2.0.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-rnZr6dML2z4IARI4zPGQV4arDikF/9OXZQzrC01dLmn0CZxU5U5OLd/m1T7YkGRj5UitjeoCtg/zorlgMQcdTg=="],
 
     "@oslojs/jwt/@oslojs/encoding": ["@oslojs/encoding@0.4.1", "", {}, "sha512-hkjo6MuIK/kQR5CrGNdAPZhS01ZCXuWDRJ187zh6qqF2+yMHZpD9fAYpX8q2bOO6Ryhl3XpCT6kUX76N8hhm4Q=="],
 

--- a/package.json
+++ b/package.json
@@ -89,11 +89,11 @@
   },
   "packageManager": "bun@1.3.11",
   "catalog": {
-    "effect": "4.0.0-beta.59",
-    "@effect/platform-bun": "4.0.0-beta.59",
-    "@effect/platform-node": "4.0.0-beta.59",
-    "@effect/atom-react": "4.0.0-beta.59",
-    "@effect/vitest": "4.0.0-beta.59",
+    "effect": "4.0.0-beta.66",
+    "@effect/platform-bun": "4.0.0-beta.66",
+    "@effect/platform-node": "4.0.0-beta.66",
+    "@effect/atom-react": "4.0.0-beta.66",
+    "@effect/vitest": "4.0.0-beta.66",
     "@types/node": "^24.3.1",
     "bun-types": "^1.2.22",
     "drizzle-orm": "^0.45.0",
@@ -122,7 +122,7 @@
     "quickjs-emscripten": "^0.31.0",
     "@jitl/quickjs-wasmfile-release-sync": "0.31.0",
     "tsup": "^8.5.0",
-    "@effect/opentelemetry": "4.0.0-beta.59"
+    "@effect/opentelemetry": "4.0.0-beta.66"
   },
   "patchedDependencies": {
     "postgres@3.4.9": "patches/postgres@3.4.9.patch",

--- a/packages/core/api/src/account/handlers.ts
+++ b/packages/core/api/src/account/handlers.ts
@@ -14,7 +14,7 @@ import { AccountProvider, type AccountHeaders } from "./service";
 // ---------------------------------------------------------------------------
 
 const requestHeaders = Effect.map(
-  HttpServerRequest.HttpServerRequest.asEffect(),
+  HttpServerRequest.HttpServerRequest,
   (req): AccountHeaders => ({ ...req.headers }),
 );
 

--- a/packages/core/api/src/server/executor-app.ts
+++ b/packages/core/api/src/server/executor-app.ts
@@ -382,7 +382,7 @@ export const make = <
   const prefix = config.mountPrefix;
   const prefixedRouter = prefix
     ? Layer.effect(HttpRouter.HttpRouter)(
-        Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed(prefix)),
+        Effect.map(HttpRouter.HttpRouter, (router) => router.prefixed(prefix)),
       )
     : undefined;
 
@@ -399,7 +399,7 @@ export const make = <
   const authenticate = (
     request: Request,
   ): Effect.Effect<Principal, IdentityFailure, IdentityProvider> =>
-    Effect.flatMap(IdentityProvider.asEffect(), (provider) => provider.authenticate(request));
+    Effect.flatMap(IdentityProvider, (provider) => provider.authenticate(request));
 
   // The per-request layer combined into the middleware: cloud's `requestScoped`
   // (the postgres socket) with `providers.identity` PROVIDE-MERGEd over it, so the

--- a/packages/core/api/src/server/fixed-execution-middleware.ts
+++ b/packages/core/api/src/server/fixed-execution-middleware.ts
@@ -103,7 +103,7 @@ export const makeFixedExecutionMiddleware = <
   }>()(
     Effect.gen(function* () {
       const captured = yield* Effect.context<RCapture>();
-      const { executor, engine, extensions } = yield* FixedExecutionProvider.asEffect();
+      const { executor, engine, extensions } = yield* FixedExecutionProvider;
       return (httpEffect) =>
         Effect.gen(function* () {
           const request = yield* HttpServerRequest.HttpServerRequest;

--- a/packages/core/sdk/src/testing.ts
+++ b/packages/core/sdk/src/testing.ts
@@ -80,7 +80,7 @@ export const serveTestHttpApp = (
   EffectScope.Scope
 > =>
   makeTestHttpServer(
-    HttpServer.serve(HttpServerRequest.HttpServerRequest.asEffect().pipe(Effect.flatMap(handler))),
+    HttpServer.serve(HttpServerRequest.HttpServerRequest.pipe(Effect.flatMap(handler))),
   );
 
 export const serveTestHttpServerLayer = (

--- a/packages/core/sdk/src/testing/oauth-test-server.ts
+++ b/packages/core/sdk/src/testing/oauth-test-server.ts
@@ -242,9 +242,9 @@ const serveOAuthTestHttpApp = (
   Effect.gen(function* () {
     const context = yield* Layer.build(
       Layer.fresh(
-        HttpServer.serve(
-          HttpServerRequest.HttpServerRequest.asEffect().pipe(Effect.flatMap(handler)),
-        ).pipe(Layer.provideMerge(NodeHttpServer.layerTest)),
+        HttpServer.serve(HttpServerRequest.HttpServerRequest.pipe(Effect.flatMap(handler))).pipe(
+          Layer.provideMerge(NodeHttpServer.layerTest),
+        ),
       ),
     ).pipe(Effect.mapError((address) => new OAuthTestServerAddressError({ address })));
     const server = Context.get(context, HttpServer.HttpServer);


### PR DESCRIPTION
Bumps the `effect` / `@effect/*` catalog from `beta.59` → `beta.66`.

The only breaking change across this range is the removal of `.asEffect()` on `Context.Service` tags — a tag is now directly yieldable/usable as its own Effect. Migrated all 20 call sites (`X.asEffect()` → `X`), e.g. `HttpServerRequest.HttpServerRequest.asEffect()` → `HttpServerRequest.HttpServerRequest`.

Base of a small stack standardizing our Effect patterns (tracing/observability, error model, consistency).

**Verified:** typecheck (all 38 packages), lint (`--deny-warnings`, 0/0), format, and core test suites (sdk 254 / api 29 / execution / host-mcp).

Draft — changeset + full e2e still to come.
