### PR TITLE
Fix self-host data loss on restart (WAL split-brain) + production-image e2e target

### DIFF
--- a/.changeset/wal-split-brain-selfhost.md
+++ b/.changeset/wal-split-brain-selfhost.md
@@ -1,0 +1,17 @@
+---
+"@executor-js/host-selfhost": patch
+---
+
+Fix self-hosted data loss on restart. The auth bootstrap built a throwaway
+Better Auth instance to run migrations and seed the org before the
+organization id was known, then discarded it. Its libSQL connection — a
+different native build than the executor's — was garbage-collected mid-boot,
+and that close unlinked the shared SQLite WAL out from under the executor's
+still-open connection. Every executor write (integrations, connections, the
+generated tools) then landed in a deleted WAL file and vanished on the next
+restart, surfacing as a reconnected account whose tools had silently
+disappeared.
+
+The bootstrap now uses a single long-lived auth instance with the
+organization id late-bound, so there is no second connection to be closed
+mid-boot and no split WAL.

--- a/apps/host-selfhost/src/auth/better-auth.ts
+++ b/apps/host-selfhost/src/auth/better-auth.ts
@@ -44,16 +44,24 @@ const SIGNUP_PATH = "/sign-up/email";
 // FK-dependent reads at boot and WAL is already a file-level mode), and the
 // shared file stays consistent because writes go through SQLite's file lock.
 //
-// NEVER call .destroy() on the resulting Kysely instance during normal
-// operation — SelfHostDb owns the file lifecycle and closes its client at
-// shutdown; the dialect's connection is GC'd with the auth instance.
+// We build exactly ONE auth instance, held for the process lifetime. An earlier
+// design built a throwaway "bootstrap" instance to run migrations + seed before
+// the org id was known, then discarded it — but its LibsqlDialect connection
+// (a DIFFERENT native libSQL build than SelfHostDb's) was GC-closed mid-boot,
+// and that close unlinked the shared `-wal` out from under SelfHostDb's
+// still-open connection. Every executor write then landed in a deleted WAL
+// inode and vanished on the next restart (the "reconnected account, zero tools"
+// data-loss bug). Keeping one long-lived auth connection — with the org id
+// late-bound the same way the signup gate's `getAuth` already is — removes the
+// discarded connection entirely. NEVER call .destroy() during normal operation;
+// SelfHostDb owns the file lifecycle and closes its client at shutdown.
 //
 // `satisfies BetterAuthOptions` (not a return annotation) keeps the literal
 // plugin tuple so `betterAuth` infers the plugin-augmented `auth.api` and
 // session/user shapes (activeOrganizationId, role, createUser, ...).
 // ---------------------------------------------------------------------------
 
