### PR TITLE
[codex] Use connection prefixes in execute description

### DIFF
--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -22,7 +22,6 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres, { type Sql } from "postgres";
 
 import { createExecutorMcpServer } from "@executor-js/host-mcp/tool-server";
-import { buildExecuteDescription } from "@executor-js/execution";
 import {
   McpSessionDOBase,
   type BuiltMcpServer,
@@ -30,6 +29,7 @@ import {
   type McpSessionInit,
   type SessionMeta,
 } from "@executor-js/cloudflare/mcp/durable-object";
+import { buildExecuteDescription } from "@executor-js/execution";
 
 // The DO only needs the neutral boot-scoped service (WorkOSClient). It never
 // bills, so it does NOT depend on any billing service — `CloudExecutionStackLayer`
@@ -195,13 +195,9 @@ export class McpSessionDO extends McpSessionDOBase<CloudSessionDbHandle> {
         Effect.provide(CloudExecutionStackLayer),
         Effect.withSpan("McpSessionDO.makeExecutionStack"),
       );
-      // Build the description here so the postgres query it runs
-      // (`executor.integrations.list`) lands as a child of `McpSessionDO.createRuntime`.
-      // It also tags the span with this org's integration/connection inventory
-      // (slugs, kinds, plugin ids, connection counts) — see `buildExecuteDescription`
-      // — so a failing init names *what* it was resolving without re-listing.
-      // host-mcp would otherwise call `Effect.runPromise(engine.getDescription)`
-      // at its async MCP-SDK boundary and orphan the sub-span.
+      // Build the description here so `executor.connections.list()` stays under
+      // the DO startup span and the MCP SDK receives a concrete string instead
+      // of invoking `engine.getDescription` across its async boundary.
       const description = yield* buildExecuteDescription(executor);
       const sessionElicitationMode = sessionMeta.elicitationMode ?? "model";
       const mcpServer = yield* createExecutorMcpServer({

--- a/packages/core/execution/src/description.test.ts
+++ b/packages/core/execution/src/description.test.ts
@@ -1,23 +1,53 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
-import { IntegrationSlug, createExecutor, definePlugin } from "@executor-js/sdk";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ProviderItemId,
+  ProviderKey,
+  createExecutor,
+  definePlugin,
+  type CredentialProvider,
+} from "@executor-js/sdk";
 import { makeTestConfig } from "@executor-js/sdk/testing";
 
 import { buildExecuteDescription } from "./description";
 
-// v2 port: namespaces are the integration catalog, not v1 `staticSources`.
-// Two plugins register integrations whose slugs are distinct from their
-// pluginIds. If `buildExecuteDescription` ever renders the wrong field (e.g.
-// pluginId, an internal UUID, or a display name), these assertions fail — the
-// class of bug a hand-rolled fake `Executor` would miss.
+const memoryProvider = (): CredentialProvider => {
+  const store = new Map<string, string>();
+  return {
+    key: ProviderKey.make("memory"),
+    writable: true,
+    get: (id) => Effect.sync(() => store.get(String(id)) ?? null),
+    set: (id, value) => Effect.sync(() => void store.set(String(id), value)),
+    has: (id) => Effect.sync(() => store.has(String(id))),
+    list: () =>
+      Effect.sync(() =>
+        Array.from(store.keys()).map((key) => ({
+          id: ProviderItemId.make(key),
+          name: key,
+        })),
+      ),
+  };
+};
+
+const GITHUB = IntegrationSlug.make("github");
+const SLACK = IntegrationSlug.make("slack");
+const TEMPLATE = AuthTemplateSlug.make("apiKey");
+
+// v2 port: available entries are saved connection prefixes, not integration
+// slugs. Multiple saved connections can point at the same integration, and the
+// callable path needs `<integration>.<owner>.<connection>`.
 const githubPlugin = definePlugin(() => ({
   id: "github-plugin" as const,
+  credentialProviders: [memoryProvider()],
   storage: () => ({}),
   extension: (ctx) => ({
     seed: () =>
       ctx.core.integrations.register({
-        slug: IntegrationSlug.make("github"),
+        slug: GITHUB,
         description: "GitHub",
         config: {},
       }),
@@ -30,7 +60,7 @@ const slackPlugin = definePlugin(() => ({
   extension: (ctx) => ({
     seed: () =>
       ctx.core.integrations.register({
-        slug: IntegrationSlug.make("slack"),
+        slug: SLACK,
         description: "Slack Workspace",
         config: {},
       }),
@@ -38,48 +68,57 @@ const slackPlugin = definePlugin(() => ({
 }))();
 
 describe("buildExecuteDescription", () => {
-  it.effect(
-    "renders real integration slugs as namespaces (sorted) through the real executor flow",
-    () =>
-      Effect.gen(function* () {
-        // Intentionally register in non-alphabetical order — the formatter
-        // is expected to sort by integration slug.
-        const executor = yield* createExecutor(
-          makeTestConfig({ plugins: [slackPlugin, githubPlugin] as const }),
-        );
-        yield* executor["slack-plugin"].seed();
-        yield* executor["github-plugin"].seed();
+  it.effect("renders real connection prefixes separately through the real executor flow", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [slackPlugin, githubPlugin] as const }),
+      );
+      yield* executor["slack-plugin"].seed();
+      yield* executor["github-plugin"].seed();
+      yield* executor.connections.create({
+        owner: "user",
+        name: ConnectionName.make("personal"),
+        integration: GITHUB,
+        template: TEMPLATE,
+        value: "user-token",
+      });
+      yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("prod"),
+        integration: GITHUB,
+        template: TEMPLATE,
+        value: "org-token",
+      });
 
-        const description = yield* buildExecuteDescription(executor);
+      const description = yield* buildExecuteDescription(executor);
 
-        // Stable anchor from the workflow preamble.
-        expect(description).toContain("Execute TypeScript in a sandboxed runtime");
-        // The namespaces section header.
-        expect(description).toContain("## Available namespaces");
-        // Each integration renders with its ACTUAL slug, without descriptions or plugin ids.
-        expect(description).toContain("- `github`");
-        expect(description).toContain("- `slack`");
-        expect(description).not.toContain("Slack Workspace");
-        expect(description).not.toContain("`github-plugin`");
-        expect(description).not.toContain("`slack-plugin`");
+      // Stable anchor from the workflow preamble.
+      expect(description).toContain("Execute TypeScript in a sandboxed runtime");
+      expect(description).toContain("## Available connection prefixes");
+      expect(description).toContain("- `github.org.prod`");
+      expect(description).toContain("- `github.user.personal`");
+      expect(description).not.toContain("## Available namespaces");
+      expect(description).not.toContain("Slack Workspace");
+      expect(description).not.toContain("`github-plugin`");
+      expect(description).not.toContain("`slack-plugin`");
+      expect(description).not.toContain("- `github`");
 
-        // Sort order: `github` before `slack`.
-        const githubIdx = description.indexOf("`github`");
-        const slackIdx = description.indexOf("`slack`");
-        expect(githubIdx).toBeGreaterThan(-1);
-        expect(slackIdx).toBeGreaterThan(-1);
-        expect(githubIdx).toBeLessThan(slackIdx);
-      }),
+      const orgIdx = description.indexOf("`github.org.prod`");
+      const userIdx = description.indexOf("`github.user.personal`");
+      expect(orgIdx).toBeGreaterThan(-1);
+      expect(userIdx).toBeGreaterThan(-1);
+      expect(orgIdx).toBeLessThan(userIdx);
+    }),
   );
 
-  it.effect("omits the Available namespaces section when no integrations are registered", () =>
+  it.effect("omits the Available connection prefixes section when no connections exist", () =>
     Effect.gen(function* () {
       const executor = yield* createExecutor(makeTestConfig({ plugins: [] as const }));
 
       const description = yield* buildExecuteDescription(executor);
 
       expect(description).toContain("Execute TypeScript in a sandboxed runtime");
-      expect(description).not.toContain("## Available namespaces");
+      expect(description).not.toContain("## Available connection prefixes");
     }),
   );
 });

--- a/packages/core/execution/src/description.ts
+++ b/packages/core/execution/src/description.ts
@@ -1,51 +1,59 @@
 import { Effect } from "effect";
-import type { Executor, Integration } from "@executor-js/sdk/core";
+import type { Connection, Executor } from "@executor-js/sdk/core";
 
 /**
  * Builds a tool description dynamically.
  *
  * Structure:
  *   1. Workflow (top — critical, least likely to be truncated)
- *   2. Available namespaces (bottom)
+ *   2. Available connection prefixes (bottom)
  *
- * v2: namespaces are the integration catalog. A tool's sandbox address is
- * `tools.<integration>.<owner>.<connection>.<tool>`, so the integration slug
- * is the first callable segment the model needs to know about.
+ * v2: callable API tools are scoped by saved connections. A tool's sandbox
+ * address is `tools.<integration>.<owner>.<connection>.<tool>`, so the useful
+ * inventory is the connection prefix rather than only the integration slug.
  */
 export const buildExecuteDescription = (executor: Executor): Effect.Effect<string> =>
   Effect.gen(function* () {
-    const integrations: readonly Integration[] = yield* executor.integrations.list().pipe(
+    const connections: readonly Connection[] = yield* executor.connections.list().pipe(
       // oxlint-disable-next-line executor/no-effect-escape-hatch -- boundary: ExecutionEngine.getDescription currently exposes no error channel; engine typed-error widening is covered separately
       Effect.orDie,
-      Effect.withSpan("executor.integrations.list"),
+      Effect.withSpan("executor.connections.list"),
     );
 
-    const description = yield* Effect.sync(() => formatDescription(integrations)).pipe(
+    const description = yield* Effect.sync(() =>
+      formatDescription(connections.map((connection) => connectionPath(connection))),
+    ).pipe(
       Effect.withSpan("schema.compile.description", {
-        attributes: { "executor.integration_count": integrations.length },
+        attributes: { "executor.connection_count": connections.length },
       }),
     );
 
     yield* Effect.annotateCurrentSpan({
-      "executor.integration_count": integrations.length,
+      "executor.connection_count": connections.length,
       "schema.kind": "execute",
-      // Integration inventory so a failing session build (which runs this
-      // during init) names *what* it was resolving: empty/OpenAPI-only
-      // catalogs build cleanly, catalogs with remote MCP integrations are the
-      // ones that fail.
-      "executor.integration_slugs": integrations
-        .map((integration) => String(integration.slug))
+      // Connection inventory so a failing session build (which runs this during
+      // init) names the callable prefixes it resolved without listing tools.
+      "executor.connection_addresses": connections
+        .map((connection) => connectionPath(connection))
         .slice(0, 50)
         .join(","),
-      "executor.integration_kinds": [
-        ...new Set(integrations.map((integration) => integration.kind)),
+      "executor.connection_integrations": [
+        ...new Set(connections.map((connection) => String(connection.integration))),
+      ].join(","),
+      "executor.connection_owners": [
+        ...new Set(connections.map((connection) => connection.owner)),
       ].join(","),
     });
 
     return description;
   }).pipe(Effect.withSpan("schema.describe.execute"));
 
-const formatDescription = (integrations: readonly Integration[]): string => {
+const connectionPath = (connection: Connection): string => {
+  const address = String(connection.address);
+  return address.startsWith("tools.") ? address.slice("tools.".length) : address;
+};
+
+const formatDescription = (connectionPrefixes: readonly string[]): string => {
   const lines: string[] = [
     "Execute TypeScript in a sandboxed runtime with access to configured API tools.",
     "",
@@ -55,19 +63,19 @@ const formatDescription = (integrations: readonly Integration[]): string => {
     '2. `const path = matches[0]?.path; if (!path) return "No matching tools found.";`',
     "3. `const details = await tools.describe.tool({ path });`",
     "4. Use `details.inputTypeScript` / `details.outputTypeScript` and `details.typeScriptDefinitions` for compact shapes.",
-    "5. Use `tools.executor.sources.list()` when you need configured integration inventory.",
+    "5. Use `tools.executor.coreTools.connections.list({})` when you need live saved-connection inventory.",
     "6. Call the tool: `const result = await tools.<path>(input);`",
     "",
     "## Rules",
     "",
     "- `tools.search()` returns paginated, ranked matches: `{ items, total, hasMore, nextOffset }`. Best-first. Use short intent phrases like `github issues`, `repo details`, or `create calendar event`.",
     '- When you already know the namespace, narrow with `tools.search({ namespace: "github", query: "issues" })`.',
-    "- `tools.executor.sources.list()` returns the same paged shape: `{ items: [{ id, toolCount, ... }], total, hasMore, nextOffset }`.",
+    "- `tools.executor.coreTools.connections.list({})` returns saved connections with `{ address, integration, owner, name, ... }`. The `address` field includes the leading `tools.` root.",
     "- Tool calls return a value union: `{ ok: true, data }` for success or `{ ok: false, error: { code, message, status?, details?, retryable? } }` for expected tool/domain failures. Branch on `result.ok`.",
-    "- If `hasMore` is true and you didn't find what you need, fetch the next page: `tools.search({ query, offset: nextOffset, limit })`. Same `offset` parameter on `tools.executor.sources.list({ offset, limit })`.",
-    "- Always use the full address when calling tools: `tools.<integration>.<owner>.<connection>.<tool>(args)`. The `path` returned by `tools.search()` / `tools.describe.tool()` is already this exact address — call `tools[path]` rather than guessing segments.",
-    "- The `tools` object is a lazy proxy — `Object.keys(tools)` won't work. Use `tools.search()` or `tools.executor.sources.list()` instead.",
-    '- Pass an object to system tools, e.g. `tools.search({ query: "..." })`, `tools.executor.sources.list()`, and `tools.describe.tool({ path })`.',
+    "- If `tools.search()` returns `hasMore: true` and you didn't find what you need, fetch the next page: `tools.search({ query, offset: nextOffset, limit })`.",
+    "- Always use the full address when calling tools: `tools.<integration>.<owner>.<connection>.<tool>(args)`. The `path` returned by `tools.search()` / `tools.describe.tool()` is already the exact path under `tools` — call `tools[path]` rather than guessing segments.",
+    "- The `tools` object is a lazy proxy — `Object.keys(tools)` won't work. Use `tools.search()` or `tools.executor.coreTools.connections.list({})` instead.",
+    '- Pass an object to system tools, e.g. `tools.search({ query: "..." })`, `tools.executor.coreTools.connections.list({})`, and `tools.describe.tool({ path })`.',
     "- `tools.describe.tool()` returns compact TypeScript shapes. Use `inputTypeScript`, `outputTypeScript`, and `typeScriptDefinitions`.",
     "- For tools that return large collections (e.g. `getStates`, `getAll`), filter results in code rather than calling per-item tools.",
     "- Do not use `fetch` — all API calls go through `tools.*`.",
@@ -75,18 +83,17 @@ const formatDescription = (integrations: readonly Integration[]): string => {
     "- TypeScript type syntax (`: T`, `as T`, generics, interfaces, type aliases) is stripped before execution — feel free to write idiomatic TypeScript using the shapes from `tools.describe.tool()`. Decorators and `enum` are not supported.",
   ];
 
-  if (integrations.length > 0) {
+  if (connectionPrefixes.length > 0) {
     lines.push("");
-    lines.push("## Available namespaces");
+    lines.push("## Available connection prefixes");
     lines.push("");
-    const sorted = [...integrations]
-      .sort((a, b) => String(a.slug).localeCompare(String(b.slug)))
-      .slice(0, 50);
-    for (const integration of sorted) {
-      lines.push(`- \`${integration.slug}\``);
+    lines.push("These are paths under `tools.`; append the final tool segment.");
+    const sorted = [...connectionPrefixes].sort((a, b) => a.localeCompare(b)).slice(0, 50);
+    for (const prefix of sorted) {
+      lines.push(`- \`${prefix}\``);
     }
-    if (integrations.length > sorted.length) {
-      lines.push(`- ... ${integrations.length - sorted.length} more`);
+    if (connectionPrefixes.length > sorted.length) {
+      lines.push(`- ... ${connectionPrefixes.length - sorted.length} more`);
     }
   }
 

--- a/packages/core/sdk/src/executor.test.ts
+++ b/packages/core/sdk/src/executor.test.ts
@@ -444,15 +444,29 @@ describe("createExecutor", () => {
           id: ProviderItemId.make("v"),
         },
       });
+      yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("other"),
+        integration: INTEG,
+        template: TEMPLATE,
+        from: {
+          provider: ProviderKey.make("memory"),
+          id: ProviderItemId.make("v"),
+        },
+      });
 
-      const result = yield* Effect.result(executor.execute(addr("nope"), {}));
+      const result = yield* Effect.result(executor.execute(addr("un"), {}));
       expect(Result.isFailure(result)).toBe(true);
       if (!Result.isFailure(result)) return;
       const error = result.failure;
       expect(Predicate.isTagged(error, "ToolNotFoundError")).toBe(true);
       const suggestions = (error as ToolNotFoundError).suggestions ?? [];
-      // The two produced tools are suggested.
-      expect(suggestions.length).toBeGreaterThan(0);
+      expect(suggestions).toEqual([addr("run")]);
+      expect(
+        suggestions.every((suggestion) =>
+          String(suggestion).startsWith(`tools.${INTEG}.org.${CONN}.`),
+        ),
+      ).toBe(true);
     }),
   );
 });

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -2434,10 +2434,42 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // execute — the invoke path.
     // ------------------------------------------------------------------
 
-    const toolSuggestions = (
-      address: ToolAddress,
-      rows: readonly ToolRow[],
-    ): readonly ToolAddress[] => rows.map((row) => rowToTool(row).address).slice(0, 5);
+    const TOOL_SUGGESTION_LIMIT = 5;
+
+    const toolSuggestions = (rows: readonly ToolRow[]): readonly ToolAddress[] =>
+      rows.map((row) => rowToTool(row).address);
+
+    const toolRowsForConnectionWhere = (parsed: ParsedToolAddress) => (b: AnyCb) =>
+      b.and(
+        byOwner(parsed.owner)(b),
+        b("integration", "=", String(parsed.integration)),
+        b("connection", "=", String(parsed.connection)),
+      );
+
+    const searchToolRowsForConnection = (
+      parsed: ParsedToolAddress,
+    ): Effect.Effect<readonly ToolRow[], StorageFailure> =>
+      core.findMany("tool", {
+        where: (b: AnyCb) =>
+          b.and(
+            toolRowsForConnectionWhere(parsed)(b),
+            b.or(
+              b("name", "contains", String(parsed.tool)),
+              b("description", "contains", String(parsed.tool)),
+            ),
+          ),
+        orderBy: ["name", "asc"],
+        limit: TOOL_SUGGESTION_LIMIT,
+      });
+
+    const findToolRowsForConnection = (
+      parsed: ParsedToolAddress,
+    ): Effect.Effect<readonly ToolRow[], StorageFailure> =>
+      core.findMany("tool", {
+        where: toolRowsForConnectionWhere(parsed),
+        orderBy: ["name", "asc"],
+        limit: TOOL_SUGGESTION_LIMIT,
+      });
 
     const execute = (
       address: ToolAddress,
@@ -2508,10 +2540,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             ),
         });
         if (!row) {
-          const all = yield* core.findMany("tool", {});
+          const searchMatches = yield* searchToolRowsForConnection(parsed);
+          const connectionTools =
+            searchMatches.length > 0 ? searchMatches : yield* findToolRowsForConnection(parsed);
           return yield* new ToolNotFoundError({
             address,
-            suggestions: toolSuggestions(address, all),
+            suggestions: toolSuggestions(connectionTools),
           });
         }
 


### PR DESCRIPTION
## Summary
- Build the execute tool description from `executor.connections.list()`.
- Show saved connection prefixes instead of bare integration slugs.
- Scope missing-tool suggestions to the requested connection.

## Checks
- `vitest run src/description.test.ts`
- `vitest run src/executor.test.ts`
- `bun run typecheck` in `apps/cloud`
- `bun run typecheck` in `packages/core/sdk`
- `oxfmt --check` on touched files