### PR TITLE
[codex] Declare effect as peer dependency

### DIFF
--- a/.changeset/effect-peer-dependency.md
+++ b/.changeset/effect-peer-dependency.md
@@ -1,0 +1,16 @@
+---
+"@executor-js/codemode-core": patch
+"@executor-js/config": patch
+"@executor-js/execution": patch
+"@executor-js/plugin-file-secrets": patch
+"@executor-js/plugin-graphql": patch
+"@executor-js/plugin-keychain": patch
+"@executor-js/plugin-mcp": patch
+"@executor-js/plugin-onepassword": patch
+"@executor-js/plugin-openapi": patch
+"@executor-js/runtime-quickjs": patch
+"@executor-js/sdk": patch
+"executor": patch
+---
+
+Move `effect` from `dependencies` to `peerDependencies` in the published library packages so consumers provide a single shared Effect instance.

--- a/apps/cli/release-notes/next.md
+++ b/apps/cli/release-notes/next.md
@@ -17,7 +17,10 @@
 - Retrying OAuth sign-in no longer starts an avoidable second Dynamic Client Registration request.
 - Reconnecting an OAuth source keeps the previously registered DCR scope list intact.
 - MCP sources now describe output types as Executor's full successful `CallToolResult` data shape instead of only the upstream `structuredContent` schema.
+- Published `@executor-js/*` libraries now use the consumer's `effect` dependency instead of installing their own copy, avoiding duplicated Effect service identity. Thanks @aryasaatvik (#876)
 
 ## Breaking changes
 
-None.
+### Published package consumers
+
+Published `@executor-js/*` libraries now declare `effect` as a peer dependency. If you install these libraries directly, make sure your app has `effect` installed as a direct dependency.

--- a/bun.lock
+++ b/bun.lock
@@ -431,7 +431,6 @@
       "version": "1.4.33",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
         "jiti": "^2.6.1",
         "jsonc-parser": "^3.3.1",
       },
@@ -439,9 +438,13 @@
         "@effect/platform-node": "catalog:",
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/core/execution": {
@@ -450,16 +453,19 @@
       "dependencies": {
         "@executor-js/codemode-core": "workspace:*",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@executor-js/runtime-quickjs": "workspace:*",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/core/fumadb": {
@@ -511,7 +517,6 @@
       "version": "1.4.33",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
-        "effect": "catalog:",
         "fractional-indexing": "^3.2.0",
         "fumadb": "workspace:*",
         "oauth4webapi": "^3.8.5",
@@ -524,6 +529,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "drizzle-orm": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
@@ -532,6 +538,7 @@
       "peerDependencies": {
         "@effect/atom-react": "catalog:",
         "@effect/platform-node": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -623,16 +630,19 @@
         "@standard-schema/spec": "^1.0.0",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
-        "effect": "catalog:",
         "sucrase": "^3.35.1",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/kernel/ir": {
@@ -690,16 +700,19 @@
       "version": "1.4.33",
       "dependencies": {
         "@executor-js/codemode-core": "workspace:*",
-        "effect": "catalog:",
         "quickjs-emscripten": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/plugins/desktop-settings": {
@@ -758,13 +771,16 @@
       "version": "1.4.33",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/plugins/graphql": {
@@ -774,7 +790,6 @@
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
         "graphql": "^16.12.0",
         "graphql-yoga": "^5.17.0",
       },
@@ -786,6 +801,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -795,6 +811,7 @@
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@tanstack/react-router": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -862,14 +879,17 @@
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "@napi-rs/keyring": "^1.2.0",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "effect": "catalog:",
       },
     },
     "packages/plugins/mcp": {
@@ -881,7 +901,6 @@
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "effect": "catalog:",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -892,6 +911,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -901,6 +921,7 @@
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@tanstack/react-router": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -919,7 +940,6 @@
         "@1password/sdk": "^0.4.1-beta.1",
         "@effect/atom-react": "catalog:",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
@@ -927,6 +947,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -935,6 +956,7 @@
         "@effect/atom-react": "catalog:",
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
+        "effect": "catalog:",
         "react": ">=18",
       },
       "optionalPeers": [
@@ -951,7 +973,6 @@
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
-        "effect": "catalog:",
         "lucide-react": "^1.7.0",
         "openapi-types": "^12.1.3",
         "yaml": "^2.7.1",
@@ -964,6 +985,7 @@
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
@@ -973,6 +995,7 @@
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@tanstack/react-router": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
       },
       "optionalPeers": [
@@ -989,18 +1012,19 @@
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "@workos-inc/node": "^8.11.1",
-        "effect": "catalog:",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
         "@types/node": "catalog:",
         "@types/react": "catalog:",
+        "effect": "catalog:",
         "react": "catalog:",
         "tsup": "catalog:",
         "vitest": "catalog:",
       },
       "peerDependencies": {
         "@executor-js/react": "workspace:*",
+        "effect": "catalog:",
         "react": ">=18",
       },
       "optionalPeers": [

--- a/packages/core/config/package.json
+++ b/packages/core/config/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:",
     "jiti": "^2.6.1",
     "jsonc-parser": "^3.3.1"
   },
@@ -45,8 +44,12 @@
     "@effect/platform-node": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -44,16 +44,19 @@
   },
   "dependencies": {
     "@executor-js/codemode-core": "workspace:*",
-    "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@executor-js/runtime-quickjs": "workspace:*",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -80,7 +80,6 @@
   },
   "dependencies": {
     "@standard-schema/spec": "^1.1.0",
-    "effect": "catalog:",
     "fractional-indexing": "^3.2.0",
     "fumadb": "workspace:*",
     "oauth4webapi": "^3.8.5"
@@ -93,6 +92,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "drizzle-orm": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
@@ -101,6 +101,7 @@
   "peerDependencies": {
     "@effect/atom-react": "catalog:",
     "@effect/platform-node": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/kernel/core/package.json
+++ b/packages/kernel/core/package.json
@@ -41,15 +41,18 @@
     "@standard-schema/spec": "^1.0.0",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
-    "effect": "catalog:",
     "sucrase": "^3.35.1"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/kernel/runtime-quickjs/package.json
+++ b/packages/kernel/runtime-quickjs/package.json
@@ -38,15 +38,18 @@
   },
   "dependencies": {
     "@executor-js/codemode-core": "workspace:*",
-    "effect": "catalog:",
     "quickjs-emscripten": "catalog:"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/plugins/file-secrets/package.json
+++ b/packages/plugins/file-secrets/package.json
@@ -44,13 +44,16 @@
     "typecheck:slow": "bunx tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -64,7 +64,6 @@
     "@effect/platform-node": "catalog:",
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:",
     "graphql": "^16.12.0",
     "graphql-yoga": "^5.17.0"
   },
@@ -76,6 +75,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -85,6 +85,7 @@
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@tanstack/react-router": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/keychain/package.json
+++ b/packages/plugins/keychain/package.json
@@ -45,14 +45,17 @@
   },
   "dependencies": {
     "@executor-js/sdk": "workspace:*",
-    "@napi-rs/keyring": "^1.2.0",
-    "effect": "catalog:"
+    "@napi-rs/keyring": "^1.2.0"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "effect": "catalog:"
   }
 }

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -66,7 +66,6 @@
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "effect": "catalog:",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -77,6 +76,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -86,6 +86,7 @@
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@tanstack/react-router": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/onepassword/package.json
+++ b/packages/plugins/onepassword/package.json
@@ -56,8 +56,7 @@
     "@1password/op-js": "^0.1.13",
     "@1password/sdk": "^0.4.1-beta.1",
     "@effect/atom-react": "catalog:",
