### PR TITLE
Connect card: pin the MCP install URL to the URL's org (fix wrong-org flash)

### DIFF
--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -275,6 +275,15 @@ function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
   // which is the same origin, so the key never changes and nothing remounts.
   const connection = ssrOrigin ? ({ kind: "http", origin: ssrOrigin } as const) : undefined;
   const activeSlug = auth.organization.slug;
+  // The org context's slug feeds the connect card's `/<slug>/mcp` install URL.
+  // Prefer the URL's slug over the session's: on first paint `auth.organization`
+  // comes from the SSR auth-hint (the COOKIE's org), so a multi-org user viewing
+  // /<orgB> while their cookie still points at orgA would briefly render orgA's
+  // slug in the copyable URL before /account/me (URL-scoped) corrects it. The
+  // URL slug is the actual request scope and is correct on the very first paint,
+  // so sourcing it from there removes that flash. Falls back to the session slug
+  // on a bare URL (which OrgSlugGate is about to canonicalize onto it anyway).
+  const scopeSlug = urlOrgSlug ?? activeSlug;
 
   return (
     <AutumnProvider pathPrefix="/api/billing">
@@ -284,7 +293,7 @@ function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
             <ExecutorPluginsProvider plugins={clientPlugins}>
               <OrganizationProvider
                 organizationId={auth.organization.id}
-                organizationSlug={activeSlug}
+                organizationSlug={scopeSlug}
               >
                 {/* The org header scopes every request to the URL's org, so
                     reaching here means the caller is a member of `activeSlug`


### PR DESCRIPTION
A multi-org user loading `/<orgB>` while their session cookie still points at
orgA saw orgA's slug flash into the copyable `npx add-mcp .../<slug>/mcp` URL
before `/account/me` resolved — a worse-than-cosmetic bug, since the wrong
endpoint is copyable.

## Cause

On first paint `auth.organization` comes from the SSR auth-hint, which is scoped
to the **cookie's** org (the gate deliberately doesn't do a WorkOS membership
lookup per document request). But the page is scoped to the **URL's** org. The
connect card reads `useOrganizationSlug()`, which `__root.tsx` seeded from
`auth.organization.slug` — so until `/account/me` (URL-scoped) resolved, the
card rendered the cookie org's slug.

## Fix

Seed `OrganizationProvider`'s slug from the URL's `{-$orgSlug}` param
(`urlOrgSlug ?? activeSlug`). The URL slug is the actual request scope and is
correct on the very first paint (it's in the path during SSR too), so the wrong
slug never appears. Falls back to the session slug on a bare URL, which
`OrgSlugGate` is about to canonicalize onto it anyway. `OrgSlugGate` keeps using
the session slug for canonicalization; only the install-URL context changes.

`useOrganizationSlug` is consumed **only** by the connect card
(`McpInstallCard`), so there's no other blast radius — the `organizationId`
consumers are untouched.

## Verification

Typecheck/lint/format clean. The fix is a one-line seed change; correctness
holds across steady-state, the multi-org flash, bare-URL canonicalize, and
foreign-slug 404 (verified by reasoning — a sub-second first-paint flash is too
timing/highlight-brittle to pin in e2e reliably). Happy to demo live on a
two-org dev instance.
