### PR TITLE
Restore migrated integration display icons

### DIFF
--- a/packages/core/api/src/handlers/integrations.ts
+++ b/packages/core/api/src/handlers/integrations.ts
@@ -13,6 +13,7 @@ const toResponse = (i: Integration) => ({
   canRemove: i.canRemove,
   canRefresh: i.canRefresh,
   authMethods: i.authMethods,
+  ...(i.displayUrl ? { displayUrl: i.displayUrl } : {}),
 });
 
 export const IntegrationsHandlers = HttpApiBuilder.group(ExecutorApi, "integrations", (handlers) =>

--- a/packages/core/api/src/integrations/api.ts
+++ b/packages/core/api/src/integrations/api.ts
@@ -67,6 +67,8 @@ const IntegrationResponse = Schema.Struct({
   /** Declared auth methods derived from the owning plugin's stored config.
    *  Always present (possibly empty) so the client never handles absence. */
   authMethods: Schema.Array(AuthMethodDescriptorSchema),
+  /** Non-secret URL derived from opaque integration config for favicons. */
+  displayUrl: Schema.optional(Schema.String),
 });
 
 const UpdateIntegrationPayload = Schema.Struct({

--- a/packages/core/api/src/integrations/integrations-auth-methods.test.ts
+++ b/packages/core/api/src/integrations/integrations-auth-methods.test.ts
@@ -52,15 +52,25 @@ const declaringPlugin = definePlugin(() => ({
   id: "declaring" as const,
   storage: () => ({}),
   describeAuthMethods: (record: IntegrationRecord): readonly AuthMethodDescriptor[] => {
-    const config = record.config as { readonly methods?: readonly AuthMethodDescriptor[] };
+    const config = record.config as {
+      readonly methods?: readonly AuthMethodDescriptor[];
+      readonly displayUrl?: string;
+    };
     return config?.methods ?? [];
   },
+  describeIntegrationDisplay: (record: IntegrationRecord) => {
+    const config = record.config as {
+      readonly methods?: readonly AuthMethodDescriptor[];
+      readonly displayUrl?: string;
+    };
+    return { url: config?.displayUrl };
+  },
   extension: (ctx) => ({
-    seed: (slug: IntegrationSlug, methods: readonly AuthMethodDescriptor[]) =>
+    seed: (slug: IntegrationSlug, methods: readonly AuthMethodDescriptor[], displayUrl?: string) =>
       ctx.core.integrations.register({
         slug,
         description: String(slug),
-        config: { methods },
+        config: { methods, displayUrl },
       }),
   }),
 }))();
@@ -93,6 +103,7 @@ const handlerContextFor = (executor: Executor) =>
 interface IntegrationResponseBody {
   readonly slug: string;
   readonly authMethods: readonly AuthMethodDescriptor[];
+  readonly displayUrl?: string;
 }
 
 describe("catalog surfaces declared auth methods", () => {
@@ -164,6 +175,29 @@ describe("catalog surfaces declared auth methods", () => {
       const bare = body.find((i) => i.slug === "bare-server");
       expect(oauth?.authMethods).toEqual([OAUTH_METHOD]);
       expect(bare?.authMethods).toEqual([]);
+    }),
+  );
+
+  it.effect("surfaces plugin-derived display URLs without exposing config", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: [declaringPlugin] }));
+      const slug = IntegrationSlug.make("autumn");
+      yield* executor.declaring.seed(slug, [], "https://api.useautumn.com");
+
+      const web = yield* webHandlerFor(executor);
+      const context = handlerContextFor(executor);
+
+      const response = yield* Effect.promise(() =>
+        web.handler(
+          new Request(`http://localhost/integrations/${encodeURIComponent(String(slug))}`),
+          context,
+        ),
+      );
+      expect(response.status).toBe(200);
+      const body = (yield* Effect.promise(() => response.json())) as IntegrationResponseBody;
+
+      expect(body.displayUrl).toBe("https://api.useautumn.com");
+      expect("config" in body).toBe(false);
     }),
   );
 });

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -421,6 +421,7 @@ const decodeJsonColumn = (value: unknown): unknown => {
 const rowToIntegration = (
   row: IntegrationRow,
   authMethods: readonly AuthMethodDescriptor[] = [],
+  displayUrl?: string,
 ): Integration => ({
   slug: IntegrationSlug.make(row.slug),
   description: row.description,
@@ -428,6 +429,7 @@ const rowToIntegration = (
   canRemove: Boolean(row.can_remove),
   canRefresh: Boolean(row.can_refresh),
   authMethods,
+  ...(displayUrl ? { displayUrl } : {}),
 });
 
 const rowToIntegrationRecord = (
@@ -1479,13 +1481,29 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }
     };
 
+    const describeDisplayUrlForRow = (row: IntegrationRow): string | undefined => {
+      const runtime = runtimes.get(row.plugin_id);
+      const describe = runtime?.plugin.describeIntegrationDisplay;
+      if (!describe) return undefined;
+      const record = rowToIntegrationRecord(row);
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: plugin-authored projector must never fail the catalog read
+      try {
+        const display = describe(record);
+        return display.url && display.url.length > 0 ? display.url : undefined;
+      } catch {
+        return undefined;
+      }
+    };
+
     const integrationsList = (): Effect.Effect<readonly Integration[], StorageFailure> =>
       core
         .findMany("integration", {})
         .pipe(
           Effect.map((rows) => [
             ...staticSources().map(staticSourceToIntegration),
-            ...rows.map((row) => rowToIntegration(row, describeAuthMethodsForRow(row))),
+            ...rows.map((row) =>
+              rowToIntegration(row, describeAuthMethodsForRow(row), describeDisplayUrlForRow(row)),
+            ),
           ]),
         );
 
@@ -1496,7 +1514,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const staticSource = staticSources().find((source) => source.id === String(slug));
         if (staticSource) return staticSourceToIntegration(staticSource);
         const row = yield* findIntegrationRow(slug);
-        return row ? rowToIntegration(row, describeAuthMethodsForRow(row)) : null;
+        return row
+          ? rowToIntegration(row, describeAuthMethodsForRow(row), describeDisplayUrlForRow(row))
+          : null;
       });
 
     const integrationsGetRecord = (

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -75,6 +75,7 @@ export type {
   AuthPlacementDescriptor,
   Integration,
   IntegrationConfig,
+  IntegrationDisplayDescriptor,
   RegisterIntegrationInput,
 } from "./integration";
 export type {

--- a/packages/core/sdk/src/integration.ts
+++ b/packages/core/sdk/src/integration.ts
@@ -19,6 +19,11 @@ import type { IntegrationSlug } from "./ids";
 // connection-inference behavior (no regression).
 // ---------------------------------------------------------------------------
 
+export interface IntegrationDisplayDescriptor {
+  /** Non-secret URL suitable for display metadata such as favicons. */
+  readonly url?: string;
+}
+
 /** Where a credential value is carried on the outbound request. Mirrors the
  *  client's `Placement`. */
 export interface AuthPlacementDescriptor {
@@ -77,6 +82,9 @@ export interface Integration {
   /** Declared auth methods derived from the owning plugin's stored config (a
    *  derived projection, not a DB column). Always present, possibly empty. */
   readonly authMethods: readonly AuthMethodDescriptor[];
+  /** Non-secret display URL derived by the owning plugin from opaque config.
+   *  Used for catalog favicons; never includes credentials or plugin config. */
+  readonly displayUrl?: string;
 }
 
 /** Plugin-owned, opaque-to-core configuration stored on the integration row. The

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -11,6 +11,7 @@ import type {
   AuthMethodDescriptor,
   Integration,
   IntegrationConfig,
+  IntegrationDisplayDescriptor,
   RegisterIntegrationInput,
 } from "./integration";
 import type { ToolRow } from "./core-schema";
@@ -460,6 +461,13 @@ export interface PluginSpec<
   readonly describeAuthMethods?: (
     integration: IntegrationRecord,
   ) => readonly AuthMethodDescriptor[];
+
+  /** Project this plugin's opaque integration config into safe catalog-visible
+   *  display metadata. This is intentionally narrow: the client needs a URL for
+   *  favicons without receiving the full plugin config. */
+  readonly describeIntegrationDisplay?: (
+    integration: IntegrationRecord,
+  ) => IntegrationDisplayDescriptor;
 
   /** URL autodetection hook for onboarding. */
   readonly detect?: (input: {

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -34,6 +34,7 @@ export type {
   AuthPlacementDescriptor,
   Integration,
   IntegrationConfig,
+  IntegrationDisplayDescriptor,
 } from "./integration";
 export type {
   Connection,

--- a/packages/plugins/graphql/src/sdk/describe-auth-methods.test.ts
+++ b/packages/plugins/graphql/src/sdk/describe-auth-methods.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { IntegrationSlug, type IntegrationConfig, type IntegrationRecord } from "@executor-js/sdk";
 
-import { describeGraphqlAuthMethods } from "./plugin";
+import { describeGraphqlAuthMethods, describeGraphqlIntegrationDisplay } from "./plugin";
 
 // ---------------------------------------------------------------------------
 // `describeGraphqlAuthMethods` projects the stored GraphQL config into the
@@ -130,5 +130,21 @@ describe("describeGraphqlAuthMethods", () => {
     expect(describeGraphqlAuthMethods(recordWith({ not: "a graphql config" }))).toEqual([]);
     expect(describeGraphqlAuthMethods(recordWith(null))).toEqual([]);
     expect(describeGraphqlAuthMethods(recordWith("garbage"))).toEqual([]);
+  });
+
+  it("projects endpoint as display metadata", () => {
+    expect(
+      describeGraphqlIntegrationDisplay(
+        recordWith({
+          endpoint: "https://api.github.com/graphql",
+          name: "GitHub",
+          authenticationTemplate: [],
+        }),
+      ),
+    ).toEqual({ url: "https://api.github.com/graphql" });
+  });
+
+  it("does not expose display metadata for malformed configs", () => {
+    expect(describeGraphqlIntegrationDisplay(recordWith({ not: "graphql" }))).toEqual({});
   });
 });

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -510,6 +510,13 @@ export const describeGraphqlAuthMethods = (
   });
 };
 
+export const describeGraphqlIntegrationDisplay = (
+  record: IntegrationRecord,
+): { readonly url?: string } => {
+  const config = Option.getOrUndefined(decodeGraphqlIntegrationConfigOption(record.config));
+  return { url: config?.endpoint };
+};
+
 // ---------------------------------------------------------------------------
 // Auth-template merge — append the incoming custom methods onto the existing
 // `authenticationTemplate`, replacing entries whose slug matches and assigning a
@@ -789,6 +796,7 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
     },
 
     describeAuthMethods: describeGraphqlAuthMethods,
+    describeIntegrationDisplay: describeGraphqlIntegrationDisplay,
 
     staticSources: (self: GraphqlPluginExtension) => [
       {

--- a/packages/plugins/mcp/src/sdk/describe-auth-methods.test.ts
+++ b/packages/plugins/mcp/src/sdk/describe-auth-methods.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { IntegrationSlug, type IntegrationConfig, type IntegrationRecord } from "@executor-js/sdk";
 
-import { describeMcpAuthMethods } from "./plugin";
+import { describeMcpAuthMethods, describeMcpIntegrationDisplay } from "./plugin";
 
 // ---------------------------------------------------------------------------
 // `describeMcpAuthMethods` projects the stored MCP config into the catalog's
@@ -99,5 +99,24 @@ describe("describeMcpAuthMethods", () => {
     expect(describeMcpAuthMethods(recordWith({ not: "an mcp config" }))).toEqual([]);
     expect(describeMcpAuthMethods(recordWith(null))).toEqual([]);
     expect(describeMcpAuthMethods(recordWith("garbage"))).toEqual([]);
+  });
+
+  it("projects remote endpoint as display metadata", () => {
+    expect(
+      describeMcpIntegrationDisplay(
+        recordWith({
+          transport: "remote",
+          endpoint: "https://mcp.posthog.com/mcp",
+          auth: { kind: "none" },
+        }),
+      ),
+    ).toEqual({ url: "https://mcp.posthog.com/mcp" });
+  });
+
+  it("does not expose display metadata for stdio or malformed configs", () => {
+    expect(
+      describeMcpIntegrationDisplay(recordWith({ transport: "stdio", command: "run" })),
+    ).toEqual({});
+    expect(describeMcpIntegrationDisplay(recordWith({ not: "mcp" }))).toEqual({});
   });
 });

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -439,6 +439,14 @@ export const describeMcpAuthMethods = (
   return [];
 };
 
+export const describeMcpIntegrationDisplay = (
+  record: IntegrationRecord,
+): { readonly url?: string } => {
+  const config = parseMcpIntegrationConfig(record.config);
+  if (!config || config.transport === "stdio") return {};
+  return { url: config.endpoint };
+};
+
 // ---------------------------------------------------------------------------
 // Plugin factory
 // ---------------------------------------------------------------------------
@@ -826,6 +834,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
       }),
 
     describeAuthMethods: describeMcpAuthMethods,