-const makeAuthOptions = (url: string, organizationId: string, gate?: SignupGate) => {
+const makeAuthOptions = (url: string, getOrganizationId: () => string, gate?: SignupGate) => {
   const config = loadConfig();
   // Always resolved (generated + persisted when no env is set); this guards only
   // an explicitly-set env secret that is too weak.
@@ -91,9 +99,12 @@ const makeAuthOptions = (url: string, organizationId: string, gate?: SignupGate)
       session: {
         create: {
           // Single-org instance: pin every session to the one organization, so
-          // every authenticated user resolves to the org scope.
+          // every authenticated user resolves to the org scope. The org id is
+          // read late (the seed resolves it AFTER this instance is built — see
+          // buildBetterAuth); no session is created during the seed, so the
+          // empty initial value is never observed.
           before: async (session: Record<string, unknown>) => ({
-            data: { ...session, activeOrganizationId: organizationId },
+            data: { ...session, activeOrganizationId: getOrganizationId() },
           }),
         },
       },
@@ -186,8 +197,8 @@ const orgHasNoMembers = async (gate: SignupGate): Promise<boolean> => {
   return (await countOrgMembers(auth, gate.organizationId)) === 0;
 };
 
-const createAuthInstance = (url: string, organizationId: string, gate?: SignupGate) =>
-  betterAuth(makeAuthOptions(url, organizationId, gate));
+const createAuthInstance = (url: string, getOrganizationId: () => string, gate?: SignupGate) =>
+  betterAuth(makeAuthOptions(url, getOrganizationId, gate));
 
 export type Auth = ReturnType<typeof createAuthInstance>;
 
@@ -203,9 +214,19 @@ export class BetterAuth extends Context.Service<BetterAuth, BetterAuthHandle>()(
 ) {}
 
 /**
- * Build the Better Auth instance: migrate, seed the org+admin, then rebuild
- * with the resolved org id pinned into the session hook. runMigrations and the
- * seed are idempotent, so this is safe on every boot.
+ * Build the single Better Auth instance: migrate, seed the org+admin, and pin
+ * the resolved org id into the (late-bound) session hook and signup gate.
+ * runMigrations and the seed are idempotent, so this is safe on every boot.
+ *
+ * One instance, not two: the org id the session-pin and gate need isn't known
+ * until the seed creates the org, but both read it lazily (a ref, like the
+ * gate's `getAuth`), so there's no need for a throwaway bootstrap instance —
+ * and so no second libSQL connection to be GC-closed mid-boot and unlink the
+ * shared WAL (see the header comment; that was the self-host data-loss bug).
+ *
+ * The gate is active during the seed, but its hooks only act on the
+ * `/sign-up/email` path — the seed's admin `createUser`/`createOrganization`
+ * pass straight through, exactly as the old gate-free bootstrap instance did.
  *
  * `url` is the SAME libSQL `file:` URL SelfHostDb opened; `client` is
  * SelfHostDb's drizzle connection to that file, used by the seed for its two
@@ -216,19 +237,27 @@ export class BetterAuth extends Context.Service<BetterAuth, BetterAuthHandle>()(
 export const buildBetterAuth = async (url: string, client: Client): Promise<BetterAuthHandle> => {
   const config = loadConfig();
 
-  // Phase 1: bootstrap instance (placeholder org, NO signup gate), create
-  // tables, seed. `runMigrations()` flows through the LibsqlDialect and is
-  // idempotent; the gate-free instance lets the seed's `createUser` through.
-  const bootstrap = createAuthInstance(url, "");
-  await (await bootstrap.$context).runMigrations();
-  await ensureInviteCodeTable(client);
-  const { organizationId, organizationName } = await seedOrgAndAdmin(bootstrap, client, config);
-
-  // Phase 2: the live instance — real org id (session pin) + the signup gate.
-  // `getAuth` resolves to this very instance, so the gate's `after` hook can
-  // call `auth.api.addMember` once a code is redeemed.
+  // The org id is resolved by the seed below, AFTER this instance is built; the
+  // session-pin hook and the gate read it through these late-bound accessors
+  // (no session is created during the seed, so the empty initial id is never
+  // observed). `getAuth` resolves to this very instance, so the gate's `after`
+  // hook can call `auth.api.addMember` once a code is redeemed.
   let auth: Auth | null = null;
-  const gate: SignupGate = { client, organizationId, getAuth: () => auth };
-  auth = createAuthInstance(url, organizationId, gate);
+  const orgRef = { id: "" };
+  const gate: SignupGate = {
+    client,
+    get organizationId() {
+      return orgRef.id;
+    },
+    getAuth: () => auth,
+  };
+
+  auth = createAuthInstance(url, () => orgRef.id, gate);
+  // `runMigrations()` flows through the LibsqlDialect and is idempotent.
+  await (await auth.$context).runMigrations();
+  await ensureInviteCodeTable(client);
+  const { organizationId, organizationName } = await seedOrgAndAdmin(auth, client, config);
+  orgRef.id = organizationId;
+
   return { auth, organizationId, organizationName, handler: auth.handler };
 };

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,1 +1,2 @@
 .dev/
+selfhost-docker.boot.log

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "test": "vitest run --project cloud && vitest run --project selfhost",
     "test:cloud": "vitest run --project cloud",
     "test:selfhost": "vitest run --project selfhost",
+    "test:selfhost-docker": "vitest run --project selfhost-docker",
     "test:watch": "vitest",
     "ports": "bun scripts/ports.ts",
     "summary": "bun scripts/summary.ts",

--- a/e2e/scenarios/restart-persistence.test.ts
+++ b/e2e/scenarios/restart-persistence.test.ts
@@ -1,0 +1,85 @@
+// Cross-target (runs where the target can restart itself — today the
+// production Docker artifact): writes survive a process restart. This is the
+// durability property a dev-server suite with a fresh data dir can never
+// catch by accident, and the one the selfhost WAL split-brain broke: the
+// executor's libSQL connection wrote to a WAL that was unlinked during boot
+// while Better Auth's connection created a fresh one, so every executor-core
+// write (integrations, connections, tools) silently vanished on restart —
+// surfacing to users as "my reconnected Google account has zero Gmail tools".
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+
+import { scenario } from "../src/scenario";
+import { Api, Restart, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+/** OpenAPI 3 spec with a single GET /ping operation. */
+const pingSpec = JSON.stringify({
+  openapi: "3.0.3",
+  info: { title: "Restart Persistence API", version: "1.0.0" },
+  servers: [{ url: "http://127.0.0.1:59998" }], // never contacted
+  paths: {
+    "/ping": {
+      get: {
+        operationId: "getPing",
+        summary: "Liveness ping",
+        responses: { "200": { description: "pong" } },
+      },
+    },
+  },
+});
+
+scenario(
+  "Durability · an integration survives an instance restart",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const restart = yield* Restart;
+    const { client } = yield* Api;
+
+    const identity = yield* target.newIdentity();
+    const before = yield* client(api, identity);
+
+    const slug = `restart-persist-${randomBytes(4).toString("hex")}`;
+    const added = yield* before.openapi.addSpec({
+      payload: {
+        spec: { kind: "blob", value: pingSpec },
+        slug,
+        authenticationTemplate: [],
+      },
+    });
+    expect(added.toolCount, "the spec registered with tools").toBeGreaterThan(0);
+
+    // The write is visible before the restart — so a post-restart absence is
+    // a durability failure, not a registration failure.
+    const integrationsBefore = yield* before.integrations.list();
+    expect(
+      integrationsBefore.map((i) => String(i.slug)),
+      "the integration is listed before the restart",
+    ).toContain(slug);
+
+    yield* restart();
+
+    // Sessions are DB-backed; sign in fresh anyway so this scenario only
+    // asserts on the executor-core rows, not on auth-session survival.
+    const after = yield* client(api, yield* target.newIdentity());
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        const integrationsAfter = yield* after.integrations.list();
+        expect(
+          integrationsAfter.map((i) => String(i.slug)),
+          "the integration survived the restart",
+        ).toContain(slug);
+      }),
+      // Shared bootstrap-admin instance — never leak the integration, even
+      // when the survival assertion fails.
+      after.openapi.removeSpec({ params: { slug } }).pipe(Effect.ignore),
+    );
+  }),
+);

