### PR TITLE
Turnkey fresh-worktree dev env: atomic per-checkout e2e ports, bootstrap, leak reaper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,9 @@ executor.jsonc
 MISTAKES.md
 DESIRES.md
 LEARNINGS.md
+
+# Agent scratch scripts (workspace-resolvable alternative to /tmp)
+scratch/
 .alchemy/
 
 # Pi coding agent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,13 @@
 ## Fresh Checkout / Worktree Setup
 
 Run `bun run bootstrap` first in any fresh checkout or worktree. It is
-idempotent: inits the vendor submodules (`vendor/emulate`, `vendor/mcporter` —
-the e2e suite needs both), runs `bun install` (whose prepare hook builds the
-internal packages dev servers fail without), and installs Playwright chromium.
+idempotent: runs `bun install` (whose prepare hook builds the internal
+packages dev servers fail without) and installs Playwright chromium.
 Skipping it is why fresh worktrees die with "Failed to resolve entry for
-package '@executor-js/vite-plugin'".
+package '@executor-js/vite-plugin'". The `vendor/` submodules are NOT
+needed — nothing imports from `vendor/` at runtime; those forks are consumed
+from npm (see `vendor/README.md`). `bun run bootstrap --forks` inits them
+only when you're deliberately developing a fork.
 
 ## Environment Gotchas (learned the hard way)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,28 @@
 # AGENTS.md
 
+## Fresh Checkout / Worktree Setup
+
+Run `bun run bootstrap` first in any fresh checkout or worktree. It is
+idempotent: inits the vendor submodules (`vendor/emulate`, `vendor/mcporter` —
+the e2e suite needs both), runs `bun install` (whose prepare hook builds the
+internal packages dev servers fail without), and installs Playwright chromium.
+Skipping it is why fresh worktrees die with "Failed to resolve entry for
+package '@executor-js/vite-plugin'".
+
+## Environment Gotchas (learned the hard way)
+
+- The shell is fish, and the working directory resets between Bash calls. Use
+  absolute paths rooted at THIS worktree (check `pwd`), never
+  `/Users/rhys/src/executor` from memory, and don't rely on a prior `cd`.
+- Don't write probe scripts to `/tmp` — they can't resolve workspace packages
+  (`effect`, `playwright`, ...). Put scratch scripts under the repo root
+  (`scratch/` is gitignored) so bun resolves the workspace.
+- `bun.lock` conflicts on rebase/merge: take either side, then re-run
+  `bun install` to regenerate it — never hand-merge the lockfile.
+- e2e dev-server ports are derived per checkout (`cd e2e && bun run ports`).
+  If a boot reports a squatted port, an old dev server leaked — kill it by
+  PID from the error message; don't move your own ports to dodge it.
+
 ## Task Completion Requirements
 
 - Use Effect Vitest for tests.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -83,10 +83,16 @@ const r = yield * session.call("execute", { code: "return 1 + 1;" });
 cd e2e
 bun run test               # boots both dev servers, runs everything
 bun run test:cloud         # one target
