### PR TITLE
One http.server span per request: the worker defers to Effect's tracer

### DIFF
--- a/apps/cloud/src/server.ts
+++ b/apps/cloud/src/server.ts
@@ -9,6 +9,7 @@ import {
 import * as Sentry from "@sentry/cloudflare";
 import handler from "@tanstack/react-start/server-entry";
 
+import { isAppOwnedPath } from "./app-paths";
 import { McpSessionDO as McpSessionDOBase } from "./mcp/session-durable-object";
 import { browserTracesResponse } from "./observability/browser-traces";
 import { flushTracerProvider, installTracerProvider } from "./observability/telemetry";
@@ -53,6 +54,16 @@ export const McpSessionDO = Sentry.instrumentDurableObjectWithSentry(
 // migration — without the OTel-SDK version-conflict that package would now
 // drag in (it pins `@opentelemetry/otlp-* ^0.200.0`, we ship ^0.214.0).
 //
+// ONLY for paths the Effect app does not own. App-owned paths (/api/*, /mcp,
+// /.well-known/* — see app-paths.ts) get their `http.server` span from
+// Effect's own HttpMiddleware.tracer, which parses `traceparent` itself and
+// parents the workos/store/db child spans. Wrapping those here too produced
+// two identical sibling `http.server` spans per request (scope
+// `executor-cloud-worker` next to scope `executor-cloud`) — double ingest,
+// and the waterfall showed a childless twin. The worker span remains for
+// everything Effect never sees: Start SSR, the marketing proxy, /_astro
+// assets.
+//
 // SimpleSpanProcessor exports synchronously at span end but the underlying
 // `fetch()` to Axiom is fire-and-forget; the Worker may terminate before it
 // completes. `ctx.waitUntil(flushTracerProvider())` keeps the isolate alive
@@ -78,6 +89,18 @@ const cloudflareHandler: ExportedHandler<Env> = {
       return fetchHandler(request, env, ctx);
     }
     const url = new URL(request.url);
+    // Effect-served paths bring their own http.server span (with traceparent
+    // join) — opening one here too would duplicate it. See the header note.
+    if (isAppOwnedPath(url.pathname)) {
+      // The provider is installed (above) and the flush still must outlive
+      // the request — Effect's BatchSpanProcessor ships on a timer.
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- adapter boundary; mirror the traced path's finally
+      try {
+        return await fetchHandler(request, env, ctx);
+      } finally {
+        ctx.waitUntil(flushTracerProvider());
+      }
+    }
     // Join the caller's W3C trace when the request carries one — the web UI
     // sends traceparent on every API fetch, so the browser's spans and this
     // request share one trace id end to end. Same parsing the DO path does


### PR DESCRIPTION
## The bug

Every API/MCP request produced **two identical sibling `http.server` spans**: the worker-boundary span `server.ts` opens (scope `executor-cloud-worker`) and the one Effect's `HttpMiddleware.tracer` opens for app-owned paths (scope `executor-cloud`). Both join the caller's `traceparent`, so they land in the same trace as twins — the waterfall shows a childless duplicate next to the real envelope (all the workos/store/db children parent under Effect's span), and server-span ingest is doubled. In the production dataset that's ~25k duplicate spans against ~40k real ones on `/mcp` alone.

The duplicate was invisible until the browser span export landed (#981) and made joined traces inspectable end to end — the first real waterfall showed the twin immediately.

## The fix

The worker now skips its envelope span for app-owned paths (`app-paths.ts`: `/api/*`, `/mcp`, `/.well-known/*`) — Effect's middleware already parses `traceparent` itself and parents the child spans there. Non-app paths (Start SSR, the marketing proxy, `/_astro` assets — which Effect never sees) keep the worker span, and the flush-on-`waitUntil` runs on both branches so batched exports survive the isolate.

After deploy, `executor-cloud-worker`-scope server spans become a meaningful signal ("non-app traffic") instead of noise.

## Verified

Against the suite-owned motel trace store (#979): API + browser scenario runs record **exactly one `http.server` span per trace** (worker scope appears only on `/` and SSR routes), and the browser→server join is intact — `executor-web` client span → `executor-cloud` server span → `workos`/`user_store`/`fumadb` children. Cloud observability unit tests 10/10; lint/format/typecheck clean.