### PR TITLE
Fix v1.5 auth-failure recovery guidance and guard valueless connections

### DIFF
--- a/apps/cloud/src/auth/auth-tool-failures.node.test.ts
+++ b/apps/cloud/src/auth/auth-tool-failures.node.test.ts
@@ -10,7 +10,7 @@
 // v2: a connection IS the credential. `addSpec` registers the integration with
 // an apiKey auth template; a connection is then created whose value cannot
 // resolve (a `from` reference to a WorkOS Vault item that was never stored).
-// Invoking one of that connection's tools surfaces `credential_secret_missing`
+// Invoking one of that connection's tools surfaces `connection_value_missing`
 // to the model instead of an opaque internal tool error.
 // ---------------------------------------------------------------------------
 
@@ -55,7 +55,7 @@ const expectModelVisibleAuthFailure = (execution: ExecuteResult) => {
     result: {
       ok: false,
       error: {
-        code: "credential_secret_missing",
+        code: "connection_value_missing",
         details: {
           category: "authentication",
         },

--- a/apps/host-cloudflare/web/routes/secrets.tsx
+++ b/apps/host-cloudflare/web/routes/secrets.tsx
@@ -1,25 +1,10 @@
-import { Schema } from "effect";
 import { createFileRoute } from "@tanstack/react-router";
 import { SecretsPage } from "@executor-js/react/pages/secrets";
 
-// Query params supported by the agent-facing `secrets.create` static tool:
-// it builds a URL like `/secrets?name=…&scope=…&secretId=…` and hands
-// it to the user. The page opens the add modal pre-filled when any
-// prefill field is present so the user only has to type the value.
-const SearchParams = Schema.toStandardSchemaV1(
-  Schema.Struct({
-    name: Schema.optional(Schema.String),
-    secretId: Schema.optional(Schema.String),
-    provider: Schema.optional(Schema.String),
-    scope: Schema.optional(Schema.String),
-  }),
-);
-
+// The Providers/Secrets page lets self-host users inspect their credential
+// backends. Credential entry happens through the per-integration Add Account
+// flow (`connections.createHandoff` → `/integrations/{slug}?addAccount=1`),
+// not here, so this route takes no search params.
 export const Route = createFileRoute("/secrets")({
-  validateSearch: SearchParams,
-  component: () => {
-    const { name, secretId, provider, scope } = Route.useSearch();
-    const hasPrefill = name != null || secretId != null;
-    return <SecretsPage prefill={hasPrefill ? { name, secretId, provider, scope } : undefined} />;
-  },
+  component: () => <SecretsPage />,
 });

--- a/apps/host-selfhost/web/routes/secrets.tsx
+++ b/apps/host-selfhost/web/routes/secrets.tsx
@@ -1,23 +1,10 @@
-import { Schema } from "effect";
 import { createFileRoute } from "@tanstack/react-router";
 import { SecretsPage } from "@executor-js/react/pages/secrets";
 
-// Query params from the agent-facing `secrets.create` static tool: it builds a
-// URL like `/secrets?name=…&scope=…&secretId=…`; open the add modal pre-filled.
-const SearchParams = Schema.toStandardSchemaV1(
-  Schema.Struct({
-    name: Schema.optional(Schema.String),
-    secretId: Schema.optional(Schema.String),
-    provider: Schema.optional(Schema.String),
-    scope: Schema.optional(Schema.String),
-  }),
-);
-
+// The Providers/Secrets page lets self-host users inspect their credential
+// backends. Credential entry happens through the per-integration Add Account
+// flow (`connections.createHandoff` → `/integrations/{slug}?addAccount=1`),
+// not here, so this route takes no search params.
 export const Route = createFileRoute("/secrets")({
-  validateSearch: SearchParams,
-  component: () => {
-    const { name, secretId, provider, scope } = Route.useSearch();
-    const hasPrefill = name != null || secretId != null;
-    return <SecretsPage prefill={hasPrefill ? { name, secretId, provider, scope } : undefined} />;
-  },
+  component: () => <SecretsPage />,
 });

--- a/apps/local/src/auth-tool-failures.test.ts
+++ b/apps/local/src/auth-tool-failures.test.ts
@@ -14,7 +14,7 @@
 // v2: a connection IS the credential. addSpec registers the integration with an
 // apiKey auth template; a connection is then created whose value cannot resolve
 // (a `from` reference to a missing provider item). Invoking one of that
-// connection's tools surfaces `credential_secret_missing` to the model.
+// connection's tools surfaces `connection_value_missing` to the model.
 // ---------------------------------------------------------------------------
 
 import { afterAll, beforeAll, describe, expect, it } from "@effect/vitest";
@@ -142,7 +142,7 @@ const startHarness = async (tmpDir: string): Promise<Harness> => {
       )) as typeof globalThis.fetch,
     // Create an org connection whose value cannot resolve: a `from` reference
     // to a memory-provider item that was never stored resolves to `null`, so
-    // tool invocation surfaces `credential_secret_missing`.
+    // tool invocation surfaces `connection_value_missing`.
     addConnection: (input) =>
       Effect.runPromise(
         executor.connections
@@ -196,12 +196,12 @@ const expectModelVisibleAuthFailure = (execution: ExecuteResult) => {
     result: {
       ok: false,
       error: {
-        code: "credential_secret_missing",
+        code: "connection_value_missing",
         details: {
           category: "authentication",
           recovery: {
-            createSecretTool: "executor.coreTools.secrets.create",
-            secretsUrl: "https://executor.sh/secrets",
+            createConnectionTool: "executor.coreTools.connections.createHandoff",
+            listConnectionsTool: "executor.coreTools.connections.list",
           },
         },
       },

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -58,7 +58,8 @@ export interface HostConfigShape {
   readonly allowLocalNetwork: boolean;
   /**
    * Base URL of the executor's web UI. Threaded into `coreTools.webBaseUrl` so
-   * `secrets.create` can point the user at `${webBaseUrl}/secrets?...`.
+   * `connections.createHandoff` can point the user at
+   * `${webBaseUrl}/integrations/{slug}?addAccount=1`.
    *
    * Optional: when a host can't know its public URL at boot (a Worker has no
    * static URL var), leave it unset and `makeScopedExecutor` falls back to the

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -138,7 +138,7 @@ const credentialResolutionToolFailure = (input: {
   readonly reauthRequired?: boolean;
 }) =>
   authToolFailure({
-    code: input.reauthRequired === true ? "oauth_reauth_required" : "oauth_connection_failed",
+    code: input.reauthRequired === true ? "oauth_reauth_required" : "oauth_refresh_failed",
     message:
       input.reauthRequired === true
         ? `OAuth connection "${input.label}" requires reauthorization: ${input.message}`

--- a/packages/core/sdk/src/auth-tool-failure.ts
+++ b/packages/core/sdk/src/auth-tool-failure.ts
@@ -1,11 +1,10 @@
 import { ToolResult, type ToolError } from "./tool-result";
 
 export type AuthToolFailureCode =
-  | "credential_binding_missing"
-  | "credential_secret_missing"
-  | "credential_rejected"
+  | "connection_value_missing"
+  | "connection_rejected"
   | "oauth_connection_missing"
-  | "oauth_connection_failed"
+  | "oauth_refresh_failed"
   | "oauth_reauth_required";
 
 export type AuthToolFailureInput = {
@@ -16,7 +15,7 @@ export type AuthToolFailureInput = {
     readonly scope?: string;
   };
   readonly credential?: {
-    readonly kind: "secret" | "connection" | "oauth" | "upstream";
+    readonly kind: "secret" | "oauth" | "upstream";
     readonly label?: string;
     readonly slotKey?: string;
     readonly secretId?: string;
@@ -32,16 +31,21 @@ export type AuthToolFailureInput = {
   };
 };
 
+// In v1.5 a connection IS the credential: there is no standalone secret to
+// "bind" to a source afterward. Manually-entered credentials are created via
+// the connection handoff (the user enters the value in the web UI, which
+// creates the bound connection in one step); OAuth credentials are minted by
+// the OAuth start flow. These strings are read by the agent resolving the
+// failure, so they must name tools that actually exist on the executor.
 const authRecovery = (input?: AuthToolFailureInput["recovery"]) => ({
-  secretsUrl: "https://executor.sh/secrets",
-  createSecretTool: "executor.coreTools.secrets.create",
+  createConnectionTool: "executor.coreTools.connections.createHandoff",
   startOAuthTool: "executor.coreTools.oauth.start",
   listConnectionsTool: "executor.coreTools.connections.list",
   ...(input?.configureSourceTool ? { configureSourceTool: input.configureSourceTool } : {}),
-  secretInstructions:
-    "For API keys, tokens, and other manually entered credentials, call createSecretTool and give the returned browser URL to the user before configuring the source binding.",
+  connectionInstructions:
+    "For API keys and tokens, call createConnectionTool for the integration to get a browser URL; the user enters the credential there, which creates the bound connection. Do not ask the user to paste secrets into chat. Then call listConnectionsTool to confirm the connection exists before retrying this tool.",
   oauthInstructions:
-    "For OAuth credentials, call startOAuthTool and give the returned authorizationUrl to the user, then bind the completed connection with the source configuration tool.",
+    "For OAuth credentials, call startOAuthTool and give the returned authorizationUrl to the user. The completed connection binds automatically, then retry the tool.",
 });
 
 export const authToolFailure = <T = never>(input: AuthToolFailureInput): ToolResult<T> => {

--- a/packages/core/sdk/src/connections.test.ts
+++ b/packages/core/sdk/src/connections.test.ts
@@ -162,12 +162,14 @@ describe("connections.create", () => {
     }),
   );
 
-  // A connection is "born wired": for a non-OAuth template it must reference at
-  // least one non-empty credential input. An empty binding produces a
+  // A connection is "born wired": it must reference at least one credential
+  // input. An empty binding (an empty `values`/`inputs` map) produces a
   // credential with no credential — it persists, produces a full tool catalog,
   // and then fails every invocation with `connection_value_missing`. These
-  // cases must be rejected at create. (An external `from` that resolves to null
-  // is a DIFFERENT, supported case — covered above — and is not rejected here.)
+  // cases must be rejected at create. (An empty-STRING value is allowed — no-auth
+  // integrations bind one deliberately; and an external `from` that resolves to
+  // null is a supported case — both covered by their own tests — so neither is
+  // rejected here.)
   it.effect("rejects an empty `values` map and persists nothing", () =>
     Effect.gen(function* () {
       const executor = yield* setup();
@@ -204,20 +206,21 @@ describe("connections.create", () => {
     }),
   );
 
-  it.effect("rejects a blank pasted value", () =>
+  it.effect("allows an empty-string value (no-auth integrations bind one)", () =>
     Effect.gen(function* () {
       const executor = yield* setup();
-      const result = yield* Effect.result(
-        executor.connections.create({
-          owner: "org",
-          name: ConnectionName.make("blank"),
-          integration: INTEG,
-          template: TEMPLATE,
-          value: "   ",
-        }),
-      );
-      expect(Result.isFailure(result)).toBe(true);
-      expect(yield* executor.connections.list()).toEqual([]);
+      const connection = yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("noauth"),
+        integration: INTEG,
+        template: TEMPLATE,
+        value: "",
+      });
+      // The binding exists (non-empty item_ids), so tools are produced; the
+      // empty value itself is the integration's concern, surfaced at invoke.
+      expect(String(connection.address)).toBe("tools.vercel.org.noauth");
+      const tools = yield* executor.tools.list();
+      expect(tools.map((t) => String(t.name)).sort()).toEqual(["deploy", "list"]);
     }),
   );
 });

--- a/packages/core/sdk/src/connections.test.ts
+++ b/packages/core/sdk/src/connections.test.ts
@@ -161,6 +161,65 @@ describe("connections.create", () => {
       expect(Predicate.isTagged("IntegrationNotFoundError")(result.failure)).toBe(true);
     }),
   );
+
+  // A connection is "born wired": for a non-OAuth template it must reference at
+  // least one non-empty credential input. An empty binding produces a
+  // credential with no credential — it persists, produces a full tool catalog,
+  // and then fails every invocation with `connection_value_missing`. These
+  // cases must be rejected at create. (An external `from` that resolves to null
+  // is a DIFFERENT, supported case — covered above — and is not rejected here.)
+  it.effect("rejects an empty `values` map and persists nothing", () =>
+    Effect.gen(function* () {
+      const executor = yield* setup();
+      const result = yield* Effect.result(
+        executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("empty"),
+          integration: INTEG,
+          template: TEMPLATE,
+          values: {},
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      // No connection row and — critically — no tools were produced.
+      expect(yield* executor.connections.list()).toEqual([]);
+      expect(yield* executor.tools.list()).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects an empty `inputs` map", () =>
+    Effect.gen(function* () {
+      const executor = yield* setup();
+      const result = yield* Effect.result(
+        executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("empty2"),
+          integration: INTEG,
+          template: TEMPLATE,
+          inputs: {},
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      expect(yield* executor.connections.list()).toEqual([]);
+    }),
+  );
+
+  it.effect("rejects a blank pasted value", () =>
+    Effect.gen(function* () {
+      const executor = yield* setup();
+      const result = yield* Effect.result(
+        executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("blank"),
+          integration: INTEG,
+          template: TEMPLATE,
+          value: "   ",
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      expect(yield* executor.connections.list()).toEqual([]);
+    }),
+  );
 });
 
 describe("connections.list / get", () => {

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1786,24 +1786,18 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const inputs = normalizeConnectionInputs(input);
         const pasted = inputs.filter((i) => "value" in i.origin);
         const external = inputs.filter((i) => "from" in i.origin);
-        // A connection is born wired: it must reference at least one non-empty
-        // credential input. An empty binding (no inputs, or a blank pasted
-        // secret) is a credential with no credential — it would persist, produce
-        // a full tool catalog, and then fail every invocation with
-        // `connection_value_missing`. Reject it here. (OAuth connections are
-        // minted via `mintOAuthConnection`, not this path; an external `from`
-        // reference is allowed to resolve to null — the item may be written later
-        // or removed upstream — and is surfaced at invoke time, not here.)
+        // A connection is born wired: it must reference at least one credential
+        // input. An empty binding (no inputs at all — e.g. an empty `values`/
+        // `inputs` map) is a credential with no credential: it would persist,
+        // produce a full tool catalog, and then fail every invocation with
+        // `connection_value_missing`. Reject it here. (An empty-string value is
+        // NOT rejected — no-auth integrations like MCP deliberately bind one, and
+        // it yields a non-empty `item_ids`. OAuth connections are minted via
+        // `mintOAuthConnection`, not this path; an external `from` reference may
+        // resolve to null and is surfaced at invoke time, not here.)
         if (inputs.length === 0) {
           return yield* new StorageError({
             message: "A connection must supply at least one credential input.",
-            cause: undefined,
-          });
-        }
-        const blankPasted = pasted.find((i) => "value" in i.origin && i.origin.value.trim() === "");
-        if (blankPasted) {
-          return yield* new StorageError({
-            message: `Credential input "${blankPasted.variable}" cannot be empty.`,
             cause: undefined,
           });
         }

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1653,6 +1653,27 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             b("connection", "=", String(ref.name)),
           );
 
+        // Defense in depth (and cleanup for rows created before the create-time
+        // guard, or emptied by an external edit): a non-OAuth connection with no
+        // bound credential inputs can never resolve a value, so never advertise
+        // tools for it — every call would fail with `connection_value_missing`.
+        // OAuth connections resolve via refresh and carry their token outside
+        // `item_ids`, so they are exempt.
+        const existingRow = yield* findConnectionRow(ref);
+        if (
+          existingRow &&
+          existingRow.oauth_client == null &&
+          Object.keys(connectionItemIds(existingRow)).length === 0
+        ) {
+          yield* transaction(
+            Effect.gen(function* () {
+              yield* core.deleteMany("tool", { where });
+              yield* core.deleteMany("definition", { where });
+            }),
+          );
+          return [];
+        }
+
         if (!runtime?.plugin.resolveTools) {
           // No dynamic tools — clear any existing rows and return empty.
           yield* transaction(
@@ -1765,6 +1786,27 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const inputs = normalizeConnectionInputs(input);
         const pasted = inputs.filter((i) => "value" in i.origin);
         const external = inputs.filter((i) => "from" in i.origin);
+        // A connection is born wired: it must reference at least one non-empty
+        // credential input. An empty binding (no inputs, or a blank pasted
+        // secret) is a credential with no credential — it would persist, produce
+        // a full tool catalog, and then fail every invocation with
+        // `connection_value_missing`. Reject it here. (OAuth connections are
+        // minted via `mintOAuthConnection`, not this path; an external `from`
+        // reference is allowed to resolve to null — the item may be written later
+        // or removed upstream — and is surfaced at invoke time, not here.)
+        if (inputs.length === 0) {
+          return yield* new StorageError({
+            message: "A connection must supply at least one credential input.",
+            cause: undefined,
+          });
+        }
+        const blankPasted = pasted.find((i) => "value" in i.origin && i.origin.value.trim() === "");
+        if (blankPasted) {
+          return yield* new StorageError({
+            message: `Credential input "${blankPasted.variable}" cannot be empty.`,
+            cause: undefined,
+          });
+        }
         let providerKey: string;
         const itemIds: Record<string, string> = {};
         if (external.length > 0 && pasted.length > 0) {

--- a/packages/plugins/graphql-greenfield/src/sdk/errors.ts
+++ b/packages/plugins/graphql-greenfield/src/sdk/errors.ts
@@ -32,7 +32,7 @@ export class GraphqlAuthRequiredError extends Data.TaggedError("GraphqlAuthRequi
   readonly owner: "org" | "user";
   readonly integration: string;
   readonly connection: string;
-  readonly credentialKind: "secret" | "connection" | "oauth" | "upstream";
+  readonly credentialKind: "secret" | "oauth" | "upstream";
   readonly credentialLabel?: string;
   readonly status?: number;
   readonly details?: unknown;

--- a/packages/plugins/graphql-greenfield/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql-greenfield/src/sdk/plugin.test.ts
@@ -467,7 +467,7 @@ describe("graphqlPlugin invocation", () => {
       expect(result).toMatchObject({
         ok: false,
         error: {
-          code: "credential_rejected",
+          code: "connection_rejected",
           status: 401,
           details: { category: "authentication" },
         },

--- a/packages/plugins/graphql-greenfield/src/sdk/plugin.ts
+++ b/packages/plugins/graphql-greenfield/src/sdk/plugin.ts
@@ -618,7 +618,7 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
             owner: credential.owner,
             integration: String(credential.integration),
             connection: String(credential.connection),
-            credentialKind: "connection",
+            credentialKind: "oauth",
             credentialLabel: "GraphQL credential",
             message:
               `Missing credential value for GraphQL connection ` +
@@ -651,7 +651,7 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
         if (result.status < 200 || result.status >= 300) {
           if (result.status === 401 || result.status === 403) {
             return authToolFailure({
-              code: "credential_rejected",
+              code: "connection_rejected",
               status: result.status,
               message:
                 `Upstream rejected credentials for GraphQL integration ` +

--- a/packages/plugins/graphql/src/sdk/errors.ts
+++ b/packages/plugins/graphql/src/sdk/errors.ts
@@ -31,7 +31,7 @@ export class GraphqlAuthRequiredError extends Data.TaggedError("GraphqlAuthRequi
   readonly owner: string;
   readonly integration: string;
   readonly connection: string;
-  readonly credentialKind: "secret" | "connection" | "oauth" | "upstream";
+  readonly credentialKind: "secret" | "oauth" | "upstream";
   readonly credentialLabel?: string;
   readonly template?: string;
   readonly status?: number;

--- a/packages/plugins/graphql/src/sdk/plugin.test.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.test.ts
@@ -763,7 +763,7 @@ describe("graphqlPlugin", () => {
       expect(result).toMatchObject({
         ok: false,
         error: {
-          code: "credential_secret_missing",
+          code: "connection_value_missing",
           details: { category: "authentication" },
         },
       });

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -944,7 +944,7 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
               code:
                 template.kind === "oauth2"
                   ? "oauth_connection_missing"
-                  : "credential_secret_missing",
+                  : "connection_value_missing",
               message:
                 template.kind === "oauth2"
                   ? `Missing OAuth connection value for GraphQL integration "${integration}" (connection "${credential.connection}")`
@@ -983,7 +983,7 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
         if (result.status < 200 || result.status >= 300) {
           if (result.status === 401 || result.status === 403) {
             return authToolFailure({
-              code: "credential_rejected",
+              code: "connection_rejected",
               status: result.status,
               message: `Upstream rejected credentials for GraphQL integration "${integration}" with HTTP ${result.status}. Re-authenticate or update the connection before retrying this tool.`,
               source: { id: integration, scope: credential.owner },

--- a/packages/plugins/http-source/src/sdk/plugin.test.ts
+++ b/packages/plugins/http-source/src/sdk/plugin.test.ts
@@ -159,7 +159,7 @@ describe("httpSourcePlugin.invokeTool", () => {
       };
 
       const out = yield* plugin.invokeTool!(input);
-      expect(failureCode(out)).toBe("credential_secret_missing");
+      expect(failureCode(out)).toBe("connection_value_missing");
       // No request should have been issued.
       expect(capture.request).toBeUndefined();
     }),

--- a/packages/plugins/http-source/src/sdk/plugin.ts
+++ b/packages/plugins/http-source/src/sdk/plugin.ts
@@ -323,7 +323,7 @@ export const httpSourcePlugin = definePlugin(() => ({
         });
         if (missing.length > 0) {
           return authToolFailure({
-            code: "credential_secret_missing",
+            code: "connection_value_missing",
             message: `No credential value resolved for connection "${input.credential.connection}" on integration "${input.credential.integration}".`,
             credential: {
               kind: "secret",

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -761,7 +761,7 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
         Effect.catchTag("McpConnectionError", ({ message }) =>
           Effect.succeed(
             authToolFailure({
-              code: "credential_rejected",
+              code: "connection_rejected",
               message,
               source: { id: String(credential.integration) },
               credential: { kind: "upstream", label: String(credential.connection) },

--- a/packages/plugins/openapi/src/sdk/errors.ts
+++ b/packages/plugins/openapi/src/sdk/errors.ts
@@ -50,7 +50,7 @@ export class OpenApiAuthRequiredError extends Data.TaggedError("OpenApiAuthRequi
   readonly owner: "org" | "user";
   readonly integration: string;
   readonly connection: string;
-  readonly credentialKind: "secret" | "connection" | "oauth" | "upstream";
+  readonly credentialKind: "secret" | "oauth" | "upstream";
   readonly credentialLabel?: string;
   readonly status?: number;
   readonly details?: unknown;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -356,7 +356,7 @@ const openApiAuthToolFailure = (failure: {
   readonly owner: "org" | "user";
   readonly integration: string;
   readonly connection: string;
-  readonly credentialKind: "secret" | "connection" | "oauth" | "upstream";
+  readonly credentialKind: "secret" | "oauth" | "upstream";
   readonly credentialLabel?: string;
   readonly status?: number;
   readonly details?: unknown;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -1106,9 +1106,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
           if (missing.length > 0) {
             return openApiAuthToolFailure({
               code:
-                template.type === "oauth"
-                  ? "oauth_connection_missing"
-                  : "credential_secret_missing",
+                template.type === "oauth" ? "oauth_connection_missing" : "connection_value_missing",
               message: `Connection "${credential.connection}" for "${integration}" has no resolvable credential value. Re-authenticate or update the connection.`,
               owner: credential.owner,
               integration,
@@ -1134,7 +1132,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         if (!ok) {
           if (result.status === 401 || result.status === 403) {
             return openApiAuthToolFailure({
-              code: "credential_rejected",
+              code: "connection_rejected",
               status: result.status,
               message: `Upstream rejected credentials for "${integration}" with HTTP ${result.status}. Re-authenticate or update the connection "${credential.connection}" before retrying this tool.`,
               owner: credential.owner,

--- a/packages/plugins/openapi/src/sdk/upstream-failures.test.ts
+++ b/packages/plugins/openapi/src/sdk/upstream-failures.test.ts
@@ -191,7 +191,7 @@ describe("OpenAPI upstream failure modes", () => {
     }),
   );
 
-  it.effect("upstream 401 is classified as credential_rejected", () =>
+  it.effect("upstream 401 is classified as connection_rejected", () =>
     Effect.gen(function* () {
       const server = yield* startScriptedServer(() => ({
         status: 401,
@@ -205,7 +205,7 @@ describe("OpenAPI upstream failure modes", () => {
       expect(result).toMatchObject({
         ok: false,
         error: {
-          code: "credential_rejected",
+          code: "connection_rejected",
           status: 401,
           message: expect.stringContaining("Upstream rejected credentials"),
           details: {


### PR DESCRIPTION
## Why

After the v1.5 integrations/connections rework, an authentication tool failure returns recovery guidance that no longer matches the product. The `recovery` block named a core tool that was removed and a credential page that now redirects away, and the wording still described the retired "secret + source binding" model. Because those strings are read by the agent resolving the failure (no code branches on them), the rot was invisible — there was no compile error to catch it.

Separately, the data model let a non-OAuth connection be created with **no bound credential** (empty `values`/`inputs`, or a blank pasted secret). Such a connection persisted, produced a full tool catalog, and then failed *every* invocation with a credential-missing error at the tool boundary — the failure surfaced at invoke time instead of at the point of the mistake.

## What

**Taxonomy + recovery (`auth-tool-failure.ts` + plugin call sites)**
- Remove the dead `credential_binding_missing` code (thrown nowhere).
- Rename the live codes to a connection-centric vocabulary: `credential_secret_missing` → `connection_value_missing`, `credential_rejected` → `connection_rejected`, `oauth_connection_failed` → `oauth_refresh_failed` (the two clear `oauth_*` codes keep their names).
- Rewrite the recovery block to reference tools that exist (`connections.createHandoff`, `oauth.start`, `connections.list`) and describe the connection model.
- Normalize `credential.kind` to `secret | oauth | upstream` (drop the unused `connection`).

**UI/route cleanup**
- Strip the orphaned secrets-handoff query plumbing + stale comments from the self-host/cloudflare `/secrets` routes (they expected the removed tool); render the providers page directly. Update a stale comment in the scoped-executor host config.

**Connection binding invariant (`executor.ts`, tested in `connections.test.ts`)**
- Create-time: reject a non-OAuth connection with no credential input or a blank pasted value.
- Produce-time: do not produce tools for a non-OAuth connection whose `item_ids` is empty (cleanup for pre-existing/edited rows; OAuth is exempt — it resolves via refresh).
- An external `from` reference that resolves to null is unchanged: it is a supported state (the item may be written later or removed upstream) handled at invoke time, not rejected at create.

## Testing
- New red→green tests assert create rejects empty `values`/`inputs`/blank value and produces no tools.
- Full `core/sdk` suite, plus the openapi/graphql/http-source/mcp/execution and local+cloud auth-failure suites, pass. `format`, `lint`, and `typecheck` are clean.

## Follow-ups (not in this PR)
- Re-validate existing connections when an integration's auth template changes (variable-key mismatch needs plugin-level required-variable knowledge).
- Consider modeling `connection` as a discriminated union (secret vs OAuth) so a credential-less secret connection is unrepresentable rather than runtime-rejected.