### PR TITLE
Fix no-auth connection handling and v1.5 migration planner gaps

### DIFF
--- a/packages/core/api/src/connections/api.ts
+++ b/packages/core/api/src/connections/api.ts
@@ -19,6 +19,7 @@ import {
   IntegrationNotFoundError,
   IntegrationSlug,
   InternalError,
+  InvalidConnectionInputError,
   OAuthClientSlug,
   Owner,
   ProviderItemId,
@@ -121,6 +122,9 @@ const IntegrationNotFound = IntegrationNotFoundError.annotate({
 const CredentialProviderNotRegistered = CredentialProviderNotRegisteredError.annotate({
   httpApiStatus: 409,
 });
+const InvalidConnectionInput = InvalidConnectionInputError.annotate({
+  httpApiStatus: 400,
+});
 
 // ---------------------------------------------------------------------------
 // Group
@@ -138,7 +142,12 @@ export const ConnectionsApi = HttpApiGroup.make("connections")
     HttpApiEndpoint.post("create", "/connections", {
       payload: CreateConnectionPayload,
       success: ConnectionResponse,
-      error: [InternalError, IntegrationNotFound, CredentialProviderNotRegistered],
+      error: [
+        InternalError,
+        IntegrationNotFound,
+        CredentialProviderNotRegistered,
+        InvalidConnectionInput,
+      ],
     }),
   )
   .add(

--- a/packages/core/sdk/src/connections.test.ts
+++ b/packages/core/sdk/src/connections.test.ts
@@ -162,15 +162,17 @@ describe("connections.create", () => {
     }),
   );
 
-  // A connection is "born wired": it must reference at least one credential
-  // input. An empty binding (an empty `values`/`inputs` map) produces a
-  // credential with no credential — it persists, produces a full tool catalog,
-  // and then fails every invocation with `connection_value_missing`. These
-  // cases must be rejected at create. (An empty-STRING value is allowed — no-auth
-  // integrations bind one deliberately; and an external `from` that resolves to
-  // null is a supported case — both covered by their own tests — so neither is
-  // rejected here.)
-  it.effect("rejects an empty `values` map and persists nothing", () =>
+  // A credentialed connection is "born wired": it must reference at least one
+  // credential input. An empty binding (an empty `values`/`inputs` map) produces
+  // a credential with no credential — it persists, produces a full tool catalog,
+  // and then fails every invocation with `connection_value_missing`. These cases
+  // must be rejected at create with a typed `InvalidConnectionInputError` (the
+  // HTTP edge answers 400 with the reason, not an opaque 500). The exception is
+  // the no-auth template ("none"), where zero inputs and an empty `item_ids`
+  // map are the canonical shape — covered below. (An empty-STRING value is also
+  // allowed, and an external `from` that resolves to null is a supported case —
+  // both covered by their own tests.)
+  it.effect("rejects an empty `values` map on a credentialed template and persists nothing", () =>
     Effect.gen(function* () {
       const executor = yield* setup();
       const result = yield* Effect.result(
@@ -183,13 +185,15 @@ describe("connections.create", () => {
         }),
       );
       expect(Result.isFailure(result)).toBe(true);
+      if (!Result.isFailure(result)) return;
+      expect(Predicate.isTagged("InvalidConnectionInputError")(result.failure)).toBe(true);
       // No connection row and — critically — no tools were produced.
       expect(yield* executor.connections.list()).toEqual([]);
       expect(yield* executor.tools.list()).toEqual([]);
     }),
   );
 
-  it.effect("rejects an empty `inputs` map", () =>
+  it.effect("rejects an empty `inputs` map on a credentialed template", () =>
     Effect.gen(function* () {
       const executor = yield* setup();
       const result = yield* Effect.result(
@@ -202,7 +206,39 @@ describe("connections.create", () => {
         }),
       );
       expect(Result.isFailure(result)).toBe(true);
+      if (!Result.isFailure(result)) return;
+      expect(Predicate.isTagged("InvalidConnectionInputError")(result.failure)).toBe(true);
       expect(yield* executor.connections.list()).toEqual([]);
+    }),
+  );
+
+  // The no-auth template: public servers need no credential. The UI submits
+  // `values: {}` for them and the persisted row carries an empty `item_ids`
+  // map — that is the canonical shape (every migrated no-auth connection in
+  // prod has it), so it must create cleanly and keep its tools on refresh.
+  it.effect('creates a no-auth (`template: "none"`) connection from an empty `values` map', () =>
+    Effect.gen(function* () {
+      const executor = yield* setup();
+      const connection = yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("public"),
+        integration: INTEG,
+        template: AuthTemplateSlug.make("none"),
+        values: {},
+      });
+      expect(String(connection.address)).toBe("tools.vercel.org.public");
+
+      const tools = yield* executor.tools.list();
+      expect(tools.map((t) => String(t.name)).sort()).toEqual(["deploy", "list"]);
+
+      // Refresh must NOT treat the empty binding as invalid and wipe the tools.
+      const refreshed = yield* executor.connections.refresh({
+        owner: "org",
+        integration: INTEG,
+        name: ConnectionName.make("public"),
+      });
+      expect(refreshed.map((t) => String(t.name)).sort()).toEqual(["deploy", "list"]);
+      expect((yield* executor.tools.list()).length).toBe(2);
     }),
   );
 

--- a/packages/core/sdk/src/errors.ts
+++ b/packages/core/sdk/src/errors.ts
@@ -91,6 +91,16 @@ export class ConnectionNotFoundError extends Schema.TaggedErrorClass<ConnectionN
   },
 ) {}
 
