### PR TITLE
CLI device-flow login for hosted accounts (`executor login`)

### DIFF
--- a/apps/cli/src/device-login.ts
+++ b/apps/cli/src/device-login.ts
@@ -1,0 +1,281 @@
+// ---------------------------------------------------------------------------
+// CLI device-login (OAuth 2.0 Device Authorization Grant, RFC 8628).
+//
+// `executor login` against a hosted server:
+//   1. discover the provider device endpoints + public client id from the
+//      server (`GET /api/auth/cli-login`),
+//   2. request a device code, show the user_code + open the verification URL,
+//   3. poll the token endpoint until the user approves in the browser,
+//   4. hand the access + refresh tokens back to be stored in the profile.
+//
+// The flow is provider-neutral: the server advertises WorkOS (cloud) or Better
+// Auth (self-host) endpoints, and both speak the same RFC 8628 wire shape, so
+// this module never branches on provider. Tokens are sent to the `/api/*`
+// plane as `Authorization: Bearer <access_token>`.
+// ---------------------------------------------------------------------------
+
+import { spawn } from "node:child_process";
+
+export interface CliLoginDiscovery {
+  readonly provider: string;
+  readonly deviceAuthorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+  readonly clientId: string;
+  readonly scope?: string;
+}
+
+export interface DeviceCodeGrant {
+  readonly deviceCode: string;
+  readonly userCode: string;
+  readonly verificationUri: string;
+  readonly verificationUriComplete?: string;
+  readonly expiresInSeconds: number;
+  readonly intervalSeconds: number;
+}
+
+export interface DeviceTokens {
+  readonly accessToken: string;
+  readonly refreshToken?: string;
+  /** Epoch seconds the access token expires, when known. */
+  readonly expiresAt?: number;
+}
+
+const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+const DEFAULT_INTERVAL_SECONDS = 5;
+
+export class DeviceLoginError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DeviceLoginError";
+  }
+}
+
+const cliLoginUrl = (origin: string): string => `${origin.replace(/\/+$/, "")}/api/auth/cli-login`;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.length > 0 ? value : undefined;
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+/**
+ * Decode a JWT access token's claims WITHOUT verifying it. The CLI only uses
+ * this for display (`whoami`, the post-login summary) and to read `exp` — the
+ * server is the only thing that verifies the token's signature.
+ */
+export const decodeAccessTokenClaims = (
+  accessToken: string,
+): Record<string, unknown> | undefined => {
+  const segments = accessToken.split(".");
+  if (segments.length !== 3) return undefined;
+  const payloadSegment = segments[1];
+  if (!payloadSegment) return undefined;
+  try {
+    const json = Buffer.from(payloadSegment, "base64url").toString("utf8");
+    const claims = JSON.parse(json) as unknown;
+    return claims && typeof claims === "object" ? (claims as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Read `exp` (epoch seconds) out of a JWT access token without verifying it. */
+export const accessTokenExpiry = (accessToken: string): number | undefined =>
+  asNumber(decodeAccessTokenClaims(accessToken)?.exp);
+
+const deriveExpiresAt = (tokens: {
+  accessToken: string;
+  expiresIn?: number;
+}): number | undefined => {
+  if (tokens.expiresIn !== undefined) {
+    return Math.floor(Date.now() / 1000) + tokens.expiresIn;
+  }
+  return accessTokenExpiry(tokens.accessToken);
+};
+
+const formBody = (fields: Record<string, string | undefined>): string => {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) params.set(key, value);
+  }
+  return params.toString();
+};
+
+const postForm = async (url: string, fields: Record<string, string | undefined>) =>
+  fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      accept: "application/json",
+    },
+    body: formBody(fields),
+  });
+
+const readJson = async (response: Response): Promise<Record<string, unknown>> => {
+  const text = await response.text();
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return { error: "invalid_response", error_description: text.slice(0, 200) };
+  }
+};
+
+export const discoverCliLogin = async (origin: string): Promise<CliLoginDiscovery> => {
+  let response: Response;
+  try {
+    response = await fetch(cliLoginUrl(origin), { headers: { accept: "application/json" } });
+  } catch (cause) {
+    throw new DeviceLoginError(
+      `Could not reach ${origin} to start login: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+  if (!response.ok) {
+    throw new DeviceLoginError(
+      `${origin} does not support CLI login (GET /api/auth/cli-login returned ${response.status}). ` +
+        "It may be an older server, or a local/unauthenticated server that needs no login.",
+    );
+  }
+  const body = await readJson(response);
+  const deviceAuthorizationEndpoint = asString(body.deviceAuthorizationEndpoint);
+  const tokenEndpoint = asString(body.tokenEndpoint);
+  const clientId = asString(body.clientId);
+  if (!deviceAuthorizationEndpoint || !tokenEndpoint || !clientId) {
+    throw new DeviceLoginError(`${origin} returned an incomplete CLI-login configuration.`);
+  }
+  return {
+    provider: asString(body.provider) ?? "unknown",
+    deviceAuthorizationEndpoint,
+    tokenEndpoint,
+    clientId,
+    scope: asString(body.scope),
+  };
+};
+
+export const requestDeviceCode = async (discovery: CliLoginDiscovery): Promise<DeviceCodeGrant> => {
+  const response = await postForm(discovery.deviceAuthorizationEndpoint, {
+    client_id: discovery.clientId,
+    scope: discovery.scope,
+  });
+  const body = await readJson(response);
+  if (!response.ok) {
+    throw new DeviceLoginError(
+      `Device authorization failed (${response.status}): ${asString(body.error_description) ?? asString(body.error) ?? "unknown error"}`,
+    );
+  }
+  const deviceCode = asString(body.device_code);
+  const userCode = asString(body.user_code);
+  const verificationUri = asString(body.verification_uri);
+  if (!deviceCode || !userCode || !verificationUri) {
+    throw new DeviceLoginError("Device authorization response was missing required fields.");
+  }
+  return {
+    deviceCode,
+    userCode,
+    verificationUri,
+    verificationUriComplete: asString(body.verification_uri_complete),
+    expiresInSeconds: asNumber(body.expires_in) ?? 300,
+    intervalSeconds: asNumber(body.interval) ?? DEFAULT_INTERVAL_SECONDS,
+  };
+};
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Poll the token endpoint until the user approves, honoring the RFC 8628
+ * pacing rules (`authorization_pending` keeps waiting, `slow_down` backs off,
+ * `access_denied` / `expired_token` are terminal).
+ */
+export const pollForDeviceTokens = async (
+  discovery: CliLoginDiscovery,
+  grant: DeviceCodeGrant,
+  options: { readonly now?: () => number } = {},
+): Promise<DeviceTokens> => {
+  const now = options.now ?? (() => Date.now());
+  const deadline = now() + grant.expiresInSeconds * 1000;
+  let intervalMs = Math.max(1, grant.intervalSeconds) * 1000;
+
+  for (;;) {
+    if (now() >= deadline) {
+      throw new DeviceLoginError("Login timed out before it was approved.");
+    }
+    await sleep(intervalMs);
+
+    const response = await postForm(discovery.tokenEndpoint, {
+      grant_type: DEVICE_CODE_GRANT_TYPE,
+      device_code: grant.deviceCode,
+      client_id: discovery.clientId,
+    });
+    const body = await readJson(response);
+
+    if (response.ok) {
+      const accessToken = asString(body.access_token);
+      if (!accessToken) {
+        throw new DeviceLoginError("Token response was missing an access token.");
+      }
+      return {
+        accessToken,
+        refreshToken: asString(body.refresh_token),
+        expiresAt: deriveExpiresAt({ accessToken, expiresIn: asNumber(body.expires_in) }),
+      };
+    }
+
+    const error = asString(body.error);
+    if (error === "authorization_pending") continue;
+    if (error === "slow_down") {
+      intervalMs += 5000;
+      continue;
+    }
+    if (error === "access_denied") {
+      throw new DeviceLoginError("Login was denied.");
+    }
+    if (error === "expired_token") {
+      throw new DeviceLoginError("The login request expired before it was approved.");
+    }
+    throw new DeviceLoginError(
+      `Login failed: ${asString(body.error_description) ?? error ?? `HTTP ${response.status}`}`,
+    );
+  }
+};
+
+/** Exchange a refresh token for a fresh access token (silent re-auth). */
+export const refreshDeviceTokens = async (input: {
+  readonly tokenEndpoint: string;
+  readonly clientId: string;
+  readonly refreshToken: string;
+}): Promise<DeviceTokens> => {
+  const response = await postForm(input.tokenEndpoint, {
+    grant_type: "refresh_token",
+    refresh_token: input.refreshToken,
+    client_id: input.clientId,
+  });
+  const body = await readJson(response);
+  if (!response.ok) {
+    throw new DeviceLoginError(
+      `Token refresh failed: ${asString(body.error_description) ?? asString(body.error) ?? `HTTP ${response.status}`}`,
+    );
+  }
+  const accessToken = asString(body.access_token);
+  if (!accessToken) throw new DeviceLoginError("Refresh response was missing an access token.");
+  return {
+    accessToken,
+    refreshToken: asString(body.refresh_token) ?? input.refreshToken,
+    expiresAt: deriveExpiresAt({ accessToken, expiresIn: asNumber(body.expires_in) }),
+  };
+};
+
+/** Best-effort open the verification URL in the user's default browser. */
+export const openBrowser = (url: string): void => {
+  const platform = process.platform;
+  const command = platform === "darwin" ? "open" : platform === "win32" ? "cmd" : "xdg-open";
+  const args = platform === "win32" ? ["/c", "start", "", url] : [url];
+  try {
+    const child = spawn(command, args, { stdio: "ignore", detached: true });
+    // Swallow async spawn failures (e.g. the opener binary is missing) — the
+    // URL is printed too, so the user can open it by hand.
+    (child as { on?: (event: "error", listener: () => void) => void }).on?.("error", () => {});
+    child.unref();
+  } catch {
+    // Ignore — the URL is also printed for manual opening.
+  }
+};

--- a/apps/cli/src/device-login.ts
+++ b/apps/cli/src/device-login.ts
@@ -79,7 +79,7 @@ const readUserEmail = (body: Record<string, unknown>): string | undefined => {
 
 /**
  * Decode a JWT access token's claims WITHOUT verifying it. The CLI only uses
- * this for display (`whoami`, the post-login summary) and to read `exp` — the
+ * this for display (`whoami`, the post-login summary) and to read `exp`, the
  * server is the only thing that verifies the token's signature.
  */
 export const decodeAccessTokenClaims = (
@@ -318,11 +318,11 @@ export const openBrowser = (url: string): void => {
   const args = platform === "win32" ? ["/c", "start", "", url] : [url];
   try {
     const child = spawn(command, args, { stdio: "ignore", detached: true });
-    // Swallow async spawn failures (e.g. the opener binary is missing) — the
+    // Swallow async spawn failures (e.g. the opener binary is missing), the
     // URL is printed too, so the user can open it by hand.
     (child as { on?: (event: "error", listener: () => void) => void }).on?.("error", () => {});
     child.unref();
   } catch {
-    // Ignore — the URL is also printed for manual opening.
+    // Ignore, the URL is also printed for manual opening.
   }
 };

--- a/apps/cli/src/device-login.ts
+++ b/apps/cli/src/device-login.ts
@@ -38,6 +38,10 @@ export interface DeviceTokens {
   readonly refreshToken?: string;
   /** Epoch seconds the access token expires, when known. */
   readonly expiresAt?: number;
+  /** The signed-in account's email, if the token response carries a user. */
+  readonly email?: string;
+  /** The bound organization id, from the response or the token's org_id claim. */
+  readonly organizationId?: string;
 }
 
 const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
@@ -57,6 +61,15 @@ const asString = (value: unknown): string | undefined =>
 
 const asNumber = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+/** Pull `user.email` out of a token response (WorkOS returns the user inline). */
+const readUserEmail = (body: Record<string, unknown>): string | undefined => {
+  const user = body.user;
+  if (user && typeof user === "object" && "email" in user) {
+    return asString((user as { email?: unknown }).email);
+  }
+  return undefined;
+};
 
 /**
  * Decode a JWT access token's claims WITHOUT verifying it. The CLI only uses
@@ -213,10 +226,16 @@ export const pollForDeviceTokens = async (
       if (!accessToken) {
         throw new DeviceLoginError("Token response was missing an access token.");
       }
+      const claims = decodeAccessTokenClaims(accessToken);
       return {
         accessToken,
         refreshToken: asString(body.refresh_token),
         expiresAt: deriveExpiresAt({ accessToken, expiresIn: asNumber(body.expires_in) }),
+        email:
+          readUserEmail(body) ?? (typeof claims?.email === "string" ? claims.email : undefined),
+        organizationId:
+          asString(body.organization_id) ??
+          (typeof claims?.org_id === "string" ? claims.org_id : undefined),
       };
     }
 

--- a/apps/cli/src/device-login.ts
+++ b/apps/cli/src/device-login.ts
@@ -22,6 +22,12 @@ export interface CliLoginDiscovery {
   readonly tokenEndpoint: string;
   readonly clientId: string;
   readonly scope?: string;
+  /**
+   * How to encode the device-authorization + token requests. RFC 8628 mandates
+   * `form` (WorkOS), but some providers' endpoints only accept JSON (Better
+   * Auth). The server tells us via discovery; defaults to `form`.
+   */
+  readonly requestFormat: "form" | "json";
 }
 
 export interface DeviceCodeGrant {
@@ -114,14 +120,24 @@ const formBody = (fields: Record<string, string | undefined>): string => {
   return params.toString();
 };
 
-const postForm = async (url: string, fields: Record<string, string | undefined>) =>
+const definedFields = (fields: Record<string, string | undefined>): Record<string, string> =>
+  Object.fromEntries(Object.entries(fields).filter(([, v]) => v !== undefined)) as Record<
+    string,
+    string
+  >;
+
+const post = async (
+  url: string,
+  fields: Record<string, string | undefined>,
+  format: "form" | "json",
+) =>
   fetch(url, {
     method: "POST",
     headers: {
-      "content-type": "application/x-www-form-urlencoded",
+      "content-type": format === "json" ? "application/json" : "application/x-www-form-urlencoded",
       accept: "application/json",
     },
-    body: formBody(fields),
+    body: format === "json" ? JSON.stringify(definedFields(fields)) : formBody(fields),
   });
 
 const readJson = async (response: Response): Promise<Record<string, unknown>> => {
@@ -162,14 +178,16 @@ export const discoverCliLogin = async (origin: string): Promise<CliLoginDiscover
     tokenEndpoint,
     clientId,
     scope: asString(body.scope),
+    requestFormat: asString(body.requestFormat) === "json" ? "json" : "form",
   };
 };
 
 export const requestDeviceCode = async (discovery: CliLoginDiscovery): Promise<DeviceCodeGrant> => {
-  const response = await postForm(discovery.deviceAuthorizationEndpoint, {
-    client_id: discovery.clientId,
-    scope: discovery.scope,
-  });
+  const response = await post(
+    discovery.deviceAuthorizationEndpoint,
+    { client_id: discovery.clientId, scope: discovery.scope },
+    discovery.requestFormat,
+  );
   const body = await readJson(response);
   if (!response.ok) {
     throw new DeviceLoginError(
@@ -214,11 +232,15 @@ export const pollForDeviceTokens = async (
     }
     await sleep(intervalMs);
 
-    const response = await postForm(discovery.tokenEndpoint, {
-      grant_type: DEVICE_CODE_GRANT_TYPE,
-      device_code: grant.deviceCode,
-      client_id: discovery.clientId,
-    });
+    const response = await post(
+      discovery.tokenEndpoint,
+      {
+        grant_type: DEVICE_CODE_GRANT_TYPE,
+        device_code: grant.deviceCode,
+        client_id: discovery.clientId,
+      },
+      discovery.requestFormat,
+    );
     const body = await readJson(response);
 
     if (response.ok) {
@@ -257,17 +279,23 @@ export const pollForDeviceTokens = async (
   }
 };
 
-/** Exchange a refresh token for a fresh access token (silent re-auth). */
+/** Exchange a refresh token for a fresh access token (silent re-auth). Only
+ * providers that issue refresh tokens reach here (WorkOS, which is form-encoded
+ * per RFC 8628); Better Auth's device flow issues no refresh token. */
 export const refreshDeviceTokens = async (input: {
   readonly tokenEndpoint: string;
   readonly clientId: string;
   readonly refreshToken: string;
 }): Promise<DeviceTokens> => {
-  const response = await postForm(input.tokenEndpoint, {
-    grant_type: "refresh_token",
-    refresh_token: input.refreshToken,
-    client_id: input.clientId,
-  });
+  const response = await post(
+    input.tokenEndpoint,
+    {
+      grant_type: "refresh_token",
+      refresh_token: input.refreshToken,
+      client_id: input.clientId,
+    },
+    "form",
+  );
   const body = await readJson(response);
   if (!response.ok) {
     throw new DeviceLoginError(

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -69,11 +69,20 @@ import { ExecutorApi } from "@executor-js/api";
 import {
   getExecutorServerAuthorizationHeader,
   normalizeExecutorServerConnection,
+  normalizeExecutorServerOrigin,
   type ExecutorLocalServerKind,
   type ExecutorLocalServerManifest,
   type ExecutorServerConnection,
   type ExecutorServerConnectionInput,
 } from "@executor-js/sdk/shared";
+import {
+  decodeAccessTokenClaims,
+  discoverCliLogin,
+  openBrowser,
+  pollForDeviceTokens,
+  refreshDeviceTokens,
+  requestDeviceCode,
+} from "./device-login";
 import {
   startServer,
   runMcpStdioServer,
@@ -587,6 +596,59 @@ const resolveRequestedExecutorServerConnection = (
     };
   });
 
+// Refresh an `oauth` (device-login) credential a minute before it expires, so
+// `executor call` against a hosted server keeps working long after the browser
+// login. The refreshed tokens are written back to the originating profile.
+const OAUTH_REFRESH_SKEW_SECONDS = 60;
+
+const profileNameFromKey = (key: string): string | null =>
+  key.startsWith("profile:") ? key.slice("profile:".length) : null;
+
+const refreshOAuthConnection = (
+  connection: ExecutorServerConnection,
+): Effect.Effect<ExecutorServerConnection, never, FileSystem.FileSystem | PlatformPath.Path> =>
+  Effect.gen(function* () {
+    const auth = connection.auth;
+    if (!auth || auth.kind !== "oauth") return connection;
+    const now = Math.floor(Date.now() / 1000);
+    if (auth.expiresAt && auth.expiresAt - now > OAUTH_REFRESH_SKEW_SECONDS) return connection;
+    // Destructure so the narrowed string types survive into the deferred
+    // `tryPromise` callback (where TS would otherwise re-widen the fields).
+    const { refreshToken, tokenEndpoint, clientId } = auth;
+    if (!refreshToken || !tokenEndpoint || !clientId) return connection;
+
+    const refreshed = yield* Effect.tryPromise({
+      try: () => refreshDeviceTokens({ tokenEndpoint, clientId, refreshToken }),
+      catch: toError,
+      // On a failed refresh, keep the existing token and let the eventual 401
+      // surface — better than blocking the command on a transient hiccup.
+    }).pipe(Effect.option);
+    if (Option.isNone(refreshed)) return connection;
+
+    const next = refreshed.value;
+    const nextConnection = normalizeExecutorServerConnection({
+      ...connection,
+      auth: {
+        kind: "oauth",
+        accessToken: next.accessToken,
+        refreshToken: next.refreshToken ?? refreshToken,
+        ...(next.expiresAt ? { expiresAt: next.expiresAt } : {}),
+        tokenEndpoint,
+        clientId,
+      },
+    });
+
+    const profileName = profileNameFromKey(connection.key);
+    if (profileName) {
+      yield* upsertCliServerConnectionProfile({
+        name: profileName,
+        connection: nextConnection,
+        makeDefault: false,
+      }).pipe(Effect.ignore);
+    }
+    return nextConnection;
+  });
+
 const resolveExecutorServerConnection = (
   target: ServerTarget,
 ): Effect.Effect<ExecutorServerConnection, Error, FileSystem.FileSystem | PlatformPath.Path> =>
@@ -612,7 +674,7 @@ const resolveExecutorServerConnection = (
       );
     }
 
-    const requested = decision.connection;
+    const requested = yield* refreshOAuthConnection(decision.connection);
     if (decision.kind === "use-active") return requested;
 
     if (!canAutoStartCliServerConnection(requested)) {
@@ -1995,6 +2057,208 @@ const serverCommand = Command.make("server").pipe(
   Command.withDescription("Manage named Executor server profiles"),
 );
 
+const deriveLoginProfileName = (origin: string): string => {
+  try {
+    const host = new URL(origin).hostname;
+    const first = host.split(".")[0];
+    return validateCliServerConnectionProfileName(first && first.length > 0 ? first : host);
+  } catch {
+    return "server";
+  }
+};
+
+const resolveLoginTarget = (input: {
+  readonly baseUrl: Option.Option<string>;
+  readonly server: Option.Option<string>;
+  readonly name: Option.Option<string>;
+}): Effect.Effect<
+  { readonly origin: string; readonly profileName: string },
+  Error,
+  FileSystem.FileSystem | PlatformPath.Path
+> =>
+  Effect.gen(function* () {
+    const baseUrl = Option.getOrUndefined(input.baseUrl);
+    const serverName = Option.getOrUndefined(input.server);
+    const explicitName = Option.getOrUndefined(input.name);
+    if (baseUrl && serverName) {
+      return yield* Effect.fail(new Error("Use either --server or --base-url, not both."));
+    }
+    if (serverName) {
+      const store = yield* readCliServerConnectionStore();
+      const profile = findCliServerConnectionProfile(store, serverName);
+      if (!profile)
+        return yield* Effect.fail(new Error(`No server profile named "${serverName}".`));
+      return {
+        origin: profile.connection.origin,
+        profileName: explicitName
+          ? validateCliServerConnectionProfileName(explicitName)
+          : profile.name,
+      };
+    }
+    if (baseUrl) {
+      const origin = normalizeExecutorServerOrigin(baseUrl);
+      return {
+        origin,
+        profileName: explicitName
+          ? validateCliServerConnectionProfileName(explicitName)
+          : deriveLoginProfileName(origin),
+      };
+    }
+    const store = yield* readCliServerConnectionStore();
+    const profile = defaultCliServerConnectionProfile(store);
+    if (profile) {
+      return {
+        origin: profile.connection.origin,
+        profileName: explicitName
+          ? validateCliServerConnectionProfileName(explicitName)
+          : profile.name,
+      };
+    }
+    return yield* Effect.fail(
+      new Error(
+        "No server to log in to. Pass --base-url <https://your-host> or --server <profile>.",
+      ),
+    );
+  });
+
+const loginNameOption = Options.string("name").pipe(
+  Options.optional,
+  Options.withDescription("Profile name to save the login under."),
+);
+
+const noBrowserOption = Options.boolean("no-browser").pipe(
+  Options.withDefault(false),
+  Options.withDescription("Print the verification URL instead of opening a browser."),
+);
+
+const loginCommand = Command.make(
+  "login",
+  {
+    baseUrl: serverBaseUrl,
+    server: serverProfile,
+    name: loginNameOption,
+    noBrowser: noBrowserOption,
+  },
+  ({ baseUrl, server, name, noBrowser }) =>
+    Effect.gen(function* () {
+      const selected = yield* resolveLoginTarget({ baseUrl, server, name });
+      const discovery = yield* Effect.tryPromise({
+        try: () => discoverCliLogin(selected.origin),
+        catch: toError,
+      });
+      const grant = yield* Effect.tryPromise({
+        try: () => requestDeviceCode(discovery),
+        catch: toError,
+      });
+      const verifyUrl = grant.verificationUriComplete ?? grant.verificationUri;
+      console.log("");
+      console.log(`To sign in, open:  ${verifyUrl}`);
+      console.log(`and confirm the code:  ${grant.userCode}`);
+      console.log("");
+      if (!noBrowser) openBrowser(verifyUrl);
+      console.log("Waiting for you to approve in the browser...");
+      const tokens = yield* Effect.tryPromise({
+        try: () => pollForDeviceTokens(discovery, grant),
+        catch: toError,
+      });
+      yield* upsertCliServerConnectionProfile({
+        name: selected.profileName,
+        connection: {
+          kind: "http",
+          origin: selected.origin,
+          auth: {
+            kind: "oauth",
+            accessToken: tokens.accessToken,
+            ...(tokens.refreshToken ? { refreshToken: tokens.refreshToken } : {}),
+            ...(tokens.expiresAt ? { expiresAt: tokens.expiresAt } : {}),
+            tokenEndpoint: discovery.tokenEndpoint,
+            clientId: discovery.clientId,
+          },
+        },
+        makeDefault: true,
+      });
+      const claims = decodeAccessTokenClaims(tokens.accessToken);
+      console.log("");
+      console.log(
+        `Logged in to ${selected.origin} (profile "${selected.profileName}", now the default).`,
+      );
+      const email = claims?.email;
+      const org = claims?.org_id;
+      const sub = claims?.sub;
+      if (typeof email === "string") console.log(`Email: ${email}`);
+      if (typeof org === "string") console.log(`Organization: ${org}`);
+      else if (typeof sub === "string") console.log(`User: ${sub}`);
+    }),
+).pipe(Command.withDescription("Sign in to a hosted Executor server in the browser (device flow)"));
+
+const logoutCommand = Command.make(
+  "logout",
+  { baseUrl: serverBaseUrl, server: serverProfile },
+  ({ baseUrl, server }) =>
+    Effect.gen(function* () {
+      const selected = yield* resolveLoginTarget({ baseUrl, server, name: Option.none() });
+      const store = yield* readCliServerConnectionStore();
+      const profile = findCliServerConnectionProfile(store, selected.profileName);
+      if (!profile) {
+        console.log(`No server profile named "${selected.profileName}".`);
+        return;
+      }
+      if (!profile.connection.auth) {
+        console.log(`Profile "${profile.name}" has no stored credentials.`);
+        return;
+      }
+      yield* upsertCliServerConnectionProfile({
+        name: profile.name,
+        connection: {
+          kind: profile.connection.kind,
+          origin: profile.connection.origin,
+          displayName: profile.connection.displayName,
+        },
+        makeDefault: store.defaultProfile === profile.name,
+      });
+      console.log(
+        `Logged out of ${profile.connection.origin} (cleared credentials for "${profile.name}").`,
+      );
+    }),
+).pipe(Command.withDescription("Clear stored credentials for a server profile"));
+
+const whoamiCommand = Command.make(
+  "whoami",
+  { baseUrl: serverBaseUrl, server: serverProfile },
+  ({ baseUrl, server }) =>
+    Effect.gen(function* () {
+      const requested = yield* resolveRequestedExecutorServerConnection(
+        serverTargetFromOptions({ baseUrl, server }),
+      );
+      const connection = yield* refreshOAuthConnection(requested.connection);
+      const auth = connection.auth;
+      console.log(`Server: ${connection.origin}`);
+      if (!auth) {
+        console.log("Not logged in (no stored credentials).");
+        return;
+      }
+      if (auth.kind === "oauth") {
+        const claims = decodeAccessTokenClaims(auth.accessToken);
+        const email = claims?.email;
+        const sub = claims?.sub;
+        const org = claims?.org_id;
+        if (typeof email === "string") console.log(`Email: ${email}`);
+        if (typeof sub === "string") console.log(`User: ${sub}`);
+        if (typeof org === "string") console.log(`Organization: ${org}`);
+        if (auth.expiresAt) {
+          const remaining = auth.expiresAt - Math.floor(Date.now() / 1000);
+          console.log(
+            remaining > 0
+              ? `Token valid for ~${Math.round(remaining / 60)} min.`
+              : "Token expired (refreshes on next use).",
+          );
+        }
+        return;
+      }
+      console.log(`Authenticated via ${auth.kind}.`);
+    }),
+).pipe(Command.withDescription("Show who you're signed in as on a server"));
+
 const webCommand = Command.make(
   "web",
   {
@@ -2562,6 +2826,9 @@ const root = Command.make("executor").pipe(
     resumeCommand,
     toolsCommand,
     installCommand,
+    loginCommand,
+    logoutCommand,
+    whoamiCommand,
     serverCommand,
     webCommand,
     daemonCommand,

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -147,6 +147,7 @@ import {
   setDefaultCliServerConnectionProfile,
   upsertCliServerConnectionProfile,
   validateCliServerConnectionProfileName,
+  type CliServerConnectionStore,
 } from "./server-profile";
 import {
   buildResumeContentTemplate,
@@ -2057,29 +2058,77 @@ const serverCommand = Command.make("server").pipe(
   Command.withDescription("Manage named Executor server profiles"),
 );
 
-const deriveLoginProfileName = (origin: string): string => {
+const loginHostLabel = (origin: string): string => {
   try {
     const host = new URL(origin).hostname;
     const first = host.split(".")[0];
-    return validateCliServerConnectionProfileName(first && first.length > 0 ? first : host);
+    return first && first.length > 0 ? first : host;
   } catch {
     return "server";
   }
 };
 
-const resolveLoginTarget = (input: {
+const sanitizeProfileName = (raw: string): string => {
+  const cleaned = raw
+    .trim()
+    .replace(/[^A-Za-z0-9_.-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned.length > 0 ? cleaned : "server";
+};
+
+// The (origin, user, org) a stored oauth profile authenticates as — lets us
+// recognize a re-login to the SAME account (update in place) versus a
+// different account on the same host (needs its own profile).
+const oauthAccountIdentity = (connection: ExecutorServerConnection): string | null => {
+  const auth = connection.auth;
+  if (!auth || auth.kind !== "oauth") return null;
+  const claims = decodeAccessTokenClaims(auth.accessToken);
+  const sub = typeof claims?.sub === "string" ? claims.sub : undefined;
+  const org = typeof claims?.org_id === "string" ? claims.org_id : undefined;
+  return sub && org ? `${connection.origin}|${sub}|${org}` : null;
+};
+
+// Name a login's profile by the ACCOUNT it authenticates (email, falling back
+// to user id), not the hostname — so two accounts on the same server get
+// distinct profiles instead of clobbering each other (the way opencode keys
+// accounts by email/url). A re-login to the same account reuses its profile.
+const chooseLoginProfileName = (
+  store: CliServerConnectionStore,
+  account: {
+    readonly origin: string;
+    readonly sub?: string;
+    readonly org?: string;
+    readonly email?: string;
+  },
+): string => {
+  const identity =
+    account.sub && account.org ? `${account.origin}|${account.sub}|${account.org}` : null;
+  if (identity) {
+    const existing = store.profiles.find((p) => oauthAccountIdentity(p.connection) === identity);
+    if (existing) return existing.name;
+  }
+  const base = sanitizeProfileName(account.email ?? account.sub ?? loginHostLabel(account.origin));
+  if (!store.profiles.some((p) => p.name === base)) return base;
+  for (let suffix = 2; ; suffix += 1) {
+    const candidate = `${base}-${suffix}`;
+    if (!store.profiles.some((p) => p.name === candidate)) return candidate;
+  }
+};
+
+// Resolve which server a login/logout targets: an existing profile (--server
+// or the default) or a bare origin (--base-url). The profile name is decided
+// later, from the authenticated account.
+const resolveLoginOrigin = (input: {
   readonly baseUrl: Option.Option<string>;
   readonly server: Option.Option<string>;
-  readonly name: Option.Option<string>;
 }): Effect.Effect<
-  { readonly origin: string; readonly profileName: string },
+  { readonly origin: string; readonly profile: ReturnType<typeof findCliServerConnectionProfile> },
   Error,
   FileSystem.FileSystem | PlatformPath.Path
 > =>
   Effect.gen(function* () {
     const baseUrl = Option.getOrUndefined(input.baseUrl);
     const serverName = Option.getOrUndefined(input.server);
-    const explicitName = Option.getOrUndefined(input.name);
     if (baseUrl && serverName) {
       return yield* Effect.fail(new Error("Use either --server or --base-url, not both."));
     }
@@ -2088,32 +2137,14 @@ const resolveLoginTarget = (input: {
       const profile = findCliServerConnectionProfile(store, serverName);
       if (!profile)
         return yield* Effect.fail(new Error(`No server profile named "${serverName}".`));
-      return {
-        origin: profile.connection.origin,
-        profileName: explicitName
-          ? validateCliServerConnectionProfileName(explicitName)
-          : profile.name,
-      };
+      return { origin: profile.connection.origin, profile };
     }
     if (baseUrl) {
-      const origin = normalizeExecutorServerOrigin(baseUrl);
-      return {
-        origin,
-        profileName: explicitName
-          ? validateCliServerConnectionProfileName(explicitName)
-          : deriveLoginProfileName(origin),
-      };
+      return { origin: normalizeExecutorServerOrigin(baseUrl), profile: null };
     }
     const store = yield* readCliServerConnectionStore();
     const profile = defaultCliServerConnectionProfile(store);
-    if (profile) {
-      return {
-        origin: profile.connection.origin,
-        profileName: explicitName
-          ? validateCliServerConnectionProfileName(explicitName)
-          : profile.name,
-      };
-    }
+    if (profile) return { origin: profile.connection.origin, profile };
     return yield* Effect.fail(
       new Error(
         "No server to log in to. Pass --base-url <https://your-host> or --server <profile>.",
@@ -2123,7 +2154,7 @@ const resolveLoginTarget = (input: {
 
 const loginNameOption = Options.string("name").pipe(
   Options.optional,
-  Options.withDescription("Profile name to save the login under."),
+  Options.withDescription("Profile name to save the login under (defaults to your account)."),
 );
 
 const noBrowserOption = Options.boolean("no-browser").pipe(
@@ -2141,9 +2172,10 @@ const loginCommand = Command.make(
   },
   ({ baseUrl, server, name, noBrowser }) =>
     Effect.gen(function* () {
-      const selected = yield* resolveLoginTarget({ baseUrl, server, name });
+      const target = yield* resolveLoginOrigin({ baseUrl, server });
+      const explicitName = Option.getOrUndefined(name);
       const discovery = yield* Effect.tryPromise({
-        try: () => discoverCliLogin(selected.origin),
+        try: () => discoverCliLogin(target.origin),
         catch: toError,
       });
       const grant = yield* Effect.tryPromise({
@@ -2161,11 +2193,28 @@ const loginCommand = Command.make(
         try: () => pollForDeviceTokens(discovery, grant),
         catch: toError,
       });
+
+      const claims = decodeAccessTokenClaims(tokens.accessToken);
+      const sub = typeof claims?.sub === "string" ? claims.sub : undefined;
+      const org =
+        tokens.organizationId ?? (typeof claims?.org_id === "string" ? claims.org_id : undefined);
+      const email = tokens.email;
+
+      // Name by account so a different account on the same host doesn't clobber
+      // an existing login; --server / the default profile / --name pin it.
+      const store = yield* readCliServerConnectionStore();
+      const profileName = explicitName
+        ? validateCliServerConnectionProfileName(explicitName)
+        : target.profile
+          ? target.profile.name
+          : chooseLoginProfileName(store, { origin: target.origin, sub, org, email });
+
       yield* upsertCliServerConnectionProfile({
-        name: selected.profileName,
+        name: profileName,
         connection: {
           kind: "http",
-          origin: selected.origin,
+          origin: target.origin,
+          ...(email ? { displayName: email } : {}),
           auth: {
             kind: "oauth",
             accessToken: tokens.accessToken,
@@ -2177,17 +2226,12 @@ const loginCommand = Command.make(
         },
         makeDefault: true,
       });
-      const claims = decodeAccessTokenClaims(tokens.accessToken);
+
       console.log("");
-      console.log(
-        `Logged in to ${selected.origin} (profile "${selected.profileName}", now the default).`,
-      );
-      const email = claims?.email;
-      const org = claims?.org_id;
-      const sub = claims?.sub;
-      if (typeof email === "string") console.log(`Email: ${email}`);
-      if (typeof org === "string") console.log(`Organization: ${org}`);
-      else if (typeof sub === "string") console.log(`User: ${sub}`);
+      console.log(`Logged in to ${target.origin} (profile "${profileName}", now the default).`);
+      if (email) console.log(`Account: ${email}`);
+      if (org) console.log(`Organization: ${org}`);
+      else if (sub) console.log(`User: ${sub}`);
     }),
 ).pipe(Command.withDescription("Sign in to a hosted Executor server in the browser (device flow)"));
 
@@ -2196,11 +2240,13 @@ const logoutCommand = Command.make(
   { baseUrl: serverBaseUrl, server: serverProfile },
   ({ baseUrl, server }) =>
     Effect.gen(function* () {
-      const selected = yield* resolveLoginTarget({ baseUrl, server, name: Option.none() });
+      const target = yield* resolveLoginOrigin({ baseUrl, server });
       const store = yield* readCliServerConnectionStore();
-      const profile = findCliServerConnectionProfile(store, selected.profileName);
+      // --server / default give the profile directly; --base-url matches by origin.
+      const profile =
+        target.profile ?? store.profiles.find((p) => p.connection.origin === target.origin) ?? null;
       if (!profile) {
-        console.log(`No server profile named "${selected.profileName}".`);
+        console.log(`No stored login for ${target.origin}.`);
         return;
       }
       if (!profile.connection.auth) {
@@ -2239,10 +2285,11 @@ const whoamiCommand = Command.make(
       }
       if (auth.kind === "oauth") {
         const claims = decodeAccessTokenClaims(auth.accessToken);
-        const email = claims?.email;
         const sub = claims?.sub;
         const org = claims?.org_id;
-        if (typeof email === "string") console.log(`Email: ${email}`);
+        // The email lives on the profile's displayName (WorkOS access tokens
+        // don't carry an email claim); the token carries sub + org_id.
+        if (connection.displayName.includes("@")) console.log(`Account: ${connection.displayName}`);
         if (typeof sub === "string") console.log(`User: ${sub}`);
         if (typeof org === "string") console.log(`Organization: ${org}`);
         if (auth.expiresAt) {

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -622,7 +622,7 @@ const refreshOAuthConnection = (
       try: () => refreshDeviceTokens({ tokenEndpoint, clientId, refreshToken }),
       catch: toError,
       // On a failed refresh, keep the existing token and let the eventual 401
-      // surface — better than blocking the command on a transient hiccup.
+      // surface, better than blocking the command on a transient hiccup.
     }).pipe(Effect.option);
     if (Option.isNone(refreshed)) return connection;
 
@@ -682,7 +682,7 @@ const resolveExecutorServerConnection = (
       // An authenticated remote connection (oauth device-login, bearer key, or
       // basic password): use it directly. The /api/health liveness probe is only
       // a gate for the local auto-start decision and isn't necessarily exposed
-      // by hosted servers — the real API call surfaces any connectivity/auth
+      // by hosted servers, the real API call surfaces any connectivity/auth
       // error with proper context.
       if (requested.auth) return requested;
       if (yield* isServerReachable(requested.origin)) {
@@ -2082,7 +2082,7 @@ const sanitizeProfileName = (raw: string): string => {
   return cleaned.length > 0 ? cleaned : "server";
 };
 
-// The (origin, user, org) a stored oauth profile authenticates as — lets us
+// The (origin, user, org) a stored oauth profile authenticates as, lets us
 // recognize a re-login to the SAME account (update in place) versus a
 // different account on the same host (needs its own profile).
 const oauthAccountIdentity = (connection: ExecutorServerConnection): string | null => {
@@ -2095,7 +2095,7 @@ const oauthAccountIdentity = (connection: ExecutorServerConnection): string | nu
 };
 
 // Name a login's profile by the ACCOUNT it authenticates (email, falling back
-// to user id), not the hostname — so two accounts on the same server get
+// to user id), not the hostname, so two accounts on the same server get
 // distinct profiles instead of clobbering each other (the way opencode keys
 // accounts by email/url). A re-login to the same account reuses its profile.
 const chooseLoginProfileName = (

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -679,6 +679,12 @@ const resolveExecutorServerConnection = (
     if (decision.kind === "use-active") return requested;
 
     if (!canAutoStartCliServerConnection(requested)) {
+      // An authenticated remote connection (oauth device-login, bearer key, or
+      // basic password): use it directly. The /api/health liveness probe is only
+      // a gate for the local auto-start decision and isn't necessarily exposed
+      // by hosted servers — the real API call surfaces any connectivity/auth
+      // error with proper context.
+      if (requested.auth) return requested;
       if (yield* isServerReachable(requested.origin)) {
         return requested;
       }

--- a/apps/cli/src/server-connection.ts
+++ b/apps/cli/src/server-connection.ts
@@ -43,8 +43,10 @@ export const withCliServerAuthFallback = (
 
 export const canAutoStartCliServerConnection = (connection: ExecutorServerConnection): boolean => {
   if (connection.kind !== "http") return false;
-  // Explicit auth means the user is pointing at an existing server (e.g. a
-  // desktop sidecar or a remote), not asking us to spin up a local daemon.
+  // A stored credential (basic password, bearer key, or an oauth device-login
+  // token) means the user is targeting an EXISTING authenticated server — never
+  // spawn a local daemon for it, even when it happens to be on http://localhost
+  // (e.g. a hosted server reached over a tunnel, or a local e2e cloud server).
   if (connection.auth) return false;
   const url = new URL(connection.origin);
   return url.protocol === "http:" && canAutoStartLocalDaemonForHost(url.hostname);

--- a/apps/cli/src/server-connection.ts
+++ b/apps/cli/src/server-connection.ts
@@ -44,7 +44,7 @@ export const withCliServerAuthFallback = (
 export const canAutoStartCliServerConnection = (connection: ExecutorServerConnection): boolean => {
   if (connection.kind !== "http") return false;
   // A stored credential (basic password, bearer key, or an oauth device-login
-  // token) means the user is targeting an EXISTING authenticated server — never
+  // token) means the user is targeting an EXISTING authenticated server, never
   // spawn a local daemon for it, even when it happens to be on http://localhost
   // (e.g. a hosted server reached over a tunnel, or a local e2e cloud server).
   if (connection.auth) return false;

--- a/apps/cli/src/server-profile.ts
+++ b/apps/cli/src/server-profile.ts
@@ -52,6 +52,14 @@ const PersistedAuth = Schema.Union([
     kind: Schema.Literal("bearer"),
     token: Schema.String,
   }),
+  Schema.Struct({
+    kind: Schema.Literal("oauth"),
+    accessToken: Schema.String,
+    refreshToken: Schema.optional(Schema.String),
+    expiresAt: Schema.optional(Schema.Number),
+    tokenEndpoint: Schema.optional(Schema.String),
+    clientId: Schema.optional(Schema.String),
+  }),
 ]);
 
 const PersistedConnection = Schema.Struct({

--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Layer } from "effect";
+import { SignJWT, createLocalJWKSet, exportJWK, generateKeyPair } from "jose";
+
+import { ApiKeyService } from "../auth/api-keys";
+import { UserStoreService } from "../auth/context";
+import type { JwtBearerConfig } from "../auth/workos-auth-provider";
+import { WorkOSClient, type WorkOSClientService } from "../auth/workos";
+import { resolveProtectedPrincipal } from "./protected";
+
+const createdAt = new Date("2026-01-01T00:00:00.000Z");
+const issuer = "https://test-authkit.example.com";
+const audience = "client_test_audience";
+
+// A WorkOS access-token JWT verifier backed by a local RS256 key pair (no
+// network), plus a signer that mints tokens for it. Mirrors
+// `mcp/mcp-auth.node.test.ts`.
+const makeJwt = async () => {
+  const { publicKey, privateKey } = await generateKeyPair("RS256");
+  const jwk = await exportJWK(publicKey);
+  const jwks = createLocalJWKSet({ keys: [{ ...jwk, kid: "test-key" }] });
+  const config: JwtBearerConfig = { jwks, issuer, audience };
+  const sign = (claims: Record<string, unknown>, expiration: string | number = "5m") =>
+    new SignJWT(claims)
+      .setProtectedHeader({ alg: "RS256", kid: "test-key" })
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setSubject("user_123")
+      .setIssuedAt()
+      .setExpirationTime(expiration)
+      .sign(privateKey);
+  return { config, sign };
+};
+
+// The api-key path must never run for a JWT bearer — die loudly if it does.
+const stubApiKeys = Layer.succeed(ApiKeyService)({
+  validate: () => Effect.die("JWT bearer must not hit ApiKeyService.validate"),
+  listUserKeys: () => Effect.succeed([]),
+  createUserKey: () => Effect.die("JWT auth test does not create API keys"),
+  revokeUserKey: () => Effect.void,
+});
+
+const stubWorkOS = Layer.succeed(
+  WorkOSClient,
+  new Proxy({} as WorkOSClientService, {
+    get: (_target, prop) => {
+      if (prop === "listUserMemberships") {
+        return (userId: string) =>
+          Effect.succeed({
+            data:
+              userId === "user_123"
+                ? [{ userId, organizationId: "org_123", status: "active" }]
+                : [],
+          });
+      }
+      return () => Effect.die(`unexpected WorkOSClient.${String(prop)} call`);
+    },
+  }),
+);
+
+const stubUsers = Layer.succeed(UserStoreService)({
+  use: (fn) =>
+    Effect.promise(() =>
+      fn({
+        ensureAccount: async (id: string) => ({ id, createdAt }),
+        getAccount: async (id: string) => ({ id, createdAt }),
+        upsertOrganization: async (org: { id: string; name: string }) => ({ ...org, createdAt }),
+        getOrganization: async (id: string) => ({ id, name: `Org ${id}`, createdAt }),
+      }),
+    ),
+});
+
+const run = (request: Request, jwt: JwtBearerConfig) =>
+  resolveProtectedPrincipal(request, jwt).pipe(
+    Effect.provide(Layer.mergeAll(stubApiKeys, stubWorkOS, stubUsers)),
+  );
+
+const request = (token: string) =>
+  new Request("https://executor.test/api/tools", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+describe("protected JWT (device-login) auth", () => {
+  it.effect("resolves a valid WorkOS access token into protected identity", () =>
+    Effect.gen(function* () {
+      const { config, sign } = yield* Effect.promise(() => makeJwt());
+      const token = yield* Effect.promise(() => sign({ org_id: "org_123" }));
+
+      const identity = yield* run(request(token), config);
+
+      expect(identity).toEqual({
+        accountId: "user_123",
+        organizationId: "org_123",
+        organizationName: "Org org_123",
+        email: "",
+        name: null,
+        avatarUrl: null,
+        roles: [],
+      });
+    }),
+  );
+
+  it.effect("rejects an expired access token as Unauthorized", () =>
+    Effect.gen(function* () {
+      const { config, sign } = yield* Effect.promise(() => makeJwt());
+      // Expired one hour ago.
+      const token = yield* Effect.promise(() =>
+        sign({ org_id: "org_123" }, Math.floor(Date.now() / 1000) - 3600),
+      );
+
+      const error = yield* Effect.flip(run(request(token), config));
+
+      expect(error).toMatchObject({
+        _tag: "Unauthorized",
+        code: "invalid_access_token",
+      });
+    }),
+  );
+
+  it.effect("rejects a token signed by a different key as Unauthorized", () =>
+    Effect.gen(function* () {
+      const { config } = yield* Effect.promise(() => makeJwt());
+      const other = yield* Effect.promise(() => makeJwt());
+      const token = yield* Effect.promise(() => other.sign({ org_id: "org_123" }));
+
+      const error = yield* Effect.flip(run(request(token), config));
+
+      expect(error).toMatchObject({ _tag: "Unauthorized", code: "invalid_access_token" });
+    }),
+  );
+
+  it.effect("rejects a token with no org_id as NoOrganization", () =>
+    Effect.gen(function* () {
+      const { config, sign } = yield* Effect.promise(() => makeJwt());
+      const token = yield* Effect.promise(() => sign({}));
+
+      const error = yield* Effect.flip(run(request(token), config));
+
+      expect(error).toMatchObject({ _tag: "NoOrganization", code: "no_organization" });
+    }),
+  );
+
+  it.effect("rejects a valid token whose org membership is not active", () =>
+    Effect.gen(function* () {
+      const { config, sign } = yield* Effect.promise(() => makeJwt());
+      // org_999 is not in the membership stub -> not authorized.
+      const token = yield* Effect.promise(() => sign({ org_id: "org_999" }));
+
+      const error = yield* Effect.flip(run(request(token), config));
+
+      expect(error).toMatchObject({ _tag: "NoOrganization", code: "no_organization" });
+    }),
+  );
+});

--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -32,7 +32,7 @@ const makeJwt = async () => {
   return { config, sign };
 };
 
-// The api-key path must never run for a JWT bearer — die loudly if it does.
+// The api-key path must never run for a JWT bearer, die loudly if it does.
 const stubApiKeys = Layer.succeed(ApiKeyService)({
   validate: () => Effect.die("JWT bearer must not hit ApiKeyService.validate"),
   listUserKeys: () => Effect.succeed([]),

--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -64,8 +64,23 @@ const stubUsers = Layer.succeed(UserStoreService)({
       fn({
         ensureAccount: async (id: string) => ({ id, createdAt }),
         getAccount: async (id: string) => ({ id, createdAt }),
-        upsertOrganization: async (org: { id: string; name: string }) => ({ ...org, createdAt }),
-        getOrganization: async (id: string) => ({ id, name: `Org ${id}`, createdAt }),
+        upsertOrganization: async (org: { id: string; name: string }) => ({
+          ...org,
+          slug: `org-slug-${org.id}`,
+          createdAt,
+        }),
+        getOrganization: async (id: string) => ({
+          id,
+          name: `Org ${id}`,
+          slug: `org-slug-${id}`,
+          createdAt,
+        }),
+        getOrganizationBySlug: async (slug: string) => ({
+          id: "org_by_slug",
+          name: `Org ${slug}`,
+          slug,
+          createdAt,
+        }),
       }),
     ),
 });

--- a/apps/cloud/src/auth/api-jwt-bearer.ts
+++ b/apps/cloud/src/auth/api-jwt-bearer.ts
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------
+// The `/api/*` plane's WorkOS JWT bearer config.
+//
+// The protected HTTP API accepts THREE credential forms on the `Authorization`
+// header, in this precedence: a WorkOS access-token JWT (CLI device-login,
+// `executor login`), then a WorkOS API key, then — with no header — the
+// sealed-session cookie. This module supplies the JWT-verification config
+// (JWKS + issuer + audience) the JWT branch needs.
+//
+// It mirrors the MCP plane's setup (`mcp/auth.ts`): the SAME AuthKit JWKS,
+// issuer (`MCP_AUTHKIT_DOMAIN`), and audience (`WORKOS_CLIENT_ID`). A device
+// access token minted by AuthKit is byte-for-byte the same kind of token the
+// MCP plane already verifies, so a CLI can hold ONE credential for both planes.
+//
+// This is the `cloudflare:workers`-reading leaf; `workos-auth-provider.ts`
+// stays env-free and receives this config as a plain value, so its node-pool
+// resolver tests can inject a local JWKS instead.
+// ---------------------------------------------------------------------------
+
+import { env } from "cloudflare:workers";
+
+import { createCachedRemoteJWKSet } from "./jwks-cache";
+import type { JwtBearerConfig } from "./workos-auth-provider";
+
+const AUTHKIT_DOMAIN = env.MCP_AUTHKIT_DOMAIN ?? "https://signin.executor.sh";
+
+// Module-scope cache, same rationale as `mcp/auth.ts`: one JWKS fetch per
+// isolate-hour rather than one per cold isolate. The two caches (here + MCP)
+// are independent module scopes hitting the same upstream; the 1h TTL keeps
+// the duplication cheap.
+export const workosApiJwtBearerConfig: JwtBearerConfig = {
+  jwks: createCachedRemoteJWKSet(new URL(`${AUTHKIT_DOMAIN}/oauth2/jwks`)),
+  issuer: AUTHKIT_DOMAIN,
+  audience: env.WORKOS_CLIENT_ID,
+};

--- a/apps/cloud/src/auth/api-jwt-bearer.ts
+++ b/apps/cloud/src/auth/api-jwt-bearer.ts
@@ -3,7 +3,7 @@
 //
 // The protected HTTP API accepts THREE credential forms on the `Authorization`
 // header, in this precedence: a WorkOS access-token JWT (CLI device-login,
-// `executor login`), then a WorkOS API key, then — with no header — the
+// `executor login`), then a WorkOS API key, then, with no header, the
 // sealed-session cookie. This module supplies the JWT-verification config
 // (JWKS + issuer + audience) the JWT branch needs.
 //

--- a/apps/cloud/src/auth/api.ts
+++ b/apps/cloud/src/auth/api.ts
@@ -44,6 +44,17 @@ const CreateOrganizationResponse = Schema.Struct({
   slug: Schema.String,
 });
 
+// CLI device-login discovery (`executor login`). Tells the CLI where to run
+// the OAuth 2.0 Device Authorization Grant (RFC 8628) and which public client
+// to use. The CLI hits these provider endpoints directly, gets a WorkOS access
+// token (a JWT), and sends it as a Bearer to the `/api/*` plane.
+const CliLoginResponse = Schema.Struct({
+  provider: Schema.Literal("workos"),
+  deviceAuthorizationEndpoint: Schema.String,
+  tokenEndpoint: Schema.String,
+  clientId: Schema.String,
+});
+
 // `state` is optional — some WorkOS-initiated redirects arrive at the
 // callback without the state we set on /auth/login. The CSRF check is
 // only enforced when state is present (see callback handler).
@@ -156,7 +167,8 @@ export class CloudAuthPublicApi extends HttpApiGroup.make("cloudAuthPublic")
       query: AuthCallbackSearch,
       error: AuthErrors,
     }),
-  ) {}
+  )
+  .add(HttpApiEndpoint.get("cliLogin", "/auth/cli-login", { success: CliLoginResponse })) {}
 
 /** Session auth endpoints — require a logged-in user, may not have an org */
 export class CloudAuthApi extends HttpApiGroup.make("cloudAuth")

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -238,7 +238,7 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
         }),
       )
       // CLI device-login discovery. The WorkOS device endpoints live on the