-# attach to an already-running server while iterating:
-E2E_CLOUD_URL=http://127.0.0.1:4798 ../node_modules/.bin/vitest run --project cloud <file>
-E2E_SELFHOST_URL=http://localhost:4799 ../node_modules/.bin/vitest run --project selfhost <file>
+bun run ports              # print THIS checkout's derived ports
+# attach to an already-running server while iterating (use `bun run ports` URLs):
+E2E_CLOUD_URL=http://127.0.0.1:<port> ../node_modules/.bin/vitest run --project cloud <file>
+E2E_SELFHOST_URL=http://localhost:<port> ../node_modules/.bin/vitest run --project selfhost <file>
 ```
+
+Ports are derived per checkout (hash of the repo root — see `src/ports.ts`),
+so suites in different worktrees never fight. If a port is somehow taken, the
+boot fails fast naming the squatting process; kill it or override with
+`E2E_CLOUD_PORT`-style env vars.
 
 Each run writes `runs/<target>/<slug>/result.json` plus any browser artifacts
 (trace.zip / session.mp4 / screenshots). `bun run serve` hosts the scenario ×
@@ -94,7 +100,8 @@ target matrix; a run page links the trace into Playwright's trace viewer.
 
 ## Discovering endpoints
 
-- The full OpenAPI spec: `curl http://127.0.0.1:4798/api/openapi.json` (cloud).
+- The full OpenAPI spec: `curl http://127.0.0.1:<cloud port>/api/openapi.json`
+  (cloud; port from `bun run ports`).
 - The typed client mirrors it: `client.<group>.<endpoint>(...)` with groups
   tools/integrations/connections/providers/executions/oauth/policies.
 - To see payload shapes, read the API definitions under

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -89,10 +89,13 @@ E2E_CLOUD_URL=http://127.0.0.1:<port> ../node_modules/.bin/vitest run --project 
 E2E_SELFHOST_URL=http://localhost:<port> ../node_modules/.bin/vitest run --project selfhost <file>
 ```
 
-Ports are derived per checkout (hash of the repo root — see `src/ports.ts`),
-so suites in different worktrees never fight. If a port is somehow taken, the
-boot fails fast naming the squatting process; kill it or override with
-`E2E_CLOUD_PORT`-style env vars.
+Ports are claimed at boot (see `src/ports.ts`): each checkout hashes its repo
+root to a preferred block, atomically locks it (a held lock port makes races
+impossible), and walks to the next free block if it's locked or squatted — so
+concurrent suites in different worktrees can never collide or attach to each
+other's servers. `bun run ports` shows the preferred block; the boot log says
+if a suite moved. `E2E_*_PORT` env vars pin ports explicitly (no probing) and
+`E2E_<TARGET>_URL` attaches to a running instance.
 
 Each run writes `runs/<target>/<slug>/result.json` plus any browser artifacts
 (trace.zip / session.mp4 / screenshots). `bun run serve` hosts the scenario ×

--- a/e2e/cloud/sources-api.test.ts
+++ b/e2e/cloud/sources-api.test.ts
@@ -184,13 +184,12 @@ scenario(
         }),
       );
       expect(execution.isError, "the execution succeeded").toBe(false);
+      // Payload-first: `data` IS the upstream body; transport facts (status,
+      // headers) ride in the optional `http` side channel.
       expect(execution.structured, "the tool returned the upstream's echo").toMatchObject({
         result: {
           ok: true,
-          data: {
-            status: 200,
-            data: { message: "hello", suffix: "world", path: "/echo/hello" },
-          },
+          data: { message: "hello", suffix: "world", path: "/echo/hello" },
         },
       });
 

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,7 @@
     "test:selfhost": "vitest run --project selfhost",
     "test:watch": "vitest",
     "ports": "bun scripts/ports.ts",
+    "summary": "bun scripts/summary.ts",
     "viewer:build": "bun scripts/rebuild-viewer.ts",
     "serve": "bun scripts/rebuild-viewer.ts && bun scripts/serve.ts",
     "typecheck": "tsc --noEmit",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "test:cloud": "vitest run --project cloud",
     "test:selfhost": "vitest run --project selfhost",
     "test:watch": "vitest",
+    "ports": "bun scripts/ports.ts",
     "viewer:build": "bun scripts/rebuild-viewer.ts",
     "serve": "bun scripts/rebuild-viewer.ts && bun scripts/serve.ts",
     "typecheck": "tsc --noEmit",

--- a/e2e/scripts/ports.ts
+++ b/e2e/scripts/ports.ts
@@ -1,6 +1,11 @@
 // Print this checkout's derived e2e ports (see src/ports.ts) so an agent or
 // human can curl the booted servers or attach with E2E_<TARGET>_URL.
-import { AUTUMN_EMULATOR_PORT, CLOUD_DB_PORT, CLOUD_PORT, WORKOS_EMULATOR_PORT } from "../targets/cloud";
+import {
+  AUTUMN_EMULATOR_PORT,
+  CLOUD_DB_PORT,
+  CLOUD_PORT,
+  WORKOS_EMULATOR_PORT,
+} from "../targets/cloud";
 import { SELFHOST_PORT } from "../targets/selfhost";
 import { repoRoot } from "../src/ports";
 

--- a/e2e/scripts/ports.ts
+++ b/e2e/scripts/ports.ts
@@ -1,0 +1,12 @@
+// Print this checkout's derived e2e ports (see src/ports.ts) so an agent or
+// human can curl the booted servers or attach with E2E_<TARGET>_URL.
+import { AUTUMN_EMULATOR_PORT, CLOUD_DB_PORT, CLOUD_PORT, WORKOS_EMULATOR_PORT } from "../targets/cloud";
+import { SELFHOST_PORT } from "../targets/selfhost";
+import { repoRoot } from "../src/ports";
+
+console.log(`e2e ports for ${repoRoot}`);
+console.log(`  cloud           http://127.0.0.1:${CLOUD_PORT}`);
+console.log(`  cloud dev-db    ${CLOUD_DB_PORT}`);
+console.log(`  workos emulator ${WORKOS_EMULATOR_PORT}`);
+console.log(`  autumn emulator ${AUTUMN_EMULATOR_PORT}`);
+console.log(`  selfhost        http://localhost:${SELFHOST_PORT}`);

