### PR TITLE
e2e scenarios declare dependencies via Effect DI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -337,9 +337,11 @@
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
+        "@types/node": "^25.9.2",
         "@types/react": "catalog:",
         "@types/react-dom": "catalog:",
         "@vitejs/plugin-react": "catalog:",
+        "typescript": "catalog:",
         "vite": "catalog:",
         "vitest": "catalog:",
       },
@@ -5158,6 +5160,8 @@
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "@executor-js/e2e/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
     "@executor-js/emulate/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "@executor-js/emulate/jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
@@ -5813,6 +5817,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@executor-js/e2e/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@executor-js/mcporter/rolldown/@oxc-project/types": ["@oxc-project/types@0.130.0", "", {}, "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q=="],
 

--- a/e2e/cloud/account-api.test.ts
+++ b/e2e/cloud/account-api.test.ts
@@ -8,104 +8,108 @@ import { Effect } from "effect";
 import { AccountHttpApi } from "@executor-js/api";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 scenario(
   "Account · /account/me reflects the signed-in user and their organization",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(AccountHttpApi, identity);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(AccountHttpApi, identity);
 
-      const me = yield* client.account.me();
-      expect(me.user.email, "the session's own user is reported").toBe(identity.label);
-      expect(me.user.id, "the user has a stable id").toMatch(/^user_/);
-      // newIdentity() created this identity's org as "Org <local-part>".
-      const orgName = `Org ${identity.label.split("@")[0]}`;
-      expect(me.organization?.name, "the active organization is the identity's own").toBe(orgName);
-    }),
+    const me = yield* client.account.me();
+    expect(me.user.email, "the session's own user is reported").toBe(identity.label);
+    expect(me.user.id, "the user has a stable id").toMatch(/^user_/);
+    // newIdentity() created this identity's org as "Org <local-part>".
+    const orgName = `Org ${identity.label.split("@")[0]}`;
+    expect(me.organization?.name, "the active organization is the identity's own").toBe(orgName);
+  }),
 );
 
 scenario(
   "Account · an API key is minted once, authorizes the API as a bearer, and can be revoked",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(AccountHttpApi, identity);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(AccountHttpApi, identity);
 
-      // Create: the plaintext secret is returned exactly once, masked everywhere else.
-      const created = yield* client.account.createApiKey({ payload: { name: "e2e key" } });
-      expect(created.name, "the key carries the requested name").toBe("e2e key");
-      expect(created.value, "create returns the one-time plaintext secret").not.toBe("");
-      expect(created.obfuscatedValue, "the display value is masked, not the secret").not.toBe(
-        created.value,
-      );
+    // Create: the plaintext secret is returned exactly once, masked everywhere else.
+    const created = yield* client.account.createApiKey({ payload: { name: "e2e key" } });
+    expect(created.name, "the key carries the requested name").toBe("e2e key");
+    expect(created.value, "create returns the one-time plaintext secret").not.toBe("");
+    expect(created.obfuscatedValue, "the display value is masked, not the secret").not.toBe(
+      created.value,
+    );
 
-      // The created secret is a working credential for the protected API.
-      const bearer = yield* Effect.promise(() =>
-        fetch(new URL("/api/integrations", ctx.target.baseUrl), {
-          headers: { authorization: `Bearer ${created.value}` },
-        }),
-      );
-      expect(bearer.status, "the bearer authenticates the protected API").toBe(200);
-      const integrations = (yield* Effect.promise(() => bearer.json())) as ReadonlyArray<{
-        slug: string;
-      }>;
-      expect(
-        integrations.map((i) => i.slug),
-        "the authorized call sees the workspace's integrations",
-      ).toContain("executor");
+    // The created secret is a working credential for the protected API.
+    const bearer = yield* Effect.promise(() =>
+      fetch(new URL("/api/integrations", target.baseUrl), {
+        headers: { authorization: `Bearer ${created.value}` },
+      }),
+    );
+    expect(bearer.status, "the bearer authenticates the protected API").toBe(200);
+    const integrations = (yield* Effect.promise(() => bearer.json())) as ReadonlyArray<{
+      slug: string;
+    }>;
+    expect(
+      integrations.map((i) => i.slug),
+      "the authorized call sees the workspace's integrations",
+    ).toContain("executor");
 
-      // List: the key shows up masked; the plaintext secret is never re-served.
-      const listed = yield* client.account.listApiKeys();
-      const mine = listed.apiKeys.find((key) => key.id === created.id);
-      expect(mine?.name, "the created key appears in the list").toBe("e2e key");
-      expect(JSON.stringify(listed), "the list never leaks the plaintext secret").not.toContain(
-        created.value,
-      );
+    // List: the key shows up masked; the plaintext secret is never re-served.
+    const listed = yield* client.account.listApiKeys();
+    const mine = listed.apiKeys.find((key) => key.id === created.id);
+    expect(mine?.name, "the created key appears in the list").toBe("e2e key");
+    expect(JSON.stringify(listed), "the list never leaks the plaintext secret").not.toContain(
+      created.value,
+    );
 
-      // Revoke: the key disappears from the account.
-      const revoked = yield* client.account.revokeApiKey({ params: { apiKeyId: created.id } });
-      expect(revoked.success, "revoke reports success").toBe(true);
-      const after = yield* client.account.listApiKeys();
-      expect(
-        after.apiKeys.map((key) => key.id),
-        "the revoked key is gone from the list",
-      ).not.toContain(created.id);
-    }),
+    // Revoke: the key disappears from the account.
+    const revoked = yield* client.account.revokeApiKey({ params: { apiKeyId: created.id } });
+    expect(revoked.success, "revoke reports success").toBe(true);
+    const after = yield* client.account.listApiKeys();
+    expect(
+      after.apiKeys.map((key) => key.id),
+      "the revoked key is gone from the list",
+    ).not.toContain(created.id);
+  }),
 );
 
 scenario(
   "Account · the account surface refuses anonymous and organization-less callers",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      // Anonymous: no session cookie at all → 401.
-      const anonymous = yield* Effect.promise(() =>
-        fetch(new URL("/api/account/me", ctx.target.baseUrl)),
-      );
-      expect(anonymous.status, "no session → unauthorized").toBe(401);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
 
-      // A real session that has not joined an organization yet: identity is
-      // visible (drives onboarding), but org-scoped resources are forbidden.
-      const orgless = yield* ctx.target.newIdentity({ org: false });
-      const me = yield* Effect.promise(() =>
-        fetch(new URL("/api/account/me", ctx.target.baseUrl), { headers: orgless.headers ?? {} }),
-      );
-      expect(me.status, "an org-less session can still see itself").toBe(200);
-      const body = (yield* Effect.promise(() => me.json())) as {
-        user: { email: string };
-        organization: unknown;
-      };
-      expect(body.user.email, "it is the signed-in user").toBe(orgless.label);
-      expect(body.organization, "no organization is active yet").toBeNull();
+    // Anonymous: no session cookie at all → 401.
+    const anonymous = yield* Effect.promise(() =>
+      fetch(new URL("/api/account/me", target.baseUrl)),
+    );
+    expect(anonymous.status, "no session → unauthorized").toBe(401);
 
-      const keys = yield* Effect.promise(() =>
-        fetch(new URL("/api/account/api-keys", ctx.target.baseUrl), {
-          headers: orgless.headers ?? {},
-        }),
-      );
-      expect(keys.status, "org-scoped API keys are forbidden without an organization").toBe(403);
-    }),
+    // A real session that has not joined an organization yet: identity is
+    // visible (drives onboarding), but org-scoped resources are forbidden.
+    const orgless = yield* target.newIdentity({ org: false });
+    const me = yield* Effect.promise(() =>
+      fetch(new URL("/api/account/me", target.baseUrl), { headers: orgless.headers ?? {} }),
+    );
+    expect(me.status, "an org-less session can still see itself").toBe(200);
+    const body = (yield* Effect.promise(() => me.json())) as {
+      user: { email: string };
+      organization: unknown;
+    };
+    expect(body.user.email, "it is the signed-in user").toBe(orgless.label);
+    expect(body.organization, "no organization is active yet").toBeNull();
+
+    const keys = yield* Effect.promise(() =>
+      fetch(new URL("/api/account/api-keys", target.baseUrl), {
+        headers: orgless.headers ?? {},
+      }),
+    );
+    expect(keys.status, "org-scoped API keys are forbidden without an organization").toBe(403);
+  }),
 );

--- a/e2e/cloud/auth-session.test.ts
+++ b/e2e/cloud/auth-session.test.ts
@@ -8,6 +8,7 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 /** First `Set-Cookie` header for `name`, as the raw header string. */
 const setCookieFor = (response: Response, name: string): string => {
@@ -19,109 +20,121 @@ const setCookieFor = (response: Response, name: string): string => {
 
 scenario(
   "Auth · login redirects to hosted AuthKit carrying a short-lived CSRF state cookie",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/api/auth/login", ctx.target.baseUrl), { redirect: "manual" }),
-      );
-      expect(response.status, "login hands the browser to AuthKit").toBe(302);
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
 
-      const authorizeUrl = new URL(response.headers.get("location") ?? "");
-      const state = authorizeUrl.searchParams.get("state") ?? "";
-      expect(state, "the redirect carries an unguessable CSRF state").toMatch(/^[0-9a-f]{64}$/);
-      expect(
-        authorizeUrl.searchParams.get("redirect_uri"),
-        "AuthKit is told to come back to this deployment's callback",
-      ).toBe(new URL("/api/auth/callback", ctx.target.baseUrl).toString());
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/api/auth/login", target.baseUrl), { redirect: "manual" }),
+    );
+    expect(response.status, "login hands the browser to AuthKit").toBe(302);
 
-      const stateCookie = setCookieFor(response, "wos-login-state");
-      expect(stateCookie, "the same state is pinned in a cookie for the callback").toContain(
-        `wos-login-state=${state}`,
-      );
-      expect(stateCookie, "the login state expires quickly").toContain("Max-Age=600");
-      expect(stateCookie, "the login state is not readable by page scripts").toContain("HttpOnly");
-    }),
+    const authorizeUrl = new URL(response.headers.get("location") ?? "");
+    const state = authorizeUrl.searchParams.get("state") ?? "";
+    expect(state, "the redirect carries an unguessable CSRF state").toMatch(/^[0-9a-f]{64}$/);
+    expect(
+      authorizeUrl.searchParams.get("redirect_uri"),
+      "AuthKit is told to come back to this deployment's callback",
+    ).toBe(new URL("/api/auth/callback", target.baseUrl).toString());
+
+    const stateCookie = setCookieFor(response, "wos-login-state");
+    expect(stateCookie, "the same state is pinned in a cookie for the callback").toContain(
+      `wos-login-state=${state}`,
+    );
+    expect(stateCookie, "the login state expires quickly").toContain("Max-Age=600");
+    expect(stateCookie, "the login state is not readable by page scripts").toContain("HttpOnly");
+  }),
 );
 
 scenario(
   "Auth · the callback rejects forged or incomplete redirects without exchanging the code",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const callback = (search: string, cookie?: string) =>
-        Effect.promise(() =>
-          fetch(new URL(`/api/auth/callback${search}`, ctx.target.baseUrl), {
-            redirect: "manual",
-            ...(cookie ? { headers: { cookie } } : {}),
-          }),
-        );
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
 
-      // A state that matches no login-state cookie (no login ever started).
-      const noCookie = yield* callback("?code=attacker-code&state=attacker-state");
-      expect(noCookie.status, "a state with no matching login cookie is refused").toBe(400);
-      expect(
-        setCookieFor(noCookie, "wos-session"),
-        "no session is minted from the forged redirect",
-      ).toBe("");
-
-      // A state that contradicts the login-state cookie the browser holds.
-      const mismatched = yield* callback(
-        "?code=attacker-code&state=attacker-state",
-        "wos-login-state=0000000000000000000000000000000000000000000000000000000000000000",
+    const callback = (search: string, cookie?: string) =>
+      Effect.promise(() =>
+        fetch(new URL(`/api/auth/callback${search}`, target.baseUrl), {
+          redirect: "manual",
+          ...(cookie ? { headers: { cookie } } : {}),
+        }),
       );
-      expect(mismatched.status, "a state contradicting the login cookie is refused").toBe(400);
-      expect(
-        setCookieFor(mismatched, "wos-session"),
-        "no session is minted from the mismatched redirect",
-      ).toBe("");
 
-      // A redirect that never carried the authorization code at all.
-      const noCode = yield* callback("");
-      expect(noCode.status, "a callback without a code is refused").toBe(400);
-    }),
+    // A state that matches no login-state cookie (no login ever started).
+    const noCookie = yield* callback("?code=attacker-code&state=attacker-state");
+    expect(noCookie.status, "a state with no matching login cookie is refused").toBe(400);
+    expect(
+      setCookieFor(noCookie, "wos-session"),
+      "no session is minted from the forged redirect",
+    ).toBe("");
+
+    // A state that contradicts the login-state cookie the browser holds.
+    const mismatched = yield* callback(
+      "?code=attacker-code&state=attacker-state",
+      "wos-login-state=0000000000000000000000000000000000000000000000000000000000000000",
+    );
+    expect(mismatched.status, "a state contradicting the login cookie is refused").toBe(400);
+    expect(
+      setCookieFor(mismatched, "wos-session"),
+      "no session is minted from the mismatched redirect",
+    ).toBe("");
+
+    // A redirect that never carried the authorization code at all.
+    const noCode = yield* callback("");
+    expect(noCode.status, "a callback without a code is refused").toBe(400);
+  }),
 );
 
 scenario(
   "Auth · a completed login's session cookie authorizes the session API",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      // newIdentity() IS the full product login (login → AuthKit → callback);
-      // its headers carry the genuine sealed-session cookie the callback set.
-      const identity = yield* ctx.target.newIdentity();
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
 
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/api/auth/me", ctx.target.baseUrl), { headers: identity.headers ?? {} }),
-      );
-      expect(response.status, "the sealed-session cookie is accepted").toBe(200);
-      const me = (yield* Effect.promise(() => response.json())) as {
-        user: { email: string };
-        organization: { id: string } | null;
-      };
-      expect(me.user.email, "the session belongs to the user who logged in").toBe(identity.label);
-      expect(me.organization?.id, "the session carries the active organization").toMatch(/^org_/);
-    }),
+    // newIdentity() IS the full product login (login → AuthKit → callback);
+    // its headers carry the genuine sealed-session cookie the callback set.
+    const identity = yield* target.newIdentity();
+
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/api/auth/me", target.baseUrl), { headers: identity.headers ?? {} }),
+    );
+    expect(response.status, "the sealed-session cookie is accepted").toBe(200);
+    const me = (yield* Effect.promise(() => response.json())) as {
+      user: { email: string };
+      organization: { id: string } | null;
+    };
+    expect(me.user.email, "the session belongs to the user who logged in").toBe(identity.label);
+    expect(me.organization?.id, "the session carries the active organization").toMatch(/^org_/);
+  }),
 );
 
 scenario(
   "Auth · logout sends the user home and tells the browser to drop the session",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
 
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/api/auth/logout", ctx.target.baseUrl), {
-          method: "POST",
-          redirect: "manual",
-          headers: identity.headers ?? {},
-        }),
-      );
-      expect(response.status, "logout redirects back to the landing page").toBe(302);
-      expect(response.headers.get("location"), "the destination is home").toBe("/");
-      const cleared = setCookieFor(response, "wos-session");
-      expect(cleared, "the session cookie is expired immediately").toContain("Max-Age=0");
-      expect(cleared, "the cookie value is wiped").toContain("wos-session=;");
-    }),
+    const identity = yield* target.newIdentity();
+
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/api/auth/logout", target.baseUrl), {
+        method: "POST",
+        redirect: "manual",
+        headers: identity.headers ?? {},
+      }),
+    );
+    expect(response.status, "logout redirects back to the landing page").toBe(302);
+    expect(response.headers.get("location"), "the destination is home").toBe("/");
+    const cleared = setCookieFor(response, "wos-session");
+    expect(cleared, "the session cookie is expired immediately").toContain("Max-Age=0");
+    expect(cleared, "the cookie value is wiped").toContain("wos-session=;");
+  }),
 );

--- a/e2e/cloud/auth-tool-failures.test.ts
+++ b/e2e/cloud/auth-tool-failures.test.ts
@@ -18,6 +18,7 @@ import {
 } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 
@@ -35,75 +36,76 @@ const pingSpec = JSON.stringify({
 
 scenario(
   "Executions · a tool call with an unresolvable credential fails with connection_value_missing",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(api, identity);
 
-      // Identifier-safe slug: it becomes a property path in the sandbox code.
-      const slug = IntegrationSlug.make(`authscn${randomBytes(4).toString("hex")}`);
-      yield* client.openapi.addSpec({
-        payload: {
-          spec: { kind: "blob", value: pingSpec },
-          slug,
-          baseUrl: "https://api.example.test",
-          authenticationTemplate: [
-            {
-              slug: "apiKey",
-              type: "apiKey",
-              headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
-            },
-          ],
-        },
-      });
-
-      // A connection whose value cannot resolve: a `from` reference into the
-      // real credential provider, pointing at an item that was never stored.
-      const providers = yield* client.providers.list();
-      expect(providers.length, "a credential provider is registered").toBeGreaterThan(0);
-      yield* client.connections.create({
-        payload: {
-          owner: "org",
-          name: ConnectionName.make("main"),
-          integration: slug,
-          template: AuthTemplateSlug.make("apiKey"),
-          from: { provider: providers[0]!, id: ProviderItemId.make(`${slug}-never-stored`) },
-        },
-      });
-
-      // The tool is in the catalog; its address is the sandbox call path.
-      const tools = yield* client.tools.list();
-      const tool = tools.find((entry) => String(entry.integration) === String(slug));
-      expect(tool?.address, "the integration's tool is in the catalog").toBeDefined();
-
-      const execution = yield* client.executions.execute({
-        payload: {
-          code: [`const result = await ${tool!.address}({});`, "return result;"].join("\n"),
-        },
-      });
-
-      expect(execution.status, "the execution itself completes").toBe("completed");
-      if (execution.status !== "completed") return; // unreachable — narrowing only
-      expect(execution.isError, "an auth failure is a model-visible result, not a tool error").toBe(
-        false,
-      );
-      expect(
-        JSON.stringify(execution.structured).toLowerCase(),
-        "no opaque internal tool error reaches the model",
-      ).not.toContain("internal tool error");
-      expect(
-        execution.structured,
-        "the model sees a structured authentication failure it can act on",
-      ).toMatchObject({
-        status: "completed",
-        result: {
-          ok: false,
-          error: {
-            code: "connection_value_missing",
-            details: { category: "authentication" },
+    // Identifier-safe slug: it becomes a property path in the sandbox code.
+    const slug = IntegrationSlug.make(`authscn${randomBytes(4).toString("hex")}`);
+    yield* client.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: pingSpec },
+        slug,
+        baseUrl: "https://api.example.test",
+        authenticationTemplate: [
+          {
+            slug: "apiKey",
+            type: "apiKey",
+            headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
           },
+        ],
+      },
+    });
+
+    // A connection whose value cannot resolve: a `from` reference into the
+    // real credential provider, pointing at an item that was never stored.
+    const providers = yield* client.providers.list();
+    expect(providers.length, "a credential provider is registered").toBeGreaterThan(0);
+    yield* client.connections.create({
+      payload: {
+        owner: "org",
+        name: ConnectionName.make("main"),
+        integration: slug,
+        template: AuthTemplateSlug.make("apiKey"),
+        from: { provider: providers[0]!, id: ProviderItemId.make(`${slug}-never-stored`) },
+      },
+    });
+
+    // The tool is in the catalog; its address is the sandbox call path.
+    const tools = yield* client.tools.list({ query: {} });
+    const tool = tools.find((entry) => String(entry.integration) === String(slug));
+    expect(tool?.address, "the integration's tool is in the catalog").toBeDefined();
+
+    const execution = yield* client.executions.execute({
+      payload: {
+        code: [`const result = await ${tool!.address}({});`, "return result;"].join("\n"),
+      },
+    });
+
+    expect(execution.status, "the execution itself completes").toBe("completed");
+    if (execution.status !== "completed") return; // unreachable — narrowing only
+    expect(execution.isError, "an auth failure is a model-visible result, not a tool error").toBe(
+      false,
+    );
+    expect(
+      JSON.stringify(execution.structured).toLowerCase(),
+      "no opaque internal tool error reaches the model",
+    ).not.toContain("internal tool error");
+    expect(
+      execution.structured,
+      "the model sees a structured authentication failure it can act on",
+    ).toMatchObject({
+      status: "completed",
+      result: {
+        ok: false,
+        error: {
+          code: "connection_value_missing",
+          details: { category: "authentication" },
         },
-      });
-    }),
+      },
+    });
+  }),
 );

--- a/e2e/cloud/connect-panel.test.ts
+++ b/e2e/cloud/connect-panel.test.ts
@@ -5,45 +5,47 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
 
 scenario(
   "Connect · the agent-connect panel gives working copy for both transports",
-  { needs: ["browser"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
 
-      yield* ctx.browser.session(identity, async ({ page, step }) => {
-        await step("Open the Integrations page", async () => {
-          await page.goto("/", { waitUntil: "networkidle" });
-          await page.getByText("Connect an agent").first().waitFor();
-        });
-
-        const command = () => page.locator("code").first().innerText();
-
-        await step("Remote HTTP is the default transport", async () => {
-          await page.getByText("Connect an agent").first().waitFor();
-        });
-        const httpCommand = await command();
-        expect(httpCommand, "the default command adds the MCP server").toContain("npx add-mcp");
-        expect(httpCommand, "the HTTP command is org-scoped").toMatch(/\/org_[^/]+\/mcp/);
-        expect(httpCommand).toContain("--transport http");
-
-        await step("Switch to Standard I/O", async () => {
-          await page.getByRole("tab", { name: "Standard I/O" }).click();
-          await page.waitForLoadState("networkidle");
-        });
-        const stdioCommand = await command();
-        expect(stdioCommand, "the command changed for stdio").not.toBe(httpCommand);
-        expect(stdioCommand, "stdio does not use the HTTP transport").not.toContain(
-          "--transport http",
-        );
-
-        await step("Switch back to Remote HTTP", async () => {
-          await page.getByRole("tab", { name: "Remote HTTP" }).click();
-          await page.waitForLoadState("networkidle");
-        });
-        expect(await command(), "the HTTP command is restored").toContain("--transport http");
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Open the Integrations page", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.getByText("Connect an agent").first().waitFor();
       });
-    }),
+
+      const command = () => page.locator("code").first().innerText();
+
+      await step("Remote HTTP is the default transport", async () => {
+        await page.getByText("Connect an agent").first().waitFor();
+      });
+      const httpCommand = await command();
+      expect(httpCommand, "the default command adds the MCP server").toContain("npx add-mcp");
+      expect(httpCommand, "the HTTP command is org-scoped").toMatch(/\/org_[^/]+\/mcp/);
+      expect(httpCommand).toContain("--transport http");
+
+      await step("Switch to Standard I/O", async () => {
+        await page.getByRole("tab", { name: "Standard I/O" }).click();
+        await page.waitForLoadState("networkidle");
+      });
+      const stdioCommand = await command();
+      expect(stdioCommand, "the command changed for stdio").not.toBe(httpCommand);
+      expect(stdioCommand, "stdio does not use the HTTP transport").not.toContain(
+        "--transport http",
+      );
+
+      await step("Switch back to Remote HTTP", async () => {
+        await page.getByRole("tab", { name: "Remote HTTP" }).click();
+        await page.waitForLoadState("networkidle");
+      });
+      expect(await command(), "the HTTP command is restored").toContain("--transport http");
+    });
+  }),
 );