-      // WorkOS API host (`WORKOS_API_URL`, or api.workos.com in production —
+      // WorkOS API host (`WORKOS_API_URL`, or api.workos.com in production,
       // the SAME base the SDK uses, so e2e points the CLI at the emulator with
       // zero extra wiring). The CLI runs RFC 8628 against them as a public
       // client (no secret) and gets a WorkOS access-token JWT back.

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -236,6 +236,22 @@ export const CloudAuthPublicHandlers = HttpApiBuilder.group(
             STATE_COOKIE,
           );
         }),
+      )
+      // CLI device-login discovery. The WorkOS device endpoints live on the
+      // WorkOS API host (`WORKOS_API_URL`, or api.workos.com in production —
+      // the SAME base the SDK uses, so e2e points the CLI at the emulator with
+      // zero extra wiring). The CLI runs RFC 8628 against them as a public
+      // client (no secret) and gets a WorkOS access-token JWT back.
+      .handle("cliLogin", () =>
+        Effect.sync(() => {
+          const base = (env.WORKOS_API_URL ?? "https://api.workos.com").replace(/\/+$/, "");
+          return {
+            provider: "workos" as const,
+            deviceAuthorizationEndpoint: `${base}/user_management/authorize/device`,
+            tokenEndpoint: `${base}/user_management/authenticate`,
+            clientId: env.WORKOS_CLIENT_ID,
+          };
+        }),
       ),
 );
 

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -107,7 +107,7 @@ const looksLikeJwt = (token: string): boolean => token.split(".").length === 3;
 /**
  * Resolve a WorkOS access-token JWT (CLI `executor login`) into a protected
  * `Principal`. Verifies the token against AuthKit's JWKS (issuer + audience),
- * then live-checks org membership — exactly like the api-key path. The
+ * then live-checks org membership, exactly like the api-key path. The
  * `org_id` claim must be present (a token with no org context is rejected as
  * `NoOrganization`). Mirrors the MCP plane's JWT verify, reusing the same
  * `cloudflare:workers`-free verifier so a CLI holds ONE credential for both
@@ -151,7 +151,7 @@ const resolveJwtPrincipal = (token: string, jwt: JwtBearerConfig) =>
  * Resolve a `Bearer` credential into a `Principal`: a WorkOS access-token JWT
  * (when `jwt` config is supplied and the value looks like a JWT) or a WorkOS
  * API key. Returns `null` when there is no `Authorization` header, so the
- * caller falls through to the sealed-session path. (Kept the historical name —
+ * caller falls through to the sealed-session path. (Kept the historical name,
  * the re-export and resolver tests reference it.)
  */
 export const resolveApiKeyPrincipal = (request: Request, jwt: JwtBearerConfig | null = null) =>

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -29,6 +29,7 @@
 
 import { Effect, Layer } from "effect";
 import { HttpServerResponse } from "effect/unstable/http";
