### PR TITLE
Fix Google OAuth reconnect UI

### DIFF
--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -87,10 +87,6 @@ function AccountRow(props: {
           <CardStackEntryDescription className="mt-1 text-xs text-amber-700 dark:text-amber-400">
             This integration now needs access this connection wasn't granted.
           </CardStackEntryDescription>
-        ) : connection.expiresAt != null ? (
-          <CardStackEntryDescription className="mt-1 text-xs text-muted-foreground">
-            Token expires {new Date(connection.expiresAt).toLocaleString()}
-          </CardStackEntryDescription>
         ) : null}
       </CardStackEntryContent>
       <CardStackEntryActions className="self-start pt-0.5">

--- a/packages/react/src/plugins/oauth-reconnect.test.ts
+++ b/packages/react/src/plugins/oauth-reconnect.test.ts
@@ -94,4 +94,18 @@ describe("missingScopes (Part 2 informational subset warning)", () => {
     expect(missingScopes([" a ", "a", "b", ""], ["a"])).toEqual(["b"]);
     expect(missingScopes(["a", "b"], [" a ", "a", ""])).toEqual(["b"]);
   });
+
+  it("treats Google's expanded userinfo scopes as OIDC profile/email grants", () => {
+    expect(
+      missingScopes(
+        ["profile", "email", "https://www.googleapis.com/auth/calendar"],
+        [
+          "https://www.googleapis.com/auth/userinfo.profile",
+          "https://www.googleapis.com/auth/userinfo.email",
+          "https://www.googleapis.com/auth/calendar",
+          "openid",
+        ],
+      ),
+    ).toEqual([]);
+  });
 });

--- a/packages/react/src/plugins/oauth-reconnect.ts
+++ b/packages/react/src/plugins/oauth-reconnect.ts
@@ -52,13 +52,23 @@ export function oauthReconnectPayload(connection: Connection): OAuthStartPayload
 // explicable. Never blocks connect.
 // ---------------------------------------------------------------------------
 
-/** Normalize a scope list: trim, drop empties, de-dupe (order-preserving). A
- *  scope set is compared as a SET — duplicates and blanks never widen it. */
+const OAUTH_SCOPE_ALIASES: Readonly<Record<string, string>> = {
+  // Google accepts OIDC shorthand scopes but records the expanded People API
+  // scopes in token responses. Treat them as the same grant for reconsent UI.
+  "https://www.googleapis.com/auth/userinfo.email": "email",
+  "https://www.googleapis.com/auth/userinfo.profile": "profile",
+};
+
+const canonicalScope = (scope: string): string => OAUTH_SCOPE_ALIASES[scope] ?? scope;
+
+/** Normalize a scope list: trim, canonicalize known provider aliases, drop
+ *  empties, de-dupe (order-preserving). A scope set is compared as a SET —
+ *  duplicates and blanks never widen it. */
 const normalizeScopes = (scopes: readonly string[]): readonly string[] => {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const raw of scopes) {
-    const scope = raw.trim();
+    const scope = canonicalScope(raw.trim());
     if (scope.length === 0 || seen.has(scope)) continue;
     seen.add(scope);
     out.push(scope);


### PR DESCRIPTION
## Summary

- Treat Google's expanded `userinfo.email` / `userinfo.profile` scopes as the OIDC `email` / `profile` grants for reconnect warnings.
- Hide token expiration timestamps from connection rows.

## Validation

- `bun run --cwd packages/react typecheck`
- `bun run --cwd packages/react test src/plugins/oauth-reconnect.test.ts`
- `git diff --check`

Note: the package checks were run in the main checkout before creating this clean worktree; the clean worktree does not have local dependencies installed.
