### PR TITLE
Self-host + cross-host: consistent public-origin resolution (platform detect, actionable errors, pinned outbound URLs)

### DIFF
--- a/.changeset/selfhost-zero-config-origin.md
+++ b/.changeset/selfhost-zero-config-origin.md
@@ -1,0 +1,11 @@
+---
+"executor": patch
+---
+
+Self-hosted instances now detect their public URL automatically on common
+platforms. When `EXECUTOR_WEB_BASE_URL` is not set, the server reads the origin
+a host injects (Railway, Render, Fly, Vercel, Netlify, Heroku, Azure, and
+Cloudflare Pages) instead of defaulting to localhost — so a platform deploy
+works with zero configuration and no longer fails sign-in with "Invalid origin".
+When the origin still can't be determined, that error is replaced with a clear
+message telling you exactly which `EXECUTOR_WEB_BASE_URL` value to set.

--- a/.changeset/selfhost-zero-config-origin.md
+++ b/.changeset/selfhost-zero-config-origin.md
@@ -3,9 +3,14 @@
 ---
 
 Self-hosted instances now detect their public URL automatically on common
-platforms. When `EXECUTOR_WEB_BASE_URL` is not set, the server reads the origin
-a host injects (Railway, Render, Fly, Vercel, Netlify, Heroku, Azure, and
-Cloudflare Pages) instead of defaulting to localhost — so a platform deploy
-works with zero configuration and no longer fails sign-in with "Invalid origin".
-When the origin still can't be determined, that error is replaced with a clear
-message telling you exactly which `EXECUTOR_WEB_BASE_URL` value to set.
+platforms, and origin handling is consistent across every host. When
+`EXECUTOR_WEB_BASE_URL` is not set, the server reads the origin a host injects
+(Railway, Render, Fly, Vercel, Netlify, Heroku, Azure, Cloudflare Pages) instead
+of defaulting to localhost — so a platform deploy works with zero configuration
+and no longer fails sign-in with "Invalid origin". When the origin still can't be
+determined, that error is replaced with a clear message telling you exactly which
+`EXECUTOR_WEB_BASE_URL` value to set, and a startup warning fires on any non-dev
+deploy that falls back to localhost. The MCP browser-approval link a self-host
+sends to clients now uses the pinned public URL (reachable behind a reverse
+proxy) rather than the server's internal address. These resolution rules now live
+in one shared helper used by every host.

--- a/apps/cloud/src/org/handlers.ts
+++ b/apps/cloud/src/org/handlers.ts
@@ -90,9 +90,12 @@ export const OrgHandlers = HttpApiBuilder.group(OrgHttpApi, "org", (handlers) =>
         }
 
         const workos = yield* WorkOSClient;
+        // WorkOS requires an ABSOLUTE returnUrl — fall back to the pinned origin
+        // (matching every other VITE_PUBLIC_SITE_URL site in this host), not a
+        // bare relative path that WorkOS would reject.
         const { link } = yield* workos.generateDomainVerificationPortalLink(
           auth.organizationId,
-          env.VITE_PUBLIC_SITE_URL ? `${env.VITE_PUBLIC_SITE_URL}/org` : "/org",
+          `${env.VITE_PUBLIC_SITE_URL ?? "https://executor.sh"}/org`,
         );
         return { link };
       }),

--- a/apps/host-cloudflare/src/config.ts
+++ b/apps/host-cloudflare/src/config.ts
@@ -1,6 +1,9 @@
 import type { D1Database, DurableObjectNamespace, R2Bucket } from "@cloudflare/workers-types";
 
 import { isValidOrgSlug } from "@executor-js/api";
+import { missingPublicOriginWarning, resolvePublicOrigin } from "@executor-js/sdk/public-origin";
+
+let warnedNoCloudflareOrigin = false;
 
 // ---------------------------------------------------------------------------
 // Cloudflare host config. Unlike self-host (process.env + a data dir), a Worker
@@ -97,6 +100,17 @@ export const loadConfig = (env: CloudflareEnv): CloudflareConfig => {
       "EXECUTOR_SECRET_KEY must be set (wrangler secret put EXECUTOR_SECRET_KEY) — it encrypts stored secrets at rest in D1",
     );
   }
