### PR TITLE
[codex] Align connection-name test expectations

### DIFF
--- a/apps/cloud/src/api/secrets-api.node.test.ts
+++ b/apps/cloud/src/api/secrets-api.node.test.ts
@@ -11,7 +11,12 @@ import { Effect, Result } from "effect";
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
 import { Schema } from "effect";
 
-import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  connectionIdentifier,
+} from "@executor-js/sdk";
 import { makeOpenApiHttpApiTestAddSpecPayload } from "@executor-js/plugin-openapi/testing";
 
 import { asOrg } from "../testing/api-harness";
@@ -25,6 +30,8 @@ const PingApi = HttpApi.make("connectionsApiTest")
   .annotateMerge(OpenApi.annotations({ title: "Connections API Test", version: "1.0.0" }));
 
 const TEMPLATE_API_KEY = AuthTemplateSlug.make("apiKey");
+const canonicalConnectionName = (name: ConnectionName): ConnectionName =>
+  connectionIdentifier(String(name));
 
 // Registers a minimal openapi integration so connections have something to bind
 // to, then returns its slug.
@@ -48,6 +55,7 @@ describe("connections api (HTTP)", () => {
       const org = `org_${crypto.randomUUID()}`;
       const integration = yield* registerIntegration(org);
       const name = ConnectionName.make(`conn_${crypto.randomUUID().slice(0, 8)}`);
+      const storedName = canonicalConnectionName(name);
 
       const secretValue = "sk-test-abc";
       const created = yield* asOrg(org, (client) =>
@@ -62,20 +70,20 @@ describe("connections api (HTTP)", () => {
           },
         }),
       );
-      expect(created.name).toBe(name);
+      expect(created.name).toBe(storedName);
       expect(created.owner).toBe("org");
       expect(JSON.stringify(created)).not.toContain(secretValue);
 
       const list = yield* asOrg(org, (client) =>
         client.connections.list({ query: { integration } }),
       );
-      expect(list.find((c) => c.name === name)?.identityLabel).toBe("My API Token");
+      expect(list.find((c) => c.name === storedName)?.identityLabel).toBe("My API Token");
       expect(JSON.stringify(list)).not.toContain(secretValue);
 
       const fetched = yield* asOrg(org, (client) =>
-        client.connections.get({ params: { owner: "org", integration, name } }),
+        client.connections.get({ params: { owner: "org", integration, name: storedName } }),
       );
-      expect(fetched.name).toBe(name);
+      expect(fetched.name).toBe(storedName);
       expect(fetched.integration).toBe(integration);
     }),
   );