+    describeIntegrationDisplay: describeMcpIntegrationDisplay,
 
     integrationConfigure: {
       type: "mcp",

--- a/packages/plugins/openapi/src/sdk/describe-auth-methods.test.ts
+++ b/packages/plugins/openapi/src/sdk/describe-auth-methods.test.ts
@@ -6,7 +6,7 @@ import {
   type IntegrationRecord,
 } from "@executor-js/sdk/core";
 
-import { describeOpenApiAuthMethods } from "./plugin";
+import { describeOpenApiAuthMethods, describeOpenApiIntegrationDisplay } from "./plugin";
 import { variable, type Authentication } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -93,5 +93,30 @@ describe("describeOpenApiAuthMethods", () => {
         config: { not: "openapi" } as IntegrationConfig,
       }),
     ).toEqual([]);
+  });
+
+  it("projects baseUrl as display metadata", () => {
+    expect(
+      describeOpenApiIntegrationDisplay({
+        ...recordWith([]),
+        config: {
+          spec: "{}",
+          sourceUrl: "https://api.example.com/openapi.json",
+          baseUrl: "https://api.example.com",
+        } as IntegrationConfig,
+      }),
+    ).toEqual({ url: "https://api.example.com" });
+  });
+
+  it("falls back to sourceUrl for display metadata", () => {
+    expect(
+      describeOpenApiIntegrationDisplay({
+        ...recordWith([]),
+        config: {
+          spec: "{}",
+          sourceUrl: "https://api.example.com/openapi.json",
+        } as IntegrationConfig,
+      }),
+    ).toEqual({ url: "https://api.example.com/openapi.json" });
   });
 });

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -648,6 +648,13 @@ export const describeOpenApiAuthMethods = (
   );
 };
 
