### PR TITLE
Stop reporting clean sidecar shutdowns as desktop crashes

### DIFF
--- a/apps/desktop/src/main/diagnostics.ts
+++ b/apps/desktop/src/main/diagnostics.ts
@@ -25,7 +25,13 @@ import log from "electron-log/main.js";
 import * as Sentry from "@sentry/electron/main";
 import { getServerSettings } from "./settings";
 
-const sentryDsn = __EXECUTOR_SENTRY_DSN__;
+// Packaged builds always use the DSN baked in at build time. The non-packaged
+// override is a test seam: the desktop e2e points crash reporting at a local
+// sink so it can assert what is (and isn't) reported. It can never redirect a
+// real user's reports — production is always packaged, where the override is
+// dead and the baked DSN wins.
+const sentryDsn =
+  (app.isPackaged ? undefined : process.env.EXECUTOR_DESKTOP_SENTRY_DSN) || __EXECUTOR_SENTRY_DSN__;
 
 // The informal cross-tool opt-out (consoledonottrack.com). Checked before
 // any SDK initializes, and it covers all three processes because the

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -23,6 +23,7 @@ import {
   startSidecar,
   stopSidecar,
   onUnexpectedSidecarExit,
+  markAppQuitting,
   SidecarPortInUseError,
   type SidecarConnection,
 } from "./sidecar";
