### PR TITLE
Make the local v1→v2 gate ledger-stamped and journal-corruption-proof

### DIFF
--- a/apps/local/src/db/data-migrations.ts
+++ b/apps/local/src/db/data-migrations.ts
@@ -5,7 +5,7 @@
 // renamed.
 // ---------------------------------------------------------------------------
 
-import { sqliteDataMigration, type SqliteDataMigration } from "@executor-js/sdk";
+import { Effect, sqliteDataMigration, type SqliteDataMigration } from "@executor-js/sdk";
 import { runSqliteAuthConfigMigration } from "@executor-js/sdk/http-auth";
 import {
   openApiOutputSchemaDataMigration,
@@ -14,8 +14,15 @@ import {
 import { graphqlIntrospectionBlobDataMigration } from "@executor-js/plugin-graphql";
 
 import { authConfigTransforms } from "./auth-config-migration";
+import { LOCAL_V1_V2_LEDGER_NAME } from "./v1-v2-migration";
 
 export const localDataMigrations: readonly SqliteDataMigration[] = [
+  // The v1→v2 gate itself runs BEFORE the executor (and this registry) can
+  // exist — see migrateLocalV1ToV2IfNeeded in executor.ts. This entry only
+  // stamps the outcome: by the time the registry runs, the database is v2
+  // (it was either migrated or inspected and found already-v2), and the
+  // stamp short-circuits every future boot's schema probing.
+  { name: LOCAL_V1_V2_LEDGER_NAME, run: () => Effect.void },
   // Rewrite pre-canonical integration auth configs (incl. v1→v2 outputs)
   // into the shared placements model.
   sqliteDataMigration("2026-06-05-auth-config-placements", (client) =>

--- a/apps/local/src/db/v1-v2-boot-drive.test.ts
+++ b/apps/local/src/db/v1-v2-boot-drive.test.ts
@@ -1,0 +1,430 @@
+// ---------------------------------------------------------------------------
+// Full-boot stress drive: the REAL local executor stack (v1 gate → fumadb
+// DDL → data-migration ledger → createExecutor) booted repeatedly over
+// databases in every migration state, then exercised with real work — a
+// live OpenAPI spec added through executor.openapi.addSpec, a connection
+// created, and tools invoked against a real HTTP server. Each scenario then
+// REBOOTS the same database file and proves everything still works: the
+// definitive check that migrations converge and never eat data.
+//
+// This is the test the 2026-06-11 desktop crash was missing: the sidecar
+// died inside the v1 gate before any request could be served, on a database
+// state no unit test had seeded.
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { HttpApi, HttpApiBuilder, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
+import { Schema } from "effect";
+
+import { collectTables } from "@executor-js/api/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  Subject,
+  Tenant,
+  ToolAddress,
+  createExecutor,
+  isToolResult,
+  runSqliteDataMigrations,
+} from "@executor-js/sdk";
+import { memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+import { openApiPlugin } from "@executor-js/plugin-openapi";
+import { serveOpenApiHttpApiTestServer } from "@executor-js/plugin-openapi/testing";
+import { fileSecretsPlugin } from "@executor-js/plugin-file-secrets";
+
+import { executeSql, openLocalLibsql, queryRows } from "./libsql";
+import { localDataMigrations } from "./data-migrations";
+import { migrateLocalV1ToV2IfNeeded } from "./v1-v2-migration";
+import { createSqliteFumaDb } from "./sqlite-fumadb";
+
+const TENANT = "executor-workspace-drive77";
+const legacyDir = join(import.meta.dirname, "../../drizzle-legacy-v1");
+
+let workDir: string;
+let previousXdgDataHome: string | undefined;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "executor-v1v2-drive-"));
+  previousXdgDataHome = process.env.XDG_DATA_HOME;
+  process.env.XDG_DATA_HOME = join(workDir, "xdg");
+});
+
+afterEach(() => {
+  if (previousXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = previousXdgDataHome;
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// A real API to migrate against and call after boot.
+// ---------------------------------------------------------------------------
+
+const Widget = Schema.Struct({ id: Schema.Number, name: Schema.String });
+
+const WidgetsGroup = HttpApiGroup.make("widgets")
+  .add(HttpApiEndpoint.get("listWidgets", "/widgets", { success: Schema.Array(Widget) }))
+  .add(
+    HttpApiEndpoint.post("createWidget", "/widgets", {
+      payload: Schema.Struct({ name: Schema.String }),
+      success: Widget,
+    }),
+  );
+
+const DriveApi = HttpApi.make("driveApi").add(WidgetsGroup);
+
+const WIDGETS = [
+  { id: 1, name: "flux capacitor" },
+  { id: 2, name: "sprocket" },
+];
+
+const WidgetsLive = HttpApiBuilder.group(DriveApi, "widgets", (handlers) =>
+  handlers
+    .handle("listWidgets", () => Effect.succeed(WIDGETS.map((w) => Widget.make(w))))
+    .handle("createWidget", (req) =>
+      Effect.succeed(Widget.make({ id: WIDGETS.length + 1, name: req.payload.name })),
+    ),
+);
+
+// ---------------------------------------------------------------------------
+// Boot the real local stack over a database file. Mirrors
+// apps/local/src/executor.ts's createLocalExecutorLayer (gate → DDL →
+// ledger → createExecutor) with test-friendly plugins.
+// ---------------------------------------------------------------------------
+
+const bootRealStack = async (dbPath: string) => {
+  const migration = await migrateLocalV1ToV2IfNeeded({
+    sqlitePath: dbPath,
+    tables: collectTables(),
+    namespace: "executor_local",
+    tenantId: TENANT,
+  });
+  const sqlite = await createSqliteFumaDb({
+    tables: collectTables(),
+    namespace: "executor_local",
+    path: dbPath,
+  });
+  await Effect.runPromise(runSqliteDataMigrations(sqlite.client, localDataMigrations));
+  const executor = await Effect.runPromise(
+    createExecutor({
+      tenant: Tenant.make(TENANT),
+      subject: Subject.make("local"),
+      db: sqlite.db,
+      plugins: [
+        openApiPlugin({ httpClientLayer: FetchHttpClient.layer }),
+        fileSecretsPlugin({ directory: join(workDir, "secrets") }),
+        memoryCredentialsPlugin(),
+      ] as const,
+      onElicitation: "accept-all",
+    }),
+  );
+  return {
+    migration,
+    executor,
+    client: sqlite.client,
+    dispose: async () => {
+      await Effect.runPromise(Effect.ignore(executor.close()));
+      await sqlite.close();
+    },
+  };
+};
+
+/** Seed a REAL v1-final database via the frozen legacy chain, with an mcp
+ *  source the migration must carry over. */
+const seedV1Final = async (dbPath: string, options?: { wipeJournal?: boolean }) => {
+  const client = await openLocalLibsql(dbPath);
+  await migrate(drizzle({ client }), { migrationsFolder: legacyDir });
+  const now = Date.now();
+  await executeSql(
+    client,
+    "INSERT INTO source (id, scope_id, plugin_id, kind, name, url, can_remove, can_refresh, can_edit, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 1, 1, 1, ?, ?)",
+    ["context7", TENANT, "mcp", "mcp", "Context7", "https://mcp.context7.com/mcp", now, now],
+  );
+  await executeSql(
+    client,
+    "INSERT INTO plugin_storage (id, scope_id, plugin_id, collection, key, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    [
+      "mcp-source-context7",
+      TENANT,
+      "mcp",
+      "source",
+      "context7",
+      JSON.stringify({
+        config: { transport: "remote", endpoint: "https://mcp.context7.com/mcp" },
+      }),
+      now,
+      now,
+    ],
+  );
+  if (options?.wipeJournal) await executeSql(client, "DELETE FROM __drizzle_migrations");
+  client.close();
+};
+
+/** addSpec + connection + live invocation through the booted executor. */
+const driveOpenApiWork = (
+  stack: Awaited<ReturnType<typeof bootRealStack>>,
+  server: { readonly specJson: string },
+  slug: string,
+) =>
+  Effect.gen(function* () {
+    const added = yield* stack.executor.openapi.addSpec({
+      spec: { kind: "blob", value: server.specJson },
+      slug,
+      authenticationTemplate: [
+        {
+          slug: AuthTemplateSlug.make("apiKey"),
+          type: "apiKey",
+          headers: { "x-api-key": [{ type: "variable" as const, name: "token" }] },
+        },
+      ],
+    });
+    expect(added.toolCount).toBeGreaterThanOrEqual(2);
+
+    yield* stack.executor.connections.create({
+      owner: "org",
+      name: ConnectionName.make("main"),
+      integration: IntegrationSlug.make(slug),
+      template: AuthTemplateSlug.make("apiKey"),
+      value: "test-key-123",
+    });
+
+    const list = yield* stack.executor.execute(
+      ToolAddress.make(`tools.${slug}.org.main.widgets.listWidgets`),
+      {},
+    );
+    expect(isToolResult(list) && list.ok).toBe(true);
+    if (!isToolResult(list) || !list.ok) return;
+    // Payload-first contract holds through a migrated database too.
+    expect(list.data).toEqual(WIDGETS);
+    expect((list as { http?: { status: number } }).http?.status).toBe(200);
+
+    const created = yield* stack.executor.execute(
+      ToolAddress.make(`tools.${slug}.org.main.widgets.createWidget`),
+      { body: { name: "doodad" } },
+    );
+    expect(isToolResult(created) && created.ok).toBe(true);
+    if (!isToolResult(created) || !created.ok) return;
+    expect(created.data).toEqual({ id: 3, name: "doodad" });
+  });
+
+const expectToolRows = async (dbPath: string, slug: string, minCount: number) => {
+  const client = await openLocalLibsql(dbPath);
+  const rows = await queryRows<{ n: number }>(
+    client,
+    "SELECT COUNT(*) AS n FROM tool WHERE integration = ?",
+    [slug],
+  );
+  expect(Number(rows[0]?.n)).toBeGreaterThanOrEqual(minCount);
+  client.close();
+};
+
+describe("full-boot drive across migration states", () => {
+  it.effect("fresh database: boot → add spec → invoke → reboot → invoke again", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const dbPath = join(workDir, "fresh.db");
+        const server = yield* serveOpenApiHttpApiTestServer({
+          api: DriveApi,
+          handlersLayer: WidgetsLive,
+        });
+
+        // Boot 1: fresh file, everything from zero.
+        const stack1 = yield* Effect.promise(() => bootRealStack(dbPath));
+        expect(stack1.migration.migrated).toBe(false);
+        yield* driveOpenApiWork(stack1, server, "drive_api");
+        yield* Effect.promise(() => stack1.dispose());
+
+        // Boot 2: same file. Gate short-circuits via stamp, ledger no-ops,
+        // and the persisted connection + tools still invoke live.
+        const stack2 = yield* Effect.promise(() => bootRealStack(dbPath));
+        expect(stack2.migration.migrated).toBe(false);
+        const again = yield* stack2.executor.execute(
+          ToolAddress.make("tools.drive_api.org.main.widgets.listWidgets"),
+          {},
+        );
+        expect(isToolResult(again) && again.ok).toBe(true);
+        if (!isToolResult(again) || !again.ok) return;
+        expect(again.data).toEqual(WIDGETS);
+        yield* Effect.promise(() => stack2.dispose());
+
+        yield* Effect.promise(() => expectToolRows(dbPath, "drive_api", 2));
+      }),
+    ),
+  );
+
+  it.effect("v1-final database: migrate → carried data present → new work → reboot", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const dbPath = join(workDir, "v1.db");
+        yield* Effect.promise(() => seedV1Final(dbPath));
+        const server = yield* serveOpenApiHttpApiTestServer({
+          api: DriveApi,
+          handlersLayer: WidgetsLive,
+        });
+
+        // Boot 1: the v1 gate migrates, then the SAME boot does real work.
+        const stack1 = yield* Effect.promise(() => bootRealStack(dbPath));
+        expect(stack1.migration.migrated).toBe(true);
+        const integrations = yield* stack1.executor.integrations.list();
+        expect(integrations.map((i) => String(i.slug))).toContain("context7");
+        yield* driveOpenApiWork(stack1, server, "drive_api");
+        yield* Effect.promise(() => stack1.dispose());
+
+        // Boot 2: nothing re-migrates; migrated v1 data AND post-migration
+        // work both survive.
+        const stack2 = yield* Effect.promise(() => bootRealStack(dbPath));
+        expect(stack2.migration.migrated).toBe(false);
+        const integrations2 = yield* stack2.executor.integrations.list();
+        const slugs = integrations2.map((i) => String(i.slug));
+        expect(slugs).toContain("context7");
+        expect(slugs).toContain("drive_api");
+        yield* Effect.promise(() => stack2.dispose());
+      }),
+    ),
+  );
+
+  it.effect(
+    "the crash-state database (v1-final, empty journal): boots, migrates, drives work",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const dbPath = join(workDir, "crash.db");
+          yield* Effect.promise(() => seedV1Final(dbPath, { wipeJournal: true }));
+          const server = yield* serveOpenApiHttpApiTestServer({
+            api: DriveApi,
+            handlersLayer: WidgetsLive,
+          });
+
+          // Pre-fix: this boot threw `table blob already exists`.
+          const stack = yield* Effect.promise(() => bootRealStack(dbPath));
+          expect(stack.migration.migrated).toBe(true);
+          yield* driveOpenApiWork(stack, server, "drive_api");
+          yield* Effect.promise(() => stack.dispose());
+
+          const reboot = yield* Effect.promise(() => bootRealStack(dbPath));
+          expect(reboot.migration.migrated).toBe(false);
+          yield* Effect.promise(() => reboot.dispose());
+        }),
+      ),
+  );
+
+  it.effect("five consecutive reboots of a migrated database are all no-ops", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const dbPath = join(workDir, "loop.db");
+        yield* Effect.promise(() => seedV1Final(dbPath));
+
+        const first = yield* Effect.promise(() => bootRealStack(dbPath));
+        expect(first.migration.migrated).toBe(true);
+        yield* Effect.promise(() => first.dispose());
+
+        for (let i = 0; i < 5; i++) {
+          const stack = yield* Effect.promise(() => bootRealStack(dbPath));
+          expect(stack.migration.migrated).toBe(false);
+          expect(stack.migration.warnings).toEqual([]);
+          yield* Effect.promise(() => stack.dispose());
+        }
+
+        // Exactly one backup file set was created (the real migration), not
+        // one per boot.
+        const { readdirSync } = yield* Effect.promise(() => import("node:fs"));
+        const backups = readdirSync(workDir).filter((name) => name.includes(".v1-v2-"));
+        const mainFiles = backups.filter(
+          (name) => !name.endsWith("-wal") && !name.endsWith("-shm"),
+        );
+        expect(mainFiles.length).toBe(1);
+      }),
+    ),
+  );
+
+  // ------------------------------------------------------------------
+  // Scale: the REAL vendored Cloudflare spec (16MB, ~2,800 operations)
+  // through a database that just came out of the crash-state migration.
+  // Catches anything the migration leaves behind that only shows up
+  // under a production-sized catalog (constraint violations, slow paths,
+  // schema drift between migrated and fresh rows).
+  // ------------------------------------------------------------------
+  it.effect(
+    "real Cloudflare spec (16MB, ~2800 ops) loads and describes on a crash-state-migrated database",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const dbPath = join(workDir, "scale.db");
+          yield* Effect.promise(() => seedV1Final(dbPath, { wipeJournal: true }));
+
+          const stack = yield* Effect.promise(() => bootRealStack(dbPath));
+          expect(stack.migration.migrated).toBe(true);
+
+          const { readFileSync } = yield* Effect.promise(() => import("node:fs"));
+          const { resolve: resolvePath } = yield* Effect.promise(() => import("node:path"));
+          const cloudflareSpec = readFileSync(
+            resolvePath(
+              import.meta.dirname,
+              "../../../../packages/plugins/openapi/fixtures/cloudflare.json",
+            ),
+            "utf-8",
+          );
+
+          const added = yield* stack.executor.openapi.addSpec({
+            spec: { kind: "blob", value: cloudflareSpec },
+            slug: "cloudflare_api",
+            authenticationTemplate: [
+              {
+                slug: AuthTemplateSlug.make("apiKey"),
+                type: "apiKey",
+                headers: {
+                  authorization: ["Bearer ", { type: "variable" as const, name: "token" }],
+                },
+              },
+            ],
+          });
+          expect(added.toolCount).toBeGreaterThan(1000);
+
+          yield* stack.executor.connections.create({
+            owner: "org",
+            name: ConnectionName.make("main"),
+            integration: IntegrationSlug.make("cloudflare_api"),
+            template: AuthTemplateSlug.make("apiKey"),
+            value: "cf-test-token",
+          });
+
+          // The full production-sized catalog persisted through the
+          // migrated database; schema previews resolve (payload-first, no
+          // transport envelope).
+          const tools = yield* stack.executor.tools.list({ includeAnnotations: false });
+          const cfTools = tools.filter((tool) => String(tool.integration) === "cloudflare_api");
+          expect(cfTools.length).toBeGreaterThan(1000);
+
+          // tools.list is a light projection (no schema columns); resolve a
+          // few schemas through tools.schema and assert the output preview
+          // is payload-first (no transport-envelope headers map).
+          const sampled = cfTools.slice(0, 25);
+          const schemas = yield* Effect.all(
+            sampled.map((tool) => stack.executor.tools.schema(tool.address)),
+          );
+          const withOutput = schemas.find((schema) => schema?.outputTypeScript !== undefined);
+          expect(withOutput).toBeDefined();
+          expect(withOutput?.outputTypeScript).not.toContain("headers: { [k: string]: string; }");
+
+          yield* Effect.promise(() => stack.dispose());
+
+          // Reboot under the full catalog: gate + ledger stay no-ops.
+          const reboot = yield* Effect.promise(() => bootRealStack(dbPath));
+          expect(reboot.migration.migrated).toBe(false);
+          const tools2 = yield* reboot.executor.tools.list({ includeAnnotations: false });
+          expect(
+            tools2.filter((tool) => String(tool.integration) === "cloudflare_api").length,
+          ).toBe(cfTools.length);
+          yield* Effect.promise(() => reboot.dispose());
+        }),
+      ),
+    { timeout: 120_000 },
+  );
+});

