### PR TITLE
[codex] Fix OAuth MCP authorization URLs

### DIFF
--- a/apps/cloud/scripts/migrate-v1-v2.ts
+++ b/apps/cloud/scripts/migrate-v1-v2.ts
@@ -42,6 +42,8 @@ import {
   migrateV1PluginStorageRuntimeRow,
   migrateV1ToolAnnotations,
   migrationOAuthAuthorizationUrlFor as authorizationUrlFor,
+  migrationOAuthClientAuthorizationUrlResolutionSource as oauthAuthorizationResolutionSource,
+  migrationOAuthClientNeedsAuthorizationUrlResolution as needsOAuthAuthorizationResolution,
   migrationOAuthClientPlanKey as oauthClientPlanKey,
   migrationSourceKey,
   parseScope,
@@ -151,7 +153,7 @@ export interface CloudOAuthAuthorizationUrlRepairRow {
   readonly slug: string;
   readonly currentAuthorizationUrl: string;
   readonly repairedAuthorizationUrl: string;
-  readonly metadataUrl: string;
+  readonly resolutionSource: string;
 }
 
 export interface CloudOAuthAuthorizationUrlRepairResult {
@@ -1204,8 +1206,7 @@ export const repairCloudOAuthAuthorizationUrls = async (
   const changed: CloudOAuthAuthorizationUrlRepairRow[] = [];
   let checked = 0;
   for (const clientRow of plan.oauthClients) {
-    const metadataUrl = clientRow.authorizationServerMetadataUrl?.trim();
-    if (!metadataUrl) continue;
+    if (!needsOAuthAuthorizationResolution(clientRow)) continue;
     checked++;
 
     const currentAuthorizationUrl = currentAuthorizationUrls.get(oauthClientPlanKey(clientRow));
@@ -1225,15 +1226,15 @@ export const repairCloudOAuthAuthorizationUrls = async (
       slug: clientRow.slug,
       currentAuthorizationUrl,
       repairedAuthorizationUrl,
-      metadataUrl,
+      resolutionSource: oauthAuthorizationResolutionSource(clientRow),
     });
   }
 
-  log(`oauth repair:      ${checked} metadata-backed client(s) checked`);
+  log(`oauth repair:      ${checked} discoverable client(s) checked`);
   log(`oauth repair:      ${changed.length} client(s) need authorization_url update`);
   for (const row of changed) {
     log(
-      `  - ${row.tenant}/${row.owner}/${row.subject || "<org>"}/${row.slug}: ${row.currentAuthorizationUrl} -> ${row.repairedAuthorizationUrl}`,
+      `  - ${row.tenant}/${row.owner}/${row.subject || "<org>"}/${row.slug}: ${row.currentAuthorizationUrl} -> ${row.repairedAuthorizationUrl} (via ${row.resolutionSource})`,
     );
   }
 

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -102,6 +102,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
             grant: payload.grant,
             clientId: payload.clientId,
             clientSecret: payload.clientSecret,
+            resource: payload.resource ?? null,
           });
           return { client };
         }),
@@ -117,6 +118,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
             registrationEndpoint: payload.registrationEndpoint,
             authorizationUrl: payload.authorizationUrl,
             tokenUrl: payload.tokenUrl,
