### PR TITLE
Fix desktop sidecar packaging and release pipeline

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -29,22 +29,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # smoke: run the compiled-sidecar smoke test on legs whose target
+          # matches the runner (the mac x64 leg cross-compiles on an arm64
+          # runner, so its binary can't be executed natively there).
           - os: macos-latest
             arch: arm64
             platform: mac
             bun-target: bun-darwin-arm64
+            smoke: true
           - os: macos-latest
             arch: x64
             platform: mac
             bun-target: bun-darwin-x64
+            smoke: false
           - os: ubuntu-latest
             arch: x64
             platform: linux
             bun-target: bun-linux-x64
+            smoke: true
           - os: windows-latest
             arch: x64
             platform: win
             bun-target: bun-windows-x64
+            smoke: true
 
     runs-on: ${{ matrix.os }}
 
@@ -90,6 +97,15 @@ jobs:
         run: bun ./scripts/build-sidecar.ts
         working-directory: apps/desktop
 
+      # Gate the release on the compiled binary actually booting. v1.5.0/.1
+      # shipped sidecars that died on launch (missing libsql native binding) —
+      # a regression dev mode can't catch because `bun run` resolves
+      # node_modules that `bun build --compile` does not bundle.
+      - name: Smoke test compiled sidecar
+        if: matrix.smoke
+        run: bun run test:smoke
+        working-directory: apps/desktop
+
       - name: Build Electron main/preload/renderer
         run: bunx --bun electron-vite build
         working-directory: apps/desktop
@@ -123,6 +139,16 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
         run: bunx --bun electron-builder --${{ matrix.platform }} --${{ matrix.arch }} --publish never --config electron-builder.config.ts
         working-directory: apps/desktop
+
+      # The two mac legs each emit a latest-mac.yml listing only their own
+      # arch. Rename per-arch here; the release job merges them back into the
+      # single latest-mac.yml electron-updater clients fetch. Without this,
+      # merge-multiple in the release job lets one arch clobber the other and
+      # every Mac gets pointed at whichever leg uploaded last.
+      - name: Rename mac update manifest per arch
+        if: matrix.platform == 'mac'
+        shell: bash
+        run: mv apps/desktop/dist/latest-mac.yml "apps/desktop/dist/latest-mac-${{ matrix.arch }}.yml"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -165,6 +191,15 @@ jobs:
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Merge mac update manifests
+        run: |
+          set -euo pipefail
+          bun scripts/merge-latest-mac-yml.ts \
+            artifacts/latest-mac-x64.yml \
+            artifacts/latest-mac-arm64.yml \
+            artifacts/latest-mac.yml
+          rm artifacts/latest-mac-x64.yml artifacts/latest-mac-arm64.yml
 
       - name: Upload to GitHub Release
         env:

--- a/apps/desktop/electron-builder.config.ts
+++ b/apps/desktop/electron-builder.config.ts
@@ -43,8 +43,14 @@ const config: Configuration = {
     entitlementsInherit: "build/entitlements.mac.plist",
     notarize: true,
   },
