### PR TITLE
Follow cross-origin redirects in hosted HTTP client, stripping credentials

### DIFF
--- a/packages/core/sdk/src/hosted-http-client.test.ts
+++ b/packages/core/sdk/src/hosted-http-client.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Predicate, Result } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
-import {
-  makeHostedHttpClientLayer,
-  validateHostedOutboundUrl,
-} from "./hosted-http-client";
+import { makeHostedHttpClientLayer, validateHostedOutboundUrl } from "./hosted-http-client";
 
 describe("hosted outbound HTTP client", () => {
   it.effect("allows public HTTP and HTTPS URLs", () =>
@@ -26,30 +23,24 @@ describe("hosted outbound HTTP client", () => {
         "http://169.254.169.254/latest/meta-data/",
       ]) {
         const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
-        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(
-          true,
-        );
+        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(true);
       }
     }),
   );
 
-  it.effect(
-    "rejects IPv4-mapped IPv6 URLs for local and private networks",
-    () =>
-      Effect.gen(function* () {
-        for (const url of [
-          "http://[::ffff:127.0.0.1]:3000",
-          "http://[::ffff:10.0.0.1]/openapi.json",
-          "http://[::ffff:172.16.0.1]/graphql",
-          "http://[::ffff:192.168.1.10]/mcp",
-          "http://[::ffff:169.254.169.254]/latest/meta-data/",
-        ]) {
-          const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
-          expect(
-            Predicate.isTagged(error, "HostedOutboundRequestBlocked"),
-          ).toBe(true);
-        }
-      }),
+  it.effect("rejects IPv4-mapped IPv6 URLs for local and private networks", () =>
+    Effect.gen(function* () {
+      for (const url of [
+        "http://[::ffff:127.0.0.1]:3000",
+        "http://[::ffff:10.0.0.1]/openapi.json",
+        "http://[::ffff:172.16.0.1]/graphql",
+        "http://[::ffff:192.168.1.10]/mcp",
+        "http://[::ffff:169.254.169.254]/latest/meta-data/",
+      ]) {
+        const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
+        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(true);
+      }
+    }),
   );
 
   it.effect("can allow local network URLs explicitly", () =>
@@ -76,73 +67,64 @@ describe("hosted outbound HTTP client", () => {
       }) as typeof globalThis.fetch;
       const result = yield* Effect.gen(function* () {
         const client = yield* HttpClient.HttpClient;
-        return yield* client.execute(
-          HttpClientRequest.get("https://public.example/start"),
-        );
-      }).pipe(
-        Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })),
-        Effect.result,
-      );
+        return yield* client.execute(HttpClientRequest.get("https://public.example/start"));
+      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })), Effect.result);
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);
     }),
   );
 
-  it.effect(
-    "follows cross-origin redirects but strips credential headers",
-    () =>
-      Effect.gen(function* () {
-        const seen: Array<{
-          url: string;
-          authorization: string | null;
-          cookie: string | null;
-        }> = [];
-        const fakeFetch: typeof globalThis.fetch = (async (input, init) => {
-          const url = input instanceof Request ? input.url : String(input);
-          const headers = new Headers(init?.headers);
-          seen.push({
-            url,
-            authorization: headers.get("authorization"),
-            cookie: headers.get("cookie"),
+  it.effect("follows cross-origin redirects but strips credential headers", () =>
+    Effect.gen(function* () {
+      const seen: Array<{
+        url: string;
+        authorization: string | null;
+        cookie: string | null;
+      }> = [];
+      const fakeFetch: typeof globalThis.fetch = (async (input, init) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const headers = new Headers(init?.headers);
+        seen.push({
+          url,
+          authorization: headers.get("authorization"),
+          cookie: headers.get("cookie"),
+        });
+        if (url === "https://api.example/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://cdn.example/blob" },
           });
-          if (url === "https://api.example/start") {
-            return new Response(null, {
-              status: 302,
-              headers: { location: "https://cdn.example/blob" },
-            });
-          }
-          return new Response("bytes", { status: 200 });
-        }) as typeof globalThis.fetch;
+        }
+        return new Response("bytes", { status: 200 });
+      }) as typeof globalThis.fetch;
 
-        const response = yield* Effect.gen(function* () {
-          const client = yield* HttpClient.HttpClient;
-          return yield* client.execute(
-            HttpClientRequest.get("https://api.example/start").pipe(
-              HttpClientRequest.setHeaders({
-                authorization: "Bearer secret",
-                cookie: "session=abc",
-                accept: "application/octet-stream",
-              }),
-            ),
-          );
-        }).pipe(
-          Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })),
+      const response = yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* client.execute(
+          HttpClientRequest.get("https://api.example/start").pipe(
+            HttpClientRequest.setHeaders({
+              authorization: "Bearer secret",
+              cookie: "session=abc",
+              accept: "application/octet-stream",
+            }),
+          ),
         );
+      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })));
 
