### PR TITLE
Emit named GraphQL operations for generated tools

### DIFF
--- a/.changeset/named-graphql-operations.md
+++ b/.changeset/named-graphql-operations.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+GraphQL sources now emit named operations (e.g. `query Hello { ... }`) instead of anonymous ones. This fixes invocation against servers that reject anonymous operations, and gives APM tooling that keys on the operation name a meaningful value. The operation name is derived from the root field name.

--- a/.changeset/named-graphql-operations.md
+++ b/.changeset/named-graphql-operations.md
@@ -1,5 +1,5 @@
 ---
-"executor": patch
+"@executor-js/plugin-graphql": patch
 ---
 
 GraphQL sources now emit named operations (e.g. `query Hello { ... }`) instead of anonymous ones. This fixes invocation against servers that reject anonymous operations, and gives APM tooling that keys on the operation name a meaningful value. The operation name is derived from the root field name.

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -361,19 +361,26 @@ describe("graphqlPlugin real protocol server", () => {
   it.effect("sends named operations derived from the field name", () =>
     Effect.gen(function* () {
       const server = yield* serveGreetingServer;
-      const executor = yield* createExecutor(
-        makeTestConfig({ plugins: [graphqlPlugin()] as const }),
-      );
+      const executor = yield* makeExecutor();
 
-      yield* executor.graphql.addSource({
+      yield* executor.graphql.addIntegration({
         endpoint: server.endpoint,
-        scope: TEST_SCOPE,
-        namespace: "named_ops",
+        slug: "named_ops",
       });
+      yield* createOrgConnection(executor, {
+        integration: "named_ops",
+        name: "main",
+        template: "none",
+        value: "unused",
+      });
+
+      yield* executor.execute(toolAddr("named_ops", "main", "query.hello"), { name: "Ada" });
       yield* server.clearRequests;
 
-      yield* executor.tools.invoke("named_ops.query.hello", { name: "Ada" });
-      yield* executor.tools.invoke("named_ops.mutation.setGreeting", { message: "hi" });
+      yield* executor.execute(toolAddr("named_ops", "main", "query.hello"), { name: "Ada" });
+      yield* executor.execute(toolAddr("named_ops", "main", "mutation.setGreeting"), {
+        message: "hi",
+      });
 
       const requests = yield* server.requests;
       expect(requests[0]?.payload.query).toMatch(/^query Hello\b/);

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -358,6 +358,29 @@ describe("graphqlPlugin real protocol server", () => {
     }),
   );
 
+  it.effect("sends named operations derived from the field name", () =>
+    Effect.gen(function* () {
+      const server = yield* serveGreetingServer;
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [graphqlPlugin()] as const }),
+      );
+
+      yield* executor.graphql.addSource({
+        endpoint: server.endpoint,
+        scope: TEST_SCOPE,
+        namespace: "named_ops",
+      });
+      yield* server.clearRequests;
+
+      yield* executor.tools.invoke("named_ops.query.hello", { name: "Ada" });
+      yield* executor.tools.invoke("named_ops.mutation.setGreeting", { message: "hi" });
+
+      const requests = yield* server.requests;
+      expect(requests[0]?.payload.query).toMatch(/^query Hello\b/);
+      expect(requests[1]?.payload.query).toMatch(/^mutation SetGreeting\b/);
+    }),
+  );
+
   it.effect("surfaces non-2xx invocation responses as ToolResult.fail", () =>
     Effect.gen(function* () {
       const server = yield* serveTestHttpApp((request) =>

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -233,12 +233,19 @@ const buildSelectionSet = (
   return subFields.length > 0 ? `{ ${subFields.join(" ")} }` : "";
 };
 
+// Name every generated operation: some servers reject anonymous operations, and
+// APM tooling keys traces off the operation name. Field names are already valid
+// GraphQL name tokens, so the upper-cased field name is a safe operation name.
+const operationNameForField = (fieldName: string): string =>
+  fieldName.charAt(0).toUpperCase() + fieldName.slice(1);
+
 const buildOperationStringForField = (
   kind: GraphqlOperationKind,
   field: IntrospectionField,
   types: ReadonlyMap<string, IntrospectionType>,
 ): string => {
   const opType = kind === "query" ? "query" : "mutation";
+  const opName = operationNameForField(field.name);
 
   const varDefs = field.args.map((arg) => {
     const typeName = formatTypeRef(arg.type);
@@ -251,7 +258,7 @@ const buildOperationStringForField = (
   const varDefsStr = varDefs.length > 0 ? `(${varDefs.join(", ")})` : "";
   const argPassStr = argPasses.length > 0 ? `(${argPasses.join(", ")})` : "";
 
-  return `${opType}${varDefsStr} { ${field.name}${argPassStr}${selectionSet ? ` ${selectionSet}` : ""} }`;
+  return `${opType} ${opName}${varDefsStr} { ${field.name}${argPassStr}${selectionSet ? ` ${selectionSet}` : ""} }`;
 };
 
 interface PreparedOperation {
@@ -299,7 +306,7 @@ const prepareOperations = (
     const entry = fieldMap.get(key);
     const operationString = entry
       ? buildOperationStringForField(entry.kind, entry.field, typeMap)
-      : `${extracted.kind} { ${extracted.fieldName} }`;
+      : `${extracted.kind} ${operationNameForField(extracted.fieldName)} { ${extracted.fieldName} }`;
 
     const binding = OperationBinding.make({
       kind: extracted.kind,


### PR DESCRIPTION
## Problem

Generated GraphQL operations are anonymous — e.g. `query($slug: ID!) { contentcollection(slug: $slug) { ... } }`. Two consequences:

- Servers that require named operations reject every invocation. (Apollo Server can be configured this way; some gateways enforce it unconditionally and return a 400 before the resolver runs.)
- APM/observability tooling (Apollo Studio, New Relic, Datadog) keys traces and transaction names off the operation name, so all anonymous operations collapse into a single unnamed bucket.

## Change

Derive an operation name from the root field and emit it in the generated document, so `contentcollection` produces:

```graphql
query Contentcollection($slug: ID!) { contentcollection(slug: $slug) { ... } }
```

- `buildOperationStringForField` and the anonymous fallback path both name the operation.
- The name is the root field name with its first character upper-cased; GraphQL field names are already valid name tokens, so no further escaping is needed.
- Each generated document contains exactly one operation, so there is no naming-collision concern.
- The request body is unchanged otherwise; servers derive `operationName` from the document, so no separate `operationName` field is required.

## Tests

Added a test asserting a query and a mutation are sent as named operations (`query Hello …`, `mutation SetGreeting …`). Full `@executor-js/plugin-graphql` suite passes; typecheck, oxfmt, and oxlint are clean.
