### PR TITLE
Add busy_timeout to the local libSQL connection

### DIFF
--- a/apps/local/src/db/libsql.ts
+++ b/apps/local/src/db/libsql.ts
@@ -26,6 +26,13 @@ export const openLocalLibsql = async (path: string): Promise<Client> => {
   // first enabling. Re-apply both since libSQL gives no shared handle.
   await client.execute("PRAGMA foreign_keys = ON");
   await client.execute("PRAGMA journal_mode = WAL");
+  // busy_timeout is per-connection (default 0 = fail immediately on a lock).
+  // Under the supervised-daemon model a single process owns this file, but a
+  // second OS process can still transiently hold the write lock (e.g. a CLI
+  // tool, the v1→v2 migration reader, or a launchd restart racing the old
+  // pid). Give writers a 5s retry window instead of an instant SQLITE_BUSY.
+  // Matches the self-host open path (self-host-db.ts).
+  await client.execute("PRAGMA busy_timeout = 5000");
   return client;
 };
 


### PR DESCRIPTION
Adds a per-connection `PRAGMA busy_timeout = 5000` to the local libSQL open path, matching the self-host configuration.

WAL gives concurrent readers + a single writer, but with the default `busy_timeout = 0` a second writer fails immediately with `SQLITE_BUSY`. A 5s retry window absorbs the brief contention that happens when a second OS process transiently holds the write lock — a CLI tool, the v1→v2 migration reader, or a supervised daemon restart racing the previous pid.

`openLocalLibsql` is the single open site for the local app (the FumaDB handle and the migration reader both route through it), so the pragma applies everywhere.

Base of a small stack that moves the local MCP gateway onto an OS-supervised daemon.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#1003** 👈 current
2. #1004
3. #1005
<!-- stack:links:end -->