+import type { JWTVerifyGetKey } from "jose";
 
 import {
   IdentityProvider,
@@ -39,6 +40,7 @@ import {
 import type { FailureRenderingStrategy, IdentityFailure, Principal } from "@executor-js/api/server";
 
 import { ApiKeyService } from "./api-keys";
+import { workosApiJwtBearerConfig } from "./api-jwt-bearer";
 import { BEARER_PREFIX } from "./bearer";
 import {
   authorizeOrganization,
@@ -49,6 +51,20 @@ import { UserStoreService } from "./context";
 import { sealedSessionDisplayName } from "./middleware";
 import type { UserStoreError, WorkOSError } from "./errors";
 import { WorkOSClient } from "./workos";
+import { verifyWorkOSMcpAccessToken } from "../mcp/jwt";
+
+/**
+ * The config the bearer-JWT branch needs to verify a WorkOS access token:
+ * the AuthKit JWKS resolver plus the issuer + audience to assert. Passed in
+ * as a plain value so this module stays `cloudflare:workers`-free and the
+ * node-pool resolver tests can inject a local JWKS. Production supplies
+ * {@link workosApiJwtBearerConfig} (built from `cloudflare:workers` env).
+ */
+export interface JwtBearerConfig {
+  readonly jwks: JWTVerifyGetKey;
+  readonly issuer: string;
+  readonly audience: string;
+}
 
 // The exact machine codes + messages each rejected path has always emitted.
 // Carried on the shared identity error so the failure strategy renders the
@@ -70,8 +86,75 @@ const NO_ORGANIZATION_IN_SESSION = {
   code: "no_organization",
   message: "No organization in session",
 };
+const INVALID_ACCESS_TOKEN = {
+  code: "invalid_access_token",
+  message: "Invalid or expired access token",
+};
+const ACCESS_TOKEN_VERIFICATION_UNAVAILABLE = {
+  code: "access_token_verification_unavailable",
+  message: "Access token verification is temporarily unavailable",
+};
+const NO_ORGANIZATION_IN_ACCESS_TOKEN = {
+  code: "no_organization",
+  message: "No organization in access token",
+};
 
-export const resolveApiKeyPrincipal = (request: Request) =>
+// A bearer value with three dot-separated segments is a JWT (a WorkOS access
+// token from the CLI device-login); anything else is treated as an API key.
+// Same discriminator the MCP plane uses (`mcp/auth.ts`).
+const looksLikeJwt = (token: string): boolean => token.split(".").length === 3;
+
+/**
+ * Resolve a WorkOS access-token JWT (CLI `executor login`) into a protected
+ * `Principal`. Verifies the token against AuthKit's JWKS (issuer + audience),
+ * then live-checks org membership — exactly like the api-key path. The
+ * `org_id` claim must be present (a token with no org context is rejected as
+ * `NoOrganization`). Mirrors the MCP plane's JWT verify, reusing the same
+ * `cloudflare:workers`-free verifier so a CLI holds ONE credential for both
+ * the `/api/*` and `/mcp` planes.
+ */
+const resolveJwtPrincipal = (token: string, jwt: JwtBearerConfig) =>
+  Effect.gen(function* () {
+    const verified = yield* verifyWorkOSMcpAccessToken(token, jwt.jwks, {
+      issuer: jwt.issuer,
+      audience: jwt.audience,
+    }).pipe(
+      Effect.catchTag("McpJwtVerificationError", (error) =>
+        Effect.fail(
+          error.reason === "system"
+            ? new Unavailable(ACCESS_TOKEN_VERIFICATION_UNAVAILABLE)
+            : new Unauthorized(INVALID_ACCESS_TOKEN),
+        ),
+      ),
+    );
+
+    if (!verified || !verified.accountId) return yield* new Unauthorized(INVALID_ACCESS_TOKEN);
+    if (!verified.organizationId) {
+      return yield* new NoOrganization(NO_ORGANIZATION_IN_ACCESS_TOKEN);
+    }
+
+    const org = yield* authorizeOrganization(verified.accountId, verified.organizationId);
+    if (!org) return yield* new NoOrganization(NO_ORGANIZATION_IN_ACCESS_TOKEN);
+
+    return {
+      accountId: verified.accountId,
+      organizationId: org.id,
+      organizationName: org.name,
+      email: "",
+      name: null,
+      avatarUrl: null,
+      roles: [],
+    } satisfies Principal;
+  });
+
+/**
+ * Resolve a `Bearer` credential into a `Principal`: a WorkOS access-token JWT
+ * (when `jwt` config is supplied and the value looks like a JWT) or a WorkOS
+ * API key. Returns `null` when there is no `Authorization` header, so the
+ * caller falls through to the sealed-session path. (Kept the historical name —
+ * the re-export and resolver tests reference it.)
+ */
+export const resolveApiKeyPrincipal = (request: Request, jwt: JwtBearerConfig | null = null) =>
   Effect.gen(function* () {
     const authHeader = request.headers.get("authorization");
     if (!authHeader) return null;
@@ -82,6 +165,8 @@ export const resolveApiKeyPrincipal = (request: Request) =>
 
     const value = authHeader.slice(BEARER_PREFIX.length).trim();
     if (!value) return yield* new Unauthorized(INVALID_API_KEY);
+
+    if (jwt && looksLikeJwt(value)) return yield* resolveJwtPrincipal(value, jwt);
 
     const apiKeys = yield* ApiKeyService;
     const principal = yield* apiKeys
@@ -149,14 +234,15 @@ export const resolveSessionPrincipal = (request: Request) =>
  */
 export const resolveProtectedPrincipal = (
   request: Request,
+  jwt: JwtBearerConfig | null = null,
 ): Effect.Effect<
   Principal,
   Unauthorized | NoOrganization | Unavailable | UserStoreError | WorkOSError,
   WorkOSClient | ApiKeyService | UserStoreService
 > =>
   Effect.gen(function* () {
-    const apiKeyPrincipal = yield* resolveApiKeyPrincipal(request);
-    if (apiKeyPrincipal) return apiKeyPrincipal;
+    const bearerPrincipal = yield* resolveApiKeyPrincipal(request, jwt);
+    if (bearerPrincipal) return bearerPrincipal;
     return yield* resolveSessionPrincipal(request);
   });
 
@@ -180,7 +266,7 @@ export const workosIdentityLayer: Layer.Layer<
     const context = yield* Effect.context<WorkOSClient | ApiKeyService | UserStoreService>();
     return IdentityProvider.of({
       authenticate: (request) =>
-        resolveProtectedPrincipal(request).pipe(
+        resolveProtectedPrincipal(request, workosApiJwtBearerConfig).pipe(
           // `UserStoreError` / `WorkOSError` are org-resolution infra failures —
           // surface as a 500 defect, exactly as the old inline resolver let them
           // bubble. The narrow `die` here is the runtime edge for that infra

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -56,7 +56,7 @@ const escapeHtml = (value: string): string =>
 // Server-rendered verification page for the CLI device flow. It binds the
 // signed-in user to the pending code (GET /api/auth/device) and approves/denies
 // it (POST /api/auth/device/approve|deny) via same-origin fetches carrying the
-// session cookie — so the human just confirms the code and clicks Authorize.
+// session cookie, so the human just confirms the code and clicks Authorize.
 const renderDevicePage = (userCode: string): string => {
   const code = JSON.stringify(userCode);
   return `<!doctype html>
@@ -191,12 +191,12 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
     },
     extensions: {
       routes: [
-        // CLI device-login discovery — must precede the /api/auth/* wildcard
+        // CLI device-login discovery, must precede the /api/auth/* wildcard
         // below (Better Auth would otherwise 404 it).
         HttpRouter.add("GET", "/api/auth/cli-login", cliLoginHandler),
         // The device-flow verification page (verification_uri).
         HttpRouter.add("GET", "/device", devicePageHandler),
-        // Better Auth owns the rest of /api/auth/* — the full path reaches it.
+        // Better Auth owns the rest of /api/auth/*, the full path reaches it.
         HttpRouter.add("*", "/api/auth/*", HttpEffect.fromWebHandler(authHandler)),
         // Browser approval of paused MCP executions: the console resume page
         // reads paused detail (GET) and records the decision (POST .../resume),

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -47,84 +47,6 @@ export interface MakeSelfHostAppOptions {
   readonly dbPath?: string;
 }
 
-const escapeHtml = (value: string): string =>
-  value.replace(
-    /[&<>"']/g,
-    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
-  );
-
-// Server-rendered verification page for the CLI device flow. It binds the
-// signed-in user to the pending code (GET /api/auth/device) and approves/denies
-// it (POST /api/auth/device/approve|deny) via same-origin fetches carrying the
-// session cookie, so the human just confirms the code and clicks Authorize.
-const renderDevicePage = (userCode: string): string => {
-  const code = JSON.stringify(userCode);
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Authorize device · Executor</title>
-<style>
-  body { font-family: ui-sans-serif, system-ui, sans-serif; background: #0b0b0c; color: #e7e7ea;
-         display: grid; place-items: center; min-height: 100vh; margin: 0; }
-  .card { background: #161618; border: 1px solid #2a2a2e; border-radius: 12px; padding: 32px;
-          width: 360px; text-align: center; }
-  h1 { font-size: 18px; margin: 0 0 4px; }
-  p { color: #a1a1aa; font-size: 14px; margin: 8px 0 20px; }
-  .code { font-family: ui-monospace, monospace; font-size: 28px; letter-spacing: 4px;
-          background: #0b0b0c; border: 1px solid #2a2a2e; border-radius: 8px; padding: 12px; margin: 12px 0; }
-  button { font: inherit; border: 0; border-radius: 8px; padding: 10px 16px; cursor: pointer; margin: 4px; }
-  .approve { background: #5b5bd6; color: white; }
-  .deny { background: transparent; color: #a1a1aa; border: 1px solid #2a2a2e; }
-  a { color: #8b8bf0; }
-</style>
-</head>
-<body>
-<div class="card" id="card">
-  <h1>Authorize this device</h1>
-  <p>Confirm the code shown in your terminal.</p>
-  <div class="code">${escapeHtml(userCode)}</div>
-  <div id="actions" hidden>
-    <button class="approve" id="approve">Authorize device</button>
-    <button class="deny" id="deny">Deny</button>
-  </div>
-  <p id="status">Checking your session…</p>
-</div>
-<script>
-  const userCode = ${code};
-  const card = document.getElementById("card");
-  const actions = document.getElementById("actions");
-  const status = document.getElementById("status");
-  const done = (msg) => { actions.hidden = true; status.textContent = msg; };
-  const post = (path) => fetch("/api/auth/device/" + path, {
-    method: "POST", credentials: "include",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ userCode }),
-  });
-  (async () => {
-    // Bind the signed-in user to the pending code.
-    const bound = await fetch("/api/auth/device?user_code=" + encodeURIComponent(userCode), {
-      credentials: "include", headers: { accept: "application/json" },
-    }).then((r) => r.ok).catch(() => false);
-    if (!bound) {
-      status.innerHTML = 'Sign in to this Executor first, then reopen this link. <a href="/login">Sign in</a>';
-      return;
-    }
-    actions.hidden = false;
-    status.textContent = "";
-    document.getElementById("approve").onclick = async () => {
-      done((await post("approve")).ok ? "Device approved. Return to your terminal." : "Could not approve. Try again.");
-    };
-    document.getElementById("deny").onclick = async () => {
-      await post("deny"); done("Request denied. You can close this window.");
-    };
-  })();
-</script>
-</body>
-</html>`;
-};
-
 export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
   const config = loadConfig();
 
@@ -168,16 +90,6 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
       ),
   );
 
-  // The verification page the device flow's verification_uri points at. Binds
-  // the signed-in user to the pending code and approves/denies it via Better
-  // Auth's device endpoints (same-origin, with the session cookie).
-  const devicePageHandler = HttpEffect.fromWebHandler(async (request) => {
-    const userCode = new URL(request.url).searchParams.get("user_code") ?? "";
-    return new Response(renderDevicePage(userCode), {
-      headers: { "content-type": "text/html; charset=utf-8" },
-    });
-  });
-
   const { appLayer, toWebHandler } = ExecutorApp.make({
     plugins: selfHostPlugins,
     providers: {
@@ -192,10 +104,9 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
     extensions: {
       routes: [
         // CLI device-login discovery, must precede the /api/auth/* wildcard
-        // below (Better Auth would otherwise 404 it).
+        // below (Better Auth would otherwise 404 it). The verification page it
+        // points at (/device) is a console SPA route (web/device.tsx).
         HttpRouter.add("GET", "/api/auth/cli-login", cliLoginHandler),
-        // The device-flow verification page (verification_uri).
-        HttpRouter.add("GET", "/device", devicePageHandler),
         // Better Auth owns the rest of /api/auth/*, the full path reaches it.
         HttpRouter.add("*", "/api/auth/*", HttpEffect.fromWebHandler(authHandler)),
         // Browser approval of paused MCP executions: the console resume page

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -47,6 +47,84 @@ export interface MakeSelfHostAppOptions {
   readonly dbPath?: string;
 }
 
+const escapeHtml = (value: string): string =>
+  value.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] ?? c,
+  );
+
+// Server-rendered verification page for the CLI device flow. It binds the
+// signed-in user to the pending code (GET /api/auth/device) and approves/denies
+// it (POST /api/auth/device/approve|deny) via same-origin fetches carrying the
+// session cookie — so the human just confirms the code and clicks Authorize.
+const renderDevicePage = (userCode: string): string => {
+  const code = JSON.stringify(userCode);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Authorize device · Executor</title>
+<style>
+  body { font-family: ui-sans-serif, system-ui, sans-serif; background: #0b0b0c; color: #e7e7ea;
+         display: grid; place-items: center; min-height: 100vh; margin: 0; }
+  .card { background: #161618; border: 1px solid #2a2a2e; border-radius: 12px; padding: 32px;
+          width: 360px; text-align: center; }
+  h1 { font-size: 18px; margin: 0 0 4px; }
+  p { color: #a1a1aa; font-size: 14px; margin: 8px 0 20px; }
+  .code { font-family: ui-monospace, monospace; font-size: 28px; letter-spacing: 4px;
+          background: #0b0b0c; border: 1px solid #2a2a2e; border-radius: 8px; padding: 12px; margin: 12px 0; }
+  button { font: inherit; border: 0; border-radius: 8px; padding: 10px 16px; cursor: pointer; margin: 4px; }
+  .approve { background: #5b5bd6; color: white; }
+  .deny { background: transparent; color: #a1a1aa; border: 1px solid #2a2a2e; }
+  a { color: #8b8bf0; }
+</style>
+</head>
+<body>
+<div class="card" id="card">
+  <h1>Authorize this device</h1>
+  <p>Confirm the code shown in your terminal.</p>
+  <div class="code">${escapeHtml(userCode)}</div>
+  <div id="actions" hidden>
+    <button class="approve" id="approve">Authorize device</button>
+    <button class="deny" id="deny">Deny</button>
+  </div>
+  <p id="status">Checking your session…</p>
+</div>
+<script>
+  const userCode = ${code};
+  const card = document.getElementById("card");
+  const actions = document.getElementById("actions");
+  const status = document.getElementById("status");
+  const done = (msg) => { actions.hidden = true; status.textContent = msg; };
+  const post = (path) => fetch("/api/auth/device/" + path, {
+    method: "POST", credentials: "include",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ userCode }),
+  });
+  (async () => {
+    // Bind the signed-in user to the pending code.
+    const bound = await fetch("/api/auth/device?user_code=" + encodeURIComponent(userCode), {
+      credentials: "include", headers: { accept: "application/json" },
+    }).then((r) => r.ok).catch(() => false);
+    if (!bound) {
+      status.innerHTML = 'Sign in to this Executor first, then reopen this link. <a href="/login">Sign in</a>';
+      return;
+    }
+    actions.hidden = false;
+    status.textContent = "";
+    document.getElementById("approve").onclick = async () => {
+      done((await post("approve")).ok ? "Device approved. Return to your terminal." : "Could not approve. Try again.");
+    };
+    document.getElementById("deny").onclick = async () => {
+      await post("deny"); done("Request denied. You can close this window.");
+    };
+  })();
+</script>
+</body>
+</html>`;
+};
+
 export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
   const config = loadConfig();
 
@@ -72,6 +150,34 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
   // a reverse proxy (not the internal 127.0.0.1 bind from the request URL).
   const mcp = makeSelfHostMcpSeams(dbHandle, betterAuth, config.webBaseUrl);
 
+  // CLI device-login discovery (`executor login`). Points the CLI at Better
+  // Auth's device endpoints; `requestFormat: "json"` because those endpoints
+  // only accept JSON (unlike WorkOS's form-encoded ones). The issued token is a
+  // Better Auth session that `bearer()` accepts on the /api/* plane.
+  const cliLoginHandler = HttpEffect.fromWebHandler(
+    async () =>
+      new Response(
+        JSON.stringify({
+          provider: "better-auth",
+          deviceAuthorizationEndpoint: `${config.webBaseUrl}/api/auth/device/code`,
+          tokenEndpoint: `${config.webBaseUrl}/api/auth/device/token`,
+          clientId: "executor-cli",
+          requestFormat: "json",
+        }),
+        { headers: { "content-type": "application/json" } },
+      ),
+  );
+
+  // The verification page the device flow's verification_uri points at. Binds
+  // the signed-in user to the pending code and approves/denies it via Better
+  // Auth's device endpoints (same-origin, with the session cookie).
+  const devicePageHandler = HttpEffect.fromWebHandler(async (request) => {
+    const userCode = new URL(request.url).searchParams.get("user_code") ?? "";
+    return new Response(renderDevicePage(userCode), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  });
+
   const { appLayer, toWebHandler } = ExecutorApp.make({
     plugins: selfHostPlugins,
     providers: {
@@ -85,7 +191,12 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
     },
     extensions: {
       routes: [
-        // Better Auth owns /api/auth/* — the full path reaches it unmodified.
+        // CLI device-login discovery — must precede the /api/auth/* wildcard
+        // below (Better Auth would otherwise 404 it).
+        HttpRouter.add("GET", "/api/auth/cli-login", cliLoginHandler),
+        // The device-flow verification page (verification_uri).
+        HttpRouter.add("GET", "/device", devicePageHandler),
+        // Better Auth owns the rest of /api/auth/* — the full path reaches it.
         HttpRouter.add("*", "/api/auth/*", HttpEffect.fromWebHandler(authHandler)),
         // Browser approval of paused MCP executions: the console resume page
         // reads paused detail (GET) and records the decision (POST .../resume),

--- a/apps/host-selfhost/src/auth/better-auth.ts
+++ b/apps/host-selfhost/src/auth/better-auth.ts
@@ -114,13 +114,14 @@ const makeAuthOptions = (client: Client, getOrganizationId: () => string, gate?:
       admin(),
       apiKey({ enableSessionForAPIKeys: true, rateLimit: { enabled: false } }),
       bearer(),
-      // RFC 8628 device authorization — the CLI `executor login` flow. Registers
+      // RFC 8628 device authorization, the CLI `executor login` flow. Registers
       // /device/code + /device/token + the approval endpoints; the issued token
       // is an opaque session that `bearer()` (above) accepts as `Authorization:
       // Bearer` on the /api/* plane. `validateClient` is left unset, so any
-      // client_id is accepted (the CLI presents "executor-cli"). The approval
-      // page lives at /device (served by the self-host app).
-      deviceAuthorization(),
+      // client_id is accepted (the CLI presents "executor-cli"). `verificationUri`
+      // is the page the user opens to confirm the code — the self-host app serves
+      // it at /device (this is also the Better Auth default; pinned for clarity).
+      deviceAuthorization({ verificationUri: "/device" }),
       // `consentPage` makes the MCP authorize flow redirect to a human approval
       // screen instead of auto-issuing a code — but ONLY when the request
       // carries `prompt=consent`. MCP clients don't send that, so the self-host

--- a/apps/host-selfhost/src/auth/better-auth.ts
+++ b/apps/host-selfhost/src/auth/better-auth.ts
@@ -1,6 +1,6 @@
 import { betterAuth, type BetterAuthOptions } from "better-auth";
 import { APIError } from "better-auth/api";
-import { admin, bearer, mcp, organization } from "better-auth/plugins";
+import { admin, bearer, deviceAuthorization, mcp, organization } from "better-auth/plugins";
 import { apiKey } from "@better-auth/api-key";
 import { type Client } from "@libsql/client";
 import { LibsqlDialect, type LibsqlDialectConfig } from "@libsql/kysely-libsql";
@@ -114,6 +114,13 @@ const makeAuthOptions = (client: Client, getOrganizationId: () => string, gate?:
       admin(),
       apiKey({ enableSessionForAPIKeys: true, rateLimit: { enabled: false } }),
       bearer(),
+      // RFC 8628 device authorization — the CLI `executor login` flow. Registers
+      // /device/code + /device/token + the approval endpoints; the issued token
+      // is an opaque session that `bearer()` (above) accepts as `Authorization:
+      // Bearer` on the /api/* plane. `validateClient` is left unset, so any
+      // client_id is accepted (the CLI presents "executor-cli"). The approval
+      // page lives at /device (served by the self-host app).
+      deviceAuthorization(),
       // `consentPage` makes the MCP authorize flow redirect to a human approval
       // screen instead of auto-issuing a code — but ONLY when the request
       // carries `prompt=consent`. MCP clients don't send that, so the self-host

--- a/apps/host-selfhost/vite.config.ts
+++ b/apps/host-selfhost/vite.config.ts
@@ -76,9 +76,6 @@ function executorApiPlugin(): Plugin {
           path.startsWith("/mcp/") ||
           path === "/docs" ||
           path.startsWith("/docs/") ||
-          // The CLI device-login verification page (verification_uri), served by
-          // the Effect router; without this the SPA fallback answers it instead.
-          path === "/device" ||
           // RFC 9728 / RFC 8414 OAuth discovery the MCP client fetches before
           // auth. Served by the Effect router in prod; without this the SPA
           // index.html fallback answers 200-with-HTML and breaks discovery.

--- a/apps/host-selfhost/vite.config.ts
+++ b/apps/host-selfhost/vite.config.ts
@@ -76,6 +76,9 @@ function executorApiPlugin(): Plugin {
           path.startsWith("/mcp/") ||
           path === "/docs" ||
           path.startsWith("/docs/") ||
+          // The CLI device-login verification page (verification_uri), served by
+          // the Effect router; without this the SPA fallback answers it instead.
+          path === "/device" ||
           // RFC 9728 / RFC 8414 OAuth discovery the MCP client fetches before
           // auth. Served by the Effect router in prod; without this the SPA
           // index.html fallback answers 200-with-HTML and breaks discovery.

--- a/apps/host-selfhost/web/device.tsx
+++ b/apps/host-selfhost/web/device.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+
+import { Button } from "@executor-js/react/components/button";
+
+// ---------------------------------------------------------------------------
+// CLI device-login verification page. Better Auth's deviceAuthorization()
+// plugin ships the JSON device API but no UI, so this is the page its
+// `verificationUri` (/device) points at. `executor login` prints the code and
+// opens this URL; the user confirms it and authorizes the device.
+//
+// Flow: on load we claim the pending code for the signed-in session (GET
+// /api/auth/device?user_code, the plugin's bind step), then Approve/Deny POST
+// to /api/auth/device/{approve,deny}. Like McpConsentPage, this is rendered
+// chromeless INSIDE the auth gate (so the user is already signed in) via a
+// static import in routes/__root.tsx, and drives the endpoints with plain fetch
+// (the same convention the MCP consent screen uses).
+// ---------------------------------------------------------------------------
+
+type Phase = "binding" | "ready" | "approved" | "denied" | "error";
+
+export const DevicePage = () => {
+  const params = new URLSearchParams(globalThis.window?.location.search ?? "");
+  const userCode = params.get("user_code") ?? "";
+  const [phase, setPhase] = useState<Phase>("binding");
+  const [busy, setBusy] = useState<"approve" | "deny" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!userCode) {
+      setPhase("error");
+      setError("This link is missing its device code.");
+      return;
+    }
+    let alive = true;
+    // Claim the pending code for this session; only the same session can then
+    // approve or deny it.
+    const bind = async () => {
+      const res = await fetch(
+        `${globalThis.location.origin}/api/auth/device?user_code=${encodeURIComponent(userCode)}`,
+        { credentials: "include", headers: { accept: "application/json" } },
+      );
+      if (!alive) return;
+      if (res.ok) {
+        setPhase("ready");
+      } else {
+        setPhase("error");
+        setError("This device code is unknown, already used, or expired.");
+      }
+    };
+    void bind();
+    return () => {
+      alive = false;
+    };
+  }, [userCode]);
+
+  const decide = async (accept: boolean) => {
+    setBusy(accept ? "approve" : "deny");
+    setError(null);
+    const res = await fetch(
+      `${globalThis.location.origin}/api/auth/device/${accept ? "approve" : "deny"}`,
+      {
+        method: "POST",
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userCode }),
+      },
+    );
+    setBusy(null);
+    if (!res.ok) {
+      setError("Could not record your decision. The code may have expired, try again.");
+      return;
+    }
+    setPhase(accept ? "approved" : "denied");
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+      <div
+        id="device-approval"
+        className="w-full max-w-md space-y-5 rounded-xl border border-border bg-card p-6 text-center shadow-sm"
+      >
+        <div className="space-y-1">
+          <h1 className="font-display text-2xl tracking-tight text-foreground">
+            Authorize this device
+          </h1>
+          <p className="text-sm text-muted-foreground">Confirm the code shown in your terminal.</p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-background/50 p-4 font-mono text-2xl tracking-[0.3em] text-foreground">
+          {userCode || "XXXX-XXXX"}
+        </div>
+
+        {phase === "binding" && <p className="text-sm text-muted-foreground">Checking the code…</p>}
+
+        {phase === "ready" && (
+          <>
+            <p className="text-xs text-muted-foreground">
+              A signed-in device will be able to act as your account through the CLI.
+            </p>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <div className="flex gap-3">
+              <Button
+                id="device-deny"
+                type="button"
+                variant="outline"
+                className="flex-1"
+                disabled={busy !== null}
+                onClick={() => void decide(false)}
+              >
+                {busy === "deny" ? "Denying…" : "Deny"}
+              </Button>
+              <Button
+                id="device-approve"
+                type="button"
+                className="flex-1"
+                disabled={busy !== null}
+                onClick={() => void decide(true)}
+              >
+                {busy === "approve" ? "Authorizing…" : "Authorize device"}
+              </Button>
+            </div>
+          </>
+        )}
+
+        {phase === "approved" && (
+          <p className="text-sm text-foreground">Device approved. Return to your terminal.</p>
+        )}
+        {phase === "denied" && (
+          <p className="text-sm text-muted-foreground">
+            Request denied. You can close this window.
+          </p>
+        )}
+        {phase === "error" && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+    </div>
+  );
+};

--- a/apps/host-selfhost/web/routes/__root.tsx
+++ b/apps/host-selfhost/web/routes/__root.tsx
@@ -11,6 +11,7 @@ import { Shell, defaultShellNavItems } from "@executor-js/react/multiplayer/shel
 import { plugins as clientPlugins } from "virtual:executor/plugins-client";
 
 import { authClient } from "../auth-client";
+import { DevicePage } from "../device";
 import { McpConsentPage } from "../mcp-consent";
 import { LoginPage } from "../login";
 import { SetupPage } from "../setup";
@@ -121,6 +122,20 @@ function RootComponent() {
       <AuthProvider>
         <AuthGate>
           <McpConsentPage />
+          <Toaster />
+        </AuthGate>
+      </AuthProvider>
+    );
+  }
+
+  // The CLI device-login verification page: chromeless, inside the auth gate
+  // (the user signs in here if needed, then authorizes the code). Same
+  // static-import + pathname-branch convention as /mcp-consent.
+  if (pathname === "/device") {
+    return (
+      <AuthProvider>
+        <AuthGate>
+          <DevicePage />
           <Toaster />
         </AuthGate>
       </AuthProvider>

--- a/e2e/cloud/cli-device-login.test.ts
+++ b/e2e/cloud/cli-device-login.test.ts
@@ -9,6 +9,7 @@
 // mcpConsent. The session then runs `whoami` and `tools sources`; a clean exit
 // of that chain proves the resulting WorkOS access token (a JWT) is accepted by
 // the protected `/api/*` plane.
+import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -91,7 +92,10 @@ scenario(
     // The stored profile carries an oauth device-login credential, not a key.
     const store = JSON.parse(readFileSync(join(dataDir, "server-connections.json"), "utf8")) as {
       defaultProfile: string | null;
-      profiles: Array<{ name: string; connection: { auth?: { kind: string; accessToken?: string } } }>;
+      profiles: Array<{
+        name: string;
+        connection: { auth?: { kind: string; accessToken?: string } };
+      }>;
     };
     expect(store.defaultProfile, "the login became the default profile").toBe("cloud");
     const cloudProfile = store.profiles.find((p) => p.name === "cloud");
@@ -101,5 +105,77 @@ scenario(
     expect(typeof cloudProfile?.connection.auth?.accessToken, "an access token is stored").toBe(
       "string",
     );
+  }),
+);
+
+// Run `executor login` as a subprocess, approving the device for `approveEmail`
+// the moment the verification URL is printed (raw stdout, no PTY).
+const runCliLogin = (
+  args: readonly string[],
+  dataDir: string,
+  approveEmail: string,
+): Promise<{ code: number | null; stdout: string }> =>
+  new Promise((res, rej) => {
+    const env = { ...process.env, EXECUTOR_DATA_DIR: dataDir };
+    for (const k of ["EXECUTOR_API_KEY", "EXECUTOR_AUTH_TOKEN", "EXECUTOR_AUTH_PASSWORD"]) {
+      delete (env as Record<string, string | undefined>)[k];
+    }
+    const child = spawn("bun", ["run", CLI_ENTRY, ...args], { cwd: REPO_ROOT, env });
+    let stdout = "";
+    let approved = false;
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString();
+      if (approved) return;
+      const match = stdout.match(/(https?:\/\/\S*user_code=\S+)/);
+      if (!match) return;
+      approved = true;
+      const url = new URL(match[1]);
+      url.searchParams.set("login_hint", approveEmail);
+      void fetch(url, { redirect: "manual" });
+    });
+    child.stderr.on("data", () => {});
+    child.on("error", rej);
+    child.on("close", (code) => res({ code, stdout }));
+  });
+
+scenario(
+  "CLI · two accounts on the same host get separate profiles",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    if (target.name !== "cloud") return;
+
+    const runDir = yield* RunDir;
+    const dataDir = join(runDir, "multi-home");
+
+    // Two distinct hosted accounts (different user + org) on the SAME server.
+    const a = yield* target.newIdentity();
+    const b = yield* target.newIdentity();
+    const emailA = a.credentials?.email ?? a.label;
+    const emailB = b.credentials?.email ?? b.label;
+
+    // Log in as each with NO --name, so naming is driven by the account.
+    const loginA = yield* Effect.promise(() =>
+      runCliLogin(["login", "--base-url", CLOUD_BASE_URL, "--no-browser"], dataDir, emailA),
+    );
+    expect(loginA.code, "first login exited cleanly").toBe(0);
+    const loginB = yield* Effect.promise(() =>
+      runCliLogin(["login", "--base-url", CLOUD_BASE_URL, "--no-browser"], dataDir, emailB),
+    );
+    expect(loginB.code, "second login exited cleanly").toBe(0);
+
+    const store = JSON.parse(readFileSync(join(dataDir, "server-connections.json"), "utf8")) as {
+      defaultProfile: string | null;
+      profiles: Array<{
+        name: string;
+        connection: { origin: string; displayName?: string; auth?: { kind: string } };
+      }>;
+    };
+    const oauthProfiles = store.profiles.filter((p) => p.connection.auth?.kind === "oauth");
+    // The second login must NOT clobber the first — both accounts kept.
+    expect(oauthProfiles.length, "both accounts retained as separate profiles").toBe(2);
+    expect(new Set(oauthProfiles.map((p) => p.name)).size, "profile names are distinct").toBe(2);
+    const emails = new Set(oauthProfiles.map((p) => p.connection.displayName));
+    expect(emails.has(emailA) && emails.has(emailB), "both account emails present").toBe(true);
   }),
 );

--- a/e2e/cloud/cli-device-login.test.ts
+++ b/e2e/cloud/cli-device-login.test.ts
@@ -1,10 +1,10 @@
 // Cloud: the CLI `executor login` device-authorization flow end to end against
-// the real cloud app — terminal AND browser, both recorded for the viewer. The
+// the real cloud app, terminal AND browser, both recorded for the viewer. The
 // actual `executor` binary runs the OAuth 2.0 Device Authorization Grant
 // (RFC 8628) in a real terminal (terminal.cast): it prints the verification URL
 // and polls. The browser leg is REAL too (session.mp4): Playwright opens that
 // URL, confirms the code, and clicks "Authorize device" on the WorkOS
-// emulator's verification page — exactly the human hop, the way the MCP
+// emulator's verification page, exactly the human hop, the way the MCP
 // approval scenarios drive their browser step. The terminal then runs `whoami`
 // and `tools sources`; a clean exit of that chain proves the resulting WorkOS
 // access token (a JWT) is accepted by the protected `/api/*` plane.
@@ -33,7 +33,16 @@ scenario(
       // Cloud-only: the discovery endpoint + WorkOS device flow are this target's.
       if (target.name !== "cloud") return;
 
-      // Slow + hold the browser steps so the recording is watchable.
+      // Slow + hold the browser steps so the recording is watchable. Scoped to
+      // this scenario and restored after (files run serially, so a leaked flag
+      // would slow every later scenario).
+      const prevFilm = process.env.E2E_FILM;
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          if (prevFilm === undefined) delete process.env.E2E_FILM;
+          else process.env.E2E_FILM = prevFilm;
+        }),
+      );
       process.env.E2E_FILM = "1";
 
       const cli = yield* Cli;
@@ -41,7 +50,7 @@ scenario(
       const runDir = yield* RunDir;
       const dataDir = join(runDir, "cli-home");
 
-      // A fresh signed-in user with an org — the org is what the device token's
+      // A fresh signed-in user with an org, the org is what the device token's
       // org_id claim binds to, and what the /api plane authorizes against.
       const identity = yield* target.newIdentity();
       const email = identity.credentials?.email ?? identity.label;
@@ -58,8 +67,8 @@ scenario(
       });
 
       // The terminal journey, recorded to terminal.cast. `&&` means a clean
-      // exit only happens if every step — including the authenticated /api call
-      // (`tools sources`) — succeeded.
+      // exit only happens if every step, including the authenticated /api call
+      // (`tools sources`), succeeded.
       const cli_ = `bun run ${CLI_ENTRY}`;
       const journey =
         `${cli_} login --base-url ${CLOUD_BASE_URL} --no-browser --name cloud && ` +
@@ -90,7 +99,7 @@ scenario(
         },
       );
 
-      // The browser leg — a REAL Playwright session approving the device on the
+      // The browser leg, a REAL Playwright session approving the device on the
       // verification page (recorded to session.mp4 + per-step screenshots). Runs
       // concurrently with the terminal: it waits for the printed URL, then
       // approves while the CLI is mid-poll.
@@ -205,7 +214,7 @@ scenario(
       }>;
     };
     const oauthProfiles = store.profiles.filter((p) => p.connection.auth?.kind === "oauth");
-    // The second login must NOT clobber the first — both accounts kept.
+    // The second login must NOT clobber the first, both accounts kept.
     expect(oauthProfiles.length, "both accounts retained as separate profiles").toBe(2);
     expect(new Set(oauthProfiles.map((p) => p.name)).size, "profile names are distinct").toBe(2);
     const emails = new Set(oauthProfiles.map((p) => p.connection.displayName));

--- a/e2e/cloud/cli-device-login.test.ts
+++ b/e2e/cloud/cli-device-login.test.ts
@@ -1,0 +1,105 @@
+// Cloud: the CLI `executor login` device-authorization flow end to end against
+// the real cloud app, driven in a REAL terminal (recorded to terminal.cast for
+// the viewer). A fresh user+org is minted through the product login, then the
+// actual `executor` binary runs the OAuth 2.0 Device Authorization Grant
+// (RFC 8628) against the WorkOS emulator the cloud advertises: it asks for a
+// device code, prints the verification URL, and polls. The "browser" leg is
+// completed headlessly — the test approves the device as this user via the
+// emulator's login_hint path, exactly like the MCP OAuth scenarios drive
+// mcpConsent. The session then runs `whoami` and `tools sources`; a clean exit
+// of that chain proves the resulting WorkOS access token (a JWT) is accepted by
+// the protected `/api/*` plane.
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Cli, RunDir, Target } from "../src/services";
+import { CLOUD_BASE_URL } from "../targets/cloud";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CLI_ENTRY = join(REPO_ROOT, "apps", "cli", "src", "main.ts");
+
+scenario(
+  "CLI · executor login device flow → authenticated /api call",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    // Cloud-only: the discovery endpoint + WorkOS device flow are this target's.
+    if (target.name !== "cloud") return;
+
+    const cli = yield* Cli;
+    const runDir = yield* RunDir;
+    const dataDir = join(runDir, "cli-home");
+
+    // A fresh signed-in user with an org — the org is what the device token's
+    // org_id claim binds to, and what the /api plane authorizes against.
+    const identity = yield* target.newIdentity();
+    const email = identity.credentials?.email ?? identity.label;
+
+    const env = { ...process.env, EXECUTOR_DATA_DIR: dataDir };
+    for (const key of ["EXECUTOR_API_KEY", "EXECUTOR_AUTH_TOKEN", "EXECUTOR_AUTH_PASSWORD"]) {
+      delete (env as Record<string, string | undefined>)[key];
+    }
+
+    // One terminal session, recorded: log in (approving the device when the
+    // verification URL appears), then prove the stored token works by reading
+    // identity back and making a real /api call. `&&` means a clean exit only
+    // happens if every step — including the authenticated /api call — succeeded.
+    const cli_ = `bun run ${CLI_ENTRY}`;
+    const journey =
+      `${cli_} login --base-url ${CLOUD_BASE_URL} --no-browser --name cloud && ` +
+      `${cli_} whoami --server cloud && ` +
+      `${cli_} tools sources --server cloud`;
+
+    const finalScreen = yield* cli.session(
+      ["bash", "-c", journey],
+      async (session) => {
+        // The CLI prints the verification URL; approve it in the "browser".
+        await session.screen.waitForText(/user_code=/, { timeoutMs: 45_000 });
+        const screen = await session.screen.text();
+        const match = screen.match(/(https?:\/\/\S*user_code=\S+)/);
+        if (!match) throw new Error(`verification URL not found on screen:\n${screen}`);
+        const verificationUrl = new URL(match[1]);
+        verificationUrl.searchParams.set("login_hint", email);
+        const approve = await fetch(verificationUrl, { redirect: "manual" });
+        if (approve.status >= 400) {
+          throw new Error(`device approval failed (${approve.status})`);
+        }
+        await session.screen.waitForText("Logged in to", { timeoutMs: 45_000 });
+        const exit = await session.waitForExit({ timeoutMs: 45_000 });
+        if (exit.reason !== "exited" || exit.exit.code !== 0) {
+          throw new Error(`journey did not exit cleanly: ${JSON.stringify(exit)}`);
+        }
+        return session.screen.text();
+      },
+      {
+        cwd: REPO_ROOT,
+        env,
+        record: join(runDir, "terminal.cast"),
+        viewport: { cols: 300, rows: 48 },
+      },
+    );
+
+    // whoami read the org back out of the stored token (WorkOS access tokens
+    // carry sub + org_id, not email).
+    expect(finalScreen, "whoami reported the bound organization").toMatch(/org_\w+/);
+
+    // The stored profile carries an oauth device-login credential, not a key.
+    const store = JSON.parse(readFileSync(join(dataDir, "server-connections.json"), "utf8")) as {
+      defaultProfile: string | null;
+      profiles: Array<{ name: string; connection: { auth?: { kind: string; accessToken?: string } } }>;
+    };
+    expect(store.defaultProfile, "the login became the default profile").toBe("cloud");
+    const cloudProfile = store.profiles.find((p) => p.name === "cloud");
+    expect(cloudProfile?.connection.auth?.kind, "credential is an oauth device token").toBe(
+      "oauth",
+    );
+    expect(typeof cloudProfile?.connection.auth?.accessToken, "an access token is stored").toBe(
+      "string",
+    );
+  }),
+);

--- a/e2e/cloud/cli-device-login.test.ts
+++ b/e2e/cloud/cli-device-login.test.ts
@@ -1,14 +1,13 @@
 // Cloud: the CLI `executor login` device-authorization flow end to end against
-// the real cloud app, driven in a REAL terminal (recorded to terminal.cast for
-// the viewer). A fresh user+org is minted through the product login, then the
+// the real cloud app — terminal AND browser, both recorded for the viewer. The
 // actual `executor` binary runs the OAuth 2.0 Device Authorization Grant
-// (RFC 8628) against the WorkOS emulator the cloud advertises: it asks for a
-// device code, prints the verification URL, and polls. The "browser" leg is
-// completed headlessly — the test approves the device as this user via the
-// emulator's login_hint path, exactly like the MCP OAuth scenarios drive
-// mcpConsent. The session then runs `whoami` and `tools sources`; a clean exit
-// of that chain proves the resulting WorkOS access token (a JWT) is accepted by
-// the protected `/api/*` plane.
+// (RFC 8628) in a real terminal (terminal.cast): it prints the verification URL
+// and polls. The browser leg is REAL too (session.mp4): Playwright opens that
+// URL, confirms the code, and clicks "Authorize device" on the WorkOS
+// emulator's verification page — exactly the human hop, the way the MCP
+// approval scenarios drive their browser step. The terminal then runs `whoami`
+// and `tools sources`; a clean exit of that chain proves the resulting WorkOS
+// access token (a JWT) is accepted by the protected `/api/*` plane.
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -18,7 +17,7 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
-import { Cli, RunDir, Target } from "../src/services";
+import { Browser, Cli, RunDir, Target } from "../src/services";
 import { CLOUD_BASE_URL } from "../targets/cloud";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -26,86 +25,116 @@ const CLI_ENTRY = join(REPO_ROOT, "apps", "cli", "src", "main.ts");
 
 scenario(
   "CLI · executor login device flow → authenticated /api call",
-  { timeout: 120_000 },
-  Effect.gen(function* () {
-    const target = yield* Target;
-    // Cloud-only: the discovery endpoint + WorkOS device flow are this target's.
-    if (target.name !== "cloud") return;
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      // Cloud-only: the discovery endpoint + WorkOS device flow are this target's.
+      if (target.name !== "cloud") return;
 
-    const cli = yield* Cli;
-    const runDir = yield* RunDir;
-    const dataDir = join(runDir, "cli-home");
+      // Slow + hold the browser steps so the recording is watchable.
+      process.env.E2E_FILM = "1";
 
-    // A fresh signed-in user with an org — the org is what the device token's
-    // org_id claim binds to, and what the /api plane authorizes against.
-    const identity = yield* target.newIdentity();
-    const email = identity.credentials?.email ?? identity.label;
+      const cli = yield* Cli;
+      const browser = yield* Browser;
+      const runDir = yield* RunDir;
+      const dataDir = join(runDir, "cli-home");
 
-    const env = { ...process.env, EXECUTOR_DATA_DIR: dataDir };
-    for (const key of ["EXECUTOR_API_KEY", "EXECUTOR_AUTH_TOKEN", "EXECUTOR_AUTH_PASSWORD"]) {
-      delete (env as Record<string, string | undefined>)[key];
-    }
+      // A fresh signed-in user with an org — the org is what the device token's
+      // org_id claim binds to, and what the /api plane authorizes against.
+      const identity = yield* target.newIdentity();
+      const email = identity.credentials?.email ?? identity.label;
 
-    // One terminal session, recorded: log in (approving the device when the
-    // verification URL appears), then prove the stored token works by reading
-    // identity back and making a real /api call. `&&` means a clean exit only
-    // happens if every step — including the authenticated /api call — succeeded.
-    const cli_ = `bun run ${CLI_ENTRY}`;
-    const journey =
-      `${cli_} login --base-url ${CLOUD_BASE_URL} --no-browser --name cloud && ` +
-      `${cli_} whoami --server cloud && ` +
-      `${cli_} tools sources --server cloud`;
+      const env = { ...process.env, EXECUTOR_DATA_DIR: dataDir };
+      for (const key of ["EXECUTOR_API_KEY", "EXECUTOR_AUTH_TOKEN", "EXECUTOR_AUTH_PASSWORD"]) {
+        delete (env as Record<string, string | undefined>)[key];
+      }
 
-    const finalScreen = yield* cli.session(
-      ["bash", "-c", journey],
-      async (session) => {
-        // The CLI prints the verification URL; approve it in the "browser".
-        await session.screen.waitForText(/user_code=/, { timeoutMs: 45_000 });
-        const screen = await session.screen.text();
-        const match = screen.match(/(https?:\/\/\S*user_code=\S+)/);
-        if (!match) throw new Error(`verification URL not found on screen:\n${screen}`);
-        const verificationUrl = new URL(match[1]);
-        verificationUrl.searchParams.set("login_hint", email);
-        const approve = await fetch(verificationUrl, { redirect: "manual" });
-        if (approve.status >= 400) {
-          throw new Error(`device approval failed (${approve.status})`);
-        }
-        await session.screen.waitForText("Logged in to", { timeoutMs: 45_000 });
-        const exit = await session.waitForExit({ timeoutMs: 45_000 });
-        if (exit.reason !== "exited" || exit.exit.code !== 0) {
-          throw new Error(`journey did not exit cleanly: ${JSON.stringify(exit)}`);
-        }
-        return session.screen.text();
-      },
-      {
-        cwd: REPO_ROOT,
-        env,
-        record: join(runDir, "terminal.cast"),
-        viewport: { cols: 300, rows: 48 },
-      },
-    );
+      // Hand the printed verification URL from the terminal fiber to the browser.
+      let resolveUrl!: (url: string) => void;
+      const verificationUrl = new Promise<string>((r) => {
+        resolveUrl = r;
+      });
 
-    // whoami read the org back out of the stored token (WorkOS access tokens
-    // carry sub + org_id, not email).
-    expect(finalScreen, "whoami reported the bound organization").toMatch(/org_\w+/);
+      // The terminal journey, recorded to terminal.cast. `&&` means a clean
+      // exit only happens if every step — including the authenticated /api call
+      // (`tools sources`) — succeeded.
+      const cli_ = `bun run ${CLI_ENTRY}`;
+      const journey =
+        `${cli_} login --base-url ${CLOUD_BASE_URL} --no-browser --name cloud && ` +
+        `${cli_} whoami --server cloud && ` +
+        `${cli_} tools sources --server cloud`;
 
-    // The stored profile carries an oauth device-login credential, not a key.
-    const store = JSON.parse(readFileSync(join(dataDir, "server-connections.json"), "utf8")) as {
-      defaultProfile: string | null;
-      profiles: Array<{
-        name: string;
-        connection: { auth?: { kind: string; accessToken?: string } };
-      }>;
-    };
-    expect(store.defaultProfile, "the login became the default profile").toBe("cloud");
-    const cloudProfile = store.profiles.find((p) => p.name === "cloud");
-    expect(cloudProfile?.connection.auth?.kind, "credential is an oauth device token").toBe(
-      "oauth",
-    );
-    expect(typeof cloudProfile?.connection.auth?.accessToken, "an access token is stored").toBe(
-      "string",
-    );
-  }),
+      const terminal = cli.session(
+        ["bash", "-c", journey],
+        async (session) => {
+          await session.screen.waitForText(/user_code=/, { timeoutMs: 60_000 });
+          const match = (await session.screen.text()).match(/(https?:\/\/\S*user_code=\S+)/);
+          if (!match) throw new Error("verification URL not found on screen");
+          resolveUrl(match[1]);
+          await session.screen.waitForText("Logged in to", { timeoutMs: 60_000 });
+          const exit = await session.waitForExit({ timeoutMs: 60_000 });
+          if (exit.reason !== "exited" || exit.exit.code !== 0) {
+            throw new Error(
+              `journey did not exit cleanly: ${JSON.stringify(exit)}\n${await session.screen.text()}`,
+            );
+          }
+          return session.screen.text();
+        },
+        {
+          cwd: REPO_ROOT,
+          env,
+          record: join(runDir, "terminal.cast"),
+          viewport: { cols: 300, rows: 48 },
+        },
+      );
+
+      // The browser leg — a REAL Playwright session approving the device on the
+      // verification page (recorded to session.mp4 + per-step screenshots). Runs
+      // concurrently with the terminal: it waits for the printed URL, then
+      // approves while the CLI is mid-poll.
+      const browserApproval = Effect.gen(function* () {
+        const url = yield* Effect.promise(() => verificationUrl);
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the device verification link from the terminal", async () => {
+            await page.goto(url, { waitUntil: "domcontentloaded" });
+            await page
+              .getByRole("button", { name: /Authorize device/i })
+              .waitFor({ timeout: 15_000 });
+          });
+          await step("Confirm the code and authorize the device", async () => {
+            // The visible email field (existing-user quick buttons also carry a
+            // hidden name="email", so target the typed input by type).
+            await page.locator('input[type="email"]').fill(email);
+            await page.getByRole("button", { name: /Authorize device/i }).click();
+            await page.getByText(/Device approved/i).waitFor({ timeout: 15_000 });
+          });
+        });
+      });
+
+      const [finalScreen] = yield* Effect.all([terminal, browserApproval], {
+        concurrency: "unbounded",
+      });
+      expect(finalScreen, "whoami reported the bound organization").toMatch(/org_\w+/);
+
+      // The stored profile carries an oauth device-login credential, not a key.
+      const store = JSON.parse(readFileSync(join(dataDir, "server-connections.json"), "utf8")) as {
+        defaultProfile: string | null;
+        profiles: Array<{
+          name: string;
+          connection: { auth?: { kind: string; accessToken?: string } };
+        }>;
+      };
+      expect(store.defaultProfile, "the login became the default profile").toBe("cloud");
+      const cloudProfile = store.profiles.find((p) => p.name === "cloud");
+      expect(cloudProfile?.connection.auth?.kind, "credential is an oauth device token").toBe(
+        "oauth",
+      );
+      expect(typeof cloudProfile?.connection.auth?.accessToken, "an access token is stored").toBe(
+        "string",
+      );
+    }),
+  ),
 );
 
 // Run `executor login` as a subprocess, approving the device for `approveEmail`

