### PR TITLE
Store OpenAPI specs and GraphQL snapshots in the blob seam, not integration.config

### DIFF
--- a/packages/core/sdk/src/blob.ts
+++ b/packages/core/sdk/src/blob.ts
@@ -157,6 +157,17 @@ export const makeInMemoryBlobStore = (): BlobStore => {
   };
 };
 
+/** Hex SHA-256 of a UTF-8 string — the content-address key plugins use for
+ *  write-once blobs (`put(key(hash), …)` is then idempotent and orphaned
+ *  writes are harmless). Web Crypto, so it runs on Workers/Bun/Node alike. */
+export const sha256Hex = (text: string): Effect.Effect<string> =>
+  Effect.promise(async () => {
+    const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+    return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join(
+      "",
+    );
+  });
+
 const blobId = (namespace: string, key: string): string => JSON.stringify([namespace, key]);
 
 type BlobRow = {

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1834,6 +1834,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             config: decodeJsonColumn(integrationRow.config),
             connection: ref,
             template: existingRow ? AuthTemplateSlug.make(existingRow.template) : null,
+            storage: runtime.storage,
             getValue: () => resolveConnectionValueByRef(ref),
             getValues: () => resolveConnectionValuesByRef(ref),
           })

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -174,6 +174,7 @@ export {
   pluginBlobStore,
   makeInMemoryBlobStore,
   makeFumaBlobStore,
+  sha256Hex,
   type BlobStore,
   type PluginBlobStore,
   type OwnerPartitions,

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -187,11 +187,16 @@ export interface PluginCtx<TStore = unknown> {
 // refresh / oauth.complete; the result is stamped with addresses and persisted.
 // ---------------------------------------------------------------------------
 
-export interface ResolveToolsInput {
+export interface ResolveToolsInput<TStore = unknown> {
   /** The catalog record (public projection) whose connection is being resolved. */
   readonly integration: Integration;
   /** The plugin's stored opaque config for that integration. */
   readonly config: IntegrationConfig;
+  /** The plugin's typed store — the same instance the extension ctx sees.
+   *  Lets spec-derived plugins load build artifacts kept behind the storage
+   *  facades (e.g. a content-addressed spec blob) instead of inlining them
+   *  in `config`. */
+  readonly storage: TStore;
   /** The connection whose tools are being resolved. */
   readonly connection: ConnectionRef;
   /** Which of the integration's declared auth methods the connection binds
@@ -443,7 +448,7 @@ export interface PluginSpec<
    *  create / refresh / oauth.complete; the result is stamped with addresses
    *  and persisted per-connection. Omit for plugins with no dynamic tools. */
   readonly resolveTools?: (
-    input: ResolveToolsInput,
+    input: ResolveToolsInput<TStore>,
   ) => Effect.Effect<ResolveToolsResult, StorageFailure>;
 
   /** Invoke a dynamic tool. Called when the static-handler map doesn't have the

--- a/packages/plugins/graphql/src/sdk/plugin.ts
+++ b/packages/plugins/graphql/src/sdk/plugin.ts
@@ -10,6 +10,7 @@ import {
   IntegrationDetectionResult,
   IntegrationSlug,
   mergeAuthTemplates,
+  sha256Hex,
   ToolName,
   ToolResult,
   type AuthMethodDescriptor,
@@ -413,17 +414,32 @@ const introspectHeadersForConnection = (
   return { headers, queryParams };
 };
 
-/** Introspect a config live or from its stored JSON, applying connection auth.
- *  `parseIntrospectionJson` short-circuits the network when a schema snapshot is
- *  present; otherwise this introspects the endpoint with the rendered credential. */
+/** Resolve a config's introspection snapshot text: legacy rows inline it in
+ *  `introspectionJson`; new rows point at the plugin blob store via
+ *  `introspectionHash`. Null when the integration has no snapshot (live
+ *  introspection territory). */
+const loadIntrospectionJson = (
+  storage: GraphqlStore,
+  config: GraphqlIntegrationConfig,
+): Effect.Effect<string | null, StorageFailure> => {
+  if (config.introspectionJson != null) return Effect.succeed(config.introspectionJson);
+  if (config.introspectionHash != null) return storage.getIntrospection(config.introspectionHash);
+  return Effect.succeed(null);
+};
+
+/** Introspect a config live or from its stored snapshot, applying connection
+ *  auth. A non-null `introspectionJson` (loaded via `loadIntrospectionJson`)
+ *  short-circuits the network; otherwise this introspects the endpoint with
+ *  the rendered credential. */
 const introspectForConnection = (
   config: GraphqlIntegrationConfig,
+  introspectionJson: string | null,
   values: Record<string, string | null>,
   templateSlug: AuthTemplateSlug | null,
   httpClientLayer: Layer.Layer<HttpClient.HttpClient>,
 ): Effect.Effect<IntrospectionResult, GraphqlIntrospectionError> => {
-  if (config.introspectionJson) {
-    return parseIntrospectionJson(config.introspectionJson);
+  if (introspectionJson != null) {
+    return parseIntrospectionJson(introspectionJson);
   }
   const auth = introspectHeadersForConnection(config, values, templateSlug);
   return introspect(
@@ -463,13 +479,15 @@ const materializeOperations = (
       Object.assign(queryParams, rendered.queryParams);
     }
 
-    const introspection = config.introspectionJson
-      ? yield* parseIntrospectionJson(config.introspectionJson)
-      : yield* introspect(
-          config.endpoint,
-          Object.keys(headers).length > 0 ? headers : undefined,
-          Object.keys(queryParams).length > 0 ? queryParams : undefined,
-        ).pipe(Effect.provide(httpClientLayer));
+    const introspectionJson = yield* loadIntrospectionJson(ctx.storage, config);
+    const introspection =
+      introspectionJson != null
+        ? yield* parseIntrospectionJson(introspectionJson)
+        : yield* introspect(
+            config.endpoint,
+            Object.keys(headers).length > 0 ? headers : undefined,
+            Object.keys(queryParams).length > 0 ? queryParams : undefined,
+          ).pipe(Effect.provide(httpClientLayer));
 
     const { result } = yield* extract(introspection).pipe(
       Effect.catch(() =>
@@ -577,55 +595,68 @@ const makeGraphqlExtension = (ctx: PluginCtx<GraphqlStore>) => {
     });
 
   const addIntegrationTransaction = (input: GraphqlAddIntegrationInput, slug: IntegrationSlug) =>
-    ctx.transaction(
-      Effect.gen(function* () {
-        const baseConfig = buildConfig(input);
+    Effect.gen(function* () {
+      const baseConfig = buildConfig(input);
 
-        // No pre-supplied schema → register WITHOUT introspecting. Tools (and
-        // their operation bindings) are produced lazily when a connection is
-        // created (`resolveTools`) / a tool is first invoked (`invokeTool`),
-        // using that connection's credential.
-        if (baseConfig.introspectionJson === undefined) {
-          yield* ctx.core.integrations.register({
+      // No pre-supplied schema → register WITHOUT introspecting. Tools (and
+      // their operation bindings) are produced lazily when a connection is
+      // created (`resolveTools`) / a tool is first invoked (`invokeTool`),
+      // using that connection's credential.
+      if (baseConfig.introspectionJson === undefined) {
+        yield* ctx.transaction(
+          ctx.core.integrations.register({
             slug,
             description: baseConfig.name,
             config: baseConfig,
             canRemove: true,
             canRefresh: true,
+          }),
+        );
+        return { slug: String(slug), name: baseConfig.name, toolCount: 0 };
+      }
+
+      // Pre-supplied introspection JSON: parse it offline (no network) and
+      // persist the operation bindings + snapshot so production stays offline.
+      const introspection = yield* parseIntrospectionJson(baseConfig.introspectionJson);
+      const { result } = yield* extract(introspection);
+      const prepared = prepareOperations(result.fields, introspection);
+
+      // Snapshot the resolved schema so tool production never needs a live
+      // HTTP layer (D6: tools are spec-derived and identical per connection).
+      // The snapshot text goes to the plugin blob store (content-addressed,
+      // written OUTSIDE the transaction — re-puts are idempotent and an
+      // aborted register leaves only an unreferenced blob), and the config
+      // carries only its hash.
+      const snapshotJson = JSON.stringify({ data: introspection });
+      const introspectionHash = yield* sha256Hex(snapshotJson);
+      const { introspectionJson: _inline, ...withoutInline } = baseConfig;
+      const config = GraphqlIntegrationConfig.make({
+        ...withoutInline,
+        introspectionHash,
+      });
+
+      yield* ctx.storage.putIntrospection(introspectionHash, snapshotJson);
+
+      yield* ctx.transaction(
+        Effect.gen(function* () {
+          yield* ctx.storage.replaceOperations(String(slug), toStoredOperations(slug, prepared));
+
+          yield* ctx.core.integrations.register({
+            slug,
+            description: config.name,
+            config,
+            canRemove: true,
+            canRefresh: true,
           });
-          return { slug: String(slug), name: baseConfig.name, toolCount: 0 };
-        }
+        }),
+      );
 
-        // Pre-supplied introspection JSON: parse it offline (no network) and
-        // persist the operation bindings + snapshot so production stays offline.
-        const introspection = yield* parseIntrospectionJson(baseConfig.introspectionJson);
-        const { result } = yield* extract(introspection);
-        const prepared = prepareOperations(result.fields, introspection);
-
-        // Snapshot the resolved schema so tool production never needs a live
-        // HTTP layer (D6: tools are spec-derived and identical per connection).
-        const config = GraphqlIntegrationConfig.make({
-          ...baseConfig,
-          introspectionJson: JSON.stringify({ data: introspection }),
-        });
-
-        yield* ctx.storage.replaceOperations(String(slug), toStoredOperations(slug, prepared));
-
-        yield* ctx.core.integrations.register({
-          slug,
-          description: config.name,
-          config,
-          canRemove: true,
-          canRefresh: true,
-        });
-
-        return {
-          slug: String(slug),
-          name: config.name,
-          toolCount: prepared.length,
-        };
-      }),
-    );
+      return {
+        slug: String(slug),
+        name: config.name,
+        toolCount: prepared.length,
+      };
+    });
 
   const configureIntegration = (slug: string, input: GraphqlConfigureInput) =>
     Effect.gen(function* () {
@@ -648,6 +679,9 @@ const makeGraphqlExtension = (ctx: PluginCtx<GraphqlStore>) => {
         name: input.name?.trim() || current.name,
         ...(current.introspectionJson !== undefined
           ? { introspectionJson: current.introspectionJson }
+          : {}),
+        ...(current.introspectionHash !== undefined
+          ? { introspectionHash: current.introspectionHash }
           : {}),
         ...((input.headers ?? current.headers) !== undefined
           ? { headers: input.headers ?? current.headers }
@@ -852,26 +886,30 @@ export const graphqlPlugin = definePlugin((options?: GraphqlPluginOptions) => {
     resolveTools: ({
       config,
       template,
+      storage,
       getValues,
     }: {
       readonly config: IntegrationConfig;
       readonly template: AuthTemplateSlug | null;
+      readonly storage: GraphqlStore;
       readonly getValues: () => Effect.Effect<Record<string, string | null>, unknown>;
     }) =>
       Effect.gen(function* () {
         const decoded = yield* decodeGraphqlIntegrationConfig(config).pipe(Effect.option);
         if (Option.isNone(decoded)) return { tools: [] };
         const graphqlConfig = decoded.value;
+        const introspectionJson = yield* loadIntrospectionJson(storage, graphqlConfig);
         // Live introspection (no stored snapshot) needs the connection's
         // credential inputs for auth-required endpoints; resolve them lazily.
         const values =
-          graphqlConfig.introspectionJson === undefined
+          introspectionJson == null
             ? yield* getValues().pipe(
                 Effect.catch(() => Effect.succeed({} as Record<string, string | null>)),
               )
             : ({} as Record<string, string | null>);
         const introspection = yield* introspectForConnection(
           graphqlConfig,
+          introspectionJson,
           values,
           template,
           options?.httpClientLayer ?? httpClientLayerFallback,

--- a/packages/plugins/graphql/src/sdk/store.ts
+++ b/packages/plugins/graphql/src/sdk/store.ts
@@ -71,6 +71,12 @@ const rowToOperation = (row: PluginStorageEntry): StoredOperation | null => {
   };
 };
 
+/** Blob key for an introspection snapshot's content hash. Content-addressed
+ *  so re-puts are idempotent and identical schemas share one blob per
+ *  partition. */
+export const introspectionBlobKey = (introspectionHash: string): string =>
+  `introspection/${introspectionHash}`;
+
 export interface GraphqlStore {
   /** Replace the stored operation bindings for an integration. */
   readonly replaceOperations: (
@@ -85,9 +91,20 @@ export interface GraphqlStore {
     integration: string,
   ) => Effect.Effect<readonly StoredOperation[], StorageFailure>;
   readonly removeOperations: (integration: string) => Effect.Effect<void, StorageFailure>;
+  /** Persist an introspection JSON snapshot under its content hash. Org-owned
+   *  and content-addressed; never removed on integration removal because
+   *  another integration in the tenant may share the hash. */
+  readonly putIntrospection: (
+    introspectionHash: string,
+    introspectionJson: string,
+  ) => Effect.Effect<void, StorageFailure>;
+  /** Load an introspection snapshot by content hash; null when absent. */
+  readonly getIntrospection: (
+    introspectionHash: string,
+  ) => Effect.Effect<string | null, StorageFailure>;
 }
 
-export const makeDefaultGraphqlStore = ({ pluginStorage }: StorageDeps): GraphqlStore => {
+export const makeDefaultGraphqlStore = ({ pluginStorage, blobs }: StorageDeps): GraphqlStore => {
   const listOperationRows = (integration: string) =>
     pluginStorage
       .list({
@@ -137,5 +154,12 @@ export const makeDefaultGraphqlStore = ({ pluginStorage }: StorageDeps): Graphql
       ),
 
     removeOperations,
+
+    putIntrospection: (introspectionHash, introspectionJson) =>
+      blobs.put(introspectionBlobKey(introspectionHash), introspectionJson, {
+        owner: CATALOG_OWNER,
+      }),
+
+    getIntrospection: (introspectionHash) => blobs.get(introspectionBlobKey(introspectionHash)),
   };
 };

--- a/packages/plugins/graphql/src/sdk/types.ts
+++ b/packages/plugins/graphql/src/sdk/types.ts
@@ -172,9 +172,13 @@ export const GraphqlIntegrationConfig = Schema.Struct({
   endpoint: Schema.String,
   /** Display name for the integration. */
   name: Schema.String,
-  /** Optional introspection JSON text (when the endpoint doesn't support
-   *  live introspection). */
+  /** Inlined introspection JSON text. Legacy rows only: new snapshots live in
+   *  the plugin blob store and the config carries `introspectionHash` instead,
+   *  so a multi-MB schema never rides along on catalog reads. */
   introspectionJson: Schema.optional(Schema.String),
+  /** Hex SHA-256 of the introspection JSON snapshot — the content address of
+   *  the blob (`introspection/<hash>` in the plugin blob store). */
+  introspectionHash: Schema.optional(Schema.String),
   /** Static headers applied to every request (and to add-time introspection). */
   headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   /** Static query parameters applied to every request. */

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -100,11 +100,12 @@ const IntegrationView = Schema.Struct({
   canRefresh: Schema.Boolean,
 });
 
-// The full opaque integration config, surfaced for the configure UX. Unlike
+// The integration config surfaced for the configure UX. Unlike
 // `IntegrationView` (catalog identity only), this carries the
-// `authenticationTemplate` the configure flow reads/writes.
+// `authenticationTemplate` the configure flow reads/writes. The spec text is
+// deliberately NOT served: it's a multi-MB build artifact in the plugin blob
+// store, and no client reads it (the configure UI only touches the template).
 const OpenApiConfigView = Schema.Struct({
-  spec: Schema.String,
   sourceUrl: Schema.optional(Schema.String),
   googleDiscoveryUrls: Schema.optional(Schema.Array(Schema.String)),
   baseUrl: Schema.optional(Schema.String),

--- a/packages/plugins/openapi/src/api/handlers.ts
+++ b/packages/plugins/openapi/src/api/handlers.ts
@@ -87,7 +87,6 @@ export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "ope
           const config = yield* ext.getConfig(params.slug);
           return config
             ? {
-                spec: config.spec,
                 sourceUrl: config.sourceUrl,
                 googleDiscoveryUrls: config.googleDiscoveryUrls
                   ? [...config.googleDiscoveryUrls]

--- a/packages/plugins/openapi/src/sdk/config.ts
+++ b/packages/plugins/openapi/src/sdk/config.ts
@@ -15,9 +15,13 @@ import type { Authentication } from "./types";
 //
 // In v2 there are NO credential bindings, NO per-source secret slots, and NO
 // StoredSource credential config. The config carries only:
-//   - the OpenAPI spec text (inlined) OR the source URL to (re)fetch from,
+//   - the content hash of the spec blob (legacy rows inline the text instead)
+//     and/or the source URL to (re)fetch from,
 //   - the optional base URL override,
 //   - the auth templates a connection's value is rendered through.
+// The resolved spec text itself lives in the plugin blob store, keyed
+// `spec/<specHash>` — it's a build input for resolveTools/refresh, not data
+// any list/invoke path should pay to load.
 // ---------------------------------------------------------------------------
 
 const OAuthAuthenticationSchema = Schema.Struct({
@@ -31,8 +35,13 @@ const OAuthAuthenticationSchema = Schema.Struct({
 export const AuthenticationSchema = Schema.Union([OAuthAuthenticationSchema, ApiKeyAuthMethod]);
 
 export const OpenApiIntegrationConfigSchema = Schema.Struct({
-  /** Inlined OpenAPI document text (resolved + parsed source of truth). */
-  spec: Schema.String,
+  /** Inlined OpenAPI document text. Legacy rows only: new registrations store
+   *  the resolved text in the plugin blob store and carry `specHash` instead,
+   *  so multi-MB documents never ride along on catalog reads. */
+  spec: Schema.optional(Schema.String),
+  /** Hex SHA-256 of the resolved spec text — the content address of the spec
+   *  blob (`spec/<hash>` in the plugin blob store). */
+  specHash: Schema.optional(Schema.String),
   /** Origin URL the spec was fetched from, when known. Enables refresh. */
   sourceUrl: Schema.optional(Schema.String),
   /** Google Discovery bundle URLs, when the spec came from a Google bundle. */

--- a/packages/plugins/openapi/src/sdk/migrate-config.ts
+++ b/packages/plugins/openapi/src/sdk/migrate-config.ts
@@ -54,7 +54,7 @@ const migrateEntry = (entry: unknown): unknown | null => {
  *  canonical, no auth templates, or not this plugin's shape). Idempotent. */
 export const migrateOpenApiAuthConfig = (config: unknown): unknown | null => {
   if (typeof config !== "object" || config === null) return null;
-  if (!("spec" in config)) return null;
+  if (!("spec" in config) && !("specHash" in config)) return null;
   if (!("authenticationTemplate" in config)) return null;
 
   const entries = (config as { authenticationTemplate: unknown }).authenticationTemplate;

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -11,6 +11,7 @@ import {
   authToolFailure,
   definePlugin,
   mergeAuthTemplates,
+  sha256Hex,
   tool,
   type AuthMethodDescriptor,
   type Integration,
@@ -553,6 +554,22 @@ export const describeOpenApiIntegrationDisplay = (
 };
 
 // ---------------------------------------------------------------------------
+// Spec text resolution — the stored config carries the spec's content hash
+// (`specHash` → blob `spec/<hash>`); legacy rows still inline the text in
+// `spec`. Every reader goes through this loader so both shapes work until the
+// inline rows are backfilled.
+// ---------------------------------------------------------------------------
+
+const loadSpecText = (
+  storage: OpenapiStore,
+  config: OpenApiIntegrationConfig,
+): Effect.Effect<string | null, StorageFailure> => {
+  if (config.spec != null) return Effect.succeed(config.spec);
+  if (config.specHash != null) return storage.getSpec(config.specHash);
+  return Effect.succeed(null);
+};
+
+// ---------------------------------------------------------------------------
 // Spec → tool definitions (shared by addSpec, resolveTools, and detect)
 // ---------------------------------------------------------------------------
 
@@ -721,8 +738,10 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
             return yield* new IntegrationAlreadyExistsError({ slug });
           }
 
+          const specHash = yield* sha256Hex(resolved.specText);
+
           const integrationConfig: OpenApiIntegrationConfig = {
-            spec: resolved.specText,
+            specHash,
             ...(specInputToSourceUrl(config.spec) !== undefined
               ? { sourceUrl: specInputToSourceUrl(config.spec) }
               : {}),
@@ -745,6 +764,12 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
                 ? { authenticationTemplate: resolved.authenticationTemplate }
                 : {}),
           };
+
+          // The spec blob is written OUTSIDE the transaction: it's
+          // content-addressed (re-puts are idempotent) and an aborted register
+          // leaves only an unreferenced blob behind — while blob backends like
+          // R2 couldn't roll back with the transaction anyway.
+          yield* ctx.storage.putSpec(specHash, resolved.specText);
 
           yield* ctx.transaction(
             Effect.gen(function* () {
@@ -936,17 +961,22 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
     // Produce one tool per spec operation. Spec-derived, identical for every
     // connection on the integration — so `getValue` is never called here. The
     // operation bindings invokeTool needs are persisted at addSpec time; this
-    // hook only shapes the per-connection ToolDefs from the catalog config.
+    // hook only shapes the per-connection ToolDefs from the spec blob the
+    // catalog config points at.
     resolveTools: ({
       config,
+      storage,
     }: {
       readonly integration: Integration;
       readonly config: IntegrationConfig;
+      readonly storage: OpenapiStore;
     }): Effect.Effect<ResolveToolsResult, StorageFailure> =>
       Effect.gen(function* () {
         const openApiConfig = decodeOpenApiIntegrationConfig(config);
         if (!openApiConfig) return { tools: [], definitions: {} };
-        const compiled = yield* compileSpec(openApiConfig.spec).pipe(
+        const specText = yield* loadSpecText(storage, openApiConfig);
+        if (specText == null) return { tools: [], definitions: {} };
+        const compiled = yield* compileSpec(specText).pipe(
           Effect.catch(() => Effect.succeed(null)),
         );
         if (!compiled) return { tools: [], definitions: {} };
@@ -973,13 +1003,18 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         const config = decodeOpenApiIntegrationConfig(credential.config);
 
         // Resolve the operation binding from the plugin store; fall back to
-        // deriving it from the catalog spec when the store has no row (e.g. an
-        // integration registered without going through addSpec).
+        // re-deriving it from the spec blob when the store has no row (e.g. an
+        // integration registered without going through addSpec). The fallback
+        // is the ONLY invoke-path spec read — the hot path never loads it.
         let binding = (yield* invokeCtx.storage.getOperation(integration, toolRow.name))?.binding;
         if (!binding && config) {
-          const compiled = yield* compileSpec(config.spec).pipe(
+          const specText = yield* loadSpecText(invokeCtx.storage, config).pipe(
             Effect.catch(() => Effect.succeed(null)),
           );
+          const compiled =
+            specText == null
+              ? null
+              : yield* compileSpec(specText).pipe(Effect.catch(() => Effect.succeed(null)));
           binding = compiled
             ? storedOperationsFromCompiled(integration, compiled).find(
                 (op) => op.toolName === toolRow.name,

--- a/packages/plugins/openapi/src/sdk/spec-blob.test.ts
+++ b/packages/plugins/openapi/src/sdk/spec-blob.test.ts
@@ -1,0 +1,188 @@
+// ---------------------------------------------------------------------------
+// OpenAPI plugin — spec-in-blob storage coverage.
+//
+// The resolved spec text must live in the plugin blob store (content-addressed
+// `spec/<sha256>`), NOT inline in `integration.config`: the catalog row rides
+// along on every integrations list, so a multi-MB inline spec turns a
+// metadata read into a bulk transfer. These tests pin:
+//   - addSpec stores a pointer config (`specHash`, no inline `spec`) and the
+//     blob round-trips through the store,
+//   - the e2e path (addSpec → connection → invoke) works off the blob,
+//   - legacy rows that still inline `spec` resolve tools unchanged,
+//   - remove + re-add of the same spec is idempotent over the shared blob.
+// ---------------------------------------------------------------------------
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Schema } from "effect";
+import { FetchHttpClient, HttpServerRequest } from "effect/unstable/http";
+import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
+
+import {
+  createExecutor,
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ToolAddress,
+  sha256Hex,
+  type IntegrationConfig,
+} from "@executor-js/sdk";
+import { makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+import { variable } from "@executor-js/sdk/http-auth";
+
+import { openApiPlugin } from "./plugin";
+import type { OpenapiStore } from "./store";
+import type { AuthenticationInput } from "./types";
+import {
+  makeOpenApiHttpApiTestSourceConfig,
+  serveOpenApiHttpApiTestServer,
+  unwrapInvocation,
+} from "../testing";
+
+const testPlugins = (httpClientLayer = FetchHttpClient.layer) =>
+  [openApiPlugin({ httpClientLayer }), memoryCredentialsPlugin()] as const;
+
+const EchoHeaders = Schema.Struct({
+  "x-api-key": Schema.optional(Schema.String),
+});
+
+const EchoGroup = HttpApiGroup.make("items").add(
+  HttpApiEndpoint.get("echoHeaders", "/echo-headers", { success: EchoHeaders }),
+);
+const TestApi = HttpApi.make("testApi").add(EchoGroup);
+
+const EchoGroupLive = HttpApiBuilder.group(TestApi, "items", (handlers) =>
+  handlers.handle("echoHeaders", () =>
+    Effect.gen(function* () {
+      const req = yield* HttpServerRequest.HttpServerRequest;
+      return EchoHeaders.make({ "x-api-key": req.headers["x-api-key"] });
+    }),
+  ),
+);
+
+const specText = () => {
+  const spec = makeOpenApiHttpApiTestSourceConfig(TestApi, {}).spec;
+  if (spec.kind === "blob") return spec.value;
+  if (spec.kind === "googleDiscoveryBundle") return spec.urls[0] ?? "";
+  return spec.url;
+};
+
+const apiKeyTemplate: AuthenticationInput = {
+  slug: AuthTemplateSlug.make("apiKey"),
+  type: "apiKey",
+  headers: { "x-api-key": [variable("token")] },
+};
+
+describe("OpenAPI plugin — spec blob storage", () => {
+  it.effect("addSpec stores a content pointer, not the inline spec text", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+        const text = specText();
+
+        yield* executor.openapi.addSpec({
+          spec: { kind: "blob", value: text },
+          slug: "blob_api",
+        });
+
+        const config = yield* executor.openapi.getConfig("blob_api");
+        expect(config?.spec).toBeUndefined();
+        expect(config?.specHash).toBe(yield* sha256Hex(text));
+      }),
+    ),
+  );
+
+  it.effect("invokes a tool end-to-end off the blob-backed spec", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOpenApiHttpApiTestServer({
+          api: TestApi,
+          handlersLayer: EchoGroupLive,
+        });
+        const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+        yield* executor.openapi.addSpec({
+          spec: { kind: "blob", value: server.specJson },
+          slug: "blob_invoke",
+          baseUrl: server.baseUrl,
+          authenticationTemplate: [apiKeyTemplate],
+        });
+        yield* executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("main"),
+          integration: IntegrationSlug.make("blob_invoke"),
+          template: AuthTemplateSlug.make("apiKey"),
+          value: "secret-key-123",
+        });
+
+        const result = unwrapInvocation(
+          yield* executor.execute(
+            ToolAddress.make("tools.blob_invoke.org.main.items.echoHeaders"),
+            {},
+          ),
+        ).data as { "x-api-key"?: string };
+
+        expect(result["x-api-key"]).toBe("secret-key-123");
+      }),
+    ),
+  );
+
+  it.effect("resolveTools still derives tools from a legacy inline-spec config", () =>
+    Effect.gen(function* () {
+      const plugin = openApiPlugin({ httpClientLayer: FetchHttpClient.layer });
+      // A legacy row inlines the spec; the loader must never touch the store.
+      const storage: OpenapiStore = {
+        putOperations: () => Effect.void,
+        getOperation: () => Effect.succeed(null),
+        listOperations: () => Effect.succeed([]),
+        removeOperations: () => Effect.void,
+        putSpec: () => Effect.void,
+        getSpec: () => Effect.succeed(null),
+      };
+
+      const result = yield* plugin.resolveTools!({
+        integration: {
+          slug: IntegrationSlug.make("legacy_api"),
+          description: "legacy",
+          kind: "openapi",
+          canRemove: true,
+          canRefresh: false,
+          authMethods: [],
+        },
+        config: { spec: specText() } as IntegrationConfig,
+        connection: {
+          owner: "org",
+          integration: IntegrationSlug.make("legacy_api"),
+          name: ConnectionName.make("main"),
+        },
+        template: null,
+        storage,
+        getValue: () => Effect.succeed(null),
+        getValues: () => Effect.succeed({}),
+      });
+
+      expect(result.tools.map((tool) => String(tool.name))).toContain("items.echoHeaders");
+    }),
+  );
+
+  it.effect("remove + re-add of the same spec is idempotent over the shared blob", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+        const text = specText();
+
+        yield* executor.openapi.addSpec({ spec: { kind: "blob", value: text }, slug: "re_add" });
+        yield* executor.openapi.removeSpec("re_add");
+        // The blob deliberately survives removal (another integration may share
+        // the hash); re-adding must re-point at it without conflict.
+        const second = yield* executor.openapi.addSpec({
+          spec: { kind: "blob", value: text },
+          slug: "re_add",
+        });
+
+        expect(second.toolCount).toBeGreaterThan(0);
+        const config = yield* executor.openapi.getConfig("re_add");
+        expect(config?.specHash).toBe(yield* sha256Hex(text));
+      }),
+    ),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -9,8 +9,10 @@ import {
 import { OperationBinding } from "./types";
 
 // ---------------------------------------------------------------------------
-// OpenAPI plugin store (v2). The catalog row (integration.config) owns the spec
-// + auth templates; this store keeps only the per-operation invocation bindings
+// OpenAPI plugin store (v2). The catalog row (integration.config) owns the
+// auth templates plus the spec's content hash; the resolved spec text itself
+// lives in the plugin blob store under `spec/<hash>` (it's multi-MB and only
+// a build input). This store keeps the per-operation invocation bindings
 // (method / path / params), keyed by integration slug, so `invokeTool` can map
 // a tool name back to its HTTP operation without re-parsing the spec on every
 // call. There are NO credential bindings, slots, or StoredSource credential
@@ -64,6 +66,10 @@ const rowToOperation = (row: PluginStorageEntry): StoredOperation | null => {
 const operationKey = (integration: string, toolName: string): string =>
   `${integration}.${toolName}`;
 
+/** Blob key for a spec's content hash. Content-addressed so re-puts are
+ *  idempotent and identical specs share one blob per partition. */
+export const specBlobKey = (specHash: string): string => `spec/${specHash}`;
+
 export interface OpenapiStore {
   /** Replace all stored operations for an integration. */
   readonly putOperations: (
@@ -81,9 +87,15 @@ export interface OpenapiStore {
   ) => Effect.Effect<readonly StoredOperation[], StorageFailure>;
   /** Drop all stored operations for an integration. */
   readonly removeOperations: (integration: string) => Effect.Effect<void, StorageFailure>;
+  /** Persist resolved spec text under its content hash. Org-owned and
+   *  content-addressed; never removed on integration removal because another
+   *  integration in the tenant may share the hash. */
+  readonly putSpec: (specHash: string, specText: string) => Effect.Effect<void, StorageFailure>;
+  /** Load spec text by content hash; null when no blob exists. */
+  readonly getSpec: (specHash: string) => Effect.Effect<string | null, StorageFailure>;
 }
 
-export const makeDefaultOpenapiStore = ({ pluginStorage }: StorageDeps): OpenapiStore => {
+export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): OpenapiStore => {
   const operationData = (operation: StoredOperation) => ({
     integration: operation.integration,
     toolName: operation.toolName,
@@ -133,5 +145,10 @@ export const makeDefaultOpenapiStore = ({ pluginStorage }: StorageDeps): Openapi
       ),
 
     removeOperations,
+
+    putSpec: (specHash, specText) =>
+      blobs.put(specBlobKey(specHash), specText, { owner: STORE_OWNER }),
+
+    getSpec: (specHash) => blobs.get(specBlobKey(specHash)),
   };
 };


### PR DESCRIPTION
## What

`integration.config` inlined the full resolved OpenAPI spec text (and any GraphQL introspection snapshot). Every integrations list loaded those multi-MB blobs and immediately discarded them after projecting auth methods and a display URL: the worst case paid tens of MB per list call, and `GET /api/integrations` p95 ran ~8s with ~97% of slow traces inside the single `integration.findMany` span.

The resolved text now lives in the plugin blob store, content-addressed and org-owned:

- openapi: blob `spec/<sha256>`, config carries `specHash`
- graphql: blob `introspection/<sha256>`, config carries `introspectionHash`

Day-to-day paths touch only the small relational rows. Invoke still runs off the stored operation bindings; its store-miss fallback (the only invoke-path spec read) recompiles from the blob. The spec is loaded solely at import/refresh, which is the only place it's a real input.

## Contract changes

- `ResolveToolsInput` now carries the plugin's typed `storage` (the same instance the extension ctx sees). The hook previously had no way to reach plugin storage, and it's where the spec must be loaded. Existing plugins that don't use it are unaffected — their narrower handler signatures remain assignable.
- The openapi `getConfig` endpoint no longer serves the spec text. No client read it (the configure UI only touches `authenticationTemplate`), and it shipped megabytes per request.

## Compatibility

- Legacy rows that still inline `spec` / `introspectionJson` decode and resolve unchanged through a shared loader; the follow-up backfill PR rewrites them.
- Blob writes happen outside transactions (object-store backends can't roll back); content addressing makes re-puts idempotent and orphans harmless.
- Blobs are never deleted on integration removal — another integration in the tenant may share the hash, and remove + re-add of the same spec re-points at the existing blob.

## Testing

- New `spec-blob.test.ts`: pointer-shaped config after addSpec, end-to-end invoke off the blob-backed spec, legacy inline-spec resolution, remove/re-add idempotence.
- Full gates: format, lint, typecheck, full test suite.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #958
2. **#959** 👈 current
3. #960
<!-- stack:links:end -->