@@ -100,6 +108,7 @@ describe("connections api (HTTP)", () => {
       const org = `org_${crypto.randomUUID()}`;
       const integration = yield* registerIntegration(org);
       const name = ConnectionName.make(`conn_${crypto.randomUUID().slice(0, 8)}`);
+      const storedName = canonicalConnectionName(name);
 
       yield* asOrg(org, (client) =>
         Effect.gen(function* () {
@@ -107,7 +116,7 @@ describe("connections api (HTTP)", () => {
             payload: { owner: "org", name, integration, template: TEMPLATE_API_KEY, value: "v" },
           });
           const removed = yield* client.connections.remove({
-            params: { owner: "org", integration, name },
+            params: { owner: "org", integration, name: storedName },
           });
           expect(removed.removed).toBe(true);
         }),
@@ -116,10 +125,12 @@ describe("connections api (HTTP)", () => {
       const list = yield* asOrg(org, (client) =>
         client.connections.list({ query: { integration } }),
       );
-      expect(list.map((c) => c.name)).not.toContain(name);
+      expect(list.map((c) => c.name)).not.toContain(storedName);
 
       const afterGet = yield* asOrg(org, (client) =>
-        client.connections.get({ params: { owner: "org", integration, name } }).pipe(Effect.result),
+        client.connections
+          .get({ params: { owner: "org", integration, name: storedName } })
+          .pipe(Effect.result),
       );
       expect(Result.isFailure(afterGet)).toBe(true);
     }),
@@ -145,6 +156,7 @@ describe("connections api (HTTP)", () => {
       const org = `org_${crypto.randomUUID()}`;
       const integration = yield* registerIntegration(org);
       const name = ConnectionName.make(`conn_${crypto.randomUUID().slice(0, 8)}`);
+      const storedName = canonicalConnectionName(name);
 
       const first = yield* asOrg(org, (client) =>
         Effect.gen(function* () {
@@ -161,7 +173,7 @@ describe("connections api (HTTP)", () => {
           return yield* client.connections.list({ query: { integration } });
         }),
       );
-      expect(first.find((c) => c.name === name)?.identityLabel).toBe("first");
+      expect(first.find((c) => c.name === storedName)?.identityLabel).toBe("first");
 
       const second = yield* asOrg(org, (client) =>
         Effect.gen(function* () {
@@ -178,7 +190,7 @@ describe("connections api (HTTP)", () => {
           return yield* client.connections.list({ query: { integration } });
         }),
       );
-      expect(second.find((c) => c.name === name)?.identityLabel).toBe("updated");
+      expect(second.find((c) => c.name === storedName)?.identityLabel).toBe("updated");
     }),
   );
 });

--- a/apps/cloud/src/secrets-isolation.e2e.node.test.ts
+++ b/apps/cloud/src/secrets-isolation.e2e.node.test.ts
@@ -23,7 +23,12 @@ import { Effect } from "effect";
 import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
 import { Schema } from "effect";
 
-import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  connectionIdentifier,
+} from "@executor-js/sdk";
 import { makeOpenApiHttpApiTestAddSpecPayload } from "@executor-js/plugin-openapi/testing";
 
 import { asUser } from "./testing/api-harness";
@@ -33,6 +38,8 @@ const nextOrgId = () => `org_iso_${uniq()}`;
 const nextUserId = () => `user_iso_${uniq()}`;
 
 const TEMPLATE_API_KEY = AuthTemplateSlug.make("apiKey");
+const canonicalConnectionName = (name: ConnectionName): ConnectionName =>
+  connectionIdentifier(String(name));
 
 const PingApi = HttpApi.make("isolationApiTest")
   .add(
@@ -66,6 +73,7 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const alice = nextUserId();
       const charlie = nextUserId();
       const name = ConnectionName.make(`conn_${uniq()}`);
+      const storedName = canonicalConnectionName(name);
 
       const integrationA = yield* registerIntegration(alice, orgA);
       yield* asUser(alice, orgA, (client) =>
@@ -84,7 +92,7 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const charlieList = yield* asUser(charlie, orgB, (client) =>
         client.connections.list({ query: {} }),
       );
-      expect(charlieList.map((c) => c.name)).not.toContain(name);
+      expect(charlieList.map((c) => c.name)).not.toContain(storedName);
     }),
   );
 
@@ -94,6 +102,7 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const aliceId = nextUserId();
       const bobId = nextUserId();
       const name = ConnectionName.make(`conn_${uniq()}`);
+      const storedName = canonicalConnectionName(name);
 
       const integration = yield* registerIntegration(aliceId, organizationId);
 
@@ -115,13 +124,13 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const bobUserList = yield* asUser(bobId, organizationId, (client) =>
         client.connections.list({ query: { integration, owner: "user" } }),
       );
-      expect(bobUserList.map((c) => c.name)).not.toContain(name);
+      expect(bobUserList.map((c) => c.name)).not.toContain(storedName);
 
       // And Alice still sees her own connection.
       const aliceUserList = yield* asUser(aliceId, organizationId, (client) =>
         client.connections.list({ query: { integration, owner: "user" } }),
       );
-      expect(aliceUserList.map((c) => c.name)).toContain(name);
+      expect(aliceUserList.map((c) => c.name)).toContain(storedName);
     }),
   );
 
@@ -131,6 +140,7 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const adminId = nextUserId();
       const memberId = nextUserId();
       const name = ConnectionName.make(`conn_${uniq()}`);
+      const storedName = canonicalConnectionName(name);
 
       const integration = yield* registerIntegration(adminId, organizationId);
       yield* asUser(adminId, organizationId, (client) =>
@@ -151,8 +161,8 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const memberList = yield* asUser(memberId, organizationId, (client) =>
         client.connections.list({ query: { integration, owner: "org" } }),
       );
-      expect(adminList.map((c) => c.name)).toContain(name);
-      expect(memberList.map((c) => c.name)).toContain(name);
+      expect(adminList.map((c) => c.name)).toContain(storedName);
+      expect(memberList.map((c) => c.name)).toContain(storedName);
     }),
   );
 
@@ -162,6 +172,7 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const orgA = nextOrgId();
       const orgB = nextOrgId();
       const name = ConnectionName.make(`conn_${uniq()}`);
+      const storedName = canonicalConnectionName(name);
 
       const integrationA = yield* registerIntegration(userId, orgA);
       yield* asUser(userId, orgA, (client) =>
@@ -181,13 +192,13 @@ describe("cloud connection isolation (HTTP, owner model)", () => {
       const listInB = yield* asUser(userId, orgB, (client) =>
         client.connections.list({ query: {} }),
       );
-      expect(listInB.map((c) => c.name)).not.toContain(name);
+      expect(listInB.map((c) => c.name)).not.toContain(storedName);
 
       // Sanity: still visible under org A's user-owner list.
       const listInA = yield* asUser(userId, orgA, (client) =>
         client.connections.list({ query: { integration: integrationA, owner: "user" } }),
       );
-      expect(listInA.map((c) => c.name)).toContain(name);
+      expect(listInA.map((c) => c.name)).toContain(storedName);
     }),
   );
 });

