### PR TITLE
Developer-session e2e: chat-theater recordings, focus timeline, one-mp4 films

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -133,3 +133,32 @@ When handing results to the user, follow the evidence contract in the root
   values, not booleans — `expect(list).toContain(x)`, never
   `expect(list.includes(x)).toBe(true)` — so failures show the data.
 - Keep it deterministic: no sleeps; wait on conditions.
+
+## Developer-session recordings (chat theater + desk)
+
+Some scenarios are meant to be WATCHED — they show the product the way a
+developer actually uses it. Three tiers, pick deliberately:
+
+1. **Chat theater** (`src/clients/chat-theater.ts`): the default for
+   product-flow recordings. The "agent" is a chat renderer in a recorded
+   PTY; every tool spinner brackets a REAL mcporter MCP call (OAuth,
+   execute, approval resume). No inference, no third-party binary.
+   Exemplar: `scenarios/connect-handoff-session.test.ts`. Artifacts:
+   `terminal.cast` (the chat) + `session.mp4` (browser hops); the viewer
+   plays them in story order.
+2. **Replay brain + real client** (`src/clients/replay-brain.ts`): when the
+   third-party CLIENT's behavior is under test (OpenCode/Claude Code
+   protocol handling). A scripted OpenAI-wire server plays the LLM; the
+   real client does everything else. Script by transcript inspection, never
+   turn counting.
+3. **Real-inference evals**: a different axis (performance distributions,
+   not pass/fail). Not in this suite.
+
+**The Desk** (`desk/`): films a scenario on one virtual Linux desktop — the
+chat renderer in a visible xterm, the browser as a real headed window, one
+ffmpeg x11grab. The film replaces session.mp4 in the run dir; the scenario
+file is unchanged (chat-theater switches transports on `E2E_DESK=1`).
+
+```
+e2e/desk/run.sh [scenario] [project]   # docker; first run builds + installs
+```

--- a/e2e/desk/Dockerfile
+++ b/e2e/desk/Dockerfile
@@ -1,0 +1,27 @@
+# The Desk: a virtual Linux desktop that e2e scenarios are FILMED on — one
+# Xvfb display showing a real terminal window (the chat) and a real headed
+# Chromium (the browser hop), captured by a single ffmpeg x11grab into one
+# session.mp4. No splicing: the film is the screen.
+#
+# The repo is bind-mounted at /repo at runtime; node_modules and caches live
+# in named volumes (host artifacts are macOS-native and can't be reused).
+FROM node:22-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb openbox xterm ffmpeg xdotool x11-utils x11-xserver-utils \
+    fonts-dejavu-core fonts-noto-color-emoji \
+    curl unzip ca-certificates git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Bun — the repo's package manager and script runner.
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13" \
+  && ln -s /root/.bun/bin/bun /usr/local/bin/bun \
+  && ln -s /root/.bun/bin/bun /usr/local/bin/bunx
+
+# Chromium + system deps baked into the image, pinned to the repo's
+# playwright version so the runtime install check is a no-op.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN npx -y playwright@1.60.0 install --with-deps chromium && rm -rf /root/.npm
+
+WORKDIR /repo
+ENTRYPOINT ["bash", "e2e/desk/entry.sh"]