@@ -888,6 +889,11 @@ if (ensureSingleInstance()) {
   });
 
   app.on("before-quit", async (event) => {
+    // Latch the quit intent first, synchronously: from here on, a sidecar exit
+    // is part of shutdown. A process-group SIGINT can race ahead of the SIGTERM
+    // stopConnection sends below, and without this it would be misreported as a
+    // crash (the Sentry "Sidecar exited unexpectedly (code=130)" false positive).
+    markAppQuitting();
     if (!connection) return;
     // A supervised daemon must keep serving after the app quits — don't stop it,
     // and don't block the quit on teardown we don't need to do.

--- a/apps/desktop/src/main/sidecar-exit.ts
+++ b/apps/desktop/src/main/sidecar-exit.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure classification of a sidecar's *post-boot* exit (the child died after it
+ * had already reported ready). Kept free of electron/log imports so the rule is
+ * unit-testable in isolation — `sidecar.ts` owns the I/O around it.
+ *
+ * The trap this guards against: the desktop only marks an exit "expected" when
+ * it stopped the child itself via `stopSidecar` (which sends SIGTERM). A signal
+ * that arrives any other way — most commonly a process-group SIGINT racing
+ * ahead of teardown — would otherwise be filed as a crash, painting the crash
+ * screen over (and Sentry-reporting) what was really a clean shutdown.
+ *
+ * Classification is on the exit code/signal alone — the OS's verdict on whether
+ * the process ended normally. We deliberately do NOT inspect stderr: the buffer
+ * is a rolling tail of the whole session (a startup log line would make it
+ * non-empty), so it is a poor proxy for "errored at exit". A genuine internal
+ * fault in the daemon is reported with a real stack by the sidecar's own
+ * crash reporter (@sentry/bun, see sidecar/server.ts); this main-process path
+ * is only the coarse "the child vanished" net, so it should fire on abnormal
+ * exits and stay quiet on clean ones.
+ */
+
+// Exit codes a process reports when it shuts down through its own handler:
+// 0 is a graceful success; 130 = 128 + SIGINT(2) and 143 = 128 + SIGTERM(15)
+// are the conventional codes an interrupted program exits with (an Effect
+// `runMain` program interrupted by SIGINT exits 130).
+const CLEAN_SHUTDOWN_EXIT_CODES: ReadonlySet<number> = new Set([0, 130, 143]);
+
+// When no handler runs, the process dies on the raw signal instead and Node
+// reports the signal name with a null code. SIGINT/SIGTERM are orderly stop
+// requests; SIGKILL/SIGSEGV/etc. are not and fall through to "crash".
+const CLEAN_SHUTDOWN_SIGNALS: ReadonlySet<string> = new Set(["SIGINT", "SIGTERM"]);
+
+export type PostBootSidecarExitDecision =
+  /** We asked it to stop, or the app is quitting — say nothing, do nothing. */
+  | { readonly kind: "expected" }
+  /**
+   * A graceful or signal-driven exit (code 0/130/143, or a raw SIGINT/SIGTERM)
+   * that bypassed `stopSidecar`. The web UI is dead so the recovery screen still
+   * has to show, but this is a healthy shutdown and must not be reported.
+   */
+  | { readonly kind: "recover" }
+  /** A genuine fault (abnormal exit / hard kill): surface recovery UI *and* report. */
+  | { readonly kind: "crash" };
+
+export const classifyPostBootSidecarExit = (input: {
+  /** The child was passed to `stopSidecar` (we initiated this stop). */
+  readonly expected: boolean;
+  /** `before-quit` has fired — the whole app is tearing down. */
+  readonly appQuitting: boolean;
+  readonly code: number | null;
+  readonly signal: string | null;
+}): PostBootSidecarExitDecision => {
+  if (input.expected || input.appQuitting) return { kind: "expected" };
+  const cleanShutdown =
+    (input.code !== null && CLEAN_SHUTDOWN_EXIT_CODES.has(input.code)) ||
+    (input.signal !== null && CLEAN_SHUTDOWN_SIGNALS.has(input.signal));
+  return cleanShutdown ? { kind: "recover" } : { kind: "crash" };
+};

--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -24,6 +24,7 @@ import {
 import { loadOrMintLocalAuthToken } from "./local-auth";
 import { getServerSettings } from "./settings";
 import { reportSidecarCrash, sidecarCrashReportingEnv } from "./diagnostics";
+import { classifyPostBootSidecarExit } from "./sidecar-exit";
 import { SERVER_SETTINGS_USERNAME, type DesktopServerSettings } from "../shared/server-settings";
 
 // Sidecar output is echoed to the terminal (visible when Electron is run
@@ -38,6 +39,15 @@ const STDERR_TAIL_LIMIT = 8 * 1024;
 // Children deliberately stopped via stopSidecar (quit, restart, update) —
 // their exits are expected and must not be reported as crashes.
 const expectedExits = new WeakSet<ChildProcess>();
+
+// Flipped by main/index.ts the moment the app begins quitting. A sidecar exit
+// during teardown is part of shutdown even when a process-group signal (SIGINT)
+// races ahead of stopSidecar's SIGTERM — so once this is set, no post-boot exit
+// is reported as a crash. One-way latch: the process is on its way out.
+let appQuitting = false;
+export const markAppQuitting = (): void => {
+  appQuitting = true;
+};
 
 // Main/index.ts subscribes to swap the dead web UI for the in-window crash
 // screen. A callback (not an import) keeps this module free of window
@@ -409,11 +419,27 @@ export async function startSidecar(options: StartOptions = {}): Promise<SidecarC
 
     const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
       if (resolved) {
-        // Post-boot exit: expected when we stopped it ourselves (quit,
-        // restart, update); anything else is a sidecar crash under a live
-        // window — log it and report upstream with the stderr tail.
-        if (expectedExits.has(child)) {
+        // Post-boot exit. Expected when we stopped it ourselves (quit, restart,
+        // update) or the app is mid-quit; a clean signal-driven exit that raced
+        // past stopSidecar still needs the recovery screen but isn't a crash;
+        // anything else is a real fault — report it with the stderr tail.
+        const decision = classifyPostBootSidecarExit({
+          expected: expectedExits.has(child),
+          appQuitting,
+          code,
+          signal,
+        });
+        if (decision.kind === "expected") {
           sidecarLog.info(`exited (code=${code} signal=${signal})`);
+          return;
+        }
+        if (decision.kind === "recover") {
+          // A clean exit (code 0/130/143 or a raw SIGINT/SIGTERM) that bypassed
+          // stopSidecar — e.g. a process-group signal during teardown. The web
+          // UI is dead, so surface the recovery screen, but don't file a healthy
+          // shutdown as a crash.
+          sidecarLog.warn(`exited via clean shutdown (code=${code} signal=${signal})`);
+          unexpectedExitListener?.();
           return;
         }
         const message = `Sidecar exited unexpectedly (code=${code} signal=${signal})`;

--- a/e2e/desktop/sidecar-clean-shutdown-not-reported.test.ts
+++ b/e2e/desktop/sidecar-clean-shutdown-not-reported.test.ts
@@ -1,0 +1,213 @@
+// Desktop-only: proves the *telemetry* contract around a dying sidecar — the
+// distinction the on-screen crash flow can't show, because a clean shutdown and
+// a hard kill paint the SAME recovery screen. The only observable difference is
+// what reaches Sentry, so this launches the real Electron app pointed at a local
+// Sentry envelope sink (via the non-packaged EXECUTOR_DESKTOP_SENTRY_DSN seam)
+// and asserts:
+//   - SIGKILL (hard kill)  → a "Sidecar exited unexpectedly" crash IS reported
+//   - SIGINT  (clean stop) → the recovery screen shows but NOTHING is reported
+//
+// The negative is made conclusive with a fence: a second SIGKILL after the
+// SIGINT. Sentry's transport is FIFO per client, so once the fence's crash
+// envelope has arrived, any envelope the SIGINT would have produced (enqueued
+// earlier) must already be present too — its absence is real, not just slow.
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { createRequire } from "node:module";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { gunzipSync } from "node:zlib";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { _electron } from "playwright";
+
+import { scenario } from "../src/scenario";
+import { RunDir } from "../src/services";
+
+const appDir = fileURLToPath(new URL("../../apps/desktop/", import.meta.url));
+const electronBinary = createRequire(join(appDir, "package.json"))("electron") as string;
+
+const SIDECAR_CRASH_MESSAGE = "Sidecar exited unexpectedly";
+
+scenario(
+  "Desktop · a clean sidecar shutdown recovers without a crash report",
+  { timeout: 300_000 },
+  Effect.gen(function* () {
+    const runDir = yield* RunDir;
+    yield* Effect.promise(() => run(runDir));
+  }),
+);
+
+/** Minimal Sentry ingest: every POSTed envelope body (gunzipped) is buffered. */
+const startSentrySink = async (): Promise<{
+  server: Server;
+  dsn: string;
+  envelopes: string[];
+}> => {
+  const envelopes: string[] = [];
+  const server = createServer((req, res) => {
+    if (req.method !== "POST") {
+      res.writeHead(200);
+      res.end("ok");
+      return;
+    }
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => {
+      let body = Buffer.concat(chunks);
+      if (req.headers["content-encoding"] === "gzip") {
+        // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: tolerate a non-gzip body rather than dropping the envelope
+        try {
+          body = gunzipSync(body);
+        } catch {
+          // fall through with the raw bytes
+        }
+      }
+      envelopes.push(body.toString("utf8"));
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ id: "e2e" }));
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+  const { port } = server.address() as AddressInfo;
+  // DSN shape: http://<publicKey>@<host>/<projectId> — the SDK POSTs envelopes
+  // to http://<host>/api/<projectId>/envelope/, which the sink accepts wholesale.
+  return { server, dsn: `http://e2e@127.0.0.1:${port}/1`, envelopes };
+};
+
+const run = async (runDir: string) => {
+  const { server: sink, dsn, envelopes } = await startSentrySink();
+  const home = mkdtempSync(join(tmpdir(), "executor-desktop-sentry-e2e-"));
+  const videoTmp = join(runDir, ".video-tmp");
+  let stepIndex = 0;
+
+  const crashReports = () => envelopes.filter((e) => e.includes(SIDECAR_CRASH_MESSAGE));
+  const sigkillReports = () =>
+    crashReports().filter((e) => e.includes(`${SIDECAR_CRASH_MESSAGE} (code=null signal=SIGKILL)`));
+
+  const waitFor = async (predicate: () => boolean, label: string, timeoutMs = 60_000) => {
+    const start = Date.now();
+    while (!predicate()) {
+      if (Date.now() - start > timeoutMs) {
+        throw new Error(`timed out waiting for ${label}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+  };
+
+  const app = await _electron.launch({
+    executablePath: electronBinary,
+    args: [appDir],
+    cwd: appDir,
+    // EXECUTOR_DESKTOP_SENTRY_DSN turns on main-process crash reporting in the
+    // non-packaged build and routes it at the sink. HOME isolates a fresh data
+    // dir from any real install on this machine.
+    env: { ...process.env, HOME: home, EXECUTOR_DESKTOP_SENTRY_DSN: dsn },
+    recordVideo: { dir: videoTmp, size: { width: 1280, height: 800 } },
+    timeout: 120_000,
+  });
+
+  const manifestPath = join(home, ".executor/server-control/server.json");
+  const sidecarPid = (): number => {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as { pid: number };
+    expect(manifest.pid, "sidecar pid recorded in the server manifest").toBeGreaterThan(0);
+    return manifest.pid;
+  };
+
+  try {
+    const page = await app.firstWindow({ timeout: 120_000 });
+    const step = async (label: string, body: () => Promise<void>) => {
+      await body();
+      stepIndex += 1;
+      const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      await page.screenshot({
+        path: join(runDir, `${String(stepIndex).padStart(2, "0")}-${slug}.png`),
+      });
+    };
+
+    await step("app boots into the web console", async () => {
+      await page.getByText("Settings").first().waitFor({ timeout: 120_000 });
+    });
+
+    // SIGKILL #1 — the report path. Establishes that the sink works and a hard
+    // kill IS reported, which also calibrates that envelopes arrive in time.
+    await step("a hard kill (SIGKILL) is reported as a crash", async () => {
+      process.kill(sidecarPid(), "SIGKILL");
+      await page.getByText("stopped unexpectedly").waitFor({ timeout: 30_000 });
+      await waitFor(() => sigkillReports().length >= 1, "the first SIGKILL crash report");
+    });
+
+    await step("restart heals the app", async () => {
+      await page.locator("#restart").click();
+      await page.getByText("Settings").first().waitFor({ timeout: 120_000 });
+    });
+
+    // SIGINT — the clean-shutdown path. The dev sidecar handles SIGINT and exits
+    // 0; the app surfaces the SAME recovery screen, but this must NOT be reported.
+    await step("a clean stop (SIGINT) shows recovery but is not reported", async () => {
+      process.kill(sidecarPid(), "SIGINT");
+      await page.getByText("stopped unexpectedly").waitFor({ timeout: 30_000 });
+    });
+
+    await step("restart heals the app again", async () => {
+      await page.locator("#restart").click();
+      await page.getByText("Settings").first().waitFor({ timeout: 120_000 });
+    });
+
+    // SIGKILL #2 — the fence. Once its crash envelope has landed, FIFO ordering
+    // guarantees any envelope the SIGINT would have produced is already here.
+    await step("fence: a second hard kill is reported", async () => {
+      process.kill(sidecarPid(), "SIGKILL");
+      await page.getByText("stopped unexpectedly").waitFor({ timeout: 30_000 });
+      await waitFor(() => sigkillReports().length >= 2, "the fence SIGKILL crash report");
+    });
+
+    // The verdict: every sidecar-exit crash reported was a SIGKILL — the SIGINT
+    // in between contributed nothing.
+    const reports = crashReports();
+    expect(
+      reports.length,
+      `only the two SIGKILLs were reported, got: ${JSON.stringify(reports.map(firstLine))}`,
+    ).toBe(2);
+    expect(
+      reports.every((e) => e.includes("signal=SIGKILL")),
+      "no clean SIGINT shutdown (code=0 / signal=null) was reported as a crash",
+    ).toBe(true);
+  } finally {
+    const page = app.windows()[0];
+    const video = page?.video();
+    await app.close().catch(() => {});
+    await new Promise<void>((resolve) => sink.close(() => resolve()));
+    const recordedPath = await video?.path().catch(() => undefined);
+    if (recordedPath && existsSync(recordedPath)) {
+      await promisify(execFile)("ffmpeg", [
+        "-y",
+        "-i",
+        recordedPath,
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-crf",
+        "26",
+        "-pix_fmt",
+        "yuv420p",
+        "-movflags",
+        "+faststart",
+        join(runDir, "session.mp4"),
+      ]).catch(() => {});
+    }
+    rmSync(videoTmp, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
+  }
+};
+
+const firstLine = (envelope: string): string => {
+  const match = envelope.match(new RegExp(`${SIDECAR_CRASH_MESSAGE}[^"\\\\]*`));
+  return match ? match[0] : envelope.slice(0, 80);
+};


### PR DESCRIPTION
## Problem

The desktop app filed spurious crash reports of the form:

> Sidecar exited unexpectedly (code=130 signal=null)

`code=130` is `128 + SIGINT(2)` — the sidecar was **interrupted by SIGINT and shut down cleanly through its own signal handler**. The attached `stderrTail` was empty, confirming no fault occurred.

It got misclassified because `sidecar.ts` only treats a post-boot exit as *expected* when the desktop itself called `stopSidecar` (which sends **SIGTERM**). A SIGINT arriving any other way — most plausibly a process-group signal racing ahead of teardown, since the child shares the Electron main process's group — fell through to `reportSidecarCrash` **and** swapped the live UI for the crash screen, over what was really a healthy shutdown.

## Fix

Classify the post-boot exit on its **exit code/signal alone**:

1. **Quit-intent latch** — `markAppQuitting()` is set synchronously at the top of `before-quit`, *before* `stopConnection`'s `await`. Once the app is quitting, no sidecar exit is reported, closing the race where a SIGINT beats the SIGTERM.
2. **Clean-shutdown classification** — a graceful or signal-driven exit (code `0`/`130`/`143`, or a raw `SIGINT`/`SIGTERM`) is a shutdown, not a crash: it still surfaces the recovery screen (the web UI is dead, the user needs a way out) but is **not** reported. Abnormal exits — other non-zero codes, `SIGKILL`, a `null` code — still report exactly as before.

stderr is deliberately **not** consulted: the buffer is a rolling session tail (a startup log line makes it non-empty), so it's a poor proxy for "errored at exit". A genuine internal fault in the daemon is reported with a real stack by the sidecar's own crash reporter (`@sentry/bun`); this main-process path is the coarse "the child vanished" net, so it should fire only on abnormal exits.

The decision logic lives in a pure, electron-free helper (`sidecar-exit.ts`).

## Proof — black-box, through the real app

The on-screen flow can't show this bug: a clean shutdown and a hard kill paint the **same** recovery screen — the only difference is what reaches Sentry. So [`e2e/desktop/sidecar-clean-shutdown-not-reported.test.ts`](../blob/claude/sidecar-shutdown-false-crash/e2e/desktop/sidecar-clean-shutdown-not-reported.test.ts) launches the real Electron app pointed at a **local Sentry envelope sink** (via a non-packaged `EXECUTOR_DESKTOP_SENTRY_DSN` seam in `diagnostics.ts`, dead in production) and asserts:

- **SIGKILL** → a `Sidecar exited unexpectedly` crash **is** reported, and
- **SIGINT** → the recovery screen shows but **nothing** is reported,

with a **second SIGKILL as an ordering fence** — Sentry's transport is FIFO per client, so once the fence's envelope has arrived, any envelope the SIGINT would have produced is already present too; its absence is real, not just slow.

Verification:
- `vitest run --project desktop sidecar-clean-shutdown-not-reported` → **1 passed** (~25s)
- existing `sidecar-crash-screen` scenario (SIGKILL → crash screen → restart heals) → **still passes** (~16s), confirming SIGKILL is still classified as a crash
- `apps/desktop` + `e2e` typecheck, repo `oxlint`, `oxfmt --check` — all clean

## Notes for reviewers

- **Test seam:** `EXECUTOR_DESKTOP_SENTRY_DSN` overrides the baked-in DSN **only when `!app.isPackaged`**. Production is always packaged, so it can never redirect a real user's reports.
- **Coverage boundary:** the e2e exercises the dev sidecar (exit `0` on SIGINT) and SIGKILL. The prod-only `130`/`143` codes aren't hit by the dev-electron target; they're covered by the pure classifier's construction. The earlier pure unit test was dropped in favour of this black-box proof.