--- a/e2e/cloud/connection-owner-isolation.test.ts
+++ b/e2e/cloud/connection-owner-isolation.test.ts
@@ -19,7 +19,8 @@ import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
-import type { Identity, Target } from "../src/target";
+import { Api, Target } from "../src/services";
+import type { Identity, Target as TargetShape } from "../src/target";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 type Client = HttpApiClient.ForApi<typeof api>;
@@ -66,7 +67,7 @@ const freshConnectionName = () => ConnectionName.make(`conn${randomBytes(4).toSt
 
 const cookieOf = (identity: Identity): string => identity.headers?.["cookie"] ?? "";
 
-const postJson = (target: Target, path: string, identity: Identity, body: unknown) =>
+const postJson = (target: TargetShape, path: string, identity: Identity, body: unknown) =>
   Effect.promise(async () => {
     const response = await fetch(new URL(path, target.baseUrl), {
       method: "POST",
@@ -94,7 +95,7 @@ const withRefreshedSession = (identity: Identity, response: Response): Identity 
 
 /** Invite `member` into `admin`'s org and accept — the real invite flow.
  *  Returns the member identity with its session re-bound to that org. */
-const joinOrg = (target: Target, admin: Identity, member: Identity) =>
+const joinOrg = (target: TargetShape, admin: Identity, member: Identity) =>
   Effect.gen(function* () {
     const inviteResponse = yield* postJson(target, "/api/account/members/invite", admin, {
       email: member.credentials?.email,
@@ -107,14 +108,14 @@ const joinOrg = (target: Target, admin: Identity, member: Identity) =>
   });
 
 /** Create another org for this account; returns the identity bound to it. */
-const createAnotherOrg = (target: Target, identity: Identity, name: string) =>
+const createAnotherOrg = (target: TargetShape, identity: Identity, name: string) =>
   Effect.gen(function* () {
     const response = yield* postJson(target, "/api/auth/create-organization", identity, { name });
     return withRefreshedSession(identity, response);
   });
 
 /** Switch this account's active org; returns the identity bound to it. */
-const switchOrg = (target: Target, identity: Identity, organizationId: string) =>
+const switchOrg = (target: TargetShape, identity: Identity, organizationId: string) =>
   Effect.gen(function* () {
     const response = yield* postJson(target, "/api/auth/switch-organization", identity, {
       organizationId,
@@ -123,7 +124,7 @@ const switchOrg = (target: Target, identity: Identity, organizationId: string) =
   });
 
 /** The org this identity's session is currently bound to. */
-const activeOrganizationId = (target: Target, identity: Identity) =>
+const activeOrganizationId = (target: TargetShape, identity: Identity) =>
   Effect.promise(async () => {
     const response = await fetch(new URL("/api/auth/me", target.baseUrl), {
       headers: { cookie: cookieOf(identity) },
@@ -136,154 +137,157 @@ const activeOrganizationId = (target: Target, identity: Identity) =>
 
 scenario(
   "Connections · a user-owned connection is private to its creator, even inside the same org",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const admin = yield* ctx.target.newIdentity();
-      const invitee = yield* ctx.target.newIdentity({ org: false });
-      const colleague = yield* joinOrg(ctx.target, admin, invitee);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const admin = yield* target.newIdentity();
+    const invitee = yield* target.newIdentity({ org: false });
+    const colleague = yield* joinOrg(target, admin, invitee);
 
-      const adminClient = yield* ctx.api.client(api, admin);
-      const colleagueClient = yield* ctx.api.client(api, colleague);
+    const adminClient = yield* client(api, admin);
+    const colleagueClient = yield* client(api, colleague);
 
-      const integration = yield* registerIntegration(adminClient);
-      const name = freshConnectionName();
-      const secretValue = `personal-token-${randomBytes(8).toString("hex")}`;
+    const integration = yield* registerIntegration(adminClient);
+    const name = freshConnectionName();
+    const secretValue = `personal-token-${randomBytes(8).toString("hex")}`;
 
-      // The admin stores a PERSONAL (user-owned) credential.
-      yield* adminClient.connections.create({
-        payload: {
-          owner: "user",
-          name,
-          integration,
-          template: TEMPLATE_API_KEY,
-          value: secretValue,
-        },
-      });
+    // The admin stores a PERSONAL (user-owned) credential.
+    yield* adminClient.connections.create({
+      payload: {
+        owner: "user",
+        name,
+        integration,
+        template: TEMPLATE_API_KEY,
+        value: secretValue,
+      },
+    });
 
-      // A colleague in the SAME org sees neither the connection nor its bytes.
-      const colleagueUserList = yield* colleagueClient.connections.list({
-        query: { integration, owner: "user" },
-      });
-      expect(
-        colleagueUserList.map((connection) => connection.name),
-        "a co-worker's user-owned list has no trace of the admin's personal connection",
-      ).not.toContain(name);
+    // A colleague in the SAME org sees neither the connection nor its bytes.
+    const colleagueUserList = yield* colleagueClient.connections.list({
+      query: { integration, owner: "user" },
+    });
+    expect(
+      colleagueUserList.map((connection) => connection.name),
+      "a co-worker's user-owned list has no trace of the admin's personal connection",
+    ).not.toContain(name);
 
-      const colleagueAll = yield* colleagueClient.connections.list({ query: {} });
-      expect(
-        colleagueAll.map((connection) => connection.name),
-        "the personal connection is absent from the co-worker's full list too",
-      ).not.toContain(name);
-      expect(
-        JSON.stringify(colleagueAll),
-        "the personal secret appears nowhere in the co-worker's view",
-      ).not.toContain(secretValue);
+    const colleagueAll = yield* colleagueClient.connections.list({ query: {} });
+    expect(
+      colleagueAll.map((connection) => connection.name),
+      "the personal connection is absent from the co-worker's full list too",
+    ).not.toContain(name);
+    expect(
+      JSON.stringify(colleagueAll),
+      "the personal secret appears nowhere in the co-worker's view",
+    ).not.toContain(secretValue);
 
-      // And the creator still sees their own connection.
-      const adminUserList = yield* adminClient.connections.list({
-        query: { integration, owner: "user" },
-      });
-      expect(
-        adminUserList.map((connection) => connection.name),
-        "the creator still sees their own personal connection",
-      ).toContain(name);
-    }),
+    // And the creator still sees their own connection.
+    const adminUserList = yield* adminClient.connections.list({
+      query: { integration, owner: "user" },
+    });
+    expect(
+      adminUserList.map((connection) => connection.name),
+      "the creator still sees their own personal connection",
+    ).toContain(name);
+  }),
 );
 
 scenario(
   "Connections · an org-owned connection is shared with every member of the org",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const admin = yield* ctx.target.newIdentity();
-      const invitee = yield* ctx.target.newIdentity({ org: false });
-      const member = yield* joinOrg(ctx.target, admin, invitee);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const admin = yield* target.newIdentity();
+    const invitee = yield* target.newIdentity({ org: false });
+    const member = yield* joinOrg(target, admin, invitee);
 
-      const adminClient = yield* ctx.api.client(api, admin);
-      const memberClient = yield* ctx.api.client(api, member);
+    const adminClient = yield* client(api, admin);
+    const memberClient = yield* client(api, member);
 
-      const integration = yield* registerIntegration(adminClient);
-      const name = freshConnectionName();
+    const integration = yield* registerIntegration(adminClient);
+    const name = freshConnectionName();
 
-      // The admin stores a SHARED (org-owned) credential.
-      yield* adminClient.connections.create({
-        payload: {
-          owner: "org",
-          name,
-          integration,
-          template: TEMPLATE_API_KEY,
-          value: "shared-org-key",
-        },
-      });
+    // The admin stores a SHARED (org-owned) credential.
+    yield* adminClient.connections.create({
+      payload: {
+        owner: "org",
+        name,
+        integration,
+        template: TEMPLATE_API_KEY,
+        value: "shared-org-key",
+      },
+    });
 
-      const adminOrgList = yield* adminClient.connections.list({
-        query: { integration, owner: "org" },
-      });
-      const memberOrgList = yield* memberClient.connections.list({
-        query: { integration, owner: "org" },
-      });
-      expect(
-        adminOrgList.map((connection) => connection.name),
-        "the admin sees the shared org connection",
-      ).toContain(name);
-      expect(
-        memberOrgList.map((connection) => connection.name),
-        "an invited member sees the shared org connection too",
-      ).toContain(name);
-    }),
+    const adminOrgList = yield* adminClient.connections.list({
+      query: { integration, owner: "org" },
+    });
+    const memberOrgList = yield* memberClient.connections.list({
+      query: { integration, owner: "org" },
+    });
+    expect(
+      adminOrgList.map((connection) => connection.name),
+      "the admin sees the shared org connection",
+    ).toContain(name);
+    expect(
+      memberOrgList.map((connection) => connection.name),
+      "an invited member sees the shared org connection too",
+    ).toContain(name);
+  }),
 );
 
 scenario(
   "Connections · the same account in two orgs gets two separate credential spaces",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const userInOrgA = yield* ctx.target.newIdentity();
-      const orgAId = yield* activeOrganizationId(ctx.target, userInOrgA);
-      const clientA = yield* ctx.api.client(api, userInOrgA);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const userInOrgA = yield* target.newIdentity();
+    const orgAId = yield* activeOrganizationId(target, userInOrgA);
+    const clientA = yield* client(api, userInOrgA);
 
-      const integration = yield* registerIntegration(clientA);
-      const name = freshConnectionName();
-      yield* clientA.connections.create({
-        payload: {
-          owner: "user",
-          name,
-          integration,
-          template: TEMPLATE_API_KEY,
-          value: "value-in-org-a",
-        },
-      });
+    const integration = yield* registerIntegration(clientA);
+    const name = freshConnectionName();
+    yield* clientA.connections.create({
+      payload: {
+        owner: "user",
+        name,
+        integration,
+        template: TEMPLATE_API_KEY,
+        value: "value-in-org-a",
+      },
+    });
 
-      // The SAME account creates and switches into a second org.
-      const userInOrgB = yield* createAnotherOrg(
-        ctx.target,
-        userInOrgA,
-        `Second Org ${randomBytes(3).toString("hex")}`,
-      );
-      const clientB = yield* ctx.api.client(api, userInOrgB);
+    // The SAME account creates and switches into a second org.
+    const userInOrgB = yield* createAnotherOrg(
+      target,
+      userInOrgA,
+      `Second Org ${randomBytes(3).toString("hex")}`,
+    );
+    const clientB = yield* client(api, userInOrgB);
 
-      const orgBIntegrations = yield* clientB.integrations.list();
-      expect(
-        orgBIntegrations.map((entry) => entry.slug),
-        "the new org does not see org A's integration",
-      ).not.toContain(integration);
+    const orgBIntegrations = yield* clientB.integrations.list();
+    expect(
+      orgBIntegrations.map((entry) => entry.slug),
+      "the new org does not see org A's integration",
+    ).not.toContain(integration);
 
-      const orgBConnections = yield* clientB.connections.list({ query: {} });
-      expect(
-        orgBConnections.map((connection) => connection.name),
-        "the user's org-A connection is invisible from their second org",
-      ).not.toContain(name);
+    const orgBConnections = yield* clientB.connections.list({ query: {} });
+    expect(
+      orgBConnections.map((connection) => connection.name),
+      "the user's org-A connection is invisible from their second org",
+    ).not.toContain(name);
 
-      // Switching back to org A, the connection is still theirs.
-      const backInOrgA = yield* switchOrg(ctx.target, userInOrgB, orgAId);
-      const clientABack = yield* ctx.api.client(api, backInOrgA);
-      const orgAUserList = yield* clientABack.connections.list({
-        query: { integration, owner: "user" },
-      });
-      expect(
-        orgAUserList.map((connection) => connection.name),
-        "back in org A, the user-owned connection is still there",
-      ).toContain(name);
-    }),
+    // Switching back to org A, the connection is still theirs.
+    const backInOrgA = yield* switchOrg(target, userInOrgB, orgAId);
+    const clientABack = yield* client(api, backInOrgA);
+    const orgAUserList = yield* clientABack.connections.list({
+      query: { integration, owner: "user" },
+    });
+    expect(
+      orgAUserList.map((connection) => connection.name),
+      "back in org A, the user-owned connection is still there",
+    ).toContain(name);
+  }),
 );

--- a/e2e/cloud/connections-credentials.test.ts
+++ b/e2e/cloud/connections-credentials.test.ts
@@ -15,6 +15,7 @@ import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 type Client = HttpApiClient.ForApi<typeof api>;
@@ -58,150 +59,154 @@ const freshConnectionName = () => ConnectionName.make(`conn${randomBytes(4).toSt
 
 scenario(
   "Connections · a stored credential round-trips as metadata and never echoes its value",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const integration = yield* registerIntegration(client);
-      const name = freshConnectionName();
-      const secretValue = `sk-test-${randomBytes(8).toString("hex")}`;
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(api, identity);
+    const integration = yield* registerIntegration(client);
+    const name = freshConnectionName();
+    const secretValue = `sk-test-${randomBytes(8).toString("hex")}`;
 
-      const created = yield* client.connections.create({
-        payload: {
-          owner: "org",
-          name,
-          integration,
-          template: TEMPLATE_API_KEY,
-          identityLabel: "My API Token",
-          value: secretValue,
-        },
-      });
-      expect(created.name, "create returns the stored connection name").toBe(name);
-      expect(created.owner, "the connection is filed under its owner").toBe("org");
-      expect(JSON.stringify(created), "the create response never carries the secret").not.toContain(
-        secretValue,
-      );
-
-      const list = yield* client.connections.list({ query: { integration } });
-      const listed = list.find((connection) => connection.name === name);
-      expect(listed?.identityLabel, "the listed connection keeps its label").toBe("My API Token");
-      expect(JSON.stringify(list), "the list never carries the secret").not.toContain(secretValue);
-
-      const fetched = yield* client.connections.get({
-        params: { owner: "org", integration, name },
-      });
-      expect(fetched.name, "get returns the connection by its identifier").toBe(name);
-      expect(fetched.integration, "get returns the connection bound to its integration").toBe(
+    const created = yield* client.connections.create({
+      payload: {
+        owner: "org",
+        name,
         integration,
-      );
-      expect(JSON.stringify(fetched), "get never carries the secret").not.toContain(secretValue);
-    }),
+        template: TEMPLATE_API_KEY,
+        identityLabel: "My API Token",
+        value: secretValue,
+      },
+    });
+    expect(created.name, "create returns the stored connection name").toBe(name);
+    expect(created.owner, "the connection is filed under its owner").toBe("org");
+    expect(JSON.stringify(created), "the create response never carries the secret").not.toContain(
+      secretValue,
+    );
+
+    const list = yield* client.connections.list({ query: { integration } });
+    const listed = list.find((connection) => connection.name === name);
+    expect(listed?.identityLabel, "the listed connection keeps its label").toBe("My API Token");
+    expect(JSON.stringify(list), "the list never carries the secret").not.toContain(secretValue);
+
+    const fetched = yield* client.connections.get({
+      params: { owner: "org", integration, name },
+    });
+    expect(fetched.name, "get returns the connection by its identifier").toBe(name);
+    expect(fetched.integration, "get returns the connection bound to its integration").toBe(
+      integration,
+    );
+    expect(JSON.stringify(fetched), "get never carries the secret").not.toContain(secretValue);
+  }),
 );
 
 scenario(
   "Connections · re-creating the same connection replaces it instead of duplicating",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const integration = yield* registerIntegration(client);
-      const name = freshConnectionName();
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(api, identity);
+    const integration = yield* registerIntegration(client);
+    const name = freshConnectionName();
 
-      yield* client.connections.create({
-        payload: {
-          owner: "org",
-          name,
-          integration,
-          template: TEMPLATE_API_KEY,
-          identityLabel: "first key",
-          value: "first-value",
-        },
-      });
-      const first = yield* client.connections.list({ query: { integration } });
-      expect(
-        first.filter((connection) => connection.name === name).map((c) => c.identityLabel),
-        "the first create stores one row with its label",
-      ).toEqual(["first key"]);
+    yield* client.connections.create({
+      payload: {
+        owner: "org",
+        name,
+        integration,
+        template: TEMPLATE_API_KEY,
+        identityLabel: "first key",
+        value: "first-value",
+      },
+    });
+    const first = yield* client.connections.list({ query: { integration } });
+    expect(
+      first.filter((connection) => connection.name === name).map((c) => c.identityLabel),
+      "the first create stores one row with its label",
+    ).toEqual(["first key"]);
 
-      yield* client.connections.create({
-        payload: {
-          owner: "org",
-          name,
-          integration,
-          template: TEMPLATE_API_KEY,
-          identityLabel: "rotated key",
-          value: "second-value",
-        },
-      });
-      const second = yield* client.connections.list({ query: { integration } });
-      expect(
-        second.filter((connection) => connection.name === name).map((c) => c.identityLabel),
-        "re-creating the same (owner, integration, name) updates the row in place",
-      ).toEqual(["rotated key"]);
-    }),
+    yield* client.connections.create({
+      payload: {
+        owner: "org",
+        name,
+        integration,
+        template: TEMPLATE_API_KEY,
+        identityLabel: "rotated key",
+        value: "second-value",
+      },
+    });
+    const second = yield* client.connections.list({ query: { integration } });
+    expect(
+      second.filter((connection) => connection.name === name).map((c) => c.identityLabel),
+      "re-creating the same (owner, integration, name) updates the row in place",
+    ).toEqual(["rotated key"]);
+  }),
 );
 
 scenario(
   "Connections · a removed connection disappears from both list and get",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const integration = yield* registerIntegration(client);
-      const name = freshConnectionName();
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(api, identity);
+    const integration = yield* registerIntegration(client);
+    const name = freshConnectionName();
 
-      yield* client.connections.create({
-        payload: { owner: "org", name, integration, template: TEMPLATE_API_KEY, value: "v" },
-      });
+    yield* client.connections.create({
+      payload: { owner: "org", name, integration, template: TEMPLATE_API_KEY, value: "v" },
+    });
 
-      const removed = yield* client.connections.remove({
-        params: { owner: "org", integration, name },
-      });
-      expect(removed.removed, "remove acknowledges the deletion").toBe(true);
+    const removed = yield* client.connections.remove({
+      params: { owner: "org", integration, name },
+    });
+    expect(removed.removed, "remove acknowledges the deletion").toBe(true);
 
-      const list = yield* client.connections.list({ query: { integration } });
-      expect(
-        list.map((connection) => connection.name),
-        "the removed connection is gone from the list",
-      ).not.toContain(name);
+    const list = yield* client.connections.list({ query: { integration } });
+    expect(
+      list.map((connection) => connection.name),
+      "the removed connection is gone from the list",
+    ).not.toContain(name);
 
-      const error = yield* client.connections
-        .get({ params: { owner: "org", integration, name } })
-        .pipe(Effect.flip);
-      expect(
-        (error as { _tag?: string })._tag,
-        "get after remove fails with the typed not-found error",
-      ).toBe("ConnectionNotFoundError");
-    }),
+    const error = yield* client.connections
+      .get({ params: { owner: "org", integration, name } })
+      .pipe(Effect.flip);
+    expect(
+      (error as { _tag?: string })._tag,
+      "get after remove fails with the typed not-found error",
+    ).toBe("ConnectionNotFoundError");
+  }),
 );
 
 scenario(
   "Connections · reading or removing an unknown connection fails with not-found",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const integration = yield* registerIntegration(client);
-      const missing = freshConnectionName();
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: apiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiClient(api, identity);
+    const integration = yield* registerIntegration(client);
+    const missing = freshConnectionName();
 
-      const getError = yield* client.connections
-        .get({ params: { owner: "org", integration, name: missing } })
-        .pipe(Effect.flip);
-      expect(
-        (getError as { _tag?: string })._tag,
-        "get on an unknown connection fails with the typed not-found error",
-      ).toBe("ConnectionNotFoundError");
+    const getError = yield* client.connections
+      .get({ params: { owner: "org", integration, name: missing } })
+      .pipe(Effect.flip);
+    expect(
+      (getError as { _tag?: string })._tag,
+      "get on an unknown connection fails with the typed not-found error",
+    ).toBe("ConnectionNotFoundError");
 
-      const removeError = yield* client.connections
-        .remove({ params: { owner: "org", integration, name: missing } })
-        .pipe(Effect.flip);
-      expect(
-        (removeError as { _tag?: string })._tag,
-        "remove on an unknown connection fails with the typed not-found error",
-      ).toBe("ConnectionNotFoundError");
-    }),
+    const removeError = yield* client.connections
+      .remove({ params: { owner: "org", integration, name: missing } })
+      .pipe(Effect.flip);
+    expect(
+      (removeError as { _tag?: string })._tag,
+      "remove on an unknown connection fails with the typed not-found error",
+    ).toBe("ConnectionNotFoundError");
+  }),
 );

--- a/e2e/cloud/mcp-client-sessions.test.ts
+++ b/e2e/cloud/mcp-client-sessions.test.ts
@@ -16,6 +16,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
 import type { Identity } from "../src/target";
 
 const coreApi = composePluginApi([] as const);
@@ -45,7 +46,7 @@ const connectClient = async (
   return { client, transport };
 };
 
-const textOf = (result: { content?: unknown }): string =>
+const textOf = (result: { content?: unknown; toolResult?: unknown }): string =>
   ((result.content ?? []) as Array<{ type: string; text?: string }>)
     .filter((part) => part.type === "text")
     .map((part) => part.text)
@@ -56,158 +57,153 @@ const closeQuietly = (connected: Connected): Effect.Effect<void> =>
 
 scenario(
   "MCP sessions · a real MCP client connects, lists tools, and executes code",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      const session = yield* Effect.promise(() => connectClient(ctx.target.mcpUrl, bearer));
-      yield* Effect.gen(function* () {
-        expect(
-          session.client.getServerVersion()?.name,
-          "the handshake reports the product server",
-        ).toBe("executor");
-        expect(session.transport.sessionId, "the transport holds a session id").toEqual(
-          expect.any(String),
-        );
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const session = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer));
+    yield* Effect.gen(function* () {
+      expect(
+        session.client.getServerVersion()?.name,
+        "the handshake reports the product server",
+      ).toBe("executor");
+      expect(session.transport.sessionId, "the transport holds a session id").toEqual(
+        expect.any(String),
+      );
 
-        const { tools } = yield* Effect.promise(() => session.client.listTools());
-        expect(
-          tools.map((tool) => tool.name),
-          "the execute tool is advertised",
-        ).toContain("execute");
-        expect(
-          tools.map((tool) => tool.name),
-          "the resume tool is advertised",
-        ).toContain("resume");
+      const { tools } = yield* Effect.promise(() => session.client.listTools());
+      expect(
+        tools.map((tool) => tool.name),
+        "the execute tool is advertised",
+      ).toContain("execute");
+      expect(
+        tools.map((tool) => tool.name),
+        "the resume tool is advertised",
+      ).toContain("resume");
 
-        const result = yield* Effect.promise(() =>
-          session.client.callTool({ name: "execute", arguments: { code: "return 6 * 7;" } }),
-        );
-        expect(result.isError, "the call succeeds").not.toBe(true);
-        expect(textOf(result), "the sandbox returns the value").toContain("42");
-      }).pipe(Effect.ensuring(closeQuietly(session)));
-    }),
+      const result = yield* Effect.promise(() =>
+        session.client.callTool({ name: "execute", arguments: { code: "return 6 * 7;" } }),
+      );
+      expect(result.isError, "the call succeeds").not.toBe(true);
+      expect(textOf(result), "the sandbox returns the value").toContain("42");
+    }).pipe(Effect.ensuring(closeQuietly(session)));
+  }),
 );
 
 scenario(
   "MCP sessions · a second client resuming the session id continues the session",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
 
-      // First connection establishes the session, does real work, then goes
-      // away — the laptop-closed / process-restarted case.
-      const first = yield* Effect.promise(() => connectClient(ctx.target.mcpUrl, bearer));
-      const sessionId = first.transport.sessionId;
-      expect(sessionId, "the first client got a session id").toEqual(expect.any(String));
-      const before = yield* Effect.promise(() =>
-        first.client.callTool({ name: "execute", arguments: { code: 'return "before";' } }),
-      ).pipe(Effect.ensuring(closeQuietly(first)));
-      expect(textOf(before), "the first client's call succeeded").toContain("before");
+    // First connection establishes the session, does real work, then goes
+    // away — the laptop-closed / process-restarted case.
+    const first = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer));
+    const sessionId = first.transport.sessionId;
+    expect(sessionId, "the first client got a session id").toEqual(expect.any(String));
+    const before = yield* Effect.promise(() =>
+      first.client.callTool({ name: "execute", arguments: { code: 'return "before";' } }),
+    ).pipe(Effect.ensuring(closeQuietly(first)));
+    expect(textOf(before), "the first client's call succeeded").toContain("before");
 
-      // A brand-new client resumes with nothing but the session id. The
-      // session's Durable Object state persists across connections — this is
-      // the restore guarantee.
-      const second = yield* Effect.promise(() =>
-        connectClient(ctx.target.mcpUrl, bearer, sessionId),
+    // A brand-new client resumes with nothing but the session id. The
+    // session's Durable Object state persists across connections — this is
+    // the restore guarantee.
+    const second = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer, sessionId));
+    yield* Effect.gen(function* () {
+      expect(second.transport.sessionId, "the session id is preserved, not reissued").toBe(
+        sessionId,
       );
-      yield* Effect.gen(function* () {
-        expect(second.transport.sessionId, "the session id is preserved, not reissued").toBe(
-          sessionId,
-        );
-        const { tools } = yield* Effect.promise(() => second.client.listTools());
-        expect(
-          tools.map((tool) => tool.name),
-          "the resumed session serves requests",
-        ).toContain("execute");
-        const after = yield* Effect.promise(() =>
-          second.client.callTool({ name: "execute", arguments: { code: 'return "after";' } }),
-        );
-        expect(after.isError, "the resumed session executes code").not.toBe(true);
-        expect(textOf(after), "the resumed session returns results").toContain("after");
-      }).pipe(Effect.ensuring(closeQuietly(second)));
-    }),
+      const { tools } = yield* Effect.promise(() => second.client.listTools());
+      expect(
+        tools.map((tool) => tool.name),
+        "the resumed session serves requests",
+      ).toContain("execute");
+      const after = yield* Effect.promise(() =>
+        second.client.callTool({ name: "execute", arguments: { code: 'return "after";' } }),
+      );
+      expect(after.isError, "the resumed session executes code").not.toBe(true);
+      expect(textOf(after), "the resumed session returns results").toContain("after");
+    }).pipe(Effect.ensuring(closeQuietly(second)));
+  }),
 );
 
 scenario(
   "MCP sessions · an unknown session id fails fast with a clean error, not a hang",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      // A session id the server never issued (right shape, never minted).
-      const session = yield* Effect.promise(() =>
-        connectClient(ctx.target.mcpUrl, bearer, "0".repeat(64)),
-      );
-      const failure = yield* Effect.flip(
-        Effect.tryPromise({
-          try: () => session.client.listTools(),
-          catch: (cause) => cause,
-        }),
-      ).pipe(
-        Effect.timeoutOrElse({
-          duration: "15 seconds",
-          orElse: () =>
-            Effect.die(new Error("listTools on an unknown session hung instead of failing")),
-        }),
-        Effect.ensuring(closeQuietly(session)),
-      );
-      expect(String(failure), "the server answered with a JSON-RPC error envelope").toContain(
-        "jsonrpc",
-      );
-    }),
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    // A session id the server never issued (right shape, never minted).
+    const session = yield* Effect.promise(() =>
+      connectClient(target.mcpUrl, bearer, "0".repeat(64)),
+    );
+    const failure = yield* Effect.flip(
+      Effect.tryPromise({
+        try: () => session.client.listTools(),
+        catch: (cause) => cause,
+      }),
+    ).pipe(
+      Effect.timeoutOrElse({
+        duration: "15 seconds",
+        orElse: () =>
+          Effect.die(new Error("listTools on an unknown session hung instead of failing")),
+      }),
+      Effect.ensuring(closeQuietly(session)),
+    );
+    expect(String(failure), "the server answered with a JSON-RPC error envelope").toContain(
+      "jsonrpc",
+    );
+  }),
 );
 
 scenario(
   "MCP sessions · two concurrent clients hold isolated sessions that don't interfere",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      const [alpha, beta] = yield* Effect.promise(() =>
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const [alpha, beta] = yield* Effect.promise(() =>
+      Promise.all([connectClient(target.mcpUrl, bearer), connectClient(target.mcpUrl, bearer)]),
+    );
+    yield* Effect.gen(function* () {
+      expect(alpha.transport.sessionId, "each client gets its own session").not.toBe(
+        beta.transport.sessionId,
+      );
+
+      const [alphaResult, betaResult] = yield* Effect.promise(() =>
         Promise.all([
-          connectClient(ctx.target.mcpUrl, bearer),
-          connectClient(ctx.target.mcpUrl, bearer),
+          alpha.client.callTool({
+            name: "execute",
+            arguments: {
+              code: 'await new Promise((resolve) => setTimeout(resolve, 300));\nreturn "alpha-result";',
+            },
+          }),
+          beta.client.callTool({
+            name: "execute",
+            arguments: { code: 'return "beta-result";' },
+          }),
         ]),
       );
-      yield* Effect.gen(function* () {
-        expect(alpha.transport.sessionId, "each client gets its own session").not.toBe(
-          beta.transport.sessionId,
-        );
-
-        const [alphaResult, betaResult] = yield* Effect.promise(() =>
-          Promise.all([
-            alpha.client.callTool({
-              name: "execute",
-              arguments: {
-                code: 'await new Promise((resolve) => setTimeout(resolve, 300));\nreturn "alpha-result";',
-              },
-            }),
-            beta.client.callTool({
-              name: "execute",
-              arguments: { code: 'return "beta-result";' },
-            }),
-          ]),
-        );
-        expect(textOf(alphaResult), "the first session got its own answer").toContain(
-          "alpha-result",
-        );
-        expect(textOf(alphaResult), "no cross-talk into the first session").not.toContain(
-          "beta-result",
-        );
-        expect(textOf(betaResult), "the second session got its own answer").toContain(
-          "beta-result",
-        );
-        expect(textOf(betaResult), "no cross-talk into the second session").not.toContain(
-          "alpha-result",
-        );
-      }).pipe(Effect.ensuring(closeQuietly(alpha)), Effect.ensuring(closeQuietly(beta)));
-    }),
+      expect(textOf(alphaResult), "the first session got its own answer").toContain("alpha-result");
+      expect(textOf(alphaResult), "no cross-talk into the first session").not.toContain(
+        "beta-result",
+      );
+      expect(textOf(betaResult), "the second session got its own answer").toContain("beta-result");
+      expect(textOf(betaResult), "no cross-talk into the second session").not.toContain(
+        "alpha-result",
+      );
+    }).pipe(Effect.ensuring(closeQuietly(alpha)), Effect.ensuring(closeQuietly(beta)));
+  }),
 );
 
 const APPROVAL_TARGET_TOOL = "executor.coreTools.policies.list";
@@ -219,55 +215,53 @@ return JSON.stringify(result);
 
 scenario(
   "MCP sessions · a paused approval survives the client reconnecting and resumes",
-  { needs: ["api", "mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const api = yield* ctx.api.client(coreApi, identity);
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const api = yield* client(coreApi, identity);
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
 
-      // Gate a built-in tool behind human approval; the org is fresh, so the
-      // gate affects no other scenario, but remove it anyway on every exit.
-      const policy = yield* api.policies.create({
-        payload: { owner: "org", pattern: APPROVAL_TARGET_TOOL, action: "require_approval" },
-      });
+    // Gate a built-in tool behind human approval; the org is fresh, so the
+    // gate affects no other scenario, but remove it anyway on every exit.
+    const policy = yield* api.policies.create({
+      payload: { owner: "org", pattern: APPROVAL_TARGET_TOOL, action: "require_approval" },
+    });
 
-      yield* Effect.gen(function* () {
-        const first = yield* Effect.promise(() => connectClient(ctx.target.mcpUrl, bearer));
-        const sessionId = first.transport.sessionId;
-        const paused = yield* Effect.promise(() =>
-          first.client.callTool({ name: "execute", arguments: { code: GATED_CODE } }),
-        ).pipe(Effect.ensuring(closeQuietly(first)));
-        const pausedText = textOf(paused);
-        expect(pausedText, "the gated call pauses instead of completing").toContain(
-          "Execution paused",
-        );
-        const executionId = /\bexecutionId:\s*(\S+)/.exec(pausedText)?.[1];
-        expect(executionId, "the paused result carries the executionId").toEqual(
-          expect.any(String),
-        );
-
-        // The user answers from a NEW client on the same session — the paused
-        // execution lives in the session, not the connection.
-        const second = yield* Effect.promise(() =>
-          connectClient(ctx.target.mcpUrl, bearer, sessionId),
-        );
-        const resumed = yield* Effect.promise(() =>
-          second.client.callTool({
-            name: "resume",
-            arguments: { executionId: executionId ?? "", action: "accept", content: "{}" },
-          }),
-        ).pipe(Effect.ensuring(closeQuietly(second)));
-        expect(resumed.isError, "the resumed execution completes").not.toBe(true);
-        expect(textOf(resumed), "the gated tool's result comes back after approval").toContain(
-          APPROVAL_TARGET_TOOL,
-        );
-      }).pipe(
-        Effect.ensuring(
-          api.policies
-            .remove({ params: { policyId: policy.id }, payload: { owner: "org" } })
-            .pipe(Effect.ignore),
-        ),
+    yield* Effect.gen(function* () {
+      const first = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer));
+      const sessionId = first.transport.sessionId;
+      const paused = yield* Effect.promise(() =>
+        first.client.callTool({ name: "execute", arguments: { code: GATED_CODE } }),
+      ).pipe(Effect.ensuring(closeQuietly(first)));
+      const pausedText = textOf(paused);
+      expect(pausedText, "the gated call pauses instead of completing").toContain(
+        "Execution paused",
       );
-    }),
+      const executionId = /\bexecutionId:\s*(\S+)/.exec(pausedText)?.[1];
+      expect(executionId, "the paused result carries the executionId").toEqual(expect.any(String));
+
+      // The user answers from a NEW client on the same session — the paused
+      // execution lives in the session, not the connection.
+      const second = yield* Effect.promise(() => connectClient(target.mcpUrl, bearer, sessionId));
+      const resumed = yield* Effect.promise(() =>
+        second.client.callTool({
+          name: "resume",
+          arguments: { executionId: executionId ?? "", action: "accept", content: "{}" },
+        }),
+      ).pipe(Effect.ensuring(closeQuietly(second)));
+      expect(resumed.isError, "the resumed execution completes").not.toBe(true);
+      expect(textOf(resumed), "the gated tool's result comes back after approval").toContain(
+        APPROVAL_TARGET_TOOL,
+      );
+    }).pipe(
+      Effect.ensuring(
+        api.policies
+          .remove({ params: { policyId: policy.id }, payload: { owner: "org" } })
+          .pipe(Effect.ignore),
+      ),
+    );
+  }),
 );

--- a/e2e/cloud/mcp-protocol.test.ts
+++ b/e2e/cloud/mcp-protocol.test.ts
@@ -16,6 +16,7 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Mcp, Target } from "../src/services";
 import type { Identity } from "../src/target";
 
 const JSON_AND_SSE = "application/json, text/event-stream";
@@ -97,142 +98,140 @@ const openSession = async (mcpUrl: string, bearer: string): Promise<string> => {
 scenario(
   "MCP protocol · /mcp answers a CORS preflight allowing the headers an MCP client sends",
   {},
-  (ctx) =>
-    Effect.gen(function* () {
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/mcp", ctx.target.baseUrl), {
-          method: "OPTIONS",
-          headers: {
-            origin: "https://claude.ai",
-            "access-control-request-method": "POST",
-            "access-control-request-headers": "authorization, content-type, mcp-session-id",
-          },
-        }),
-      );
-      expect(response.status, "the preflight succeeds").toBe(204);
-      const allowedMethods = (response.headers.get("access-control-allow-methods") ?? "")
-        .split(",")
-        .map((method) => method.trim());
-      expect(allowedMethods, "POST (requests) is allowed").toContain("POST");
-      expect(allowedMethods, "GET (standalone SSE) is allowed").toContain("GET");
-      expect(allowedMethods, "DELETE (session termination) is allowed").toContain("DELETE");
-      const allowedHeaders = response.headers.get("access-control-allow-headers") ?? "";
-      expect(allowedHeaders, "the bearer header is allowed").toContain("authorization");
-      expect(allowedHeaders, "the JSON body header is allowed").toContain("content-type");
-      expect(allowedHeaders, "the session header is allowed").toContain("mcp-session-id");
-    }),
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/mcp", target.baseUrl), {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://claude.ai",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "authorization, content-type, mcp-session-id",
+        },
+      }),
+    );
+    expect(response.status, "the preflight succeeds").toBe(204);
+    const allowedMethods = (response.headers.get("access-control-allow-methods") ?? "")
+      .split(",")
+      .map((method) => method.trim());
+    expect(allowedMethods, "POST (requests) is allowed").toContain("POST");
+    expect(allowedMethods, "GET (standalone SSE) is allowed").toContain("GET");
+    expect(allowedMethods, "DELETE (session termination) is allowed").toContain("DELETE");
+    const allowedHeaders = response.headers.get("access-control-allow-headers") ?? "";
+    expect(allowedHeaders, "the bearer header is allowed").toContain("authorization");
+    expect(allowedHeaders, "the JSON body header is allowed").toContain("content-type");
+    expect(allowedHeaders, "the session header is allowed").toContain("mcp-session-id");
+  }),
 );
 
 scenario(
   "MCP protocol · protected-resource metadata advertises a discoverable authorization server",
   {},
-  (ctx) =>
-    Effect.gen(function* () {
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/.well-known/oauth-protected-resource/mcp", ctx.target.baseUrl), {
-          headers: { origin: "https://claude.ai" },
-        }),
-      );
-      expect(response.status, "the discovery document is public").toBe(200);
-      expect(
-        response.headers.get("access-control-allow-origin"),
-        "discovery is readable cross-origin",
-      ).toBe("*");
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/.well-known/oauth-protected-resource/mcp", target.baseUrl), {
+        headers: { origin: "https://claude.ai" },
+      }),
+    );
+    expect(response.status, "the discovery document is public").toBe(200);
+    expect(
+      response.headers.get("access-control-allow-origin"),
+      "discovery is readable cross-origin",
+    ).toBe("*");
 
-      const body = (yield* Effect.promise(() => response.json())) as {
-        readonly resource: string;
-        readonly authorization_servers: ReadonlyArray<string>;
-        readonly bearer_methods_supported: ReadonlyArray<string>;
-        readonly scopes_supported: ReadonlyArray<string>;
-      };
-      expect(body, "the metadata names the MCP resource and its auth server").toEqual({
-        resource: new URL("/mcp", ctx.target.baseUrl).toString(),
-        authorization_servers: [expect.any(String)],
-        bearer_methods_supported: ["header"],
-        scopes_supported: [],
-      });
+    const body = (yield* Effect.promise(() => response.json())) as {
+      readonly resource: string;
+      readonly authorization_servers: ReadonlyArray<string>;
+      readonly bearer_methods_supported: ReadonlyArray<string>;
+      readonly scopes_supported: ReadonlyArray<string>;
+    };
+    expect(body, "the metadata names the MCP resource and its auth server").toEqual({
+      resource: new URL("/mcp", target.baseUrl).toString(),
+      authorization_servers: [expect.any(String)],
+      bearer_methods_supported: ["header"],
+      scopes_supported: [],
+    });
 