--- a/e2e/desk/entry.sh
+++ b/e2e/desk/entry.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Desk entrypoint (runs inside the desk image): boot a display, roll one
+# camera on it, run the scenario with E2E_DESK=1 so its windows land on the
+# display, then drop the film into the scenario's run dir as session.mp4.
+set -euo pipefail
+
+SCENARIO="${DESK_SCENARIO:-scenarios/connect-handoff-session.test.ts}"
+PROJECT="${DESK_PROJECT:-cloud}"
+SIZE="${DESK_SIZE:-1440x900}"
+
+echo "[desk] installing dependencies (cached in a volume after first run)…"
+bun install --frozen-lockfile
+
+echo "[desk] display :99 at ${SIZE}"
+Xvfb :99 -screen 0 "${SIZE}x24" -nolisten tcp &
+export DISPLAY=:99
+sleep 0.5
+openbox &
+xsetroot -solid "#0b0b10" || true
+
+mkdir -p /desk-out
+echo "[desk] camera rolling"
+ffmpeg -loglevel error -f x11grab -framerate 24 -video_size "$SIZE" -i :99 \
+  -c:v libx264 -preset veryfast -crf 24 -pix_fmt yuv420p -y /desk-out/desk.mp4 &
+FFMPEG_PID=$!
+
+set +e
+(cd e2e && E2E_DESK=1 npx vitest run --project "$PROJECT" "$SCENARIO")
+STATUS=$?
+set -e
+
+sleep 1
+kill -INT "$FFMPEG_PID" 2>/dev/null || true
+wait "$FFMPEG_PID" 2>/dev/null || true
+
+# The desk film IS the session recording — it replaces the browser-only
+# video the surface recorded inside the run.
+RUN_DIR=$(ls -dt e2e/runs/"$PROJECT"/*/ 2>/dev/null | head -1)
+if [ -n "$RUN_DIR" ] && [ -f /desk-out/desk.mp4 ]; then
+  cp /desk-out/desk.mp4 "${RUN_DIR}session.mp4"
+  echo "[desk] film → ${RUN_DIR}session.mp4"
+fi
+exit "$STATUS"

--- a/e2e/desk/run.sh
+++ b/e2e/desk/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Film a scenario on the Desk (one virtual desktop, one recording).
+#   e2e/desk/run.sh [scenario-path] [project]
+# First run builds the image and fills the node_modules volume; later runs
+# reuse both.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+docker build -t executor-e2e-desk e2e/desk
+
+docker run --rm \
+  -v "$PWD":/repo \
+  -v executor-desk-node-modules:/repo/node_modules \
+  -v executor-desk-bun-cache:/root/.bun/install/cache \
+  -e DESK_SCENARIO="${1:-scenarios/connect-handoff-session.test.ts}" \
+  -e DESK_PROJECT="${2:-cloud}" \
+  executor-e2e-desk

--- a/e2e/scenarios/connect-handoff-session.test.ts
+++ b/e2e/scenarios/connect-handoff-session.test.ts
@@ -110,23 +110,25 @@ scenario(
         { title: "executor agent — connect Resend", record: join(runDir, "terminal.cast") },
         (chat) =>
           Effect.gen(function* () {
-            // Real MCP OAuth + tool discovery happens behind this spinner.
-            yield* chat.tool("mcp · authorize and list tools", session.listTools());
+            // Real MCP OAuth + tool discovery happens behind this call.
+            yield* chat.tool(
+              { name: "executor (mcp)", result: (tools) => `${tools.length} tools available` },
+              session.listTools(),
+            );
 
             yield* chat.user(
               "Add the Resend API to my executor and give me a link to connect my account",
             );
             yield* chat.assistant("I'll register the Resend API in your Executor now.");
             const added = yield* chat.tool(
-              "executor.execute · openapi.addSpec(resend)",
+              { name: "execute", input: addSpecCode(integration) },
               executeJson(session, addSpecCode(integration)),
-              (result) => `${String(result.toolCount)} tools`,
             );
             expect(added.ok, `addSpec succeeded: ${JSON.stringify(added)}`).toBe(true);
 
             yield* chat.assistant("Registered. Creating your connect link…");
             const handoff = yield* chat.tool(
-              "executor.execute · connections.createHandoff",
+              { name: "execute", input: createHandoffCode(integration) },
               executeJson(session, createHandoffCode(integration)),
             );
             expect(handoff.ok, `createHandoff succeeded: ${JSON.stringify(handoff)}`).toBe(true);
@@ -163,9 +165,8 @@ scenario(
             yield* chat.user("Connected, now send a test email to prove it works");
             yield* chat.assistant("Sending a test email through your new connection…");
             const sent = yield* chat.tool(
-              "resend.emails.sendEmail · via the pasted connection",
+              { name: "execute", input: sendEmailCode(integration, emailSubject) },
               executeJson(session, sendEmailCode(integration, emailSubject)),
-              (result) => `path ${String(result.path)}`,
             );
             expect(sent.ok, `email sent through the connection: ${JSON.stringify(sent)}`).toBe(
               true,

--- a/e2e/scenarios/connect-handoff-session.test.ts
+++ b/e2e/scenarios/connect-handoff-session.test.ts
@@ -1,38 +1,25 @@
 // The connect handoff as a DEVELOPER SESSION — the way a human actually
-// tests this: chat with a real agent in a real terminal, the agent wires up
-// the API over MCP and drops a connect link in the chat, you open the link
-// in a browser and paste your key, then come back to the terminal and ask
-// the agent to prove the connection works.
+// tests this: an agent chat in a real terminal where the agent wires up the
+// API over MCP and drops a connect link, a browser hop to paste the key,
+// then back to the chat to prove the connection works with a live send.
 //
-// Replay brain, real hands: the LLM is a scripted local server
-// (clients/replay-brain.ts) so the conversation is deterministic, but
-// EVERYTHING else is real — the installed OpenCode binary renders the TUI,
-// does MCP OAuth against this deployment, executes the brain's tool calls
-// through the real /mcp endpoint, and the pasted key round-trips through the
-// real add-account UI into a connection that hits the real emulated provider
-// (resend.emulators.dev), whose request ledger is the final evidence.
-//
-// The terminal PTY stays open for the WHOLE session (one terminal.cast,
-// one timeline); the browser hop runs concurrently as the "user" and the
-// chat resumes when it's done. A Desk surface can later film both windows
-// as one screen recording without changing this scenario's shape.
-import { spawnSync } from "node:child_process";
+// No inference, no third-party agent binary: the "agent" is the chat
+// theater (src/clients/chat-theater.ts) presenting REAL mcporter MCP calls
+// — OAuth, execute, approval pause/resume all genuine, every tool spinner
+// on screen bracketing the actual call it narrates. The provider on the
+// other side is real too (resend.emulators.dev); its request ledger is the
+// final evidence.
 import { randomBytes } from "node:crypto";
-import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { expect } from "@effect/vitest";
-import { Effect, Exit, Fiber } from "effect";
+import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
-import { Browser, Cli, Mcp, OpenCode, RunDir, Target } from "../src/services";
-import {
-  serveReplayBrain,
-  type BrainContext,
-  type BrainResponse,
-} from "../src/clients/replay-brain";
+import { Browser, Cli, Mcp, RunDir, Target } from "../src/services";
+import { withChatTheater } from "../src/clients/chat-theater";
+import type { McpSession } from "../src/surfaces/mcp";
 
-const SERVER_NAME = "executor";
 const EMULATOR_BASE = "https://resend.emulators.dev";
 
 const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
@@ -110,85 +97,17 @@ const sent = await t({
 return { ok: sent.ok, path, result: sent.ok ? sent.data : sent.error };
 `;
 
-// Lines the terminal waits for — the brain says them, the PTY assertion
-// reads them off the rendered TUI. Kept short and ASCII so terminal line
-// wrapping and glyph rendering can't break the substring match.
-const SAY_LINK_READY = "Open this link to connect your Resend account";
-const SAY_EMAIL_SENT = "Test email sent";
-
-interface SessionState {
-  handoffUrl: string | undefined;
-  browserDone: boolean;
-  scriptNotes: string[];
-}
-
-/** The scripted side of the conversation, as inspection of the transcript —
- *  no turn counting, so approval-pause detours and OpenCode's side requests
- *  (title generation etc.) don't derail it. */
-const makeBrainScript = (input: {
-  readonly integration: string;
-  readonly emailSubject: string;
-  readonly state: SessionState;
-}) => {
-  const { integration, emailSubject, state } = input;
-  return (ctx: BrainContext): BrainResponse => {
-    // OpenCode's very first request can fire before its MCP tool registry
-    // loads (zero tools offered). Stall politely; it re-asks with tools.
-    if (ctx.toolNames.length === 0) {
-      return { text: "One moment…" };
+/** Run `execute`, auto-approving a paused execution (policy elicitation)
+ *  once, and parse the sandbox's JSON return value. */
+const executeJson = (session: McpSession, code: string) =>
+  Effect.gen(function* () {
+    let result = yield* session.call("execute", { code });
+    if (result.text.includes("executionId:")) {
+      result = yield* session.approvePaused(result.text);
     }
-    // Agent returned a tool result — continue the current job.
-    if (ctx.lastRole === "tool" && ctx.lastToolResult !== undefined) {
-      const result = ctx.lastToolResult;
-
-      // Approval gate: resume whatever paused.
-      const paused = /executionId[":\s]+"?([\w-]+)/.exec(result);
-      if (result.includes("Execution paused") && paused?.[1]) {
-        return {
-          tool: { name: "resume", args: { executionId: paused[1], action: "accept" } },
-        };
-      }
-
-      const handoffUrl = /https?:\/\/[^"\s\\]+\/integrations\/[^"\s\\]+/.exec(result)?.[0];
-      if (handoffUrl) {
-        state.handoffUrl = handoffUrl;
-        return {
-          text: `${SAY_LINK_READY}:\n\n${handoffUrl}\n\nTell me once you've pasted your API key.`,
-        };
-      }
-
-      if (result.includes('"toolCount"')) {
-        return {
-          text: "The Resend API is registered. Creating your connect link…",
-          tool: { name: "execute", args: { code: createHandoffCode(integration) } },
-        };
-      }
-
-      if (result.includes(emailSubject) || /"ok":\s*true/.test(result)) {
-        return { text: `${SAY_EMAIL_SENT} - your Resend connection works.` };
-      }
-
-      state.scriptNotes.push(`unexpected tool result: ${result.slice(0, 300)}`);
-      return { text: "Something unexpected came back — stopping here." };
-    }
-
-    // Fresh human turn.
-    if (/add the resend api/i.test(ctx.lastUser)) {
-      return {
-        text: "I'll register the Resend API in your Executor now.",
-        tool: { name: "execute", args: { code: addSpecCode(integration) } },
-      };
-    }
-    if (/send a test email/i.test(ctx.lastUser)) {
-      return {
-        text: "Sending a test email through your new connection…",
-        tool: { name: "execute", args: { code: sendEmailCode(integration, emailSubject) } },
-      };
-    }
-    // OpenCode side requests (session titles, warm-up pings).
-    return { text: "Connect Resend" };
-  };
-};
+    expect(result.ok, `execute completed (got: ${result.text.slice(0, 400)})`).toBe(true);
+    return JSON.parse(result.text) as Record<string, unknown>;
+  });
 
 const mintEmulatorApiKey = Effect.promise(async () => {
   const response = await fetch(`${EMULATOR_BASE}/_emulate/credentials`, {
@@ -202,17 +121,14 @@ const mintEmulatorApiKey = Effect.promise(async () => {
   return token;
 });
 
-const sleep = (ms: number) => new Promise<void>((tick) => setTimeout(tick, ms));
-
 scenario(
   "Connect · developer session: agent chat → handoff link → paste key → verified send",
-  { timeout: 360_000 },
+  { timeout: 240_000 },
   Effect.scoped(
     Effect.gen(function* () {
       const target = yield* Target;
       const mcp = yield* Mcp;
       const browser = yield* Browser;
-      const opencode = yield* OpenCode;
       const cli = yield* Cli;
       const runDir = yield* RunDir;
 
@@ -220,143 +136,77 @@ scenario(
       const emailSubject = unique("dev-session");
       const apiKey = yield* mintEmulatorApiKey;
       const identity = yield* target.newIdentity();
-      const email = identity.credentials?.email ?? identity.label;
+      const session = mcp.session(identity);
 
-      const state: SessionState = { handoffUrl: undefined, browserDone: false, scriptNotes: [] };
-      const brain = yield* serveReplayBrain(makeBrainScript({ integration, emailSubject, state }));
-      // The conversation transcript is evidence too — written even on failure.
-      yield* Effect.addFinalizer(() =>
-        Effect.sync(() =>
-          writeFileSync(
-            join(runDir, "chat-brain.json"),
-            JSON.stringify(
-              { requests: brain.requests(), errors: brain.errors(), notes: state.scriptNotes },
-              null,
-              2,
-            ),
-          ),
-        ),
-      );
+      yield* withChatTheater(
+        cli,
+        { title: "executor agent — connect Resend", record: join(runDir, "terminal.cast") },
+        (chat) =>
+          Effect.gen(function* () {
+            // Real MCP OAuth + tool discovery happens behind this spinner.
+            yield* chat.tool("mcp · authorize and list tools", session.listTools());
 
-      const home = opencode.makeHome(SERVER_NAME, mcp.url, { chatBrainUrl: brain.baseUrl });
-      yield* Effect.sync(() => opencode.warmUp(home));
-      // Pre-download the openai-compatible provider package off camera, in a
-      // project with the brain but NO MCP (touching /mcp before `mcp auth`
-      // breaks the auth flow — see warmUp).
-      yield* Effect.sync(() => {
-        const warm = join(home.projectDir, "..", "chat-warmup");
-        mkdirSync(warm, { recursive: true });
-        writeFileSync(
-          join(warm, "opencode.json"),
-          JSON.stringify({
-            autoupdate: false,
-            share: "disabled",
-            model: "replay/replay-model",
-            provider: {
-              replay: {
-                name: "Replay",
-                npm: "@ai-sdk/openai-compatible",
-                options: { baseURL: brain.baseUrl, apiKey: "replay-key" },
-                models: { "replay-model": { name: "Replay Model" } },
-              },
-            },
+            yield* chat.user(
+              "Add the Resend API to my executor and give me a link to connect my account",
+            );
+            yield* chat.assistant("I'll register the Resend API in your Executor now.");
+            const added = yield* chat.tool(
+              "executor.execute · openapi.addSpec(resend)",
+              executeJson(session, addSpecCode(integration)),
+              (result) => `${String(result.toolCount)} tool`,
+            );
+            expect(added.ok, `addSpec succeeded: ${JSON.stringify(added)}`).toBe(true);
+
+            yield* chat.assistant("Registered. Creating your connect link…");
+            const handoff = yield* chat.tool(
+              "executor.execute · connections.createHandoff",
+              executeJson(session, createHandoffCode(integration)),
+            );
+            expect(handoff.ok, `createHandoff succeeded: ${JSON.stringify(handoff)}`).toBe(true);
+            const handoffUrl = String(handoff.url);
+            expect(new URL(handoffUrl).origin, "handoff targets this deployment").toBe(
+              new URL(target.baseUrl).origin,
+            );
+
+            yield* chat.assistant(
+              `Open this link to connect your Resend account:\n\n${handoffUrl}\n\nTell me once you've pasted your API key.`,
+            );
+
+            // The browser hop — the terminal session stays open while the
+            // "user" pastes the key; the paste is the real add-account UI.
+            yield* chat.status("you, in the browser: opening the link and pasting the API key…");
+            yield* browser.session(identity, async ({ page, step }) => {
+              await step("Open the connect link from the chat", async () => {
+                await page.goto(handoffUrl, { waitUntil: "networkidle" });
+                await page
+                  .getByRole("heading", { name: /Add connection/ })
+                  .waitFor({ timeout: 15_000 });
+              });
+              await step("Paste the Resend API key and connect", async () => {
+                const credential = page.getByPlaceholder(/paste the value \/ token/i);
+                await credential.waitFor({ timeout: 15_000 });
+                await credential.fill(apiKey);
+                await page.getByRole("button", { name: "Add connection", exact: true }).click();
+                await page
+                  .getByRole("heading", { name: /Add connection/ })
+                  .waitFor({ state: "hidden", timeout: 20_000 });
+              });
+            });
+
+            yield* chat.user("Connected, now send a test email to prove it works");
+            yield* chat.assistant("Sending a test email through your new connection…");
+            const sent = yield* chat.tool(
+              "resend.emails.sendEmail · via the pasted connection",
+              executeJson(session, sendEmailCode(integration, emailSubject)),
+              (result) => `path ${String(result.path)}`,
+            );
+            expect(sent.ok, `email sent through the connection: ${JSON.stringify(sent)}`).toBe(
+              true,
+            );
+
+            yield* chat.assistant("Test email sent - your Resend connection works.");
           }),
-        );
-        spawnSync("opencode", ["run", "-m", "replay/replay-model", "warmup ping"], {
-          cwd: warm,
-          env: home.env,
-          timeout: 120_000,
-        });
-      });
-
-      // The "user at the browser": waits for the agent to produce the link,
-      // opens it, pastes the key — while the terminal session stays open.
-      const browserWork = Effect.gen(function* () {
-        yield* Effect.promise(async () => {
-          const deadline = Date.now() + 240_000;
-          while (state.handoffUrl === undefined) {
-            if (Date.now() > deadline) throw new Error("handoff URL never appeared in chat");
-            await sleep(300);
-          }
-        });
-        yield* browser.session(identity, async ({ page, step }) => {
-          await step("Open the connect link from the chat", async () => {
-            await page.goto(state.handoffUrl ?? "", { waitUntil: "networkidle" });
-            await page
-              .getByRole("heading", { name: /Add connection/ })
-              .waitFor({ timeout: 15_000 });
-          });
-          await step("Paste the Resend API key and connect", async () => {
-            const credential = page.getByPlaceholder(/paste the value \/ token/i);
-            await credential.waitFor({ timeout: 15_000 });
-            await credential.fill(apiKey);
-            await page.getByRole("button", { name: "Add connection", exact: true }).click();
-            await page
-              .getByRole("heading", { name: /Add connection/ })
-              .waitFor({ state: "hidden", timeout: 20_000 });
-          });
-        });
-      });
-      const browserFiber = yield* Effect.forkChild(
-        Effect.gen(function* () {
-          const exit = yield* Effect.exit(browserWork);
-          state.browserDone = true;
-          return exit;
-        }),
       );
-
-      yield* cli.session(
-        ["bash", "--norc"],
-        async (term) => {
-          await term.screen.waitForText("$", { timeoutMs: 10_000 });
-
-          // MCP OAuth on camera, consent played off camera. Wait for the
-          // flow's own completion text — the shell prompt was already on
-          // screen before the command, so it can't gate anything.
-          const consent = opencode.completeOAuthConsent(home, email, home.openedUrls().length);
-          await term.keyboard.type(`opencode mcp auth ${SERVER_NAME}`);
-          await term.keyboard.press("Enter");
-          await consent;
-          await term.screen.waitForText("Authentication successful", { timeoutMs: 60_000 });
-          await sleep(1_500); // let the auth UI finish and the prompt repaint
-
-          // Into the TUI for the conversation.
-          await term.keyboard.type("opencode");
-          await term.keyboard.press("Enter");
-          await term.screen.waitForText("Replay Model", { timeoutMs: 90_000 });
-
-          await term.keyboard.type(
-            "Add the Resend API to my executor and give me a link to connect my account",
-          );
-          await term.keyboard.press("Enter");
-          await term.screen.waitForText(SAY_LINK_READY, { timeoutMs: 180_000 });
-
-          // The human walks over to the browser; the chat waits.
-          const deadline = Date.now() + 180_000;
-          while (!state.browserDone) {
-            if (Date.now() > deadline) throw new Error("browser side never finished");
-            await sleep(300);
-          }
-
-          await sleep(750); // let the TUI settle before the next message
-          await term.keyboard.type("Connected, now send a test email to prove it works");
-          await term.keyboard.press("Enter");
-          await term.screen.waitForText(SAY_EMAIL_SENT, { timeoutMs: 180_000 });
-        },
-        {
-          cwd: home.projectDir,
-          env: { ...home.env, PS1: "$ ", BASH_SILENCE_DEPRECATION_WARNING: "1" },
-          record: join(runDir, "terminal.cast"),
-          viewport: { cols: 100, rows: 40 },
-        },
-      );
-
-      const browserExit = yield* Fiber.join(browserFiber);
-      expect(Exit.isSuccess(browserExit), `browser side succeeded: ${String(browserExit)}`).toBe(
-        true,
-      );
-      expect(brain.errors(), "replay brain script ran clean").toEqual([]);
-      expect(state.scriptNotes, "conversation followed the script").toEqual([]);
 
       // Final evidence: the emulator's ledger saw the send from Executor.
       const ledger = yield* Effect.promise(async () =>

--- a/e2e/scenarios/connect-handoff-session.test.ts
+++ b/e2e/scenarios/connect-handoff-session.test.ts
@@ -1,0 +1,371 @@
+// The connect handoff as a DEVELOPER SESSION — the way a human actually
+// tests this: chat with a real agent in a real terminal, the agent wires up
+// the API over MCP and drops a connect link in the chat, you open the link
+// in a browser and paste your key, then come back to the terminal and ask
+// the agent to prove the connection works.
+//
+// Replay brain, real hands: the LLM is a scripted local server
+// (clients/replay-brain.ts) so the conversation is deterministic, but
+// EVERYTHING else is real — the installed OpenCode binary renders the TUI,
+// does MCP OAuth against this deployment, executes the brain's tool calls
+// through the real /mcp endpoint, and the pasted key round-trips through the
+// real add-account UI into a connection that hits the real emulated provider
+// (resend.emulators.dev), whose request ledger is the final evidence.
+//
+// The terminal PTY stays open for the WHOLE session (one terminal.cast,
+// one timeline); the browser hop runs concurrently as the "user" and the
+// chat resumes when it's done. A Desk surface can later film both windows
+// as one screen recording without changing this scenario's shape.
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { expect } from "@effect/vitest";
+import { Effect, Exit, Fiber } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Cli, Mcp, OpenCode, RunDir, Target } from "../src/services";
+import {
+  serveReplayBrain,
+  type BrainContext,
+  type BrainResponse,
+} from "../src/clients/replay-brain";
+
+const SERVER_NAME = "executor";
+const EMULATOR_BASE = "https://resend.emulators.dev";
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+/** Resend subset spec pointed at the emulator, with an explicit apiKey
+ *  template so the add-account modal renders a paste-a-token flow. */
+const resendSpec = {
+  openapi: "3.0.3",
+  info: { title: "Resend (emulated)", version: "1.0.0" },
+  paths: {
+    "/emails": {
+      post: {
+        operationId: "sendEmail",
+        tags: ["emails"],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  from: { type: "string" },
+                  to: { type: "string" },
+                  subject: { type: "string" },
+                  html: { type: "string" },
+                },
+                required: ["from", "to", "subject"],
+              },
+            },
+          },
+        },
+        responses: { "200": { description: "sent" } },
+      },
+    },
+  },
+} as const;
+
+const addSpecCode = (slug: string) => `
+const added = await tools.executor.openapi.addSpec({
+  spec: { kind: "blob", value: ${JSON.stringify(JSON.stringify(resendSpec))} },
+  slug: ${JSON.stringify(slug)},
+  baseUrl: ${JSON.stringify(EMULATOR_BASE)},
+  authenticationTemplate: [{
+    type: "apiKey",
+    label: "API key",
+    headers: { Authorization: ["Bearer ", { type: "variable", name: "apiKey" }] },
+  }],
+});
+return added.ok ? { ok: true, slug: added.data.slug, toolCount: added.data.toolCount } : { ok: false, error: added.error };
+`;
+
+const createHandoffCode = (slug: string) => `
+const handoff = await tools.executor.coreTools.connections.createHandoff({
+  integration: ${JSON.stringify(slug)},
+  owner: "org",
+  label: "Resend",
+});
+return handoff.ok ? { ok: true, url: handoff.data.url } : { ok: false, error: handoff.error };
+`;
+
+const sendEmailCode = (slug: string, subject: string) => `
+const found = await tools.search({ namespace: ${JSON.stringify(slug)}, query: "send email", limit: 5 });
+const path = found.items[0]?.path;
+if (!path) return { ok: false, error: "no send tool found" };
+let t = tools;
+for (const seg of path.split(".")) t = t[seg];
+const sent = await t({
+  body: {
+    from: "onboarding@example.com",
+    to: "dev-session@example.com",
+    subject: ${JSON.stringify(subject)},
+    html: "<p>connect-handoff developer session</p>",
+  },
+});
+return { ok: sent.ok, path, result: sent.ok ? sent.data : sent.error };
+`;
+
+// Lines the terminal waits for — the brain says them, the PTY assertion
+// reads them off the rendered TUI. Kept short and ASCII so terminal line
+// wrapping and glyph rendering can't break the substring match.
+const SAY_LINK_READY = "Open this link to connect your Resend account";
+const SAY_EMAIL_SENT = "Test email sent";
+
+interface SessionState {
+  handoffUrl: string | undefined;
+  browserDone: boolean;
+  scriptNotes: string[];
+}
+
+/** The scripted side of the conversation, as inspection of the transcript —
+ *  no turn counting, so approval-pause detours and OpenCode's side requests
+ *  (title generation etc.) don't derail it. */
+const makeBrainScript = (input: {
+  readonly integration: string;
+  readonly emailSubject: string;
+  readonly state: SessionState;
+}) => {
+  const { integration, emailSubject, state } = input;
+  return (ctx: BrainContext): BrainResponse => {
+    // OpenCode's very first request can fire before its MCP tool registry
+    // loads (zero tools offered). Stall politely; it re-asks with tools.
+    if (ctx.toolNames.length === 0) {
+      return { text: "One moment…" };
+    }
+    // Agent returned a tool result — continue the current job.
+    if (ctx.lastRole === "tool" && ctx.lastToolResult !== undefined) {
+      const result = ctx.lastToolResult;
+
+      // Approval gate: resume whatever paused.
+      const paused = /executionId[":\s]+"?([\w-]+)/.exec(result);
+      if (result.includes("Execution paused") && paused?.[1]) {
+        return {
+          tool: { name: "resume", args: { executionId: paused[1], action: "accept" } },
+        };
+      }
+
+      const handoffUrl = /https?:\/\/[^"\s\\]+\/integrations\/[^"\s\\]+/.exec(result)?.[0];
+      if (handoffUrl) {
+        state.handoffUrl = handoffUrl;
+        return {
+          text: `${SAY_LINK_READY}:\n\n${handoffUrl}\n\nTell me once you've pasted your API key.`,
+        };
+      }
+
+      if (result.includes('"toolCount"')) {
+        return {
+          text: "The Resend API is registered. Creating your connect link…",
+          tool: { name: "execute", args: { code: createHandoffCode(integration) } },
+        };
+      }
+
+      if (result.includes(emailSubject) || /"ok":\s*true/.test(result)) {
+        return { text: `${SAY_EMAIL_SENT} - your Resend connection works.` };
+      }
+
+      state.scriptNotes.push(`unexpected tool result: ${result.slice(0, 300)}`);
+      return { text: "Something unexpected came back — stopping here." };
+    }
+
+    // Fresh human turn.
+    if (/add the resend api/i.test(ctx.lastUser)) {
+      return {
+        text: "I'll register the Resend API in your Executor now.",
+        tool: { name: "execute", args: { code: addSpecCode(integration) } },
+      };
+    }
+    if (/send a test email/i.test(ctx.lastUser)) {
+      return {
+        text: "Sending a test email through your new connection…",
+        tool: { name: "execute", args: { code: sendEmailCode(integration, emailSubject) } },
+      };
+    }
+    // OpenCode side requests (session titles, warm-up pings).
+    return { text: "Connect Resend" };
+  };
+};
+
+const mintEmulatorApiKey = Effect.promise(async () => {
+  const response = await fetch(`${EMULATOR_BASE}/_emulate/credentials`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ type: "api-key" }),
+  });
+  const body = (await response.json()) as { credential?: { token?: string } };
+  const token = body.credential?.token;
+  if (!token) throw new Error(`emulator credential mint failed: ${JSON.stringify(body)}`);
+  return token;
+});
+
+const sleep = (ms: number) => new Promise<void>((tick) => setTimeout(tick, ms));
+
+scenario(
+  "Connect · developer session: agent chat → handoff link → paste key → verified send",
+  { timeout: 360_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const mcp = yield* Mcp;
+      const browser = yield* Browser;
+      const opencode = yield* OpenCode;
+      const cli = yield* Cli;
+      const runDir = yield* RunDir;
+
+      const integration = unique("resendsesh");
+      const emailSubject = unique("dev-session");
+      const apiKey = yield* mintEmulatorApiKey;
+      const identity = yield* target.newIdentity();
+      const email = identity.credentials?.email ?? identity.label;
+
+      const state: SessionState = { handoffUrl: undefined, browserDone: false, scriptNotes: [] };
+      const brain = yield* serveReplayBrain(makeBrainScript({ integration, emailSubject, state }));
+      // The conversation transcript is evidence too — written even on failure.
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() =>
+          writeFileSync(
+            join(runDir, "chat-brain.json"),
+            JSON.stringify(
+              { requests: brain.requests(), errors: brain.errors(), notes: state.scriptNotes },
+              null,
+              2,
+            ),
+          ),
+        ),
+      );
+
+      const home = opencode.makeHome(SERVER_NAME, mcp.url, { chatBrainUrl: brain.baseUrl });
+      yield* Effect.sync(() => opencode.warmUp(home));
+      // Pre-download the openai-compatible provider package off camera, in a
+      // project with the brain but NO MCP (touching /mcp before `mcp auth`
+      // breaks the auth flow — see warmUp).
+      yield* Effect.sync(() => {
+        const warm = join(home.projectDir, "..", "chat-warmup");
+        mkdirSync(warm, { recursive: true });
+        writeFileSync(
+          join(warm, "opencode.json"),
+          JSON.stringify({
+            autoupdate: false,
+            share: "disabled",
+            model: "replay/replay-model",
+            provider: {
+              replay: {
+                name: "Replay",
+                npm: "@ai-sdk/openai-compatible",
+                options: { baseURL: brain.baseUrl, apiKey: "replay-key" },
+                models: { "replay-model": { name: "Replay Model" } },
+              },
+            },
+          }),
+        );
+        spawnSync("opencode", ["run", "-m", "replay/replay-model", "warmup ping"], {
+          cwd: warm,
+          env: home.env,
+          timeout: 120_000,
+        });
+      });
+
+      // The "user at the browser": waits for the agent to produce the link,
+      // opens it, pastes the key — while the terminal session stays open.
+      const browserWork = Effect.gen(function* () {
+        yield* Effect.promise(async () => {
+          const deadline = Date.now() + 240_000;
+          while (state.handoffUrl === undefined) {
+            if (Date.now() > deadline) throw new Error("handoff URL never appeared in chat");
+            await sleep(300);
+          }
+        });
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the connect link from the chat", async () => {
+            await page.goto(state.handoffUrl ?? "", { waitUntil: "networkidle" });
+            await page
+              .getByRole("heading", { name: /Add connection/ })
+              .waitFor({ timeout: 15_000 });
+          });
+          await step("Paste the Resend API key and connect", async () => {
+            const credential = page.getByPlaceholder(/paste the value \/ token/i);
+            await credential.waitFor({ timeout: 15_000 });
+            await credential.fill(apiKey);
+            await page.getByRole("button", { name: "Add connection", exact: true }).click();
+            await page
+              .getByRole("heading", { name: /Add connection/ })
+              .waitFor({ state: "hidden", timeout: 20_000 });
+          });
+        });
+      });
+      const browserFiber = yield* Effect.forkChild(
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(browserWork);
+          state.browserDone = true;
+          return exit;
+        }),
+      );
+
+      yield* cli.session(
+        ["bash", "--norc"],
+        async (term) => {
+          await term.screen.waitForText("$", { timeoutMs: 10_000 });
+
+          // MCP OAuth on camera, consent played off camera. Wait for the
+          // flow's own completion text — the shell prompt was already on
+          // screen before the command, so it can't gate anything.
+          const consent = opencode.completeOAuthConsent(home, email, home.openedUrls().length);
+          await term.keyboard.type(`opencode mcp auth ${SERVER_NAME}`);
+          await term.keyboard.press("Enter");
+          await consent;
+          await term.screen.waitForText("Authentication successful", { timeoutMs: 60_000 });
+          await sleep(1_500); // let the auth UI finish and the prompt repaint
+
+          // Into the TUI for the conversation.
+          await term.keyboard.type("opencode");
+          await term.keyboard.press("Enter");
+          await term.screen.waitForText("Replay Model", { timeoutMs: 90_000 });
+
+          await term.keyboard.type(
+            "Add the Resend API to my executor and give me a link to connect my account",
+          );
+          await term.keyboard.press("Enter");
+          await term.screen.waitForText(SAY_LINK_READY, { timeoutMs: 180_000 });
+
+          // The human walks over to the browser; the chat waits.
+          const deadline = Date.now() + 180_000;
+          while (!state.browserDone) {
+            if (Date.now() > deadline) throw new Error("browser side never finished");
+            await sleep(300);
+          }
+
+          await sleep(750); // let the TUI settle before the next message
+          await term.keyboard.type("Connected, now send a test email to prove it works");
+          await term.keyboard.press("Enter");
+          await term.screen.waitForText(SAY_EMAIL_SENT, { timeoutMs: 180_000 });
+        },
+        {
+          cwd: home.projectDir,
+          env: { ...home.env, PS1: "$ ", BASH_SILENCE_DEPRECATION_WARNING: "1" },
+          record: join(runDir, "terminal.cast"),
+          viewport: { cols: 100, rows: 40 },
+        },
+      );
+
+      const browserExit = yield* Fiber.join(browserFiber);
+      expect(Exit.isSuccess(browserExit), `browser side succeeded: ${String(browserExit)}`).toBe(
+        true,
+      );
+      expect(brain.errors(), "replay brain script ran clean").toEqual([]);
+      expect(state.scriptNotes, "conversation followed the script").toEqual([]);
+
+      // Final evidence: the emulator's ledger saw the send from Executor.
+      const ledger = yield* Effect.promise(async () =>
+        (await fetch(`${EMULATOR_BASE}/_emulate/ledger`)).text(),
+      );
+      expect(
+        ledger.includes(emailSubject),
+        "the emulator request ledger recorded the test email",
+      ).toBe(true);
+    }),
+  ),
+);

