### PR TITLE
Fix desktop publish: cross-target install glob and Windows migration rename

### DIFF
--- a/.changeset/desktop-publish-fixes.md
+++ b/.changeset/desktop-publish-fixes.md
@@ -1,0 +1,8 @@
+---
+"executor": patch
+---
+
+Desktop packaging follow-ups from the v1.5.2 release run:
+
+- Fixed the Intel mac desktop build failing in CI (the cross-target dependency install was being glob-expanded by the shell).
+- Fixed the first-launch data migration on Windows: renaming the previous database file could hit a transient `EBUSY` while the just-closed SQLite handle was released, so the move now retries briefly instead of failing startup.

--- a/apps/desktop/scripts/build-sidecar.ts
+++ b/apps/desktop/scripts/build-sidecar.ts
@@ -199,10 +199,18 @@ if (!existsSync(APPS_LOCAL_DIST)) {
 // Cross-target builds (e.g. the mac x64 leg on an arm64 runner) need the other
 // platform's optional native packages on disk before we can stage them.
 // `--cpu=* --os=*` extracts them all without modifying the lockfile. Mirrors
-// apps/cli/src/build.ts.
+// apps/cli/src/build.ts — Bun.spawn, not Bun.$, because the shell
+// glob-expands the bare `*` in `--cpu=*` and fails with "no matches found".
 if (!targetIsCurrentPlatform) {
   console.log("[build-sidecar] installing optional native deps for all platforms...");
-  await $`bun install --frozen-lockfile --cpu=* --os=*`.cwd(REPO_ROOT);
+  const proc = Bun.spawn(["bun", "install", "--frozen-lockfile", "--cpu=*", "--os=*"], {
+    cwd: REPO_ROOT,
+    stdio: ["ignore", "inherit", "inherit"],
+  });
+  if ((await proc.exited) !== 0) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: build-time fatal
+    throw new Error("bun install --cpu=* --os=* failed");
+  }
 }
 
 // Resolve the native bindings up front so a missing platform package fails the

--- a/apps/local/src/db/v1-v2-migration.ts
+++ b/apps/local/src/db/v1-v2-migration.ts
@@ -879,11 +879,29 @@ const insertPlan = async (
   }
 };
 
-const moveSqliteFileSet = (source: string, target: string): void => {
-  fs.renameSync(source, target);
+// Windows reports EBUSY/EPERM on rename for a short window after a SQLite
+// handle closes (handle release lags the close call, and antivirus scanners
+// briefly lock the file). POSIX renames never hit this — retry with a short
+// backoff instead of failing the whole migration.
+const renameWithRetry = async (source: string, target: string): Promise<void> => {
+  const delaysMs = [50, 100, 250, 500, 1000];
+  for (let attempt = 0; ; attempt++) {
+    try {
+      fs.renameSync(source, target);
+      return;
+    } catch (cause) {
+      const code = (cause as NodeJS.ErrnoException).code;
+      if ((code !== "EBUSY" && code !== "EPERM") || attempt >= delaysMs.length) throw cause;
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, delaysMs[attempt]));
+    }
+  }
+};
+
+const moveSqliteFileSet = async (source: string, target: string): Promise<void> => {
+  await renameWithRetry(source, target);
   for (const suffix of ["-wal", "-shm"] as const) {
     if (fs.existsSync(`${source}${suffix}`))
-      fs.renameSync(`${source}${suffix}`, `${target}${suffix}`);
+      await renameWithRetry(`${source}${suffix}`, `${target}${suffix}`);
   }
 };
 
@@ -925,7 +943,7 @@ export const migrateLocalV1ToV2IfNeeded = async (
     const backupPath = backupPathFor(options.sqlitePath);
 
     reader.close();
-    moveSqliteFileSet(options.sqlitePath, backupPath);
+    await moveSqliteFileSet(options.sqlitePath, backupPath);
 
     let target: Awaited<ReturnType<typeof createSqliteFumaDb>> | null = null;
     try {
@@ -955,7 +973,7 @@ export const migrateLocalV1ToV2IfNeeded = async (
     } catch (cause) {
       if (target) await target.close();
       removeSqliteFileSet(options.sqlitePath);
-      if (fs.existsSync(backupPath)) moveSqliteFileSet(backupPath, options.sqlitePath);
+      if (fs.existsSync(backupPath)) await moveSqliteFileSet(backupPath, options.sqlitePath);
       throw cause;
     }
   } finally {


### PR DESCRIPTION
Two fixes for the desktop legs that failed in the v1.5.2 publish run (the new smoke gate did its job — neither would have been caught before publishing previously):

- **mac x64**: the cross-target native-deps install ran through Bun's `$` shell, which glob-expands the bare `*` in `--cpu=*` and fails with "no matches found". Switched to `Bun.spawn` with an argv array, matching `apps/cli/src/build.ts`.
- **Windows**: the compiled-sidecar smoke test caught the v1→v2 data migration failing with `EBUSY` when renaming `data.db` immediately after closing the SQLite handle — Windows releases file handles asynchronously (and runner antivirus takes short-lived locks), unlike POSIX where renaming an open file is fine. The file-set move now retries briefly on `EBUSY`/`EPERM`. This would have affected real Windows installs migrating v1 data, not just CI.

Includes a changeset (patch) so the fixed desktop artifacts ship as the next release; v1.5.2's desktop legs built from the tag and can't pick these up.

Testing: migration suite green; `BUN_TARGET=bun-darwin-x64` sidecar build now completes on an arm64 host and stages x86_64 bindings; arm64 `test:smoke` green; format/lint/typecheck green.