--- a/apps/host-selfhost/src/multi-user.test.ts
+++ b/apps/host-selfhost/src/multi-user.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterAll, expect, test } from "@effect/vitest";
+import { connectionIdentifier } from "@executor-js/sdk/shared";
 
 import { mintInviteCode } from "./testing/mint-invite";
 
@@ -18,6 +19,7 @@ const { handler, dispose } = await makeSelfHostApiHandler();
 afterAll(() => dispose());
 
 const BASE = "http://localhost:4788";
+const connectionName = (name: string): string => String(connectionIdentifier(name));
 
 const TINY_SPEC = JSON.stringify({
   openapi: "3.0.0",
@@ -166,14 +168,20 @@ test("multiple accounts share one org but isolate per-user connections", async (
 
   // Alice sees both her user connection and the org connection.
   const aliceConns = await connectionAddresses(alice);
-  expect(aliceConns.some((a) => a.includes("user") && a.includes("alice-private"))).toBe(true);
-  expect(aliceConns.some((a) => a.includes("org") && a.includes("team-shared"))).toBe(true);
+  expect(
+    aliceConns.some((a) => a.includes("user") && a.includes(connectionName("alice-private"))),
+  ).toBe(true);
+  expect(
+    aliceConns.some((a) => a.includes("org") && a.includes(connectionName("team-shared"))),
+  ).toBe(true);
 
   // Bob — a different user in the SAME org — sees the org connection but NOT
   // Alice's user-owned one.
   const bobConns = await connectionAddresses(bob);
-  expect(bobConns.some((a) => a.includes("org") && a.includes("team-shared"))).toBe(true);
-  expect(bobConns.some((a) => a.includes("alice-private"))).toBe(false);
+  expect(bobConns.some((a) => a.includes("org") && a.includes(connectionName("team-shared")))).toBe(
+    true,
+  );
+  expect(bobConns.some((a) => a.includes(connectionName("alice-private")))).toBe(false);
 });
 
 test("each account can execute code in its own scoped sandbox", async () => {

--- a/apps/host-selfhost/src/scope-isolation.test.ts
+++ b/apps/host-selfhost/src/scope-isolation.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterAll, expect, test } from "@effect/vitest";
+import { connectionIdentifier } from "@executor-js/sdk/shared";
 
 process.env.EXECUTOR_DATA_DIR = mkdtempSync(join(tmpdir(), "eh-iso-"));
 
@@ -39,6 +40,9 @@ const headersFor = (userId: string, organizationId: string): Record<string, stri
   "x-test-org": organizationId,
   "content-type": "application/json",
 });
+
+const connectionNameForUser = (userId: string): string =>
+  String(connectionIdentifier(`conn-${userId}`));
 
 // Seed, as the given identity, a tenant-scoped integration plus a user-owned
 // connection named after the subject. Tenant isolation means each identity's
@@ -109,10 +113,10 @@ test("concurrent requests with distinct identities get disjoint, correct executo
     // Each response reflects ONLY its own request's identity — no bleed. The
     // subject's own user connection is present, and no OTHER subject's is.
     expect(result.status).toBe(200);
-    expect(result.addresses.some((a) => a.includes(`conn-${userId}`))).toBe(true);
+    expect(result.addresses.some((a) => a.includes(connectionNameForUser(userId)))).toBe(true);
     const otherUsers = identities.map((id) => id.userId).filter((u) => u !== userId);
     for (const other of otherUsers) {
-      expect(result.addresses.some((a) => a.includes(`conn-${other}`))).toBe(false);
+      expect(result.addresses.some((a) => a.includes(connectionNameForUser(other)))).toBe(false);
     }
   });
 }, 15_000);

--- a/packages/core/api/src/scoped-targets.test.ts
+++ b/packages/core/api/src/scoped-targets.test.ts
@@ -211,7 +211,7 @@ describe("core API owner-scoped writes (v2)", () => {
       };
       expect(body).toMatchObject({
         owner: "user",
-        name: "api-key",
+        name: "apiKey",
         provider: "memory",
       });
     }),


### PR DESCRIPTION
## Summary
- update connection-name expectations after callable-name normalization
- use the shared connection-name normalizer in cloud and self-host tests
- keep HTTP get/remove assertions aligned with the stored canonical connection name

## Root cause
Recent connection creation changes normalize free-form connection names into JS-callable identifiers before storage. Several API and host tests still expected the original hyphen/underscore input names.

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `bun run test` in `packages/core/api`
- `bun run test` in `apps/host-selfhost`
- `node ../../node_modules/vitest/vitest.mjs run src/api/secrets-api.node.test.ts src/secrets-isolation.e2e.node.test.ts --config vitest.node.config.ts` in `apps/cloud`