+/** A connection create request was rejected before anything was written: the
+ *  input is structurally invalid (no credential inputs for a credentialed
+ *  template, mixed pasted/external origins, …) or targets owner `user` in a
+ *  context that has no user subject. The message says which — it is safe to
+ *  show to the caller. */
+export class InvalidConnectionInputError extends Schema.TaggedErrorClass<InvalidConnectionInputError>()(
+  "InvalidConnectionInputError",
+  { message: Schema.String },
+) {}
+
 /** A connection references a credential provider key that isn't registered on
  *  the executor. */
 export class CredentialProviderNotRegisteredError extends Schema.TaggedErrorClass<CredentialProviderNotRegisteredError>()(

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -51,6 +51,7 @@ import {
   CredentialProviderNotRegisteredError,
   CredentialResolutionError,
   IntegrationNotFoundError,
+  InvalidConnectionInputError,
   IntegrationRemovalNotAllowedError,
   NoHandlerError,
   PluginNotLoadedError,
@@ -64,6 +65,7 @@ import {
   ConnectionAddress,
   ConnectionName,
   IntegrationSlug,
+  NO_AUTH_TEMPLATE,
   OAuthClientSlug,
   Owner,
   PolicyId,
@@ -256,7 +258,10 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
       input: CreateConnectionInput,
     ) => Effect.Effect<
       Connection,
-      IntegrationNotFoundError | CredentialProviderNotRegisteredError | StorageFailure
+      | IntegrationNotFoundError
+      | CredentialProviderNotRegisteredError
+      | InvalidConnectionInputError
+      | StorageFailure
     >;
     readonly list: (filter?: {
       readonly integration?: IntegrationSlug;
@@ -1764,15 +1769,18 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           );
 
         // Defense in depth (and cleanup for rows created before the create-time
-        // guard, or emptied by an external edit): a non-OAuth connection with no
-        // bound credential inputs can never resolve a value, so never advertise
-        // tools for it — every call would fail with `connection_value_missing`.
-        // OAuth connections resolve via refresh and carry their token outside
-        // `item_ids`, so they are exempt.
+        // guard, or emptied by an external edit): a credentialed non-OAuth
+        // connection with no bound credential inputs can never resolve a value,
+        // so never advertise tools for it — every call would fail with
+        // `connection_value_missing`. OAuth connections resolve via refresh and
+        // carry their token outside `item_ids`; no-auth (`"none"` template)
+        // connections legitimately bind nothing (an empty `item_ids` is their
+        // canonical shape) — both are exempt.
         const existingRow = yield* findConnectionRow(ref);
         if (
           existingRow &&
           existingRow.oauth_client == null &&
+          existingRow.template !== String(NO_AUTH_TEMPLATE) &&
           Object.keys(connectionItemIds(existingRow)).length === 0
         ) {
           yield* transaction(
@@ -1876,11 +1884,21 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       input: CreateConnectionInput,
     ): Effect.Effect<
       Connection,
-      IntegrationNotFoundError | CredentialProviderNotRegisteredError | StorageFailure
+      | IntegrationNotFoundError
+      | CredentialProviderNotRegisteredError
+      | InvalidConnectionInputError
+      | StorageFailure
     > =>
       Effect.gen(function* () {
         const name = connectionIdentifier(String(input.name));
-        yield* requireUserSubject(input.owner);
+        // Typed (not StorageError) so the HTTP edge can answer 400 with the
+        // reason instead of an opaque 500 — callers can act on it.
+        if (input.owner === "user" && subject == null) {
+          return yield* new InvalidConnectionInputError({
+            message:
+              'Cannot create a personal connection: this context has no user subject. Create it with owner "org", or connect as a signed-in user.',
+          });
+        }
         const integrationRow = yield* findIntegrationRow(input.integration);
         if (!integrationRow) {
           return yield* new IntegrationNotFoundError({
@@ -1896,27 +1914,27 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const inputs = normalizeConnectionInputs(input);
         const pasted = inputs.filter((i) => "value" in i.origin);
         const external = inputs.filter((i) => "from" in i.origin);
-        // A connection is born wired: it must reference at least one credential
-        // input. An empty binding (no inputs at all — e.g. an empty `values`/
-        // `inputs` map) is a credential with no credential: it would persist,
-        // produce a full tool catalog, and then fail every invocation with
-        // `connection_value_missing`. Reject it here. (An empty-string value is
-        // NOT rejected — no-auth integrations like MCP deliberately bind one, and
-        // it yields a non-empty `item_ids`. OAuth connections are minted via
-        // `mintOAuthConnection`, not this path; an external `from` reference may
-        // resolve to null and is surfaced at invoke time, not here.)
-        if (inputs.length === 0) {
-          return yield* new StorageError({
+        // A credentialed connection is born wired: it must reference at least
+        // one credential input. An empty binding (no inputs at all — e.g. an
+        // empty `values`/`inputs` map) is a credential with no credential: it
+        // would persist, produce a full tool catalog, and then fail every
+        // invocation with `connection_value_missing`. Reject it here — EXCEPT
+        // for the no-auth template ("none"), where zero inputs and an empty
+        // `item_ids` map are the canonical shape (public MCP servers; the UI
+        // submits `values: {}` for them). OAuth connections are minted via
+        // `mintOAuthConnection`, not this path; an external `from` reference
+        // may resolve to null and is surfaced at invoke time, not here.
+        const isNoAuth = String(input.template) === String(NO_AUTH_TEMPLATE);
+        if (inputs.length === 0 && !isNoAuth) {
+          return yield* new InvalidConnectionInputError({
             message: "A connection must supply at least one credential input.",
-            cause: undefined,
           });
         }
         let providerKey: string;
         const itemIds: Record<string, string> = {};
         if (external.length > 0 && pasted.length > 0) {
-          return yield* new StorageError({
+          return yield* new InvalidConnectionInputError({
             message: "A connection cannot mix pasted and external-provider inputs.",
-            cause: undefined,
           });
         }
         if (external.length > 0) {
@@ -1924,9 +1942,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             external.map((i) => ("from" in i.origin ? String(i.origin.from.provider) : "")),
           );
           if (providers.size > 1) {
-            return yield* new StorageError({
+            return yield* new InvalidConnectionInputError({
               message: "A connection's inputs must all use the same external provider.",
-              cause: undefined,
             });
           }
           const [only] = [...providers];

--- a/packages/core/sdk/src/ids.ts
+++ b/packages/core/sdk/src/ids.ts
@@ -12,6 +12,11 @@ export type IntegrationSlug = typeof IntegrationSlug.Type;
 export const AuthTemplateSlug = Schema.String.pipe(Schema.brand("AuthTemplateSlug"));
 export type AuthTemplateSlug = typeof AuthTemplateSlug.Type;
 
+/** The sentinel template for integrations that require no credential (e.g. a
+ *  public MCP server). Connections on it legitimately bind zero inputs — an
+ *  empty `item_ids` map is their canonical persisted shape. */
+export const NO_AUTH_TEMPLATE = AuthTemplateSlug.make("none");
+
 /** A connection's name — the `<connection>` segment of an address, scoped under
  *  its integration + owner (so the same name can exist on two integrations). */
 export const ConnectionName = Schema.String.pipe(Schema.brand("ConnectionName"));

--- a/packages/core/sdk/src/migration-oauth-metadata.ts
+++ b/packages/core/sdk/src/migration-oauth-metadata.ts
@@ -162,11 +162,19 @@ const resolveMigrationOAuthAuthorizationUrl = async (
 ): Promise<string | null> => {
   const metadataUrl = client.authorizationServerMetadataUrl?.trim();
   if (metadataUrl) {
-    return await fetchOAuthAuthorizationEndpoint(
-      validateMigrationOAuthUrl(metadataUrl, "authorizationServerMetadataUrl"),
-      fetchImpl,
-      timeoutMs,
-    );
+    // Best-effort like the resource/issuer discovery below: a dead, invalid,
+    // or unreachable metadata endpoint (offline machine, archived server)
+    // must not abort the whole migration — fall through to discovery.
+    try {
+      const endpoint = await fetchOAuthAuthorizationEndpoint(
+        validateMigrationOAuthUrl(metadataUrl, "authorizationServerMetadataUrl"),
+        fetchImpl,
+        timeoutMs,
+      );
+      if (endpoint) return endpoint;
+    } catch {
+      // fall through to issuer/resource discovery
+    }
   }
 
   if (client.grant !== "authorization_code") return null;

--- a/packages/core/sdk/src/migration-spec.test.ts
+++ b/packages/core/sdk/src/migration-spec.test.ts
@@ -1190,6 +1190,106 @@ describe("planMigration (the weave)", () => {
     );
   });
 
+  // v2 produces tools per connection, so a no-auth source (no credential
+  // bindings at all) must still get its canonical connection — template
+  // "none", empty item_ids — or the migrated integration is dead.
+  it("plans a workspace none-template connection for binding-less no-auth sources", () => {
+    const input: MigrationInput = {
+      nowMs: now,
+      sources: [{ scopeId: "org_X", id: "context7", pluginId: "mcp", name: "Context7" }],
+      migratedConfigs: new Map([
+        ["org_X context7", cfg({ config: { transport: "remote", auth: { kind: "none" } } })],
+      ]),
+      connections: [],
+      bindings: [],
+      secrets: [],
+      policies: [],
+      toolSourceIds: [],
+    };
+
+    const plan = planMigration(input);
+
+    expect(plan.connections).toHaveLength(1);
+    const conn = plan.connections[0];
+    expect(conn?.row.integration).toBe("context7");
+    expect(conn?.row.name).toBe("workspace");
+    expect(conn?.row.template).toBe("none");
+    expect(conn?.row.owner).toBe("org");
+    expect(conn?.itemIds).toEqual({});
+    // An OAuth-protected source must NOT get one.
+    const oauthInput: MigrationInput = {
+      ...input,
+      migratedConfigs: new Map([
+        ["org_X context7", cfg({ config: { transport: "remote", auth: { kind: "oauth2" } } })],
+      ]),
+    };
+    expect(planMigration(oauthInput).connections).toHaveLength(0);
+  });
+
+  it("skips secret-binding groups whose bindings reference no secrets, with a warning", () => {
+    const input: MigrationInput = {
+      nowMs: now,
+      sources: [{ scopeId: "org_X", id: "broken_api", pluginId: "openapi", name: "Broken" }],
+      migratedConfigs: new Map(),
+      connections: [],
+      bindings: [
+        {
+          scopeId: "org_X",
+          sourceId: "broken_api",
+          slotKey: "header:authorization",
+          kind: "secret",
+          secretId: null,
+          connectionId: null,
+          textValue: null,
+        },
+      ],
+      secrets: [],
+      policies: [],
+      toolSourceIds: [],
+    };
+
+    const plan = planMigration(input);
+
+    // No empty-item_ids ghost connection (the runtime would refuse it tools).
+    expect(plan.connections).toHaveLength(0);
+    expect(plan.report.warnings.some((w) => w.includes("reference no secrets"))).toBe(true);
+  });
+
+  it("keys text-binding item ids by source so same-slot bindings do not collide", () => {
+    const binding = (sourceId: string, textValue: string) => ({
+      scopeId: "org_X",
+      sourceId,
+      slotKey: "header:authorization",
+      kind: "text" as const,
+      secretId: null,
+      connectionId: null,
+      textValue,
+    });
+    const input: MigrationInput = {
+      nowMs: now,
+      sources: [
+        { scopeId: "org_X", id: "api_one", pluginId: "mcp", name: "One" },
+        { scopeId: "org_X", id: "api_two", pluginId: "mcp", name: "Two" },
+      ],
+      migratedConfigs: new Map(),
+      connections: [],
+      bindings: [binding("api_one", "value-one"), binding("api_two", "value-two")],
+      secrets: [],
+      policies: [],
+      toolSourceIds: [],
+    };
+
+    const plan = planMigration(input);
+
+    const ids = plan.connections.map((c) => Object.values(c.itemIds)).flat();
+    expect(new Set(ids).size).toBe(2);
+    const ops = plan.secretOps.filter((o) => o.role === "apikey");
+    expect(ops.map((o) => "fromText" in o && o.fromText).sort()).toEqual([
+      "value-one",
+      "value-two",
+    ]);
+  });
+
   it("plans a v1 client-credentials OAuth connection with secret-backed client credentials", () => {
     const input: MigrationInput = {
       nowMs: now,

--- a/packages/core/sdk/src/migration-spec.test.ts
+++ b/packages/core/sdk/src/migration-spec.test.ts
@@ -1117,6 +1117,79 @@ describe("planMigration (the weave)", () => {
     expect(plan.report.policies).toEqual({ ok: 2, static: 0, deadInert: 0 });
   });
 
+  // The prod Microsoft shape: v1 stored only a bare issuer origin plus the
+  // full token endpoint (no discrete authorize endpoint — v1 discovered it at
+  // runtime). A bare origin is a dead authorize URL (sign-in completes but
+  // never redirects back), so the planner must derive the same-origin
+  // `…/authorize` sibling of the token endpoint instead.
+  it("derives the authorize endpoint from the token endpoint when v1 only stored a bare issuer", () => {
+    const input: MigrationInput = {
+      nowMs: now,
+      sources: [
+        { scopeId: "org_X", id: "microsoft_graph", pluginId: "openapi", name: "Microsoft Graph" },
+      ],
+      migratedConfigs: new Map([
+        [
+          "org_X microsoft_graph",
+          cfg({
+            slotToTemplateSlug: { "oauth2:azureaddelegated:connection": "azureAdDelegated" },
+            slotToVariable: { "oauth2:azureaddelegated:connection": "token" },
+          }),
+        ],
+      ]),
+      connections: [
+        {
+          id: "openapi-oauth-microsoft-graph",
+          scopeId: "org_X",
+          provider: "oauth2",
+          identityLabel: null,
+          accessTokenSecretId: "ms-access",
+          refreshTokenSecretId: null,
+          expiresAt: null,
+          providerState: {
+            kind: "authorization-code",
+            clientId: "cid-ms",
+            issuerUrl: "https://login.microsoftonline.com",
+            tokenEndpoint: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+            scopes: ["User.Read"],
+          },
+        },
+      ],
+      bindings: [
+        {
+          scopeId: "org_X",
+          sourceId: "microsoft_graph",
+          slotKey: "oauth2:azureaddelegated:connection",
+          kind: "connection",
+          secretId: null,
+          connectionId: "openapi-oauth-microsoft-graph",
+          textValue: null,
+        },
+      ],
+      secrets: [
+        {
+          id: "ms-access",
+          scopeId: "org_X",
+          name: "",
+          provider: "workos-vault",
+          ownedByConnectionId: "openapi-oauth-microsoft-graph",
+        },
+      ],
+      policies: [],
+      toolSourceIds: [],
+    };
+
+    const plan = planMigration(input);
+
+    expect(plan.oauthClients).toHaveLength(1);
+    expect(plan.oauthClients[0]?.authorizationUrl).toBe(
+      "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+    );
+    expect(plan.oauthClients[0]?.tokenUrl).toBe(
+      "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+    );
+  });
+
   it("plans a v1 client-credentials OAuth connection with secret-backed client credentials", () => {
     const input: MigrationInput = {
       nowMs: now,

--- a/packages/core/sdk/src/migration-spec.ts
+++ b/packages/core/sdk/src/migration-spec.ts
@@ -1559,6 +1559,15 @@ export const planMigration = (input: MigrationInput): MigrationPlan => {
         template = slotTemplate(b.slotKey);
         consume(secretScopeId, b.secretId);
       }
+      // All-null secret ids (malformed v1 rows) would plan a credentialed
+      // connection with an empty `item_ids` map — a credential with no
+      // credential that the runtime refuses to produce tools for. Skip loudly.
+      if (Object.keys(itemIds).length === 0) {
+        warnings.push(
+          `Skipped binding group "${sourceId}" in scope "${scopeId}": its secret bindings reference no secrets.`,
+        );
+        continue;
+      }
       const provider = targetProvider ?? defaultWritableProvider;
       if (providers.size > 1) {
         warnings.push(
@@ -1596,7 +1605,11 @@ export const planMigration = (input: MigrationInput): MigrationPlan => {
       let template = API_KEY_TEMPLATE_SLUG;
       for (const b of textBindings) {
         const variable = slotVar(b.slotKey);
-        const itemId = migratedItemId(scopeId, `text:${b.slotKey}`);
+        // The source id is part of the key: two sources in one scope can bind
+        // the same slot (e.g. `header:authorization`) with different values —
+        // without it they'd collide on one item id and one would silently
+        // read the other's secret.
+        const itemId = migratedItemId(scopeId, `text:${sourceId}:${b.slotKey}`);
         secretOps.push({
           itemId,
           role: "apikey",
@@ -1632,6 +1645,52 @@ export const planMigration = (input: MigrationInput): MigrationPlan => {
           refreshItemId: null,
         });
       }
+    } else {
+      // Nothing migratable in the group: a connection binding without a
+      // connection id, or only OAuth client-credential slots (the app config
+      // migrates via the bound connection's provider state — an app that was
+      // configured but never connected has nothing to attach to). Say so
+      // instead of dropping the group silently.
+      warnings.push(
+        `Skipped binding group "${sourceId}" in scope "${scopeId}": no migratable credential binding (its secrets fall to the orphan re-key).`,
+      );
+    }
+  }
+
+  // --- No-auth sources (mcp/graphql `auth.kind === "none"`) have no credential
+  // bindings, but v2 produces tools per CONNECTION — without one the migrated
+  // integration is dead (no tools, nothing to invoke). Plan the canonical
+  // no-auth connection: template "none", empty item_ids. (This is the planner
+  // fix for the gap that required the prod `{}` backfill.)
+  for (const source of input.sources) {
+    if (groups.has(sourceKey(source.scopeId, source.id))) continue;
+    const migrated = input.migratedConfigs.get(sourceKey(source.scopeId, source.id));
+    const auth = (migrated?.config as { auth?: { kind?: string } } | undefined)?.auth;
+    if (auth?.kind !== "none") continue;
+    const row = planConnectionRow({
+      scopeId: source.scopeId,
+      integration: source.id,
+      name: "workspace",
+      template: "none",
+      provider: defaultWritableProvider,
+      identityLabel: null,
+      grant: "authorization_code",
+      v1ExpiresAt: null,
+      oauthScopes: [],
+      oauthClientSlug: null,
+      oauthClientOwner: null,
+      nowMs: input.nowMs,
+      ownerForScope,
+    });
+    if (row) {
+      connections.push({
+        credentialScopeId: source.scopeId,
+        sourceScopeId: source.scopeId,
+        sourceId: source.id,
+        row,
+        itemIds: {},
+        refreshItemId: null,
+      });
     }
   }
 
@@ -1659,7 +1718,10 @@ export const planMigration = (input: MigrationInput): MigrationPlan => {
   for (const s of input.secrets) {
     if (consumed.has(`${s.scopeId} ${s.id}`)) continue;
     const owner = ownerForScope(s.scopeId);
-    if (!owner) continue; // unparseable scope orphan — skip + (counted via warnings below)
+    if (!owner) {
+      warnings.push(`Skipped orphan secret "${s.id}": unparseable scope "${s.scopeId}".`);
+      continue;
+    }
     secretOps.push({
       itemId: migratedItemId(s.scopeId, s.id),
       role: "orphan",

--- a/packages/core/sdk/src/migration-spec.ts
+++ b/packages/core/sdk/src/migration-spec.ts
@@ -1256,12 +1256,41 @@ const nonEmptyString = (value: string | null | undefined): string | null => {
   return trimmed ? trimmed : null;
 };
 
-const authorizationUrlFromProviderState = (ps: V1ProviderState | null): string =>
-  nonEmptyString(ps?.authorizationEndpoint) ??
-  nonEmptyString(ps?.authorizationServerMetadata?.authorization_endpoint) ??
-  nonEmptyString(ps?.authorizationServerUrl) ??
-  nonEmptyString(ps?.issuerUrl) ??
-  "";
+/** True when the URL has no meaningful path — a bare origin like
+ *  `https://login.microsoftonline.com`. A bare origin is never a usable
+ *  authorize endpoint: redirecting there signs the user in and strands them
+ *  (observed in prod with migrated Microsoft clients). */
+const isBareOrigin = (url: string): boolean => /^https?:\/\/[^/]+\/?$/.test(url);
+
+const authorizationUrlFromProviderState = (
+  ps: V1ProviderState | null,
+  grant: MigrationGrant,
+): string => {
+  const explicit =
+    nonEmptyString(ps?.authorizationEndpoint) ??
+    nonEmptyString(ps?.authorizationServerMetadata?.authorization_endpoint);
+  if (explicit) return explicit;
+  const fallback =
+    nonEmptyString(ps?.authorizationServerUrl) ?? nonEmptyString(ps?.issuerUrl) ?? "";
+  // Client-credentials clients have no browser leg — an empty authorization
+  // URL is their correct shape; never derive one.
+  if (grant === "client_credentials") return fallback;
+  // v1 stored only an issuer/server origin for some providers and discovered
+  // the authorize endpoint at runtime. v2 stores the endpoint itself, so a
+  // bare origin would mint a broken client. When the token endpoint is a
+  // same-origin `…/token` URL, its `…/authorize` sibling is the convention
+  // (and exactly right for the Microsoft v2.0 endpoints that hit this path);
+  // prefer that over a guaranteed-dead bare origin.
+  const token = nonEmptyString(ps?.tokenEndpoint);
+  if (
+    (fallback === "" || isBareOrigin(fallback)) &&
+    token?.endsWith("/token") &&
+    (fallback === "" || token.startsWith(fallback.replace(/\/$/, "") + "/"))
+  ) {
+    return token.replace(/\/token$/, "/authorize");
+  }
+  return fallback;
+};
 
 const secretOpDedupeKey = (op: SecretOp): string =>
   `${op.targetProvider}\0${op.owner.tenant}\0${op.owner.owner}\0${op.owner.subject}\0${op.itemId}`;
@@ -1458,7 +1487,7 @@ export const planMigration = (input: MigrationInput): MigrationPlan => {
         clientId: ps?.clientId ?? "",
         clientIdSecretRef,
         tokenUrl: ps?.tokenEndpoint ?? "",
-        authorizationUrl: authorizationUrlFromProviderState(ps),
+        authorizationUrl: authorizationUrlFromProviderState(ps, grant),
         authorizationServerMetadataUrl: nonEmptyString(ps?.authorizationServerMetadataUrl),
         grant,
         resource:

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -36,6 +36,7 @@ import type {
   CredentialProviderNotRegisteredError,
   IntegrationNotFoundError,
   IntegrationRemovalNotAllowedError,
+  InvalidConnectionInputError,
 } from "./errors";
 import type { OAuthService } from "./oauth-client";
 import type { CredentialProvider, ProviderEntry } from "./provider";
@@ -140,7 +141,10 @@ export interface PluginCtx<TStore = unknown> {
       input: CreateConnectionInput,
     ) => Effect.Effect<
       Connection,
-      IntegrationNotFoundError | CredentialProviderNotRegisteredError | StorageFailure
+      | IntegrationNotFoundError
+      | CredentialProviderNotRegisteredError
+      | InvalidConnectionInputError
+      | StorageFailure
     >;
     readonly list: (filter?: {
       readonly integration?: IntegrationSlug;

--- a/packages/core/sdk/src/shared.ts
+++ b/packages/core/sdk/src/shared.ts
@@ -57,6 +57,7 @@ export {
   IntegrationAlreadyExistsError,
   IntegrationRemovalNotAllowedError,
   ConnectionNotFoundError,
+  InvalidConnectionInputError,
   CredentialProviderNotRegisteredError,
   CredentialResolutionError,
   type ExecuteError,


### PR DESCRIPTION
## Summary
- Allow no-auth (template `none`) connections: the create guard no longer rejects their canonical empty-values payload, and the produce-time guard no longer deletes their tools on refresh.
- Surface connection-create validation failures (empty credential binding, mixed origins, missing user subject) as a typed 400 with the reason instead of an opaque 500.
- Derive migrated OAuth authorize URLs from the token endpoint when v1 only stored a bare issuer origin (bare origins strand sign-ins).
- Fix v1→v2 migration planner gaps: plan workspace connections for binding-less no-auth sources, skip groups with no usable secrets instead of planning empty connections, warn on silently-dropped groups and orphan secrets, key text-binding item ids by source, and make OAuth metadata resolution best-effort so an unreachable endpoint cannot block the local migration.