+  // Same arch rule as mac (see comment above): never pin `arch:` in the
+  // target objects. The win/linux pins used to force both archs out of a
+  // single x64 matrix leg, embedding an x64 sidecar binary inside the
+  // "arm64" installers — DOA on linux-arm64, emulated on win-arm64. Each
+  // workflow leg's --x64/--arm64 flag decides what gets built, so an arm64
+  // artifact only exists once a leg stages an arm64 sidecar for it.
   win: {
-    target: [{ target: "nsis", arch: ["x64", "arm64"] }],
+    target: ["nsis"],
   },
   nsis: {
     oneClick: true,
@@ -52,11 +58,7 @@ const config: Configuration = {
   },
   linux: {
     category: "Development",
-    target: [
-      { target: "AppImage", arch: ["x64", "arm64"] },
-      { target: "deb", arch: ["x64", "arm64"] },
-      { target: "rpm", arch: ["x64", "arm64"] },
-    ],
+    target: ["AppImage", "deb", "rpm"],
   },
   publish: {
     provider: "github",

--- a/apps/desktop/scripts/build-sidecar.ts
+++ b/apps/desktop/scripts/build-sidecar.ts
@@ -37,6 +37,112 @@ const targetIsWindows = BUN_TARGET.includes("windows") || process.platform === "
 const binaryName = targetIsWindows ? "executor-sidecar.exe" : "executor-sidecar";
 const sidecarBinary = resolve(SIDECAR_OUT_DIR, binaryName);
 
+/**
+ * Normalized `<os>-<arch>[-<abi>]` key for the compile target, derived from
+ * BUN_TARGET (`bun` = the runner's own platform). Matches the keys used by
+ * apps/cli/src/build.ts's native-binding maps.
+ */
+const targetKey =
+  BUN_TARGET === "bun"
+    ? `${process.platform}-${process.arch}`
+    : BUN_TARGET.replace(/^bun-/, "").replace(/^windows-/, "win32-");
+
+const targetIsCurrentPlatform = targetKey === `${process.platform}-${process.arch}`;
+
+// `bun build --compile` does not bundle `.node` native addons into bunfs, so
+// the sidecar's eager `require('@libsql/<plat>')` (and the keychain plugin's
+// lazy keyring load) would fail at runtime. We stage each binding next to the
+// binary; src/sidecar/native-bindings.ts (the sidecar's first import) points
+// the loaders at them via EXECUTOR_LIBSQL_NATIVE_PATH /
+// EXECUTOR_KEYRING_NATIVE_PATH. Mirrors apps/cli/src/build.ts.
+const LIBSQL_NATIVE_VERSION = "0.5.29";
+const resolveLibsqlNative = (): string => {
+  const platformMap: Record<string, string> = {
+    "darwin-arm64": "darwin-arm64",
+    "darwin-x64": "darwin-x64",
+    // The compiled binary runs on Bun, which libSQL's loader treats as glibc
+    // (its musl->gnu workaround), so non-musl linux targets need the -gnu binding.
+    "linux-arm64": "linux-arm64-gnu",
+    "linux-x64": "linux-x64-gnu",
+    "win32-arm64": "win32-arm64-msvc",
+    "win32-x64": "win32-x64-msvc",
+  };
+  const target = platformMap[targetKey];
+  if (!target) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: build-time fatal
+    throw new Error(`No @libsql native binding mapping for target ${targetKey}`);
+  }
+  const pkg = `@libsql/${target}`;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: build-time resolution falls back to bun's store layout
+  try {
+    const req = createRequire(join(APPS_LOCAL, "package.json"));
+    return join(dirname(req.resolve(`${pkg}/package.json`)), "index.node");
+  } catch {
+    const bunPath = join(
+      REPO_ROOT,
+      `node_modules/.bun/${pkg.replace("/", "+")}@${LIBSQL_NATIVE_VERSION}/node_modules/${pkg}/index.node`,
+    );
+    if (!existsSync(bunPath)) {
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: build-time fatal
+      throw new Error(
+        `Cannot resolve ${pkg} for the sidecar. Run \`bun install --cpu=* --os=*\` so cross-target native bindings are present.`,
+      );
+    }
+    return bunPath;
+  }
+};
+
+const resolveKeyringNative = (): string => {
+  const platformMap: Record<string, { pkg: string; node: string }> = {
+    "darwin-arm64": {
+      pkg: "@napi-rs/keyring-darwin-arm64",
+      node: "keyring.darwin-arm64.node",
+    },
+    "darwin-x64": {
+      pkg: "@napi-rs/keyring-darwin-x64",
+      node: "keyring.darwin-x64.node",
+    },
+    "linux-arm64": {
+      pkg: "@napi-rs/keyring-linux-arm64-gnu",
+      node: "keyring.linux-arm64-gnu.node",
+    },
+    "linux-x64": {
+      pkg: "@napi-rs/keyring-linux-x64-gnu",
+      node: "keyring.linux-x64-gnu.node",
+    },
+    "win32-arm64": {
+      pkg: "@napi-rs/keyring-win32-arm64-msvc",
+      node: "keyring.win32-arm64-msvc.node",
+    },
+    "win32-x64": {
+      pkg: "@napi-rs/keyring-win32-x64-msvc",
+      node: "keyring.win32-x64-msvc.node",
+    },
+  };
+  const entry = platformMap[targetKey];
+  if (!entry) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: build-time fatal
+    throw new Error(`No @napi-rs/keyring native binding mapping for target ${targetKey}`);
+  }
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: build-time resolution falls back to bun's store layout
+  try {
+    const req = createRequire(join(REPO_ROOT, "node_modules", "@napi-rs/keyring", "package.json"));
+    return join(dirname(req.resolve(`${entry.pkg}/package.json`)), entry.node);
+  } catch {
+    const bunPath = join(
+      REPO_ROOT,
+      `node_modules/.bun/${entry.pkg.replace("/", "+")}@1.2.0/node_modules/${entry.pkg}/${entry.node}`,
+    );
+    if (!existsSync(bunPath)) {
+      // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: build-time fatal
+      throw new Error(
+        `Cannot resolve ${entry.pkg} for the sidecar. Run \`bun install --cpu=* --os=*\` so cross-target native bindings are present.`,
+      );
+    }
+    return bunPath;
+  }
+};
+
 // QuickJS ships its WASM as a side asset; `bun build --compile` can't pull
 // it into bunfs, so we stage it next to the binary and the sidecar entry
 // preloads it via `setQuickJSModule` before any server import.