+export const describeOpenApiIntegrationDisplay = (
+  record: IntegrationRecord,
+): { readonly url?: string } => {
+  const config = decodeOpenApiIntegrationConfig(record.config);
+  return { url: config?.baseUrl ?? config?.sourceUrl };
+};
+
 // ---------------------------------------------------------------------------
 // Spec → tool definitions (shared by addSpec, resolveTools, and detect)
 // ---------------------------------------------------------------------------
@@ -1018,6 +1025,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
     ],
 
     describeAuthMethods: describeOpenApiAuthMethods,
+    describeIntegrationDisplay: describeOpenApiIntegrationDisplay,
 
     // Produce one tool per spec operation. Spec-derived, identical for every
     // connection on the integration — so `getValue` is never called here. The

--- a/packages/react/src/components/command-palette.tsx
+++ b/packages/react/src/components/command-palette.tsx
@@ -55,6 +55,7 @@ export function CommandPalette() {
             id: String(integration.slug),
             name: integration.description || String(integration.slug),
             kind: integration.kind,
+            url: integration.displayUrl,
           })),
       }),
     [integrationsResult],

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -139,10 +139,14 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
               >
                 <IntegrationFavicon
                   icon={integrationPresetIconUrl(
-                    { id: slug, kind: integration.kind, name },
+                    { id: slug, kind: integration.kind, name, url: integration.displayUrl },
                     integrationPlugins,
                   )}
