### PR TITLE
Replay the legacy v1 schema chain before the v1→v2 data migration

### DIFF
--- a/.changeset/legacy-v1-migration-replay.md
+++ b/.changeset/legacy-v1-migration-replay.md
@@ -1,0 +1,5 @@
+---
+"executor": patch
+---
+
+Fix `executor web` crashing with `no such table: plugin_storage` when upgrading from an older v1 release. The v1 → v2 data migration now replays the bundled legacy schema migrations first, so databases last touched by any pre-1.5 version are brought up to the final v1 schema before their data is migrated.

--- a/apps/cli/src/build.ts
+++ b/apps/cli/src/build.ts
@@ -252,13 +252,15 @@ const createEmbeddedWebUISource = async (mode: BuildMode) => {
 };
 
 // ---------------------------------------------------------------------------
-// Embedded drizzle migrations — inlined as text imports so drizzle's
+// Embedded legacy v1 drizzle migrations — inlined as text imports so drizzle's
 // `migrate()` (which reads a folder from disk) can be given a tmpdir
-// populated from the inlined contents at runtime.
+// populated from the inlined contents at runtime. The v1→v2 data migration
+// replays this chain to bring an older v1 database up to v1-final before
+// reading it (v2's own schema is created from FumaDB DDL, not this folder).
 // ---------------------------------------------------------------------------
 
 const createEmbeddedMigrationsSource = async () => {
-  const migrationsDir = resolve(webRoot, "drizzle");
+  const migrationsDir = resolve(webRoot, "drizzle-legacy-v1");
   const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: migrationsDir })))
     .map((f) => f.replaceAll("\\", "/"))
     .sort();