-    "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:"
+    "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
@@ -65,6 +64,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -73,6 +73,7 @@
     "@effect/atom-react": "catalog:",
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
+    "effect": "catalog:",
     "react": ">=18"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -64,7 +64,6 @@
     "@effect/platform-node": "catalog:",
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
-    "effect": "catalog:",
     "lucide-react": "^1.7.0",
     "openapi-types": "^12.1.3",
     "yaml": "^2.7.1"
@@ -77,6 +76,7 @@
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
@@ -86,6 +86,7 @@
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@tanstack/react-router": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/plugins/workos-vault/package.json
+++ b/packages/plugins/workos-vault/package.json
@@ -54,19 +54,20 @@
   },
   "dependencies": {
     "@executor-js/sdk": "workspace:*",
-    "@workos-inc/node": "^8.11.1",
-    "effect": "catalog:"
+    "@workos-inc/node": "^8.11.1"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
+    "effect": "catalog:",
     "react": "catalog:",
     "tsup": "catalog:",
     "vitest": "catalog:"
   },
   "peerDependencies": {
     "@executor-js/react": "workspace:*",
+    "effect": "catalog:",
     "react": ">=18"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary

Reapplies #876 on current `main` by moving `effect` out of runtime dependencies and into `peerDependencies` plus `devDependencies` for the published Executor library packages.

This keeps consumers on one shared Effect instance, preserves current package metadata from `main` such as the OpenAPI `lucide-react` dependency, and updates the WorkOS Vault package manifest for consistency even though that package is currently ignored by changesets/publish smoke.

Also adds the changeset and release-note guidance for direct package consumers to install `effect` explicitly.

## Validation

- `bun run lint:release-notes`
- `bun run format:check`
- `bun run lint`
- `git diff --check`
- `bun run typecheck`
- `bunx changeset status --since=origin/main`
- `bun run release:smoke:packages`
- `bunx turbo run test --concurrency=4`

Note: the default local `bun run test` aggregate hit self-host timeout pressure under full Turbo concurrency; the affected `apps/host-selfhost` suite passed in isolation and the full package set passed with Turbo concurrency limited to 4.