### PR TITLE
SSR the connect-card MCP URL from the request origin — no 127.0.0.1 flash

### DIFF
--- a/apps/cloud/src/auth/ssr-gate.ts
+++ b/apps/cloud/src/auth/ssr-gate.ts
@@ -220,9 +220,14 @@ export const authGateMiddleware = createMiddleware({ type: "request" }).server(
     // Serve the document WITH the verified identity: the hint rides to the
     // SSR render through middleware context (the root loader reads it), so
     // the server paints the real authenticated shell — no loading state, no
-    // skeleton. Set-cookie writes ride on the rendered response.
+    // skeleton. The request origin rides along too: it's what the connect
+    // card's MCP URL is built from, and the server knows it (the SPA only
+    // learns `window.location.origin` after mount), so passing it here lets
+    // SSR render the real `https://…/<org>/mcp` instead of the client-side
+    // `http://127.0.0.1:4000` default — which would otherwise flash until
+    // hydration corrected it. Set-cookie writes ride on the rendered response.
     const { hint, mint } = await resolveAuthHint(session, cookieHeader);
-    const result = await next({ context: { authHint: hint } });
+    const result = await next({ context: { authHint: hint, origin: url.origin } });
     if (!mint && !session.refreshedSession) return result;
 
     const response = new Response(result.response.body, result.response);

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -93,16 +93,27 @@ function NotFoundPage() {
 
 export const Route = createRootRoute({
   notFoundComponent: NotFoundPage,
-  // The verified identity the SSR gate attached to this document request
-  // (ssr-gate.ts → middleware context → serverContext). Loader data is
-  // dehydrated, so the client's first render sees the SAME hint the server
-  // rendered with — the two can't disagree. Client-side re-runs have no
-  // serverContext and return null, which is fine: the hint only seeds
-  // initial state (AuthProvider holds it from there).
-  loader: (opts) => ({
-    authHint:
-      (opts as { serverContext?: { authHint?: AuthHint | null } }).serverContext?.authHint ?? null,
-  }),
+  // What the SSR gate attached to this document request (ssr-gate.ts →
+  // middleware context → serverContext). Loader data is dehydrated, so the
+  // client's first render sees the SAME values the server rendered with — the
+  // two can't disagree:
+  //   - authHint: the verified identity, seeding AuthProvider's initial state.
+  //   - origin:   the request origin, seeding the server connection so the
+  //               connect-card MCP URL SSRs as the real origin instead of the
+  //               127.0.0.1 client-side default (which would flash to the real
+  //               value at hydration).
+  // Client-side re-runs have no serverContext and return null; both consumers
+  // fall back gracefully (the hint is already held, the origin to the
+  // window-derived global).
+  loader: (opts) => {
+    const serverContext = (
+      opts as { serverContext?: { authHint?: AuthHint | null; origin?: string } }
+    ).serverContext;
+    return {
+      authHint: serverContext?.authHint ?? null,
+      origin: serverContext?.origin ?? null,
+    };
+  },
   head: () => ({
     meta: [
       { charSet: "utf-8" },
@@ -142,11 +153,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 }
 
 function RootComponent() {
-  const { authHint } = Route.useLoaderData();
+  const { authHint, origin } = Route.useLoaderData();
   return (
     <PostHogProvider client={posthog}>
       <AuthProvider initialHint={authHint}>
-        <AuthGate />
+        <AuthGate ssrOrigin={origin} />
       </AuthProvider>
     </PostHogProvider>
   );
@@ -182,7 +193,7 @@ function ShellErrorFallback() {
   );
 }
 
-function AuthGate() {
+function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
   const auth = useAuth();
   const location = useLocation();
   const navigate = useNavigate();
@@ -236,10 +247,17 @@ function AuthGate() {
     return <BlankScreen />;
   }
 
+  // Seed the server connection from the SSR origin so origin-derived UI (the
+  // connect card's MCP URL) renders the real host on the first paint instead
+  // of the 127.0.0.1 default the client-side global falls back to during SSR.
+  // Null on client loader re-runs → undefined → the window-derived global,
+  // which is the same origin, so the key never changes and nothing remounts.
+  const connection = ssrOrigin ? ({ kind: "http", origin: ssrOrigin } as const) : undefined;
+
   return (
     <AutumnProvider pathPrefix="/api/billing">
       <Sentry.ErrorBoundary fallback={<ShellErrorFallback />} showDialog={false}>
-        <ExecutorProvider onHandledError={captureFrontendError}>
+        <ExecutorProvider connection={connection} onHandledError={captureFrontendError}>
           <React.Suspense fallback={<BlankScreen />}>
             <ExecutorPluginsProvider plugins={clientPlugins}>
               <OrganizationProvider organizationId={auth.organization.id}>

--- a/e2e/cloud/connect-card-ssr-origin.test.ts
+++ b/e2e/cloud/connect-card-ssr-origin.test.ts
@@ -1,0 +1,72 @@
+// Cloud-specific: now that the gate renders the REAL shell during SSR (no
+// skeleton), the integrations landing page's connect card is part of the very
+// first painted HTML — including its `npx add-mcp <url>` install command. That
+// URL is built from the server connection's origin, and the SPA only learns
+// `window.location.origin` after it mounts; the SSR default is the desktop/CLI
+// fallback `http://127.0.0.1:4000`. If SSR rendered with that default, the
+// command would paint `127.0.0.1:4000` and then flip to the real host at
+// hydration — a visible flash of the wrong URL on the first thing the user is
+// told to copy.
+//
+// The gate now threads the request origin to the render, so the command is
+// SSR'd against the REAL host from the first byte. These scenarios pin that on
+// the raw document (pre-JS), where a flash would be observable, against the
+// real WorkOS emulator session.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+/** A document navigation request — what the SSR gate keys on. */
+const documentRequest = (url: URL, cookie: string) =>
+  Effect.promise(() =>
+    fetch(url, { redirect: "manual", headers: { accept: "text/html", cookie } }),
+  );
+
+/**
+ * The install command is rendered inside a <pre> (shiki's grammar isn't loaded
+ * during SSR, so the code block falls back to plain text). Stripping tags
+ * reassembles the literal command even if hydration would later tokenize it
+ * into colored spans.
+ */
+const installEndpointFromHtml = (html: string): string | null => {
+  const text = html.replace(/<[^>]+>/g, " ");
+  return /add-mcp\s+(https?:\/\/\S+\/mcp)/.exec(text)?.[1] ?? null;
+};
+
+scenario(
+  "Connect card · the install command SSRs against the real host, never the 127.0.0.1 default",
+  {},
+  Effect.gen(function* () {
+    // Gate: the REST API plane is mounted on this target.
+    yield* Api;
+    const target = yield* Target;
+    const expectedOrigin = new URL(target.baseUrl).origin;
+
+    const identity = yield* target.newIdentity();
+    const response = yield* documentRequest(
+      new URL("/", target.baseUrl),
+      identity.headers!.cookie!,
+    );
+    expect(response.status, "the authenticated landing page is served").toBe(200);
+
+    const html = yield* Effect.promise(() => response.text());
+    // The card is part of the first paint (the whole point of deleting the
+    // skeleton) — if it weren't SSR'd, there'd be no flash to fix and this
+    // guard would be vacuous, so assert it's actually there.
+    const endpoint = installEndpointFromHtml(html);
+    expect(endpoint, "the connect card's install command is in the SSR'd HTML").not.toBeNull();
+
+    // The fix: the command's origin is the host that served the document, not
+    // the client-side fallback the SPA would otherwise paint before mounting.
+    expect(new URL(endpoint!).origin, "the install URL uses the real serving origin").toBe(
+      expectedOrigin,
+    );
+    expect(endpoint!, "…and not the desktop/CLI default that used to flash").not.toContain(
+      "127.0.0.1:4000",
+    );
+    // It's still the org-scoped path the user actually needs.
+    expect(endpoint!, "the install URL stays org-scoped").toMatch(/\/org_[^/]+\/mcp$/);
+  }),
+);

--- a/e2e/scripts/boot-stack.ts
+++ b/e2e/scripts/boot-stack.ts
@@ -1,0 +1,71 @@
+// One-off: boot a cloud stack (emulators + dev-db + vite) for ad-hoc
+// recording, outside vitest. Same wiring as setup/cloud.globalsetup.ts.
+//
+// Usage: bun e2e/scripts/boot-stack.ts <cloud-app-dir> <port>
+//   (emulators take port+1/+2, dev-db port+3; Ctrl-C tears down)
+import { rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { createEmulator } from "@executor-js/emulate";
+
+import { bootProcesses, waitForHttp } from "../setup/boot";
+
+const [cloudDirArg, portArg] = process.argv.slice(2);
+if (!cloudDirArg || !portArg) {
+  console.error("usage: bun e2e/scripts/boot-stack.ts <cloud-app-dir> <port>");
+  process.exit(1);
+}
+const cloudDir = resolve(cloudDirArg);
+const port = Number(portArg);
+const baseUrl = `http://127.0.0.1:${port}`;
+
+const workos = await createEmulator({ service: "workos", port: port + 1 });
+const autumn = await createEmulator({ service: "autumn", port: port + 2 });
+
+const dbPath = resolve(cloudDir, ".e2e-record-db");
+rmSync(dbPath, { recursive: true, force: true });
+
+const env = {
+  WORKOS_API_URL: workos.url,
+  AUTUMN_API_URL: autumn.url,
+  WORKOS_API_KEY: "sk_test_emulate",
+  WORKOS_CLIENT_ID: "client_e2e_emulate",
+  WORKOS_COOKIE_PASSWORD: "e2e_cookie_password_0123456789abcdef0123456789abcdef",
+  AUTUMN_SECRET_KEY: "am_test_emulate",
+  ENCRYPTION_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  DATABASE_URL: `postgresql://postgres:postgres@127.0.0.1:${port + 3}/postgres`,
+  EXECUTOR_DIRECT_DATABASE_URL: "true",
+  CLOUDFLARE_INCLUDE_PROCESS_ENV: "true",
+  VITE_PUBLIC_SITE_URL: baseUrl,
+  MCP_AUTHKIT_DOMAIN: workos.url,
+  MCP_RESOURCE_ORIGIN: baseUrl,
+  ALLOW_LOCAL_NETWORK: "true",
+  DEV_DB_PORT: String(port + 3),
+  DEV_DB_PATH: dbPath,
+};
+
+const procs = bootProcesses(
+  [
+    { cmd: "bun", args: ["run", "scripts/dev-db.ts"], cwd: cloudDir, env },
+    {
+      cmd: "bunx",
+      args: ["vite", "dev", "--port", String(port), "--strictPort", "--host", "127.0.0.1"],
+      cwd: cloudDir,
+      env,
+    },
+  ],
+  { label: "record-stack" },
+);
+
+await waitForHttp(baseUrl);
+await waitForHttp(`${baseUrl}/api/auth/login`, { expectRedirect: true });
+console.log(`ready: ${baseUrl}`);
+
+const teardown = async () => {
+  await procs.teardown();
+  await workos.close();
+  await autumn.close();
+  process.exit(0);
+};
+process.on("SIGINT", () => void teardown());
+process.on("SIGTERM", () => void teardown());

--- a/e2e/scripts/record-connect-card.ts
+++ b/e2e/scripts/record-connect-card.ts
@@ -79,7 +79,14 @@ const shoot = async (label: string, javaScriptEnabled: boolean, outPath: string)
   });
   await context.addCookies([{ name: cookieName!, value: cookieValue!, url: baseUrl }]);
   const page = await context.newPage();
-  await page.goto("/", { waitUntil: javaScriptEnabled ? "networkidle" : "commit" });
+  // Always wait for the stylesheet to land (networkidle) before shooting: it's
+  // render-blocking, so a real first paint already has `color-scheme: light
+  // dark` applied and shiki's light-dark() syntax colors resolve to the dark
+  // palette. Screenshotting at `commit` (pre-stylesheet) would instead capture
+  // the light palette — an artifact no user sees. JS stays disabled for the
+  // SSR shot only to freeze the pre-hydration origin (no client correction),
+  // not to skip CSS.
+  await page.goto("/", { waitUntil: "networkidle" });
   // The install command is the thing that flashes; screenshot just its block.
   const command = page.locator('pre:has-text("add-mcp")').first();
   await command.waitFor({ state: "visible", timeout: 15_000 });

--- a/e2e/scripts/record-connect-card.ts
+++ b/e2e/scripts/record-connect-card.ts
@@ -1,0 +1,96 @@
+// One-off recorder for the connect-card SSR-origin before/after.
+//
+// Captures the install command exactly as it FIRST paints (server-rendered,
+// JS disabled — the literal SSR HTML) and again after the client hydrates,
+// against a running cloud stack. On the buggy build the first paint shows the
+// `http://127.0.0.1:4000` default and then flips to the real host at
+// hydration; on the fixed build both frames already show the real host.
+//
+// It mints a real signed-in session through the headless WorkOS-emulator login
+// (the same flow targets/cloud.ts uses), then screenshots just the command
+// block so the URL is legible.
+//
+// Usage: bun e2e/scripts/record-connect-card.ts <base-url> <out-prefix>
+//   writes <out-prefix>-ssr.png (first paint) and <out-prefix>-hydrated.png
+import { randomUUID } from "node:crypto";
+
+import { chromium } from "playwright";
+
+const [baseUrl, outPrefix] = process.argv.slice(2);
+if (!baseUrl || !outPrefix) {
+  console.error("usage: bun e2e/scripts/record-connect-card.ts <base-url> <out-prefix>");
+  process.exit(1);
+}
+
+const cookiePair = (response: Response, name: string): string | undefined => {
+  for (const header of response.headers.getSetCookie?.() ?? []) {
+    if (header.startsWith(`${name}=`)) return header.split(";")[0];
+  }
+  return undefined;
+};
+
+// The real product login, headless (login → hosted AuthKit → callback), then
+// the real create-organization flow so the card renders an org-scoped URL.
+const signInWithOrg = async (email: string): Promise<string> => {
+  const login = await fetch(new URL("/api/auth/login", baseUrl), { redirect: "manual" });
+  const stateCookie = cookiePair(login, "wos-login-state");
+  const authorizeUrl = new URL(login.headers.get("location") ?? "");
+  if (!stateCookie) throw new Error(`login did not redirect to AuthKit (${login.status})`);
+  authorizeUrl.searchParams.set("login_hint", email);
+  const consent = await fetch(authorizeUrl, { redirect: "manual" });
+  const callbackUrl = consent.headers.get("location");
+  if (consent.status !== 302 || !callbackUrl) {
+    throw new Error(`AuthKit emulator did not redirect (${consent.status})`);
+  }
+  const callback = await fetch(callbackUrl, {
+    redirect: "manual",
+    headers: { cookie: stateCookie },
+  });
+  let session = cookiePair(callback, "wos-session");
+  if (!session) throw new Error(`callback set no session (${callback.status})`);
+
+  const label = email.split("@")[0]!;
+  const created = await fetch(new URL("/api/auth/create-organization", baseUrl), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: new URL(baseUrl).origin,
+      cookie: session,
+    },
+    body: JSON.stringify({ name: `Org ${label}` }),
+  });
+  if (!created.ok) throw new Error(`create-organization failed (${created.status})`);
+  session = cookiePair(created, "wos-session") ?? session;
+  return session; // "wos-session=<sealed>"
+};
+
+const email = `user-${randomUUID().slice(0, 8)}@e2e.test`;
+const session = await signInWithOrg(email);
+const [cookieName, cookieValue] = session.split(/=(.*)/s);
+
+const browser = await chromium.launch();
+
+const shoot = async (label: string, javaScriptEnabled: boolean, outPath: string): Promise<void> => {
+  const context = await browser.newContext({
+    colorScheme: "dark",
+    viewport: { width: 1280, height: 800 },
+    baseURL: baseUrl,
+    javaScriptEnabled,
+  });
+  await context.addCookies([{ name: cookieName!, value: cookieValue!, url: baseUrl }]);
+  const page = await context.newPage();
+  await page.goto("/", { waitUntil: javaScriptEnabled ? "networkidle" : "commit" });
+  // The install command is the thing that flashes; screenshot just its block.
+  const command = page.locator('pre:has-text("add-mcp")').first();
+  await command.waitFor({ state: "visible", timeout: 15_000 });
+  const text = (await command.innerText()).replace(/\s+/g, " ").trim();
+  console.log(`${label}: ${text}`);
+  await command.screenshot({ path: outPath });
+  await context.close();
+};
+
+await shoot("ssr (first paint)", false, `${outPrefix}-ssr.png`);
+await shoot("hydrated", true, `${outPrefix}-hydrated.png`);
+
+await browser.close();
+console.log(`wrote ${outPrefix}-ssr.png and ${outPrefix}-hydrated.png`);

--- a/e2e/scripts/record-unauth-visit.ts
+++ b/e2e/scripts/record-unauth-visit.ts
@@ -1,0 +1,50 @@
+// One-off recorder for the unauth-skeleton before/after comparison.
+//
+// Drives a SIGNED-OUT visit to the cloud root against a running stack,
+// holding /api/account/me open long enough that the loading window is
+// visible, and saves the session video.
+//
+// Usage: bun e2e/scripts/record-unauth-visit.ts <base-url> <out.mp4>
+import { copyFileSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { chromium } from "playwright";
+
+const [baseUrl, outPath] = process.argv.slice(2);
+if (!baseUrl || !outPath) {
+  console.error("usage: bun e2e/scripts/record-unauth-visit.ts <base-url> <out.mp4>");
+  process.exit(1);
+}
+
+const videoTmp = mkdtempSync(join(tmpdir(), "unauth-visit-"));
+const browser = await chromium.launch();
+const context = await browser.newContext({
+  colorScheme: "dark",
+  viewport: { width: 1280, height: 800 },
+  recordVideo: { dir: videoTmp, size: { width: 1280, height: 800 } },
+  baseURL: baseUrl,
+});
+const page = await context.newPage();
+
+// Hold the auth probe open — this is the window where the wrong UI flashes
+// (or, after the fix, where the right UI is already painted).
+await page.route("**/api/account/me", async (route) => {
+  await new Promise((resolve) => setTimeout(resolve, 2_500));
+  await route.continue();
+});
+
+// A beat of blank page so the navigation moment is visible in the recording.
+await page.goto("about:blank");
+await page.waitForTimeout(700);
+await page.goto("/", { waitUntil: "commit" });
+// Cover the probe window plus the settle, whatever this stack renders.
+await page.waitForTimeout(4_500);
+
+await context.close();
+const video = readdirSync(videoTmp).find((file) => file.endsWith(".webm"));
+if (!video) throw new Error("no video produced");
+copyFileSync(join(videoTmp, video), outPath);
+rmSync(videoTmp, { recursive: true, force: true });
+await browser.close();
+console.log(`recorded ${outPath}`);


### PR DESCRIPTION
## Problem

#986 deleted the full-page skeleton, so the integrations **connect card** is now part of the first server-rendered HTML — including its `npx add-mcp <url>` install command. That URL is built from the server connection origin, which the SPA only learns (`window.location.origin`) *after* it mounts. So SSR fell back to the desktop/CLI default `http://127.0.0.1:4000`, and the command flashed to the real host at hydration — on the very first thing the user is told to copy.

## Change

The gate already verifies the session per document request and has the request origin in hand. It's threaded through the same `serverContext → root loader` seam as the auth hint, and `ExecutorProvider`'s connection is seeded from it — so the command SSRs against the real host from the first byte. On client-side loader re-runs the origin is null and falls back to the window-derived global (same origin, so nothing remounts).

- `apps/cloud/src/auth/ssr-gate.ts` — attach `origin: url.origin` to the served-document context, beside the auth hint.
- `apps/cloud/src/routes/__root.tsx` — the root loader reads it; `AuthGate` seeds `ExecutorProvider connection={{ kind: "http", origin }}`.

## Recording

The clip steps through each build's first paint (JS disabled — the literal SSR HTML) and its post-hydration state. **Before:** the command paints `127.0.0.1:4000`, then flips to the real host. **After:** the real host from the first paint, unchanged through hydration.

![Connect-card MCP URL — first paint, before/after the SSR origin fix](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/connect-card-flash-02daa446.gif)

## Test coverage

- `e2e/cloud/connect-card-ssr-origin.test.ts` — the served document's install command uses the serving origin and never the `127.0.0.1:4000` default. Reverting the seed renders `4000`, so the guard isn't vacuous.

The recording is reproducible: `e2e/scripts/boot-stack.ts` boots a stack, `e2e/scripts/record-connect-card.ts` captures the SSR-vs-hydrated command frames against it.

