### PR TITLE
Render the real shell from the gate's verified identity — delete the full-page skeleton

### DIFF
--- a/apps/cloud/src/auth/route-paths.ts
+++ b/apps/cloud/src/auth/route-paths.ts
@@ -1,0 +1,10 @@
+// Route sets shared between the SSR auth gate (server) and the root
+// AuthGate (client) — one source of truth so the two layers can't disagree
+// about which pages a given auth state may see. Pure data, safe in both
+// bundles.
+
+/** Pages that render for SIGNED-OUT visitors (the gate lets them through). */
+export const PUBLIC_PATHS = new Set(["/login"]);
+
+/** Pages an authenticated-but-org-less user is FOR (everything else redirects to onboarding). */
+export const ONBOARDING_PATHS = new Set(["/create-org", "/setup-mcp"]);

--- a/apps/cloud/src/auth/ssr-gate.ts
+++ b/apps/cloud/src/auth/ssr-gate.ts
@@ -1,13 +1,19 @@
 // ---------------------------------------------------------------------------
 // SSR auth gate — the server-side session check for DOCUMENT requests.
 //
-// Before this gate, every signed-out visitor was served the SPA, whose root
-// AuthGate SSRs the AUTHENTICATED app-shell skeleton until a client-side
-// `/account/me` round trip 401s — the "bad skeleton on unauthed state" flash.
-// The sealed `wos-session` cookie can be verified right here in the worker
+// The sealed `wos-session` cookie is verified right here in the worker
 // (unseal + JWT check against cached JWKS — no per-request WorkOS round trip
-// except token refresh), so signed-out visitors are 302'd to /login before any
-// app HTML exists, and signed-in visitors proceed knowing the session is real.
+// except token refresh), so by the time the SPA is served the server KNOWS
+// who it's serving:
+//
+// - signed out → 302 /login (carrying ?returnTo=) before any app HTML exists
+// - org-less   → 302 /create-org (onboarding owns those sessions)
+// - signed in  → the document is served WITH the verified identity: the
+//   auth-hint travels to the SSR render via request-middleware context (the
+//   root loader picks it up), and is minted as a cookie when the browser
+//   doesn't hold a current one — so the very first paint is the real app
+//   shell, never a skeleton. The hint is display-only; /account/me remains
+//   the authority and the client keeps it fresh from then on.
 //
 // Scope: GET/HEAD requests that are document navigations (sec-fetch-dest /
 // accept), excluding app-owned paths (/api, /mcp — they answer for themselves
@@ -15,19 +21,31 @@
 // ---------------------------------------------------------------------------
 
 import { createMiddleware } from "@tanstack/react-start";
-import { Effect, Exit, ManagedRuntime } from "effect";
+import { Effect, Exit, Layer, ManagedRuntime } from "effect";
 
-import { AUTH_HINT_COOKIE } from "@executor-js/react/multiplayer/auth-hint";
+import {
+  AUTH_HINT_COOKIE,
+  AUTH_HINT_MAX_AGE_SECONDS,
+  decodeAuthHint,
+  encodeAuthHint,
+  type AuthHint,
+} from "@executor-js/react/multiplayer/auth-hint";
 
 import { isAppOwnedPath } from "../app-paths";
+import { makeDbLayer } from "../db/db";
+import { makeUserStoreLayer, UserStoreService } from "./context";
 import { parseCookie } from "./cookies";
+import { sealedSessionDisplayName } from "./middleware";
 import { loginPath, safeReturnTo } from "./return-to";
+import { ONBOARDING_PATHS, PUBLIC_PATHS } from "./route-paths";
 import { WorkOSClient } from "./workos";
 
 const SESSION_COOKIE = "wos-session";
 /** Mirrors the handlers' COOKIE_OPTIONS (path /, HttpOnly, Lax, 7d, Secure). */
 const SESSION_COOKIE_ATTRIBUTES = "Path=/; HttpOnly; Secure; SameSite=Lax";
 const SESSION_MAX_AGE = 60 * 60 * 24 * 7;