--- a/e2e/cloud/cli-device-login.test.ts
+++ b/e2e/cloud/cli-device-login.test.ts
@@ -18,6 +18,7 @@ import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
 import { Browser, Cli, RunDir, Target } from "../src/services";
+import { enterFocus } from "../src/timeline";
 import { CLOUD_BASE_URL } from "../targets/cloud";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -110,6 +111,9 @@ scenario(
             await page.getByText(/Device approved/i).waitFor({ timeout: 15_000 });
           });
         });
+        // Cut the synced player back to the terminal for the "Logged in" + the
+        // authenticated /api call that follow the browser approval.
+        yield* Effect.promise(() => enterFocus(runDir, "terminal"));
       });
 
       const [finalScreen] = yield* Effect.all([terminal, browserApproval], {

--- a/e2e/selfhost/cli-device-login.test.ts
+++ b/e2e/selfhost/cli-device-login.test.ts
@@ -1,5 +1,5 @@
 // Self-host: the CLI `executor login` device-authorization flow end to end
-// against the self-host app (Better Auth) — terminal AND browser, both recorded.
+// against the self-host app (Better Auth), terminal AND browser, both recorded.
 // The `executor` binary runs RFC 8628 in a real terminal (terminal.cast): it
 // discovers Better Auth's device endpoints via /api/auth/cli-login, prints the
 // verification URL, and polls. The browser leg is REAL (session.mp4): Playwright
@@ -30,7 +30,16 @@ scenario(
       const target = yield* Target;
       if (target.name !== "selfhost") return;
 
-      // Slow + hold the browser steps so the recording is watchable.
+      // Slow + hold the browser steps so the recording is watchable. Scoped to
+      // this scenario and restored after (files run serially, so a leaked flag
+      // would slow every later scenario).
+      const prevFilm = process.env.E2E_FILM;
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          if (prevFilm === undefined) delete process.env.E2E_FILM;
+          else process.env.E2E_FILM = prevFilm;
+        }),
+      );
       process.env.E2E_FILM = "1";
 
       const cli = yield* Cli;