--- a/apps/local/drizzle-legacy-v1/0000_overconfident_sharon_carter.sql
+++ b/apps/local/drizzle-legacy-v1/0000_overconfident_sharon_carter.sql
@@ -1,0 +1,180 @@
+CREATE TABLE `blob` (
+	`namespace` text NOT NULL,
+	`key` text NOT NULL,
+	`value` text NOT NULL,
+	PRIMARY KEY(`namespace`, `key`)
+);
+--> statement-breakpoint
+CREATE TABLE `definition` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`plugin_id` text NOT NULL,
+	`name` text NOT NULL,
+	`schema` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `definition_scope_id_idx` ON `definition` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `definition_source_id_idx` ON `definition` (`source_id`);--> statement-breakpoint
+CREATE INDEX `definition_plugin_id_idx` ON `definition` (`plugin_id`);--> statement-breakpoint
+CREATE TABLE `google_discovery_binding` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`binding` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `google_discovery_binding_scope_id_idx` ON `google_discovery_binding` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `google_discovery_binding_source_id_idx` ON `google_discovery_binding` (`source_id`);--> statement-breakpoint
+CREATE TABLE `google_discovery_oauth_session` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`session` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `google_discovery_oauth_session_scope_id_idx` ON `google_discovery_oauth_session` (`scope_id`);--> statement-breakpoint
+CREATE TABLE `google_discovery_source` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`name` text NOT NULL,
+	`config` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `google_discovery_source_scope_id_idx` ON `google_discovery_source` (`scope_id`);--> statement-breakpoint
+CREATE TABLE `graphql_operation` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`binding` text NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `graphql_operation_scope_id_idx` ON `graphql_operation` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `graphql_operation_source_id_idx` ON `graphql_operation` (`source_id`);--> statement-breakpoint
+CREATE TABLE `graphql_source` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`name` text NOT NULL,
+	`endpoint` text NOT NULL,
+	`headers` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `graphql_source_scope_id_idx` ON `graphql_source` (`scope_id`);--> statement-breakpoint
+CREATE TABLE `mcp_binding` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`binding` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `mcp_binding_scope_id_idx` ON `mcp_binding` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `mcp_binding_source_id_idx` ON `mcp_binding` (`source_id`);--> statement-breakpoint
+CREATE TABLE `mcp_oauth_session` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`session` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `mcp_oauth_session_scope_id_idx` ON `mcp_oauth_session` (`scope_id`);--> statement-breakpoint
+CREATE TABLE `mcp_source` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`name` text NOT NULL,
+	`config` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `mcp_source_scope_id_idx` ON `mcp_source` (`scope_id`);--> statement-breakpoint
+CREATE TABLE `openapi_oauth_session` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`session` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `openapi_oauth_session_scope_id_idx` ON `openapi_oauth_session` (`scope_id`);--> statement-breakpoint
+CREATE TABLE `openapi_operation` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`binding` text NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `openapi_operation_scope_id_idx` ON `openapi_operation` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_operation_source_id_idx` ON `openapi_operation` (`source_id`);--> statement-breakpoint
+CREATE TABLE `openapi_source` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`name` text NOT NULL,
+	`spec` text NOT NULL,
+	`base_url` text,
+	`headers` text,
+	`oauth2` text,
+	`invocation_config` text NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `openapi_source_scope_id_idx` ON `openapi_source` (`scope_id`);--> statement-breakpoint
+CREATE TABLE `secret` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`name` text NOT NULL,
+	`provider` text NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `secret_scope_id_idx` ON `secret` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `secret_provider_idx` ON `secret` (`provider`);--> statement-breakpoint
+CREATE TABLE `source` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`plugin_id` text NOT NULL,
+	`kind` text NOT NULL,
+	`name` text NOT NULL,
+	`url` text,
+	`can_remove` integer DEFAULT true NOT NULL,
+	`can_refresh` integer DEFAULT false NOT NULL,
+	`can_edit` integer DEFAULT false NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `source_scope_id_idx` ON `source` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `source_plugin_id_idx` ON `source` (`plugin_id`);--> statement-breakpoint
+CREATE TABLE `tool` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`plugin_id` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text NOT NULL,
+	`input_schema` text,
+	`output_schema` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `tool_scope_id_idx` ON `tool` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `tool_source_id_idx` ON `tool` (`source_id`);--> statement-breakpoint
+CREATE INDEX `tool_plugin_id_idx` ON `tool` (`plugin_id`);

--- a/apps/local/drizzle-legacy-v1/0001_sour_catseye.sql
+++ b/apps/local/drizzle-legacy-v1/0001_sour_catseye.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `openapi_source` ADD `source_url` text;

--- a/apps/local/drizzle-legacy-v1/0002_lively_sue_storm.sql
+++ b/apps/local/drizzle-legacy-v1/0002_lively_sue_storm.sql
@@ -1,0 +1,20 @@
+CREATE TABLE `connection` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`provider` text NOT NULL,
+	`kind` text NOT NULL,
+	`identity_label` text,
+	`access_token_secret_id` text NOT NULL,
+	`refresh_token_secret_id` text,
+	`expires_at` integer,
+	`scope` text,
+	`provider_state` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `connection_scope_id_idx` ON `connection` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `connection_provider_idx` ON `connection` (`provider`);--> statement-breakpoint
+ALTER TABLE `secret` ADD `owned_by_connection_id` text;--> statement-breakpoint
+CREATE INDEX `secret_owned_by_connection_id_idx` ON `secret` (`owned_by_connection_id`);

--- a/apps/local/drizzle-legacy-v1/0003_little_silk_fever.sql
+++ b/apps/local/drizzle-legacy-v1/0003_little_silk_fever.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `openapi_source_binding` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source_id` text NOT NULL,
+	`source_scope_id` text NOT NULL,
+	`target_scope_id` text NOT NULL,
+	`slot` text NOT NULL,
+	`value` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_source_id_idx` ON `openapi_source_binding` (`source_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_source_scope_id_idx` ON `openapi_source_binding` (`source_scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_target_scope_id_idx` ON `openapi_source_binding` (`target_scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_slot_idx` ON `openapi_source_binding` (`slot`);--> statement-breakpoint
+ALTER TABLE `connection` DROP COLUMN `kind`;

--- a/apps/local/drizzle-legacy-v1/0004_add_tool_policy.sql
+++ b/apps/local/drizzle-legacy-v1/0004_add_tool_policy.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `tool_policy` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`pattern` text NOT NULL,
+	`action` text NOT NULL,
+	-- Fractional-indexing key (Jira lexorank style). Lex-ordered text;
+	-- always subdivisible by lengthening, so reorders never run out of
+	-- room.
+	`position` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+-- List queries are always `WHERE scope_id = ? ORDER BY position`, so the
+-- composite index serves both the filter and the sort from one btree.
+CREATE INDEX `tool_policy_scope_id_position_idx` ON `tool_policy` (`scope_id`, `position`);

--- a/apps/local/drizzle-legacy-v1/0005_repair_mcp_oauth_session.sql
+++ b/apps/local/drizzle-legacy-v1/0005_repair_mcp_oauth_session.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `mcp_oauth_session` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`session` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `mcp_oauth_session_scope_id_idx` ON `mcp_oauth_session` (`scope_id`);

--- a/apps/local/drizzle-legacy-v1/0006_neat_terror.sql
+++ b/apps/local/drizzle-legacy-v1/0006_neat_terror.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `oauth2_session` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`plugin_id` text NOT NULL,
+	`strategy` text NOT NULL,
+	`connection_id` text NOT NULL,
+	`token_scope` text NOT NULL,
+	`redirect_url` text NOT NULL,
+	`payload` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `oauth2_session_scope_id_idx` ON `oauth2_session` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `oauth2_session_plugin_id_idx` ON `oauth2_session` (`plugin_id`);--> statement-breakpoint
+CREATE INDEX `oauth2_session_connection_id_idx` ON `oauth2_session` (`connection_id`);--> statement-breakpoint
+DROP TABLE `google_discovery_oauth_session`;--> statement-breakpoint
+DROP TABLE `mcp_oauth_session`;--> statement-breakpoint
+DROP TABLE `openapi_oauth_session`;--> statement-breakpoint
+ALTER TABLE `graphql_source` ADD `query_params` text;--> statement-breakpoint
+ALTER TABLE `graphql_source` ADD `auth` text;--> statement-breakpoint
+ALTER TABLE `openapi_source` ADD `query_params` text;

--- a/apps/local/drizzle-legacy-v1/0007_normalize_plugin_secret_refs.sql
+++ b/apps/local/drizzle-legacy-v1/0007_normalize_plugin_secret_refs.sql
@@ -1,0 +1,579 @@
+-- Normalize all plugin secret/connection refs out of JSON columns
+-- into proper relational shape: graphql, openapi, mcp,
+-- google-discovery. Each block is a self-contained backfill of one
+-- plugin's tables; collected here so the schema lands in one
+-- migration step instead of four sequential ones.
+--
+-- Old shape (per plugin):
+--   {plugin}_source.{auth, headers, query_params, ...}: json blobs
+--   openapi_source_binding.value:                       json union
+--   {plugin}_source.config.{auth, headers, queryParams}: nested json
+--
+-- New shape (per plugin):
+--   Flat auth_* columns on the parent (auth_kind enum + per-kind id
+--   columns, all indexed where they hold refs).
+--   Child tables for SecretBackedMap entries: one row per (source,
+--   header_name) keyed by JSON tuple [source_id,name] so user keys
+--   with separators don't collide. `secret_id` indexed for the
+--   usagesForSecret query.
+
+-- ============================================================
+-- graphql
+-- ============================================================
+
+-- Normalize graphql plugin: move secret/connection refs out of JSON
+-- columns into proper relational shape so usagesForSecret /
+-- usagesForConnection are one indexed SELECT instead of a JSON scan.
+--
+-- Old shape:
+--   graphql_source.headers      json   Record<name, string | {secretId,prefix?}>
+--   graphql_source.query_params json   Record<name, string | {secretId,prefix?}>
+--   graphql_source.auth         json   {kind:"none"} | {kind:"oauth2", connectionId}
+--
+-- New shape:
+--   graphql_source.auth_kind          enum("none","oauth2") NOT NULL
+--   graphql_source.auth_connection_id text indexed nullable
+--   graphql_source_header(scope_id, id, source_id, name, kind, text_value, secret_id, secret_prefix)
+--   graphql_source_query_param(scope_id, id, source_id, name, kind, text_value, secret_id, secret_prefix)
+
+CREATE TABLE `graphql_source_header` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `graphql_source_header_scope_id_idx` ON `graphql_source_header` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `graphql_source_header_source_id_idx` ON `graphql_source_header` (`source_id`);--> statement-breakpoint
+CREATE INDEX `graphql_source_header_secret_id_idx` ON `graphql_source_header` (`secret_id`);--> statement-breakpoint
+
+CREATE TABLE `graphql_source_query_param` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `graphql_source_query_param_scope_id_idx` ON `graphql_source_query_param` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `graphql_source_query_param_source_id_idx` ON `graphql_source_query_param` (`source_id`);--> statement-breakpoint
+CREATE INDEX `graphql_source_query_param_secret_id_idx` ON `graphql_source_query_param` (`secret_id`);--> statement-breakpoint
+
+-- New auth columns. `auth_kind` defaults to "none" so existing rows that
+-- predate this migration are valid even if the json was null.
+ALTER TABLE `graphql_source` ADD `auth_kind` text DEFAULT 'none' NOT NULL;--> statement-breakpoint
+ALTER TABLE `graphql_source` ADD `auth_connection_id` text;--> statement-breakpoint
+CREATE INDEX `graphql_source_auth_connection_id_idx` ON `graphql_source` (`auth_connection_id`);--> statement-breakpoint
+
+-- Backfill auth from the JSON column. json_extract returns NULL for
+-- missing paths, so a row with auth=NULL or kind="none" leaves
+-- auth_connection_id NULL and auth_kind defaulted to "none".
+UPDATE `graphql_source`
+SET
+	`auth_kind` = COALESCE(json_extract(`auth`, '$.kind'), 'none'),
+	`auth_connection_id` = json_extract(`auth`, '$.connectionId')
+WHERE `auth` IS NOT NULL;--> statement-breakpoint
+
+-- Backfill headers. For each (source, header_name) pair: if the value
+-- is a json object with .secretId, write a kind=secret row; otherwise
+-- write a kind=text row with the literal string. json_each iterates
+-- the keys of the headers object.
+INSERT OR IGNORE INTO `graphql_source_header`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, h.`key`),
+	s.`id`,
+	h.`key`,
+	CASE
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN h.`type` = 'object' THEN NULL ELSE h.`value` END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.prefix') ELSE NULL END
+FROM `graphql_source` s, json_each(s.`headers`) h
+WHERE s.`headers` IS NOT NULL;--> statement-breakpoint
+
+-- Same for query_params.
+INSERT OR IGNORE INTO `graphql_source_query_param`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, q.`key`),
+	s.`id`,
+	q.`key`,
+	CASE
+		WHEN q.`type` = 'object' AND json_extract(q.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN q.`type` = 'object' THEN NULL ELSE q.`value` END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.prefix') ELSE NULL END
+FROM `graphql_source` s, json_each(s.`query_params`) q
+WHERE s.`query_params` IS NOT NULL;--> statement-breakpoint
+
+-- Drop the old JSON columns. SQLite ≥ 3.35 supports ALTER TABLE DROP
+-- COLUMN directly; bun's bundled SQLite is well past that.
+ALTER TABLE `graphql_source` DROP COLUMN `headers`;--> statement-breakpoint
+ALTER TABLE `graphql_source` DROP COLUMN `query_params`;--> statement-breakpoint
+ALTER TABLE `graphql_source` DROP COLUMN `auth`;
+
+--> statement-breakpoint
+
+-- ============================================================
+-- openapi
+-- ============================================================
+
+-- Normalize openapi plugin: move every direct secret/connection ref out
+-- of JSON columns into proper relational shape.
+--
+-- Old shape:
+--   openapi_source.query_params      json   Record<name, string | {secretId,prefix?}>
+--   openapi_source.invocation_config json   { specFetchCredentials?: { headers, queryParams } }
+--   openapi_source_binding.value     json   discriminated union
+--                                           {kind:"secret",secretId} | {kind:"connection",connectionId} | {kind:"text",text}
+--
+-- New shape:
+--   openapi_source_binding gains kind/secret_id/connection_id/text_value columns.
+--   `headers` / `oauth2` on openapi_source stay JSON because they hold
+--   slot names, not direct refs — the actual credentials reach those
+--   slots through openapi_source_binding rows, which ARE normalized.
+--   openapi_source_query_param: child table, secret-backed entries.
+--   openapi_source_spec_fetch_header / spec_fetch_query_param: child
+--   tables for the equivalent maps inside specFetchCredentials.
+
+CREATE TABLE `openapi_source_query_param` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `openapi_source_query_param_scope_id_idx` ON `openapi_source_query_param` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_query_param_source_id_idx` ON `openapi_source_query_param` (`source_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_query_param_secret_id_idx` ON `openapi_source_query_param` (`secret_id`);--> statement-breakpoint
+
+CREATE TABLE `openapi_source_spec_fetch_header` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `openapi_source_spec_fetch_header_scope_id_idx` ON `openapi_source_spec_fetch_header` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_spec_fetch_header_source_id_idx` ON `openapi_source_spec_fetch_header` (`source_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_spec_fetch_header_secret_id_idx` ON `openapi_source_spec_fetch_header` (`secret_id`);--> statement-breakpoint
+
+CREATE TABLE `openapi_source_spec_fetch_query_param` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `openapi_source_spec_fetch_query_param_scope_id_idx` ON `openapi_source_spec_fetch_query_param` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_spec_fetch_query_param_source_id_idx` ON `openapi_source_spec_fetch_query_param` (`source_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_spec_fetch_query_param_secret_id_idx` ON `openapi_source_spec_fetch_query_param` (`secret_id`);--> statement-breakpoint
+
+-- New columns on openapi_source_binding to flatten the value json.
+-- `kind` defaults to 'text' so the ALTER works on existing rows; the
+-- backfill below stamps the real value.
+ALTER TABLE `openapi_source_binding` ADD `kind` text DEFAULT 'text' NOT NULL;--> statement-breakpoint
+ALTER TABLE `openapi_source_binding` ADD `secret_id` text;--> statement-breakpoint
+ALTER TABLE `openapi_source_binding` ADD `connection_id` text;--> statement-breakpoint
+ALTER TABLE `openapi_source_binding` ADD `text_value` text;--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_secret_id_idx` ON `openapi_source_binding` (`secret_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_connection_id_idx` ON `openapi_source_binding` (`connection_id`);--> statement-breakpoint
+
+-- Backfill the binding columns from the legacy `value` JSON. We pull
+-- $.kind into `kind` directly; for each kind the matching id field
+-- (`secretId` / `connectionId` / `text`) gets copied into the matching
+-- column. Rows whose value JSON is malformed or missing $.kind fall
+-- through to kind='text' with a NULL text_value — same as a missing
+-- text binding, the source will surface "binding not configured" at
+-- invoke time rather than crashing the migration.
+UPDATE `openapi_source_binding`
+SET
+	`kind` = COALESCE(json_extract(`value`, '$.kind'), 'text'),
+	`secret_id` = CASE WHEN json_extract(`value`, '$.kind') = 'secret' THEN json_extract(`value`, '$.secretId') ELSE NULL END,
+	`connection_id` = CASE WHEN json_extract(`value`, '$.kind') = 'connection' THEN json_extract(`value`, '$.connectionId') ELSE NULL END,
+	`text_value` = CASE WHEN json_extract(`value`, '$.kind') = 'text' THEN json_extract(`value`, '$.text') ELSE NULL END
+WHERE `value` IS NOT NULL;--> statement-breakpoint
+
+-- Backfill openapi_source_query_param from openapi_source.query_params.
+-- json_each iterates the keys of the query_params object. For each
+-- entry: if the value is an object with .secretId, write a kind=secret
+-- row; otherwise write a kind=text row with the literal string.
+INSERT OR IGNORE INTO `openapi_source_query_param`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, q.`key`),
+	s.`id`,
+	q.`key`,
+	CASE
+		WHEN q.`type` = 'object' AND json_extract(q.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN q.`type` = 'object' THEN NULL ELSE q.`value` END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.prefix') ELSE NULL END
+FROM `openapi_source` s, json_each(s.`query_params`) q
+WHERE s.`query_params` IS NOT NULL;--> statement-breakpoint
+
+-- Backfill openapi_source_spec_fetch_header from
+-- openapi_source.invocation_config.specFetchCredentials.headers. Same
+-- shape as query_params; the JSON path is one level deeper.
+INSERT OR IGNORE INTO `openapi_source_spec_fetch_header`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, h.`key`),
+	s.`id`,
+	h.`key`,
+	CASE
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN h.`type` = 'object' THEN NULL ELSE h.`value` END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.prefix') ELSE NULL END
+FROM `openapi_source` s, json_each(json_extract(s.`invocation_config`, '$.specFetchCredentials.headers')) h
+WHERE json_extract(s.`invocation_config`, '$.specFetchCredentials.headers') IS NOT NULL;--> statement-breakpoint
+
+INSERT OR IGNORE INTO `openapi_source_spec_fetch_query_param`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, q.`key`),
+	s.`id`,
+	q.`key`,
+	CASE
+		WHEN q.`type` = 'object' AND json_extract(q.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN q.`type` = 'object' THEN NULL ELSE q.`value` END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.prefix') ELSE NULL END
+FROM `openapi_source` s, json_each(json_extract(s.`invocation_config`, '$.specFetchCredentials.queryParams')) q
+WHERE json_extract(s.`invocation_config`, '$.specFetchCredentials.queryParams') IS NOT NULL;--> statement-breakpoint
+
+-- Preserve any legacy OAuth payload from invocation_config.oauth2 into
+-- the still-existing oauth2 column before we drop invocation_config.
+-- migrateLegacyConnections runs after drizzle migrations and reads
+-- oauth2 to detect the legacy shape; without this, rows that only had
+-- their OAuth payload under invocation_config.oauth2 would lose it.
+UPDATE `openapi_source`
+SET `oauth2` = json_extract(`invocation_config`, '$.oauth2')
+WHERE `oauth2` IS NULL
+  AND json_extract(`invocation_config`, '$.oauth2') IS NOT NULL;--> statement-breakpoint
+
+-- Drop the legacy JSON columns now that everything is normalized.
+ALTER TABLE `openapi_source_binding` DROP COLUMN `value`;--> statement-breakpoint
+ALTER TABLE `openapi_source` DROP COLUMN `query_params`;--> statement-breakpoint
+ALTER TABLE `openapi_source` DROP COLUMN `invocation_config`;
+
+--> statement-breakpoint
+
+-- ============================================================
+-- mcp
+-- ============================================================
+
+-- Normalize mcp plugin: lift the McpConnectionAuth secret/connection
+-- refs and the SecretBackedMap headers/query_params out of
+-- mcp_source.config JSON into proper columns / child tables.
+--
+-- Old shape:
+--   mcp_source.config (json) — McpStoredSourceData discriminated union
+--     remote: { transport, endpoint, remoteTransport?, queryParams?,
+--               headers?, auth: McpConnectionAuth }
+--     stdio:  { transport, command, args?, env?, cwd? }
+--
+-- New shape:
+--   mcp_source gains: auth_kind enum, auth_header_name, auth_secret_id,
+--     auth_secret_prefix, auth_connection_id, auth_client_id_secret_id,
+--     auth_client_secret_secret_id. The remaining structural fields
+--     stay in `config` as JSON because they're plugin-private and
+--     vary by transport.
+--   mcp_source_header / mcp_source_query_param: child tables for
+--     remote sources' SecretBackedMap entries (same column shape as
+--     graphql_source_header / openapi_source_query_param).
+
+CREATE TABLE `mcp_source_header` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `mcp_source_header_scope_id_idx` ON `mcp_source_header` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `mcp_source_header_source_id_idx` ON `mcp_source_header` (`source_id`);--> statement-breakpoint
+CREATE INDEX `mcp_source_header_secret_id_idx` ON `mcp_source_header` (`secret_id`);--> statement-breakpoint
+
+CREATE TABLE `mcp_source_query_param` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `mcp_source_query_param_scope_id_idx` ON `mcp_source_query_param` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `mcp_source_query_param_source_id_idx` ON `mcp_source_query_param` (`source_id`);--> statement-breakpoint
+CREATE INDEX `mcp_source_query_param_secret_id_idx` ON `mcp_source_query_param` (`secret_id`);--> statement-breakpoint
+
+-- New auth columns. `auth_kind` defaults to "none" so the ALTER passes
+-- on existing rows; the backfill below stamps the real value.
+ALTER TABLE `mcp_source` ADD `auth_kind` text DEFAULT 'none' NOT NULL;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_header_name` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_secret_id` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_secret_prefix` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_connection_id` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_client_id_secret_id` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_client_secret_secret_id` text;--> statement-breakpoint
+CREATE INDEX `mcp_source_auth_secret_id_idx` ON `mcp_source` (`auth_secret_id`);--> statement-breakpoint
+CREATE INDEX `mcp_source_auth_connection_id_idx` ON `mcp_source` (`auth_connection_id`);--> statement-breakpoint
+CREATE INDEX `mcp_source_auth_client_id_secret_id_idx` ON `mcp_source` (`auth_client_id_secret_id`);--> statement-breakpoint
+CREATE INDEX `mcp_source_auth_client_secret_secret_id_idx` ON `mcp_source` (`auth_client_secret_secret_id`);--> statement-breakpoint
+
+-- Backfill auth columns from config.auth — but only for rows whose
+-- config.auth matches the *current* shape:
+--   - kind=none           (no extra fields)
+--   - kind=header         (secretId present)
+--   - kind=oauth2         (connectionId present)
+-- Truly-legacy rows (inline OAuth shape with accessTokenSecretId etc.)
+-- are left untouched here so the post-migrate `migrateLegacyConnections`
+-- script can convert them to a Connection and write the resulting
+-- pointer to these columns. Setting auth_kind explicitly to NULL/none
+-- on those rows would lose the legacy payload before it gets converted.
+UPDATE `mcp_source`
+SET
+	`auth_kind` = json_extract(`config`, '$.auth.kind'),
+	`auth_header_name` = json_extract(`config`, '$.auth.headerName'),
+	`auth_secret_id` = json_extract(`config`, '$.auth.secretId'),
+	`auth_secret_prefix` = json_extract(`config`, '$.auth.prefix'),
+	`auth_connection_id` = json_extract(`config`, '$.auth.connectionId'),
+	`auth_client_id_secret_id` = json_extract(`config`, '$.auth.clientIdSecretId'),
+	`auth_client_secret_secret_id` = json_extract(`config`, '$.auth.clientSecretSecretId')
+WHERE `config` IS NOT NULL
+  AND (
+    -- kind=none and "no auth at all" both leave auth_kind defaulted to
+    -- 'none' (the column DEFAULT), so we only UPDATE rows that have a
+    -- non-trivial current-shape auth payload to extract.
+    (
+      json_extract(`config`, '$.auth.kind') = 'header'
+      AND json_extract(`config`, '$.auth.secretId') IS NOT NULL
+    )
+    OR (
+      json_extract(`config`, '$.auth.kind') = 'oauth2'
+      AND json_extract(`config`, '$.auth.connectionId') IS NOT NULL
+    )
+  );--> statement-breakpoint
+
+-- Backfill mcp_source_header from config.headers. Remote sources only;
+-- stdio's config has no `.headers` key so json_each returns nothing.
+INSERT OR IGNORE INTO `mcp_source_header`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, h.`key`),
+	s.`id`,
+	h.`key`,
+	CASE
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN h.`type` = 'object' THEN NULL ELSE h.`value` END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.prefix') ELSE NULL END
+FROM `mcp_source` s, json_each(json_extract(s.`config`, '$.headers')) h
+WHERE json_extract(s.`config`, '$.headers') IS NOT NULL;--> statement-breakpoint
+
+INSERT OR IGNORE INTO `mcp_source_query_param`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, q.`key`),
+	s.`id`,
+	q.`key`,
+	CASE
+		WHEN q.`type` = 'object' AND json_extract(q.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN q.`type` = 'object' THEN NULL ELSE q.`value` END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.prefix') ELSE NULL END
+FROM `mcp_source` s, json_each(json_extract(s.`config`, '$.queryParams')) q
+WHERE json_extract(s.`config`, '$.queryParams') IS NOT NULL;--> statement-breakpoint
+
+-- Strip the now-extracted fields from the legacy config JSON. Skip
+-- rows whose config.auth still holds a legacy inline-OAuth payload —
+-- migrateLegacyConnections needs to read it to mint the matching
+-- Connection. headers/queryParams are always safe to strip (already
+-- copied to child tables). SQLite's json_remove returns the input
+-- unchanged when a path is missing, so stdio rows pass through
+-- cleanly.
+UPDATE `mcp_source`
+SET `config` = json_remove(`config`, '$.headers', '$.queryParams')
+WHERE `config` IS NOT NULL;--> statement-breakpoint
+
+UPDATE `mcp_source`
+SET `config` = json_remove(`config`, '$.auth')
+WHERE `config` IS NOT NULL
+  AND (
+    json_extract(`config`, '$.auth.kind') = 'none'
+    OR (
+      json_extract(`config`, '$.auth.kind') = 'header'
+      AND json_extract(`config`, '$.auth.secretId') IS NOT NULL
+    )
+    OR (
+      json_extract(`config`, '$.auth.kind') = 'oauth2'
+      AND json_extract(`config`, '$.auth.connectionId') IS NOT NULL
+    )
+  );
+
+--> statement-breakpoint
+
+-- ============================================================
+-- google-discovery
+-- ============================================================
+
+-- Normalize google-discovery plugin: lift the GoogleDiscoveryAuth and
+-- the credentials.{headers,queryParams} SecretBackedMaps out of
+-- google_discovery_source.config JSON.
+--
+-- Old shape:
+--   google_discovery_source.config (json) — GoogleDiscoveryStoredSourceData
+--     with `auth: {kind:"none"} | {kind:"oauth2", connectionId, clientId..., clientSecret..., scopes}`
+--     and optional `credentials: { headers?, queryParams? }`
+--
+-- New shape:
+--   google_discovery_source gains: auth_kind, auth_connection_id,
+--     auth_client_id_secret_id, auth_client_secret_secret_id, auth_scopes.
+--   google_discovery_source_credential_header / _query_param: child
+--     tables for the SecretBackedMap entries.
+
+CREATE TABLE `google_discovery_source_credential_header` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `google_discovery_source_credential_header_scope_id_idx` ON `google_discovery_source_credential_header` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `google_discovery_source_credential_header_source_id_idx` ON `google_discovery_source_credential_header` (`source_id`);--> statement-breakpoint
+CREATE INDEX `google_discovery_source_credential_header_secret_id_idx` ON `google_discovery_source_credential_header` (`secret_id`);--> statement-breakpoint
+
+CREATE TABLE `google_discovery_source_credential_query_param` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`secret_prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `google_discovery_source_credential_query_param_scope_id_idx` ON `google_discovery_source_credential_query_param` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `google_discovery_source_credential_query_param_source_id_idx` ON `google_discovery_source_credential_query_param` (`source_id`);--> statement-breakpoint
+CREATE INDEX `google_discovery_source_credential_query_param_secret_id_idx` ON `google_discovery_source_credential_query_param` (`secret_id`);--> statement-breakpoint
+
+ALTER TABLE `google_discovery_source` ADD `auth_kind` text DEFAULT 'none' NOT NULL;--> statement-breakpoint
+ALTER TABLE `google_discovery_source` ADD `auth_connection_id` text;--> statement-breakpoint
+ALTER TABLE `google_discovery_source` ADD `auth_client_id_secret_id` text;--> statement-breakpoint
+ALTER TABLE `google_discovery_source` ADD `auth_client_secret_secret_id` text;--> statement-breakpoint
+ALTER TABLE `google_discovery_source` ADD `auth_scopes` text;--> statement-breakpoint
+CREATE INDEX `google_discovery_source_auth_connection_id_idx` ON `google_discovery_source` (`auth_connection_id`);--> statement-breakpoint
+CREATE INDEX `google_discovery_source_auth_client_id_secret_id_idx` ON `google_discovery_source` (`auth_client_id_secret_id`);--> statement-breakpoint
+CREATE INDEX `google_discovery_source_auth_client_secret_secret_id_idx` ON `google_discovery_source` (`auth_client_secret_secret_id`);--> statement-breakpoint
+
+-- Backfill auth columns from config.auth.
+UPDATE `google_discovery_source`
+SET
+	`auth_kind` = COALESCE(json_extract(`config`, '$.auth.kind'), 'none'),
+	`auth_connection_id` = json_extract(`config`, '$.auth.connectionId'),
+	`auth_client_id_secret_id` = json_extract(`config`, '$.auth.clientIdSecretId'),
+	`auth_client_secret_secret_id` = json_extract(`config`, '$.auth.clientSecretSecretId'),
+	`auth_scopes` = json_extract(`config`, '$.auth.scopes')
+WHERE `config` IS NOT NULL;--> statement-breakpoint
+
+-- Backfill credential header / query_param child rows.
+INSERT OR IGNORE INTO `google_discovery_source_credential_header`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, h.`key`),
+	s.`id`,
+	h.`key`,
+	CASE
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN h.`type` = 'object' THEN NULL ELSE h.`value` END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN h.`type` = 'object' THEN json_extract(h.`value`, '$.prefix') ELSE NULL END
+FROM `google_discovery_source` s, json_each(json_extract(s.`config`, '$.credentials.headers')) h
+WHERE json_extract(s.`config`, '$.credentials.headers') IS NOT NULL;--> statement-breakpoint
+
+INSERT OR IGNORE INTO `google_discovery_source_credential_query_param`
+	(`scope_id`, `id`, `source_id`, `name`, `kind`, `text_value`, `secret_id`, `secret_prefix`)
+SELECT
+	s.`scope_id`,
+	json_array(s.`id`, q.`key`),
+	s.`id`,
+	q.`key`,
+	CASE
+		WHEN q.`type` = 'object' AND json_extract(q.`value`, '$.secretId') IS NOT NULL THEN 'secret'
+		ELSE 'text'
+	END,
+	CASE WHEN q.`type` = 'object' THEN NULL ELSE q.`value` END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.secretId') ELSE NULL END,
+	CASE WHEN q.`type` = 'object' THEN json_extract(q.`value`, '$.prefix') ELSE NULL END
+FROM `google_discovery_source` s, json_each(json_extract(s.`config`, '$.credentials.queryParams')) q
+WHERE json_extract(s.`config`, '$.credentials.queryParams') IS NOT NULL;--> statement-breakpoint
+
+-- Strip the extracted fields from the legacy config JSON.
+UPDATE `google_discovery_source`
+SET `config` = json_remove(`config`, '$.auth', '$.credentials')
+WHERE `config` IS NOT NULL;

--- a/apps/local/drizzle-legacy-v1/0008_scoped_credentials_cutover.sql
+++ b/apps/local/drizzle-legacy-v1/0008_scoped_credentials_cutover.sql
@@ -1,0 +1,1220 @@
+--
+-- Slug-normalization staging table.
+--
+-- 0008 originally inlined a 41-deep `replace(replace(... lower(...) ...))`
+-- chain everywhere it derived a slot_key from a header / param / oauth
+-- scheme name. bun:sqlite's lemon parser stack overflows on that depth on
+-- platforms with smaller thread stacks (notably the compiled CLI binary on
+-- macOS), so we precompute slugs once into a temp table and reference them
+-- via flat scalar subqueries below.
+--
+CREATE TEMP TABLE `__slug_norm` (
+	`raw` text PRIMARY KEY,
+	`slug` text NOT NULL DEFAULT ''
+);--> statement-breakpoint
+
+INSERT OR IGNORE INTO `__slug_norm` (`raw`)
+SELECT DISTINCT `raw` FROM (
+	SELECT h.`key` AS `raw` FROM `openapi_source` s, json_each(s.`headers`) h
+		WHERE s.`headers` IS NOT NULL AND h.`type` = 'object'
+	UNION
+	SELECT json_extract(s.`oauth2`, '$.securitySchemeName') FROM `openapi_source` s
+		WHERE s.`oauth2` IS NOT NULL
+	UNION
+	SELECT `name` FROM `openapi_source_query_param` WHERE `name` IS NOT NULL
+	UNION
+	SELECT `name` FROM `openapi_source_spec_fetch_header` WHERE `name` IS NOT NULL
+	UNION
+	SELECT `name` FROM `openapi_source_spec_fetch_query_param` WHERE `name` IS NOT NULL
+	UNION
+	SELECT `name` FROM `graphql_source_header` WHERE `name` IS NOT NULL
+	UNION
+	SELECT `name` FROM `graphql_source_query_param` WHERE `name` IS NOT NULL
+	UNION
+	SELECT `name` FROM `mcp_source_header` WHERE `name` IS NOT NULL
+	UNION
+	SELECT `name` FROM `mcp_source_query_param` WHERE `name` IS NOT NULL
+) WHERE `raw` IS NOT NULL AND `raw` != '';--> statement-breakpoint
+
+UPDATE `__slug_norm` SET `slug` = lower(trim(`raw`));--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, char(9), '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, char(10), '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, char(13), '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, ' ', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '_', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '.', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, ':', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '/', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '@', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '+', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '&', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '?', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '#', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '%', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '$', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, ',', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, ';', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '(', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, ')', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '[', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, ']', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '{', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '}', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '=', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '~', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '!', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, char(34), '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, char(39), '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, char(92), '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '|', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '*', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '<', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '>', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = replace(`slug`, '--', '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = trim(`slug`, '-');--> statement-breakpoint
+UPDATE `__slug_norm` SET `slug` = CASE WHEN `slug` = '' THEN 'default' ELSE `slug` END;--> statement-breakpoint
+
+-- local scoped credential/source-slot/OAuth cutover.
+-- Squashes the PR-local migration chain into one runtime schema transition.
+-- 0008_add_credential_binding.sql
+CREATE TABLE `credential_binding` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`plugin_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`source_scope_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`secret_id` text,
+	`connection_id` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX `credential_binding_scope_id_idx` ON `credential_binding` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `credential_binding_plugin_id_idx` ON `credential_binding` (`plugin_id`);--> statement-breakpoint
+CREATE INDEX `credential_binding_source_id_idx` ON `credential_binding` (`source_id`);--> statement-breakpoint
+CREATE INDEX `credential_binding_source_scope_id_idx` ON `credential_binding` (`source_scope_id`);--> statement-breakpoint
+CREATE INDEX `credential_binding_slot_key_idx` ON `credential_binding` (`slot_key`);--> statement-breakpoint
+CREATE INDEX `credential_binding_kind_idx` ON `credential_binding` (`kind`);--> statement-breakpoint
+CREATE INDEX `credential_binding_secret_id_idx` ON `credential_binding` (`secret_id`);--> statement-breakpoint
+CREATE INDEX `credential_binding_connection_id_idx` ON `credential_binding` (`connection_id`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_openapi_source_binding` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source_id` text NOT NULL,
+	`source_scope_id` text NOT NULL,
+	`target_scope_id` text NOT NULL,
+	`slot` text NOT NULL,
+	`kind` text NOT NULL,
+	`secret_id` text,
+	`connection_id` text,
+	`text_value` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_openapi_source_binding`("id", "source_id", "source_scope_id", "target_scope_id", "slot", "kind", "secret_id", "connection_id", "text_value", "created_at", "updated_at") SELECT "id", "source_id", "source_scope_id", "target_scope_id", "slot", "kind", "secret_id", "connection_id", "text_value", "created_at", "updated_at" FROM `openapi_source_binding`;--> statement-breakpoint
+DROP TABLE `openapi_source_binding`;--> statement-breakpoint
+ALTER TABLE `__new_openapi_source_binding` RENAME TO `openapi_source_binding`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_source_id_idx` ON `openapi_source_binding` (`source_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_source_scope_id_idx` ON `openapi_source_binding` (`source_scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_target_scope_id_idx` ON `openapi_source_binding` (`target_scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_slot_idx` ON `openapi_source_binding` (`slot`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_secret_id_idx` ON `openapi_source_binding` (`secret_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_binding_connection_id_idx` ON `openapi_source_binding` (`connection_id`);--> statement-breakpoint
+
+-- 0009_migrate_openapi_source_bindings.sql
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`,
+	`scope_id`,
+	`plugin_id`,
+	`source_id`,
+	`source_scope_id`,
+	`slot_key`,
+	`kind`,
+	`text_value`,
+	`secret_id`,
+	`connection_id`,
+	`created_at`,
+	`updated_at`
+)
+SELECT
+	json_array('openapi', `source_scope_id`, `source_id`, `slot`),
+	`target_scope_id`,
+	'openapi',
+	`source_id`,
+	`source_scope_id`,
+	`slot`,
+	`kind`,
+	`text_value`,
+	`secret_id`,
+	`connection_id`,
+	`created_at`,
+	`updated_at`
+FROM `openapi_source_binding`;--> statement-breakpoint
+DROP TABLE `openapi_source_binding`;--> statement-breakpoint
+
+-- 0010_openapi_credential_slots.sql
+-- Convert OpenAPI's remaining direct credential references to source-owned
+-- slot structure plus shared core credential_binding rows. Runtime code only
+-- reads the final slot model; this migration is the one-shot bridge.
+
+-- Existing header JSON may still contain SecretBackedValue objects. Preserve
+-- the source-owned header names, move secret ids to credential_binding, and
+-- rewrite each object to { kind: "binding", slot, prefix? }.
+CREATE TEMP TABLE `__openapi_header_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__openapi_header_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	s.`scope_id`,
+	s.`id`,
+	'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`key`), 'default') AS `slot_key`
+FROM `openapi_source` s, json_each(s.`headers`) h
+WHERE s.`headers` IS NOT NULL
+  AND h.`type` = 'object'
+  AND json_extract(h.`value`, '$.kind') IS NULL
+  AND json_extract(h.`value`, '$.secretId') IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__openapi_header_slot_preflight`;--> statement-breakpoint
+
+WITH header_rows AS (
+	SELECT
+		s.`scope_id`,
+		s.`id` AS `source_id`,
+		h.`key` AS `name`,
+		'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`key`), 'default') AS `slot_key`,
+		json_extract(h.`value`, '$.secretId') AS `secret_id`
+	FROM `openapi_source` s, json_each(s.`headers`) h
+	WHERE s.`headers` IS NOT NULL
+	  AND h.`type` = 'object'
+	  AND json_extract(h.`value`, '$.kind') IS NULL
+	  AND json_extract(h.`value`, '$.secretId') IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM header_rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`slot_key`
+);--> statement-breakpoint
+
+UPDATE `openapi_source`
+SET `headers` = (
+	SELECT json_group_object(
+		h.`key`,
+		CASE
+			WHEN h.`type` = 'object'
+			  AND json_extract(h.`value`, '$.kind') IS NULL
+			  AND json_extract(h.`value`, '$.secretId') IS NOT NULL
+			  AND json_extract(h.`value`, '$.prefix') IS NOT NULL
+				THEN json_object(
+					'kind', 'binding',
+					'slot', 'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`key`), 'default'),
+					'prefix', json_extract(h.`value`, '$.prefix')
+				)
+			WHEN h.`type` = 'object'
+			  AND json_extract(h.`value`, '$.kind') IS NULL
+			  AND json_extract(h.`value`, '$.secretId') IS NOT NULL
+				THEN json_object(
+					'kind', 'binding',
+					'slot', 'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`key`), 'default')
+				)
+			WHEN h.`type` IN ('object', 'array') THEN json(h.`value`)
+			ELSE h.`value`
+		END
+	)
+	FROM json_each(`openapi_source`.`headers`) h
+)
+WHERE `headers` IS NOT NULL;--> statement-breakpoint
+
+-- OAuth2Auth JSON becomes OAuth2SourceConfig JSON plus explicit bindings for
+-- the client id, optional client secret, and live connection id.
+WITH oauth_rows AS (
+	SELECT
+		s.`scope_id`,
+		s.`id` AS `source_id`,
+		json_extract(s.`oauth2`, '$.securitySchemeName') AS `security_scheme_name`,
+		'oauth2:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = json_extract(s.`oauth2`, '$.securitySchemeName')), 'default') || ':client-id' AS `client_id_slot`,
+		json_extract(s.`oauth2`, '$.clientIdSecretId') AS `client_id_secret_id`,
+		json_extract(s.`oauth2`, '$.connectionId') AS `connection_id`
+	FROM `openapi_source` s
+	WHERE s.`oauth2` IS NOT NULL
+	  AND json_extract(s.`oauth2`, '$.connectionId') IS NOT NULL
+	  AND json_extract(s.`oauth2`, '$.clientIdSecretId') IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`client_id_slot`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`client_id_slot`,
+	'secret',
+	NULL,
+	r.`client_id_secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM oauth_rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`client_id_slot`
+);--> statement-breakpoint
+
+WITH oauth_rows AS (
+	SELECT
+		s.`scope_id`,
+		s.`id` AS `source_id`,
+		'oauth2:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = json_extract(s.`oauth2`, '$.securitySchemeName')), 'default') || ':client-secret' AS `client_secret_slot`,
+		json_extract(s.`oauth2`, '$.clientSecretSecretId') AS `client_secret_secret_id`
+	FROM `openapi_source` s
+	WHERE s.`oauth2` IS NOT NULL
+	  AND json_extract(s.`oauth2`, '$.connectionId') IS NOT NULL
+	  AND json_extract(s.`oauth2`, '$.clientSecretSecretId') IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`client_secret_slot`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`client_secret_slot`,
+	'secret',
+	NULL,
+	r.`client_secret_secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM oauth_rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`client_secret_slot`
+);--> statement-breakpoint
+
+WITH oauth_rows AS (
+	SELECT
+		s.`scope_id`,
+		s.`id` AS `source_id`,
+		'oauth2:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = json_extract(s.`oauth2`, '$.securitySchemeName')), 'default') || ':connection' AS `connection_slot`,
+		json_extract(s.`oauth2`, '$.connectionId') AS `connection_id`
+	FROM `openapi_source` s
+	WHERE s.`oauth2` IS NOT NULL
+	  AND json_extract(s.`oauth2`, '$.connectionId') IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`connection_slot`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`connection_slot`,
+	'connection',
+	NULL,
+	NULL,
+	r.`connection_id`,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM oauth_rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`connection_slot`
+);--> statement-breakpoint
+
+UPDATE `openapi_source`
+SET `oauth2` = json_object(
+	'kind', 'oauth2',
+	'securitySchemeName', json_extract(`oauth2`, '$.securitySchemeName'),
+	'flow', json_extract(`oauth2`, '$.flow'),
+	'tokenUrl', json_extract(`oauth2`, '$.tokenUrl'),
+	'authorizationUrl', json_extract(`oauth2`, '$.authorizationUrl'),
+	'issuerUrl', json_extract(`oauth2`, '$.issuerUrl'),
+	'clientIdSlot', 'oauth2:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = json_extract(`oauth2`, '$.securitySchemeName')), 'default') || ':client-id',
+	'clientSecretSlot',
+		CASE
+			WHEN json_extract(`oauth2`, '$.clientSecretSecretId') IS NULL THEN NULL
+			ELSE 'oauth2:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = json_extract(`oauth2`, '$.securitySchemeName')), 'default') || ':client-secret'
+		END,
+	'connectionSlot', 'oauth2:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = json_extract(`oauth2`, '$.securitySchemeName')), 'default') || ':connection',
+	'scopes', json(COALESCE(json_extract(`oauth2`, '$.scopes'), '[]'))
+)
+WHERE `oauth2` IS NOT NULL
+  AND json_extract(`oauth2`, '$.connectionId') IS NOT NULL;--> statement-breakpoint
+
+-- Child credential rows become source-owned binding slots.
+CREATE TEMP TABLE `__openapi_query_param_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__openapi_query_param_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	r.`scope_id`,
+	r.`source_id`,
+	'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = r.`name`), 'default') AS `slot_key`
+FROM `openapi_source_query_param` r
+WHERE r.`kind` = 'secret' AND r.`secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__openapi_query_param_slot_preflight`;--> statement-breakpoint
+
+WITH rows AS (
+	SELECT
+		r.`scope_id`,
+		r.`source_id`,
+		'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = r.`name`), 'default') AS `slot_key`,
+		r.`secret_id`
+	FROM `openapi_source_query_param` r
+	WHERE r.`kind` = 'secret' AND r.`secret_id` IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`slot_key`
+);--> statement-breakpoint
+
+ALTER TABLE `openapi_source_query_param` ADD `slot_key` text;--> statement-breakpoint
+ALTER TABLE `openapi_source_query_param` ADD `prefix` text;--> statement-breakpoint
+UPDATE `openapi_source_query_param`
+SET
+	`slot_key` = 'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = `name`), 'default'),
+	`prefix` = `secret_prefix`,
+	`kind` = 'binding'
+WHERE `kind` = 'secret';--> statement-breakpoint
+DROP INDEX `openapi_source_query_param_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `openapi_source_query_param` DROP COLUMN `secret_id`;--> statement-breakpoint
+ALTER TABLE `openapi_source_query_param` DROP COLUMN `secret_prefix`;--> statement-breakpoint
+
+CREATE TEMP TABLE `__openapi_spec_fetch_header_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__openapi_spec_fetch_header_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	r.`scope_id`,
+	r.`source_id`,
+	'spec_fetch_header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = r.`name`), 'default') AS `slot_key`
+FROM `openapi_source_spec_fetch_header` r
+WHERE r.`kind` = 'secret' AND r.`secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__openapi_spec_fetch_header_slot_preflight`;--> statement-breakpoint
+
+WITH rows AS (
+	SELECT
+		r.`scope_id`,
+		r.`source_id`,
+		'spec_fetch_header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = r.`name`), 'default') AS `slot_key`,
+		r.`secret_id`
+	FROM `openapi_source_spec_fetch_header` r
+	WHERE r.`kind` = 'secret' AND r.`secret_id` IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`slot_key`
+);--> statement-breakpoint
+
+ALTER TABLE `openapi_source_spec_fetch_header` ADD `slot_key` text;--> statement-breakpoint
+ALTER TABLE `openapi_source_spec_fetch_header` ADD `prefix` text;--> statement-breakpoint
+UPDATE `openapi_source_spec_fetch_header`
+SET
+	`slot_key` = 'spec_fetch_header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = `name`), 'default'),
+	`prefix` = `secret_prefix`,
+	`kind` = 'binding'
+WHERE `kind` = 'secret';--> statement-breakpoint
+DROP INDEX `openapi_source_spec_fetch_header_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `openapi_source_spec_fetch_header` DROP COLUMN `secret_id`;--> statement-breakpoint
+ALTER TABLE `openapi_source_spec_fetch_header` DROP COLUMN `secret_prefix`;--> statement-breakpoint
+
+CREATE TEMP TABLE `__openapi_spec_fetch_query_param_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__openapi_spec_fetch_query_param_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	r.`scope_id`,
+	r.`source_id`,
+	'spec_fetch_query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = r.`name`), 'default') AS `slot_key`
+FROM `openapi_source_spec_fetch_query_param` r
+WHERE r.`kind` = 'secret' AND r.`secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__openapi_spec_fetch_query_param_slot_preflight`;--> statement-breakpoint
+
+WITH rows AS (
+	SELECT
+		r.`scope_id`,
+		r.`source_id`,
+		'spec_fetch_query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = r.`name`), 'default') AS `slot_key`,
+		r.`secret_id`
+	FROM `openapi_source_spec_fetch_query_param` r
+	WHERE r.`kind` = 'secret' AND r.`secret_id` IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`slot_key`
+);--> statement-breakpoint
+
+ALTER TABLE `openapi_source_spec_fetch_query_param` ADD `slot_key` text;--> statement-breakpoint
+ALTER TABLE `openapi_source_spec_fetch_query_param` ADD `prefix` text;--> statement-breakpoint
+UPDATE `openapi_source_spec_fetch_query_param`
+SET
+	`slot_key` = 'spec_fetch_query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = `name`), 'default'),
+	`prefix` = `secret_prefix`,
+	`kind` = 'binding'
+WHERE `kind` = 'secret';--> statement-breakpoint
+DROP INDEX `openapi_source_spec_fetch_query_param_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `openapi_source_spec_fetch_query_param` DROP COLUMN `secret_id`;--> statement-breakpoint
+ALTER TABLE `openapi_source_spec_fetch_query_param` DROP COLUMN `secret_prefix`;--> statement-breakpoint
+
+-- 0011_graphql_credential_slots.sql
+-- Convert GraphQL's direct credential references to source-owned slot
+-- structure plus shared core credential_binding rows. Runtime code only
+-- reads the final slot model; this migration is the one-shot bridge.
+
+ALTER TABLE `graphql_source` ADD `auth_connection_slot` text;--> statement-breakpoint
+
+UPDATE `graphql_source`
+SET `auth_connection_slot` = 'auth:oauth2:connection'
+WHERE `auth_kind` = 'oauth2'
+  AND `auth_connection_id` IS NOT NULL;--> statement-breakpoint
+
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('graphql', s.`scope_id`, s.`id`, 'auth:oauth2:connection'),
+	s.`scope_id`,
+	'graphql',
+	s.`id`,
+	s.`scope_id`,
+	'auth:oauth2:connection',
+	'connection',
+	NULL,
+	NULL,
+	s.`auth_connection_id`,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM `graphql_source` s
+WHERE s.`auth_kind` = 'oauth2'
+  AND s.`auth_connection_id` IS NOT NULL;--> statement-breakpoint
+
+DROP INDEX `graphql_source_auth_connection_id_idx`;--> statement-breakpoint
+ALTER TABLE `graphql_source` DROP COLUMN `auth_connection_id`;--> statement-breakpoint
+
+ALTER TABLE `graphql_source_header` ADD `slot_key` text;--> statement-breakpoint
+ALTER TABLE `graphql_source_header` ADD `prefix` text;--> statement-breakpoint
+
+CREATE TEMP TABLE `__graphql_header_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__graphql_header_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	h.`scope_id`,
+	h.`source_id`,
+	'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`name`), 'default') AS `slot_key`
+FROM `graphql_source_header` h
+WHERE h.`kind` = 'secret'
+  AND h.`secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__graphql_header_slot_preflight`;--> statement-breakpoint
+
+WITH header_rows AS (
+	SELECT
+		h.`scope_id`,
+		h.`source_id`,
+		h.`name`,
+		'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`name`), 'default') AS `slot_key`,
+		h.`secret_id`,
+		h.`secret_prefix`
+	FROM `graphql_source_header` h
+	WHERE h.`kind` = 'secret'
+	  AND h.`secret_id` IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('graphql', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'graphql',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM header_rows r;--> statement-breakpoint
+
+UPDATE `graphql_source_header`
+SET
+	`kind` = 'binding',
+	`slot_key` = 'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = `name`), 'default'),
+	`prefix` = `secret_prefix`,
+	`text_value` = NULL
+WHERE `kind` = 'secret'
+  AND `secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP INDEX `graphql_source_header_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `graphql_source_header` DROP COLUMN `secret_id`;--> statement-breakpoint
+ALTER TABLE `graphql_source_header` DROP COLUMN `secret_prefix`;--> statement-breakpoint
+
+ALTER TABLE `graphql_source_query_param` ADD `slot_key` text;--> statement-breakpoint
+ALTER TABLE `graphql_source_query_param` ADD `prefix` text;--> statement-breakpoint
+
+CREATE TEMP TABLE `__graphql_query_param_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__graphql_query_param_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	q.`scope_id`,
+	q.`source_id`,
+	'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = q.`name`), 'default') AS `slot_key`
+FROM `graphql_source_query_param` q
+WHERE q.`kind` = 'secret'
+  AND q.`secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__graphql_query_param_slot_preflight`;--> statement-breakpoint
+
+WITH query_param_rows AS (
+	SELECT
+		q.`scope_id`,
+		q.`source_id`,
+		q.`name`,
+		'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = q.`name`), 'default') AS `slot_key`,
+		q.`secret_id`,
+		q.`secret_prefix`
+	FROM `graphql_source_query_param` q
+	WHERE q.`kind` = 'secret'
+	  AND q.`secret_id` IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('graphql', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'graphql',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM query_param_rows r;--> statement-breakpoint
+
+UPDATE `graphql_source_query_param`
+SET
+	`kind` = 'binding',
+	`slot_key` = 'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = `name`), 'default'),
+	`prefix` = `secret_prefix`,
+	`text_value` = NULL
+WHERE `kind` = 'secret'
+  AND `secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP INDEX `graphql_source_query_param_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `graphql_source_query_param` DROP COLUMN `secret_id`;--> statement-breakpoint
+ALTER TABLE `graphql_source_query_param` DROP COLUMN `secret_prefix`;--> statement-breakpoint
+
+-- 0012_mcp_credential_slots.sql
+-- Convert MCP direct credential references to source-owned slot structure
+-- plus shared core credential_binding rows. Runtime code only reads the
+-- final slot model; this migration is the one-shot bridge from old data.
+
+ALTER TABLE `mcp_source` ADD `auth_header_slot` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_header_prefix` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_connection_slot` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_client_id_slot` text;--> statement-breakpoint
+ALTER TABLE `mcp_source` ADD `auth_client_secret_slot` text;--> statement-breakpoint
+
+UPDATE `mcp_source`
+SET
+	`auth_header_slot` = 'auth:header',
+	`auth_header_prefix` = `auth_secret_prefix`
+WHERE `auth_kind` = 'header'
+  AND `auth_secret_id` IS NOT NULL;--> statement-breakpoint
+
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('mcp', s.`scope_id`, s.`id`, 'auth:header'),
+	s.`scope_id`,
+	'mcp',
+	s.`id`,
+	s.`scope_id`,
+	'auth:header',
+	'secret',
+	NULL,
+	s.`auth_secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM `mcp_source` s
+WHERE s.`auth_kind` = 'header'
+  AND s.`auth_secret_id` IS NOT NULL;--> statement-breakpoint
+
+UPDATE `mcp_source`
+SET
+	`auth_connection_slot` = 'auth:oauth2:connection',
+	`auth_client_id_slot` = CASE
+		WHEN `auth_client_id_secret_id` IS NOT NULL THEN 'auth:oauth2:client-id'
+		ELSE NULL
+	END,
+	`auth_client_secret_slot` = CASE
+		WHEN `auth_client_secret_secret_id` IS NOT NULL THEN 'auth:oauth2:client-secret'
+		ELSE NULL
+	END
+WHERE `auth_kind` = 'oauth2'
+  AND `auth_connection_id` IS NOT NULL;--> statement-breakpoint
+
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('mcp', s.`scope_id`, s.`id`, 'auth:oauth2:connection'),
+	s.`scope_id`,
+	'mcp',
+	s.`id`,
+	s.`scope_id`,
+	'auth:oauth2:connection',
+	'connection',
+	NULL,
+	NULL,
+	s.`auth_connection_id`,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM `mcp_source` s
+WHERE s.`auth_kind` = 'oauth2'
+  AND s.`auth_connection_id` IS NOT NULL;--> statement-breakpoint
+
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('mcp', s.`scope_id`, s.`id`, 'auth:oauth2:client-id'),
+	s.`scope_id`,
+	'mcp',
+	s.`id`,
+	s.`scope_id`,
+	'auth:oauth2:client-id',
+	'secret',
+	NULL,
+	s.`auth_client_id_secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM `mcp_source` s
+WHERE s.`auth_kind` = 'oauth2'
+  AND s.`auth_client_id_secret_id` IS NOT NULL;--> statement-breakpoint
+
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('mcp', s.`scope_id`, s.`id`, 'auth:oauth2:client-secret'),
+	s.`scope_id`,
+	'mcp',
+	s.`id`,
+	s.`scope_id`,
+	'auth:oauth2:client-secret',
+	'secret',
+	NULL,
+	s.`auth_client_secret_secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM `mcp_source` s
+WHERE s.`auth_kind` = 'oauth2'
+  AND s.`auth_client_secret_secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP INDEX `mcp_source_auth_secret_id_idx`;--> statement-breakpoint
+DROP INDEX `mcp_source_auth_connection_id_idx`;--> statement-breakpoint
+DROP INDEX `mcp_source_auth_client_id_secret_id_idx`;--> statement-breakpoint
+DROP INDEX `mcp_source_auth_client_secret_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `mcp_source` DROP COLUMN `auth_secret_id`;--> statement-breakpoint
+ALTER TABLE `mcp_source` DROP COLUMN `auth_secret_prefix`;--> statement-breakpoint
+ALTER TABLE `mcp_source` DROP COLUMN `auth_connection_id`;--> statement-breakpoint
+ALTER TABLE `mcp_source` DROP COLUMN `auth_client_id_secret_id`;--> statement-breakpoint
+ALTER TABLE `mcp_source` DROP COLUMN `auth_client_secret_secret_id`;--> statement-breakpoint
+
+ALTER TABLE `mcp_source_header` ADD `slot_key` text;--> statement-breakpoint
+ALTER TABLE `mcp_source_header` ADD `prefix` text;--> statement-breakpoint
+
+CREATE TEMP TABLE `__mcp_header_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__mcp_header_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	h.`scope_id`,
+	h.`source_id`,
+	'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`name`), 'default') AS `slot_key`
+FROM `mcp_source_header` h
+WHERE h.`kind` = 'secret'
+  AND h.`secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__mcp_header_slot_preflight`;--> statement-breakpoint
+
+WITH header_rows AS (
+	SELECT
+		h.`scope_id`,
+		h.`source_id`,
+		h.`name`,
+		'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`name`), 'default') AS `slot_key`,
+		h.`secret_id`,
+		h.`secret_prefix`
+	FROM `mcp_source_header` h
+	WHERE h.`kind` = 'secret'
+	  AND h.`secret_id` IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('mcp', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'mcp',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM header_rows r;--> statement-breakpoint
+
+UPDATE `mcp_source_header`
+SET
+	`kind` = 'binding',
+	`slot_key` = 'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = `name`), 'default'),
+	`prefix` = `secret_prefix`,
+	`text_value` = NULL
+WHERE `kind` = 'secret'
+  AND `secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP INDEX `mcp_source_header_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `mcp_source_header` DROP COLUMN `secret_id`;--> statement-breakpoint
+ALTER TABLE `mcp_source_header` DROP COLUMN `secret_prefix`;--> statement-breakpoint
+
+ALTER TABLE `mcp_source_query_param` ADD `slot_key` text;--> statement-breakpoint
+ALTER TABLE `mcp_source_query_param` ADD `prefix` text;--> statement-breakpoint
+
+CREATE TEMP TABLE `__mcp_query_param_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__mcp_query_param_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	q.`scope_id`,
+	q.`source_id`,
+	'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = q.`name`), 'default') AS `slot_key`
+FROM `mcp_source_query_param` q
+WHERE q.`kind` = 'secret'
+  AND q.`secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP TABLE `__mcp_query_param_slot_preflight`;--> statement-breakpoint
+
+WITH query_param_rows AS (
+	SELECT
+		q.`scope_id`,
+		q.`source_id`,
+		q.`name`,
+		'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = q.`name`), 'default') AS `slot_key`,
+		q.`secret_id`,
+		q.`secret_prefix`
+	FROM `mcp_source_query_param` q
+	WHERE q.`kind` = 'secret'
+	  AND q.`secret_id` IS NOT NULL
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('mcp', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'mcp',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM query_param_rows r;--> statement-breakpoint
+
+UPDATE `mcp_source_query_param`
+SET
+	`kind` = 'binding',
+	`slot_key` = 'query_param:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = `name`), 'default'),
+	`prefix` = `secret_prefix`,
+	`text_value` = NULL
+WHERE `kind` = 'secret'
+  AND `secret_id` IS NOT NULL;--> statement-breakpoint
+
+DROP INDEX `mcp_source_query_param_secret_id_idx`;--> statement-breakpoint
+ALTER TABLE `mcp_source_query_param` DROP COLUMN `secret_id`;--> statement-breakpoint
+ALTER TABLE `mcp_source_query_param` DROP COLUMN `secret_prefix`;--> statement-breakpoint
+
+-- 0013_normalize_oauth_connections.sql
+-- Normalize pre-unified OAuth connection rows to the canonical core
+-- provider/provider_state shape. Runtime refresh only reads provider='oauth2'
+-- and provider_state.kind after this one-shot data migration.
+
+UPDATE `connection`
+SET
+  `provider` = 'oauth2',
+  `provider_state` = json_object(
+    'kind', CASE json_extract(`provider_state`, '$.flow')
+      WHEN 'authorizationCode' THEN 'authorization-code'
+      ELSE 'client-credentials'
+    END,
+    'tokenEndpoint', json_extract(`provider_state`, '$.tokenUrl'),
+    'issuerUrl', NULL,
+    'clientIdSecretId', json_extract(`provider_state`, '$.clientIdSecretId'),
+    'clientSecretSecretId', CASE json_extract(`provider_state`, '$.flow')
+      WHEN 'clientCredentials' THEN coalesce(json_extract(`provider_state`, '$.clientSecretSecretId'), '')
+      ELSE json_extract(`provider_state`, '$.clientSecretSecretId')
+    END,
+    'clientAuth', 'body',
+    'scopes', coalesce(json_extract(`provider_state`, '$.scopes'), json('[]')),
+    'scope', `scope`
+  ),
+  `updated_at` = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE `provider` = 'openapi:oauth2'
+  AND json_extract(`provider_state`, '$.flow') IN ('authorizationCode', 'clientCredentials');--> statement-breakpoint
+
+UPDATE `connection`
+SET
+  `provider` = 'oauth2',
+  `provider_state` = json_object(
+    'kind', 'dynamic-dcr',
+    'tokenEndpoint', coalesce(
+      json_extract(`provider_state`, '$.tokenEndpoint'),
+      json_extract(`provider_state`, '$.authorizationServerMetadata.token_endpoint'),
+      ''
+    ),
+    'issuerUrl', json_extract(`provider_state`, '$.authorizationServerMetadata.issuer'),
+    'authorizationServerUrl', json_extract(`provider_state`, '$.authorizationServerUrl'),
+    'authorizationServerMetadataUrl', json_extract(`provider_state`, '$.authorizationServerMetadataUrl'),
+    'idTokenSigningAlgValuesSupported', coalesce(
+      json_extract(`provider_state`, '$.authorizationServerMetadata.id_token_signing_alg_values_supported'),
+      json('[]')
+    ),
+    'clientId', coalesce(json_extract(`provider_state`, '$.clientInformation.client_id'), ''),
+    'clientSecretSecretId', NULL,
+    'clientAuth', CASE json_extract(`provider_state`, '$.clientInformation.token_endpoint_auth_method')
+      WHEN 'client_secret_basic' THEN 'basic'
+      ELSE 'body'
+    END,
+    'scopes', json('[]'),
+    'scope', `scope`,
+    'resource', json_extract(`provider_state`, '$.endpoint')
+  ),
+  `updated_at` = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE `provider` = 'mcp:oauth2';--> statement-breakpoint
+
+UPDATE `connection`
+SET
+  `provider` = 'oauth2',
+  `provider_state` = json_object(
+    'kind', 'authorization-code',
+    'tokenEndpoint', 'https://oauth2.googleapis.com/token',
+    'issuerUrl', 'https://accounts.google.com',
+    'clientIdSecretId', json_extract(`provider_state`, '$.clientIdSecretId'),
+    'clientSecretSecretId', json_extract(`provider_state`, '$.clientSecretSecretId'),
+    'clientAuth', 'body',
+    'scopes', coalesce(json_extract(`provider_state`, '$.scopes'), json('[]')),
+    'scope', `scope`
+  ),
+  `updated_at` = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE `provider` IN ('google-discovery:google', 'google-discovery:oauth2');--> statement-breakpoint
+
+-- 0014_openapi_header_rows.sql
+-- Move OpenAPI request headers out of openapi_source.headers JSON and into
+-- the same child-row slot model used by query params and spec-fetch
+-- credentials. Runtime code reads only openapi_source_header after this.
+
+CREATE TABLE `openapi_source_header` (
+	`id` text NOT NULL,
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kind` text NOT NULL,
+	`text_value` text,
+	`slot_key` text,
+	`prefix` text,
+	PRIMARY KEY(`scope_id`, `id`)
+);--> statement-breakpoint
+CREATE INDEX `openapi_source_header_scope_id_idx` ON `openapi_source_header` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `openapi_source_header_source_id_idx` ON `openapi_source_header` (`source_id`);--> statement-breakpoint
+
+CREATE TEMP TABLE `__openapi_header_row_slot_preflight` (
+	`scope_id` text NOT NULL,
+	`source_id` text NOT NULL,
+	`slot_key` text NOT NULL,
+	PRIMARY KEY (`scope_id`, `source_id`, `slot_key`)
+);--> statement-breakpoint
+
+INSERT INTO `__openapi_header_row_slot_preflight` (`scope_id`, `source_id`, `slot_key`)
+SELECT
+	s.`scope_id`,
+	s.`id`,
+	'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`key`), 'default') AS `slot_key`
+FROM `openapi_source` s, json_each(s.`headers`) h
+WHERE s.`headers` IS NOT NULL
+  AND h.`type` = 'object'
+  AND json_extract(h.`value`, '$.secretId') IS NOT NULL
+  AND COALESCE(json_extract(h.`value`, '$.kind'), 'secret') = 'secret';--> statement-breakpoint
+
+DROP TABLE `__openapi_header_row_slot_preflight`;--> statement-breakpoint
+
+WITH header_rows AS (
+	SELECT
+		s.`scope_id`,
+		s.`id` AS `source_id`,
+		h.`key` AS `name`,
+		'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`key`), 'default') AS `slot_key`,
+		json_extract(h.`value`, '$.secretId') AS `secret_id`
+	FROM `openapi_source` s, json_each(s.`headers`) h
+	WHERE s.`headers` IS NOT NULL
+	  AND h.`type` = 'object'
+	  AND json_extract(h.`value`, '$.secretId') IS NOT NULL
+	  AND COALESCE(json_extract(h.`value`, '$.kind'), 'secret') = 'secret'
+)
+INSERT OR REPLACE INTO `credential_binding` (
+	`id`, `scope_id`, `plugin_id`, `source_id`, `source_scope_id`, `slot_key`,
+	`kind`, `text_value`, `secret_id`, `connection_id`, `created_at`, `updated_at`
+)
+SELECT
+	json_array('openapi', r.`scope_id`, r.`source_id`, r.`slot_key`),
+	r.`scope_id`,
+	'openapi',
+	r.`source_id`,
+	r.`scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM header_rows r
+WHERE NOT EXISTS (
+	SELECT 1 FROM `credential_binding` b
+	WHERE b.`scope_id` = r.`scope_id`
+	  AND b.`plugin_id` = 'openapi'
+	  AND b.`source_id` = r.`source_id`
+	  AND b.`source_scope_id` = r.`scope_id`
+	  AND b.`slot_key` = r.`slot_key`
+);--> statement-breakpoint
+
+INSERT OR REPLACE INTO `openapi_source_header` (
+	`id`, `scope_id`, `source_id`, `name`, `kind`, `text_value`, `slot_key`, `prefix`
+)
+SELECT
+	json_array(s.`id`, h.`key`),
+	s.`scope_id`,
+	s.`id`,
+	h.`key`,
+	CASE
+		WHEN h.`type` = 'text' THEN 'text'
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.kind') = 'text' THEN 'text'
+		ELSE 'binding'
+	END,
+	CASE
+		WHEN h.`type` = 'text' THEN h.`value`
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.kind') = 'text'
+			THEN json_extract(h.`value`, '$.text')
+		ELSE NULL
+	END,
+	CASE
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.kind') = 'binding'
+			THEN json_extract(h.`value`, '$.slot')
+		WHEN h.`type` = 'object' AND json_extract(h.`value`, '$.secretId') IS NOT NULL
+			THEN 'header:' || COALESCE((SELECT `slug` FROM `__slug_norm` WHERE `raw` = h.`key`), 'default')
+		ELSE NULL
+	END,
+	CASE
+		WHEN h.`type` = 'object'
+			THEN COALESCE(json_extract(h.`value`, '$.prefix'), json_extract(h.`value`, '$.secretPrefix'))
+		ELSE NULL
+	END
+FROM `openapi_source` s, json_each(s.`headers`) h
+WHERE s.`headers` IS NOT NULL
+  AND (
+	h.`type` = 'text'
+	OR (
+		h.`type` = 'object'
+		AND (
+			json_extract(h.`value`, '$.kind') IN ('binding', 'text')
+			OR json_extract(h.`value`, '$.secretId') IS NOT NULL
+		)
+	)
+);--> statement-breakpoint
+
+ALTER TABLE `openapi_source` DROP COLUMN `headers`;
+
+--> statement-breakpoint
+DROP TABLE `__slug_norm`;

--- a/apps/local/drizzle-legacy-v1/0009_repair_openapi_oauth_cutover_residue.sql
+++ b/apps/local/drizzle-legacy-v1/0009_repair_openapi_oauth_cutover_residue.sql
@@ -1,0 +1,253 @@
+-- Repair OpenAPI OAuth residue from the scoped-credential cutover.
+
+UPDATE `connection`
+SET `provider` = 'oauth2',
+    `updated_at` = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE `provider` = 'openapi:oauth2'
+  AND json_extract(`provider_state`, '$.kind') IS NOT NULL;--> statement-breakpoint
+
+WITH oauth_connections AS (
+	SELECT
+		b.`scope_id`,
+		b.`id` AS `binding_id`,
+		b.`plugin_id`,
+		b.`source_id`,
+		b.`source_scope_id`,
+		json_extract(s.`oauth2`, '$.clientIdSlot') AS `slot_key`,
+		json_extract(c.`provider_state`, '$.clientIdSecretId') AS `secret_id`,
+		b.`created_at`
+	FROM `credential_binding` b
+	JOIN `openapi_source` s
+	  ON s.`id` = b.`source_id`
+	 AND s.`scope_id` = b.`source_scope_id`
+	JOIN `connection` c
+	  ON c.`id` = b.`connection_id`
+	 AND c.`scope_id` = b.`scope_id`
+	WHERE b.`plugin_id` = 'openapi'
+	  AND b.`kind` = 'connection'
+	  AND s.`oauth2` IS NOT NULL
+	  AND c.`provider` = 'oauth2'
+	  AND json_extract(c.`provider_state`, '$.clientIdSecretId') IS NOT NULL
+	  AND coalesce(json_extract(c.`provider_state`, '$.clientIdSecretId'), '') <> ''
+)
+UPDATE `credential_binding`
+SET
+	`secret_id` = (
+		SELECT r.`secret_id`
+		FROM oauth_connections r
+		WHERE r.`scope_id` = `credential_binding`.`scope_id`
+		  AND r.`plugin_id` = `credential_binding`.`plugin_id`
+		  AND r.`source_id` = `credential_binding`.`source_id`
+		  AND r.`source_scope_id` = `credential_binding`.`source_scope_id`
+		  AND r.`slot_key` = `credential_binding`.`slot_key`
+		LIMIT 1
+	),
+	`text_value` = NULL,
+	`connection_id` = NULL,
+	`updated_at` = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE `kind` = 'secret'
+  AND EXISTS (
+		SELECT 1
+		FROM oauth_connections r
+		WHERE r.`scope_id` = `credential_binding`.`scope_id`
+		  AND r.`plugin_id` = `credential_binding`.`plugin_id`
+		  AND r.`source_id` = `credential_binding`.`source_id`
+		  AND r.`source_scope_id` = `credential_binding`.`source_scope_id`
+		  AND r.`slot_key` = `credential_binding`.`slot_key`
+	);--> statement-breakpoint
+
+WITH oauth_connections AS (
+	SELECT
+		b.`scope_id`,
+		b.`id` AS `binding_id`,
+		b.`plugin_id`,
+		b.`source_id`,
+		b.`source_scope_id`,
+		json_extract(s.`oauth2`, '$.clientIdSlot') AS `slot_key`,
+		json_extract(c.`provider_state`, '$.clientIdSecretId') AS `secret_id`,
+		b.`created_at`
+	FROM `credential_binding` b
+	JOIN `openapi_source` s
+	  ON s.`id` = b.`source_id`
+	 AND s.`scope_id` = b.`source_scope_id`
+	JOIN `connection` c
+	  ON c.`id` = b.`connection_id`
+	 AND c.`scope_id` = b.`scope_id`
+	WHERE b.`plugin_id` = 'openapi'
+	  AND b.`kind` = 'connection'
+	  AND s.`oauth2` IS NOT NULL
+	  AND c.`provider` = 'oauth2'
+	  AND json_extract(c.`provider_state`, '$.clientIdSecretId') IS NOT NULL
+	  AND coalesce(json_extract(c.`provider_state`, '$.clientIdSecretId'), '') <> ''
+)
+INSERT INTO `credential_binding` (
+	`id`,
+	`scope_id`,
+	`plugin_id`,
+	`source_id`,
+	`source_scope_id`,
+	`slot_key`,
+	`kind`,
+	`text_value`,
+	`secret_id`,
+	`connection_id`,
+	`created_at`,
+	`updated_at`
+)
+SELECT
+	json_array('oconn-openapi-oauth-client', r.`binding_id`, r.`scope_id`, r.`slot_key`),
+	r.`scope_id`,
+	r.`plugin_id`,
+	r.`source_id`,
+	r.`source_scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	r.`created_at`,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM oauth_connections r
+WHERE r.`slot_key` IS NOT NULL
+  AND NOT EXISTS (
+		SELECT 1
+		FROM `credential_binding` existing
+		WHERE existing.`scope_id` = r.`scope_id`
+		  AND existing.`plugin_id` = r.`plugin_id`
+		  AND existing.`source_id` = r.`source_id`
+		  AND existing.`source_scope_id` = r.`source_scope_id`
+		  AND existing.`slot_key` = r.`slot_key`
+	)
+ON CONFLICT(`scope_id`, `id`) DO UPDATE SET
+	`plugin_id` = excluded.`plugin_id`,
+	`source_id` = excluded.`source_id`,
+	`source_scope_id` = excluded.`source_scope_id`,
+	`slot_key` = excluded.`slot_key`,
+	`kind` = excluded.`kind`,
+	`text_value` = excluded.`text_value`,
+	`secret_id` = excluded.`secret_id`,
+	`connection_id` = excluded.`connection_id`,
+	`updated_at` = excluded.`updated_at`;--> statement-breakpoint
+
+WITH oauth_connections AS (
+	SELECT
+		b.`scope_id`,
+		b.`id` AS `binding_id`,
+		b.`plugin_id`,
+		b.`source_id`,
+		b.`source_scope_id`,
+		json_extract(s.`oauth2`, '$.clientSecretSlot') AS `slot_key`,
+		json_extract(c.`provider_state`, '$.clientSecretSecretId') AS `secret_id`,
+		b.`created_at`
+	FROM `credential_binding` b
+	JOIN `openapi_source` s
+	  ON s.`id` = b.`source_id`
+	 AND s.`scope_id` = b.`source_scope_id`
+	JOIN `connection` c
+	  ON c.`id` = b.`connection_id`
+	 AND c.`scope_id` = b.`scope_id`
+	WHERE b.`plugin_id` = 'openapi'
+	  AND b.`kind` = 'connection'
+	  AND s.`oauth2` IS NOT NULL
+	  AND c.`provider` = 'oauth2'
+	  AND json_extract(c.`provider_state`, '$.clientSecretSecretId') IS NOT NULL
+	  AND coalesce(json_extract(c.`provider_state`, '$.clientSecretSecretId'), '') <> ''
+)
+UPDATE `credential_binding`
+SET
+	`secret_id` = (
+		SELECT r.`secret_id`
+		FROM oauth_connections r
+		WHERE r.`scope_id` = `credential_binding`.`scope_id`
+		  AND r.`plugin_id` = `credential_binding`.`plugin_id`
+		  AND r.`source_id` = `credential_binding`.`source_id`
+		  AND r.`source_scope_id` = `credential_binding`.`source_scope_id`
+		  AND r.`slot_key` = `credential_binding`.`slot_key`
+		LIMIT 1
+	),
+	`text_value` = NULL,
+	`connection_id` = NULL,
+	`updated_at` = CAST(strftime('%s', 'now') AS INTEGER) * 1000
+WHERE `kind` = 'secret'
+  AND EXISTS (
+		SELECT 1
+		FROM oauth_connections r
+		WHERE r.`scope_id` = `credential_binding`.`scope_id`
+		  AND r.`plugin_id` = `credential_binding`.`plugin_id`
+		  AND r.`source_id` = `credential_binding`.`source_id`
+		  AND r.`source_scope_id` = `credential_binding`.`source_scope_id`
+		  AND r.`slot_key` = `credential_binding`.`slot_key`
+	);--> statement-breakpoint
+
+WITH oauth_connections AS (
+	SELECT
+		b.`scope_id`,
+		b.`id` AS `binding_id`,
+		b.`plugin_id`,
+		b.`source_id`,
+		b.`source_scope_id`,
+		json_extract(s.`oauth2`, '$.clientSecretSlot') AS `slot_key`,
+		json_extract(c.`provider_state`, '$.clientSecretSecretId') AS `secret_id`,
+		b.`created_at`
+	FROM `credential_binding` b
+	JOIN `openapi_source` s
+	  ON s.`id` = b.`source_id`
+	 AND s.`scope_id` = b.`source_scope_id`
+	JOIN `connection` c
+	  ON c.`id` = b.`connection_id`
+	 AND c.`scope_id` = b.`scope_id`
+	WHERE b.`plugin_id` = 'openapi'
+	  AND b.`kind` = 'connection'
+	  AND s.`oauth2` IS NOT NULL
+	  AND c.`provider` = 'oauth2'
+	  AND json_extract(c.`provider_state`, '$.clientSecretSecretId') IS NOT NULL
+	  AND coalesce(json_extract(c.`provider_state`, '$.clientSecretSecretId'), '') <> ''
+)
+INSERT INTO `credential_binding` (
+	`id`,
+	`scope_id`,
+	`plugin_id`,
+	`source_id`,
+	`source_scope_id`,
+	`slot_key`,
+	`kind`,
+	`text_value`,
+	`secret_id`,
+	`connection_id`,
+	`created_at`,
+	`updated_at`
+)
+SELECT
+	json_array('oconn-openapi-oauth-secret', r.`binding_id`, r.`scope_id`, r.`slot_key`),
+	r.`scope_id`,
+	r.`plugin_id`,
+	r.`source_id`,
+	r.`source_scope_id`,
+	r.`slot_key`,
+	'secret',
+	NULL,
+	r.`secret_id`,
+	NULL,
+	r.`created_at`,
+	CAST(strftime('%s', 'now') AS INTEGER) * 1000
+FROM oauth_connections r
+WHERE r.`slot_key` IS NOT NULL
+  AND NOT EXISTS (
+		SELECT 1
+		FROM `credential_binding` existing
+		WHERE existing.`scope_id` = r.`scope_id`
+		  AND existing.`plugin_id` = r.`plugin_id`
+		  AND existing.`source_id` = r.`source_id`
+		  AND existing.`source_scope_id` = r.`source_scope_id`
+		  AND existing.`slot_key` = r.`slot_key`
+	)
+ON CONFLICT(`scope_id`, `id`) DO UPDATE SET
+	`plugin_id` = excluded.`plugin_id`,
+	`source_id` = excluded.`source_id`,
+	`source_scope_id` = excluded.`source_scope_id`,
+	`slot_key` = excluded.`slot_key`,
+	`kind` = excluded.`kind`,
+	`text_value` = excluded.`text_value`,
+	`secret_id` = excluded.`secret_id`,
+	`connection_id` = excluded.`connection_id`,
+	`updated_at` = excluded.`updated_at`;

--- a/apps/local/drizzle-legacy-v1/0010_add_credential_binding_secret_scope.sql
+++ b/apps/local/drizzle-legacy-v1/0010_add_credential_binding_secret_scope.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `credential_binding` ADD COLUMN `secret_scope_id` text;--> statement-breakpoint
+CREATE INDEX `credential_binding_secret_scope_id_idx` ON `credential_binding` (`secret_scope_id`);

--- a/apps/local/drizzle-legacy-v1/0011_plugin_storage_sources.sql
+++ b/apps/local/drizzle-legacy-v1/0011_plugin_storage_sources.sql
@@ -1,0 +1,215 @@
+CREATE TABLE IF NOT EXISTS `openapi_source` (`id` text NOT NULL, `scope_id` text NOT NULL, `name` text NOT NULL, `spec` text NOT NULL, `source_url` text, `base_url` text, `oauth2` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `openapi_operation` (`id` text NOT NULL, `scope_id` text NOT NULL, `source_id` text NOT NULL, `binding` text NOT NULL);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `openapi_source_header` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `openapi_source_query_param` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `openapi_source_spec_fetch_header` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `openapi_source_spec_fetch_query_param` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `graphql_source` (`id` text NOT NULL, `scope_id` text NOT NULL, `name` text NOT NULL, `endpoint` text NOT NULL, `auth_kind` text NOT NULL DEFAULT 'none', `auth_connection_slot` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `graphql_source_header` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `graphql_source_query_param` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `graphql_operation` (`id` text NOT NULL, `scope_id` text NOT NULL, `source_id` text NOT NULL, `binding` text NOT NULL);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `mcp_source` (`id` text NOT NULL, `scope_id` text NOT NULL, `name` text NOT NULL, `config` text NOT NULL, `auth_kind` text NOT NULL DEFAULT 'none', `auth_header_name` text, `auth_header_slot` text, `auth_header_prefix` text, `auth_connection_slot` text, `auth_client_id_slot` text, `auth_client_secret_slot` text, `created_at` integer);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `mcp_source_header` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `mcp_source_query_param` (`id` text, `scope_id` text, `source_id` text, `name` text, `kind` text, `text_value` text, `slot_key` text, `prefix` text);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `mcp_binding` (`id` text NOT NULL, `scope_id` text NOT NULL, `source_id` text NOT NULL, `binding` text NOT NULL, `created_at` integer);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `plugin_storage` (
+  `id` text NOT NULL,
+  `scope_id` text NOT NULL,
+  `plugin_id` text NOT NULL,
+  `collection` text NOT NULL,
+  `key` text NOT NULL,
+  `data` text NOT NULL,
+  `created_at` integer NOT NULL,
+  `updated_at` integer NOT NULL,
+  PRIMARY KEY(`scope_id`, `id`)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `plugin_storage_scope_id_idx` ON `plugin_storage` (`scope_id`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `plugin_storage_plugin_id_collection_idx` ON `plugin_storage` (`plugin_id`, `collection`);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `plugin_storage_key_idx` ON `plugin_storage` (`key`);
+--> statement-breakpoint
+INSERT OR REPLACE INTO `plugin_storage` (`id`, `scope_id`, `plugin_id`, `collection`, `key`, `data`, `created_at`, `updated_at`)
+SELECT
+  json_array('openapi', 'source', s.`id`),
+  s.`scope_id`,
+  'openapi',
+  'source',
+  s.`id`,
+  json_object(
+    'namespace', s.`id`,
+    'scope', s.`scope_id`,
+    'name', s.`name`,
+    'config', json_patch(
+      json_patch(
+        json_patch(
+          json_patch(
+            json_patch(
+              json_patch(
+                json_object('spec', s.`spec`),
+                CASE WHEN s.`source_url` IS NULL THEN json_object() ELSE json_object('sourceUrl', s.`source_url`) END
+              ),
+              CASE WHEN s.`base_url` IS NULL THEN json_object() ELSE json_object('baseUrl', s.`base_url`) END
+            ),
+            CASE WHEN h.`headers` IS NULL THEN json_object() ELSE json_object('headers', json(h.`headers`)) END
+          ),
+          CASE WHEN q.`queryParams` IS NULL THEN json_object() ELSE json_object('queryParams', json(q.`queryParams`)) END
+        ),
+        CASE WHEN sfh.`headers` IS NULL AND sfq.`queryParams` IS NULL THEN json_object() ELSE json_object('specFetchCredentials', json_patch(
+          CASE WHEN sfh.`headers` IS NULL THEN json_object() ELSE json_object('headers', json(sfh.`headers`)) END,
+          CASE WHEN sfq.`queryParams` IS NULL THEN json_object() ELSE json_object('queryParams', json(sfq.`queryParams`)) END
+        )) END
+      ),
+      CASE WHEN s.`oauth2` IS NULL THEN json_object() ELSE json_object('oauth2', json(s.`oauth2`)) END
+    )
+  ),
+  unixepoch('now') * 1000,
+  unixepoch('now') * 1000
+FROM `openapi_source` s
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `headers`
+  FROM `openapi_source_header`
+  GROUP BY `scope_id`, `source_id`
+) h ON h.`scope_id` = s.`scope_id` AND h.`source_id` = s.`id`
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `queryParams`
+  FROM `openapi_source_query_param`
+  GROUP BY `scope_id`, `source_id`
+) q ON q.`scope_id` = s.`scope_id` AND q.`source_id` = s.`id`
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `headers`
+  FROM `openapi_source_spec_fetch_header`
+  GROUP BY `scope_id`, `source_id`
+) sfh ON sfh.`scope_id` = s.`scope_id` AND sfh.`source_id` = s.`id`
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `queryParams`
+  FROM `openapi_source_spec_fetch_query_param`
+  GROUP BY `scope_id`, `source_id`
+) sfq ON sfq.`scope_id` = s.`scope_id` AND sfq.`source_id` = s.`id`;
+--> statement-breakpoint
+INSERT OR REPLACE INTO `plugin_storage` (`id`, `scope_id`, `plugin_id`, `collection`, `key`, `data`, `created_at`, `updated_at`)
+SELECT json_array('openapi', 'operation', o.`id`), o.`scope_id`, 'openapi', 'operation', o.`id`, json_object('toolId', o.`id`, 'sourceId', o.`source_id`, 'binding', json(o.`binding`)), unixepoch('now') * 1000, unixepoch('now') * 1000
+FROM `openapi_operation` o;
+--> statement-breakpoint
+INSERT OR REPLACE INTO `plugin_storage` (`id`, `scope_id`, `plugin_id`, `collection`, `key`, `data`, `created_at`, `updated_at`)
+SELECT
+  json_array('graphql', 'source', s.`id`),
+  s.`scope_id`,
+  'graphql',
+  'source',
+  s.`id`,
+  json_object(
+    'namespace', s.`id`,
+    'scope', s.`scope_id`,
+    'name', s.`name`,
+    'endpoint', s.`endpoint`,
+    'headers', COALESCE(json(h.`headers`), json_object()),
+    'queryParams', COALESCE(json(q.`queryParams`), json_object()),
+    'auth', CASE WHEN s.`auth_kind` = 'oauth2' AND s.`auth_connection_slot` IS NOT NULL THEN json_object('kind', 'oauth2', 'connectionSlot', s.`auth_connection_slot`) ELSE json_object('kind', 'none') END
+  ),
+  unixepoch('now') * 1000,
+  unixepoch('now') * 1000
+FROM `graphql_source` s
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `headers`
+  FROM `graphql_source_header`
+  GROUP BY `scope_id`, `source_id`
+) h ON h.`scope_id` = s.`scope_id` AND h.`source_id` = s.`id`
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `queryParams`
+  FROM `graphql_source_query_param`
+  GROUP BY `scope_id`, `source_id`
+) q ON q.`scope_id` = s.`scope_id` AND q.`source_id` = s.`id`;
+--> statement-breakpoint
+INSERT OR REPLACE INTO `plugin_storage` (`id`, `scope_id`, `plugin_id`, `collection`, `key`, `data`, `created_at`, `updated_at`)
+SELECT json_array('graphql', 'operation', o.`id`), o.`scope_id`, 'graphql', 'operation', o.`id`, json_object('toolId', o.`id`, 'sourceId', o.`source_id`, 'binding', json(o.`binding`)), unixepoch('now') * 1000, unixepoch('now') * 1000
+FROM `graphql_operation` o;
+--> statement-breakpoint
+INSERT OR REPLACE INTO `plugin_storage` (`id`, `scope_id`, `plugin_id`, `collection`, `key`, `data`, `created_at`, `updated_at`)
+SELECT
+  json_array('mcp', 'source', s.`id`),
+  s.`scope_id`,
+  'mcp',
+  'source',
+  s.`id`,
+  json_object(
+    'namespace', s.`id`,
+    'scope', s.`scope_id`,
+    'name', s.`name`,
+    'config', CASE WHEN json_extract(s.`config`, '$.transport') = 'remote' THEN json_patch(
+      json_patch(
+        json_patch(
+          json(s.`config`),
+          CASE WHEN h.`headers` IS NULL THEN json_object() ELSE json_object('headers', json(h.`headers`)) END
+        ),
+        CASE WHEN q.`queryParams` IS NULL THEN json_object() ELSE json_object('queryParams', json(q.`queryParams`)) END
+      ),
+      json_object('auth',
+        CASE
+          WHEN s.`auth_kind` = 'header' THEN json_object('kind', 'header', 'headerName', COALESCE(s.`auth_header_name`, ''), 'secretSlot', s.`auth_header_slot`, 'prefix', s.`auth_header_prefix`)
+          WHEN s.`auth_kind` = 'oauth2' THEN json_object('kind', 'oauth2', 'connectionSlot', s.`auth_connection_slot`, 'clientIdSlot', s.`auth_client_id_slot`, 'clientSecretSlot', s.`auth_client_secret_slot`)
+          ELSE json_object('kind', 'none')
+        END
+      )
+    ) ELSE json(s.`config`) END
+  ),
+  unixepoch('now') * 1000,
+  unixepoch('now') * 1000
+FROM `mcp_source` s
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `headers`
+  FROM `mcp_source_header`
+  GROUP BY `scope_id`, `source_id`
+) h ON h.`scope_id` = s.`scope_id` AND h.`source_id` = s.`id`
+LEFT JOIN (
+  SELECT `scope_id`, `source_id`, json_group_object(`name`, CASE WHEN `kind` = 'text' THEN json_quote(`text_value`) ELSE json_object('kind', 'binding', 'slot', `slot_key`, 'prefix', `prefix`) END) AS `queryParams`
+  FROM `mcp_source_query_param`
+  GROUP BY `scope_id`, `source_id`
+) q ON q.`scope_id` = s.`scope_id` AND q.`source_id` = s.`id`;
+--> statement-breakpoint
+INSERT OR REPLACE INTO `plugin_storage` (`id`, `scope_id`, `plugin_id`, `collection`, `key`, `data`, `created_at`, `updated_at`)
+SELECT json_array('mcp', 'binding', b.`id`), b.`scope_id`, 'mcp', 'binding', b.`id`, json_object('namespace', b.`source_id`, 'toolId', b.`id`, 'binding', json(b.`binding`)), COALESCE(b.`created_at`, unixepoch('now') * 1000), unixepoch('now') * 1000
+FROM `mcp_binding` b;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `openapi_source`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `openapi_operation`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `openapi_source_header`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `openapi_source_query_param`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `openapi_source_spec_fetch_header`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `openapi_source_spec_fetch_query_param`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `graphql_source`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `graphql_source_header`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `graphql_source_query_param`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `graphql_operation`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `mcp_source`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `mcp_source_header`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `mcp_source_query_param`;
+--> statement-breakpoint
+DROP TABLE IF EXISTS `mcp_binding`;

--- a/apps/local/drizzle-legacy-v1/0012_connection_identity_override.sql
+++ b/apps/local/drizzle-legacy-v1/0012_connection_identity_override.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `connection` ADD `identity_override` text;

--- a/apps/local/drizzle-legacy-v1/meta/_journal.json
+++ b/apps/local/drizzle-legacy-v1/meta/_journal.json
@@ -1,0 +1,97 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1776367901699,
+      "tag": "0000_overconfident_sharon_carter",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776680432025,
+      "tag": "0001_sour_catseye",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776732062873,
+      "tag": "0002_lively_sue_storm",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1776976132767,
+      "tag": "0003_little_silk_fever",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777800000000,
+      "tag": "0004_add_tool_policy",
+      "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1777850000000,
+      "tag": "0005_repair_mcp_oauth_session",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1777850000001,
+      "tag": "0006_neat_terror",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1778100000000,
+      "tag": "0007_normalize_plugin_secret_refs",
+      "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1778128200000,
+      "tag": "0008_scoped_credentials_cutover",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1778192434062,
+      "tag": "0009_repair_openapi_oauth_cutover_residue",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1778192434063,
+      "tag": "0010_add_credential_binding_secret_scope",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1779087600000,
+      "tag": "0011_plugin_storage_sources",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1779998400000,
+      "tag": "0012_connection_identity_override",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/local/src/db/v1-v2-migration.test.ts
+++ b/apps/local/src/db/v1-v2-migration.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
 import { Buffer } from "node:buffer";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -14,6 +16,12 @@ import { migrateLocalV1ToV2IfNeeded } from "./v1-v2-migration";
 const AuthFile = Schema.Record(Schema.String, Schema.String);
 const decodeAuthFile = Schema.decodeUnknownSync(Schema.fromJsonString(AuthFile));
 const decodeUnknownJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+// Preserves every journal field (`when`, `breakpoints`, …) — drizzle's
+// migrator needs them, so only `entries` is typed for the truncation filter.
+const decodeJournal = (text: string) =>
+  decodeUnknownJson(text) as {
+    readonly entries: ReadonlyArray<{ readonly idx: number; readonly tag: string }>;
+  };
 
 let workDir: string;
 let previousXdgDataHome: string | undefined;
@@ -1105,6 +1113,77 @@ describe("local v1 -> v2 migration", () => {
         resource: "https://mcp.pscale.dev/mcp/planetscale",
       },
     ]);
+    client.close();
+  });
+
+  // Regression: a database last touched by a release OLDER than v1-final
+  // (pre-0011 — no `plugin_storage` table) must be replayed through the
+  // bundled legacy drizzle chain before the v1→v2 data migration reads it.
+  // Without the replay, migration crashed with "no such table: plugin_storage"
+  // on every fresh 1.5.0 install over old data.
+  it("replays the legacy drizzle chain for a v1 database that predates v1-final", async () => {
+    const scopeId = "executor-workspace-abcd1234";
+    const dataDir = join(workDir, "data");
+    const dbPath = join(dataDir, "data.db");
+    mkdirSync(dataDir, { recursive: true });
+
+    // Build a REAL pre-0011 v1 database: apply the vendored legacy chain
+    // truncated after 0010, so drizzle records the genuine hashes and the
+    // schema has per-plugin source tables but no `plugin_storage`.
+    const legacyDir = join(import.meta.dirname, "../../drizzle-legacy-v1");
+    const truncatedDir = join(workDir, "legacy-truncated");
+    mkdirSync(join(truncatedDir, "meta"), { recursive: true });
+    const journal = decodeJournal(
+      readFileSync(join(legacyDir, "meta", "_journal.json")).toString(),
+    );
+    const kept = journal.entries.filter((entry) => entry.idx <= 10);
+    for (const entry of kept) {
+      writeFileSync(
+        join(truncatedDir, `${entry.tag}.sql`),
+        readFileSync(join(legacyDir, `${entry.tag}.sql`)),
+      );
+    }
+    writeFileSync(
+      join(truncatedDir, "meta", "_journal.json"),
+      JSON.stringify({ ...journal, entries: kept }),
+    );
+
+    const seed = await openLocalLibsql(dbPath);
+    await migrate(drizzle({ client: seed }), { migrationsFolder: truncatedDir });
+    const missing = await seed.execute(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'plugin_storage'",
+    );
+    expect(missing.rows).toEqual([]); // genuinely pre-0011
+    const now = Date.now();
+    await executeSql(
+      seed,
+      "INSERT INTO source (id, scope_id, plugin_id, kind, name, url, can_remove, can_refresh, can_edit, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 1, 1, 1, ?, ?)",
+      ["context7", scopeId, "mcp", "mcp", "Context7", "https://mcp.context7.com/mcp", now, now],
+    );
+    await executeSql(
+      seed,
+      "INSERT INTO mcp_source (id, scope_id, name, config, created_at) VALUES (?, ?, ?, ?, ?)",
+      [
+        "context7",
+        scopeId,
+        "Context7",
+        JSON.stringify({ transport: "remote", endpoint: "https://mcp.context7.com/mcp" }),
+        now,
+      ],
+    );
+    seed.close();
+
+    const result = await migrateLocalV1ToV2IfNeeded({
+      sqlitePath: dbPath,
+      tables: collectTables(),
+      namespace: "executor_local",
+      tenantId: scopeId,
+    });
+
+    expect(result.migrated).toBe(true);
+    const client = await openLocalLibsql(dbPath);
+    const integrations = await client.execute("SELECT tenant, slug, plugin_id FROM integration");
+    expect(integrations.rows).toEqual([{ tenant: scopeId, slug: "context7", plugin_id: "mcp" }]);
     client.close();
   });
 });