-      // The advertised server must itself be discoverable — that is what lets
-      // an MCP client complete OAuth from nothing but the resource URL.
-      const issuer = body.authorization_servers[0] ?? "";
-      const authServer = (yield* Effect.promise(async () =>
-        (await fetch(new URL("/.well-known/oauth-authorization-server", issuer))).json(),
-      )) as Record<string, unknown>;
-      expect(
-        authServer["authorization_endpoint"],
-        "the auth server publishes its authorize endpoint",
-      ).toEqual(expect.any(String));
-      expect(authServer["token_endpoint"], "the auth server publishes its token endpoint").toEqual(
-        expect.any(String),
-      );
-      expect(
-        authServer["registration_endpoint"],
-        "dynamic client registration is available",
-      ).toEqual(expect.any(String));
-    }),
+    // The advertised server must itself be discoverable — that is what lets
+    // an MCP client complete OAuth from nothing but the resource URL.
+    const issuer = body.authorization_servers[0] ?? "";
+    const authServer = (yield* Effect.promise(async () =>
+      (await fetch(new URL("/.well-known/oauth-authorization-server", issuer))).json(),
+    )) as Record<string, unknown>;
+    expect(
+      authServer["authorization_endpoint"],
+      "the auth server publishes its authorize endpoint",
+    ).toEqual(expect.any(String));
+    expect(authServer["token_endpoint"], "the auth server publishes its token endpoint").toEqual(
+      expect.any(String),
+    );
+    expect(authServer["registration_endpoint"], "dynamic client registration is available").toEqual(
+      expect.any(String),
+    );
+  }),
 );
 
 scenario(
   "MCP protocol · org-scoped discovery metadata points at the org-scoped resource",
   {},
-  (ctx) =>
-    Effect.gen(function* () {
-      const orgId = `org_e2e_${randomBytes(4).toString("hex")}`;
-      const [bare, scoped] = yield* Effect.promise(() =>
-        Promise.all([
-          fetch(new URL("/.well-known/oauth-protected-resource/mcp", ctx.target.baseUrl)).then(
-            (r) => r.json() as Promise<{ authorization_servers: ReadonlyArray<string> }>,
-          ),
-          fetch(new URL(`/.well-known/oauth-protected-resource/${orgId}/mcp`, ctx.target.baseUrl)),
-        ]),
-      );
-      expect(scoped.status, "the org-scoped discovery path is served").toBe(200);
-      const body = (yield* Effect.promise(() => scoped.json())) as Record<string, unknown>;
-      expect(body["resource"], "the resource is the org-scoped MCP URL").toBe(
-        new URL(`/${orgId}/mcp`, ctx.target.baseUrl).toString(),
-      );
-      expect(
-        body["authorization_servers"],
-        "the org-scoped variant points at the same auth server",
-      ).toEqual(bare.authorization_servers);
-    }),
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const orgId = `org_e2e_${randomBytes(4).toString("hex")}`;
+    const [bare, scoped] = yield* Effect.promise(() =>
+      Promise.all([
+        fetch(new URL("/.well-known/oauth-protected-resource/mcp", target.baseUrl)).then(
+          (r) => r.json() as Promise<{ authorization_servers: ReadonlyArray<string> }>,
+        ),
+        fetch(new URL(`/.well-known/oauth-protected-resource/${orgId}/mcp`, target.baseUrl)),
+      ]),
+    );
+    expect(scoped.status, "the org-scoped discovery path is served").toBe(200);
+    const body = (yield* Effect.promise(() => scoped.json())) as Record<string, unknown>;
+    expect(body["resource"], "the resource is the org-scoped MCP URL").toBe(
+      new URL(`/${orgId}/mcp`, target.baseUrl).toString(),
+    );
+    expect(
+      body["authorization_servers"],
+      "the org-scoped variant points at the same auth server",
+    ).toEqual(bare.authorization_servers);
+  }),
 );
 
 scenario(
   "MCP protocol · a request without a bearer is challenged with the resource metadata",
   {},
-  (ctx) =>
-    Effect.gen(function* () {
-      const response = yield* Effect.promise(() =>
-        mcpPost(ctx.target.mcpUrl, { body: INITIALIZE_REQUEST }),
-      );
-      expect(response.status, "anonymous requests are rejected").toBe(401);
-      const wwwAuth = response.headers.get("www-authenticate") ?? "";
-      expect(wwwAuth, "the challenge is a Bearer challenge").toContain(
-        'Bearer resource_metadata="',
-      );
-      expect(wwwAuth, "the challenge points at the discovery document").toContain(
-        new URL("/.well-known/oauth-protected-resource/mcp", ctx.target.baseUrl).toString(),
-      );
-      expect(wwwAuth, "a missing token carries no error code (per RFC 6750)").not.toContain(
-        "error=",
-      );
-      expect(
-        response.headers.get("access-control-expose-headers") ?? "",
-        "browsers can read the challenge",
-      ).toContain("WWW-Authenticate");
-      expect(yield* Effect.promise(() => response.json()), "the body is a JSON-RPC error").toEqual({
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Unauthorized" },
-        id: null,
-      });
-    }),
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const response = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { body: INITIALIZE_REQUEST }),
+    );
+    expect(response.status, "anonymous requests are rejected").toBe(401);
+    const wwwAuth = response.headers.get("www-authenticate") ?? "";
+    expect(wwwAuth, "the challenge is a Bearer challenge").toContain('Bearer resource_metadata="');
+    expect(wwwAuth, "the challenge points at the discovery document").toContain(
+      new URL("/.well-known/oauth-protected-resource/mcp", target.baseUrl).toString(),
+    );
+    expect(wwwAuth, "a missing token carries no error code (per RFC 6750)").not.toContain("error=");
+    expect(
+      response.headers.get("access-control-expose-headers") ?? "",
+      "browsers can read the challenge",
+    ).toContain("WWW-Authenticate");
+    expect(yield* Effect.promise(() => response.json()), "the body is a JSON-RPC error").toEqual({
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Unauthorized" },
+      id: null,
+    });
+  }),
 );
 
-scenario("MCP protocol · a garbage bearer is rejected as an invalid token", {}, (ctx) =>
+scenario(
+  "MCP protocol · a garbage bearer is rejected as an invalid token",
+  {},
   Effect.gen(function* () {
+    const target = yield* Target;
     const response = yield* Effect.promise(() =>
-      mcpPost(ctx.target.mcpUrl, { bearer: "bogus.bogus.bogus", body: INITIALIZE_REQUEST }),
+      mcpPost(target.mcpUrl, { bearer: "bogus.bogus.bogus", body: INITIALIZE_REQUEST }),
     );
     expect(response.status, "an unverifiable token is rejected").toBe(401);
     const wwwAuth = response.headers.get("www-authenticate") ?? "";
@@ -240,7 +239,7 @@ scenario("MCP protocol · a garbage bearer is rejected as an invalid token", {},
       'error="invalid_token"',
     );
     expect(wwwAuth, "the challenge still points at the discovery document").toContain(
-      new URL("/.well-known/oauth-protected-resource/mcp", ctx.target.baseUrl).toString(),
+      new URL("/.well-known/oauth-protected-resource/mcp", target.baseUrl).toString(),
     );
     expect(yield* Effect.promise(() => response.json()), "the body is a JSON-RPC error").toEqual({
       jsonrpc: "2.0",
@@ -252,310 +251,315 @@ scenario("MCP protocol · a garbage bearer is rejected as an invalid token", {},
 
 scenario(
   "MCP protocol · a valid bearer whose user has no organization cannot open a session",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      // A brand-new user straight through OAuth — never visited the web app,
-      // never created or joined an org.
-      const bearer = yield* ctx.mcp.mintBearer(`no-org-${randomUUID().slice(0, 8)}@e2e.test`);
-      const response = yield* Effect.promise(() =>
-        mcpPost(ctx.target.mcpUrl, { bearer, body: INITIALIZE_REQUEST }),
-      );
-      expect(response.status, "the org gate fires before any session is created").toBe(403);
-      const body = (yield* Effect.promise(() => response.json())) as JsonRpcError;
-      expect(body.error.code, "the error is the MCP auth error code").toBe(-32001);
-      expect(body.error.message, "the error tells the user what is missing").toMatch(
-        /no organization/i,
-      );
-    }),
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    // A brand-new user straight through OAuth — never visited the web app,
+    // never created or joined an org.
+    const bearer = yield* mcp.mintBearer(`no-org-${randomUUID().slice(0, 8)}@e2e.test`);
+    const response = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer, body: INITIALIZE_REQUEST }),
+    );
+    expect(response.status, "the org gate fires before any session is created").toBe(403);
+    const body = (yield* Effect.promise(() => response.json())) as JsonRpcError;
+    expect(body.error.code, "the error is the MCP auth error code").toBe(-32001);
+    expect(body.error.message, "the error tells the user what is missing").toMatch(
+      /no organization/i,
+    );
+  }),
 );
 
 scenario(
   "MCP protocol · the URL can pin the active org, but membership is enforced",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      const ownOrg = orgIdOf(bearer);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const ownOrg = orgIdOf(bearer);
 
-      const member = yield* Effect.promise(() =>
-        mcpPost(new URL(`/${ownOrg}/mcp`, ctx.target.baseUrl), {
-          bearer,
-          body: INITIALIZE_REQUEST,
-        }),
-      );
-      expect(member.status, "the member's own org-scoped URL opens a session").toBe(200);
-      expect(
-        member.headers.get("mcp-session-id"),
-        "the org-scoped session is a real session",
-      ).toBeTruthy();
-      yield* Effect.promise(() => member.text());
+    const member = yield* Effect.promise(() =>
+      mcpPost(new URL(`/${ownOrg}/mcp`, target.baseUrl), {
+        bearer,
+        body: INITIALIZE_REQUEST,
+      }),
+    );
+    expect(member.status, "the member's own org-scoped URL opens a session").toBe(200);
+    expect(
+      member.headers.get("mcp-session-id"),
+      "the org-scoped session is a real session",
+    ).toBeTruthy();
+    yield* Effect.promise(() => member.text());
 
-      const foreignOrg = `org_e2e_${randomBytes(4).toString("hex")}`;
-      const foreign = yield* Effect.promise(() =>
-        mcpPost(new URL(`/${foreignOrg}/mcp`, ctx.target.baseUrl), {
-          bearer,
-          body: INITIALIZE_REQUEST,
-        }),
-      );
-      expect(foreign.status, "an org the user is no member of is rejected").toBe(403);
-      const body = (yield* Effect.promise(() => foreign.json())) as JsonRpcError;
-      expect(body.error.code, "the rejection is the MCP auth error code").toBe(-32001);
-      expect(body.error.message, "the URL is a selector, not a trust boundary").toMatch(
-        /no organization/i,
-      );
-    }),
+    const foreignOrg = `org_e2e_${randomBytes(4).toString("hex")}`;
+    const foreign = yield* Effect.promise(() =>
+      mcpPost(new URL(`/${foreignOrg}/mcp`, target.baseUrl), {
+        bearer,
+        body: INITIALIZE_REQUEST,
+      }),
+    );
+    expect(foreign.status, "an org the user is no member of is rejected").toBe(403);
+    const body = (yield* Effect.promise(() => foreign.json())) as JsonRpcError;
+    expect(body.error.code, "the rejection is the MCP auth error code").toBe(-32001);
+    expect(body.error.message, "the URL is a selector, not a trust boundary").toMatch(
+      /no organization/i,
+    );
+  }),
 );
 
 scenario(
   "MCP protocol · a non-org path segment is not claimed by the MCP route",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      // `/settings/mcp` must fall through to app routing rather than being
-      // swallowed by the MCP filter — only `org_…`-shaped segments are claimed.
-      const response = yield* Effect.promise(() =>
-        mcpPost(new URL("/settings/mcp", ctx.target.baseUrl), {
-          bearer,
-          body: INITIALIZE_REQUEST,
-        }),
-      );
-      expect(
-        response.headers.get("mcp-session-id"),
-        "no MCP session is opened on an app route",
-      ).toBeNull();
-      const body = (yield* Effect.promise(() => response.text())) as string;
-      expect(body, "the response is not a JSON-RPC envelope").not.toContain('"jsonrpc"');
-    }),
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    // `/settings/mcp` must fall through to app routing rather than being
+    // swallowed by the MCP filter — only `org_…`-shaped segments are claimed.
+    const response = yield* Effect.promise(() =>
+      mcpPost(new URL("/settings/mcp", target.baseUrl), {
+        bearer,
+        body: INITIALIZE_REQUEST,
+      }),
+    );
+    expect(
+      response.headers.get("mcp-session-id"),
+      "no MCP session is opened on an app route",
+    ).toBeNull();
+    const body = (yield* Effect.promise(() => response.text())) as string;
+    expect(body, "the response is not a JSON-RPC envelope").not.toContain('"jsonrpc"');
+  }),
 );
 
 scenario(
   "MCP protocol · verbs outside the MCP transport are rejected with a JSON-RPC 405",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      const statuses: Array<{ method: string; status: number; body: JsonRpcError }> = [];
-      for (const method of ["PUT", "PATCH"]) {
-        const response = yield* Effect.promise(() =>
-          fetch(ctx.target.mcpUrl, {
-            method,
-            headers: {
-              accept: JSON_AND_SSE,
-              "content-type": "application/json",
-              authorization: `Bearer ${bearer}`,
-            },
-            body: JSON.stringify(TOOLS_LIST_REQUEST),
-          }),
-        );
-        statuses.push({
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const statuses: Array<{ method: string; status: number; body: JsonRpcError }> = [];
+    for (const method of ["PUT", "PATCH"]) {
+      const response = yield* Effect.promise(() =>
+        fetch(target.mcpUrl, {
           method,
-          status: response.status,
-          body: (yield* Effect.promise(() => response.json())) as JsonRpcError,
-        });
-      }
-      expect(
-        statuses.map(({ method, status }) => `${method}:${status}`),
-        "PUT and PATCH never reach the session engine",
-      ).toEqual(["PUT:405", "PATCH:405"]);
-      for (const { body } of statuses) {
-        expect(body.error.code, "the rejection is a JSON-RPC error").toBe(-32001);
-        expect(body.error.message, "the rejection names the problem").toMatch(
-          /method not allowed/i,
-        );
-      }
-    }),
+          headers: {
+            accept: JSON_AND_SSE,
+            "content-type": "application/json",
+            authorization: `Bearer ${bearer}`,
+          },
+          body: JSON.stringify(TOOLS_LIST_REQUEST),
+        }),
+      );
+      statuses.push({
+        method,
+        status: response.status,
+        body: (yield* Effect.promise(() => response.json())) as JsonRpcError,
+      });
+    }
+    expect(
+      statuses.map(({ method, status }) => `${method}:${status}`),
+      "PUT and PATCH never reach the session engine",
+    ).toEqual(["PUT:405", "PATCH:405"]);
+    for (const { body } of statuses) {
+      expect(body.error.code, "the rejection is a JSON-RPC error").toBe(-32001);
+      expect(body.error.message, "the rejection names the problem").toMatch(/method not allowed/i);
+    }
+  }),
 );
 
 scenario(
   "MCP protocol · initialize opens a session and notifications are accepted with 202",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
 
-      const initialize = yield* Effect.promise(() =>
-        mcpPost(ctx.target.mcpUrl, { bearer, body: INITIALIZE_REQUEST }),
-      );
-      expect(initialize.status, "initialize succeeds").toBe(200);
-      const sessionId = initialize.headers.get("mcp-session-id");
-      expect(sessionId, "the server assigns a session id").toBeTruthy();
-      expect(
-        initialize.headers.get("access-control-expose-headers") ?? "",
-        "browser clients can read the session id",
-      ).toContain("mcp-session-id");
-      yield* Effect.promise(() => initialize.text());
+    const initialize = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer, body: INITIALIZE_REQUEST }),
+    );
+    expect(initialize.status, "initialize succeeds").toBe(200);
+    const sessionId = initialize.headers.get("mcp-session-id");
+    expect(sessionId, "the server assigns a session id").toBeTruthy();
+    expect(
+      initialize.headers.get("access-control-expose-headers") ?? "",
+      "browser clients can read the session id",
+    ).toContain("mcp-session-id");
+    yield* Effect.promise(() => initialize.text());
 
-      const notification = yield* Effect.promise(() =>
-        mcpPost(ctx.target.mcpUrl, {
-          bearer,
-          sessionId: sessionId ?? "",
-          body: INITIALIZED_NOTIFICATION,
-        }),
-      );
-      expect(notification.status, "notifications are accepted, not answered").toBe(202);
-      expect(yield* Effect.promise(() => notification.text()), "the body is empty").toBe("");
-    }),
+    const notification = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, {
+        bearer,
+        sessionId: sessionId ?? "",
+        body: INITIALIZED_NOTIFICATION,
+      }),
+    );
+    expect(notification.status, "notifications are accepted, not answered").toBe(202);
+    expect(yield* Effect.promise(() => notification.text()), "the body is empty").toBe("");
+  }),
 );
 
 scenario(
   "MCP protocol · a terminated session's id is rejected with a reconnect error",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      const sessionId = yield* Effect.promise(() => openSession(ctx.target.mcpUrl, bearer));
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, bearer));
 