@@ -81,7 +90,7 @@ scenario(
         },
       );
 
-      // The browser leg — approve on the self-host /device page (session cookie
+      // The browser leg, approve on the self-host /device page (session cookie
       // from the identity authorizes it). Recorded to session.mp4.
       const browserApproval = Effect.gen(function* () {
         const url = yield* Effect.promise(() => verificationUrl);
@@ -103,7 +112,7 @@ scenario(
         yield* Effect.promise(() => enterFocus(runDir, "terminal"));
       });
 
-      // Reaching here means the whole `&&` chain exited 0 — including the
+      // Reaching here means the whole `&&` chain exited 0, including the
       // authenticated `tools sources` /api call.
       yield* Effect.all([terminal, browserApproval], { concurrency: "unbounded" });
 

--- a/e2e/selfhost/cli-device-login.test.ts
+++ b/e2e/selfhost/cli-device-login.test.ts
@@ -16,6 +16,7 @@ import { Effect } from "effect";
 
 import { scenario } from "../src/scenario";
 import { Browser, Cli, RunDir, Target } from "../src/services";
+import { enterFocus } from "../src/timeline";
 import { SELFHOST_BASE_URL } from "../targets/selfhost";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -97,6 +98,9 @@ scenario(
             await page.getByText(/Device approved/i).waitFor({ timeout: 15_000 });
           });
         });
