### PR TITLE
refactor(errors): make ToolInvocationError schema-backed

### DIFF
--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -1,4 +1,4 @@
-import { Data, Schema } from "effect";
+import { Schema } from "effect";
 
 import { ConnectionId, ToolId, SecretId } from "./ids";
 
@@ -14,11 +14,14 @@ export class ToolNotFoundError extends Schema.TaggedErrorClass<ToolNotFoundError
   },
 ) {}
 
-export class ToolInvocationError extends Data.TaggedError("ToolInvocationError")<{
-  readonly toolId: ToolId;
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class ToolInvocationError extends Schema.TaggedErrorClass<ToolInvocationError>()(
+  "ToolInvocationError",
+  {
+    toolId: ToolId,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect),
+  },
+) {}
 
 /** Tool row exists in the DB but its owning plugin isn't loaded. Means
  *  the tool was registered by a plugin that's no longer present in the


### PR DESCRIPTION
Makes `ToolInvocationError` schema-backed.

It was the only `Data.TaggedError` in the 16-member `ExecutorError` union, so converting it (`cause` → `Schema.optional(Schema.Defect)`) makes the whole union — which is returned across the SDK/MCP wire — fully schema-encodable.

Investigation showed the remaining `Data.TaggedError` errors are either internal or mapped to a `ToolResult` failure before the wire (the "module-private" exception), so they intentionally stay as `Data`. This is a tighter scope than the original audit assumed — the error model was closer to good than expected.

Stacked on #882.

**Verified:** typecheck (all 38 packages), lint (0/0), format, sdk tests.

Draft.