-      const terminate = yield* Effect.promise(() =>
-        fetch(ctx.target.mcpUrl, {
-          method: "DELETE",
-          headers: { authorization: `Bearer ${bearer}`, "mcp-session-id": sessionId },
-        }),
-      );
-      expect(terminate.status, "the client can terminate its session").toBe(200);
-      yield* Effect.promise(() => terminate.text());
+    const terminate = yield* Effect.promise(() =>
+      fetch(target.mcpUrl, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${bearer}`, "mcp-session-id": sessionId },
+      }),
+    );
+    expect(terminate.status, "the client can terminate its session").toBe(200);
+    yield* Effect.promise(() => terminate.text());
 
-      const reuse = yield* Effect.promise(() =>
-        mcpPost(ctx.target.mcpUrl, { bearer, sessionId, body: TOOLS_LIST_REQUEST }),
-      );
-      expect(reuse.status, "the dead session id no longer works").toBe(404);
-      const body = (yield* Effect.promise(() => reuse.json())) as JsonRpcError;
-      expect(body.error.code, "the rejection is a JSON-RPC error").toBe(-32001);
-      expect(body.error.message, "the client is told to reconnect").toMatch(/timed out|reconnect/i);
-    }),
+    const reuse = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer, sessionId, body: TOOLS_LIST_REQUEST }),
+    );
+    expect(reuse.status, "the dead session id no longer works").toBe(404);
+    const body = (yield* Effect.promise(() => reuse.json())) as JsonRpcError;
+    expect(body.error.code, "the rejection is a JSON-RPC error").toBe(-32001);
+    expect(body.error.message, "the client is told to reconnect").toMatch(/timed out|reconnect/i);
+  }),
 );
 
 scenario(
   "MCP protocol · a session cannot be ridden by a different account's bearer",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const victim = yield* ctx.target.newIdentity();
-      const attacker = yield* ctx.target.newIdentity();
-      const victimBearer = yield* ctx.mcp.mintBearer(emailOf(victim));
-      const attackerBearer = yield* ctx.mcp.mintBearer(emailOf(attacker));
-      const sessionId = yield* Effect.promise(() => openSession(ctx.target.mcpUrl, victimBearer));
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const victim = yield* target.newIdentity();
+    const attacker = yield* target.newIdentity();
+    const victimBearer = yield* mcp.mintBearer(emailOf(victim));
+    const attackerBearer = yield* mcp.mintBearer(emailOf(attacker));
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, victimBearer));
 
-      // The attacker authenticates fine — but with a leaked session id of a
-      // session that is not theirs.
-      const hijack = yield* Effect.promise(() =>
-        mcpPost(ctx.target.mcpUrl, {
-          bearer: attackerBearer,
-          sessionId,
-          body: TOOLS_LIST_REQUEST,
-        }),
-      );
-      expect(hijack.status, "the leaked session id is useless to another account").toBe(403);
-      const body = (yield* Effect.promise(() => hijack.json())) as JsonRpcError;
-      expect(body.error.code, "the rejection is the session-ownership error").toBe(-32003);
-      expect(body.error.message, "the error names the ownership violation").toMatch(
-        /does not belong/i,
-      );
+    // The attacker authenticates fine — but with a leaked session id of a
+    // session that is not theirs.
+    const hijack = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, {
+        bearer: attackerBearer,
+        sessionId,
+        body: TOOLS_LIST_REQUEST,
+      }),
+    );
+    expect(hijack.status, "the leaked session id is useless to another account").toBe(403);
+    const body = (yield* Effect.promise(() => hijack.json())) as JsonRpcError;
+    expect(body.error.code, "the rejection is the session-ownership error").toBe(-32003);
+    expect(body.error.message, "the error names the ownership violation").toMatch(
+      /does not belong/i,
+    );
 
-      // The owner is unaffected.
-      const owner = yield* Effect.promise(() =>
-        mcpPost(ctx.target.mcpUrl, { bearer: victimBearer, sessionId, body: TOOLS_LIST_REQUEST }),
-      );
-      expect(owner.status, "the rightful owner keeps using the session").toBe(200);
-      yield* Effect.promise(() => owner.text());
-    }),
+    // The owner is unaffected.
+    const owner = yield* Effect.promise(() =>
+      mcpPost(target.mcpUrl, { bearer: victimBearer, sessionId, body: TOOLS_LIST_REQUEST }),
+    );
+    expect(owner.status, "the rightful owner keeps using the session").toBe(200);
+    yield* Effect.promise(() => owner.text());
+  }),
 );
 
 scenario(
   "MCP protocol · a dropped standalone SSE stream can be reopened",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      const sessionId = yield* Effect.promise(() => openSession(ctx.target.mcpUrl, bearer));
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, bearer));
 
-      const openSse = () =>
-        fetch(ctx.target.mcpUrl, {
-          method: "GET",
-          headers: {
-            accept: "text/event-stream",
-            authorization: `Bearer ${bearer}`,
-            "mcp-protocol-version": PROTOCOL_VERSION,
-            "mcp-session-id": sessionId,
-          },
-        });
+    const openSse = () =>
+      fetch(target.mcpUrl, {
+        method: "GET",
+        headers: {
+          accept: "text/event-stream",
+          authorization: `Bearer ${bearer}`,
+          "mcp-protocol-version": PROTOCOL_VERSION,
+          "mcp-session-id": sessionId,
+        },
+      });
 
-      const first = yield* Effect.promise(openSse);
-      expect(first.status, "the standalone SSE stream opens").toBe(200);
-      expect(first.headers.get("content-type") ?? "", "the stream speaks SSE").toContain(
-        "text/event-stream",
-      );
+    const first = yield* Effect.promise(openSse);
+    expect(first.status, "the standalone SSE stream opens").toBe(200);
+    expect(first.headers.get("content-type") ?? "", "the stream speaks SSE").toContain(
+      "text/event-stream",
+    );
 
-      // A client that lost its stream (network blip, laptop sleep) reconnects
-      // with the same session id — the server accepts the replacement.
-      const second = yield* Effect.promise(openSse);
-      expect(second.status, "a reconnect on the same session succeeds").toBe(200);
-      expect(second.headers.get("content-type") ?? "", "the reconnect speaks SSE").toContain(
-        "text/event-stream",
-      );
+    // A client that lost its stream (network blip, laptop sleep) reconnects
+    // with the same session id — the server accepts the replacement.
+    const second = yield* Effect.promise(openSse);
+    expect(second.status, "a reconnect on the same session succeeds").toBe(200);
+    expect(second.headers.get("content-type") ?? "", "the reconnect speaks SSE").toContain(
+      "text/event-stream",
+    );
 
-      yield* Effect.promise(() => first.body?.cancel().catch(() => undefined) ?? Promise.resolve());
-      yield* Effect.promise(
-        () => second.body?.cancel().catch(() => undefined) ?? Promise.resolve(),
-      );
-    }),
+    yield* Effect.promise(() => first.body?.cancel().catch(() => undefined) ?? Promise.resolve());
+    yield* Effect.promise(() => second.body?.cancel().catch(() => undefined) ?? Promise.resolve());
+  }),
 );
 
 scenario(
   "MCP protocol · overlapping tools/call requests with colliding JSON-RPC ids both complete",
-  { needs: ["mcp-oauth"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const bearer = yield* ctx.mcp.mintBearer(emailOf(identity));
-      const sessionId = yield* Effect.promise(() => openSession(ctx.target.mcpUrl, bearer));
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const bearer = yield* mcp.mintBearer(emailOf(identity));
+    const sessionId = yield* Effect.promise(() => openSession(target.mcpUrl, bearer));
 
-      // Both calls use id 1 — a sloppy-but-legal client. Each POST must get
-      // its own response back; neither may be dropped or cross-wired.
-      const callExecute = (code: string) =>
-        mcpPost(ctx.target.mcpUrl, {
-          bearer,
-          sessionId,
-          body: {
-            jsonrpc: "2.0",
-            id: 1,
-            method: "tools/call",
-            params: { name: "execute", arguments: { code } },
-          },
-        });
+    // Both calls use id 1 — a sloppy-but-legal client. Each POST must get
+    // its own response back; neither may be dropped or cross-wired.
+    const callExecute = (code: string) =>
+      mcpPost(target.mcpUrl, {
+        bearer,
+        sessionId,
+        body: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/call",
+          params: { name: "execute", arguments: { code } },
+        },
+      });
 
-      const responses = yield* Effect.promise(() =>
-        Promise.all([
-          callExecute('await new Promise((resolve) => setTimeout(resolve, 500));\nreturn "first";'),
-          callExecute('return "second";'),
-        ]),
-      );
-      expect(
-        responses.map((response) => response.status),
-        "both overlapping calls return",
-      ).toEqual([200, 200]);
+    const responses = yield* Effect.promise(() =>
+      Promise.all([
+        callExecute('await new Promise((resolve) => setTimeout(resolve, 500));\nreturn "first";'),
+        callExecute('return "second";'),
+      ]),
+    );
+    expect(
+      responses.map((response) => response.status),
+      "both overlapping calls return",
+    ).toEqual([200, 200]);
 
-      const bodies = (yield* Effect.promise(() =>
-        Promise.all(responses.map((response) => response.json())),
-      )) as Array<{
-        readonly result?: { readonly content?: ReadonlyArray<{ readonly text?: string }> };
-        readonly error?: unknown;
-      }>;
-      const texts = bodies.map(
-        (body) => body.result?.content?.map((item) => item.text).join("\n") ?? "",
-      );
-      expect(texts.join(" | "), "the slow call's result arrives").toContain("first");
-      expect(texts.join(" | "), "the fast call's result arrives").toContain("second");
-      expect(
-        bodies.map((body) => body.error),
-        "neither call errors",
-      ).toEqual([undefined, undefined]);
-    }),
+    const bodies = (yield* Effect.promise(() =>
+      Promise.all(responses.map((response) => response.json())),
+    )) as Array<{
+      readonly result?: { readonly content?: ReadonlyArray<{ readonly text?: string }> };
+      readonly error?: unknown;
+    }>;
+    const texts = bodies.map(
+      (body) => body.result?.content?.map((item) => item.text).join("\n") ?? "",
+    );
+    expect(texts.join(" | "), "the slow call's result arrives").toContain("first");
+    expect(texts.join(" | "), "the fast call's result arrives").toContain("second");
+    expect(
+      bodies.map((body) => body.error),
+      "neither call errors",
+    ).toEqual([undefined, undefined]);
+  }),
 );

--- a/e2e/cloud/oauth-connections.test.ts
+++ b/e2e/cloud/oauth-connections.test.ts
@@ -137,7 +137,7 @@ scenario(
           authenticationTemplate: [
             {
               slug: "oauth",
-              type: "oauth",
+              kind: "oauth2",
               authorizationUrl: oauth.authorizationEndpoint,
               tokenUrl: oauth.tokenEndpoint,
               scopes: ["read"],

--- a/e2e/cloud/oauth-connections.test.ts
+++ b/e2e/cloud/oauth-connections.test.ts
@@ -23,6 +23,7 @@ import {
 import { serveOAuthTestServer } from "@executor-js/sdk/testing";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 
@@ -40,188 +41,194 @@ const redirected = <R extends { status: string }>(
 
 scenario(
   "OAuth · probe discovers an authorization server's endpoints from its issuer URL",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const oauth = yield* serveOAuthTestServer();
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const oauth = yield* serveOAuthTestServer();
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
 
-        const probed = yield* client.oauth.probe({ payload: { url: oauth.issuerUrl } });
-        expect(probed.authorizationUrl, "probe found the authorization endpoint").toBe(
-          oauth.authorizationEndpoint,
-        );
-        expect(probed.tokenUrl, "probe found the token endpoint").toBe(oauth.tokenEndpoint);
-      }),
-    ),
+      const probed = yield* client.oauth.probe({ payload: { url: oauth.issuerUrl } });
+      expect(probed.authorizationUrl, "probe found the authorization endpoint").toBe(
+        oauth.authorizationEndpoint,
+      );
+      expect(probed.tokenUrl, "probe found the token endpoint").toBe(oauth.tokenEndpoint);
+    }),
+  ),
 );
 
 scenario(
   "OAuth · a registered OAuth app is listed for its owner without leaking the secret",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const oauth = yield* serveOAuthTestServer();
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = OAuthClientSlug.make(unique("oauthc"));
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const oauth = yield* serveOAuthTestServer();
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const slug = OAuthClientSlug.make(unique("oauthc"));
 
-        const created = yield* client.oauth.createClient({
-          payload: {
-            owner: "org",
-            slug,
-            authorizationUrl: oauth.authorizationEndpoint,
-            tokenUrl: oauth.tokenEndpoint,
-            grant: "authorization_code",
-            clientId: "test-client",
-            clientSecret: "test-secret",
-          },
-        });
-        expect(created.client, "the app keeps the requested slug").toBe(slug);
-
-        const clients = yield* client.oauth.listClients();
-        const mine = clients.find((entry) => entry.slug === slug);
-        expect(mine, "the registered app appears in the owner's list").toMatchObject({
+      const created = yield* client.oauth.createClient({
+        payload: {
           owner: "org",
           slug,
+          authorizationUrl: oauth.authorizationEndpoint,
+          tokenUrl: oauth.tokenEndpoint,
           grant: "authorization_code",
           clientId: "test-client",
-        });
-        expect(
-          JSON.stringify(clients),
-          "the client secret never appears in the list projection",
-        ).not.toContain("test-secret");
-      }),
-    ),
+          clientSecret: "test-secret",
+        },
+      });
+      expect(created.client, "the app keeps the requested slug").toBe(slug);
+
+      const clients = yield* client.oauth.listClients();
+      const mine = clients.find((entry) => entry.slug === slug);
+      expect(mine, "the registered app appears in the owner's list").toMatchObject({
+        owner: "org",
+        slug,
+        grant: "authorization_code",
+        clientId: "test-client",
+      });
+      expect(
+        JSON.stringify(clients),
+        "the client secret never appears in the list projection",
+      ).not.toContain("test-secret");
+    }),
+  ),
 );
 
 scenario(
   "OAuth · the authorization-code flow mints a connection (start → consent → complete)",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const oauth = yield* serveOAuthTestServer();
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeClient } = yield* Api;
+      const oauth = yield* serveOAuthTestServer();
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
 
-        // An integration that declares an oauth auth template — the integration
-        // is what the minted connection attaches to.
-        const integration = IntegrationSlug.make(unique("oauthint"));
-        yield* client.openapi.addSpec({
-          payload: {
-            spec: {
-              kind: "blob",
-              value: JSON.stringify({
-                openapi: "3.0.3",
-                info: { title: "OAuth-protected API", version: "1.0.0" },
-                paths: {
-                  "/me": {
-                    get: {
-                      operationId: "getMe",
-                      tags: ["default"],
-                      responses: { "200": { description: "the caller" } },
-                    },
+      // An integration that declares an oauth auth template — the integration
+      // is what the minted connection attaches to.
+      const integration = IntegrationSlug.make(unique("oauthint"));
+      yield* client.openapi.addSpec({
+        payload: {
+          spec: {
+            kind: "blob",
+            value: JSON.stringify({
+              openapi: "3.0.3",
+              info: { title: "OAuth-protected API", version: "1.0.0" },
+              paths: {
+                "/me": {
+                  get: {
+                    operationId: "getMe",
+                    tags: ["default"],
+                    responses: { "200": { description: "the caller" } },
                   },
                 },
-              }),
-            },
-            slug: integration,
-            baseUrl: "http://127.0.0.1:59999",
-            authenticationTemplate: [
-              {
-                slug: "oauth",
-                type: "oauth",
-                authorizationUrl: oauth.authorizationEndpoint,
-                tokenUrl: oauth.tokenEndpoint,
-                scopes: ["read"],
               },
-            ],
+            }),
           },
-        });
-
-        const clientSlug = OAuthClientSlug.make(unique("oauthc"));
-        yield* client.oauth.createClient({
-          payload: {
-            owner: "org",
-            slug: clientSlug,
-            authorizationUrl: oauth.authorizationEndpoint,
-            tokenUrl: oauth.tokenEndpoint,
-            grant: "authorization_code",
-            clientId: "test-client",
-            clientSecret: "test-secret",
-          },
-        });
-
-        // start: the product persists a session and hands back the authorize URL.
-        const started = redirected(
-          yield* client.oauth.start({
-            payload: {
-              client: clientSlug,
-              clientOwner: "org",
-              owner: "org",
-              name: ConnectionName.make("main"),
-              integration,
-              template: AuthTemplateSlug.make("oauth"),
+          slug: integration,
+          baseUrl: "http://127.0.0.1:59999",
+          authenticationTemplate: [
+            {
+              slug: "oauth",
+              type: "oauth",
+              authorizationUrl: oauth.authorizationEndpoint,
+              tokenUrl: oauth.tokenEndpoint,
+              scopes: ["read"],
             },
-          }),
-        );
-        expect(
-          started.authorizationUrl,
-          "the redirect points at the authorization server",
-        ).toContain(oauth.authorizationEndpoint);
+          ],
+        },
+      });
 
-        // The user consents on the authorization server (headless here): the
-        // authorize page bounces to the login form, and submitting credentials
-        // redirects back to the product's callback with an authorization code.
-        const authorize = yield* Effect.promise(() =>
-          fetch(started.authorizationUrl, { redirect: "manual" }),
-        );
-        expect(authorize.status, "the authorize endpoint sends the user to log in").toBe(302);
-        const consent = yield* Effect.promise(() =>
-          fetch(authorize.headers.get("location") ?? "", {
-            method: "POST",
-            redirect: "manual",
-            headers: {
-              authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
-            },
-          }),
-        );
-        expect(consent.status, "granting consent redirects back to the product").toBe(302);
-        const callback = new URL(consent.headers.get("location") ?? "");
-        expect(callback.searchParams.get("state"), "the callback carries the session's state").toBe(
-          String(started.state),
-        );
-        const code = callback.searchParams.get("code");
-        expect(code, "the callback carries an authorization code").not.toBeNull();
-
-        // complete: the product exchanges the code and mints the connection.
-        const connection = yield* client.oauth.complete({
-          payload: { state: started.state, code: code ?? "" },
-        });
-        expect(connection, "the minted connection is bound to the integration").toMatchObject({
+      const clientSlug = OAuthClientSlug.make(unique("oauthc"));
+      yield* client.oauth.createClient({
+        payload: {
           owner: "org",
-          name: "main",
-          integration,
-          template: "oauth",
-          oauthClient: clientSlug,
-        });
+          slug: clientSlug,
+          authorizationUrl: oauth.authorizationEndpoint,
+          tokenUrl: oauth.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        },
+      });
 
-        const connections = yield* client.connections.list({ query: { integration } });
-        expect(
-          connections.map((c) => `${c.owner}/${String(c.name)}`),
-          "the connection is listed for the integration",
-        ).toContain("org/main");
-      }),
-    ),
+      // start: the product persists a session and hands back the authorize URL.
+      const started = redirected(
+        yield* client.oauth.start({
+          payload: {
+            client: clientSlug,
+            clientOwner: "org",
+            owner: "org",
+            name: ConnectionName.make("main"),
+            integration,
+            template: AuthTemplateSlug.make("oauth"),
+          },
+        }),
+      );
+      expect(started.authorizationUrl, "the redirect points at the authorization server").toContain(
+        oauth.authorizationEndpoint,
+      );
+
+      // The user consents on the authorization server (headless here): the
+      // authorize page bounces to the login form, and submitting credentials
+      // redirects back to the product's callback with an authorization code.
+      const authorize = yield* Effect.promise(() =>
+        fetch(started.authorizationUrl, { redirect: "manual" }),
+      );
+      expect(authorize.status, "the authorize endpoint sends the user to log in").toBe(302);
+      const consent = yield* Effect.promise(() =>
+        fetch(authorize.headers.get("location") ?? "", {
+          method: "POST",
+          redirect: "manual",
+          headers: {
+            authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+          },
+        }),
+      );
+      expect(consent.status, "granting consent redirects back to the product").toBe(302);
+      const callback = new URL(consent.headers.get("location") ?? "");
+      expect(callback.searchParams.get("state"), "the callback carries the session's state").toBe(
+        String(started.state),
+      );
+      const code = callback.searchParams.get("code");
+      expect(code, "the callback carries an authorization code").not.toBeNull();
+
+      // complete: the product exchanges the code and mints the connection.
+      const connection = yield* client.oauth.complete({
+        payload: { state: started.state, code: code ?? "" },
+      });
+      expect(connection, "the minted connection is bound to the integration").toMatchObject({
+        owner: "org",
+        name: "main",
+        integration,
+        template: "oauth",
+        oauthClient: clientSlug,
+      });
+
+      const connections = yield* client.connections.list({ query: { integration } });
+      expect(
+        connections.map((c) => `${c.owner}/${String(c.name)}`),
+        "the connection is listed for the integration",
+      ).toContain("org/main");
+    }),
+  ),
 );
 
-scenario("OAuth · cancelling an unknown session is idempotent", { needs: ["api"] }, (ctx) =>
+scenario(
+  "OAuth · cancelling an unknown session is idempotent",
+  {},
   Effect.gen(function* () {
-    const identity = yield* ctx.target.newIdentity();
-    const client = yield* ctx.api.client(api, identity);
+    const target = yield* Target;
+    const { client: makeClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeClient(api, identity);
 
     const cancelled = yield* client.oauth.cancel({
       payload: { state: OAuthState.make("oauth2_session_does_not_exist") },

--- a/e2e/cloud/onboarding-mcp-url.test.ts
+++ b/e2e/cloud/onboarding-mcp-url.test.ts
@@ -5,54 +5,56 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
 
 scenario(
   "Onboarding · the MCP setup step hands the user their org-scoped MCP server URL",
-  { needs: ["browser"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity({ org: false });
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity({ org: false });
 
-      yield* ctx.browser.session(identity, async ({ page, step }) => {
-        await step(
-          "A fresh user without an org lands on the create-org onboarding page",
-          async () => {
-            await page.goto("/", { waitUntil: "networkidle" });
-            // Step 1 of 2 — the org-name input is the landmark that proves we're on onboarding.
-            await page.getByPlaceholder("Northwind Labs").waitFor();
-          },
-        );
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step(
+        "A fresh user without an org lands on the create-org onboarding page",
+        async () => {
+          await page.goto("/", { waitUntil: "networkidle" });
+          // Step 1 of 2 — the org-name input is the landmark that proves we're on onboarding.
+          await page.getByPlaceholder("Northwind Labs").waitFor();
+        },
+      );
 
-        await step("Create an organization to advance to the MCP setup step", async () => {
-          await page.getByPlaceholder("Northwind Labs").fill("Test Org");
-          await page.getByRole("button", { name: "Create organization" }).click();
-          // Successful creation navigates to the 'Connect your MCP client' step.
-          await page.getByText("Connect your MCP client").waitFor();
-        });
-
-        await step("Read the MCP server URL displayed on the setup page", async () => {
-          const urlSection = page.getByRole("region", { name: "MCP server URL" });
-          await urlSection.waitFor();
-          // Wait until the endpoint is populated (the component defers origin to useEffect).
-          await page.waitForFunction(() => {
-            const section = document.querySelector('[aria-label="MCP server URL"]');
-            const span = section?.querySelector("span.font-mono");
-            return span && span.textContent !== "…" && span.textContent !== "";
-          });
-        });
-
-        const mcpUrlSection = page.getByRole("region", { name: "MCP server URL" });
-        const mcpUrl = await mcpUrlSection.locator("span.font-mono").innerText();
-        expect(mcpUrl, "MCP URL is org-scoped").toMatch(/\/org_[^/]+\/mcp/);
-
-        const installSection = page.getByRole("region", { name: "Install command" });
-        await installSection.waitFor();
-        const installCommand = await installSection.locator("code").innerText();
-
-        // The install command must reference the SAME org as the displayed URL
-        // — not a different one or a bare /mcp path.
-        const orgId = /\/(org_[^/]+)\/mcp/.exec(mcpUrl)?.[1] ?? "(no org segment in MCP URL)";
-        expect(installCommand, "the install command references the same org").toContain(orgId);
+      await step("Create an organization to advance to the MCP setup step", async () => {
+        await page.getByPlaceholder("Northwind Labs").fill("Test Org");
+        await page.getByRole("button", { name: "Create organization" }).click();
+        // Successful creation navigates to the 'Connect your MCP client' step.
+        await page.getByText("Connect your MCP client").waitFor();
       });
-    }),
+
+      await step("Read the MCP server URL displayed on the setup page", async () => {
+        const urlSection = page.getByRole("region", { name: "MCP server URL" });
+        await urlSection.waitFor();
+        // Wait until the endpoint is populated (the component defers origin to useEffect).
+        await page.waitForFunction(() => {
+          const section = document.querySelector('[aria-label="MCP server URL"]');
+          const span = section?.querySelector("span.font-mono");
+          return span && span.textContent !== "…" && span.textContent !== "";
+        });
+      });
+
+      const mcpUrlSection = page.getByRole("region", { name: "MCP server URL" });
+      const mcpUrl = await mcpUrlSection.locator("span.font-mono").innerText();
+      expect(mcpUrl, "MCP URL is org-scoped").toMatch(/\/org_[^/]+\/mcp/);
+
+      const installSection = page.getByRole("region", { name: "Install command" });
+      await installSection.waitFor();
+      const installCommand = await installSection.locator("code").innerText();
+
+      // The install command must reference the SAME org as the displayed URL
+      // — not a different one or a bare /mcp path.
+      const orgId = /\/(org_[^/]+)\/mcp/.exec(mcpUrl)?.[1] ?? "(no org segment in MCP URL)";
+      expect(installCommand, "the install command references the same org").toContain(orgId);
+    });
+  }),
 );

--- a/e2e/cloud/org-limit.test.ts
+++ b/e2e/cloud/org-limit.test.ts
@@ -7,96 +7,96 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Billing, Browser, Target } from "../src/services";
 
 const FREE_LIMIT = 3;
 
 scenario(
   "Billing · the free plan stops organization creation after 3",
-  { needs: ["browser", "billing"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity({ org: false });
+  {},
+  Effect.gen(function* () {
+    // Gate: billing limits are enforced on this target.
+    yield* Billing;
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity({ org: false });
 
-      yield* ctx.browser.session(identity, async ({ page, step }) => {
-        await step("A fresh user lands on onboarding (no organization yet)", async () => {
-          await page.goto("/", { waitUntil: "networkidle" });
-          await page.getByPlaceholder("Northwind Labs").waitFor();
-        });
-
-        await step(`Create "Acme 1" (1 of ${FREE_LIMIT} allowed on the free plan)`, async () => {
-          await page.getByPlaceholder("Northwind Labs").fill("Acme 1");
-          await page.getByRole("button", { name: "Create organization" }).click();
-          // Onboarding step 2 — proves the first org was created.
-          await page.getByText("Connect your MCP client").waitFor();
-        });
-
-        await step("Continue into the app", async () => {
-          await page.getByRole("button", { name: "Continue to app" }).click();
-          await page.getByText("Integrations").first().waitFor();
-          // Let the router navigation fully settle (slow on a cold dev server)
-          // before opening menus — a late remount closes them mid-interaction.
-          await page.waitForURL(/\/$/, { timeout: 30_000 });
-          await page.waitForLoadState("networkidle");
-        });
-
-        const openCreateOrgModal = async (currentOrg: string) => {
-          // Under parallel-suite load the radix menu re-renders while the org
-          // list loads; a click can land on a closing menu. Bounded retry with
-          // a clean reopen keeps the journey honest without 30s hangs.
-          for (let attempt = 1; ; attempt++) {
-            try {
-              await page.keyboard.press("Escape");
-              await page.getByRole("button", { name: /Test User/ }).click();
-              await page.getByRole("menuitem", { name: currentOrg }).click({ timeout: 5_000 });
-              const subContent = page.locator('[data-slot="dropdown-menu-sub-content"]');
-              await subContent.waitFor({ state: "visible", timeout: 5_000 });
-              await subContent
-                .getByText("Create organization", { exact: true })
-                .click({ timeout: 5_000 });
-              await page.getByText("Add another organization").waitFor({ timeout: 5_000 });
-              return;
-            } catch (error) {
-              if (attempt >= 3) throw error;
-            }
-          }
-        };
-
-        for (let i = 2; i <= FREE_LIMIT; i++) {
-          await step(`Open the org switcher and choose "Create organization"`, async () => {
-            await openCreateOrgModal(`Acme ${i - 1}`);
-          });
-          await step(`Create "Acme ${i}" (${i} of ${FREE_LIMIT})`, async () => {
-            await page.getByPlaceholder("Northwind Labs").fill(`Acme ${i}`);
-            await page.getByRole("button", { name: "Create organization" }).click();
-            // The modal closes and the session switches into the new org.
-            await page.getByText("Add another organization").waitFor({ state: "hidden" });
-            await page.getByRole("button", { name: new RegExp(`Acme ${i}`) }).waitFor();
-          });
-        }
-
-        await step("Attempt a 4th organization (over the free limit)", async () => {
-          await openCreateOrgModal(`Acme ${FREE_LIMIT}`);
-          await page.getByPlaceholder("Northwind Labs").fill("Acme 4");
-          await page.getByRole("button", { name: "Create organization" }).click();
-          await page.locator("p.text-destructive").first().waitFor();
-        });
-
-        const errorText = await page.locator("p.text-destructive").first().innerText();
-        expect(errorText.length, "the UI shows a visible refusal").toBeGreaterThan(0);
-
-        // Cross-check through the session API, with the browser's own session
-        // cookie (fetched explicitly — the Secure cookie isn't replayed by
-        // page.request over plain http).
-        const cookie = (await page.context().cookies())
-          .map((c) => `${c.name}=${c.value}`)
-          .join("; ");
-        const response = await fetch(new URL("/api/auth/organizations", ctx.target.baseUrl), {
-          headers: { cookie },
-        });
-        const body = (await response.json()) as { organizations: ReadonlyArray<{ name: string }> };
-        expect(body.organizations.length, "exactly the free-plan allowance exists").toBe(
-          FREE_LIMIT,
-        );
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("A fresh user lands on onboarding (no organization yet)", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.getByPlaceholder("Northwind Labs").waitFor();
       });
-    }),
+
+      await step(`Create "Acme 1" (1 of ${FREE_LIMIT} allowed on the free plan)`, async () => {
+        await page.getByPlaceholder("Northwind Labs").fill("Acme 1");
+        await page.getByRole("button", { name: "Create organization" }).click();
+        // Onboarding step 2 — proves the first org was created.
+        await page.getByText("Connect your MCP client").waitFor();
+      });
+
+      await step("Continue into the app", async () => {
+        await page.getByRole("button", { name: "Continue to app" }).click();
+        await page.getByText("Integrations").first().waitFor();
+        // Let the router navigation fully settle (slow on a cold dev server)
+        // before opening menus — a late remount closes them mid-interaction.
+        await page.waitForURL(/\/$/, { timeout: 30_000 });
+        await page.waitForLoadState("networkidle");
+      });
+
+      const openCreateOrgModal = async (currentOrg: string) => {
+        // Under parallel-suite load the radix menu re-renders while the org
+        // list loads; a click can land on a closing menu. Bounded retry with
+        // a clean reopen keeps the journey honest without 30s hangs.
+        for (let attempt = 1; ; attempt++) {
+          try {
+            await page.keyboard.press("Escape");
+            await page.getByRole("button", { name: /Test User/ }).click();
+            await page.getByRole("menuitem", { name: currentOrg }).click({ timeout: 5_000 });
+            const subContent = page.locator('[data-slot="dropdown-menu-sub-content"]');
+            await subContent.waitFor({ state: "visible", timeout: 5_000 });
+            await subContent
+              .getByText("Create organization", { exact: true })
+              .click({ timeout: 5_000 });
+            await page.getByText("Add another organization").waitFor({ timeout: 5_000 });
+            return;
+          } catch (error) {
+            if (attempt >= 3) throw error;
+          }
+        }
+      };
+
+      for (let i = 2; i <= FREE_LIMIT; i++) {
+        await step(`Open the org switcher and choose "Create organization"`, async () => {
+          await openCreateOrgModal(`Acme ${i - 1}`);
+        });
+        await step(`Create "Acme ${i}" (${i} of ${FREE_LIMIT})`, async () => {
+          await page.getByPlaceholder("Northwind Labs").fill(`Acme ${i}`);
+          await page.getByRole("button", { name: "Create organization" }).click();
+          // The modal closes and the session switches into the new org.
+          await page.getByText("Add another organization").waitFor({ state: "hidden" });
+          await page.getByRole("button", { name: new RegExp(`Acme ${i}`) }).waitFor();
+        });
+      }
+
+      await step("Attempt a 4th organization (over the free limit)", async () => {
+        await openCreateOrgModal(`Acme ${FREE_LIMIT}`);
+        await page.getByPlaceholder("Northwind Labs").fill("Acme 4");
+        await page.getByRole("button", { name: "Create organization" }).click();
+        await page.locator("p.text-destructive").first().waitFor();
+      });
+
+      const errorText = await page.locator("p.text-destructive").first().innerText();
+      expect(errorText.length, "the UI shows a visible refusal").toBeGreaterThan(0);
+
+      // Cross-check through the session API, with the browser's own session
+      // cookie (fetched explicitly — the Secure cookie isn't replayed by
+      // page.request over plain http).
+      const cookie = (await page.context().cookies()).map((c) => `${c.name}=${c.value}`).join("; ");
+      const response = await fetch(new URL("/api/auth/organizations", target.baseUrl), {
+        headers: { cookie },
+      });
+      const body = (await response.json()) as { organizations: ReadonlyArray<{ name: string }> };
+      expect(body.organizations.length, "exactly the free-plan allowance exists").toBe(FREE_LIMIT);
+    });
+  }),
 );

--- a/e2e/cloud/org-switcher.test.ts
+++ b/e2e/cloud/org-switcher.test.ts
@@ -7,139 +7,134 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
 
 scenario(
   "Organizations · switching organizations switches the workspace",
-  { needs: ["browser"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity({ org: false });
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity({ org: false });
 
-      yield* ctx.browser.session(identity, async ({ page, step }) => {
-        // ── Step 1: onboarding, create the first org ─────────────────────
-        await step("Fresh user lands on onboarding (no organization yet)", async () => {
-          await page.goto("/", { waitUntil: "networkidle" });
-          await page.getByPlaceholder("Northwind Labs").waitFor();
-        });
-
-        const ORG_1 = "Switcher Org One";
-        const ORG_2 = "Switcher Org Two";
-
-        await step(`Create "${ORG_1}" via onboarding`, async () => {
-          await page.getByPlaceholder("Northwind Labs").fill(ORG_1);
-          await page.getByRole("button", { name: "Create organization" }).click();
-          // Onboarding step 2 — proves the first org was created.
-          await page.getByText("Connect your MCP client").waitFor();
-        });
-
-        await step("Continue into the app", async () => {
-          await page.getByRole("button", { name: "Continue to app" }).click();
-          await page.getByText("Integrations").first().waitFor();
-          // Let the router navigation fully settle before opening menus — a late
-          // remount closes them mid-interaction.
-          await page.waitForURL(/\/$/, { timeout: 30_000 });
-          await page.waitForLoadState("networkidle");
-        });
-
-        // ── Step 2: create the second org via the account-menu switcher ──
-        await step('Open the org switcher and choose "Create organization"', async () => {
-          // Bounded retry: under parallel-suite load the radix menu re-renders
-          // while the org list loads and a click can land on a closing menu.
-          for (let attempt = 1; ; attempt++) {
-            try {
-              await page.keyboard.press("Escape");
-              await page.getByRole("button", { name: /Test User/ }).click();
-              await page.getByRole("menuitem", { name: ORG_1 }).click({ timeout: 5_000 });
-              const subContent = page.locator('[data-slot="dropdown-menu-sub-content"]');
-              await subContent.waitFor({ state: "visible", timeout: 5_000 });
-              await subContent
-                .getByText("Create organization", { exact: true })
-                .click({ timeout: 5_000 });
-              await page.getByText("Add another organization").waitFor({ timeout: 5_000 });
-              break;
-            } catch (error) {
-              if (attempt >= 3) throw error;
-            }
-          }
-        });
-
-        await step(`Create "${ORG_2}" via the org switcher modal`, async () => {
-          await page.getByPlaceholder("Northwind Labs").fill(ORG_2);
-          await page.getByRole("button", { name: "Create organization" }).click();
-          // The modal closes and the session switches into the new org.
-          await page.getByText("Add another organization").waitFor({ state: "hidden" });
-          // Confirm the account button now shows ORG_2.
-          await page.getByRole("button", { name: new RegExp(ORG_2) }).waitFor();
-        });
-
-        // Capture the label while we are in ORG_2 as a baseline.
-        const labelAfterOrg2 = await page
-          .getByRole("button", { name: new RegExp(ORG_2) })
-          .innerText();
-        expect(labelAfterOrg2, "account button shows the second org after creation").toContain(
-          ORG_2,
-        );
-
-        // ── Step 3: switch back to the first org ─────────────────────────
-        // The org-switcher sub-menu shows org IDs (not names) because the stub's
-        // getOrganization returns the ID as the name. The currently-active org is
-        // rendered with data-disabled="" (Radix convention). The only item without
-        // data-disabled that isn't "Create organization" is ORG_1.
-        await step(`Open the org switcher and switch back to "${ORG_1}"`, async () => {
-          await page.waitForLoadState("networkidle");
-          await page.getByRole("button", { name: /Test User/ }).click();
-          // Click the SubTrigger (shows current org name = ORG_2) to expand the list.
-          await page.getByRole("menuitem", { name: ORG_2 }).click();
-          // Wait for the sub-content to open.
-          await page
-            .locator('[data-slot="dropdown-menu-sub-content"]')
-            .waitFor({ state: "visible" });
-          // The organizationsAtom loads asynchronously — wait until the loading state
-          // clears and the org items appear. The org items have data-disabled="" when
-          // active and no data-disabled when not. "Create organization" is always shown
-          // and always enabled; wait until there are at least 2 non-disabled items
-          // (the non-active org + "Create organization") before clicking.
-          await page
-            .locator('[data-slot="dropdown-menu-sub-content"]')
-            .locator('[role="menuitem"]:not([data-disabled])')
-            .nth(1)
-            .waitFor();
-          // Now the sub-content has loaded. The org items appear BEFORE the separator and
-          // "Create organization". ORG_1 (non-active, not disabled) appears before ORG_2
-          // (active, disabled) and before "Create organization". Click the first
-          // non-disabled item that is NOT "Create organization" — that is ORG_1.
-          await page
-            .locator('[data-slot="dropdown-menu-sub-content"]')
-            .locator('[role="menuitem"]:not([data-disabled])')
-            .filter({ hasNot: page.getByText("Create organization") })
-            .first()
-            .click();
-          // The menu closes, the page reloads, and the session switches into ORG_1.
-          await page.getByRole("button", { name: new RegExp(ORG_1) }).waitFor();
-        });
-
-        // ── Assert: workspace label reflects the first org ───────────────
-        const labelAfterSwitch = await page
-          .getByRole("button", { name: new RegExp(ORG_1) })
-          .innerText();
-        expect(
-          labelAfterSwitch,
-          "account button shows the first org after switching back",
-        ).toContain(ORG_1);
-
-        // Cross-check the active org through the session API.
-        const cookie = (await page.context().cookies())
-          .map((c) => `${c.name}=${c.value}`)
-          .join("; ");
-        const response = await fetch(new URL("/api/auth/organizations", ctx.target.baseUrl), {
-          headers: { cookie },
-        });
-        const body = (await response.json()) as {
-          organizations: ReadonlyArray<{ name: string }>;
-          activeOrganizationId?: string;
-        };
-        expect(response.ok).toBe(true);
-        expect(body.organizations.length, "exactly two organizations exist for this user").toBe(2);
+    yield* browser.session(identity, async ({ page, step }) => {
+      // ── Step 1: onboarding, create the first org ─────────────────────
+      await step("Fresh user lands on onboarding (no organization yet)", async () => {
+        await page.goto("/", { waitUntil: "networkidle" });
+        await page.getByPlaceholder("Northwind Labs").waitFor();
       });
-    }),
+
+      const ORG_1 = "Switcher Org One";
+      const ORG_2 = "Switcher Org Two";
+
+      await step(`Create "${ORG_1}" via onboarding`, async () => {
+        await page.getByPlaceholder("Northwind Labs").fill(ORG_1);
+        await page.getByRole("button", { name: "Create organization" }).click();
+        // Onboarding step 2 — proves the first org was created.
+        await page.getByText("Connect your MCP client").waitFor();
+      });
+
+      await step("Continue into the app", async () => {
+        await page.getByRole("button", { name: "Continue to app" }).click();
+        await page.getByText("Integrations").first().waitFor();
+        // Let the router navigation fully settle before opening menus — a late
+        // remount closes them mid-interaction.
+        await page.waitForURL(/\/$/, { timeout: 30_000 });
+        await page.waitForLoadState("networkidle");
+      });
+
+      // ── Step 2: create the second org via the account-menu switcher ──
+      await step('Open the org switcher and choose "Create organization"', async () => {
+        // Bounded retry: under parallel-suite load the radix menu re-renders
+        // while the org list loads and a click can land on a closing menu.
+        for (let attempt = 1; ; attempt++) {
+          try {
+            await page.keyboard.press("Escape");
+            await page.getByRole("button", { name: /Test User/ }).click();
+            await page.getByRole("menuitem", { name: ORG_1 }).click({ timeout: 5_000 });
+            const subContent = page.locator('[data-slot="dropdown-menu-sub-content"]');
+            await subContent.waitFor({ state: "visible", timeout: 5_000 });
+            await subContent
+              .getByText("Create organization", { exact: true })
+              .click({ timeout: 5_000 });
+            await page.getByText("Add another organization").waitFor({ timeout: 5_000 });
+            break;
+          } catch (error) {
+            if (attempt >= 3) throw error;
+          }
+        }
+      });
+
+      await step(`Create "${ORG_2}" via the org switcher modal`, async () => {
+        await page.getByPlaceholder("Northwind Labs").fill(ORG_2);
+        await page.getByRole("button", { name: "Create organization" }).click();
+        // The modal closes and the session switches into the new org.
+        await page.getByText("Add another organization").waitFor({ state: "hidden" });
+        // Confirm the account button now shows ORG_2.
+        await page.getByRole("button", { name: new RegExp(ORG_2) }).waitFor();
+      });
+
+      // Capture the label while we are in ORG_2 as a baseline.
+      const labelAfterOrg2 = await page
+        .getByRole("button", { name: new RegExp(ORG_2) })
+        .innerText();
+      expect(labelAfterOrg2, "account button shows the second org after creation").toContain(ORG_2);
+
+      // ── Step 3: switch back to the first org ─────────────────────────
+      // The org-switcher sub-menu shows org IDs (not names) because the stub's
+      // getOrganization returns the ID as the name. The currently-active org is
+      // rendered with data-disabled="" (Radix convention). The only item without
+      // data-disabled that isn't "Create organization" is ORG_1.
+      await step(`Open the org switcher and switch back to "${ORG_1}"`, async () => {
+        await page.waitForLoadState("networkidle");
+        await page.getByRole("button", { name: /Test User/ }).click();
+        // Click the SubTrigger (shows current org name = ORG_2) to expand the list.
+        await page.getByRole("menuitem", { name: ORG_2 }).click();
+        // Wait for the sub-content to open.
+        await page.locator('[data-slot="dropdown-menu-sub-content"]').waitFor({ state: "visible" });
+        // The organizationsAtom loads asynchronously — wait until the loading state
+        // clears and the org items appear. The org items have data-disabled="" when
+        // active and no data-disabled when not. "Create organization" is always shown
+        // and always enabled; wait until there are at least 2 non-disabled items
+        // (the non-active org + "Create organization") before clicking.
+        await page
+          .locator('[data-slot="dropdown-menu-sub-content"]')
+          .locator('[role="menuitem"]:not([data-disabled])')
+          .nth(1)
+          .waitFor();
+        // Now the sub-content has loaded. The org items appear BEFORE the separator and
+        // "Create organization". ORG_1 (non-active, not disabled) appears before ORG_2
+        // (active, disabled) and before "Create organization". Click the first
+        // non-disabled item that is NOT "Create organization" — that is ORG_1.
+        await page
+          .locator('[data-slot="dropdown-menu-sub-content"]')
+          .locator('[role="menuitem"]:not([data-disabled])')
+          .filter({ hasNot: page.getByText("Create organization") })
+          .first()
+          .click();
+        // The menu closes, the page reloads, and the session switches into ORG_1.
+        await page.getByRole("button", { name: new RegExp(ORG_1) }).waitFor();
+      });
+
+      // ── Assert: workspace label reflects the first org ───────────────
+      const labelAfterSwitch = await page
+        .getByRole("button", { name: new RegExp(ORG_1) })
+        .innerText();
+      expect(labelAfterSwitch, "account button shows the first org after switching back").toContain(
+        ORG_1,
+      );
+
+      // Cross-check the active org through the session API.
+      const cookie = (await page.context().cookies()).map((c) => `${c.name}=${c.value}`).join("; ");
+      const response = await fetch(new URL("/api/auth/organizations", target.baseUrl), {
+        headers: { cookie },
+      });
+      const body = (await response.json()) as {
+        organizations: ReadonlyArray<{ name: string }>;
+        activeOrganizationId?: string;
+      };
+      expect(response.ok).toBe(true);
+      expect(body.organizations.length, "exactly two organizations exist for this user").toBe(2);
+    });
+  }),
 );

--- a/e2e/cloud/sources-api.test.ts
+++ b/e2e/cloud/sources-api.test.ts
@@ -28,6 +28,7 @@ import { serveOpenApiEchoTestServer } from "@executor-js/plugin-openapi/testing"
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin(), mcpHttpPlugin(), graphqlHttpPlugin()] as const);
 
@@ -69,310 +70,199 @@ const completed = <R extends { status: string; text: string }>(
 
 scenario(
   "Integrations · an OpenAPI spec round-trips the catalog: add, fetch, update, remove",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = newSlug("srcapi");
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(api, identity);
+    const slug = newSlug("srcapi");
 
-      const added = yield* client.openapi.addSpec({
-        payload: {
-          spec: { kind: "blob", value: pingSpec },
-          slug,
-          baseUrl: "http://127.0.0.1:59999", // never contacted during registration
-        },
-      });
-      expect(added.slug, "the integration keeps the requested slug").toBe(slug);
-      expect(added.toolCount, "the single operation was extracted as a tool").toBe(1);
+    const added = yield* client.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: pingSpec },
+        slug,
+        baseUrl: "http://127.0.0.1:59999", // never contacted during registration
+      },
+    });
+    expect(added.slug, "the integration keeps the requested slug").toBe(slug);
+    expect(added.toolCount, "the single operation was extracted as a tool").toBe(1);
 
-      const listed = yield* client.integrations.list();
-      expect(
-        listed.map((i) => String(i.slug)),
-        "the new integration is in the catalog",
-      ).toContain(slug);
+    const listed = yield* client.integrations.list();
+    expect(
+      listed.map((i) => String(i.slug)),
+      "the new integration is in the catalog",
+    ).toContain(slug);
 
-      const fetched = yield* client.openapi.getIntegration({ params: { slug } });
-      expect(fetched, "the stored integration is fetchable through the plugin route").toMatchObject(
-        { slug, kind: "openapi" },
-      );
+    const fetched = yield* client.openapi.getIntegration({ params: { slug } });
+    expect(fetched, "the stored integration is fetchable through the plugin route").toMatchObject({
+      slug,
+      kind: "openapi",
+    });
 
-      yield* client.integrations.update({
-        params: { slug },
-        payload: { description: "Renamed API" },
-      });
-      const updated = yield* client.integrations.get({ params: { slug } });
-      expect(updated?.description, "the description change round-trips").toBe("Renamed API");
+    yield* client.integrations.update({
+      params: { slug },
+      payload: { description: "Renamed API" },
+    });
+    const updated = yield* client.integrations.get({ params: { slug } });
+    expect(updated?.description, "the description change round-trips").toBe("Renamed API");
 
-      yield* client.integrations.remove({ params: { slug } });
-      const after = yield* client.integrations.list();
-      expect(
-        after.map((i) => String(i.slug)),
-        "the removed integration drops off the catalog",
-      ).not.toContain(slug);
-    }),
+    yield* client.integrations.remove({ params: { slug } });
+    const after = yield* client.integrations.list();
+    expect(
+      after.map((i) => String(i.slug)),
+      "the removed integration drops off the catalog",
+    ).not.toContain(slug);
+  }),
 );
 
 scenario(
   "Integrations · previewSpec reports a spec's operations before anything is stored",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(api, identity);
 
-      const preview = yield* client.openapi.previewSpec({ payload: { spec: pingSpec } });
-      expect(preview.operationCount, "the preview counts the spec's operations").toBe(1);
-      expect(preview.operations, "the preview lists each operation's identity").toEqual([
-        expect.objectContaining({ operationId: "ping", method: "get", path: "/ping" }),
-      ]);
-    }),
+    const preview = yield* client.openapi.previewSpec({ payload: { spec: pingSpec } });
+    expect(preview.operationCount, "the preview counts the spec's operations").toBe(1);
+    expect(preview.operations, "the preview lists each operation's identity").toEqual([
+      expect.objectContaining({ operationId: "ping", method: "get", path: "/ping" }),
+    ]);
+  }),
 );
 
 scenario(
   "Integrations · a connected OpenAPI operation executes against the live upstream API",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        // A real upstream HTTP API on 127.0.0.1, closed by the scope's finalizer.
-        const server = yield* serveOpenApiEchoTestServer();
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = newSlug("srcapi");
-
-        yield* client.openapi.addSpec({
-          payload: {
-            spec: { kind: "blob", value: server.specJson },
-            slug,
-            description: "Invocable upstream API",
-            baseUrl: server.baseUrl,
-          },
-        });
-
-        // A connection mints + persists the per-connection tools.
-        yield* client.connections.create({
-          payload: {
-            owner: "org",
-            name: MAIN,
-            integration: slug,
-            template: API_KEY,
-            value: "static-token",
-          },
-        });
-
-        const tools = yield* client.tools.list({ query: { integration: slug } });
-        const address = `tools.${slug}.org.main.echo.echoMessage`;
-        expect(
-          tools.map((tool) => String(tool.address)),
-          "the operation is stamped as a per-connection tool",
-        ).toContain(address);
-
-        const execution = completed(
-          yield* client.executions.execute({
-            payload: {
-              code: [
-                `const result = await ${address}({ message: "hello", suffix: "world" });`,
-                "return result;",
-              ].join("\n"),
-            },
-          }),
-        );
-        expect(execution.isError, "the execution succeeded").toBe(false);
-        expect(execution.structured, "the tool returned the upstream's echo").toMatchObject({
-          result: {
-            ok: true,
-            data: {
-              status: 200,
-              data: { message: "hello", suffix: "world", path: "/echo/hello" },
-            },
-          },
-        });
-
-        const requests = yield* server.requests;
-        expect(
-          requests.map((request) => request.path),
-          "the upstream API actually received the call",
-        ).toContain("/echo/hello");
-      }),
-    ),
-);
-
-scenario(
-  "Integrations · MCP addServer registers the catalog row without dialing the endpoint",
-  { needs: ["api"] },
-  (ctx) =>
+  {},
+  Effect.scoped(
     Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = newSlug("srcmcp");
-
-      // Discovery is deferred to connection time, so a dead endpoint still
-      // registers successfully and is fetchable afterwards.
-      const added = yield* client.mcp.addServer({
-        payload: {
-          transport: "remote",
-          name: "Broken MCP",
-          endpoint: "http://127.0.0.1:1/mcp",
-          remoteTransport: "auto",
-          slug,
-        },
-      });
-      expect(added.slug, "the dead endpoint registered anyway").toBe(slug);
-
-      const fetched = yield* client.mcp.getServer({ params: { slug } });
-      expect(fetched, "the stored server keeps the submitted config").toMatchObject({
-        slug,
-        config: {
-          transport: "remote",
-          endpoint: "http://127.0.0.1:1/mcp",
-          remoteTransport: "auto",
-        },
-      });
-    }),
-);
-
-scenario(
-  "Integrations · a connected MCP server's tool executes through the execution surface",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const server = yield* serveMcpServer(() =>
-          makeGreetingMcpServer({
-            name: "e2e-mcp",
-            toolDescription: "Echoes from the e2e MCP server",
-            text: "mcp-ok",
-          }),
-        );
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = newSlug("srcmcp");
-
-        yield* client.mcp.addServer({
-          payload: {
-            transport: "remote",
-            name: "E2E MCP",
-            endpoint: server.endpoint,
-            remoteTransport: "streamable-http",
-            slug,
-          },
-        });
-
-        yield* client.connections.create({
-          payload: {
-            owner: "org",
-            name: MAIN,
-            integration: slug,
-            template: NONE,
-            value: "unused",
-          },
-        });
-
-        const tools = yield* client.tools.list({ query: { integration: slug } });
-        const address = `tools.${slug}.org.main.simple_echo`;
-        expect(
-          tools.map((tool) => String(tool.address)),
-          "the discovered MCP tool is stamped on the connection",
-        ).toContain(address);
-
-        const execution = completed(
-          yield* client.executions.execute({
-            payload: {
-              code: [`const result = await ${address}({});`, "return result;"].join("\n"),
-            },
-          }),
-        );
-        expect(execution.isError, "the execution succeeded").toBe(false);
-        expect(execution.structured, "the MCP tool's content came back").toMatchObject({
-          result: { ok: true, data: { content: [{ type: "text", text: "mcp-ok" }] } },
-        });
-
-        const requests = yield* server.requests;
-        expect(
-          requests.length,
-          "the live MCP server was dialed for discovery and again for the call",
-        ).toBeGreaterThanOrEqual(2);
-      }),
-    ),
-);
-
-scenario(
-  "Integrations · a connected GraphQL endpoint's query executes through the execution surface",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const server = yield* serveGraphqlTestServer({
-          schema: makeGreetingGraphqlSchema({ includeMutation: false }),
-        });
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = newSlug("srcgql");
-
-        const added = yield* client.graphql.addIntegration({
-          payload: { endpoint: server.endpoint, slug, name: "E2E GraphQL" },
-        });
-        expect(added.slug, "the integration keeps the requested slug").toBe(slug);
-
-        yield* client.connections.create({
-          payload: {
-            owner: "org",
-            name: MAIN,
-            integration: slug,
-            template: NONE,
-            value: "unused",
-          },
-        });
-
-        const tools = yield* client.tools.list({ query: { integration: slug } });
-        const address = `tools.${slug}.org.main.query.hello`;
-        expect(
-          tools.map((tool) => String(tool.address)),
-          "the introspected query is stamped as a tool",
-        ).toContain(address);
-
-        const execution = completed(
-          yield* client.executions.execute({
-            payload: {
-              code: [`const result = await ${address}({ name: "Ada" });`, "return result;"].join(
-                "\n",
-              ),
-            },
-          }),
-        );
-        expect(execution.isError, "the execution succeeded").toBe(false);
-        expect(execution.structured, "the resolver's greeting came back").toMatchObject({
-          result: { ok: true, data: { hello: "Hello Ada" } },
-        });
-
-        const requests = yield* server.requests;
-        expect(
-          requests.map((request) => request.payload.query ?? ""),
-          "the endpoint was introspected to build the tool catalog",
-        ).toContainEqual(expect.stringContaining("__schema"));
-        expect(
-          requests.map((request) => request.payload.variables),
-          "the invocation's arguments reached the upstream resolver",
-        ).toContainEqual({ name: "Ada" });
-      }),
-    ),
-);
-
-scenario(
-  "Connections · org-shared and personal connections coexist with distinct tool addresses",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
+      const target = yield* Target;
+      const apiSurface = yield* Api;
+      // A real upstream HTTP API on 127.0.0.1, closed by the scope's finalizer.
+      const server = yield* serveOpenApiEchoTestServer();
+      const identity = yield* target.newIdentity();
+      const client = yield* apiSurface.client(api, identity);
       const slug = newSlug("srcapi");
 
       yield* client.openapi.addSpec({
         payload: {
-          spec: { kind: "blob", value: pingSpec },
+          spec: { kind: "blob", value: server.specJson },
           slug,
-          baseUrl: "http://127.0.0.1:59999",
+          description: "Invocable upstream API",
+          baseUrl: server.baseUrl,
+        },
+      });
+
+      // A connection mints + persists the per-connection tools.
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: MAIN,
+          integration: slug,
+          template: API_KEY,
+          value: "static-token",
+        },
+      });
+
+      const tools = yield* client.tools.list({ query: { integration: slug } });
+      const address = `tools.${slug}.org.main.echo.echoMessage`;
+      expect(
+        tools.map((tool) => String(tool.address)),
+        "the operation is stamped as a per-connection tool",
+      ).toContain(address);
+
+      const execution = completed(
+        yield* client.executions.execute({
+          payload: {
+            code: [
+              `const result = await ${address}({ message: "hello", suffix: "world" });`,
+              "return result;",
+            ].join("\n"),
+          },
+        }),
+      );
+      expect(execution.isError, "the execution succeeded").toBe(false);
+      expect(execution.structured, "the tool returned the upstream's echo").toMatchObject({
+        result: {
+          ok: true,
+          data: {
+            status: 200,
+            data: { message: "hello", suffix: "world", path: "/echo/hello" },
+          },
+        },
+      });
+
+      const requests = yield* server.requests;
+      expect(
+        requests.map((request) => request.path),
+        "the upstream API actually received the call",
+      ).toContain("/echo/hello");
+    }),
+  ),
+);
+
+scenario(
+  "Integrations · MCP addServer registers the catalog row without dialing the endpoint",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(api, identity);
+    const slug = newSlug("srcmcp");
+
+    // Discovery is deferred to connection time, so a dead endpoint still
+    // registers successfully and is fetchable afterwards.
+    const added = yield* client.mcp.addServer({
+      payload: {
+        transport: "remote",
+        name: "Broken MCP",
+        endpoint: "http://127.0.0.1:1/mcp",
+        remoteTransport: "auto",
+        slug,
+      },
+    });
+    expect(added.slug, "the dead endpoint registered anyway").toBe(slug);
+
+    const fetched = yield* client.mcp.getServer({ params: { slug } });
+    expect(fetched, "the stored server keeps the submitted config").toMatchObject({
+      slug,
+      config: {
+        transport: "remote",
+        endpoint: "http://127.0.0.1:1/mcp",
+        remoteTransport: "auto",
+      },
+    });
+  }),
+);
+
+scenario(
+  "Integrations · a connected MCP server's tool executes through the execution surface",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const apiSurface = yield* Api;
+      const server = yield* serveMcpServer(() =>
+        makeGreetingMcpServer({
+          name: "e2e-mcp",
+          toolDescription: "Echoes from the e2e MCP server",
+          text: "mcp-ok",
+        }),
+      );
+      const identity = yield* target.newIdentity();
+      const client = yield* apiSurface.client(api, identity);
+      const slug = newSlug("srcmcp");
+
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "E2E MCP",
+          endpoint: server.endpoint,
+          remoteTransport: "streamable-http",
+          slug,
         },
       });
 
@@ -381,47 +271,166 @@ scenario(
           owner: "org",
           name: MAIN,
           integration: slug,
-          template: API_KEY,
-          value: "org-secret",
+          template: NONE,
+          value: "unused",
         },
       });
+
+      const tools = yield* client.tools.list({ query: { integration: slug } });
+      const address = `tools.${slug}.org.main.simple_echo`;
+      expect(
+        tools.map((tool) => String(tool.address)),
+        "the discovered MCP tool is stamped on the connection",
+      ).toContain(address);
+
+      const execution = completed(
+        yield* client.executions.execute({
+          payload: {
+            code: [`const result = await ${address}({});`, "return result;"].join("\n"),
+          },
+        }),
+      );
+      expect(execution.isError, "the execution succeeded").toBe(false);
+      expect(execution.structured, "the MCP tool's content came back").toMatchObject({
+        result: { ok: true, data: { content: [{ type: "text", text: "mcp-ok" }] } },
+      });
+
+      const requests = yield* server.requests;
+      expect(
+        requests.length,
+        "the live MCP server was dialed for discovery and again for the call",
+      ).toBeGreaterThanOrEqual(2);
+    }),
+  ),
+);
+
+scenario(
+  "Integrations · a connected GraphQL endpoint's query executes through the execution surface",
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const apiSurface = yield* Api;
+      const server = yield* serveGraphqlTestServer({
+        schema: makeGreetingGraphqlSchema({ includeMutation: false }),
+      });
+      const identity = yield* target.newIdentity();
+      const client = yield* apiSurface.client(api, identity);
+      const slug = newSlug("srcgql");
+
+      const added = yield* client.graphql.addIntegration({
+        payload: { endpoint: server.endpoint, slug, name: "E2E GraphQL" },
+      });
+      expect(added.slug, "the integration keeps the requested slug").toBe(slug);
+
       yield* client.connections.create({
         payload: {
-          owner: "user",
-          name: PERSONAL,
+          owner: "org",
+          name: MAIN,
           integration: slug,
-          template: API_KEY,
-          value: "personal-secret",
+          template: NONE,
+          value: "unused",
         },
       });
 
-      // Each connection stamps its own address-keyed copy of the tool.
       const tools = yield* client.tools.list({ query: { integration: slug } });
-      const addresses = tools.map((tool) => String(tool.address));
-      expect(addresses, "the org connection has its own tool address").toContain(
-        `tools.${slug}.org.main.default.ping`,
-      );
-      expect(addresses, "the personal connection has its own tool address").toContain(
-        `tools.${slug}.user.personal.default.ping`,
-      );
-
-      // Owner filters separate the two credentials cleanly.
-      const userConnections = yield* client.connections.list({
-        query: { integration: slug, owner: "user" },
-      });
+      const address = `tools.${slug}.org.main.query.hello`;
       expect(
-        userConnections.map((c) => `${c.owner}/${String(c.name)}`),
-        "the user filter returns only the personal connection",
-      ).toEqual(["user/personal"]);
+        tools.map((tool) => String(tool.address)),
+        "the introspected query is stamped as a tool",
+      ).toContain(address);
 
-      const orgConnections = yield* client.connections.list({
-        query: { integration: slug, owner: "org" },
+      const execution = completed(
+        yield* client.executions.execute({
+          payload: {
+            code: [`const result = await ${address}({ name: "Ada" });`, "return result;"].join(
+              "\n",
+            ),
+          },
+        }),
+      );
+      expect(execution.isError, "the execution succeeded").toBe(false);
+      expect(execution.structured, "the resolver's greeting came back").toMatchObject({
+        result: { ok: true, data: { hello: "Hello Ada" } },
       });
+
+      const requests = yield* server.requests;
       expect(
-        orgConnections.map((c) => `${c.owner}/${String(c.name)}`),
-        "the org filter returns only the shared connection",
-      ).toEqual(["org/main"]);
+        requests.map((request) => request.payload.query ?? ""),
+        "the endpoint was introspected to build the tool catalog",
+      ).toContainEqual(expect.stringContaining("__schema"));
+      expect(
+        requests.map((request) => request.payload.variables),
+        "the invocation's arguments reached the upstream resolver",
+      ).toContainEqual({ name: "Ada" });
     }),
+  ),
+);
+
+scenario(
+  "Connections · org-shared and personal connections coexist with distinct tool addresses",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(api, identity);
+    const slug = newSlug("srcapi");
+
+    yield* client.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: pingSpec },
+        slug,
+        baseUrl: "http://127.0.0.1:59999",
+      },
+    });
+
+    yield* client.connections.create({
+      payload: {
+        owner: "org",
+        name: MAIN,
+        integration: slug,
+        template: API_KEY,
+        value: "org-secret",
+      },
+    });
+    yield* client.connections.create({
+      payload: {
+        owner: "user",
+        name: PERSONAL,
+        integration: slug,
+        template: API_KEY,
+        value: "personal-secret",
+      },
+    });
+
+    // Each connection stamps its own address-keyed copy of the tool.
+    const tools = yield* client.tools.list({ query: { integration: slug } });
+    const addresses = tools.map((tool) => String(tool.address));
+    expect(addresses, "the org connection has its own tool address").toContain(
+      `tools.${slug}.org.main.default.ping`,
+    );
+    expect(addresses, "the personal connection has its own tool address").toContain(
+      `tools.${slug}.user.personal.default.ping`,
+    );
+
+    // Owner filters separate the two credentials cleanly.
+    const userConnections = yield* client.connections.list({
+      query: { integration: slug, owner: "user" },
+    });
+    expect(
+      userConnections.map((c) => `${c.owner}/${String(c.name)}`),
+      "the user filter returns only the personal connection",
+    ).toEqual(["user/personal"]);
+
+    const orgConnections = yield* client.connections.list({
+      query: { integration: slug, owner: "org" },
+    });
+    expect(
+      orgConnections.map((c) => `${c.owner}/${String(c.name)}`),
+      "the org filter returns only the shared connection",
+    ).toEqual(["org/main"]);
+  }),
 );
 
 // The Cloudflare OpenAPI spec is the biggest real spec we care about: 16MB,
@@ -435,35 +444,36 @@ const CLOUDFLARE_SPEC_PATH = fileURLToPath(
 
 scenario(
   "Integrations · the full 16MB Cloudflare spec (2,700+ operations) registers and removes cleanly",
-  { needs: ["api"], timeout: 180_000 },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = newSlug("srccf");
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(api, identity);
+    const slug = newSlug("srccf");
 
-      const added = yield* client.openapi.addSpec({
-        payload: {
-          spec: { kind: "blob", value: readFileSync(CLOUDFLARE_SPEC_PATH, "utf-8") },
-          slug,
-          description: "Cloudflare API",
-          baseUrl: "https://api.cloudflare.com/client/v4",
-        },
-      });
-      expect(added.slug, "the giant spec registered").toBe(slug);
-      expect(added.toolCount, "thousands of operations were extracted").toBeGreaterThan(1000);
+    const added = yield* client.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: readFileSync(CLOUDFLARE_SPEC_PATH, "utf-8") },
+        slug,
+        description: "Cloudflare API",
+        baseUrl: "https://api.cloudflare.com/client/v4",
+      },
+    });
+    expect(added.slug, "the giant spec registered").toBe(slug);
+    expect(added.toolCount, "thousands of operations were extracted").toBeGreaterThan(1000);
 
-      const listed = yield* client.integrations.list();
-      expect(
-        listed.map((i) => String(i.slug)),
-        "the integration is in the catalog",
-      ).toContain(slug);
+    const listed = yield* client.integrations.list();
+    expect(
+      listed.map((i) => String(i.slug)),
+      "the integration is in the catalog",
+    ).toContain(slug);
 
-      yield* client.integrations.remove({ params: { slug } });
-      const after = yield* client.integrations.list();
-      expect(
-        after.map((i) => String(i.slug)),
-        "the giant integration removes cleanly",
-      ).not.toContain(slug);
-    }),
+    yield* client.integrations.remove({ params: { slug } });
+    const after = yield* client.integrations.list();
+    expect(
+      after.map((i) => String(i.slug)),
+      "the giant integration removes cleanly",
+    ).not.toContain(slug);
+  }),
 );

--- a/e2e/cloud/sources-refresh.test.ts
+++ b/e2e/cloud/sources-refresh.test.ts
@@ -19,6 +19,7 @@ import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin(), mcpHttpPlugin()] as const);
 
@@ -72,116 +73,119 @@ const serveJson = (body: string) =>
 
 scenario(
   "Connections · refreshing an MCP connection re-dials the live server and replaces its tools",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        // The factory is re-invoked per MCP session, so flipping `toolName`
-        // changes what the NEXT discovery dial sees.
-        let toolName = "before_refresh";
-        const server = yield* serveMcpServer(() =>
-          makeGreetingMcpServer({ name: "refresh-mcp", toolName, text: "ok" }),
-        );
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = newSlug("refmcp");
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const apiSurface = yield* Api;
+      // The factory is re-invoked per MCP session, so flipping `toolName`
+      // changes what the NEXT discovery dial sees.
+      let toolName = "before_refresh";
+      const server = yield* serveMcpServer(() =>
+        makeGreetingMcpServer({ name: "refresh-mcp", toolName, text: "ok" }),
+      );
+      const identity = yield* target.newIdentity();
+      const client = yield* apiSurface.client(api, identity);
+      const slug = newSlug("refmcp");
 
-        yield* client.mcp.addServer({
-          payload: {
-            transport: "remote",
-            name: "Refresh MCP",
-            endpoint: server.endpoint,
-            remoteTransport: "streamable-http",
-            slug,
-          },
-        });
-        yield* client.connections.create({
-          payload: {
-            owner: "org",
-            name: MAIN,
-            integration: slug,
-            template: NONE,
-            value: "unused",
-          },
-        });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "Refresh MCP",
+          endpoint: server.endpoint,
+          remoteTransport: "streamable-http",
+          slug,
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: MAIN,
+          integration: slug,
+          template: NONE,
+          value: "unused",
+        },
+      });
 
-        const before = yield* client.tools.list({ query: { integration: slug } });
-        expect(
-          before.map((tool) => String(tool.address)),
-          "the connection stamped the server's current tool",
-        ).toContain(`tools.${slug}.org.main.before_refresh`);
+      const before = yield* client.tools.list({ query: { integration: slug } });
+      expect(
+        before.map((tool) => String(tool.address)),
+        "the connection stamped the server's current tool",
+      ).toContain(`tools.${slug}.org.main.before_refresh`);
 
-        // The server's catalog changes; only a refresh may pick that up.
-        toolName = "after_refresh";
-        const refreshed = yield* client.connections.refresh({
-          params: { owner: "org", integration: slug, name: MAIN },
-        });
-        expect(
-          refreshed.map((tool) => String(tool.address)),
-          "refresh returns the re-discovered tool set",
-        ).toContain(`tools.${slug}.org.main.after_refresh`);
+      // The server's catalog changes; only a refresh may pick that up.
+      toolName = "after_refresh";
+      const refreshed = yield* client.connections.refresh({
+        params: { owner: "org", integration: slug, name: MAIN },
+      });
+      expect(
+        refreshed.map((tool) => String(tool.address)),
+        "refresh returns the re-discovered tool set",
+      ).toContain(`tools.${slug}.org.main.after_refresh`);
 
-        const after = yield* client.tools.list({ query: { integration: slug } });
-        const addresses = after.map((tool) => String(tool.address));
-        expect(addresses, "the stale tool row is gone").not.toContain(
-          `tools.${slug}.org.main.before_refresh`,
-        );
-        expect(addresses, "the new tool row is persisted").toContain(
-          `tools.${slug}.org.main.after_refresh`,
-        );
-      }),
-    ),
+      const after = yield* client.tools.list({ query: { integration: slug } });
+      const addresses = after.map((tool) => String(tool.address));
+      expect(addresses, "the stale tool row is gone").not.toContain(
+        `tools.${slug}.org.main.before_refresh`,
+      );
+      expect(addresses, "the new tool row is persisted").toContain(
+        `tools.${slug}.org.main.after_refresh`,
+      );
+    }),
+  ),
 );
 
 scenario(
   "Integrations · a spec registered from a URL is refreshable (canRefresh)",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const specServer = yield* serveJson(pingSpec);
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = newSlug("refurl");
-
-        yield* client.openapi.addSpec({
-          payload: {
-            spec: { kind: "url", url: specServer.url },
-            slug,
-            baseUrl: "http://127.0.0.1:59999",
-          },
-        });
-
-        const integration = yield* client.integrations.get({ params: { slug } });
-        expect(
-          integration?.canRefresh,
-          "a URL-sourced spec can be re-fetched, so the integration is refreshable",
-        ).toBe(true);
-      }),
-    ),
-);
-
-scenario(
-  "Integrations · a spec pasted as a blob is not refreshable (canRefresh)",
-  { needs: ["api"] },
-  (ctx) =>
+  {},
+  Effect.scoped(
     Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = newSlug("refblob");
+      const target = yield* Target;
+      const apiSurface = yield* Api;
+      const specServer = yield* serveJson(pingSpec);
+      const identity = yield* target.newIdentity();
+      const client = yield* apiSurface.client(api, identity);
+      const slug = newSlug("refurl");
 
       yield* client.openapi.addSpec({
         payload: {
-          spec: { kind: "blob", value: pingSpec },
+          spec: { kind: "url", url: specServer.url },
           slug,
-          baseUrl: "https://api.example.test",
+          baseUrl: "http://127.0.0.1:59999",
         },
       });
 
       const integration = yield* client.integrations.get({ params: { slug } });
       expect(
         integration?.canRefresh,
-        "a pasted blob has no upstream to re-poll, so the integration is not refreshable",
-      ).toBe(false);
+        "a URL-sourced spec can be re-fetched, so the integration is refreshable",
+      ).toBe(true);
     }),
+  ),
+);
+
+scenario(
+  "Integrations · a spec pasted as a blob is not refreshable (canRefresh)",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(api, identity);
+    const slug = newSlug("refblob");
+
+    yield* client.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: pingSpec },
+        slug,
+        baseUrl: "https://api.example.test",
+      },
+    });
+
+    const integration = yield* client.integrations.get({ params: { slug } });
+    expect(
+      integration?.canRefresh,
+      "a pasted blob has no upstream to re-poll, so the integration is not refreshable",
+    ).toBe(false);
+  }),
 );

--- a/e2e/cloud/surface-reachability.test.ts
+++ b/e2e/cloud/surface-reachability.test.ts
@@ -7,105 +7,107 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Api, Billing, Target } from "../src/services";
 
 scenario(
   "Surfaces · Swagger UI and the OpenAPI spec document the mounted API",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const docs = yield* Effect.promise(() => fetch(new URL("/api/docs", ctx.target.baseUrl)));
-      expect(docs.status, "Swagger UI is served").toBe(200);
-      expect(docs.headers.get("content-type"), "as an HTML page").toContain("text/html");
-      const docsHtml = yield* Effect.promise(() => docs.text());
-      expect(docsHtml.toLowerCase(), "it is the Swagger UI shell").toContain("swagger");
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
+    const docs = yield* Effect.promise(() => fetch(new URL("/api/docs", target.baseUrl)));
+    expect(docs.status, "Swagger UI is served").toBe(200);
+    expect(docs.headers.get("content-type"), "as an HTML page").toContain("text/html");
+    const docsHtml = yield* Effect.promise(() => docs.text());
+    expect(docsHtml.toLowerCase(), "it is the Swagger UI shell").toContain("swagger");
 
-      const spec = yield* Effect.promise(() =>
-        fetch(new URL("/api/openapi.json", ctx.target.baseUrl)),
-      );
-      expect(spec.status, "the OpenAPI spec is served").toBe(200);
-      expect(spec.headers.get("content-type"), "as JSON").toContain("application/json");
-      const parsed = (yield* Effect.promise(() => spec.json())) as {
-        paths?: Record<string, unknown>;
-      };
-      const paths = Object.keys(parsed.paths ?? {});
-      expect(paths, "the core protected API is documented").toContain("/api/integrations");
-      expect(paths, "the session-auth plane is documented").toContain("/api/auth/me");
-      expect(paths, "the org plane is documented").toContain("/api/org/domains");
-      expect(paths, "path-param routes are documented").toContain(
-        "/api/executions/{executionId}/resume",
-      );
-    }),
+    const spec = yield* Effect.promise(() => fetch(new URL("/api/openapi.json", target.baseUrl)));
+    expect(spec.status, "the OpenAPI spec is served").toBe(200);
+    expect(spec.headers.get("content-type"), "as JSON").toContain("application/json");
+    const parsed = (yield* Effect.promise(() => spec.json())) as {
+      paths?: Record<string, unknown>;
+    };
+    const paths = Object.keys(parsed.paths ?? {});
+    expect(paths, "the core protected API is documented").toContain("/api/integrations");
+    expect(paths, "the session-auth plane is documented").toContain("/api/auth/me");
+    expect(paths, "the org plane is documented").toContain("/api/org/domains");
+    expect(paths, "path-param routes are documented").toContain(
+      "/api/executions/{executionId}/resume",
+    );
+  }),
 );
 
 scenario(
   "Surfaces · the billing proxy answers with its own 401 JSON, not the SPA fallback",
-  { needs: ["api", "billing"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/api/billing/customer", ctx.target.baseUrl), {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: "{}",
-        }),
-      );
-      // The regression returned the SPA fallback (200 text/html). The real
-      // billing route is reached and rejects the unauthenticated call itself.
-      expect(response.status, "the billing route rejects the anonymous call").toBe(401);
-      expect(response.headers.get("content-type"), "with a JSON body").toContain(
-        "application/json",
-      );
-      const body = yield* Effect.promise(() => response.json());
-      expect(body, "the structured refusal a client can act on").toEqual({
-        error: "Unauthorized",
-        code: "unauthorized",
-      });
-    }),
+  {},
+  Effect.gen(function* () {
+    // Gates: the REST API plane is mounted and billing is enforced here.
+    yield* Api;
+    yield* Billing;
+    const target = yield* Target;
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/api/billing/customer", target.baseUrl), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+    );
+    // The regression returned the SPA fallback (200 text/html). The real
+    // billing route is reached and rejects the unauthenticated call itself.
+    expect(response.status, "the billing route rejects the anonymous call").toBe(401);
+    expect(response.headers.get("content-type"), "with a JSON body").toContain("application/json");
+    const body = yield* Effect.promise(() => response.json());
+    expect(body, "the structured refusal a client can act on").toEqual({
+      error: "Unauthorized",
+      code: "unauthorized",
+    });
+  }),
 );
 
 scenario(
   "Surfaces · every protected plane refuses anonymous callers with structured JSON",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      // The core protected API: anonymous callers hit the auth gate, which
-      // answers in JSON (never the SPA) with the documented refusal body.
-      const core = yield* Effect.promise(() =>
-        fetch(new URL("/api/integrations", ctx.target.baseUrl)),
-      );
-      expect(core.status, "no credentials → no organization to act in").toBe(403);
-      expect(core.headers.get("content-type"), "the gate answers in JSON").toContain(
-        "application/json",
-      );
-      expect(yield* Effect.promise(() => core.json()), "the documented refusal body").toEqual({
-        error: "No organization in session",
-        code: "no_organization",
-      });
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
+    // The core protected API: anonymous callers hit the auth gate, which
+    // answers in JSON (never the SPA) with the documented refusal body.
+    const core = yield* Effect.promise(() => fetch(new URL("/api/integrations", target.baseUrl)));
+    expect(core.status, "no credentials → no organization to act in").toBe(403);
+    expect(core.headers.get("content-type"), "the gate answers in JSON").toContain(
+      "application/json",
+    );
+    expect(yield* Effect.promise(() => core.json()), "the documented refusal body").toEqual({
+      error: "No organization in session",
+      code: "no_organization",
+    });
 
-      // The session-auth plane is mounted and gated.
-      const sessionMe = yield* Effect.promise(() =>
-        fetch(new URL("/api/auth/me", ctx.target.baseUrl)),
-      );
-      expect(sessionMe.status, "the session API requires a session").toBe(401);
+    // The session-auth plane is mounted and gated.
+    const sessionMe = yield* Effect.promise(() => fetch(new URL("/api/auth/me", target.baseUrl)));
+    expect(sessionMe.status, "the session API requires a session").toBe(401);
 
-      // The org plane is mounted and gated.
-      const orgDomains = yield* Effect.promise(() =>
-        fetch(new URL("/api/org/domains", ctx.target.baseUrl)),
-      );
-      expect(orgDomains.status, "the org API requires a session").toBe(401);
-    }),
+    // The org plane is mounted and gated.
+    const orgDomains = yield* Effect.promise(() =>
+      fetch(new URL("/api/org/domains", target.baseUrl)),
+    );
+    expect(orgDomains.status, "the org API requires a session").toBe(401);
+  }),
 );
 
 scenario(
   "Surfaces · unknown /api routes are a real 404, not the SPA fallback",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const response = yield* Effect.promise(() =>
-        fetch(new URL("/api/this-route-does-not-exist", ctx.target.baseUrl)),
-      );
-      expect(response.status, "the API plane owns its 404s").toBe(404);
-      const body = yield* Effect.promise(() => response.text());
-      expect(body, "no SPA HTML leaks out of the API plane").not.toContain("<!DOCTYPE html");
-    }),
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/api/this-route-does-not-exist", target.baseUrl)),
+    );
+    expect(response.status, "the API plane owns its 404s").toBe(404);
+    const body = yield* Effect.promise(() => response.text());
+    expect(body, "no SPA HTML leaks out of the API plane").not.toContain("<!DOCTYPE html");
+  }),
 );

--- a/e2e/cloud/tenant-isolation.test.ts
+++ b/e2e/cloud/tenant-isolation.test.ts
@@ -13,6 +13,7 @@ import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 type Client = HttpApiClient.ForApi<typeof api>;
@@ -49,89 +50,91 @@ const addPingSpec = (client: Client, slug: IntegrationSlug, description?: string
 
 scenario(
   "Tenant isolation · integrations, tools, and connections in one org are invisible to another",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const orgA = yield* ctx.target.newIdentity();
-      const orgB = yield* ctx.target.newIdentity();
-      const clientA = yield* ctx.api.client(api, orgA);
-      const clientB = yield* ctx.api.client(api, orgB);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const orgA = yield* target.newIdentity();
+    const orgB = yield* target.newIdentity();
+    const clientA = yield* client(api, orgA);
+    const clientB = yield* client(api, orgB);
 
-      const slug = IntegrationSlug.make(`tenant-scn-${randomBytes(4).toString("hex")}`);
-      const connectionName = ConnectionName.make(`tenantconn${randomBytes(4).toString("hex")}`);
-      const secretValue = `tenant-secret-${randomBytes(8).toString("hex")}`;
+    const slug = IntegrationSlug.make(`tenant-scn-${randomBytes(4).toString("hex")}`);
+    const connectionName = ConnectionName.make(`tenantconn${randomBytes(4).toString("hex")}`);
+    const secretValue = `tenant-secret-${randomBytes(8).toString("hex")}`;
 
-      // Org A registers an integration and stores a credential against it.
-      yield* addPingSpec(clientA, slug);
-      yield* clientA.connections.create({
-        payload: {
-          owner: "org",
-          name: connectionName,
-          integration: slug,
-          template: TEMPLATE_API_KEY,
-          value: secretValue,
-        },
-      });
+    // Org A registers an integration and stores a credential against it.
+    yield* addPingSpec(clientA, slug);
+    yield* clientA.connections.create({
+      payload: {
+        owner: "org",
+        name: connectionName,
+        integration: slug,
+        template: TEMPLATE_API_KEY,
+        value: secretValue,
+      },
+    });
 
-      // Sanity from org A's own side: the integration is really there.
-      const aIntegrations = yield* clientA.integrations.list();
-      expect(
-        aIntegrations.map((integration) => integration.slug),
-        "org A sees its own integration",
-      ).toContain(slug);
+    // Sanity from org A's own side: the integration is really there.
+    const aIntegrations = yield* clientA.integrations.list();
+    expect(
+      aIntegrations.map((integration) => integration.slug),
+      "org A sees its own integration",
+    ).toContain(slug);
 
-      // Org B sees none of it — catalog, tools, connections, or secret bytes.
-      const bIntegrations = yield* clientB.integrations.list();
-      expect(
-        bIntegrations.map((integration) => integration.slug),
-        "org B's integration catalog has no trace of org A's integration",
-      ).not.toContain(slug);
+    // Org B sees none of it — catalog, tools, connections, or secret bytes.
+    const bIntegrations = yield* clientB.integrations.list();
+    expect(
+      bIntegrations.map((integration) => integration.slug),
+      "org B's integration catalog has no trace of org A's integration",
+    ).not.toContain(slug);
 
-      const bTools = yield* clientB.tools.list();
-      const leakedTools = bTools
-        .filter((tool) => String(tool.address).includes(slug))
-        .map((tool) => tool.address);
-      expect(leakedTools, "no org-A tool leaks into org B's tool catalog").toEqual([]);
+    const bTools = yield* clientB.tools.list({ query: {} });
+    const leakedTools = bTools
+      .filter((tool) => String(tool.address).includes(slug))
+      .map((tool) => tool.address);
+    expect(leakedTools, "no org-A tool leaks into org B's tool catalog").toEqual([]);
 
-      const bView = yield* clientB.openapi.getIntegration({ params: { slug } });
-      expect(bView, "fetching org A's integration by slug from org B yields nothing").toBeNull();
+    const bView = yield* clientB.openapi.getIntegration({ params: { slug } });
+    expect(bView, "fetching org A's integration by slug from org B yields nothing").toBeNull();
 
-      const bConnections = yield* clientB.connections.list({ query: {} });
-      expect(
-        bConnections.map((connection) => connection.name),
-        "org A's connection is not in org B's connection list",
-      ).not.toContain(connectionName);
-      expect(
-        JSON.stringify(bConnections),
-        "org A's secret value appears nowhere in org B's view",
-      ).not.toContain(secretValue);
-    }),
+    const bConnections = yield* clientB.connections.list({ query: {} });
+    expect(
+      bConnections.map((connection) => connection.name),
+      "org A's connection is not in org B's connection list",
+    ).not.toContain(connectionName);
+    expect(
+      JSON.stringify(bConnections),
+      "org A's secret value appears nowhere in org B's view",
+    ).not.toContain(secretValue);
+  }),
 );
 
 scenario(
   "Tenant isolation · the same integration slug in two orgs is two independent records",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const orgA = yield* ctx.target.newIdentity();
-      const orgB = yield* ctx.target.newIdentity();
-      const clientA = yield* ctx.api.client(api, orgA);
-      const clientB = yield* ctx.api.client(api, orgB);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const orgA = yield* target.newIdentity();
+    const orgB = yield* target.newIdentity();
+    const clientA = yield* client(api, orgA);
+    const clientB = yield* client(api, orgB);
 
-      // Both orgs register the SAME slug — neither blocks the other.
-      const slug = IntegrationSlug.make(`shared-scn-${randomBytes(4).toString("hex")}`);
-      yield* addPingSpec(clientA, slug, "Org A API");
-      yield* addPingSpec(clientB, slug, "Org B API");
+    // Both orgs register the SAME slug — neither blocks the other.
+    const slug = IntegrationSlug.make(`shared-scn-${randomBytes(4).toString("hex")}`);
+    yield* addPingSpec(clientA, slug, "Org A API");
+    yield* addPingSpec(clientB, slug, "Org B API");
 
-      // Updating org A's record must not mutate org B's same-slug record.
-      yield* clientA.integrations.update({
-        params: { slug },
-        payload: { description: "Org A Updated API" },
-      });
+    // Updating org A's record must not mutate org B's same-slug record.
+    yield* clientA.integrations.update({
+      params: { slug },
+      payload: { description: "Org A Updated API" },
+    });
 
-      const aIntegration = yield* clientA.integrations.get({ params: { slug } });
-      const bIntegration = yield* clientB.integrations.get({ params: { slug } });
-      expect(aIntegration.description, "org A sees its own update").toBe("Org A Updated API");
-      expect(bIntegration.description, "org B's same-slug record is untouched").toBe("Org B API");
-    }),
+    const aIntegration = yield* clientA.integrations.get({ params: { slug } });
+    const bIntegration = yield* clientB.integrations.get({ params: { slug } });
+    expect(aIntegration.description, "org A sees its own update").toBe("Org A Updated API");
+    expect(bIntegration.description, "org B's same-slug record is untouched").toBe("Org B API");
+  }),
 );

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,8 @@
     "test:selfhost": "vitest run --project selfhost",
     "test:watch": "vitest",
     "viewer:build": "bun scripts/rebuild-viewer.ts",
-    "serve": "bun scripts/rebuild-viewer.ts && bun scripts/serve.ts"
+    "serve": "bun scripts/rebuild-viewer.ts && bun scripts/serve.ts",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@executor-js/api": "workspace:*",
@@ -30,9 +31,11 @@
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
+    "@types/node": "^25.9.2",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@vitejs/plugin-react": "catalog:",
+    "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"
   }

--- a/e2e/scenarios/api-tools.test.ts
+++ b/e2e/scenarios/api-tools.test.ts
@@ -6,23 +6,32 @@ import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const coreApi = composePluginApi([] as const);
 
-scenario("API · typed client lists the available tools", { needs: ["api"] }, (ctx) =>
+scenario(
+  "API · typed client lists the available tools",
+  {},
   Effect.gen(function* () {
-    const identity = yield* ctx.target.newIdentity();
-    const client = yield* ctx.api.client(coreApi, identity);
-    const tools = yield* client.tools.list();
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const api = yield* client(coreApi, identity);
+    const tools = yield* api.tools.list({ query: {} });
     expect(tools.length, "at least one tool is exposed").toBeGreaterThan(0);
   }),
 );
 
-scenario("API · a fresh identity starts with zero connections", { needs: ["api"] }, (ctx) =>
+scenario(
+  "API · a fresh identity starts with zero connections",
+  {},
   Effect.gen(function* () {
-    const identity = yield* ctx.target.newIdentity();
-    const client = yield* ctx.api.client(coreApi, identity);
-    const connections = yield* client.connections.list();
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const api = yield* client(coreApi, identity);
+    const connections = yield* api.connections.list({ query: {} });
     expect(connections.length, "no connections leak across identities").toBe(0);
   }),
 );

--- a/e2e/scenarios/auth-methods-ui.test.ts
+++ b/e2e/scenarios/auth-methods-ui.test.ts
@@ -14,64 +14,66 @@ import { Effect } from "effect";
 import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 
 import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
 
 scenario(
   "Auth methods · the add flow declares an API key alongside the detected method",
-  { needs: ["browser"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        // An OPEN server: the probe connects without auth, so the method list
-        // seeds with the detected "no authentication" row. The server name is
-        // unique per run — the derived integration namespace must not collide
-        // on targets whose identities share one tenant (selfhost admin).
-        const server = yield* serveMcpServer(() =>
-          makeGreetingMcpServer({ name: `open-mcp-${randomBytes(3).toString("hex")}` }),
-        );
-        const identity = yield* ctx.target.newIdentity();
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      // An OPEN server: the probe connects without auth, so the method list
+      // seeds with the detected "no authentication" row. The server name is
+      // unique per run — the derived integration namespace must not collide
+      // on targets whose identities share one tenant (selfhost admin).
+      const server = yield* serveMcpServer(() =>
+        makeGreetingMcpServer({ name: `open-mcp-${randomBytes(3).toString("hex")}` }),
+      );
+      const identity = yield* target.newIdentity();
 
-        yield* ctx.browser.session(identity, async ({ page, step }) => {
-          await step("Open the add-MCP flow pointed at the server", async () => {
-            await page.goto(`/integrations/add/mcp?url=${encodeURIComponent(server.endpoint)}`, {
-              waitUntil: "networkidle",
-            });
-            // The URL auto-probes (debounced); the method list appears once
-            // the probe lands.
-            await page.getByText("How does this server authenticate?").waitFor();
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the add-MCP flow pointed at the server", async () => {
+          await page.goto(`/integrations/add/mcp?url=${encodeURIComponent(server.endpoint)}`, {
+            waitUntil: "networkidle",
           });
-
-          await step("The probe seeded the detected method", async () => {
-            await page.getByText("Method 1 · Detected").waitFor();
-          });
-
-          await step("Declare an API key method alongside it", async () => {
-            await page.getByRole("button", { name: "Add method" }).click();
-            await page.getByText("Method 2").waitFor();
-            // The new row opens on the API key editor with the standard
-            // Authorization-header placement prefilled.
-            const headerName = page.getByPlaceholder("Authorization").last();
-            await headerName.waitFor();
-          });
-
-          await step("Add the source with both methods", async () => {
-            await page.getByRole("button", { name: "Add source" }).click();
-            // onComplete routes to the new integration's detail hub.
-            await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
-            await page.getByText("Connections").first().waitFor();
-          });
-
-          await step("The connect modal offers both methods", async () => {
-            await page.getByRole("button", { name: "Add connection" }).first().click();
-            await page.getByRole("tab", { name: "No authentication" }).waitFor();
-            await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
-          });
-
-          const tabs = await page.getByRole("tab").allInnerTexts();
-          expect(tabs.join(", "), "both declared methods are selectable").toContain(
-            "No authentication",
-          );
-          expect(tabs.join(", ")).toContain("API key (Authorization)");
+          // The URL auto-probes (debounced); the method list appears once
+          // the probe lands.
+          await page.getByText("How does this server authenticate?").waitFor();
         });
-      }),
-    ),
+
+        await step("The probe seeded the detected method", async () => {
+          await page.getByText("Method 1 · Detected").waitFor();
+        });
+
+        await step("Declare an API key method alongside it", async () => {
+          await page.getByRole("button", { name: "Add method" }).click();
+          await page.getByText("Method 2").waitFor();
+          // The new row opens on the API key editor with the standard
+          // Authorization-header placement prefilled.
+          const headerName = page.getByPlaceholder("Authorization").last();
+          await headerName.waitFor();
+        });
+
+        await step("Add the source with both methods", async () => {
+          await page.getByRole("button", { name: "Add source" }).click();
+          // onComplete routes to the new integration's detail hub.
+          await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
+          await page.getByText("Connections").first().waitFor();
+        });
+
+        await step("The connect modal offers both methods", async () => {
+          await page.getByRole("button", { name: "Add connection" }).first().click();
+          await page.getByRole("tab", { name: "No authentication" }).waitFor();
+          await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
+        });
+
+        const tabs = await page.getByRole("tab").allInnerTexts();
+        expect(tabs.join(", "), "both declared methods are selectable").toContain(
+          "No authentication",
+        );
+        expect(tabs.join(", ")).toContain("API key (Authorization)");
+      });
+    }),
+  ),
 );

--- a/e2e/scenarios/auth-methods.test.ts
+++ b/e2e/scenarios/auth-methods.test.ts
@@ -21,6 +21,7 @@ import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/
 import { variable } from "@executor-js/sdk/http-auth";
 
 import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
 
 const api = composePluginApi([mcpHttpPlugin(), graphqlHttpPlugin()] as const);
 
@@ -32,205 +33,209 @@ const MCP_ENDPOINT = "http://127.0.0.1:59998/mcp";
 
 scenario(
   "Auth methods · an MCP server can declare OAuth and an API key side by side",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = freshSlug("mcp_multiauth");
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+    const slug = freshSlug("mcp_multiauth");
 
-      yield* client.mcp.addServer({
-        payload: {
-          transport: "remote",
-          name: "Multi-auth MCP",
-          endpoint: MCP_ENDPOINT,
-          slug,
-          authenticationTemplate: [
-            { kind: "oauth2" },
-            { type: "apiKey", headers: { "X-Api-Key": ["Bearer ", variable("token")] } },
-          ],
-        },
+    yield* client.mcp.addServer({
+      payload: {
+        transport: "remote",
+        name: "Multi-auth MCP",
+        endpoint: MCP_ENDPOINT,
+        slug,
+        authenticationTemplate: [
+          { kind: "oauth2" },
+          { type: "apiKey", headers: { "X-Api-Key": ["Bearer ", variable("token")] } },
+        ],
+      },
+    });
+
+    yield* Effect.gen(function* () {
+      const integration = yield* client.integrations.get({
+        params: { slug: IntegrationSlug.make(slug) },
       });
 
-      yield* Effect.gen(function* () {
-        const integration = yield* client.integrations.get({
-          params: { slug: IntegrationSlug.make(slug) },
-        });
+      // Both methods project into the catalog (a slug-less single-header
+      // apikey method gets the carrier-derived `header` slug), so the
+      // connect flow can offer either and a connection binds one by slug.
+      expect(
+        integration.authMethods.map((m) => ({ kind: m.kind, template: m.template })),
+        "the catalog lists both declared methods",
+      ).toEqual([
+        { kind: "oauth", template: "oauth2" },
+        { kind: "apikey", template: "header" },
+      ]);
 
-        // Both methods project into the catalog (a slug-less single-header
-        // apikey method gets the carrier-derived `header` slug), so the
-        // connect flow can offer either and a connection binds one by slug.
-        expect(
-          integration.authMethods.map((m) => ({ kind: m.kind, template: m.template })),
-          "the catalog lists both declared methods",
-        ).toEqual([
-          { kind: "oauth", template: "oauth2" },
-          { kind: "apikey", template: "header" },
-        ]);
-
-        const apiKey = integration.authMethods.find((m) => m.kind === "apikey");
-        expect(apiKey?.placements, "the API key method carries its header placement").toEqual([
-          { carrier: "header", name: "X-Api-Key", prefix: "Bearer " },
-        ]);
-      }).pipe(
-        Effect.ensuring(
-          client.mcp
-            .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
-            .pipe(Effect.ignore),
-        ),
-      );
-    }),
+      const apiKey = integration.authMethods.find((m) => m.kind === "apikey");
+      expect(apiKey?.placements, "the API key method carries its header placement").toEqual([
+        { carrier: "header", name: "X-Api-Key", prefix: "Bearer " },
+      ]);
+    }).pipe(
+      Effect.ensuring(
+        client.mcp
+          .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+          .pipe(Effect.ignore),
+      ),
+    );
+  }),
 );
 
 scenario(
   "Auth methods · adding an API key method keeps a detected OAuth method",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = freshSlug("mcp_oauth_plus_key");
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+    const slug = freshSlug("mcp_oauth_plus_key");
 
-      // The add flow registered what the probe detected: OAuth only.
-      yield* client.mcp.addServer({
+    // The add flow registered what the probe detected: OAuth only.
+    yield* client.mcp.addServer({
+      payload: {
+        transport: "remote",
+        name: "OAuth MCP",
+        endpoint: MCP_ENDPOINT,
+        slug,
+        authenticationTemplate: [{ kind: "oauth2" }],
+      },
+    });
+
+    yield* Effect.gen(function* () {
+      // "+ Custom method" merge-appends — it must not displace OAuth.
+      const configured = yield* client.mcp.configureAuth({
+        params: { slug: IntegrationSlug.make(slug) },
         payload: {
-          transport: "remote",
-          name: "OAuth MCP",
-          endpoint: MCP_ENDPOINT,
-          slug,
-          authenticationTemplate: [{ kind: "oauth2" }],
+          authenticationTemplate: [
+            { type: "apiKey", headers: { "X-Api-Key": [variable("token")] } },
+          ],
         },
       });
+      expect(
+        configured.authenticationTemplate.map((m) => m.kind),
+        "the declared set now holds both methods",
+      ).toEqual(["oauth2", "apikey"]);
+      expect(
+        configured.authenticationTemplate[1]?.slug,
+        "the custom method gets its own custom_ slug",
+      ).toMatch(/^custom_/);
 
-      yield* Effect.gen(function* () {
-        // "+ Custom method" merge-appends — it must not displace OAuth.
-        const configured = yield* client.mcp.configureAuth({
-          params: { slug: IntegrationSlug.make(slug) },
-          payload: {
-            authenticationTemplate: [
-              { type: "apiKey", headers: { "X-Api-Key": [variable("token")] } },
-            ],
-          },
-        });
-        expect(
-          configured.authenticationTemplate.map((m) => m.kind),
-          "the declared set now holds both methods",
-        ).toEqual(["oauth2", "apikey"]);
-        expect(
-          configured.authenticationTemplate[1]?.slug,
-          "the custom method gets its own custom_ slug",
-        ).toMatch(/^custom_/);
-
-        const integration = yield* client.integrations.get({
-          params: { slug: IntegrationSlug.make(slug) },
-        });
-        expect(
-          integration.authMethods.map((m) => m.kind),
-          "the catalog offers OAuth and the API key",
-        ).toEqual(["oauth", "apikey"]);
-      }).pipe(
-        Effect.ensuring(
-          client.mcp
-            .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
-            .pipe(Effect.ignore),
-        ),
-      );
-    }),
+      const integration = yield* client.integrations.get({
+        params: { slug: IntegrationSlug.make(slug) },
+      });
+      expect(
+        integration.authMethods.map((m) => m.kind),
+        "the catalog offers OAuth and the API key",
+      ).toEqual(["oauth", "apikey"]);
+    }).pipe(
+      Effect.ensuring(
+        client.mcp
+          .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+          .pipe(Effect.ignore),
+      ),
+    );
+  }),
 );
 
 scenario(
   "Auth methods · a no-auth MCP server can declare an API key method later",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = freshSlug("mcp_open_plus_key");
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+    const slug = freshSlug("mcp_open_plus_key");
 
-      // No declared auth — the server advertises nothing.
-      yield* client.mcp.addServer({
-        payload: { transport: "remote", name: "Open MCP", endpoint: MCP_ENDPOINT, slug },
+    // No declared auth — the server advertises nothing.
+    yield* client.mcp.addServer({
+      payload: { transport: "remote", name: "Open MCP", endpoint: MCP_ENDPOINT, slug },
+    });
+
+    yield* Effect.gen(function* () {
+      const before = yield* client.integrations.get({
+        params: { slug: IntegrationSlug.make(slug) },
       });
+      expect(
+        before.authMethods.map((m) => m.kind),
+        "an open server starts with the no-auth method",
+      ).toEqual(["none"]);
 
-      yield* Effect.gen(function* () {
-        const before = yield* client.integrations.get({
-          params: { slug: IntegrationSlug.make(slug) },
-        });
-        expect(
-          before.authMethods.map((m) => m.kind),
-          "an open server starts with the no-auth method",
-        ).toEqual(["none"]);
-
-        yield* client.mcp.configureAuth({
-          params: { slug: IntegrationSlug.make(slug) },
-          payload: {
-            authenticationTemplate: [
-              { type: "apiKey", headers: { Authorization: ["Bearer ", variable("token")] } },
-            ],
-          },
-        });
-
-        const after = yield* client.integrations.get({
-          params: { slug: IntegrationSlug.make(slug) },
-        });
-        expect(
-          after.authMethods.map((m) => m.kind),
-          "no-auth and the declared API key coexist",
-        ).toEqual(["none", "apikey"]);
-      }).pipe(
-        Effect.ensuring(
-          client.mcp
-            .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
-            .pipe(Effect.ignore),
-        ),
-      );
-    }),
-);
-
-scenario(
-  "Auth methods · a GraphQL source registers multiple auth methods at add time",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const slug = freshSlug("graphql_multiauth");
-
-      yield* client.graphql.addIntegration({
+      yield* client.mcp.configureAuth({
+        params: { slug: IntegrationSlug.make(slug) },
         payload: {
-          endpoint: "http://127.0.0.1:59998/graphql",
-          slug,
-          name: "Multi-auth GraphQL",
           authenticationTemplate: [
-            { slug: "apiKey", type: "apiKey", headers: { "X-Api-Key": [variable("token")] } },
-            { slug: "apikey-2", type: "apiKey", queryParams: { api_key: [variable("token")] } },
+            { type: "apiKey", headers: { Authorization: ["Bearer ", variable("token")] } },
           ],
         },
       });
 
-      yield* Effect.gen(function* () {
-        const integration = yield* client.integrations.get({
-          params: { slug: IntegrationSlug.make(slug) },
-        });
-        expect(
-          integration.authMethods.map((m) => ({ template: m.template, kind: m.kind })),
-          "both declared methods are in the catalog",
-        ).toEqual([
-          { template: "apiKey", kind: "apikey" },
-          { template: "apikey-2", kind: "apikey" },
-        ]);
-        expect(
-          integration.authMethods[1]?.placements,
-          "the second method carries its query placement",
-        ).toEqual([{ carrier: "query", name: "api_key", prefix: "" }]);
-      }).pipe(
-        Effect.ensuring(
-          client.integrations
-            .remove({ params: { slug: IntegrationSlug.make(slug) } })
-            .pipe(Effect.ignore),
-        ),
-      );
-    }),
+      const after = yield* client.integrations.get({
+        params: { slug: IntegrationSlug.make(slug) },
+      });
+      expect(
+        after.authMethods.map((m) => m.kind),
+        "no-auth and the declared API key coexist",
+      ).toEqual(["none", "apikey"]);
+    }).pipe(
+      Effect.ensuring(
+        client.mcp
+          .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+          .pipe(Effect.ignore),
+      ),
+    );
+  }),
+);
+
+scenario(
+  "Auth methods · a GraphQL source registers multiple auth methods at add time",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+    const slug = freshSlug("graphql_multiauth");
+
+    yield* client.graphql.addIntegration({
+      payload: {
+        endpoint: "http://127.0.0.1:59998/graphql",
+        slug,
+        name: "Multi-auth GraphQL",
+        authenticationTemplate: [
+          { slug: "apiKey", type: "apiKey", headers: { "X-Api-Key": [variable("token")] } },
+          { slug: "apikey-2", type: "apiKey", queryParams: { api_key: [variable("token")] } },
+        ],
+      },
+    });
+
+    yield* Effect.gen(function* () {
+      const integration = yield* client.integrations.get({
+        params: { slug: IntegrationSlug.make(slug) },
+      });
+      expect(
+        integration.authMethods.map((m) => ({ template: m.template, kind: m.kind })),
+        "both declared methods are in the catalog",
+      ).toEqual([
+        { template: "apiKey", kind: "apikey" },
+        { template: "apikey-2", kind: "apikey" },
+      ]);
+      expect(
+        integration.authMethods[1]?.placements,
+        "the second method carries its query placement",
+      ).toEqual([{ carrier: "query", name: "api_key", prefix: "" }]);
+    }).pipe(
+      Effect.ensuring(
+        client.integrations
+          .remove({ params: { slug: IntegrationSlug.make(slug) } })
+          .pipe(Effect.ignore),
+      ),
+    );
+  }),
 );
 
 // ---------------------------------------------------------------------------
@@ -244,11 +249,14 @@ scenario(
 
 scenario(
   "Auth methods · one source mixes oauth, a 2-input header+query method, a bearer header, and a query token",
-  { needs: ["api", "mcp-oauth"] },
-  (ctx) =>
+  {},
+  Effect.scoped(
     Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
       const slug = freshSlug("mcp_extreme");
 
       // A real MCP server that records every request it receives.
@@ -346,7 +354,7 @@ scenario(
 
         // Discovery dialed the server per connection; every connection
         // produced its own addressed tool.
-        const tools = yield* client.tools.list();
+        const tools = yield* client.tools.list({ query: {} });
         const names = tools
           .filter((tool) => String(tool.integration) === slug)
           .map((tool) => String(tool.address));
@@ -359,7 +367,7 @@ scenario(
         // Invoke through the MCP surface (the real agent path: execute runs
         // sandbox code that calls the addressed tool), then assert the WIRE:
         // what the recording server received for each connection.
-        const session = ctx.mcp.session(identity);
+        const session = mcp.session(identity);
 
         const invokeAndCapture = (conn: string, marker: string) =>
           Effect.gen(function* () {
@@ -427,4 +435,5 @@ scenario(
         ),
       );
     }),
+  ),
 );

--- a/e2e/scenarios/integrations.test.ts
+++ b/e2e/scenarios/integrations.test.ts
@@ -6,28 +6,30 @@ import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const coreApi = composePluginApi([] as const);
 
 scenario(
   "Integrations · a fresh workspace ships the built-in executor integration ready to use",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(coreApi, identity);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const api = yield* client(coreApi, identity);
 
-      const integrations = yield* client.integrations.list();
-      const builtin = integrations.find((i) => i.slug === "executor");
-      expect(builtin, "the 'executor' integration is in the catalog").toBeDefined();
-      expect(builtin?.kind).toBe("built-in");
-      expect(builtin?.canRemove, "the built-in integration is permanent").toBe(false);
+    const integrations = yield* api.integrations.list();
+    const builtin = integrations.find((i) => i.slug === "executor");
+    expect(builtin, "the 'executor' integration is in the catalog").toBeDefined();
+    expect(builtin?.kind).toBe("built-in");
+    expect(builtin?.canRemove, "the built-in integration is permanent").toBe(false);
 
-      const tools = yield* client.tools.list();
-      const executorTools = tools.filter((t) => t.integration === "executor");
-      expect(
-        executorTools.length,
-        "tools are available out of the box, no connection setup needed",
-      ).toBeGreaterThan(0);
-    }),
+    const tools = yield* api.tools.list({ query: {} });
+    const executorTools = tools.filter((t) => t.integration === "executor");
+    expect(
+      executorTools.length,
+      "tools are available out of the box, no connection setup needed",
+    ).toBeGreaterThan(0);
+  }),
 );

--- a/e2e/scenarios/mcp-execute.test.ts
+++ b/e2e/scenarios/mcp-execute.test.ts
@@ -5,11 +5,16 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
+import { Mcp, Target } from "../src/services";
 
-scenario("MCP · OAuth connect, then execute code in the sandbox", { needs: ["mcp-oauth"] }, (ctx) =>
+scenario(
+  "MCP · OAuth connect, then execute code in the sandbox",
+  {},
   Effect.gen(function* () {
-    const identity = yield* ctx.target.newIdentity();
-    const session = ctx.mcp.session(identity);
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const session = mcp.session(identity);
 
     const tools = yield* session.listTools();
     expect(tools, "the execute tool is advertised").toContain("execute");

--- a/e2e/scenarios/mcp-opencode-real.test.ts
+++ b/e2e/scenarios/mcp-opencode-real.test.ts
@@ -18,94 +18,97 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
-import { completeOAuthConsent, makeOpenCodeHome, warmUp } from "../src/clients/opencode";
+import { Cli, Mcp, OpenCode, RunDir, Target, TtlControl } from "../src/services";
 
 const SERVER_NAME = "executor";
 const TTL_SECONDS = 15;
 
 scenario(
   "MCP OAuth lifecycle · the real OpenCode binary stays signed in across token expiry",
-  { needs: ["mcp-oauth", "opencode", "ttl-control"], timeout: 180_000 },
-  (ctx) =>
-    Effect.gen(function* () {
-      const setTtl = ctx.target.setAccessTokenTtl;
-      if (!setTtl)
-        return yield* Effect.die(new Error("ttl-control target lacks setAccessTokenTtl"));
-      const identity = yield* ctx.target.newIdentity();
-      const email = identity.credentials?.email ?? identity.label;
-      const home = makeOpenCodeHome(SERVER_NAME, ctx.target.mcpUrl);
-      // First-run database migration happens off camera.
-      yield* Effect.sync(() => warmUp(home));
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const opencode = yield* OpenCode;
+    const setTtl = yield* TtlControl;
+    const runDir = yield* RunDir;
+    const cli = yield* Cli;
 
-      yield* setTtl(TTL_SECONDS);
-      yield* ctx.cli
-        .session(
-          ["bash", "--norc"],
-          async (term) => {
-            // Don't type into a shell that hasn't painted its prompt yet —
-            // early keystrokes echo above the prompt in the recording.
-            await term.screen.waitForText("$", { timeoutMs: 10_000 });
+    const identity = yield* target.newIdentity();
+    const email = identity.credentials?.email ?? identity.label;
+    const home = opencode.makeHome(SERVER_NAME, mcp.url);
+    // First-run database migration happens off camera.
+    yield* Effect.sync(() => opencode.warmUp(home));
 
-            // A command is done when its echoed line is on screen AND the
-            // bare prompt is back after it — no sentinel noise, no clears,
-            // and the pre-command prompt can't satisfy the wait. Returns
-            // only what THIS command produced, so earlier output can't
-            // satisfy a later assertion and the scrollback stays natural.
-            const outputAfter = (text: string, line: string): string | null => {
-              const echoed = text.lastIndexOf(line);
-              if (echoed === -1) return null;
-              const after = text.slice(echoed + line.length);
-              return after.trimEnd().endsWith("\n$") ? after : null;
-            };
-            const sh = async (line: string, timeoutMs: number) => {
-              await term.keyboard.type(line);
-              await term.keyboard.press("Enter");
-              const snapshot = await term.screen.waitUntil(
-                (current) => outputAfter(current.text, line) !== null,
-                { timeoutMs },
-              );
-              return outputAfter(snapshot.text, line) ?? "";
-            };
+    yield* setTtl(TTL_SECONDS);
+    yield* cli
+      .session(
+        ["bash", "--norc"],
+        async (term) => {
+          // Don't type into a shell that hasn't painted its prompt yet —
+          // early keystrokes echo above the prompt in the recording.
+          await term.screen.waitForText("$", { timeoutMs: 10_000 });
 
-            // OpenCode completes MCP OAuth for real: discovery, DCR, PKCE,
-            // its own scope request, its own token store.
-            const consent = completeOAuthConsent(home, email, home.openedUrls().length);
-            const auth = await sh(`opencode mcp auth ${SERVER_NAME}`, 60_000);
-            await consent;
-            expect(auth, "opencode mcp auth completes").not.toContain("failed");
-
-            // While the token is fresh, OpenCode is a working MCP client.
-            const fresh = await sh("opencode mcp list", 60_000);
-            expect(fresh, "OpenCode connects on a fresh token").toContain("connected");
-
-            // The access token genuinely expires on camera (server-honored
-            // TTL, no fakes), then the same command runs again.
-            const expired = await sh(
-              `sleep ${TTL_SECONDS + 3}; opencode mcp list`,
-              (TTL_SECONDS + 3) * 1000 + 60_000,
+          // A command is done when its echoed line is on screen AND the
+          // bare prompt is back after it — no sentinel noise, no clears,
+          // and the pre-command prompt can't satisfy the wait. Returns
+          // only what THIS command produced, so earlier output can't
+          // satisfy a later assertion and the scrollback stays natural.
+          const outputAfter = (text: string, line: string): string | null => {
+            const echoed = text.lastIndexOf(line);
+            if (echoed === -1) return null;
+            const after = text.slice(echoed + line.length);
+            return after.trimEnd().endsWith("\n$") ? after : null;
+          };
+          const sh = async (line: string, timeoutMs: number) => {
+            await term.keyboard.type(line);
+            await term.keyboard.press("Enter");
+            const snapshot = await term.screen.waitUntil(
+              (current) => outputAfter(current.text, line) !== null,
+              { timeoutMs },
             );
+            return outputAfter(snapshot.text, line) ?? "";
+          };
 
-            // The experience a user deserves: still signed in. OpenCode
-            // requested exactly the scopes our metadata advertises; whether
-            // it got a refresh token decides this assertion — that's the bug.
-            const tokens = home.storedTokens(SERVER_NAME);
-            expect(
-              expired,
-              `OpenCode stays signed in across token expiry (its store holds ${
-                tokens?.refreshToken ? "a refresh token" : "NO refresh token"
-              })`,
-            ).toContain("connected");
-          },
-          {
-            cwd: home.projectDir,
-            env: { ...home.env, PS1: "$ ", BASH_SILENCE_DEPRECATION_WARNING: "1" },
-            record: join(ctx.dir, "terminal.cast"),
-            // Tall enough that the whole session stays on screen — the
-            // per-command slice in sh() depends on the echoed line not
-            // scrolling away.
-            viewport: { cols: 100, rows: 40 },
-          },
-        )
-        .pipe(Effect.ensuring(setTtl(null)));
-    }),
+          // OpenCode completes MCP OAuth for real: discovery, DCR, PKCE,
+          // its own scope request, its own token store.
+          const consent = opencode.completeOAuthConsent(home, email, home.openedUrls().length);
+          const auth = await sh(`opencode mcp auth ${SERVER_NAME}`, 60_000);
+          await consent;
+          expect(auth, "opencode mcp auth completes").not.toContain("failed");
+
+          // While the token is fresh, OpenCode is a working MCP client.
+          const fresh = await sh("opencode mcp list", 60_000);
+          expect(fresh, "OpenCode connects on a fresh token").toContain("connected");
+
+          // The access token genuinely expires on camera (server-honored
+          // TTL, no fakes), then the same command runs again.
+          const expired = await sh(
+            `sleep ${TTL_SECONDS + 3}; opencode mcp list`,
+            (TTL_SECONDS + 3) * 1000 + 60_000,
+          );
+
+          // The experience a user deserves: still signed in. OpenCode
+          // requested exactly the scopes our metadata advertises; whether
+          // it got a refresh token decides this assertion — that's the bug.
+          const tokens = home.storedTokens(SERVER_NAME);
+          expect(
+            expired,
+            `OpenCode stays signed in across token expiry (its store holds ${
+              tokens?.refreshToken ? "a refresh token" : "NO refresh token"
+            })`,
+          ).toContain("connected");
+        },
+        {
+          cwd: home.projectDir,
+          env: { ...home.env, PS1: "$ ", BASH_SILENCE_DEPRECATION_WARNING: "1" },
+          record: join(runDir, "terminal.cast"),
+          // Tall enough that the whole session stays on screen — the
+          // per-command slice in sh() depends on the echoed line not
+          // scrolling away.
+          viewport: { cols: 100, rows: 40 },
+        },
+      )
+      .pipe(Effect.ensuring(setTtl(null)));
+  }),
 );

--- a/e2e/scenarios/oauth-callback-url.test.ts
+++ b/e2e/scenarios/oauth-callback-url.test.ts
@@ -30,6 +30,7 @@ import {
 import { serveOAuthTestServer } from "@executor-js/sdk/testing";
 
 import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 
@@ -63,7 +64,7 @@ const oauthIntegrationSpec = (oauth: {
     authenticationTemplate: [
       {
         slug: "oauth",
-        type: "oauth" as const,
+        kind: "oauth2" as const,
         authorizationUrl: oauth.authorizationEndpoint,
         tokenUrl: oauth.tokenEndpoint,
         scopes: ["read"],
@@ -73,97 +74,99 @@ const oauthIntegrationSpec = (oauth: {
 
 scenario(
   "OAuth · the authorization-code flow redirects to this platform's /api/oauth/callback",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const oauth = yield* serveOAuthTestServer();
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-
-        // What the registration form shows for THIS target — the same value the
-        // React `oauthCallbackUrl()` helper resolves from `window.location`.
-        const expectedCallback = new URL("/api/oauth/callback", ctx.target.baseUrl).toString();
-
-        const integration = IntegrationSlug.make(unique("cburlint"));
-        yield* client.openapi.addSpec({
-          payload: { ...oauthIntegrationSpec(oauth), slug: integration },
-        });
-
-        const clientSlug = OAuthClientSlug.make(unique("cburlc"));
-        yield* client.oauth.createClient({
-          payload: {
-            owner: "org",
-            slug: clientSlug,
-            authorizationUrl: oauth.authorizationEndpoint,
-            tokenUrl: oauth.tokenEndpoint,
-            grant: "authorization_code",
-            clientId: "test-client",
-            clientSecret: "test-secret",
-          },
-        });
-
-        // start WITHOUT a redirectUri — the platform falls back to its OWN
-        // configured callback, which is exactly what the form would have shown.
-        const started = yield* client.oauth.start({
-          payload: {
-            client: clientSlug,
-            clientOwner: "org",
-            owner: "org",
-            name: ConnectionName.make("main"),
-            integration,
-            template: AuthTemplateSlug.make("oauth"),
-          },
-        });
-        expect(
-          started.status,
-          "oauth.start hands back a redirect to the authorization server",
-        ).toBe("redirect");
-        const authorizationUrl = started.status === "redirect" ? started.authorizationUrl : "";
-
-        const redirectUri = new URL(authorizationUrl).searchParams.get("redirect_uri");
-        expect(
-          redirectUri,
-          "the authorization request redirects to this platform's served callback",
-        ).toBe(expectedCallback);
-      }),
-    ),
-);
-
-scenario(
-  "OAuth · registering an app in the connect modal shows the callback URL to allow-list",
-  { needs: ["browser"] },
-  (ctx) =>
+  {},
+  Effect.scoped(
     Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
       const oauth = yield* serveOAuthTestServer();
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
-      const expectedCallback = new URL("/api/oauth/callback", ctx.target.baseUrl).toString();
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
 
-      // An OAuth integration with no registered app yet, so the connect modal
-      // offers the "Register app" CTA (no automatic registration to short-circuit
-      // it).
-      const integration = IntegrationSlug.make(unique("cburlui"));
+      // What the registration form shows for THIS target — the same value the
+      // React `oauthCallbackUrl()` helper resolves from `window.location`.
+      const expectedCallback = new URL("/api/oauth/callback", target.baseUrl).toString();
+
+      const integration = IntegrationSlug.make(unique("cburlint"));
       yield* client.openapi.addSpec({
         payload: { ...oauthIntegrationSpec(oauth), slug: integration },
       });
 
-      yield* ctx.browser.session(identity, async ({ page, step }) => {
-        await step("Open the connect modal for an OAuth integration", async () => {
-          await page.goto(`/integrations/${String(integration)}?addAccount=1`, {
-            waitUntil: "networkidle",
-          });
-          await page.getByRole("button", { name: "Register app", exact: true }).click();
-        });
-
-        await step("The OAuth app form shows this platform's callback URL", async () => {
-          const callback = page.locator("#oauth-callback-url");
-          await callback.waitFor();
-          const shown = (await callback.textContent())?.trim();
-          expect(shown, "the displayed callback URL matches the platform's served callback").toBe(
-            expectedCallback,
-          );
-        });
+      const clientSlug = OAuthClientSlug.make(unique("cburlc"));
+      yield* client.oauth.createClient({
+        payload: {
+          owner: "org",
+          slug: clientSlug,
+          authorizationUrl: oauth.authorizationEndpoint,
+          tokenUrl: oauth.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        },
       });
-    }).pipe(Effect.scoped),
+
+      // start WITHOUT a redirectUri — the platform falls back to its OWN
+      // configured callback, which is exactly what the form would have shown.
+      const started = yield* client.oauth.start({
+        payload: {
+          client: clientSlug,
+          clientOwner: "org",
+          owner: "org",
+          name: ConnectionName.make("main"),
+          integration,
+          template: AuthTemplateSlug.make("oauth"),
+        },
+      });
+      expect(started.status, "oauth.start hands back a redirect to the authorization server").toBe(
+        "redirect",
+      );
+      const authorizationUrl = started.status === "redirect" ? started.authorizationUrl : "";
+
+      const redirectUri = new URL(authorizationUrl).searchParams.get("redirect_uri");
+      expect(
+        redirectUri,
+        "the authorization request redirects to this platform's served callback",
+      ).toBe(expectedCallback);
+    }),
+  ),
+);
+
+scenario(
+  "OAuth · registering an app in the connect modal shows the callback URL to allow-list",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const browser = yield* Browser;
+    const oauth = yield* serveOAuthTestServer();
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+    const expectedCallback = new URL("/api/oauth/callback", target.baseUrl).toString();
+
+    // An OAuth integration with no registered app yet, so the connect modal
+    // offers the "Register app" CTA (no automatic registration to short-circuit
+    // it).
+    const integration = IntegrationSlug.make(unique("cburlui"));
+    yield* client.openapi.addSpec({
+      payload: { ...oauthIntegrationSpec(oauth), slug: integration },
+    });
+
+    yield* browser.session(identity, async ({ page, step }) => {
+      await step("Open the connect modal for an OAuth integration", async () => {
+        await page.goto(`/integrations/${String(integration)}?addAccount=1`, {
+          waitUntil: "networkidle",
+        });
+        await page.getByRole("button", { name: "Register app", exact: true }).click();
+      });
+
+      await step("The OAuth app form shows this platform's callback URL", async () => {
+        const callback = page.locator("#oauth-callback-url");
+        await callback.waitFor();
+        const shown = (await callback.textContent())?.trim();
+        expect(shown, "the displayed callback URL matches the platform's served callback").toBe(
+          expectedCallback,
+        );
+      });
+    });
+  }).pipe(Effect.scoped),
 );

--- a/e2e/scenarios/openapi-source.test.ts
+++ b/e2e/scenarios/openapi-source.test.ts
@@ -20,6 +20,7 @@ import {
 } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 
@@ -42,74 +43,73 @@ const greetSpec = (baseUrl: string): string =>
 
 scenario(
   "OpenAPI · registering a spec exposes its operations as tools",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const apiClient = yield* client(api, identity);
 
-      // Unique slug per run: selfhost shares the bootstrap-admin identity, so
-      // the prefix keeps parallel/repeated runs out of each other's catalogs.
-      const slug = `openapi-scn-greet-${randomBytes(4).toString("hex")}`;
-      const specBaseUrl = "http://127.0.0.1:59999"; // never contacted during registration
+    // Unique slug per run: selfhost shares the bootstrap-admin identity, so
+    // the prefix keeps parallel/repeated runs out of each other's catalogs.
+    const slug = `openapi-scn-greet-${randomBytes(4).toString("hex")}`;
+    const specBaseUrl = "http://127.0.0.1:59999"; // never contacted during registration
 
-      yield* Effect.ensuring(
-        Effect.gen(function* () {
-          const added = yield* client.openapi.addSpec({
-            payload: {
-              spec: { kind: "blob", value: greetSpec(specBaseUrl) },
-              slug,
-              baseUrl: specBaseUrl,
-              authenticationTemplate: [
-                {
-                  slug: "apiKey",
-                  type: "apiKey",
-                  headers: { "x-api-key": [{ type: "variable", name: "token" }] },
-                },
-              ],
-            },
-          });
-          expect(added.toolCount, "the spec's operations were extracted as tools").toBeGreaterThan(
-            0,
-          );
-          expect(added.slug, "the integration keeps the requested slug").toBe(slug);
-
-          // The catalog stamps tools once a connection exists; a `from` provider
-          // reference avoids any vault round-trip.
-          const providers = yield* client.providers.list();
-          expect(providers.length, "a credential provider is available").toBeGreaterThan(0);
-
-          yield* client.connections.create({
-            payload: {
-              owner: "org",
-              name: ConnectionName.make("main"),
-              integration: IntegrationSlug.make(slug),
-              template: AuthTemplateSlug.make("apiKey"),
-              from: { provider: providers[0]!, id: ProviderItemId.make(randomUUID()) },
-            },
-          });
-
-          const tools = yield* client.tools.list();
-          const mine = tools.filter((tool) => String(tool.integration) === slug).map((t) => t.name);
-          expect(mine.join(", "), "the spec's operation is in the tool catalog").toContain(
-            "getGreeting",
-          );
-        }),
-        // Selfhost shares one bootstrap admin, so this scenario must not leak
-        // its connection or integration — otherwise a cross-target guarantee
-        // like "a fresh identity starts with zero connections" would see it.
-        Effect.gen(function* () {
-          yield* client.connections
-            .remove({
-              params: {
-                owner: "org",
-                integration: IntegrationSlug.make(slug),
-                name: ConnectionName.make("main"),
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        const added = yield* apiClient.openapi.addSpec({
+          payload: {
+            spec: { kind: "blob", value: greetSpec(specBaseUrl) },
+            slug,
+            baseUrl: specBaseUrl,
+            authenticationTemplate: [
+              {
+                slug: "apiKey",
+                type: "apiKey",
+                headers: { "x-api-key": [{ type: "variable", name: "token" }] },
               },
-            })
-            .pipe(Effect.ignore);
-          yield* client.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
-        }),
-      );
-    }),
+            ],
+          },
+        });
+        expect(added.toolCount, "the spec's operations were extracted as tools").toBeGreaterThan(0);
+        expect(added.slug, "the integration keeps the requested slug").toBe(slug);
+
+        // The catalog stamps tools once a connection exists; a `from` provider
+        // reference avoids any vault round-trip.
+        const providers = yield* apiClient.providers.list();
+        expect(providers.length, "a credential provider is available").toBeGreaterThan(0);
+
+        yield* apiClient.connections.create({
+          payload: {
+            owner: "org",
+            name: ConnectionName.make("main"),
+            integration: IntegrationSlug.make(slug),
+            template: AuthTemplateSlug.make("apiKey"),
+            from: { provider: providers[0]!, id: ProviderItemId.make(randomUUID()) },
+          },
+        });
+
+        const tools = yield* apiClient.tools.list({ query: {} });
+        const mine = tools.filter((tool) => String(tool.integration) === slug).map((t) => t.name);
+        expect(mine.join(", "), "the spec's operation is in the tool catalog").toContain(
+          "getGreeting",
+        );
+      }),
+      // Selfhost shares one bootstrap admin, so this scenario must not leak
+      // its connection or integration — otherwise a cross-target guarantee
+      // like "a fresh identity starts with zero connections" would see it.
+      Effect.gen(function* () {
+        yield* apiClient.connections
+          .remove({
+            params: {
+              owner: "org",
+              integration: IntegrationSlug.make(slug),
+              name: ConnectionName.make("main"),
+            },
+          })
+          .pipe(Effect.ignore);
+        yield* apiClient.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore);
+      }),
+    );
+  }),
 );

--- a/e2e/scenarios/policies.test.ts
+++ b/e2e/scenarios/policies.test.ts
@@ -5,28 +5,30 @@ import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const coreApi = composePluginApi([] as const);
 
 scenario(
   "Policies · a created policy appears in the list for the owning identity",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(coreApi, identity);
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const api = yield* client(coreApi, identity);
 
-      const created = yield* client.policies.create({
-        payload: { owner: "org", pattern: "policies-scn.*", action: "block" },
-      });
-      expect(created.owner).toBe("org");
-      expect(created.pattern).toBe("policies-scn.*");
-      expect(created.action).toBe("block");
+    const created = yield* api.policies.create({
+      payload: { owner: "org", pattern: "policies-scn.*", action: "block" },
+    });
+    expect(created.owner).toBe("org");
+    expect(created.pattern).toBe("policies-scn.*");
+    expect(created.action).toBe("block");
 
-      const list = yield* client.policies.list();
-      const found = list.find((p) => p.id === created.id);
-      expect(found, "created policy appears in the list").toBeDefined();
-      expect(found?.pattern, "listed entry preserves the pattern").toBe("policies-scn.*");
-      expect(found?.action, "listed entry preserves the action").toBe("block");
-    }),
+    const list = yield* api.policies.list();
+    const found = list.find((p) => p.id === created.id);
+    expect(found, "created policy appears in the list").toBeDefined();
+    expect(found?.pattern, "listed entry preserves the pattern").toBe("policies-scn.*");
+    expect(found?.action, "listed entry preserves the action").toBe("block");
+  }),
 );

--- a/e2e/scenarios/tools-contract.test.ts
+++ b/e2e/scenarios/tools-contract.test.ts
@@ -6,14 +6,19 @@ import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const coreApi = composePluginApi([] as const);
 
-scenario("Tools · every advertised tool is well-formed enough to call", { needs: ["api"] }, (ctx) =>
+scenario(
+  "Tools · every advertised tool is well-formed enough to call",
+  {},
   Effect.gen(function* () {
-    const identity = yield* ctx.target.newIdentity();
-    const client = yield* ctx.api.client(coreApi, identity);
-    const tools = yield* client.tools.list();
+    const target = yield* Target;
+    const { client } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const api = yield* client(coreApi, identity);
+    const tools = yield* api.tools.list({ query: {} });
 
     expect(tools.length, "the catalog advertises tools").toBeGreaterThan(0);
 

--- a/e2e/selfhost/auth-methods-ui.test.ts
+++ b/e2e/selfhost/auth-methods-ui.test.ts
@@ -21,219 +21,236 @@ import { OAuthTestServer } from "@executor-js/sdk/testing";
 import { IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
 
 const api = composePluginApi([mcpHttpPlugin()] as const);
 
 scenario(
   "Auth methods · a detected-OAuth server gets an API key declared alongside",
-  { needs: ["browser"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        // An OAuth-PROTECTED server: the probe gets a 401 with protected-
-        // resource metadata pointing at the test OAuth issuer, so the method
-        // list seeds with the detected OAuth row.
-        const server = yield* serveMcpServerWithOAuth(
-          () => makeGreetingMcpServer({ name: `oauth-mcp-${randomBytes(3).toString("hex")}` }),
-          { path: "/mcp" },
-        );
-        const identity = yield* ctx.target.newIdentity();
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      // An OAuth-PROTECTED server: the probe gets a 401 with protected-
+      // resource metadata pointing at the test OAuth issuer, so the method
+      // list seeds with the detected OAuth row.
+      const server = yield* serveMcpServerWithOAuth(
+        () =>
+          makeGreetingMcpServer({
+            name: `oauth-mcp-${randomBytes(3).toString("hex")}`,
+          }),
+        { path: "/mcp" },
+      );
+      const identity = yield* target.newIdentity();
 
-        yield* ctx.browser.session(identity, async ({ page, step }) => {
-          await step("Open the add-MCP flow pointed at the server", async () => {
-            await page.goto(`/integrations/add/mcp?url=${encodeURIComponent(server.endpoint)}`, {
-              waitUntil: "networkidle",
-            });
-            await page.getByText("How does this server authenticate?").waitFor();
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the add-MCP flow pointed at the server", async () => {
+          await page.goto(`/integrations/add/mcp?url=${encodeURIComponent(server.endpoint)}`, {
+            waitUntil: "networkidle",
           });
-
-          await step("The probe detected OAuth", async () => {
-            await page.getByText("Method 1 · Detected").waitFor();
-            // The OAuth editor declares discovery-at-connect, not pasted URLs.
-            await page.getByText("OAuth metadata is discovered from this server").waitFor();
-          });
-
-          await step("Declare an API key method alongside OAuth", async () => {
-            await page.getByRole("button", { name: "Add method" }).click();
-            await page.getByText("Method 2").waitFor();
-            await page.getByPlaceholder("Authorization").last().waitFor();
-          });
-
-          await step("Add the source with both methods", async () => {
-            await page.getByRole("button", { name: "Add source" }).click();
-            await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, { timeout: 30_000 });
-            await page.getByText("Connections").first().waitFor();
-          });
-
-          await step("The connect modal offers OAuth and the API key", async () => {
-            await page.getByRole("button", { name: "Add connection" }).first().click();
-            await page.getByRole("tab", { name: "OAuth" }).waitFor();
-            await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
-          });
+          await page.getByText("How does this server authenticate?").waitFor();
         });
-      }),
-    ).pipe(Effect.provide(OAuthTestServer.layer())),
+
+        await step("The probe detected OAuth", async () => {
+          await page.getByText("Method 1 · Detected").waitFor();
+          // The OAuth editor declares discovery-at-connect, not pasted URLs.
+          await page.getByText("OAuth metadata is discovered from this server").waitFor();
+        });
+
+        await step("Declare an API key method alongside OAuth", async () => {
+          await page.getByRole("button", { name: "Add method" }).click();
+          await page.getByText("Method 2").waitFor();
+          await page.getByPlaceholder("Authorization").last().waitFor();
+        });
+
+        await step("Add the source with both methods", async () => {
+          await page.getByRole("button", { name: "Add source" }).click();
+          await page.waitForURL(/\/integrations\/(?!add\b)[^/?]+$/, {
+            timeout: 30_000,
+          });
+          await page.getByText("Connections").first().waitFor();
+        });
+
+        await step("The connect modal offers OAuth and the API key", async () => {
+          await page.getByRole("button", { name: "Add connection" }).first().click();
+          await page.getByRole("tab", { name: "OAuth" }).waitFor();
+          await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
+        });
+      });
+    }),
+  ).pipe(Effect.provide(OAuthTestServer.layer())),
 );
 
 scenario(
   "Auth methods · a custom method added in the connect modal keeps OAuth",
-  { needs: ["browser", "api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        // A server that only accepts the bearer key — the connection created
-        // through the custom method must render it on the wire.
-        const token = `e2e-modal-key-${randomBytes(6).toString("hex")}`;
-        const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
-          auth: {
-            validateAuthorization: (authorization) =>
-              Effect.succeed(authorization === `Bearer ${token}`),
-          },
-        });
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeApiClient } = yield* Api;
+      // A server that only accepts the bearer key — the connection created
+      // through the custom method must render it on the wire.
+      const token = `e2e-modal-key-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
 
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = `mcp-modal-key-${randomBytes(3).toString("hex")}`;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = `mcp-modal-key-${randomBytes(3).toString("hex")}`;
 
-        // The integration as the add flow would have left it: OAuth only.
-        yield* client.mcp.addServer({
-          payload: {
-            transport: "remote",
-            name: "OAuth-only MCP",
-            endpoint: server.endpoint,
-            slug,
-            authenticationTemplate: [{ kind: "oauth2" }],
-          },
-        });
+      // The integration as the add flow would have left it: OAuth only.
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "OAuth-only MCP",
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [{ kind: "oauth2" }],
+        },
+      });
 