--- a/e2e/scripts/ports.ts
+++ b/e2e/scripts/ports.ts
@@ -1,5 +1,8 @@
-// Print this checkout's derived e2e ports (see src/ports.ts) so an agent or
-// human can curl the booted servers or attach with E2E_<TARGET>_URL.
+// Print this checkout's PREFERRED e2e ports (see src/ports.ts). These are
+// where a suite normally boots; if the block is locked or squatted at boot
+// time, claimPorts walks to the next free block and the suite logs the move.
+// When attaching mid-run, the booted vite's actual port is authoritative —
+// check the suite's log line or `ps | grep 'vite dev'`.
 import {
   AUTUMN_EMULATOR_PORT,
   CLOUD_DB_PORT,
@@ -9,7 +12,7 @@ import {
 import { SELFHOST_PORT } from "../targets/selfhost";
 import { repoRoot } from "../src/ports";
 
-console.log(`e2e ports for ${repoRoot}`);
+console.log(`preferred e2e ports for ${repoRoot}`);
 console.log(`  cloud           http://127.0.0.1:${CLOUD_PORT}`);
 console.log(`  cloud dev-db    ${CLOUD_DB_PORT}`);
 console.log(`  workos emulator ${WORKOS_EMULATOR_PORT}`);

--- a/e2e/scripts/summary.ts
+++ b/e2e/scripts/summary.ts
@@ -1,0 +1,39 @@
+// One-line-per-failure digest of the last e2e run: reads
+// runs/<target>/<slug>/result.json and prints pass/fail counts plus each
+// failure's scenario name. `bun run summary [target...]` (default: all).
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const runsDir = fileURLToPath(new URL("../runs/", import.meta.url));
+
+const targets =
+  process.argv.length > 2
+    ? process.argv.slice(2)
+    : readdirSync(runsDir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+
+for (const target of targets) {
+  const targetDir = join(runsDir, target);
+  let slugs: string[];
+  try {
+    slugs = readdirSync(targetDir);
+  } catch {
+    console.log(`${target}: no runs`);
+    continue;
+  }
+  const failures: { scenario: string; endedAt: string }[] = [];
+  let passed = 0;
+  for (const slug of slugs) {
+    try {
+      const result = JSON.parse(readFileSync(join(targetDir, slug, "result.json"), "utf8"));
+      if (result.ok) passed++;
+      else failures.push({ scenario: result.scenario ?? slug, endedAt: result.endedAt ?? "?" });
+    } catch {
+      // No result.json (partial run dir) — not a verdict either way.
+    }
+  }
+  console.log(`${target}: ${passed} passed, ${failures.length} failed`);
+  for (const failure of failures) console.log(`  FAIL ${failure.scenario} (${failure.endedAt})`);
+}

--- a/e2e/setup/boot.ts
+++ b/e2e/setup/boot.ts
@@ -2,7 +2,8 @@
 // server, wait until it answers HTTP, and hand vitest a teardown. The apps own
 // what runs (their dev stack, their stub flags); this file only owns process
 // lifecycle, so it stays target-agnostic.
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { connect } from "node:net";
 
 export interface BootedProcesses {
   readonly teardown: () => Promise<void>;
@@ -70,6 +71,43 @@ export const bootProcesses = (
       }
     },
   };
+};
+
+// A port already in LISTEN before we boot means waitForHttp would silently
+// attach to a FOREIGN server (a leaked dev server from another checkout or a
+// crashed prior run) — every scenario then fails with baffling auth errors
+// instead of one clear message. Fail fast and name the squatter.
+export const ensurePortsFree = async (
+  ports: ReadonlyArray<{ readonly port: number; readonly label: string }>,
+): Promise<void> => {
+  for (const { port, label } of ports) {
+    const inUse = await new Promise<boolean>((resolve) => {
+      const socket = connect({ port, host: "127.0.0.1" });
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", () => resolve(false));
+      socket.setTimeout(1_000, () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+    if (!inUse) continue;
+    let owner = "(lsof unavailable)";
+    try {
+      owner = execFileSync("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], {
+        encoding: "utf8",
+      }).trim();
+    } catch {
+      // lsof failing is fine — the error below carries the essential fact.
+    }
+    throw new Error(
+      `e2e: port ${port} (${label}) is already in use — likely a leaked dev server ` +
+        `from another checkout or a previous run. Kill it or set the E2E_*_PORT/URL ` +
+        `env vars to relocate.\n${owner}`,
+    );
+  }
 };
 
 export const waitForHttp = async (

--- a/e2e/setup/boot.ts
+++ b/e2e/setup/boot.ts
@@ -2,8 +2,7 @@
 // server, wait until it answers HTTP, and hand vitest a teardown. The apps own
 // what runs (their dev stack, their stub flags); this file only owns process
 // lifecycle, so it stays target-agnostic.
-import { execFileSync, spawn, type ChildProcess } from "node:child_process";
-import { connect } from "node:net";
+import { spawn, type ChildProcess } from "node:child_process";
 
 export interface BootedProcesses {
   readonly teardown: () => Promise<void>;
@@ -71,43 +70,6 @@ export const bootProcesses = (
       }
     },
   };
-};
-
-// A port already in LISTEN before we boot means waitForHttp would silently
-// attach to a FOREIGN server (a leaked dev server from another checkout or a
-// crashed prior run) — every scenario then fails with baffling auth errors
-// instead of one clear message. Fail fast and name the squatter.
-export const ensurePortsFree = async (
-  ports: ReadonlyArray<{ readonly port: number; readonly label: string }>,
-): Promise<void> => {
-  for (const { port, label } of ports) {
-    const inUse = await new Promise<boolean>((resolve) => {
-      const socket = connect({ port, host: "127.0.0.1" });
-      socket.once("connect", () => {
-        socket.destroy();
-        resolve(true);
-      });
-      socket.once("error", () => resolve(false));
-      socket.setTimeout(1_000, () => {
-        socket.destroy();
-        resolve(false);
-      });
-    });
-    if (!inUse) continue;
-    let owner = "(lsof unavailable)";
-    try {
-      owner = execFileSync("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN"], {
-        encoding: "utf8",
-      }).trim();
-    } catch {
-      // lsof failing is fine — the error below carries the essential fact.
-    }
-    throw new Error(
-      `e2e: port ${port} (${label}) is already in use — likely a leaked dev server ` +
-        `from another checkout or a previous run. Kill it or set the E2E_*_PORT/URL ` +
-        `env vars to relocate.\n${owner}`,
-    );
-  }
 };
 
 export const waitForHttp = async (

--- a/e2e/setup/cloud.globalsetup.ts
+++ b/e2e/setup/cloud.globalsetup.ts
@@ -10,16 +10,9 @@ import { fileURLToPath } from "node:url";
 // Vendored fork import (same pattern as mcporter).
 import { createEmulator } from "@executor-js/emulate";
 
-import { bootProcesses, ensurePortsFree, waitForHttp } from "./boot";
-import {
-  CLOUD_BASE_URL,
-  CLOUD_DB_PORT,
-  CLOUD_PORT,
-  WORKOS_EMULATOR_PORT,
-  AUTUMN_EMULATOR_PORT,
-  E2E_WORKOS_CLIENT_ID,
-  E2E_COOKIE_PASSWORD,
-} from "../targets/cloud";
+import { claimPorts } from "../src/ports";
+import { E2E_COOKIE_PASSWORD, E2E_WORKOS_CLIENT_ID } from "../targets/cloud";
+import { bootProcesses, waitForHttp } from "./boot";
 
 const cloudDir = fileURLToPath(new URL("../../apps/cloud/", import.meta.url));
 
@@ -29,12 +22,19 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
     return;
   }
 
-  await ensurePortsFree([
-    { port: CLOUD_PORT, label: "cloud vite dev" },
-    { port: CLOUD_DB_PORT, label: "cloud dev-db (PGlite)" },
-    { port: WORKOS_EMULATOR_PORT, label: "WorkOS emulator" },
-    { port: AUTUMN_EMULATOR_PORT, label: "Autumn emulator" },
+  // Claim a free port block (preferred block first, walk forward past
+  // squatters/colliding checkouts) and publish via env so the test workers —
+  // spawned after this — derive the same URLs. The imported targets/cloud
+  // constants were computed BEFORE the claim, so use the claimed values here.
+  const { ports, release } = await claimPorts([
+    { envVar: "E2E_CLOUD_PORT", offset: 0, label: "cloud vite dev" },
+    { envVar: "E2E_CLOUD_DB_PORT", offset: 1, label: "cloud dev-db (PGlite)" },
+    { envVar: "E2E_WORKOS_EMULATOR_PORT", offset: 2, label: "WorkOS emulator" },
+    { envVar: "E2E_AUTUMN_EMULATOR_PORT", offset: 3, label: "Autumn emulator" },
   ]);
+  const cloudPort = ports.E2E_CLOUD_PORT!;
+  const dbPort = ports.E2E_CLOUD_DB_PORT!;
+  const baseUrl = `http://127.0.0.1:${cloudPort}`;
 
   // Fresh dev DB per suite run — hermetic, like the selfhost data dir. The
   // WorkOS emulator mints org ids from a per-process counter, so a persisted
@@ -46,8 +46,8 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
   // MCP access tokens minted by the emulator's OAuth server must carry the
   // app's client id as audience (what the resource server verifies).
   process.env.EMULATE_WORKOS_AUDIENCE = E2E_WORKOS_CLIENT_ID;
-  const workos = await createEmulator({ service: "workos", port: WORKOS_EMULATOR_PORT });
-  const autumn = await createEmulator({ service: "autumn", port: AUTUMN_EMULATOR_PORT });
+  const workos = await createEmulator({ service: "workos", port: ports.E2E_WORKOS_EMULATOR_PORT! });
+  const autumn = await createEmulator({ service: "autumn", port: ports.E2E_AUTUMN_EMULATOR_PORT! });
 
   const env = {
     // Real client, emulated service.
@@ -58,16 +58,16 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
     WORKOS_COOKIE_PASSWORD: E2E_COOKIE_PASSWORD,
     AUTUMN_SECRET_KEY: "am_test_emulate",
     ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    DATABASE_URL: `postgresql://postgres:postgres@127.0.0.1:${CLOUD_DB_PORT}/postgres`,
+    DATABASE_URL: `postgresql://postgres:postgres@127.0.0.1:${dbPort}/postgres`,
     EXECUTOR_DIRECT_DATABASE_URL: "true",
     CLOUDFLARE_INCLUDE_PROCESS_ENV: "true",
-    VITE_PUBLIC_SITE_URL: CLOUD_BASE_URL,
+    VITE_PUBLIC_SITE_URL: baseUrl,
     // The AuthKit domain (MCP OAuth metadata + JWKS) is the emulator too.
     MCP_AUTHKIT_DOMAIN: workos.url,
-    MCP_RESOURCE_ORIGIN: CLOUD_BASE_URL,
+    MCP_RESOURCE_ORIGIN: baseUrl,
     ALLOW_LOCAL_NETWORK: "true",
     // Throwaway PGlite on its own port + dir so it never fights `bun dev`.
-    DEV_DB_PORT: String(CLOUD_DB_PORT),
+    DEV_DB_PORT: String(dbPort),
     DEV_DB_PATH: dbPath,
   };
 
@@ -76,7 +76,7 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
       { cmd: "bun", args: ["run", "scripts/dev-db.ts"], cwd: cloudDir, env },
       {
         cmd: "bunx",
-        args: ["vite", "dev", "--port", String(CLOUD_PORT), "--strictPort", "--host", "127.0.0.1"],
+        args: ["vite", "dev", "--port", String(cloudPort), "--strictPort", "--host", "127.0.0.1"],
         cwd: cloudDir,
         env,
       },
@@ -85,18 +85,20 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
   );
 
   try {
-    await waitForHttp(CLOUD_BASE_URL);
+    await waitForHttp(baseUrl);
     // The API plane is ready when login actually redirects to AuthKit.
-    await waitForHttp(`${CLOUD_BASE_URL}/api/auth/login`, { expectRedirect: true });
+    await waitForHttp(`${baseUrl}/api/auth/login`, { expectRedirect: true });
   } catch (error) {
     await procs.teardown();
     await workos.close();
     await autumn.close();
+    await release();
     throw error;
   }
   return async () => {
     await procs.teardown();
     await workos.close();
     await autumn.close();
+    await release();
   };
 }

--- a/e2e/setup/cloud.globalsetup.ts
+++ b/e2e/setup/cloud.globalsetup.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from "node:url";
 // Vendored fork import (same pattern as mcporter).
 import { createEmulator } from "@executor-js/emulate";
 
-import { bootProcesses, waitForHttp } from "./boot";
+import { bootProcesses, ensurePortsFree, waitForHttp } from "./boot";
 import {
   CLOUD_BASE_URL,
   CLOUD_DB_PORT,
@@ -28,6 +28,13 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
     await waitForHttp(process.env.E2E_CLOUD_URL);
     return;
   }
+
+  await ensurePortsFree([
+    { port: CLOUD_PORT, label: "cloud vite dev" },
+    { port: CLOUD_DB_PORT, label: "cloud dev-db (PGlite)" },
+    { port: WORKOS_EMULATOR_PORT, label: "WorkOS emulator" },
+    { port: AUTUMN_EMULATOR_PORT, label: "Autumn emulator" },
+  ]);
 
   // Fresh dev DB per suite run — hermetic, like the selfhost data dir. The
   // WorkOS emulator mints org ids from a per-process counter, so a persisted

--- a/e2e/setup/selfhost.globalsetup.ts
+++ b/e2e/setup/selfhost.globalsetup.ts
@@ -6,7 +6,7 @@ import { rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { bootProcesses, waitForHttp } from "./boot";
+import { bootProcesses, ensurePortsFree, waitForHttp } from "./boot";
 import { SELFHOST_ADMIN, SELFHOST_BASE_URL, SELFHOST_PORT } from "../targets/selfhost";
 
 const selfhostDir = fileURLToPath(new URL("../../apps/host-selfhost/", import.meta.url));
@@ -16,6 +16,8 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
     await waitForHttp(process.env.E2E_SELFHOST_URL);
     return;
   }
+
+  await ensurePortsFree([{ port: SELFHOST_PORT, label: "selfhost vite dev" }]);
 
   // Fresh data dir per suite run — hermetic; in-suite isolation comes from
   // fresh identities, not resets.

--- a/e2e/setup/selfhost.globalsetup.ts
+++ b/e2e/setup/selfhost.globalsetup.ts
@@ -6,8 +6,9 @@ import { rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { bootProcesses, ensurePortsFree, waitForHttp } from "./boot";
-import { SELFHOST_ADMIN, SELFHOST_BASE_URL, SELFHOST_PORT } from "../targets/selfhost";
+import { claimPorts } from "../src/ports";
+import { SELFHOST_ADMIN } from "../targets/selfhost";
+import { bootProcesses, waitForHttp } from "./boot";
 
 const selfhostDir = fileURLToPath(new URL("../../apps/host-selfhost/", import.meta.url));
 
@@ -17,7 +18,15 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
     return;
   }
 
-  await ensurePortsFree([{ port: SELFHOST_PORT, label: "selfhost vite dev" }]);
+  // Claim a free port (preferred block first, walk forward past squatters)
+  // and publish via env so the test workers derive the same URL. The imported
+  // targets/selfhost constants were computed BEFORE the claim — don't use them
+  // for ports/URLs here.
+  const { ports, release } = await claimPorts([
+    { envVar: "E2E_SELFHOST_PORT", offset: 4, label: "selfhost vite dev" },
+  ]);
+  const port = ports.E2E_SELFHOST_PORT!;
+  const baseUrl = `http://localhost:${port}`;
 
   // Fresh data dir per suite run — hermetic; in-suite isolation comes from
   // fresh identities, not resets.
@@ -28,14 +37,14 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
     [
       {
         cmd: "bunx",
-        args: ["--bun", "vite", "dev", "--port", String(SELFHOST_PORT), "--strictPort"],
+        args: ["--bun", "vite", "dev", "--port", String(port), "--strictPort"],
         cwd: selfhostDir,
         env: {
           EXECUTOR_DATA_DIR: dataDir,
           BETTER_AUTH_SECRET: "executor-selfhost-e2e-secret-0123456789",
           EXECUTOR_BOOTSTRAP_ADMIN_EMAIL: SELFHOST_ADMIN.email,
           EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD: SELFHOST_ADMIN.password,
-          EXECUTOR_WEB_BASE_URL: SELFHOST_BASE_URL,
+          EXECUTOR_WEB_BASE_URL: baseUrl,
           // The harness boots loopback MCP/OAuth test servers and points the
           // instance at them; the hosted SSRF guard would otherwise block
           // outbound probes/dials to localhost. Hermetic test instance only.
@@ -47,10 +56,14 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
   );
 
   try {
-    await waitForHttp(SELFHOST_BASE_URL);
+    await waitForHttp(baseUrl);
   } catch (error) {
     await procs.teardown();
+    await release();
     throw error;
   }
-  return procs.teardown;
+  return async () => {
+    await procs.teardown();
+    await release();
+  };
 }

--- a/e2e/src/ports.ts
+++ b/e2e/src/ports.ts
@@ -1,0 +1,33 @@
+// Per-checkout port derivation: every checkout (main repo, agent worktree,
+// /tmp rig) gets its own deterministic block of e2e ports, so concurrent
+// suites never fight over a shared default. The collision failure mode is
+// brutal: vite's --strictPort exit is swallowed by the boot glue and
+// waitForHttp happily attaches to the OTHER checkout's server, failing dozens
+// of scenarios with baffling auth errors instead of one clear bind error.
+// Individual E2E_*_PORT env vars still override, and E2E_<TARGET>_URL still
+// attaches to a running instance.
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** The repo root identifies the checkout (stable regardless of process cwd). */
+export const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+
+// FNV-1a — tiny, deterministic, and the same value in every process of this
+// checkout (globalsetup and test workers must agree on the ports).
+const hash = (text: string): number => {
+  let h = 2166136261;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+};
+
+// 400 blocks of 10 ports in 42000..45999: unprivileged, clear of common dev
+// servers, and below macOS's ephemeral range (49152+).
+export const portBlock = 42000 + (hash(repoRoot) % 400) * 10;
+
+export const e2ePort = (envVar: string, offset: number): number => {
+  const fromEnv = process.env[envVar];
+  return fromEnv ? Number(fromEnv) : portBlock + offset;
+};

--- a/e2e/src/ports.ts
+++ b/e2e/src/ports.ts
@@ -1,11 +1,18 @@
 // Per-checkout port derivation: every checkout (main repo, agent worktree,
-// /tmp rig) gets its own deterministic block of e2e ports, so concurrent
-// suites never fight over a shared default. The collision failure mode is
-// brutal: vite's --strictPort exit is swallowed by the boot glue and
-// waitForHttp happily attaches to the OTHER checkout's server, failing dozens
-// of scenarios with baffling auth errors instead of one clear bind error.
-// Individual E2E_*_PORT env vars still override, and E2E_<TARGET>_URL still
-// attaches to a running instance.
+// /tmp rig) hashes its repo root into a PREFERRED block of e2e ports, so
+// concurrent suites normally never fight over a shared default. The hash is
+// only a preference, not a guarantee (28 checkouts over 400 blocks is
+// birthday-paradox territory) — the globalsetups call `claimPorts`, which
+// probes the preferred block and walks forward to the next fully-free one,
+// then publishes the claimed ports via the E2E_*_PORT env vars so vitest's
+// test workers (spawned after globalsetup) compute the same URLs. The
+// collision failure mode this kills is brutal: vite's --strictPort exit is
+// swallowed by the boot glue and waitForHttp happily attaches to the OTHER
+// checkout's server, failing dozens of scenarios with baffling auth errors
+// instead of one clear bind error. Individual E2E_*_PORT env vars still
+// override everything, and E2E_<TARGET>_URL still attaches to a running
+// instance.
+import { connect, createServer, type Server } from "node:net";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -24,10 +31,117 @@ const hash = (text: string): number => {
 };
 
 // 400 blocks of 10 ports in 42000..45999: unprivileged, clear of common dev
-// servers, and below macOS's ephemeral range (49152+).
-export const portBlock = 42000 + (hash(repoRoot) % 400) * 10;
+// servers, and below macOS's ephemeral range (49152+). Offsets 0-8 are
+// claimable; offset 9 is the block's lock port (held for the suite's
+// lifetime to make claims atomic across concurrent suites).
+const BLOCK_BASE = 42000;
+const BLOCK_SIZE = 10;
+const BLOCK_COUNT = 400;
+const LOCK_OFFSET = BLOCK_SIZE - 1;
+export const portBlock = BLOCK_BASE + (hash(repoRoot) % BLOCK_COUNT) * BLOCK_SIZE;
 
 export const e2ePort = (envVar: string, offset: number): number => {
   const fromEnv = process.env[envVar];
   return fromEnv ? Number(fromEnv) : portBlock + offset;
 };
+
+const isListening = (port: number): Promise<boolean> =>
+  new Promise((done) => {
+    const socket = connect({ port, host: "127.0.0.1" });
+    socket.once("connect", () => {
+      socket.destroy();
+      done(true);
+    });
+    socket.once("error", () => done(false));
+    socket.setTimeout(1_000, () => {
+      socket.destroy();
+      done(false);
+    });
+  });
+
+export interface PortClaim {
+  readonly envVar: string;
+  readonly offset: number;
+  readonly label: string;
+}
+
+export interface ClaimedPorts {
+  readonly ports: Record<string, number>;
+  /** Releases the block's lock port — call from the suite teardown. */
+  readonly release: () => Promise<void>;
+}
+
+// Binding is atomic where probing is not: holding the block's lock port for
+// the suite's lifetime means two suites racing for the same block can never
+// both win (the second bind EADDRINUSEs and walks on).
+const tryLockBlock = (block: number): Promise<Server | undefined> =>
+  new Promise((done) => {
+    const server = createServer();
+    server.once("error", () => done(undefined));
+    server.listen(block + LOCK_OFFSET, "127.0.0.1", () => done(server));
+  });
+
+/**
+ * Claim a free set of ports for a target and publish them via env. Starts at
+ * this checkout's preferred block and walks forward block-by-block until it
+ * can atomically lock a block whose requested ports are all free — so two
+ * checkouts whose hashes collide (or a leaked server squatting the preferred
+ * block) degrade to "boot one block over" instead of attaching to a foreign
+ * server. Explicit env overrides win and are never probed or locked: if you
+ * pin a port and it's busy, vite's --strictPort fails visibly. A target
+ * re-claiming inside an already-locked process (cloud + selfhost projects in
+ * one vitest run) shares the block via disjoint offsets.
+ */
+export const claimPorts = async (claims: ReadonlyArray<PortClaim>): Promise<ClaimedPorts> => {
+  const ports: Record<string, number> = {};
+  const unpinned = claims.filter((claim) => {
+    const pinned = process.env[claim.envVar];
+    if (pinned) ports[claim.envVar] = Number(pinned);
+    return !pinned;
+  });
+  if (unpinned.length === 0) return { ports, release: async () => {} };
+
+  for (let attempt = 0; attempt < BLOCK_COUNT; attempt++) {
+    const block =
+      BLOCK_BASE + ((portBlock - BLOCK_BASE + attempt * BLOCK_SIZE) % (BLOCK_COUNT * BLOCK_SIZE));
+    // This process may already hold the block's lock (the other target's
+    // globalsetup in the same vitest run); reuse it instead of re-locking.
+    let lock = heldLocks.get(block);
+    if (!lock) {
+      lock = await tryLockBlock(block);
+      if (!lock) {
+        console.warn(`[e2e] port block ${block} is locked by another suite; trying next block`);
+        continue;
+      }
+      heldLocks.set(block, lock);
+    }
+    const busy = await Promise.all(unpinned.map((claim) => isListening(block + claim.offset)));
+    if (busy.some(Boolean)) {
+      const taken = unpinned
+        .filter((_, index) => busy[index])
+        .map((claim) => `${block + claim.offset} (${claim.label})`);
+      console.warn(
+        `[e2e] port block ${block} has squatters — ${taken.join(", ")}; trying next block`,
+      );
+      continue; // Keep the lock: a half-busy block is still ours, just unusable now.
+    }
+    for (const claim of unpinned) {
+      const port = block + claim.offset;
+      ports[claim.envVar] = port;
+      // Workers spawn after globalsetup, so they inherit these and agree.
+      process.env[claim.envVar] = String(port);
+    }
+    return {
+      ports,
+      release: async () => {
+        const held = heldLocks.get(block);
+        if (!held) return;
+        heldLocks.delete(block);
+        await new Promise<void>((done) => held.close(() => done()));
+      },
+    };
+  }
+  throw new Error("e2e: no free port block found — the 42000-45999 range is exhausted?");
+};
+
+const heldLocks = new Map<number, Server>();

--- a/e2e/targets/cloud.ts
+++ b/e2e/targets/cloud.ts
@@ -8,13 +8,14 @@ import { randomUUID } from "node:crypto";
 
 import { Effect } from "effect";
 
+import { e2ePort } from "../src/ports";
 import type { Identity, Target } from "../src/target";
 
-export const CLOUD_PORT = Number(process.env.E2E_CLOUD_PORT ?? 4798);
-export const CLOUD_DB_PORT = Number(process.env.E2E_CLOUD_DB_PORT ?? 5436);
+export const CLOUD_PORT = e2ePort("E2E_CLOUD_PORT", 0);
+export const CLOUD_DB_PORT = e2ePort("E2E_CLOUD_DB_PORT", 1);
 export const CLOUD_BASE_URL = process.env.E2E_CLOUD_URL ?? `http://127.0.0.1:${CLOUD_PORT}`;
-export const WORKOS_EMULATOR_PORT = Number(process.env.E2E_WORKOS_EMULATOR_PORT ?? 4914);
-export const AUTUMN_EMULATOR_PORT = Number(process.env.E2E_AUTUMN_EMULATOR_PORT ?? 4915);
+export const WORKOS_EMULATOR_PORT = e2ePort("E2E_WORKOS_EMULATOR_PORT", 2);
+export const AUTUMN_EMULATOR_PORT = e2ePort("E2E_AUTUMN_EMULATOR_PORT", 3);
 export const E2E_WORKOS_CLIENT_ID = "client_e2e_emulate";
 export const E2E_COOKIE_PASSWORD = "e2e_cookie_password_0123456789abcdef0123456789abcdef";
 

--- a/e2e/targets/selfhost.ts
+++ b/e2e/targets/selfhost.ts
@@ -6,9 +6,10 @@ import { Effect } from "effect";
 
 import { cookieConsentStrategy } from "@executor-js/mcporter";
 
+import { e2ePort } from "../src/ports";
 import type { Identity, Target } from "../src/target";
 
-export const SELFHOST_PORT = Number(process.env.E2E_SELFHOST_PORT ?? 4799);
+export const SELFHOST_PORT = e2ePort("E2E_SELFHOST_PORT", 4);
 export const SELFHOST_BASE_URL =
   process.env.E2E_SELFHOST_URL ?? `http://localhost:${SELFHOST_PORT}`;
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
   ],
   "type": "module",
   "scripts": {
+    "bootstrap": "bun run scripts/bootstrap.ts",
+    "reap": "bun run scripts/reap-dev-servers.ts",
     "dev": "turbo run dev --filter='!@executor-js/desktop' --filter='!@executor-js/cloud'",
     "dev:desktop": "turbo run dev",
     "dev:cli": "EXECUTOR_DEV=1 EXECUTOR_DATA_DIR=${EXECUTOR_DATA_DIR:-apps/local/.executor-dev} bun run apps/cli/src/main.ts",

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -1,7 +1,12 @@
-// One-command setup for a fresh checkout or agent worktree: submodules,
-// dependencies (whose prepare hook builds the internal packages dev servers
-// need), and the Playwright browser the e2e suite drives. Idempotent and
-// safe to re-run; each step prints what it is doing.
+// One-command setup for a fresh checkout or agent worktree: dependencies
+// (whose prepare hook builds the internal packages dev servers need) and the
+// Playwright browser the e2e suite drives. Idempotent and safe to re-run;
+// each step prints what it is doing.
+//
+// The vendor/ submodules are intentionally NOT initialized: nothing imports
+// from vendor/ at runtime — those forks are consumed as published npm
+// packages (see vendor/README.md). Pass --forks only when deliberately
+// developing a fork.
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
@@ -14,7 +19,9 @@ const run = (label: string, cmd: string, args: ReadonlyArray<string>) => {
   execFileSync(cmd, [...args], { cwd: repoRoot, stdio: "inherit" });
 };
 
-run("vendor submodules", "git", ["submodule", "update", "--init", "--recursive"]);
+if (process.argv.includes("--forks")) {
+  run("vendor fork submodules", "git", ["submodule", "update", "--init", "--recursive"]);
+}
 
 // `bun install` runs the workspace prepare hook, which builds
 // @executor-js/vite-plugin and @executor-js/react — the two artifacts the

--- a/scripts/bootstrap.ts
+++ b/scripts/bootstrap.ts
@@ -1,0 +1,32 @@
+// One-command setup for a fresh checkout or agent worktree: submodules,
+// dependencies (whose prepare hook builds the internal packages dev servers
+// need), and the Playwright browser the e2e suite drives. Idempotent and
+// safe to re-run; each step prints what it is doing.
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
+
+const run = (label: string, cmd: string, args: ReadonlyArray<string>) => {
+  console.log(`\n[bootstrap] ${label}: ${cmd} ${args.join(" ")}`);
+  execFileSync(cmd, [...args], { cwd: repoRoot, stdio: "inherit" });
+};
+
+run("vendor submodules", "git", ["submodule", "update", "--init", "--recursive"]);
+
+// `bun install` runs the workspace prepare hook, which builds
+// @executor-js/vite-plugin and @executor-js/react — the two artifacts the
+// apps' vite dev servers fail without in a fresh worktree.
+run("dependencies (+ prepare builds)", "bun", ["install"]);
+
+// e2e browser scenarios need Playwright's chromium; the cache is shared
+// per-machine so this is a fast no-op when already present.
+run("playwright chromium", "bunx", ["playwright", "install", "chromium"]);
+
+if (!existsSync(resolve(repoRoot, "node_modules/.bin/vitest"))) {
+  throw new Error("bootstrap: vitest missing after install — bun install likely failed");
+}
+
+console.log("\n[bootstrap] done — `cd e2e && bun run test` runs the full suite.");

--- a/scripts/reap-dev-servers.ts
+++ b/scripts/reap-dev-servers.ts
@@ -61,5 +61,7 @@ for (const c of candidates) {
 }
 
 if (!killAll && candidates.some((c) => !c.orphan)) {
-  console.log("\nLive-checkout servers were kept (another session may own them); --all kills those too.");
+  console.log(
+    "\nLive-checkout servers were kept (another session may own them); --all kills those too.",
+  );
 }

--- a/scripts/reap-dev-servers.ts
+++ b/scripts/reap-dev-servers.ts
@@ -1,0 +1,65 @@
+// Find (and optionally kill) leaked dev-stack processes — vite dev servers,
+// PGlite dev-dbs, e2e emulators — left behind when a session dies without
+// running its teardown. Default: kill only ORPHANS (processes whose checkout
+// path no longer exists, e.g. a removed worktree) and list the rest.
+// `--all` also kills live-checkout servers (do this only when you know no
+// other agent session is using them). `--dry-run` lists without killing.
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const killAll = args.has("--all");
+
+const DEV_PATTERN = /vite dev|dev-db\.ts|scripts\/dev\.ts/;
+
+const ps = execFileSync("ps", ["-axo", "pid=,command="], { encoding: "utf8" });
+
+interface Candidate {
+  readonly pid: number;
+  readonly command: string;
+  readonly checkout: string | undefined;
+  readonly orphan: boolean;
+}
+
+const candidates: Candidate[] = [];
+for (const line of ps.split("\n")) {
+  const match = line.match(/^\s*(\d+)\s+(.*)$/);
+  if (!match) continue;
+  const [, pidText, command] = match;
+  if (!DEV_PATTERN.test(command!)) continue;
+  if (Number(pidText) === process.pid) continue;
+  // The checkout root is whatever absolute path prefixes node_modules/ or a
+  // workspace dir in the command line.
+  const pathMatch = command!.match(/(\/[^ ]*?)\/(?:node_modules|apps|packages|e2e)\//);
+  const checkout = pathMatch?.[1];
+  const orphan = checkout !== undefined && !existsSync(checkout);
+  candidates.push({ pid: Number(pidText), command: command!.slice(0, 160), checkout, orphan });
+}
+
+if (candidates.length === 0) {
+  console.log("reap: no dev-stack processes found.");
+  process.exit(0);
+}
+
+for (const c of candidates) {
+  const shouldKill = !dryRun && (c.orphan || killAll);
+  const tag = c.orphan ? "ORPHAN" : "live  ";
+  console.log(`${shouldKill ? "KILL " : "keep "} ${tag} pid=${c.pid} ${c.command}`);
+  if (shouldKill) {
+    try {
+      // Group kill (detached boots) with a direct-pid fallback.
+      try {
+        process.kill(-c.pid, "SIGTERM");
+      } catch {
+        process.kill(c.pid, "SIGTERM");
+      }
+    } catch (error) {
+      console.error(`  failed to kill ${c.pid}: ${String(error)}`);
+    }
+  }
+}
+
+if (!killAll && candidates.some((c) => !c.orphan)) {
+  console.log("\nLive-checkout servers were kept (another session may own them); --all kills those too.");
+}


### PR DESCRIPTION
## Why

Running the e2e suite from a fresh worktree failed 31/78 cloud scenarios with misleading auth errors ("AuthKit emulator did not redirect (403)", "No organization in session"). Root cause: every checkout shared the same default ports (4798/4799/...), a leaked vite dev server from another checkout was squatting 4798, vite's `--strictPort` exit was swallowed by the boot glue, and `waitForHttp` silently attached to the foreign checkout's server. Fresh worktrees also start with empty vendor submodules and unbuilt internal packages, so the first dev-server boot dies with "Failed to resolve entry for package '@executor-js/vite-plugin'".

## What

**Atomic per-checkout port claiming** (`e2e/src/ports.ts`)
- Each checkout hashes its repo root to a preferred block of 10 ports (42000–45999).
- At boot, `claimPorts` binds the block's reserved lock port (held for the suite's lifetime — two racing suites can't both win), probes the rest for squatters, and walks forward block-by-block until it owns a fully free block.
- Claimed ports are published via `E2E_*_PORT` env so vitest workers (spawned after globalsetup) agree; explicit env pins skip claiming, `E2E_<TARGET>_URL` still attaches to a running instance.
- Verified by squatting the preferred block and watching the suite relocate one block over and pass.

**One-command setup** (`bun run bootstrap`)
- Idempotent: vendor submodules + `bun install` (prepare hook builds the packages dev servers need) + Playwright chromium. Validated from a cold worktree straight to a green suite.

**Leak cleanup + run digest**
- `bun run reap` lists leaked dev stacks, kills orphans whose checkout is gone (`--all` for the rest).
- `cd e2e && bun run ports` prints the preferred block; `bun run summary` digests `runs/*/result.json` into pass/fail counts.

**Test fix**
- `cloud/sources-api.test.ts` still asserted the pre-#956 `{status, data}` transport envelope; updated to the payload-first shape with the `http` side channel.

**Docs**
- AGENTS.md: fresh-checkout setup section + environment gotchas; e2e/AGENTS.md: port-claiming behavior.

## Validation

- Full suite green from this worktree and from a second cold-bootstrapped worktree running concurrently (each on its own block).
- Collision drill: with the preferred block's lock + selfhost port squatted, the suite logged the move and passed 17/17 one block over.
- `format:check`, `lint`, e2e `typecheck` pass.

Two pre-existing under-load flakes surfaced during full runs (auth-methods `tool_not_found` race, connect-handoff modal timeout); both pass in isolation and are unrelated to this change.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#973** 👈 current
2. #977
<!-- stack:links:end -->