@@ -54,11 +160,15 @@ const resolveQuickJsWasmPath = (): string => {
   return wasmPath;
 };
 
-// Drizzle's migrator takes a folder path at runtime. The compiled sidecar
-// cannot rely on apps/local/drizzle existing on disk, so inline every migration
-// as text and let apps/local extract them to a temp folder during startup.
+// The v1→v2 data migration replays the legacy v1 drizzle chain
+// (apps/local/drizzle-legacy-v1) before reading a legacy database. The
+// compiled sidecar cannot rely on that folder existing on disk, so inline
+// every migration as text and let apps/local extract them to a temp folder
+// during startup. Mirrors apps/cli/src/build.ts — embedding the wrong dir
+// (e.g. the v2 chain in drizzle/) makes the sidecar treat every real legacy
+// database as "history does not match" and skip the replay.
 const createEmbeddedMigrationsSource = async () => {
-  const migrationsDir = resolve(APPS_LOCAL, "drizzle");
+  const migrationsDir = resolve(APPS_LOCAL, "drizzle-legacy-v1");
   const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: migrationsDir })))
     .map((file) => file.replaceAll("\\", "/"))
     .sort();
@@ -86,6 +196,20 @@ if (!existsSync(APPS_LOCAL_DIST)) {
   );
 }
 
+// Cross-target builds (e.g. the mac x64 leg on an arm64 runner) need the other
+// platform's optional native packages on disk before we can stage them.
+// `--cpu=* --os=*` extracts them all without modifying the lockfile. Mirrors
+// apps/cli/src/build.ts.
+if (!targetIsCurrentPlatform) {
+  console.log("[build-sidecar] installing optional native deps for all platforms...");
+  await $`bun install --frozen-lockfile --cpu=* --os=*`.cwd(REPO_ROOT);
+}
+
+// Resolve the native bindings up front so a missing platform package fails the
+// build before the (slow) compile, and cross-target builds get a clear message.
+const libsqlNativePath = resolveLibsqlNative();
+const keyringNativePath = resolveKeyringNative();
+
 await rm(SIDECAR_OUT_DIR, { recursive: true, force: true });
 await rm(WEB_UI_OUT_DIR, { recursive: true, force: true });
 await mkdir(SIDECAR_OUT_DIR, { recursive: true });