-        // Remove the integration (and the connection it creates) afterward —
-        // selfhost identities share one tenant, so a leaked connection would
-        // break the "fresh identity has zero connections" scenario.
-        yield* Effect.gen(function* () {
-          yield* ctx.browser.session(identity, async ({ page, step }) => {
-            await step("Open the integration's connect modal", async () => {
-              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
-              await page.getByRole("button", { name: "Add connection" }).first().click();
-              await page.getByRole("tab", { name: "OAuth" }).waitFor();
+      // Remove the integration (and the connection it creates) afterward —
+      // selfhost identities share one tenant, so a leaked connection would
+      // break the "fresh identity has zero connections" scenario.
+      yield* Effect.gen(function* () {
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the integration's connect modal", async () => {
+            await page.goto(`/integrations/${slug}`, {
+              waitUntil: "networkidle",
             });
-
-            await step("Add a custom API key method from the modal", async () => {
-              await page.getByRole("button", { name: "Add authentication method" }).click();
-              await page.getByLabel("Method name").fill("Team API key");
-              await page.getByPlaceholder("Authorization").fill("Authorization");
-              await page.getByPlaceholder("Bearer ").fill("Bearer ");
-              await page.getByRole("button", { name: "Add method" }).click();
-            });
-
-            await step("OAuth survives next to the new method", async () => {
-              await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
-              await page.getByRole("tab", { name: "OAuth" }).waitFor();
-            });
-
-            await step("Connect through the new method", async () => {
-              await page.getByPlaceholder("paste the value / token").fill(token);
-              await page.getByRole("button", { name: "Add connection" }).click();
-              await page.getByText("Connection added").waitFor();
-            });
+            await page.getByRole("button", { name: "Add connection" }).first().click();
+            await page.getByRole("tab", { name: "OAuth" }).waitFor();
           });
 
-          // Wire proof: discovery for the new connection hit the server with
-          // the credential rendered through the custom method.
-          const requests = yield* server.requests;
-          expect(
-            requests.some((request) => request.authorization === `Bearer ${token}`),
-            "the server saw the bearer rendered through the custom method",
-          ).toBe(true);
-        }).pipe(
-          Effect.ensuring(
-            client.mcp
-              .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
-              .pipe(Effect.ignore),
-          ),
-        );
-      }),
-    ),
+          await step("Add a custom API key method from the modal", async () => {
+            await page.getByRole("button", { name: "Add authentication method" }).click();
+            await page.getByLabel("Method name").fill("Team API key");
+            await page.getByPlaceholder("Authorization").fill("Authorization");
+            await page.getByPlaceholder("Bearer ").fill("Bearer ");
+            await page.getByRole("button", { name: "Add method" }).click();
+          });
+
+          await step("OAuth survives next to the new method", async () => {
+            await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
+            await page.getByRole("tab", { name: "OAuth" }).waitFor();
+          });
+
+          await step("Connect through the new method", async () => {
+            await page.getByPlaceholder("paste the value / token").fill(token);
+            await page.getByRole("button", { name: "Add connection" }).click();
+            await page.getByText("Connection added").waitFor();
+          });
+        });
+
+        // Wire proof: discovery for the new connection hit the server with
+        // the credential rendered through the custom method.
+        const requests = yield* server.requests;
+        expect(
+          requests.some((request) => request.authorization === `Bearer ${token}`),
+          "the server saw the bearer rendered through the custom method",
+        ).toBe(true);
+      }).pipe(
+        Effect.ensuring(
+          client.mcp
+            .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+            .pipe(Effect.ignore),
+        ),
+      );
+    }),
+  ),
 );
 
 scenario(
   "Auth methods · the connect modal collects one value per input of a 2-input method",
-  { needs: ["browser", "api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        // A method with TWO credential inputs: a bearer header rendered from
-        // `api_token` and a team-id query param rendered from `team_id`. The
-        // server requires both on every request, so the connect-time
-        // discovery dial only succeeds when the modal collected both values.
-        const apiToken = `e2e-two-input-${randomBytes(4).toString("hex")}`;
-        const teamId = `team-${randomBytes(3).toString("hex")}`;
-        const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
-          auth: {
-            validateAuthorization: (authorization) =>
-              Effect.succeed(authorization === `Bearer ${apiToken}`),
-          },
-        });
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const browser = yield* Browser;
+      const { client: makeApiClient } = yield* Api;
+      // A method with TWO credential inputs: a bearer header rendered from
+      // `api_token` and a team-id query param rendered from `team_id`. The
+      // server requires both on every request, so the connect-time
+      // discovery dial only succeeds when the modal collected both values.
+      const apiToken = `e2e-two-input-${randomBytes(4).toString("hex")}`;
+      const teamId = `team-${randomBytes(3).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${apiToken}`),
+        },
+      });
 
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = `mcp-two-input-${randomBytes(3).toString("hex")}`;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = `mcp-two-input-${randomBytes(3).toString("hex")}`;
 
