### PR TITLE
Org slugs: mint at insert + NOT NULL; consolidated auth-routing flow test

### DIFF
--- a/apps/cloud/drizzle/0004_nervous_quasar.sql
+++ b/apps/cloud/drizzle/0004_nervous_quasar.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "organizations" ALTER COLUMN "slug" SET NOT NULL;

--- a/apps/cloud/drizzle/meta/0004_snapshot.json
+++ b/apps/cloud/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1242 @@
+{
+  "id": "1187b7aa-fdd6-412a-bcfb-20d6ea8f8644",
+  "prevId": "80591016-4fb7-47d8-ab60-9a5c8eaea9c8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_account_id_accounts_id_fk": {
+          "name": "memberships_account_id_accounts_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_account_id_organization_id_pk": {
+          "name": "memberships_account_id_organization_id_pk",
+          "columns": ["account_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blob": {
+      "name": "blob",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definition": {
+      "name": "definition",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration": {
+      "name": "integration",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_session": {
+      "name": "oauth_session",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_storage": {
+      "name": "plugin_storage",
+      "schema": "",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_executor_cloud_settings": {
+      "name": "private_executor_cloud_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool": {
+      "name": "tool",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_policy": {
+      "name": "tool_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1781283644753,
       "tag": "0003_friendly_monster_badoon",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1781375837041,
+      "tag": "0004_nervous_quasar",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cloud/scripts/backfill-org-slugs.ts
+++ b/apps/cloud/scripts/backfill-org-slugs.ts
@@ -1,16 +1,19 @@
 /* oxlint-disable executor/no-try-catch-or-throw -- boundary: out-of-band migration script over a raw postgres connection */
 // ---------------------------------------------------------------------------
 // One-off data backfill: mint URL slugs for organizations that predate the
-// slug column. Run OUT-OF-BAND against the database after applying the
-// schema migration that adds `organizations.slug` (0002):
+// slug column (added by migration 0003, nullable).
 //
 //   bun run db:backfill-org-slugs:prod   # op run --env-file=.env.production
 //   bun run db:backfill-org-slugs:dev    # against the local PGlite dev db
 //
-// Idempotent — already-slugged rows are skipped, so re-running is safe. The
-// runtime also lazily mints slugs on first resolution (see
-// auth/organization.ts), so this backfill is belt-and-braces for bulk
-// pre-warming rather than a deploy gate.
+// Idempotent — already-slugged rows are skipped, so re-running is safe.
+//
+// Ordering matters: the runtime now mints a slug at the moment a row is
+// inserted and NO LONGER self-heals null slugs, and migration 0004 makes the
+// column NOT NULL. So this backfill is the SOLE way pre-existing null-slug rows
+// get a slug, and it MUST run BEFORE 0004 is applied (a null row would fail the
+// NOT NULL alter). The correct sequence is: backfill (this script) → deploy the
+// mint-at-insert code → apply 0004.
 // Pass --dry-run to print the plan without writing.
 // ---------------------------------------------------------------------------
 
@@ -47,8 +50,8 @@ for (const row of rows) {
   planned.add(slug);
   console.log(`${row.id}  ${JSON.stringify(row.name)} -> ${slug}`);
   if (dryRun) continue;
-  // Guard WHERE slug IS NULL: a concurrently-deployed runtime may have lazily
-  // minted this org's slug between our read and this write.
+  // Guard WHERE slug IS NULL keeps re-runs idempotent (and tolerates a row that
+  // gained a slug between our read and this write).
   await sql`UPDATE organizations SET slug = ${slug} WHERE id = ${row.id} AND slug IS NULL`;
   updated += 1;
 }

--- a/apps/cloud/src/api/protected-api-key-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-api-key-auth.node.test.ts
@@ -50,7 +50,7 @@ const stubUsers = Layer.succeed(UserStoreService)({
         getAccount: async (id: string) => ({ id, createdAt }),
         upsertOrganization: async (org: { id: string; name: string }) => ({
           ...org,
-          slug: null,
+          slug: `org-slug-${org.id}`,
           createdAt,
         }),
         getOrganization: async (id: string) => ({
@@ -63,11 +63,6 @@ const stubUsers = Layer.succeed(UserStoreService)({
           id: "org_by_slug",
           name: `Org ${slug}`,
           slug,
-          createdAt,
-        }),
-        ensureOrganizationSlug: async (org: { id: string; name: string; slug: string | null }) => ({
-          ...org,
-          slug: org.slug ?? `org-slug-${org.id}`,
           createdAt,
         }),
       }),

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -342,10 +342,10 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
 
           const org = yield* workos.createOrganization(name);
           yield* workos.createMembership(org.id, session.accountId, "admin");
+          // `upsertOrganization` mints the slug at insert — no separate heal step.
           const mirrored = yield* users.use((s) =>
             s.upsertOrganization({ id: org.id, name: org.name }),
           );
-          const slugged = yield* users.use((s) => s.ensureOrganizationSlug(mirrored));
 
           // Try to attach the new org to the current session. This can fail
           // (or silently return a session still scoped to the old org) when
@@ -372,7 +372,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           }
 
           (yield* SessionCookies).set("wos-session", refreshed, RESPONSE_COOKIE_OPTIONS);
-          return { id: org.id, name: org.name, slug: slugged.slug };
+          return { id: org.id, name: org.name, slug: mirrored.slug };
         }),
       )
       .handle("pendingInvitations", () =>
@@ -441,12 +441,12 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
             return yield* new WorkOSError();
           }
 
-          // Mirror the org locally so domain tables can FK against it.
+          // Mirror the org locally so domain tables can FK against it; the
+          // upsert mints the slug at insert — no separate heal step.
           const org = yield* workos.getOrganization(invitation.organizationId);
           const mirrored = yield* users.use((s) =>
             s.upsertOrganization({ id: org.id, name: org.name }),
           );
-          const slugged = yield* users.use((s) => s.ensureOrganizationSlug(mirrored));
 
           // Attach the just-accepted org to the current session. Same shape
           // as createOrganization: refresh + verify; if we can't pin the
@@ -468,7 +468,7 @@ export const CloudSessionAuthHandlers = HttpApiBuilder.group(
           }
 
           (yield* SessionCookies).set("wos-session", refreshed, RESPONSE_COOKIE_OPTIONS);
-          return { id: org.id, name: org.name, slug: slugged.slug };
+          return { id: org.id, name: org.name, slug: mirrored.slug };
         }),
       )
       .handle("getMcpPaused", ({ params }) =>

--- a/apps/cloud/src/auth/org-selector-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-selector-auth.node.test.ts
@@ -60,9 +60,10 @@ const stubUsers = Layer.succeed(UserStoreService)({
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),
         getAccount: async (id: string) => ({ id, createdAt }),
+        // Slug is minted at insert now — the stub returns a slugged row.
         upsertOrganization: async (org: { id: string; name: string }) => ({
           ...org,
-          slug: null,
+          slug: org.id,
           createdAt,
         }),
         getOrganization: async (id: string) => ({ id, name: `Org ${id}`, slug: id, createdAt }),
@@ -72,11 +73,6 @@ const stubUsers = Layer.succeed(UserStoreService)({
           id: slug === URL_SLUG ? URL_ORG : "org_outsider",
           name: `Org ${slug}`,
           slug,
-          createdAt,
-        }),
-        ensureOrganizationSlug: async (org: { id: string; name: string; slug: string | null }) => ({
-          ...org,
-          slug: org.slug ?? org.id,
           createdAt,
         }),
       }),

--- a/apps/cloud/src/auth/organization.ts
+++ b/apps/cloud/src/auth/organization.ts
@@ -29,22 +29,20 @@ import { WorkOSClient } from "./workos";
 // unknown org is read. All other callers just do `getOrganization` and get
 // a self-healing lookup for free.
 //
-// URL slugs are OURS (WorkOS orgs have none): resolution also lazily mints a
-// slug for any org that predates them, so every resolved org is routable at
-// `/<slug>/…` without a separate backfill dependency.
+// URL slugs are OURS (WorkOS orgs have none) and are minted at the moment a
+// row is inserted — `upsertOrganization` is the single mint point, so the
+// mirror-on-first-read below produces a slugged, routable org without any
+// read-path healing.
 
 export const resolveOrganization = (organizationId: string) =>
   Effect.gen(function* () {
     const users = yield* UserStoreService;
     const existing = yield* users.use((s) => s.getOrganization(organizationId));
-    if (existing) return yield* users.use((s) => s.ensureOrganizationSlug(existing));
+    if (existing) return existing;
 
     const workos = yield* WorkOSClient;
     const fresh = yield* workos.getOrganization(organizationId);
-    const mirrored = yield* users.use((s) =>
-      s.upsertOrganization({ id: fresh.id, name: fresh.name }),
-    );
-    return yield* users.use((s) => s.ensureOrganizationSlug(mirrored));
+    return yield* users.use((s) => s.upsertOrganization({ id: fresh.id, name: fresh.name }));
   });
 
 // ---------------------------------------------------------------------------

--- a/apps/cloud/src/auth/ssr-gate.ts
+++ b/apps/cloud/src/auth/ssr-gate.ts
@@ -139,22 +139,18 @@ const resolveAuthHint = async (
 };
 
 // The sealed session carries the org ID but not its name/slug; the local
-// mirror has both (the slug minted lazily for orgs that predate slugs). Only
-// consulted when minting (absent/mismatched hint) — never on the steady-state
-// path — and over per-request layers, because a connection cached in the
-// shared runtime would be reused across requests, which Cloudflare forbids. A
-// miss or failure reads as empty strings — display-only, corrected by the
-// client's /account/me write.
+// mirror has both (every org row is born with a slug — see
+// `upsertOrganization`). Only consulted when minting the hint (absent/mismatched
+// cookie) — never on the steady-state path — and over per-request layers,
+// because a connection cached in the shared runtime would be reused across
+// requests, which Cloudflare forbids. A miss or failure reads as empty strings
+// — display-only, corrected by the client's /account/me write.
 const organizationDisplay = async (
   organizationId: string,
 ): Promise<{ name: string; slug: string }> => {
   const exit = await getRuntime().runPromiseExit(
     Effect.flatMap(UserStoreService.asEffect(), (users) =>
-      users.use(async (store) => {
-        const org = await store.getOrganization(organizationId);
-        if (!org) return null;
-        return store.ensureOrganizationSlug(org);
-      }),
+      users.use((store) => store.getOrganization(organizationId)),
     ).pipe(Effect.provide(Layer.provide(makeUserStoreLayer(), makeDbLayer()))),
   );
   return Exit.isSuccess(exit)

--- a/apps/cloud/src/auth/user-store.ts
+++ b/apps/cloud/src/auth/user-store.ts
@@ -17,9 +17,6 @@ import type { DrizzleDb } from "../db/db";
 export type Account = typeof accounts.$inferSelect;
 export type Organization = typeof organizations.$inferSelect;
 
-/** An organization row whose slug has been minted (see `ensureOrganizationSlug`). */
-export type SluggedOrganization = Organization & { readonly slug: string };
-
 export const makeUserStore = (db: DrizzleDb) => {
   const getOrganization = async (id: string) => {
     const rows = await db.select().from(organizations).where(eq(organizations.id, id));
@@ -34,38 +31,45 @@ export const makeUserStore = (db: DrizzleDb) => {
     return rows.length > 0;
   };
 
-  // The unique index can reject a candidate when two requests race to mint
-  // slugs (for the same org or colliding candidates); surface that as null
-  // and let the caller re-read or retry.
-  const trySetSlug = async (organizationId: string, slug: string) => {
-    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: a unique-index violation from a concurrent mint is an expected race, not a failure
-    try {
-      const [updated] = await db
-        .update(organizations)
-        .set({ slug })
-        .where(eq(organizations.id, organizationId))
-        .returning();
-      return updated ?? null;
-    } catch {
-      return null;
-    }
+  // Insert a brand-new org row carrying a freshly-minted slug. `ON CONFLICT DO
+  // NOTHING` (no target) absorbs BOTH unique violations without throwing: an
+  // id collision (the org was mirrored concurrently) and a slug collision (the
+  // candidate was claimed by a different org). Returns the inserted row, or
+  // null when either conflict swallowed the insert — the caller decides whether
+  // to re-read (id race) or retry with a new candidate (slug race).
+  const tryInsertOrg = async (id: string, name: string, slug: string) => {
+    const [row] = await db
+      .insert(organizations)
+      .values({ id, name, slug })
+      .onConflictDoNothing()
+      .returning();
+    return row ?? null;
   };
 
-  // Mint and persist a slug for an org that predates slugs (or was mirrored
-  // before its name was known). Slugs are stable once set — renames do NOT
-  // regenerate them, so org URLs survive.
-  const ensureOrganizationSlug = async (org: Organization): Promise<SluggedOrganization> => {
-    if (org.slug) return org as SluggedOrganization;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const slug = await generateOrgSlug(org.name, slugTaken);
-      const updated = await trySetSlug(org.id, slug);
-      if (updated?.slug) return updated as SluggedOrganization;
-      // Lost a race: either another request minted this org's slug (re-read
-      // and return), or the candidate got claimed by a different org (retry).
-      const fresh = await getOrganization(org.id);
-      if (fresh?.slug) return fresh as SluggedOrganization;
+  // Every new org row is born with a slug — there is no nullable window and no
+  // self-healing. Existing rows keep their slug (stable across renames, so org
+  // URLs survive) and only refresh their name.
+  const upsertOrganization = async (org: { id: string; name: string }) => {
+    const existing = await getOrganization(org.id);
+    if (existing) {
+      const [updated] = await db
+        .update(organizations)
+        .set({ name: org.name })
+        .where(eq(organizations.id, org.id))
+        .returning();
+      return updated ?? existing;
     }
-    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: slug minting exhausted retries; surfacing loudly beats silently unslugged orgs
+    for (let attempt = 0; attempt < 4; attempt++) {
+      const slug = await generateOrgSlug(org.name, slugTaken);
+      const inserted = await tryInsertOrg(org.id, org.name, slug);
+      if (inserted) return inserted;
+      // The insert was swallowed by a conflict. If the id now exists, a
+      // concurrent request mirrored it — return that row. Otherwise the slug
+      // candidate collided; loop and mint a fresh one.
+      const fresh = await getOrganization(org.id);
+      if (fresh) return fresh;
+    }
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: slug minting exhausted retries; surfacing loudly beats a silently unslugged org
     throw new Error(`unable to mint a slug for organization ${org.id}`);
   };
 
@@ -84,17 +88,7 @@ export const makeUserStore = (db: DrizzleDb) => {
 
     // --- Organizations ---
 
-    upsertOrganization: async (org: { id: string; name: string }) => {
-      const [result] = await db
-        .insert(organizations)
-        .values(org)
-        .onConflictDoUpdate({
-          target: organizations.id,
-          set: { name: org.name },
-        })
-        .returning();
-      return result!;
-    },
+    upsertOrganization,
 
     getOrganization,
 
@@ -102,7 +96,5 @@ export const makeUserStore = (db: DrizzleDb) => {
       const rows = await db.select().from(organizations).where(eq(organizations.slug, slug));
       return rows[0] ?? null;
     },
-
-    ensureOrganizationSlug,
   };
 };

--- a/apps/cloud/src/db/db.test.ts
+++ b/apps/cloud/src/db/db.test.ts
@@ -22,6 +22,7 @@
 
 import { describe, it, expect } from "@effect/vitest";
 import { Effect, Layer } from "effect";
+import { isValidOrgSlug } from "@executor-js/api";
 
 import { DbService } from "./db";
 import { makeUserStore } from "../auth/user-store";
@@ -117,4 +118,38 @@ describe("DbService", () => {
     expect(result?.id).toBe(organizationId);
     expect(result?.name).toBe("Acme");
   }, 15_000);
+});
+
+describe("upsertOrganization · slug is minted at insert", () => {
+  const upsert = (org: { id: string; name: string }) =>
+    program(
+      Effect.gen(function* () {
+        const { db } = yield* DbService;
+        return yield* Effect.promise(() => makeUserStore(db).upsertOrganization(org));
+      }),
+    );
+
+  it("mints a valid slug on insert", async () => {
+    const org = await upsert({ id: `org_${crypto.randomUUID()}`, name: "Slug Mint Co" });
+    expect(org.slug, "a new org row is born with a slug").toBeTruthy();
+    expect(isValidOrgSlug(org.slug), "the minted slug fits the URL grammar").toBe(true);
+  });
+
+  it("keeps the slug stable across renames (conflict updates name only)", async () => {
+    const id = `org_${crypto.randomUUID()}`;
+    const created = await upsert({ id, name: "Original Name" });
+    const renamed = await upsert({ id, name: "Renamed Org" });
+    expect(renamed.slug, "the slug survives a rename").toBe(created.slug);
+    expect(renamed.name, "the name is refreshed on conflict").toBe("Renamed Org");
+  });
+
+  it("discriminates same-name collisions into distinct slugs", async () => {
+    // Same name → same slug base; the second insert collides on the unique
+    // index and gets a discriminated slug.
+    const name = `Collide ${crypto.randomUUID().slice(0, 8)}`;
+    const a = await upsert({ id: `org_${crypto.randomUUID()}`, name });
+    const b = await upsert({ id: `org_${crypto.randomUUID()}`, name });
+    expect(a.slug).not.toBe(b.slug);
+    expect(isValidOrgSlug(a.slug) && isValidOrgSlug(b.slug), "both slugs are valid").toBe(true);
+  });
 });

--- a/apps/cloud/src/db/schema.ts
+++ b/apps/cloud/src/db/schema.ts
@@ -22,15 +22,17 @@ export const accounts = pgTable("accounts", {
 /**
  * Organization (billing entity, scoping root). The `id` is the WorkOS
  * organization ID. The `slug` is OURS, not WorkOS's (their org object has no
- * slug): minted at create time, lazily backfilled for orgs first seen via the
- * mirror's self-heal path, and stable across renames so org URLs don't break.
+ * slug): minted at the moment a row is inserted (the single mint point is
+ * `upsertOrganization`) and stable across renames so org URLs don't break.
+ * NOT NULL — there is no nullable window: legacy rows were backfilled once and
+ * every insert since carries a slug.
  */
 export const organizations = pgTable(
   "organizations",
   {
     id: text("id").primaryKey(),
     name: text("name").notNull(),
-    slug: text("slug"),
+    slug: text("slug").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({

--- a/e2e/cloud/auth-routing-flow.test.ts
+++ b/e2e/cloud/auth-routing-flow.test.ts
@@ -1,0 +1,74 @@
+// Cloud-only (browser): the whole auth-routing arc in ONE session, end to end
+// through the real dev server (the e2e cloud target boots `vite dev` with the
+// SSR gate active, so this is the same routing that runs in prod):
+//
+//   signed out  →  /login
+//   click Sign in  →  WorkOS (emulator) callback  →  org-less → /create-org
+//   create the first org  →  canonical dashboard at /<slug>
+//
+// The individual hops are also covered piecewise (cloud/unauthenticated-skeleton,
+// cloud/session-gate, scenarios/org-slug-routing) — those pin edge cases this
+// narrative doesn't (invalid-cookie clearing, token refresh, returnTo
+// open-redirect, unknown-slug 404). This one is the regression guard for the
+// happy path as a single continuous flow, and is the only test that pins the
+// bare-`/` → `/<slug>/` dashboard canonicalization a fresh login lands on.
+//
+// The headless helpers sign in via a `login_hint` query param, but the
+// emulator's hosted AuthKit also serves a real form ("continue as a new user"),
+// so the browser flow just fills it — genuinely end-to-end through the UI.
+import { randomUUID } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Target } from "../src/services";
+
+scenario(
+  "Auth routing · signed out → login → onboarding → dashboard, one browser session",
+  {},
+  Effect.gen(function* () {
+    const browser = yield* Browser;
+    yield* Target;
+
+    // A brand-new user the emulator provisions on first login_hint — no org, so
+    // the post-callback document is gated to onboarding.
+    const email = `flow-${randomUUID().slice(0, 8)}@e2e.test`;
+
+    // No cookies → a clean, signed-out browser.
+    const anonymous = { label: "anonymous" };
+
+    yield* browser.session(anonymous, async ({ page, step }) => {
+      await step("Signed out, the root redirects to /login", async () => {
+        await page.goto("/", { waitUntil: "commit" });
+        await page.getByText("Sign in to manage your tools and sources").waitFor();
+      });
+      expect(new URL(page.url()).pathname, "the signed-out root lands on /login").toBe("/login");
+
+      await step("Sign in through the UI → org-less session lands on onboarding", async () => {
+        await page.getByRole("link", { name: "Sign in" }).click();
+        // The emulator's hosted AuthKit form: provision a brand-new user.
+        await page.getByPlaceholder("new-user@example.com").fill(email);
+        await page.getByRole("button", { name: /Continue/ }).click();
+        // callback mints the session → SSR gate sees no org → /create-org.
+        await page.waitForURL((url) => url.pathname === "/create-org", { timeout: 30_000 });
+        await page.getByPlaceholder("Northwind Labs").waitFor({ timeout: 30_000 });
+      });
+
+      await step("Create the first org → canonical dashboard at /<slug>", async () => {
+        await page.getByPlaceholder("Northwind Labs").fill("Flow Test Org");
+        await page.getByRole("button", { name: "Create organization" }).click();
+        await page.getByText("Connect your MCP client").waitFor({ timeout: 30_000 });
+        await page.getByRole("button", { name: "Continue to app" }).click();
+        // The bare landing canonicalizes onto the new org's slug.
+        await page.waitForURL((url) => /^\/[a-z0-9-]+\/?$/.test(url.pathname), { timeout: 30_000 });
+        await page.getByText("Integrations").first().waitFor({ timeout: 30_000 });
+      });
+
+      expect(
+        /^\/[a-z0-9-]+\/?$/.test(new URL(page.url()).pathname),
+        "the signed-in user ends on their org-slug dashboard",
+      ).toBe(true);
+    });
+  }),
+);


### PR DESCRIPTION
Follow-up to the org-slug work (#974/#999/#1000). Two things.

## 1. Org slugs: mint at insert, drop lazy minting, `NOT NULL`

`organizations.slug` was nullable and the runtime self-healed it — every
`resolveOrganization` (and the SSR gate) lazily minted a slug for any row that
lacked one. That left a permanent nullable state and a heal-on-read cost.

Now a slug is minted at the **single moment a row is inserted**:
`upsertOrganization` generates the slug on INSERT (`ON CONFLICT DO NOTHING`
absorbs both the id-race and the slug-collision-race, retrying with a fresh
candidate) and keeps the existing slug on conflict. The three insert sites —
`createOrganization`, `acceptInvitation`, and the WorkOS-fallback upsert inside
`resolveOrganization` — all get a slug for free; `resolveOrganization` and the
SSR gate's `organizationDisplay` no longer heal. `ensureOrganizationSlug` /
`trySetSlug` / `SluggedOrganization` are deleted.

The column becomes `NOT NULL` (migration `0004`). The API/React contracts were
already non-nullable, so there's no client ripple; self-host and Cloudflare set
slug statically at boot and don't touch this Postgres column.

**Deploy order (strict — documented in `backfill-org-slugs.ts`):** the old code
inserts a NULL slug then heals, so `NOT NULL` must not land while it serves.
1. Backfill prod (current code live): `db:backfill-org-slugs:prod`
2. Deploy this code (mint-at-insert; no NULL inserts)
3. Apply `0004`: `db:migrate:prod`

Cloud migrations are manual (no boot/deploy auto-migrate), so the unapplied
`0004` sitting in the repo between steps is safe.

## 2. One consolidated auth-routing flow test

`e2e/cloud/auth-routing-flow.test.ts` — a single browser session walking the
whole arc through the real dev-server SSR gate (routing-identical to prod):
signed out → `/login` → hosted-AuthKit sign-in → org-less onboarding →
create org → canonical `/<slug>` dashboard. The hops are covered piecewise by
the existing `unauthenticated-skeleton` / `session-gate` / `org-slug-routing`
tests (kept as-is for their edge cases); this is the narrative regression guard
and the only test pinning the bare-`/` → `/<slug>/` dashboard canonicalization a
fresh login lands on.

## Verification

- Local: typecheck 39/39, lint, format, cloud unit tests (incl. new
  `upsertOrganization` mint-at-insert / collision tests). New flow scenario green;
  existing org/auth e2e (session-gate, org-slug-routing, org-multitab, org-switcher,
  org-slug-foreign) green.
- Prod (me, in order): backfill → deploy → `0004`, verifying slug counts and the
  `NOT NULL` constraint.

## Note: a pre-existing failing test (not from this PR)

`unauthenticated-skeleton.test.ts` → "unknown paths are a real 404 page" fails on
`origin/main` too (verified by stashing this PR's changes). After the merged
stateless-URL work, an unknown single-segment path (`/this-page-does-not-exist`)
is now treated as a *foreign org slug* → an unframed 404, so that older test's
"the real shell frames the 404" assertion no longer holds. Left out of scope
here; worth a small follow-up to decide whether unknown top-level paths should
render a shell-framed 404 or update the test.
