### PR TITLE
[codex] Fix Changesets changelog generation

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -6,7 +6,14 @@ This repo uses Changesets to drive releases for the published `executor` CLI.
 
 Only `executor` is managed directly by Changesets.
 
-Release PRs should only version the published CLI package instead of the rest of the workspace.
+Release PRs should only mention the published CLI package directly. Changesets
+will still version the fixed release group and dependent public packages as
+needed, and will update each affected package's `CHANGELOG.md`.
+
+Write the changeset body as the package changelog entry you want to appear in
+the Version Packages PR and in the affected package changelogs. Keep broader
+user-facing launch notes in `apps/cli/release-notes/next.md`; those are used for
+the GitHub Release body.
 
 ## Beta releases
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.3/schema.json",
-  "changelog": false,
+  "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [
     [

--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,1 @@
-# executor changelog
-
-This file exists so Changesets' release PR workflow can update package release metadata.
-
-Canonical user-facing release notes are published on GitHub Releases.
+# executor

--- a/apps/desktop/CHANGELOG.md
+++ b/apps/desktop/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/desktop changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/desktop

--- a/apps/host-cloudflare/CHANGELOG.md
+++ b/apps/host-cloudflare/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/host-cloudflare changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/host-cloudflare

--- a/apps/host-selfhost/CHANGELOG.md
+++ b/apps/host-selfhost/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/host-selfhost changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/host-selfhost

--- a/examples/all-plugins/CHANGELOG.md
+++ b/examples/all-plugins/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/example-all-plugins changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/example-all-plugins

--- a/examples/docs-sdk-quickstart/CHANGELOG.md
+++ b/examples/docs-sdk-quickstart/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/example-docs-sdk-quickstart changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/example-docs-sdk-quickstart

--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/app changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/app

--- a/packages/core/api/CHANGELOG.md
+++ b/packages/core/api/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/api changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/api

--- a/packages/core/cli/CHANGELOG.md
+++ b/packages/core/cli/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/cli changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/cli

--- a/packages/core/config/CHANGELOG.md
+++ b/packages/core/config/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/config changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/config

--- a/packages/core/execution/CHANGELOG.md
+++ b/packages/core/execution/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/execution changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/execution

--- a/packages/core/integrations-registry/CHANGELOG.md
+++ b/packages/core/integrations-registry/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/integrations-registry changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/integrations-registry

--- a/packages/core/sdk/CHANGELOG.md
+++ b/packages/core/sdk/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/core changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/sdk

--- a/packages/core/test-servers/CHANGELOG.md
+++ b/packages/core/test-servers/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/test-servers changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/test-servers

--- a/packages/core/vite-plugin/CHANGELOG.md
+++ b/packages/core/vite-plugin/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/vite-plugin changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/vite-plugin

--- a/packages/hosts/cloudflare/CHANGELOG.md
+++ b/packages/hosts/cloudflare/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/cloudflare changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/cloudflare

--- a/packages/hosts/mcp/CHANGELOG.md
+++ b/packages/hosts/mcp/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/host-mcp changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/host-mcp

--- a/packages/kernel/core/CHANGELOG.md
+++ b/packages/kernel/core/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/codemode-core changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/codemode-core

--- a/packages/kernel/ir/CHANGELOG.md
+++ b/packages/kernel/ir/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/ir changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/ir

--- a/packages/kernel/runtime-deno-subprocess/CHANGELOG.md
+++ b/packages/kernel/runtime-deno-subprocess/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/runtime-deno-subprocess changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/runtime-deno-subprocess

--- a/packages/kernel/runtime-quickjs/CHANGELOG.md
+++ b/packages/kernel/runtime-quickjs/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/runtime-quickjs changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/runtime-quickjs

--- a/packages/plugins/desktop-settings/CHANGELOG.md
+++ b/packages/plugins/desktop-settings/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/plugin-desktop-settings changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/plugin-desktop-settings

--- a/packages/plugins/encrypted-secrets/CHANGELOG.md
+++ b/packages/plugins/encrypted-secrets/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/plugin-encrypted-secrets changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/plugin-encrypted-secrets

--- a/packages/plugins/example/CHANGELOG.md
+++ b/packages/plugins/example/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/plugin-example changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/plugin-example

--- a/packages/plugins/file-secrets/CHANGELOG.md
+++ b/packages/plugins/file-secrets/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/plugin-file-secrets changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/plugin-file-secrets

--- a/packages/plugins/graphql-greenfield/CHANGELOG.md
+++ b/packages/plugins/graphql-greenfield/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/plugin-graphql-greenfield changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/plugin-graphql-greenfield

--- a/packages/plugins/graphql/CHANGELOG.md
+++ b/packages/plugins/graphql/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/plugin-graphql changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/plugin-graphql

--- a/packages/plugins/http-source/CHANGELOG.md
+++ b/packages/plugins/http-source/CHANGELOG.md
@@ -1,6 +1,1 @@
-# @executor-js/plugin-http-source changelog
-
-This file exists for `changesets/action@v1` compatibility (it reads every
-workspace package's `CHANGELOG.md` to build the Version Packages PR).
-Canonical user-facing release notes are at `apps/cli/release-notes/next.md`
-and on the GitHub Releases page.
+# @executor-js/plugin-http-source

--- a/packages/plugins/keychain/CHANGELOG.md
+++ b/packages/plugins/keychain/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/plugin-keychain changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/plugin-keychain

--- a/packages/plugins/mcp/CHANGELOG.md
+++ b/packages/plugins/mcp/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/plugin-mcp changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/plugin-mcp

--- a/packages/plugins/onepassword/CHANGELOG.md
+++ b/packages/plugins/onepassword/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/plugin-onepassword changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/plugin-onepassword

--- a/packages/plugins/openapi/CHANGELOG.md
+++ b/packages/plugins/openapi/CHANGELOG.md
@@ -1,4 +1,1 @@
-# @executor-js/plugin-openapi changelog
-
-This file exists for Changesets release workflow compatibility.
-Canonical user-facing release notes are published on GitHub Releases.
+# @executor-js/plugin-openapi

--- a/scripts/check-changelog-stubs.ts
+++ b/scripts/check-changelog-stubs.ts
@@ -3,15 +3,16 @@
  * Verifies every workspace package directory has a `CHANGELOG.md` file.
  *
  * `changesets/action@v1` (the GitHub Action wrapping the Changesets CLI in
- * `release.yml`) reads every workspace package's `CHANGELOG.md` to build
- * the Version Packages PR description. If any is missing, the action
- * crashes with `ENOENT` at release time and blocks the release.
+ * `release.yml`) creates the Version Packages PR after `changeset version`
+ * updates package versions and changelogs. Every workspace package should have
+ * a `CHANGELOG.md` seed so Changesets has a stable file to update and the
+ * action never falls back to missing-file behavior. Keep seed files H1-only:
+ * Changesets inserts generated version sections immediately after the H1, so
+ * any placeholder prose would become part of the first generated release notes.
  *
- * The CLI alone (with `changelog: false` in `.changeset/config.json`)
- * doesn't need them — but we run via the Action, which does.
- *
- * The stubs themselves are not user-facing. Canonical release notes are
- * at `apps/cli/release-notes/next.md` and on the GitHub Releases page.
+ * GitHub Release notes are still authored separately at
+ * `apps/cli/release-notes/next.md`; package changelogs are generated from
+ * `.changeset/*.md`.
  *
  * Usage:
  *   bun run scripts/check-changelog-stubs.ts        # fail on missing
@@ -39,12 +40,7 @@ const findWorkspacePackages = (): string[] => {
   return [...dirs].sort();
 };
 
-const STUB_TEMPLATE = (name: string) =>
-  `# ${name} changelog\n\n` +
-  "This file exists for `changesets/action@v1` compatibility (it reads every\n" +
-  "workspace package's `CHANGELOG.md` to build the Version Packages PR).\n" +
-  "Canonical user-facing release notes are at `apps/cli/release-notes/next.md`\n" +
-  "and on the GitHub Releases page.\n";
+const STUB_TEMPLATE = (name: string) => `# ${name}\n`;
 
 const fix = process.argv.includes("--fix");
 const missing: string[] = [];
@@ -67,9 +63,8 @@ for (const pkgDir of findWorkspacePackages()) {
 if (!fix && missing.length > 0) {
   console.error(
     `\nMissing CHANGELOG.md in ${missing.length} workspace package(s):\n  - ${missing.join("\n  - ")}\n\n` +
-      "These are required by `changesets/action@v1` (the GitHub Action wrapping\n" +
-      "Changesets in release.yml). Without them, release.yml crashes with ENOENT\n" +
-      "and the Version Packages PR can't open.\n\n" +
+      "These seed files are required so Changesets can update every affected\n" +
+      "workspace changelog during the Version Packages PR.\n\n" +
       "Run `bun run scripts/check-changelog-stubs.ts --fix` to create stubs.\n",
   );
   process.exit(1);


### PR DESCRIPTION
## Summary

Fixes the Version Packages changelog output generated by Changesets.

The release PR body was pasting placeholder `CHANGELOG.md` prose because `.changeset/config.json` disabled changelog generation with `changelog: false`. When `changeset version` ran, package versions changed but package changelog sections were not generated, so `changesets/action` had no real release entries to include.

This PR:
- turns package changelog generation back on with `@changesets/cli/changelog`
- normalizes seed-only `CHANGELOG.md` files to H1-only files using package names
- updates the changelog seed checker so future seed files stay H1-only
- documents that `.changeset/*.md` bodies are the package changelog entries, while `apps/cli/release-notes/next.md` remains the GitHub Release body

## Validation

- rehearsed `bun run changeset:version` locally and confirmed generated sections no longer include placeholder text
- `bun run lint:changelog-stubs`
- `bun run format:check`

## References

- Changesets config supports `changelog` generators: https://github.com/changesets/changesets/blob/main/docs/config-file-options.md
- Changesets Action creates/updates the Version Packages PR from `changeset version`: https://github.com/changesets/action