-        yield* client.mcp.addServer({
-          payload: {
-            transport: "remote",
-            name: "Two-input MCP",
-            endpoint: server.endpoint,
-            slug,
-            authenticationTemplate: [
-              {
-                slug: "token_and_team",
-                type: "apiKey",
-                headers: { Authorization: ["Bearer ", { type: "variable", name: "api_token" }] },
-                queryParams: { team_id: [{ type: "variable", name: "team_id" }] },
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "Two-input MCP",
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              slug: "token_and_team",
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "api_token" }],
               },
-            ],
-          },
-        });
+              queryParams: { team_id: [{ type: "variable", name: "team_id" }] },
+            },
+          ],
+        },
+      });
 
-        yield* Effect.gen(function* () {
-          yield* ctx.browser.session(identity, async ({ page, step }) => {
-            await step("Open the integration's connect modal", async () => {
-              await page.goto(`/integrations/${slug}`, { waitUntil: "networkidle" });
-              await page.getByRole("button", { name: "Add connection" }).first().click();
-              await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
+      yield* Effect.gen(function* () {
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the integration's connect modal", async () => {
+            await page.goto(`/integrations/${slug}`, {
+              waitUntil: "networkidle",
             });
-
-            await step("The method renders one field per credential input", async () => {
-              await page.getByPlaceholder("paste Authorization").waitFor();
-              await page.getByPlaceholder("paste team_id").waitFor();
-            });
-
-            await step("Fill both values and connect", async () => {
-              await page.getByPlaceholder("paste Authorization").fill(apiToken);
-              await page.getByPlaceholder("paste team_id").fill(teamId);
-              await page.getByRole("button", { name: "Add connection" }).click();
-              await page.getByText("Connection added").waitFor();
-            });
+            await page.getByRole("button", { name: "Add connection" }).first().click();
+            await page.getByRole("tab", { name: "API key (Authorization)" }).waitFor();
           });
 
-          // Wire proof: the discovery dial rendered BOTH inputs — the bearer
-          // header (the server rejects anything else) and the team-id query.
-          const requests = yield* server.requests;
-          expect(
-            requests.some(
-              (request) =>
-                request.authorization === `Bearer ${apiToken}` &&
-                request.url.includes(`team_id=${teamId}`),
-            ),
-            "the server saw the bearer header and the team-id query param together",
-          ).toBe(true);
-        }).pipe(
-          Effect.ensuring(
-            client.mcp
-              .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
-              .pipe(Effect.ignore),
+          await step("The method renders one field per credential input", async () => {
+            await page.getByPlaceholder("paste Authorization").waitFor();
+            await page.getByPlaceholder("paste team_id").waitFor();
+          });
+
+          await step("Fill both values and connect", async () => {
+            await page.getByPlaceholder("paste Authorization").fill(apiToken);
+            await page.getByPlaceholder("paste team_id").fill(teamId);
+            await page.getByRole("button", { name: "Add connection" }).click();
+            await page.getByText("Connection added").waitFor();
+          });
+        });
+
+        // Wire proof: the discovery dial rendered BOTH inputs — the bearer
+        // header (the server rejects anything else) and the team-id query.
+        const requests = yield* server.requests;
+        expect(
+          requests.some(
+            (request) =>
+              request.authorization === `Bearer ${apiToken}` &&
+              request.url.includes(`team_id=${teamId}`),
           ),
-        );
-      }),
-    ),
+          "the server saw the bearer header and the team-id query param together",
+        ).toBe(true);
+      }).pipe(
+        Effect.ensuring(
+          client.mcp
+            .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+            .pipe(Effect.ignore),
+        ),
+      );
+    }),
+  ),
 );

