### PR TITLE
Give the Connect-an-agent card header room at the top

### DIFF
--- a/packages/react/src/components/mcp-install-card.tsx
+++ b/packages/react/src/components/mcp-install-card.tsx
@@ -240,7 +240,7 @@ export function McpInstallCard(props: { className?: string }) {
 
   const header = (
     <CardStackHeader
-      className="items-start pt-3 pb-1"
+      className="items-start pt-4 pb-1"
       rightSlot={
         showStdio ? (
           <TabsList>


### PR DESCRIPTION
## Problem

In the **Connect an agent** card, the title sat only **12px** below the card's top border (`CardStackHeader` override `pt-3`), leaving it visually jammed against the edge.

## Fix

Bump the header's top padding to `pt-4` (16px) — enough breathing room above the title while staying balanced against the footer's 12px bottom inset. One-line change.

## Before / After

Captured from the running self-host app (real component, real styling, real install command) by booting the product with the header at `pt-3` vs `pt-4`.

| Before — `pt-3` (title hugs the top) | After — `pt-4` (room above the title) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/connect-an-agent-before-78d7f589.png) | ![after](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/connect-an-agent-after-d522ea25.png) |