--- a/e2e/scenarios/connect-handoff-session.test.ts
+++ b/e2e/scenarios/connect-handoff-session.test.ts
@@ -24,49 +24,16 @@ const EMULATOR_BASE = "https://resend.emulators.dev";
 
 const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
 
-/** Resend subset spec pointed at the emulator, with an explicit apiKey
- *  template so the add-account modal renders a paste-a-token flow. */
-const resendSpec = {
-  openapi: "3.0.3",
-  info: { title: "Resend (emulated)", version: "1.0.0" },
-  paths: {
-    "/emails": {
-      post: {
-        operationId: "sendEmail",
-        tags: ["emails"],
-        requestBody: {
-          required: true,
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  from: { type: "string" },
-                  to: { type: "string" },
-                  subject: { type: "string" },
-                  html: { type: "string" },
-                },
-                required: ["from", "to", "subject"],
-              },
-            },
-          },
-        },
-        responses: { "200": { description: "sent" } },
-      },
-    },
-  },
-} as const;
+// The emulator serves its own OpenAPI document (bearer auth, base URL in
+// `servers`) — adding by URL with nothing else is exactly what an agent
+// does, and the platform derives the paste-a-token auth method from the
+// spec's security scheme.
+const EMULATOR_SPEC_URL = `${EMULATOR_BASE}/openapi.json`;
 
 const addSpecCode = (slug: string) => `
 const added = await tools.executor.openapi.addSpec({
-  spec: { kind: "blob", value: ${JSON.stringify(JSON.stringify(resendSpec))} },
+  spec: { kind: "url", url: ${JSON.stringify(EMULATOR_SPEC_URL)} },
   slug: ${JSON.stringify(slug)},
-  baseUrl: ${JSON.stringify(EMULATOR_BASE)},
-  authenticationTemplate: [{
-    type: "apiKey",
-    label: "API key",
-    headers: { Authorization: ["Bearer ", { type: "variable", name: "apiKey" }] },
-  }],
 });
 return added.ok ? { ok: true, slug: added.data.slug, toolCount: added.data.toolCount } : { ok: false, error: added.error };
 `;