--- a/e2e/selfhost/mcp-approve.test.ts
+++ b/e2e/selfhost/mcp-approve.test.ts
@@ -13,6 +13,7 @@ import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 
 import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
 
 const coreApi = composePluginApi([] as const);
 
@@ -23,17 +24,22 @@ const result = await tools.executor.coreTools.policies.list({});
 return JSON.stringify(result);
 `;
 
-scenario("MCP · a paused execution resumes after human approval", { needs: ["mcp-oauth"] }, (ctx) =>
+scenario(
+  "MCP · a paused execution resumes after human approval",
+  {},
   Effect.gen(function* () {
-    const identity = yield* ctx.target.newIdentity();
-    const client = yield* ctx.api.client(coreApi, identity);
+    const target = yield* Target;
+    const apiSurface = yield* Api;
+    const mcp = yield* Mcp;
+    const identity = yield* target.newIdentity();
+    const client = yield* apiSurface.client(coreApi, identity);
 
     const policy = yield* client.policies.create({
       payload: { owner: "org", pattern: APPROVAL_TARGET_TOOL, action: "require_approval" },
     });
 
     yield* Effect.gen(function* () {
-      const session = ctx.mcp.session(identity);
+      const session = mcp.session(identity);
 
       // Warm up the MCP session before the gated call so the OAuth handshake
       // does not race with the policy window.

--- a/e2e/selfhost/mcp-multi-auth.test.ts
+++ b/e2e/selfhost/mcp-multi-auth.test.ts
@@ -16,79 +16,81 @@ import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/t
 import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
 
 const api = composePluginApi([mcpHttpPlugin()] as const);
 
 scenario(
   "Auth methods · the connection's chosen method renders the credential on the wire",
-  { needs: ["api"] },
-  (ctx) =>
-    Effect.scoped(
-      Effect.gen(function* () {
-        const token = `e2e-key-${randomBytes(6).toString("hex")}`;
-        const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
-          auth: {
-            validateAuthorization: (authorization) =>
-              Effect.succeed(authorization === `Bearer ${token}`),
-          },
-        });
+  {},
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const token = `e2e-key-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
 
-        const identity = yield* ctx.target.newIdentity();
-        const client = yield* ctx.api.client(api, identity);
-        const slug = freshSlug("mcp-wire-auth");
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+      const slug = freshSlug("mcp-wire-auth");
 
-        // Two declared methods — the connection must pick the right one.
-        yield* client.mcp.addServer({
-          payload: {
-            transport: "remote",
-            name: "Wire-auth MCP",
-            endpoint: server.endpoint,
-            slug,
-            authenticationTemplate: [
-              { kind: "oauth2" },
-              {
-                type: "apiKey",
-                headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
-              },
-            ],
-          },
-        });
-
-        yield* Effect.gen(function* () {
-          // Create the connection through the HEADER method (template slug
-          // "header") with a pasted key. Tool discovery dials the server with
-          // the rendered credential at create time.
-          yield* client.connections.create({
-            payload: {
-              owner: "org",
-              name: ConnectionName.make("wire-auth-key"),
-              integration: IntegrationSlug.make(slug),
-              template: AuthTemplateSlug.make("header"),
-              value: token,
+      // Two declared methods — the connection must pick the right one.
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: "Wire-auth MCP",
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            { kind: "oauth2" },
+            {
+              type: "apiKey",
+              headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
             },
-          });
+          ],
+        },
+      });
 
