### PR TITLE
Handle manual-auth MCP probes

### DIFF
--- a/packages/plugins/mcp/src/api/group.ts
+++ b/packages/plugins/mcp/src/api/group.ts
@@ -54,6 +54,7 @@ const ProbeEndpointPayload = Schema.Struct({
 
 const ProbeEndpointResponse = Schema.Struct({
   connected: Schema.Boolean,
+  requiresAuthentication: Schema.Boolean,
   requiresOAuth: Schema.Boolean,
   supportsDynamicRegistration: Schema.Boolean,
   name: Schema.String,

--- a/packages/plugins/mcp/src/react/AddMcpSource.tsx
+++ b/packages/plugins/mcp/src/react/AddMcpSource.tsx
@@ -83,6 +83,7 @@ function findPreset(id: string | undefined): McpPreset | undefined {
 
 type ProbeResult = {
   connected: boolean;
+  requiresAuthentication: boolean;
   requiresOAuth: boolean;
   supportsDynamicRegistration: boolean;
   name: string;
@@ -220,7 +221,9 @@ export default function AddMcpSource(props: {
   const allowedAuthKinds: readonly AuthTemplateEditorKind[] =
     probe?.requiresOAuth && probe.supportsDynamicRegistration
       ? ["oauth"]
-      : ["none", "apikey", "oauth"];
+      : probe?.requiresAuthentication
+        ? ["apikey", "oauth"]
+        : ["none", "apikey", "oauth"];
 
   const remoteIdentity = useIntegrationIdentity({
     fallbackName:
@@ -270,7 +273,12 @@ export default function AddMcpSource(props: {
     setAuthValue(
       exit.value.requiresOAuth
         ? { kind: "oauth", authorizationUrl: "", tokenUrl: "", scopes: [] }
-        : { kind: "none" },
+        : exit.value.requiresAuthentication
+          ? {
+              kind: "apikey",
+              placements: [{ carrier: "header", name: "Authorization", prefix: "Bearer " }],
+            }
+          : { kind: "none" },
     );
     dispatch({ type: "probe-ok", probe: exit.value });
   }, [state.url, doProbe]);

--- a/packages/plugins/mcp/src/react/McpRemoteSourceFields.tsx
+++ b/packages/plugins/mcp/src/react/McpRemoteSourceFields.tsx
@@ -25,6 +25,8 @@ export type McpRemoteSourcePreview = {
   readonly name: string;
   readonly serverName: string | null;
   readonly connected: boolean;
+  readonly requiresAuthentication: boolean;
+  readonly requiresOAuth: boolean;
   readonly toolCount: number | null;
 };
 
@@ -44,7 +46,11 @@ export function McpRemoteSourceFields(props: {
       ? props.preview.toolCount === null
         ? null
         : `${props.preview.toolCount} tool${props.preview.toolCount !== 1 ? "s" : ""} available`
-      : "OAuth required to discover tools"
+      : props.preview.requiresOAuth
+        ? "OAuth required to discover tools"
+        : props.preview.requiresAuthentication
+          ? "Authentication required to discover tools"
+          : "Ready to add"
     : null;
 
   if (props.preview) {
@@ -71,12 +77,19 @@ export function McpRemoteSourceFields(props: {
                 >
                   Connected
                 </Badge>
-              ) : (
+              ) : props.preview.requiresOAuth ? (
                 <Badge
                   variant="outline"
                   className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
                 >
                   OAuth required
+                </Badge>
+              ) : (
+                <Badge
+                  variant="outline"
+                  className="border-amber-500/20 bg-amber-500/10 text-[10px] text-amber-600 dark:text-amber-400"
+                >
+                  Auth required
                 </Badge>
               )}
             </CardStackEntryActions>

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
+import { HttpServerResponse } from "effect/unstable/http";
 
 import {
   AuthTemplateSlug,
@@ -8,7 +9,11 @@ import {
   ToolAddress,
   createExecutor,
 } from "@executor-js/sdk";
-import { makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+import {
+  makeTestConfig,
+  memoryCredentialsPlugin,
+  serveTestHttpApp,
+} from "@executor-js/sdk/testing";
 
 import { mcpPlugin, userFacingProbeMessage } from "./plugin";
 import { extractManifestFromListToolsResult, deriveMcpNamespace, joinToolPath } from "./manifest";
@@ -244,6 +249,42 @@ describe("mcpPlugin", () => {
       yield* executor.close();
       yield* Effect.promise(() => config.testDb.close());
     }),
+  );
+
+  it.effect("probeEndpoint returns manual auth when MCP requires auth without OAuth metadata", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveTestHttpApp((request) =>
+          Effect.succeed(
+            (request.url ?? "").includes("/.well-known/")
+              ? HttpServerResponse.text("missing", { status: 404 })
+              : HttpServerResponse.jsonUnsafe(
+                  {
+                    jsonrpc: "2.0",
+                    id: null,
+                    error: { code: -32000, message: "Unauthorized: Valid API key required." },
+                  },
+                  { status: 401, headers: { "www-authenticate": "Bearer" } },
+                ),
+          ),
+        );
+        const config = makeTestConfig({ plugins: [mcpPlugin()] as const });
+        const executor = yield* createExecutor(config);
+
+        const result = yield* executor.mcp.probeEndpoint(server.url("/mcp"));
+
+        expect(result).toMatchObject({
+          connected: false,
+          requiresAuthentication: true,
+          requiresOAuth: false,
+          supportsDynamicRegistration: false,
+          toolCount: null,
+        });
+
+        yield* executor.close();
+        yield* Effect.promise(() => config.testDb.close());
+      }),
+    ),
   );
 });
 

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -123,6 +123,7 @@ const McpProbeEndpointInputSchema = Schema.Struct({
 
 const McpProbeEndpointOutputSchema = Schema.Struct({
   connected: Schema.Boolean,
+  requiresAuthentication: Schema.Boolean,
   requiresOAuth: Schema.Boolean,
   supportsDynamicRegistration: Schema.Boolean,
   name: Schema.String,
@@ -544,6 +545,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           if (result.ok && result.manifest) {
             return {
               connected: true,
+              requiresAuthentication: false,
               requiresOAuth: false,
               supportsDynamicRegistration: false,
               name: result.manifest.server?.name ?? name,
@@ -577,8 +579,22 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           if (probeResult.ok) {
             return {
               connected: false,
+              requiresAuthentication: true,
               requiresOAuth: true,
               supportsDynamicRegistration: probeResult.oauth.registrationEndpoint != null,
+              name,
+              slug,
+              toolCount: null,
+              serverName: null,
+            } satisfies McpProbeResult;
+          }
+
+          if (shape.requiresAuth) {
+            return {
+              connected: false,
+              requiresAuthentication: true,
+              requiresOAuth: false,
+              supportsDynamicRegistration: false,
               name,
               slug,
               toolCount: null,
@@ -589,7 +605,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
           return yield* new McpConnectionError({
             transport: "remote",
             message:
-              "This server requires authentication, but OAuth metadata wasn't found. Add credentials (Authorization header, query parameter, or API key) below and retry.",
+              "This endpoint looks like MCP, but Executor couldn't discover tools from it. Check the URL and try again.",
           });
         }).pipe(
           Effect.withSpan("mcp.plugin.probe_endpoint", {


### PR DESCRIPTION
## Summary

- Treat MCP endpoints that require authentication but do not publish OAuth metadata as manual-auth endpoints instead of failed probes.
- Show the Add MCP Source auth editor in that state and default it to an Authorization header template.
- Add coverage for an MCP-shaped 401 response without OAuth metadata.

## Validation

- `bun run --cwd packages/plugins/mcp test src/sdk/plugin.test.ts`
- `bun run --cwd packages/plugins/mcp typecheck`
- `bun x oxfmt --check packages/plugins/mcp/src/sdk/plugin.ts packages/plugins/mcp/src/sdk/plugin.test.ts packages/plugins/mcp/src/api/group.ts packages/plugins/mcp/src/react/AddMcpSource.tsx packages/plugins/mcp/src/react/McpRemoteSourceFields.tsx`
