### PR TITLE
Add self-host OAuth apps route

### DIFF
--- a/apps/host-selfhost/web/routeTree.gen.ts
+++ b/apps/host-selfhost/web/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as ToolsRouteImport } from './routes/tools'
 import { Route as SecretsRouteImport } from './routes/secrets'
 import { Route as PoliciesRouteImport } from './routes/policies'
+import { Route as OauthAppsRouteImport } from './routes/oauth-apps'
 import { Route as ApiKeysRouteImport } from './routes/api-keys'
 import { Route as AdminRouteImport } from './routes/admin'
 import { Route as IndexRouteImport } from './routes/index'
@@ -36,6 +37,11 @@ const SecretsRoute = SecretsRouteImport.update({
 const PoliciesRoute = PoliciesRouteImport.update({
   id: '/policies',
   path: '/policies',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OauthAppsRoute = OauthAppsRouteImport.update({
+  id: '/oauth-apps',
+  path: '/oauth-apps',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiKeysRoute = ApiKeysRouteImport.update({
@@ -94,6 +100,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/admin': typeof AdminRoute
   '/api-keys': typeof ApiKeysRoute
+  '/oauth-apps': typeof OauthAppsRoute
   '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
@@ -109,6 +116,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/admin': typeof AdminRoute
   '/api-keys': typeof ApiKeysRoute
+  '/oauth-apps': typeof OauthAppsRoute
   '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
@@ -125,6 +133,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/admin': typeof AdminRoute
   '/api-keys': typeof ApiKeysRoute
+  '/oauth-apps': typeof OauthAppsRoute
   '/policies': typeof PoliciesRoute
   '/secrets': typeof SecretsRoute
   '/tools': typeof ToolsRoute
@@ -142,6 +151,7 @@ export interface FileRouteTypes {
     | '/'
     | '/admin'
     | '/api-keys'
+    | '/oauth-apps'
     | '/policies'
     | '/secrets'
     | '/tools'
@@ -157,6 +167,7 @@ export interface FileRouteTypes {
     | '/'
     | '/admin'
     | '/api-keys'
+    | '/oauth-apps'
     | '/policies'
     | '/secrets'
     | '/tools'
@@ -172,6 +183,7 @@ export interface FileRouteTypes {
     | '/'
     | '/admin'
     | '/api-keys'
+    | '/oauth-apps'
     | '/policies'
     | '/secrets'
     | '/tools'
@@ -188,6 +200,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AdminRoute: typeof AdminRoute
   ApiKeysRoute: typeof ApiKeysRoute
+  OauthAppsRoute: typeof OauthAppsRoute
   PoliciesRoute: typeof PoliciesRoute
   SecretsRoute: typeof SecretsRoute
   ToolsRoute: typeof ToolsRoute
@@ -221,6 +234,13 @@ declare module '@tanstack/react-router' {
       path: '/policies'
       fullPath: '/policies'
       preLoaderRoute: typeof PoliciesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/oauth-apps': {
+      id: '/oauth-apps'
+      path: '/oauth-apps'
+      fullPath: '/oauth-apps'
+      preLoaderRoute: typeof OauthAppsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api-keys': {
@@ -300,6 +320,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AdminRoute: AdminRoute,
   ApiKeysRoute: ApiKeysRoute,
+  OauthAppsRoute: OauthAppsRoute,
   PoliciesRoute: PoliciesRoute,
   SecretsRoute: SecretsRoute,
   ToolsRoute: ToolsRoute,

--- a/apps/host-selfhost/web/routes/oauth-apps.tsx
+++ b/apps/host-selfhost/web/routes/oauth-apps.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { OAuthAppsPage } from "@executor-js/react/pages/oauth-apps";
+
+export const Route = createFileRoute("/oauth-apps")({
+  component: OAuthAppsPage,
+});


### PR DESCRIPTION
## Summary
- register the shared OAuth Apps page in the self-host route table
- regenerate the self-host TanStack route tree so `/oauth-apps` resolves from the sidebar

## Verification
- bun run --cwd apps/host-selfhost build
- bun run --cwd apps/host-selfhost typecheck