-          const tools = yield* client.tools.list();
-          const mine = tools.filter((tool) => String(tool.integration) === slug);
-          expect(
-            mine.map((tool) => String(tool.name)).join(", "),
-            "discovery through the header method found the server's tool",
-          ).toContain("simple_echo");
+      yield* Effect.gen(function* () {
+        // Create the connection through the HEADER method (template slug
+        // "header") with a pasted key. Tool discovery dials the server with
+        // the rendered credential at create time.
+        yield* client.connections.create({
+          payload: {
+            owner: "org",
+            name: ConnectionName.make("wire-auth-key"),
+            integration: IntegrationSlug.make(slug),
+            template: AuthTemplateSlug.make("header"),
+            value: token,
+          },
+        });
 
-          const requests = yield* server.requests;
-          expect(
-            requests.some((request) => request.authorization === `Bearer ${token}`),
-            "the server saw the credential rendered through the chosen method",
-          ).toBe(true);
-        }).pipe(
-          Effect.ensuring(
-            client.mcp
-              .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
-              .pipe(Effect.ignore),
-          ),
-        );
-      }),
-    ),
+        const tools = yield* client.tools.list({ query: {} });
+        const mine = tools.filter((tool) => String(tool.integration) === slug);
+        expect(
+          mine.map((tool) => String(tool.name)).join(", "),
+          "discovery through the header method found the server's tool",
+        ).toContain("simple_echo");
+
+        const requests = yield* server.requests;
+        expect(
+          requests.some((request) => request.authorization === `Bearer ${token}`),
+          "the server saw the credential rendered through the chosen method",
+        ).toBe(true);
+      }).pipe(
+        Effect.ensuring(
+          client.mcp
+            .removeServer({ params: { slug: IntegrationSlug.make(slug) } })
+            .pipe(Effect.ignore),
+        ),
+      );
+    }),
+  ),
 );
 
 const freshSlug = (prefix: string): string => `${prefix}-${randomBytes(4).toString("hex")}`;

--- a/e2e/selfhost/oauth-app-modal.test.ts
+++ b/e2e/selfhost/oauth-app-modal.test.ts
@@ -15,6 +15,7 @@ import { composePluginApi } from "@executor-js/api/server";
 import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 
 import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
 
 const api = composePluginApi([openApiHttpPlugin()] as const);
 
@@ -37,133 +38,135 @@ const greetSpec = (baseUrl: string): string =>
 
 scenario(
   "OAuth apps · a registered app is edited and removed from the connect modal",
-  { needs: ["browser"], timeout: 180_000 },
-  (ctx) =>
-    Effect.gen(function* () {
-      const identity = yield* ctx.target.newIdentity();
-      const client = yield* ctx.api.client(api, identity);
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const browser = yield* Browser;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
 
-      // Selfhost shares the bootstrap-admin identity, so prefix every resource
-      // with a per-run id to stay out of parallel/repeated runs' way.
-      const id = randomBytes(4).toString("hex");
-      const integration = `oauth-modal-scn-${id}`;
-      const appName = `oauthmodalapp${id}`; // lowercase+digits → slug === appName
-      // The picker humanizes the slug for display ("oauthmodalappab12" →
-      // "Oauthmodalappab12"); used to assert the row is gone after removal.
-      const appDisplayName = appName.charAt(0).toUpperCase() + appName.slice(1);
-      const specBaseUrl = "http://127.0.0.1:59998"; // never contacted
+    // Selfhost shares the bootstrap-admin identity, so prefix every resource
+    // with a per-run id to stay out of parallel/repeated runs' way.
+    const id = randomBytes(4).toString("hex");
+    const integration = `oauth-modal-scn-${id}`;
+    const appName = `oauthmodalapp${id}`; // lowercase+digits → slug === appName
+    // The picker humanizes the slug for display ("oauthmodalappab12" →
+    // "Oauthmodalappab12"); used to assert the row is gone after removal.
+    const appDisplayName = appName.charAt(0).toUpperCase() + appName.slice(1);
+    const specBaseUrl = "http://127.0.0.1:59998"; // never contacted
 
-      // Stand up an integration that declares a bring-your-own OAuth2 method.
-      // The endpoints are inert — app management never calls them.
-      yield* client.openapi.addSpec({
-        payload: {
-          spec: { kind: "blob", value: greetSpec(specBaseUrl) },
-          slug: integration,
-          baseUrl: specBaseUrl,
-          authenticationTemplate: [
-            {
-              slug: "oauth",
-              kind: "oauth2",
-              authorizationUrl: "https://auth.example/authorize",
-              tokenUrl: "https://auth.example/token",
-              scopes: [],
-            },
-          ],
-        },
-      });
+    // Stand up an integration that declares a bring-your-own OAuth2 method.
+    // The endpoints are inert — app management never calls them.
+    yield* client.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: greetSpec(specBaseUrl) },
+        slug: integration,
+        baseUrl: specBaseUrl,
+        authenticationTemplate: [
+          {
+            slug: "oauth",
+            kind: "oauth2",
+            authorizationUrl: "https://auth.example/authorize",
+            tokenUrl: "https://auth.example/token",
+            scopes: [],
+          },
+        ],
+      },
+    });
 
-      yield* Effect.ensuring(
-        Effect.gen(function* () {
-          yield* ctx.browser.session(identity, async ({ page, step }) => {
-            const actions = page.getByRole("button", { name: `Actions for ${appName}` });
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        yield* browser.session(identity, async ({ page, step }) => {
+          const actions = page.getByRole("button", { name: `Actions for ${appName}` });
 
-            await step("Open the integration and start a new connection", async () => {
-              await page.goto(`/integrations/${integration}`, { waitUntil: "networkidle" });
-              await page.getByRole("button", { name: "Add connection" }).click();
-              // OAuth2 is the integration's only method, so the modal opens on
-              // the OAuth app step with nothing registered yet. (`exact` avoids
-              // the "Register app for help" tooltip button in the form.)
-              await page.getByRole("button", { name: "Register app", exact: true }).waitFor();
-            });
-
-            await step("Register a bring-your-own OAuth app", async () => {
-              await page.getByRole("button", { name: "Register app", exact: true }).click();
-              await page.locator("#oauth-app-name").fill(appName);
-              await page.locator("#oauth-client-id").fill("client-one");
-              await page.locator("#oauth-client-secret").fill("secret-one");
-              await page.getByRole("button", { name: "Register app", exact: true }).click();
-              // Back on the picker, the new app is selectable AND manageable —
-              // the per-app actions menu is what replaced the old apps page.
-              await actions.waitFor();
-            });
-
-            await step("Edit opens the app prefilled with its stored client id", async () => {
-              await actions.click();
-              await page.getByRole("menuitem", { name: "Edit" }).click();
-              await page.getByText(`Edit ${appName}`).waitFor();
-              expect(
-                await page.locator("#oauth-client-id").inputValue(),
-                "the edit form prefills the stored client id",
-              ).toBe("client-one");
-            });
-
-            await step("Change the client id and save the edit", async () => {
-              await page.locator("#oauth-client-id").fill("client-two");
-              await page.locator("#oauth-client-secret").fill("secret-two");
-              await page.getByRole("button", { name: "Register app", exact: true }).click();
-              await actions.waitFor();
-            });
-
-            await step("Reopening the app shows the saved client id", async () => {
-              await actions.click();
-              await page.getByRole("menuitem", { name: "Edit" }).click();
-              await page.getByText(`Edit ${appName}`).waitFor();
-              expect(
-                await page.locator("#oauth-client-id").inputValue(),
-                "the edit persisted to the saved app",
-              ).toBe("client-two");
-              await page.getByRole("button", { name: "Cancel" }).click();
-              await actions.waitFor();
-            });
-
-            await step("Remove the app and confirm", async () => {
-              await actions.click();
-              await page.getByRole("menuitem", { name: "Remove" }).click();
-              await page.getByRole("button", { name: "Remove app" }).click();
-              // The row (and its actions menu) is gone from the picker, and the
-              // empty-state register CTA is back — no app left for this method.
-              await actions.waitFor({ state: "detached" });
-              await page.getByRole("button", { name: "Register app", exact: true }).waitFor();
-              // Scope to the modal so the "Removed …" success toast (which
-              // echoes the slug) doesn't count as a lingering picker row.
-              expect(
-                await page.getByRole("dialog").getByText(appDisplayName).count(),
-                "the removed app no longer appears in the picker",
-              ).toBe(0);
-            });
+          await step("Open the integration and start a new connection", async () => {
+            await page.goto(`/integrations/${integration}`, { waitUntil: "networkidle" });
+            await page.getByRole("button", { name: "Add connection" }).click();
+            // OAuth2 is the integration's only method, so the modal opens on
+            // the OAuth app step with nothing registered yet. (`exact` avoids
+            // the "Register app for help" tooltip button in the form.)
+            await page.getByRole("button", { name: "Register app", exact: true }).waitFor();
           });
 
-          // The removal is real, not just visual: the app is gone from the API
-          // (asserted before the finalizer, which would also remove it).
-          const remaining = yield* client.oauth.listClients();
-          expect(
-            remaining.map((c) => String(c.slug)),
-            "the removed app is gone from the OAuth client catalog",
-          ).not.toContain(appName);
-        }),
-        // Finalizer: never leak the integration or a half-removed app into the
-        // shared selfhost instance, even if a step above failed mid-flow.
-        Effect.gen(function* () {
-          const clients = yield* client.oauth.listClients().pipe(Effect.orElseSucceed(() => []));
-          for (const c of clients) {
-            if (String(c.slug) === appName) {
-              yield* client.oauth
-                .removeClient({ params: { slug: c.slug }, payload: { owner: c.owner } })
-                .pipe(Effect.ignore);
-            }
+          await step("Register a bring-your-own OAuth app", async () => {
+            await page.getByRole("button", { name: "Register app", exact: true }).click();
+            await page.locator("#oauth-app-name").fill(appName);
+            await page.locator("#oauth-client-id").fill("client-one");
+            await page.locator("#oauth-client-secret").fill("secret-one");
+            await page.getByRole("button", { name: "Register app", exact: true }).click();
+            // Back on the picker, the new app is selectable AND manageable —
+            // the per-app actions menu is what replaced the old apps page.
+            await actions.waitFor();
+          });
+
+          await step("Edit opens the app prefilled with its stored client id", async () => {
+            await actions.click();
+            await page.getByRole("menuitem", { name: "Edit" }).click();
+            await page.getByText(`Edit ${appName}`).waitFor();
+            expect(
+              await page.locator("#oauth-client-id").inputValue(),
+              "the edit form prefills the stored client id",
+            ).toBe("client-one");
+          });
+
+          await step("Change the client id and save the edit", async () => {
+            await page.locator("#oauth-client-id").fill("client-two");
+            await page.locator("#oauth-client-secret").fill("secret-two");
+            await page.getByRole("button", { name: "Register app", exact: true }).click();
+            await actions.waitFor();
+          });
+
+          await step("Reopening the app shows the saved client id", async () => {
+            await actions.click();
+            await page.getByRole("menuitem", { name: "Edit" }).click();
+            await page.getByText(`Edit ${appName}`).waitFor();
+            expect(
+              await page.locator("#oauth-client-id").inputValue(),
+              "the edit persisted to the saved app",
+            ).toBe("client-two");
+            await page.getByRole("button", { name: "Cancel" }).click();
+            await actions.waitFor();
+          });
+
+          await step("Remove the app and confirm", async () => {
+            await actions.click();
+            await page.getByRole("menuitem", { name: "Remove" }).click();
+            await page.getByRole("button", { name: "Remove app" }).click();
+            // The row (and its actions menu) is gone from the picker, and the
+            // empty-state register CTA is back — no app left for this method.
+            await actions.waitFor({ state: "detached" });
+            await page.getByRole("button", { name: "Register app", exact: true }).waitFor();
+            // Scope to the modal so the "Removed …" success toast (which
+            // echoes the slug) doesn't count as a lingering picker row.
+            expect(
+              await page.getByRole("dialog").getByText(appDisplayName).count(),
+              "the removed app no longer appears in the picker",
+            ).toBe(0);
+          });
+        });
+
+        // The removal is real, not just visual: the app is gone from the API
+        // (asserted before the finalizer, which would also remove it).
+        const remaining = yield* client.oauth.listClients();
+        expect(
+          remaining.map((c) => String(c.slug)),
+          "the removed app is gone from the OAuth client catalog",
+        ).not.toContain(appName);
+      }),
+      // Finalizer: never leak the integration or a half-removed app into the
+      // shared selfhost instance, even if a step above failed mid-flow.
+      Effect.gen(function* () {
+        const clients = yield* client.oauth.listClients().pipe(Effect.orElseSucceed(() => []));
+        for (const c of clients) {
+          if (String(c.slug) === appName) {
+            yield* client.oauth
+              .removeClient({ params: { slug: c.slug }, payload: { owner: c.owner } })
+              .pipe(Effect.ignore);
           }
-          yield* client.openapi.removeSpec({ params: { slug: integration } }).pipe(Effect.ignore);
-        }),
-      );
-    }),
+        }
+        yield* client.openapi.removeSpec({ params: { slug: integration } }).pipe(Effect.ignore);
+      }),
+    );
+  }),
 );

--- a/e2e/src/scenario.ts
+++ b/e2e/src/scenario.ts
@@ -1,23 +1,30 @@
-// scenario(): the one way a test is written. Picks the target from E2E_TARGET
-// (set by the vitest project), skips when the target lacks a needed capability,
-// and provides the surface drivers. Correctness lives in the test code and its
-// vitest assertions — there is no recording layer. What survives per run is a
-// small result.json (for the scenario × target matrix) plus whatever artifacts
-// the browser surface produced (video, screenshots, trace.zip).
+// scenario(): the one way a test is written. The body is an Effect whose
+// requirements ARE its capability declaration: it yields services (src/
+// services.ts) and nothing else — no needs list. The target provides what it
+// has; yielding a service the target lacks surfaces as Effect's own
+// missing-service defect, which the runner classifies into a vitest skip
+// with the missing service named in the matrix. Convention: yield services
+// at the top of the body, so a skip happens before any real work.
+// Correctness lives in the test code and its vitest assertions — there is no
+// recording layer. What survives per run is a small result.json (for the
+// scenario × target matrix) plus whatever artifacts the surfaces produced
+// (browser video/trace/screenshots, terminal casts).
 import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { it } from "@effect/vitest";
-import { Cause, Effect } from "effect";
+import { Cause, Context, Effect } from "effect";
 import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 
-import type { Capability, Target } from "./target";
+import type { Target as TargetShape } from "./target";
 import { resolveTarget } from "../targets/registry";
-import { makeApiSurface, type ApiSurface } from "./surfaces/api";
-import { makeBrowserSurface, type BrowserSurface } from "./surfaces/browser";
-import { makeCliSurface, type CliSurface } from "./surfaces/cli";
-import { makeMcpSurface, type McpSurface } from "./surfaces/mcp";
+import { makeApiSurface } from "./surfaces/api";
+import { makeBrowserSurface } from "./surfaces/browser";
+import { makeCliSurface } from "./surfaces/cli";
+import { makeMcpSurface } from "./surfaces/mcp";
+import { completeOAuthConsent, hasOpenCode, makeOpenCodeHome, warmUp } from "./clients/opencode";
+import { Api, Billing, Browser, Cli, Mcp, OpenCode, RunDir, Target, TtlControl } from "./services";
 import { buildManifest } from "./viewer/manifest";
 
 export const RUNS_DIR = fileURLToPath(new URL("../runs/", import.meta.url));
@@ -29,59 +36,84 @@ export const slugify = (text: string): string =>
     .replace(/^-+|-+$/g, "")
     .slice(0, 80);
 
-export interface ScenarioContext {
-  readonly target: Target;
-  /** Artifact directory for this run (browser video/screenshots/trace land here). */
-  readonly dir: string;
-  readonly api: ApiSurface;
-  readonly browser: BrowserSurface;
-  readonly cli: CliSurface;
-  readonly mcp: McpSurface;
-}
-
 export interface ScenarioOptions {
-  readonly needs?: ReadonlyArray<Capability>;
   readonly timeout?: number;
 }
+
+type AllServices = Target | RunDir | Cli | Api | Browser | Mcp | Billing | OpenCode | TtlControl;
+
+/**
+ * What this target on this host can provide. Services beyond the base are
+ * conditional, so the claimed type is the full union — yielding an absent
+ * one fails with Effect's missing-service defect, which the runner turns
+ * into the skip.
+ */
+const contextFor = (target: TargetShape, dir: string): Context.Context<AllServices> => {
+  let context = Context.empty().pipe(
+    Context.add(Target, target),
+    Context.add(RunDir, dir),
+    Context.add(Cli, makeCliSurface()),
+  ) as Context.Context<AllServices>;
+  const has = target.capabilities.has.bind(target.capabilities);
+  if (has("api")) context = Context.add(context, Api, makeApiSurface(target));
+  if (has("browser")) context = Context.add(context, Browser, makeBrowserSurface(dir, target));
+  if (has("mcp-oauth")) context = Context.add(context, Mcp, makeMcpSurface(target));
+  if (has("billing")) context = Context.add(context, Billing, true);
+  if (hasOpenCode()) {
+    context = Context.add(context, OpenCode, {
+      makeHome: makeOpenCodeHome,
+      warmUp,
+      completeOAuthConsent,
+    });
+  }
+  if (target.setAccessTokenTtl) {
+    context = Context.add(context, TtlControl, target.setAccessTokenTtl);
+  }
+  return context;
+};
 
 export const scenario = (
   name: string,
   options: ScenarioOptions,
-  body: (ctx: ScenarioContext) => Effect.Effect<void, unknown, HttpClient.HttpClient>,
+  body: Effect.Effect<void, unknown, AllServices | HttpClient.HttpClient>,
 ): void => {
   const target = resolveTarget();
-  const missing = (options.needs ?? []).filter((c) => !target.capabilities.has(c));
   const dir = join(RUNS_DIR, target.name, slugify(name));
+  const context = contextFor(target, dir);
   const testFile = captureTestFile();
-
-  if (missing.length > 0) {
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(
-      join(dir, "skipped.json"),
-      JSON.stringify({ scenario: name, target: target.name, missing }, null, 1),
-    );
-    it.skip(`${name} [needs ${missing.join(", ")} — not on ${target.name}]`, () => {});
-    return;
-  }
 
   it.live(
     name,
-    () =>
+    (testCtx) =>
       Effect.gen(function* () {
         // A run's directory is the run — never mix artifacts across attempts.
         rmSync(dir, { recursive: true, force: true });
         mkdirSync(dir, { recursive: true });
         const startedAt = Date.now();
-        const ctx: ScenarioContext = {
-          target,
-          dir,
-          api: makeApiSurface(target),
-          browser: makeBrowserSurface(dir, target),
-          cli: makeCliSurface(),
-          mcp: makeMcpSurface(target),
-        };
-        const exit = yield* Effect.exit(body(ctx));
+        const exit = yield* Effect.exit(
+          body.pipe(Effect.provideContext(context)) as Effect.Effect<
+            void,
+            unknown,
+            HttpClient.HttpClient
+          >,
+        );
         const endedAt = Date.now();
+
+        // Yielding a service this target can't provide is the skip signal.
+        const missing = exit._tag === "Failure" ? missingServices(exit.cause) : [];
+        if (missing.length > 0) {
+          rmSync(dir, { recursive: true, force: true });
+          mkdirSync(dir, { recursive: true });
+          writeFileSync(
+            join(dir, "skipped.json"),
+            JSON.stringify({ scenario: name, target: target.name, missing }, null, 1),
+          );
+          buildManifest(RUNS_DIR);
+          return yield* Effect.sync(() =>
+            testCtx.skip(`needs ${missing.join(", ")} — not on ${target.name}`),
+          );
+        }
+
         const error = exit._tag === "Failure" ? failureMessage(exit.cause) : undefined;
         // The test source is the review artifact — ship this scenario's code
         // (imports + sibling scenarios stripped) alongside the run.
@@ -111,6 +143,14 @@ export const scenario = (
       }).pipe(Effect.provide(FetchHttpClient.layer)),
     options.timeout ?? 120_000,
   );
+};
+
+/** Service keys (sans the e2e/ prefix) whose absence caused this failure. */
+const missingServices = (cause: Cause.Cause<unknown>): ReadonlyArray<string> => {
+  const rendered = String(Cause.squash(cause));
+  return [...rendered.matchAll(/Service not found: e2e\/([^\s(]+)/g)]
+    .map((match) => match[1] ?? "")
+    .filter((name, index, all) => name !== "" && all.indexOf(name) === index);
 };
 
 const failureMessage = (cause: Cause.Cause<unknown>): string => {

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -1,0 +1,49 @@
+// The scenario environment as Effect services. A scenario declares what it
+// needs by yielding these tags; the requirements surface in its R channel,
+// where the compiler checks them against the `needs` list (the same tags as
+// runtime values — what drives skip records for targets that lack one).
+// Target/RunDir/Cli are always provided; the rest depend on the target's
+// capabilities and the host environment.
+import { Context, type Effect } from "effect";
+
+import type { Target as TargetShape } from "./target";
+import type { ApiSurface } from "./surfaces/api";
+import type { BrowserSurface } from "./surfaces/browser";
+import type { CliSurface } from "./surfaces/cli";
+import type { McpSurface } from "./surfaces/mcp";
+import type { completeOAuthConsent, makeOpenCodeHome, warmUp } from "./clients/opencode";
+
+/** The target under test (always provided). */
+export class Target extends Context.Service<Target, TargetShape>()("e2e/target") {}
+
+/** This run's artifact directory (always provided). */
+export class RunDir extends Context.Service<RunDir, string>()("e2e/run-dir") {}
+
+/** Real-PTY terminal sessions with cast recording (always provided — host machinery, not a target trait). */
+export class Cli extends Context.Service<Cli, CliSurface>()("e2e/cli") {}
+
+/** Typed HttpApiClient over the wire (target capability "api"). */
+export class Api extends Context.Service<Api, ApiSurface>()("e2e/api") {}
+
+/** Playwright browser sessions with video/trace (target capability "browser"). */
+export class Browser extends Context.Service<Browser, BrowserSurface>()("e2e/browser") {}
+
+/** MCP client sessions + headless OAuth flows (target capability "mcp-oauth"). */
+export class Mcp extends Context.Service<Mcp, McpSurface>()("e2e/mcp-oauth") {}
+
+/** Marker: billing limits are enforced on this target. */
+export class Billing extends Context.Service<Billing, true>()("e2e/billing") {}
+
+/** The real OpenCode binary, hermetically driveable (present when installed on this host). */
+export interface OpenCodeClient {
+  readonly makeHome: typeof makeOpenCodeHome;
+  readonly warmUp: typeof warmUp;
+  readonly completeOAuthConsent: typeof completeOAuthConsent;
+}
+export class OpenCode extends Context.Service<OpenCode, OpenCodeClient>()("e2e/opencode") {}
+
+/** Compress (or restore, with null) the authorization server's access-token TTL. */
+export class TtlControl extends Context.Service<
+  TtlControl,
+  (seconds: number | null) => Effect.Effect<void>
+>()("e2e/ttl-control") {}

--- a/e2e/src/surfaces/api.ts
+++ b/e2e/src/surfaces/api.ts
@@ -5,19 +5,21 @@
 // vitest's job; a failed call surfaces as a typed HttpClientError in the
 // test output.
 import { Effect } from "effect";
-import { HttpApiClient } from "effect/unstable/httpapi";
+import { HttpApiClient, type HttpApi, type HttpApiGroup } from "effect/unstable/httpapi";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
 import type { Identity, Target } from "../target";
 
-type AnyApi = Parameters<typeof HttpApiClient.make>[0];
-
 export interface ApiSurface {
   /** Typed client for `apiDef`, authenticated as `identity`. */
-  readonly client: <A extends AnyApi>(
-    apiDef: A,
+  readonly client: <ApiId extends string, Groups extends HttpApiGroup.Any>(
+    apiDef: HttpApi.HttpApi<ApiId, Groups>,
     identity: Identity,
-  ) => Effect.Effect<HttpApiClient.Client<A, never>, unknown, HttpClient.HttpClient>;
+  ) => Effect.Effect<
+    HttpApiClient.Client<Groups>,
+    unknown,
+    HttpClient.HttpClient | HttpApiGroup.MiddlewareClient<Groups>
+  >;
 }
 
 export const makeApiSurface = (target: Target): ApiSurface => ({

--- a/e2e/src/surfaces/mcp.ts
+++ b/e2e/src/surfaces/mcp.ts
@@ -30,6 +30,8 @@ export interface McpSession {
 }
 
 export interface McpSurface {
+  /** The target's MCP endpoint — yield this surface to depend on it existing. */
+  readonly url: string;
   readonly session: (identity: Identity) => McpSession;
   /**
    * Mint a real MCP bearer headlessly: protected-resource discovery →
@@ -104,7 +106,10 @@ const mintBearerFlow = async (target: Target, email: string): Promise<string> =>
     createHash("sha256").update(verifier).digest("base64url"),
   );
   authorizeUrl.searchParams.set("code_challenge_method", "S256");
-  const { code } = await consent({ authorizationUrl: authorizeUrl.toString() });
+  const { code } = await consent({
+    authorizationUrl: authorizeUrl.toString(),
+    redirectUrl: redirectUri,
+  });
 
   const token = (await (
     await fetch(metadata.token_endpoint, {
@@ -124,6 +129,7 @@ const mintBearerFlow = async (target: Target, email: string): Promise<string> =>
 };
 
 export const makeMcpSurface = (target: Target): McpSurface => ({
+  url: target.mcpUrl,
   mintBearer: (email) => Effect.promise(() => mintBearerFlow(target, email)),
   session: (identity) => {
     const serverName = target.name;

--- a/e2e/src/target.ts
+++ b/e2e/src/target.ts
@@ -6,14 +6,14 @@
 // own dev-server boot (see setup/*.globalsetup.ts which call into the app).
 import type { Effect } from "effect";
 
+// Deployment traits only. Host-environment services (the OpenCode binary)
+// and ones implied by an optional Target method (setAccessTokenTtl →
+// TtlControl) are derived in scenario.ts, not declared here.
 export type Capability =
   | "api" // typed HttpApiClient over the wire
   | "browser" // web UI reachable + identity injectable into a browser context
   | "mcp-oauth" // MCP endpoint with a headless OAuth consent path
-  | "cli" // a CLI/TUI entry point exists for this target
-  | "billing" // billing limits are enforced (cloud-only)
-  | "opencode" // the real OpenCode binary is installed on this host
-  | "ttl-control"; // the authorization server's access-token TTL is test-adjustable
+  | "billing"; // billing limits are enforced (cloud-only)
 
 export interface Identity {
   /** Shown in transcripts ("user_ab12cd") */
@@ -41,7 +41,7 @@ export interface Target {
   /** Headless OAuth consent for the MCP surface, when "mcp-oauth" is supported. */
   readonly mcpConsent?: (
     identity: Identity,
-  ) => (request: { authorizationUrl: string }) => Promise<{ code: string }>;
+  ) => (request: { authorizationUrl: string; redirectUrl: string }) => Promise<{ code: string }>;
   /**
    * Compress (or restore, with null) the authorization server's access-token
    * lifetime, when "ttl-control" is supported — what lets token-expiry

--- a/e2e/targets/cloud.ts
+++ b/e2e/targets/cloud.ts
@@ -8,8 +8,7 @@ import { randomUUID } from "node:crypto";
 
 import { Effect } from "effect";
 
-import type { Capability, Identity, Target } from "../src/target";
-import { hasOpenCode } from "../src/clients/opencode";
+import type { Identity, Target } from "../src/target";
 
 export const CLOUD_PORT = Number(process.env.E2E_CLOUD_PORT ?? 4798);
 export const CLOUD_DB_PORT = Number(process.env.E2E_CLOUD_DB_PORT ?? 5436);
@@ -55,17 +54,9 @@ export const cloudTarget = (): Target => ({
   name: "cloud",
   baseUrl: CLOUD_BASE_URL,
   mcpUrl: `${CLOUD_BASE_URL}/mcp`,
-  capabilities: new Set<Capability>([
-    "api",
-    "browser",
-    "billing",
-    "mcp-oauth",
-    // Cloud's authorization server is the WorkOS emulator, so token-expiry
-    // scenarios can compress the lifecycle.
-    "ttl-control",
-    // Real-client capability is environmental, not a property of the deployment.
-    ...(hasOpenCode() ? (["opencode"] as const) : []),
-  ]),
+  capabilities: new Set(["api", "browser", "billing", "mcp-oauth"]),
+  // Cloud's authorization server is the WorkOS emulator, so token-expiry
+  // scenarios can compress the lifecycle (the TtlControl service).
   setAccessTokenTtl: (seconds) =>
     Effect.promise(async () => {
       const response = await fetch(`http://127.0.0.1:${WORKOS_EMULATOR_PORT}/_emulate/seed`, {

--- a/e2e/targets/selfhost.ts
+++ b/e2e/targets/selfhost.ts
@@ -6,8 +6,7 @@ import { Effect } from "effect";
 
 import { cookieConsentStrategy } from "@executor-js/mcporter";
 
-import type { Capability, Identity, Target } from "../src/target";
-import { hasOpenCode } from "../src/clients/opencode";
+import type { Identity, Target } from "../src/target";
 
 export const SELFHOST_PORT = Number(process.env.E2E_SELFHOST_PORT ?? 4799);
 export const SELFHOST_BASE_URL =
@@ -49,17 +48,12 @@ export const selfhostTarget = (): Target => ({
   name: "selfhost",
   baseUrl: SELFHOST_BASE_URL,
   mcpUrl: `${SELFHOST_BASE_URL}/mcp`,
-  // No "billing" (no limits) and no "ttl-control" yet (Better Auth is the
+  // No "billing" (no limits) and no setAccessTokenTtl yet (Better Auth is the
   // authorization server; its token TTL isn't test-adjustable, so token-expiry
   // scenarios skip here). Identity is the bootstrap admin for now —
   // single-tenant; per-test invite-signup isolation is the next step here, so
   // browser scenarios must prefix the resources they create.
-  capabilities: new Set<Capability>([
-    "api",
-    "browser",
-    "mcp-oauth",
-    ...(hasOpenCode() ? (["opencode"] as const) : []),
-  ]),
+  capabilities: new Set(["api", "browser", "mcp-oauth"]),
   newIdentity: () =>
     Effect.promise(async (): Promise<Identity> => {
       // Sign in once and carry the session in both shapes: `headers` for the

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": ["src", "cloud", "scenarios", "selfhost", "setup", "targets", "scripts", "viewer/src"]
+}

--- a/e2e/viewer/src/vite-env.d.ts
+++ b/e2e/viewer/src/vite-env.d.ts
@@ -1,0 +1,17 @@
+/// <reference types="vite/client" />
+
+// monaco-editor's package exports don't expose the esm subpaths to TypeScript
+// (vite resolves them fine); the main entry's types ARE editor.api's.
+declare module "monaco-editor/esm/vs/editor/editor.api" {
+  export * from "monaco-editor";
+}
+declare module "monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution" {}
+
+// No published types; the player is created imperatively and disposed.
+declare module "asciinema-player" {
+  export function create(
+    src: string,
+    element: HTMLElement,
+    options?: Record<string, unknown>,
+  ): { dispose: () => void };
+}


### PR DESCRIPTION
Stacked on #945 (review only the commits unique to this branch). Stack: #931 → #944 → #945 → #942.

The scenario environment becomes Effect services: `Target`/`RunDir`/`Cli` always provided; `Api`/`Browser`/`Mcp`/`Billing`/`OpenCode`/`TtlControl` added to the per-run `Context` only when the target (or host) provides them. A scenario body is a plain Effect that yields what it uses — the string `needs` array and the hand-rolled `ctx` record are gone.

Skipping needs no declaration: yielding a service the target lacks surfaces as Effect's missing-service defect, which the runner classifies into a vitest runtime skip with the missing services named in the matrix record. Scenarios that depend on a deployment trait without calling its surface gate with a bare yield.

Also adds the package's first tsconfig + typecheck script (surfacing latent type errors, now fixed).

Verified: cloud 67/69 (the 2 intended repro reds), selfhost 8 passed + 3 skipped via the new mechanism, typecheck/lint/format green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #944
2. #945
3. **#942** 👈 current
4. #947
5. #951
<!-- stack:links:end -->