+  const enableDevAuth = env.ENABLE_DEV_AUTH === "true";
+  const webBaseUrl = resolvePublicOrigin({ explicit: env.VITE_PUBLIC_SITE_URL, env: {} });
+  if (!webBaseUrl && !enableDevAuth && !warnedNoCloudflareOrigin) {
+    warnedNoCloudflareOrigin = true;
+    console.warn(
+      missingPublicOriginWarning({
+        varName: "VITE_PUBLIC_SITE_URL",
+        fallback: "the per-request origin",
+      }),
+    );
+  }
   return {
     accessTeamDomain: env.ACCESS_TEAM_DOMAIN.replace(/^https?:\/\//, "").replace(/\/+$/, ""),
     accessAud: env.ACCESS_AUD,
@@ -108,9 +122,13 @@ export const loadConfig = (env: CloudflareEnv): CloudflareConfig => {
     organizationSlug: resolveOrgSlug(env.SELF_HOSTED_ORG_SLUG),
     secretKey,
     allowLocalNetwork: env.ALLOW_LOCAL_NETWORK === "true",
-    // No static URL on a Worker — leave unset when VITE_PUBLIC_SITE_URL is absent
-    // and let the request origin drive it (RequestWebOrigin). Explicit still wins.
-    webBaseUrl: env.VITE_PUBLIC_SITE_URL,
-    enableDevAuth: env.ENABLE_DEV_AUTH === "true",
+    // Pinned origin via the shared resolver. A Worker receives no PaaS platform
+    // vars (env: {} — there is nothing to detect), so only the explicit
+    // VITE_PUBLIC_SITE_URL applies; when it's unset we leave webBaseUrl undefined
+    // and let the per-request origin drive it (request.url — Cloudflare-set, not
+    // spoofable via Host). Warn once on a real deployment so the operator pins it,
+    // mirroring self-host (gated on enableDevAuth = local `wrangler dev`).
+    webBaseUrl,
+    enableDevAuth,
   };
 };

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -91,12 +91,24 @@ export class McpSessionDO extends McpSessionDOBase<CfSessionDbHandle> {
           elicitationMode === "browser"
             ? {
                 mode: "browser" as const,
-                approvalUrl: (executionId) =>
-                  buildResumeApprovalUrl({
-                    origin: sessionMeta.webOrigin ?? config.webBaseUrl ?? "http://localhost",
+                approvalUrl: (executionId) => {
+                  // webOrigin is captured per-request at session create; for a
+                  // legacy session cold-restored without it, fall back to the
+                  // pinned site URL. If neither exists, the link would be
+                  // unreachable — fail VISIBLY (a logged, obviously-invalid host)
+                  // instead of silently pointing the human at http://localhost.
+                  const origin = sessionMeta.webOrigin ?? config.webBaseUrl;
+                  if (!origin) {
+                    console.error(
+                      "[executor-cloudflare] cannot build MCP approval URL: no session web origin and VITE_PUBLIC_SITE_URL is unset. Set VITE_PUBLIC_SITE_URL so approval links are reachable.",
+                    );
+                  }
+                  return buildResumeApprovalUrl({
+                    origin: origin ?? "https://unconfigured-origin.invalid",
                     executionId,
                     sessionId: self.sessionId,
-                  }),
+                  });
+                },
               }
             : { mode: elicitationMode },
       });

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -68,7 +68,9 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
   const { identityLayer, authHandler, betterAuth } = await resolveAuthProviders(dbHandle);
 
   // ---- the in-process MCP serving seams (+ shutdown hook) ----------------