-                  url={integrationInferredUrl({ id: slug, name }) ?? undefined}
+                  url={
+                    integration.displayUrl ??
+                    integrationInferredUrl({ id: slug, name }) ??
+                    undefined
+                  }
                 />
                 <span className="flex-1 truncate">{name}</span>
               </Link>

--- a/packages/react/src/pages/integrations.tsx
+++ b/packages/react/src/pages/integrations.tsx
@@ -407,11 +407,15 @@ function IntegrationGrid(props: { integrations: readonly Integration[] }) {
               <Link to="/integrations/$namespace" params={{ namespace: slug }}>
                 <IntegrationIconWithAccount
                   icon={integrationPresetIconUrl(
-                    { id: slug, kind: integration.kind, name },
+                    { id: slug, kind: integration.kind, name, url: integration.displayUrl },
                     integrationPlugins,
                   )}
                   sourceId={slug}
-                  url={integrationInferredUrl({ id: slug, name }) ?? undefined}
+                  url={
+                    integration.displayUrl ??
+                    integrationInferredUrl({ id: slug, name }) ??
+                    undefined
+                  }
                 />
                 <CardStackEntryContent>
                   <CardStackEntryTitle>{name}</CardStackEntryTitle>


### PR DESCRIPTION
Restores migrated integration icons by exposing a safe, plugin-derived display URL on the public integration catalog response.

Root cause: v1 sidebar icons could fall back to `source.url`, but v2 integrations intentionally hide opaque plugin config. Migrated URLs still existed in config (`baseUrl`, `sourceUrl`, or `endpoint`), but the React catalog views could no longer use them for favicons.

Changes:
- Adds `displayUrl` to the public `Integration` projection.
- Adds `describeIntegrationDisplay` as a plugin hook for safe catalog metadata.
- Projects display URLs for OpenAPI, MCP, and GraphQL integrations.
- Threads `displayUrl` through the sidebar, integrations grid, and command palette icon rendering.
- Adds API and plugin projector coverage.

Validation:
- `bun run test -- src/integrations/integrations-auth-methods.test.ts` in `packages/core/api`
- `bun run test -- src/sdk/describe-auth-methods.test.ts` in `packages/plugins/mcp`
- `bun run test -- src/sdk/describe-auth-methods.test.ts` in `packages/plugins/openapi`
- `bun run test -- src/sdk/describe-auth-methods.test.ts` in `packages/plugins/graphql`
- `bun run typecheck` in `packages/core/sdk`, `packages/core/api`, `packages/plugins/mcp`, `packages/plugins/openapi`, `packages/plugins/graphql`, and `packages/react`
- targeted `bunx oxfmt --check ...`
