### PR TITLE
Advertise MCP OAuth scopes so spec-faithful clients get refresh tokens

### DIFF
--- a/apps/cloud/src/mcp/oauth-metadata.ts
+++ b/apps/cloud/src/mcp/oauth-metadata.ts
@@ -22,7 +22,10 @@ export const protectedResourceMetadataResponse = (organizationId: string | null 
     resource: resourceUrlFor(organizationId),
     authorization_servers: [AUTHKIT_DOMAIN],
     bearer_methods_supported: ["header"],
-    scopes_supported: [],
+    // Spec-faithful clients (OpenCode, mcporter) request exactly what is
+    // advertised here; without offline_access they get no refresh token and
+    // silently sign out at every access-token expiry.
+    scopes_supported: ["openid", "profile", "email", "offline_access"],
   });
 
 export const authorizationServerMetadataResponse: Effect.Effect<Response> = Effect.tryPromise({

--- a/e2e/cloud/mcp-protocol.test.ts
+++ b/e2e/cloud/mcp-protocol.test.ts
@@ -150,7 +150,10 @@ scenario(
       resource: new URL("/mcp", target.baseUrl).toString(),
       authorization_servers: [expect.any(String)],
       bearer_methods_supported: ["header"],
-      scopes_supported: [],
+      // offline_access MUST stay advertised: spec-faithful clients request
+      // exactly this list, and it is what earns them a refresh token (the
+      // OpenCode daily re-auth bug).
+      scopes_supported: ["openid", "profile", "email", "offline_access"],
     });
 
     // The advertised server must itself be discoverable — that is what lets


### PR DESCRIPTION
Stacked on #947 (review only the commit unique to this branch). This is the fix the repro in #945 was held red for.

## The bug

Cloud's MCP protected-resource metadata advertised `scopes_supported: []`. Clients that request exactly what the metadata advertises (OpenCode, mcporter) therefore sent no `scope` parameter, never asked for `offline_access`, never received a refresh token — and silently signed out at every access-token expiry. Users experienced it as having to re-authenticate daily. Clients that hardcode their scope list were unaffected, which is why it went unnoticed.

## The fix

One line: advertise `["openid", "profile", "email", "offline_access"]`. The protocol test now locks the list with a comment explaining why `offline_access` must stay.

## Before / after, same scenario

The repro from #945 — the real opencode binary authenticating, then crossing a genuine server-honored token expiry on camera.

Red (before, from #945): comes back `needs authentication`, token store holds no refresh token.

![before: OpenCode signed out after token expiry](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-oauth-lifecycle-the-real-opencode-binary-stays-signed-in-across-token-expiry-7d9836e7.gif)

Green (after, this PR): still `connected` — OpenCode refreshed silently, no user interaction.

![after: OpenCode stays connected across token expiry](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/mcp-oauth-lifecycle-the-real-opencode-binary-stays-signed-in-across-token-expiry-41bada41.gif)

## Verification

Full e2e suite from cold at this commit: 75 passed, 1 skipped (the repro on the self-host target, which has no token-TTL knob), zero failures — the first fully green run, with the #945 repro now acting as a regression lock. Format, lint, and cloud typecheck green.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #944
2. #945
3. #942
4. #947
5. **#951** 👈 current
<!-- stack:links:end -->