### PR TITLE
Release: changeset for local v1→v2 upgrade hardening

### DIFF
--- a/.changeset/local-v1-v2-ledger.md
+++ b/.changeset/local-v1-v2-ledger.md
@@ -1,0 +1,15 @@
+---
+"executor": patch
+---
+
+**Hardened the local v1→v2 database upgrade**
+
+Upgrading a local database created by an older (v1) release is now resilient to
+interrupted or partially-written upgrade state:
+
+- The one-time upgrade is recorded in the migration ledger, so it is never
+  re-attempted on later boots. Databases that have already upgraded are detected
+  from the ledger and skip the upgrade path entirely.
+- Replaying the legacy schema now tolerates a missing or truncated migration
+  journal instead of failing to start, so a database left in a half-written
+  state from a previous crash boots cleanly.


### PR DESCRIPTION
Adds the missing changeset for #982, which merged without one (so no version bump was cut).

Targets `executor` at **patch** per the changeset convention — the fixed release group (SDK, plugins, desktop) bumps along, taking the published version **1.5.7 → 1.5.8**.

Merging this lands the changeset on `main`, which makes the Release workflow open the **Version Packages** PR. Merging *that* publishes the packages, tags `v1.5.8`, and triggers the CLI + desktop builds.

The shipped fix (already on main): the local v1→v2 database upgrade is now ledger-stamped so it never re-runs, and the legacy-schema replay tolerates a missing/truncated migration journal instead of crashing on boot.