--- a/apps/local/src/db/v1-v2-ledger.test.ts
+++ b/apps/local/src/db/v1-v2-ledger.test.ts
@@ -1,0 +1,360 @@
+// ---------------------------------------------------------------------------
+// Local boot-migration correctness: the v1→v2 gate × the data-migration
+// ledger, across every database state a real install can be in.
+//
+// The crash this guards against (observed on a real ~/.executor/data.db,
+// 2026-06-11): a database with the full v1-final schema but an EMPTY
+// `__drizzle_migrations` journal. The old prefix check read "0 applied" as
+// a valid prefix of the legacy chain and replayed migration 0000 over the
+// existing tables → `SQLITE_ERROR: table blob already exists` → the
+// desktop sidecar died at startup, on every boot, with no way out.
+//
+// The fix has three layers, each tested here:
+//   1. replayLegacyV1Migrations gates on the `plugin_storage` schema marker
+//      (what the snapshot reader actually needs) before consulting the
+//      journal, and treats an empty journal over existing tables as
+//      unusable history rather than a fresh chain.
+//   2. The boot ledger stamps LOCAL_V1_V2_LEDGER_NAME after the first
+//      successful pass, so detection never re-runs on later boots — the
+//      stamp, not data shape, is the source of truth.
+//   3. The full boot sequence (gate → fumadb DDL → ledger) converges from
+//      every starting state and the resulting executor actually works:
+//      a real OpenAPI spec is added, a connection created, and a live tool
+//      call made against a real HTTP server, twice (boot → reboot).
+// ---------------------------------------------------------------------------
+
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect, Schema } from "effect";
+
+import { collectTables } from "@executor-js/api/server";
+import { runSqliteDataMigrations } from "@executor-js/sdk";
+
+import { executeSql, openLocalLibsql, queryRows } from "./libsql";
+import { localDataMigrations } from "./data-migrations";
+import { LOCAL_V1_V2_LEDGER_NAME, migrateLocalV1ToV2IfNeeded } from "./v1-v2-migration";
+import { createSqliteFumaDb } from "./sqlite-fumadb";
+
+const decodeUnknownJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
+const decodeJournal = (text: string) =>
+  decodeUnknownJson(text) as {
+    readonly entries: ReadonlyArray<{ readonly idx: number; readonly tag: string }>;
+  };
+
+let workDir: string;
+let previousXdgDataHome: string | undefined;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), "executor-v1v2-ledger-"));
+  previousXdgDataHome = process.env.XDG_DATA_HOME;
+  process.env.XDG_DATA_HOME = join(workDir, "xdg");
+});
+
+afterEach(() => {
+  if (previousXdgDataHome === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = previousXdgDataHome;
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+const TENANT = "executor-workspace-ledger99";
+const legacyDir = join(import.meta.dirname, "../../drizzle-legacy-v1");
+
+/** Apply the real vendored legacy chain (optionally truncated) so the
+ *  database carries genuine drizzle hashes — exactly what a real pre-v1.5
+ *  release produced. */
+const applyLegacyChain = async (dbPath: string, upToIdx?: number): Promise<void> => {
+  let folder = legacyDir;
+  if (upToIdx !== undefined) {
+    folder = join(workDir, `legacy-upto-${upToIdx}`);
+    mkdirSync(join(folder, "meta"), { recursive: true });
+    const journal = decodeJournal(
+      readFileSync(join(legacyDir, "meta", "_journal.json")).toString(),
+    );
+    const kept = journal.entries.filter((entry) => entry.idx <= upToIdx);
+    for (const entry of kept) {
+      writeFileSync(
+        join(folder, `${entry.tag}.sql`),
+        readFileSync(join(legacyDir, `${entry.tag}.sql`)),
+      );
+    }
+    writeFileSync(
+      join(folder, "meta", "_journal.json"),
+      JSON.stringify({ ...journal, entries: kept }),
+    );
+  }
+  const client = await openLocalLibsql(dbPath);
+  await migrate(drizzle({ client }), { migrationsFolder: folder });
+  client.close();
+};
+
+/** Seed one mcp source row (the minimal real v1 content the planner maps to
+ *  an integration). */
+const seedV1Content = async (dbPath: string): Promise<void> => {
+  const client = await openLocalLibsql(dbPath);
+  const now = Date.now();
+  await executeSql(
+    client,
+    "INSERT INTO source (id, scope_id, plugin_id, kind, name, url, can_remove, can_refresh, can_edit, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 1, 1, 1, ?, ?)",
+    ["context7", TENANT, "mcp", "mcp", "Context7", "https://mcp.context7.com/mcp", now, now],
+  );
+  // plugin_storage only exists at v1-final; mcp_source always exists.
+  const hasPluginStorage =
+    (await queryRows(client, "SELECT name FROM sqlite_master WHERE name = 'plugin_storage'"))
+      .length > 0;
+  if (hasPluginStorage) {
+    await executeSql(
+      client,
+      "INSERT INTO plugin_storage (id, scope_id, plugin_id, collection, key, data, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      [
+        "mcp-source-context7",
+        TENANT,
+        "mcp",
+        "source",
+        "context7",
+        JSON.stringify({
+          config: { transport: "remote", endpoint: "https://mcp.context7.com/mcp" },
+        }),
+        now,
+        now,
+      ],
+    );
+  } else {
+    await executeSql(
+      client,
+      "INSERT INTO mcp_source (id, scope_id, name, config, created_at) VALUES (?, ?, ?, ?, ?)",
+      [
+        "context7",
+        TENANT,
+        "Context7",
+        JSON.stringify({ transport: "remote", endpoint: "https://mcp.context7.com/mcp" }),
+        now,
+      ],
+    );
+  }
+  client.close();
+};
+
+/** The boot sequence apps/local/src/executor.ts runs, minus the executor:
+ *  v1 gate → fumadb DDL → ledger. Returns what each phase reported. */
+const bootOnce = async (dbPath: string) => {
+  const migration = await migrateLocalV1ToV2IfNeeded({
+    sqlitePath: dbPath,
+    tables: collectTables(),
+    namespace: "executor_local",
+    tenantId: TENANT,
+  });
+  const sqlite = await createSqliteFumaDb({
+    tables: collectTables(),
+    namespace: "executor_local",
+    path: dbPath,
+  });
+  const applied = await Effect.runPromise(
+    runSqliteDataMigrations(sqlite.client, localDataMigrations),
+  );
+  const ledger = await queryRows<{ name: string }>(
+    sqlite.client,
+    "SELECT name FROM data_migration ORDER BY name",
+  );
+  await sqlite.close();
+  return { migration, applied, ledger: ledger.map((row) => row.name) };
+};
+
+const expectV2WithContext7 = async (dbPath: string) => {
+  const client = await openLocalLibsql(dbPath);
+  const integrations = await queryRows<{ tenant: string; slug: string; plugin_id: string }>(
+    client,
+    "SELECT tenant, slug, plugin_id FROM integration",
+  );
+  expect(integrations).toEqual([{ tenant: TENANT, slug: "context7", plugin_id: "mcp" }]);
+  client.close();
+};
+
+describe("local v1→v2 gate × data-migration ledger", () => {
+  // ------------------------------------------------------------------
+  // THE crash repro: v1-final schema, EMPTY drizzle journal.
+  // ------------------------------------------------------------------
+  it("boots a v1-final database whose drizzle journal is empty (the observed crash state)", async () => {
+    const dbPath = join(workDir, "data.db");
+    await applyLegacyChain(dbPath);
+    await seedV1Content(dbPath);
+    // Reproduce the corruption: wipe the journal rows but keep every table —
+    // exactly the state of the real crashed ~/.executor/data.db.
+    const corrupt = await openLocalLibsql(dbPath);
+    await executeSql(corrupt, "DELETE FROM __drizzle_migrations");
+    corrupt.close();
+
+    // Pre-fix this threw `table blob already exists` out of the legacy
+    // replay. Post-fix the schema marker (plugin_storage exists) short-
+    // circuits the replay entirely — the journal is never consulted, so the
+    // migration proceeds with no warnings.
+    const boot1 = await bootOnce(dbPath);
+    expect(boot1.migration.migrated).toBe(true);
+    expect(boot1.migration.warnings).toEqual([]);
+    expect(boot1.ledger).toContain(LOCAL_V1_V2_LEDGER_NAME);
+    await expectV2WithContext7(dbPath);
+
+    // Reboot: stamped, nothing re-runs, data intact.
+    const boot2 = await bootOnce(dbPath);
+    expect(boot2.migration.migrated).toBe(false);
+    expect(boot2.applied).toEqual([]);
+    await expectV2WithContext7(dbPath);
+  });
+
+  // ------------------------------------------------------------------
+  // Worse corruption: PRE-v1-final schema (no plugin_storage) AND a wiped
+  // journal. The schema marker can't short-circuit, the journal is useless,
+  // and a naive 0000-replay would crash. The tolerant replay re-executes
+  // the frozen chain skipping already-done statements, which builds
+  // plugin_storage (via 0011's real backfill of mcp_source) and the
+  // migration completes with the integration intact.
+  // ------------------------------------------------------------------
+  it("recovers a mid-chain database with a wiped journal via tolerant replay", async () => {
+    const dbPath = join(workDir, "data.db");
+    await applyLegacyChain(dbPath, 10); // pre-0011: no plugin_storage
+    await seedV1Content(dbPath); // lands in mcp_source (pre-0011 shape)
+    const corrupt = await openLocalLibsql(dbPath);
+    await executeSql(corrupt, "DELETE FROM __drizzle_migrations");
+    corrupt.close();
+
+    const boot1 = await bootOnce(dbPath);
+    expect(boot1.migration.migrated).toBe(true);
+    expect(boot1.migration.warnings.some((warning) => warning.includes("tolerant replay"))).toBe(
+      true,
+    );
+    expect(boot1.ledger).toContain(LOCAL_V1_V2_LEDGER_NAME);
+    // The 0011 backfill ran for real: the mcp_source row became a
+    // plugin_storage source row, which planMigration turned into the
+    // integration.
+    await expectV2WithContext7(dbPath);
+
+    const boot2 = await bootOnce(dbPath);
+    expect(boot2.migration.migrated).toBe(false);
+  });
+
+  // ------------------------------------------------------------------
+  // Healthy v1-final database (journal intact): the normal upgrade path.
+  // ------------------------------------------------------------------
+  it("migrates a healthy v1-final database and never re-enters the gate", async () => {
+    const dbPath = join(workDir, "data.db");
+    await applyLegacyChain(dbPath);
+    await seedV1Content(dbPath);
+
+    const boot1 = await bootOnce(dbPath);
+    expect(boot1.migration.migrated).toBe(true);
+    expect(boot1.applied).toContain(LOCAL_V1_V2_LEDGER_NAME);
+    await expectV2WithContext7(dbPath);
+
+    const boot2 = await bootOnce(dbPath);
+    expect(boot2.migration.migrated).toBe(false);
+    expect(boot2.applied).toEqual([]);
+
+    const boot3 = await bootOnce(dbPath);
+    expect(boot3.migration.migrated).toBe(false);
+  });
+
+  // ------------------------------------------------------------------
+  // Mid-chain v1 database: legacy replay still works, then migrates.
+  // ------------------------------------------------------------------
+  it("replays the legacy chain for a pre-v1-final database, then migrates and stamps", async () => {
+    const dbPath = join(workDir, "data.db");
+    await applyLegacyChain(dbPath, 10); // pre-0011: no plugin_storage yet
+    await seedV1Content(dbPath);
+
+    const boot1 = await bootOnce(dbPath);
+    expect(boot1.migration.migrated).toBe(true);
+    expect(boot1.ledger).toContain(LOCAL_V1_V2_LEDGER_NAME);
+    await expectV2WithContext7(dbPath);
+
+    const boot2 = await bootOnce(dbPath);
+    expect(boot2.migration.migrated).toBe(false);
+  });
+
+  // ------------------------------------------------------------------
+  // Fresh database: no v1 anything; ledger stamps immediately.
+  // ------------------------------------------------------------------
+  it("stamps a fresh database without ever probing v1 shape again", async () => {
+    const dbPath = join(workDir, "data.db");
+
+    const boot1 = await bootOnce(dbPath);
+    expect(boot1.migration.migrated).toBe(false);
+    expect(boot1.applied).toContain(LOCAL_V1_V2_LEDGER_NAME);
+
+    const boot2 = await bootOnce(dbPath);
+    expect(boot2.applied).toEqual([]);
+  });
+
+  // ------------------------------------------------------------------
+  // The stamp protects against FUTURE shape-detector confusion: once
+  // stamped, even a database that *looks* v1 (residual legacy tables)
+  // is never re-migrated.
+  // ------------------------------------------------------------------
+  it("a stamped database is never re-migrated even if v1-looking tables appear", async () => {
+    const dbPath = join(workDir, "data.db");
+    await bootOnce(dbPath); // fresh boot → stamped
+
+    // Simulate residue that fools the shape detector: a `source` table with
+    // scope_id, exactly what isLocalV1Database keys on.
+    const client = await openLocalLibsql(dbPath);
+    await executeSql(
+      client,
+      "CREATE TABLE IF NOT EXISTS source (id text, scope_id text, plugin_id text, kind text, name text)",
+    );
+    client.close();
+
+    const boot = await bootOnce(dbPath);
+    expect(boot.migration.migrated).toBe(false); // stamp wins over shape
+  });
+
+  // ------------------------------------------------------------------
+  // Downgrade tolerance: an older (pre-ledger) binary booting a stamped
+  // database ignores the stamp table; re-upgrading must not re-migrate.
+  // ------------------------------------------------------------------
+  it("survives a downgrade/re-upgrade cycle without re-entering the migration", async () => {
+    const dbPath = join(workDir, "data.db");
+    await applyLegacyChain(dbPath);
+    await seedV1Content(dbPath);
+    await bootOnce(dbPath); // upgrade: migrated + stamped
+
+    // "Old binary" wrote rows while ignoring the ledger — simulate its only
+    // observable effect: data written without ledger awareness.
+    const client = await openLocalLibsql(dbPath);
+    const nowMs = Date.now();
+    await executeSql(
+      client,
+      "INSERT INTO plugin_storage (tenant, owner, subject, plugin_id, collection, key, data, created_at, updated_at, row_id) VALUES (?, 'org', '', 'mcp', 'scratch', 'k', '{}', ?, ?, 'r1')",
+      [TENANT, nowMs, nowMs],
+    );
+    client.close();
+
+    const boot = await bootOnce(dbPath);
+    expect(boot.migration.migrated).toBe(false);
+    expect(boot.applied).toEqual([]);
+    await expectV2WithContext7(dbPath);
+  });
+
+  // ------------------------------------------------------------------
+  // Ledger ordering: the v1 stamp is the FIRST registry entry, so a
+  // pre-ledger v2 database stamps it together with the others.
+  // ------------------------------------------------------------------
+  it("stamps all three registry entries on a pre-ledger v2 database", async () => {
+    const dbPath = join(workDir, "data.db");
+    // v2 database created without any ledger (pre-#956 build).
+    const sqlite = await createSqliteFumaDb({
+      tables: collectTables(),
+      namespace: "executor_local",
+      path: dbPath,
+    });
+    await sqlite.close();
+
+    const boot = await bootOnce(dbPath);
+    expect(boot.migration.migrated).toBe(false);
+    // Every registry entry stamps, with the v1 gate first. Assert against
+    // the registry itself so this survives future appends.
+    expect(boot.applied).toEqual(localDataMigrations.map((migration) => migration.name));
+    expect(boot.applied[0]).toBe(LOCAL_V1_V2_LEDGER_NAME);
+  });
+});

--- a/apps/local/src/db/v1-v2-migration.ts
+++ b/apps/local/src/db/v1-v2-migration.ts
@@ -135,6 +135,27 @@ const isLocalV1Database = async (client: Client): Promise<boolean> => {
 };
 
 // ---------------------------------------------------------------------------
+// Data-migration-ledger gate.
+//
+// Once a database has passed the v1 gate (either it was migrated, or it was
+// inspected and found to be v2-native), the boot ledger stamps
+// LOCAL_V1_V2_LEDGER_NAME (see apps/local/src/db/data-migrations.ts). On
+// every later boot the stamp short-circuits this module before any schema
+// probing — the stamp row, not the data shape, is the source of truth.
+// ---------------------------------------------------------------------------
+
+export const LOCAL_V1_V2_LEDGER_NAME = "2026-06-11-local-v1-to-v2";
+
+const hasV1GateStamp = async (client: Client): Promise<boolean> => {
+  if (!(await tableExists(client, "data_migration"))) return false;
+  return (
+    (await queryFirst(client, "SELECT name FROM data_migration WHERE name = ?", [
+      LOCAL_V1_V2_LEDGER_NAME,
+    ])) != null
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Legacy v1 schema replay.
 //
 // The v1→v2 data migration below reads the v1-FINAL schema (it queries
@@ -181,30 +202,93 @@ const readAppliedLegacyMigrationHashes = async (client: Client): Promise<readonl
     )
   ).map((row) => row.hash);
 
-/** Bring a v1 database that predates v1-final up to the last v1 schema. Only
- *  replays when the database's drizzle history is a strict prefix of the
- *  bundled legacy chain — anything else is left as-is with a warning (the
- *  data migration may still succeed if the schema is close enough). */
-const replayLegacyV1Migrations = async (client: Client, warnings: string[]): Promise<void> => {
-  if (!(await tableExists(client, "__drizzle_migrations"))) {
-    warnings.push(
-      "v1 database has no drizzle migration history; skipping the legacy schema replay.",
-    );
-    return;
-  }
+// Errors a statement raises when its work is already done — or when it
+// references schema from an earlier era that a later (already-applied)
+// migration removed ("no such table/column", "has no column named"). The
+// legacy chain's data statements are idempotent by construction (INSERT OR
+// IGNORE / OR REPLACE, conditional UPDATEs), so a chain re-executed over a
+// database in an unknown mid-chain state converges by skipping exactly these.
+const TOLERANT_REPLAY_SKIPPABLE =
+  /already exists|duplicate column name|no such table|no such column|no such index|has no column/i;
+
+const readLegacyJournalTags = (migrationsFolder: string): readonly string[] => {
+  const journal = JSON.parse(
+    fs.readFileSync(join(migrationsFolder, "meta", "_journal.json")).toString(),
+  ) as { entries: ReadonlyArray<{ idx: number; tag: string }> };
+  return [...journal.entries].sort((left, right) => left.idx - right.idx).map((entry) => entry.tag);
+};
+
+/** Recovery path for a v1 database whose drizzle journal can't be trusted
+ *  (wiped, rewritten by another tool, or from an unknown build): re-execute
+ *  the entire frozen legacy chain statement-by-statement, skipping the
+ *  errors that mean "already applied". Statements the database has already
+ *  seen fail with `already exists`/`duplicate column`/`no such ...` and are
+ *  skipped; statements it never reached execute for real. The chain's own
+ *  0011 backfill then populates `plugin_storage` from the per-plugin source
+ *  tables, which is exactly the shape `readV1Snapshot` needs. */
+const tolerantReplayLegacyChain = async (client: Client, warnings: string[]): Promise<void> => {
   const migrationsFolder = resolveLegacyMigrationsFolder();
-  const bundled = readBundledLegacyMigrationHashes(migrationsFolder);
-  const applied = await readAppliedLegacyMigrationHashes(client);
-  const isPrefix =
-    applied.length <= bundled.length && applied.every((hash, index) => hash === bundled[index]);
-  if (!isPrefix) {
-    warnings.push(
-      "v1 database migration history does not match this build's bundled legacy migrations; reading the schema as-is.",
-    );
-    return;
+  let executed = 0;
+  let skipped = 0;
+  for (const tag of readLegacyJournalTags(migrationsFolder)) {
+    const sql = fs.readFileSync(join(migrationsFolder, `${tag}.sql`)).toString();
+    for (const chunk of sql.split("--> statement-breakpoint")) {
+      const statement = chunk.trim();
+      if (statement.length === 0) continue;
+      try {
+        await client.execute(statement);
+        executed++;
+      } catch (cause) {
+        // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: classifying raw SqliteError text from the libSQL driver
+        const message = cause instanceof Error ? cause.message : String(cause);
+        if (!TOLERANT_REPLAY_SKIPPABLE.test(message)) throw cause;
+        skipped++;
+      }
+    }
   }
-  if (applied.length === bundled.length) return; // already v1-final
-  await migrate(drizzle({ client }), { migrationsFolder });
+  warnings.push(
+    `v1 database had unusable drizzle migration history; recovered the v1-final schema by tolerant replay (${executed} statements applied, ${skipped} already done).`,
+  );
+};
+
+/** Bring a v1 database up to the v1-final schema `readV1Snapshot` requires.
+ *
+ *  The replay exists for ONE reader: `readV1Snapshot` queries
+ *  `plugin_storage`, which appears in legacy migration 0011. Real-world v1
+ *  databases show up in franken-states the journal can't describe — the
+ *  observed crash case was a v1-final schema (plugin_storage and all) with
+ *  an EMPTY `__drizzle_migrations` journal, which the old prefix check read
+ *  as "nothing applied" and replayed from 0000 straight into
+ *  `table blob already exists`. So the gates, in order:
+ *
+ *  1. Schema marker: `plugin_storage` exists → the schema is already
+ *     sufficient; never consult the journal, never replay.
+ *  2. Journal is a non-empty strict prefix of the bundled chain → the exact
+ *     drizzle replay every pre-v1.5 release performed (fast, hash-checked).
+ *  3. Anything else (missing/empty/foreign journal) → tolerant replay; the
+ *     old behavior of "skip and read as-is" just crashed later in
+ *     `readV1Snapshot` on the missing `plugin_storage` table. */
+const replayLegacyV1Migrations = async (client: Client, warnings: string[]): Promise<void> => {
+  if (await tableExists(client, "plugin_storage")) return;
+
+  if (await tableExists(client, "__drizzle_migrations")) {
+    const applied = await readAppliedLegacyMigrationHashes(client);
+    if (applied.length > 0) {
+      const migrationsFolder = resolveLegacyMigrationsFolder();
+      const bundled = readBundledLegacyMigrationHashes(migrationsFolder);
+      const isPrefix =
+        applied.length < bundled.length && applied.every((hash, index) => hash === bundled[index]);
+      // A full-length journal can't be trusted here: plugin_storage is
+      // missing (checked above), so a journal claiming v1-final is lying —
+      // fall through to the tolerant replay.
+      if (isPrefix) {
+        await migrate(drizzle({ client }), { migrationsFolder });
+        return;
+      }
+    }
+  }
+
+  await tolerantReplayLegacyChain(client, warnings);
 };
 
 const textDecoder = new TextDecoder();
@@ -930,6 +1014,11 @@ export const migrateLocalV1ToV2IfNeeded = async (
 
   const reader = await openLocalLibsql(options.sqlitePath);
   try {
+    // Ledger short-circuit: once a database has been through this gate the
+    // boot data-migration registry stamps it, and the stamp — not schema
+    // shape — decides. Probing by shape on every boot is what made a v2
+    // database with residual v1-looking state re-enter the migration.
+    if (await hasV1GateStamp(reader)) return { migrated: false, warnings: [] };
     if (!(await isLocalV1Database(reader))) return { migrated: false, warnings: [] };
     const replayWarnings: string[] = [];
     await replayLegacyV1Migrations(reader, replayWarnings);


### PR DESCRIPTION
## What

Fix desktop crashes on boot

## Testing

All against real libSQL databases built by the real frozen legacy chain:

- **`v1-v2-ledger.test.ts`** — 8-state matrix: the exact crash state (v1-final + empty journal); mid-chain + wiped journal (proves 0011's backfill actually executes during tolerant replay, not just "doesn't crash"); healthy v1-final; pre-v1-final drizzle replay; fresh DB; stamped DB with v1-looking residue (stamp wins); downgrade → re-upgrade; pre-ledger v2 DB stamping order.
- **`v1-v2-boot-drive.test.ts`** — full-stack boot drives (gate → fumadb DDL → ledger → `createExecutor`) with real work after every boot: `addSpec`, a connection, live HTTP tool invocations (payload-first + `http.status` asserted through a migrated database); a 5-reboot loop asserting no-op convergence and exactly one backup file; and the real 16MB Cloudflare spec (2,800+ operations) added on a crash-state-migrated database, catalog intact after reboot.
- **The actual crashed database**: a copy of the real `~/.executor/data.db` through the fixed boot — migrates (1 integration carried), stamps, second boot fully no-ops, 407ms.

Full repo gates: format, lint, typecheck, full test suite.

## Known remaining gap (pre-existing, out of scope)

A hard kill (power loss/SIGKILL) in the milliseconds between the backup rename and the new v2 file being written would leave the next boot starting fresh, with the user's data intact in the `.v1-v2-<timestamp>` backup. The error path already restores the backup; the process-death path can't. An atomic temp-file swap is a small follow-up.