-        expect(response.status).toBe(200);
-        expect(seen).toHaveLength(2);
-        expect(seen[0]).toMatchObject({
-          url: "https://api.example/start",
-          authorization: "Bearer secret",
-          cookie: "session=abc",
-        });
-        expect(seen[1]).toMatchObject({
-          url: "https://cdn.example/blob",
-          authorization: null,
-          cookie: null,
-        });
-      }),
+      expect(response.status).toBe(200);
+      expect(seen).toHaveLength(2);
+      expect(seen[0]).toMatchObject({
+        url: "https://api.example/start",
+        authorization: "Bearer secret",
+        cookie: "session=abc",
+      });
+      expect(seen[1]).toMatchObject({
+        url: "https://cdn.example/blob",
+        authorization: null,
+        cookie: null,
+      });
+    }),
   );
 
   it.effect("keeps credential headers on same-origin redirects", () =>
@@ -198,13 +180,8 @@ describe("hosted outbound HTTP client", () => {
 
       const result = yield* Effect.gen(function* () {
         const client = yield* HttpClient.HttpClient;
-        return yield* client.execute(
-          HttpClientRequest.get("https://api.example/start"),
-        );
-      }).pipe(
-        Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })),
-        Effect.result,
-      );
+        return yield* client.execute(HttpClientRequest.get("https://api.example/start"));
+      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })), Effect.result);
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);

--- a/packages/core/sdk/src/hosted-http-client.test.ts
+++ b/packages/core/sdk/src/hosted-http-client.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect, Predicate, Result } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 
-import { makeHostedHttpClientLayer, validateHostedOutboundUrl } from "./hosted-http-client";
+import {
+  makeHostedHttpClientLayer,
+  validateHostedOutboundUrl,
+} from "./hosted-http-client";
 
 describe("hosted outbound HTTP client", () => {
   it.effect("allows public HTTP and HTTPS URLs", () =>
@@ -23,24 +26,30 @@ describe("hosted outbound HTTP client", () => {
         "http://169.254.169.254/latest/meta-data/",
       ]) {
         const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
-        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(true);
+        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(
+          true,
+        );
       }
     }),
   );
 
-  it.effect("rejects IPv4-mapped IPv6 URLs for local and private networks", () =>
-    Effect.gen(function* () {
-      for (const url of [
-        "http://[::ffff:127.0.0.1]:3000",
-        "http://[::ffff:10.0.0.1]/openapi.json",
-        "http://[::ffff:172.16.0.1]/graphql",
-        "http://[::ffff:192.168.1.10]/mcp",
-        "http://[::ffff:169.254.169.254]/latest/meta-data/",
-      ]) {
-        const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
-        expect(Predicate.isTagged(error, "HostedOutboundRequestBlocked")).toBe(true);
-      }
-    }),
+  it.effect(
+    "rejects IPv4-mapped IPv6 URLs for local and private networks",
+    () =>
+      Effect.gen(function* () {
+        for (const url of [
+          "http://[::ffff:127.0.0.1]:3000",
+          "http://[::ffff:10.0.0.1]/openapi.json",
+          "http://[::ffff:172.16.0.1]/graphql",
+          "http://[::ffff:192.168.1.10]/mcp",
+          "http://[::ffff:169.254.169.254]/latest/meta-data/",
+        ]) {
+          const error = yield* validateHostedOutboundUrl(url).pipe(Effect.flip);
+          expect(
+            Predicate.isTagged(error, "HostedOutboundRequestBlocked"),
+          ).toBe(true);
+        }
+      }),
   );
 
   it.effect("can allow local network URLs explicitly", () =>
@@ -67,15 +76,112 @@ describe("hosted outbound HTTP client", () => {
       }) as typeof globalThis.fetch;
       const result = yield* Effect.gen(function* () {
         const client = yield* HttpClient.HttpClient;
-        return yield* client.execute(HttpClientRequest.get("https://public.example/start"));
-      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })), Effect.result);
+        return yield* client.execute(
+          HttpClientRequest.get("https://public.example/start"),
+        );
+      }).pipe(
+        Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })),
+        Effect.result,
+      );
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);
     }),
   );
 