--- a/e2e/setup/selfhost-docker.boot.ts
+++ b/e2e/setup/selfhost-docker.boot.ts
@@ -1,0 +1,122 @@
+// Boot recipe for the selfhost PRODUCTION Docker artifact: build the image
+// from this checkout's apps/host-selfhost/Dockerfile (or use
+// E2E_SELFHOST_DOCKER_IMAGE, e.g. a published ghcr tag), then run it.
+//
+// The container runs with HOST networking, for the same reason the dev-server
+// target sets EXECUTOR_ALLOW_LOCAL_NETWORK: scenarios boot loopback helper
+// servers (OAuth test servers, MCP stubs) on the host and point the instance
+// at 127.0.0.1 URLs — under bridge networking the container's loopback is a
+// different universe and every one of those dials fails. Host networking
+// needs Docker Engine ≥ 26 on Docker Desktop (mac/win); the boot fails loudly
+// if the daemon lacks it.
+//
+// Data is an anonymous volume (the image declares VOLUME /data), removed with
+// the container — hermetic per suite, same as the dev target's fresh data dir.
+import { execFile } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+import { selfhostDockerContainerName } from "../targets/selfhost-docker";
+import { waitForHttp, type BootedProcesses } from "./boot";
+
+const exec = promisify(execFile);
+
+export const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+export interface SelfhostDockerBootOptions {
+  readonly port: number;
+  readonly webBaseUrl: string;
+  readonly admin: { readonly email: string; readonly password: string };
+  readonly logFile?: string;
+}
+
+const log = (file: string | undefined, text: string): void => {
+  if (file) appendFileSync(file, `${text}\n`);
+  else console.error(`[e2e:selfhost-docker] ${text}`);
+};
+
+/**
+ * Resolve the image to run: an explicit E2E_SELFHOST_DOCKER_IMAGE wins
+ * (pull-if-absent is docker's own behavior at run time); otherwise build
+ * from this checkout so the suite tests the artifact the current code
+ * produces. The build is the expensive step (~minutes cold, seconds warm —
+ * the Dockerfile's layers cache on the lockfile), which is the cost of
+ * testing what users deploy instead of a dev server.
+ */
+const resolveImage = async (logFile?: string): Promise<string> => {
+  const pinned = process.env.E2E_SELFHOST_DOCKER_IMAGE;
+  if (pinned) return pinned;
+  const image = "executor-selfhost:e2e";
+  log(logFile, `building ${image} from ${repoRoot}apps/host-selfhost/Dockerfile`);
+  await exec("docker", ["build", "-f", "apps/host-selfhost/Dockerfile", "-t", image, "."], {
+    cwd: repoRoot,
+    maxBuffer: 64 * 1024 * 1024,
+  }).catch((error: { stdout?: string; stderr?: string }) => {
+    log(logFile, String(error.stdout ?? ""));
+    log(logFile, String(error.stderr ?? ""));
+    throw new Error("selfhost-docker: image build failed — see log");
+  });
+  return image;
+};
+
+export const bootSelfhostDocker = async (
+  options: SelfhostDockerBootOptions,
+): Promise<BootedProcesses> => {
+  const image = await resolveImage(options.logFile);
+  const name = selfhostDockerContainerName(options.port);
+
+  // A previous suite that died without teardown leaves the named container
+  // squatting — remove it (and its anonymous volume) before booting.
+  await exec("docker", ["rm", "-f", "-v", name]).catch(() => {});
+
+  const args = [
+    "run",
+    "--detach",
+    "--name",
+    name,
+    "--network",
+    "host",
+    "-e",
+    `PORT=${options.port}`,
+    "-e",
+    "BETTER_AUTH_SECRET=executor-selfhost-e2e-secret-0123456789",
+    "-e",
+    `EXECUTOR_BOOTSTRAP_ADMIN_EMAIL=${options.admin.email}`,
+    "-e",
+    `EXECUTOR_BOOTSTRAP_ADMIN_PASSWORD=${options.admin.password}`,
+    "-e",
+    `EXECUTOR_WEB_BASE_URL=${options.webBaseUrl}`,
+    // Same rationale as the dev target: the harness boots loopback MCP/OAuth
+    // test servers and points the instance at them.
+    "-e",
+    "EXECUTOR_ALLOW_LOCAL_NETWORK=true",
+    image,
+  ];
+  log(options.logFile, `docker ${args.join(" ")}`);
+  await exec("docker", args).catch((error: { stderr?: string }) => {
+    throw new Error(`selfhost-docker: docker run failed: ${String(error.stderr ?? error)}`);
+  });
+
+  try {
+    await waitForHttp(`${options.webBaseUrl}/api/health`, { timeoutMs: 120_000 });
+  } catch (error) {
+    const { stdout } = await exec("docker", ["logs", "--tail", "100", name]).catch(() => ({
+      stdout: "(docker logs unavailable)",
+    }));
+    log(options.logFile, String(stdout));
+    await exec("docker", ["rm", "-f", "-v", name]).catch(() => {});
+    throw error;
+  }
+
+  return {
+    teardown: async () => {
+      if (options.logFile) {
+        const { stdout } = await exec("docker", ["logs", name]).catch(() => ({ stdout: "" }));
+        if (stdout) appendFileSync(options.logFile, stdout);
+      }
+      await exec("docker", ["rm", "-f", "-v", name]).catch(() => {});
+    },
+    pids: [],
+  };
+};

