### PR TITLE
cli: service install takes over a running daemon instead of refusing (seamless upgrade)

### DIFF
--- a/apps/cli/src/daemon.test.ts
+++ b/apps/cli/src/daemon.test.ts
@@ -7,6 +7,7 @@ import {
   canAutoStartLocalDaemonForHost,
   isDevCliEntrypoint,
   isExecutorServerReachable,
+  planServiceInstall,
 } from "./daemon";
 
 describe("isDevCliEntrypoint", () => {
@@ -92,4 +93,72 @@ describe("isExecutorServerReachable", () => {
       expect(reachable).toBe(true);
     }),
   );
+});
+
+describe("planServiceInstall", () => {
+  it("no-ops when the supervised service already runs THIS version", () => {
+    expect(
+      planServiceInstall({
+        registered: true,
+        running: true,
+        activeVersion: "1.5.11",
+        currentVersion: "1.5.11",
+      }),
+    ).toBe("noop");
+  });
+
+  it("reinstalls when the supervised service runs an OLDER version (the upgrade)", () => {
+    expect(
+      planServiceInstall({
+        registered: true,
+        running: true,
+        activeVersion: "1.5.10",
+        currentVersion: "1.5.11",
+      }),
+    ).toBe("reinstall");
+  });
+
+  it("reinstalls when the supervised service is up but its version is unknown/unreachable", () => {
+    expect(
+      planServiceInstall({
+        registered: true,
+        running: true,
+        activeVersion: null,
+        currentVersion: "1.5.11",
+      }),
+    ).toBe("reinstall");
+  });
+
+  it("takes over when a daemon is running but NOT as the supervised service", () => {
+    // The upgrade case that used to wall the user off: a foreground `executor
+    // web` / manual `daemon run` / old desktop sidecar holds the data dir while
+    // the OS service isn't registered+running yet.
+    expect(
+      planServiceInstall({
+        registered: false,
+        running: false,
+        activeVersion: "1.5.10",
+        currentVersion: "1.5.11",
+      }),
+    ).toBe("takeover-then-install");
+    expect(
+      planServiceInstall({
+        registered: true, // registered but not running (stopped/flapping) → still take over
+        running: false,
+        activeVersion: null,
+        currentVersion: "1.5.11",
+      }),
+    ).toBe("takeover-then-install");
+  });
+
+  it("installs cleanly on a fresh machine (nothing running)", () => {
+    expect(
+      planServiceInstall({
+        registered: false,
+        running: false,
+        activeVersion: null,
+        currentVersion: "1.5.11",
+      }),
+    ).toBe("takeover-then-install");
+  });
 });

--- a/apps/cli/src/daemon.ts
+++ b/apps/cli/src/daemon.ts
@@ -282,3 +282,37 @@ export const chooseDaemonPort = (input: {
     }
     return fallbackPort;
   });
+
+// ---------------------------------------------------------------------------
+// Service-install planning (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * What `service install` should do given the current service + daemon state.
+ * `service install` IS the upgrade path (the `service status` command points
+ * users at it on version drift), so it must take over a machine that already
+ * has a daemon running rather than refuse and make the user hunt for a pid.
+ */
+export type ServiceInstallPlan = "noop" | "reinstall" | "takeover-then-install";
+
+/**
+ * Decide the install action:
+ * - `noop`: the supervised service is already running THIS version.
+ * - `reinstall`: the supervised service is registered + running but drifted to
+ *   another version (or its manifest is unreachable) — bootout→bootstrap
+ *   repoints the unit at the current binary and restarts it.
+ * - `takeover-then-install`: no supervised service is up, so any local daemon
+ *   that holds the data dir (a foreground `web`, a manual `daemon run`, an old
+ *   desktop sidecar) must be stopped first, then the service installed.
+ */
+export const planServiceInstall = (input: {
+  readonly registered: boolean;
+  readonly running: boolean;
+  readonly activeVersion: string | null;
+  readonly currentVersion: string;
+}): ServiceInstallPlan => {
+  if (input.registered && input.running) {
+    return input.activeVersion === input.currentVersion ? "noop" : "reinstall";
+  }
+  return "takeover-then-install";
+};

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -71,6 +71,7 @@ import {
   isExecutorServerReachable,
   isDevCliEntrypoint,
   parseDaemonBaseUrl,
+  planServiceInstall,
   spawnDetached,
   waitForReachable,
   waitForUnreachable,
@@ -100,7 +101,6 @@ import {
   acquireLocalServerStartLock,
   readLocalServerManifest,
   releaseLocalServerStartLock,
-  removeLocalServerManifest,
   removeLocalServerManifestIfOwnedBy,
   resolveExecutorDataDir,
   writeLocalServerManifest,
@@ -284,6 +284,52 @@ const assertNoOtherActiveLocalServer = (): Effect.Effect<
         ].join("\n"),
       ),
     );