-  it.effect("rejects cross-origin redirects before following them", () =>
+  it.effect(
+    "follows cross-origin redirects but strips credential headers",
+    () =>
+      Effect.gen(function* () {
+        const seen: Array<{
+          url: string;
+          authorization: string | null;
+          cookie: string | null;
+        }> = [];
+        const fakeFetch: typeof globalThis.fetch = (async (input, init) => {
+          const url = input instanceof Request ? input.url : String(input);
+          const headers = new Headers(init?.headers);
+          seen.push({
+            url,
+            authorization: headers.get("authorization"),
+            cookie: headers.get("cookie"),
+          });
+          if (url === "https://api.example/start") {
+            return new Response(null, {
+              status: 302,
+              headers: { location: "https://cdn.example/blob" },
+            });
+          }
+          return new Response("bytes", { status: 200 });
+        }) as typeof globalThis.fetch;
+
+        const response = yield* Effect.gen(function* () {
+          const client = yield* HttpClient.HttpClient;
+          return yield* client.execute(
+            HttpClientRequest.get("https://api.example/start").pipe(
+              HttpClientRequest.setHeaders({
+                authorization: "Bearer secret",
+                cookie: "session=abc",
+                accept: "application/octet-stream",
+              }),
+            ),
+          );
+        }).pipe(
+          Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })),
+        );
+
+        expect(response.status).toBe(200);
+        expect(seen).toHaveLength(2);
+        expect(seen[0]).toMatchObject({
+          url: "https://api.example/start",
+          authorization: "Bearer secret",
+          cookie: "session=abc",
+        });
+        expect(seen[1]).toMatchObject({
+          url: "https://cdn.example/blob",
+          authorization: null,
+          cookie: null,
+        });
+      }),
+  );
+
+  it.effect("keeps credential headers on same-origin redirects", () =>
+    Effect.gen(function* () {
+      const seen: Array<{ url: string; authorization: string | null }> = [];
+      const fakeFetch: typeof globalThis.fetch = (async (input, init) => {
+        const url = input instanceof Request ? input.url : String(input);
+        seen.push({
+          url,
+          authorization: new Headers(init?.headers).get("authorization"),
+        });
+        if (url === "https://api.example/start") {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "/moved" },
+          });
+        }
+        return new Response("ok", { status: 200 });
+      }) as typeof globalThis.fetch;
+
+      const response = yield* Effect.gen(function* () {
+        const client = yield* HttpClient.HttpClient;
+        return yield* client.execute(
+          HttpClientRequest.get("https://api.example/start").pipe(
+            HttpClientRequest.setHeaders({ authorization: "Bearer secret" }),
+          ),
+        );
+      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })));
+
+      expect(response.status).toBe(200);
+      expect(seen).toHaveLength(2);
+      expect(seen[1]).toMatchObject({
+        url: "https://api.example/moved",
+        authorization: "Bearer secret",
+      });
+    }),
+  );
+
+  it.effect("rejects cross-origin redirects to private addresses", () =>
     Effect.gen(function* () {
       let calls = 0;
       const fakeFetch: typeof globalThis.fetch = (async (input) => {
@@ -84,7 +190,7 @@ describe("hosted outbound HTTP client", () => {
         if (url === "https://api.example/start") {
           return new Response(null, {
             status: 302,
-            headers: { location: "https://elsewhere.example/next" },
+            headers: { location: "http://169.254.169.254/latest/meta-data/" },
           });
         }
         return new Response("unexpected", { status: 200 });
@@ -92,8 +198,13 @@ describe("hosted outbound HTTP client", () => {
 
       const result = yield* Effect.gen(function* () {
         const client = yield* HttpClient.HttpClient;
-        return yield* client.execute(HttpClientRequest.get("https://api.example/start"));
-      }).pipe(Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })), Effect.result);
+        return yield* client.execute(
+          HttpClientRequest.get("https://api.example/start"),
+        );
+      }).pipe(
+        Effect.provide(makeHostedHttpClientLayer({ fetch: fakeFetch })),
+        Effect.result,
+      );
 
       expect(Result.isFailure(result)).toBe(true);
       expect(calls).toBe(1);

--- a/packages/core/sdk/src/hosted-http-client.ts
+++ b/packages/core/sdk/src/hosted-http-client.ts
@@ -15,9 +15,7 @@ export interface HostedHttpClientOptions {
   readonly fetch?: typeof globalThis.fetch;
 }
 
-const parseIpv4 = (
-  hostname: string,
-): readonly [number, number, number, number] | null => {
+const parseIpv4 = (hostname: string): readonly [number, number, number, number] | null => {
   const parts = hostname.split(".");
   if (parts.length !== 4) return null;
   const parsed: number[] = [];
@@ -60,12 +58,7 @@ const parseIpv4MappedIpv6 = (
   return [high >> 8, high & 0xff, low >> 8, low & 0xff];
 };
 
-const isPrivateIpv4 = ([a, b]: readonly [
-  number,
-  number,
-  number,
-  number,
-]): boolean =>
+const isPrivateIpv4 = ([a, b]: readonly [number, number, number, number]): boolean =>
   a === 0 ||
   a === 10 ||
   a === 127 ||
@@ -85,8 +78,7 @@ const isBlockedMetadataHostname = (hostname: string): boolean => {
 
 const isLocalOrPrivateHostname = (hostname: string): boolean => {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (normalized === "localhost" || normalized.endsWith(".localhost"))
-    return true;
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) return true;
   const ipv4 = parseIpv4(normalized);
   if (ipv4) return isPrivateIpv4(ipv4);
   const mappedIpv4 = parseIpv4MappedIpv6(normalized);
@@ -135,11 +127,7 @@ export const validateHostedOutboundUrl = (
     }
   });
 
-const CREDENTIAL_HEADERS = [
-  "authorization",
-  "proxy-authorization",
-  "cookie",
-] as const;
+const CREDENTIAL_HEADERS = ["authorization", "proxy-authorization", "cookie"] as const;
 
 const stripCredentialHeaders = (init: RequestInit | undefined): RequestInit => {
   const headers = new Headers(init?.headers);
@@ -189,9 +177,7 @@ export const makeHostedHttpClientLayer = (
   FetchHttpClient.layer.pipe(
     Layer.provide(
       options.fetch
-        ? Layer.succeed(FetchHttpClient.Fetch)(
-            guardFetch(options.fetch, options),
-          )
+        ? Layer.succeed(FetchHttpClient.Fetch)(guardFetch(options.fetch, options))
         : Layer.effect(
             FetchHttpClient.Fetch,
             Effect.map(Effect.service(FetchHttpClient.Fetch), (underlying) =>

--- a/packages/core/sdk/src/hosted-http-client.ts
+++ b/packages/core/sdk/src/hosted-http-client.ts
@@ -15,7 +15,9 @@ export interface HostedHttpClientOptions {
   readonly fetch?: typeof globalThis.fetch;
 }
 
-const parseIpv4 = (hostname: string): readonly [number, number, number, number] | null => {
+const parseIpv4 = (
+  hostname: string,
+): readonly [number, number, number, number] | null => {
   const parts = hostname.split(".");
   if (parts.length !== 4) return null;
   const parsed: number[] = [];
@@ -58,7 +60,12 @@ const parseIpv4MappedIpv6 = (
   return [high >> 8, high & 0xff, low >> 8, low & 0xff];
 };
 
-const isPrivateIpv4 = ([a, b]: readonly [number, number, number, number]): boolean =>
+const isPrivateIpv4 = ([a, b]: readonly [
+  number,
+  number,
+  number,
+  number,
+]): boolean =>
   a === 0 ||
   a === 10 ||
   a === 127 ||
@@ -78,7 +85,8 @@ const isBlockedMetadataHostname = (hostname: string): boolean => {
 
 const isLocalOrPrivateHostname = (hostname: string): boolean => {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  if (normalized === "localhost" || normalized.endsWith(".localhost")) return true;
+  if (normalized === "localhost" || normalized.endsWith(".localhost"))
+    return true;
   const ipv4 = parseIpv4(normalized);
   if (ipv4) return isPrivateIpv4(ipv4);
   const mappedIpv4 = parseIpv4MappedIpv6(normalized);
@@ -127,6 +135,18 @@ export const validateHostedOutboundUrl = (
     }
   });
 
+const CREDENTIAL_HEADERS = [
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+] as const;
+
+const stripCredentialHeaders = (init: RequestInit | undefined): RequestInit => {
+  const headers = new Headers(init?.headers);
+  for (const name of CREDENTIAL_HEADERS) headers.delete(name);
+  return { ...init, headers };
+};
+
 const guardFetch = (
   underlying: typeof globalThis.fetch,
   options: HostedHttpClientOptions,
@@ -134,10 +154,14 @@ const guardFetch = (
   (async (input, init) => {
     const maxRedirects = options.maxRedirects ?? 10;
     let current: Parameters<typeof globalThis.fetch>[0] | URL = input;
+    let currentInit = init;
     for (let redirects = 0; redirects <= maxRedirects; redirects++) {
       const url = current instanceof Request ? current.url : String(current);
       Effect.runSync(validateHostedOutboundUrl(url, options));
-      const response = await underlying(current, { ...init, redirect: "manual" });
+      const response = await underlying(current, {
+        ...currentInit,
+        redirect: "manual",
+      });
       if (
         response.status >= 300 &&
         response.status < 400 &&
@@ -145,19 +169,18 @@ const guardFetch = (
         redirects < maxRedirects
       ) {
         const next = new URL(response.headers.get("location")!, url);
+        // Cross-origin redirects are followed (the loop re-validates every
+        // hop), but credentials minted for the original origin must not leak
+        // to the redirect target — same as fetch/curl behavior.
         if (next.origin !== new URL(url).origin) {
-          // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: fetch-compatible adapter must reject blocked requests
-          throw new HostedOutboundRequestBlocked({
-            url: next.toString(),
-            reason: "Cross-origin redirects are not allowed",
-          });
+          currentInit = stripCredentialHeaders(currentInit);
         }
         current = next.toString();
         continue;
       }
       return response;
     }
-    return await underlying(current, { ...init, redirect: "manual" });
+    return await underlying(current, { ...currentInit, redirect: "manual" });
   }) as typeof globalThis.fetch;
 
 export const makeHostedHttpClientLayer = (
@@ -166,7 +189,9 @@ export const makeHostedHttpClientLayer = (
   FetchHttpClient.layer.pipe(
     Layer.provide(
       options.fetch
-        ? Layer.succeed(FetchHttpClient.Fetch)(guardFetch(options.fetch, options))
+        ? Layer.succeed(FetchHttpClient.Fetch)(
+            guardFetch(options.fetch, options),
+          )
         : Layer.effect(
             FetchHttpClient.Fetch,
             Effect.map(Effect.service(FetchHttpClient.Fetch), (underlying) =>


### PR DESCRIPTION
## What

The hosted outbound HTTP client previously rejected every cross-origin redirect. Many APIs respond to download endpoints with a 302 to a pre-signed URL on a different origin (e.g. Microsoft Graph drive-item `/content`, GitHub Actions log downloads, S3-style presigned URLs), so those tools failed on every call.

The client now follows cross-origin redirects the way fetch/curl do:

- **Every hop is still validated** against the outbound policy before any request is made — metadata endpoints, localhost, and private/link-local addresses (including IPv4-mapped IPv6) remain blocked, redirect or not.
- **Credential headers are stripped on cross-origin hops** — `authorization`, `proxy-authorization`, and `cookie` are removed when a redirect leaves the original origin, so upstream tokens never reach the redirect target. Same-origin redirects keep credentials.
- The existing `maxRedirects` cap (default 10) is unchanged.

## Tests

- Cross-origin redirect is followed and credential headers are stripped on the second hop.
- Same-origin redirect keeps credential headers.
- Cross-origin redirect to a private address is still blocked before the request is made.
- Verified live against a real cross-origin 302 (GitHub archive download → codeload.github.com): 200 with bytes.