### PR TITLE
Embed e2e run recordings in PR descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,21 @@ attribution/trailers to commits, commit messages, PRs, or generated files.
 Pull request titles and descriptions are going to a public GitHub repo, so
 avoid using specific names or internal info unless explicitly stated to.
 
+## Show Changes in PR Descriptions
+
+When a change is user-visible and an e2e scenario covers it, embed the run's
+recording in the PR description — reviewers should see the change, not just
+read about it.
+
+```
+bun e2e/scripts/pr-media.ts e2e/runs/<target>/<scenario-slug>
+```
+
+converts the run's recording (browser `session.mp4` or `terminal.cast`) to a
+gif, uploads it to the `e2e-media` branch, and prints PR-ready markdown to
+paste into the body. Run screenshots (`*.png`) can be passed directly too. If
+no scenario covers the change yet, that is usually the cue to write one.
+
 ## Collaboration Notes
 
 The user uses speech to text occasionally, so if sentences are weird or words

--- a/e2e/scripts/pr-media.ts
+++ b/e2e/scripts/pr-media.ts
@@ -1,0 +1,164 @@
+// Turn an e2e run's recording into PR-ready markdown.
+//
+// GitHub only renders media inline from URLs it can fetch, and there is no
+// API for the drag-and-drop user-asset upload — so this converts the run's
+// recording to a gif (the one format that renders inline from a raw repo
+// URL), commits it to the orphan `e2e-media` branch through the git database
+// API (never touching the local worktree), and prints markdown to paste into
+// the PR description.
+//
+// Usage: bun e2e/scripts/pr-media.ts <run-dir-or-artifact> [...more]
+//   run dir        e2e/runs/<target>/<scenario-slug> — picks session.mp4 or
+//                  terminal.cast and labels the gif from result.json
+//   session.mp4    browser recording (ffmpeg -> gif)
+//   terminal.cast  terminal recording (agg -> gif; brew install agg)
+//   *.png          run screenshot, uploaded as-is
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+
+const MEDIA_BRANCH = "e2e-media";
+// Above this GitHub's image proxy stops rendering the gif inline.
+const RENDER_LIMIT_BYTES = 10 * 1024 * 1024;
+
+const run = (command: string, args: ReadonlyArray<string>): string =>
+  execFileSync(command, [...args], {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+
+const ghJson = (args: ReadonlyArray<string>): unknown => JSON.parse(run("gh", ["api", ...args]));
+
+interface Artifact {
+  readonly path: string;
+  readonly label: string;
+  readonly slug: string;
+}
+
+/** A run dir resolves to its recording; a file stands for itself. */
+const resolveArtifact = (input: string): Artifact => {
+  const path = resolve(input);
+  if (!existsSync(path)) throw new Error(`no such path: ${input}`);
+  if (!statSync(path).isDirectory()) {
+    return {
+      path,
+      label: basename(path),
+      slug: basename(path).replace(/\.[^.]+$/, ""),
+    };
+  }
+  const recording = ["session.mp4", "terminal.cast"]
+    .map((name) => join(path, name))
+    .find(existsSync);
+  if (!recording) throw new Error(`${input} has no session.mp4 or terminal.cast`);
+  let label = basename(path);
+  try {
+    const result = JSON.parse(readFileSync(join(path, "result.json"), "utf8")) as {
+      scenario?: string;
+      target?: string;
+    };
+    if (result.scenario) label = `${result.scenario} (${result.target ?? "e2e"})`;
+  } catch {
+    // skipped/partial runs still have a recording worth showing
+  }
+  return { path: recording, label, slug: basename(path) };
+};
+
+const toGif = (artifact: Artifact): string => {
+  if (artifact.path.endsWith(".png")) return artifact.path;
+  const out = join(tmpdir(), `${artifact.slug}.gif`);
+  if (artifact.path.endsWith(".cast")) {
+    run("agg", ["--idle-time-limit", "2", "--font-size", "14", artifact.path, out]);
+  } else {
+    // Two-pass palette keeps UI text crisp at a size GitHub will render.
+    const filter =
+      "fps=8,scale=960:-2:flags=lanczos,split[a][b];" +
+      "[a]palettegen=max_colors=128[p];[b][p]paletteuse=dither=bayer:bayer_scale=5";
+    run("ffmpeg", ["-y", "-loglevel", "error", "-i", artifact.path, "-vf", filter, out]);
+  }
+  return out;
+};
+
+/** Commit a file to the media branch via the git database API; returns its raw URL. */
+const upload = (repo: string, localPath: string, mediaPath: string): string => {
+  const bytes = readFileSync(localPath);
+  const request = join(tmpdir(), `pr-media-blob-${process.pid}.json`);
+  writeFileSync(request, JSON.stringify({ content: bytes.toString("base64"), encoding: "base64" }));
+  const blob = ghJson([`repos/${repo}/git/blobs`, "--method", "POST", "--input", request]) as {
+    sha: string;
+  };
+
+  // Tip of the media branch, if it exists — the branch is orphan on first use.
+  let parent: { commit: string; tree: string } | undefined;
+  try {
+    const ref = ghJson([`repos/${repo}/git/ref/heads/${MEDIA_BRANCH}`]) as {
+      object: { sha: string };
+    };
+    const commit = ghJson([`repos/${repo}/git/commits/${ref.object.sha}`]) as {
+      tree: { sha: string };
+    };
+    parent = { commit: ref.object.sha, tree: commit.tree.sha };
+  } catch {
+    parent = undefined;
+  }
+
+  writeFileSync(
+    request,
+    JSON.stringify({
+      ...(parent ? { base_tree: parent.tree } : {}),
+      tree: [{ path: mediaPath, mode: "100644", type: "blob", sha: blob.sha }],
+    }),
+  );
+  const tree = ghJson([`repos/${repo}/git/trees`, "--method", "POST", "--input", request]) as {
+    sha: string;
+  };
+  writeFileSync(
+    request,
+    JSON.stringify({
+      message: `Add ${mediaPath}`,
+      tree: tree.sha,
+      parents: parent ? [parent.commit] : [],
+    }),
+  );
+  const commit = ghJson([`repos/${repo}/git/commits`, "--method", "POST", "--input", request]) as {
+    sha: string;
+  };
+  writeFileSync(
+    request,
+    parent
+      ? JSON.stringify({ sha: commit.sha })
+      : JSON.stringify({ ref: `refs/heads/${MEDIA_BRANCH}`, sha: commit.sha }),
+  );
+  ghJson(
+    parent
+      ? [`repos/${repo}/git/refs/heads/${MEDIA_BRANCH}`, "--method", "PATCH", "--input", request]
+      : [`repos/${repo}/git/refs`, "--method", "POST", "--input", request],
+  );
+  return `https://raw.githubusercontent.com/${repo}/${MEDIA_BRANCH}/${mediaPath}`;
+};
+
+const inputs = process.argv.slice(2);
+if (inputs.length === 0) {
+  console.error("usage: bun e2e/scripts/pr-media.ts <run-dir-or-artifact> [...more]");
+  process.exit(1);
+}
+
+const repo = run("gh", ["repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"]).trim();
+const blocks: Array<string> = [];
+for (const input of inputs) {
+  const artifact = resolveArtifact(input);
+  const gif = toGif(artifact);
+  const size = statSync(gif).size;
+  if (size > RENDER_LIMIT_BYTES) {
+    console.error(
+      `warning: ${basename(gif)} is ${(size / 1024 / 1024).toFixed(1)} MB — GitHub will not render it inline; trim the scenario or lower fps`,
+    );
+  }
+  const hash = createHash("sha256").update(readFileSync(gif)).digest("hex").slice(0, 8);
+  const extension = gif.endsWith(".png") ? "png" : "gif";
+  const url = upload(repo, gif, `${artifact.slug}-${hash}.${extension}`);
+  blocks.push(`![${artifact.label}](${url})`);
+}
+
+console.log(`\n${blocks.join("\n\n")}\n`);


### PR DESCRIPTION
Stacked on #942 (review only the commit unique to this branch).

## What this is

PRs that change user-visible behavior should show the change, not just describe it — and the e2e setup already produces the evidence (browser `session.mp4` per Playwright run, `terminal.cast` per recorded PTY run). This adds the one-command bridge from a run directory to a PR body, plus an AGENTS.md note so agents reach for it by default.

## How it works

```
bun e2e/scripts/pr-media.ts e2e/runs/<target>/<scenario-slug>
```

- Picks the run's recording (`session.mp4` or `terminal.cast`; a `.png` screenshot path works directly) and labels it from `result.json`.
- Converts to gif — the one format GitHub renders inline from a raw repo URL (there is no API for the drag-and-drop user-asset upload): ffmpeg two-pass palette for video, `agg` for casts (matching the viewer's idle compression).
- Commits the gif to the orphan `e2e-media` branch through the git database API — content-hashed filename, no local worktree involvement, no media in the main branch's history.
- Prints PR-ready markdown.

## Demo

Output of running it on two real runs (now embedded in #946 and #945):

![OAuth · the app registration form shows the callback URL to allow-list (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/oauth-the-app-registration-form-shows-the-callback-url-to-allow-list-35991a3b.gif)

![MCP OAuth lifecycle · the real OpenCode binary stays signed in across token expiry (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-oauth-lifecycle-the-real-opencode-binary-stays-signed-in-across-token-expiry-7d9836e7.gif)

## Verification

Format, lint, and the e2e package typecheck are green; both demo gifs above were produced and uploaded by the script itself.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #944
2. #945
3. #942
4. **#947** 👈 current
5. #951
<!-- stack:links:end -->