### PR TITLE
[codex] Fix desktop OAuth callback URL

### DIFF
--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -238,6 +238,7 @@ export async function startSidecar(options: StartOptions = {}): Promise<SidecarC
   }
 
   let child: ChildProcess;
+  const webBaseUrl = `http://${hostname}:${settings.port}`;
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: spawn can throw synchronously and the local startup lock must be released
   try {
     child = spawn(command, args, {
@@ -247,6 +248,8 @@ export async function startSidecar(options: StartOptions = {}): Promise<SidecarC
         ...process.env,
         EXECUTOR_PORT: String(settings.port),
         EXECUTOR_HOST: hostname,
+        EXECUTOR_WEB_BASE_URL: webBaseUrl,
+        PORT: String(settings.port),
         // Only export the password env var when auth is enabled — the sidecar
         // treats an empty password as "no auth required". Matches the CLI's
         // `executor web` default.

--- a/apps/local/src/executor.ts
+++ b/apps/local/src/executor.ts
@@ -181,11 +181,11 @@ const createLocalExecutorLayer = () => {
         plugins,
         onElicitation: "accept-all",
         oauthEndpointUrlPolicy: { allowHttp: true },
-        // EXPLICIT OAuth callback — the daemon serves the v2 `/oauth/callback`
+        // EXPLICIT OAuth callback — the daemon serves the v2 `/api/oauth/callback`
         // route on the same origin as the web UI. Derived from `webBaseUrl`
         // (loopback localhost is correct + intended for the local CLI, but it
         // is wired explicitly here rather than relying on a hidden default).
-        redirectUri: new URL("/oauth/callback", webBaseUrl).toString(),
+        redirectUri: new URL("/api/oauth/callback", webBaseUrl).toString(),
         // Built-in agent-facing tools (integrations / connections / policies).
         coreTools: {
           webBaseUrl,

--- a/apps/local/src/mcp-oauth.test.ts
+++ b/apps/local/src/mcp-oauth.test.ts
@@ -96,8 +96,8 @@ const startHarness = async (tmpDir: string): Promise<Harness> => {
       onElicitation: "accept-all",
       oauthEndpointUrlPolicy: { allowHttp: true },
       // EXPLICIT OAuth callback — required now that the localhost default is
-      // gone; the local daemon serves `/oauth/callback` on the web origin.
-      redirectUri: "http://localhost:4788/oauth/callback",
+      // gone; the local daemon serves `/api/oauth/callback` on the web origin.
+      redirectUri: "http://localhost:4788/api/oauth/callback",
     }),
   );
 
@@ -225,6 +225,9 @@ describe("local oauth (real OAuth discovery + stubbed start)", () => {
           expect(started.status).toBe("redirect");
           const redirect = started as Extract<typeof started, { status: "redirect" }>;
           expect(redirect.authorizationUrl).toContain(oauth.authorizationEndpoint);
+          expect(redirect.authorizationUrl).toContain(
+            encodeURIComponent("http://localhost:4788/api/oauth/callback"),
+          );
           expect(redirect.state).toBeTruthy();
         }),
       ),


### PR DESCRIPTION
## Summary

Fixes the local OAuth callback URL generated when Executor runs inside the desktop sidecar.

Desktop was starting the sidecar on its configured port, usually `127.0.0.1:4789`, but the local executor OAuth setup still fell back to the CLI default `localhost:4788`. That produced authorization URLs whose callback could not reach the running desktop server.

This PR:
- passes `EXECUTOR_WEB_BASE_URL` and `PORT` from the Electron main process into the sidecar
- advertises the served `/api/oauth/callback` route as the local OAuth redirect URI
- updates the local MCP OAuth test to assert the callback URL in generated authorization links

## Validation

- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd apps/local typecheck`
- `../../node_modules/.bin/vitest run --config vitest.config.ts src/mcp-oauth.test.ts` from `apps/local`