+        // Cut the synced player back to the terminal for the "Logged in" + the
+        // authenticated /api call that follow the browser approval.
+        yield* Effect.promise(() => enterFocus(runDir, "terminal"));
       });
 
       // Reaching here means the whole `&&` chain exited 0 — including the

--- a/e2e/selfhost/cli-device-login.test.ts
+++ b/e2e/selfhost/cli-device-login.test.ts
@@ -1,0 +1,122 @@
+// Self-host: the CLI `executor login` device-authorization flow end to end
+// against the self-host app (Better Auth) — terminal AND browser, both recorded.
+// The `executor` binary runs RFC 8628 in a real terminal (terminal.cast): it
+// discovers Better Auth's device endpoints via /api/auth/cli-login, prints the
+// verification URL, and polls. The browser leg is REAL (session.mp4): Playwright
+// opens the self-host /device page (signed in via the session cookie) and clicks
+// "Authorize device". The terminal then runs `whoami` and `tools sources`; a
+// clean exit of that chain proves the Better Auth device token is accepted as a
+// Bearer on the protected /api/* plane.
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { scenario } from "../src/scenario";
+import { Browser, Cli, RunDir, Target } from "../src/services";
+import { SELFHOST_BASE_URL } from "../targets/selfhost";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CLI_ENTRY = join(REPO_ROOT, "apps", "cli", "src", "main.ts");
+
+scenario(
+  "CLI · executor login device flow → authenticated /api call",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      if (target.name !== "selfhost") return;
+
+      // Slow + hold the browser steps so the recording is watchable.
+      process.env.E2E_FILM = "1";
+
+      const cli = yield* Cli;
+      const browser = yield* Browser;
+      const runDir = yield* RunDir;
+      const dataDir = join(runDir, "cli-home");
+
+      // A signed-in identity (its session cookie authorizes the /device page).
+      const identity = yield* target.newIdentity();
+
+      const env = { ...process.env, EXECUTOR_DATA_DIR: dataDir };
+      for (const key of ["EXECUTOR_API_KEY", "EXECUTOR_AUTH_TOKEN", "EXECUTOR_AUTH_PASSWORD"]) {
+        delete (env as Record<string, string | undefined>)[key];
+      }
+
+      let resolveUrl!: (url: string) => void;
+      const verificationUrl = new Promise<string>((r) => {
+        resolveUrl = r;
+      });
+
+      const cli_ = `bun run ${CLI_ENTRY}`;
+      const journey =
+        `${cli_} login --base-url ${SELFHOST_BASE_URL} --no-browser --name selfhost && ` +
+        `${cli_} whoami --server selfhost && ` +
+        `${cli_} tools sources --server selfhost`;
+
+      const terminal = cli.session(
+        ["bash", "-c", journey],
+        async (session) => {
+          await session.screen.waitForText(/user_code=/, { timeoutMs: 60_000 });
+          const match = (await session.screen.text()).match(/(https?:\/\/\S*user_code=\S+)/);
+          if (!match) throw new Error("verification URL not found on screen");
+          resolveUrl(match[1]);
+          await session.screen.waitForText("Logged in to", { timeoutMs: 60_000 });
+          const exit = await session.waitForExit({ timeoutMs: 60_000 });
+          if (exit.reason !== "exited" || exit.exit.code !== 0) {
+            throw new Error(
+              `journey did not exit cleanly: ${JSON.stringify(exit)}\n${await session.screen.text()}`,
+            );
+          }
+          return session.screen.text();
+        },
+        {
+          cwd: REPO_ROOT,
+          env,
+          record: join(runDir, "terminal.cast"),
+          viewport: { cols: 300, rows: 48 },
+        },
+      );
+
+      // The browser leg — approve on the self-host /device page (session cookie
+      // from the identity authorizes it). Recorded to session.mp4.
+      const browserApproval = Effect.gen(function* () {
+        const url = yield* Effect.promise(() => verificationUrl);
+        yield* browser.session(identity, async ({ page, step }) => {
+          await step("Open the device verification page", async () => {
+            await page.goto(url, { waitUntil: "domcontentloaded" });
+            // The Authorize button appears once the page binds the signed-in user.
+            await page
+              .getByRole("button", { name: /Authorize device/i })
+              .waitFor({ timeout: 20_000 });
+          });
+          await step("Authorize the device", async () => {
+            await page.getByRole("button", { name: /Authorize device/i }).click();
+            await page.getByText(/Device approved/i).waitFor({ timeout: 15_000 });
+          });
+        });
+      });
+
+      // Reaching here means the whole `&&` chain exited 0 — including the
+      // authenticated `tools sources` /api call.
+      yield* Effect.all([terminal, browserApproval], { concurrency: "unbounded" });
+
+      // The stored profile carries an oauth device-login credential, not a key.
+      const store = JSON.parse(readFileSync(join(dataDir, "server-connections.json"), "utf8")) as {
+        defaultProfile: string | null;
+        profiles: Array<{
+          name: string;
+          connection: { auth?: { kind: string; accessToken?: string } };
+        }>;
+      };
+      expect(store.defaultProfile, "the login became the default profile").toBe("selfhost");
+      const profile = store.profiles.find((p) => p.name === "selfhost");
+      expect(profile?.connection.auth?.kind, "credential is an oauth device token").toBe("oauth");
+      expect(typeof profile?.connection.auth?.accessToken, "an access token is stored").toBe(
+        "string",
+      );
+    }),
+  ),
+);