--- a/e2e/setup/selfhost-docker.boot.ts
+++ b/e2e/setup/selfhost-docker.boot.ts
@@ -10,19 +10,27 @@
 // needs Docker Engine ≥ 26 on Docker Desktop (mac/win); the boot fails loudly
 // if the daemon lacks it.
 //
-// Data is an anonymous volume (the image declares VOLUME /data), removed with
-// the container — hermetic per suite, same as the dev target's fresh data dir.
+// Data lives in a NAMED volume so the target's restart() can destroy the
+// container and start a fresh one against the same data — a real deployment
+// cycle (upgrade/reboot), not a warm in-place restart. The volume is removed
+// in teardown — hermetic per suite, same as the dev target's fresh data dir.
 import { execFile } from "node:child_process";
 import { appendFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 
-import { selfhostDockerContainerName } from "../targets/selfhost-docker";
 import { waitForHttp, type BootedProcesses } from "./boot";
 
 const exec = promisify(execFile);
 
 export const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+
+/** Container/volume names — derived identically by the globalsetup (boot,
+ * teardown) and the target (restart), which run in different processes. */
+export const selfhostDockerContainerName = (port: number): string =>
+  `executor-e2e-selfhost-docker-${port}`;
+export const selfhostDockerVolumeName = (port: number): string =>
+  `executor-e2e-selfhost-docker-data-${port}`;
 
 export interface SelfhostDockerBootOptions {
   readonly port: number;
@@ -60,16 +68,23 @@ const resolveImage = async (logFile?: string): Promise<string> => {
   return image;
 };
 
-export const bootSelfhostDocker = async (
-  options: SelfhostDockerBootOptions,
-): Promise<BootedProcesses> => {
-  const image = await resolveImage(options.logFile);
+export interface RunContainerOptions {
+  readonly image: string;
+  readonly port: number;
+  readonly webBaseUrl: string;
+  readonly admin: { readonly email: string; readonly password: string };
+  readonly logFile?: string;
+}
+
+/**
+ * Start ONE container of the production image against the named data volume
+ * and wait for health. Used by the suite boot and by the target's restart()
+ * — a restart starts a genuinely new container, so it MUST run the exact
+ * same way the boot did.
+ */
+export const runSelfhostContainer = async (options: RunContainerOptions): Promise<void> => {
   const name = selfhostDockerContainerName(options.port);
-
-  // A previous suite that died without teardown leaves the named container
-  // squatting — remove it (and its anonymous volume) before booting.
-  await exec("docker", ["rm", "-f", "-v", name]).catch(() => {});
-
+  const volume = selfhostDockerVolumeName(options.port);
   const args = [
     "run",
     "--detach",
@@ -77,6 +92,8 @@ export const bootSelfhostDocker = async (
     name,
     "--network",
     "host",
+    "--volume",
+    `${volume}:/data`,
     "-e",
     `PORT=${options.port}`,
     "-e",
@@ -91,7 +108,7 @@ export const bootSelfhostDocker = async (
     // test servers and points the instance at them.
     "-e",
     "EXECUTOR_ALLOW_LOCAL_NETWORK=true",
-    image,
+    options.image,
   ];
   log(options.logFile, `docker ${args.join(" ")}`);
   await exec("docker", args).catch((error: { stderr?: string }) => {
@@ -105,17 +122,49 @@ export const bootSelfhostDocker = async (
       stdout: "(docker logs unavailable)",
     }));
     log(options.logFile, String(stdout));
-    await exec("docker", ["rm", "-f", "-v", name]).catch(() => {});
+    await exec("docker", ["rm", "-f", name]).catch(() => {});
     throw error;
   }
+};
+
+/**
+ * A deployment shutdown, as orchestrators do it: SIGTERM (docker stop's
+ * 10s default grace, then SIGKILL), flush the container's logs, remove the
+ * container. The volume stays — it's the deployment's persistent data.
+ */
+export const stopSelfhostContainer = async (port: number, logFile?: string): Promise<void> => {
+  const name = selfhostDockerContainerName(port);
+  await exec("docker", ["stop", name]).catch(() => {});
+  if (logFile) {
+    const { stdout } = await exec("docker", ["logs", name]).catch(() => ({ stdout: "" }));
+    if (stdout) appendFileSync(logFile, stdout);
+  }
+  await exec("docker", ["rm", "-f", name]).catch(() => {});
+};
+
+export const bootSelfhostDocker = async (
+  options: SelfhostDockerBootOptions,
+): Promise<BootedProcesses> => {
+  const image = await resolveImage(options.logFile);
+  const name = selfhostDockerContainerName(options.port);
+  const volume = selfhostDockerVolumeName(options.port);
+
+  // A previous suite that died without teardown leaves the named container
+  // and volume squatting — remove both for a hermetic boot.
+  await exec("docker", ["rm", "-f", name]).catch(() => {});
+  await exec("docker", ["volume", "rm", "-f", volume]).catch(() => {});
+
+  await runSelfhostContainer({ image, ...options });
+
+  // The target's restart() runs in a different process (test worker, not
+  // globalsetup) and must re-run the same image. claimPorts-style env
+  // publication: workers spawn after globalsetup, so they inherit this.
+  process.env.E2E_SELFHOST_DOCKER_RESOLVED_IMAGE = image;
 
   return {
     teardown: async () => {
-      if (options.logFile) {
-        const { stdout } = await exec("docker", ["logs", name]).catch(() => ({ stdout: "" }));
-        if (stdout) appendFileSync(options.logFile, stdout);
-      }
-      await exec("docker", ["rm", "-f", "-v", name]).catch(() => {});
+      await stopSelfhostContainer(options.port, options.logFile);
+      await exec("docker", ["volume", "rm", "-f", volume]).catch(() => {});
     },
     pids: [],
   };

--- a/e2e/setup/selfhost-docker.globalsetup.ts
+++ b/e2e/setup/selfhost-docker.globalsetup.ts
@@ -1,0 +1,41 @@
+// Boot the selfhost-docker target: claim a port, then build + run the
+// production image (selfhost-docker.boot.ts). Set E2E_SELFHOST_DOCKER_URL to
+// attach to a running instance, or E2E_SELFHOST_DOCKER_IMAGE to test a
+// published image (e.g. ghcr.io/<owner>/executor-selfhost:latest) instead of
+// building from this checkout.
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { claimPorts } from "../src/ports";
+import { SELFHOST_ADMIN } from "../targets/selfhost";
+import { waitForHttp } from "./boot";
+import { bootSelfhostDocker } from "./selfhost-docker.boot";
+
+export default async function setup(): Promise<(() => Promise<void>) | void> {
+  if (process.env.E2E_SELFHOST_DOCKER_URL) {
+    await waitForHttp(process.env.E2E_SELFHOST_DOCKER_URL);
+    return;
+  }
+
+  const { ports, release } = await claimPorts([
+    { envVar: "E2E_SELFHOST_DOCKER_PORT", offset: 5, label: "selfhost docker" },
+  ]);
+  const port = ports.E2E_SELFHOST_DOCKER_PORT!;
+
+  let procs;
+  try {
+    procs = await bootSelfhostDocker({
+      port,
+      webBaseUrl: `http://localhost:${port}`,
+      admin: SELFHOST_ADMIN,
+      logFile: resolve(fileURLToPath(new URL("../", import.meta.url)), "selfhost-docker.boot.log"),
+    });
+  } catch (error) {
+    await release();
+    throw error;
+  }
+  return async () => {
+    await procs.teardown();
+    await release();
+  };
+}

--- a/e2e/src/scenario.ts
+++ b/e2e/src/scenario.ts
@@ -25,7 +25,18 @@ import { makeBrowserSurface } from "./surfaces/browser";
 import { makeCliSurface } from "./surfaces/cli";
 import { makeMcpSurface } from "./surfaces/mcp";
 import { completeOAuthConsent, hasOpenCode, makeOpenCodeHome, warmUp } from "./clients/opencode";
-import { Api, Billing, Browser, Cli, Mcp, OpenCode, RunDir, Target, TtlControl } from "./services";
+import {
+  Api,
+  Billing,
+  Browser,
+  Cli,
+  Mcp,
+  OpenCode,
+  Restart,
+  RunDir,
+  Target,
+  TtlControl,
+} from "./services";
 import { buildManifest } from "./viewer/manifest";
 
 export const RUNS_DIR = fileURLToPath(new URL("../runs/", import.meta.url));
@@ -41,7 +52,17 @@ export interface ScenarioOptions {
   readonly timeout?: number;
 }
 
-type AllServices = Target | RunDir | Cli | Api | Browser | Mcp | Billing | OpenCode | TtlControl;
+type AllServices =
+  | Target
+  | RunDir
+  | Cli
+  | Api
+  | Browser
+  | Mcp
+  | Billing
+  | OpenCode
+  | TtlControl
+  | Restart;
 
 /**
  * What this target on this host can provide. Services beyond the base are
@@ -69,6 +90,9 @@ const contextFor = (target: TargetShape, dir: string): Context.Context<AllServic
   }
   if (target.setAccessTokenTtl) {
     context = Context.add(context, TtlControl, target.setAccessTokenTtl);
+  }
+  if (target.restart) {
+    context = Context.add(context, Restart, target.restart);
   }
   return context;
 };

--- a/e2e/src/services.ts
+++ b/e2e/src/services.ts
@@ -47,3 +47,10 @@ export class TtlControl extends Context.Service<
   TtlControl,
   (seconds: number | null) => Effect.Effect<void>
 >()("e2e/ttl-control") {}
+
+/**
+ * Restart the instance, keeping its data. What lets durability scenarios
+ * assert that writes survive a process restart — the property a dev server
+ * with a fresh data dir can never test by accident.
+ */
+export class Restart extends Context.Service<Restart, () => Effect.Effect<void>>()("e2e/restart") {}

--- a/e2e/src/target.ts
+++ b/e2e/src/target.ts
@@ -48,4 +48,10 @@ export interface Target {
    * scenarios cross a REAL expiry in seconds instead of an hour.
    */
   readonly setAccessTokenTtl?: (seconds: number | null) => Effect.Effect<void>;
+  /**
+   * Restart the instance, keeping its data — resolves when it answers HTTP
+   * again. What lets durability scenarios assert that writes survive a
+   * process restart (→ the Restart service).
+   */
+  readonly restart?: () => Effect.Effect<void>;
 }

--- a/e2e/targets/registry.ts
+++ b/e2e/targets/registry.ts
@@ -5,10 +5,12 @@ import type { Target } from "../src/target";
 import { cloudTarget } from "./cloud";
 import { desktopTarget } from "./desktop";
 import { selfhostTarget } from "./selfhost";
+import { selfhostDockerTarget } from "./selfhost-docker";
 
 const factories: Record<string, () => Target> = {
   cloud: cloudTarget,
   selfhost: selfhostTarget,
+  "selfhost-docker": selfhostDockerTarget,
   desktop: desktopTarget,
 };
 

--- a/e2e/targets/selfhost-docker.ts
+++ b/e2e/targets/selfhost-docker.ts
@@ -1,0 +1,65 @@
+// The PRODUCTION self-host artifact as a target: the Docker image from
+// apps/host-selfhost/Dockerfile (production Vite build, `bun src/serve.ts`,
+// /data volume) instead of the dev server. Same surface as the selfhost
+// target — same bootstrap admin, same Better Auth sign-in, same MCP consent —
+// so the whole scenario suite runs against what users actually deploy. Boot
+// lives in setup/selfhost-docker.globalsetup.ts.
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { Effect } from "effect";
+
+import { cookieConsentStrategy } from "@executor-js/mcporter";
+
+import { e2ePort } from "../src/ports";
+import type { Identity, Target } from "../src/target";
+import { waitForHttp } from "../setup/boot";
+import { SELFHOST_ADMIN, signInSession } from "./selfhost";
+
+const exec = promisify(execFile);
+
+export const SELFHOST_DOCKER_PORT = e2ePort("E2E_SELFHOST_DOCKER_PORT", 5);
+export const SELFHOST_DOCKER_BASE_URL =
+  process.env.E2E_SELFHOST_DOCKER_URL ?? `http://localhost:${SELFHOST_DOCKER_PORT}`;
+
+/** The globalsetup's container name — derived the same way on both sides. */
+export const selfhostDockerContainerName = (port: number): string =>
+  `executor-e2e-selfhost-docker-${port}`;
+
+export const selfhostDockerTarget = (): Target => ({
+  name: "selfhost-docker",
+  baseUrl: SELFHOST_DOCKER_BASE_URL,
+  mcpUrl: `${SELFHOST_DOCKER_BASE_URL}/mcp`,
+  capabilities: new Set(["api", "browser", "mcp-oauth"]),
+  newIdentity: () =>
+    Effect.promise(async (): Promise<Identity> => {
+      const { cookieHeader, cookies } = await signInSession(
+        SELFHOST_DOCKER_BASE_URL,
+        SELFHOST_ADMIN,
+      );
+      return {
+        label: SELFHOST_ADMIN.email,
+        credentials: SELFHOST_ADMIN,
+        headers: { cookie: cookieHeader },
+        cookies,
+      };
+    }),
+  mcpConsent: (identity: Identity) =>
+    cookieConsentStrategy({
+      appBaseUrl: SELFHOST_DOCKER_BASE_URL,
+      email: identity.credentials?.email ?? SELFHOST_ADMIN.email,
+      password: identity.credentials?.password ?? SELFHOST_ADMIN.password,
+    }),
+  // `docker restart` keeps the container's volume — exactly a user upgrading
+  // or rebooting their deployment. Only when this process owns the container
+  // (attach mode can't assume the instance is restartable docker).
+  ...(process.env.E2E_SELFHOST_DOCKER_URL
+    ? {}
+    : {
+        restart: () =>
+          Effect.promise(async () => {
+            await exec("docker", ["restart", selfhostDockerContainerName(SELFHOST_DOCKER_PORT)]);
+            await waitForHttp(`${SELFHOST_DOCKER_BASE_URL}/api/health`, { timeoutMs: 120_000 });
+          }),
+      }),
+});

--- a/e2e/targets/selfhost-docker.ts
+++ b/e2e/targets/selfhost-docker.ts
@@ -4,27 +4,18 @@
 // target — same bootstrap admin, same Better Auth sign-in, same MCP consent —
 // so the whole scenario suite runs against what users actually deploy. Boot
 // lives in setup/selfhost-docker.globalsetup.ts.
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-
 import { Effect } from "effect";
 
 import { cookieConsentStrategy } from "@executor-js/mcporter";
 
 import { e2ePort } from "../src/ports";
 import type { Identity, Target } from "../src/target";
-import { waitForHttp } from "../setup/boot";
+import { runSelfhostContainer, stopSelfhostContainer } from "../setup/selfhost-docker.boot";
 import { SELFHOST_ADMIN, signInSession } from "./selfhost";
-
-const exec = promisify(execFile);
 
 export const SELFHOST_DOCKER_PORT = e2ePort("E2E_SELFHOST_DOCKER_PORT", 5);
 export const SELFHOST_DOCKER_BASE_URL =
   process.env.E2E_SELFHOST_DOCKER_URL ?? `http://localhost:${SELFHOST_DOCKER_PORT}`;
-
-/** The globalsetup's container name — derived the same way on both sides. */
-export const selfhostDockerContainerName = (port: number): string =>
-  `executor-e2e-selfhost-docker-${port}`;
 
 export const selfhostDockerTarget = (): Target => ({
   name: "selfhost-docker",
@@ -50,16 +41,26 @@ export const selfhostDockerTarget = (): Target => ({
       email: identity.credentials?.email ?? SELFHOST_ADMIN.email,
       password: identity.credentials?.password ?? SELFHOST_ADMIN.password,
     }),
-  // `docker restart` keeps the container's volume — exactly a user upgrading
-  // or rebooting their deployment. Only when this process owns the container
-  // (attach mode can't assume the instance is restartable docker).
+  // A real deployment cycle, not a warm `docker restart`: graceful stop
+  // (SIGTERM + docker's grace), remove the container, start a NEW one from
+  // the same image against the same data volume — what an upgrade, reboot,
+  // or `compose down && up` does to a user's instance. Only when this suite
+  // owns the container (attach mode can't assume the instance is docker).
   ...(process.env.E2E_SELFHOST_DOCKER_URL
     ? {}
     : {
         restart: () =>
           Effect.promise(async () => {
-            await exec("docker", ["restart", selfhostDockerContainerName(SELFHOST_DOCKER_PORT)]);
-            await waitForHttp(`${SELFHOST_DOCKER_BASE_URL}/api/health`, { timeoutMs: 120_000 });
+            // Published by the globalsetup after it resolved/built the image.
+            const image = process.env.E2E_SELFHOST_DOCKER_RESOLVED_IMAGE;
+            if (!image) throw new Error("selfhost-docker: no resolved image — boot ran?");
+            await stopSelfhostContainer(SELFHOST_DOCKER_PORT);
+            await runSelfhostContainer({
+              image,
+              port: SELFHOST_DOCKER_PORT,
+              webBaseUrl: SELFHOST_DOCKER_BASE_URL,
+              admin: SELFHOST_ADMIN,
+            });
           }),
       }),
 });

--- a/e2e/targets/selfhost.ts
+++ b/e2e/targets/selfhost.ts
@@ -23,7 +23,7 @@ export const SELFHOST_ADMIN = {
 // and the {name,value} list Playwright injects into a browser context. The
 // `origin` header is required — Better Auth rejects state-changing requests
 // without it.
-const signInSession = async (
+export const signInSession = async (
   baseUrl: string,
   credentials: { readonly email: string; readonly password: string },
 ): Promise<{

--- a/e2e/vitest.config.ts
+++ b/e2e/vitest.config.ts
@@ -26,6 +26,18 @@ export default defineConfig({
       // selfhost identities are the shared bootstrap admin for now — run files
       // serially until per-test invite-signup isolation lands.
       project("selfhost", { fileParallelism: false }),
+      // The same app as the PRODUCTION Docker artifact (the image users
+      // deploy: production build, bun serve.ts, /data volume) instead of the
+      // dev server. Runs the cross-target scenarios AND the selfhost/**
+      // scenarios — it is the same single-tenant app, so they all apply.
+      // Needs a docker daemon with host-networking support (Engine ≥ 26 on
+      // Docker Desktop); not part of the default `npm run test` chain — run
+      // with `npm run test:selfhost-docker` (release gate + CI for the
+      // publish workflow).
+      project("selfhost-docker", {
+        include: ["scenarios/**/*.test.ts", "selfhost/**/*.test.ts"],
+        fileParallelism: false,
+      }),
       // The Electron desktop app. Only desktop/** scenarios — the desktop
       // target provides none of the standard surfaces (each scenario
       // launches its own app via Playwright's electron driver), so running


### PR DESCRIPTION
## Summary

Fixes a data-loss bug in the single-container self-hosted deployment: after a restart (upgrade, reboot, `compose down && up`), every integration, connection, and generated tool silently disappeared, while the user's accounts still showed as connected. The visible symptom was a reconnected account whose tools had vanished and would not come back on re-auth.

Also adds the test infrastructure that makes this class of bug catchable: an e2e target that runs the **production Docker image** (not a dev server), and a durability scenario that survives a real restart.

## Root cause

The self-host auth bootstrap built a throwaway Better Auth instance to run migrations and seed the org before the organization id was known, then discarded it. That instance opened its own libSQL connection — a *different* native SQLite build than the executor's long-lived connection. When the discarded instance was garbage-collected mid-boot, SQLite's last-connection-close path unlinked the shared write-ahead log (`-wal`) out from under the executor connection, which still held it open. From that point every executor write landed in a deleted WAL file: visible to the running process, but never checkpointed into the database. The next restart started from the last consistent on-disk state — before any of those writes — so the integrations and tools were gone.

## Fix

Collapse the two-phase bootstrap into a single long-lived auth instance, reading the organization id through a late-bound accessor (the same pattern the signup gate already used for its instance reference). With no discarded connection, nothing closes mid-boot to unlink the WAL. The change is contained to the auth bootstrap; the signup gate is inert during the seed because its hooks only act on the sign-up path.

## Tests added

- **`selfhost-docker` e2e target** — builds the production image from the checkout (or attaches to a published tag) and runs the full cross-target scenario suite plus the self-host-only scenarios against the real artifact, with host networking so the existing loopback test servers stay reachable. Nothing previously exercised the deployed image; the dev-server target could not have caught this.
- **`restart-persistence` scenario** — registers an integration, performs a real deployment cycle (graceful stop, container removed, a fresh container started against the same data volume), and asserts the integration survived. Optional `Target.restart` capability so targets that cannot restart themselves skip it.

## Verification

- A connection-level reproduction confirms the WAL inode is now stable across boot + GC and post-GC writes are durable (previously the WAL was unlinked and subsequent reads hit `SQLITE_IOERR`).
- `restart-persistence` goes from failing to passing against the rebuilt production image — the same scenario fails on the pre-fix image.
- Self-host auth / boot / first-run / invite unit tests pass, as does the production-image API + MCP-OAuth slice, confirming auth still works after collapsing to one instance.

## Follow-ups (not in this PR)

- Tool generation silently yields zero tools when a spec blob is missing; it should re-fetch or surface an error instead of failing invisibly.
- Wire the `selfhost-docker` target into the image publish workflow as a pre-push smoke + persistence gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
