### PR TITLE
[codex] Allow adding MCP sources without tool discovery

### DIFF
--- a/packages/plugins/mcp/src/sdk/discover.ts
+++ b/packages/plugins/mcp/src/sdk/discover.ts
@@ -3,6 +3,8 @@
 // ---------------------------------------------------------------------------
 
 import { Effect } from "effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import type { McpConnector } from "./connection";
 import { McpToolDiscoveryError } from "./errors";
@@ -11,6 +13,15 @@ import {
   isListToolsResult,
   type McpToolManifest,
 } from "./manifest";
+
+const ErrorWithMessage = Schema.Struct({ message: Schema.String });
+const decodeErrorWithMessage = Schema.decodeUnknownOption(ErrorWithMessage);
+
+const listToolsFailureMessage = (error: unknown): string =>
+  Option.match(decodeErrorWithMessage(error), {
+    onNone: () => "Failed listing MCP tools",
+    onSome: ({ message }) => `Failed listing MCP tools: ${message}`,
+  });
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -38,10 +49,10 @@ export const discoverTools = (
     // List tools
     const listResult = yield* Effect.tryPromise({
       try: () => connection.client.listTools(),
-      catch: () =>
+      catch: (error) =>
         new McpToolDiscoveryError({
           stage: "list_tools",
-          message: "Failed listing MCP tools",
+          message: listToolsFailureMessage(error),
         }),
     });
 

--- a/packages/plugins/mcp/src/sdk/plugin.test.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import { HttpServerResponse } from "effect/unstable/http";
 
 import {
@@ -30,6 +32,11 @@ import { makeAnnotationsMcpServer, serveMcpServer } from "../testing";
 // elicitation.test.ts + owner-isolation.test.ts.
 
 const TEMPLATE = AuthTemplateSlug.make("none");
+const JsonRpcRequest = Schema.Struct({
+  id: Schema.optional(Schema.Unknown),
+  method: Schema.String,
+});
+const decodeJsonRpcRequest = Schema.decodeUnknownOption(Schema.fromJsonString(JsonRpcRequest));
 
 // ---------------------------------------------------------------------------
 // Manifest extraction
@@ -384,6 +391,59 @@ describe("mcpPlugin", () => {
           requiresOAuth: false,
           supportsDynamicRegistration: false,
           toolCount: null,
+        });
+
+        yield* executor.close();
+        yield* Effect.promise(() => config.testDb.close());
+      }),
+    ),
+  );
+
+  it.effect("probeEndpoint allows adding MCP-shaped endpoints when tool discovery fails", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveTestHttpApp((request) =>
+          Effect.gen(function* () {
+            const body = yield* request.text.pipe(Effect.catch(() => Effect.succeed("")));
+            const parsed = Option.getOrElse(decodeJsonRpcRequest(body), () => ({
+              id: null,
+              method: "",
+            }));
+            const payload = parsed.method === "tools/list"
+              ? {
+                  jsonrpc: "2.0",
+                  id: parsed.id,
+                  error: {
+                    code: -32603,
+                    message: "Internal error while listing tools",
+                  },
+                }
+              : {
+                  jsonrpc: "2.0",
+                  id: parsed.id,
+                  result: {
+                    protocolVersion: "2025-06-18",
+                    capabilities: { tools: { listChanged: true } },
+                    serverInfo: { name: "tinybird-mcp", version: "1.12.4" },
+                  },
+                };
+            return HttpServerResponse.text(`event: message\ndata: ${JSON.stringify(payload)}\n\n`, {
+              headers: { "content-type": "text/event-stream" },
+            });
+          }),
+        );
+        const config = makeTestConfig({ plugins: [mcpPlugin()] as const });
+        const executor = yield* createExecutor(config);
+
+        const result = yield* executor.mcp.probeEndpoint(server.url("/"));
+
+        expect(result).toMatchObject({
+          connected: false,
+          requiresAuthentication: true,
+          requiresOAuth: false,
+          supportsDynamicRegistration: false,
+          toolCount: null,
+          serverName: null,
         });
 
         yield* executor.close();

--- a/packages/plugins/mcp/src/sdk/plugin.ts
+++ b/packages/plugins/mcp/src/sdk/plugin.ts
@@ -575,7 +575,9 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
 
           const result = yield* discoverTools(connector).pipe(
             Effect.map((m) => ({ ok: true as const, manifest: m })),
-            Effect.catch(() => Effect.succeed({ ok: false as const, manifest: null })),
+            Effect.catch((error) =>
+              Effect.succeed({ ok: false as const, manifest: null, error }),
+            ),
             Effect.withSpan("mcp.plugin.discover_tools"),
           );
 
@@ -639,11 +641,16 @@ export const mcpPlugin = definePlugin((options?: McpPluginOptions) => {
             } satisfies McpProbeResult;
           }
 
-          return yield* new McpConnectionError({
-            transport: "remote",
-            message:
-              "This endpoint looks like MCP, but Executor couldn't discover tools from it. Check the URL and try again.",
-          });
+          return {
+            connected: false,
+            requiresAuthentication: true,
+            requiresOAuth: false,
+            supportsDynamicRegistration: false,
+            name,
+            slug,
+            toolCount: null,
+            serverName: null,
+          } satisfies McpProbeResult;
         }).pipe(
           Effect.withSpan("mcp.plugin.probe_endpoint", {
             attributes: { "mcp.endpoint": typeof input === "string" ? input : input.endpoint },


### PR DESCRIPTION
## Summary

- Preserve MCP `tools/list` failure messages through discovery errors.
- Allow MCP-shaped endpoints to be added even when unauthenticated tool discovery fails.
- Add regression coverage for an endpoint that initializes successfully but fails `tools/list`, requiring the user to configure authentication manually.

## Root Cause

The add-source flow treated a successful MCP shape probe plus failed tool discovery as a hard failure unless the shape probe itself proved authentication was required. That blocked valid MCP servers whose unauthenticated `initialize` succeeds but `tools/list` fails before credentials are configured.

## User Impact

Users can now add a remote MCP source first, choose the authentication template manually, and connect credentials later, matching the OpenAPI source flow.

## Validation

- `bunx vitest run src/sdk/plugin.test.ts` from `packages/plugins/mcp`
- `bun run typecheck` from `packages/plugins/mcp`