@@ -153,7 +120,7 @@ scenario(
             const added = yield* chat.tool(
               "executor.execute · openapi.addSpec(resend)",
               executeJson(session, addSpecCode(integration)),
-              (result) => `${String(result.toolCount)} tool`,
+              (result) => `${String(result.toolCount)} tools`,
             );
             expect(added.ok, `addSpec succeeded: ${JSON.stringify(added)}`).toBe(true);
 

--- a/e2e/scripts/film.ts
+++ b/e2e/scripts/film.ts
@@ -1,0 +1,149 @@
+// Film a run: turn a chat-theater run's two real recordings into ONE mp4
+// that plays like a screen recording of a developer tabbing between
+// full-screen windows — terminal, browser, terminal. No virtual desktop,
+// no splice of anything synthetic: both segments are the real recordings,
+// cut at the moment the session actually moved between them.
+//
+//   bun scripts/film.ts runs/<target>/<slug>
+//
+// Mechanics: the terminal.cast contains dead air while the "user" was in
+// the browser (the chat was genuinely idle). We render the cast to video
+// with NO idle compression (so cast time == video time), cut it at the
+// browser hop, and put the browser session.mp4 in the gap. The hop is
+// located by the scenario's narrator line ("…in the browser…"), falling
+// back to the largest output gap. Output: film.mp4 next to the inputs —
+// the viewer plays it as the session when present.
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const runDir = resolve(process.argv[2] ?? "");
+const castPath = join(runDir, "terminal.cast");
+const browserPath = join(runDir, "session.mp4");
+if (!existsSync(castPath) || !existsSync(browserPath)) {
+  console.error(`film: need terminal.cast + session.mp4 in ${runDir}`);
+  process.exit(1);
+}
+
+const run = (cmd: string, args: string[]) => execFileSync(cmd, args, { stdio: "pipe" });
+const probeSeconds = (file: string): number =>
+  Number(
+    execFileSync("ffprobe", [
+      ...["-v", "quiet", "-show_entries", "format=duration"],
+      ...["-of", "csv=p=0", file],
+    ])
+      .toString()
+      .trim(),
+  );
+
+// ---------------------------------------------------------------------------
+// Locate the browser hop in cast time.
+// ---------------------------------------------------------------------------
+
+interface CastEvent {
+  readonly at: number;
+  readonly text: string;
+}
+
+const events: CastEvent[] = readFileSync(castPath, "utf8")
+  .split("\n")
+  .slice(1)
+  .filter(Boolean)
+  .map((line) => JSON.parse(line) as [number, string, string])
+  .filter((event) => event[1] === "o")
+  .map((event) => ({ at: event[0], text: event[2] }));
+
+const castEnd = events.at(-1)?.at ?? 0;
+
+/** Hop start: the narrator line the scenario prints as it moves to the
+ *  browser; hop end: the next visible output after it. Falls back to the
+ *  largest inter-event gap (the hop is the only long silence). */
+const findHop = (): { start: number; end: number } => {
+  const markerIndex = events.findIndex((event) => event.text.includes("in the browser"));
+  if (markerIndex !== -1) {
+    const start = events[markerIndex];
+    const after = events
+      .slice(markerIndex + 1)
+      .find((event) => event.at > (start?.at ?? 0) + 1 && event.text.trim().length > 0);
+    if (start && after) return { start: start.at + 0.8, end: after.at };
+  }
+  let best = { start: 0, end: 0 };
+  for (let i = 1; i < events.length; i += 1) {
+    const previous = events[i - 1];
+    const current = events[i];
+    if (previous && current && current.at - previous.at > best.end - best.start) {
+      best = { start: previous.at, end: current.at };
+    }
+  }
+  return best;
+};
+
+const hop = findHop();
+if (hop.end - hop.start < 2) {
+  console.error(`film: no browser hop found in the cast (gap ${hop.end - hop.start}s)`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Render + cut + concatenate. One canvas (the browser video's size), every
+// segment scaled/padded onto it — full-screen cuts, like tabbing.
+// ---------------------------------------------------------------------------
+
+const work = mkdtempSync(join(tmpdir(), "e2e-film-"));
+const castGif = join(work, "cast.gif");
+const castVideo = join(work, "cast.mp4");
+
+// No idle compression: cast video time must equal cast event time so the
+// cut points land exactly.
+run("agg", [
+  "--idle-time-limit",
+  String(Math.ceil(castEnd) + 60),
+  "--font-size",
+  "16",
+  castPath,
+  castGif,
+]);
+run("ffmpeg", [
+  ...["-y", "-i", castGif],
+  // agg's gif can have odd dimensions; libx264 requires even.
+  ...["-vf", "scale=ceil(iw/2)*2:ceil(ih/2)*2"],
+  ...["-pix_fmt", "yuv420p", "-r", "24", castVideo],
+]);
+
+const browserSeconds = probeSeconds(browserPath);
+const FIT =
+  "scale=1280:800:force_original_aspect_ratio=decrease,pad=1280:800:(ow-iw)/2:(oh-ih)/2:color=0x0b0b10,setsar=1,fps=24,format=yuv420p";
+
+const filmPath = join(runDir, "film.mp4");
+run("ffmpeg", [
+  "-y",
+  ...["-i", castVideo],
+  ...["-i", browserPath],
+  "-filter_complex",
+  [
+    `[0:v]trim=0:${hop.start.toFixed(2)},setpts=PTS-STARTPTS,${FIT}[act1]`,
+    `[1:v]${FIT}[act2]`,
+    `[0:v]trim=${hop.end.toFixed(2)},setpts=PTS-STARTPTS,${FIT}[act3]`,
+    `[act1][act2][act3]concat=n=3:v=1:a=0[out]`,
+  ].join(";"),
+  ...["-map", "[out]"],
+  ...["-c:v", "libx264", "-preset", "veryfast", "-crf", "24", "-movflags", "+faststart"],
+  filmPath,
+]);
+rmSync(work, { recursive: true, force: true });
+
+// Register the film in the run's artifact list so the viewer offers it.
+const resultPath = join(runDir, "result.json");
+if (existsSync(resultPath)) {
+  const result = JSON.parse(readFileSync(resultPath, "utf8")) as { artifacts?: string[] };
+  if (Array.isArray(result.artifacts) && !result.artifacts.includes("film.mp4")) {
+    result.artifacts.push("film.mp4");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(resultPath, JSON.stringify(result, null, 1));
+  }
+}
+
+console.log(
+  `film: ${filmPath}\n  act 1 terminal 0–${hop.start.toFixed(1)}s · act 2 browser ${browserSeconds.toFixed(1)}s · act 3 terminal ${(castEnd - hop.end).toFixed(1)}s`,
+);

--- a/e2e/scripts/film.ts
+++ b/e2e/scripts/film.ts
@@ -1,22 +1,24 @@
-// Film a run: turn a chat-theater run's two real recordings into ONE mp4
-// that plays like a screen recording of a developer tabbing between
-// full-screen windows — terminal, browser, terminal. No virtual desktop,
-// no splice of anything synthetic: both segments are the real recordings,
-// cut at the moment the session actually moved between them.
+// Film a run: turn a chat-theater run's real recordings into ONE mp4 that
+// plays like a screen recording of a developer tabbing between full-screen
+// windows — terminal, browser, terminal. Both segments are the genuine
+// recordings; the only editorial act is the cut, exactly like real tabbing.
 //
 //   bun scripts/film.ts runs/<target>/<slug>
 //
-// Mechanics: the terminal.cast contains dead air while the "user" was in
-// the browser (the chat was genuinely idle). We render the cast to video
-// with NO idle compression (so cast time == video time), cut it at the
-// browser hop, and put the browser session.mp4 in the gap. The hop is
-// located by the scenario's narrator line ("…in the browser…"), falling
-// back to the largest output gap. Output: film.mp4 next to the inputs —
-// the viewer plays it as the session when present.
+// The cut list comes from the run's focus timeline (src/timeline.ts):
+// surfaces mark focus as a side effect of acting — a Playwright step
+// focuses the browser, a chat event focuses the terminal — so the
+// operations themselves decide where the film cuts, for any number of
+// hops. Runs without a timeline fall back to the narrator-line / largest-
+// gap heuristic. The cast renders with NO idle compression so cast time
+// equals video time. Output: film.mp4, registered in result.json — the
+// viewer plays it as the session when present.
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+
+import { readTimeline } from "../src/timeline";
 
 const runDir = resolve(process.argv[2] ?? "");
 const castPath = join(runDir, "terminal.cast");
@@ -38,7 +40,7 @@ const probeSeconds = (file: string): number =>
   );
 
 // ---------------------------------------------------------------------------
-// Locate the browser hop in cast time.
+// Build the cut list: acts of { source, from, to } in each source's clock.
 // ---------------------------------------------------------------------------
 
 interface CastEvent {
@@ -56,51 +58,87 @@ const events: CastEvent[] = readFileSync(castPath, "utf8")
 
 const castEnd = events.at(-1)?.at ?? 0;
 
-/** Hop start: the narrator line the scenario prints as it moves to the
- *  browser; hop end: the next visible output after it. Falls back to the
- *  largest inter-event gap (the hop is the only long silence). */
-const findHop = (): { start: number; end: number } => {
-  const markerIndex = events.findIndex((event) => event.text.includes("in the browser"));
-  if (markerIndex !== -1) {
-    const start = events[markerIndex];
-    const after = events
-      .slice(markerIndex + 1)
-      .find((event) => event.at > (start?.at ?? 0) + 1 && event.text.trim().length > 0);
-    if (start && after) return { start: start.at + 0.8, end: after.at };
-  }
-  let best = { start: 0, end: 0 };
-  for (let i = 1; i < events.length; i += 1) {
-    const previous = events[i - 1];
-    const current = events[i];
-    if (previous && current && current.at - previous.at > best.end - best.start) {
-      best = { start: previous.at, end: current.at };
-    }
-  }
-  return best;
-};
-
-const hop = findHop();
-if (hop.end - hop.start < 2) {
-  console.error(`film: no browser hop found in the cast (gap ${hop.end - hop.start}s)`);
-  process.exit(1);
+interface Act {
+  readonly source: "terminal" | "browser";
+  readonly from: number;
+  readonly to: number;
 }
 
+/** Acts from the focus timeline: each contiguous focus run becomes a cut of
+ *  that window's recording, mapped via the recording-start anchors. */
+const actsFromTimeline = (): Act[] | null => {
+  const timeline = readTimeline(runDir);
+  if (!timeline || timeline.focus.length < 2) return null;
+  const terminalAnchor = timeline.anchors.terminal;
+  const browserAnchor = timeline.anchors.browser;
+  if (terminalAnchor === undefined || browserAnchor === undefined) return null;
+
+  const browserEnd = probeSeconds(browserPath);
+  const toMedia = (window: Act["source"], wallMs: number) =>
+    Math.max(0, (wallMs - (window === "terminal" ? terminalAnchor : browserAnchor)) / 1000);
+
+  const acts: Act[] = [];
+  for (let i = 0; i < timeline.focus.length; i += 1) {
+    const current = timeline.focus[i];
+    if (!current) continue;
+    const nextAt = timeline.focus[i + 1]?.at;
+    const from = i === 0 && current.window === "terminal" ? 0 : toMedia(current.window, current.at);
+    const mediaEnd = current.window === "terminal" ? castEnd : browserEnd;
+    const to =
+      nextAt === undefined ? mediaEnd : Math.min(toMedia(current.window, nextAt), mediaEnd);
+    if (to - from > 0.5) acts.push({ source: current.window, from, to });
+  }
+  return acts.length >= 2 ? acts : null;
+};
+
+/** Fallback for runs without a timeline: one browser hop located by the
+ *  narrator line, or the largest output gap in the cast. */
+const actsFromHeuristic = (): Act[] => {
+  const findHop = (): { start: number; end: number } => {
+    const markerIndex = events.findIndex((event) => event.text.includes("in the browser"));
+    if (markerIndex !== -1) {
+      const start = events[markerIndex];
+      const after = events
+        .slice(markerIndex + 1)
+        .find((event) => event.at > (start?.at ?? 0) + 1 && event.text.trim().length > 0);
+      if (start && after) return { start: start.at + 0.8, end: after.at };
+    }
+    let best = { start: 0, end: 0 };
+    for (let i = 1; i < events.length; i += 1) {
+      const previous = events[i - 1];
+      const current = events[i];
+      if (previous && current && current.at - previous.at > best.end - best.start) {
+        best = { start: previous.at, end: current.at };
+      }
+    }
+    return best;
+  };
+  const hop = findHop();
+  if (hop.end - hop.start < 2) {
+    console.error(`film: no browser hop found in the cast (gap ${hop.end - hop.start}s)`);
+    process.exit(1);
+  }
+  return [
+    { source: "terminal", from: 0, to: hop.start },
+    { source: "browser", from: 0, to: probeSeconds(browserPath) },
+    { source: "terminal", from: hop.end, to: castEnd },
+  ];
+};
+
+const acts = actsFromTimeline() ?? actsFromHeuristic();
+
 // ---------------------------------------------------------------------------
-// Render + cut + concatenate. One canvas (the browser video's size), every
-// segment scaled/padded onto it — full-screen cuts, like tabbing.
+// Render + cut + concatenate onto one canvas — full-screen cuts, like
+// tabbing.
 // ---------------------------------------------------------------------------
 
 const work = mkdtempSync(join(tmpdir(), "e2e-film-"));
 const castGif = join(work, "cast.gif");
 const castVideo = join(work, "cast.mp4");
 
-// No idle compression: cast video time must equal cast event time so the
-// cut points land exactly.
 run("agg", [
-  "--idle-time-limit",
-  String(Math.ceil(castEnd) + 60),
-  "--font-size",
-  "16",
+  ...["--idle-time-limit", String(Math.ceil(castEnd) + 60)],
+  ...["--font-size", "16"],
   castPath,
   castGif,
 ]);
@@ -111,21 +149,23 @@ run("ffmpeg", [
   ...["-pix_fmt", "yuv420p", "-r", "24", castVideo],
 ]);
 
-const browserSeconds = probeSeconds(browserPath);
 const FIT =
   "scale=1280:800:force_original_aspect_ratio=decrease,pad=1280:800:(ow-iw)/2:(oh-ih)/2:color=0x0b0b10,setsar=1,fps=24,format=yuv420p";
 
 const filmPath = join(runDir, "film.mp4");
+const inputIndex = { terminal: 0, browser: 1 } as const;
+const filters = acts.map(
+  (act, index) =>
+    `[${inputIndex[act.source]}:v]trim=${act.from.toFixed(2)}:${act.to.toFixed(2)},setpts=PTS-STARTPTS,${FIT}[act${index}]`,
+);
 run("ffmpeg", [
   "-y",
   ...["-i", castVideo],
   ...["-i", browserPath],
   "-filter_complex",
   [
-    `[0:v]trim=0:${hop.start.toFixed(2)},setpts=PTS-STARTPTS,${FIT}[act1]`,
-    `[1:v]${FIT}[act2]`,
-    `[0:v]trim=${hop.end.toFixed(2)},setpts=PTS-STARTPTS,${FIT}[act3]`,
-    `[act1][act2][act3]concat=n=3:v=1:a=0[out]`,
+    ...filters,
+    `${acts.map((_, index) => `[act${index}]`).join("")}concat=n=${acts.length}:v=1:a=0[out]`,
   ].join(";"),
   ...["-map", "[out]"],
   ...["-c:v", "libx264", "-preset", "veryfast", "-crf", "24", "-movflags", "+faststart"],
@@ -139,11 +179,15 @@ if (existsSync(resultPath)) {
   const result = JSON.parse(readFileSync(resultPath, "utf8")) as { artifacts?: string[] };
   if (Array.isArray(result.artifacts) && !result.artifacts.includes("film.mp4")) {
     result.artifacts.push("film.mp4");
-    const { writeFileSync } = await import("node:fs");
     writeFileSync(resultPath, JSON.stringify(result, null, 1));
   }
 }
 
 console.log(
-  `film: ${filmPath}\n  act 1 terminal 0–${hop.start.toFixed(1)}s · act 2 browser ${browserSeconds.toFixed(1)}s · act 3 terminal ${(castEnd - hop.end).toFixed(1)}s`,
+  `film: ${filmPath}\n${acts
+    .map(
+      (act, index) =>
+        `  act ${index + 1} ${act.source} ${act.from.toFixed(1)}–${act.to.toFixed(1)}s`,
+    )
+    .join("\n")}`,
 );

--- a/e2e/scripts/pr-media.ts
+++ b/e2e/scripts/pr-media.ts
@@ -8,8 +8,9 @@
 // the PR description.
 //
 // Usage: bun e2e/scripts/pr-media.ts <run-dir-or-artifact> [...more]
-//   run dir        e2e/runs/<target>/<scenario-slug> — picks session.mp4 or
-//                  terminal.cast and labels the gif from result.json
+//   run dir        e2e/runs/<target>/<scenario-slug> — picks film.mp4 (the
+//                  whole session), else session.mp4, else terminal.cast;
+//                  labels the gif from result.json
 //   session.mp4    browser recording (ffmpeg -> gif)
 //   terminal.cast  terminal recording (agg -> gif; brew install agg)
 //   *.png          run screenshot, uploaded as-is
@@ -48,10 +49,13 @@ const resolveArtifact = (input: string): Artifact => {
       slug: basename(path).replace(/\.[^.]+$/, ""),
     };
   }
-  const recording = ["session.mp4", "terminal.cast"]
+  // film.mp4 (scripts/film.ts) is the whole session — terminal chat AND the
+  // browser hop, cut in time order; the bare browser session.mp4 is only the
+  // hop, so it must never win when a film exists.
+  const recording = ["film.mp4", "session.mp4", "terminal.cast"]
     .map((name) => join(path, name))
     .find(existsSync);
-  if (!recording) throw new Error(`${input} has no session.mp4 or terminal.cast`);
+  if (!recording) throw new Error(`${input} has no film.mp4, session.mp4, or terminal.cast`);
   let label = basename(path);
   try {
     const result = JSON.parse(readFileSync(join(path, "result.json"), "utf8")) as {

--- a/e2e/src/clients/agent-chat-tui.ts
+++ b/e2e/src/clients/agent-chat-tui.ts
@@ -1,0 +1,128 @@
+// The chat renderer half of the chat theater (see chat-theater.ts): a tiny
+// agent-chat TUI that runs inside the recorded PTY and paints whatever the
+// scenario's REAL MCP calls are doing. It performs no logic of its own — it
+// reads base64-encoded JSON events on stdin and renders them with the
+// pacing of a chat session (typed user input, streamed agent text, live
+// tool spinners that run exactly as long as the real call did).
+//
+// Run with: bun agent-chat-tui.ts "<session title>"
+import { createInterface } from "node:readline";
+
+type TheaterEvent =
+  | { readonly type: "user"; readonly text: string }
+  | { readonly type: "assistant"; readonly text: string }
+  | { readonly type: "tool-start"; readonly label: string }
+  | { readonly type: "tool-end"; readonly ok: boolean; readonly note?: string }
+  | { readonly type: "status"; readonly text: string }
+  | { readonly type: "done" };
+
+const out = (text: string) => process.stdout.write(text);
+
+// The PTY would otherwise echo every incoming event line into the recording.
+if (process.stdin.isTTY) process.stdin.setRawMode(true);
+
+const DIM = "\x1b[2m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const MAGENTA = "\x1b[35m";
+const CLEAR_LINE = "\x1b[2K\r";
+
+const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+const sleep = (ms: number) => new Promise<void>((tick) => setTimeout(tick, ms));
+
+const title = process.argv[2] ?? "executor session";
+out(`${BOLD}${MAGENTA}●${RESET} ${BOLD}${title}${RESET}\n`);
+out(`${DIM}${"─".repeat(Math.min(96, title.length + 24))}${RESET}\n`);
+
+let spinnerTimer: ReturnType<typeof setInterval> | undefined;
+let spinnerLabel = "";
+
+const startSpinner = (label: string) => {
+  spinnerLabel = label;
+  let frame = 0;
+  out("\n");
+  spinnerTimer = setInterval(() => {
+    out(`${CLEAR_LINE}  ${CYAN}${SPINNER[frame % SPINNER.length]}${RESET} ${DIM}${label}${RESET}`);
+    frame += 1;
+  }, 80);
+};
+
+const stopSpinner = (ok: boolean, note?: string) => {
+  if (spinnerTimer) clearInterval(spinnerTimer);
+  spinnerTimer = undefined;
+  const mark = ok ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
+  out(`${CLEAR_LINE}  ${mark} ${DIM}${spinnerLabel}${note ? ` — ${note}` : ""}${RESET}\n`);
+};
+
+const handle = async (event: TheaterEvent): Promise<boolean> => {
+  switch (event.type) {
+    case "user": {
+      out(`\n${BOLD}${CYAN}┃ you${RESET}  `);
+      for (const ch of event.text) {
+        out(ch);
+        await sleep(18);
+      }
+      out("\n");
+      return true;
+    }
+    case "assistant": {
+      out(`\n${BOLD}${MAGENTA}● agent${RESET}  `);
+      for (const piece of event.text.match(/.{1,3}/gs) ?? []) {
+        out(piece);
+        await sleep(12);
+      }
+      out("\n");
+      return true;
+    }
+    case "tool-start": {
+      startSpinner(event.label);
+      return true;
+    }
+    case "tool-end": {
+      stopSpinner(event.ok, event.note);
+      return true;
+    }
+    case "status": {
+      out(`\n  ${DIM}· ${event.text}${RESET}\n`);
+      return true;
+    }
+    case "done": {
+      out(`\n${DIM}${"─".repeat(40)}${RESET}\n${GREEN}✦ session complete${RESET}\n`);
+      return false;
+    }
+  }
+};
+
+// Events arrive faster than they render; process strictly in order so the
+// animations (not arrival time) set the pacing.
+const queue: TheaterEvent[] = [];
+let draining = false;
+const drain = async () => {
+  if (draining) return;
+  draining = true;
+  while (queue.length > 0) {
+    const event = queue.shift();
+    if (!event) break;
+    const keepGoing = await handle(event);
+    if (!keepGoing) {
+      process.exit(0);
+    }
+  }
+  draining = false;
+};
+
+createInterface({ input: process.stdin, terminal: false }).on("line", (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: PTY stdin may echo stray keystrokes that aren't base64 JSON; ignore them
+  try {
+    queue.push(JSON.parse(Buffer.from(trimmed, "base64").toString("utf8")) as TheaterEvent);
+  } catch {
+    return;
+  }
+  void drain();
+});

--- a/e2e/src/clients/agent-chat-tui.ts
+++ b/e2e/src/clients/agent-chat-tui.ts
@@ -17,8 +17,19 @@ import { createInterface } from "node:readline";
 type TheaterEvent =
   | { readonly type: "user"; readonly text: string }
   | { readonly type: "assistant"; readonly text: string }
-  | { readonly type: "tool-start"; readonly label: string }
-  | { readonly type: "tool-end"; readonly ok: boolean; readonly note?: string }
+  | {
+      readonly type: "tool-start";
+      readonly name: string;
+      /** The call's real input, pre-rendered as preview lines. */
+      readonly input?: readonly string[];
+    }
+  | {
+      readonly type: "tool-end";
+      readonly ok: boolean;
+      /** First line of the call's real result. */
+      readonly result?: string;
+      readonly seconds?: number;
+    }
   | { readonly type: "status"; readonly text: string }
   | { readonly type: "done" };
 
@@ -46,23 +57,36 @@ out(`${BOLD}${MAGENTA}●${RESET} ${BOLD}${title}${RESET}\n`);
 out(`${DIM}${"─".repeat(Math.min(96, title.length + 24))}${RESET}\n`);
 
 let spinnerTimer: ReturnType<typeof setInterval> | undefined;
-let spinnerLabel = "";
+let spinnerName = "";
 
-const startSpinner = (label: string) => {
-  spinnerLabel = label;
+// A tool call renders the way agent TUIs render them: the tool's name, the
+// call's real input as an indented block, a spinner while the real call
+// runs, then the real result's first line with the real duration.
+//
+//   ⚙ execute
+//   │ const added = await tools.executor.openapi.addSpec({
+//   │   spec: { kind: "url", url: "https://…/openapi.json" },
+//   ⠼ running…
+//   ✓ 2.3s  {"ok":true,"slug":"resend","toolCount":9}
+const startTool = (name: string, input?: readonly string[]) => {
+  spinnerName = name;
+  out(`\n  ${MAGENTA}⚙${RESET} ${BOLD}${name}${RESET}\n`);
+  for (const line of input ?? []) {
+    out(`  ${DIM}│ ${line.slice(0, 92)}${RESET}\n`);
+  }
   let frame = 0;
-  out("\n");
   spinnerTimer = setInterval(() => {
-    out(`${CLEAR_LINE}  ${CYAN}${SPINNER[frame % SPINNER.length]}${RESET} ${DIM}${label}${RESET}`);
+    out(`${CLEAR_LINE}  ${CYAN}${SPINNER[frame % SPINNER.length]}${RESET} ${DIM}running…${RESET}`);
     frame += 1;
   }, 80);
 };
 
-const stopSpinner = (ok: boolean, note?: string) => {
+const endTool = (ok: boolean, result?: string, seconds?: number) => {
   if (spinnerTimer) clearInterval(spinnerTimer);
   spinnerTimer = undefined;
-  const mark = ok ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`;
-  out(`${CLEAR_LINE}  ${mark} ${DIM}${spinnerLabel}${note ? ` — ${note}` : ""}${RESET}\n`);
+  const mark = ok ? `${GREEN}✓${RESET}` : `${RED}✗ ${spinnerName}${RESET}`;
+  const took = seconds !== undefined ? `${DIM}${seconds.toFixed(1)}s${RESET}  ` : "";
+  out(`${CLEAR_LINE}  ${mark} ${took}${DIM}${(result ?? "").slice(0, 88)}${RESET}\n`);
 };
 
 const handle = async (event: TheaterEvent): Promise<boolean> => {
@@ -86,11 +110,11 @@ const handle = async (event: TheaterEvent): Promise<boolean> => {
       return true;
     }
     case "tool-start": {
-      startSpinner(event.label);
+      startTool(event.name, event.input);
       return true;
     }
     case "tool-end": {
-      stopSpinner(event.ok, event.note);
+      endTool(event.ok, event.result, event.seconds);
       return true;
     }
     case "status": {

--- a/e2e/src/clients/agent-chat-tui.ts
+++ b/e2e/src/clients/agent-chat-tui.ts
@@ -5,7 +5,13 @@
 // pacing of a chat session (typed user input, streamed agent text, live
 // tool spinners that run exactly as long as the real call did).
 //
-// Run with: bun agent-chat-tui.ts "<session title>"
+// Run with: bun agent-chat-tui.ts "<session title>" [events-fifo]
+//
+// Two transports: events arrive base64-encoded one-per-line either on stdin
+// (PTY mode — the chat theater types them into the recorded terminal) or on
+// a FIFO path (desk mode — the renderer runs inside a visible xterm on the
+// virtual desktop, where stdin belongs to the terminal emulator).
+import { createReadStream, writeFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 type TheaterEvent =
@@ -35,6 +41,7 @@ const SPINNER = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", 
 const sleep = (ms: number) => new Promise<void>((tick) => setTimeout(tick, ms));
 
 const title = process.argv[2] ?? "executor session";
+const eventsFifo = process.argv[3];
 out(`${BOLD}${MAGENTA}●${RESET} ${BOLD}${title}${RESET}\n`);
 out(`${DIM}${"─".repeat(Math.min(96, title.length + 24))}${RESET}\n`);
 
@@ -92,6 +99,12 @@ const handle = async (event: TheaterEvent): Promise<boolean> => {
     }
     case "done": {
       out(`\n${DIM}${"─".repeat(40)}${RESET}\n${GREEN}✦ session complete${RESET}\n`);
+      if (eventsFifo) {
+        // Desk mode: ack completion to the driver, then linger so the
+        // closing frame stays on camera before the xterm vanishes.
+        writeFileSync(`${eventsFifo}.done`, "");
+        await sleep(4_000);
+      }
       return false;
     }
   }
@@ -115,7 +128,8 @@ const drain = async () => {
   draining = false;
 };
 
-createInterface({ input: process.stdin, terminal: false }).on("line", (line) => {
+const input = eventsFifo ? createReadStream(eventsFifo) : process.stdin;
+createInterface({ input, terminal: false }).on("line", (line) => {
   const trimmed = line.trim();
   if (!trimmed) return;
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: PTY stdin may echo stray keystrokes that aren't base64 JSON; ignore them

--- a/e2e/src/clients/chat-theater.ts
+++ b/e2e/src/clients/chat-theater.ts
@@ -39,12 +39,19 @@ export interface ChatTheater {
   readonly user: (text: string) => Effect.Effect<void>;
   /** The agent's reply, streamed on screen. */
   readonly assistant: (text: string) => Effect.Effect<void>;
-  /** Run a REAL effect behind a live tool spinner; the spinner runs exactly
-   *  as long as the call does and resolves to ✓/✗ with its outcome. */
+  /** Run a REAL effect rendered as a tool call: the tool's name, the call's
+   *  real input block, a spinner for exactly as long as the call runs, then
+   *  the call's real result line with the real duration. */
   readonly tool: <A, E, R>(
-    label: string,
+    call: {
+      /** Tool name as an agent TUI would show it (e.g. "execute"). */
+      readonly name: string;
+      /** The call's real input — rendered as the indented block. */
+      readonly input?: string;
+      /** Render the result's display line (defaults to JSON of the value). */
+      readonly result?: (value: A) => string;
+    },
     work: Effect.Effect<A, E, R>,
-    note?: (result: A) => string | undefined,
   ) => Effect.Effect<A, E, R>;
   /** A dim narrator line (e.g. "waiting for the browser hop"). */
   readonly status: (text: string) => Effect.Effect<void>;
@@ -55,19 +62,32 @@ const sleep = (ms: number) => new Promise<void>((tick) => setTimeout(tick, ms));
 const encode = (event: TheaterEvent) =>
   `${Buffer.from(JSON.stringify(event)).toString("base64")}\n`;
 
+/** Input block, like a TUI's call preview: trimmed lines, capped count. */
+const inputPreview = (input: string | undefined): string[] | undefined => {
+  if (!input) return undefined;
+  const lines = input
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim().length > 0);
+  return lines.length > 7 ? [...lines.slice(0, 6), `… +${lines.length - 6} lines`] : lines;
+};
+
 const makeTheater = (push: (event: TheaterEvent) => Effect.Effect<void>): ChatTheater => ({
   user: (text) => push({ type: "user", text }),
   assistant: (text) => push({ type: "assistant", text }),
   status: (text) => push({ type: "status", text }),
-  tool: (label, work, note) =>
+  tool: (call, work) =>
     Effect.gen(function* () {
-      yield* push({ type: "tool-start", label });
+      yield* push({ type: "tool-start", name: call.name, input: inputPreview(call.input) });
+      const startedAt = Date.now();
       const exit = yield* Effect.exit(work);
+      const seconds = (Date.now() - startedAt) / 1000;
       if (Exit.isSuccess(exit)) {
-        yield* push({ type: "tool-end", ok: true, note: note?.(exit.value) });
+        const line = call.result ? call.result(exit.value) : JSON.stringify(exit.value);
+        yield* push({ type: "tool-end", ok: true, result: line, seconds });
         return exit.value;
       }
-      yield* push({ type: "tool-end", ok: false, note: "failed" });
+      yield* push({ type: "tool-end", ok: false, result: "failed", seconds });
       return yield* exit;
     }),
 });

--- a/e2e/src/clients/chat-theater.ts
+++ b/e2e/src/clients/chat-theater.ts
@@ -1,0 +1,118 @@
+// Chat theater: agent-chat presentation over REAL mcporter MCP calls — no
+// inference, no third-party agent binary. The scenario stays in Effect land
+// making real calls; a forked PTY runs the chat renderer
+// (agent-chat-tui.ts) and this driver feeds it events, so the terminal.cast
+// reads like a developer chatting with an agent while every tool spinner
+// brackets the genuine call it narrates.
+//
+// Division of labor in the e2e stack:
+//   - chat theater (this): deterministic PRODUCT-flow recordings
+//   - replay brain + real client (replay-brain.ts): CLIENT-behavior tests
+//     (OpenCode/Claude Code protocol handling), still no inference
+//   - real-inference evals: a separate axis entirely — performance
+//     distributions, not pass/fail scenarios
+import { fileURLToPath } from "node:url";
+
+import { Effect, Exit, Fiber } from "effect";
+
+import type { CliSurface } from "../surfaces/cli";
+
+const RENDERER = fileURLToPath(new URL("./agent-chat-tui.ts", import.meta.url));
+
+interface TheaterEvent {
+  readonly type: "user" | "assistant" | "tool-start" | "tool-end" | "status" | "done";
+  readonly [key: string]: unknown;
+}
+
+export interface ChatTheater {
+  /** The human's chat line, typed out on screen. */
+  readonly user: (text: string) => Effect.Effect<void>;
+  /** The agent's reply, streamed on screen. */
+  readonly assistant: (text: string) => Effect.Effect<void>;
+  /** Run a REAL effect behind a live tool spinner; the spinner runs exactly
+   *  as long as the call does and resolves to ✓/✗ with its outcome. */
+  readonly tool: <A, E, R>(
+    label: string,
+    work: Effect.Effect<A, E, R>,
+    note?: (result: A) => string | undefined,
+  ) => Effect.Effect<A, E, R>;
+  /** A dim narrator line (e.g. "waiting for the browser hop"). */
+  readonly status: (text: string) => Effect.Effect<void>;
+}
+
+/**
+ * Open a recorded PTY running the chat renderer, hand the scenario a
+ * ChatTheater handle, and close the session (footer + exit) when the body
+ * finishes — success or failure, so the cast always ends cleanly.
+ */
+export const withChatTheater = <A, E, R>(
+  cli: CliSurface,
+  options: {
+    readonly title: string;
+    readonly record: string;
+    readonly viewport?: { readonly cols: number; readonly rows: number };
+  },
+  body: (theater: ChatTheater) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.gen(function* () {
+    const queue: TheaterEvent[] = [];
+    let closed = false;
+
+    const push = (event: TheaterEvent) =>
+      Effect.sync(() => {
+        if (!closed) queue.push(event);
+      });
+
+    // The PTY pump: forward queued events as base64 lines (keystroke-safe),
+    // and return once the renderer paints its completion footer.
+    const pump = cli.session(
+      ["bun", RENDERER, options.title],
+      async (term) => {
+        // Don't type until the renderer has painted its header — before that
+        // it hasn't set raw mode yet, and the PTY would echo the event line
+        // into the recording.
+        await term.screen.waitForText(options.title, { timeoutMs: 30_000 });
+        const deadline = Date.now() + 30 * 60 * 1000;
+        for (;;) {
+          const event = queue.shift();
+          if (event) {
+            const line = Buffer.from(JSON.stringify(event)).toString("base64");
+            await term.keyboard.type(`${line}\n`);
+            if (event.type === "done") break;
+            continue;
+          }
+          if (Date.now() > deadline) break;
+          await new Promise<void>((tick) => setTimeout(tick, 40));
+        }
+        await term.screen.waitForText("session complete", { timeoutMs: 60_000 });
+      },
+      {
+        record: options.record,
+        viewport: options.viewport ?? { cols: 100, rows: 32 },
+      },
+    );
+    const pumpFiber = yield* Effect.forkChild(Effect.exit(pump));
+
+    const theater: ChatTheater = {
+      user: (text) => push({ type: "user", text }),
+      assistant: (text) => push({ type: "assistant", text }),
+      status: (text) => push({ type: "status", text }),
+      tool: (label, work, note) =>
+        Effect.gen(function* () {
+          yield* push({ type: "tool-start", label });
+          const exit = yield* Effect.exit(work);
+          if (Exit.isSuccess(exit)) {
+            yield* push({ type: "tool-end", ok: true, note: note?.(exit.value) });
+            return exit.value;
+          }
+          yield* push({ type: "tool-end", ok: false, note: "failed" });
+          return yield* exit;
+        }),
+    };
+
+    const result = yield* Effect.exit(body(theater));
+    yield* push({ type: "done" });
+    closed = true;
+    yield* Fiber.join(pumpFiber);
+    return yield* result;
+  });

--- a/e2e/src/clients/chat-theater.ts
+++ b/e2e/src/clients/chat-theater.ts
@@ -19,11 +19,12 @@
 import { spawn, spawnSync } from "node:child_process";
 import { createWriteStream, existsSync, mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Effect, Exit, Fiber } from "effect";
 
+import { markFocus, markRecordingStart } from "../timeline";
 import type { CliSurface } from "../surfaces/cli";
 
 const RENDERER = fileURLToPath(new URL("./agent-chat-tui.ts", import.meta.url));
@@ -99,11 +100,16 @@ const ptyTheater = <A, E, R>(
   body: (theater: ChatTheater) => Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> =>
   Effect.gen(function* () {
+    const runDir = dirname(options.record);
     const queue: TheaterEvent[] = [];
     let closed = false;
     const push = (event: TheaterEvent) =>
       Effect.sync(() => {
-        if (!closed) queue.push(event);
+        if (!closed) {
+          // Chatting IS focusing the terminal window.
+          if (event.type !== "done") markFocus(runDir, "terminal");
+          queue.push(event);
+        }
       });
 
     const pump = cli.session(
@@ -113,6 +119,9 @@ const ptyTheater = <A, E, R>(
         // it hasn't set raw mode yet, and the PTY would echo the event line
         // into the recording.
         await term.screen.waitForText(options.title, { timeoutMs: 30_000 });
+        // The cast's clock started with the PTY moments ago; anchor it for
+        // the run's focus timeline (scripts/film.ts cuts on these).
+        markRecordingStart(runDir, "terminal");
         const deadline = Date.now() + 30 * 60 * 1000;
         for (;;) {
           const event = queue.shift();

--- a/e2e/src/clients/chat-theater.ts
+++ b/e2e/src/clients/chat-theater.ts
@@ -1,9 +1,14 @@
 // Chat theater: agent-chat presentation over REAL mcporter MCP calls — no
 // inference, no third-party agent binary. The scenario stays in Effect land
-// making real calls; a forked PTY runs the chat renderer
-// (agent-chat-tui.ts) and this driver feeds it events, so the terminal.cast
-// reads like a developer chatting with an agent while every tool spinner
-// brackets the genuine call it narrates.
+// making real calls; a chat renderer (agent-chat-tui.ts) paints them, so
+// the recording reads like a developer chatting with an agent while every
+// tool spinner brackets the genuine call it narrates.
+//
+// Two stages for the same play:
+//   - PTY mode (default): the renderer runs in a recorded PTY → terminal.cast
+//   - Desk mode (E2E_DESK=1): the renderer runs in a visible xterm on the
+//     virtual desktop (events over a FIFO) and the desk's single x11grab
+//     films it together with the headed browser — one screen, one mp4
 //
 // Division of labor in the e2e stack:
 //   - chat theater (this): deterministic PRODUCT-flow recordings
@@ -11,6 +16,10 @@
 //     (OpenCode/Claude Code protocol handling), still no inference
 //   - real-inference evals: a separate axis entirely — performance
 //     distributions, not pass/fail scenarios
+import { spawn, spawnSync } from "node:child_process";
+import { createWriteStream, existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Effect, Exit, Fiber } from "effect";
@@ -40,31 +49,63 @@ export interface ChatTheater {
   readonly status: (text: string) => Effect.Effect<void>;
 }
 
+const sleep = (ms: number) => new Promise<void>((tick) => setTimeout(tick, ms));
+
+const encode = (event: TheaterEvent) =>
+  `${Buffer.from(JSON.stringify(event)).toString("base64")}\n`;
+
+const makeTheater = (push: (event: TheaterEvent) => Effect.Effect<void>): ChatTheater => ({
+  user: (text) => push({ type: "user", text }),
+  assistant: (text) => push({ type: "assistant", text }),
+  status: (text) => push({ type: "status", text }),
+  tool: (label, work, note) =>
+    Effect.gen(function* () {
+      yield* push({ type: "tool-start", label });
+      const exit = yield* Effect.exit(work);
+      if (Exit.isSuccess(exit)) {
+        yield* push({ type: "tool-end", ok: true, note: note?.(exit.value) });
+        return exit.value;
+      }
+      yield* push({ type: "tool-end", ok: false, note: "failed" });
+      return yield* exit;
+    }),
+});
+
+export interface TheaterOptions {
+  readonly title: string;
+  readonly record: string;
+  readonly viewport?: { readonly cols: number; readonly rows: number };
+}
+
 /**
- * Open a recorded PTY running the chat renderer, hand the scenario a
- * ChatTheater handle, and close the session (footer + exit) when the body
- * finishes — success or failure, so the cast always ends cleanly.
+ * Open the chat renderer, hand the scenario a ChatTheater handle, and close
+ * the session (footer + exit) when the body finishes — success or failure,
+ * so the recording always ends cleanly.
  */
 export const withChatTheater = <A, E, R>(
   cli: CliSurface,
-  options: {
-    readonly title: string;
-    readonly record: string;
-    readonly viewport?: { readonly cols: number; readonly rows: number };
-  },
+  options: TheaterOptions,
+  body: (theater: ChatTheater) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  process.env.E2E_DESK === "1" ? deskTheater(options, body) : ptyTheater(cli, options, body);
+
+// ---------------------------------------------------------------------------
+// PTY mode: renderer in a recorded PTY; events typed in as base64 lines.
+// ---------------------------------------------------------------------------
+
+const ptyTheater = <A, E, R>(
+  cli: CliSurface,
+  options: TheaterOptions,
   body: (theater: ChatTheater) => Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> =>
   Effect.gen(function* () {
     const queue: TheaterEvent[] = [];
     let closed = false;
-
     const push = (event: TheaterEvent) =>
       Effect.sync(() => {
         if (!closed) queue.push(event);
       });
 
-    // The PTY pump: forward queued events as base64 lines (keystroke-safe),
-    // and return once the renderer paints its completion footer.
     const pump = cli.session(
       ["bun", RENDERER, options.title],
       async (term) => {
@@ -76,13 +117,12 @@ export const withChatTheater = <A, E, R>(
         for (;;) {
           const event = queue.shift();
           if (event) {
-            const line = Buffer.from(JSON.stringify(event)).toString("base64");
-            await term.keyboard.type(`${line}\n`);
+            await term.keyboard.type(encode(event));
             if (event.type === "done") break;
             continue;
           }
           if (Date.now() > deadline) break;
-          await new Promise<void>((tick) => setTimeout(tick, 40));
+          await sleep(40);
         }
         await term.screen.waitForText("session complete", { timeoutMs: 60_000 });
       },
@@ -93,26 +133,56 @@ export const withChatTheater = <A, E, R>(
     );
     const pumpFiber = yield* Effect.forkChild(Effect.exit(pump));
 
-    const theater: ChatTheater = {
-      user: (text) => push({ type: "user", text }),
-      assistant: (text) => push({ type: "assistant", text }),
-      status: (text) => push({ type: "status", text }),
-      tool: (label, work, note) =>
-        Effect.gen(function* () {
-          yield* push({ type: "tool-start", label });
-          const exit = yield* Effect.exit(work);
-          if (Exit.isSuccess(exit)) {
-            yield* push({ type: "tool-end", ok: true, note: note?.(exit.value) });
-            return exit.value;
-          }
-          yield* push({ type: "tool-end", ok: false, note: "failed" });
-          return yield* exit;
-        }),
-    };
-
-    const result = yield* Effect.exit(body(theater));
+    const result = yield* Effect.exit(body(makeTheater(push)));
     yield* push({ type: "done" });
     closed = true;
     yield* Fiber.join(pumpFiber);
+    return yield* result;
+  });
+
+// ---------------------------------------------------------------------------
+// Desk mode: renderer in a visible xterm on the virtual desktop; events over
+// a FIFO. No cast — the desk's x11grab films the screen.
+// ---------------------------------------------------------------------------
+
+const deskTheater = <A, E, R>(
+  options: TheaterOptions,
+  body: (theater: ChatTheater) => Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.gen(function* () {
+    const root = mkdtempSync(join(tmpdir(), "desk-theater-"));
+    const fifo = join(root, "events.fifo");
+    spawnSync("mkfifo", [fifo]);
+
+    const xterm = spawn(
+      "xterm",
+      [
+        // -u8 + a UTF-8 locale: the renderer speaks box-drawing and bullets.
+        ...["-u8", "-fa", "DejaVu Sans Mono", "-fs", "13"],
+        ...["-bg", "#0b0b10", "-fg", "#e8e8ea"],
+        ...["-geometry", "112x34+48+40", "-T", options.title],
+        ...["-e", "bun", RENDERER, options.title, fifo],
+      ],
+      { stdio: "ignore", env: { ...process.env, LANG: "C.UTF-8", LC_ALL: "C.UTF-8" } },
+    );
+    // Opening the write end parks until the renderer opens the read end.
+    const writer = createWriteStream(fifo);
+    const push = (event: TheaterEvent) =>
+      Effect.sync(() => {
+        writer.write(encode(event));
+      });
+
+    const result = yield* Effect.exit(body(makeTheater(push)));
+    yield* push({ type: "done" });
+    yield* Effect.promise(async () => {
+      // Renderer acks the footer, lingers for the camera, then exits with
+      // its xterm. Don't hang the run on a wedged terminal.
+      const ackDeadline = Date.now() + 30_000;
+      while (!existsSync(`${fifo}.done`) && Date.now() < ackDeadline) await sleep(200);
+      const exitDeadline = Date.now() + 10_000;
+      while (xterm.exitCode === null && Date.now() < exitDeadline) await sleep(200);
+      if (xterm.exitCode === null) xterm.kill();
+      writer.end();
+    });
     return yield* result;
   });

--- a/e2e/src/clients/opencode.ts
+++ b/e2e/src/clients/opencode.ts
@@ -24,8 +24,18 @@ export interface OpenCodeHome {
   ) => { accessToken?: string; refreshToken?: string; expiresAt?: number } | undefined;
 }
 
-/** A throwaway OpenCode installation configured with one remote MCP server. */
-export const makeOpenCodeHome = (serverName: string, mcpUrl: string): OpenCodeHome => {
+/** A throwaway OpenCode installation configured with one remote MCP server.
+ *
+ *  With `chatBrainUrl` set, the config also declares a `replay` provider
+ *  pointing OpenCode's LLM traffic at a local replay brain
+ *  (clients/replay-brain.ts) and selects it as the model — real agent,
+ *  scripted conversation. Tool permissions are pre-allowed so the recorded
+ *  TUI session flows without approval dialogs. */
+export const makeOpenCodeHome = (
+  serverName: string,
+  mcpUrl: string,
+  options?: { readonly chatBrainUrl?: string },
+): OpenCodeHome => {
   const root = mkdtempSync(join(tmpdir(), "e2e-opencode-"));
   const projectDir = join(root, "project");
   const dataDir = join(root, "data");
@@ -38,6 +48,22 @@ export const makeOpenCodeHome = (serverName: string, mcpUrl: string): OpenCodeHo
     JSON.stringify({
       $schema: "https://opencode.ai/config.json",
       mcp: { [serverName]: { type: "remote", url: mcpUrl } },
+      ...(options?.chatBrainUrl
+        ? {
+            autoupdate: false,
+            share: "disabled",
+            model: "replay/replay-model",
+            permission: { "*": "allow" },
+            provider: {
+              replay: {
+                name: "Replay",
+                npm: "@ai-sdk/openai-compatible",
+                options: { baseURL: options.chatBrainUrl, apiKey: "replay-key" },
+                models: { "replay-model": { name: "Replay Model" } },
+              },
+            },
+          }
+        : {}),
     }),
   );
   // OpenCode launches the OAuth URL via `open`; the shim records it instead.

--- a/e2e/src/clients/replay-brain.ts
+++ b/e2e/src/clients/replay-brain.ts
@@ -1,0 +1,208 @@
+// Replay brain: a local server speaking the OpenAI chat-completions wire
+// (SSE streaming, tool calls) that a REAL agent (OpenCode) uses as its LLM.
+// The scenario scripts the brain; the agent does everything else for real —
+// TUI rendering, MCP discovery/auth, tool execution against the target,
+// result round-trips. "Replay brain, real hands": deterministic conversation,
+// zero modeled client behavior.
+//
+// The brain is a state machine, not a fixed turn list: each request gets a
+// normalized view of the conversation so far and the scenario's `respond`
+// callback decides what the "model" says next (text, a tool call, or both).
+// That lets a script absorb variable-length detours — approval pauses that
+// need a resume call, retries — without index bookkeeping.
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Effect, Scope } from "effect";
+
+/** What the scenario's script sees per request. */
+export interface BrainContext {
+  /** 0-based count of requests served before this one. */
+  readonly requestIndex: number;
+  /** Role of the final message — "user" means a fresh human turn, "tool"
+   *  means the agent is returning a tool result for the brain to continue. */
+  readonly lastRole: string;
+  /** The latest user-role message content (the human's chat input). */
+  readonly lastUser: string;
+  /** The latest tool-role message content (last tool result), if any. */
+  readonly lastToolResult: string | undefined;
+  /** Tool names offered in this request (already namespaced by the agent). */
+  readonly toolNames: ReadonlyArray<string>;
+}
+
+/** What the "model" does next. `tool.name` may be a suffix — the brain
+ *  resolves it against the request's offered tool names, so scripts don't
+ *  hardcode the agent's MCP namespacing. */
+export interface BrainResponse {
+  readonly text?: string;
+  readonly tool?: { readonly name: string; readonly args: unknown };
+}
+
+export interface ReplayBrain {
+  /** Base URL for the agent's provider config (…/v1). */
+  readonly baseUrl: string;
+  /** Every request body served, in order (for post-hoc assertions). */
+  readonly requests: () => ReadonlyArray<BrainRequest>;
+  /** Script errors (mismatched expectations, throws) — assert empty. */
+  readonly errors: () => ReadonlyArray<string>;
+}
+
+export interface BrainRequest {
+  readonly messages: ReadonlyArray<{ role: string; content: string }>;
+  readonly toolNames: ReadonlyArray<string>;
+}
+
+interface WireMessage {
+  readonly role: string;
+  readonly content?: unknown;
+  readonly tool_calls?: ReadonlyArray<unknown>;
+}
+
+interface WireBody {
+  readonly messages?: ReadonlyArray<WireMessage>;
+  readonly tools?: ReadonlyArray<{ function?: { name?: string } }>;
+}
+
+const contentText = (content: unknown): string => {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        typeof part === "object" && part !== null && "text" in part
+          ? String((part as { text: unknown }).text)
+          : "",
+      )
+      .join("");
+  }
+  return "";
+};
+
+const sseChunk = (delta: Record<string, unknown>, finish: string | null) =>
+  `data: ${JSON.stringify({
+    id: "chatcmpl-replay",
+    object: "chat.completion.chunk",
+    created: 0,
+    model: "replay-model",
+    choices: [{ index: 0, delta, finish_reason: finish }],
+  })}\n\n`;
+
+/**
+ * Serve a scripted brain for the lifetime of the surrounding scope.
+ * `respond` is called once per chat-completions request.
+ */
+export const serveReplayBrain = (
+  respond: (ctx: BrainContext) => BrainResponse,
+): Effect.Effect<ReplayBrain, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.callback<{ server: Server; brain: ReplayBrain }>((resume) => {
+      const served: BrainRequest[] = [];
+      const errors: string[] = [];
+
+      const server = createServer((request, response) => {
+        if (!request.url?.includes("/chat/completions")) {
+          response.writeHead(404).end();
+          return;
+        }
+        let raw = "";
+        request.on("data", (piece: Buffer) => (raw += piece.toString("utf8")));
+        request.on("end", () => {
+          const body = JSON.parse(raw || "{}") as WireBody;
+          const messages = (body.messages ?? []).map((message) => ({
+            role: message.role,
+            content: contentText(message.content),
+          }));
+          const toolNames = (body.tools ?? [])
+            .map((tool) => tool.function?.name ?? "")
+            .filter(Boolean);
+          const requestIndex = served.length;
+          served.push({ messages, toolNames });
+
+          const lastOf = (role: string) =>
+            [...messages].reverse().find((message) => message.role === role)?.content;
+
+          let scripted: BrainResponse;
+          // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: a throwing script must surface as a recorded error + a stop response, not a hung agent
+          try {
+            scripted = respond({
+              requestIndex,
+              lastRole: messages.at(-1)?.role ?? "",
+              lastUser: lastOf("user") ?? "",
+              lastToolResult: lastOf("tool"),
+              toolNames,
+            });
+          } catch (error) {
+            errors.push(`respond() threw on request ${requestIndex}: ${String(error)}`);
+            scripted = { text: "(replay brain script error)" };
+          }
+
+          // Resolve a scripted tool name against the agent's namespaced names.
+          let resolvedTool: { name: string; args: unknown } | undefined;
+          if (scripted.tool) {
+            const wanted = scripted.tool.name;
+            const match =
+              toolNames.find((name) => name === wanted) ??
+              toolNames.find((name) => name.endsWith(wanted));
+            if (match) {
+              resolvedTool = { name: match, args: scripted.tool.args };
+            } else {
+              errors.push(
+                `request ${requestIndex}: no offered tool matches "${wanted}" (offered: ${toolNames.join(", ")})`,
+              );
+            }
+          }
+
+          response.writeHead(200, {
+            "content-type": "text/event-stream",
+            "cache-control": "no-cache",
+            connection: "keep-alive",
+          });
+          response.write(sseChunk({ role: "assistant" }, null));
+          if (scripted.text) {
+            // A few chunks so the TUI streams like a real model reply.
+            for (const piece of scripted.text.match(/.{1,24}/gs) ?? []) {
+              response.write(sseChunk({ content: piece }, null));
+            }
+          }
+          if (resolvedTool) {
+            response.write(
+              sseChunk(
+                {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: `call_${requestIndex}`,
+                      type: "function",
+                      function: {
+                        name: resolvedTool.name,
+                        arguments: JSON.stringify(resolvedTool.args ?? {}),
+                      },
+                    },
+                  ],
+                },
+                null,
+              ),
+            );
+          }
+          response.write(sseChunk({}, resolvedTool ? "tool_calls" : "stop"));
+          response.write("data: [DONE]\n\n");
+          response.end();
+        });
+      });
+
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as AddressInfo;
+        resume(
+          Effect.succeed({
+            server,
+            brain: {
+              baseUrl: `http://127.0.0.1:${port}/v1`,
+              requests: () => served,
+              errors: () => errors,
+            },
+          }),
+        );
+      });
+    }),
+    (resource: { server: Server; brain: ReplayBrain }) =>
+      Effect.sync(() => void resource.server.close()),
+  ).pipe(Effect.map(({ brain }) => brain));

--- a/e2e/src/scenario.ts
+++ b/e2e/src/scenario.ts
@@ -9,7 +9,8 @@
 // recording layer. What survives per run is a small result.json (for the
 // scenario × target matrix) plus whatever artifacts the surfaces produced
 // (browser video/trace/screenshots, terminal casts).
-import { mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -136,6 +137,29 @@ export const scenario = (
             1,
           ),
         );
+        // A run with both recordings is ONE developer session — splice them
+        // into film.mp4 (scripts/film.ts cuts on the focus timeline) so the
+        // viewer plays a single recording, not parts. Best-effort: missing
+        // agg/ffmpeg or a film failure never fails the run; the parts stay
+        // and the viewer falls back to cast + video in story order.
+        if (
+          exit._tag === "Success" &&
+          existsSync(join(dir, "terminal.cast")) &&
+          existsSync(join(dir, "session.mp4"))
+        ) {
+          yield* Effect.sync(() => {
+            // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: optional post-processing over external tooling (agg, ffmpeg)
+            try {
+              execFileSync(
+                "bun",
+                [fileURLToPath(new URL("../scripts/film.ts", import.meta.url)), dir],
+                { stdio: "pipe", timeout: 120_000 },
+              );
+            } catch {
+              // parts remain the artifacts
+            }
+          });
+        }
         buildManifest(RUNS_DIR);
         if (exit._tag === "Failure") {
           return yield* Effect.failCause(exit.cause);

--- a/e2e/src/surfaces/browser.ts
+++ b/e2e/src/surfaces/browser.ts
@@ -11,6 +11,7 @@ import { promisify } from "node:util";
 import { Effect } from "effect";
 import { chromium, type Page } from "playwright";
 
+import { markFocus, markRecordingStart } from "../timeline";
 import type { Identity, Target } from "../target";
 
 export interface BrowserSession {
@@ -66,11 +67,16 @@ export const makeBrowserSurface = (dir: string, target: Target): BrowserSurface 
           );
         }
         const page = await context.newPage();
+        // The session video's clock starts with the page; anchor it for the
+        // run's focus timeline (scripts/film.ts cuts on these).
+        markRecordingStart(dir, "browser");
         return { browser, context, page, videoTmp, shots: { count: 0 } };
       }),
       ({ page, context, shots }) =>
         Effect.promise(async () => {
           const step = async (label: string, action: (page: Page) => Promise<void>) => {
+            // Acting on the page IS focusing the browser window.
+            markFocus(dir, "browser");
             await context.tracing.group(label);
             try {
               await action(page);

--- a/e2e/src/surfaces/browser.ts
+++ b/e2e/src/surfaces/browser.ts
@@ -42,7 +42,17 @@ export const makeBrowserSurface = (dir: string, target: Target): BrowserSurface 
         const videoTmp = join(dir, ".video-tmp");
         mkdirSync(videoTmp, { recursive: true });
 
-        const browser = await chromium.launch();
+        // On the desk (E2E_DESK), the browser is a real headed window on the
+        // virtual display — the desk's single screen recording films it next
+        // to the chat terminal, exactly like a developer tabbing over.
+        const browser = await chromium.launch(
+          process.env.E2E_DESK === "1"
+            ? {
+                headless: false,
+                args: ["--window-position=300,40", "--window-size=1100,830"],
+              }
+            : {},
+        );
         const context = await browser.newContext({
           colorScheme: "dark",
           viewport: { width: 1280, height: 800 },

--- a/e2e/src/timeline.ts
+++ b/e2e/src/timeline.ts
@@ -1,0 +1,47 @@
+// The run's focus timeline: which window the scenario was acting on, when.
+//
+// Focus is DERIVED, never declared — driving a Playwright page focuses the
+// browser window; pushing a chat/terminal event focuses the terminal. The
+// surfaces call markFocus as a side effect of normal operations, so any
+// scenario gets a faithful "where was the developer looking" track for
+// free, and scripts/film.ts can cut the session recordings exactly where
+// the action moved. Anchors map wall-clock to each recording's own clock.
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type TimelineWindow = "terminal" | "browser";
+
+export interface Timeline {
+  /** Wall-clock ms when each recording's clock started. */
+  readonly anchors: { terminal?: number; browser?: number };
+  /** Focus transitions (first event per contiguous run of a window). */
+  readonly focus: Array<{ at: number; window: TimelineWindow }>;
+}
+
+const fileFor = (runDir: string) => join(runDir, "timeline.json");
+
+const read = (runDir: string): Timeline => {
+  const file = fileFor(runDir);
+  if (!existsSync(file)) return { anchors: {}, focus: [] };
+  return JSON.parse(readFileSync(file, "utf8")) as Timeline;
+};
+
+const write = (runDir: string, timeline: Timeline) =>
+  writeFileSync(fileFor(runDir), JSON.stringify(timeline, null, 1));
+
+/** Record that `window`'s recording clock starts now. */
+export const markRecordingStart = (runDir: string, window: TimelineWindow): void => {
+  const timeline = read(runDir);
+  write(runDir, { ...timeline, anchors: { ...timeline.anchors, [window]: Date.now() } });
+};
+
+/** Record that the scenario is acting on `window` (deduped per run). */
+export const markFocus = (runDir: string, window: TimelineWindow): void => {
+  const timeline = read(runDir);
+  if (timeline.focus.at(-1)?.window === window) return;
+  timeline.focus.push({ at: Date.now(), window });
+  write(runDir, timeline);
+};
+
+export const readTimeline = (runDir: string): Timeline | null =>
+  existsSync(fileFor(runDir)) ? read(runDir) : null;

--- a/e2e/viewer/src/App.tsx
+++ b/e2e/viewer/src/App.tsx
@@ -193,7 +193,7 @@ const RunView = ({ target, slug }: { target: string; slug: string }) => {
             className={tab === "media" ? "tab active" : "tab"}
             onClick={() => setTab("media")}
           >
-            ▶ {video ? "video" : "terminal"}
+            ▶ {cast && video ? "session" : video ? "video" : "terminal"}
           </button>
           <button
             className={tab === "source" ? "tab active" : "tab"}
@@ -209,18 +209,24 @@ const RunView = ({ target, slug }: { target: string; slug: string }) => {
           <TestSource url={`${base}/test.ts`} />
         </Suspense>
       )}
-      {cast && !video && tab === "media" && (
+      {/* A run with BOTH recordings is one session in time order: the
+          terminal chat is the spine, the browser video is the hop that
+          happens in the middle of it. Show them in that order. */}
+      {cast && tab === "media" && (
         <Suspense fallback={<p className="dim">loading recording…</p>}>
+          {video && <h2 className="section">1 · the chat, in the terminal</h2>}
           <TerminalCast url={`${base}/${cast}`} />
         </Suspense>
       )}
       {video && tab === "media" && (
         <>
-          {/* muted is required for browsers to honor autoplay */}
+          {cast && <h2 className="section">2 · the browser hop, mid-chat</h2>}
+          {/* muted is required for browsers to honor autoplay; don't
+              autoplay when it's the second act of a session */}
           <video
             className="hero-video"
             controls
-            autoPlay
+            autoPlay={!cast}
             muted
             playsInline
             preload="auto"

--- a/e2e/viewer/src/App.tsx
+++ b/e2e/viewer/src/App.tsx
@@ -155,8 +155,13 @@ const RunView = ({ target, slug }: { target: string; slug: string }) => {
 
   const has = (name: string) => result.artifacts.includes(name);
   const screenshots = result.artifacts.filter((a) => a.endsWith(".png")).sort();
-  const video = has("session.mp4") ? "session.mp4" : has("session.webm") ? "session.webm" : null;
-  const cast = has("terminal.cast") ? "terminal.cast" : null;
+  // film.mp4 (scripts/film.ts) is the whole session as one video — terminal,
+  // browser hop, terminal, cut like tabbing between full-screen windows.
+  // When present it IS the session; the parts stay on disk for debugging.
+  const film = has("film.mp4") ? "film.mp4" : null;
+  const video =
+    film ?? (has("session.mp4") ? "session.mp4" : has("session.webm") ? "session.webm" : null);
+  const cast = film ? null : has("terminal.cast") ? "terminal.cast" : null;
   const media = video ?? cast;
   const traceUrl = has("trace.zip")
     ? `https://trace.playwright.dev/?trace=${encodeURIComponent(


### PR DESCRIPTION
Watchable e2e runs that read like a developer actually using the product: chat with an agent in a terminal, get a connect link, paste a key in the browser, come back and verify — all real calls, recorded.

![Connect · developer session: agent chat → handoff link → paste key → verified send (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/connect-developer-session-agent-chat-handoff-link-paste-key-verified-send-4f091d25.gif)

## What's in here

- **Chat theater** (`e2e/src/clients/chat-theater.ts` + `agent-chat-tui.ts`): the default for product-flow recordings. A chat renderer runs in the recorded PTY; every tool call on screen brackets a REAL mcporter MCP call (OAuth, execute, approval resume). Tool calls render like an agent TUI — tool name, the call's real input block, live spinner for the call's real duration, the real result line. No inference, no third-party binary, ~28s per run.
- **Replay brain** (`e2e/src/clients/replay-brain.ts`): a scripted OpenAI-wire chat-completions server for the distinct tier where a third-party CLIENT's behavior is under test (the real OpenCode binary chats through it; scripted by transcript inspection, not turn counting).
- **Focus timeline** (`e2e/src/timeline.ts`): acting on a window IS focusing it — Playwright steps mark the browser focused, chat events mark the terminal focused. Surfaces emit `timeline.json` as a side effect of normal driving.
- **`e2e/scripts/film.ts`**: cuts the run's two real recordings into ONE mp4 that plays like a screen capture of tabbing between full-screen windows, using the focus timeline as the edit decision list. No display server needed (agg + ffmpeg).
- **The Desk** (`e2e/desk/`): optional Docker stage that films a scenario on a real virtual desktop (visible xterm + headed Chromium, single x11grab) for when actual window layering matters. Scenario files are identical across all presentations.
- **Viewer**: runs with both a cast and a video play in story order; `film.mp4` plays as the session when present.
- **Scenario** (`e2e/scenarios/connect-handoff-session.test.ts`): the connect-handoff developer session — adds the emulated Resend API by its served spec URL only (emulators.dev now serves OpenAPI documents from every REST emulator), pastes an emulator-minted key through the real add-account UI, and proves the connection with a send confirmed by the emulator's request ledger.

## Relationship to #957

Was stacked on #957 (addSpec auth derivation), which has merged — this branch is now based directly on main. The connect-handoff developer-session scenario is the end-to-end regression gate for that fix.


## Split into a stack

This PR was split — it now carries only the recording framework above. The rest of the original work follows in:

- e2e distributed tracing (suite-owned motel, browser OTLP, trace join)
- the live session player + trace rail in the runs viewer
- production browser span export → Axiom

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#962** 👈 current
2. #979
3. #980
4. #981
<!-- stack:links:end -->