-  const mcp = makeSelfHostMcpSeams(dbHandle, betterAuth);
+  // Pass the pinned public origin so browser-approval URLs are reachable behind
+  // a reverse proxy (not the internal 127.0.0.1 bind from the request URL).
+  const mcp = makeSelfHostMcpSeams(dbHandle, betterAuth, config.webBaseUrl);
 
   const { appLayer, toWebHandler } = ExecutorApp.make({
     plugins: selfHostPlugins,

--- a/apps/host-selfhost/src/auth/better-auth.ts
+++ b/apps/host-selfhost/src/auth/better-auth.ts
@@ -88,9 +88,15 @@ const makeAuthOptions = (client: Client, getOrganizationId: () => string, gate?:
       type: "sqlite" as const,
     },
     secret,
-    baseURL: config.webBaseUrl,
     // The browser Origin must match this exactly; CLI/MCP bearer requests carry
-    // no Origin and are unaffected.
+    // no Origin and are unaffected. `config.webBaseUrl` resolves from an explicit
+    // EXECUTOR_WEB_BASE_URL, else a platform-injected origin (Railway/Render/Fly/
+    // …), else localhost — so a PaaS deploy is zero-config and any other host
+    // sets the one variable (a loud warning fires on the localhost fallback).
+    // See config.ts. We deliberately do NOT derive this from the request `Host`:
+    // matching the ecosystem (Windmill `BASE_URL`, n8n `WEBHOOK_URL`), a pinned
+    // origin keeps host-header injection out of OAuth redirects and links.
+    baseURL: config.webBaseUrl,
     trustedOrigins: [config.webBaseUrl],
     emailAndPassword: { enabled: true },
     // `apiKey` issues long-lived personal keys (the API-keys page). With

--- a/apps/host-selfhost/src/auth/index.ts
+++ b/apps/host-selfhost/src/auth/index.ts
@@ -2,10 +2,12 @@ import { Layer } from "effect";
 
 import { IdentityProvider } from "@executor-js/api/server";
 
+import { loadConfig } from "../config";
 import type { SelfHostDbHandle } from "../db/self-host-db";
 import { BetterAuth, buildBetterAuth, type BetterAuthHandle } from "./better-auth";
 import { betterAuthIdentityLayer } from "./identity";
 import { consentRedirectClientId, withClientName, withForcedMcpConsent } from "./force-mcp-consent";
+import { rewriteInvalidOrigin } from "./invalid-origin-help";
 
 export { BetterAuth, buildBetterAuth, type BetterAuthHandle } from "./better-auth";
 export { betterAuthIdentityLayer } from "./identity";
@@ -56,8 +58,13 @@ export const resolveAuthProviders = async (
   // authorize so a connecting client is gated on /mcp-consent rather than
   // silently granted a token (see ./force-mcp-consent), and enrich the
   // resulting consent redirect with the registered client name.
+  const config = loadConfig();
   const authHandler = async (request: Request): Promise<Response> => {
     const response = await betterAuth.handler(withForcedMcpConsent(request));
+    // Turn Better Auth's bare 403 "Invalid origin" into a setup instruction —
+    // on a fresh deploy it almost always means the public URL needs configuring.
+    const friendlier = await rewriteInvalidOrigin(request, response, config.webBaseUrl);
+    if (friendlier) return friendlier;
     if (response.status !== 302) return response;
     const clientId = consentRedirectClientId(response.headers.get("location"));
     if (!clientId) return response;

--- a/apps/host-selfhost/src/auth/invalid-origin-help.test.ts
+++ b/apps/host-selfhost/src/auth/invalid-origin-help.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@effect/vitest";
+
+import { invalidOriginHelp, originOf, rewriteInvalidOrigin } from "./invalid-origin-help";
+
+const req = (headers: Record<string, string>) =>
+  new Request("https://svc.internal/api/auth/sign-up/email", { method: "POST", headers });
+
+test("originOf prefers Origin, then x-forwarded-host, then host", () => {
+  expect(originOf(req({ origin: "https://app.example.com" }))).toBe("https://app.example.com");
+  expect(
+    originOf(req({ "x-forwarded-host": "app.example.com", "x-forwarded-proto": "https" })),
+  ).toBe("https://app.example.com");
+  expect(originOf(req({ host: "app.example.com" }))).toBe("https://app.example.com");
+});
+
+test("the help message names the URL to set", () => {
+  const msg = invalidOriginHelp("https://app.example.com", "http://localhost:4788");
+  expect(msg).toContain("EXECUTOR_WEB_BASE_URL");
+  expect(msg).toContain("https://app.example.com");
+  expect(msg).toContain("http://localhost:4788");
+});
+
+test("rewriteInvalidOrigin replaces a 403 'Invalid origin' with the setup message, keeping the code", async () => {
+  const original = new Response(
+    JSON.stringify({ code: "INVALID_ORIGIN", message: "Invalid origin" }),
+    {
+      status: 403,
+      headers: { "content-type": "application/json" },
+    },
+  );
+  const rewritten = await rewriteInvalidOrigin(
+    req({ origin: "https://app.example.com" }),
+    original,
+    "http://localhost:4788",
+  );
+  expect(rewritten).not.toBeNull();
+  expect(rewritten!.status).toBe(403);
+  const body = (await rewritten!.json()) as { code: string; message: string };
+  expect(body.code).toBe("INVALID_ORIGIN");
+  expect(body.message).toContain("EXECUTOR_WEB_BASE_URL");
+  expect(body.message).toContain("https://app.example.com");
+});
+
+test("rewriteInvalidOrigin passes other responses through untouched", async () => {
+  expect(await rewriteInvalidOrigin(req({}), new Response("ok", { status: 200 }), "x")).toBeNull();
+  const otherErr = new Response(JSON.stringify({ message: "An invite code is required" }), {
+    status: 403,
+  });
+  expect(await rewriteInvalidOrigin(req({}), otherErr, "x")).toBeNull();
+});

--- a/apps/host-selfhost/src/auth/invalid-origin-help.ts
+++ b/apps/host-selfhost/src/auth/invalid-origin-help.ts
@@ -1,0 +1,49 @@
+// Better Auth rejects any request whose Origin isn't the configured webBaseUrl
+// with a bare 403 "Invalid origin". On a self-host deploy that almost always
+// means the instance's public URL wasn't detected or configured — so we replace
+// that dead-end with a message naming the exact fix (the URL to set). The error
+// `code` is preserved so programmatic clients are unaffected; only the
+// human-facing `message` changes.
+
+const INVALID_ORIGIN = /invalid origin/i;
+
+/** The origin a request came from: the browser `Origin`, else the proxy host. */
+export const originOf = (request: Request): string | null => {
+  const explicit = request.headers.get("origin");
+  if (explicit) return explicit;
+  const host = request.headers.get("x-forwarded-host") ?? request.headers.get("host");
+  if (!host) return null;
+  const proto = request.headers.get("x-forwarded-proto") ?? "https";
+  return `${proto}://${host}`;
+};
+
+/** Actionable replacement for "Invalid origin". */
+export const invalidOriginHelp = (requestOrigin: string | null, webBaseUrl: string): string =>
+  requestOrigin
+    ? `This Executor instance is configured for ${webBaseUrl}, but you're connecting from ${requestOrigin}. ` +
+      `Set the EXECUTOR_WEB_BASE_URL environment variable to ${requestOrigin} and restart the server, then try again. ` +
+      `(Railway, Render, Fly, Vercel, and similar hosts are detected automatically; set it explicitly for a custom domain or other host.)`
+    : `This Executor instance is configured for ${webBaseUrl}. If you're reaching it at a different address, ` +
+      `set EXECUTOR_WEB_BASE_URL to that address and restart the server.`;
+
+/**
+ * If `response` is Better Auth's 403 "Invalid origin", return a friendlier copy
+ * with the same status + `code` but an actionable message. Otherwise null — the
+ * caller passes the original response through untouched.
+ */
+export const rewriteInvalidOrigin = async (
+  request: Request,
+  response: Response,
+  webBaseUrl: string,
+): Promise<Response | null> => {
+  if (response.status !== 403) return null;
+  const body = await response.clone().text();
+  if (!INVALID_ORIGIN.test(body)) return null;
+  const message = invalidOriginHelp(originOf(request), webBaseUrl);
+  const headers = new Headers(response.headers);
+  headers.set("content-type", "application/json");
+  return new Response(JSON.stringify({ code: "INVALID_ORIGIN", message }), {
+    status: 403,
+    headers,
+  });
+};

--- a/apps/host-selfhost/src/auth/origin-resolution.test.ts
+++ b/apps/host-selfhost/src/auth/origin-resolution.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { expect, test } from "@effect/vitest";
+
+import { loadConfig } from "../config";
+
+// Keep generated secret/key files out of the repo (loadConfig persists them).
+process.env.EXECUTOR_DATA_DIR ??= mkdtempSync(join(tmpdir(), "origin-cfg-"));
+
+// The "Invalid origin" sign-up failure on a PaaS came from webBaseUrl defaulting
+// to localhost: Better Auth's trustedOrigins is [config.webBaseUrl], so the real
+// public origin never matched. The fix resolves webBaseUrl from the platform's
+// injected origin (Railway/Render/Fly/…) when EXECUTOR_WEB_BASE_URL is unset, so
+// a PaaS deploy is zero-config. These pin that resolution; the origin check that
+// consumes it is Better Auth's and unchanged.
+
+// Clear every origin source so each test starts from a known state (no
+// try/finally — these are the only env vars these cases read).
+const PLATFORM_VARS = [
+  "EXECUTOR_WEB_BASE_URL",
+  "RAILWAY_PUBLIC_DOMAIN",
+  "RENDER_EXTERNAL_URL",
+  "RENDER_EXTERNAL_HOSTNAME",
+  "FLY_APP_NAME",
+  "VERCEL_URL",
+];
+const resetOriginEnv = (): void => {
+  for (const key of PLATFORM_VARS) delete process.env[key];
+  process.env.PORT = "4788";
+};
+
+test("webBaseUrl falls back to localhost with no public origin", () => {
+  resetOriginEnv();
+  expect(loadConfig().webBaseUrl).toBe("http://localhost:4788");
+});
+
+test("webBaseUrl auto-resolves from a platform host var (Railway, host only → https)", () => {
+  resetOriginEnv();
+  process.env.RAILWAY_PUBLIC_DOMAIN = "demo-production.up.railway.app";
+  expect(loadConfig().webBaseUrl).toBe("https://demo-production.up.railway.app");
+});
+
+test("webBaseUrl auto-resolves from a platform URL var (Render, full URL, trailing slash trimmed)", () => {
+  resetOriginEnv();
+  process.env.RENDER_EXTERNAL_URL = "https://demo.onrender.com/";
+  expect(loadConfig().webBaseUrl).toBe("https://demo.onrender.com");
+});
+
+test("Fly's app name becomes the .fly.dev origin", () => {
+  resetOriginEnv();
+  process.env.FLY_APP_NAME = "demo-app";
+  expect(loadConfig().webBaseUrl).toBe("https://demo-app.fly.dev");
+});
+
+test("an explicit EXECUTOR_WEB_BASE_URL always wins over a platform var", () => {
+  resetOriginEnv();
+  process.env.RAILWAY_PUBLIC_DOMAIN = "ignored.up.railway.app";
+  process.env.EXECUTOR_WEB_BASE_URL = "https://pinned.example.com";
+  expect(loadConfig().webBaseUrl).toBe("https://pinned.example.com");
+});

--- a/apps/host-selfhost/src/config.ts
+++ b/apps/host-selfhost/src/config.ts
@@ -103,6 +103,61 @@ export const resolveAuthSecret = (): string => {
   return generated;
 };
 
+// Public origin a PaaS injects for this service, e.g. Railway's
+// `RAILWAY_PUBLIC_DOMAIN`. Mirrors the ordering of @t3-oss/env-core's
+// `getPlatformOrigin` preset (MIT) — these are platform-set (not client-set)
+// values, so building absolute URLs from them is safe (unlike the request
+// `Host`). Returns an origin (`https://host`) or undefined. We deliberately omit
+// the generic `PUBLIC_URL`/`APP_URL` from that preset: `PUBLIC_URL` is a *path*
+// in some toolchains (CRA), not an origin, and would mislead here.
+const getPlatformOrigin = (env = process.env): string | undefined => {
+  const host =
+    env.RAILWAY_PUBLIC_DOMAIN ??
+    env.RENDER_EXTERNAL_HOSTNAME ??
+    env.VERCEL_PROJECT_PRODUCTION_URL ??
+    env.VERCEL_URL ??
+    env.HEROKU_APP_DEFAULT_DOMAIN_NAME ??
+    env.WEBSITE_HOSTNAME ?? // Azure App Service
+    env.WEBSITE_DEFAULT_HOSTNAME ??
+    (env.FLY_APP_NAME ? `${env.FLY_APP_NAME}.fly.dev` : undefined) ??
+    (env.SITE_NAME ? `${env.SITE_NAME}.netlify.app` : undefined);
+  const url =
+    env.RENDER_EXTERNAL_URL ??
+    env.DEPLOY_PRIME_URL ?? // Netlify (deploy/branch previews)
+    env.URL ?? // Netlify (primary site URL)
+    env.CF_PAGES_URL ??
+    (host ? `https://${host}` : undefined);
+  return url?.replace(/\/+$/, "");
+};
+
+let warnedNoPublicUrl = false;
+
+// The public origin used to build absolute links (OAuth redirects, MCP OAuth
+// metadata, the connect-card URL). Priority: an explicit EXECUTOR_WEB_BASE_URL,
+// then a platform-injected origin (zero-config on Railway/Render/Fly/…), then a
+// localhost fallback for local dev. NEVER derived from the request `Host` —
+// that's spoofable and would let host-header injection poison those links (the
+// request origin is only trusted for the CSRF/`trustedOrigins` check, which is
+// same-origin-safe; see better-auth.ts).
+const resolveWebBaseUrl = (port: number): string => {
+  const explicit = process.env.EXECUTOR_WEB_BASE_URL?.trim();
+  if (explicit) return explicit;
+  const platform = getPlatformOrigin();
+  if (platform) return platform;
+  const fallback = `http://localhost:${port}`;
+  // A deployed instance with no detectable origin will mint localhost OAuth
+  // redirects / email links — warn once so the operator sets the variable
+  // (signup itself still works; trustedOrigins takes the origin from the
+  // request). Quiet in dev, where localhost is correct.
+  if (!warnedNoPublicUrl && process.env.NODE_ENV === "production") {
+    warnedNoPublicUrl = true;
+    console.warn(
+      `[executor] EXECUTOR_WEB_BASE_URL is not set and no platform origin was detected; falling back to ${fallback}. Sign-in works, but OAuth redirects, MCP metadata, and connect links will use this URL. Set EXECUTOR_WEB_BASE_URL to your public origin (e.g. https://your-instance.example.com).`,
+    );
+  }
+  return fallback;
+};
+
 export const loadConfig = (): SelfHostConfig => {
   const port = Number.parseInt(process.env.PORT ?? "4788", 10);
   const dataDir = resolveDataDir();
@@ -110,7 +165,7 @@ export const loadConfig = (): SelfHostConfig => {
     host: process.env.EXECUTOR_HOST ?? "127.0.0.1",
     port,
     dbPath: process.env.EXECUTOR_DB_PATH ?? join(dataDir, "data.db"),
-    webBaseUrl: process.env.EXECUTOR_WEB_BASE_URL ?? `http://localhost:${port}`,
+    webBaseUrl: resolveWebBaseUrl(port),
     allowLocalNetwork: process.env.EXECUTOR_ALLOW_LOCAL_NETWORK === "true",
     authSecret: resolveAuthSecret(),
     bootstrapAdminEmail: process.env.EXECUTOR_BOOTSTRAP_ADMIN_EMAIL,

--- a/apps/host-selfhost/src/config.ts
+++ b/apps/host-selfhost/src/config.ts
@@ -3,6 +3,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { isValidOrgSlug } from "@executor-js/api";
+import {
+  missingPublicOriginWarning,
+  resolvePublicOrigin,
+  shouldWarnMissingPublicOrigin,
+} from "@executor-js/sdk/public-origin";
 
 // ---------------------------------------------------------------------------
 // Self-host server config — a single typed surface parsed from the
@@ -103,57 +108,27 @@ export const resolveAuthSecret = (): string => {
   return generated;
 };
 
-// Public origin a PaaS injects for this service, e.g. Railway's
-// `RAILWAY_PUBLIC_DOMAIN`. Mirrors the ordering of @t3-oss/env-core's
-// `getPlatformOrigin` preset (MIT) — these are platform-set (not client-set)
-// values, so building absolute URLs from them is safe (unlike the request
-// `Host`). Returns an origin (`https://host`) or undefined. We deliberately omit
-// the generic `PUBLIC_URL`/`APP_URL` from that preset: `PUBLIC_URL` is a *path*
-// in some toolchains (CRA), not an origin, and would mislead here.
-const getPlatformOrigin = (env = process.env): string | undefined => {
-  const host =
-    env.RAILWAY_PUBLIC_DOMAIN ??
-    env.RENDER_EXTERNAL_HOSTNAME ??
-    env.VERCEL_PROJECT_PRODUCTION_URL ??
-    env.VERCEL_URL ??
-    env.HEROKU_APP_DEFAULT_DOMAIN_NAME ??
-    env.WEBSITE_HOSTNAME ?? // Azure App Service
-    env.WEBSITE_DEFAULT_HOSTNAME ??
-    (env.FLY_APP_NAME ? `${env.FLY_APP_NAME}.fly.dev` : undefined) ??
-    (env.SITE_NAME ? `${env.SITE_NAME}.netlify.app` : undefined);
-  const url =
-    env.RENDER_EXTERNAL_URL ??
-    env.DEPLOY_PRIME_URL ?? // Netlify (deploy/branch previews)
-    env.URL ?? // Netlify (primary site URL)
-    env.CF_PAGES_URL ??
-    (host ? `https://${host}` : undefined);
-  return url?.replace(/\/+$/, "");
-};
-
 let warnedNoPublicUrl = false;
 
 // The public origin used to build absolute links (OAuth redirects, MCP OAuth
-// metadata, the connect-card URL). Priority: an explicit EXECUTOR_WEB_BASE_URL,
-// then a platform-injected origin (zero-config on Railway/Render/Fly/…), then a
-// localhost fallback for local dev. NEVER derived from the request `Host` —
-// that's spoofable and would let host-header injection poison those links (the
-// request origin is only trusted for the CSRF/`trustedOrigins` check, which is
-// same-origin-safe; see better-auth.ts).
+// metadata, the connect-card URL). Priority via the shared resolver: an explicit
+// EXECUTOR_WEB_BASE_URL, then a platform-injected origin (zero-config on
+// Railway/Render/Fly/…), then a localhost fallback for local dev. NEVER derived
+// from the request `Host` — that's spoofable and would let host-header injection
+// poison those links (the request origin is only trusted for the CSRF/
+// `trustedOrigins` check, which is same-origin-safe; see better-auth.ts).
 const resolveWebBaseUrl = (port: number): string => {
-  const explicit = process.env.EXECUTOR_WEB_BASE_URL?.trim();
-  if (explicit) return explicit;
-  const platform = getPlatformOrigin();
-  if (platform) return platform;
+  const resolved = resolvePublicOrigin({
+    explicit: process.env.EXECUTOR_WEB_BASE_URL,
+    env: process.env,
+  });
+  if (resolved) return resolved;
   const fallback = `http://localhost:${port}`;
-  // A deployed instance with no detectable origin will mint localhost OAuth
-  // redirects / email links — warn once so the operator sets the variable
-  // (signup itself still works; trustedOrigins takes the origin from the
-  // request). Quiet in dev, where localhost is correct.
-  if (!warnedNoPublicUrl && process.env.NODE_ENV === "production") {
+  // A deployed instance with no detectable origin mints localhost links — warn
+  // once (unless local dev/test) so the operator sets the variable.
+  if (!warnedNoPublicUrl && shouldWarnMissingPublicOrigin(process.env.NODE_ENV)) {
     warnedNoPublicUrl = true;
-    console.warn(
-      `[executor] EXECUTOR_WEB_BASE_URL is not set and no platform origin was detected; falling back to ${fallback}. Sign-in works, but OAuth redirects, MCP metadata, and connect links will use this URL. Set EXECUTOR_WEB_BASE_URL to your public origin (e.g. https://your-instance.example.com).`,
-    );
+    console.warn(missingPublicOriginWarning({ varName: "EXECUTOR_WEB_BASE_URL", fallback }));
   }
   return fallback;
 };

--- a/apps/host-selfhost/src/mcp/index.ts
+++ b/apps/host-selfhost/src/mcp/index.ts
@@ -103,8 +103,9 @@ const makeApprovalHandler =
 export const makeSelfHostMcpSeams = (
   dbHandle: SelfHostDbHandle,
   betterAuth: BetterAuthHandle,
+  webBaseUrl?: string,
 ): SelfHostMcpSeams => {
-  const sessionStore = makeSelfHostMcpSessionStore(dbHandle);
+  const sessionStore = makeSelfHostMcpSessionStore(dbHandle, webBaseUrl);
   const auth: Layer.Layer<McpAuthProvider, never, IdentityProvider> = selfHostMcpAuth.pipe(
     Layer.provide(Layer.succeed(BetterAuth)(betterAuth)),
   );

--- a/apps/host-selfhost/src/mcp/session-store.ts
+++ b/apps/host-selfhost/src/mcp/session-store.ts
@@ -24,12 +24,20 @@ import { SelfHostExecutionStackLayer } from "../execution";
 
 export { McpEngineBuildError } from "@executor-js/host-mcp/in-memory-session-store";
 
-/** Build the in-process session store (plus its `close()` hook) over the DB handle. */
-export const makeSelfHostMcpSessionStore = (db: SelfHostDbHandle): InMemoryMcpSessionStore =>
+/**
+ * Build the in-process session store (plus its `close()` hook) over the DB
+ * handle. `webBaseUrl` is the pinned public origin so browser-approval URLs use
+ * the reachable public address rather than the internal bind behind a proxy.
+ */
+export const makeSelfHostMcpSessionStore = (
+  db: SelfHostDbHandle,
+  webBaseUrl?: string,
+): InMemoryMcpSessionStore =>
   makeInMemoryMcpSessionStore(
     makeMcpBuildServer(
       SelfHostExecutionStackLayer.pipe(Layer.provide(Layer.succeed(SelfHostDb)(db))),
     ),
+    { webBaseUrl },
   );
 
 /** The `McpSessionStore` envelope seam over a freshly built in-process store. */

--- a/packages/core/sdk/package.json
+++ b/packages/core/sdk/package.json
@@ -24,7 +24,8 @@
     "./client": "./src/client.ts",
     "./testing": "./src/testing.ts",
     "./migration": "./src/migration-spec.ts",
-    "./http-auth": "./src/http-auth/index.ts"
+    "./http-auth": "./src/http-auth/index.ts",
+    "./public-origin": "./src/public-origin.ts"
   },
   "publishConfig": {
     "access": "public",
@@ -75,6 +76,12 @@
         "import": {
           "types": "./dist/http-auth.d.ts",
           "default": "./dist/http-auth.js"
+        }
+      },
+      "./public-origin": {
+        "import": {
+          "types": "./dist/public-origin.d.ts",
+          "default": "./dist/public-origin.js"
         }
       }
     }

--- a/packages/core/sdk/src/public-origin.test.ts
+++ b/packages/core/sdk/src/public-origin.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@effect/vitest";
+
+import {
+  getPlatformOrigin,
+  missingPublicOriginWarning,
+  resolvePublicOrigin,
+  shouldWarnMissingPublicOrigin,
+} from "./public-origin";
+
+test("getPlatformOrigin reads host-only vars as https, trims trailing slash on URL vars", () => {
+  expect(getPlatformOrigin({ RAILWAY_PUBLIC_DOMAIN: "demo.up.railway.app" })).toBe(
+    "https://demo.up.railway.app",
+  );
+  expect(getPlatformOrigin({ RENDER_EXTERNAL_URL: "https://demo.onrender.com/" })).toBe(
+    "https://demo.onrender.com",
+  );
+  expect(getPlatformOrigin({ FLY_APP_NAME: "demo" })).toBe("https://demo.fly.dev");
+  expect(getPlatformOrigin({ SITE_NAME: "demo" })).toBe("https://demo.netlify.app");
+  expect(getPlatformOrigin({})).toBeUndefined();
+  // A Worker env (no platform vars) yields nothing — the caller falls back.
+  expect(getPlatformOrigin({ SOME_OTHER: "x" })).toBeUndefined();
+});
+
+test("resolvePublicOrigin: explicit wins over platform, else platform, else undefined", () => {
+  expect(
+    resolvePublicOrigin({
+      explicit: "https://pinned.example.com",
+      env: { RAILWAY_PUBLIC_DOMAIN: "x" },
+    }),
+  ).toBe("https://pinned.example.com");
+  expect(
+    resolvePublicOrigin({ explicit: "  ", env: { RAILWAY_PUBLIC_DOMAIN: "demo.up.railway.app" } }),
+  ).toBe("https://demo.up.railway.app");
+  expect(resolvePublicOrigin({ explicit: undefined, env: {} })).toBeUndefined();
+});
+
+test("shouldWarnMissingPublicOrigin warns unless dev/test", () => {
+  expect(shouldWarnMissingPublicOrigin("production")).toBe(true);
+  expect(shouldWarnMissingPublicOrigin("staging")).toBe(true);
+  expect(shouldWarnMissingPublicOrigin(undefined)).toBe(true);
+  expect(shouldWarnMissingPublicOrigin("development")).toBe(false);
+  expect(shouldWarnMissingPublicOrigin("test")).toBe(false);
+});
+
+test("missingPublicOriginWarning names the var and the fallback", () => {
+  const msg = missingPublicOriginWarning({
+    varName: "EXECUTOR_WEB_BASE_URL",
+    fallback: "http://localhost:4788",
+  });
+  expect(msg).toContain("EXECUTOR_WEB_BASE_URL");
+  expect(msg).toContain("http://localhost:4788");
+});

--- a/packages/core/sdk/src/public-origin.ts
+++ b/packages/core/sdk/src/public-origin.ts
@@ -1,0 +1,77 @@
+// Shared resolution of a host's PUBLIC ORIGIN — the pinned base URL every host
+// uses to build absolute outbound links (OAuth redirect_uri, MCP OAuth metadata,
+// connect/approval URLs, email links). One implementation so the hosts don't
+// drift (selfhost had the platform-detect chain; cloud/cloudflare did not).
+//
+// SECURITY: this is for SERVER-SIDE OUTBOUND urls, so the origin must come from
+// a TRUSTED source — an operator-set env var, or a platform-injected deploy-time
+// var — NEVER from the request `Host`/`X-Forwarded-Host` (host-header injection
+// would let an attacker poison those links). The request origin may still be
+// used for CSRF/origin validation and client-side display; that is each host's
+// concern, not this module's.
+
+/** A read-only environment record (process.env, or a Worker `env` binding). */
+export type EnvRecord = Record<string, string | undefined>;
+
+/**
+ * The public origin a platform-as-a-service injects for this deployment, e.g.
+ * Railway's `RAILWAY_PUBLIC_DOMAIN`. Ordering mirrors `@t3-oss/env-core`'s
+ * `getPlatformOrigin` preset (MIT) — all platform-SET (not client-set) values,
+ * so building absolute URLs from them is safe. Returns an origin (`https://host`,
+ * no trailing slash) or undefined. The generic `PUBLIC_URL`/`APP_URL` from that
+ * preset are deliberately omitted: `PUBLIC_URL` is a *path* in some toolchains
+ * (CRA), not an origin. Cloudflare Workers receive none of these, so it returns
+ * undefined there — expected; the Worker falls back to its own request origin.
+ */
+export const getPlatformOrigin = (env: EnvRecord): string | undefined => {
+  const host =
+    env.RAILWAY_PUBLIC_DOMAIN ??
+    env.RENDER_EXTERNAL_HOSTNAME ??
+    env.VERCEL_PROJECT_PRODUCTION_URL ??
+    env.VERCEL_URL ??
+    env.HEROKU_APP_DEFAULT_DOMAIN_NAME ??
+    env.WEBSITE_HOSTNAME ?? // Azure App Service
+    env.WEBSITE_DEFAULT_HOSTNAME ??
+    (env.FLY_APP_NAME ? `${env.FLY_APP_NAME}.fly.dev` : undefined) ??
+    (env.SITE_NAME ? `${env.SITE_NAME}.netlify.app` : undefined);
+  const url =
+    env.RENDER_EXTERNAL_URL ??
+    env.DEPLOY_PRIME_URL ?? // Netlify (deploy/branch previews)
+    env.URL ?? // Netlify (primary site URL)
+    env.CF_PAGES_URL ??
+    (host ? `https://${host}` : undefined);
+  return url?.replace(/\/+$/, "");
+};
+
+/**
+ * Resolve a deployment's pinned public origin: an explicit operator-set value
+ * wins, else a platform-injected origin, else undefined (the caller supplies its
+ * own fallback — a `localhost:PORT` for a Node host, a production constant or the
+ * per-request origin for a Worker — and decides whether to warn).
+ */
+export const resolvePublicOrigin = (options: {
+  readonly explicit?: string | undefined;
+  readonly env: EnvRecord;
+}): string | undefined => {
+  const explicit = options.explicit?.trim();
+  if (explicit) return explicit;
+  return getPlatformOrigin(options.env);
+};
+
+/**
+ * True unless this is explicitly local dev or a test run. A staging/demo deploy
+ * often leaves `NODE_ENV` unset, and silently using a localhost fallback there is
+ * the footgun we want surfaced — so warn by default.
+ */
+export const shouldWarnMissingPublicOrigin = (nodeEnv: string | undefined): boolean =>
+  nodeEnv !== "development" && nodeEnv !== "test";
+
+/** The one-time warning shown when a host falls back for its public origin. */
+export const missingPublicOriginWarning = (options: {
+  readonly varName: string;
+  readonly fallback: string;
+}): string =>
+  `[executor] ${options.varName} is not set and no platform origin was detected; ` +
+  `falling back to ${options.fallback}. OAuth redirects, MCP metadata, and connect ` +
+  `links will use this — set ${options.varName} to your public origin ` +
+  `(e.g. https://your-instance.example.com).`;

--- a/packages/hosts/mcp/src/in-memory-session-store.ts
+++ b/packages/hosts/mcp/src/in-memory-session-store.ts
@@ -5,7 +5,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { formatPausedExecution, type ExecutionEngine } from "@executor-js/execution";
 
 import {
-  approvalUrlForRequest,
+  buildResumeApprovalUrl,
   decodeResumeResponse,
   formatResumeAcknowledgement,
   readElicitationMode,
@@ -122,6 +122,12 @@ const RESUME_PATH = /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)\/res
  */
 export const makeInMemoryMcpSessionStore = (
   buildServer: McpBuildServer,
+  // The host's pinned public origin, used to build browser-approval URLs the
+  // human opens. When set (e.g. a public-internet self-host behind a reverse
+  // proxy) it is preferred over the request URL — whose host would be the
+  // internal bind address (127.0.0.1:PORT), unreachable for the user. Omit it on
+  // loopback hosts (local/desktop), where the request URL is already correct.
+  options: { readonly webBaseUrl?: string } = {},
 ): InMemoryMcpSessionStore => {
   const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
   const servers = new Map<string, McpServer>();
@@ -192,7 +198,14 @@ export const makeInMemoryMcpSessionStore = (
     return {
       elicitationMode: {
         mode: "browser",
-        approvalUrl: (executionId) => approvalUrlForRequest(request, executionId, sessionId()),
+        // Prefer the pinned public origin; fall back to the request URL (correct
+        // for loopback hosts, the internal bind address behind a proxy).
+        approvalUrl: (executionId) =>
+          buildResumeApprovalUrl({
+            origin: options.webBaseUrl ?? request.url,
+            executionId,
+            sessionId: sessionId(),
+          }),
       },
       browserApprovalStore: approvals.store,
     };


### PR DESCRIPTION
## Summary

Self-hosting on a platform-as-a-service (Railway, Render, Fly, …) failed sign-in
with a bare 403 **"Invalid origin"** because `webBaseUrl` defaulted to
`http://localhost:<port>` when no public URL was configured. Fixing that, then a
full audit of every web-URL site (202 inventoried, 84 verified) confirmed the
architecture is sound — outbound URLs are pinned, request-origin is used only for
CSRF/display, no host-header-injection holes — but origin resolution was split
across hosts with a few gaps. This PR makes it consistent.

## Changes

**Shared resolver.** New `@executor-js/sdk/public-origin`:
`getPlatformOrigin()` (platform-detect chain, ordering from `@t3-oss/env-core`'s
preset: Railway / Render / Vercel / Fly / Heroku / Azure / Netlify / Cloudflare
Pages — minus the CRA-ambiguous `PUBLIC_URL`), `resolvePublicOrigin()`
(explicit env → platform → undefined), and the missing-origin warning helpers.
Self-host and Cloudflare configs both use it instead of diverging.

**Self-host** (`config.ts`): resolve `webBaseUrl` = `EXECUTOR_WEB_BASE_URL` →
platform-detect → localhost, pinned (never the request `Host`). On the localhost
fallback, warn unless `NODE_ENV` is `development`/`test`. Better Auth's bare
"Invalid origin" is rewritten (`auth/invalid-origin-help.ts`) into a message
naming the exact `EXECUTOR_WEB_BASE_URL` to set, with `code` preserved.

**Cross-host consistency fixes from the audit:**
- Cloudflare: pin `VITE_PUBLIC_SITE_URL` via the resolver + warn once on a real
  deploy when it's unset (mirrors self-host).
- Cloudflare MCP session DO: replace the silent `http://localhost` approval-URL
  fallback with a logged, visibly-invalid origin — a misconfigured deploy fails
  loudly instead of handing clients an unreachable localhost link.
- Cloud: WorkOS Admin Portal `returnUrl` fell back to a bare relative `/org`
  (WorkOS needs absolute) — use the pinned origin like every other site.
- MCP in-process session store: thread the pinned `webBaseUrl` so the self-host
  browser-approval link uses the public URL, not the internal `127.0.0.1` bind
  behind a reverse proxy (local/desktop keep `request.url` — loopback is correct).

## Verification

End-to-end against the production self-host Docker image: `RAILWAY_PUBLIC_DOMAIN`
set, no `EXECUTOR_WEB_BASE_URL` → browser-shaped sign-up returns **200**; nothing
set → the actionable setup message instead of bare "Invalid origin". Unit tests
cover the shared resolver, the platform-origin cases, and the error-rewrite
helper. Typecheck + lint clean; selfhost 48, host-mcp 32, cloud 128,
host-cloudflare 10, sdk public-origin 4 tests green.

The in-process auth handler used by unit tests does not exercise Better Auth's
origin-check middleware, so origin behavior is verified against the real HTTP
server (the image), not the handler in isolation.