+/** Same attributes the client write uses — minus HttpOnly: the SPA reads it. */
+const HINT_COOKIE_ATTRIBUTES = "Path=/; Secure; SameSite=Lax";
 
 const isDocumentRequest = (request: Request): boolean => {
   if (request.method !== "GET" && request.method !== "HEAD") return false;
@@ -48,7 +66,14 @@ const isDocumentRequest = (request: Request): boolean => {
 let runtime: ManagedRuntime.ManagedRuntime<WorkOSClient, unknown> | undefined;
 const getRuntime = () => (runtime ??= ManagedRuntime.make(WorkOSClient.Default));
 
-type VerifiedSession = { readonly refreshedSession?: string | undefined };
+type VerifiedSession = {
+  readonly userId: string;
+  readonly email: string;
+  readonly name: string | null;
+  readonly avatarUrl: string | null;
+  readonly organizationId: string | null;
+  readonly refreshedSession?: string | undefined;
+};
 
 // EVERY failure collapses to "signed out" — WorkOS errors inside the effect
 // and layer-construction errors like a bad cookie password (runPromiseExit
@@ -58,8 +83,74 @@ const verifySession = async (sealed: string): Promise<VerifiedSession | null> =>
   const exit = await getRuntime().runPromiseExit(
     Effect.flatMap(WorkOSClient.asEffect(), (workos) => workos.authenticateSealedSession(sealed)),
   );
-  return Exit.isSuccess(exit) ? exit.value : null;
+  if (!Exit.isSuccess(exit) || exit.value === null) return null;
+  const result = exit.value;
+  return {
+    userId: result.userId,
+    email: result.email,
+    name: sealedSessionDisplayName(result),
+    avatarUrl: result.avatarUrl ?? null,
+    organizationId: result.organizationId ?? null,
+    refreshedSession: result.refreshedSession,
+  };
 };
+
+// ── Auth hint ────────────────────────────────────────────────────────────────
+
+/**
+ * The hint this request should be served with: the browser's own cookie when
+ * it already matches the verified identity, else one minted fresh from the
+ * session. `mint` is set when the cookie must also be (re)written — identity
+ * data freshness (a renamed user/org) is the CLIENT's job via /account/me,
+ * so the gate only steps in when the ids are wrong, never to rewrite display
+ * fields (which would ping-pong with the client's authoritative write).
+ */
+const resolveAuthHint = async (
+  session: VerifiedSession,
+  cookieHeader: string | null,
+): Promise<{ hint: AuthHint; mint: boolean }> => {
+  const existing = decodeAuthHint(parseCookie(cookieHeader, AUTH_HINT_COOKIE));
+  if (
+    existing &&
+    existing.user.id === session.userId &&
+    (existing.organization?.id ?? null) === session.organizationId
+  ) {
+    return { hint: existing, mint: false };
+  }
+  return {
+    hint: {
+      v: 1,
+      user: {
+        id: session.userId,
+        email: session.email,
+        name: session.name,
+        avatarUrl: session.avatarUrl,
+      },
+      organization: session.organizationId
+        ? { id: session.organizationId, name: await organizationName(session.organizationId) }
+        : null,
+    },
+    mint: true,
+  };
+};
+
+// The sealed session carries the org ID but not its name; the local mirror
+// has it. Only consulted when minting (absent/mismatched hint) — never on the
+// steady-state path — and over per-request layers, because a connection cached
+// in the shared runtime would be reused across requests, which Cloudflare
+// forbids. A miss or failure reads as "" — display-only, corrected by the
+// client's /account/me write.
+const organizationName = async (organizationId: string): Promise<string> => {
+  const exit = await getRuntime().runPromiseExit(
+    Effect.flatMap(UserStoreService.asEffect(), (users) =>
+      users.use((store) => store.getOrganization(organizationId)),
+    ).pipe(Effect.provide(Layer.provide(makeUserStoreLayer(), makeDbLayer()))),
+  );
+  return Exit.isSuccess(exit) ? (exit.value?.name ?? "") : "";
+};
+
+const hintSetCookie = (hint: AuthHint) =>
+  `${AUTH_HINT_COOKIE}=${encodeAuthHint(hint)}; ${HINT_COOKIE_ATTRIBUTES}; Max-Age=${AUTH_HINT_MAX_AGE_SECONDS}`;
 
 const sessionSetCookie = (sealed: string) =>
   `${SESSION_COOKIE}=${sealed}; ${SESSION_COOKIE_ATTRIBUTES}; Max-Age=${SESSION_MAX_AGE}`;
@@ -88,12 +179,13 @@ export const authGateMiddleware = createMiddleware({ type: "request" }).server(
   async ({ pathname, request, next }) => {
     if (isAppOwnedPath(pathname) || !isDocumentRequest(request)) return next();
 
-    const sealed = parseCookie(request.headers.get("cookie"), SESSION_COOKIE);
+    const cookieHeader = request.headers.get("cookie");
+    const sealed = parseCookie(cookieHeader, SESSION_COOKIE);
     const url = new URL(request.url);
 
-    // /login is the one page signed-out visitors are FOR; a signed-in visitor
-    // landing here is bounced straight back to where they were headed.
-    if (pathname === "/login") {
+    // Public pages are what signed-out visitors are FOR; a signed-in visitor
+    // landing on /login is bounced straight back to where they were headed.
+    if (PUBLIC_PATHS.has(pathname)) {
       const session = sealed ? await verifySession(sealed) : null;
       if (!session) return next();
       return redirect(safeReturnTo(url.searchParams.get("returnTo")) ?? "/", {
@@ -118,14 +210,32 @@ export const authGateMiddleware = createMiddleware({ type: "request" }).server(
       return redirect("/", { refreshedSession: session.refreshedSession });
     }
 
-    const result = await next();
+    // A session with no organization belongs in onboarding — same decision
+    // the client AuthGate makes mid-session, made here before the document
+    // exists so the app shell is never painted for an org-less session.
+    if (!session.organizationId && !ONBOARDING_PATHS.has(pathname)) {
+      return redirect("/create-org", { refreshedSession: session.refreshedSession });
+    }
+
+    // Serve the document WITH the verified identity: the hint rides to the
+    // SSR render through middleware context (the root loader reads it), so
+    // the server paints the real authenticated shell — no loading state, no
+    // skeleton. Set-cookie writes ride on the rendered response.
+    const { hint, mint } = await resolveAuthHint(session, cookieHeader);
+    const result = await next({ context: { authHint: hint } });
+    if (!mint && !session.refreshedSession) return result;
+
+    const response = new Response(result.response.body, result.response);
+    if (mint) {
+      // The browser holds no current hint — mint one so the NEXT load (and
+      // any client-side read) sees the same identity this render used.
+      response.headers.append("set-cookie", hintSetCookie(hint));
+    }
     if (session.refreshedSession) {
       // WorkOS refresh tokens are single-use: the rotated sealed session MUST
       // reach the browser or the next expiry logs the user out.
-      const response = new Response(result.response.body, result.response);
       response.headers.append("set-cookie", sessionSetCookie(session.refreshedSession));
-      return response;
     }
-    return result;
+    return { ...result, response };
   },
 );

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -14,21 +14,16 @@ import { PostHogProvider } from "posthog-js/react";
 import type { FrontendErrorReporter } from "@executor-js/react/api/error-reporting";
 import { ExecutorProvider } from "@executor-js/react/api/provider";
 import { OrganizationProvider } from "@executor-js/react/api/organization-context";
-import { Skeleton } from "@executor-js/react/components/skeleton";
 import { Toaster } from "@executor-js/react/components/sonner";
 import { ExecutorPluginsProvider } from "@executor-js/sdk/client";
 import { plugins as clientPlugins } from "virtual:executor/plugins-client";
+import type { AuthHint } from "@executor-js/react/multiplayer/auth-hint";
 import { AuthProvider, useAuth } from "../web/auth";
 import { loginPath } from "../auth/return-to";
+import { ONBOARDING_PATHS, PUBLIC_PATHS } from "../auth/route-paths";
 import { SupportOptions } from "../web/components/support-options";
 import { Shell } from "../web/shell";
 import appCss from "@executor-js/react/globals.css?url";
-
-const ONBOARDING_PATHS = new Set(["/create-org", "/setup-mcp"]);
-// Routes that render for SIGNED-OUT visitors — the auth gate stays out of
-// their way entirely (the SSR gate in auth/ssr-gate.ts bounces signed-in
-// visitors off /login before the document is even served).
-const PUBLIC_PATHS = new Set(["/login"]);
 
 if (typeof window !== "undefined" && import.meta.env.VITE_PUBLIC_SENTRY_DSN) {
   Sentry.init({
@@ -98,6 +93,16 @@ function NotFoundPage() {
 
 export const Route = createRootRoute({
   notFoundComponent: NotFoundPage,
+  // The verified identity the SSR gate attached to this document request
+  // (ssr-gate.ts → middleware context → serverContext). Loader data is
+  // dehydrated, so the client's first render sees the SAME hint the server
+  // rendered with — the two can't disagree. Client-side re-runs have no
+  // serverContext and return null, which is fine: the hint only seeds
+  // initial state (AuthProvider holds it from there).
+  loader: (opts) => ({
+    authHint:
+      (opts as { serverContext?: { authHint?: AuthHint | null } }).serverContext?.authHint ?? null,
+  }),
   head: () => ({
     meta: [
       { charSet: "utf-8" },
@@ -137,74 +142,22 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 }
 
 function RootComponent() {
+  const { authHint } = Route.useLoaderData();
   return (
     <PostHogProvider client={posthog}>
-      <AuthProvider>
+      <AuthProvider initialHint={authHint}>
         <AuthGate />
       </AuthProvider>
     </PostHogProvider>
   );
 }
 
-function ShellSkeleton() {
-  return (
-    <div className="flex h-screen overflow-hidden">
-      {/* Desktop sidebar skeleton */}
-      <aside className="hidden w-52 shrink-0 border-r border-sidebar-border bg-sidebar md:flex md:flex-col lg:w-56">
-        <div className="flex h-12 shrink-0 items-center border-b border-sidebar-border px-4">
-          <Skeleton className="h-4 w-20" />
-        </div>
-        <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-2">
-          <Skeleton className="h-7 w-full rounded-md" />
-          <Skeleton className="h-7 w-full rounded-md" />
-          <Skeleton className="h-7 w-full rounded-md" />
-          <Skeleton className="h-7 w-full rounded-md" />
-          <div className="mt-5 mb-2 px-2.5">
-            <Skeleton className="h-3 w-14" />
-          </div>
-          <div className="flex flex-col gap-1">
-            <Skeleton className="h-7 w-11/12 rounded-md" />
-            <Skeleton className="h-7 w-10/12 rounded-md" />
-            <Skeleton className="h-7 w-9/12 rounded-md" />
-          </div>
-        </nav>
-        <div className="shrink-0 border-t border-sidebar-border px-3 py-2.5">
-          <div className="flex items-center gap-2.5">
-            <Skeleton className="size-7 rounded-full" />
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <Skeleton className="h-3 w-24" />
-              <Skeleton className="h-3 w-16" />
-            </div>
-          </div>
-        </div>
-      </aside>
-
-      {/* Main content skeleton */}
-      <main className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        {/* Mobile top bar */}
-        <div className="flex h-12 shrink-0 items-center justify-between border-b border-border bg-background px-4 md:hidden">
-          <Skeleton className="size-7 rounded-md" />
-          <Skeleton className="h-4 w-20" />
-          <div className="w-7 shrink-0" />
-        </div>
-
-        <div className="flex min-h-0 flex-1 flex-col gap-6 px-6 py-8">
-          <div className="flex items-center justify-between">
-            <div className="flex flex-col gap-2">
-              <Skeleton className="h-6 w-40" />
-              <Skeleton className="h-4 w-64" />
-            </div>
-            <Skeleton className="h-8 w-28 rounded-md" />
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-24 w-full rounded-lg" />
-            ))}
-          </div>
-        </div>
-      </main>
-    </div>
-  );
+// Neutral, layout-free placeholder for the moments no UI is correct yet: a
+// redirect in flight, or the (post-gate, near-impossible) hint-less verified
+// load. Never the app shell's silhouette — that bet is the bug this file's
+// gate exists to prevent.
+function BlankScreen() {
+  return <div className="h-screen bg-background" />;
 }
 
 function ShellErrorFallback() {
@@ -236,6 +189,9 @@ function AuthGate() {
   const isOnboardingRoute = ONBOARDING_PATHS.has(location.pathname);
   const isPublicRoute = PUBLIC_PATHS.has(location.pathname);
 
+  // The SSR gate already bounced fresh org-less document requests to
+  // /create-org; this catches the MID-SESSION transitions (org deleted,
+  // membership revoked → /account/me now reports no org).
   const needsOrgRedirect =
     auth.status === "authenticated" &&
     auth.organization == null &&
@@ -262,20 +218,14 @@ function AuthGate() {
     return <Outlet />;
   }
 
-  // Signed-out visitors never reach this point on a fresh document request —
-  // the SSR gate (auth/ssr-gate.ts) redirected them to /login before the SPA
-  // was served. So "loading" here means a VERIFIED signed-in user whose
-  // /account/me is still in flight (and usually not even that: the auth-hint
-  // cookie resolves them to "authenticated" a frame after mount), making the
-  // app-shell skeleton the right placeholder again.
-  if (auth.status === "loading") {
-    return <ShellSkeleton />;
-  }
-
-  // Mid-session sign-out (logout elsewhere, expiry): blank for the moment the
-  // redirect effect above needs — never a skeleton for an app they're out of.
-  if (auth.status === "unauthenticated") {
-    return <div className="h-screen bg-background" />;
+  // Every state that isn't "authenticated with an org, on a page that wants
+  // the shell" is a moment between redirects or an edge the gates make
+  // near-impossible (a verified user whose hint hasn't seeded yet). Neutral
+  // blank — the one placeholder that's correct whatever happens next. The
+  // app-shell skeleton this file used to render here is exactly the
+  // wrong-UI flash the SSR gate + hint exist to prevent.
+  if (auth.status === "loading" || auth.status === "unauthenticated") {
+    return <BlankScreen />;
   }
 
   if (isOnboardingRoute) {
@@ -283,14 +233,14 @@ function AuthGate() {
   }
 
   if (auth.organization == null) {
-    return <ShellSkeleton />;
+    return <BlankScreen />;
   }
 
   return (
     <AutumnProvider pathPrefix="/api/billing">
       <Sentry.ErrorBoundary fallback={<ShellErrorFallback />} showDialog={false}>
         <ExecutorProvider onHandledError={captureFrontendError}>
-          <React.Suspense fallback={<ShellSkeleton />}>
+          <React.Suspense fallback={<BlankScreen />}>
             <ExecutorPluginsProvider plugins={clientPlugins}>
               <OrganizationProvider organizationId={auth.organization.id}>
                 <Shell />

--- a/apps/cloud/src/web/auth.tsx
+++ b/apps/cloud/src/web/auth.tsx
@@ -7,6 +7,7 @@ import {
   useAuth,
   type IdentifyFn,
 } from "@executor-js/react/multiplayer/auth-context";
+import type { AuthHint } from "@executor-js/react/multiplayer/auth-hint";
 
 import { CloudApiClient } from "./client";
 
@@ -44,7 +45,13 @@ export const acceptInvitation = CloudApiClient.mutation("cloudAuth", "acceptInvi
 
 // ── Provider ───────────────────────────────────────────────────────────────
 
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+export const AuthProvider = ({
+  children,
+  initialHint,
+}: {
+  children: React.ReactNode;
+  initialHint?: AuthHint | null;
+}) => {
   const posthog = usePostHog();
 
   const onIdentify = React.useCallback<IdentifyFn>(
@@ -64,5 +71,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     [posthog],
   );
 
-  return <SharedAuthProvider onIdentify={onIdentify}>{children}</SharedAuthProvider>;
+  return (
+    <SharedAuthProvider onIdentify={onIdentify} initialHint={initialHint}>
+      {children}
+    </SharedAuthProvider>
+  );
 };

--- a/e2e/cloud/auth-hint.test.ts
+++ b/e2e/cloud/auth-hint.test.ts
@@ -1,10 +1,11 @@
-// Cloud-specific: the auth-hint cookie lifecycle. The sealed session is
-// HttpOnly, so on a fresh page load the SPA can't know it's signed in until
-// /account/me resolves — the hint (executor-auth-hint, non-HttpOnly, written
-// by AuthProvider once /account/me confirms) is what lets the NEXT load paint
-// the real app shell immediately instead of a skeleton. These scenarios pin
-// the full loop: confirmed identity writes it, the next load seeds from it
-// while the probe is still in flight, and logout takes it away.
+// Cloud-specific: the auth-hint lifecycle that lets the app paint the REAL
+// authenticated shell with no full-page skeleton, ever. The sealed session is
+// HttpOnly, so the SPA can't derive identity from it — instead the SSR gate
+// verifies the session per document request, renders the shell from that
+// verified identity, and MINTS the non-HttpOnly hint cookie
+// (executor-auth-hint) when the browser doesn't hold a current one. From
+// then on AuthProvider keeps the hint fresh on every confirmed /account/me
+// and logout takes it away with the session.
 import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
@@ -14,7 +15,7 @@ import { Browser, Target } from "../src/services";
 const HINT_COOKIE = "executor-auth-hint";
 
 scenario(
-  "Auth hint · a confirmed session writes the hint, and the next load paints the real shell from it",
+  "Auth hint · the FIRST load on a fresh browser paints the real shell — the gate minted the hint",
   {},
   Effect.gen(function* () {
     const browser = yield* Browser;
@@ -22,25 +23,10 @@ scenario(
     const identity = yield* target.newIdentity();
 
     yield* browser.session(identity, async ({ page, step }) => {
-      const hintCookie = async () =>
-        (await page.context().cookies()).find((cookie) => cookie.name === HINT_COOKIE);
-
-      await step("First signed-in load → /account/me confirms → the hint is written", async () => {
-        await page.goto("/", { waitUntil: "commit" });
-        await page.getByRole("link", { name: "Policies" }).waitFor();
-        // The write happens in an effect after /account/me resolves.
-        await expect.poll(hintCookie, { timeout: 10_000 }).toBeTruthy();
-      });
-
-      const hint = (await hintCookie())!;
-      expect(hint.httpOnly, "the hint is readable by the SPA — that's its job").toBe(false);
-      expect(
-        decodeURIComponent(hint.value),
-        "it carries the confirmed identity (display data only)",
-      ).toContain(identity.label);
-
-      // Hold the auth probe open on the SECOND load. Without the hint this
-      // window is a full-page skeleton; with it, the real shell.
+      // Hold the auth probe open from the very first request. This browser
+      // has NEVER loaded the app — no hint cookie exists — which used to be
+      // the one case that still showed a full-page skeleton for the whole
+      // /account/me round trip.
       let probeResolved = false;
       await page.route("**/api/account/me", async (route) => {
         await new Promise((resolve) => setTimeout(resolve, 2_000));
@@ -48,19 +34,34 @@ scenario(
         await route.continue();
       });
 
-      await step("Reload: the real app shell paints while /account/me is in flight", async () => {
+      await step("First-ever load: the real app shell, immediately", async () => {
         await page.goto("/", { waitUntil: "commit" });
-        // Real nav text — the loading skeleton has no text at all.
+        // Real nav text — a skeleton has no text at all.
         await page.getByRole("link", { name: "Policies" }).waitFor();
       });
 
-      expect(probeResolved, "the shell did NOT wait for /account/me — the hint seeded it").toBe(
-        false,
-      );
+      expect(probeResolved, "the shell did NOT wait for /account/me").toBe(false);
+      // The full-page skeleton was a text-free silhouette; the real shell has
+      // the nav AND this identity's own data in the footer — the SSR render
+      // knew who it was serving. (Per-SECTION skeletons for in-flight data
+      // are fine; the silhouette of the whole app is what must never paint.)
+      // newIdentity names the org after the user (`Org user-xxxx`), so the
+      // footer's org line is identity-specific text no other user would show.
+      const orgName = `Org ${identity.label.split("@")[0]}`;
       expect(
-        await page.getByRole("link", { name: "Billing" }).isVisible(),
-        "it is the full signed-in nav, not a placeholder",
+        await page.getByText(orgName).first().isVisible(),
+        "the shell footer shows THIS identity's organization",
       ).toBe(true);
+
+      // The identity the shell painted from is now pinned for next time: the
+      // gate minted the hint cookie on the document response itself.
+      const hint = (await page.context().cookies()).find((c) => c.name === HINT_COOKIE);
+      expect(hint, "the gate minted the hint on the first response").toBeTruthy();
+      expect(hint!.httpOnly, "the hint is readable by the SPA — that's its job").toBe(false);
+      expect(
+        decodeURIComponent(hint!.value),
+        "it carries the verified identity (display data only)",
+      ).toContain(identity.label);
     });
   }),
 );
@@ -74,7 +75,7 @@ scenario(
     const identity = yield* target.newIdentity();
 
     yield* browser.session(identity, async ({ page, step }) => {
-      await step("Load the app signed in (the hint gets written)", async () => {
+      await step("Load the app signed in (the hint arrives with it)", async () => {
         await page.goto("/", { waitUntil: "commit" });
         await page.getByRole("link", { name: "Policies" }).waitFor();
         await expect

--- a/e2e/cloud/session-gate.test.ts
+++ b/e2e/cloud/session-gate.test.ts
@@ -81,6 +81,34 @@ scenario(
   }),
 );
 
+scenario(
+  "Session gate · an org-less session is sent to onboarding before the app shell exists",
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
+
+    // A verified user with no organization belongs in onboarding — the gate
+    // decides that at the edge, so the app shell (whose every query needs an
+    // org) is never even served.
+    const orgless = yield* target.newIdentity({ org: false });
+    const gated = yield* documentRequest(
+      new URL("/tools", target.baseUrl),
+      orgless.headers!.cookie!,
+    );
+    expect(gated.status, "the app page is not served org-less").toBe(302);
+    expect(gated.headers.get("location"), "…onboarding owns this session").toBe("/create-org");
+
+    // The onboarding page itself is served (no redirect loop).
+    const onboarding = yield* documentRequest(
+      new URL("/create-org", target.baseUrl),
+      orgless.headers!.cookie!,
+    );
+    expect(onboarding.status, "/create-org renders for the org-less session").toBe(200);
+  }),
+);
+
 // The sealed wos-session is iron-sealed JSON { accessToken, refreshToken, … }.
 // Corrupting the access token's signature makes the gate's verify fail the
 // same way an EXPIRED token does (invalid JWT → refresh path) — without

--- a/e2e/cloud/unauthenticated-skeleton.test.ts
+++ b/e2e/cloud/unauthenticated-skeleton.test.ts
@@ -162,10 +162,17 @@ scenario(
         await page.goto("/this-page-does-not-exist", { waitUntil: "commit" });
         await page.getByText("Page not found").waitFor();
       });
+      // The 404 renders INSIDE the real shell (nav + identity), not as a
+      // text-free full-page silhouette. Per-section skeletons in the sidebar
+      // (the integration list mid-fetch) are honest loading states and fine.
       expect(
-        await page.locator('[data-slot="skeleton"]').count(),
-        "no app-shell skeleton on the 404 page",
-      ).toBe(0);
+        await page.getByRole("link", { name: "Policies" }).isVisible(),
+        "the real shell frames the 404",
+      ).toBe(true);
+      expect(
+        await page.getByText("Go home").isVisible(),
+        "with the 404 page's action, not a dead end",
+      ).toBe(true);
     });
   }),
 );

--- a/packages/react/src/multiplayer/auth-context.tsx
+++ b/packages/react/src/multiplayer/auth-context.tsx
@@ -25,6 +25,13 @@ import {
 // as loading — which the host should never let happen for signed-out users
 // (cloud redirects them to /login during SSR). The hint is display-only;
 // the resolved `/account/me` answer always wins.
+//
+// Hosts whose server can see the hint at render time (cloud: the SSR gate
+// passes it through the root loader) provide `initialHint`, and the
+// authenticated shell is SSR'd outright — both the server render and the
+// first client render derive from the same dehydrated value, so they agree
+// by construction. Hosts without that seam (self-host) omit it and keep the
+// post-mount cookie read: SSR paints loading, the hint applies a frame later.
 // ---------------------------------------------------------------------------
 
 export type AuthUser = {
@@ -63,19 +70,23 @@ const hintState = (hint: AuthHint | null): AuthState | null =>
 const AuthProviderClient = ({
   children,
   onIdentify,
+  initialHint = null,
 }: {
   children: React.ReactNode;
   onIdentify?: IdentifyFn;
+  initialHint?: AuthHint | null;
 }) => {
   const result = useAtomValue(meAtom);
 
-  // The hint applies one frame AFTER mount: SSR always renders the loading
-  // state and the first client render must match that HTML, so the cookie
-  // read is deferred to an effect (the documented pattern for client-only
-  // values). The flip costs a frame, not a network round trip.
-  const [hint, setHint] = useState<AuthHint | null>(null);
+  // With a server-provided hint the first client render matches the SSR'd
+  // authenticated HTML outright (both derive from the same dehydrated value).
+  // Without one, the cookie read is deferred to an effect: SSR rendered
+  // loading, and the first client render must match that HTML — the flip
+  // costs a frame, not a network round trip. Initial-value-only state: later
+  // loader re-runs (which lose the server context) must not yank the seed.
+  const [hint, setHint] = useState<AuthHint | null>(initialHint);
   useEffect(() => {
-    setHint(readAuthHintCookie());
+    setHint((current) => current ?? readAuthHintCookie());
   }, []);
 
   // What `/account/me` actually said — the authority. The atom value only
@@ -127,12 +138,27 @@ const AuthProviderClient = ({
 export const AuthProvider = ({
   children,
   onIdentify,
+  initialHint = null,
 }: {
   children: React.ReactNode;
   onIdentify?: IdentifyFn;
+  /**
+   * The auth hint as the HOST's server saw it on this request (cloud: from
+   * the SSR gate via the root loader, dehydrated to the client). When set,
+   * SSR paints the authenticated shell instead of a loading state.
+   */
+  initialHint?: AuthHint | null;
 }) => {
   if (typeof window === "undefined") {
-    return <AuthContext.Provider value={{ status: "loading" }}>{children}</AuthContext.Provider>;
+    return (
+      <AuthContext.Provider value={hintState(initialHint) ?? { status: "loading" }}>
+        {children}
+      </AuthContext.Provider>
+    );
   }
-  return <AuthProviderClient onIdentify={onIdentify}>{children}</AuthProviderClient>;
+  return (
+    <AuthProviderClient onIdentify={onIdentify} initialHint={initialHint}>
+      {children}
+    </AuthProviderClient>
+  );
 };

--- a/packages/react/src/multiplayer/auth-hint.tsx
+++ b/packages/react/src/multiplayer/auth-hint.tsx
@@ -40,12 +40,13 @@ export type AuthHint = typeof AuthHintSchema.Type;
 
 const AuthHintFromJson = Schema.fromJsonString(AuthHintSchema);
 const decodeAuthHintJson = Schema.decodeUnknownOption(AuthHintFromJson);
-const encodeAuthHintJson = Schema.encodeSync(AuthHintFromJson);
 // The cookie value arrives percent-encoded; a truncated/corrupted one can
 // make decodeURIComponent itself throw, which must read as "no hint".
 const decodeUriComponentOption = Option.liftThrowable(decodeURIComponent);
 
-/** Encode a hint as a cookie VALUE (URI-encoded JSON). */
+const encodeAuthHintJson = Schema.encodeSync(AuthHintFromJson);
+
+/** Encode a hint as a wire-ready cookie VALUE (URI-encoded JSON). */
 export const encodeAuthHint = (hint: AuthHint): string =>
   encodeURIComponent(encodeAuthHintJson(hint));
 


### PR DESCRIPTION
## Problem

After the SSR auth gate landed (#975), the full-page `ShellSkeleton` was still what every signed-in load painted first. That was backwards: the gate has already unsealed and verified the session on the very request it's serving, so the server *knows* who the user is — and then rendered a silhouette that says "we don't know who you are." A fresh browser (no hint cookie yet) sat on that skeleton for the whole `/account/me` round trip.

## Change

The gate's verified identity now drives the SSR render, and the full-page skeleton is deleted.

**Gate resolves the auth hint server-side** (`apps/cloud/src/auth/ssr-gate.ts`): the browser's hint cookie is used when its user/org ids match the verified session; otherwise a hint is minted from the session (org name from the local mirror, over per-request DB layers). The hint is threaded to the SSR render via request-middleware context, and minted as a `Set-Cookie` on the response when the browser didn't hold a current one. The gate only re-mints on id mismatch — display-field freshness (renames) stays the client's job via `/account/me`, so the two writers can't ping-pong.

**SSR paints the authenticated shell** (`packages/react/src/multiplayer/auth-context.tsx`, `apps/cloud/src/routes/__root.tsx`): the root route's loader picks the hint out of `serverContext` and dehydrates it, and `AuthProvider` takes it as `initialHint` — the server render and the first client render derive from the same value, so they agree by construction. Hosts without the seam (self-host) keep the post-mount cookie read unchanged.

**Org-less sessions redirect at the edge**: a verified session with no organization is 302'd to `/create-org` before the document exists (route sets shared between gate and client via `auth/route-paths.ts`). The client AuthGate's org branch now only covers mid-session transitions.

**`ShellSkeleton` is deleted** (~60 lines): every remaining fallback is a neutral blank screen for moments between redirects. Per-section skeletons (e.g. the sidebar's integration list while it fetches) are untouched — those represent data that genuinely is loading.

## The first-ever load on a fresh browser

No hint cookie anywhere, `/api/account/me` held open for 2 s — the real shell with the user's identity paints immediately, and the response minted the hint for next time:

![Auth hint · the FIRST load on a fresh browser paints the real shell — the gate minted the hint (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/auth-hint-the-first-load-on-a-fresh-browser-paints-the-real-shell-the-gate-minte-07b5c826.gif)

## Test coverage

- `e2e/cloud/auth-hint.test.ts` — rewritten headline scenario: fresh browser, probe held open → real shell with this identity's org in the footer before `/account/me` resolves, hint minted on the document response; logout still clears hint + session.
- `e2e/cloud/session-gate.test.ts` — new scenario: org-less session → `302 /create-org` at the edge; `/create-org` itself serves without a redirect loop.
- `e2e/cloud/unauthenticated-skeleton.test.ts` — 404 assertion updated: shell-framed 404 with the real nav (the old zero-skeleton count now trips on honest per-section skeletons).

All 14 auth-related e2e scenarios green; format, lint, typecheck, and unit tests pass. The two `connect-handoff` e2e failures in the full cloud run fail identically on clean main (emulator payload cap, unrelated).

---

**Follow-up:** painting the real shell means the connect card's `npx add-mcp <url>` is now in the first SSR'd HTML — and its MCP URL flashed `127.0.0.1:4000` before hydration. Fixed separately in #991.
