### PR TITLE
Fix crash template menu reference (Executor, not Help)

### DIFF
--- a/.github/ISSUE_TEMPLATE/desktop-crash.yml
+++ b/.github/ISSUE_TEMPLATE/desktop-crash.yml
@@ -52,7 +52,7 @@ body:
     attributes:
       label: Diagnostics / logs
       description: |
-        If the app opens far enough to show a menu, use **Help → Export Diagnostics…**
+        If the app opens far enough to show a menu, open the **Executor** menu → **Export Diagnostics…**
         (or **Report a Problem…**) and attach the zip — it has everything we need and no secrets.
 
         Otherwise, attach the log file directly:


### PR DESCRIPTION
Docs-only follow-up to #965. The crash issue template told users to open `Help → Export Diagnostics…`, but there's no Help menu — those items are under the Executor app menu (matches the pinned triage issue #966).