### PR TITLE
Surface OAuth reauth failures from tool calls

### DIFF
--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -7,6 +7,7 @@ import {
   ElicitationResponse,
   FormElicitation,
   IntegrationSlug,
+  OAuthClientSlug,
   ProviderItemId,
   ProviderKey,
   ToolName,
@@ -18,7 +19,12 @@ import {
   type Elicit,
   type ToolDef,
 } from "@executor-js/sdk";
-import { makeTestConfig, typeCheckOutputTypeScript } from "@executor-js/sdk/testing";
+import {
+  makeTestConfig,
+  memoryCredentialsPlugin,
+  serveOAuthTestServer,
+  typeCheckOutputTypeScript,
+} from "@executor-js/sdk/testing";
 import { makeQuickJsExecutor } from "@executor-js/runtime-quickjs";
 import { createExecutionEngine } from "./engine";
 import {
@@ -77,6 +83,8 @@ const acceptAll = () => Effect.succeed(ElicitationResponse.make({ action: "accep
 
 const TEMPLATE = AuthTemplateSlug.make("apiKey");
 const CONN = ConnectionName.make("main");
+const OAUTH_TEMPLATE = AuthTemplateSlug.make("oauth");
+const OAUTH_CLIENT = OAuthClientSlug.make("records-app");
 
 type DescribedToolContract = {
   readonly outputTypeScript: string;
@@ -257,6 +265,30 @@ const errorPlugin = makeTestPlugin({
     },
   ],
 });
+
+const oauthErrorPlugin = definePlugin(() => ({
+  id: "oauth-error-test" as const,
+  storage: () => ({}),
+  resolveTools: () =>
+    Effect.succeed({
+      tools: [
+        {
+          name: ToolName.make("queryRows"),
+          description: "Query rows",
+          inputSchema: EmptyInputJson,
+        },
+      ],
+    }),
+  invokeTool: ({ credential }) => Effect.succeed({ token: credential.value }),
+  extension: (ctx) => ({
+    seed: () =>
+      ctx.core.integrations.register({
+        slug: IntegrationSlug.make("oauth_records"),
+        description: "OAuth records",
+        config: {},
+      }),
+  }),
+}))();
 
 const validatedInputPlugin = makeTestPlugin({
   pluginId: "validated-input-test",
@@ -889,6 +921,80 @@ describe("tool discovery", () => {
         },
       });
     }),
+  );
+
+  it.effect("returns OAuth reauth failures as ToolResult.fail instead of throwing", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const config = makeTestConfig({
+          plugins: [memoryCredentialsPlugin(), oauthErrorPlugin] as const,
+        });
+        const executor = yield* createExecutor(config);
+        yield* executor["oauth-error-test"].seed();
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: OAUTH_CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: server.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: OAUTH_CLIENT,
+          clientOwner: "org",
+          name: CONN,
+          integration: IntegrationSlug.make("oauth_records"),
+          template: OAUTH_TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+        yield* executor.oauth.complete({ state: started.state, code: callback.code });
+
+        yield* Effect.promise(() =>
+          config.db.updateMany("connection", {
+            where: (b) =>
+              b.and(b("integration", "=", "oauth_records"), b("name", "=", String(CONN))),
+            set: {
+              expires_at: Date.now() - 60_000,
+              refresh_item_id: "missing-refresh-token",
+            },
+          }),
+        );
+
+        const invoker = makeExecutorToolInvoker(executor, {
+          invokeOptions: { onElicitation: acceptAll },
+        });
+        const result = yield* invoker.invoke({
+          path: "oauth_records.org.main.queryRows",
+          args: {},
+        });
+
+        expect(result).toMatchObject({
+          ok: false,
+          error: {
+            code: "oauth_reauth_required",
+            message:
+              'OAuth connection "oauth_records.org.main" requires reauthorization: Stored refresh token could not be resolved.',
+            details: {
+              category: "authentication",
+              credential: {
+                kind: "oauth",
+                label: "oauth_records.org.main",
+              },
+            },
+            retryable: false,
+          },
+        });
+      }),
+    ),
   );
 
   it.effect("returns missing tool dispatches as ToolResult.fail", () =>

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -4,10 +4,17 @@ import type {
   Executor,
   InvokeOptions,
   Integration,
+  ToolError,
   Tool,
   ToolSchemaView,
 } from "@executor-js/sdk/core";
-import { isToolResult, ToolResult, ToolAddress, parseToolAddress } from "@executor-js/sdk/core";
+import {
+  authToolFailure,
+  isToolResult,
+  ToolResult,
+  ToolAddress,
+  parseToolAddress,
+} from "@executor-js/sdk/core";
 import type { SandboxToolInvoker } from "@executor-js/codemode-core";
 import { ExecutionToolError } from "./errors";
 
@@ -125,9 +132,24 @@ const validationIssues = (value: unknown): readonly unknown[] | null => {
   return Array.isArray(issues) ? issues : null;
 };
 
-const expectedToolFailure = (
-  value: unknown,
-): { readonly code: string; readonly message: string; readonly details?: unknown } | null => {
+const credentialResolutionToolFailure = (input: {
+  readonly label: string;
+  readonly message: string;
+  readonly reauthRequired?: boolean;
+}) =>
+  authToolFailure({
+    code: input.reauthRequired === true ? "oauth_reauth_required" : "oauth_connection_failed",
+    message:
+      input.reauthRequired === true
+        ? `OAuth connection "${input.label}" requires reauthorization: ${input.message}`
+        : `OAuth connection "${input.label}" could not be resolved: ${input.message}`,
+    credential: {
+      kind: "oauth",
+      label: input.label,
+    },
+  });
+
+const expectedToolFailure = (value: unknown): ToolError | null => {
   if (Predicate.isTagged(value, "ToolNotFoundError") && "address" in value) {
     const suggestions =
       "suggestions" in value && Array.isArray(value.suggestions)
@@ -197,6 +219,15 @@ export const makeExecutorToolInvoker = (
 
     const address = pathToAddress(path);
     const result = yield* executor.execute(address, args, options.invokeOptions).pipe(
+      Effect.catchTag("CredentialResolutionError", (err) =>
+        Effect.succeed(
+          credentialResolutionToolFailure({
+            label: `${err.integration}.${err.owner}.${err.name}`,
+            message: err.message,
+            reauthRequired: err.reauthRequired,
+          }),
+        ),
+      ),
       Effect.catchCause((cause) => {
         const err = cause.reasons.find(Cause.isFailReason)?.error;
         const expected = expectedToolFailure(err);

--- a/packages/core/sdk/src/oxlint-plugin-executor.test.ts
+++ b/packages/core/sdk/src/oxlint-plugin-executor.test.ts
@@ -140,6 +140,36 @@ describe("executor oxlint plugin", () => {
     expect(result.stderr).toBe("");
   });
 
+  it("allows typed error messages in Effect.catchTag handlers", async () => {
+    const result = await runOxlintOn(
+      "catch-tag-message.ts",
+      `
+        import { Effect } from "effect";
+
+        declare const program: Effect.Effect<string, { _tag: "DomainError"; message: string }>;
+
+        export const handled = program.pipe(
+          Effect.catchTag("DomainError", (err) => Effect.succeed(err.message)),
+        );
+      `,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Found 0 warnings and 0 errors.");
+  });
+
+  it("rejects unknown error messages outside Effect.catchTag handlers", async () => {
+    const result = await runOxlintOn(
+      "unknown-message.ts",
+      `
+        export const format = (err: unknown) => String((err as { message: string }).message);
+      `,
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("executor(no-unknown-error-message)");
+  });
+
   it("rejects hand-rolled null predicates in Effect files", async () => {
     const result = await runOxlintOn(
       "manual-null-predicate.ts",

--- a/scripts/oxlint-plugin-executor/rules/no-unknown-error-message.js
+++ b/scripts/oxlint-plugin-executor/rules/no-unknown-error-message.js
@@ -1,4 +1,10 @@
-import { getPropertyName, isIdentifier, nodeName, unwrapExpression } from "../utils.js";
+import {
+  getCallName,
+  getPropertyName,
+  isIdentifier,
+  nodeName,
+  unwrapExpression,
+} from "../utils.js";
 
 const stringMessage =
   "Do not stringify unknown errors. Keep typed failures in Effect or normalize at a typed boundary. Skill: wrdn-effect-typed-errors.";
@@ -12,6 +18,47 @@ const errorLikeNames = new Set(["cause", "e", "err", "error", "reason", "unknown
 const isErrorLikeIdentifier = (node) => {
   const name = nodeName(unwrapExpression(node));
   return errorLikeNames.has(name);
+};
+
+const parameterName = (node) => {
+  const unwrapped = unwrapExpression(node);
+  return isIdentifier(unwrapped) ? unwrapped.name : undefined;
+};
+
+const isCatchTagHandler = (node) => {
+  if (node?.type !== "ArrowFunctionExpression" && node?.type !== "FunctionExpression") {
+    return false;
+  }
+
+  const parent = node.parent;
+  if (
+    parent?.type === "CallExpression" &&
+    parent.arguments?.[1] === node &&
+    getCallName(parent.callee) === "catchTag"
+  ) {
+    return true;
+  }
+
+  const objectExpression = parent?.type === "Property" ? parent.parent : undefined;
+  const callExpression =
+    objectExpression?.type === "ObjectExpression" ? objectExpression.parent : undefined;
+  return (
+    callExpression?.type === "CallExpression" && getCallName(callExpression.callee) === "catchTags"
+  );
+};
+
+const isCatchTagHandlerIdentifier = (node) => {
+  const name = nodeName(unwrapExpression(node));
+  if (!name) return false;
+
+  let current = node?.parent;
+  while (current) {
+    if (current.type === "ArrowFunctionExpression" || current.type === "FunctionExpression") {
+      return isCatchTagHandler(current) && parameterName(current.params?.[0]) === name;
+    }
+    current = current.parent;
+  }
+  return false;
 };
 
 export default {
@@ -31,12 +78,14 @@ export default {
       },
       MemberExpression(node) {
         if (getPropertyName(node.property) !== "message") return;
+        if (isCatchTagHandlerIdentifier(node.object)) return;
         if (isErrorLikeIdentifier(node.object)) {
           context.report({ node, message: messagePropertyMessage });
         }
       },
       VariableDeclarator(node) {
         if (node.id?.type !== "ObjectPattern" || !isErrorLikeIdentifier(node.init)) return;
+        if (isCatchTagHandlerIdentifier(node.init)) return;
         for (const property of node.id.properties ?? []) {
           if (property.type !== "Property") continue;
           if (getPropertyName(property.key) === "message") {


### PR DESCRIPTION
## Summary
- Convert credential resolution failures during sandbox tool dispatch into structured auth ToolResult failures
- Return oauth_reauth_required for reauthorization cases instead of an opaque internal tool error
- Add a regression test for an expired OAuth connection whose stored refresh token cannot be resolved

## Verification
- bunx oxfmt --check packages/core/execution/src/tool-invoker.ts packages/core/execution/src/tool-invoker.test.ts
- bun run --cwd packages/core/execution typecheck
- bun run --cwd packages/core/execution test src/tool-invoker.test.ts