### PR TITLE
[codex] Include desktop in release changeset

### DIFF
--- a/.changeset/executor-1-5-release.md
+++ b/.changeset/executor-1-5-release.md
@@ -1,4 +1,5 @@
 ---
+"@executor-js/desktop": minor
 "executor": minor
 ---
 


### PR DESCRIPTION
## Summary

- Add @executor-js/desktop to the pending 1.5.0 release changeset.
- Ensure the generated desktop package changelog gets the release note instead of a bare version heading.

## Validation

- bun run lint:release-notes
- bun run lint:changelog-stubs
- bunx changeset status --since=origin/main