+  });
+
+/**
+ * Take over the local server that currently owns this data directory, if any —
+ * the seam that makes `service install` (and a supervised daemon launching while
+ * a predecessor is still up) an UPGRADE rather than a wall. Whatever holds the
+ * data dir — a foreground `executor web`, a manually-started `daemon run`, an
+ * old desktop sidecar — writes the same server-control manifest, so reading it
+ * identifies the one process we are entitled to replace (same data dir = same
+ * logical singleton). SIGTERM it (graceful: it releases the port + removes its
+ * own records), wait until it stops serving, then clear any stale manifest. A
+ * dead/own-pid manifest is just cleaned. Returns the manifest we replaced (for
+ * messaging), or null when there was nothing live to take over.
+ */
+const takeOverActiveLocalServer = (): Effect.Effect<
+  ExecutorLocalServerManifest | null,
+  Error,
+  FileSystem.FileSystem | PlatformPath.Path
+> =>
+  Effect.gen(function* () {
+    const manifest = yield* readLocalServerManifest();
+    if (!manifest) return null;
+    if (!isPidAlive(manifest.pid) || manifest.pid === process.pid) {
+      yield* removeLocalServerManifestIfOwnedBy({ pid: manifest.pid }).pipe(Effect.ignore);
+      return null;
+    }
+    // Graceful stop; ignore a kill error (pid may have just exited) — the
+    // unreachable wait is the real gate.
+    yield* terminatePid(manifest.pid).pipe(Effect.ignore);
+    const stopped = yield* waitForUnreachable({
+      check: isServerReachable(manifest.connection.origin),
+      timeoutMs: DAEMON_STOP_TIMEOUT_MS,
+      intervalMs: DAEMON_BOOT_POLL_MS,
+    });
+    if (!stopped) {
+      return yield* Effect.fail(
+        new Error(
+          [
+            `The existing Executor ${manifest.kind} at ${manifest.connection.origin} (pid ${manifest.pid}) did not stop within ${DAEMON_STOP_TIMEOUT_MS / 1000}s.`,
+            "Stop it manually and re-run.",
+          ].join("\n"),
+        ),
+      );
+    }
+    yield* removeLocalServerManifestIfOwnedBy({ pid: manifest.pid }).pipe(Effect.ignore);
+    return manifest;
   });
 
 const publishLocalServerManifest = (input: {
@@ -897,7 +943,13 @@ const runDaemonSession = (input: {
         // and crash-loop under KeepAlive. (Found by a real reboot test with
         // integration data in the DB.)
         if (process.env.EXECUTOR_SUPERVISED) {
-          yield* removeLocalServerManifest().pipe(Effect.ignore);
+          // launchd/systemd is the singleton — take over whatever held this data
+          // dir: a stale manifest from before a reboot, or a foreground/old
+          // predecessor that survived because it wasn't the unit the OS started
+          // (e.g. the desktop app installed the service while a CLI `web` ran).
+          // Best-effort: if the port is somehow still held, startServer fails and
+          // KeepAlive retries.
+          yield* takeOverActiveLocalServer().pipe(Effect.ignore);
         } else {
           yield* assertNoOtherActiveLocalServer();
         }
@@ -907,15 +959,26 @@ const runDaemonSession = (input: {
         if (existing) {
           const existingUrl = daemonBaseUrl(existing.hostname, existing.port);
           if (isPidAlive(existing.pid) && (yield* isServerReachable(existingUrl))) {
-            return yield* Effect.fail(
-              new Error(
-                [
-                  `A daemon is already running for scope ${scopeId} on ${daemonHost}.`,
-                  `Existing daemon: ${existingUrl} (pid ${existing.pid}).`,
-                  `Stop it first: ${cliPrefix} daemon stop`,
-                ].join("\n"),
-              ),
-            );
+            if (process.env.EXECUTOR_SUPERVISED) {
+              // A live predecessor recorded in the pointer (a manual `daemon run`):
+              // stop it and claim the scope, rather than refusing and crash-looping.
+              yield* terminatePid(existing.pid).pipe(Effect.ignore);
+              yield* waitForUnreachable({
+                check: isServerReachable(existingUrl),
+                timeoutMs: DAEMON_STOP_TIMEOUT_MS,
+                intervalMs: DAEMON_BOOT_POLL_MS,
+              });
+            } else {
+              return yield* Effect.fail(
+                new Error(
+                  [
+                    `A daemon is already running for scope ${scopeId} on ${daemonHost}.`,
+                    `Existing daemon: ${existingUrl} (pid ${existing.pid}).`,
+                    `Stop it first: ${cliPrefix} daemon stop`,
+                  ].join("\n"),
+                ),
+              );
+            }
           }
           yield* cleanupPointer({ hostname: existing.hostname, scopeId, port: existing.port });
         }
@@ -2135,26 +2198,38 @@ const serviceInstallCommand = Command.make(
         return;
       }
 
-      // Don't fight an already-running local server against the same data dir
-      // (a desktop sidecar, a foreground `executor web`, or an existing daemon).
-      const active = yield* readActiveLocalServerManifest();
-      if (active) {
-        const status = yield* backend.status();
-        if (status.registered && status.running && active.kind === "cli-daemon") {
-          console.log(
-            `Executor service already running at ${active.connection.origin} (pid ${active.pid}).`,
-          );
-          return;
-        }
-        return yield* Effect.fail(
-          new Error(
-            [
-              `A local Executor ${active.kind} is already running at ${active.connection.origin} (pid ${active.pid}).`,
-              `Stop it first (quit the desktop app, or \`${cliPrefix} daemon stop\`), then re-run install.`,
-            ].join("\n"),
-          ),
-        );
+      // `service install` IS the upgrade path (see `service status` drift hint),
+      // so it must not wall off a machine that already has a daemon running —
+      // the user wouldn't know to kill it. Two cases:
+      //   1. The supervised service is already up → (re)install repoints the unit
+      //      at THIS binary and restarts it (bootout→bootstrap). Same version is
+      //      a friendly no-op; an older version is the actual upgrade.
+      //   2. Anything else holds the data dir (a foreground `executor web`, a
+      //      manual `daemon run`, an old desktop sidecar) → take it over (stop it)
+      //      before installing, so the supervised daemon can claim the port.
+      const status = yield* backend.status();
+      const active = yield* readActiveLocalServerManifest().pipe(Effect.orElseSucceed(() => null));
+      const plan = planServiceInstall({
+        registered: status.registered,
+        running: status.running,
+        activeVersion: active?.owner.version ?? null,
+        currentVersion: CLI_VERSION,
+      });
+      if (plan === "noop") {
+        const where = active ? ` at ${active.connection.origin} (pid ${active.pid})` : "";
+        console.log(`Executor service already running${where}.`);
+        return;
       }
+      if (plan === "takeover-then-install") {
+        const replaced = yield* takeOverActiveLocalServer();
+        if (replaced) {
+          console.log(
+            `Replaced the running Executor ${replaced.kind} (pid ${replaced.pid}) at ${replaced.connection.origin}.`,
+          );
+        }
+      }
+      // plan === "reinstall" falls through: backend.install's bootout→bootstrap
+      // repoints the unit at this binary and restarts it cleanly.
 
       // The unit carries no secret: the supervised daemon mints/loads its bearer
       // from auth.json (under EXECUTOR_DATA_DIR) on first boot, and clients read

--- a/e2e/scripts/repro-upgrade-takeover.ts
+++ b/e2e/scripts/repro-upgrade-takeover.ts
@@ -1,0 +1,102 @@
+// UPGRADE STRESS: `service install` must TAKE OVER a daemon that is already
+// running (the upgrade path), not refuse and make the user hunt for a pid.
+// Stage a predecessor daemon (executor daemon run, like an old install or a
+// `executor web` a user left running), then `service install` the supervised
+// daemon, and assert the predecessor was stopped and the supervised service now
+// owns the canonical port — exactly one daemon. Exits non-zero if it did NOT
+// take over (the pre-fix bug). Manual VM harness (real launchd); always
+// discards the guest.
+//
+//   bun e2e/scripts/repro-upgrade-takeover.ts
+import { tartVm } from "../src/vm/tart";
+
+const t0 = Date.now();
+const log = (m: string) => console.log(`[+${((Date.now() - t0) / 1000).toFixed(0)}s] ${m}`);
+const PORT = 4789;
+
+const main = async () => {
+  log("provisioning tart macos guest...");
+  const vm = await tartVm("macos", "arm64").provision();
+  log(`provisioned host=${vm.host}`);
+  try {
+    const dir = "~/ed";
+    const exe = `${dir}/executor`;
+    await vm.ssh(`rm -rf ${dir} && mkdir -p ${dir}`);
+    log("pushing darwin CLI binary...");
+    await vm.push("/tmp/wt-ops/apps/cli/dist/executor-darwin-arm64/bin/.", `${dir}/`);
+    await vm.ssh(`chmod +x ${exe}; xattr -dr com.apple.quarantine ${dir} 2>/dev/null || true`);
+    log(`version: ${(await vm.ssh(`${exe} --version`)).stdout.trim()}`);
+
+    // 1) PREDECESSOR: a daemon the user already has running (manual daemon run).
+    log("starting PREDECESSOR daemon (executor daemon run --foreground)...");
+    await vm.ssh(
+      `nohup ${exe} daemon run --foreground --port ${PORT} > /tmp/pre.log 2>&1 & echo started`,
+    );
+    let preReachable = false;
+    for (let i = 0; i < 20; i++) {
+      const h = await vm.ssh(
+        `curl -s -o /dev/null -w '%{http_code}' --max-time 3 http://127.0.0.1:${PORT}/api/health`,
+      );
+      if (h.stdout.trim() === "200") {
+        preReachable = true;
+        break;
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    log(`predecessor reachable: ${preReachable}`);
+    const prePid = (
+      await vm.ssh(`lsof -ti tcp:${PORT} -sTCP:LISTEN 2>/dev/null | head -1`)
+    ).stdout.trim();
+    log(`predecessor owns :${PORT} as pid ${prePid}`);
+
+    // 2) UPGRADE: install the supervised service while the predecessor runs.
+    log("running `executor service install` (the upgrade) WITH predecessor still running...");
+    const install = await vm.ssh(`${exe} service install --port ${PORT} 2>&1`);
+    log(`install exit=${install.code}\n${install.stdout.trim()}\n${install.stderr.trim()}`);
+
+    // 3) OBSERVE for ~25s: does the supervised service take over, or flap?
+    await new Promise((r) => setTimeout(r, 25000));
+    const uid = (await vm.ssh("id -u")).stdout.trim();
+    const print = await vm.ssh(
+      `launchctl print gui/${uid}/sh.executor.daemon 2>/dev/null | grep -iE 'state|pid|last exit|runs' | head`,
+    );
+    log(`launchctl print:\n${print.stdout.trim() || "(service not found)"}`);
+    const errlog = await vm.ssh(`tail -8 ~/.executor/logs/daemon.error.log 2>/dev/null`);
+    log(`daemon.error.log tail:\n${errlog.stdout.trim() || "(empty)"}`);
+    const ownerNow = (
+      await vm.ssh(`lsof -ti tcp:${PORT} -sTCP:LISTEN 2>/dev/null | head -1`)
+    ).stdout.trim();
+    const procCount = (
+      await vm.ssh(`pgrep -fl 'executor daemon run' 2>/dev/null | wc -l`)
+    ).stdout.trim();
+    const preAlive = (
+      await vm.ssh(`kill -0 ${prePid} 2>/dev/null && echo alive || echo dead`)
+    ).stdout.trim();
+    log(
+      `AFTER: :${PORT} owned by pid ${ownerNow} (predecessor was ${prePid}, now ${preAlive}); 'daemon run' procs=${procCount}`,
+    );
+
+    // The bug: predecessor still owns the port (no takeover), and either the
+    // service errored or it's flapping / a 2nd daemon exists.
+    const tookOver = ownerNow !== "" && ownerNow !== prePid && preAlive === "dead";
+    if (tookOver) {
+      log("RESULT=TOOK-OVER (predecessor stopped, supervised owns the port) — upgrade is clean");
+    } else {
+      log(
+        "RESULT=NO-TAKEOVER (predecessor still owns the port / service did not replace it) — BUG",
+      );
+      throw new Error("service install did not take over the running predecessor");
+    }
+  } finally {
+    log("discarding guest VM");
+    await vm.discard();
+    log("discarded");
+  }
+};
+
+main()
+  .then(() => process.exit(0))
+  .catch((e) => {
+    console.error("REPRO-ERROR", e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## The bug (upgrade flow)

`service install` is the upgrade path — `service status` literally tells users to
run it on version drift — but it **refused** whenever any daemon already owned
the data dir:

```
$ executor service install --port 4789
A local Executor cli-daemon is already running at http://localhost:4789 (pid 631).
Stop it first (quit the desktop app, or `executor daemon stop`), then re-run install.
   → exit 1; predecessor keeps the port; no service installed
```

On a real upgrade (`npm i -g executor@latest && executor service install`, or the
desktop app auto-installing the service) the user has **no idea which pid to
kill**, so the upgrade just fails. Reproduced in a real macOS VM (before this
change): `install exit=1`, predecessor still owns `:4789`.

## The fix — take over, don't refuse

Whatever holds the data dir (a foreground `executor web`, a manual `daemon run`,
or an old desktop sidecar) writes the **same** `server-control` manifest, so it's
the one process we're entitled to replace. The data dir is never touched, so
connections / secrets / the bearer survive.

- **`service install`** plans via a pure, unit-tested `planServiceInstall`:
  - `noop` — supervised service already runs this version
  - `reinstall` — supervised service runs an older/unreachable version → bootout→bootstrap repoints + restarts
  - `takeover-then-install` — something else holds the data dir → SIGTERM it, wait until it stops serving, clear its records, then install
- **Supervised daemon startup** (`runDaemonSession` under `EXECUTOR_SUPERVISED`)
  now takes over a surviving predecessor (manifest owner *and* a pointer-recorded
  `daemon run`) instead of failing and crash-looping under `KeepAlive`.

## Proof

`e2e/scripts/repro-upgrade-takeover.ts` (real macOS VM, real launchd):

| | result |
|---|---|
| before | `install exit=1`; predecessor (pid 631) keeps `:4789`; **NO-TAKEOVER** |
| after  | `install exit=0`; "Replaced the running Executor cli-daemon (pid 635)"; supervised service owns `:4789` (new pid); exactly one daemon — **TOOK-OVER** |

Plus unit tests for `planServiceInstall` (noop / reinstall / takeover / fresh).