--- a/e2e/src/surfaces/cli.ts
+++ b/e2e/src/surfaces/cli.ts
@@ -3,11 +3,12 @@
 // vitest; pass `record` to save an asciicast v2 the viewer can replay. The
 // recording is written in release so a timeout still leaves the evidence.
 import { writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
 import { Effect } from "effect";
 import { TerminalControl, type Session } from "@kitlangton/terminal-control";
 
-import { beat } from "../timeline";
+import { beat, enterFocus, markRecordingStart } from "../timeline";
 
 export interface CliSurface {
   readonly session: <T>(
@@ -67,10 +68,16 @@ export const makeCliSurface = (): CliSurface => ({
           record: options?.record ? true : undefined,
           viewport: options?.viewport,
         });
-        return { tc, session };
+        // Anchor the terminal recording on the run's focus timeline (symmetric
+        // with the browser surface), so a combined cli+browser scenario gets the
+        // synced SessionPlayer view (terminal/browser cuts + URL bar) for free.
+        const runDir = options?.record ? dirname(options.record) : null;
+        if (runDir) markRecordingStart(runDir, "terminal");
+        return { tc, session, runDir };
       }),
-      ({ session }) =>
+      ({ session, runDir }) =>
         Effect.promise(async () => {
+          if (runDir) await enterFocus(runDir, "terminal");
           const result = await drive(session);
           // Hold the terminal's final frame (e.g. "connected") before the
           // recording stops, so it isn't a single flash in the film. Filming

--- a/packages/core/sdk/src/server-connection.ts
+++ b/packages/core/sdk/src/server-connection.ts
@@ -15,6 +15,18 @@ export type ExecutorServerAuth =
   | {
       readonly kind: "bearer";
       readonly token: string;
+    }
+  | {
+      // OAuth 2.0 device-flow credential from `executor login` against a hosted
+      // server. The access token is sent as a Bearer; `refreshToken` +
+      // `expiresAt` (epoch seconds) + `tokenEndpoint` + `clientId` let the CLI
+      // refresh it before expiry without a fresh browser login.
+      readonly kind: "oauth";
+      readonly accessToken: string;
+      readonly refreshToken?: string;
+      readonly expiresAt?: number;
+      readonly tokenEndpoint?: string;
+      readonly clientId?: string;
     };
 
 export interface ExecutorServerConnection {
@@ -125,6 +137,7 @@ export const getExecutorServerAuthorizationHeader = (
   const auth = connection.auth;
   if (!auth) return null;
   if (auth.kind === "bearer") return `Bearer ${auth.token}`;
+  if (auth.kind === "oauth") return `Bearer ${auth.accessToken}`;
   const encoded = encodeBasicCredentials(
     `${auth.username ?? DEFAULT_EXECUTOR_SERVER_USERNAME}:${auth.password}`,
   );
@@ -140,6 +153,14 @@ const ExecutorServerAuthJson = Schema.Union([
   Schema.Struct({
     kind: Schema.Literal("bearer"),
     token: Schema.String,
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("oauth"),
+    accessToken: Schema.String,
+    refreshToken: Schema.optional(Schema.String),
+    expiresAt: Schema.optional(Schema.Number),
+    tokenEndpoint: Schema.optional(Schema.String),
+    clientId: Schema.optional(Schema.String),
   }),
 ]);
 


### PR DESCRIPTION
## What

Lets users sign the CLI into a hosted Executor account using the OAuth 2.0 **Device Authorization Grant (RFC 8628)** — the flow WorkOS AuthKit and Better Auth both recommend for CLIs — instead of manually creating and pasting an API key.

```
executor login --base-url https://<your-host>
# prints a code + verification URL, opens the browser, polls
executor whoami
executor call ...   # now authenticated as your org
```

## How it works

1. `executor login` calls `GET /api/auth/cli-login` to discover the provider's device endpoints + public client id.
2. It runs RFC 8628 (request device code → show code + verification URL → poll the token endpoint), then stores the access + refresh token in the server profile.
3. Subsequent commands send `Authorization: Bearer <access_token>` and refresh the token before it expires.

## Changes

- **CLI**: `login` / `logout` / `whoami` commands + a provider-neutral device-flow client (`apps/cli/src/device-login.ts`).
- **SDK + CLI profile**: new `oauth` auth kind (access/refresh/expiry) alongside `basic`/`bearer`.
- **Cloud**: the protected `/api/*` plane now accepts a WorkOS access-token JWT as a bearer (reusing the existing MCP JWT verifier), plus a public `/api/auth/cli-login` discovery endpoint.
- **Fix**: a stored credential no longer triggers local-daemon auto-start for an `http://localhost` server.
- **Tests**: unit tests for the new JWT bearer path; a cloud e2e scenario that drives the real `executor` binary end to end through the device flow and asserts an authenticated `/api/*` call (records a terminal cast for the viewer).

## Status / notes

- Draft. The flow is provider-neutral; **self-host parity (Better Auth device authorization) is a follow-up**.
- Driving the cloud e2e requires a device-flow-capable build of the service emulator (developed in the fork). That needs to be published and the dependency bumped before this can merge — until then a local `file:` override (not committed) supplies it. e2e is green locally against that build.
- Gates green locally: typecheck, lint, format, unit tests, and the new + existing MCP-OAuth e2e scenarios.
