### PR TITLE
Add typed PostHog product-event instrumentation for cloud

### DIFF
--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -12,6 +12,7 @@ import { AutumnProvider } from "autumn-js/react";
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
 import type { FrontendErrorReporter } from "@executor-js/react/api/error-reporting";
+import { AnalyticsProvider, type AnalyticsClient } from "@executor-js/react/api/analytics";
 import { ExecutorProvider } from "@executor-js/react/api/provider";
 import { OrganizationProvider } from "@executor-js/react/api/organization-context";
 import { Toaster } from "@executor-js/react/components/sonner";
@@ -55,6 +56,11 @@ if (typeof window !== "undefined" && import.meta.env.VITE_PUBLIC_POSTHOG_KEY) {
     },
   });
 }
+
+const analyticsClient: AnalyticsClient | undefined =
+  typeof window !== "undefined" && import.meta.env.VITE_PUBLIC_POSTHOG_KEY
+    ? (name, properties) => posthog.capture(name, properties)
+    : undefined;
 
 const captureFrontendError: FrontendErrorReporter = (error, context) => {
   Sentry.captureException(error, (scope) => {
@@ -145,9 +151,11 @@ function RootComponent() {
   const { authHint } = Route.useLoaderData();
   return (
     <PostHogProvider client={posthog}>
-      <AuthProvider initialHint={authHint}>
-        <AuthGate />
-      </AuthProvider>
+      <AnalyticsProvider client={analyticsClient}>
+        <AuthProvider initialHint={authHint}>
+          <AuthGate />
+        </AuthProvider>
+      </AnalyticsProvider>
     </PostHogProvider>
   );
 }

--- a/apps/cloud/src/routes/app/billing.tsx
+++ b/apps/cloud/src/routes/app/billing.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useCustomer, useListPlans } from "autumn-js/react";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import { Badge } from "@executor-js/react/components/badge";
 
@@ -93,7 +94,10 @@ function BillingPage() {
               <Button
                 variant="ghost"
                 type="button"
-                onClick={() => openCustomerPortal()}
+                onClick={() => {
+                  trackEvent("billing_cancel_plan_clicked", { plan_id: planId });
+                  openCustomerPortal();
+                }}
                 className="rounded-md px-3 py-1.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10"
               >
                 Cancel plan
@@ -101,6 +105,7 @@ function BillingPage() {
             )}
             <Link
               to="/billing/plans"
+              onClick={() => trackEvent("billing_manage_opened")}
               className="rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
             >
               Manage

--- a/apps/cloud/src/routes/app/billing_.plans.tsx
+++ b/apps/cloud/src/routes/app/billing_.plans.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useCustomer, useListPlans } from "autumn-js/react";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import { Badge } from "@executor-js/react/components/badge";
 import {
@@ -199,6 +200,19 @@ function PlansPage() {
                         type="button"
                         disabled={loadingPlan !== null}
                         onClick={async () => {
+                          // Before attach(): it assigns window.location.href to
+                          // the checkout URL while resolving, so anything after
+                          // the await races the page unload.
+                          if (
+                            action === "activate" ||
+                            action === "upgrade" ||
+                            action === "downgrade"
+                          ) {
+                            trackEvent("billing_plan_selected", {
+                              plan_id: plan.id,
+                              action: action as "activate" | "upgrade" | "downgrade",
+                            });
+                          }
                           setLoadingPlan(plan.id);
                           await attach({ planId: plan.id, redirectMode: "always" });
                           setLoadingPlan(null);

--- a/apps/cloud/src/routes/app/org.tsx
+++ b/apps/cloud/src/routes/app/org.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Exit } from "effect";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { useCustomer } from "autumn-js/react";
 import { toast } from "sonner";
@@ -65,6 +66,7 @@ function DomainsSection() {
       params: { domainId },
       reactivityKeys: orgDomainWriteKeys,
     });
+    trackEvent("org_domain_removed", { success: Exit.isSuccess(exit) });
     toast[Exit.isSuccess(exit) ? "success" : "error"](
       Exit.isSuccess(exit) ? `Removed ${domain}` : "Failed to remove domain",
     );
@@ -74,6 +76,7 @@ function DomainsSection() {
     const exit = await doGetVerificationLink({
       reactivityKeys: orgDomainWriteKeys,
     });
+    trackEvent("org_domain_added", { success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) {
       window.open(exit.value.link, "_blank");
     } else {

--- a/apps/cloud/src/web/components/create-organization-form.tsx
+++ b/apps/cloud/src/web/components/create-organization-form.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useAtomSet } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
 import { authWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
 
@@ -35,6 +36,7 @@ export function useCreateOrganizationForm(options: {
     setError(null);
     const exit = await doCreate({ payload: { name: trimmed }, reactivityKeys: authWriteKeys });
     setCreating(false);
+    trackEvent("org_created", { success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) {
       options.onSuccess(exit.value);
     } else {

--- a/apps/cloud/src/web/components/org-menu-slot.tsx
+++ b/apps/cloud/src/web/components/org-menu-slot.tsx
@@ -3,6 +3,7 @@ import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import { authWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import {
   Dialog,
@@ -59,6 +60,7 @@ function OrganizationSwitcherItems(props: { activeOrganizationId: string | null 
       payload: { organizationId },
       reactivityKeys: authWriteKeys,
     });
+    trackEvent("org_switched", { success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) window.location.reload();
   };
 

--- a/apps/cloud/src/web/components/support-options.tsx
+++ b/apps/cloud/src/web/components/support-options.tsx
@@ -1,3 +1,4 @@
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import {
   Popover,
@@ -43,6 +44,7 @@ export function SupportOptions() {
         <a
           key={link.label}
           href={link.href}
+          onClick={() => trackEvent("support_link_clicked", { label: link.label })}
           className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 font-medium text-foreground transition-colors hover:bg-muted"
         >
           <link.icon className="size-4" />

--- a/apps/cloud/src/web/components/support-slot.tsx
+++ b/apps/cloud/src/web/components/support-slot.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import {
   Dialog,
@@ -34,7 +35,10 @@ export function SupportSlot() {
       <Button
         type="button"
         variant="ghost"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          trackEvent("support_opened");
+          setOpen(true);
+        }}
         className="flex h-auto w-full items-center justify-start gap-2.5 rounded-md px-2.5 py-1.5 text-sm font-normal text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground"
       >
         <HelpIcon className="size-3.5 text-muted-foreground" />

--- a/apps/cloud/src/web/pages/create-org.tsx
+++ b/apps/cloud/src/web/pages/create-org.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "@tanstack/react-router";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import { authWriteKeys } from "@executor-js/react/api/reactivity-keys";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import { Skeleton } from "@executor-js/react/components/skeleton";
 
@@ -62,6 +63,7 @@ export const CreateOrgPage = () => {
       reactivityKeys: authWriteKeys,
     });
     setAcceptingId(null);
+    trackEvent("org_invitation_accepted", { success: Exit.isSuccess(exit) });
     if (!Exit.isSuccess(exit)) {
       setErrorByInvitationId((prev) => ({
         ...prev,

--- a/apps/cloud/src/web/pages/login.tsx
+++ b/apps/cloud/src/web/pages/login.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { AUTH_PATHS } from "../../auth/api";
 import { safeReturnTo } from "../../auth/return-to";
 
@@ -16,6 +17,7 @@ export const LoginPage = ({ returnTo }: { returnTo?: string | undefined }) => {
         </div>
         <a
           href={loginHref}
+          onClick={() => trackEvent("login_cta_clicked")}
           className="inline-flex h-10 w-full items-center justify-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground shadow hover:bg-primary/90 transition-colors"
         >
           Sign in

--- a/apps/cloud/src/web/pages/setup-mcp.tsx
+++ b/apps/cloud/src/web/pages/setup-mcp.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { Button } from "@executor-js/react/components/button";
 import { CodeBlock } from "@executor-js/react/components/code-block";
 import {
@@ -69,7 +70,18 @@ export const SetupMcpPage = () => {
             <span className="min-w-0 flex-1 truncate font-mono text-sm text-foreground/90">
               {endpoint || "…"}
             </span>
-            {endpoint && <CopyButton value={endpoint} />}
+            {endpoint && (
+              <CopyButton
+                value={endpoint}
+                onCopy={() =>
+                  trackEvent("mcp_install_command_copied", {
+                    transport: "http",
+                    elicitation_mode: elicitationMode,
+                    surface: "setup_mcp",
+                  })
+                }
+              />
+            )}
           </div>
           <p className="text-xs text-muted-foreground">Paste this into your MCP client config.</p>
         </section>
@@ -117,7 +129,17 @@ export const SetupMcpPage = () => {
           <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
             Install command
           </p>
-          <CodeBlock code={command} lang="bash" />
+          <CodeBlock
+            code={command}
+            lang="bash"
+            onCopy={() =>
+              trackEvent("mcp_install_command_copied", {
+                transport: "http",
+                elicitation_mode: elicitationMode,
+                surface: "setup_mcp",
+              })
+            }
+          />
           <p className="text-xs text-muted-foreground">Adds the server to a supported agent.</p>
         </section>
 
@@ -125,12 +147,21 @@ export const SetupMcpPage = () => {
           {/* oxlint-disable-next-line react/forbid-elements */}
           <button
             type="button"
-            onClick={() => void navigate({ to: "/" })}
+            onClick={() => {
+              trackEvent("setup_mcp_skipped");
+              void navigate({ to: "/" });
+            }}
             className="text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
             Skip for now
           </button>
-          <Button size="sm" onClick={() => void navigate({ to: "/" })}>
+          <Button
+            size="sm"
+            onClick={() => {
+              trackEvent("setup_mcp_completed");
+              void navigate({ to: "/" });
+            }}
+          >
             Continue to app
           </Button>
         </div>

--- a/apps/cloud/src/web/shell.tsx
+++ b/apps/cloud/src/web/shell.tsx
@@ -1,4 +1,5 @@
 import { Shell as SharedShell, defaultShellNavItems } from "@executor-js/react/multiplayer/shell";
+import { trackEvent } from "@executor-js/react/api/analytics";
 import { AUTH_PATHS } from "../auth/api";
 import { OrgMenuSlot } from "./components/org-menu-slot";
 import { SupportSlot } from "./components/support-slot";
@@ -22,6 +23,7 @@ const navItems = [
 
 const signOut = async () => {
   await fetch(AUTH_PATHS.logout, { method: "POST" });
+  trackEvent("signed_out");
   window.location.href = "/";
 };
 

--- a/packages/react/src/api/analytics.test.ts
+++ b/packages/react/src/api/analytics.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "@effect/vitest";
+
+import {
+  setAnalyticsClient,
+  trackEvent,
+  type AnalyticsEventName,
+  type AnalyticsEvents,
+} from "./analytics";
+
+afterEach(() => {
+  setAnalyticsClient(null);
+});
+
+describe("analytics seam", () => {
+  it("is a no-op when no client is mounted", () => {
+    expect(() => trackEvent("integration_connect_dialog_opened")).not.toThrow();
+  });
+
+  it("forwards name and properties to the mounted client", () => {
+    const seen: Array<{ name: AnalyticsEventName; properties: unknown }> = [];
+    setAnalyticsClient((name, properties) => {
+      seen.push({ name, properties });
+    });
+
+    trackEvent("integration_added", { plugin_key: "openapi", integration_slug: "github" });
+
+    expect(seen).toEqual([
+      {
+        name: "integration_added",
+        properties: { plugin_key: "openapi", integration_slug: "github" },
+      },
+    ]);
+  });
+
+  it("sends an empty properties object when none are given", () => {
+    const seen: Array<unknown> = [];
+    setAnalyticsClient((_name, properties) => {
+      seen.push(properties);
+    });
+
+    trackEvent("support_opened");
+
+    expect(seen).toEqual([{}]);
+  });
+
+  it("stops forwarding after the client is unset", () => {
+    let calls = 0;
+    setAnalyticsClient(() => {
+      calls += 1;
+    });
+    trackEvent("support_opened");
+    setAnalyticsClient(null);
+    trackEvent("support_opened");
+
+    expect(calls).toBe(1);
+  });
+
+  it("event property values stay primitive (catalog sanity)", () => {
+    // Compile-time catalog checks: a property bag is always an object of
+    // primitives — no nested user data structures sneak in.
+    const sample: AnalyticsEvents["tool_run_submitted"] = {
+      integration_slug: "github",
+      tool_name: "issues_list",
+      args_mode: "form",
+      result: "completed",
+      is_error: false,
+    };
+    expect(Object.values(sample).every((v) => typeof v !== "object")).toBe(true);
+  });
+});

--- a/packages/react/src/api/analytics.tsx
+++ b/packages/react/src/api/analytics.tsx
@@ -1,0 +1,209 @@
+import * as React from "react";
+
+// ---------------------------------------------------------------------------
+// Product-analytics seam — same DI shape as ./error-reporting: a module-level
+// client set by a provider the HOST mounts, and a free `trackEvent` function
+// callsites import directly (works outside React, e.g. oauth-popup callbacks).
+// No client mounted (local, self-host, cloudflare, tests) → every call is a
+// no-op. Cloud mounts `AnalyticsProvider` with a posthog-backed client.
+//
+// `AnalyticsEvents` is the single catalog of every product event: names are
+// `object_verb` snake_case, properties are snake_case. A callsite with a typo
+// or an undeclared property is a type error, so the catalog can't drift from
+// the instrumentation.
+//
+// BROWSER-ONLY by design: during SSR the host mounts no client (cloud's is
+// undefined when `window` is absent), and on shared-module-scope runtimes
+// (Cloudflare Workers) every SSR render resets the singleton to null. Server-
+// side product events need their own seam — do not route them through this one.
+//
+// PROPERTY RULES — properties must never carry:
+//   - secrets, tokens, credential values, copied clipboard contents
+//   - emails, person/org names, or any user-entered free text
+//   - connection names or tool ADDRESSES (both embed user-entered label text;
+//     integration slugs and spec-derived tool names are fine)
+//   - policy patterns (user-entered globs) — use `pattern_kind` instead
+// Identity attaches via posthog identify/group (the host's concern), never as
+// event properties.
+// ---------------------------------------------------------------------------
+
+type Owner = "org" | "user";
+
+export interface AnalyticsEvents {
+  // ── Integrations ─────────────────────────────────────────────────────────
+  integration_connect_dialog_opened: {};
+  integration_detect_submitted: {
+    success: boolean;
+    detected_kind?: string;
+    confidence?: string;
+  };
+  integration_add_started: {
+    plugin_key: string;
+    via: "detect" | "manual" | "preset" | "command_palette";
+    preset_id?: string;
+  };
+  integration_added: { plugin_key: string; integration_slug?: string };
+  integration_add_cancelled: { plugin_key: string };
+  integration_removed: { integration_slug: string; success: boolean };
+  integration_refreshed: {
+    integration_slug: string;
+    connection_count: number;
+    success: boolean;
+  };
+  integration_renamed: { integration_slug: string; success: boolean };
+
+  // ── Connections & auth ───────────────────────────────────────────────────
+  connection_add_opened: {
+    integration_slug: string;
+    has_oauth_method: boolean;
+    has_api_key_method: boolean;
+  };
+  connection_credential_submitted: {
+    integration_slug: string;
+    owner: Owner;
+    credential_origin: "paste" | "onepassword";
+    success: boolean;
+  };
+  connection_oauth_started: {
+    integration_slug: string;
+    owner: Owner;
+    flow: "byo" | "dcr";
+    success: boolean;
+    dcr_fallback?: boolean;
+  };
+  connection_reconnected: { integration_slug: string; owner: Owner; success: boolean };
+  connection_removed: { integration_slug: string; owner: Owner; success: boolean };
+  oauth_completed: { success: boolean };
+  oauth_popup_blocked: {};
+  oauth_client_registered: {
+    owner: Owner;
+    grant: string;
+    via_dcr: boolean;
+    success: boolean;
+  };
+  oauth_client_removed: { owner: Owner };
+  custom_auth_method_created: { integration_slug: string; kind: string };
+  custom_auth_method_removed: { integration_slug: string };
+
+  // ── Tools ────────────────────────────────────────────────────────────────
+  tool_selected: { integration_slug: string; tool_name: string };
+  tool_run_submitted: {
+    integration_slug: string;
+    tool_name: string;
+    args_mode: "form" | "json";
+    result: "completed" | "paused" | "failed";
+    is_error?: boolean;
+  };
+  tool_id_copied: { integration_slug: string; tool_name: string };
+  tool_policy_set: { action: string; pattern_kind: "exact" | "group"; owner: Owner };
+  tool_policy_cleared: { pattern_kind: "exact" | "group"; owner: Owner };
+
+  // ── Policies page ────────────────────────────────────────────────────────
+  policy_created: { action: string; owner: Owner; success: boolean };
+  policy_action_changed: { action: string; owner: Owner; success: boolean };
+  policy_removed: { owner: Owner; success: boolean };
+  policy_reordered: { owner: Owner; direction: "up" | "down"; success: boolean };
+
+  // ── API keys ─────────────────────────────────────────────────────────────
+  api_key_created: { success: boolean };
+  api_key_revoked: { success: boolean };
+  api_key_copied: { kind: "value" | "bearer_header" };
+
+  // ── Organization ─────────────────────────────────────────────────────────
+  org_renamed: { success: boolean };
+  org_member_invited: { role: string; success: boolean };
+  org_member_role_changed: { role: string; success: boolean };
+  org_member_removed: { success: boolean };
+
+  // ── Executions & approvals ───────────────────────────────────────────────
+  resume_approval_submitted: {
+    action: "accept" | "decline" | "cancel";
+    interaction_kind?: string;
+    chained_to_next?: boolean;
+    success: boolean;
+  };
+  resume_return_prompt_copied: { action: "accept" | "decline" | "cancel" };
+
+  // ── MCP install / onboarding ─────────────────────────────────────────────
+  mcp_install_command_copied: {
+    transport: "http" | "stdio";
+    elicitation_mode?: string;
+    surface: "integrations" | "setup_mcp";
+  };
+  mcp_install_transport_switched: { transport: "http" | "stdio" };
+  mcp_install_elicitation_mode_changed: { elicitation_mode: string };
+
+  // ── Command palette ──────────────────────────────────────────────────────
+  command_palette_navigated: {
+    kind: "integration" | "add_integration" | "preset";
+    plugin_key?: string;
+  };
+
+  // ── Cloud: auth & onboarding ─────────────────────────────────────────────
+  login_cta_clicked: {};
+  signed_out: {};
+  org_created: { success: boolean };
+  org_switched: { success: boolean };
+  org_invitation_accepted: { success: boolean };
+  setup_mcp_completed: {};
+  setup_mcp_skipped: {};
+
+  // ── Cloud: billing & support ─────────────────────────────────────────────
+  billing_plan_selected: {
+    plan_id: string;
+    action: "activate" | "upgrade" | "downgrade";
+  };
+  billing_manage_opened: {};
+  billing_cancel_plan_clicked: { plan_id: string };
+  support_opened: {};
+  support_link_clicked: { label: string };
+  org_domain_added: { success: boolean };
+  org_domain_removed: { success: boolean };
+}
+
+export type AnalyticsEventName = keyof AnalyticsEvents;
+
+/**
+ * The host-supplied sink. Cloud backs this with `posthog.capture`; hosts that
+ * mount no provider get the no-op default.
+ */
+export type AnalyticsClient = <Name extends AnalyticsEventName>(
+  name: Name,
+  properties: AnalyticsEvents[Name],
+) => void;
+
+let currentAnalyticsClient: AnalyticsClient | null = null;
+
+/**
+ * Imperative injection point — what `AnalyticsProvider` uses, and the hook for
+ * non-React hosts (or tests). Pass `null` to restore the no-op default.
+ */
+export const setAnalyticsClient = (client: AnalyticsClient | null): void => {
+  currentAnalyticsClient = client;
+};
+
+/**
+ * Record one product event. Safe to call from anywhere (React handlers,
+ * Effect callbacks, plain modules); a host without a mounted client makes
+ * this a no-op. Events with no properties may omit the second argument.
+ */
+export const trackEvent = <Name extends AnalyticsEventName>(
+  name: Name,
+  ...rest: {} extends AnalyticsEvents[Name]
+    ? [properties?: AnalyticsEvents[Name]]
+    : [properties: AnalyticsEvents[Name]]
+): void => {
+  currentAnalyticsClient?.(name, rest[0] ?? ({} as AnalyticsEvents[Name]));
+};
+
+/**
+ * Declarative mount for React hosts — sets the module-level client during
+ * render, exactly like `FrontendErrorReporterProvider` does for error
+ * reporting. Mount once at the app root, ABOVE any tree that fires events
+ * (in cloud that is the document root, not ExecutorProvider, because the
+ * login/onboarding routes render outside the authenticated shell).
+ */
+export const AnalyticsProvider = (props: React.PropsWithChildren<{ client?: AnalyticsClient }>) => {
+  currentAnalyticsClient = props.client ?? null;
+  return <>{props.children}</>;
+};

--- a/packages/react/src/components/accounts-section.tsx
+++ b/packages/react/src/components/accounts-section.tsx
@@ -16,6 +16,7 @@ import {
 import { connectionWriteKeys } from "../api/reactivity-keys";
 import { messageFromExit } from "../api/error-reporting";
 import { ownerLabel, useOwnerDisplay } from "../api/owner-display";
+import { trackEvent } from "../api/analytics";
 import type { AuthMethod } from "../lib/auth-placements";
 import {
   connectionNeedsReconsent,
@@ -182,11 +183,21 @@ function OwnerAccounts(props: {
       });
       if (Exit.isFailure(startExit)) {
         toast.error(messageFromExit(startExit, "Failed to reconnect"));
+        trackEvent("connection_reconnected", {
+          integration_slug: String(connection.integration),
+          owner: connection.owner,
+          success: false,
+        });
         return;
       }
       const started = startExit.value;
       if (started.status === "connected") {
         toast.success("Reconnected");
+        trackEvent("connection_reconnected", {
+          integration_slug: String(connection.integration),
+          owner: connection.owner,
+          success: true,
+        });
         return;
       }
       void oauthPopup.openAuthorization({
@@ -198,9 +209,19 @@ function OwnerAccounts(props: {
           }),
         onSuccess: () => {
           toast.success("Reconnected");
+          trackEvent("connection_reconnected", {
+            integration_slug: String(connection.integration),
+            owner: connection.owner,
+            success: true,
+          });
         },
         onError: () => {
           toast.error("Failed to reconnect");
+          trackEvent("connection_reconnected", {
+            integration_slug: String(connection.integration),
+            owner: connection.owner,
+            success: false,
+          });
         },
       });
       return;
@@ -213,6 +234,11 @@ function OwnerAccounts(props: {
         name: connection.name,
       },
       reactivityKeys: connectionWriteKeys,
+    });
+    trackEvent("connection_reconnected", {
+      integration_slug: String(connection.integration),
+      owner: connection.owner,
+      success: Exit.isSuccess(exit),
     });
     if (Exit.isFailure(exit)) {
       toast.error(messageFromExit(exit, "Failed to reconnect"));
@@ -227,6 +253,11 @@ function OwnerAccounts(props: {
         name: connection.name,
       },
       reactivityKeys: connectionWriteKeys,
+    });
+    trackEvent("connection_removed", {
+      integration_slug: String(connection.integration),
+      owner: connection.owner,
+      success: Exit.isSuccess(exit),
     });
     if (Exit.isFailure(exit)) {
       toast.error(messageFromExit(exit, "Failed to remove connection"));
@@ -333,7 +364,16 @@ export function AccountsSection(props: {
           type="button"
           variant="outline"
           size="sm"
-          onClick={() => setAdding(true)}
+          onClick={() => {
+            trackEvent("connection_add_opened", {
+              integration_slug: String(integration),
+              has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
+              has_api_key_method: methods.some(
+                (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
+              ),
+            });
+            setAdding(true);
+          }}
           disabled={!canAddConnection}
         >
           Add connection
@@ -355,7 +395,16 @@ export function AccountsSection(props: {
             type="button"
             className="mt-4"
             size="sm"
-            onClick={() => setAdding(true)}
+            onClick={() => {
+              trackEvent("connection_add_opened", {
+                integration_slug: String(integration),
+                has_oauth_method: methods.some((m: AuthMethod) => m.kind === "oauth"),
+                has_api_key_method: methods.some(
+                  (m: AuthMethod) => m.kind !== "oauth" && m.kind !== "none",
+                ),
+              });
+              setAdding(true);
+            }}
             disabled={!canAddConnection}
           >
             Add a connection

--- a/packages/react/src/components/add-account-modal.tsx
+++ b/packages/react/src/components/add-account-modal.tsx
@@ -27,6 +27,7 @@ import {
 } from "../api/atoms";
 import { connectionWriteKeys, oauthClientWriteKeys } from "../api/reactivity-keys";
 import { messageFromExit } from "../api/error-reporting";
+import { trackEvent } from "../api/analytics";
 import { useOrganizationId } from "../api/organization-context";
 import { ownerLabel, ownerLabelForHost, useOwnerDisplay } from "../api/owner-display";
 import {
@@ -865,6 +866,7 @@ export function AddAccountModal(props: {
       payload: { owner: client.owner },
       reactivityKeys: oauthClientWriteKeys,
     });
+    trackEvent("oauth_client_removed", { owner: client.owner });
     toast.success(`Removed ${String(client.slug)}`);
     if (pickedApp === String(client.slug)) setPickedApp(null);
   };
@@ -880,6 +882,10 @@ export function AddAccountModal(props: {
   // so the user can immediately add an account with it. The catalog refresh
   // (via the plugin's `integrationWriteKeys`) reconciles it shortly after.
   const handleCustomMethodCreated = (created: AuthMethod): void => {
+    trackEvent("custom_auth_method_created", {
+      integration_slug: String(integration),
+      kind: created.kind,
+    });
     setCreatedMethods((current: readonly AuthMethod[]) => [
       ...current.filter((m: AuthMethod) => m.id !== created.id),
       created,
@@ -897,6 +903,7 @@ export function AddAccountModal(props: {
     if (!removeCustomMethod) return;
     const removed = await removeCustomMethod(methodToRemove);
     if (!removed) return;
+    trackEvent("custom_auth_method_removed", { integration_slug: String(integration) });
     setCreatedMethods((current: readonly AuthMethod[]) =>
       current.filter((m: AuthMethod) => authMethodKey(m) !== authMethodKey(methodToRemove)),
     );
@@ -948,6 +955,12 @@ export function AddAccountModal(props: {
           : { ...commonPayload, values: payloadOrigin.values },
       reactivityKeys: connectionWriteKeys,
     });
+    trackEvent("connection_credential_submitted", {
+      integration_slug: String(integration),
+      owner,
+      credential_origin: credentialOrigin,
+      success: Exit.isSuccess(exit),
+    });
     if (Exit.isFailure(exit)) {
       setSubmitting(false);
       toast.error(messageFromExit(exit, "Failed to add connection"));
@@ -986,6 +999,12 @@ export function AddAccountModal(props: {
         reactivityKeys: connectionWriteKeys,
       });
       setCcBusy(false);
+      trackEvent("connection_oauth_started", {
+        integration_slug: String(integration),
+        owner: connectionOwner,
+        flow: "byo",
+        success: Exit.isSuccess(exit),
+      });
       if (Exit.isFailure(exit)) {
         toast.error(messageFromExit(exit, "Failed to connect"));
         return;
@@ -994,8 +1013,31 @@ export function AddAccountModal(props: {
       close();
       return;
     }
+    // Fire once per attempt: success when the authorization actually started
+    // (URL minted, popup open), failure only for start-phase errors — later
+    // completion errors belong to oauth_completed, not this event.
+    let startReported = false;
     void oauthPopup.start({
       payload,
+      onAuthorizationStarted: () => {
+        startReported = true;
+        trackEvent("connection_oauth_started", {
+          integration_slug: String(integration),
+          owner: connectionOwner,
+          flow: "byo",
+          success: true,
+        });
+      },
+      onError: () => {
+        if (startReported) return;
+        startReported = true;
+        trackEvent("connection_oauth_started", {
+          integration_slug: String(integration),
+          owner: connectionOwner,
+          flow: "byo",
+          success: false,
+        });
+      },
       onSuccess: () => {
         toast.success("Connection added");
         close();
@@ -1076,6 +1118,13 @@ export function AddAccountModal(props: {
       },
     );
     setDcrBusy(false);
+    trackEvent("connection_oauth_started", {
+      integration_slug: String(integration),
+      owner: dcrOwner,
+      flow: "dcr",
+      success: outcome.kind === "started",
+      ...(outcome.kind === "fallback" ? { dcr_fallback: true } : {}),
+    });
     if (outcome.kind === "fallback") {
       setDcrFailed(true);
       toast.error("Automatic setup unavailable — register an app");

--- a/packages/react/src/components/code-block.tsx
+++ b/packages/react/src/components/code-block.tsx
@@ -87,8 +87,10 @@ export function CodeBlock(props: {
   maxHeight?: string;
   className?: string;
   theme?: ShikiThemeProp;
+  /** Fires after a successful copy. Receives nothing — the code may be sensitive. */
+  onCopy?: () => void;
 }) {
-  const { code, lang: langHint, title, className, theme } = props;
+  const { code, lang: langHint, title, className, theme, onCopy } = props;
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -102,9 +104,10 @@ export function CodeBlock(props: {
   const handleCopy = useCallback(() => {
     void navigator.clipboard.writeText(code).then(() => {
       setCopied(true);
+      onCopy?.();
       setTimeout(() => setCopied(false), 1500);
     });
-  }, [code]);
+  }, [code, onCopy]);
 
   return (
     <div className={cn("rounded-lg border border-border bg-card/60 overflow-hidden", className)}>

--- a/packages/react/src/components/command-palette.tsx
+++ b/packages/react/src/components/command-palette.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { PlusIcon } from "lucide-react";
+import { trackEvent } from "../api/analytics";
 import type { Integration } from "@executor-js/sdk/shared";
 import { IntegrationFavicon, integrationPresetIconUrl } from "./integration-favicon";
 import { integrationsOptimisticAtom } from "../api/atoms";
@@ -92,6 +93,7 @@ export function CommandPalette() {
   const goToIntegration = useCallback(
     (id: string) => {
       close();
+      trackEvent("command_palette_navigated", { kind: "integration", plugin_key: id });
       void navigate({ to: "/integrations/$namespace", params: { namespace: id } });
     },
     [close, navigate],
@@ -100,6 +102,8 @@ export function CommandPalette() {
   const goToAdd = useCallback(
     (pluginKey: string) => {
       close();
+      trackEvent("command_palette_navigated", { kind: "add_integration", plugin_key: pluginKey });
+      trackEvent("integration_add_started", { plugin_key: pluginKey, via: "command_palette" });
       void navigate({
         to: "/integrations/add/$pluginKey",
         params: { pluginKey },
@@ -111,6 +115,12 @@ export function CommandPalette() {
   const goToPreset = useCallback(
     (pluginKey: string, presetId: string, presetUrl?: string) => {
       close();
+      trackEvent("command_palette_navigated", { kind: "preset", plugin_key: pluginKey });
+      trackEvent("integration_add_started", {
+        plugin_key: pluginKey,
+        via: "command_palette",
+        preset_id: presetId,
+      });
       const search: Record<string, string> = { preset: presetId };
       if (presetUrl) search.url = presetUrl;
       void navigate({

--- a/packages/react/src/components/copy-button.tsx
+++ b/packages/react/src/components/copy-button.tsx
@@ -7,16 +7,20 @@ function CopyButton({
   value,
   label,
   className,
+  onCopy,
 }: {
   value: string;
   label?: string;
   className?: string;
+  /** Fires after a successful copy. Receives nothing — the copied value may be sensitive. */
+  onCopy?: () => void;
 }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
     void navigator.clipboard.writeText(value).then(() => {
       setCopied(true);
+      onCopy?.();
       setTimeout(() => setCopied(false), 1500);
     });
   };

--- a/packages/react/src/components/mcp-install-card.tsx
+++ b/packages/react/src/components/mcp-install-card.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { trackEvent } from "../api/analytics";
 import CursorIcon from "@lobehub/icons/es/Cursor/components/Mono";
 import ClaudeIcon from "@lobehub/icons/es/Claude/components/Color";
 import OpenCodeIcon from "@lobehub/icons/es/OpenCode/components/Mono";
@@ -179,7 +180,11 @@ export function McpInstallCard(props: { className?: string }) {
           <NativeSelect
             size="sm"
             value={elicitationMode}
-            onChange={(event) => setHttpElicitationMode(event.target.value as McpElicitationMode)}
+            onChange={(event) => {
+              const next = event.target.value as McpElicitationMode;
+              setHttpElicitationMode(next);
+              trackEvent("mcp_install_elicitation_mode_changed", { elicitation_mode: next });
+            }}
             aria-label="Elicitation mode"
             className="min-w-44"
           >
@@ -241,7 +246,17 @@ export function McpInstallCard(props: { className?: string }) {
   const body = (
     <CardStackContent>
       <div className="px-4 pt-1 pb-3">
-        <CodeBlock code={command} lang="bash" />
+        <CodeBlock
+          code={command}
+          lang="bash"
+          onCopy={() =>
+            trackEvent("mcp_install_command_copied", {
+              transport: mode,
+              elicitation_mode: elicitationMode,
+              surface: "integrations",
+            })
+          }
+        />
         {advancedControls && <div className="mt-3">{advancedControls}</div>}
       </div>
       <div className="flex items-center px-4 py-3">{agentLogos}</div>
@@ -251,7 +266,14 @@ export function McpInstallCard(props: { className?: string }) {
   return (
     <CardStack className={props.className}>
       {showStdio ? (
-        <Tabs value={mode} onValueChange={(v) => setMode(v as TransportMode)}>
+        <Tabs
+          value={mode}
+          onValueChange={(v) => {
+            const next = v as TransportMode;
+            setMode(next);
+            trackEvent("mcp_install_transport_switched", { transport: next });
+          }}
+        >
           {header}
           <TabsContent value="http">{body}</TabsContent>
           <TabsContent value="stdio">{body}</TabsContent>

--- a/packages/react/src/components/oauth-client-form.tsx
+++ b/packages/react/src/components/oauth-client-form.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 
 import { createOAuthClientOptimistic, probeOAuth, registerDynamicOAuthClient } from "../api/atoms";
 import { ownerLabelForHost } from "../api/owner-display";
+import { trackEvent } from "../api/analytics";
 import { useOrganizationId } from "../api/organization-context";
 import { oauthClientWriteKeys } from "../api/reactivity-keys";
 import { uniqueClientSlug } from "../plugins/use-effective-oauth-client";
@@ -199,9 +200,11 @@ export function OAuthClientForm(props: {
     });
     if (Exit.isFailure(exit)) {
       setRegistering(false);
+      trackEvent("oauth_client_registered", { owner, grant, via_dcr: true, success: false });
       toast.error("Automatic registration failed — enter a client ID and secret instead");
       return;
     }
+    trackEvent("oauth_client_registered", { owner, grant, via_dcr: true, success: true });
     toast.success(`Registered ${integrationName} OAuth app`);
     onCreated({ owner, slug });
   };
@@ -225,9 +228,11 @@ export function OAuthClientForm(props: {
     });
     if (Exit.isFailure(exit)) {
       setSubmitting(false);
+      trackEvent("oauth_client_registered", { owner, grant, via_dcr: false, success: false });
       toast.error("Failed to register OAuth app");
       return;
     }
+    trackEvent("oauth_client_registered", { owner, grant, via_dcr: false, success: true });
     toast.success(`Registered ${integrationName} OAuth app`);
     onCreated({ owner, slug });
   };

--- a/packages/react/src/components/tool-detail.tsx
+++ b/packages/react/src/components/tool-detail.tsx
@@ -29,6 +29,7 @@ import { CopyButton } from "./copy-button";
 import { ChevronRight, ChevronDownIcon } from "lucide-react";
 import { cn } from "../lib/utils";
 import { toPolicyPattern } from "../lib/policy-pattern";
+import { trackEvent } from "../api/analytics";
 import {
   POLICY_ACTION_LABEL,
   POLICY_ACTIONS_IN_ORDER,
@@ -223,7 +224,17 @@ export function ToolDetail(props: {
           )}
           <div className="mt-1 flex items-center gap-2">
             <h3 className="text-base font-semibold text-foreground truncate">{displayName}</h3>
-            <CopyButton value={String(props.address)} label="Copy tool ID" />
+            <CopyButton
+              value={String(props.address)}
+              label="Copy tool ID"
+              onCopy={() => {
+                const nameParts = props.toolName.split(".");
+                trackEvent("tool_id_copied", {
+                  integration_slug: nameParts[0] ?? props.toolName,
+                  tool_name: nameParts.slice(1).join(".") || props.toolName,
+                });
+              }}
+            />
             <PolicyBadgeMenu
               toolName={props.toolName}
               policy={props.policy}

--- a/packages/react/src/components/tool-run-panel.tsx
+++ b/packages/react/src/components/tool-run-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from "@executor-js/sdk/shared";
 
 import { executeCode, toolSchemaAtom } from "../api/atoms";
+import { trackEvent } from "../api/analytics";
 import { Badge } from "./badge";
 import { Button } from "./button";
 import { Label } from "./label";
@@ -219,15 +220,34 @@ export function ToolRunPanel(props: {
     setRunning(false);
 
     if (Exit.isFailure(exit)) {
+      trackEvent("tool_run_submitted", {
+        integration_slug: integration,
+        tool_name: toolName,
+        args_mode: argsMode,
+        result: "failed",
+      });
       toast.error("Failed to run tool");
       return;
     }
 
     const value = exit.value;
     if (value.status === "paused") {
+      trackEvent("tool_run_submitted", {
+        integration_slug: integration,
+        tool_name: toolName,
+        args_mode: argsMode,
+        result: "paused",
+      });
       setResult({ kind: "paused", text: value.text });
       return;
     }
+    trackEvent("tool_run_submitted", {
+      integration_slug: integration,
+      tool_name: toolName,
+      args_mode: argsMode,
+      result: "completed",
+      ...(value.isError ? { is_error: true } : {}),
+    });
     setResult({
       kind: "completed",
       text: value.text,

--- a/packages/react/src/components/tool-tree.tsx
+++ b/packages/react/src/components/tool-tree.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronRightIcon, MoreHorizontalIcon, SearchIcon, XIcon } from "lucide-react";
 import type { EffectivePolicy, Owner, ToolPolicyAction } from "@executor-js/sdk/shared";
 import { ownerLabel, useOwnerDisplay } from "../api/owner-display";
+import { trackEvent } from "../api/analytics";
 import { toPolicyPattern } from "../lib/policy-pattern";
 import { Badge } from "./badge";
 import { Button } from "./button";
@@ -498,7 +499,14 @@ function ToolTreeBody(props: {
             tool={row.tool}
             depth={row.depth}
             active={row.tool.id === selectedToolId}
-            onSelect={() => onSelect(row.tool.id)}
+            onSelect={() => {
+              const nameParts = row.tool.name.split(".");
+              trackEvent("tool_selected", {
+                integration_slug: nameParts[0] ?? row.tool.name,
+                tool_name: nameParts.slice(1).join(".") || row.tool.name,
+              });
+              onSelect(row.tool.id);
+            }}
             search={search}
             onSetPolicy={onSetPolicy}
             onClearPolicy={onClearPolicy}

--- a/packages/react/src/hooks/use-policy-actions.ts
+++ b/packages/react/src/hooks/use-policy-actions.ts
@@ -11,6 +11,7 @@ import {
   updatePolicyOptimistic,
 } from "../api/atoms";
 import { policyWriteKeys } from "../api/reactivity-keys";
+import { trackEvent } from "../api/analytics";
 
 // Specificity score for ordering. Higher = more specific = should sit at a
 // lower position-key (higher precedence). New rules are auto-placed below
@@ -107,6 +108,7 @@ export const usePolicyActions = (owner: Owner = "org"): PolicyAction => {
 
   const set = useCallback(
     async (pattern: string, action: ToolPolicyAction) => {
+      const patternKind = pattern.endsWith(".*") ? "group" : "exact";
       const existing = findExact(pattern);
       if (existing) {
         if (existing.action === action) return;
@@ -115,6 +117,7 @@ export const usePolicyActions = (owner: Owner = "org"): PolicyAction => {
           payload: { owner, action },
           reactivityKeys: policyWriteKeys,
         });
+        trackEvent("tool_policy_set", { action, pattern_kind: patternKind, owner });
         return;
       }
       const position = computePosition(pattern);
@@ -125,6 +128,7 @@ export const usePolicyActions = (owner: Owner = "org"): PolicyAction => {
             : { owner, pattern, action, position },
         reactivityKeys: policyWriteKeys,
       });
+      trackEvent("tool_policy_set", { action, pattern_kind: patternKind, owner });
     },
     [owner, doCreate, doUpdate, findExact, computePosition],
   );
@@ -137,6 +141,10 @@ export const usePolicyActions = (owner: Owner = "org"): PolicyAction => {
         params: { policyId: PolicyId.make(existing.id) },
         payload: { owner },
         reactivityKeys: policyWriteKeys,
+      });
+      trackEvent("tool_policy_cleared", {
+        pattern_kind: pattern.endsWith(".*") ? "group" : "exact",
+        owner,
       });
     },
     [owner, doRemove, findExact],

--- a/packages/react/src/pages/api-keys.tsx
+++ b/packages/react/src/pages/api-keys.tsx
@@ -4,6 +4,7 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { toast } from "sonner";
 import { apiKeyWriteKeys } from "../api/reactivity-keys";
+import { trackEvent } from "../api/analytics";
 import { apiKeysAtom, createApiKey, revokeApiKey } from "../api/account-atoms";
 import { Button } from "../components/button";
 import { CopyButton } from "../components/copy-button";
@@ -71,6 +72,7 @@ export function ApiKeysPage() {
     setCreating(true);
     const exit = await doCreate({ payload: { name: trimmed }, reactivityKeys: apiKeyWriteKeys });
     setCreating(false);
+    trackEvent("api_key_created", { success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) {
       setCreatedKey(exit.value);
       setName("");
@@ -84,6 +86,7 @@ export function ApiKeysPage() {
     setRevokingId(key.id);
     const exit = await doRevoke({ params: { apiKeyId: key.id }, reactivityKeys: apiKeyWriteKeys });
     setRevokingId(null);
+    trackEvent("api_key_revoked", { success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) {
       toast.success(`Revoked ${key.name}`);
       return;
@@ -212,7 +215,10 @@ export function ApiKeysPage() {
                     className="font-mono text-xs"
                     data-ph-mask
                   />
-                  <CopyButton value={createdKey.value} />
+                  <CopyButton
+                    value={createdKey.value}
+                    onCopy={() => trackEvent("api_key_copied", { kind: "value" })}
+                  />
                 </div>
               </div>
               <div className="grid gap-1.5">
@@ -224,7 +230,10 @@ export function ApiKeysPage() {
                     className="font-mono text-xs"
                     data-ph-mask
                   />
-                  <CopyButton value={`Authorization: Bearer ${createdKey.value}`} />
+                  <CopyButton
+                    value={`Authorization: Bearer ${createdKey.value}`}
+                    onCopy={() => trackEvent("api_key_copied", { kind: "bearer_header" })}
+                  />
                 </div>
               </div>
               <p className="text-sm leading-6 text-muted-foreground">

--- a/packages/react/src/pages/integration-add.tsx
+++ b/packages/react/src/pages/integration-add.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { useIntegrationPlugins } from "@executor-js/sdk/client";
+import { trackEvent } from "../api/analytics";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -52,6 +53,10 @@ export function AddIntegrationPage(props: {
             initialPreset={preset}
             initialNamespace={namespace}
             onComplete={(slug?: string) => {
+              trackEvent("integration_added", {
+                plugin_key: pluginKey,
+                ...(slug ? { integration_slug: slug } : {}),
+              });
               void navigate(
                 slug
                   ? { to: "/integrations/$namespace", params: { namespace: slug } }
@@ -59,6 +64,7 @@ export function AddIntegrationPage(props: {
               );
             }}
             onCancel={() => {
+              trackEvent("integration_add_cancelled", { plugin_key: pluginKey });
               void navigate({ to: "/" });
             }}
           />

--- a/packages/react/src/pages/integration-detail.tsx
+++ b/packages/react/src/pages/integration-detail.tsx
@@ -2,6 +2,7 @@ import { Suspense, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useAtomValue, useAtomSet, useAtomRefresh } from "@effect/atom-react";
 import * as Exit from "effect/Exit";
+import { trackEvent } from "../api/analytics";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import {
   AuthTemplateSlug,
@@ -281,6 +282,10 @@ export function IntegrationDetailPage(props: { namespace: string }) {
       params: { slug },
       reactivityKeys: integrationWriteKeys,
     });
+    trackEvent("integration_removed", {
+      integration_slug: String(slug),
+      success: Exit.isSuccess(exit),
+    });
     if (Exit.isFailure(exit)) {
       setDeleting(false);
       setConfirmDelete(false);
@@ -295,13 +300,22 @@ export function IntegrationDetailPage(props: { namespace: string }) {
     // v2: refresh re-resolves tools per connection. Refresh every connection of
     // this integration for the active owner.
     const connections = AsyncResult.isSuccess(connectionsResult) ? connectionsResult.value : [];
+    const refreshExits: boolean[] = [];
+    let connectionCount = 0;
     for (const connection of connections) {
       if (connection.integration !== slug) continue;
-      await doRefresh({
+      connectionCount++;
+      const refreshExit = await doRefresh({
         params: { owner: connection.owner, integration: slug, name: connection.name },
         reactivityKeys: connectionWriteKeys,
       });
+      refreshExits.push(Exit.isSuccess(refreshExit));
     }
+    trackEvent("integration_refreshed", {
+      integration_slug: String(slug),
+      connection_count: connectionCount,
+      success: connectionCount > 0 && refreshExits.every(Boolean),
+    });
     setRefreshing(false);
   };
 
@@ -335,6 +349,10 @@ export function IntegrationDetailPage(props: { namespace: string }) {
       reactivityKeys: integrationWriteKeys,
     });
     setSavingName(false);
+    trackEvent("integration_renamed", {
+      integration_slug: String(slug),
+      success: Exit.isSuccess(exit),
+    });
     if (Exit.isFailure(exit)) return;
     cancelRename();
   };

--- a/packages/react/src/pages/integrations.tsx
+++ b/packages/react/src/pages/integrations.tsx
@@ -11,6 +11,7 @@ import {
   type IntegrationPreset,
 } from "@executor-js/sdk/client";
 import { detectIntegration, integrationsOptimisticAtom } from "../api/atoms";
+import { trackEvent } from "../api/analytics";
 import { McpInstallCard } from "../components/mcp-install-card";
 import { Button } from "../components/button";
 import { Badge } from "../components/badge";
@@ -77,7 +78,14 @@ export function IntegrationsPage() {
               Tool providers available in this workspace.
             </p>
           </div>
-          <Button onClick={() => setConnectOpen(true)} size="sm" className="shrink-0 gap-1.5">
+          <Button
+            onClick={() => {
+              setConnectOpen(true);
+              trackEvent("integration_connect_dialog_opened");
+            }}
+            size="sm"
+            className="shrink-0 gap-1.5"
+          >
             <PlusIcon className="size-4" />
             Connect
           </Button>
@@ -94,7 +102,14 @@ export function IntegrationsPage() {
           onFailure: () => <p className="text-sm text-destructive">Failed to load integrations</p>,
           onSuccess: ({ value }) => {
             if (value.length === 0) {
-              return <EmptyIntegrations onConnect={() => setConnectOpen(true)} />;
+              return (
+                <EmptyIntegrations
+                  onConnect={() => {
+                    setConnectOpen(true);
+                    trackEvent("integration_connect_dialog_opened");
+                  }}
+                />
+              );
             }
 
             return (
@@ -158,24 +173,33 @@ function ConnectDialog(props: { open: boolean; onOpenChange: (open: boolean) => 
       reactivityKeys: [],
     });
     if (Exit.isFailure(exit)) {
+      trackEvent("integration_detect_submitted", { success: false });
       setError("Detection failed. Try adding an integration manually.");
       setDetecting(false);
       return;
     }
     const results = exit.value;
     if (results.length === 0) {
+      trackEvent("integration_detect_submitted", { success: false });
       setError("Could not detect an integration type from this URL. Try adding manually.");
       setDetecting(false);
       return;
     }
     const detected = bestDetection(results);
     if (!detected) {
+      trackEvent("integration_detect_submitted", { success: false });
       setError("Could not detect an integration type from this URL. Try adding manually.");
       setDetecting(false);
       return;
     }
+    trackEvent("integration_detect_submitted", {
+      success: true,
+      detected_kind: detected.kind,
+      confidence: detected.confidence,
+    });
     const pluginKey = KIND_TO_PLUGIN_KEY[detected.kind] ?? detected.kind;
     if (integrationPlugins.some((p) => p.key === pluginKey)) {
+      trackEvent("integration_add_started", { plugin_key: pluginKey, via: "detect" });
       closeAndReset();
       void navigate({
         to: "/integrations/add/$pluginKey",
@@ -238,7 +262,10 @@ function ConnectDialog(props: { open: boolean; onOpenChange: (open: boolean) => 
                   key={p.key}
                   to="/integrations/add/$pluginKey"
                   params={{ pluginKey: p.key }}
-                  onClick={closeAndReset}
+                  onClick={() => {
+                    trackEvent("integration_add_started", { plugin_key: p.key, via: "manual" });
+                    closeAndReset();
+                  }}
                   className="rounded-md border border-border px-3 py-1.5 text-xs font-medium transition-colors hover:bg-muted"
                 >
                   {p.label}
@@ -347,7 +374,14 @@ function PresetGrid(props: {
                     to="/integrations/add/$pluginKey"
                     params={{ pluginKey }}
                     search={search}
-                    onClick={props.onPick}
+                    onClick={() => {
+                      trackEvent("integration_add_started", {
+                        plugin_key: pluginKey,
+                        via: "preset",
+                        preset_id: preset.id,
+                      });
+                      props.onPick();
+                    }}
                   >
                     <CardStackEntryMedia>
                       {preset.icon ? (

--- a/packages/react/src/pages/org.tsx
+++ b/packages/react/src/pages/org.tsx
@@ -3,6 +3,7 @@ import { Exit, Match } from "effect";
 import { useAtomValue, useAtomSet } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { toast } from "sonner";
+import { trackEvent } from "../api/analytics";
 import { orgMemberWriteKeys, orgInfoWriteKeys } from "../api/reactivity-keys";
 import {
   Dialog,
@@ -144,6 +145,7 @@ export function OrgPage(props: { domainsSection?: React.ReactNode }) {
       params: { membershipId },
       reactivityKeys: orgMemberWriteKeys,
     });
+    trackEvent("org_member_removed", { success: Exit.isSuccess(exit) });
     toast[Exit.isSuccess(exit) ? "success" : "error"](
       Exit.isSuccess(exit) ? `Removed ${name}` : "Failed to remove member",
     );
@@ -155,6 +157,7 @@ export function OrgPage(props: { domainsSection?: React.ReactNode }) {
       payload: { roleSlug },
       reactivityKeys: orgMemberWriteKeys,
     });
+    trackEvent("org_member_role_changed", { role: roleSlug, success: Exit.isSuccess(exit) });
     toast[Exit.isSuccess(exit) ? "success" : "error"](
       Exit.isSuccess(exit) ? `Role changed to ${roleName}` : "Failed to change role",
     );
@@ -171,6 +174,7 @@ export function OrgPage(props: { domainsSection?: React.ReactNode }) {
       payload: { name: trimmed },
       reactivityKeys: orgInfoWriteKeys,
     });
+    trackEvent("org_renamed", { success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) {
       toast.success("Organization name updated");
     } else {
@@ -397,6 +401,7 @@ function InviteDialog(props: {
       },
       reactivityKeys: orgMemberWriteKeys,
     });
+    trackEvent("org_member_invited", { role: state.roleSlug, success: Exit.isSuccess(exit) });
     if (Exit.isSuccess(exit)) {
       toast.success(`Invitation sent to ${state.email.trim()}`);
       dispatch({ type: "reset" });

--- a/packages/react/src/pages/policies.tsx
+++ b/packages/react/src/pages/policies.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
+import { trackEvent } from "../api/analytics";
 import { generateKeyBetween } from "fractional-indexing";
 import { ChevronDownIcon } from "lucide-react";
 import {
@@ -281,8 +282,8 @@ function PolicyRow(props: {
 export function PoliciesPage() {
   const policies = useAtomValue(policiesOptimisticAtom);
   const doCreate = useAtomSet(createPolicyOptimistic, { mode: "promiseExit" });
-  const doUpdate = useAtomSet(updatePolicyOptimistic, { mode: "promise" });
-  const doRemove = useAtomSet(removePolicyOptimistic, { mode: "promise" });
+  const doUpdate = useAtomSet(updatePolicyOptimistic, { mode: "promiseExit" });
+  const doRemove = useAtomSet(removePolicyOptimistic, { mode: "promiseExit" });
   const [busy, setBusy] = useState(false);
   const ownerDisplay = useOwnerDisplay();
   // Policies default to org/workspace. On local this is the hidden Local owner
@@ -303,6 +304,11 @@ export function PoliciesPage() {
       },
       reactivityKeys: policyWriteKeys,
     });
+    trackEvent("policy_created", {
+      action: input.action,
+      owner: input.owner,
+      success: Exit.isSuccess(exit),
+    });
     if (Exit.isFailure(exit)) {
       setBusy(false);
       return;
@@ -311,26 +317,41 @@ export function PoliciesPage() {
   };
 
   const handleUpdate = async (policy: { id: string; owner: Owner }, action: ToolPolicyAction) => {
-    await doUpdate({
+    const exit = await doUpdate({
       params: { policyId: PolicyId.make(policy.id) },
       payload: { owner: policy.owner, action },
       reactivityKeys: policyWriteKeys,
     });
+    trackEvent("policy_action_changed", {
+      action,
+      owner: policy.owner,
+      success: Exit.isSuccess(exit),
+    });
   };
 
   const handleRemove = async (policy: { id: string; owner: Owner }) => {
-    await doRemove({
+    const exit = await doRemove({
       params: { policyId: PolicyId.make(policy.id) },
       payload: { owner: policy.owner },
       reactivityKeys: policyWriteKeys,
     });
+    trackEvent("policy_removed", { owner: policy.owner, success: Exit.isSuccess(exit) });
   };
 
-  const handleMove = async (policy: { id: string; owner: Owner }, position: string) => {
-    await doUpdate({
+  const handleMove = async (
+    policy: { id: string; owner: Owner },
+    position: string,
+    direction: "up" | "down",
+  ) => {
+    const exit = await doUpdate({
       params: { policyId: PolicyId.make(policy.id) },
       payload: { owner: policy.owner, position },
       reactivityKeys: policyWriteKeys,
+    });
+    trackEvent("policy_reordered", {
+      owner: policy.owner,
+      direction,
+      success: Exit.isSuccess(exit),
     });
   };
 
@@ -444,10 +465,18 @@ export function PoliciesPage() {
                             handleUpdate({ id: p.id, owner: p.owner }, action)
                           }
                           onMoveUp={() =>
-                            handleMove({ id: p.id, owner: p.owner }, positionAbove(p.id, p.owner))
+                            handleMove(
+                              { id: p.id, owner: p.owner },
+                              positionAbove(p.id, p.owner),
+                              "up",
+                            )
                           }
                           onMoveDown={() =>
-                            handleMove({ id: p.id, owner: p.owner }, positionBelow(p.id, p.owner))
+                            handleMove(
+                              { id: p.id, owner: p.owner },
+                              positionBelow(p.id, p.owner),
+                              "down",
+                            )
                           }
                         />
                       );

--- a/packages/react/src/pages/resume-approval.tsx
+++ b/packages/react/src/pages/resume-approval.tsx
@@ -6,6 +6,7 @@ import { Check, ExternalLink, Loader2, ShieldCheck, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { pausedExecutionAtom, resumeExecution } from "../api/atoms";
+import { trackEvent } from "../api/analytics";
 import { Button } from "../components/button";
 import { CopyButton } from "../components/copy-button";
 import { type ElicitationAction, useElicitationApproval } from "../components/elicitation-approval";
@@ -173,6 +174,12 @@ export function ResumeApprovalPageView(props: {
       const exit = await resume(currentExecutionId, action, content);
 
       if (Exit.isFailure(exit)) {
+        trackEvent("resume_approval_submitted", {
+          action,
+          ...(interaction?.kind != null ? { interaction_kind: interaction.kind } : {}),
+          chained_to_next: false,
+          success: false,
+        });
         setStatus({ state: "failed", message: failureMessage(exit) });
         return;
       }
@@ -180,6 +187,12 @@ export function ResumeApprovalPageView(props: {
       if (exit.value.status === "paused") {
         const nextExecutionId = executionIdFromStructured(exit.value.structured);
         if (!nextExecutionId) {
+          trackEvent("resume_approval_submitted", {
+            action,
+            ...(interaction?.kind != null ? { interaction_kind: interaction.kind } : {}),
+            chained_to_next: false,
+            success: false,
+          });
           setStatus({
             state: "failed",
             message: "The next paused execution did not include an id.",
@@ -187,19 +200,31 @@ export function ResumeApprovalPageView(props: {
           return;
         }
 
+        trackEvent("resume_approval_submitted", {
+          action,
+          ...(interaction?.kind != null ? { interaction_kind: interaction.kind } : {}),
+          chained_to_next: true,
+          success: true,
+        });
         setCurrentExecutionId(nextExecutionId);
         setNextPaused({ text: exit.value.text, structured: exit.value.structured });
         setStatus({ state: "idle" });
         return;
       }
 
+      trackEvent("resume_approval_submitted", {
+        action,
+        ...(interaction?.kind != null ? { interaction_kind: interaction.kind } : {}),
+        chained_to_next: false,
+        success: true,
+      });
       setStatus({
         state: "done",
         action,
         text: exit.value.text || "The paused execution has been resumed.",
       });
     },
-    [approval, currentExecutionId, resume],
+    [approval, currentExecutionId, interaction, resume],
   );
 
   const busy = status.state === "submitting";
@@ -276,6 +301,7 @@ export function ResumeApprovalPageView(props: {
               value={returnPrompt[status.action]}
               label="Copy prompt"
               className="h-9 px-4"
+              onCopy={() => trackEvent("resume_return_prompt_copied", { action: status.action })}
             />
           ) : (
             <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">

--- a/packages/react/src/plugins/oauth-sign-in.tsx
+++ b/packages/react/src/plugins/oauth-sign-in.tsx
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 
 import { cancelOAuth, oauthConnectionCompleted, startOAuth } from "../api/atoms";
+import { trackEvent } from "../api/analytics";
 import { messageFromExit, messageFromUnknown, useReportHandledError } from "../api/error-reporting";
 import {
   openOAuthPopup,
@@ -166,6 +167,7 @@ export function useOAuthPopupFlow<
       const reservedPopup = desktopBridge ? null : reserveOAuthPopup({ popupName });
       if (!desktopBridge && !reservedPopup) {
         const message = popupBlockedMessage ?? "Sign-in popup was blocked by the browser";
+        trackEvent("oauth_popup_blocked");
         setBusy(false);
         setError(message);
         input.onError?.(message);
@@ -213,6 +215,7 @@ export function useOAuthPopupFlow<
         sessionRef.current = null;
 
         if (!result.ok) {
+          trackEvent("oauth_completed", { success: false });
           setBusy(false);
           setError(result.error);
           input.onError?.(result.error, result.errorDetails);
@@ -230,6 +233,7 @@ export function useOAuthPopupFlow<
             message,
             metadata: input.reportMetadata,
           });
+          trackEvent("oauth_completed", { success: false });
           setBusy(false);
           setError(message);
           input.onError?.(message);
@@ -248,11 +252,13 @@ export function useOAuthPopupFlow<
             message,
             metadata: input.reportMetadata,
           });
+          trackEvent("oauth_completed", { success: false });
           setBusy(false);
           setError(message);
           input.onError?.(message);
           return;
         }
+        trackEvent("oauth_completed", { success: true });
         setBusy(false);
       };
       const handleClosed = () => {
@@ -263,6 +269,7 @@ export function useOAuthPopupFlow<
         // callback or TTL cleanup; only explicit cancel deletes the session.
         const message =
           popupClosedMessage ?? "Sign-in cancelled - popup was closed before completing the flow.";
+        trackEvent("oauth_completed", { success: false });
         setBusy(false);
         setError(message);
         input.onError?.(message);
@@ -272,6 +279,7 @@ export function useOAuthPopupFlow<
         sessionRef.current = null;
         cancelSession(response.state);
         const message = popupBlockedMessage ?? "Sign-in popup was blocked by the browser";
+        trackEvent("oauth_completed", { success: false });
         setBusy(false);
         setError(message);
         input.onError?.(message);


### PR DESCRIPTION
Adds a typed analytics seam in `@executor-js/react` and instruments the shared console + cloud surfaces with product events.

- **Seam** (`packages/react/src/api/analytics.tsx`): a typed `AnalyticsEvents` catalog + `trackEvent()` + `AnalyticsProvider`, mirroring the existing `FrontendErrorReporter` DI pattern. No-op unless a host mounts a client. Cloud mounts a `posthog.capture` client; other hosts mount nothing (no-op).
- **~60 events** across integrations, connections/auth, tools, policies, API keys, org, resume approvals, MCP install, command palette, and cloud onboarding/billing/support.
- Properties carry only non-PII slugs/enums — no user-entered text, connection names, tool addresses, policy patterns, or copied values. `CopyButton`/`CodeBlock` gained an `onCopy` callback so copy events never see the copied value.
- `success`-bearing events fire once per resolved outcome.

Gates: `format:check`, `lint`, `typecheck`, `test` all pass.