### PR TITLE
[codex] Publish self-host Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,20 @@ jobs:
       - name: Build Electron main/preload/renderer
         run: bunx --bun electron-vite build
         working-directory: apps/desktop
+
+  selfhost-docker-smoke:
+    name: Self-host Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build self-host image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/host-selfhost/Dockerfile
+          push: false
+          tags: executor-selfhost:ci

--- a/.github/workflows/publish-executor-package.yml
+++ b/.github/workflows/publish-executor-package.yml
@@ -82,3 +82,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run publish-desktop.yml -f tag="$RELEASE_TAG"
+
+      - name: Trigger self-host Docker publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run publish-selfhost-docker.yml -f tag="$RELEASE_TAG"

--- a/.github/workflows/publish-selfhost-docker.yml
+++ b/.github/workflows/publish-selfhost-docker.yml
@@ -1,0 +1,107 @@
+name: Publish Self-host Docker Image
+run-name: "${{ format('publish self-host docker {0}', inputs.tag) }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Git tag to publish (e.g. v1.5.0)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-selfhost-docker-${{ inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Validate release tag
+        env:
+          RAW_RELEASE_TAG: ${{ inputs.tag }}
+        run: bun run scripts/validate-release-ref.ts --tag-env RAW_RELEASE_TAG --write-env RELEASE_TAG
+
+      - name: Checkout release tag
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT || github.token }}
+        run: |
+          auth_remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --force --tags "$auth_remote" "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          git checkout --detach "$RELEASE_TAG"
+
+      - name: Resolve image metadata
+        id: image
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_TAG#v}"
+          owner="$(printf '%s' "$GITHUB_REPOSITORY_OWNER" | tr '[:upper:]' '[:lower:]')"
+          image="ghcr.io/${owner}/executor-selfhost"
+          revision="$(git rev-parse HEAD)"
+
+          if [[ "$version" == *-* ]]; then
+            channel="beta"
+          else
+            channel="latest"
+          fi
+
+          {
+            echo "image=$image"
+            echo "version=$version"
+            echo "channel=$channel"
+            echo "tags<<TAGS"
+            echo "${image}:${RELEASE_TAG}"
+            echo "${image}:${version}"
+            echo "${image}:${channel}"
+            echo "TAGS"
+            echo "labels<<LABELS"
+            echo "org.opencontainers.image.title=Executor self-host"
+            echo "org.opencontainers.image.description=Single-container self-hosted Executor"
+            echo "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}"
+            echo "org.opencontainers.image.revision=${revision}"
+            echo "org.opencontainers.image.version=${version}"
+            echo "LABELS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push self-host image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/host-selfhost/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.image.outputs.tags }}
+          labels: ${{ steps.image.outputs.labels }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,9 @@
 # Releasing
 
-This repo uses Changesets for version orchestration and two publish paths:
-the CLI (`executor` npm package plus its platform packages) and the
-`@executor-js/*` library packages (`core`, `sdk`, and the public plugins).
+This repo uses Changesets for version orchestration and three publish paths:
+the CLI (`executor` npm package plus its platform packages), the
+`@executor-js/*` library packages (`core`, `sdk`, and the public plugins), and
+the self-host Docker image.
 
 ## Normal release flow
 
@@ -21,6 +22,12 @@ the CLI (`executor` npm package plus its platform packages) and the
      - performs a full dry-run release build before publish
      - publishes the CLI npm package under the correct dist-tag
      - creates or updates the GitHub release with build artifacts
+     - dispatches `.github/workflows/publish-desktop.yml`
+     - dispatches `.github/workflows/publish-selfhost-docker.yml`
+6. The self-host Docker workflow publishes `ghcr.io/rhyssullivan/executor-selfhost`
+   for `linux/amd64` and `linux/arm64`:
+   - stable releases get `vX.Y.Z`, `X.Y.Z`, and `latest`
+   - prereleases get `vX.Y.Z-...`, `X.Y.Z-...`, and `beta`
 
 ## Beta releases
 
@@ -51,6 +58,10 @@ That produces:
 To pack the `@executor-js/*` library packages without publishing:
 
 - `bun run release:publish:packages:dry-run`
+
+To validate the self-host Dockerfile locally without publishing:
+
+- `docker build -f apps/host-selfhost/Dockerfile -t executor-selfhost:local .`
 
 ## Release notes
 

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -7,6 +7,10 @@
 - OAuth Dynamic Client Registration data is reused across retries and reconnects, including scopes, so providers are not asked to register duplicate clients.
 - MCP tool output schemas now match the actual invocation result envelope, including `content`, `structuredContent`, `_meta`, and `isError`.
 
+### Self-hosted Docker image
+
+- Self-hosted Executor now publishes a multi-architecture GHCR image at `ghcr.io/rhyssullivan/executor-selfhost`, with stable releases tagged as `latest` and prereleases tagged as `beta`.
+
 ## UI
 
 - No UI-only changes in this patch.

--- a/apps/host-selfhost/Dockerfile
+++ b/apps/host-selfhost/Dockerfile
@@ -32,6 +32,9 @@ RUN rm -rf node_modules && bun install --frozen-lockfile --production --ignore-s
 # ── Runtime stage: serve the built app under Bun ────────────────────────────
 FROM oven/bun:1 AS runtime
 WORKDIR /app
+LABEL org.opencontainers.image.source="https://github.com/RhysSullivan/executor" \
+      org.opencontainers.image.description="Single-container self-hosted Executor" \
+      org.opencontainers.image.licenses="MIT"
 ENV NODE_ENV=production \
     EXECUTOR_HOST=0.0.0.0 \
     PORT=4788 \

--- a/apps/host-selfhost/README.md
+++ b/apps/host-selfhost/README.md
@@ -7,6 +7,18 @@ external database, worker, or proxy.
 
 ## Run it
 
+Using the published image:
+
+```bash
+docker run -d \
+  --name executor-selfhost \
+  -p 4788:4788 \
+  -v executor-data:/data \
+  ghcr.io/rhyssullivan/executor-selfhost:latest
+```
+
+Or build from a repository clone:
+
 ```bash
 # From this directory:
 docker compose up -d --build

--- a/docs/self-hosting/guide.mdx
+++ b/docs/self-hosting/guide.mdx
@@ -5,11 +5,31 @@ description: Run Executor on your own infrastructure in a single container.
 
 Executor self-hosts as **one container** — the database (SQLite/libSQL), the
 QuickJS code sandbox, and the MCP server all run in-process. There is no separate
-database, worker, or proxy to operate, and no required configuration: a bare
-`docker compose up` boots a working instance and walks you through creating the
-admin account in the browser.
+database, worker, or proxy to operate, and no required configuration: a published
+image or a bare `docker compose up` boots a working instance and walks you
+through creating the admin account in the browser.
 
 ## Quick start
+
+Using the published GHCR image:
+
+```bash
+docker run -d \
+  --name executor-selfhost \
+  -p 4788:4788 \
+  -v executor-data:/data \
+  ghcr.io/rhyssullivan/executor-selfhost:latest
+```
+
+Then open [http://localhost:4788](http://localhost:4788). On a fresh instance
+you'll see a **setup screen** — create the first admin account, and you're in.
+
+Published images are tagged as:
+
+- `ghcr.io/rhyssullivan/executor-selfhost:latest` for the latest stable release
+- `ghcr.io/rhyssullivan/executor-selfhost:beta` for the latest prerelease
+- `ghcr.io/rhyssullivan/executor-selfhost:vX.Y.Z` for a pinned release tag
+- `ghcr.io/rhyssullivan/executor-selfhost:X.Y.Z` for the same pinned version without `v`
 
 From a clone of the repository:
 
@@ -17,9 +37,6 @@ From a clone of the repository:
 cd apps/host-selfhost
 docker compose up -d --build
 ```
-
-Then open [http://localhost:4788](http://localhost:4788). On a fresh instance
-you'll see a **setup screen** — create the first admin account, and you're in.
 
 That's the whole install. The container persists its data (database and
 generated keys) in the `executor-data` volume, so it survives restarts and
@@ -106,6 +123,20 @@ before starting the container. Keep the backup safe: it contains your secret
 keys as well as your data.
 
 ## Upgrading
+
+If you use the published image:
+
+```bash
+docker pull ghcr.io/rhyssullivan/executor-selfhost:latest
+docker rm -f executor-selfhost
+docker run -d \
+  --name executor-selfhost \
+  -p 4788:4788 \
+  -v executor-data:/data \
+  ghcr.io/rhyssullivan/executor-selfhost:latest
+```
+
+If you build from source:
 
 ```bash
 cd apps/host-selfhost


### PR DESCRIPTION
## Summary

- Add a workflow to publish the self-host Executor image to GHCR for release tags.
- Trigger the Docker image publish after the CLI release workflow succeeds.
- Add a CI smoke build for the self-host Dockerfile.
- Document the published image tags and update the release notes.

## Image tags

- Stable: `ghcr.io/rhyssullivan/executor-selfhost:vX.Y.Z`, `ghcr.io/rhyssullivan/executor-selfhost:X.Y.Z`, `ghcr.io/rhyssullivan/executor-selfhost:latest`
- Prerelease: `ghcr.io/rhyssullivan/executor-selfhost:vX.Y.Z-...`, `ghcr.io/rhyssullivan/executor-selfhost:X.Y.Z-...`, `ghcr.io/rhyssullivan/executor-selfhost:beta`

## Validation

- `ruby -e 'ARGV.each { |path| YAML.load_file(path) }; puts "yaml ok"' -ryaml .github/workflows/ci.yml .github/workflows/publish-executor-package.yml .github/workflows/publish-selfhost-docker.yml`
- `bun run lint:release-notes`
- `bun run format:check`
- `bun run lint`
- stable/prerelease image metadata shell checks

Could not run a local Docker build because the local Docker daemon is not running: `Cannot connect to the Docker daemon at unix:///Users/rhyssullivan/.docker/run/docker.sock`.