+            resource: payload.resource ?? null,
             scopes: payload.scopes,
             tokenEndpointAuthMethodsSupported: payload.tokenEndpointAuthMethodsSupported,
             clientName: payload.clientName,

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -64,6 +64,7 @@ const CreateClientPayload = Schema.Struct({
   grant: Schema.Literals(["authorization_code", "client_credentials"]),
   clientId: Schema.String,
   clientSecret: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 const CreateClientResponse = Schema.Struct({
@@ -83,6 +84,7 @@ const RegisterDynamicPayload = Schema.Struct({
   registrationEndpoint: Schema.String,
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   scopes: Schema.Array(Schema.String),
   tokenEndpointAuthMethodsSupported: Schema.optional(Schema.Array(Schema.String)),
   clientName: Schema.optional(Schema.String),
@@ -105,6 +107,7 @@ const OAuthClientSummaryResponse = Schema.Struct({
   grant: Schema.Literals(["authorization_code", "client_credentials"]),
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   clientId: Schema.String,
 });
 
@@ -191,6 +194,7 @@ const ProbePayload = Schema.Struct({
 const ProbeResponse = Schema.Struct({
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   scopesSupported: Schema.optional(Schema.Array(Schema.String)),
   registrationEndpoint: Schema.optional(Schema.NullOr(Schema.String)),
   tokenEndpointAuthMethodsSupported: Schema.optional(Schema.Array(Schema.String)),

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -183,6 +183,7 @@ const OAuthClientOutput = Schema.Struct({
   grant: OAuthGrantSchema,
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   clientId: Schema.String,
 });
 const OAuthClientsListOutput = Schema.Struct({
@@ -207,6 +208,7 @@ const OAuthRegisterDynamicInput = Schema.Struct({
   registrationEndpoint: Schema.String,
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   scopes: Schema.Array(Schema.String),
   tokenEndpointAuthMethodsSupported: Schema.optional(Schema.Array(Schema.String)),
   clientName: Schema.optional(Schema.String),
@@ -222,6 +224,7 @@ const OAuthProbeInput = Schema.Struct({
 const OAuthProbeOutput = Schema.Struct({
   authorizationUrl: Schema.String,
   tokenUrl: Schema.String,
+  resource: Schema.optional(Schema.NullOr(Schema.String)),
   scopesSupported: Schema.optional(Schema.Array(Schema.String)),
   registrationEndpoint: Schema.optional(Schema.NullOr(Schema.String)),
   tokenEndpointAuthMethodsSupported: Schema.optional(Schema.Array(Schema.String)),
@@ -526,6 +529,7 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 grant: client.grant,
                 authorizationUrl: client.authorizationUrl,
                 tokenUrl: client.tokenUrl,
+                resource: client.resource ?? null,
                 clientId: client.clientId,
               })),
             })),
@@ -565,6 +569,7 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 registrationEndpoint: input.registrationEndpoint,
                 authorizationUrl: input.authorizationUrl,
                 tokenUrl: input.tokenUrl,
+                resource: input.resource ?? null,
                 scopes: input.scopes,
                 tokenEndpointAuthMethodsSupported: input.tokenEndpointAuthMethodsSupported,
                 clientName: input.clientName,
@@ -595,6 +600,7 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
             Effect.map(ctx.oauth.probe({ url: input.url }), (result) => ({
               authorizationUrl: result.authorizationUrl,
               tokenUrl: result.tokenUrl,
+              resource: result.resource ?? null,
               scopesSupported: result.scopesSupported,
               registrationEndpoint: result.registrationEndpoint ?? null,
               tokenEndpointAuthMethodsSupported: result.tokenEndpointAuthMethodsSupported,

--- a/packages/core/sdk/src/migration-oauth-metadata.test.ts
+++ b/packages/core/sdk/src/migration-oauth-metadata.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  migrationOAuthAuthorizationUrlFor,
+  migrationOAuthClientAuthorizationUrlResolutionSource,
+  migrationOAuthClientNeedsAuthorizationUrlResolution,
+  migrationOAuthClientPlanKey,
+  resolveMigrationOAuthAuthorizationUrls,
+  type MigrationOAuthMetadataFetch,
+  type MigrationPlan,
+} from "./migration-spec";
+
+type OAuthClient = MigrationPlan["oauthClients"][number];
+
+const ownerKeys = { owner: "user" as const, subject: "user_1", tenant: "org_1" };
+
+const oauthClient = (overrides: Partial<OAuthClient> = {}): OAuthClient => ({
+  ownerKeys,
+  clientId: "client-id",
+  tokenUrl: "https://oauth.example.com/token",
+  authorizationUrl: "https://oauth.example.com/authorize",
+  grant: "authorization_code",
+  resource: null,
+  clientSecretRef: null,
+  slug: "oauth",
+  clientSecretItemId: null,
+  ...overrides,
+});
+
+const migrationPlan = (oauthClients: readonly OAuthClient[]): MigrationPlan => ({
+  integrations: [],
+  oauthClients,
+  connections: [],
+  secretOps: [],
+  policies: [],
+  report: {
+    integrations: 0,
+    oauthClients: oauthClients.length,
+    connections: 0,
+    secretOps: 0,
+    staleConnections: 0,
+    policies: { ok: 0, static: 0, deadInert: 0 },
+    warnings: [],
+  },
+});
+
+const jsonResponse = (
+  body: unknown,
+  status = 200,
+): Awaited<ReturnType<MigrationOAuthMetadataFetch>> => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+});
+
+const fetchFixture = (
+  responses: Readonly<Record<string, { readonly body: unknown; readonly status?: number }>>,
+): {
+  readonly fetch: MigrationOAuthMetadataFetch;
+  readonly seen: readonly string[];
+} => {
+  const seen: string[] = [];
+  return {
+    seen,
+    fetch: async (input) => {
+      seen.push(input);
+      const response = responses[input];
+      if (!response) return jsonResponse({ error: "not_found" }, 404);
+      return jsonResponse(response.body, response.status ?? 200);
+    },
+  };
+};
+
+describe("resolveMigrationOAuthAuthorizationUrls", () => {
+  it("uses an archived authorization-server metadata URL when present", async () => {
+    const metadataUrl =
+      "https://mcp.pscale.dev/.well-known/oauth-authorization-server/mcp/planetscale";
+    const client = oauthClient({
+      slug: "planetscale",
+      authorizationUrl: "https://mcp.pscale.dev/mcp/planetscale",
+      authorizationServerMetadataUrl: metadataUrl,
+      resource: "https://mcp.pscale.dev/mcp/planetscale",
+    });
+    const fixture = fetchFixture({
+      [metadataUrl]: {
+        body: {
+          authorization_endpoint: "https://app.planetscale.com/oauth/authorize",
+        },
+      },
+    });
+
+    const resolved = await resolveMigrationOAuthAuthorizationUrls(migrationPlan([client]), {
+      fetch: fixture.fetch,
+    });
+
+    expect(fixture.seen).toEqual([metadataUrl]);
+    expect(resolved.get(migrationOAuthClientPlanKey(client))).toBe(
+      "https://app.planetscale.com/oauth/authorize",
+    );
+    expect(migrationOAuthAuthorizationUrlFor(client, resolved)).toBe(
+      "https://app.planetscale.com/oauth/authorize",
+    );
+  });
+
+  it("discovers an MCP authorization endpoint through protected-resource metadata", async () => {
+    const client = oauthClient({
+      slug: "linear",
+      authorizationUrl: "https://mcp.linear.example.com",
+      tokenUrl: "https://mcp.linear.example.com/token",
+      resource: "https://mcp.linear.example.com/mcp",
+    });
+    const fixture = fetchFixture({
+      "https://mcp.linear.example.com/.well-known/oauth-protected-resource/mcp": {
+        body: { authorization_servers: ["https://mcp.linear.example.com"] },
+      },
+      "https://mcp.linear.example.com/.well-known/oauth-authorization-server": {
+        body: {
+          authorization_endpoint: "https://mcp.linear.example.com/authorize",
+        },
+      },
+    });
+
+    const resolved = await resolveMigrationOAuthAuthorizationUrls(migrationPlan([client]), {
+      fetch: fixture.fetch,
+    });
+
+    expect(fixture.seen).toEqual([
+      "https://mcp.linear.example.com/.well-known/oauth-protected-resource/mcp",
+      "https://mcp.linear.example.com/.well-known/oauth-authorization-server",
+    ]);
+    expect(resolved.get(migrationOAuthClientPlanKey(client))).toBe(
+      "https://mcp.linear.example.com/authorize",
+    );
+  });
+
+  it("discovers an authorization endpoint from an issuer-root authorization URL", async () => {
+    const client = oauthClient({
+      slug: "spotify",
+      authorizationUrl: "https://accounts.example.com",
+      tokenUrl: "https://accounts.example.com/api/token",
+    });
+    const fixture = fetchFixture({
+      "https://accounts.example.com/.well-known/oauth-authorization-server": {
+        body: {
+          authorization_endpoint: "https://accounts.example.com/authorize",
+        },
+      },
+    });
+
+    const resolved = await resolveMigrationOAuthAuthorizationUrls(migrationPlan([client]), {
+      fetch: fixture.fetch,
+    });
+
+    expect(resolved.get(migrationOAuthClientPlanKey(client))).toBe(
+      "https://accounts.example.com/authorize",
+    );
+  });
+
+  it("leaves an existing authorization endpoint unchanged when discovery cannot prove a replacement", async () => {
+    const client = oauthClient({
+      slug: "apollo",
+      authorizationUrl: "https://mcp.apollo.example.com/mcp/oauth_metadata/redirect_to_authorize",
+      tokenUrl: "https://mcp.apollo.example.com/api/v1/oauth/token",
+    });
+    const fixture = fetchFixture({});
+
+    const resolved = await resolveMigrationOAuthAuthorizationUrls(migrationPlan([client]), {
+      fetch: fixture.fetch,
+    });
+
+    expect(resolved.has(migrationOAuthClientPlanKey(client))).toBe(false);
+    expect(migrationOAuthAuthorizationUrlFor(client, resolved)).toBe(
+      "https://mcp.apollo.example.com/mcp/oauth_metadata/redirect_to_authorize",
+    );
+  });
+
+  it("marks metadata, resource, and issuer-backed authorization-code clients as discoverable", () => {
+    expect(
+      migrationOAuthClientNeedsAuthorizationUrlResolution(
+        oauthClient({ authorizationServerMetadataUrl: "https://oauth.example.com/metadata" }),
+      ),
+    ).toBe(true);
+    expect(
+      migrationOAuthClientNeedsAuthorizationUrlResolution(
+        oauthClient({ resource: "https://mcp.example.com/mcp" }),
+      ),
+    ).toBe(true);
+    expect(migrationOAuthClientNeedsAuthorizationUrlResolution(oauthClient())).toBe(true);
+    expect(
+      migrationOAuthClientNeedsAuthorizationUrlResolution(
+        oauthClient({ grant: "client_credentials", authorizationUrl: "", resource: null }),
+      ),
+    ).toBe(false);
+    expect(
+      migrationOAuthClientAuthorizationUrlResolutionSource(
+        oauthClient({
+          authorizationServerMetadataUrl: "",
+          resource: "https://mcp.example.com/mcp",
+        }),
+      ),
+    ).toBe("https://mcp.example.com/mcp");
+  });
+});

--- a/packages/core/sdk/src/migration-oauth-metadata.ts
+++ b/packages/core/sdk/src/migration-oauth-metadata.ts
@@ -10,6 +10,12 @@ const OAuthAuthorizationServerMetadata = Schema.Struct({
 const decodeOAuthAuthorizationServerMetadata = Schema.decodeUnknownSync(
   OAuthAuthorizationServerMetadata,
 );
+const OAuthProtectedResourceMetadata = Schema.Struct({
+  authorization_servers: Schema.optional(Schema.Array(Schema.String)),
+});
+const decodeOAuthProtectedResourceMetadata = Schema.decodeUnknownSync(
+  OAuthProtectedResourceMetadata,
+);
 const DEFAULT_OAUTH_METADATA_TIMEOUT_MS = 20_000;
 
 export type MigrationOAuthMetadataFetch = (
@@ -49,58 +55,185 @@ const validateMigrationOAuthUrl = (value: string, label: string): string => {
   return trimmed;
 };
 
-const fetchOAuthAuthorizationEndpoint = async (
-  metadataUrl: string,
+const fetchOAuthJson = async (
+  url: string,
   fetchImpl: MigrationOAuthMetadataFetch,
   timeoutMs: number,
-): Promise<string> => {
+): Promise<unknown> => {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const response = await fetchImpl(metadataUrl, {
+    const response = await fetchImpl(url, {
       headers: { accept: "application/json" },
       signal: controller.signal,
     });
     if (!response.ok) {
-      throw new Error(
-        `OAuth authorization-server metadata ${metadataUrl} returned HTTP ${response.status}`,
-      );
+      throw new Error(`OAuth metadata ${url} returned HTTP ${response.status}`);
     }
-    const metadata = decodeOAuthAuthorizationServerMetadata(await response.json());
-    return validateMigrationOAuthUrl(metadata.authorization_endpoint, "authorization_endpoint");
+    return await response.json();
   } finally {
     clearTimeout(timeout);
   }
 };
 
+const fetchOAuthAuthorizationEndpoint = async (
+  metadataUrl: string,
+  fetchImpl: MigrationOAuthMetadataFetch,
+  timeoutMs: number,
+): Promise<string> => {
+  const metadata = decodeOAuthAuthorizationServerMetadata(
+    await fetchOAuthJson(metadataUrl, fetchImpl, timeoutMs),
+  );
+  return validateMigrationOAuthUrl(metadata.authorization_endpoint, "authorization_endpoint");
+};
+
+const wellKnownAuthorizationServerUrlFor = (
+  issuer: string,
+  algorithm: "oauth2" | "oidc",
+): string => {
+  const url = new URL(validateMigrationOAuthUrl(issuer, "issuer"));
+  const origin = `${url.protocol}//${url.host}`;
+  const path = url.pathname.replace(/\/+$/, "");
+  const suffix = algorithm === "oauth2" ? "oauth-authorization-server" : "openid-configuration";
+  return path && path !== "/"
+    ? `${origin}/.well-known/${suffix}${path}`
+    : `${origin}/.well-known/${suffix}`;
+};
+
+const resolveAuthorizationEndpointFromIssuer = async (
+  issuer: string,
+  fetchImpl: MigrationOAuthMetadataFetch,
+  timeoutMs: number,
+): Promise<string | null> => {
+  for (const algorithm of ["oauth2", "oidc"] as const) {
+    try {
+      return await fetchOAuthAuthorizationEndpoint(
+        wellKnownAuthorizationServerUrlFor(issuer, algorithm),
+        fetchImpl,
+        timeoutMs,
+      );
+    } catch {
+      // Best-effort fallback discovery: try the next standards-defined location.
+    }
+  }
+  return null;
+};
+
+const protectedResourceMetadataUrlsFor = (resource: string): readonly string[] => {
+  const url = new URL(validateMigrationOAuthUrl(resource, "resource"));
+  const origin = `${url.protocol}//${url.host}`;
+  const path = url.pathname.replace(/\/+$/, "");
+  const urls: string[] = [];
+  if (path && path !== "/") {
+    urls.push(`${origin}/.well-known/oauth-protected-resource${path}`);
+  }
+  urls.push(`${origin}/.well-known/oauth-protected-resource`);
+  return urls;
+};
+
+const discoverAuthorizationServersFromResource = async (
+  resource: string,
+  fetchImpl: MigrationOAuthMetadataFetch,
+  timeoutMs: number,
+): Promise<readonly string[]> => {
+  for (const metadataUrl of protectedResourceMetadataUrlsFor(resource)) {
+    try {
+      const metadata = decodeOAuthProtectedResourceMetadata(
+        await fetchOAuthJson(metadataUrl, fetchImpl, timeoutMs),
+      );
+      return metadata.authorization_servers ?? [];
+    } catch {
+      // Best-effort fallback discovery: try the next protected-resource location.
+    }
+  }
+  return [];
+};
+
+const pushCandidate = (candidates: string[], value: string | null | undefined): void => {
+  const trimmed = value?.trim();
+  if (!trimmed || candidates.includes(trimmed)) return;
+  candidates.push(trimmed);
+};
+
+const resolveMigrationOAuthAuthorizationUrl = async (
+  client: MigrationPlan["oauthClients"][number],
+  fetchImpl: MigrationOAuthMetadataFetch,
+  timeoutMs: number,
+): Promise<string | null> => {
+  const metadataUrl = client.authorizationServerMetadataUrl?.trim();
+  if (metadataUrl) {
+    return await fetchOAuthAuthorizationEndpoint(
+      validateMigrationOAuthUrl(metadataUrl, "authorizationServerMetadataUrl"),
+      fetchImpl,
+      timeoutMs,
+    );
+  }
+
+  if (client.grant !== "authorization_code") return null;
+
+  const candidates: string[] = [];
+  if (client.resource?.trim()) {
+    try {
+      for (const issuer of await discoverAuthorizationServersFromResource(
+        client.resource,
+        fetchImpl,
+        timeoutMs,
+      )) {
+        pushCandidate(candidates, issuer);
+      }
+    } catch {
+      // Best-effort: fall through to the stored authorization URL candidate.
+    }
+  }
+  pushCandidate(candidates, client.authorizationUrl);
+
+  for (const candidate of candidates) {
+    const endpoint = await resolveAuthorizationEndpointFromIssuer(candidate, fetchImpl, timeoutMs);
+    if (endpoint) return endpoint;
+  }
+  return null;
+};
+
+export const migrationOAuthClientNeedsAuthorizationUrlResolution = (
+  client: MigrationPlan["oauthClients"][number],
+): boolean =>
+  !!client.authorizationServerMetadataUrl?.trim() ||
+  (client.grant === "authorization_code" &&
+    (!!client.resource?.trim() || !!client.authorizationUrl.trim()));
+
+export const migrationOAuthClientAuthorizationUrlResolutionSource = (
+  client: MigrationPlan["oauthClients"][number],
+): string =>
+  client.authorizationServerMetadataUrl?.trim() ||
+  client.resource?.trim() ||
+  client.authorizationUrl.trim();
+
 export const resolveMigrationOAuthAuthorizationUrls = async (
   plan: MigrationPlan,
   options: ResolveMigrationOAuthAuthorizationUrlsOptions = {},
 ): Promise<ReadonlyMap<string, string>> => {
-  const clientsWithMetadata = plan.oauthClients.filter((client) =>
-    client.authorizationServerMetadataUrl?.trim(),
+  const clientsToResolve = plan.oauthClients.filter(
+    migrationOAuthClientNeedsAuthorizationUrlResolution,
   );
-  if (clientsWithMetadata.length === 0) return new Map();
+  if (clientsToResolve.length === 0) return new Map();
 
   const fetchImpl = options.fetch;
   if (!fetchImpl) {
     throw new Error("OAuth metadata resolution requires an injected fetch implementation.");
   }
   const timeoutMs = options.timeoutMs ?? DEFAULT_OAUTH_METADATA_TIMEOUT_MS;
-  const endpointByMetadataUrl = new Map<string, Promise<string>>();
+  const endpointByPlanKey = new Map<string, Promise<string | null>>();
   const resolved = new Map<string, string>();
 
-  for (const client of clientsWithMetadata) {
-    const metadataUrl = validateMigrationOAuthUrl(
-      client.authorizationServerMetadataUrl ?? "",
-      "authorizationServerMetadataUrl",
-    );
-    let endpoint = endpointByMetadataUrl.get(metadataUrl);
+  for (const client of clientsToResolve) {
+    const key = migrationOAuthClientPlanKey(client);
+    let endpoint = endpointByPlanKey.get(key);
     if (!endpoint) {
-      endpoint = fetchOAuthAuthorizationEndpoint(metadataUrl, fetchImpl, timeoutMs);
-      endpointByMetadataUrl.set(metadataUrl, endpoint);
+      endpoint = resolveMigrationOAuthAuthorizationUrl(client, fetchImpl, timeoutMs);
+      endpointByPlanKey.set(key, endpoint);
     }
-    resolved.set(migrationOAuthClientPlanKey(client), await endpoint);
+    const authorizationUrl = await endpoint;
+    if (authorizationUrl) resolved.set(key, authorizationUrl);
   }
 
   return resolved;

--- a/packages/core/sdk/src/migration-spec.ts
+++ b/packages/core/sdk/src/migration-spec.ts
@@ -15,6 +15,8 @@ import { connectionIdentifier } from "./connection-name-identifier";
 
 export {
   migrationOAuthAuthorizationUrlFor,
+  migrationOAuthClientAuthorizationUrlResolutionSource,
+  migrationOAuthClientNeedsAuthorizationUrlResolution,
   migrationOAuthClientPlanKey,
   resolveMigrationOAuthAuthorizationUrls,
   type MigrationOAuthMetadataFetch,

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -66,6 +66,7 @@ export interface OAuthClientSummary {
   readonly grant: OAuthGrant;
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  readonly resource?: string | null;
   readonly clientId: string;
 }
 
@@ -111,6 +112,10 @@ export interface OAuthProbeInput {
 export interface OAuthProbeResult {
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  /** RFC 8707 resource indicator discovered from protected-resource metadata.
+   *  Persist this on DCR clients so authorize/token/refresh requests stay bound
+   *  to the protected resource. */
+  readonly resource?: string | null;
   readonly scopesSupported?: readonly string[];
   /** Whether the server advertises dynamic client registration (RFC 7591). */
   readonly registrationEndpoint?: string | null;
@@ -129,6 +134,7 @@ export interface RegisterDynamicClientInput {
   readonly registrationEndpoint: string;
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  readonly resource?: string | null;
   readonly scopes: readonly string[];
   /** Auth methods the server advertises. When it allows `none` a public
    *  (PKCE-only, no secret) client is registered; otherwise `client_secret_post`. */

--- a/packages/core/sdk/src/oauth-list-clients.test.ts
+++ b/packages/core/sdk/src/oauth-list-clients.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
+import { Effect, Predicate } from "effect";
 
 import { OAuthClientSlug } from "./ids";
 import { makeTestWorkspaceHarness, memoryCredentialsPlugin } from "./test-config";
@@ -18,6 +18,35 @@ const ORG_CLIENT = OAuthClientSlug.make("acme-org");
 const USER_CLIENT = OAuthClientSlug.make("acme-user");
 
 describe("oauth.listClients", () => {
+  it.effect("rejects metadata URLs persisted as authorization URLs", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const { executor } = yield* makeTestWorkspaceHarness({ plugins });
+
+        const error = yield* Effect.flip(
+          executor.oauth.createClient({
+            owner: "org",
+            slug: ORG_CLIENT,
+            authorizationUrl: "https://mcp.example.com/.well-known/oauth-authorization-server",
+            tokenUrl: "https://mcp.example.com/token",
+            grant: "authorization_code",
+            clientId: "client-id",
+            clientSecret: "client-secret",
+          }),
+        );
+
+        expect(Predicate.isTagged("StorageError")(error)).toBe(true);
+        expect(error).toEqual(
+          expect.objectContaining({
+            _tag: "StorageError",
+            message: expect.stringContaining("authorization endpoint"),
+          }),
+        );
+        expect(yield* executor.oauth.listClients()).toEqual([]);
+      }),
+    ),
+  );
+
   it.effect("returns owner-visible clients as summaries without the secret", () =>
     Effect.scoped(
       Effect.gen(function* () {
@@ -60,6 +89,7 @@ describe("oauth.listClients", () => {
           grant: "authorization_code",
           authorizationUrl: "https://acme.test/authorize",
           tokenUrl: "https://acme.test/token",
+          resource: null,
           clientId: "org-client-id",
         });
         expect(user!.owner).toBe("user");

--- a/packages/core/sdk/src/oauth-register-dynamic.test.ts
+++ b/packages/core/sdk/src/oauth-register-dynamic.test.ts
@@ -57,6 +57,7 @@ describe("oauth.registerDynamicClient", () => {
         const probe = yield* executor.oauth.probe({ url: server.mcpResourceUrl });
         expect(probe.registrationEndpoint).toBe(server.registrationEndpoint);
         expect(probe.tokenEndpointAuthMethodsSupported).toContain("none");
+        expect(probe.resource).toBe(server.mcpResourceUrl);
 
         // Register dynamically — NO client id/secret pasted by the user.
         const slug = yield* executor.oauth.registerDynamicClient({
@@ -65,6 +66,7 @@ describe("oauth.registerDynamicClient", () => {
           registrationEndpoint: probe.registrationEndpoint!,
           authorizationUrl: probe.authorizationUrl,
           tokenUrl: probe.tokenUrl,
+          resource: probe.resource,
           scopes: ["read"],
           tokenEndpointAuthMethodsSupported: probe.tokenEndpointAuthMethodsSupported,
           clientName: "Acme DCR",
@@ -99,6 +101,9 @@ describe("oauth.registerDynamicClient", () => {
         });
         expect(started.status).toBe("redirect");
         if (started.status !== "redirect") return;
+        expect(new URL(started.authorizationUrl).searchParams.get("resource")).toBe(
+          server.mcpResourceUrl,
+        );
 
         const callback = yield* server.completeAuthorizationCodeFlow({
           authorizationUrl: started.authorizationUrl,
@@ -122,6 +127,7 @@ describe("oauth.registerDynamicClient", () => {
         );
         expect(tokenRequest).toBeDefined();
         expect(tokenRequest!.body).not.toContain("client_secret");
+        expect(new URLSearchParams(tokenRequest!.body).get("resource")).toBe(server.mcpResourceUrl);
       }),
     ),
   );

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -54,6 +54,7 @@ import {
   registerDynamicClient as registerDynamicClientDcr,
 } from "./oauth-discovery";
 import {
+  assertSupportedOAuthEndpointUrl,
   buildAuthorizationUrl,
   providerAuthorizeExtras,
   createOAuthState,
@@ -230,6 +231,66 @@ const REDIRECT_URI_REQUIRED_MESSAGE =
   "to the executor. Pass `redirectUri` to createExecutor (hosts derive it from " +
   "the web base URL / request origin as `${webBaseUrl}${mountPrefix}/oauth/callback`).";
 
+const canonicalUrlString = (value: string): string => {
+  const url = new URL(value.trim());
+  url.hash = "";
+  return url.toString();
+};
+
+const isWellKnownOAuthMetadataUrl = (value: string): boolean => {
+  const path = new URL(value.trim()).pathname.toLowerCase();
+  return (
+    path.includes("/.well-known/oauth-authorization-server") ||
+    path.includes("/.well-known/openid-configuration") ||
+    path.includes("/.well-known/oauth-protected-resource")
+  );
+};
+
+const validateSupportedEndpoint = (
+  value: string,
+  label: string,
+  endpointUrlPolicy: OAuthEndpointUrlPolicy | undefined,
+): Effect.Effect<void, StorageFailure> =>
+  Effect.try({
+    try: () => assertSupportedOAuthEndpointUrl(value, label, endpointUrlPolicy),
+    catch: (cause) =>
+      new StorageError({
+        message: `Invalid OAuth client endpoint configuration: ${label} must use https: or loopback http:.`,
+        cause,
+      }),
+  }).pipe(Effect.asVoid);
+
+const validateClientEndpoints = (
+  input: CreateOAuthClientInput,
+  endpointUrlPolicy: OAuthEndpointUrlPolicy | undefined,
+): Effect.Effect<void, StorageFailure> =>
+  Effect.gen(function* () {
+    yield* validateSupportedEndpoint(input.tokenUrl, "token_url", endpointUrlPolicy);
+    if (input.resource != null && input.resource.trim().length > 0) {
+      yield* validateSupportedEndpoint(input.resource, "resource", endpointUrlPolicy);
+    }
+    if (input.grant !== "authorization_code") return;
+    yield* validateSupportedEndpoint(
+      input.authorizationUrl,
+      "authorization_url",
+      endpointUrlPolicy,
+    );
+    if (isWellKnownOAuthMetadataUrl(input.authorizationUrl)) {
+      return yield* new StorageError({
+        message:
+          "Invalid OAuth client endpoint configuration: authorization_url must be the OAuth authorization endpoint, not a .well-known metadata URL.",
+        cause: undefined,
+      });
+    }
+    if (canonicalUrlString(input.authorizationUrl) === canonicalUrlString(input.tokenUrl)) {
+      return yield* new StorageError({
+        message:
+          "Invalid OAuth client endpoint configuration: authorization_url must not equal token_url.",
+        cause: undefined,
+      });
+    }
+  });
+
 export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
   const httpClientLayer = deps.httpClientLayer ?? FetchHttpClient.layer;
   // EXPLICIT — no localhost default. `null` means this executor has no OAuth
@@ -243,6 +304,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
     input: CreateOAuthClientInput,
   ): Effect.Effect<OAuthClientSlug, StorageFailure> =>
     Effect.gen(function* () {
+      yield* validateClientEndpoints(input, deps.endpointUrlPolicy);
       const keys = yield* Effect.try({
         try: () => deps.ownedKeys(input.owner),
         catch: (cause) =>
@@ -396,6 +458,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         slug: input.slug,
         authorizationUrl: input.authorizationUrl,
         tokenUrl: input.tokenUrl,
+        resource: input.resource ?? null,
         grant: "authorization_code",
         clientId: information.client_id,
         clientSecret: information.client_secret ?? "",
@@ -432,6 +495,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
               grant,
               authorizationUrl: String(row.authorization_url),
               tokenUrl: String(row.token_url),
+              resource: row.resource == null ? null : String(row.resource),
               clientId: String(row.client_id),
             } satisfies OAuthClientSummary);
           }),
@@ -633,6 +697,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
             // without these Google returns no refresh token and won't re-consent
             // to widen scopes on reconnect.
             extraParams: providerAuthorizeExtras(client.authorizationUrl),
+            resource: client.resource ?? undefined,
             endpointUrlPolicy: deps.endpointUrlPolicy,
           }),
         catch: (cause) =>
@@ -714,6 +779,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         redirectUrl: session.redirectUrl,
         codeVerifier: session.pkceVerifier,
         code: input.code,
+        resource: client.resource ?? undefined,
         endpointUrlPolicy: deps.endpointUrlPolicy,
       }).pipe(
         Effect.mapError(
@@ -863,6 +929,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
       return {
         authorizationUrl: as.metadata.authorization_endpoint,
         tokenUrl: as.metadata.token_endpoint,
+        resource: resource?.metadata.resource ?? null,
         scopesSupported: as.metadata.scopes_supported,
         registrationEndpoint: as.metadata.registration_endpoint ?? null,
         tokenEndpointAuthMethodsSupported: as.metadata.token_endpoint_auth_methods_supported,

--- a/packages/plugins/mcp/src/react/EditMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/EditMcpSource.tsx
@@ -1,14 +1,9 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 
-import {
-  AuthTemplateSlug,
-  IntegrationSlug,
-  OAuthClientSlug,
-  type Owner,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, IntegrationSlug } from "@executor-js/sdk/shared";
 import { createConnection } from "@executor-js/react/api/atoms";
 import { connectionWriteKeys } from "@executor-js/react/api/reactivity-keys";
 import { connectionIdentifier } from "@executor-js/react/lib/connection-name";
@@ -17,8 +12,9 @@ import {
   CredentialUsageRow,
   useCredentialTargetScope,
 } from "@executor-js/react/plugins/credential-target-scope";
-import { OAuthSignInButton, useOAuthPopupFlow } from "@executor-js/react/plugins/oauth-sign-in";
+import { OAuthSignInButton } from "@executor-js/react/plugins/oauth-sign-in";
 import { Button } from "@executor-js/react/components/button";
+import { AddAccountModal } from "@executor-js/react/components/add-account-modal";
 import {
   CardStack,
   CardStackContent,
@@ -29,6 +25,7 @@ import {
 } from "@executor-js/react/components/card-stack";
 import { Input } from "@executor-js/react/components/input";
 import { Badge } from "@executor-js/react/components/badge";
+import type { AuthMethod } from "@executor-js/react/lib/auth-placements";
 
 import { mcpServerAtom } from "./atoms";
 import type { McpIntegrationConfig } from "../sdk/types";
@@ -60,18 +57,13 @@ function RemoteEdit(props: {
   const { credentialTargetOwner, setCredentialTargetOwner, credentialScopeOptions } =
     useCredentialTargetScope();
   const doCreate = useAtomSet(createConnection, { mode: "promiseExit" });
-  const oauth = useOAuthPopupFlow({
-    popupName: "mcp-oauth",
-    popupBlockedMessage: "OAuth popup was blocked",
-    detectPopupClosed: false,
-    startErrorMessage: "Failed to start OAuth",
-  });
 
   const [headerName] = useState(auth.kind === "header" ? auth.headerName : "Authorization");
   const [apiKey, setApiKey] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
+  const [oauthModalOpen, setOauthModalOpen] = useState(false);
 
   const handleSaveKey = useCallback(async () => {
     if (apiKey.trim() === "") return;
@@ -100,22 +92,38 @@ function RemoteEdit(props: {
 
   const handleOAuth = useCallback(() => {
     setError(null);
-    const owner: Owner = credentialTargetOwner;
-    void oauth.start({
-      payload: {
-        client: OAuthClientSlug.make(String(server.slug)),
-        // MCP registers its client (DCR) under the connection owner.
-        clientOwner: owner,
-        owner,
-        name: connectionIdentifier(`${server.slug} oauth`),
-        integration: server.slug,
-        template: OAUTH_TEMPLATE,
-        identityLabel: `${server.description || String(server.slug)} OAuth`,
-      },
-      onSuccess: () => setConnected(true),
-      onError: (message: string) => setError(message),
-    });
-  }, [credentialTargetOwner, oauth, server]);
+    setOauthModalOpen(true);
+  }, []);
+
+  const oauthMethods = useMemo<readonly AuthMethod[]>(
+    () =>
+      auth.kind === "oauth2"
+        ? [
+            {
+              id: "oauth2",
+              label: "OAuth",
+              kind: "oauth",
+              source: "spec",
+              template: OAUTH_TEMPLATE,
+              placements: [],
+              oauth: { discoveryUrl: server.config.endpoint, supportsDynamicRegistration: true },
+            },
+          ]
+        : [],
+    [auth.kind, server.config.endpoint],
+  );
+  const oauthInitialState = useMemo(
+    () =>
+      oauthModalOpen && auth.kind === "oauth2"
+        ? {
+            key: `${String(server.slug)}:${credentialTargetOwner}:oauth`,
+            owner: credentialTargetOwner,
+            template: String(OAUTH_TEMPLATE),
+            label: `${server.description || String(server.slug)} OAuth`,
+          }
+        : null,
+    [auth.kind, credentialTargetOwner, oauthModalOpen, server],
+  );
 
   return (
     <div className="space-y-6">
@@ -184,12 +192,20 @@ function RemoteEdit(props: {
         >
           <CredentialControlField label="Connect via OAuth" help="Start the provider OAuth flow.">
             <OAuthSignInButton
-              busy={oauth.busy}
-              error={oauth.error}
+              busy={false}
+              error={error}
               isConnected={connected}
               onSignIn={handleOAuth}
               signingInLabel="Signing in…"
               reconnectingLabel="Reconnecting…"
+            />
+            <AddAccountModal
+              integration={server.slug}
+              integrationName={server.description || String(server.slug)}
+              methods={oauthMethods}
+              open={oauthModalOpen}
+              onOpenChange={setOauthModalOpen}
+              initialState={oauthInitialState}
             />
           </CredentialControlField>
         </CredentialUsageRow>

--- a/packages/plugins/mcp/src/react/McpSignInButton.tsx
+++ b/packages/plugins/mcp/src/react/McpSignInButton.tsx
@@ -1,17 +1,17 @@
-import { useCallback, useState } from "react";
+import { useMemo, useState } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
 import {
   AuthTemplateSlug,
   IntegrationSlug,
-  OAuthClientSlug,
   type Connection,
   type Owner,
 } from "@executor-js/sdk/shared";
 import { connectionsAllAtom } from "@executor-js/react/api/atoms";
-import { connectionIdentifier } from "@executor-js/react/lib/connection-name";
-import { OAuthSignInButton, useOAuthPopupFlow } from "@executor-js/react/plugins/oauth-sign-in";
+import { AddAccountModal } from "@executor-js/react/components/add-account-modal";
+import { OAuthSignInButton } from "@executor-js/react/plugins/oauth-sign-in";
+import type { AuthMethod } from "@executor-js/react/lib/auth-placements";
 
 import { mcpServerAtom } from "./atoms";
 
@@ -34,12 +34,7 @@ export default function McpSignInButton(props: { sourceId: string; owner?: Owner
   const targetOwner: Owner = props.owner ?? "org";
   const serverResult = useAtomValue(mcpServerAtom(slug));
   const connectionsResult = useAtomValue(connectionsAllAtom);
-  const oauth = useOAuthPopupFlow({
-    popupName: "mcp-oauth",
-    detectPopupClosed: false,
-    startErrorMessage: "Failed to start OAuth",
-  });
-  const [justConnected, setJustConnected] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
 
   const server = AsyncResult.isSuccess(serverResult) ? serverResult.value : null;
   const remote = server !== null && server.config.transport === "remote" ? server.config : null;
@@ -51,33 +46,58 @@ export default function McpSignInButton(props: { sourceId: string; owner?: Owner
     (connection: Connection) => connection.integration === slug,
   );
 
-  const handleSignIn = useCallback(() => {
-    if (server === null) return;
-    void oauth.start({
-      payload: {
-        client: OAuthClientSlug.make(String(slug)),
-        // MCP registers its client (DCR) under the connection owner.
-        clientOwner: targetOwner,
-        owner: targetOwner,
-        name: connectionIdentifier(`${slug} oauth`),
-        integration: slug,
-        template: OAUTH_TEMPLATE,
-        identityLabel: `${server.description || String(slug)} OAuth`,
-      },
-      onSuccess: () => setJustConnected(true),
-    });
-  }, [server, targetOwner, oauth, slug]);
+  const methods = useMemo<readonly AuthMethod[]>(
+    () =>
+      remote === null
+        ? []
+        : [
+            {
+              id: "oauth2",
+              label: "OAuth",
+              kind: "oauth",
+              source: "spec",
+              template: OAUTH_TEMPLATE,
+              placements: [],
+              oauth: { discoveryUrl: remote.endpoint, supportsDynamicRegistration: true },
+            },
+          ],
+    [remote],
+  );
+  const initialState = useMemo(
+    () =>
+      modalOpen && server
+        ? {
+            key: `${String(slug)}:${targetOwner}:oauth`,
+            owner: targetOwner,
+            template: String(OAUTH_TEMPLATE),
+            label: `${server.description || String(slug)} OAuth`,
+          }
+        : null,
+    [modalOpen, server, slug, targetOwner],
+  );
 
   if (!isOAuth) return null;
 
   return (
-    <OAuthSignInButton
-      busy={oauth.busy}
-      error={oauth.error}
-      isConnected={hasConnection || justConnected}
-      onSignIn={handleSignIn}
-      reconnectingLabel="Reconnecting…"
-      signingInLabel="Signing in…"
-    />
+    <>
+      <OAuthSignInButton
+        busy={false}
+        error={null}
+        isConnected={hasConnection}
+        onSignIn={() => setModalOpen(true)}
+        reconnectingLabel="Reconnecting…"
+        signingInLabel="Signing in…"
+      />
+      {server ? (
+        <AddAccountModal
+          integration={slug}
+          integrationName={server.description || String(slug)}
+          methods={methods}
+          open={modalOpen}
+          onOpenChange={setModalOpen}
+          initialState={initialState}
+        />
+      ) : null}
+    </>
   );
 }

--- a/packages/react/src/components/add-account-modal.test.ts
+++ b/packages/react/src/components/add-account-modal.test.ts
@@ -30,6 +30,7 @@ const apiKeyMethod = (id: string, source: "spec" | "custom"): AuthMethod => ({
 type ProbeResult = {
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  readonly resource?: string | null;
   readonly scopesSupported?: readonly string[];
   readonly registrationEndpoint?: string | null;
   readonly tokenEndpointAuthMethodsSupported?: readonly string[];
@@ -41,6 +42,7 @@ type RegisterArgs = {
   readonly registrationEndpoint: string;
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  readonly resource?: string | null;
   readonly scopes: readonly string[];
   readonly tokenEndpointAuthMethodsSupported?: readonly string[];
   readonly clientName: string;
@@ -176,6 +178,7 @@ describe("runDcrConnect", () => {
       return Promise.resolve({
         authorizationUrl: "https://auth.example.com/authorize",
         tokenUrl: "https://auth.example.com/token",
+        resource: "https://mcp.example.com/mcp",
         scopesSupported: ["mcp.read"],
         registrationEndpoint: "https://auth.example.com/register",
         tokenEndpointAuthMethodsSupported: ["none"],
@@ -211,6 +214,7 @@ describe("runDcrConnect", () => {
     expect(registerArgs!.registrationEndpoint).toBe("https://auth.example.com/register");
     expect(registerArgs!.authorizationUrl).toBe("https://auth.example.com/authorize");
     expect(registerArgs!.tokenUrl).toBe("https://auth.example.com/token");
+    expect(registerArgs!.resource).toBe("https://mcp.example.com/mcp");
     expect(registerArgs!.tokenEndpointAuthMethodsSupported).toEqual(["none"]);
     expect(registerArgs!.scopes).toEqual(["mcp.read"]);
     expect(registerArgs!.redirectUri).toBe("https://localhost:5394/api/oauth/callback");

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -402,6 +402,7 @@ export const connectionNameFrom = (
 type DcrProbeResult = {
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  readonly resource?: string | null;
   readonly scopesSupported?: readonly string[];
   readonly registrationEndpoint?: string | null;
   readonly tokenEndpointAuthMethodsSupported?: readonly string[];
@@ -413,6 +414,7 @@ type DcrRegisterArgs = {
   readonly registrationEndpoint: string;
   readonly authorizationUrl: string;
   readonly tokenUrl: string;
+  readonly resource?: string | null;
   readonly scopes: readonly string[];
   readonly tokenEndpointAuthMethodsSupported?: readonly string[];
   readonly clientName: string;
@@ -486,6 +488,7 @@ export async function runDcrConnect(
     registrationEndpoint,
     authorizationUrl: probe.authorizationUrl,
     tokenUrl: probe.tokenUrl,
+    resource: probe.resource ?? null,
     scopes,
     tokenEndpointAuthMethodsSupported: probe.tokenEndpointAuthMethodsSupported,
     clientName: input.integrationName,
@@ -829,6 +832,7 @@ export function AddAccountModal(props: {
               registrationEndpoint: args.registrationEndpoint,
               authorizationUrl: args.authorizationUrl,
               tokenUrl: args.tokenUrl,
+              resource: args.resource ?? null,
               scopes: args.scopes,
               tokenEndpointAuthMethodsSupported: args.tokenEndpointAuthMethodsSupported,
               clientName: args.clientName,

--- a/packages/react/src/components/oauth-client-form.tsx
+++ b/packages/react/src/components/oauth-client-form.tsx
@@ -36,6 +36,7 @@ import { RadioGroup, RadioGroupItem } from "./radio-group";
 export interface OAuthClientFormPrefill {
   readonly authorizationUrl?: string;
   readonly tokenUrl?: string;
+  readonly resource?: string | null;
   readonly scopes?: readonly string[];
   readonly grant?: OAuthGrant;
   /** Client id to seed (e.g. when editing an existing app). NOT a secret — the
@@ -88,6 +89,7 @@ export function OAuthClientForm(props: {
   const [issuerUrl, setIssuerUrl] = useState("");
   const [authorizationUrl, setAuthorizationUrl] = useState(prefill?.authorizationUrl ?? "");
   const [tokenUrl, setTokenUrl] = useState(prefill?.tokenUrl ?? "");
+  const [resource, setResource] = useState(prefill?.resource ?? null);
   const [discovering, setDiscovering] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   // DCR (RFC 7591): the registration endpoint + advertised auth methods. Seeded
@@ -143,6 +145,7 @@ export function OAuthClientForm(props: {
     const result = exit.value;
     setAuthorizationUrl(result.authorizationUrl);
     setTokenUrl(result.tokenUrl);
+    setResource(result.resource ?? null);
     // Capture DCR availability so the "Register automatically" path shows for a
     // pasted MCP/issuer URL without any client id/secret.
     setRegistrationEndpoint(result.registrationEndpoint ?? "");
@@ -165,6 +168,7 @@ export function OAuthClientForm(props: {
         registrationEndpoint: registrationEndpoint.trim(),
         authorizationUrl: authorizationUrl.trim(),
         tokenUrl: tokenUrl.trim(),
+        resource,
         // DCR sends the integration's declared scopes to the AS at registration
         // (the app itself stores none).
         scopes: [...(prefill?.scopes ?? [])],
@@ -196,6 +200,7 @@ export function OAuthClientForm(props: {
         grant,
         clientId: clientId.trim(),
         clientSecret: clientSecret.trim(),
+        resource,
       },
       reactivityKeys: oauthClientWriteKeys,
     });

--- a/packages/react/src/pages/oauth-apps.test.ts
+++ b/packages/react/src/pages/oauth-apps.test.ts
@@ -20,6 +20,7 @@ const app = (slug: string, opts?: { readonly owner?: Owner }): OAuthClientSummar
   grant: "authorization_code",
   authorizationUrl: "https://issuer.example.com/authorize",
   tokenUrl: "https://issuer.example.com/token",
+  resource: null,
   clientId: "client-id",
 });
 
@@ -27,7 +28,11 @@ const app = (slug: string, opts?: { readonly owner?: Owner }): OAuthClientSummar
 const connection = (
   integration: string,
   name: string,
-  opts?: { readonly owner?: Owner; readonly oauthClient?: string | null },
+  opts?: {
+    readonly owner?: Owner;
+    readonly oauthClient?: string | null;
+    readonly oauthClientOwner?: Owner | null;
+  },
 ): Connection => ({
   owner: opts?.owner ?? "user",
   name: ConnectionName.make(name),
@@ -43,6 +48,7 @@ const connection = (
       : opts.oauthClient === null
         ? null
         : OAuthClientSlug.make(opts.oauthClient),
+  oauthClientOwner: opts?.oauthClientOwner ?? null,
 });
 
 describe("groupClientsByOwner", () => {
@@ -78,40 +84,59 @@ describe("groupClientsByOwner", () => {
 describe("buildUsageMap / connectionsUsingClient", () => {
   it("maps connections to the app slug that minted them", () => {
     const usage = buildUsageMap([
-      connection("github", "personal", { oauthClient: "gh-app" }),
-      connection("github", "bot", { oauthClient: "gh-app" }),
-      connection("linear", "main", { oauthClient: "linear-app" }),
+      connection("github", "personal", { oauthClient: "gh-app", oauthClientOwner: "org" }),
+      connection("github", "bot", { oauthClient: "gh-app", oauthClientOwner: "org" }),
+      connection("linear", "main", { oauthClient: "linear-app", oauthClientOwner: "org" }),
     ]);
     expect(
-      connectionsUsingClient(usage, OAuthClientSlug.make("gh-app")).map((c: Connection) =>
+      connectionsUsingClient(usage, app("gh-app", { owner: "org" })).map((c: Connection) =>
         String(c.name),
       ),
     ).toEqual(["personal", "bot"]);
     expect(
-      connectionsUsingClient(usage, OAuthClientSlug.make("linear-app")).map((c: Connection) =>
+      connectionsUsingClient(usage, app("linear-app", { owner: "org" })).map((c: Connection) =>
         String(c.name),
       ),
     ).toEqual(["main"]);
   });
 
+  it("keys usage by app owner as well as slug", () => {
+    const usage = buildUsageMap([
+      connection("github", "workspace", { oauthClient: "github", oauthClientOwner: "org" }),
+      connection("github", "personal", { oauthClient: "github", oauthClientOwner: "user" }),
+    ]);
+    expect(
+      connectionsUsingClient(usage, app("github", { owner: "org" })).map((c: Connection) =>
+        String(c.name),
+      ),
+    ).toEqual(["workspace"]);
+    expect(
+      connectionsUsingClient(usage, app("github", { owner: "user" })).map((c: Connection) =>
+        String(c.name),
+      ),
+    ).toEqual(["personal"]);
+  });
+
   it("skips static connections with a null oauthClient", () => {
     const usage = buildUsageMap([
       connection("vercel", "static", { oauthClient: null }),
-      connection("github", "oauth", { oauthClient: "gh-app" }),
+      connection("github", "oauth", { oauthClient: "gh-app", oauthClientOwner: "org" }),
     ]);
-    expect(usage.has("gh-app")).toBe(true);
+    expect(usage.size).toBe(1);
     // Only the OAuth-minted connection is tracked; the static one is absent.
-    expect([...usage.keys()]).toEqual(["gh-app"]);
+    expect(connectionsUsingClient(usage, app("gh-app", { owner: "org" }))).toHaveLength(1);
   });
 
   it("returns an empty array for an app that backs no connections", () => {
-    const usage = buildUsageMap([connection("github", "oauth", { oauthClient: "gh-app" })]);
-    expect(connectionsUsingClient(usage, OAuthClientSlug.make("unused-app"))).toEqual([]);
+    const usage = buildUsageMap([
+      connection("github", "oauth", { oauthClient: "gh-app", oauthClientOwner: "org" }),
+    ]);
+    expect(connectionsUsingClient(usage, app("unused-app", { owner: "org" }))).toEqual([]);
   });
 
   it("returns an empty map when there are no connections", () => {
     const usage = buildUsageMap([]);
     expect(usage.size).toBe(0);
-    expect(connectionsUsingClient(usage, OAuthClientSlug.make("any"))).toEqual([]);
+    expect(connectionsUsingClient(usage, app("any", { owner: "org" }))).toEqual([]);
   });
 });

--- a/packages/react/src/pages/oauth-apps.tsx
+++ b/packages/react/src/pages/oauth-apps.tsx
@@ -88,9 +88,13 @@ export function groupClientsByOwner(
   });
 }
 
-/** Build a slug → connections map so each app can show what it backs. A
- *  connection maps to an app when its `oauthClient` equals the app slug; static
- *  connections (null `oauthClient`) are skipped. */
+/** Build an owner+slug → connections map so each app can show what it backs.
+ *  Connection rows can reference either a personal or workspace app with the
+ *  same slug, so owner is part of the key. Static connections (null
+ *  `oauthClient`) are skipped. */
+const oauthClientUsageKey = (owner: Owner | null | undefined, slug: OAuthClientSlug): string =>
+  `${owner ?? "org"}\0${String(slug)}`;
+
 export function buildUsageMap(
   connections: readonly Connection[],
 ): ReadonlyMap<string, readonly Connection[]> {
@@ -98,7 +102,7 @@ export function buildUsageMap(
   for (const connection of connections) {
     const slug = connection.oauthClient;
     if (slug == null) continue;
-    const key = String(slug);
+    const key = oauthClientUsageKey(connection.oauthClientOwner, slug);
     const existing = map.get(key);
     if (existing) existing.push(connection);
     else map.set(key, [connection]);
@@ -109,9 +113,9 @@ export function buildUsageMap(
 /** Connections backing one app, or an empty array. */
 export function connectionsUsingClient(
   usage: ReadonlyMap<string, readonly Connection[]>,
-  slug: OAuthClientSlug,
+  client: Pick<OAuthClientSummary, "owner" | "slug">,
 ): readonly Connection[] {
-  return usage.get(String(slug)) ?? [];
+  return usage.get(oauthClientUsageKey(client.owner, client.slug)) ?? [];
 }
 
 // ---------------------------------------------------------------------------
@@ -197,6 +201,7 @@ function OAuthAppCard(props: {
           <MetaField label="Authorization URL" value={client.authorizationUrl} copy />
         ) : null}
         <MetaField label="Token URL" value={client.tokenUrl} copy />
+        {client.resource ? <MetaField label="Resource" value={client.resource} copy /> : null}
       </div>
 
       <div className="flex flex-col gap-1.5">
@@ -421,6 +426,7 @@ export function OAuthAppsPage() {
                     prefill={{
                       authorizationUrl: dialog.client.authorizationUrl,
                       tokenUrl: dialog.client.tokenUrl,
+                      resource: dialog.client.resource ?? null,
                       grant: dialog.client.grant,
                       clientId: dialog.client.clientId,
                     }}
@@ -431,7 +437,7 @@ export function OAuthAppsPage() {
                 {dialog.kind === "remove" ? (
                   <RemoveAppDialog
                     client={dialog.client}
-                    connections={connectionsUsingClient(usage, dialog.client.slug)}
+                    connections={connectionsUsingClient(usage, dialog.client)}
                     onConfirm={() => void handleRemove(dialog.client)}
                     onClose={() => setDialog({ kind: "none" })}
                   />
@@ -468,7 +474,7 @@ export function OAuthAppsPage() {
                         <OAuthAppCard
                           key={`${client.owner}.${String(client.slug)}`}
                           client={client}
-                          connections={connectionsUsingClient(usage, client.slug)}
+                          connections={connectionsUsingClient(usage, client)}
                           onEdit={() => setDialog({ kind: "edit", client })}
                           onRemove={() => setDialog({ kind: "remove", client })}
                         />

--- a/packages/react/src/plugins/use-effective-oauth-client.test.ts
+++ b/packages/react/src/plugins/use-effective-oauth-client.test.ts
@@ -73,6 +73,22 @@ describe("selectClientsForEndpoints", () => {
     ]);
   });
 
+  it("does not match by authorize root alone when the integration declares a token endpoint", () => {
+    const authorizeOnly = app("google-authorize", {
+      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://accounts.google.com/token",
+    });
+    const result = selectClientsForEndpoints([authorizeOnly], {
+      authorizationUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+      tokenUrl: "https://oauth2.googleapis.com/token",
+    });
+    expect(result.endpointMatched).toBe(false);
+    expect(result.matched).toEqual([]);
+    expect(result.unmatched.map((a: OAuthClientOption) => String(a.slug))).toEqual([
+      "google-authorize",
+    ]);
+  });
+
   it("treats every app as usable when no endpoint is declared", () => {
     const result = selectClientsForEndpoints([google, spotify], {});
     expect(result.endpointMatched).toBe(true);

--- a/packages/react/src/plugins/use-effective-oauth-client.tsx
+++ b/packages/react/src/plugins/use-effective-oauth-client.tsx
@@ -86,14 +86,12 @@ const sortUserFirst = (apps: readonly OAuthClientOption[]): readonly OAuthClient
  * Pure matcher (no React/atoms) — split owner-visible apps into the ones that
  * match the integration's declared OAuth endpoints and the ones that don't.
  *
- * Matching is by REGISTRABLE ROOT DOMAIN ("tld+1"), unioned across both the
- * integration's `authorizationUrl` and `tokenUrl`. An app matches if EITHER of
- * its own endpoint root domains is in that union. This deliberately matches at
- * the registrable-domain level (not full host, not full PSL gymnastics): a
- * provider commonly splits authorize/token across sibling hosts on one root
- * (e.g. `accounts.google.com` + `oauth2.googleapis.com` are DIFFERENT roots, so
- * a provider that declares both has both in its union, and an app declaring
- * either matches). Unrelated providers (different root) never match.
+ * Matching is by REGISTRABLE ROOT DOMAIN ("tld+1"). When the integration
+ * declares a token endpoint, an app must match by token endpoint root; the token
+ * endpoint is what the SDK will call during code exchange/refresh and avoids
+ * authorize-root coincidences. When only an authorization endpoint is declared,
+ * the authorize root is used as the fallback compatibility signal. Unrelated
+ * providers (different root) never match.
  *
  * When the integration declares no endpoints, every app is "matched" (no filter).
  */
@@ -105,23 +103,23 @@ export function selectClientsForEndpoints(
   readonly unmatched: readonly OAuthClientOption[];
   readonly endpointMatched: boolean;
 } {
-  const wanted = new Set<string>();
-  for (const url of [endpoints.authorizationUrl, endpoints.tokenUrl]) {
-    if (!url) continue;
-    const root = getRootDomain(url);
-    if (root) wanted.add(root);
-  }
+  const wantedTokenRoot = endpoints.tokenUrl ? getRootDomain(endpoints.tokenUrl) : undefined;
+  const wantedAuthorizationRoot = endpoints.authorizationUrl
+    ? getRootDomain(endpoints.authorizationUrl)
+    : undefined;
   // No declared endpoints → no filter; every app is usable.
-  if (wanted.size === 0) {
+  if (!wantedTokenRoot && !wantedAuthorizationRoot) {
     return { matched: sortUserFirst(all), unmatched: [], endpointMatched: true };
   }
   const matched: OAuthClientOption[] = [];
   const unmatched: OAuthClientOption[] = [];
   for (const app of all) {
-    const appRoots = [getRootDomain(app.authorizationUrl), getRootDomain(app.tokenUrl)];
-    const fits = appRoots.some(
-      (root: string | undefined) => root !== undefined && wanted.has(root),
-    );
+    const appTokenRoot = getRootDomain(app.tokenUrl);
+    const appAuthorizationRoot = getRootDomain(app.authorizationUrl);
+    const fits = wantedTokenRoot
+      ? appTokenRoot === wantedTokenRoot
+      : appAuthorizationRoot === wantedAuthorizationRoot ||
+        appTokenRoot === wantedAuthorizationRoot;
     if (fits) matched.push(app);
     else unmatched.push(app);
   }


### PR DESCRIPTION
## Summary

- repair migrated OAuth authorization URLs by resolving standards-based metadata from saved metadata URLs, protected-resource metadata, or issuer roots
- preserve MCP `resource` through probe, DCR registration, OAuth client persistence, authorization redirects, and token exchange
- route legacy MCP OAuth buttons through the shared DCR account flow instead of deriving OAuth client slugs from integration slugs
- tighten OAuth app usage/matching so owner-scoped clients and token endpoint compatibility are handled correctly

## Root Cause

Some migrated clients persisted an issuer or protected-resource URL as `authorization_url` when archived v1 state did not include an explicit authorization-server metadata URL. Separately, MCP `resource` was dropped in the runtime DCR/auth-code path, which could produce incorrect authorization and token requests even after endpoint repair.

## Validation

- `bunx --bun vitest run src/migration-oauth-metadata.test.ts src/oauth-register-dynamic.test.ts src/oauth-list-clients.test.ts` from `packages/core/sdk`
- `bunx --bun vitest run src/components/add-account-modal.test.ts src/pages/oauth-apps.test.ts src/plugins/use-effective-oauth-client.test.ts` from `packages/react`
- `bun run typecheck` from `packages/core/sdk`, `packages/core/api`, `packages/react`, and `packages/plugins/mcp`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`

Production OAuth authorization URL repair was applied separately; a follow-up dry run reported zero remaining authorization URL updates.