--- a/apps/local/src/db/v1-v2-migration.ts
+++ b/apps/local/src/db/v1-v2-migration.ts
@@ -1,11 +1,13 @@
 /* oxlint-disable executor/no-json-parse, executor/no-raw-fetch, executor/no-try-catch-or-throw -- boundary: one-shot local SQLite/auth-file migration normalizes legacy on-disk state */
 
 import type { Client } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
 import { Effect } from "effect";
 import { createId } from "fumadb/cuid";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import * as fs from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { TextDecoder } from "node:util";
 
@@ -34,6 +36,7 @@ import {
 import { makeKeychainProvider } from "@executor-js/plugin-keychain";
 
 import { createSqliteFumaDb } from "./sqlite-fumadb";
+import embeddedLegacyMigrations from "./embedded-migrations.gen";
 import { executeSql, openLocalLibsql, queryFirst, queryRows } from "./libsql";
 
 type Row = Record<string, unknown>;
@@ -129,6 +132,79 @@ const isLocalV1Database = async (client: Client): Promise<boolean> => {
   if (!(await tableExists(client, "integration"))) return true;
   const connectionColumns = await columnNames(client, "connection");
   return !connectionColumns.has("tenant") || connectionColumns.has("scope_id");
+};
+
+// ---------------------------------------------------------------------------
+// Legacy v1 schema replay.
+//
+// The v1→v2 data migration below reads the v1-FINAL schema (it queries
+// `plugin_storage`, which only exists after v1 migration 0011). A database
+// last touched by an older release is still mid-chain, so replay the bundled
+// legacy drizzle migrations (`apps/local/drizzle-legacy-v1`, embedded into
+// the binary by apps/cli/src/build.ts) to bring it to v1-final first — the
+// same step every pre-v1.5 release performed at startup.
+// ---------------------------------------------------------------------------
+
+const resolveLegacyMigrationsFolder = (): string => {
+  if (!embeddedLegacyMigrations) {
+    return join(import.meta.dirname, "../../drizzle-legacy-v1");
+  }
+  // drizzle's migrate() reads a folder from disk; materialize the embedded
+  // contents into a tmpdir.
+  const dir = fs.mkdtempSync(join(tmpdir(), "executor-legacy-migrations-"));
+  for (const [rel, content] of Object.entries(embeddedLegacyMigrations)) {
+    const target = join(dir, rel);
+    fs.mkdirSync(dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  return dir;
+};
+
+const readBundledLegacyMigrationHashes = (migrationsFolder: string): readonly string[] => {
+  const journal = JSON.parse(
+    fs.readFileSync(join(migrationsFolder, "meta", "_journal.json")).toString(),
+  ) as { entries: ReadonlyArray<{ idx: number; tag: string }> };
+  return [...journal.entries]
+    .sort((left, right) => left.idx - right.idx)
+    .map((entry) =>
+      createHash("sha256")
+        .update(fs.readFileSync(join(migrationsFolder, `${entry.tag}.sql`)).toString())
+        .digest("hex"),
+    );
+};
+
+const readAppliedLegacyMigrationHashes = async (client: Client): Promise<readonly string[]> =>
+  (
+    await queryRows<{ hash: string }>(
+      client,
+      "SELECT hash FROM __drizzle_migrations ORDER BY id ASC",
+    )
+  ).map((row) => row.hash);
+
+/** Bring a v1 database that predates v1-final up to the last v1 schema. Only
+ *  replays when the database's drizzle history is a strict prefix of the
+ *  bundled legacy chain — anything else is left as-is with a warning (the
+ *  data migration may still succeed if the schema is close enough). */
+const replayLegacyV1Migrations = async (client: Client, warnings: string[]): Promise<void> => {
+  if (!(await tableExists(client, "__drizzle_migrations"))) {
+    warnings.push(
+      "v1 database has no drizzle migration history; skipping the legacy schema replay.",
+    );
+    return;
+  }
+  const migrationsFolder = resolveLegacyMigrationsFolder();
+  const bundled = readBundledLegacyMigrationHashes(migrationsFolder);
+  const applied = await readAppliedLegacyMigrationHashes(client);
+  const isPrefix =
+    applied.length <= bundled.length && applied.every((hash, index) => hash === bundled[index]);
+  if (!isPrefix) {
+    warnings.push(
+      "v1 database migration history does not match this build's bundled legacy migrations; reading the schema as-is.",
+    );
+    return;
+  }
+  if (applied.length === bundled.length) return; // already v1-final
+  await migrate(drizzle({ client }), { migrationsFolder });
 };
 
 const textDecoder = new TextDecoder();
@@ -837,6 +913,8 @@ export const migrateLocalV1ToV2IfNeeded = async (
   const reader = await openLocalLibsql(options.sqlitePath);
   try {
     if (!(await isLocalV1Database(reader))) return { migrated: false, warnings: [] };
+    const replayWarnings: string[] = [];
+    await replayLegacyV1Migrations(reader, replayWarnings);
     const snapshot = await readV1Snapshot(reader, options.tenantId);
     const plan = planMigration(snapshot.input);
     const secretValues = await collectSecretValues(plan);
@@ -872,7 +950,7 @@ export const migrateLocalV1ToV2IfNeeded = async (
         migrated: true,
         backupPath,
         report: plan.report,
-        warnings: [...plan.report.warnings, ...secretValues.warnings],
+        warnings: [...replayWarnings, ...plan.report.warnings, ...secretValues.warnings],
       };
     } catch (cause) {
       if (target) await target.close();


### PR DESCRIPTION
Fixes `executor web` crashing with `SQLITE_ERROR: no such table: plugin_storage` when 1.5.0 opens a database last touched by an older v1 release.

The v1→v2 data migration reads the v1-final schema (`plugin_storage` arrived in legacy migration 0011), but the legacy drizzle replay that every pre-1.5 release performed at startup was dropped in the rework, so mid-chain databases crash before migrating. This vendors the legacy migration chain into `apps/local/drizzle-legacy-v1` (embedded into the CLI binary the same way as before) and replays it — only when the database's recorded migration history is a hash-prefix of the bundled chain — before the v1 snapshot is read.

Regression test builds a real pre-0011 database by applying the vendored chain truncated after 0010 and asserts the migration now completes. Verified the embedding end-to-end with `release:publish:dry-run`.