@@ -107,6 +231,10 @@ try {
 
   console.log(`[build-sidecar] staging QuickJS WASM → ${SIDECAR_OUT_DIR}`);
   await cp(resolveQuickJsWasmPath(), join(SIDECAR_OUT_DIR, "emscripten-module.wasm"));
+
+  console.log(`[build-sidecar] staging native bindings (${targetKey}) → ${SIDECAR_OUT_DIR}`);
+  await cp(libsqlNativePath, join(SIDECAR_OUT_DIR, "libsql.node"));
+  await cp(keyringNativePath, join(SIDECAR_OUT_DIR, "keyring.node"));
 
   console.log(`[build-sidecar] staging web UI → ${WEB_UI_OUT_DIR}`);
   await cp(APPS_LOCAL_DIST, WEB_UI_OUT_DIR, { recursive: true });

--- a/apps/desktop/scripts/smoke-sidecar.ts
+++ b/apps/desktop/scripts/smoke-sidecar.ts
@@ -26,7 +26,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const ROOT = resolve(import.meta.dir, "..");
-const APPS_LOCAL_DRIZZLE = resolve(ROOT, "../local/drizzle");
+const APPS_LOCAL_DRIZZLE = resolve(ROOT, "../local/drizzle-legacy-v1");
 const BINARY = resolve(
   ROOT,
   "resources/sidecar",
@@ -37,9 +37,11 @@ const AUTH_PASSWORD = "smoke-test-password";
 const AUTH_HEADER = `Basic ${btoa(`executor:${AUTH_PASSWORD}`)}`;
 const READY_TIMEOUT_MS = 30_000;
 
+// Throw instead of process.exit so main()'s finally still tears down the
+// spawned sidecar + temp dirs — exiting here leaks a running sidecar process.
 const fail = (msg: string): never => {
-  console.error(`[smoke-sidecar] FAIL: ${msg}`);
-  process.exit(1);
+  // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: standalone smoke harness surfaces failures as a thrown error
+  throw new Error(`[smoke-sidecar] FAIL: ${msg}`);
 };
 
 type ToolCallResult = Awaited<ReturnType<Client["callTool"]>>;
@@ -53,56 +55,49 @@ const makeScopeId = (cwd: string): string => {
   return `${folder}-${hash}`;
 };
 
-const readLegacyMigrationHashes = async (): Promise<readonly string[]> => {
+const readLegacyMigrations = async (): Promise<readonly { sql: string; hash: string }[]> => {
   const journal = (await Bun.file(join(APPS_LOCAL_DRIZZLE, "meta/_journal.json")).json()) as {
     readonly entries: readonly { readonly idx: number; readonly tag: string }[];
   };
 
-  const hashes: string[] = [];
+  const migrations: { sql: string; hash: string }[] = [];
   for (const entry of [...journal.entries].sort((left, right) => left.idx - right.idx)) {
     const query = await Bun.file(join(APPS_LOCAL_DRIZZLE, `${entry.tag}.sql`)).text();
-    hashes.push(createHash("sha256").update(query).digest("hex"));
+    migrations.push({
+      sql: query,
+      hash: createHash("sha256").update(query).digest("hex"),
+    });
   }
-  return hashes;
+  return migrations;
 };
 
 const seedLegacyScopedSqlite = async (dataDir: string, scopeId: string): Promise<void> => {
   const db = new Database(join(dataDir, "data.db"));
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: standalone smoke harness closes the SQLite handle before spawning the sidecar
   try {
+    // Replay the real legacy v1 chain so the fixture matches the migration
+    // history the sidecar's embedded copy expects. A hand-rolled partial
+    // schema that claims the full history is applied makes the v1→v2 data
+    // migration read tables that don't exist.
+    const migrations = await readLegacyMigrations();
+    for (const migration of migrations) {
+      // `--> statement-breakpoint` markers are SQL line comments, so the
+      // whole file executes as one multi-statement batch.
+      db.exec(migration.sql);
+    }
+
     db.exec(`
-      CREATE TABLE source (
-        scope_id TEXT NOT NULL,
-        id TEXT NOT NULL,
-        plugin_id TEXT NOT NULL,
-        kind TEXT NOT NULL,
-        name TEXT NOT NULL,
-        url TEXT,
-        can_remove INTEGER NOT NULL,
-        can_refresh INTEGER NOT NULL,
-        can_edit INTEGER NOT NULL,
-        created_at INTEGER NOT NULL,
-        updated_at INTEGER NOT NULL,
-        PRIMARY KEY (scope_id, id)
-      );
-      CREATE TABLE blob (
-        namespace TEXT NOT NULL,
-        key TEXT NOT NULL,
-        value TEXT NOT NULL,
-        PRIMARY KEY (namespace, key)
-      );
       CREATE TABLE "__drizzle_migrations" (
         id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
         hash text NOT NULL,
         created_at numeric
       );
     `);
-
     const insertMigration = db.prepare(
       `INSERT INTO "__drizzle_migrations" (hash, created_at) VALUES (?, ?)`,
     );
-    for (const hash of await readLegacyMigrationHashes()) {
-      insertMigration.run(hash, Date.now());
+    for (const migration of migrations) {
+      insertMigration.run(migration.hash, Date.now());
     }
 
     db.prepare(
@@ -133,22 +128,29 @@ const seedLegacyScopedSqlite = async (dataDir: string, scopeId: string): Promise
   }
 };
 
-const assertLegacyImportCompleted = async (dataDir: string): Promise<void> => {
-  const markerPath = join(dataDir, "fumadb-sqlite-imported");
-  if (!(await Bun.file(markerPath).exists())) {
-    fail(`legacy SQLite import marker was not written at ${markerPath}`);
+// The v1→v2 migration moves the legacy SQLite file set aside as
+// `data.db.v1-v2-<ts>-<nonce>` before writing the new v2 database. Assert the
+// backup exists and still holds the seeded legacy row — that proves the
+// migration path ran (rather than the sidecar treating the DB as fresh) and
+// preserved the original data.
+const assertV1MigrationCompleted = async (dataDir: string): Promise<void> => {
+  const entries = await Array.fromAsync(new Bun.Glob("data.db.v1-v2-*").scan({ cwd: dataDir }));
+  const backups = entries.filter((name) => !name.endsWith("-wal") && !name.endsWith("-shm"));
+  if (backups.length !== 1) {
+    fail(`expected exactly one v1→v2 backup in ${dataDir}, found: ${JSON.stringify(entries)}`);
   }
 
-  const marker = (await Bun.file(markerPath).json()) as {
-    readonly importedRows?: number;
-    readonly importedTables?: readonly string[];
-    readonly backupPath?: string;
-  };
-  if ((marker.importedRows ?? 0) < 2 || !marker.importedTables?.includes("source")) {
-    fail(`legacy SQLite import marker has unexpected contents: ${JSON.stringify(marker)}`);
-  }
-  if (!marker.backupPath || !(await Bun.file(marker.backupPath).exists())) {
-    fail(`legacy SQLite backup was not preserved: ${JSON.stringify(marker)}`);
+  const backup = new Database(join(dataDir, backups[0]!), { readonly: true });
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: standalone smoke harness closes the SQLite handle it opened
+  try {
+    const row = backup.prepare("SELECT name FROM source WHERE id = 'legacy-smoke'").get() as {
+      name?: string;
+    } | null;
+    if (row?.name !== "Legacy Smoke Source") {
+      fail(`v1→v2 backup is missing the seeded legacy source row: ${JSON.stringify(row)}`);
+    }
+  } finally {
+    backup.close();
   }
 };
 
@@ -327,6 +329,14 @@ const main = async () => {
   const scopeDir = await mkdtemp(join(tmpdir(), "executor-smoke-scope-"));
   const dataDir = await mkdtemp(join(tmpdir(), "executor-smoke-data-"));
   await seedLegacyScopedSqlite(dataDir, makeScopeId(scopeDir));
+  // v2 connections reference credentials by provider item instead of carrying
+  // raw values, so seed the file-secrets provider (auth.json under
+  // XDG_DATA_HOME) with the token the sandbox's connections.create points at.
+  const xdgDir = await mkdtemp(join(tmpdir(), "executor-smoke-xdg-"));
+  await Bun.write(
+    join(xdgDir, "executor", "auth.json"),
+    `${JSON.stringify({ "petstore-token": "smoke-token" })}\n`,
+  );
   const openapi = startOpenApiServer();
 
   console.log(`[smoke-sidecar] scope:   ${scopeDir}`);
@@ -342,6 +352,7 @@ const main = async () => {
       EXECUTOR_AUTH_PASSWORD: AUTH_PASSWORD,
       EXECUTOR_SCOPE_DIR: scopeDir,
       EXECUTOR_DATA_DIR: dataDir,
+      XDG_DATA_HOME: xdgDir,
     },
     stdin: "ignore",
     stdout: "pipe",
@@ -364,12 +375,14 @@ const main = async () => {
     await rm(scopeDir, { recursive: true, force: true }).catch(() => {});
     // oxlint-disable-next-line executor/no-promise-catch -- boundary: best-effort tempdir cleanup in a standalone smoke harness
     await rm(dataDir, { recursive: true, force: true }).catch(() => {});
+    // oxlint-disable-next-line executor/no-promise-catch -- boundary: best-effort tempdir cleanup in a standalone smoke harness
+    await rm(xdgDir, { recursive: true, force: true }).catch(() => {});
   };
 
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: standalone smoke harness needs a finally to tear down the spawned binary + http server
   try {
     const port = await waitForReadyPort(proc);
-    await assertLegacyImportCompleted(dataDir);
+    await assertV1MigrationCompleted(dataDir);
     const mcpUrl = new URL(`http://127.0.0.1:${port}/mcp`);
     console.log(`[smoke-sidecar] ready on ${mcpUrl.origin}`);
 
@@ -385,11 +398,8 @@ const main = async () => {
     const hasResume = tools.tools.some((t) => t.name === "resume");
     if (!hasResume) fail(`MCP tools/list missing "resume": ${JSON.stringify(tools.tools)}`);
 
-    // Drive the running OpenAPI server through a multi-step orchestration
-    // in one execute. Covers: source registration, array list response, path
-    // param dispatch, and object responses — all going out over real HTTP from
-    // inside QuickJS.
-    const code = `
+    // Shared sandbox helper, prepended to both execute calls.
+    const unwrapHelper = `
 const unwrapToolData = (value) => {
   if (value && typeof value === "object" && "ok" in value) {
     if (!value.ok) throw new Error(value.error?.message ?? "Tool failed");
@@ -398,16 +408,46 @@ const unwrapToolData = (value) => {
   if (value && typeof value === "object" && "data" in value) return value.data;
   return value;
 };
-await tools.executor.openapi.addSource({
+`;
+
+    // Execute #1 — register the integration and create its connection. v2
+    // produces tools per connection, and the sandbox snapshots the tool tree
+    // when an execution starts, so the invocation has to happen in a second
+    // execute call.
+    const setupCode = `${unwrapHelper}
+unwrapToolData(await tools.executor.openapi.addSpec({
   spec: { kind: "url", url: ${JSON.stringify(`${openapi.origin}/openapi.json`)} },
-  name: "Petstore Smoke API",
   baseUrl: ${JSON.stringify(openapi.origin)},
-  namespace: "petstore",
-});
-const listResult = await tools.petstore.pets.listPets({});
-const list = unwrapToolData(listResult);
-const fetched = await tools.petstore.pets.getPet({ petId: list[1].id });
-const fetchedData = unwrapToolData(fetched);
+  slug: "petstore",
+}));
+unwrapToolData(await tools.executor.coreTools.connections.create({
+  owner: "org",
+  name: "main",
+  integration: "petstore",
+  template: "apiKey",
+  from: { provider: "file", id: "petstore-token" },
+}));
+return "setup-ok";
+`;
+
+    const setupResult = await completePausedResult(
+      client,
+      await client.callTool({
+        name: "execute",
+        arguments: { code: setupCode },
+      }),
+    );
+    if (setupResult.result !== "setup-ok") {
+      fail(`integration setup failed: ${JSON.stringify(setupResult)}`);
+    }
+
+    // Execute #2 — drive the running OpenAPI server. Covers per-connection
+    // tool registration, array list response, path param dispatch, and object
+    // responses — all going out over real HTTP from inside QuickJS, via the
+    // v2 `tools.<integration>.<owner>.<connection>.<tool>` address.
+    const invokeCode = `${unwrapHelper}
+const list = unwrapToolData(await tools.petstore.org.main.pets.listPets({}));
+const fetchedData = unwrapToolData(await tools.petstore.org.main.pets.getPet({ petId: list[1].id }));
 return {
   count: list.length,
   names: list.map((p) => p.name),
@@ -415,7 +455,10 @@ return {
 };
 `;
 
-    const result = await client.callTool({ name: "execute", arguments: { code } });
+    const result = await client.callTool({
+      name: "execute",
+      arguments: { code: invokeCode },
+    });
     const structured = await completePausedResult(client, result);
     const expected = {
       count: 2,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -93,7 +93,10 @@ const installBasicAuthHeader = (origin: string, password: string | null) => {
     { urls: [`${origin}/*`] },
     (details, callback) => {
       callback({
-        requestHeaders: { ...details.requestHeaders, Authorization: headerValue },
+        requestHeaders: {
+          ...details.requestHeaders,
+          Authorization: headerValue,
+        },
       });
     },
   );
@@ -234,6 +237,10 @@ const showPortInUseDialog = async (port: number) => {
   });
 };
 
+// Last non-port-conflict sidecar startup failure, surfaced by boot() in a
+// user-facing dialog instead of letting the app vanish without a window.
+let lastSidecarStartError: unknown = null;
+
 const startWithCurrentSettings = async (): Promise<SidecarConnection | null> => {
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: bind failures surface as a user-facing dialog
   try {
@@ -244,6 +251,7 @@ const startWithCurrentSettings = async (): Promise<SidecarConnection | null> => 
       await showPortInUseDialog(error.port);
       return null;
     }
+    lastSidecarStartError = error;
     log.error("Failed to start executor sidecar", error);
     return null;
   }
@@ -429,13 +437,41 @@ const runUpdateCheck = async ({ alertOnFail }: UpdateCheckOptions) => {
   }
 };
 
+// A sidecar that can't boot usually means a broken build or an incompatible
+// data dir — both states the user can't see from a dock icon that bounces
+// once and disappears. Surface the real error, and stage any available update
+// so a dead-on-arrival release can heal itself: without the explicit check
+// here, the boot-time update check never runs (it sits after a successful
+// sidecar start), so a broken app could never self-update its way out.
+const handleFatalSidecarFailure = async (error: unknown) => {
+  if (app.isPackaged) {
+    // Install whatever finishes downloading by the time the user quits the
+    // failure dialog; if it downloads while the dialog is open, the regular
+    // 'update-downloaded' prompt offers an immediate restart instead.
+    autoUpdater.autoInstallOnAppQuit = true;
+    void runUpdateCheck({ alertOnFail: false });
+  }
+  // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: sidecar startup failures arrive as plain Node errors and render in a native dialog
+  const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  await dialog.showMessageBox({
+    type: "error",
+    title: "Executor failed to start",
+    message: "The local Executor server crashed during startup.",
+    detail: `${detail.slice(0, 1800)}\n\nFull log: ${log.transports.file.getFile().path}`,
+    buttons: ["Quit"],
+  });
+};
+
 const installApplicationMenu = () => {
   const isMac = process.platform === "darwin";
   const appMenu: MenuItemConstructorOptions = {
     label: app.name,
     submenu: [
       { role: "about" },
-      { label: "Check for Updates…", click: () => void runUpdateCheck({ alertOnFail: true }) },
+      {
+        label: "Check for Updates…",
+        click: () => void runUpdateCheck({ alertOnFail: true }),
+      },
       { type: "separator" },
       ...(isMac
         ? ([
@@ -467,10 +503,14 @@ const boot = async () => {
   registerIpcHandlers();
   connection = await startWithCurrentSettings();
   if (!connection) {
-    // Even when the sidecar can't start, open the window so the user
-    // reaches Settings to change the port. Pointing at the (unreachable)
-    // baseUrl would just show ECONNREFUSED — a placeholder URL would be
-    // worse. For now: quit with the dialog already shown.
+    // Port conflicts already showed their dialog inside
+    // startWithCurrentSettings; every other failure surfaces here so the app
+    // never silently bounces-and-vanishes. Pointing a window at the
+    // (unreachable) baseUrl would just show ECONNREFUSED — a placeholder URL
+    // would be worse. For now: explain, offer the updater a chance, quit.
+    if (lastSidecarStartError != null) {
+      await handleFatalSidecarFailure(lastSidecarStartError);
+    }
     app.quit();
     return;
   }

--- a/apps/desktop/src/sidecar/native-bindings.ts
+++ b/apps/desktop/src/sidecar/native-bindings.ts
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------
+// Native-binding bootstrap for the `bun build --compile` sidecar binary.
+//
+// `bun --compile` bundles JS into bunfs but does NOT include `.node` native
+// addons, so a dynamic `require('@libsql/<platform>')` / keyring walk inside
+// the binary fails. build-sidecar.ts copies each platform's `.node` next to
+// the executable (`libsql.node`, `keyring.node`); here we publish their
+// on-disk paths via env vars the loaders read. Mirrors apps/cli/src/native-bindings.ts.
+//
+// This MUST be the FIRST import in server.ts. ES modules evaluate every import
+// before the importer's own body, and libSQL resolves its native addon EAGERLY
+// at module load (`const {...} = requireNative()` in `libsql/index.js`). So the
+// env var has to be set as a side effect of an import that is ordered before
+// the `@executor-js/local` → `@libsql/client` graph — setting it in server.ts's
+// body would run too late, after libSQL had already tried (and failed) to load.
+// ---------------------------------------------------------------------------
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const execDir = dirname(process.execPath);
+
+// libSQL: our `libsql` patch reads EXECUTOR_LIBSQL_NATIVE_PATH and loads the
+// colocated binding directly, before its (in-bunfs, doomed) platform-package walk.
+const libsqlNodeOnDisk = join(execDir, "libsql.node");
+if (
+  typeof Bun !== "undefined" &&
+  !process.env.EXECUTOR_LIBSQL_NATIVE_PATH &&
+  existsSync(libsqlNodeOnDisk)
+) {
+  process.env.EXECUTOR_LIBSQL_NATIVE_PATH = libsqlNodeOnDisk;
+}
+
+// keyring: the keychain plugin reads EXECUTOR_KEYRING_NATIVE_PATH (lazily, but
+// set here alongside libSQL so all native colocation lives in one place). We
+// can't use NAPI_RS_NATIVE_LIBRARY_PATH — @napi-rs/keyring 1.2.0's env-var
+// branch assigns to a local that gets overwritten before the binding returns.
+const keyringNodeOnDisk = join(execDir, "keyring.node");
+if (
+  typeof Bun !== "undefined" &&
+  !process.env.EXECUTOR_KEYRING_NATIVE_PATH &&
+  existsSync(keyringNodeOnDisk)
+) {
+  process.env.EXECUTOR_KEYRING_NATIVE_PATH = keyringNodeOnDisk;
+}

--- a/apps/desktop/src/sidecar/server.ts
+++ b/apps/desktop/src/sidecar/server.ts
@@ -7,6 +7,9 @@
  * announces readiness with the resolved port on stdout so the Electron
  * main process can attach a BrowserWindow to it.
  */
+// MUST stay the first import — points libSQL/keyring at the `.node` bindings
+// staged next to the compiled binary before `@executor-js/local` loads them.
+import "./native-bindings";
 import { dirname, join } from "node:path";
 
 // Pre-load QuickJS WASM for compiled binaries. `bun build --compile` can't

--- a/scripts/merge-latest-mac-yml.ts
+++ b/scripts/merge-latest-mac-yml.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * Merge per-arch electron-builder update manifests into one latest-mac.yml.
+ *
+ * The desktop publish workflow builds mac arm64 and x64 in separate matrix
+ * legs, and each electron-builder invocation emits its own latest-mac.yml
+ * listing only that arch's artifacts. electron-updater clients fetch the
+ * single `latest-mac.yml` from the release, so publishing either leg's file
+ * as-is points every Mac at one arch (arm64 users were being served x64
+ * zips). This script unions the `files` entries; electron-updater picks the
+ * right one per client by matching the running arch against the file name.
+ *
+ * Usage: bun scripts/merge-latest-mac-yml.ts <x64.yml> <arm64.yml> <out.yml>
+ * The first input's top-level path/sha512 (the legacy single-file fields read
+ * by very old updaters) are kept, so pass the x64 manifest first.
+ */
+
+interface UpdateFileEntry {
+  readonly url: string;
+  readonly sha512: string;
+  readonly size: number;
+}
+
+interface UpdateManifest {
+  readonly version: string;
+  readonly files: readonly UpdateFileEntry[];
+  readonly path: string;
+  readonly sha512: string;
+  readonly releaseDate: string;
+}
+
+const isUpdateFileEntry = (value: unknown): value is UpdateFileEntry => {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry["url"] === "string" &&
+    typeof entry["sha512"] === "string" &&
+    typeof entry["size"] === "number"
+  );
+};
+
+const parseManifest = (source: string, path: string): UpdateManifest => {
+  const raw = Bun.YAML.parse(source) as Record<string, unknown>;
+  const files = Array.isArray(raw["files"]) ? raw["files"].filter(isUpdateFileEntry) : [];
+  if (
+    typeof raw["version"] !== "string" ||
+    typeof raw["path"] !== "string" ||
+    typeof raw["sha512"] !== "string" ||
+    typeof raw["releaseDate"] !== "string" ||
+    files.length === 0
+  ) {
+    throw new Error(`Unrecognized electron-builder update manifest at ${path}`);
+  }
+  return {
+    version: raw["version"],
+    files,
+    path: raw["path"],
+    sha512: raw["sha512"],
+    releaseDate: raw["releaseDate"],
+  };
+};
+
+const serializeManifest = (manifest: UpdateManifest): string =>
+  [
+    `version: ${manifest.version}`,
+    "files:",
+    ...manifest.files.flatMap((file) => [
+      `  - url: ${file.url}`,
+      `    sha512: ${file.sha512}`,
+      `    size: ${file.size}`,
+    ]),
+    `path: ${manifest.path}`,
+    `sha512: ${manifest.sha512}`,
+    `releaseDate: '${manifest.releaseDate}'`,
+    "",
+  ].join("\n");
+
+const [primaryPath, secondaryPath, outPath] = process.argv.slice(2);
+if (!primaryPath || !secondaryPath || !outPath) {
+  throw new Error("Usage: merge-latest-mac-yml.ts <primary.yml> <secondary.yml> <out.yml>");
+}
+
+const primary = parseManifest(await Bun.file(primaryPath).text(), primaryPath);
+const secondary = parseManifest(await Bun.file(secondaryPath).text(), secondaryPath);
+
+if (primary.version !== secondary.version) {
+  throw new Error(
+    `Refusing to merge mismatched versions: ${primary.version} (${primaryPath}) vs ${secondary.version} (${secondaryPath})`,
+  );
+}
+
+const seen = new Set<string>();
+const files = [...primary.files, ...secondary.files].filter((file) => {
+  if (seen.has(file.url)) return false;
+  seen.add(file.url);
+  return true;
+});
+
+await Bun.write(outPath, serializeManifest({ ...primary, files }));
+console.log(`Merged ${primaryPath} + ${secondaryPath} → ${outPath} (${files.length} files)`);


### PR DESCRIPTION
The desktop sidecar build was missing a few pieces that the CLI build already had, which meant recent desktop builds couldn't start their local server. This brings the two builds back in line and tightens up the release workflow so this class of issue gets caught before publishing.

## Changes

**Sidecar packaging**
- Stage the `libsql.node` and `keyring.node` native bindings next to the compiled sidecar binary (`bun build --compile` doesn't bundle `.node` addons). A new `native-bindings.ts` first-import points the loaders at them, mirroring the CLI build.
- Embed the legacy v1 migration chain (`drizzle-legacy-v1`) in the sidecar instead of the v2 chain, so the v1→v2 data migration can replay it against older databases.

**Release workflow**
- Run the compiled-sidecar smoke test (`test:smoke`) in the publish workflow on legs whose target arch matches the runner. This exercises the compiled binary end to end (native bindings, embedded migrations, MCP → QuickJS → OpenAPI round trip), which dev mode can't cover.
- The two mac matrix legs each emit a `latest-mac.yml` that only lists their own arch, and the release job previously kept whichever uploaded last. They're now renamed per arch and merged into a single manifest (`scripts/merge-latest-mac-yml.ts`) so the updater serves the right artifact to each arch.
- Drop the config-level arch pins for win/linux electron-builder targets — the workflow's `--x64`/`--arm64` flag now decides what gets built, so an installer only ships a sidecar compiled for its own arch.

**Startup UX**
- When the sidecar fails to start, show an error dialog with the underlying error and log path instead of quitting silently, and check for updates with install-on-quit enabled so an affected install can pick up a fixed build on its own.

**Smoke test refresh**
- The fixture now replays the real legacy migration chain (instead of a hand-rolled partial schema), asserts the v1→v2 backup, and drives the current addSpec → connection → tool-invocation flow. Failures throw instead of exiting so the spawned sidecar is always torn down.

## Testing
- `bun run test:smoke` (desktop) green against the compiled binary, including the v1→v2 migration path.
- `scripts/merge-latest-mac-yml.ts` verified against the manifests from an existing release.
- Packaged the mac arm64 app locally and confirmed it launches and serves the UI.
- `typecheck`, `lint`, and `format:check` green on the touched packages.