### PR TITLE
Align package versions with npm and add v1.5.7 release changesets

### DIFF
--- a/.changeset/desktop-crash-reporting.md
+++ b/.changeset/desktop-crash-reporting.md
@@ -1,0 +1,9 @@
+---
+"executor": patch
+---
+
+**Desktop crash reporting and diagnostics**
+
+- The desktop app now reports crashes from all of its processes (window, main, and the local server sidecar), so launch failures and silent exits become fixable bugs instead of mysteries. Reporting is disabled in local/dev builds and honors `DO_NOT_TRACK=1` as an opt-out.
+- If the local server crashes, the app shows a crash screen with restart and update actions instead of closing silently, and the server's output is persisted to the log file.
+- New **Export Diagnostics** (menu and Settings) zips logs, crash dumps, and a redacted system manifest to Downloads — never secrets or executor data — and **Report a Problem…** prefills a GitHub issue with the diagnostics attached.

--- a/.changeset/integrations-spec-blob.md
+++ b/.changeset/integrations-spec-blob.md
@@ -1,0 +1,10 @@
+---
+"executor": patch
+"@executor-js/sdk": patch
+"@executor-js/plugin-openapi": patch
+"@executor-js/plugin-graphql": patch
+---
+
+**Faster integrations with large API specs**
+
+Resolved OpenAPI spec text and GraphQL introspection snapshots are now stored content-addressed in the plugin blob store instead of inline in each integration's stored config. Listing integrations no longer loads multi-megabyte spec blobs it immediately discards, which makes the integrations surface dramatically faster for workspaces with large specs. Existing integrations keep working: rows that still inline a spec resolve unchanged and are rewritten in place the next time they are imported or refreshed.

--- a/.changeset/republish-from-source.md
+++ b/.changeset/republish-from-source.md
@@ -1,0 +1,7 @@
+---
+"@executor-js/sdk": patch
+"@executor-js/cli": patch
+"@executor-js/fumadb": patch
+---
+
+Republish from committed source. Versions 1.5.5 and 1.5.6 of the library packages were published directly to npm to fix installs resolving the wrong `fumadb` dependency (the vendored database layer is now scoped as `@executor-js/fumadb`); that fix landed in the repo separately, and this release brings the recorded package versions back in line with npm.

--- a/bun.lock
+++ b/bun.lock
@@ -444,7 +444,7 @@
     },
     "packages/core/cli": {
       "name": "@executor-js/cli",
-      "version": "0.2.10",
+      "version": "0.2.12",
       "bin": {
         "executor-sdk": "./dist/index.js",
       },
@@ -465,7 +465,7 @@
     },
     "packages/core/config": {
       "name": "@executor-js/config",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "jiti": "^2.6.1",
@@ -486,7 +486,7 @@
     },
     "packages/core/execution": {
       "name": "@executor-js/execution",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@executor-js/codemode-core": "workspace:*",
         "@executor-js/sdk": "workspace:*",
@@ -507,7 +507,7 @@
     },
     "packages/core/fumadb": {
       "name": "@executor-js/fumadb",
-      "version": "0.3.0",
+      "version": "1.5.6",
       "dependencies": {
         "@clack/prompts": "^1.3.0",
         "@paralleldrive/cuid2": "^3.3.0",
@@ -551,7 +551,7 @@
     },
     "packages/core/sdk": {
       "name": "@executor-js/sdk",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@executor-js/fumadb": "workspace:*",
         "@standard-schema/spec": "^1.1.0",
@@ -783,7 +783,7 @@
     },
     "packages/plugins/example": {
       "name": "@executor-js/plugin-example",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
       },
@@ -806,7 +806,7 @@
     },
     "packages/plugins/file-secrets": {
       "name": "@executor-js/plugin-file-secrets",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
       },
@@ -823,7 +823,7 @@
     },
     "packages/plugins/graphql": {
       "name": "@executor-js/plugin-graphql",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
@@ -862,7 +862,7 @@
     },
     "packages/plugins/keychain": {
       "name": "@executor-js/plugin-keychain",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@executor-js/sdk": "workspace:*",
         "@napi-rs/keyring": "^1.2.0",
@@ -881,7 +881,7 @@
     },
     "packages/plugins/mcp": {
       "name": "@executor-js/plugin-mcp",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
         "@effect/platform-node": "catalog:",
@@ -921,7 +921,7 @@
     },
     "packages/plugins/onepassword": {
       "name": "@executor-js/plugin-onepassword",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@1password/op-js": "^0.1.13",
         "@1password/sdk": "^0.4.1-beta.1",
@@ -955,7 +955,7 @@
     },
     "packages/plugins/openapi": {
       "name": "@executor-js/plugin-openapi",
-      "version": "1.5.4",
+      "version": "1.5.6",
       "dependencies": {
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/cli",
-  "version": "0.2.10",
+  "version": "0.2.12",
   "description": "CLI for the executor SDK — schema generation, migrations",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/cli",
   "bugs": {

--- a/packages/core/config/package.json
+++ b/packages/core/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/config",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/config",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/core/execution/package.json
+++ b/packages/core/execution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/execution",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/execution",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/core/fumadb/package.json
+++ b/packages/core/fumadb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@executor-js/fumadb",
   "description": "A library for interacting with different databases for your package.",
-  "version": "0.3.0",
+  "version": "1.5.6",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RhysSullivan/executor.git",

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/sdk",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/core/sdk",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/example/package.json
+++ b/packages/plugins/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-example",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/example",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/file-secrets/package.json
+++ b/packages/plugins/file-secrets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-file-secrets",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/file-secrets",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/graphql/package.json
+++ b/packages/plugins/graphql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-graphql",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/graphql",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/keychain/package.json
+++ b/packages/plugins/keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-keychain",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/keychain",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/mcp/package.json
+++ b/packages/plugins/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-mcp",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/mcp",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/onepassword/package.json
+++ b/packages/plugins/onepassword/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-onepassword",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/onepassword",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@executor-js/plugin-openapi",
-  "version": "1.5.4",
+  "version": "1.5.6",
   "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/openapi",
   "bugs": {
     "url": "https://github.com/RhysSullivan/executor/issues"


### PR DESCRIPTION
## Why

The June 10 out-of-band npm publishes (the `@executor-js/fumadb` scoping fix) shipped library versions 1.5.5/1.5.6 while the repo manifests still recorded 1.5.4 (`@executor-js/cli` at 0.2.10 vs npm's 0.2.12, `@executor-js/fumadb` at 0.3.0 vs npm's 1.5.6). A normal patch release from that state would compute 1.5.5 and collide with versions already on npm.

## What

- Set the 12 affected package manifests to the version npm currently has, so the next `changeset version` computes 1.5.7 / 0.2.13 cleanly (verified with a local dry run).
- Add release changesets for everything user-facing on `main` since v1.5.4:
  - Desktop crash reporting + diagnostics export (#961)
  - Integrations spec-blob performance work (#959 / #960)
  - Republish-alignment note for the library packages (#934)

## What this does NOT do

Nothing publishes from this PR. After merge, the release workflow opens/updates the Version Packages PR; merging that is the publish trigger.