### PR TITLE
Toolkits

### DIFF
--- a/apps/cloud/executor.config.ts
+++ b/apps/cloud/executor.config.ts
@@ -3,6 +3,7 @@ import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
 import { graphqlHttpPlugin } from "@executor-js/plugin-graphql/api";
 import { workosVaultPlugin, type WorkOSVaultClient } from "@executor-js/plugin-workos-vault";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
 
 // ---------------------------------------------------------------------------
 // Single source of truth for the cloud app's plugin list.
@@ -52,5 +53,6 @@ export default defineExecutorConfig({
         credentials: workosCredentials ?? { apiKey: "", clientId: "" },
         ...(workosVaultClient ? { client: workosVaultClient } : {}),
       }),
+      toolkitsPlugin(),
     ] as const,
 });

--- a/apps/cloud/package.json
+++ b/apps/cloud/package.json
@@ -44,6 +44,7 @@
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",
     "@executor-js/plugin-openapi": "workspace:*",
+    "@executor-js/plugin-toolkits": "workspace:*",
     "@executor-js/plugin-workos-vault": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@executor-js/runtime-dynamic-worker": "workspace:*",

--- a/apps/cloud/src/mcp/session-durable-object.ts
+++ b/apps/cloud/src/mcp/session-durable-object.ts
@@ -172,6 +172,7 @@ export class McpSessionDO extends McpSessionDOBase<CloudSessionDbHandle> {
         organizationName: org.name,
         userId: token.userId,
         elicitationMode: token.elicitationMode,
+        toolkitId: token.toolkitId,
       } satisfies SessionMeta;
     }).pipe(
       Effect.withSpan("McpSessionDO.resolveSessionMeta"),
@@ -192,6 +193,7 @@ export class McpSessionDO extends McpSessionDOBase<CloudSessionDbHandle> {
         sessionMeta.userId,
         sessionMeta.organizationId,
         sessionMeta.organizationName,
+        sessionMeta.toolkitId,
       ).pipe(
         Effect.provide(CloudExecutionStackLayer),
         Effect.withSpan("McpSessionDO.makeExecutionStack"),

--- a/apps/host-cloudflare/executor.config.ts
+++ b/apps/host-cloudflare/executor.config.ts
@@ -3,6 +3,7 @@ import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
 import { graphqlHttpPlugin } from "@executor-js/plugin-graphql/api";
 import { encryptedSecretsPlugin } from "@executor-js/plugin-encrypted-secrets";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
 
 // ---------------------------------------------------------------------------
 // Plugin list for the Cloudflare web build. The Vite `executorVitePlugin` reads
@@ -20,5 +21,6 @@ export default defineExecutorConfig({
       mcpHttpPlugin({ dangerouslyAllowStdioMCP: false }),
       graphqlHttpPlugin(),
       encryptedSecretsPlugin({ key: process.env.EXECUTOR_SECRET_KEY ?? "build-time-placeholder" }),
+      toolkitsPlugin(),
     ] as const,
 });

--- a/apps/host-cloudflare/package.json
+++ b/apps/host-cloudflare/package.json
@@ -27,6 +27,7 @@
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",
     "@executor-js/plugin-openapi": "workspace:*",
+    "@executor-js/plugin-toolkits": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@executor-js/runtime-quickjs": "workspace:*",
     "@executor-js/sdk": "workspace:*",

--- a/apps/host-cloudflare/src/mcp/session-durable-object.ts
+++ b/apps/host-cloudflare/src/mcp/session-durable-object.ts
@@ -61,6 +61,7 @@ export class McpSessionDO extends McpSessionDOBase<CfSessionDbHandle> {
       organizationName: this.cfConfig.organizationName,
       userId: token.userId,
       elicitationMode: token.elicitationMode,
+      toolkitId: token.toolkitId,
     } satisfies SessionMeta);
   }
 
@@ -78,6 +79,7 @@ export class McpSessionDO extends McpSessionDOBase<CfSessionDbHandle> {
         sessionMeta.userId,
         sessionMeta.organizationId,
         sessionMeta.organizationName,
+        sessionMeta.toolkitId,
       ).pipe(Effect.provide(makeCloudflareExecutionStackLayer(config, dbHandle)));
       // Browser elicitation mode (the base owns the approval store + the HTTP
       // approval RPCs): a gated execution pauses and returns an approvalUrl into

--- a/apps/host-selfhost/executor.config.ts
+++ b/apps/host-selfhost/executor.config.ts
@@ -3,6 +3,7 @@ import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
 import { graphqlHttpPlugin } from "@executor-js/plugin-graphql/api";
 import { encryptedSecretsPlugin } from "@executor-js/plugin-encrypted-secrets";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
 
 import { resolveSecretKey } from "./src/config";
 
@@ -24,5 +25,6 @@ export default defineExecutorConfig({
       graphqlHttpPlugin(),
       // First writable secret provider -> the default for `secrets.set`.
       encryptedSecretsPlugin({ key: resolveSecretKey() }),
+      toolkitsPlugin(),
     ] as const,
 });

--- a/apps/host-selfhost/package.json
+++ b/apps/host-selfhost/package.json
@@ -30,6 +30,7 @@
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",
     "@executor-js/plugin-openapi": "workspace:*",
+    "@executor-js/plugin-toolkits": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@executor-js/runtime-quickjs": "workspace:*",
     "@executor-js/sdk": "workspace:*",

--- a/apps/local/executor.config.ts
+++ b/apps/local/executor.config.ts
@@ -6,6 +6,7 @@ import { keychainPlugin } from "@executor-js/plugin-keychain";
 import { fileSecretsPlugin } from "@executor-js/plugin-file-secrets";
 import { onepasswordHttpPlugin } from "@executor-js/plugin-onepassword/api";
 import { desktopSettingsPlugin } from "@executor-js/plugin-desktop-settings/server";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
 
 // ---------------------------------------------------------------------------
 // Single source of truth for the local app's plugin list.
@@ -29,5 +30,6 @@ export default defineExecutorConfig({
         webBaseUrl:
           process.env.EXECUTOR_WEB_BASE_URL ?? `http://localhost:${process.env.PORT ?? "4788"}`,
       }),
+      toolkitsPlugin(),
     ] as const,
 });

--- a/apps/local/package.json
+++ b/apps/local/package.json
@@ -37,6 +37,7 @@
     "@executor-js/plugin-mcp": "workspace:*",
     "@executor-js/plugin-onepassword": "workspace:*",
     "@executor-js/plugin-openapi": "workspace:*",
+    "@executor-js/plugin-toolkits": "workspace:*",
     "@executor-js/react": "workspace:*",
     "@executor-js/runtime-quickjs": "workspace:*",
     "@executor-js/sdk": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -68,6 +68,7 @@
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
         "@executor-js/plugin-openapi": "workspace:*",
+        "@executor-js/plugin-toolkits": "workspace:*",
         "@executor-js/plugin-workos-vault": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@executor-js/runtime-dynamic-worker": "workspace:*",
@@ -172,6 +173,7 @@
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
         "@executor-js/plugin-openapi": "workspace:*",
+        "@executor-js/plugin-toolkits": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@executor-js/runtime-quickjs": "workspace:*",
         "@executor-js/sdk": "workspace:*",
@@ -218,6 +220,7 @@
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
         "@executor-js/plugin-openapi": "workspace:*",
+        "@executor-js/plugin-toolkits": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@executor-js/runtime-quickjs": "workspace:*",
         "@executor-js/sdk": "workspace:*",
@@ -268,6 +271,7 @@
         "@executor-js/plugin-mcp": "workspace:*",
         "@executor-js/plugin-onepassword": "workspace:*",
         "@executor-js/plugin-openapi": "workspace:*",
+        "@executor-js/plugin-toolkits": "workspace:*",
         "@executor-js/react": "workspace:*",
         "@executor-js/runtime-quickjs": "workspace:*",
         "@executor-js/sdk": "workspace:*",
@@ -333,6 +337,7 @@
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
         "@executor-js/plugin-openapi": "workspace:*",
+        "@executor-js/plugin-toolkits": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "@kitlangton/terminal-control": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
@@ -999,6 +1004,22 @@
         "react",
       ],
     },
+    "packages/plugins/toolkits": {
+      "name": "@executor-js/plugin-toolkits",
+      "version": "1.5.12",
+      "dependencies": {
+        "@executor-js/api": "workspace:*",
+        "@executor-js/sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "@effect/vitest": "catalog:",
+        "@types/node": "catalog:",
+        "bun-types": "catalog:",
+        "tsup": "catalog:",
+        "typescript": "catalog:",
+        "vitest": "catalog:",
+      },
+    },
     "packages/plugins/workos-vault": {
       "name": "@executor-js/plugin-workos-vault",
       "version": "0.0.2",
@@ -1588,6 +1609,8 @@
     "@executor-js/plugin-onepassword": ["@executor-js/plugin-onepassword@workspace:packages/plugins/onepassword"],
 
     "@executor-js/plugin-openapi": ["@executor-js/plugin-openapi@workspace:packages/plugins/openapi"],
+
+    "@executor-js/plugin-toolkits": ["@executor-js/plugin-toolkits@workspace:packages/plugins/toolkits"],
 
     "@executor-js/plugin-workos-vault": ["@executor-js/plugin-workos-vault@workspace:packages/plugins/workos-vault"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1008,17 +1008,33 @@
       "name": "@executor-js/plugin-toolkits",
       "version": "1.5.12",
       "dependencies": {
+        "@effect/atom-react": "catalog:",
         "@executor-js/api": "workspace:*",
         "@executor-js/sdk": "workspace:*",
       },
       "devDependencies": {
         "@effect/vitest": "catalog:",
+        "@executor-js/react": "workspace:*",
         "@types/node": "catalog:",
+        "@types/react": "catalog:",
         "bun-types": "catalog:",
+        "effect": "catalog:",
+        "react": "catalog:",
         "tsup": "catalog:",
         "typescript": "catalog:",
         "vitest": "catalog:",
       },
+      "peerDependencies": {
+        "@effect/atom-react": "catalog:",
+        "@executor-js/react": "workspace:*",
+        "effect": "catalog:",
+        "react": ">=18",
+      },
+      "optionalPeers": [
+        "@effect/atom-react",
+        "@executor-js/react",
+        "react",
+      ],
     },
     "packages/plugins/workos-vault": {
       "name": "@executor-js/plugin-workos-vault",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -26,6 +26,7 @@
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",
     "@executor-js/plugin-openapi": "workspace:*",
+    "@executor-js/plugin-toolkits": "workspace:*",
     "@executor-js/sdk": "workspace:*",
     "@kitlangton/terminal-control": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/e2e/selfhost/toolkits-core-tools-scope.test.ts
+++ b/e2e/selfhost/toolkits-core-tools-scope.test.ts
@@ -9,29 +9,20 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
 import type { McpSession } from "../src/surfaces/mcp";
 
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
 const isBlocked = (text: string): boolean => text.includes("tool_blocked");
 
-const isSuccessfulGreeting = (text: string): boolean =>
-  text.includes("Hello from greeting MCP");
+const isSuccessfulGreeting = (text: string): boolean => text.includes("Hello from greeting MCP");
 
 const listConnections = (session: McpSession) =>
   session.call("execute", {
@@ -79,10 +70,7 @@ scenario(
                 {
                   type: "apiKey",
                   headers: {
-                    Authorization: [
-                      "Bearer ",
-                      { type: "variable", name: "token" },
-                    ],
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
                   },
                 },
               ],
@@ -145,12 +133,7 @@ scenario(
       expect(
         bareConns.connections.map((c) => `${c.integration}/${c.name}`),
         "bare connections.list still sees both connections",
-      ).toEqual(
-        expect.arrayContaining([
-          `${slugIn}/${connIn}`,
-          `${slugOut}/${connOut}`,
-        ]),
-      );
+      ).toEqual(expect.arrayContaining([`${slugIn}/${connIn}`, `${slugOut}/${connOut}`]));
 
       const scopedIntsResult = yield* listIntegrations(scoped);
       const bareIntsResult = yield* listIntegrations(bare);
@@ -167,20 +150,15 @@ scenario(
       };
 
       const scopedSlugs = scopedInts.integrations.map((i) => i.slug);
-      expect(
-        scopedSlugs,
-        "scoped integrations.list includes in-slice slug",
-      ).toContain(slugIn);
-      expect(
-        scopedSlugs,
-        "scoped integrations.list omits out-of-slice slug",
-      ).not.toContain(slugOut);
+      expect(scopedSlugs, "scoped integrations.list includes in-slice slug").toContain(slugIn);
+      expect(scopedSlugs, "scoped integrations.list omits out-of-slice slug").not.toContain(
+        slugOut,
+      );
 
       const bareSlugs = bareInts.integrations.map((i) => i.slug);
-      expect(
-        bareSlugs,
-        "bare integrations.list still sees both integrations",
-      ).toEqual(expect.arrayContaining([slugIn, slugOut]));
+      expect(bareSlugs, "bare integrations.list still sees both integrations").toEqual(
+        expect.arrayContaining([slugIn, slugOut]),
+      );
 
       const inSlice = yield* scoped.call("execute", {
         code: `return await tools.${slugIn}.org.${connIn}.simple_echo({});`,

--- a/e2e/selfhost/toolkits-core-tools-scope.test.ts
+++ b/e2e/selfhost/toolkits-core-tools-scope.test.ts
@@ -1,0 +1,392 @@
+// Selfhost · toolkit scope must narrow built-in core tools, not only dynamic
+// connection tools. A scoped MCP session calling `connections.list` /
+// `integrations.list` must see ONLY in-slice catalog rows; guessed out-of-slice
+// dynamic addresses are blocked at execute; per-toolkit `require_approval`
+// tightens the matching tool under that toolkit only.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+import type { McpSession } from "../src/surfaces/mcp";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const isBlocked = (text: string): boolean => text.includes("tool_blocked");
+
+const isSuccessfulGreeting = (text: string): boolean =>
+  text.includes("Hello from greeting MCP");
+
+const listConnections = (session: McpSession) =>
+  session.call("execute", {
+    code: `
+const list = await tools.executor.coreTools.connections.list({});
+return JSON.stringify(list.ok ? list.data : { error: list.error });
+`,
+  });
+
+const listIntegrations = (session: McpSession) =>
+  session.call("execute", {
+    code: `
+const list = await tools.executor.coreTools.integrations.list({});
+return JSON.stringify(list.ok ? list.data : { error: list.error });
+`,
+  });
+
+scenario(
+  "Toolkits · scoped MCP sessions narrow built-in connections.list and integrations.list",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: [
+                      "Bearer ",
+                      { type: "variable", name: "token" },
+                    ],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      const slugIn = ident("corein");
+      const slugOut = ident("coreout");
+      const connIn = ident("conn");
+      const connOut = ident("conn");
+      yield* addConnection(slugIn, connIn);
+      yield* addConnection(slugOut, connOut);
+
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("corekit"),
+          name: "Core scoped kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugIn),
+              connection: connIn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const bare = mcp.session(identity);
+
+      const scopedConnsResult = yield* listConnections(scoped);
+      const bareConnsResult = yield* listConnections(bare);
+      expect(
+        scopedConnsResult.ok,
+        `scoped connections.list must succeed; text=${scopedConnsResult.text}`,
+      ).toBe(true);
+
+      const scopedConns = JSON.parse(scopedConnsResult.text) as {
+        connections: ReadonlyArray<{ integration: string; name: string }>;
+      };
+      const bareConns = JSON.parse(bareConnsResult.text) as {
+        connections: ReadonlyArray<{ integration: string; name: string }>;
+      };
+
+      expect(
+        scopedConns.connections.map((c) => `${c.integration}/${c.name}`),
+        "scoped connections.list shows only the in-slice connection",
+      ).toEqual([`${slugIn}/${connIn}`]);
+      expect(
+        bareConns.connections.map((c) => `${c.integration}/${c.name}`),
+        "bare connections.list still sees both connections",
+      ).toEqual(
+        expect.arrayContaining([
+          `${slugIn}/${connIn}`,
+          `${slugOut}/${connOut}`,
+        ]),
+      );
+
+      const scopedIntsResult = yield* listIntegrations(scoped);
+      const bareIntsResult = yield* listIntegrations(bare);
+      expect(
+        scopedIntsResult.ok,
+        `scoped integrations.list must succeed; text=${scopedIntsResult.text}`,
+      ).toBe(true);
+
+      const scopedInts = JSON.parse(scopedIntsResult.text) as {
+        integrations: ReadonlyArray<{ slug: string }>;
+      };
+      const bareInts = JSON.parse(bareIntsResult.text) as {
+        integrations: ReadonlyArray<{ slug: string }>;
+      };
+
+      const scopedSlugs = scopedInts.integrations.map((i) => i.slug);
+      expect(
+        scopedSlugs,
+        "scoped integrations.list includes in-slice slug",
+      ).toContain(slugIn);
+      expect(
+        scopedSlugs,
+        "scoped integrations.list omits out-of-slice slug",
+      ).not.toContain(slugOut);
+
+      const bareSlugs = bareInts.integrations.map((i) => i.slug);
+      expect(
+        bareSlugs,
+        "bare integrations.list still sees both integrations",
+      ).toEqual(expect.arrayContaining([slugIn, slugOut]));
+
+      const inSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugIn}.org.${connIn}.simple_echo({});`,
+      });
+      expect(inSlice.ok, `in-slice tool runs; text=${inSlice.text}`).toBe(true);
+
+      const outSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugOut}.org.${connOut}.simple_echo({});`,
+      });
+      expect(
+        isBlocked(outSlice.text),
+        `guessed out-of-slice address must be tool_blocked; text=${outSlice.text}`,
+      ).toBe(true);
+      expect(
+        isSuccessfulGreeting(outSlice.text),
+        `out-of-slice must not run upstream; text=${outSlice.text}`,
+      ).toBe(false);
+      expect(
+        outSlice.text.includes("suggestions"),
+        `out-of-slice must not leak tool suggestions; text=${outSlice.text}`,
+      ).toBe(false);
+    }),
+  ),
+);
+
+scenario(
+  "Toolkits · scoped MCP sessions cannot create connections or policies",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const slug = ident("adm");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("admkit"),
+          name: "Admin blocked kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const newConn = ident("newconn");
+
+      const createConn = yield* scoped.call("execute", {
+        code: `
+const result = await tools.executor.coreTools.connections.create({
+  owner: "org",
+  integration: "${slug}",
+  name: "${newConn}",
+  template: "header",
+  value: "blocked-token",
+});
+return JSON.stringify(result.ok ? result.data : { error: result.error });
+`,
+      });
+      expect(
+        isBlocked(createConn.text),
+        `scoped connections.create blocked; text=${createConn.text}`,
+      ).toBe(true);
+
+      const createPolicy = yield* scoped.call("execute", {
+        code: `
+const result = await tools.executor.coreTools.policies.create({
+  owner: "org",
+  pattern: "${slug}.*",
+  action: "block",
+});
+return JSON.stringify(result.ok ? result.data : { error: result.error });
+`,
+      });
+      expect(
+        isBlocked(createPolicy.text),
+        `scoped policies.create blocked; text=${createPolicy.text}`,
+      ).toBe(true);
+    }),
+  ),
+);
+
+scenario(
+  "Toolkits · a per-toolkit require_approval rule pauses only under that toolkit",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const slug = ident("appr");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const gated = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitappr"),
+          name: "Approval gated",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+          policies: [
+            {
+              pattern: `${slug}.${conn}.simple_echo`,
+              action: "require_approval",
+            },
+          ],
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+
+      const bareRun = yield* mcp.session(identity).call("execute", { code });
+      expect(
+        bareRun.ok && !bareRun.text.includes("Execution paused"),
+        `bare session runs without toolkit approval gate; text=${bareRun.text}`,
+      ).toBe(true);
+
+      const gatedRun = yield* mcp
+        .session(identity, { toolkit: gated.slug })
+        .call("execute", { code });
+      expect(
+        gatedRun.text,
+        `toolkit require_approval pauses execution; text=${gatedRun.text}`,
+      ).toContain("Execution paused");
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-cross-user.test.ts
+++ b/e2e/selfhost/toolkits-cross-user.test.ts
@@ -1,0 +1,241 @@
+// Selfhost · cross-user visibility of toolkits. The contract under test:
+// workspace toolkits ride org-owned plugin storage (visible to every org
+// member), personal toolkits ride user-owned storage (visible only to their
+// creating subject), and the MCP toolkit selector is fail-closed — a slug the
+// caller can't resolve narrows the engine to an EMPTY slice rather than leaking
+// the slice it names. `resolveScope` returns null for a slug the caller isn't
+// entitled to (server.ts: "a cross-tenant/personal-of-another-user selector
+// returns null"), so a hijacked-slug session sees nothing.
+//
+// HARNESS CAVEAT (verified in e2e/targets/selfhost.ts): selfhost is
+// single-tenant today — `newIdentity()` always signs the SAME bootstrap admin
+// in, so two `newIdentity()` calls yield the SAME subject in the SAME org, not
+// two distinct members. We assert that fact below so the test self-documents
+// why the "a DIFFERENT user is denied" leg cannot be driven here. We instead
+// prove the enforcement MECHANISM that backs cross-user privacy and IS
+// drivable on one subject: an MCP session whose `?toolkit=` slug does not
+// resolve for the caller is narrowed to an empty slice and blocks the named
+// connection's tool at execute. (The true second-member denial belongs to a
+// multi-tenant target, e.g. cloud, once selfhost grows per-test signup.)
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and so connection names survive the create-time
+// normalize (hyphens removed + camelCased) byte-for-byte.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · workspace toolkits are visible to org members; personal toolkits stay subject-private and a non-resolving slug is fail-closed",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+
+      // Two identities + a client each. On selfhost both resolve to the
+      // bootstrap admin (same subject, same org) — see the harness caveat.
+      const idA = yield* target.newIdentity();
+      const idB = yield* target.newIdentity();
+      const clientA = yield* makeApiClient(api, idA);
+      const clientB = yield* makeApiClient(api, idB);
+
+      // Make the single-subject reality explicit: the "different member" leg of
+      // the cross-user contract degenerates here, and the assertions below are
+      // written to what selfhost can actually prove.
+      const sameSubject = idA.credentials?.email === idB.credentials?.email;
+      expect(
+        sameSubject,
+        "selfhost is single-tenant: both identities are the bootstrap admin",
+      ).toBe(true);
+
+      // Stand up two real greeting MCP servers and register each as an
+      // integration + a connection at the requested owner. `text` is distinct
+      // per connection so a successful execute is unambiguous.
+      const addConnection = (
+        slug: string,
+        conn: string,
+        owner: "org" | "user",
+        text: string,
+      ) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(
+            () => makeGreetingMcpServer({ text }),
+            {
+              auth: {
+                validateAuthorization: (authorization) =>
+                  Effect.succeed(authorization === `Bearer ${token}`),
+              },
+            },
+          );
+          yield* clientA.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: [
+                      "Bearer ",
+                      { type: "variable", name: "token" },
+                    ],
+                  },
+                },
+              ],
+            },
+          });
+          yield* clientA.connections.create({
+            payload: {
+              owner,
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // idA seeds ONE org connection and ONE personal connection, and the
+      // expected greeting each tool returns.
+      const orgSlug = ident("orgint");
+      const orgConn = ident("orgconn");
+      const orgText = `hello-org-${randomBytes(3).toString("hex")}`;
+      const personalSlug = ident("pvtint");
+      const personalConn = ident("pvtconn");
+      const personalText = `hello-pvt-${randomBytes(3).toString("hex")}`;
+      yield* addConnection(orgSlug, orgConn, "org", orgText);
+      yield* addConnection(personalSlug, personalConn, "user", personalText);
+
+      // A WORKSPACE toolkit (org-owned) over the org connection, and a PERSONAL
+      // toolkit (user-owned) over idA's own connection — both at full access.
+      const workspaceKit = yield* clientA.toolkits.create({
+        payload: {
+          slug: ident("wskit"),
+          name: "Workspace kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(orgSlug),
+              connection: orgConn,
+              access: "full",
+            },
+          ],
+        },
+      });
+      const personalKit = yield* clientA.toolkits.create({
+        payload: {
+          slug: ident("pvtkit"),
+          name: "Personal kit",
+          scope: "personal",
+          connections: [
+            {
+              integration: IntegrationSlug.make(personalSlug),
+              connection: personalConn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // (a) The other client's list. The workspace toolkit is org-owned, so it
+      // MUST be present. On a multi-tenant target the personal toolkit (a
+      // different member's user-owned data) would be ABSENT; on selfhost idB IS
+      // idA, so it is present — we assert the truth for this target and pin the
+      // workspace-visible invariant unconditionally.
+      const listB = yield* clientB.toolkits.list();
+      expect(
+        listB.some(
+          (t) => t.id === workspaceKit.id && t.slug === workspaceKit.slug,
+        ),
+        "workspace toolkit is visible to org members",
+      ).toBe(true);
+      expect(
+        listB.some((t) => t.id === personalKit.id),
+        sameSubject
+          ? "selfhost single-subject: idA's personal toolkit is visible because idB IS idA"
+          : "a personal toolkit must not appear in another member's list",
+      ).toBe(sameSubject);
+
+      // (b) An MCP session for idB scoped to the WORKSPACE slug exposes the org
+      // slice: the execute inventory mentions the org integration, and running
+      // its tool returns the org greeting (a success envelope, not an error).
+      const wsSession = mcp.session(idB, { toolkit: workspaceKit.slug });
+      const wsDesc = describeExecute(yield* wsSession.describeTools());
+      expect(
+        wsDesc,
+        "workspace-scoped inventory includes the org integration",
+      ).toContain(orgSlug);
+
+      const wsCall = yield* wsSession.call("execute", {
+        code: `return await tools.${orgSlug}.org.${orgConn}.simple_echo({});`,
+      });
+      expect(wsCall.ok, `org tool executes; text=${wsCall.text}`).toBe(true);
+      expect(
+        wsCall.text,
+        `workspace slice returns the org greeting; text=${wsCall.text}`,
+      ).toContain(orgText);
+
+      // (c) Fail-closed selector — the mechanism behind cross-user privacy. A
+      // session whose `?toolkit=` slug the caller cannot resolve is narrowed to
+      // an EMPTY slice: the named connection is neither advertised nor runnable.
+      // We exercise it two ways:
+      //   1. the personal slug from another (here: the same) subject's kit, and
+      //   2. a slug that does not exist at all,
+      // and require BOTH to behave identically — proving a personal toolkit
+      // cannot be hijacked by handing its slug to a session that isn't entitled
+      // to it. (Selfhost can't supply a second subject, so the personal slug
+      // DOES resolve here; the bogus slug is the load-bearing fail-closed proof,
+      // and the personal-slug case still confirms the personal connection is not
+      // leaked into an unrelated/empty narrowing.)
+      const hijackSession = mcp.session(idB, { toolkit: ident("ghostkit") });
+      const hijackDesc = describeExecute(yield* hijackSession.describeTools());
+      expect(
+        hijackDesc,
+        "an unresolved toolkit slug yields an empty slice — personal connection not exposed",
+      ).not.toContain(personalSlug);
+      expect(
+        hijackDesc,
+        "an unresolved toolkit slug yields an empty slice — org connection not exposed either",
+      ).not.toContain(orgSlug);
+
+      // Executing the personal connection's tool through the empty/unresolved
+      // slice is blocked: the result is never the personal greeting the tool
+      // would emit if the slice had actually exposed it.
+      const hijackCall = yield* hijackSession.call("execute", {
+        code: `return await tools.${personalSlug}.user.${personalConn}.simple_echo({});`,
+      });
+      expect(
+        hijackCall.text,
+        `unresolved-slug session must not return the personal greeting; text=${hijackCall.text}`,
+      ).not.toContain(personalText);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-cross-user.test.ts
+++ b/e2e/selfhost/toolkits-cross-user.test.ts
@@ -23,16 +23,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -41,12 +34,10 @@ const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays valid JS, and so connection names survive the create-time
 // normalize (hyphens removed + camelCased) byte-for-byte.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   "Toolkits · workspace toolkits are visible to org members; personal toolkits stay subject-private and a non-resolving slug is fail-closed",
@@ -76,23 +67,15 @@ scenario(
       // Stand up two real greeting MCP servers and register each as an
       // integration + a connection at the requested owner. `text` is distinct
       // per connection so a successful execute is unambiguous.
-      const addConnection = (
-        slug: string,
-        conn: string,
-        owner: "org" | "user",
-        text: string,
-      ) =>
+      const addConnection = (slug: string, conn: string, owner: "org" | "user", text: string) =>
         Effect.gen(function* () {
           const token = `tok-${randomBytes(6).toString("hex")}`;
-          const server = yield* serveMcpServer(
-            () => makeGreetingMcpServer({ text }),
-            {
-              auth: {
-                validateAuthorization: (authorization) =>
-                  Effect.succeed(authorization === `Bearer ${token}`),
-              },
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer({ text }), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
             },
-          );
+          });
           yield* clientA.mcp.addServer({
             payload: {
               transport: "remote",
@@ -103,10 +86,7 @@ scenario(
                 {
                   type: "apiKey",
                   headers: {
-                    Authorization: [
-                      "Bearer ",
-                      { type: "variable", name: "token" },
-                    ],
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
                   },
                 },
               ],
@@ -172,9 +152,7 @@ scenario(
       // workspace-visible invariant unconditionally.
       const listB = yield* clientB.toolkits.list();
       expect(
-        listB.some(
-          (t) => t.id === workspaceKit.id && t.slug === workspaceKit.slug,
-        ),
+        listB.some((t) => t.id === workspaceKit.id && t.slug === workspaceKit.slug),
         "workspace toolkit is visible to org members",
       ).toBe(true);
       expect(
@@ -189,10 +167,7 @@ scenario(
       // its tool returns the org greeting (a success envelope, not an error).
       const wsSession = mcp.session(idB, { toolkit: workspaceKit.slug });
       const wsDesc = describeExecute(yield* wsSession.describeTools());
-      expect(
-        wsDesc,
-        "workspace-scoped inventory includes the org integration",
-      ).toContain(orgSlug);
+      expect(wsDesc, "workspace-scoped inventory includes the org integration").toContain(orgSlug);
 
       const wsCall = yield* wsSession.call("execute", {
         code: `return await tools.${orgSlug}.org.${orgConn}.simple_echo({});`,

--- a/e2e/selfhost/toolkits-crud.test.ts
+++ b/e2e/selfhost/toolkits-crud.test.ts
@@ -1,0 +1,94 @@
+// Selfhost · Slice 1: a toolkit is owner-scoped plugin data with a CRUD API.
+// Proves the plugin's storage round-trips through real HTTP routes on the
+// selfhost server, owner/scope maps correctly, and the scope guard rejects
+// connections a toolkit isn't allowed to reference. No MCP narrowing yet.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const api = composePluginApi([toolkitsPlugin()] as const);
+const fresh = (prefix: string): string => `${prefix}-${randomBytes(4).toString("hex")}`;
+
+scenario(
+  "Toolkits · CRUD round-trips through the selfhost API",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+
+    const slug = fresh("work");
+    const created = yield* client.toolkits.create({
+      payload: { slug, name: "Work", scope: "personal", briefing: "general assistant" },
+    });
+    expect(created.slug).toBe(slug);
+    expect(created.scope).toBe("personal");
+    expect(created.inheritOrgPolicies, "defaults to inheriting org policies").toBe(true);
+    expect(created.briefing).toBe("general assistant");
+    expect(created.connections.length).toBe(0);
+
+    // round-trips through GET
+    const fetched = yield* client.toolkits.get({ params: { id: created.id } });
+    expect(fetched.id).toBe(created.id);
+    expect(fetched.name).toBe("Work");
+
+    // shows up in the owner-scoped list
+    const listed = yield* client.toolkits.list();
+    expect(
+      listed.some((t) => t.id === created.id),
+      "the created toolkit appears in the list",
+    ).toBe(true);
+
+    // PATCH mutates name + briefing
+    const patched = yield* client.toolkits.update({
+      params: { id: created.id },
+      payload: { name: "Work v2", briefing: null },
+    });
+    expect(patched.name).toBe("Work v2");
+    expect(patched.briefing).toBe(null);
+
+    // DELETE removes it; subsequent GET is a typed ToolkitNotFound
+    const removed = yield* client.toolkits.remove({ params: { id: created.id } });
+    expect(removed.removed).toBe(true);
+
+    const afterDelete = yield* Effect.flip(client.toolkits.get({ params: { id: created.id } }));
+    expect((afterDelete as { _tag?: string })._tag, "GET after delete is ToolkitNotFound").toBe(
+      "ToolkitNotFound",
+    );
+  }),
+);
+
+scenario(
+  "Toolkits · a workspace toolkit cannot reference a connection it isn't allowed to use",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+
+    const result = yield* Effect.flip(
+      client.toolkits.create({
+        payload: {
+          slug: fresh("support"),
+          name: "Support",
+          scope: "workspace",
+          connections: [
+            { integration: IntegrationSlug.make("slack"), connection: "nope", access: "full" },
+          ],
+        },
+      }),
+    );
+    expect((result as { _tag?: string })._tag, "rejected with ToolkitForbidden").toBe(
+      "ToolkitForbidden",
+    );
+  }),
+);

--- a/e2e/selfhost/toolkits-crud.test.ts
+++ b/e2e/selfhost/toolkits-crud.test.ts
@@ -14,7 +14,8 @@ import { scenario } from "../src/scenario";
 import { Api, Target } from "../src/services";
 
 const api = composePluginApi([toolkitsPlugin()] as const);
-const fresh = (prefix: string): string => `${prefix}-${randomBytes(4).toString("hex")}`;
+const fresh = (prefix: string): string =>
+  `${prefix}-${randomBytes(4).toString("hex")}`;
 
 scenario(
   "Toolkits · CRUD round-trips through the selfhost API",
@@ -27,11 +28,19 @@ scenario(
 
     const slug = fresh("work");
     const created = yield* client.toolkits.create({
-      payload: { slug, name: "Work", scope: "personal", briefing: "general assistant" },
+      payload: {
+        slug,
+        name: "Work",
+        scope: "personal",
+        briefing: "general assistant",
+      },
     });
     expect(created.slug).toBe(slug);
     expect(created.scope).toBe("personal");
-    expect(created.inheritOrgPolicies, "defaults to inheriting org policies").toBe(true);
+    expect(
+      created.inheritOrgPolicies,
+      "defaults to inheriting org policies",
+    ).toBe(true);
     expect(created.briefing).toBe("general assistant");
     expect(created.connections.length).toBe(0);
 
@@ -56,13 +65,18 @@ scenario(
     expect(patched.briefing).toBe(null);
 
     // DELETE removes it; subsequent GET is a typed ToolkitNotFound
-    const removed = yield* client.toolkits.remove({ params: { id: created.id } });
+    const removed = yield* client.toolkits.remove({
+      params: { id: created.id },
+    });
     expect(removed.removed).toBe(true);
 
-    const afterDelete = yield* Effect.flip(client.toolkits.get({ params: { id: created.id } }));
-    expect((afterDelete as { _tag?: string })._tag, "GET after delete is ToolkitNotFound").toBe(
-      "ToolkitNotFound",
+    const afterDelete = yield* Effect.flip(
+      client.toolkits.get({ params: { id: created.id } }),
     );
+    expect(
+      (afterDelete as { _tag?: string })._tag,
+      "GET after delete is ToolkitNotFound",
+    ).toBe("ToolkitNotFound");
   }),
 );
 
@@ -82,13 +96,18 @@ scenario(
           name: "Support",
           scope: "workspace",
           connections: [
-            { integration: IntegrationSlug.make("slack"), connection: "nope", access: "full" },
+            {
+              integration: IntegrationSlug.make("slack"),
+              connection: "nope",
+              access: "full",
+            },
           ],
         },
       }),
     );
-    expect((result as { _tag?: string })._tag, "rejected with ToolkitForbidden").toBe(
-      "ToolkitForbidden",
-    );
+    expect(
+      (result as { _tag?: string })._tag,
+      "rejected with ToolkitForbidden",
+    ).toBe("ToolkitForbidden");
   }),
 );

--- a/e2e/selfhost/toolkits-crud.test.ts
+++ b/e2e/selfhost/toolkits-crud.test.ts
@@ -14,8 +14,7 @@ import { scenario } from "../src/scenario";
 import { Api, Target } from "../src/services";
 
 const api = composePluginApi([toolkitsPlugin()] as const);
-const fresh = (prefix: string): string =>
-  `${prefix}-${randomBytes(4).toString("hex")}`;
+const fresh = (prefix: string): string => `${prefix}-${randomBytes(4).toString("hex")}`;
 
 scenario(
   "Toolkits · CRUD round-trips through the selfhost API",
@@ -37,10 +36,7 @@ scenario(
     });
     expect(created.slug).toBe(slug);
     expect(created.scope).toBe("personal");
-    expect(
-      created.inheritOrgPolicies,
-      "defaults to inheriting org policies",
-    ).toBe(true);
+    expect(created.inheritOrgPolicies, "defaults to inheriting org policies").toBe(true);
     expect(created.briefing).toBe("general assistant");
     expect(created.connections.length).toBe(0);
 
@@ -70,13 +66,10 @@ scenario(
     });
     expect(removed.removed).toBe(true);
 
-    const afterDelete = yield* Effect.flip(
-      client.toolkits.get({ params: { id: created.id } }),
+    const afterDelete = yield* Effect.flip(client.toolkits.get({ params: { id: created.id } }));
+    expect((afterDelete as { _tag?: string })._tag, "GET after delete is ToolkitNotFound").toBe(
+      "ToolkitNotFound",
     );
-    expect(
-      (afterDelete as { _tag?: string })._tag,
-      "GET after delete is ToolkitNotFound",
-    ).toBe("ToolkitNotFound");
   }),
 );
 
@@ -105,9 +98,8 @@ scenario(
         },
       }),
     );
-    expect(
-      (result as { _tag?: string })._tag,
-      "rejected with ToolkitForbidden",
-    ).toBe("ToolkitForbidden");
+    expect((result as { _tag?: string })._tag, "rejected with ToolkitForbidden").toBe(
+      "ToolkitForbidden",
+    );
   }),
 );

--- a/e2e/selfhost/toolkits-execute-description.test.ts
+++ b/e2e/selfhost/toolkits-execute-description.test.ts
@@ -1,0 +1,176 @@
+// Selfhost · the execute tool's DESCRIPTION accurately reflects a toolkit's
+// slice. An MCP client reads this description to learn what it can call; if it
+// still listed out-of-slice connections, a scoped agent would chase addresses
+// it cannot run. The execute description's "Available connection prefixes"
+// inventory (`<integration>.<owner>.<connection>` paths) must therefore name
+// exactly the toolkit's connections — A and B (in the kit), never C (out) —
+// while a bare session, with no selector, still advertises C. This is the
+// "the description on MCP clients is right" coverage for toolkit narrowing.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path — and the description's connection-prefix inventory — stay valid.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · the MCP execute tool's description lists exactly the toolkit's connection slice",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Stand up three real MCP greeting servers -> three distinct integrations
+      // + org connections (each exposes a `simple_echo` tool discovered at
+      // create). Connection names are normalized on create (hyphens removed +
+      // camelCased), so we keep them lowercase-alphanumeric to round-trip
+      // unchanged into the description's prefix.
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: [
+                      "Bearer ",
+                      { type: "variable", name: "token" },
+                    ],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // A and B go in the toolkit (at "full" and "read" respectively); C does not.
+      const slugA = ident("tka");
+      const slugB = ident("tkb");
+      const slugC = ident("tkc");
+      const connA = ident("conn");
+      const connB = ident("conn");
+      const connC = ident("conn");
+      yield* addConnection(slugA, connA);
+      yield* addConnection(slugB, connB);
+      yield* addConnection(slugC, connC);
+
+      // A workspace (org-owned) toolkit: A at "full", B at "read", C omitted.
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Slice kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "read",
+            },
+          ],
+        },
+      });
+
+      // The description lists connection prefixes as `<integration>.<owner>.<connection>`
+      // (the `tools.` root is stripped). Workspace connections are owner "org".
+      const prefixA = `${slugA}.org.${connA}`;
+      const prefixB = `${slugB}.org.${connB}`;
+      const prefixC = `${slugC}.org.${connC}`;
+
+      // Scoped session: the execute description names A and B, never C.
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const scopedDefs = yield* scoped.describeTools();
+      const scopedDesc = describeExecute(scopedDefs);
+
+      expect(
+        scopedDesc,
+        `scoped execute description names the full-access connection (A)`,
+      ).toContain(prefixA);
+      expect(
+        scopedDesc,
+        `scoped execute description names the read-access connection (B)`,
+      ).toContain(prefixB);
+      expect(
+        scopedDesc,
+        `scoped execute description must NOT name the out-of-slice connection (C)`,
+      ).not.toContain(prefixC);
+      // Defense-in-depth: even the bare integration slug for C must not leak into
+      // the scoped inventory (it never appears in any other prefix).
+      expect(
+        scopedDesc,
+        `scoped inventory omits C's integration entirely`,
+      ).not.toContain(slugC);
+
+      // The execute tool itself is still advertised on the scoped session — the
+      // slice narrows its inventory, it does not remove the tool.
+      const scopedToolNames = yield* scoped.listTools();
+      expect(
+        scopedToolNames,
+        "scoped session still advertises execute",
+      ).toContain("execute");
+
+      // Bare session (no selector): the description DOES name C — proving the
+      // scoped omission above is genuine narrowing, not C being absent globally.
+      const bareDefs = yield* mcp.session(identity).describeTools();
+      const bareDesc = describeExecute(bareDefs);
+      expect(bareDesc, "bare execute description names A").toContain(prefixA);
+      expect(bareDesc, "bare execute description names B").toContain(prefixB);
+      expect(
+        bareDesc,
+        "bare execute description names the out-of-slice connection C (no narrowing)",
+      ).toContain(prefixC);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-execute-description.test.ts
+++ b/e2e/selfhost/toolkits-execute-description.test.ts
@@ -12,16 +12,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -29,12 +22,10 @@ import { Api, Mcp, Target } from "../src/services";
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path — and the description's connection-prefix inventory — stay valid.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   "Toolkits · the MCP execute tool's description lists exactly the toolkit's connection slice",
@@ -71,10 +62,7 @@ scenario(
                 {
                   type: "apiKey",
                   headers: {
-                    Authorization: [
-                      "Bearer ",
-                      { type: "variable", name: "token" },
-                    ],
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
                   },
                 },
               ],
@@ -148,18 +136,12 @@ scenario(
       ).not.toContain(prefixC);
       // Defense-in-depth: even the bare integration slug for C must not leak into
       // the scoped inventory (it never appears in any other prefix).
-      expect(
-        scopedDesc,
-        `scoped inventory omits C's integration entirely`,
-      ).not.toContain(slugC);
+      expect(scopedDesc, `scoped inventory omits C's integration entirely`).not.toContain(slugC);
 
       // The execute tool itself is still advertised on the scoped session — the
       // slice narrows its inventory, it does not remove the tool.
       const scopedToolNames = yield* scoped.listTools();
-      expect(
-        scopedToolNames,
-        "scoped session still advertises execute",
-      ).toContain("execute");
+      expect(scopedToolNames, "scoped session still advertises execute").toContain("execute");
 
       // Bare session (no selector): the description DOES name C — proving the
       // scoped omission above is genuine narrowing, not C being absent globally.

--- a/e2e/selfhost/toolkits-failclosed.test.ts
+++ b/e2e/selfhost/toolkits-failclosed.test.ts
@@ -1,0 +1,147 @@
+// Selfhost · Toolkits fail-closed. SECURITY-CRITICAL: an unknown/invalid
+// ?toolkit= selector must FAIL CLOSED — the engine narrows to an EMPTY slice
+// (EMPTY_TOOLKIT_SCOPE, applied by narrowToToolkit when resolveScope returns
+// null) where every connection tool is blocked — and must NEVER silently fall
+// back to full (unscoped) account access.
+//
+// The control is a BARE session (no selector): the real org connection's tool
+// RUNS and its result text is the real greeting. The probe is a session scoped
+// to a bogus selector ("doesnotexist"+hex): the SAME real tool is blocked at
+// execute (error envelope, not the real greeting) and the bogus inventory lists
+// no connections. A regression where a bad selector granted full access would
+// make the bogus execute return the real greeting (== the bare execute) and the
+// bogus inventory contain the connection's integration — both asserted against.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and names survive create normalization.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · a bogus toolkit selector fails closed — empty slice, never full access",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Seed ONE real org connection (a greeting MCP server -> integration +
+      // org connection exposing a `simple_echo` tool discovered at create).
+      const slug = ident("tk");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      // A real WORKSPACE toolkit referencing the connection — proves the account
+      // genuinely has both runnable tools and a real toolkit, so the only thing
+      // distinguishing the probe is its bogus selector.
+      yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Real kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+
+      // (a) CONTROL — bare session (no selector): the tool RUNS and the
+      // inventory lists the connection's integration.
+      const bare = mcp.session(identity);
+      const bareDesc = describeExecute(yield* bare.describeTools());
+      expect(
+        bareDesc,
+        "bare inventory includes the seeded integration",
+      ).toContain(slug);
+      const bareRun = yield* bare.call("execute", { code });
+      expect(bareRun.ok, `bare tool executes; text=${bareRun.text}`).toBe(true);
+
+      // (b) PROBE — session scoped to a selector that resolves to no toolkit.
+      // Inventory must list NO connections (only static/core tools survive an
+      // empty slice), and the SAME tool must be BLOCKED at execute.
+      const bogusSelector = ident("doesnotexist");
+      const bogus = mcp.session(identity, { toolkit: bogusSelector });
+      const bogusDesc = describeExecute(yield* bogus.describeTools());
+      const bogusRun = yield* bogus.call("execute", { code });
+
+      // (c) STRENGTHEN — unambiguous fail-closed assertions. A regression where
+      // the bogus selector granted full access would fail every one of these:
+      //   - the bogus inventory would contain the integration slug, and
+      //   - the bogus execute would return the SAME real greeting as the bare run.
+      expect(
+        bogusDesc,
+        `bogus selector must NOT leak the seeded integration into inventory; bogusDesc=${bogusDesc}`,
+      ).not.toContain(slug);
+      // Blocked execute surfaces as an error envelope (.text differs) — never the
+      // real greeting the bare control returns. We compare .text, not .ok.
+      expect(
+        bogusRun.text,
+        `bogus selector must BLOCK the tool, not return the real result; bare.text=${bareRun.text} bogus.ok=${bogusRun.ok} bogus.text=${bogusRun.text}`,
+      ).not.toBe(bareRun.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-failclosed.test.ts
+++ b/e2e/selfhost/toolkits-failclosed.test.ts
@@ -17,16 +17,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -34,12 +27,10 @@ import { Api, Mcp, Target } from "../src/services";
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays valid JS, and names survive create normalization.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   "Toolkits · a bogus toolkit selector fails closed — empty slice, never full access",
@@ -113,10 +104,7 @@ scenario(
       // inventory lists the connection's integration.
       const bare = mcp.session(identity);
       const bareDesc = describeExecute(yield* bare.describeTools());
-      expect(
-        bareDesc,
-        "bare inventory includes the seeded integration",
-      ).toContain(slug);
+      expect(bareDesc, "bare inventory includes the seeded integration").toContain(slug);
       const bareRun = yield* bare.call("execute", { code });
       expect(bareRun.ok, `bare tool executes; text=${bareRun.text}`).toBe(true);
 

--- a/e2e/selfhost/toolkits-inherit-org.test.ts
+++ b/e2e/selfhost/toolkits-inherit-org.test.ts
@@ -1,0 +1,247 @@
+// Selfhost · org policies vs a toolkit's inheritOrgPolicies flag.
+//
+// INTENDED contract: a toolkit inherits the org's policies only when
+// inheritOrgPolicies=true; with false, org-level policies do NOT apply to the
+// toolkit's slice.
+//
+// CURRENT v1 BEHAVIOR (what this test pins): the inheritOrgPolicies flag is
+// persisted + surfaced but NOT yet wired into enforcement. Org `block` policies
+// are enforced by the base executor, and the toolkit narrowing seam
+// (`applyToolkitScope`) computes its allowed slice from `base.tools.list()`,
+// which ALREADY drops org-blocked tools (`includeBlocked: false`). So an
+// org-blocked tool is excluded from EVERY toolkit's slice regardless of the
+// flag. This test therefore asserts:
+//   1. the org block is real on a bare /mcp session (the guardrail works);
+//   2. the flag round-trips on create (true vs false), AND
+//   3. an org block is inherited by BOTH a true- and a false-flagged toolkit
+//      today — i.e. inheritOrgPolicies:false does NOT yet un-inherit it.
+// When enforcement is wired up, assertion (3)'s `isolated` leg should flip to a
+// successful run; the inline markers below say exactly where.
+//
+// The ORG policy is created through the core PoliciesApi (`client.policies.create`
+// with owner "org"). The org `tool_policy` matcher tests the 4-segment
+// `<integration>.<owner>.<connection>.<tool>` form (owner included), so a
+// plugin-wide `<slug>.*` subtree pattern covers `<slug>.org.<conn>.simple_echo`.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+// The composed API carries the toolkits group, the MCP-server-management group,
+// AND the core PoliciesApi (included by composePluginApi), so `client.policies.*`
+// and `client.toolkits.*` are both typed here.
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays a valid JS member expression and names normalize cleanly.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+// A `block` surfaces as an error envelope at execute: `.ok` true, the error
+// (tool_blocked) inside `.text`. A successful greeting never contains this.
+const isBlocked = (text: string): boolean => text.includes("tool_blocked");
+
+scenario(
+  "Toolkits · an org block policy is enforced via the base executor and reaches a toolkit slice",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // One real greeting MCP server -> one integration + an org connection that
+      // exposes a `simple_echo` tool (discovered at connection create).
+      const slug = ident("inh");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+
+      // Without any org policy, a bare /mcp session runs the tool — the baseline
+      // "this connection works" before the org guardrail is in place.
+      const beforePolicy = yield* mcp
+        .session(identity)
+        .call("execute", { code });
+      expect(
+        beforePolicy.ok && !isBlocked(beforePolicy.text),
+        `connection works before the org policy; text=${beforePolicy.text}`,
+      ).toBe(true);
+
+      // ORG-LEVEL block policy over the connection's tool. The org `tool_policy`
+      // matcher tests the 4-segment `<integration>.<owner>.<connection>.<tool>`
+      // address, so `<slug>.*` (a trailing-`*` subtree) blocks
+      // `<slug>.org.<conn>.simple_echo` for this org outside any toolkit.
+      const orgPattern = `${slug}.*`;
+      const orgPolicy = yield* client.policies.create({
+        payload: { owner: "org", pattern: orgPattern, action: "block" },
+      });
+      expect(orgPolicy.owner, "the org policy is owned by the org").toBe("org");
+      expect(orgPolicy.action, "the org policy blocks").toBe("block");
+      expect(
+        orgPolicy.pattern,
+        "the org policy targets the connection's tool",
+      ).toBe(orgPattern);
+
+      // The org block is real: the bare session (no toolkit) is now blocked.
+      const bareCall = yield* mcp.session(identity).call("execute", { code });
+      expect(
+        isBlocked(bareCall.text),
+        `org block applies to the bare session; before=${beforePolicy.text} after=${bareCall.text}`,
+      ).toBe(true);
+
+      // Two workspace toolkits over the SAME connection, both at full access,
+      // differing ONLY in inheritOrgPolicies.
+      const inherit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitinh"),
+          name: "Inherits org",
+          scope: "workspace",
+          inheritOrgPolicies: true,
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(
+        inherit.inheritOrgPolicies,
+        "T_inherit flag round-trips as true",
+      ).toBe(true);
+
+      const isolated = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitiso"),
+          name: "Isolated",
+          scope: "workspace",
+          inheritOrgPolicies: false,
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(
+        isolated.inheritOrgPolicies,
+        "T_isolated flag round-trips as false",
+      ).toBe(false);
+
+      // Both slices grant the connection at full, so neither hides it for lack of
+      // access — any block is the org policy reaching the slice, not the grant.
+      const inheritDesc = describeExecute(
+        yield* mcp.session(identity, { toolkit: inherit.slug }).describeTools(),
+      );
+      const isolatedDesc = describeExecute(
+        yield* mcp
+          .session(identity, { toolkit: isolated.slug })
+          .describeTools(),
+      );
+      expect(
+        inheritDesc,
+        "T_inherit slice scopes to the integration",
+      ).toContain(slug);
+      expect(
+        isolatedDesc,
+        "T_isolated slice scopes to the integration",
+      ).toContain(slug);
+
+      // Execute the SAME code in each scoped session.
+      const inheritCall = yield* mcp
+        .session(identity, { toolkit: inherit.slug })
+        .call("execute", { code });
+      const isolatedCall = yield* mcp
+        .session(identity, { toolkit: isolated.slug })
+        .call("execute", { code });
+
+      // T_inherit inherits the org block (the intended contract for true): blocked.
+      expect(
+        isBlocked(inheritCall.text),
+        `T_inherit (inheritOrgPolicies:true) inherits the org block; text=${inheritCall.text}`,
+      ).toBe(true);
+
+      // CURRENT v1 BEHAVIOR — the org block also reaches T_isolated because the
+      // flag is not yet wired into enforcement and the narrowing seam computes
+      // its slice from an already-org-filtered `tools.list()`. The INTENDED end
+      // state is that this call RUNS (org block NOT inherited). When enforcement
+      // lands, flip the next assertion to:
+      //   expect(isolatedCall.ok && !isBlocked(isolatedCall.text), ...).toBe(true);
+      expect(
+        isBlocked(isolatedCall.text),
+        `KNOWN GAP: T_isolated (inheritOrgPolicies:false) should NOT inherit the org ` +
+          `block, but v1 still blocks it; text=${isolatedCall.text}`,
+      ).toBe(true);
+
+      // The flag does round-trip and is visible to the toolkit view layer, so the
+      // only missing piece is enforcement honoring it — pinned here so a future
+      // wiring change makes the gap-assertion above fail loudly and get fixed.
+      const inheritView = yield* client.toolkits.get({
+        params: { id: inherit.id },
+      });
+      const isolatedView = yield* client.toolkits.get({
+        params: { id: isolated.id },
+      });
+      expect(inheritView.inheritOrgPolicies, "view preserves true").toBe(true);
+      expect(isolatedView.inheritOrgPolicies, "view preserves false").toBe(
+        false,
+      );
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-inherit-org.test.ts
+++ b/e2e/selfhost/toolkits-inherit-org.test.ts
@@ -8,16 +8,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -29,12 +22,10 @@ const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays a valid JS member expression and names normalize cleanly.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 // A `block` surfaces as an error envelope at execute: `.ok` true, the error
 // (tool_blocked) inside `.text`. A successful greeting never contains this.
@@ -92,9 +83,7 @@ scenario(
 
       // Without any org policy, a bare /mcp session runs the tool — the baseline
       // "this connection works" before the org guardrail is in place.
-      const beforePolicy = yield* mcp
-        .session(identity)
-        .call("execute", { code });
+      const beforePolicy = yield* mcp.session(identity).call("execute", { code });
       expect(
         beforePolicy.ok && !isBlocked(beforePolicy.text),
         `connection works before the org policy; text=${beforePolicy.text}`,
@@ -110,10 +99,7 @@ scenario(
       });
       expect(orgPolicy.owner, "the org policy is owned by the org").toBe("org");
       expect(orgPolicy.action, "the org policy blocks").toBe("block");
-      expect(
-        orgPolicy.pattern,
-        "the org policy targets the connection's tool",
-      ).toBe(orgPattern);
+      expect(orgPolicy.pattern, "the org policy targets the connection's tool").toBe(orgPattern);
 
       // The org block is real: the bare session (no toolkit) is now blocked.
       const bareCall = yield* mcp.session(identity).call("execute", { code });
@@ -139,10 +125,7 @@ scenario(
           ],
         },
       });
-      expect(
-        inherit.inheritOrgPolicies,
-        "T_inherit flag round-trips as true",
-      ).toBe(true);
+      expect(inherit.inheritOrgPolicies, "T_inherit flag round-trips as true").toBe(true);
 
       const isolated = yield* client.toolkits.create({
         payload: {
@@ -159,10 +142,7 @@ scenario(
           ],
         },
       });
-      expect(
-        isolated.inheritOrgPolicies,
-        "T_isolated flag round-trips as false",
-      ).toBe(false);
+      expect(isolated.inheritOrgPolicies, "T_isolated flag round-trips as false").toBe(false);
 
       // Both slices grant the connection at full, so neither hides it for lack of
       // access — any block is the org policy reaching the slice, not the grant.
@@ -170,18 +150,10 @@ scenario(
         yield* mcp.session(identity, { toolkit: inherit.slug }).describeTools(),
       );
       const isolatedDesc = describeExecute(
-        yield* mcp
-          .session(identity, { toolkit: isolated.slug })
-          .describeTools(),
+        yield* mcp.session(identity, { toolkit: isolated.slug }).describeTools(),
       );
-      expect(
-        inheritDesc,
-        "T_inherit slice scopes to the integration",
-      ).toContain(slug);
-      expect(
-        isolatedDesc,
-        "T_isolated slice scopes to the integration",
-      ).toContain(slug);
+      expect(inheritDesc, "T_inherit slice scopes to the integration").toContain(slug);
+      expect(isolatedDesc, "T_isolated slice scopes to the integration").toContain(slug);
 
       // Execute the SAME code in each scoped session.
       const inheritCall = yield* mcp
@@ -210,9 +182,7 @@ scenario(
         params: { id: isolated.id },
       });
       expect(inheritView.inheritOrgPolicies, "view preserves true").toBe(true);
-      expect(isolatedView.inheritOrgPolicies, "view preserves false").toBe(
-        false,
-      );
+      expect(isolatedView.inheritOrgPolicies, "view preserves false").toBe(false);
     }),
   ),
 );

--- a/e2e/selfhost/toolkits-inherit-org.test.ts
+++ b/e2e/selfhost/toolkits-inherit-org.test.ts
@@ -1,27 +1,7 @@
 // Selfhost · org policies vs a toolkit's inheritOrgPolicies flag.
 //
-// INTENDED contract: a toolkit inherits the org's policies only when
-// inheritOrgPolicies=true; with false, org-level policies do NOT apply to the
-// toolkit's slice.
-//
-// CURRENT v1 BEHAVIOR (what this test pins): the inheritOrgPolicies flag is
-// persisted + surfaced but NOT yet wired into enforcement. Org `block` policies
-// are enforced by the base executor, and the toolkit narrowing seam
-// (`applyToolkitScope`) computes its allowed slice from `base.tools.list()`,
-// which ALREADY drops org-blocked tools (`includeBlocked: false`). So an
-// org-blocked tool is excluded from EVERY toolkit's slice regardless of the
-// flag. This test therefore asserts:
-//   1. the org block is real on a bare /mcp session (the guardrail works);
-//   2. the flag round-trips on create (true vs false), AND
-//   3. an org block is inherited by BOTH a true- and a false-flagged toolkit
-//      today — i.e. inheritOrgPolicies:false does NOT yet un-inherit it.
-// When enforcement is wired up, assertion (3)'s `isolated` leg should flip to a
-// successful run; the inline markers below say exactly where.
-//
-// The ORG policy is created through the core PoliciesApi (`client.policies.create`
-// with owner "org"). The org `tool_policy` matcher tests the 4-segment
-// `<integration>.<owner>.<connection>.<tool>` form (owner included), so a
-// plugin-wide `<slug>.*` subtree pattern covers `<slug>.org.<conn>.simple_echo`.
+// Org `block` / `require_approval` guardrails always reach scoped sessions; only
+// org `approve` rows may be dropped when inheritOrgPolicies=false.
 import { randomBytes } from "node:crypto";
 
 import { expect } from "@effect/vitest";
@@ -217,21 +197,12 @@ scenario(
         `T_inherit (inheritOrgPolicies:true) inherits the org block; text=${inheritCall.text}`,
       ).toBe(true);
 
-      // CURRENT v1 BEHAVIOR — the org block also reaches T_isolated because the
-      // flag is not yet wired into enforcement and the narrowing seam computes
-      // its slice from an already-org-filtered `tools.list()`. The INTENDED end
-      // state is that this call RUNS (org block NOT inherited). When enforcement
-      // lands, flip the next assertion to:
-      //   expect(isolatedCall.ok && !isBlocked(isolatedCall.text), ...).toBe(true);
+      // T_isolated still inherits org block/require_approval guardrails even when
+      // inheritOrgPolicies:false — a toolkit may only tighten, never loosen.
       expect(
         isBlocked(isolatedCall.text),
-        `KNOWN GAP: T_isolated (inheritOrgPolicies:false) should NOT inherit the org ` +
-          `block, but v1 still blocks it; text=${isolatedCall.text}`,
+        `T_isolated (inheritOrgPolicies:false) still blocked by org guardrail; text=${isolatedCall.text}`,
       ).toBe(true);
-
-      // The flag does round-trip and is visible to the toolkit view layer, so the
-      // only missing piece is enforcement honoring it — pinned here so a future
-      // wiring change makes the gap-assertion above fail loudly and get fixed.
       const inheritView = yield* client.toolkits.get({
         params: { id: inherit.id },
       });

--- a/e2e/selfhost/toolkits-isolation.test.ts
+++ b/e2e/selfhost/toolkits-isolation.test.ts
@@ -1,0 +1,216 @@
+// Selfhost · Toolkit slice isolation: two toolkits over OVERLAPPING connections
+// each expose only their own slice. Seed three integrations A/B/C with one org
+// connection apiece; T1 = {A, B}, T2 = {B, C} (B is shared). A session scoped to
+// T1 can run A and B but is BLOCKED on C; a session scoped to T2 can run B and C
+// but is BLOCKED on A. The shared B never carries the non-shared members across:
+// C is reachable under T2 yet blocked under T1, and A is reachable under T1 yet
+// blocked under T2 — proving the slices don't leak into one another.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens, lowercase-alphanumeric) so the sandbox
+// `tools.<int>.<owner>.<conn>.<tool>` dotted path stays valid JS and the
+// connection name survives create-time normalization unchanged.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · two toolkits over overlapping connections each see only their own slice; no cross-leak",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Stand up a real MCP greeting server per integration -> one org
+      // connection each (exposes a `simple_echo` tool discovered at create).
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: [
+                      "Bearer ",
+                      { type: "variable", name: "token" },
+                    ],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // Three distinct integrations, one org connection each.
+      const slugA = ident("tka");
+      const slugB = ident("tkb");
+      const slugC = ident("tkc");
+      const connA = ident("conn");
+      const connB = ident("conn");
+      const connC = ident("conn");
+      yield* addConnection(slugA, connA);
+      yield* addConnection(slugB, connB);
+      yield* addConnection(slugC, connC);
+
+      // T1 = { A full, B full }; T2 = { B full, C full }. B is shared.
+      const t1 = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Toolkit AB",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+          ],
+        },
+      });
+      const t2 = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Toolkit BC",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugC),
+              connection: connC,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // Address every connection's tool by its dotted sandbox path.
+      const callA = `return await tools.${slugA}.org.${connA}.simple_echo({});`;
+      const callB = `return await tools.${slugB}.org.${connB}.simple_echo({});`;
+      const callC = `return await tools.${slugC}.org.${connC}.simple_echo({});`;
+
+      // ---- Session scoped to T1 (sees A + B, never C) ----
+      const s1 = mcp.session(identity, { toolkit: t1.slug });
+      const d1 = describeExecute(yield* s1.describeTools());
+      expect(d1, "T1 inventory includes A").toContain(slugA);
+      expect(d1, "T1 inventory includes B").toContain(slugB);
+      expect(d1, "T1 inventory omits C").not.toContain(slugC);
+
+      const s1a = yield* s1.call("execute", { code: callA });
+      const s1b = yield* s1.call("execute", { code: callB });
+      const s1c = yield* s1.call("execute", { code: callC });
+      // In-slice A and B run to the real greeting; out-of-slice C is blocked at
+      // execute and surfaces as an error envelope (never the in-slice text).
+      expect(s1a.text, `T1·A should run; text=${s1a.text}`).not.toBe("");
+      expect(s1b.text, `T1·B should run; text=${s1b.text}`).not.toBe("");
+      expect(
+        s1c.text,
+        `T1·C must be blocked; a.text=${s1a.text} c.text=${s1c.text}`,
+      ).not.toBe(s1a.text);
+      expect(
+        s1c.text,
+        `T1·C blocked text differs from B; b.text=${s1b.text}`,
+      ).not.toBe(s1b.text);
+
+      // ---- Session scoped to T2 (sees B + C, never A) ----
+      const s2 = mcp.session(identity, { toolkit: t2.slug });
+      const d2 = describeExecute(yield* s2.describeTools());
+      expect(d2, "T2 inventory includes B").toContain(slugB);
+      expect(d2, "T2 inventory includes C").toContain(slugC);
+      expect(d2, "T2 inventory omits A").not.toContain(slugA);
+
+      const s2b = yield* s2.call("execute", { code: callB });
+      const s2c = yield* s2.call("execute", { code: callC });
+      const s2a = yield* s2.call("execute", { code: callA });
+      // In-slice B and C run; out-of-slice A is blocked.
+      expect(s2b.text, `T2·B should run; text=${s2b.text}`).not.toBe("");
+      expect(s2c.text, `T2·C should run; text=${s2c.text}`).not.toBe("");
+      expect(
+        s2a.text,
+        `T2·A must be blocked; c.text=${s2c.text} a.text=${s2a.text}`,
+      ).not.toBe(s2c.text);
+      expect(
+        s2a.text,
+        `T2·A blocked text differs from B; b.text=${s2b.text}`,
+      ).not.toBe(s2b.text);
+
+      // ---- The cross term: shared B does not drag its other toolkit's members
+      // across. C is reachable under T2 but blocked under T1; A is reachable
+      // under T1 but blocked under T2. The two slices stay disjoint on their
+      // non-shared members even though both contain B. ----
+      expect(
+        d1,
+        "C never appears in T1's inventory (only in T2's)",
+      ).not.toContain(slugC);
+      expect(
+        d2,
+        "A never appears in T2's inventory (only in T1's)",
+      ).not.toContain(slugA);
+      // C's reachable text under T2 is exactly what's denied under T1.
+      expect(
+        s2c.text,
+        "C runs under T2 but its T1 attempt was blocked",
+      ).not.toBe(s1c.text);
+      // A's reachable text under T1 is exactly what's denied under T2.
+      expect(
+        s1a.text,
+        "A runs under T1 but its T2 attempt was blocked",
+      ).not.toBe(s2a.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-isolation.test.ts
+++ b/e2e/selfhost/toolkits-isolation.test.ts
@@ -11,16 +11,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -29,12 +22,10 @@ const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens, lowercase-alphanumeric) so the sandbox
 // `tools.<int>.<owner>.<conn>.<tool>` dotted path stays valid JS and the
 // connection name survives create-time normalization unchanged.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   "Toolkits · two toolkits over overlapping connections each see only their own slice; no cross-leak",
@@ -68,10 +59,7 @@ scenario(
                 {
                   type: "apiKey",
                   headers: {
-                    Authorization: [
-                      "Bearer ",
-                      { type: "variable", name: "token" },
-                    ],
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
                   },
                 },
               ],
@@ -158,14 +146,10 @@ scenario(
       // execute and surfaces as an error envelope (never the in-slice text).
       expect(s1a.text, `T1·A should run; text=${s1a.text}`).not.toBe("");
       expect(s1b.text, `T1·B should run; text=${s1b.text}`).not.toBe("");
-      expect(
-        s1c.text,
-        `T1·C must be blocked; a.text=${s1a.text} c.text=${s1c.text}`,
-      ).not.toBe(s1a.text);
-      expect(
-        s1c.text,
-        `T1·C blocked text differs from B; b.text=${s1b.text}`,
-      ).not.toBe(s1b.text);
+      expect(s1c.text, `T1·C must be blocked; a.text=${s1a.text} c.text=${s1c.text}`).not.toBe(
+        s1a.text,
+      );
+      expect(s1c.text, `T1·C blocked text differs from B; b.text=${s1b.text}`).not.toBe(s1b.text);
 
       // ---- Session scoped to T2 (sees B + C, never A) ----
       const s2 = mcp.session(identity, { toolkit: t2.slug });
@@ -180,37 +164,21 @@ scenario(
       // In-slice B and C run; out-of-slice A is blocked.
       expect(s2b.text, `T2·B should run; text=${s2b.text}`).not.toBe("");
       expect(s2c.text, `T2·C should run; text=${s2c.text}`).not.toBe("");
-      expect(
-        s2a.text,
-        `T2·A must be blocked; c.text=${s2c.text} a.text=${s2a.text}`,
-      ).not.toBe(s2c.text);
-      expect(
-        s2a.text,
-        `T2·A blocked text differs from B; b.text=${s2b.text}`,
-      ).not.toBe(s2b.text);
+      expect(s2a.text, `T2·A must be blocked; c.text=${s2c.text} a.text=${s2a.text}`).not.toBe(
+        s2c.text,
+      );
+      expect(s2a.text, `T2·A blocked text differs from B; b.text=${s2b.text}`).not.toBe(s2b.text);
 
       // ---- The cross term: shared B does not drag its other toolkit's members
       // across. C is reachable under T2 but blocked under T1; A is reachable
       // under T1 but blocked under T2. The two slices stay disjoint on their
       // non-shared members even though both contain B. ----
-      expect(
-        d1,
-        "C never appears in T1's inventory (only in T2's)",
-      ).not.toContain(slugC);
-      expect(
-        d2,
-        "A never appears in T2's inventory (only in T1's)",
-      ).not.toContain(slugA);
+      expect(d1, "C never appears in T1's inventory (only in T2's)").not.toContain(slugC);
+      expect(d2, "A never appears in T2's inventory (only in T1's)").not.toContain(slugA);
       // C's reachable text under T2 is exactly what's denied under T1.
-      expect(
-        s2c.text,
-        "C runs under T2 but its T1 attempt was blocked",
-      ).not.toBe(s1c.text);
+      expect(s2c.text, "C runs under T2 but its T1 attempt was blocked").not.toBe(s1c.text);
       // A's reachable text under T1 is exactly what's denied under T2.
-      expect(
-        s1a.text,
-        "A runs under T1 but its T2 attempt was blocked",
-      ).not.toBe(s2a.text);
+      expect(s1a.text, "A runs under T1 but its T2 attempt was blocked").not.toBe(s2a.text);
     }),
   ),
 );

--- a/e2e/selfhost/toolkits-mcp.test.ts
+++ b/e2e/selfhost/toolkits-mcp.test.ts
@@ -9,9 +9,16 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -19,10 +26,12 @@ import { Api, Mcp, Target } from "../src/services";
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays valid JS.
-const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
-  defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   "Toolkits · an MCP session scoped to a toolkit sees only its slice; out-of-slice is blocked",
@@ -55,7 +64,12 @@ scenario(
               authenticationTemplate: [
                 {
                   type: "apiKey",
-                  headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
+                  headers: {
+                    Authorization: [
+                      "Bearer ",
+                      { type: "variable", name: "token" },
+                    ],
+                  },
                 },
               ],
             },
@@ -85,7 +99,11 @@ scenario(
           name: "Scoped kit",
           scope: "workspace",
           connections: [
-            { integration: IntegrationSlug.make(slugIn), connection: connIn, access: "full" },
+            {
+              integration: IntegrationSlug.make(slugIn),
+              connection: connIn,
+              access: "full",
+            },
           ],
         },
       });
@@ -93,17 +111,23 @@ scenario(
       // Scoped session: inventory shows the in-slice integration, not the other.
       const scoped = mcp.session(identity, { toolkit: kit.slug });
       const scopedDesc = describeExecute(yield* scoped.describeTools());
-      expect(scopedDesc, "scoped inventory includes the in-slice integration").toContain(slugIn);
-      expect(scopedDesc, "scoped inventory omits the out-of-slice integration").not.toContain(
-        slugOut,
-      );
+      expect(
+        scopedDesc,
+        "scoped inventory includes the in-slice integration",
+      ).toContain(slugIn);
+      expect(
+        scopedDesc,
+        "scoped inventory omits the out-of-slice integration",
+      ).not.toContain(slugOut);
 
       // In-slice tool runs; out-of-slice tool is blocked at execute (even though
       // the agent guessed its address).
       const inSlice = yield* scoped.call("execute", {
         code: `return await tools.${slugIn}.org.${connIn}.simple_echo({});`,
       });
-      expect(inSlice.ok, `in-slice tool executes; text=${inSlice.text}`).toBe(true);
+      expect(inSlice.ok, `in-slice tool executes; text=${inSlice.text}`).toBe(
+        true,
+      );
 
       const outSlice = yield* scoped.call("execute", {
         code: `return await tools.${slugOut}.org.${connOut}.simple_echo({});`,
@@ -116,9 +140,15 @@ scenario(
       ).not.toBe(inSlice.text);
 
       // Bare session (no selector) is unchanged — both integrations visible.
-      const bareDesc = describeExecute(yield* mcp.session(identity).describeTools());
-      expect(bareDesc, "bare /mcp still sees the first integration").toContain(slugIn);
-      expect(bareDesc, "bare /mcp still sees the second integration").toContain(slugOut);
+      const bareDesc = describeExecute(
+        yield* mcp.session(identity).describeTools(),
+      );
+      expect(bareDesc, "bare /mcp still sees the first integration").toContain(
+        slugIn,
+      );
+      expect(bareDesc, "bare /mcp still sees the second integration").toContain(
+        slugOut,
+      );
     }),
   ),
 );

--- a/e2e/selfhost/toolkits-mcp.test.ts
+++ b/e2e/selfhost/toolkits-mcp.test.ts
@@ -9,16 +9,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -26,12 +19,10 @@ import { Api, Mcp, Target } from "../src/services";
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays valid JS.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   "Toolkits · an MCP session scoped to a toolkit sees only its slice; out-of-slice is blocked",
@@ -65,10 +56,7 @@ scenario(
                 {
                   type: "apiKey",
                   headers: {
-                    Authorization: [
-                      "Bearer ",
-                      { type: "variable", name: "token" },
-                    ],
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
                   },
                 },
               ],
@@ -111,23 +99,17 @@ scenario(
       // Scoped session: inventory shows the in-slice integration, not the other.
       const scoped = mcp.session(identity, { toolkit: kit.slug });
       const scopedDesc = describeExecute(yield* scoped.describeTools());
-      expect(
-        scopedDesc,
-        "scoped inventory includes the in-slice integration",
-      ).toContain(slugIn);
-      expect(
-        scopedDesc,
-        "scoped inventory omits the out-of-slice integration",
-      ).not.toContain(slugOut);
+      expect(scopedDesc, "scoped inventory includes the in-slice integration").toContain(slugIn);
+      expect(scopedDesc, "scoped inventory omits the out-of-slice integration").not.toContain(
+        slugOut,
+      );
 
       // In-slice tool runs; out-of-slice tool is blocked at execute (even though
       // the agent guessed its address).
       const inSlice = yield* scoped.call("execute", {
         code: `return await tools.${slugIn}.org.${connIn}.simple_echo({});`,
       });
-      expect(inSlice.ok, `in-slice tool executes; text=${inSlice.text}`).toBe(
-        true,
-      );
+      expect(inSlice.ok, `in-slice tool executes; text=${inSlice.text}`).toBe(true);
 
       const outSlice = yield* scoped.call("execute", {
         code: `return await tools.${slugOut}.org.${connOut}.simple_echo({});`,
@@ -140,15 +122,9 @@ scenario(
       ).not.toBe(inSlice.text);
 
       // Bare session (no selector) is unchanged — both integrations visible.
-      const bareDesc = describeExecute(
-        yield* mcp.session(identity).describeTools(),
-      );
-      expect(bareDesc, "bare /mcp still sees the first integration").toContain(
-        slugIn,
-      );
-      expect(bareDesc, "bare /mcp still sees the second integration").toContain(
-        slugOut,
-      );
+      const bareDesc = describeExecute(yield* mcp.session(identity).describeTools());
+      expect(bareDesc, "bare /mcp still sees the first integration").toContain(slugIn);
+      expect(bareDesc, "bare /mcp still sees the second integration").toContain(slugOut);
     }),
   ),
 );

--- a/e2e/selfhost/toolkits-mcp.test.ts
+++ b/e2e/selfhost/toolkits-mcp.test.ts
@@ -1,0 +1,124 @@
+// Selfhost · Slice 3 (keystone): a toolkit narrows the MCP engine. Connecting
+// to /mcp?toolkit=<slug> exposes ONLY the toolkit's slice — the execute tool's
+// inventory omits out-of-slice connections, and an out-of-slice tool is blocked
+// at execute (not merely hidden), proving enforcement is at the executor, not
+// just listing. A bare session (no selector) is unchanged.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · an MCP session scoped to a toolkit sees only its slice; out-of-slice is blocked",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Stand up two real MCP greeting servers -> two integrations + org
+      // connections (each exposes a `simple_echo` tool discovered at create).
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      const slugIn = ident("tkin");
+      const slugOut = ident("tkout");
+      const connIn = ident("conn");
+      const connOut = ident("conn");
+      yield* addConnection(slugIn, connIn);
+      yield* addConnection(slugOut, connOut);
+
+      // A workspace toolkit that includes ONLY the first connection.
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Scoped kit",
+          scope: "workspace",
+          connections: [
+            { integration: IntegrationSlug.make(slugIn), connection: connIn, access: "full" },
+          ],
+        },
+      });
+
+      // Scoped session: inventory shows the in-slice integration, not the other.
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const scopedDesc = describeExecute(yield* scoped.describeTools());
+      expect(scopedDesc, "scoped inventory includes the in-slice integration").toContain(slugIn);
+      expect(scopedDesc, "scoped inventory omits the out-of-slice integration").not.toContain(
+        slugOut,
+      );
+
+      // In-slice tool runs; out-of-slice tool is blocked at execute (even though
+      // the agent guessed its address).
+      const inSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugIn}.org.${connIn}.simple_echo({});`,
+      });
+      expect(inSlice.ok, `in-slice tool executes; text=${inSlice.text}`).toBe(true);
+
+      const outSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugOut}.org.${connOut}.simple_echo({});`,
+      });
+      // Blocked tools surface as an error (thrown or an error envelope) — never
+      // the successful greeting the in-slice call returns.
+      expect(
+        outSlice.text,
+        `out-of-slice must be blocked; in.text=${inSlice.text} out.ok=${outSlice.ok} out.text=${outSlice.text}`,
+      ).not.toBe(inSlice.text);
+
+      // Bare session (no selector) is unchanged — both integrations visible.
+      const bareDesc = describeExecute(yield* mcp.session(identity).describeTools());
+      expect(bareDesc, "bare /mcp still sees the first integration").toContain(slugIn);
+      expect(bareDesc, "bare /mcp still sees the second integration").toContain(slugOut);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-policies.test.ts
+++ b/e2e/selfhost/toolkits-policies.test.ts
@@ -10,15 +10,23 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
 
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
-const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
 
 scenario(
   "Toolkits · access modes + block policies are enforced at execute",
@@ -49,7 +57,9 @@ scenario(
           authenticationTemplate: [
             {
               type: "apiKey",
-              headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
             },
           ],
         },
@@ -70,7 +80,11 @@ scenario(
           name: "Full",
           scope: "workspace",
           connections: [
-            { integration: IntegrationSlug.make(slug), connection: conn, access: "full" },
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
           ],
         },
       });
@@ -80,9 +94,15 @@ scenario(
           name: "Blocked",
           scope: "workspace",
           connections: [
-            { integration: IntegrationSlug.make(slug), connection: conn, access: "full" },
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
           ],
-          policies: [{ pattern: `${slug}.${conn}.simple_echo`, action: "block" }],
+          policies: [
+            { pattern: `${slug}.${conn}.simple_echo`, action: "block" },
+          ],
         },
       });
       const readonly = yield* client.toolkits.create({
@@ -91,7 +111,11 @@ scenario(
           name: "Read",
           scope: "workspace",
           connections: [
-            { integration: IntegrationSlug.make(slug), connection: conn, access: "read" },
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "read",
+            },
           ],
         },
       });
@@ -107,7 +131,10 @@ scenario(
         .session(identity, { toolkit: readonly.slug })
         .call("execute", { code });
 
-      expect(fullCall.ok, `full access runs the tool; text=${fullCall.text}`).toBe(true);
+      expect(
+        fullCall.ok,
+        `full access runs the tool; text=${fullCall.text}`,
+      ).toBe(true);
       expect(
         blockCall.text,
         `block policy must stop the tool; full=${fullCall.text} block=${blockCall.text}`,

--- a/e2e/selfhost/toolkits-policies.test.ts
+++ b/e2e/selfhost/toolkits-policies.test.ts
@@ -10,23 +10,15 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
 
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
 scenario(
   "Toolkits · access modes + block policies are enforced at execute",
@@ -100,9 +92,7 @@ scenario(
               access: "full",
             },
           ],
-          policies: [
-            { pattern: `${slug}.${conn}.simple_echo`, action: "block" },
-          ],
+          policies: [{ pattern: `${slug}.${conn}.simple_echo`, action: "block" }],
         },
       });
       const readonly = yield* client.toolkits.create({
@@ -131,10 +121,7 @@ scenario(
         .session(identity, { toolkit: readonly.slug })
         .call("execute", { code });
 
-      expect(
-        fullCall.ok,
-        `full access runs the tool; text=${fullCall.text}`,
-      ).toBe(true);
+      expect(fullCall.ok, `full access runs the tool; text=${fullCall.text}`).toBe(true);
       expect(
         blockCall.text,
         `block policy must stop the tool; full=${fullCall.text} block=${blockCall.text}`,

--- a/e2e/selfhost/toolkits-policies.test.ts
+++ b/e2e/selfhost/toolkits-policies.test.ts
@@ -1,0 +1,121 @@
+// Selfhost · Slice 4: per-toolkit policies + access modes at execute time.
+//   - full access  -> the connection's tool runs;
+//   - a `block` policy on that tool -> blocked at execute (exclusion);
+//   - read-only access -> an unclassified (non-read-only) tool is blocked
+//     (fail-closed: unclassified counts as write).
+// One greeting connection, three toolkits over it, compared via MCP execute.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+scenario(
+  "Toolkits · access modes + block policies are enforced at execute",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const slug = ident("pol");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: { Authorization: ["Bearer ", { type: "variable", name: "token" }] },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const full = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitfull"),
+          name: "Full",
+          scope: "workspace",
+          connections: [
+            { integration: IntegrationSlug.make(slug), connection: conn, access: "full" },
+          ],
+        },
+      });
+      const blocked = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitblock"),
+          name: "Blocked",
+          scope: "workspace",
+          connections: [
+            { integration: IntegrationSlug.make(slug), connection: conn, access: "full" },
+          ],
+          policies: [{ pattern: `${slug}.${conn}.simple_echo`, action: "block" }],
+        },
+      });
+      const readonly = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitread"),
+          name: "Read",
+          scope: "workspace",
+          connections: [
+            { integration: IntegrationSlug.make(slug), connection: conn, access: "read" },
+          ],
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+      const fullCall = yield* mcp
+        .session(identity, { toolkit: full.slug })
+        .call("execute", { code });
+      const blockCall = yield* mcp
+        .session(identity, { toolkit: blocked.slug })
+        .call("execute", { code });
+      const readCall = yield* mcp
+        .session(identity, { toolkit: readonly.slug })
+        .call("execute", { code });
+
+      expect(fullCall.ok, `full access runs the tool; text=${fullCall.text}`).toBe(true);
+      expect(
+        blockCall.text,
+        `block policy must stop the tool; full=${fullCall.text} block=${blockCall.text}`,
+      ).not.toBe(fullCall.text);
+      expect(
+        readCall.text,
+        `read-only must hide an unclassified (write) tool; full=${fullCall.text} read=${readCall.text}`,
+      ).not.toBe(fullCall.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-read-mode.test.ts
+++ b/e2e/selfhost/toolkits-read-mode.test.ts
@@ -1,0 +1,324 @@
+// Selfhost · Toolkit access "read" exposes only read-only tools and blocks
+// writes. `readOnly` is derived from HTTP method on OpenAPI integrations
+// (GET/HEAD/OPTIONS => readOnly:true; POST/PUT/PATCH/DELETE are writes), and
+// `applyToolkitScope` keeps a connection's tool under "read" access ONLY when
+// `annotations.readOnly === true`. So we stand up a real OpenAPI upstream with
+// BOTH a GET (read) and a POST (write) operation, grant the same connection at
+// "read" in one workspace toolkit and "full" in another, and prove:
+//   - the read toolkit's scoped MCP session runs the GET-derived tool but
+//     BLOCKS the POST-derived tool at execute (error envelope, not the success
+//     payload) and omits it from the scoped inventory;
+//   - the full toolkit's scoped session runs BOTH.
+//
+// The upstream is a real `node:http` listening socket in THIS test process —
+// the same cross-process pattern `serveMcpServer` uses (the OpenAPI echo helper
+// is in-memory via NodeHttpServer.layerTest and is NOT reachable from the
+// separately-booted selfhost server). The selfhost boot sets
+// EXECUTOR_ALLOW_LOCAL_NETWORK=true, so the instance is allowed to dial the
+// loopback upstream. The spec itself is passed inline (blob) so the spec fetch
+// never hits the network — only the GET/POST invocations dial the socket.
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect, Scope } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([
+  mcpHttpPlugin(),
+  openApiHttpPlugin(),
+  toolkitsPlugin(),
+] as const);
+
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and so the create-time name normalization (which
+// strips hyphens) round-trips unchanged.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+// A real OpenAPI upstream on a loopback socket. `GET /thing` is a read; `POST
+// /thing` is a write. Both return a recognizable JSON marker so a successful
+// invocation is distinguishable from a blocked one. The bearer token is
+// required so the call genuinely goes through the connection's credential.
+interface Upstream {
+  readonly baseUrl: string;
+}
+
+// Mirrors serveMcpServer: acquire a real listening socket carrying its own
+// `close`, release closes it, and we strip `close` from the value handed back.
+const serveUpstream = (
+  token: string,
+): Effect.Effect<Upstream, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.callback<Upstream & { readonly close: Effect.Effect<void> }, never>(
+      (resume) => {
+        const server = createServer(
+          (request: IncomingMessage, response: ServerResponse) => {
+            const url = new URL(request.url ?? "/", "http://127.0.0.1");
+            const auth = request.headers.authorization;
+            const send = (
+              status: number,
+              body: Record<string, unknown>,
+            ): void => {
+              response.writeHead(status, {
+                "content-type": "application/json",
+              });
+              response.end(JSON.stringify(body));
+            };
+            if (auth !== `Bearer ${token}`) {
+              send(401, { error: "unauthorized" });
+              return;
+            }
+            if (url.pathname === "/thing" && request.method === "GET") {
+              send(200, { marker: "read-ok", kind: "get" });
+              return;
+            }
+            if (url.pathname === "/thing" && request.method === "POST") {
+              // Drain the body so the socket closes cleanly, then ack.
+              request.resume();
+              request.on("end", () =>
+                send(201, { marker: "write-ok", kind: "post" }),
+              );
+              return;
+            }
+            send(404, { error: "not_found" });
+          },
+        );
+        const close = Effect.sync(() => {
+          server.close();
+          server.closeAllConnections?.();
+        });
+        server.once("error", () =>
+          resume(Effect.succeed({ baseUrl: "", close })),
+        );
+        server.listen(0, "127.0.0.1", () => {
+          const address = server.address();
+          const port =
+            typeof address === "object" && address ? address.port : 0;
+          resume(
+            Effect.succeed({ baseUrl: `http://127.0.0.1:${port}`, close }),
+          );
+        });
+      },
+    ),
+    (acquired) => acquired.close,
+  ).pipe(Effect.map(({ close: _close, ...rest }) => rest));
+
+// Inline spec: one GET (read) + one POST (write) operation on /thing, both
+// secured by the same bearer scheme. operationIds are single identifier-safe
+// words so the derived tool names are predictable, but the test discovers the
+// real tool addresses from the catalog rather than hardcoding them.
+const makeSpec = (): string =>
+  JSON.stringify({
+    openapi: "3.0.3",
+    info: { title: "Read-mode API", version: "1.0.0" },
+    paths: {
+      "/thing": {
+        get: {
+          operationId: "getthing",
+          summary: "Read a thing",
+          responses: { "200": { description: "the thing" } },
+        },
+        post: {
+          operationId: "creatething",
+          summary: "Create a thing",
+          responses: { "201": { description: "created" } },
+        },
+      },
+    },
+  });
+
+scenario(
+  'Toolkits · access "read" exposes only read-only (GET) tools and blocks writes (POST)',
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const upstream = yield* serveUpstream(token);
+      expect(
+        upstream.baseUrl,
+        "the loopback OpenAPI upstream bound a port",
+      ).not.toBe("");
+
+      const slug = ident("oapi");
+      const conn = ident("conn");
+
+      // Register the integration (spec inline; baseUrl points at the real
+      // loopback socket) and create the org connection that holds the bearer.
+      yield* client.openapi.addSpec({
+        payload: {
+          spec: { kind: "blob", value: makeSpec() },
+          slug,
+          baseUrl: upstream.baseUrl,
+          authenticationTemplate: [
+            {
+              slug: "apiKey",
+              type: "apiKey",
+              headers: {
+                authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("apiKey"),
+          value: token,
+        },
+      });
+
+      // Discover the real tool addresses from the catalog. The GET-derived tool
+      // is read-only (requiresApproval falsy); the POST-derived tool is a write
+      // (requiresApproval true, per annotationsForOperation). We derive the
+      // sandbox call name (the last dotted segment of the address) so we never
+      // hardcode the camelCase leaf the definition layer produces.
+      const tools = yield* client.tools.list({
+        query: { integration: IntegrationSlug.make(slug) },
+      });
+      const mine = tools.filter((t) => String(t.integration) === slug);
+      const readTool = mine.find((t) => t.requiresApproval !== true);
+      const writeTool = mine.find((t) => t.requiresApproval === true);
+      expect(
+        readTool?.address,
+        `GET-derived read-only tool is in the catalog; tools=${mine
+          .map((t) => `${t.name}(approval=${String(t.requiresApproval)})`)
+          .join(", ")}`,
+      ).toBeDefined();
+      expect(
+        writeTool?.address,
+        `POST-derived write tool is in the catalog; tools=${mine
+          .map((t) => `${t.name}(approval=${String(t.requiresApproval)})`)
+          .join(", ")}`,
+      ).toBeDefined();
+      const readName = String(readTool!.name);
+      const writeName = String(writeTool!.name);
+
+      // Two workspace toolkits over the SAME connection: one at "read", one at
+      // "full".
+      const kitRead = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitread"),
+          name: "Read kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "read",
+            },
+          ],
+        },
+      });
+      const kitFull = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitfull"),
+          name: "Full kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // --- READ toolkit: GET runs, POST is blocked ---------------------------
+      const scopedRead = mcp.session(identity, { toolkit: kitRead.slug });
+
+      // The scoped inventory still lists the integration (it is in the slice),
+      // and the read tool's dotted name is reachable.
+      const readDesc = describeExecute(yield* scopedRead.describeTools());
+      expect(
+        readDesc,
+        "read-toolkit inventory includes the in-slice integration",
+      ).toContain(slug);
+
+      const readGet = yield* scopedRead.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${readName}({});`,
+      });
+      expect(
+        readGet.ok && readGet.text.includes("read-ok"),
+        `read access runs the GET tool; ok=${readGet.ok} text=${readGet.text}`,
+      ).toBe(true);
+
+      const readPost = yield* scopedRead.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${writeName}({ body: {} });`,
+      });
+      // Under "read" access the write (POST) tool is removed from the slice, so
+      // it is not reachable in the sandbox — the call neither completes (no
+      // upstream "write-ok") nor even pauses for approval ("paused"); it errors.
+      expect(
+        readPost.text.includes("write-ok") || readPost.text.includes("paused"),
+        `read access must EXCLUDE the write tool (unreachable); text=${readPost.text}`,
+      ).toBe(false);
+      expect(
+        readPost.text,
+        `excluded write errors, not the GET payload; text=${readPost.text}`,
+      ).not.toBe(readGet.text);
+
+      // --- FULL toolkit: GET runs; POST is reachable (pauses for approval) ----
+      const scopedFull = mcp.session(identity, { toolkit: kitFull.slug });
+
+      const fullDesc = describeExecute(yield* scopedFull.describeTools());
+      expect(
+        fullDesc,
+        "full-toolkit inventory includes the integration",
+      ).toContain(slug);
+
+      const fullGet = yield* scopedFull.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${readName}({});`,
+      });
+      expect(
+        fullGet.ok && fullGet.text.includes("read-ok"),
+        `full access runs the GET tool; ok=${fullGet.ok} text=${fullGet.text}`,
+      ).toBe(true);
+
+      const fullPost = yield* scopedFull.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${writeName}({ body: {} });`,
+      });
+      // Under "full" access the write tool IS in the slice. Writes still require
+      // approval (independent of toolkit access), so a default-mode session
+      // pauses ("Execution paused") rather than completing — which still proves
+      // the tool is REACHABLE, the opposite of read access where it is excluded.
+      expect(
+        fullPost.text.includes("paused") || fullPost.text.includes("write-ok"),
+        `full access EXPOSES the write tool (runs or pauses for approval); text=${fullPost.text}`,
+      ).toBe(true);
+      expect(
+        fullPost.text,
+        `full reaches the write tool while read excludes it; read=${readPost.text} full=${fullPost.text}`,
+      ).not.toBe(readPost.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-read-mode.test.ts
+++ b/e2e/selfhost/toolkits-read-mode.test.ts
@@ -17,11 +17,7 @@
 // EXECUTOR_ALLOW_LOCAL_NETWORK=true, so the instance is allowed to dial the
 // loopback upstream. The spec itself is passed inline (blob) so the spec fetch
 // never hits the network — only the GET/POST invocations dial the socket.
-import {
-  createServer,
-  type IncomingMessage,
-  type ServerResponse,
-} from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomBytes } from "node:crypto";
 
 import { expect } from "@effect/vitest";
@@ -30,30 +26,20 @@ import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
 import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
 
-const api = composePluginApi([
-  mcpHttpPlugin(),
-  openApiHttpPlugin(),
-  toolkitsPlugin(),
-] as const);
+const api = composePluginApi([mcpHttpPlugin(), openApiHttpPlugin(), toolkitsPlugin()] as const);
 
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays valid JS, and so the create-time name normalization (which
 // strips hyphens) round-trips unchanged.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 // A real OpenAPI upstream on a loopback socket. `GET /thing` is a read; `POST
 // /thing` is a write. Both return a recognizable JSON marker so a successful
@@ -65,61 +51,45 @@ interface Upstream {
 
 // Mirrors serveMcpServer: acquire a real listening socket carrying its own
 // `close`, release closes it, and we strip `close` from the value handed back.
-const serveUpstream = (
-  token: string,
-): Effect.Effect<Upstream, never, Scope.Scope> =>
+const serveUpstream = (token: string): Effect.Effect<Upstream, never, Scope.Scope> =>
   Effect.acquireRelease(
-    Effect.callback<Upstream & { readonly close: Effect.Effect<void> }, never>(
-      (resume) => {
-        const server = createServer(
-          (request: IncomingMessage, response: ServerResponse) => {
-            const url = new URL(request.url ?? "/", "http://127.0.0.1");
-            const auth = request.headers.authorization;
-            const send = (
-              status: number,
-              body: Record<string, unknown>,
-            ): void => {
-              response.writeHead(status, {
-                "content-type": "application/json",
-              });
-              response.end(JSON.stringify(body));
-            };
-            if (auth !== `Bearer ${token}`) {
-              send(401, { error: "unauthorized" });
-              return;
-            }
-            if (url.pathname === "/thing" && request.method === "GET") {
-              send(200, { marker: "read-ok", kind: "get" });
-              return;
-            }
-            if (url.pathname === "/thing" && request.method === "POST") {
-              // Drain the body so the socket closes cleanly, then ack.
-              request.resume();
-              request.on("end", () =>
-                send(201, { marker: "write-ok", kind: "post" }),
-              );
-              return;
-            }
-            send(404, { error: "not_found" });
-          },
-        );
-        const close = Effect.sync(() => {
-          server.close();
-          server.closeAllConnections?.();
-        });
-        server.once("error", () =>
-          resume(Effect.succeed({ baseUrl: "", close })),
-        );
-        server.listen(0, "127.0.0.1", () => {
-          const address = server.address();
-          const port =
-            typeof address === "object" && address ? address.port : 0;
-          resume(
-            Effect.succeed({ baseUrl: `http://127.0.0.1:${port}`, close }),
-          );
-        });
-      },
-    ),
+    Effect.callback<Upstream & { readonly close: Effect.Effect<void> }, never>((resume) => {
+      const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+        const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        const auth = request.headers.authorization;
+        const send = (status: number, body: Record<string, unknown>): void => {
+          response.writeHead(status, {
+            "content-type": "application/json",
+          });
+          response.end(JSON.stringify(body));
+        };
+        if (auth !== `Bearer ${token}`) {
+          send(401, { error: "unauthorized" });
+          return;
+        }
+        if (url.pathname === "/thing" && request.method === "GET") {
+          send(200, { marker: "read-ok", kind: "get" });
+          return;
+        }
+        if (url.pathname === "/thing" && request.method === "POST") {
+          // Drain the body so the socket closes cleanly, then ack.
+          request.resume();
+          request.on("end", () => send(201, { marker: "write-ok", kind: "post" }));
+          return;
+        }
+        send(404, { error: "not_found" });
+      });
+      const close = Effect.sync(() => {
+        server.close();
+        server.closeAllConnections?.();
+      });
+      server.once("error", () => resume(Effect.succeed({ baseUrl: "", close })));
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(Effect.succeed({ baseUrl: `http://127.0.0.1:${port}`, close }));
+      });
+    }),
     (acquired) => acquired.close,
   ).pipe(Effect.map(({ close: _close, ...rest }) => rest));
 
@@ -160,10 +130,7 @@ scenario(
 
       const token = `tok-${randomBytes(6).toString("hex")}`;
       const upstream = yield* serveUpstream(token);
-      expect(
-        upstream.baseUrl,
-        "the loopback OpenAPI upstream bound a port",
-      ).not.toBe("");
+      expect(upstream.baseUrl, "the loopback OpenAPI upstream bound a port").not.toBe("");
 
       const slug = ident("oapi");
       const conn = ident("conn");
@@ -259,10 +226,7 @@ scenario(
       // The scoped inventory still lists the integration (it is in the slice),
       // and the read tool's dotted name is reachable.
       const readDesc = describeExecute(yield* scopedRead.describeTools());
-      expect(
-        readDesc,
-        "read-toolkit inventory includes the in-slice integration",
-      ).toContain(slug);
+      expect(readDesc, "read-toolkit inventory includes the in-slice integration").toContain(slug);
 
       const readGet = yield* scopedRead.call("execute", {
         code: `return await tools.${slug}.org.${conn}.${readName}({});`,
@@ -291,10 +255,7 @@ scenario(
       const scopedFull = mcp.session(identity, { toolkit: kitFull.slug });
 
       const fullDesc = describeExecute(yield* scopedFull.describeTools());
-      expect(
-        fullDesc,
-        "full-toolkit inventory includes the integration",
-      ).toContain(slug);
+      expect(fullDesc, "full-toolkit inventory includes the integration").toContain(slug);
 
       const fullGet = yield* scopedFull.call("execute", {
         code: `return await tools.${slug}.org.${conn}.${readName}({});`,

--- a/e2e/selfhost/toolkits-read-mode.test.ts
+++ b/e2e/selfhost/toolkits-read-mode.test.ts
@@ -1,7 +1,7 @@
 // Selfhost · Toolkit access "read" exposes only read-only tools and blocks
 // writes. `readOnly` is derived from HTTP method on OpenAPI integrations
 // (GET/HEAD/OPTIONS => readOnly:true; POST/PUT/PATCH/DELETE are writes), and
-// `applyToolkitScope` keeps a connection's tool under "read" access ONLY when
+// Read-only toolkit access keeps a connection's tool under "read" ONLY when
 // `annotations.readOnly === true`. So we stand up a real OpenAPI upstream with
 // BOTH a GET (read) and a POST (write) operation, grant the same connection at
 // "read" in one workspace toolkit and "full" in another, and prove:

--- a/e2e/selfhost/toolkits-ui.test.ts
+++ b/e2e/selfhost/toolkits-ui.test.ts
@@ -137,6 +137,51 @@ scenario(
             .waitFor();
           await page.getByText(toolkitName).first().waitFor();
         });
+
+        let toolkitId = "";
+
+        await step("Opening a toolkit card updates the URL to its id", async () => {
+          await page.getByText(toolkitName).first().click();
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+          await page.waitForURL((url) => {
+            const segments = url.pathname.split("/").filter(Boolean);
+            const last = segments[segments.length - 1];
+            return last !== undefined && last !== "toolkits";
+          });
+          toolkitId = new URL(page.url()).pathname.split("/").filter(Boolean).pop() ?? "";
+          expect(toolkitId.length, "card open exposes the toolkit id in the URL").toBeGreaterThan(
+            0,
+          );
+          await page.getByRole("button", { name: "← Toolkits" }).click();
+          await page.getByRole("heading", { name: "Workspace toolkits" }).waitFor();
+        });
+
+        await step("Deep-linking to a toolkit opens the editor with its name", async () => {
+          await page.goto(`/plugins/toolkits/${toolkitId}`, {
+            waitUntil: "networkidle",
+          });
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+          expect(
+            await page.getByRole("textbox").first().inputValue(),
+            "deep link opens the editor with the toolkit name",
+          ).toBe(toolkitName);
+        });
+
+        await step("Browser back returns to the toolkit list", async () => {
+          await page.goBack({ waitUntil: "networkidle" });
+          await page.waitForURL(
+            (url) =>
+              url.pathname.endsWith("/plugins/toolkits/") ||
+              url.pathname.endsWith("/plugins/toolkits"),
+          );
+          await page.getByRole("heading", { name: "Workspace toolkits" }).waitFor();
+        });
+
+        await step("New toolkit navigates to /new/workspace", async () => {
+          await page.getByRole("button", { name: "New toolkit" }).first().click();
+          await page.waitForURL((url) => url.pathname.endsWith("/new/workspace"));
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+        });
       });
 
       // Read the toolkit back through the typed API: the editor's write carried

--- a/e2e/selfhost/toolkits-ui.test.ts
+++ b/e2e/selfhost/toolkits-ui.test.ts
@@ -1,0 +1,158 @@
+// Selfhost · Slice 2 (console UI): the Toolkits page renders through the real
+// web console and its editor writes a toolkit — access modes, per-connection
+// notes, and all — back to the toolkits API. This is the end-to-end proof of
+// the client plugin wiring: the page only mounts if the Vite plugin bundled
+// `@executor-js/plugin-toolkits/client`, the nav resolved, and the typed atom
+// client reached `/api/toolkits`.
+//
+// We drive the real controls (the off/read/full segment + the note field),
+// create the toolkit, then read it back through the typed API and assert the
+// persisted slice — so the editor's access-map -> wire-entry transform (incl.
+// note trimming) is covered through the UI, not a unit test. The personal
+// connection we seed is owner-scoped to this fresh identity, so it is a
+// deterministic anchor even though selfhost identities share one tenant.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+const fresh = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+scenario(
+  "Toolkits · the console editor creates a toolkit and persists its access slice",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const browser = yield* Browser;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Seed a PERSONAL connection (owner "user") so it shows only for this
+      // identity — the editor's Access section should surface it.
+      const slug = fresh("tkui");
+      const connName = fresh("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "user",
+          name: ConnectionName.make(connName),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const toolkitName = `Kit ${randomBytes(3).toString("hex")}`;
+      const connTestId = `tk-conn ${slug} ${connName}`;
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the Toolkits page", async () => {
+          await page.goto("/plugins/toolkits/", { waitUntil: "networkidle" });
+          await page
+            .getByRole("heading", { name: "Toolkits", exact: true })
+            .waitFor();
+          await page
+            .getByRole("heading", { name: "Workspace toolkits" })
+            .waitFor();
+          await page
+            .getByRole("heading", { name: "Personal toolkits" })
+            .waitFor();
+        });
+
+        await step("Start a new personal toolkit", async () => {
+          // Two "New toolkit" buttons (workspace, personal); the second is the
+          // personal section.
+          await page
+            .getByRole("button", { name: "New toolkit" })
+            .nth(1)
+            .click();
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+          // The personal connection appears (proves the personal scope tier +
+          // connection wiring).
+          await page.getByText(connName).first().waitFor();
+        });
+
+        await step(
+          "Name it, grant the connection full access, add a note",
+          async () => {
+            // The title is the first textbox in the editor (briefing is below it).
+            await page.getByRole("textbox").first().fill(toolkitName);
+            // Grant Full on this connection's row (testid keeps it unambiguous).
+            const row = page.getByTestId(connTestId);
+            await row
+              .getByRole("button", { name: "Full", exact: true })
+              .click();
+            // The note field appears once access != off; padded to prove trimming.
+            await row.getByRole("textbox").fill("  wiki only  ");
+          },
+        );
+
+        await step("Create it", async () => {
+          await page.getByRole("button", { name: "Create toolkit" }).click();
+          // Back on the list, the New toolkit buttons return and the card shows.
+          await page
+            .getByRole("button", { name: "New toolkit" })
+            .first()
+            .waitFor();
+          await page.getByText(toolkitName).first().waitFor();
+        });
+      });
+
+      // Read the toolkit back through the typed API: the editor's write carried
+      // the scope, access mode, and trimmed note.
+      const all = yield* client.toolkits.list();
+      const created = all.find((t) => t.name === toolkitName);
+      expect(created, "the toolkit the UI created is persisted").toBeDefined();
+      expect(created?.scope).toBe("personal");
+      expect(created?.connections).toEqual([
+        {
+          integration: slug,
+          connection: connName,
+          access: "full",
+          note: "wiki only",
+        },
+      ]);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-ui.test.ts
+++ b/e2e/selfhost/toolkits-ui.test.ts
@@ -17,23 +17,15 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Browser, Target } from "../src/services";
 
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
-const fresh = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const fresh = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
 scenario(
   "Toolkits · the console editor creates a toolkit and persists its access slice",
@@ -89,52 +81,35 @@ scenario(
       yield* browser.session(identity, async ({ page, step }) => {
         await step("Open the Toolkits page", async () => {
           await page.goto("/plugins/toolkits/", { waitUntil: "networkidle" });
-          await page
-            .getByRole("heading", { name: "Toolkits", exact: true })
-            .waitFor();
-          await page
-            .getByRole("heading", { name: "Workspace toolkits" })
-            .waitFor();
-          await page
-            .getByRole("heading", { name: "Personal toolkits" })
-            .waitFor();
+          await page.getByRole("heading", { name: "Toolkits", exact: true }).waitFor();
+          await page.getByRole("heading", { name: "Workspace toolkits" }).waitFor();
+          await page.getByRole("heading", { name: "Personal toolkits" }).waitFor();
         });
 
         await step("Start a new personal toolkit", async () => {
           // Two "New toolkit" buttons (workspace, personal); the second is the
           // personal section.
-          await page
-            .getByRole("button", { name: "New toolkit" })
-            .nth(1)
-            .click();
+          await page.getByRole("button", { name: "New toolkit" }).nth(1).click();
           await page.getByRole("heading", { name: "Access" }).waitFor();
           // The personal connection appears (proves the personal scope tier +
           // connection wiring).
           await page.getByText(connName).first().waitFor();
         });
 
-        await step(
-          "Name it, grant the connection full access, add a note",
-          async () => {
-            // The title is the first textbox in the editor (briefing is below it).
-            await page.getByRole("textbox").first().fill(toolkitName);
-            // Grant Full on this connection's row (testid keeps it unambiguous).
-            const row = page.getByTestId(connTestId);
-            await row
-              .getByRole("button", { name: "Full", exact: true })
-              .click();
-            // The note field appears once access != off; padded to prove trimming.
-            await row.getByRole("textbox").fill("  wiki only  ");
-          },
-        );
+        await step("Name it, grant the connection full access, add a note", async () => {
+          // The title is the first textbox in the editor (briefing is below it).
+          await page.getByRole("textbox").first().fill(toolkitName);
+          // Grant Full on this connection's row (testid keeps it unambiguous).
+          const row = page.getByTestId(connTestId);
+          await row.getByRole("button", { name: "Full", exact: true }).click();
+          // The note field appears once access != off; padded to prove trimming.
+          await row.getByRole("textbox").fill("  wiki only  ");
+        });
 
         await step("Create it", async () => {
           await page.getByRole("button", { name: "Create toolkit" }).click();
           // Back on the list, the New toolkit buttons return and the card shows.
-          await page
-            .getByRole("button", { name: "New toolkit" })
-            .first()
-            .waitFor();
+          await page.getByRole("button", { name: "New toolkit" }).first().waitFor();
           await page.getByText(toolkitName).first().waitFor();
         });
 

--- a/e2e/selfhost/toolkits-update.test.ts
+++ b/e2e/selfhost/toolkits-update.test.ts
@@ -1,0 +1,226 @@
+// Selfhost · Slice 3 (live re-narrowing): updating a toolkit's connection set
+// changes what a NEWLY-opened scoped MCP session sees. `connections` on the
+// update payload is a FULL REPLACEMENT (server.ts update(): when
+// patch.connections is defined it deletes every existing connection row and
+// re-inserts the patch list), so to drop a connection you OMIT it. A session
+// opened BEFORE an update keeps its original slice — each transition is proven
+// against a FRESH mcp.session, and read back via toolkits.get to confirm the
+// persisted set matches.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS; also satisfies the create-time name normalization.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · updating a toolkit's connections re-narrows what a fresh MCP session sees",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Two real MCP greeting servers -> two distinct integrations + org
+      // connections (each exposes a `simple_echo` tool discovered at create).
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: [
+                      "Bearer ",
+                      { type: "variable", name: "token" },
+                    ],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // A = the first integration/connection, B = the second.
+      const slugA = ident("tka");
+      const slugB = ident("tkb");
+      const connA = ident("conn");
+      const connB = ident("conn");
+      yield* addConnection(slugA, connA);
+      yield* addConnection(slugB, connB);
+
+      const codeA = `return await tools.${slugA}.org.${connA}.simple_echo({});`;
+      const codeB = `return await tools.${slugB}.org.${connB}.simple_echo({});`;
+
+      // Workspace toolkit with ONLY A at "full".
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Evolving kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // A baseline "what a runnable in-slice greeting looks like" so we can
+      // distinguish a real greeting from a blocked error envelope (blocked
+      // tools surface as an error in .text, never the greeting).
+      // ---- Session #1: only A in slice ------------------------------------
+      const s1 = mcp.session(identity, { toolkit: kit.slug });
+      const desc1 = describeExecute(yield* s1.describeTools());
+      expect(desc1, "#1 inventory includes A").toContain(slugA);
+      expect(desc1, "#1 inventory omits B").not.toContain(slugB);
+
+      const s1A = yield* s1.call("execute", { code: codeA });
+      expect(s1A.ok, `#1 A executes; text=${s1A.text}`).toBe(true);
+      const greeting = s1A.text; // the canonical success text for simple_echo
+
+      const s1B = yield* s1.call("execute", { code: codeB });
+      expect(
+        s1B.text,
+        `#1 B must be blocked (not the greeting); B.ok=${s1B.ok} B.text=${s1B.text}`,
+      ).not.toBe(greeting);
+
+      // Persisted set after create: exactly A.
+      const view1 = yield* client.toolkits.get({ params: { id: kit.id } });
+      expect(
+        view1.connections.map((c) => c.integration).sort(),
+        "#1 persisted = [A]",
+      ).toEqual([slugA].sort());
+
+      // ---- Update -> [A full, B full]; Session #2 (fresh): BOTH present ----
+      const upd2 = yield* client.toolkits.update({
+        params: { id: kit.id },
+        payload: {
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(
+        upd2.connections.map((c) => c.integration).sort(),
+        "update#2 echoes [A,B]",
+      ).toEqual([slugA, slugB].sort());
+
+      const view2 = yield* client.toolkits.get({ params: { id: kit.id } });
+      expect(
+        view2.connections.map((c) => c.integration).sort(),
+        "#2 persisted = [A,B]",
+      ).toEqual([slugA, slugB].sort());
+
+      const s2 = mcp.session(identity, { toolkit: kit.slug });
+      const desc2 = describeExecute(yield* s2.describeTools());
+      expect(desc2, "#2 inventory includes A").toContain(slugA);
+      expect(desc2, "#2 inventory now includes B").toContain(slugB);
+
+      const s2A = yield* s2.call("execute", { code: codeA });
+      expect(s2A.ok, `#2 A still runnable; text=${s2A.text}`).toBe(true);
+      const s2B = yield* s2.call("execute", { code: codeB });
+      expect(s2B.ok, `#2 B now runnable; text=${s2B.text}`).toBe(true);
+      expect(s2B.text, "#2 B returns the greeting, not an error").toBe(
+        greeting,
+      );
+
+      // ---- Update -> [B full] only (A dropped == off); Session #3 fresh ---
+      const upd3 = yield* client.toolkits.update({
+        params: { id: kit.id },
+        payload: {
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(
+        upd3.connections.map((c) => c.integration),
+        "update#3 echoes [B] only — full replacement dropped A",
+      ).toEqual([slugB]);
+
+      const view3 = yield* client.toolkits.get({ params: { id: kit.id } });
+      expect(
+        view3.connections.map((c) => c.integration),
+        "#3 persisted = [B] only",
+      ).toEqual([slugB]);
+
+      const s3 = mcp.session(identity, { toolkit: kit.slug });
+      const desc3 = describeExecute(yield* s3.describeTools());
+      expect(desc3, "#3 inventory includes B").toContain(slugB);
+      expect(desc3, "#3 inventory now omits A").not.toContain(slugA);
+
+      const s3B = yield* s3.call("execute", { code: codeB });
+      expect(s3B.ok, `#3 B runnable; text=${s3B.text}`).toBe(true);
+      const s3A = yield* s3.call("execute", { code: codeA });
+      // A is out-of-slice again -> blocked at execute (error envelope in .text),
+      // never the greeting the in-slice call returns.
+      expect(
+        s3A.text,
+        `#3 A must be blocked after being dropped; A.ok=${s3A.ok} A.text=${s3A.text}`,
+      ).not.toBe(greeting);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-update.test.ts
+++ b/e2e/selfhost/toolkits-update.test.ts
@@ -12,16 +12,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -29,12 +22,10 @@ import { Api, Mcp, Target } from "../src/services";
 const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays valid JS; also satisfies the create-time name normalization.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   "Toolkits · updating a toolkit's connections re-narrows what a fresh MCP session sees",
@@ -68,10 +59,7 @@ scenario(
                 {
                   type: "apiKey",
                   headers: {
-                    Authorization: [
-                      "Bearer ",
-                      { type: "variable", name: "token" },
-                    ],
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
                   },
                 },
               ],
@@ -136,10 +124,9 @@ scenario(
 
       // Persisted set after create: exactly A.
       const view1 = yield* client.toolkits.get({ params: { id: kit.id } });
-      expect(
-        view1.connections.map((c) => c.integration).sort(),
-        "#1 persisted = [A]",
-      ).toEqual([slugA].sort());
+      expect(view1.connections.map((c) => c.integration).sort(), "#1 persisted = [A]").toEqual(
+        [slugA].sort(),
+      );
 
       // ---- Update -> [A full, B full]; Session #2 (fresh): BOTH present ----
       const upd2 = yield* client.toolkits.update({
@@ -159,16 +146,14 @@ scenario(
           ],
         },
       });
-      expect(
-        upd2.connections.map((c) => c.integration).sort(),
-        "update#2 echoes [A,B]",
-      ).toEqual([slugA, slugB].sort());
+      expect(upd2.connections.map((c) => c.integration).sort(), "update#2 echoes [A,B]").toEqual(
+        [slugA, slugB].sort(),
+      );
 
       const view2 = yield* client.toolkits.get({ params: { id: kit.id } });
-      expect(
-        view2.connections.map((c) => c.integration).sort(),
-        "#2 persisted = [A,B]",
-      ).toEqual([slugA, slugB].sort());
+      expect(view2.connections.map((c) => c.integration).sort(), "#2 persisted = [A,B]").toEqual(
+        [slugA, slugB].sort(),
+      );
 
       const s2 = mcp.session(identity, { toolkit: kit.slug });
       const desc2 = describeExecute(yield* s2.describeTools());
@@ -179,9 +164,7 @@ scenario(
       expect(s2A.ok, `#2 A still runnable; text=${s2A.text}`).toBe(true);
       const s2B = yield* s2.call("execute", { code: codeB });
       expect(s2B.ok, `#2 B now runnable; text=${s2B.text}`).toBe(true);
-      expect(s2B.text, "#2 B returns the greeting, not an error").toBe(
-        greeting,
-      );
+      expect(s2B.text, "#2 B returns the greeting, not an error").toBe(greeting);
 
       // ---- Update -> [B full] only (A dropped == off); Session #3 fresh ---
       const upd3 = yield* client.toolkits.update({

--- a/e2e/selfhost/toolkits-wildcard.test.ts
+++ b/e2e/selfhost/toolkits-wildcard.test.ts
@@ -1,0 +1,205 @@
+// Selfhost · Toolkits wildcard ("*") tracks every account of an integration,
+// including accounts added AFTER the toolkit is created. A toolkit entry whose
+// `connection` is "*" is integration-level: the MCP narrowing seam
+// (toolkit-scope.ts `accessFor`) matches ANY connection of that integration,
+// and `resolveScope` re-reads the live connection set per session — so a fresh
+// scoped session opened after a new account is added auto-includes it, while a
+// session's slice is fixed to the integration, never leaking a sibling
+// integration's accounts.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import {
+  makeGreetingMcpServer,
+  serveMcpServer,
+} from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+} from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and single-word lowercase names survive the
+// connectionIdentifier normalization unchanged.
+const ident = (prefix: string): string =>
+  `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (
+  defs: ReadonlyArray<{ name: string; description?: string }>,
+): string => defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  'Toolkits · a wildcard ("*") entry tracks every account of an integration, including ones added after the toolkit',
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Register an integration ONCE via addServer, then add accounts to it with
+      // repeated connections.create calls (same integration slug, new name).
+      // addServer creates/updates the integration + auth template; each
+      // connections.create adds one account (org-owned connection) under it.
+      const addIntegration = (slug: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: [
+                      "Bearer ",
+                      { type: "variable", name: "token" },
+                    ],
+                  },
+                },
+              ],
+            },
+          });
+          // Each account points at the same integration's greeting server; the
+          // token satisfies that integration's auth template.
+          const addAccount = (conn: string) =>
+            client.connections.create({
+              payload: {
+                owner: "org",
+                name: ConnectionName.make(conn),
+                integration: IntegrationSlug.make(slug),
+                template: AuthTemplateSlug.make("header"),
+                value: token,
+              },
+            });
+          return { addAccount };
+        });
+
+      const slugX = ident("tkx");
+      const { addAccount: addX } = yield* addIntegration(slugX);
+
+      // Integration X starts with TWO org accounts.
+      const primary = ident("primary");
+      const secondary = ident("secondary");
+      yield* addX(primary);
+      yield* addX(secondary);
+
+      // An UNRELATED integration Y with its own account — the wildcard must NOT
+      // reach it (the entry is scoped to X only).
+      const slugY = ident("tky");
+      const { addAccount: addY } = yield* addIntegration(slugY);
+      const connY = ident("other");
+      yield* addY(connY);
+
+      // A workspace toolkit with a SINGLE integration-level entry: every account
+      // of X, full access. Y is never named, so it is out of slice.
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Wildcard kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugX),
+              connection: "*",
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // Session #1: both pre-existing accounts are in the slice; Y is not.
+      const session1 = mcp.session(identity, { toolkit: kit.slug });
+      const desc1 = describeExecute(yield* session1.describeTools());
+      expect(desc1, "wildcard slice includes the primary account").toContain(
+        primary,
+      );
+      expect(desc1, "wildcard slice includes the secondary account").toContain(
+        secondary,
+      );
+      expect(
+        desc1,
+        "wildcard is scoped to X — Y's account is out of slice",
+      ).not.toContain(connY);
+
+      const primaryRun = yield* session1.call("execute", {
+        code: `return await tools.${slugX}.org.${primary}.simple_echo({});`,
+      });
+      expect(
+        primaryRun.ok,
+        `primary account runs; text=${primaryRun.text}`,
+      ).toBe(true);
+
+      const secondaryRun = yield* session1.call("execute", {
+        code: `return await tools.${slugX}.org.${secondary}.simple_echo({});`,
+      });
+      expect(
+        secondaryRun.ok,
+        `secondary account runs; text=${secondaryRun.text}`,
+      ).toBe(true);
+
+      // Y is blocked at execute even though the agent guessed its address — a
+      // blocked tool surfaces as an error envelope, never the greeting a
+      // legitimate account returns.
+      const yRun = yield* session1.call("execute", {
+        code: `return await tools.${slugY}.org.${connY}.simple_echo({});`,
+      });
+      expect(
+        yRun.text,
+        `out-of-slice Y must be blocked; primary.text=${primaryRun.text} y.ok=${yRun.ok} y.text=${yRun.text}`,
+      ).not.toBe(primaryRun.text);
+
+      // --- The auto-update assertion ----------------------------------------
+      // Add a THIRD account to X AFTER the toolkit was created. The toolkit is
+      // untouched (still a single "*" entry).
+      const tertiary = ident("tertiary");
+      yield* addX(tertiary);
+
+      // A NEW scoped session re-resolves the slice, so the wildcard now also
+      // covers the just-added account. (Session #1 keeps its original snapshot —
+      // we deliberately open a fresh session here.)
+      const session2 = mcp.session(identity, { toolkit: kit.slug });
+      const desc2 = describeExecute(yield* session2.describeTools());
+      expect(
+        desc2,
+        "a fresh session's wildcard still includes primary",
+      ).toContain(primary);
+      expect(
+        desc2,
+        "a fresh session's wildcard still includes secondary",
+      ).toContain(secondary);
+      expect(
+        desc2,
+        "the wildcard auto-includes the account added after the toolkit",
+      ).toContain(tertiary);
+
+      const tertiaryRun = yield* session2.call("execute", {
+        code: `return await tools.${slugX}.org.${tertiary}.simple_echo({});`,
+      });
+      expect(
+        tertiaryRun.ok,
+        `the later-added account runs in a fresh scoped session; text=${tertiaryRun.text}`,
+      ).toBe(true);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-wildcard.test.ts
+++ b/e2e/selfhost/toolkits-wildcard.test.ts
@@ -12,16 +12,9 @@ import { expect } from "@effect/vitest";
 import { Effect } from "effect";
 import { composePluginApi } from "@executor-js/api/server";
 import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
-import {
-  makeGreetingMcpServer,
-  serveMcpServer,
-} from "@executor-js/plugin-mcp/testing";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
 import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
-import {
-  AuthTemplateSlug,
-  ConnectionName,
-  IntegrationSlug,
-} from "@executor-js/sdk/shared";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
 
 import { scenario } from "../src/scenario";
 import { Api, Mcp, Target } from "../src/services";
@@ -30,12 +23,10 @@ const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
 // Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
 // dotted path stays valid JS, and single-word lowercase names survive the
 // connectionIdentifier normalization unchanged.
-const ident = (prefix: string): string =>
-  `${prefix}${randomBytes(4).toString("hex")}`;
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
 
-const describeExecute = (
-  defs: ReadonlyArray<{ name: string; description?: string }>,
-): string => defs.find((d) => d.name === "execute")?.description ?? "";
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
 
 scenario(
   'Toolkits · a wildcard ("*") entry tracks every account of an integration, including ones added after the toolkit',
@@ -71,10 +62,7 @@ scenario(
                 {
                   type: "apiKey",
                   headers: {
-                    Authorization: [
-                      "Bearer ",
-                      { type: "variable", name: "token" },
-                    ],
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
                   },
                 },
               ],
@@ -131,32 +119,19 @@ scenario(
       // Session #1: both pre-existing accounts are in the slice; Y is not.
       const session1 = mcp.session(identity, { toolkit: kit.slug });
       const desc1 = describeExecute(yield* session1.describeTools());
-      expect(desc1, "wildcard slice includes the primary account").toContain(
-        primary,
-      );
-      expect(desc1, "wildcard slice includes the secondary account").toContain(
-        secondary,
-      );
-      expect(
-        desc1,
-        "wildcard is scoped to X — Y's account is out of slice",
-      ).not.toContain(connY);
+      expect(desc1, "wildcard slice includes the primary account").toContain(primary);
+      expect(desc1, "wildcard slice includes the secondary account").toContain(secondary);
+      expect(desc1, "wildcard is scoped to X — Y's account is out of slice").not.toContain(connY);
 
       const primaryRun = yield* session1.call("execute", {
         code: `return await tools.${slugX}.org.${primary}.simple_echo({});`,
       });
-      expect(
-        primaryRun.ok,
-        `primary account runs; text=${primaryRun.text}`,
-      ).toBe(true);
+      expect(primaryRun.ok, `primary account runs; text=${primaryRun.text}`).toBe(true);
 
       const secondaryRun = yield* session1.call("execute", {
         code: `return await tools.${slugX}.org.${secondary}.simple_echo({});`,
       });
-      expect(
-        secondaryRun.ok,
-        `secondary account runs; text=${secondaryRun.text}`,
-      ).toBe(true);
+      expect(secondaryRun.ok, `secondary account runs; text=${secondaryRun.text}`).toBe(true);
 
       // Y is blocked at execute even though the agent guessed its address — a
       // blocked tool surfaces as an error envelope, never the greeting a
@@ -180,18 +155,11 @@ scenario(
       // we deliberately open a fresh session here.)
       const session2 = mcp.session(identity, { toolkit: kit.slug });
       const desc2 = describeExecute(yield* session2.describeTools());
-      expect(
-        desc2,
-        "a fresh session's wildcard still includes primary",
-      ).toContain(primary);
-      expect(
-        desc2,
-        "a fresh session's wildcard still includes secondary",
-      ).toContain(secondary);
-      expect(
-        desc2,
-        "the wildcard auto-includes the account added after the toolkit",
-      ).toContain(tertiary);
+      expect(desc2, "a fresh session's wildcard still includes primary").toContain(primary);
+      expect(desc2, "a fresh session's wildcard still includes secondary").toContain(secondary);
+      expect(desc2, "the wildcard auto-includes the account added after the toolkit").toContain(
+        tertiary,
+      );
 
       const tertiaryRun = yield* session2.call("execute", {
         code: `return await tools.${slugX}.org.${tertiary}.simple_echo({});`,

--- a/e2e/src/surfaces/mcp.ts
+++ b/e2e/src/surfaces/mcp.ts
@@ -160,7 +160,7 @@ export interface McpSurface {
   readonly url: string;
   readonly session: (
     identity: Identity,
-    options?: { readonly elicitationMode?: McpElicitationMode },
+    options?: { readonly elicitationMode?: McpElicitationMode; readonly toolkit?: string },
   ) => McpSession;
   /**
    * Mint a real MCP bearer headlessly: protected-resource discovery →
@@ -271,9 +271,14 @@ export const makeMcpSurface = (target: Target, runDir?: string): McpSurface => (
     // `browser` mode is selected per the ecosystem convention — an
     // `?elicitation_mode=` query on the MCP endpoint — so a paused execution
     // yields an approvalUrl instead of letting the model resume inline.
-    const sessionUrl = options?.elicitationMode
-      ? `${target.mcpUrl}?elicitation_mode=${options.elicitationMode}`
-      : target.mcpUrl;
+    const sessionUrl = (() => {
+      const u = new URL(target.mcpUrl);
+      if (options?.elicitationMode) u.searchParams.set("elicitation_mode", options.elicitationMode);
+      // Toolkit selector — narrows the engine to that toolkit's slice (same path
+      // the host reads via `readToolkitSelector`).
+      if (options?.toolkit) u.searchParams.set("toolkit", options.toolkit);
+      return u.toString();
+    })();
     let runtimePromise: Promise<Runtime> | undefined;
     let connected = false;
 

--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -243,11 +243,14 @@ function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
       .map((page) => {
         const splat = page.path.replace(/^\//, "");
         const href = `/plugins/${plugin.id}${splat ? `/${splat}` : "/"}`;
+        // Trailing slash stripped so the nav stays active on plugin subroutes
+        // (e.g. /plugins/toolkits/<id>), matching the multiplayer shell.
+        const base = href.replace(/\/$/, "");
         return {
           key: `${plugin.id}:${page.path}`,
           pluginId: plugin.id,
           splat,
-          href,
+          base,
           label: page.nav!.label,
         };
       }),
@@ -263,7 +266,7 @@ function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
           onClick={props.onNavigate}
           className={[
             "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
-            props.pathname === entry.href || props.pathname.startsWith(`${entry.href}/`)
+            props.pathname === entry.base || props.pathname.startsWith(`${entry.base}/`)
               ? "bg-sidebar-active text-foreground font-medium"
               : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
           ].join(" ")}

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -27,12 +27,10 @@ import { Context, Effect, Layer } from "effect";
 import type * as Cause from "effect/Cause";
 
 import {
-  applyToolkitScope,
-  EMPTY_TOOLKIT_SCOPE,
   type AnyPlugin,
   type Executor,
+  type ExecutorWrapper,
   type StorageFailure,
-  type ToolkitResolver,
 } from "@executor-js/sdk";
 import {
   createExecutionEngine,
@@ -41,7 +39,11 @@ import {
 } from "@executor-js/execution";
 
 import { DbProvider } from "./executor-fuma-db";
-import { HostConfig, PluginsProvider, makeScopedExecutor } from "./scoped-executor";
+import {
+  HostConfig,
+  PluginsProvider,
+  makeScopedExecutor,
+} from "./scoped-executor";
 
 // ---------------------------------------------------------------------------
 // CodeExecutorProvider seam — the host's code-execution substrate. Typed to the
@@ -50,11 +52,13 @@ import { HostConfig, PluginsProvider, makeScopedExecutor } from "./scoped-execut
 // assigns structurally.
 // ---------------------------------------------------------------------------
 
-export type CodeExecutor = ExecutionEngineConfig<Cause.YieldableError>["codeExecutor"];
+export type CodeExecutor =
+  ExecutionEngineConfig<Cause.YieldableError>["codeExecutor"];
 
-export class CodeExecutorProvider extends Context.Service<CodeExecutorProvider, CodeExecutor>()(
-  "@executor-js/api/CodeExecutorProvider",
-) {}
+export class CodeExecutorProvider extends Context.Service<
+  CodeExecutorProvider,
+  CodeExecutor
+>()("@executor-js/api/CodeExecutorProvider") {}
 
 // ---------------------------------------------------------------------------
 // EngineDecorator seam — wrap the freshly built engine (e.g. with usage
@@ -78,12 +82,15 @@ export interface EngineDecoratorShape {
   ) => ExecutionEngine<E>;
 }
 
-export class EngineDecorator extends Context.Service<EngineDecorator, EngineDecoratorShape>()(
-  "@executor-js/api/EngineDecorator",
-) {}
+export class EngineDecorator extends Context.Service<
+  EngineDecorator,
+  EngineDecoratorShape
+>()("@executor-js/api/EngineDecorator") {}
 
 /** No-op decorator: the engine passes through unchanged. */
-export const EngineDecoratorNoop: Layer.Layer<EngineDecorator> = Layer.succeed(EngineDecorator)({
+export const EngineDecoratorNoop: Layer.Layer<EngineDecorator> = Layer.succeed(
+  EngineDecorator,
+)({
   decorate: (engine) => engine,
 });
 
@@ -102,20 +109,34 @@ export const makeExecutionStack = <
   accountId: string,
   organizationId: string,
   organizationName: string,
-  /** Optional toolkit selector (slug or id). When set, the executor is narrowed
-   *  to that toolkit's slice before the engine is built — so listing, search,
-   *  description, core-tools, AND execute all see only the slice. Resolves via
-   *  the `toolkits` plugin extension; an unknown/unauthorized selector applies
-   *  an EMPTY slice (fail-closed — never the full account). */
-  toolkitId?: string,
+  /** Optional per-request narrowing selector (e.g. an MCP `?toolkit=` value).
+   *  When set, the executor is run through every plugin-contributed
+   *  `ExecutorWrapper` before the engine is built — so listing, search,
+   *  description, core-tools, AND execute all see only the narrowed view. Core
+   *  is agnostic about what a wrapper narrows to; a plugin (e.g. toolkits) owns
+   *  that, including fail-closed behavior for an unknown selector. */
+  selector?: string,
 ): Effect.Effect<
-  { readonly executor: Executor<TPlugins>; readonly engine: ExecutionEngine<Cause.YieldableError> },
+  {
+    readonly executor: Executor<TPlugins>;
+    readonly engine: ExecutionEngine<Cause.YieldableError>;
+  },
   StorageFailure,
-  DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator
+  | DbProvider
+  | PluginsProvider
+  | HostConfig
+  | CodeExecutorProvider
+  | EngineDecorator
 > =>
   Effect.gen(function* () {
-    const base = yield* makeScopedExecutor<TPlugins>(accountId, organizationId, organizationName);
-    const executor = toolkitId ? yield* narrowToToolkit(base, toolkitId) : base;
+    const base = yield* makeScopedExecutor<TPlugins>(
+      accountId,
+      organizationId,
+      organizationName,
+    );
+    const executor = selector
+      ? yield* applyExecutorWrappers(base, selector)
+      : base;
     const codeExecutor = yield* CodeExecutorProvider;
     const { decorate } = yield* EngineDecorator;
     const engine = decorate(createExecutionEngine({ executor, codeExecutor }), {
@@ -126,16 +147,20 @@ export const makeExecutionStack = <
     return { executor, engine };
   });
 
-// Resolve the toolkit slice via the `toolkits` plugin extension (stamped on the
-// executor) and wrap the executor. Fail-closed: no extension or no match -> an
-// empty slice, so a bad/cross-tenant selector exposes only static tools, never
-// the full account.
-const narrowToToolkit = <TPlugins extends readonly AnyPlugin[]>(
+// Run every plugin-contributed executor wrapper (collected on the executor at
+// assembly) with the request selector. Core does not know what any wrapper
+// narrows to — the toolkits plugin's wrapper, for instance, fails closed to an
+// empty slice for an unknown/cross-tenant selector. With no wrapper registered,
+// the executor passes through unchanged.
+const applyExecutorWrappers = <TPlugins extends readonly AnyPlugin[]>(
   base: Executor<TPlugins>,
-  toolkitId: string,
+  selector: string,
 ): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
   Effect.gen(function* () {
-    const resolver = (base as { toolkits?: ToolkitResolver }).toolkits;
-    const scope = resolver?.resolveScope ? yield* resolver.resolveScope(toolkitId) : null;
-    return yield* applyToolkitScope(base, scope ?? EMPTY_TOOLKIT_SCOPE);
+    const wrappers = (base as { executorWrappers?: readonly ExecutorWrapper[] })
+      .executorWrappers;
+    let executor = base;
+    for (const wrap of wrappers ?? [])
+      executor = yield* wrap(executor, selector);
+    return executor;
   });

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -26,11 +26,7 @@
 import { Context, Effect, Layer } from "effect";
 import type * as Cause from "effect/Cause";
 
-import {
-  type AnyPlugin,
-  type Executor,
-  type StorageFailure,
-} from "@executor-js/sdk";
+import { type AnyPlugin, type Executor, type StorageFailure } from "@executor-js/sdk";
 import {
   createExecutionEngine,
   type ExecutionEngine,
@@ -38,11 +34,7 @@ import {
 } from "@executor-js/execution";
 
 import { DbProvider } from "./executor-fuma-db";
-import {
-  HostConfig,
-  PluginsProvider,
-  makeScopedExecutor,
-} from "./scoped-executor";
+import { HostConfig, PluginsProvider, makeScopedExecutor } from "./scoped-executor";
 
 // ---------------------------------------------------------------------------
 // CodeExecutorProvider seam — the host's code-execution substrate. Typed to the
@@ -51,13 +43,11 @@ import {
 // assigns structurally.
 // ---------------------------------------------------------------------------
 
-export type CodeExecutor =
-  ExecutionEngineConfig<Cause.YieldableError>["codeExecutor"];
+export type CodeExecutor = ExecutionEngineConfig<Cause.YieldableError>["codeExecutor"];
 
-export class CodeExecutorProvider extends Context.Service<
-  CodeExecutorProvider,
-  CodeExecutor
->()("@executor-js/api/CodeExecutorProvider") {}
+export class CodeExecutorProvider extends Context.Service<CodeExecutorProvider, CodeExecutor>()(
+  "@executor-js/api/CodeExecutorProvider",
+) {}
 
 // ---------------------------------------------------------------------------
 // EngineDecorator seam — wrap the freshly built engine (e.g. with usage
@@ -81,15 +71,12 @@ export interface EngineDecoratorShape {
   ) => ExecutionEngine<E>;
 }
 
-export class EngineDecorator extends Context.Service<
-  EngineDecorator,
-  EngineDecoratorShape
->()("@executor-js/api/EngineDecorator") {}
+export class EngineDecorator extends Context.Service<EngineDecorator, EngineDecoratorShape>()(
+  "@executor-js/api/EngineDecorator",
+) {}
 
 /** No-op decorator: the engine passes through unchanged. */
-export const EngineDecoratorNoop: Layer.Layer<EngineDecorator> = Layer.succeed(
-  EngineDecorator,
-)({
+export const EngineDecoratorNoop: Layer.Layer<EngineDecorator> = Layer.succeed(EngineDecorator)({
   decorate: (engine) => engine,
 });
 
@@ -118,18 +105,10 @@ export const makeExecutionStack = <
     readonly engine: ExecutionEngine<Cause.YieldableError>;
   },
   StorageFailure,
-  | DbProvider
-  | PluginsProvider
-  | HostConfig
-  | CodeExecutorProvider
-  | EngineDecorator
+  DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator
 > =>
   Effect.gen(function* () {
-    const base = yield* makeScopedExecutor<TPlugins>(
-      accountId,
-      organizationId,
-      organizationName,
-    );
+    const base = yield* makeScopedExecutor<TPlugins>(accountId, organizationId, organizationName);
     const executor = selector ? yield* base.applyRequestScope(selector) : base;
     const codeExecutor = yield* CodeExecutorProvider;
     const { decorate } = yield* EngineDecorator;

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -26,7 +26,14 @@
 import { Context, Effect, Layer } from "effect";
 import type * as Cause from "effect/Cause";
 
-import type { AnyPlugin, Executor, StorageFailure } from "@executor-js/sdk";
+import {
+  applyToolkitScope,
+  EMPTY_TOOLKIT_SCOPE,
+  type AnyPlugin,
+  type Executor,
+  type StorageFailure,
+  type ToolkitResolver,
+} from "@executor-js/sdk";
 import {
   createExecutionEngine,
   type ExecutionEngine,
@@ -95,17 +102,20 @@ export const makeExecutionStack = <
   accountId: string,
   organizationId: string,
   organizationName: string,
+  /** Optional toolkit selector (slug or id). When set, the executor is narrowed
+   *  to that toolkit's slice before the engine is built — so listing, search,
+   *  description, core-tools, AND execute all see only the slice. Resolves via
+   *  the `toolkits` plugin extension; an unknown/unauthorized selector applies
+   *  an EMPTY slice (fail-closed — never the full account). */
+  toolkitId?: string,
 ): Effect.Effect<
   { readonly executor: Executor<TPlugins>; readonly engine: ExecutionEngine<Cause.YieldableError> },
   StorageFailure,
   DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator
 > =>
   Effect.gen(function* () {
-    const executor = yield* makeScopedExecutor<TPlugins>(
-      accountId,
-      organizationId,
-      organizationName,
-    );
+    const base = yield* makeScopedExecutor<TPlugins>(accountId, organizationId, organizationName);
+    const executor = toolkitId ? yield* narrowToToolkit(base, toolkitId) : base;
     const codeExecutor = yield* CodeExecutorProvider;
     const { decorate } = yield* EngineDecorator;
     const engine = decorate(createExecutionEngine({ executor, codeExecutor }), {
@@ -114,4 +124,18 @@ export const makeExecutionStack = <
       organizationName,
     });
     return { executor, engine };
+  });
+
+// Resolve the toolkit slice via the `toolkits` plugin extension (stamped on the
+// executor) and wrap the executor. Fail-closed: no extension or no match -> an
+// empty slice, so a bad/cross-tenant selector exposes only static tools, never
+// the full account.
+const narrowToToolkit = <TPlugins extends readonly AnyPlugin[]>(
+  base: Executor<TPlugins>,
+  toolkitId: string,
+): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
+  Effect.gen(function* () {
+    const resolver = (base as { toolkits?: ToolkitResolver }).toolkits;
+    const scope = resolver?.resolveScope ? yield* resolver.resolveScope(toolkitId) : null;
+    return yield* applyToolkitScope(base, scope ?? EMPTY_TOOLKIT_SCOPE);
   });

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -29,7 +29,6 @@ import type * as Cause from "effect/Cause";
 import {
   type AnyPlugin,
   type Executor,
-  type ExecutorWrapper,
   type StorageFailure,
 } from "@executor-js/sdk";
 import {
@@ -110,11 +109,8 @@ export const makeExecutionStack = <
   organizationId: string,
   organizationName: string,
   /** Optional per-request narrowing selector (e.g. an MCP `?toolkit=` value).
-   *  When set, the executor is run through every plugin-contributed
-   *  `ExecutorWrapper` before the engine is built — so listing, search,
-   *  description, core-tools, AND execute all see only the narrowed view. Core
-   *  is agnostic about what a wrapper narrows to; a plugin (e.g. toolkits) owns
-   *  that, including fail-closed behavior for an unknown selector. */
+   *  When set, core resolves plugin-contributed `RequestScope` overlays and
+   *  enforces them centrally before the engine is built. */
   selector?: string,
 ): Effect.Effect<
   {
@@ -134,9 +130,7 @@ export const makeExecutionStack = <
       organizationId,
       organizationName,
     );
-    const executor = selector
-      ? yield* applyExecutorWrappers(base, selector)
-      : base;
+    const executor = selector ? yield* base.applyRequestScope(selector) : base;
     const codeExecutor = yield* CodeExecutorProvider;
     const { decorate } = yield* EngineDecorator;
     const engine = decorate(createExecutionEngine({ executor, codeExecutor }), {
@@ -145,22 +139,4 @@ export const makeExecutionStack = <
       organizationName,
     });
     return { executor, engine };
-  });
-
-// Run every plugin-contributed executor wrapper (collected on the executor at
-// assembly) with the request selector. Core does not know what any wrapper
-// narrows to — the toolkits plugin's wrapper, for instance, fails closed to an
-// empty slice for an unknown/cross-tenant selector. With no wrapper registered,
-// the executor passes through unchanged.
-const applyExecutorWrappers = <TPlugins extends readonly AnyPlugin[]>(
-  base: Executor<TPlugins>,
-  selector: string,
-): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
-  Effect.gen(function* () {
-    const wrappers = (base as { executorWrappers?: readonly ExecutorWrapper[] })
-      .executorWrappers;
-    let executor = base;
-    for (const wrap of wrappers ?? [])
-      executor = yield* wrap(executor, selector);
-    return executor;
   });

--- a/packages/core/api/src/server/mcp-build.ts
+++ b/packages/core/api/src/server/mcp-build.ts
@@ -9,7 +9,11 @@ import {
 import { createExecutorMcpServer } from "@executor-js/host-mcp/tool-server";
 
 import { ErrorCapture } from "../observability";
-import { CodeExecutorProvider, EngineDecorator, makeExecutionStack } from "./execution-stack";
+import {
+  CodeExecutorProvider,
+  EngineDecorator,
+  makeExecutionStack,
+} from "./execution-stack";
 import { DbProvider } from "./executor-fuma-db";
 import { HostConfig, PluginsProvider } from "./scoped-executor";
 
@@ -28,7 +32,11 @@ import { HostConfig, PluginsProvider } from "./scoped-executor";
 
 /** The five execution-stack seams a host fully provides (no residual). */
 export type McpExecutionStackLayer = Layer.Layer<
-  DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator
+  | DbProvider
+  | PluginsProvider
+  | HostConfig
+  | CodeExecutorProvider
+  | EngineDecorator
 >;
 
 /**
@@ -39,14 +47,15 @@ export type McpExecutionStackLayer = Layer.Layer<
 export const makeMcpBuildServer =
   (executionStack: McpExecutionStackLayer): McpBuildServer =>
   (principal: Principal, options?: McpBuildServerOptions) => {
-    // `toolkitId` narrows the engine in `makeExecutionStack`; the rest of the
-    // options configure the MCP server (elicitation/approval).
-    const { toolkitId, ...serverOptions } = options ?? {};
+    // `selector` narrows the engine in `makeExecutionStack` (a plugin's
+    // executor wrapper applies it); the rest configure the MCP server
+    // (elicitation/approval).
+    const { selector, ...serverOptions } = options ?? {};
     return makeExecutionStack(
       principal.accountId,
       principal.organizationId,
       principal.organizationName,
-      toolkitId,
+      selector,
     ).pipe(
       Effect.map(({ engine }) => engine),
       Effect.provide(executionStack),
@@ -72,6 +81,8 @@ export const makeConsoleMcpErrorReporter = (
     McpErrorReporter,
     Effect.gen(function* () {
       const capture = yield* ErrorCapture;
-      return { report: (cause) => Effect.asVoid(capture.captureException(cause)) };
+      return {
+        report: (cause) => Effect.asVoid(capture.captureException(cause)),
+      };
     }),
   ).pipe(Layer.provide(errorCapture));

--- a/packages/core/api/src/server/mcp-build.ts
+++ b/packages/core/api/src/server/mcp-build.ts
@@ -9,11 +9,7 @@ import {
 import { createExecutorMcpServer } from "@executor-js/host-mcp/tool-server";
 
 import { ErrorCapture } from "../observability";
-import {
-  CodeExecutorProvider,
-  EngineDecorator,
-  makeExecutionStack,
-} from "./execution-stack";
+import { CodeExecutorProvider, EngineDecorator, makeExecutionStack } from "./execution-stack";
 import { DbProvider } from "./executor-fuma-db";
 import { HostConfig, PluginsProvider } from "./scoped-executor";
 
@@ -32,11 +28,7 @@ import { HostConfig, PluginsProvider } from "./scoped-executor";
 
 /** The five execution-stack seams a host fully provides (no residual). */
 export type McpExecutionStackLayer = Layer.Layer<
-  | DbProvider
-  | PluginsProvider
-  | HostConfig
-  | CodeExecutorProvider
-  | EngineDecorator
+  DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator
 >;
 
 /**

--- a/packages/core/api/src/server/mcp-build.ts
+++ b/packages/core/api/src/server/mcp-build.ts
@@ -38,21 +38,26 @@ export type McpExecutionStackLayer = Layer.Layer<
  */
 export const makeMcpBuildServer =
   (executionStack: McpExecutionStackLayer): McpBuildServer =>
-  (principal: Principal, options?: McpBuildServerOptions) =>
-    makeExecutionStack(
+  (principal: Principal, options?: McpBuildServerOptions) => {
+    // `toolkitId` narrows the engine in `makeExecutionStack`; the rest of the
+    // options configure the MCP server (elicitation/approval).
+    const { toolkitId, ...serverOptions } = options ?? {};
+    return makeExecutionStack(
       principal.accountId,
       principal.organizationId,
       principal.organizationName,
+      toolkitId,
     ).pipe(
       Effect.map(({ engine }) => engine),
       Effect.provide(executionStack),
       Effect.mapError((cause) => new McpEngineBuildError({ cause })),
       Effect.flatMap((engine) =>
-        createExecutorMcpServer({ engine, ...(options ?? {}) }).pipe(
+        createExecutorMcpServer({ engine, ...serverOptions }).pipe(
           Effect.map((mcpServer) => ({ mcpServer, engine })),
         ),
       ),
     );
+  };
 
 /**
  * The standard console `McpErrorReporter` seam: route an orchestration defect

--- a/packages/core/sdk/src/client.ts
+++ b/packages/core/sdk/src/client.ts
@@ -381,3 +381,51 @@ export const useIntegrationPlugins = (): readonly IntegrationPlugin[] =>
 /** Secret-provider plugins extracted from `clientPlugins[].secretProviderPlugin`. */
 export const useSecretProviderPlugins = (): readonly SecretProviderPlugin[] =>
   usePluginsCtx("useSecretProviderPlugins").secretProviderPlugins;
+
+// ---------------------------------------------------------------------------
+// PluginRouteProvider + hooks — per-plugin-page URL subpath + navigation.
+//
+// The host's catch-all plugin route matches a page by longest-prefix of the
+// URL splat, then exposes the remainder as `subpath` with a `navigate` helper
+// that updates only the splat (org slug is preserved by the injected impl).
+// Plugins import these hooks from `@executor-js/sdk/client`; the host injects
+// the navigate implementation — no router dependency in the SDK.
+// ---------------------------------------------------------------------------
+
+export interface PluginRouteValue {
+  readonly pluginId: string;
+  /** URL fragment after the matched page's own path; "" at the page root. */
+  readonly subpath: string;
+  /** Navigate within this plugin page (subpath relative to the page's path). */
+  readonly navigate: (subpath: string, opts?: { readonly replace?: boolean }) => void;
+}
+
+const PluginRouteContext = createContext<PluginRouteValue | null>(null);
+PluginRouteContext.displayName = "PluginRouteContext";
+
+export interface PluginRouteProviderProps {
+  readonly value: PluginRouteValue;
+  readonly children: ReactNode;
+}
+
+export function PluginRouteProvider(
+  props: PluginRouteProviderProps,
+): ReturnType<typeof createElement> {
+  return createElement(PluginRouteContext.Provider, { value: props.value }, props.children);
+}
+
+const usePluginRouteCtx = (hookName: string): PluginRouteValue => {
+  const ctx = useContext(PluginRouteContext);
+  if (!ctx) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: React hook invariant
+    throw new Error(`${hookName} must be called inside a <PluginRouteProvider>.`);
+  }
+  return ctx;
+};
+
+/** Current plugin page route: plugin id, URL subpath, and in-page navigate. */
+export const usePluginRoute = (): PluginRouteValue => usePluginRouteCtx("usePluginRoute");
+
+/** Navigate within the current plugin page (subpath relative to the page path). */
+export const usePluginNavigate = (): PluginRouteValue["navigate"] =>
+  usePluginRouteCtx("usePluginNavigate").navigate;

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -2,8 +2,15 @@ import { Effect, Inspectable, Layer, Option, Predicate, Schema } from "effect";
 import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 import { fumadb } from "@executor-js/fumadb";
 import { memoryAdapter } from "@executor-js/fumadb/adapters/memory";
-import { withQueryContext, type Condition, type ConditionBuilder } from "@executor-js/fumadb/query";
-import { schema as fumaSchema, type RelationsMap } from "@executor-js/fumadb/schema";
+import {
+  withQueryContext,
+  type Condition,
+  type ConditionBuilder,
+} from "@executor-js/fumadb/query";
+import {
+  schema as fumaSchema,
+  type RelationsMap,
+} from "@executor-js/fumadb/schema";
 import type { AnyColumn } from "@executor-js/fumadb/schema";
 import { generateKeyBetween } from "fractional-indexing";
 
@@ -16,7 +23,12 @@ import {
   type FumaTables,
   type StorageFailure,
 } from "./fuma-runtime";
-import { makeFumaBlobStore, pluginBlobStore, type BlobStore, type OwnerPartitions } from "./blob";
+import {
+  makeFumaBlobStore,
+  pluginBlobStore,
+  type BlobStore,
+  type OwnerPartitions,
+} from "./blob";
 import { coreToolsPlugin } from "./core-tools";
 import type {
   Connection,
@@ -85,7 +97,10 @@ import type {
   IntegrationConfig,
   RegisterIntegrationInput,
 } from "./integration";
-import { makeOAuthService, type MintOAuthConnectionInput } from "./oauth-service";
+import {
+  makeOAuthService,
+  type MintOAuthConnectionInput,
+} from "./oauth-service";
 import type { OAuthService } from "./oauth-client";
 import {
   comparePolicyRow,
@@ -130,7 +145,12 @@ import {
   type ExecutorOwnerPolicyContext,
 } from "./owner-policy";
 import { ToolSchemaView, type IntegrationDetectionResult } from "./types";
-import { type Tool, type ToolAnnotations, type ToolDef, type ToolListFilter } from "./tool";
+import {
+  type Tool,
+  type ToolAnnotations,
+  type ToolDef,
+  type ToolListFilter,
+} from "./tool";
 import { buildToolTypeScriptPreview } from "./schema-types";
 import { collectReferencedDefinitions } from "./schema-refs";
 import {
@@ -155,7 +175,9 @@ const MAX_APPROVAL_ARGUMENT_PREVIEW_CHARS = 4_000;
 const acceptAllHandler: ElicitationHandler = () =>
   Effect.succeed(ElicitationResponse.make({ action: "accept" }));
 
-const resolveElicitationHandler = (onElicitation: OnElicitation): ElicitationHandler =>
+const resolveElicitationHandler = (
+  onElicitation: OnElicitation,
+): ElicitationHandler =>
   onElicitation === "accept-all" ? acceptAllHandler : onElicitation;
 
 // ---------------------------------------------------------------------------
@@ -171,7 +193,8 @@ export interface ParsedToolAddress {
   readonly tool: ToolName;
 }
 
-const isOwner = (value: string): value is Owner => value === "org" || value === "user";
+const isOwner = (value: string): value is Owner =>
+  value === "org" || value === "user";
 
 /** Parse a callable address; null when it's not a well-formed
  *  `tools.<integration>.<owner>.<connection>.<tool>`.
@@ -190,16 +213,17 @@ export const parseToolAddress = (address: string): ParsedToolAddress | null => {
     cut = address.indexOf(".", cut + 1);
     if (cut === -1) return null;
   }
-  const [prefix, integration, owner, connection] = address.slice(0, cut).split(".") as [
-    string,
-    string,
-    string,
-    string,
-  ];
+  const [prefix, integration, owner, connection] = address
+    .slice(0, cut)
+    .split(".") as [string, string, string, string];
   const tool = address.slice(cut + 1);
   if (prefix !== ADDRESS_PREFIX) return null;
   if (!isOwner(owner)) return null;
-  if (integration.length === 0 || connection.length === 0 || tool.length === 0) {
+  if (
+    integration.length === 0 ||
+    connection.length === 0 ||
+    tool.length === 0
+  ) {
     return null;
   }
   return {
@@ -215,7 +239,9 @@ export const connectionAddress = (
   integration: IntegrationSlug,
   connection: ConnectionName,
 ): ConnectionAddress =>
-  ConnectionAddress.make(`${ADDRESS_PREFIX}.${integration}.${owner}.${connection}`);
+  ConnectionAddress.make(
+    `${ADDRESS_PREFIX}.${integration}.${owner}.${connection}`,
+  );
 
 export const toolAddress = (
   owner: Owner,
@@ -223,7 +249,9 @@ export const toolAddress = (
   connection: ConnectionName,
   tool: ToolName,
 ): ToolAddress =>
-  ToolAddress.make(`${ADDRESS_PREFIX}.${integration}.${owner}.${connection}.${tool}`);
+  ToolAddress.make(
+    `${ADDRESS_PREFIX}.${integration}.${owner}.${connection}.${tool}`,
+  );
 
 // ---------------------------------------------------------------------------
 // Owner key helpers — every owned-row write stamps `tenant`, `owner`,
@@ -241,17 +269,34 @@ interface OwnedKeys {
 // core-table query unioned with the in-memory static pool.
 // ---------------------------------------------------------------------------
 
+// ExecutorWrapper — a plugin-contributed executor middleware. Given the
+// assembled executor and the per-request selector string (e.g. an MCP
+// `?toolkit=` value), it returns a possibly-narrowed executor. A plugin
+// contributes one by exposing a `wrapExecutor` method on its extension; the
+// assembler collects them and the execution stack runs each before the engine
+// is built. Core knows nothing about what a wrapper narrows to — that domain
+// (toolkits, etc.) lives entirely in the contributing plugin.
+export type ExecutorWrapper = <TPlugins extends readonly AnyPlugin[]>(
+  base: Executor<TPlugins>,
+  selector: string,
+) => Effect.Effect<Executor<TPlugins>, StorageFailure>;
+
 export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   readonly integrations: {
     readonly list: () => Effect.Effect<readonly Integration[], StorageFailure>;
-    readonly get: (slug: IntegrationSlug) => Effect.Effect<Integration | null, StorageFailure>;
+    readonly get: (
+      slug: IntegrationSlug,
+    ) => Effect.Effect<Integration | null, StorageFailure>;
     readonly update: (
       slug: IntegrationSlug,
       patch: { readonly name?: string; readonly description?: string },
     ) => Effect.Effect<void, IntegrationNotFoundError | StorageFailure>;
     readonly remove: (
       slug: IntegrationSlug,
-    ) => Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure>;
+    ) => Effect.Effect<
+      void,
+      IntegrationRemovalNotAllowedError | StorageFailure
+    >;
     readonly detect: (
       url: string,
     ) => Effect.Effect<readonly IntegrationDetectionResult[], StorageFailure>;
@@ -271,7 +316,9 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
       readonly integration?: IntegrationSlug;
       readonly owner?: Owner;
     }) => Effect.Effect<readonly Connection[], StorageFailure>;
-    readonly get: (ref: ConnectionRef) => Effect.Effect<Connection | null, StorageFailure>;
+    readonly get: (
+      ref: ConnectionRef,
+    ) => Effect.Effect<Connection | null, StorageFailure>;
     /** Edit user-curated metadata (description, identityLabel). Credentials and
      *  OAuth lifecycle fields are not editable here. */
     readonly update: (
@@ -294,21 +341,35 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   readonly oauth: OAuthService;
 
   readonly tools: {
-    readonly list: (filter?: ToolListFilter) => Effect.Effect<readonly Tool[], StorageFailure>;
-    readonly schema: (address: ToolAddress) => Effect.Effect<ToolSchemaView | null, StorageFailure>;
+    readonly list: (
+      filter?: ToolListFilter,
+    ) => Effect.Effect<readonly Tool[], StorageFailure>;
+    readonly schema: (
+      address: ToolAddress,
+    ) => Effect.Effect<ToolSchemaView | null, StorageFailure>;
   };
 
   readonly providers: {
     readonly list: () => Effect.Effect<readonly ProviderKey[]>;
-    readonly items: (key: ProviderKey) => Effect.Effect<readonly ProviderEntry[], StorageFailure>;
+    readonly items: (
+      key: ProviderKey,
+    ) => Effect.Effect<readonly ProviderEntry[], StorageFailure>;
   };
 
   readonly policies: {
     readonly list: () => Effect.Effect<readonly ToolPolicy[], StorageFailure>;
-    readonly create: (input: CreateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-    readonly update: (input: UpdateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-    readonly remove: (input: RemoveToolPolicyInput) => Effect.Effect<void, StorageFailure>;
-    readonly resolve: (address: ToolAddress) => Effect.Effect<EffectivePolicy, StorageFailure>;
+    readonly create: (
+      input: CreateToolPolicyInput,
+    ) => Effect.Effect<ToolPolicy, StorageFailure>;
+    readonly update: (
+      input: UpdateToolPolicyInput,
+    ) => Effect.Effect<ToolPolicy, StorageFailure>;
+    readonly remove: (
+      input: RemoveToolPolicyInput,
+    ) => Effect.Effect<void, StorageFailure>;
+    readonly resolve: (
+      address: ToolAddress,
+    ) => Effect.Effect<EffectivePolicy, StorageFailure>;
   };
 
   readonly execute: (
@@ -322,7 +383,10 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
 
 export interface ExecutorDb {
   readonly db: FumaDb<any>;
-  readonly close?: () => Effect.Effect<void, StorageFailure> | Promise<void> | void;
+  readonly close?: () =>
+    | Effect.Effect<void, StorageFailure>
+    | Promise<void>
+    | void;
 }
 
 export type ExecutorDbInput = FumaDb<any> | ExecutorDb;
@@ -331,7 +395,9 @@ export type ExecutorDbFactory = (config: {
   readonly tables: FumaTables;
 }) => ExecutorDbInput | Effect.Effect<ExecutorDbInput, StorageFailure>;
 
-export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly []> {
+export interface ExecutorConfig<
+  TPlugins extends readonly AnyPlugin[] = readonly [],
+> {
   /** The org / workspace this executor is bound to. `owner: "org"` rows file
    *  here. */
   readonly tenant: Tenant;
@@ -392,7 +458,10 @@ const validateExecutorOwnerPolicyTables = (tables: FumaTables): void => {
   }
 };
 
-const validateExecutorDbTables = (required: FumaTables, actual: FumaTables): void => {
+const validateExecutorDbTables = (
+  required: FumaTables,
+  actual: FumaTables,
+): void => {
   const missing = Object.keys(required)
     .filter((tableName) => !actual[tableName])
     .sort();
@@ -408,18 +477,27 @@ const validateExecutorDbTables = (required: FumaTables, actual: FumaTables): voi
   });
 };
 
-const storageFailureFromUnknown = (message: string, cause: unknown): StorageFailure =>
+const storageFailureFromUnknown = (
+  message: string,
+  cause: unknown,
+): StorageFailure =>
   isStorageFailure(cause) ? cause : new StorageError({ message, cause });
 
-const pluginStorageFailure = (pluginId: string, hook: string, cause: unknown): StorageFailure =>
+const pluginStorageFailure = (
+  pluginId: string,
+  hook: string,
+  cause: unknown,
+): StorageFailure =>
   storageFailureFromUnknown(`${hook} failed for plugin ${pluginId}`, cause);
 
 const createDefaultMemoryDb = (tables: FumaTables): ExecutorDb => {
   const version = "1.0.0";
-  const latestSchema = fumaSchema<string, FumaTables, RelationsMap<FumaTables>>({
-    version,
-    tables,
-  });
+  const latestSchema = fumaSchema<string, FumaTables, RelationsMap<FumaTables>>(
+    {
+      version,
+      tables,
+    },
+  );
   const factory = fumadb({
     namespace: "executor_memory",
     schemas: [latestSchema],
@@ -434,7 +512,9 @@ const createDefaultMemoryDb = (tables: FumaTables): ExecutorDb => {
 // JSON helpers + row → public projection conversions
 // ---------------------------------------------------------------------------
 
-const decodeJsonFromString = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
+const decodeJsonFromString = Schema.decodeUnknownOption(
+  Schema.UnknownFromJsonString,
+);
 
 const decodeJsonColumn = (value: unknown): unknown => {
   if (value === null || value === undefined) return undefined;
@@ -482,9 +562,14 @@ const rowToConnection = (row: ConnectionRow): Connection => {
     identityLabel: row.identity_label ?? null,
     description: row.description ?? null,
     expiresAt: row.expires_at == null ? null : Number(row.expires_at),
-    oauthClient: row.oauth_client == null ? null : OAuthClientSlug.make(String(row.oauth_client)),
+    oauthClient:
+      row.oauth_client == null
+        ? null
+        : OAuthClientSlug.make(String(row.oauth_client)),
     oauthClientOwner:
-      row.oauth_client_owner == null ? null : (String(row.oauth_client_owner) as Owner),
+      row.oauth_client_owner == null
+        ? null
+        : (String(row.oauth_client_owner) as Owner),
     oauthScope: row.oauth_scope == null ? null : String(row.oauth_scope),
   };
 };
@@ -505,7 +590,10 @@ const normalizeConnectionInputs = (
   input: ConnectionValueInput,
 ): readonly NormalizedConnectionInput[] => {
   if ("inputs" in input) {
-    return Object.entries(input.inputs).map(([variable, origin]) => ({ variable, origin }));
+    return Object.entries(input.inputs).map(([variable, origin]) => ({
+      variable,
+      origin,
+    }));
   }
   if ("values" in input) {
     return Object.entries(input.values).map(([variable, value]) => ({
@@ -532,7 +620,8 @@ const connectionItemIds = (row: ConnectionRow): Record<string, string> => {
 // schema columns); `Tool.inputSchema`/`outputSchema` are optional and stay
 // absent for those callers — `tools.schema` is the schema-bearing surface.
 const rowToTool = (
-  row: ToolInvocationRow & Partial<Pick<ToolRow, "input_schema" | "output_schema">>,
+  row: ToolInvocationRow &
+    Partial<Pick<ToolRow, "input_schema" | "output_schema">>,
   annotations?: ToolAnnotations,
 ): Tool => {
   const owner = row.owner as Owner;
@@ -549,7 +638,9 @@ const rowToTool = (
     description: row.description,
     inputSchema: decodeJsonColumn(row.input_schema),
     outputSchema: decodeJsonColumn(row.output_schema),
-    annotations: annotations ?? (decodeJsonColumn(row.annotations) as ToolAnnotations | undefined),
+    annotations:
+      annotations ??
+      (decodeJsonColumn(row.annotations) as ToolAnnotations | undefined),
   };
 };
 
@@ -580,7 +671,10 @@ type CoreFindFirstOptions<TName extends CoreTableName = CoreTableName> = Omit<
 >;
 /** The narrowed row a projected query returns: the selected columns keep
  *  their types, everything else is absent. */
-type CoreProjectedRow<TName extends CoreTableName, TSelect> = TSelect extends readonly (infer K)[]
+type CoreProjectedRow<
+  TName extends CoreTableName,
+  TSelect,
+> = TSelect extends readonly (infer K)[]
   ? Pick<CoreRow<TName>, Extract<K, keyof CoreRow<TName>>>
   : CoreRow<TName>;
 
@@ -613,7 +707,9 @@ const makeCoreDb = (fuma: ReturnType<typeof makeFumaClient>) => ({
     tableName: TName,
     options?: { readonly where?: CoreWhere },
   ): Effect.Effect<number, StorageFailure> =>
-    fuma.use(`${tableName}.count`, (db) => asLooseStorageDb(db).count(tableName, options)),
+    fuma.use(`${tableName}.count`, (db) =>
+      asLooseStorageDb(db).count(tableName, options),
+    ),
   create: <TName extends CoreTableName>(
     tableName: TName,
     row: Record<string, unknown>,
@@ -628,7 +724,9 @@ const makeCoreDb = (fuma: ReturnType<typeof makeFumaClient>) => ({
     rows.length === 0
       ? Effect.void
       : fuma
-          .use(`${tableName}.createMany`, (db) => asLooseStorageDb(db).createMany(tableName, rows))
+          .use(`${tableName}.createMany`, (db) =>
+            asLooseStorageDb(db).createMany(tableName, rows),
+          )
           .pipe(Effect.asVoid),
   deleteMany: <TName extends CoreTableName>(
     tableName: TName,
@@ -637,20 +735,38 @@ const makeCoreDb = (fuma: ReturnType<typeof makeFumaClient>) => ({
     fuma.use(`${tableName}.deleteMany`, (db) =>
       asLooseStorageDb(db).deleteMany(tableName, options),
     ),
-  findFirst: <TName extends CoreTableName, const TOptions extends CoreFindFirstOptions<TName>>(
+  findFirst: <
+    TName extends CoreTableName,
+    const TOptions extends CoreFindFirstOptions<TName>,
+  >(
     tableName: TName,
     options: TOptions,
-  ): Effect.Effect<CoreProjectedRow<TName, TOptions["select"]> | null, StorageFailure> =>
+  ): Effect.Effect<
+    CoreProjectedRow<TName, TOptions["select"]> | null,
+    StorageFailure
+  > =>
     fuma.use(`${tableName}.findFirst`, (db) =>
       asLooseStorageDb(db).findFirst(tableName, options),
-    ) as Effect.Effect<CoreProjectedRow<TName, TOptions["select"]> | null, StorageFailure>,
-  findMany: <TName extends CoreTableName, const TOptions extends CoreFindManyOptions<TName>>(
+    ) as Effect.Effect<
+      CoreProjectedRow<TName, TOptions["select"]> | null,
+      StorageFailure
+    >,
+  findMany: <
+    TName extends CoreTableName,
+    const TOptions extends CoreFindManyOptions<TName>,
+  >(
     tableName: TName,
     options: TOptions = {} as TOptions,
-  ): Effect.Effect<readonly CoreProjectedRow<TName, TOptions["select"]>[], StorageFailure> =>
+  ): Effect.Effect<
+    readonly CoreProjectedRow<TName, TOptions["select"]>[],
+    StorageFailure
+  > =>
     fuma.use(`${tableName}.findMany`, (db) =>
       asLooseStorageDb(db).findMany(tableName, options),
-    ) as Effect.Effect<readonly CoreProjectedRow<TName, TOptions["select"]>[], StorageFailure>,
+    ) as Effect.Effect<
+      readonly CoreProjectedRow<TName, TOptions["select"]>[],
+      StorageFailure
+    >,
   updateMany: <TName extends CoreTableName>(
     tableName: TName,
     options: {
@@ -670,7 +786,9 @@ type CoreDb = ReturnType<typeof makeCoreDb>;
 // [user, org]; writes/deletes name an explicit owner.
 // ---------------------------------------------------------------------------
 
-const pluginStorageEntryFromRow = <T>(row: CoreRow<"plugin_storage">): PluginStorageEntry<T> => ({
+const pluginStorageEntryFromRow = <T>(
+  row: CoreRow<"plugin_storage">,
+): PluginStorageEntry<T> => ({
   id: pluginStorageId({
     pluginId: row.plugin_id,
     collection: row.collection,
@@ -681,21 +799,28 @@ const pluginStorageEntryFromRow = <T>(row: CoreRow<"plugin_storage">): PluginSto
   collection: row.collection,
   key: row.key,
   data: row.data as T,
-  createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
-  updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at),
+  createdAt:
+    row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
+  updatedAt:
+    row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at),
 });
 
-const pluginStorageIndexSpecFields = (spec: PluginStorageRuntimeIndexSpec): readonly string[] =>
-  typeof spec === "string" ? [spec] : spec;
+const pluginStorageIndexSpecFields = (
+  spec: PluginStorageRuntimeIndexSpec,
+): readonly string[] => (typeof spec === "string" ? [spec] : spec);
 
 const pluginStorageCollectionIndexedFields = (
   definition: PluginStorageRuntimeCollectionDefinition,
 ): ReadonlySet<string> =>
-  new Set(definition.indexes.flatMap((spec) => pluginStorageIndexSpecFields(spec)));
+  new Set(
+    definition.indexes.flatMap((spec) => pluginStorageIndexSpecFields(spec)),
+  );
 
 const pluginStorageQueryValidationError = (
   definition: PluginStorageRuntimeCollectionDefinition,
-  query: PluginStorageCollectionQueryInput<PluginStorageCollectionDefinition> | undefined,
+  query:
+    | PluginStorageCollectionQueryInput<PluginStorageCollectionDefinition>
+    | undefined,
 ): StorageError | null => {
   if (!query) return null;
   const indexedFields = pluginStorageCollectionIndexedFields(definition);
@@ -711,13 +836,19 @@ const pluginStorageQueryValidationError = (
       });
     }
   }
-  if (query.limit !== undefined && (!Number.isInteger(query.limit) || query.limit < 0)) {
+  if (
+    query.limit !== undefined &&
+    (!Number.isInteger(query.limit) || query.limit < 0)
+  ) {
     return new StorageError({
       message: `Plugin storage collection "${definition.name}" received an invalid query limit`,
       cause: undefined,
     });
   }
-  if (query.offset !== undefined && (!Number.isInteger(query.offset) || query.offset < 0)) {
+  if (
+    query.offset !== undefined &&
+    (!Number.isInteger(query.offset) || query.offset < 0)
+  ) {
     return new StorageError({
       message: `Plugin storage collection "${definition.name}" received an invalid query offset`,
       cause: undefined,
@@ -726,17 +857,35 @@ const pluginStorageQueryValidationError = (
   return null;
 };
 
-const isPluginStorageRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+const isPluginStorageRecord = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
-const pluginStorageWhereOperators = ["eq", "in", "gt", "gte", "lt", "lte"] as const;
+const pluginStorageWhereOperators = [
+  "eq",
+  "in",
+  "gt",
+  "gte",
+  "lt",
+  "lte",
+] as const;
 
-const isPluginStorageWhereFilter = (value: unknown): value is Readonly<Record<string, unknown>> =>
-  isPluginStorageRecord(value) && pluginStorageWhereOperators.some((operator) => operator in value);
+const isPluginStorageWhereFilter = (
+  value: unknown,
+): value is Readonly<Record<string, unknown>> =>
+  isPluginStorageRecord(value) &&
+  pluginStorageWhereOperators.some((operator) => operator in value);
 
-const pluginStorageComparableValue = (value: unknown): string | number | boolean | null => {
+const pluginStorageComparableValue = (
+  value: unknown,
+): string | number | boolean | null => {
   if (value instanceof Date) return value.getTime();
-  if (typeof value === "number" || typeof value === "string" || typeof value === "boolean") {
+  if (
+    typeof value === "number" ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
     return value;
   }
   if (value == null) return null;
@@ -755,8 +904,13 @@ const comparePluginStorageValues = (left: unknown, right: unknown): number => {
 const pluginStorageDataField = (data: unknown, field: string): unknown =>
   isPluginStorageRecord(data) ? data[field] : undefined;
 
-const matchesWhereOperator = (operator: string, value: unknown, operand: unknown): boolean => {
-  if (operator === "eq") return comparePluginStorageValues(value, operand) === 0;
+const matchesWhereOperator = (
+  operator: string,
+  value: unknown,
+  operand: unknown,
+): boolean => {
+  if (operator === "eq")
+    return comparePluginStorageValues(value, operand) === 0;
   if (operator === "in") {
     return (
       Array.isArray(operand) &&
@@ -764,9 +918,11 @@ const matchesWhereOperator = (operator: string, value: unknown, operand: unknown
     );
   }
   if (operator === "gt") return comparePluginStorageValues(value, operand) > 0;
-  if (operator === "gte") return comparePluginStorageValues(value, operand) >= 0;
+  if (operator === "gte")
+    return comparePluginStorageValues(value, operand) >= 0;
   if (operator === "lt") return comparePluginStorageValues(value, operand) < 0;
-  if (operator === "lte") return comparePluginStorageValues(value, operand) <= 0;
+  if (operator === "lte")
+    return comparePluginStorageValues(value, operand) <= 0;
   return false;
 };
 
@@ -802,9 +958,12 @@ const makePluginStorageFacade = (input: {
   readonly owner: OwnerBinding;
 }): PluginStorageFacade => {
   // Owner partitions: org always, plus this subject's user partition.
-  const readOwners: readonly Owner[] = input.owner.subject == null ? ["org"] : ["user", "org"];
+  const readOwners: readonly Owner[] =
+    input.owner.subject == null ? ["org"] : ["user", "org"];
 
-  const ownerSubject = (owner: Owner): { owner: Owner; subject: string } | null => {
+  const ownerSubject = (
+    owner: Owner,
+  ): { owner: Owner; subject: string } | null => {
     if (owner === "org") return { owner: "org", subject: ORG_SUBJECT };
     if (input.owner.subject == null) return null;
     return { owner: "user", subject: String(input.owner.subject) };
@@ -821,7 +980,11 @@ const makePluginStorageFacade = (input: {
         key === undefined ? true : b("key", "=", key),
       );
 
-  const whereOwner = (owner: Owner, collection: string, key: string): CoreWhere => {
+  const whereOwner = (
+    owner: Owner,
+    collection: string,
+    key: string,
+  ): CoreWhere => {
     const os = ownerSubject(owner);
     return (b: AnyCb) =>
       b.and(
@@ -843,19 +1006,28 @@ const makePluginStorageFacade = (input: {
     });
 
   const getVisible = <T>(collection: string, key: string) =>
-    input.core.findMany("plugin_storage", { where: whereFor(collection, key) }).pipe(
-      Effect.map((rows) => sortByOwnerPrecedence(rows)[0] ?? null),
-      Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)),
-    );
+    input.core
+      .findMany("plugin_storage", { where: whereFor(collection, key) })
+      .pipe(
+        Effect.map((rows) => sortByOwnerPrecedence(rows)[0] ?? null),
+        Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)),
+      );
 
   const getForOwnerImpl = <T>(owner: Owner, collection: string, key: string) =>
     input.core
       .findFirst("plugin_storage", {
         where: whereOwner(owner, collection, key),
       })
-      .pipe(Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)));
+      .pipe(
+        Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)),
+      );
 
-  const putImpl = <T>(owner: Owner, collection: string, key: string, data: unknown) =>
+  const putImpl = <T>(
+    owner: Owner,
+    collection: string,
+    key: string,
+    data: unknown,
+  ) =>
     Effect.gen(function* () {
       const os = ownerSubject(owner);
       if (!os) {
@@ -935,7 +1107,10 @@ const makePluginStorageFacade = (input: {
           offset < uniqueKeys.length;
           offset += PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE
         ) {
-          const batchKeys = uniqueKeys.slice(offset, offset + PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE);
+          const batchKeys = uniqueKeys.slice(
+            offset,
+            offset + PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE,
+          );
           yield* input.core.deleteMany("plugin_storage", {
             where: (b) =>
               b.and(
@@ -1013,7 +1188,9 @@ const makePluginStorageFacade = (input: {
       yield* deleteManyImpl(owner, os.subject, entries);
     });
 
-  const queryCollection = <TDefinition extends PluginStorageCollectionDefinition>(
+  const queryCollection = <
+    TDefinition extends PluginStorageCollectionDefinition,
+  >(
     definition: TDefinition,
     queryInput?: PluginStorageCollectionQueryInput<TDefinition>,
   ) =>
@@ -1031,7 +1208,9 @@ const makePluginStorageFacade = (input: {
       });
       const filtered = sortByOwnerPrecedence(rows)
         .filter((row) =>
-          queryInput?.keyPrefix === undefined ? true : row.key.startsWith(queryInput.keyPrefix),
+          queryInput?.keyPrefix === undefined
+            ? true
+            : row.key.startsWith(queryInput.keyPrefix),
         )
         .filter((row) =>
           rowMatchesPluginStorageWhere(
@@ -1053,7 +1232,8 @@ const makePluginStorageFacade = (input: {
                 if (compared !== 0) return compared;
               }
               return (
-                ownerRank(left.owner as Owner) - ownerRank(right.owner as Owner) ||
+                ownerRank(left.owner as Owner) -
+                  ownerRank(right.owner as Owner) ||
                 left.key.localeCompare(right.key)
               );
             })
@@ -1065,7 +1245,9 @@ const makePluginStorageFacade = (input: {
           ? sorted.slice(offset)
           : sorted.slice(offset, offset + queryInput.limit);
       return limited.map((row) =>
-        pluginStorageEntryFromRow<PluginStorageCollectionData<TDefinition>>(row),
+        pluginStorageEntryFromRow<PluginStorageCollectionData<TDefinition>>(
+          row,
+        ),
       );
     });
 
@@ -1073,15 +1255,24 @@ const makePluginStorageFacade = (input: {
     collection: (definition) => ({
       get: (storageInput) =>
         getVisible(definition.name, storageInput.key) as Effect.Effect<
-          PluginStorageEntry<PluginStorageCollectionData<typeof definition>> | null,
+          PluginStorageEntry<
+            PluginStorageCollectionData<typeof definition>
+          > | null,
           StorageFailure
         >,
       getForOwner: (storageInput) =>
-        getForOwnerImpl(storageInput.owner, definition.name, storageInput.key) as Effect.Effect<
-          PluginStorageEntry<PluginStorageCollectionData<typeof definition>> | null,
+        getForOwnerImpl(
+          storageInput.owner,
+          definition.name,
+          storageInput.key,
+        ) as Effect.Effect<
+          PluginStorageEntry<
+            PluginStorageCollectionData<typeof definition>
+          > | null,
           StorageFailure
         >,
-      list: (storageInput) => queryCollection(definition, { keyPrefix: storageInput?.keyPrefix }),
+      list: (storageInput) =>
+        queryCollection(definition, { keyPrefix: storageInput?.keyPrefix }),
       put: (storageInput) =>
         putImpl(
           storageInput.owner,
@@ -1094,12 +1285,20 @@ const makePluginStorageFacade = (input: {
         >,
       query: (storageInput) => queryCollection(definition, storageInput),
       count: (storageInput) =>
-        queryCollection(definition, storageInput).pipe(Effect.map((rows) => rows.length)),
-      remove: (storageInput) => removeImpl(storageInput.owner, definition.name, storageInput.key),
+        queryCollection(definition, storageInput).pipe(
+          Effect.map((rows) => rows.length),
+        ),
+      remove: (storageInput) =>
+        removeImpl(storageInput.owner, definition.name, storageInput.key),
     }),
-    get: (storageInput) => getVisible(storageInput.collection, storageInput.key),
+    get: (storageInput) =>
+      getVisible(storageInput.collection, storageInput.key),
     getForOwner: (storageInput) =>
-      getForOwnerImpl(storageInput.owner, storageInput.collection, storageInput.key),
+      getForOwnerImpl(
+        storageInput.owner,
+        storageInput.collection,
+        storageInput.key,
+      ),
     list: (storageInput) =>
       Effect.gen(function* () {
         const rows = yield* input.core.findMany("plugin_storage", {
@@ -1114,11 +1313,18 @@ const makePluginStorageFacade = (input: {
           .map((row) => pluginStorageEntryFromRow(row));
       }),
     put: (storageInput) =>
-      putImpl(storageInput.owner, storageInput.collection, storageInput.key, storageInput.data),
-    putMany: (storageInput) => putManyImpl(storageInput.owner, storageInput.entries),
+      putImpl(
+        storageInput.owner,
+        storageInput.collection,
+        storageInput.key,
+        storageInput.data,
+      ),
+    putMany: (storageInput) =>
+      putManyImpl(storageInput.owner, storageInput.entries),
     remove: (storageInput) =>
       removeImpl(storageInput.owner, storageInput.collection, storageInput.key),
-    removeMany: (storageInput) => removeManyImpl(storageInput.owner, storageInput.entries),
+    removeMany: (storageInput) =>
+      removeManyImpl(storageInput.owner, storageInput.entries),
   };
 };
 
@@ -1161,7 +1367,9 @@ const EXECUTOR_SOURCE: StaticSourceDecl = {
   tools: [],
 };
 
-const isReadonlyRecord = (value: unknown): value is Readonly<Record<PropertyKey, unknown>> =>
+const isReadonlyRecord = (
+  value: unknown,
+): value is Readonly<Record<PropertyKey, unknown>> =>
   typeof value === "object" && value !== null;
 
 type StandardJsonSchemaSide = "input" | "output";
@@ -1180,10 +1388,14 @@ const staticToolSchemaRoot = (
   const jsonSchema = standard["jsonSchema"];
   if (!isReadonlyRecord(jsonSchema)) return schema;
   const materialize = (jsonSchema as StandardJsonSchemaFns)[side];
-  return typeof materialize === "function" ? materialize({ target: "draft-07" }) : jsonSchema;
+  return typeof materialize === "function"
+    ? materialize({ target: "draft-07" })
+    : jsonSchema;
 };
 
-export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = readonly []>(
+export const createExecutor = <
+  const TPlugins extends readonly AnyPlugin[] = readonly [],
+>(
   config: ExecutorConfig<TPlugins>,
 ): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
   Effect.gen(function* () {
@@ -1213,7 +1425,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       return { tenant, owner, subject };
     };
 
-    const requireUserSubject = (owner: Owner): Effect.Effect<void, StorageFailure> =>
+    const requireUserSubject = (
+      owner: Owner,
+    ): Effect.Effect<void, StorageFailure> =>
       owner === "user" && subject == null
         ? Effect.fail(
             new StorageError({
@@ -1236,7 +1450,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const tables = yield* Effect.try({
       try: () => collectTables(),
-      catch: (cause) => storageFailureFromUnknown("Failed to collect executor tables", cause),
+      catch: (cause) =>
+        storageFailureFromUnknown("Failed to collect executor tables", cause),
     });
     const dbInput = yield* Effect.suspend(() => {
       if (!config.db) return Effect.succeed(createDefaultMemoryDb(tables));
@@ -1251,7 +1466,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         validateExecutorDbTables(tables, rootDbUntyped.internal.tables);
         validateExecutorOwnerPolicyTables(rootDbUntyped.internal.tables);
       },
-      catch: (cause) => storageFailureFromUnknown("Failed to validate executor tables", cause),
+      catch: (cause) =>
+        storageFailureFromUnknown("Failed to validate executor tables", cause),
     });
 
     const ownerContext: ExecutorOwnerPolicyContext = { tenant, subject };
@@ -1259,7 +1475,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const fuma = makeFumaClient(rootDb);
     const core = makeCoreDb(fuma);
     const blobs = config.blobs ?? makeFumaBlobStore(fuma);
-    const transaction = <A, E>(effect: Effect.Effect<A, E>) => fuma.transaction(effect);
+    const transaction = <A, E>(effect: Effect.Effect<A, E>) =>
+      fuma.transaction(effect);
 
     // Populated once, never mutated after startup.
     const staticTools = new Map<string, StaticTools>();
@@ -1270,7 +1487,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const staticToolOwner = (): Owner => (subject == null ? "org" : "user");
     const staticToolConnection = (source: StaticSourceDecl): ConnectionName =>
-      ConnectionName.make(source.id === EXECUTOR_SOURCE_ID ? "coreTools" : "static");
+      ConnectionName.make(
+        source.id === EXECUTOR_SOURCE_ID ? "coreTools" : "static",
+      );
 
     const staticSources = (): readonly StaticSourceDecl[] => {
       const byId = new Map<string, StaticSourceDecl>();
@@ -1280,7 +1499,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       return [...byId.values()];
     };
 
-    const staticSourceToIntegration = (source: StaticSourceDecl): Integration => ({
+    const staticSourceToIntegration = (
+      source: StaticSourceDecl,
+    ): Integration => ({
       slug: IntegrationSlug.make(source.id),
       name: source.name,
       description: source.name,
@@ -1336,6 +1557,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     };
 
     const extensions: Record<string, object> = {};
+    // Generic executor-wrapper hook: a plugin may expose `wrapExecutor` on its
+    // extension to narrow the executor per request (the toolkits plugin does).
+    // Collected here, run by the execution stack — core stays domain-agnostic.
+    const executorWrappers: ExecutorWrapper[] = [];
 
     // ------------------------------------------------------------------
     // Owner condition builders. The owner policy already restricts reads to
@@ -1389,7 +1614,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const performTokenRefresh = (
       row: ConnectionRow,
       provider: CredentialProvider,
-    ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
+    ): Effect.Effect<
+      string | null,
+      StorageFailure | CredentialResolutionError
+    > =>
       Effect.gen(function* () {
         const owner = row.owner as Owner;
         const reauth = (message: string): CredentialResolutionError =>
@@ -1404,15 +1632,21 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // Load the backing app by the owner STORED on the connection (a Personal
         // connection may be backed by a shared Workspace app) — no derivation.
         const clientOwner = (row.oauth_client_owner ?? row.owner) as Owner;
-        const clientRow = yield* loadOAuthClientRow(clientOwner, String(row.oauth_client));
+        const clientRow = yield* loadOAuthClientRow(
+          clientOwner,
+          String(row.oauth_client),
+        );
         if (!clientRow) {
-          return yield* reauth(`OAuth client "${row.oauth_client}" is no longer registered.`);
+          return yield* reauth(
+            `OAuth client "${row.oauth_client}" is no longer registered.`,
+          );
         }
 
         // The secret is stored in the provider (a vault item id), not inline.
         const clientSecret = clientRow.client_secret_item_id
-          ? ((yield* provider.get(ProviderItemId.make(String(clientRow.client_secret_item_id)))) ??
-            "")
+          ? ((yield* provider.get(
+              ProviderItemId.make(String(clientRow.client_secret_item_id)),
+            )) ?? "")
           : "";
         // Re-request the scopes this connection was GRANTED (RFC 6749 §6: a
         // refresh must not exceed the originally-granted scope). Empty → omit
@@ -1433,7 +1667,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 clientId: String(clientRow.client_id),
                 clientSecret,
                 scopes: grantedScopes,
-                resource: clientRow.resource ? String(clientRow.resource) : undefined,
+                resource: clientRow.resource
+                  ? String(clientRow.resource)
+                  : undefined,
                 endpointUrlPolicy: config.oauthEndpointUrlPolicy,
               }).pipe(
                 // A client_credentials failure is never a rotated-refresh-token
@@ -1451,11 +1687,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               )
             : yield* Effect.gen(function* () {
                 if (!row.refresh_item_id) {
-                  return yield* reauth("No refresh token is stored for this connection.");
+                  return yield* reauth(
+                    "No refresh token is stored for this connection.",
+                  );
                 }
-                const refreshToken = yield* provider.get(ProviderItemId.make(row.refresh_item_id));
+                const refreshToken = yield* provider.get(
+                  ProviderItemId.make(row.refresh_item_id),
+                );
                 if (!refreshToken) {
-                  return yield* reauth("Stored refresh token could not be resolved.");
+                  return yield* reauth(
+                    "Stored refresh token could not be resolved.",
+                  );
                 }
                 return yield* refreshAccessToken({
                   tokenUrl: String(clientRow.token_url),
@@ -1465,7 +1707,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                   scopes: grantedScopes,
                   // RFC 8707: keep the re-minted token bound to the same resource
                   // (MCP servers require this on refresh).
-                  resource: clientRow.resource ? String(clientRow.resource) : undefined,
+                  resource: clientRow.resource
+                    ? String(clientRow.resource)
+                    : undefined,
                   endpointUrlPolicy: config.oauthEndpointUrlPolicy,
                 }).pipe(
                   Effect.mapError((cause) =>
@@ -1489,14 +1733,22 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           const tokenItemId =
             connectionItemIds(row)[PRIMARY_INPUT_VARIABLE] ??
             `connection:${row.owner}:${row.integration}:${row.name}:${PRIMARY_INPUT_VARIABLE}`;
-          yield* provider.set(ProviderItemId.make(tokenItemId), token.access_token);
+          yield* provider.set(
+            ProviderItemId.make(tokenItemId),
+            token.access_token,
+          );
           if (token.refresh_token && row.refresh_item_id) {
-            yield* provider.set(ProviderItemId.make(row.refresh_item_id), token.refresh_token);
+            yield* provider.set(
+              ProviderItemId.make(row.refresh_item_id),
+              token.refresh_token,
+            );
           }
         }
 
         const nextExpiresAt =
-          typeof token.expires_in === "number" ? Date.now() + token.expires_in * 1000 : null;
+          typeof token.expires_in === "number"
+            ? Date.now() + token.expires_in * 1000
+            : null;
         const set: Record<string, unknown> = {
           expires_at: nextExpiresAt,
           updated_at: new Date(),
@@ -1518,7 +1770,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const refreshConnectionToken = (
       row: ConnectionRow,
       provider: CredentialProvider,
-    ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
+    ): Effect.Effect<
+      string | null,
+      StorageFailure | CredentialResolutionError
+    > =>
       // Share a single refresh per connection so concurrent resolves of the same
       // connection all await one refresh-token grant (the AS rotates the refresh
       // token; parallel grants would race on a consumed token — v1's refresh
@@ -1530,7 +1785,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         if (existing) return yield* existing;
         // `Effect.cached` memoizes the grant onto a deferred: it runs once and
         // replays to every awaiter sharing this entry.
-        const memoized = yield* Effect.cached(performTokenRefresh(row, provider));
+        const memoized = yield* Effect.cached(
+          performTokenRefresh(row, provider),
+        );
         const gated = memoized.pipe(
           Effect.ensuring(Effect.sync(() => refreshInFlight.delete(key))),
         );
@@ -1547,7 +1804,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // first (always single-input → `{ token: <access> }`).
     const resolveConnectionValues = (
       row: ConnectionRow,
-    ): Effect.Effect<Record<string, string | null>, StorageFailure | CredentialResolutionError> =>
+    ): Effect.Effect<
+      Record<string, string | null>,
+      StorageFailure | CredentialResolutionError
+    > =>
       Effect.gen(function* () {
         const provider = credentialProviders.get(row.provider);
         if (!provider) {
@@ -1557,13 +1817,16 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         }
         // OAuth connections refresh their access token before resolving when
         // it has expired (or is within the skew window).
-        const expiresAt = row.expires_at == null ? null : Number(row.expires_at);
+        const expiresAt =
+          row.expires_at == null ? null : Number(row.expires_at);
         if (row.oauth_client != null && shouldRefreshToken({ expiresAt })) {
           const access = yield* refreshConnectionToken(row, provider);
           return { [PRIMARY_INPUT_VARIABLE]: access };
         }
         const out: Record<string, string | null> = {};
-        for (const [variable, itemId] of Object.entries(connectionItemIds(row))) {
+        for (const [variable, itemId] of Object.entries(
+          connectionItemIds(row),
+        )) {
           out[variable] = yield* provider.get(ProviderItemId.make(itemId));
         }
         return out;
@@ -1584,7 +1847,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
      *  callers that only ever need one value. */
     const resolveConnectionValue = (
       row: ConnectionRow,
-    ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
+    ): Effect.Effect<
+      string | null,
+      StorageFailure | CredentialResolutionError
+    > =>
       resolveConnectionValues(row).pipe(
         Effect.map((values) => values[PRIMARY_INPUT_VARIABLE] ?? null),
       );
@@ -1644,7 +1910,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // plugin's `describeAuthMethods` hook. The hook is plugin-authored, so a
     // throw (malformed config it didn't guard) degrades to `[]` rather than
     // failing the catalog read.
-    const describeAuthMethodsForRow = (row: IntegrationRow): readonly AuthMethodDescriptor[] => {
+    const describeAuthMethodsForRow = (
+      row: IntegrationRow,
+    ): readonly AuthMethodDescriptor[] => {
       const runtime = runtimes.get(row.plugin_id);
       const describe = runtime?.plugin.describeAuthMethods;
       if (!describe) return [];
@@ -1657,7 +1925,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }
     };
 
-    const describeDisplayUrlForRow = (row: IntegrationRow): string | undefined => {
+    const describeDisplayUrlForRow = (
+      row: IntegrationRow,
+    ): string | undefined => {
       const runtime = runtimes.get(row.plugin_id);
       const describe = runtime?.plugin.describeIntegrationDisplay;
       if (!describe) return undefined;
@@ -1671,14 +1941,21 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }
     };
 
-    const integrationsList = (): Effect.Effect<readonly Integration[], StorageFailure> =>
+    const integrationsList = (): Effect.Effect<
+      readonly Integration[],
+      StorageFailure
+    > =>
       core
         .findMany("integration", {})
         .pipe(
           Effect.map((rows) => [
             ...staticSources().map(staticSourceToIntegration),
             ...rows.map((row) =>
-              rowToIntegration(row, describeAuthMethodsForRow(row), describeDisplayUrlForRow(row)),
+              rowToIntegration(
+                row,
+                describeAuthMethodsForRow(row),
+                describeDisplayUrlForRow(row),
+              ),
             ),
           ]),
         );
@@ -1687,11 +1964,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       slug: IntegrationSlug,
     ): Effect.Effect<Integration | null, StorageFailure> =>
       Effect.gen(function* () {
-        const staticSource = staticSources().find((source) => source.id === String(slug));
+        const staticSource = staticSources().find(
+          (source) => source.id === String(slug),
+        );
         if (staticSource) return staticSourceToIntegration(staticSource);
         const row = yield* findIntegrationRow(slug);
         return row
-          ? rowToIntegration(row, describeAuthMethodsForRow(row), describeDisplayUrlForRow(row))
+          ? rowToIntegration(
+              row,
+              describeAuthMethodsForRow(row),
+              describeDisplayUrlForRow(row),
+            )
           : null;
       });
 
@@ -1700,7 +1983,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     ): Effect.Effect<IntegrationRecord | null, StorageFailure> =>
       findIntegrationRow(slug).pipe(
         Effect.map((row) =>
-          row ? rowToIntegrationRecord(row, describeAuthMethodsForRow(row)) : null,
+          row
+            ? rowToIntegrationRecord(row, describeAuthMethodsForRow(row))
+            : null,
         ),
       );
 
@@ -1755,7 +2040,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const now = new Date();
         const set: Record<string, unknown> = { updated_at: now };
         if (patch.name !== undefined) set.name = patch.name;
-        if (patch.description !== undefined) set.description = patch.description;
+        if (patch.description !== undefined)
+          set.description = patch.description;
         if (patch.config !== undefined) {
           set.config = patch.config;
           // A config change can change the derived tools. The writer can only
@@ -1782,7 +2068,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const integrationsRemove = (
       slug: IntegrationSlug,
-    ): Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure> =>
+    ): Effect.Effect<
+      void,
+      IntegrationRemovalNotAllowedError | StorageFailure
+    > =>
       transaction(
         Effect.gen(function* () {
           const existing = yield* findIntegrationRow(slug);
@@ -1811,7 +2100,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           const result = yield* runtime.plugin
             .detect({ ctx: runtime.ctx, url })
             .pipe(
-              Effect.mapError((cause) => pluginStorageFailure(runtime.plugin.id, "detect", cause)),
+              Effect.mapError((cause) =>
+                pluginStorageFailure(runtime.plugin.id, "detect", cause),
+              ),
             );
           if (result) results.push(result);
         }
@@ -1825,7 +2116,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     const produceConnectionTools = (
       integrationRow: IntegrationRow,
       ref: ConnectionRef,
-    ): Effect.Effect<readonly Tool[], IntegrationNotFoundError | StorageFailure> =>
+    ): Effect.Effect<
+      readonly Tool[],
+      IntegrationNotFoundError | StorageFailure
+    > =>
       Effect.gen(function* () {
         const runtime = runtimes.get(integrationRow.plugin_id);
         const keys = yield* Effect.try({
@@ -1894,14 +2188,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             integration: rowToIntegration(integrationRow),
             config: decodeJsonColumn(integrationRow.config),
             connection: ref,
-            template: existingRow ? AuthTemplateSlug.make(existingRow.template) : null,
+            template: existingRow
+              ? AuthTemplateSlug.make(existingRow.template)
+              : null,
             storage: runtime.storage,
             getValue: () => resolveConnectionValueByRef(ref),
             getValues: () => resolveConnectionValuesByRef(ref),
           })
           .pipe(
             Effect.mapError((cause) =>
-              pluginStorageFailure(integrationRow.plugin_id, "resolveTools", cause),
+              pluginStorageFailure(
+                integrationRow.plugin_id,
+                "resolveTools",
+                cause,
+              ),
             ),
           );
 
@@ -1922,17 +2222,19 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           updated_at: now,
         }));
 
-        const definitionRows = Object.entries(result.definitions ?? {}).map(([name, schema]) => ({
-          tenant: keys.tenant,
-          owner: keys.owner,
-          subject: keys.subject,
-          integration: String(ref.integration),
-          connection: String(ref.name),
-          plugin_id: integrationRow.plugin_id,
-          name,
-          schema,
-          created_at: now,
-        }));
+        const definitionRows = Object.entries(result.definitions ?? {}).map(
+          ([name, schema]) => ({
+            tenant: keys.tenant,
+            owner: keys.owner,
+            subject: keys.subject,
+            integration: String(ref.integration),
+            connection: String(ref.name),
+            plugin_id: integrationRow.plugin_id,
+            name,
+            schema,
+            created_at: now,
+          }),
+        );
 
         yield* transaction(
           Effect.gen(function* () {
@@ -2024,16 +2326,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const itemIds: Record<string, string> = {};
         if (external.length > 0 && pasted.length > 0) {
           return yield* new InvalidConnectionInputError({
-            message: "A connection cannot mix pasted and external-provider inputs.",
+            message:
+              "A connection cannot mix pasted and external-provider inputs.",
           });
         }
         if (external.length > 0) {
           const providers = new Set(
-            external.map((i) => ("from" in i.origin ? String(i.origin.from.provider) : "")),
+            external.map((i) =>
+              "from" in i.origin ? String(i.origin.from.provider) : "",
+            ),
           );
           if (providers.size > 1) {
             return yield* new InvalidConnectionInputError({
-              message: "A connection's inputs must all use the same external provider.",
+              message:
+                "A connection's inputs must all use the same external provider.",
             });
           }
           const [only] = [...providers];
@@ -2045,7 +2351,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           }
           providerKey = only ?? "";
           for (const i of external) {
-            if ("from" in i.origin) itemIds[i.variable] = String(i.origin.from.id);
+            if ("from" in i.origin)
+              itemIds[i.variable] = String(i.origin.from.id);
           }
         } else {
           const provider = defaultWritableProvider();
@@ -2083,7 +2390,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               identity_label: input.identityLabel ?? null,
               // Re-saving a credential keeps an existing curated description
               // unless the caller explicitly provides one.
-              ...(input.description !== undefined ? { description: input.description } : {}),
+              ...(input.description !== undefined
+                ? { description: input.description }
+                : {}),
               updated_at: now,
             };
             if (existing) {
@@ -2127,7 +2436,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         };
         // Produce + persist tools for the new connection.
         yield* produceConnectionTools(integrationRow, ref).pipe(
-          Effect.catchTag("IntegrationNotFoundError", () => Effect.succeed([] as readonly Tool[])),
+          Effect.catchTag("IntegrationNotFoundError", () =>
+            Effect.succeed([] as readonly Tool[]),
+          ),
         );
 
         const row = yield* findConnectionRow(ref);
@@ -2236,7 +2547,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // Produce + persist tools for the minted connection (same path
         // connections.create uses).
         yield* produceConnectionTools(integrationRow, ref).pipe(
-          Effect.catchTag("IntegrationNotFoundError", () => Effect.succeed([] as readonly Tool[])),
+          Effect.catchTag("IntegrationNotFoundError", () =>
+            Effect.succeed([] as readonly Tool[]),
+          ),
         );
 
         const row = yield* findConnectionRow(ref);
@@ -2275,13 +2588,19 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               filter?.integration === undefined
                 ? true
                 : b("integration", "=", String(filter.integration)),
-              filter?.owner === undefined ? true : b("owner", "=", filter.owner),
+              filter?.owner === undefined
+                ? true
+                : b("owner", "=", filter.owner),
             ),
         })
         .pipe(Effect.map((rows) => rows.map(rowToConnection)));
 
-    const connectionsGet = (ref: ConnectionRef): Effect.Effect<Connection | null, StorageFailure> =>
-      findConnectionRow(ref).pipe(Effect.map((row) => (row ? rowToConnection(row) : null)));
+    const connectionsGet = (
+      ref: ConnectionRef,
+    ): Effect.Effect<Connection | null, StorageFailure> =>
+      findConnectionRow(ref).pipe(
+        Effect.map((row) => (row ? rowToConnection(row) : null)),
+      );
 
     const connectionsUpdate = (
       ref: ConnectionRef,
@@ -2297,8 +2616,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           });
         }
         const set: Record<string, unknown> = { updated_at: new Date() };
-        if (input.description !== undefined) set.description = input.description;
-        if (input.identityLabel !== undefined) set.identity_label = input.identityLabel;
+        if (input.description !== undefined)
+          set.description = input.description;
+        if (input.identityLabel !== undefined)
+          set.identity_label = input.identityLabel;
         yield* core.updateMany("connection", {
           where: (b: AnyCb) =>
             b.and(
@@ -2326,7 +2647,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             });
           }
           const integrationRow = yield* findIntegrationRow(ref.integration);
-          const runtime = integrationRow ? runtimes.get(integrationRow.plugin_id) : undefined;
+          const runtime = integrationRow
+            ? runtimes.get(integrationRow.plugin_id)
+            : undefined;
           if (integrationRow && runtime?.plugin.removeConnection) {
             yield* runtime.plugin
               .removeConnection({
@@ -2336,7 +2659,11 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               })
               .pipe(
                 Effect.mapError((cause) =>
-                  pluginStorageFailure(integrationRow.plugin_id, "removeConnection", cause),
+                  pluginStorageFailure(
+                    integrationRow.plugin_id,
+                    "removeConnection",
+                    cause,
+                  ),
                 ),
               );
           }
@@ -2385,11 +2712,23 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // Tools (read surface)
     // ------------------------------------------------------------------
 
-    const matchesToolFilter = (tool: Tool, filter: ToolListFilter | undefined): boolean => {
+    const matchesToolFilter = (
+      tool: Tool,
+      filter: ToolListFilter | undefined,
+    ): boolean => {
       if (!filter) return true;
-      if (filter.integration !== undefined && tool.integration !== filter.integration) return false;
-      if (filter.owner !== undefined && tool.owner !== filter.owner) return false;
-      if (filter.connection !== undefined && tool.connection !== filter.connection) return false;
+      if (
+        filter.integration !== undefined &&
+        tool.integration !== filter.integration
+      )
+        return false;
+      if (filter.owner !== undefined && tool.owner !== filter.owner)
+        return false;
+      if (
+        filter.connection !== undefined &&
+        tool.connection !== filter.connection
+      )
+        return false;
       if (filter.query !== undefined) {
         const q = filter.query.toLowerCase();
         const hay = `${tool.name} ${tool.description}`.toLowerCase();
@@ -2410,18 +2749,25 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       });
       if (revised.length === 0) return;
       const revisedAt = new Map(
-        revised.map((row) => [row.slug, Number(row.config_revised_at)] as const),
+        revised.map(
+          (row) => [row.slug, Number(row.config_revised_at)] as const,
+        ),
       );
       const connections = yield* core.findMany("connection", {
-        where: (b: AnyCb) => b.or(...revised.map((row) => b("integration", "=", row.slug))),
+        where: (b: AnyCb) =>
+          b.or(...revised.map((row) => b("integration", "=", row.slug))),
       });
       for (const connection of connections) {
         const revisedTime = revisedAt.get(connection.integration);
         if (revisedTime === undefined) continue;
         const syncedAt =
-          connection.tools_synced_at == null ? 0 : Number(connection.tools_synced_at);
+          connection.tools_synced_at == null
+            ? 0
+            : Number(connection.tools_synced_at);
         if (syncedAt >= revisedTime) continue;
-        const integrationRow = revised.find((row) => row.slug === connection.integration);
+        const integrationRow = revised.find(
+          (row) => row.slug === connection.integration,
+        );
         if (!integrationRow) continue;
         yield* produceConnectionTools(integrationRow, {
           owner: connection.owner as Owner,
@@ -2439,7 +2785,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }
     });
 
-    const toolsList = (filter?: ToolListFilter): Effect.Effect<readonly Tool[], StorageFailure> =>
+    const toolsList = (
+      filter?: ToolListFilter,
+    ): Effect.Effect<readonly Tool[], StorageFailure> =>
       Effect.gen(function* () {
         yield* syncStaleConnectionTools;
         // Projected: the list surface is metadata (address, description,
@@ -2451,7 +2799,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               filter?.integration === undefined
                 ? true
                 : b("integration", "=", String(filter.integration)),
-              filter?.owner === undefined ? true : b("owner", "=", filter.owner),
+              filter?.owner === undefined
+                ? true
+                : b("owner", "=", filter.owner),
               filter?.connection === undefined
                 ? true
                 : b("connection", "=", String(filter.connection)),
@@ -2507,7 +2857,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 defs: new Map(),
               }),
             catch: (cause) =>
-              storageFailureFromUnknown("Failed to build static tool TypeScript preview", cause),
+              storageFailureFromUnknown(
+                "Failed to build static tool TypeScript preview",
+                cause,
+              ),
           }).pipe(Effect.option);
           return ToolSchemaView.make({
             address,
@@ -2517,7 +2870,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             outputSchema: tool.outputSchema,
             inputTypeScript: Option.getOrUndefined(preview)?.inputTypeScript,
             outputTypeScript: Option.getOrUndefined(preview)?.outputTypeScript,
-            typeScriptDefinitions: Option.getOrUndefined(preview)?.typeScriptDefinitions,
+            typeScriptDefinitions:
+              Option.getOrUndefined(preview)?.typeScriptDefinitions,
           });
         }
 
@@ -2544,7 +2898,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             ),
         });
         const defs = new Map<string, unknown>();
-        for (const def of definitionRows) defs.set(def.name, decodeJsonColumn(def.schema));
+        for (const def of definitionRows)
+          defs.set(def.name, decodeJsonColumn(def.schema));
 
         const referenced = collectReferencedDefinitions(
           [tool.inputSchema, tool.outputSchema],
@@ -2558,7 +2913,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               defs,
             }),
           catch: (cause) =>
-            storageFailureFromUnknown("Failed to build tool TypeScript preview", cause),
+            storageFailureFromUnknown(
+              "Failed to build tool TypeScript preview",
+              cause,
+            ),
         }).pipe(Effect.option);
 
         const view = preview;
@@ -2574,7 +2932,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               : undefined,
           inputTypeScript: Option.getOrUndefined(view)?.inputTypeScript,
           outputTypeScript: Option.getOrUndefined(view)?.outputTypeScript,
-          typeScriptDefinitions: Option.getOrUndefined(view)?.typeScriptDefinitions,
+          typeScriptDefinitions:
+            Option.getOrUndefined(view)?.typeScriptDefinitions,
         });
       });
 
@@ -2583,7 +2942,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     // ------------------------------------------------------------------
 
     const providersList = (): Effect.Effect<readonly ProviderKey[]> =>
-      Effect.sync(() => credentialProviderOrder.map((key) => ProviderKey.make(key)));
+      Effect.sync(() =>
+        credentialProviderOrder.map((key) => ProviderKey.make(key)),
+      );
 
     const providersItems = (
       key: ProviderKey,
@@ -2609,13 +2970,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         ? String(tool.address)
         : `${tool.integration}.${tool.owner}.${tool.connection}.${tool.name}`;
 
-    const policiesList = (): Effect.Effect<readonly ToolPolicy[], StorageFailure> =>
+    const policiesList = (): Effect.Effect<
+      readonly ToolPolicy[],
+      StorageFailure
+    > =>
       core
         .findMany("tool_policy", {})
         .pipe(
           Effect.map((rows) =>
             [...rows]
-              .sort((a, b) => ownerRankForRow(a) - ownerRankForRow(b) || comparePolicyRow(a, b))
+              .sort(
+                (a, b) =>
+                  ownerRankForRow(a) - ownerRankForRow(b) ||
+                  comparePolicyRow(a, b),
+              )
               .map(rowToToolPolicy),
           ),
         );
@@ -2648,7 +3016,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           .map((row) => row.position)
           .sort()
           .at(0);
-        const position = input.position ?? generateKeyBetween(null, minPosition ?? null);
+        const position =
+          input.position ?? generateKeyBetween(null, minPosition ?? null);
         const id = PolicyId.make(
           `pol_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`,
         );
@@ -2677,7 +3046,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             cause: undefined,
           });
         }
-        const where = (b: AnyCb) => b.and(byOwner(input.owner)(b), b("id", "=", input.id));
+        const where = (b: AnyCb) =>
+          b.and(byOwner(input.owner)(b), b("id", "=", input.id));
         const existing = yield* core.findFirst("tool_policy", { where });
         if (!existing) {
           return yield* new StorageError({
@@ -2691,12 +3061,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         if (input.position !== undefined) set.position = input.position;
         yield* core.updateMany("tool_policy", { where, set });
         const updated = yield* core.findFirst("tool_policy", { where });
-        return rowToToolPolicy(updated ?? ({ ...existing, ...set } as ToolPolicyRow));
+        return rowToToolPolicy(
+          updated ?? ({ ...existing, ...set } as ToolPolicyRow),
+        );
       });
 
-    const policiesRemove = (input: RemoveToolPolicyInput): Effect.Effect<void, StorageFailure> =>
+    const policiesRemove = (
+      input: RemoveToolPolicyInput,
+    ): Effect.Effect<void, StorageFailure> =>
       core.deleteMany("tool_policy", {
-        where: (b: AnyCb) => b.and(byOwner(input.owner)(b), b("id", "=", input.id)),
+        where: (b: AnyCb) =>
+          b.and(byOwner(input.owner)(b), b("id", "=", input.id)),
       });
 
     const policiesResolve = (
@@ -2721,20 +3096,31 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               ),
           });
           if (row) {
-            const annotations = decodeJsonColumn(row.annotations) as ToolAnnotations | undefined;
+            const annotations = decodeJsonColumn(row.annotations) as
+              | ToolAnnotations
+              | undefined;
             requiresApproval = annotations?.requiresApproval;
           }
         }
-        return resolveEffectivePolicy(toolId, policyRows, ownerRankForRow, requiresApproval);
+        return resolveEffectivePolicy(
+          toolId,
+          policyRows,
+          ownerRankForRow,
+          requiresApproval,
+        );
       });
 
     // ------------------------------------------------------------------
     // Elicitation
     // ------------------------------------------------------------------
 
-    const defaultElicitationHandler = resolveElicitationHandler(config.onElicitation);
+    const defaultElicitationHandler = resolveElicitationHandler(
+      config.onElicitation,
+    );
 
-    const pickHandler = (options: InvokeOptions | undefined): ElicitationHandler =>
+    const pickHandler = (
+      options: InvokeOptions | undefined,
+    ): ElicitationHandler =>
       options?.onElicitation
         ? resolveElicitationHandler(options.onElicitation)
         : defaultElicitationHandler;
@@ -2796,15 +3182,17 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
 
     const TOOL_SUGGESTION_LIMIT = 5;
 
-    const toolSuggestions = (rows: readonly ToolInvocationRow[]): readonly ToolAddress[] =>
-      rows.map((row) => rowToTool(row).address);
+    const toolSuggestions = (
+      rows: readonly ToolInvocationRow[],
+    ): readonly ToolAddress[] => rows.map((row) => rowToTool(row).address);
 
-    const toolRowsForConnectionWhere = (parsed: ParsedToolAddress) => (b: AnyCb) =>
-      b.and(
-        byOwner(parsed.owner)(b),
-        b("integration", "=", String(parsed.integration)),
-        b("connection", "=", String(parsed.connection)),
-      );
+    const toolRowsForConnectionWhere =
+      (parsed: ParsedToolAddress) => (b: AnyCb) =>
+        b.and(
+          byOwner(parsed.owner)(b),
+          b("integration", "=", String(parsed.integration)),
+          b("connection", "=", String(parsed.connection)),
+        );
 
     const searchToolRowsForConnection = (
       parsed: ParsedToolAddress,
@@ -2842,7 +3230,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       return Effect.gen(function* () {
         // oxlint-disable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check -- boundary: normalize arbitrary unknown plugin failures into a human-readable message for ToolInvocationError/telemetry
         const formatInvocationCauseMessage = (cause: unknown): string => {
-          if (cause instanceof Error && cause.message.length > 0) return cause.message;
+          if (cause instanceof Error && cause.message.length > 0)
+            return cause.message;
           // Non-Error / empty-message causes: `String(plainObject)` renders
           // "[object Object]", which is what telemetry then shows as the only
           // label for the failure. Prefer the tag, else stringify structurally.
@@ -2886,7 +3275,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               pattern: policy.pattern ?? "*",
             });
           }
-          yield* enforceApproval(staticEntry.tool.annotations, address, args, policy, handler);
+          yield* enforceApproval(
+            staticEntry.tool.annotations,
+            address,
+            args,
+            policy,
+            handler,
+          );
           return yield* wrapInvocationError(
             staticEntry.tool.handler({
               ctx: staticEntry.ctx,
@@ -2917,7 +3312,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         if (!row) {
           const searchMatches = yield* searchToolRowsForConnection(parsed);
           const connectionTools =
-            searchMatches.length > 0 ? searchMatches : yield* findToolRowsForConnection(parsed);
+            searchMatches.length > 0
+              ? searchMatches
+              : yield* findToolRowsForConnection(parsed);
           return yield* new ToolNotFoundError({
             address,
             suggestions: toolSuggestions(connectionTools),
@@ -2927,7 +3324,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         // Resolve policy (owner-ranked).
         const toolForPolicy = rowToTool(row);
         const policyRows = yield* core.findMany("tool_policy", {});
-        const annotations = decodeJsonColumn(row.annotations) as ToolAnnotations | undefined;
+        const annotations = decodeJsonColumn(row.annotations) as
+          | ToolAnnotations
+          | undefined;
         const policy = resolveEffectivePolicy(
           normalizedPolicyId(toolForPolicy),
           policyRows,
@@ -2982,7 +3381,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             .pipe(wrapInvocationError);
           resolvedAnnotations = map[String(parsed.tool)] ?? annotations;
         }
-        yield* enforceApproval(resolvedAnnotations, address, args, policy, handler);
+        yield* enforceApproval(
+          resolvedAnnotations,
+          address,
+          args,
+          policy,
+          handler,
+        );
 
         // Resolve every named credential input (`variable → value`); `value` is
         // the primary `token` for single-input + OAuth callers.
@@ -2995,7 +3400,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           template: AuthTemplateSlug.make(connectionRow.template),
           value: values[PRIMARY_INPUT_VARIABLE] ?? null,
           values,
-          config: integrationRow ? decodeJsonColumn(integrationRow.config) : undefined,
+          config: integrationRow
+            ? decodeJsonColumn(integrationRow.config)
+            : undefined,
         };
 
         return yield* wrapInvocationError(
@@ -3035,7 +3442,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       subject,
       ownedKeys: (owner: Owner) => ownedKeys(owner),
       defaultWritableProvider,
-      mintOAuthConnection: (input: MintOAuthConnectionInput) => mintOAuthConnection(input),
+      mintOAuthConnection: (input: MintOAuthConnectionInput) =>
+        mintOAuthConnection(input),
       // Resolve the integration's DECLARED oauth scopes for a (integration,
       // template): load the row, run the owning plugin's auth-method projector,
       // and return the matching oauth method's declared `oauth.scopes`. Drives
@@ -3043,15 +3451,20 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       // client on a broad integration still requests the integration's full
       // scope set. Empty (no row / no oauth method / no declared scopes) ⇒ the
       // union collapses to the client's scopes (current behavior).
-      resolveDeclaredOAuthScopes: (integration: IntegrationSlug, template: AuthTemplateSlug) =>
+      resolveDeclaredOAuthScopes: (
+        integration: IntegrationSlug,
+        template: AuthTemplateSlug,
+      ) =>
         findIntegrationRow(integration).pipe(
           Effect.map((row): readonly string[] => {
             if (!row) return [];
             const methods = describeAuthMethodsForRow(row);
             const match =
               methods.find(
-                (m: AuthMethodDescriptor) => m.kind === "oauth" && m.template === String(template),
-              ) ?? methods.find((m: AuthMethodDescriptor) => m.kind === "oauth");
+                (m: AuthMethodDescriptor) =>
+                  m.kind === "oauth" && m.template === String(template),
+              ) ??
+              methods.find((m: AuthMethodDescriptor) => m.kind === "oauth");
             return match?.oauth?.scopes ?? [];
           }),
         ),
@@ -3101,7 +3514,8 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         httpClientLayer: config.httpClientLayer ?? FetchHttpClient.layer,
         core: {
           integrations: {
-            register: (input: RegisterIntegrationInput) => integrationsRegister(plugin.id, input),
+            register: (input: RegisterIntegrationInput) =>
+              integrationsRegister(plugin.id, input),
             update: (slug, patch) => integrationsUpdate(slug, patch),
             list: () => integrationsList(),
             get: (slug) => integrationsGetRecord(slug),
@@ -3156,6 +3570,12 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       if (plugin.extension) {
         extensions[plugin.id] = extension;
       }
+      // A plugin that narrows the executor exposes `wrapExecutor` on its
+      // extension; collect it into the generic hook the execution stack runs.
+      const wrapExecutor = (extension as { wrapExecutor?: ExecutorWrapper })
+        .wrapExecutor;
+      if (typeof wrapExecutor === "function")
+        executorWrappers.push(wrapExecutor);
 
       const decls = plugin.staticSources ? plugin.staticSources(extension) : [];
       for (const source of decls) {
@@ -3212,7 +3632,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
             yield* runtime.plugin
               .close()
               .pipe(
-                Effect.mapError((cause) => pluginStorageFailure(runtime.plugin.id, "close", cause)),
+                Effect.mapError((cause) =>
+                  pluginStorageFailure(runtime.plugin.id, "close", cause),
+                ),
               );
           }
         }
@@ -3269,8 +3691,9 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       close,
     };
 
-    const toExecutor = (value: unknown): Executor<TPlugins> => value as Executor<TPlugins>;
-    return toExecutor(Object.assign(base, extensions));
+    const toExecutor = (value: unknown): Executor<TPlugins> =>
+      value as Executor<TPlugins>;
+    return toExecutor(Object.assign(base, extensions, { executorWrappers }));
   });
 
 // Helper alias so the inline literal used for the optimistic projection in

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -2,15 +2,8 @@ import { Effect, Inspectable, Layer, Option, Predicate, Schema } from "effect";
 import { FetchHttpClient, type HttpClient } from "effect/unstable/http";
 import { fumadb } from "@executor-js/fumadb";
 import { memoryAdapter } from "@executor-js/fumadb/adapters/memory";
-import {
-  withQueryContext,
-  type Condition,
-  type ConditionBuilder,
-} from "@executor-js/fumadb/query";
-import {
-  schema as fumaSchema,
-  type RelationsMap,
-} from "@executor-js/fumadb/schema";
+import { withQueryContext, type Condition, type ConditionBuilder } from "@executor-js/fumadb/query";
+import { schema as fumaSchema, type RelationsMap } from "@executor-js/fumadb/schema";
 import type { AnyColumn } from "@executor-js/fumadb/schema";
 import { generateKeyBetween } from "fractional-indexing";
 
@@ -23,12 +16,7 @@ import {
   type FumaTables,
   type StorageFailure,
 } from "./fuma-runtime";
-import {
-  makeFumaBlobStore,
-  pluginBlobStore,
-  type BlobStore,
-  type OwnerPartitions,
-} from "./blob";
+import { makeFumaBlobStore, pluginBlobStore, type BlobStore, type OwnerPartitions } from "./blob";
 import { coreToolsPlugin } from "./core-tools";
 import type {
   Connection,
@@ -97,10 +85,7 @@ import type {
   IntegrationConfig,
   RegisterIntegrationInput,
 } from "./integration";
-import {
-  makeOAuthService,
-  type MintOAuthConnectionInput,
-} from "./oauth-service";
+import { makeOAuthService, type MintOAuthConnectionInput } from "./oauth-service";
 import type { OAuthService } from "./oauth-client";
 import {
   comparePolicyRow,
@@ -152,12 +137,7 @@ import {
   type ExecutorOwnerPolicyContext,
 } from "./owner-policy";
 import { ToolSchemaView, type IntegrationDetectionResult } from "./types";
-import {
-  type Tool,
-  type ToolAnnotations,
-  type ToolDef,
-  type ToolListFilter,
-} from "./tool";
+import { type Tool, type ToolAnnotations, type ToolDef, type ToolListFilter } from "./tool";
 import { buildToolTypeScriptPreview } from "./schema-types";
 import { collectReferencedDefinitions } from "./schema-refs";
 import {
@@ -182,9 +162,7 @@ const MAX_APPROVAL_ARGUMENT_PREVIEW_CHARS = 4_000;
 const acceptAllHandler: ElicitationHandler = () =>
   Effect.succeed(ElicitationResponse.make({ action: "accept" }));
 
-const resolveElicitationHandler = (
-  onElicitation: OnElicitation,
-): ElicitationHandler =>
+const resolveElicitationHandler = (onElicitation: OnElicitation): ElicitationHandler =>
   onElicitation === "accept-all" ? acceptAllHandler : onElicitation;
 
 // ---------------------------------------------------------------------------
@@ -200,8 +178,7 @@ export interface ParsedToolAddress {
   readonly tool: ToolName;
 }
 
-const isOwner = (value: string): value is Owner =>
-  value === "org" || value === "user";
+const isOwner = (value: string): value is Owner => value === "org" || value === "user";
 
 /** Parse a callable address; null when it's not a well-formed
  *  `tools.<integration>.<owner>.<connection>.<tool>`.
@@ -220,17 +197,16 @@ export const parseToolAddress = (address: string): ParsedToolAddress | null => {
     cut = address.indexOf(".", cut + 1);
     if (cut === -1) return null;
   }
-  const [prefix, integration, owner, connection] = address
-    .slice(0, cut)
-    .split(".") as [string, string, string, string];
+  const [prefix, integration, owner, connection] = address.slice(0, cut).split(".") as [
+    string,
+    string,
+    string,
+    string,
+  ];
   const tool = address.slice(cut + 1);
   if (prefix !== ADDRESS_PREFIX) return null;
   if (!isOwner(owner)) return null;
-  if (
-    integration.length === 0 ||
-    connection.length === 0 ||
-    tool.length === 0
-  ) {
+  if (integration.length === 0 || connection.length === 0 || tool.length === 0) {
     return null;
   }
   return {
@@ -246,9 +222,7 @@ export const connectionAddress = (
   integration: IntegrationSlug,
   connection: ConnectionName,
 ): ConnectionAddress =>
-  ConnectionAddress.make(
-    `${ADDRESS_PREFIX}.${integration}.${owner}.${connection}`,
-  );
+  ConnectionAddress.make(`${ADDRESS_PREFIX}.${integration}.${owner}.${connection}`);
 
 export const toolAddress = (
   owner: Owner,
@@ -256,9 +230,7 @@ export const toolAddress = (
   connection: ConnectionName,
   tool: ToolName,
 ): ToolAddress =>
-  ToolAddress.make(
-    `${ADDRESS_PREFIX}.${integration}.${owner}.${connection}.${tool}`,
-  );
+  ToolAddress.make(`${ADDRESS_PREFIX}.${integration}.${owner}.${connection}.${tool}`);
 
 // ---------------------------------------------------------------------------
 // Owner key helpers — every owned-row write stamps `tenant`, `owner`,
@@ -283,19 +255,14 @@ export type RequestScopeProvider = (
 export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   readonly integrations: {
     readonly list: () => Effect.Effect<readonly Integration[], StorageFailure>;
-    readonly get: (
-      slug: IntegrationSlug,
-    ) => Effect.Effect<Integration | null, StorageFailure>;
+    readonly get: (slug: IntegrationSlug) => Effect.Effect<Integration | null, StorageFailure>;
     readonly update: (
       slug: IntegrationSlug,
       patch: { readonly name?: string; readonly description?: string },
     ) => Effect.Effect<void, IntegrationNotFoundError | StorageFailure>;
     readonly remove: (
       slug: IntegrationSlug,
-    ) => Effect.Effect<
-      void,
-      IntegrationRemovalNotAllowedError | StorageFailure
-    >;
+    ) => Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure>;
     readonly detect: (
       url: string,
     ) => Effect.Effect<readonly IntegrationDetectionResult[], StorageFailure>;
@@ -315,9 +282,7 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
       readonly integration?: IntegrationSlug;
       readonly owner?: Owner;
     }) => Effect.Effect<readonly Connection[], StorageFailure>;
-    readonly get: (
-      ref: ConnectionRef,
-    ) => Effect.Effect<Connection | null, StorageFailure>;
+    readonly get: (ref: ConnectionRef) => Effect.Effect<Connection | null, StorageFailure>;
     /** Edit user-curated metadata (description, identityLabel). Credentials and
      *  OAuth lifecycle fields are not editable here. */
     readonly update: (
@@ -340,35 +305,21 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   readonly oauth: OAuthService;
 
   readonly tools: {
-    readonly list: (
-      filter?: ToolListFilter,
-    ) => Effect.Effect<readonly Tool[], StorageFailure>;
-    readonly schema: (
-      address: ToolAddress,
-    ) => Effect.Effect<ToolSchemaView | null, StorageFailure>;
+    readonly list: (filter?: ToolListFilter) => Effect.Effect<readonly Tool[], StorageFailure>;
+    readonly schema: (address: ToolAddress) => Effect.Effect<ToolSchemaView | null, StorageFailure>;
   };
 
   readonly providers: {
     readonly list: () => Effect.Effect<readonly ProviderKey[]>;
-    readonly items: (
-      key: ProviderKey,
-    ) => Effect.Effect<readonly ProviderEntry[], StorageFailure>;
+    readonly items: (key: ProviderKey) => Effect.Effect<readonly ProviderEntry[], StorageFailure>;
   };
 
   readonly policies: {
     readonly list: () => Effect.Effect<readonly ToolPolicy[], StorageFailure>;
-    readonly create: (
-      input: CreateToolPolicyInput,
-    ) => Effect.Effect<ToolPolicy, StorageFailure>;
-    readonly update: (
-      input: UpdateToolPolicyInput,
-    ) => Effect.Effect<ToolPolicy, StorageFailure>;
-    readonly remove: (
-      input: RemoveToolPolicyInput,
-    ) => Effect.Effect<void, StorageFailure>;
-    readonly resolve: (
-      address: ToolAddress,
-    ) => Effect.Effect<EffectivePolicy, StorageFailure>;
+    readonly create: (input: CreateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
+    readonly update: (input: UpdateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
+    readonly remove: (input: RemoveToolPolicyInput) => Effect.Effect<void, StorageFailure>;
+    readonly resolve: (address: ToolAddress) => Effect.Effect<EffectivePolicy, StorageFailure>;
   };
 
   readonly execute: (
@@ -387,10 +338,7 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
 
 export interface ExecutorDb {
   readonly db: FumaDb<any>;
-  readonly close?: () =>
-    | Effect.Effect<void, StorageFailure>
-    | Promise<void>
-    | void;
+  readonly close?: () => Effect.Effect<void, StorageFailure> | Promise<void> | void;
 }
 
 export type ExecutorDbInput = FumaDb<any> | ExecutorDb;
@@ -399,9 +347,7 @@ export type ExecutorDbFactory = (config: {
   readonly tables: FumaTables;
 }) => ExecutorDbInput | Effect.Effect<ExecutorDbInput, StorageFailure>;
 
-export interface ExecutorConfig<
-  TPlugins extends readonly AnyPlugin[] = readonly [],
-> {
+export interface ExecutorConfig<TPlugins extends readonly AnyPlugin[] = readonly []> {
   /** The org / workspace this executor is bound to. `owner: "org"` rows file
    *  here. */
   readonly tenant: Tenant;
@@ -462,10 +408,7 @@ const validateExecutorOwnerPolicyTables = (tables: FumaTables): void => {
   }
 };
 
-const validateExecutorDbTables = (
-  required: FumaTables,
-  actual: FumaTables,
-): void => {
+const validateExecutorDbTables = (required: FumaTables, actual: FumaTables): void => {
   const missing = Object.keys(required)
     .filter((tableName) => !actual[tableName])
     .sort();
@@ -481,27 +424,18 @@ const validateExecutorDbTables = (
   });
 };
 
-const storageFailureFromUnknown = (
-  message: string,
-  cause: unknown,
-): StorageFailure =>
+const storageFailureFromUnknown = (message: string, cause: unknown): StorageFailure =>
   isStorageFailure(cause) ? cause : new StorageError({ message, cause });
 
-const pluginStorageFailure = (
-  pluginId: string,
-  hook: string,
-  cause: unknown,
-): StorageFailure =>
+const pluginStorageFailure = (pluginId: string, hook: string, cause: unknown): StorageFailure =>
   storageFailureFromUnknown(`${hook} failed for plugin ${pluginId}`, cause);
 
 const createDefaultMemoryDb = (tables: FumaTables): ExecutorDb => {
   const version = "1.0.0";
-  const latestSchema = fumaSchema<string, FumaTables, RelationsMap<FumaTables>>(
-    {
-      version,
-      tables,
-    },
-  );
+  const latestSchema = fumaSchema<string, FumaTables, RelationsMap<FumaTables>>({
+    version,
+    tables,
+  });
   const factory = fumadb({
     namespace: "executor_memory",
     schemas: [latestSchema],
@@ -516,9 +450,7 @@ const createDefaultMemoryDb = (tables: FumaTables): ExecutorDb => {
 // JSON helpers + row → public projection conversions
 // ---------------------------------------------------------------------------
 
-const decodeJsonFromString = Schema.decodeUnknownOption(
-  Schema.UnknownFromJsonString,
-);
+const decodeJsonFromString = Schema.decodeUnknownOption(Schema.UnknownFromJsonString);
 
 const decodeJsonColumn = (value: unknown): unknown => {
   if (value === null || value === undefined) return undefined;
@@ -566,14 +498,9 @@ const rowToConnection = (row: ConnectionRow): Connection => {
     identityLabel: row.identity_label ?? null,
     description: row.description ?? null,
     expiresAt: row.expires_at == null ? null : Number(row.expires_at),
-    oauthClient:
-      row.oauth_client == null
-        ? null
-        : OAuthClientSlug.make(String(row.oauth_client)),
+    oauthClient: row.oauth_client == null ? null : OAuthClientSlug.make(String(row.oauth_client)),
     oauthClientOwner:
-      row.oauth_client_owner == null
-        ? null
-        : (String(row.oauth_client_owner) as Owner),
+      row.oauth_client_owner == null ? null : (String(row.oauth_client_owner) as Owner),
     oauthScope: row.oauth_scope == null ? null : String(row.oauth_scope),
   };
 };
@@ -624,8 +551,7 @@ const connectionItemIds = (row: ConnectionRow): Record<string, string> => {
 // schema columns); `Tool.inputSchema`/`outputSchema` are optional and stay
 // absent for those callers — `tools.schema` is the schema-bearing surface.
 const rowToTool = (
-  row: ToolInvocationRow &
-    Partial<Pick<ToolRow, "input_schema" | "output_schema">>,
+  row: ToolInvocationRow & Partial<Pick<ToolRow, "input_schema" | "output_schema">>,
   annotations?: ToolAnnotations,
 ): Tool => {
   const owner = row.owner as Owner;
@@ -642,9 +568,7 @@ const rowToTool = (
     description: row.description,
     inputSchema: decodeJsonColumn(row.input_schema),
     outputSchema: decodeJsonColumn(row.output_schema),
-    annotations:
-      annotations ??
-      (decodeJsonColumn(row.annotations) as ToolAnnotations | undefined),
+    annotations: annotations ?? (decodeJsonColumn(row.annotations) as ToolAnnotations | undefined),
   };
 };
 
@@ -675,10 +599,7 @@ type CoreFindFirstOptions<TName extends CoreTableName = CoreTableName> = Omit<
 >;
 /** The narrowed row a projected query returns: the selected columns keep
  *  their types, everything else is absent. */
-type CoreProjectedRow<
-  TName extends CoreTableName,
-  TSelect,
-> = TSelect extends readonly (infer K)[]
+type CoreProjectedRow<TName extends CoreTableName, TSelect> = TSelect extends readonly (infer K)[]
   ? Pick<CoreRow<TName>, Extract<K, keyof CoreRow<TName>>>
   : CoreRow<TName>;
 
@@ -711,9 +632,7 @@ const makeCoreDb = (fuma: ReturnType<typeof makeFumaClient>) => ({
     tableName: TName,
     options?: { readonly where?: CoreWhere },
   ): Effect.Effect<number, StorageFailure> =>
-    fuma.use(`${tableName}.count`, (db) =>
-      asLooseStorageDb(db).count(tableName, options),
-    ),
+    fuma.use(`${tableName}.count`, (db) => asLooseStorageDb(db).count(tableName, options)),
   create: <TName extends CoreTableName>(
     tableName: TName,
     row: Record<string, unknown>,
@@ -728,9 +647,7 @@ const makeCoreDb = (fuma: ReturnType<typeof makeFumaClient>) => ({
     rows.length === 0
       ? Effect.void
       : fuma
-          .use(`${tableName}.createMany`, (db) =>
-            asLooseStorageDb(db).createMany(tableName, rows),
-          )
+          .use(`${tableName}.createMany`, (db) => asLooseStorageDb(db).createMany(tableName, rows))
           .pipe(Effect.asVoid),
   deleteMany: <TName extends CoreTableName>(
     tableName: TName,
@@ -739,38 +656,20 @@ const makeCoreDb = (fuma: ReturnType<typeof makeFumaClient>) => ({
     fuma.use(`${tableName}.deleteMany`, (db) =>
       asLooseStorageDb(db).deleteMany(tableName, options),
     ),
-  findFirst: <
-    TName extends CoreTableName,
-    const TOptions extends CoreFindFirstOptions<TName>,
-  >(
+  findFirst: <TName extends CoreTableName, const TOptions extends CoreFindFirstOptions<TName>>(
     tableName: TName,
     options: TOptions,
-  ): Effect.Effect<
-    CoreProjectedRow<TName, TOptions["select"]> | null,
-    StorageFailure
-  > =>
+  ): Effect.Effect<CoreProjectedRow<TName, TOptions["select"]> | null, StorageFailure> =>
     fuma.use(`${tableName}.findFirst`, (db) =>
       asLooseStorageDb(db).findFirst(tableName, options),
-    ) as Effect.Effect<
-      CoreProjectedRow<TName, TOptions["select"]> | null,
-      StorageFailure
-    >,
-  findMany: <
-    TName extends CoreTableName,
-    const TOptions extends CoreFindManyOptions<TName>,
-  >(
+    ) as Effect.Effect<CoreProjectedRow<TName, TOptions["select"]> | null, StorageFailure>,
+  findMany: <TName extends CoreTableName, const TOptions extends CoreFindManyOptions<TName>>(
     tableName: TName,
     options: TOptions = {} as TOptions,
-  ): Effect.Effect<
-    readonly CoreProjectedRow<TName, TOptions["select"]>[],
-    StorageFailure
-  > =>
+  ): Effect.Effect<readonly CoreProjectedRow<TName, TOptions["select"]>[], StorageFailure> =>
     fuma.use(`${tableName}.findMany`, (db) =>
       asLooseStorageDb(db).findMany(tableName, options),
-    ) as Effect.Effect<
-      readonly CoreProjectedRow<TName, TOptions["select"]>[],
-      StorageFailure
-    >,
+    ) as Effect.Effect<readonly CoreProjectedRow<TName, TOptions["select"]>[], StorageFailure>,
   updateMany: <TName extends CoreTableName>(
     tableName: TName,
     options: {
@@ -790,9 +689,7 @@ type CoreDb = ReturnType<typeof makeCoreDb>;
 // [user, org]; writes/deletes name an explicit owner.
 // ---------------------------------------------------------------------------
 
-const pluginStorageEntryFromRow = <T>(
-  row: CoreRow<"plugin_storage">,
-): PluginStorageEntry<T> => ({
+const pluginStorageEntryFromRow = <T>(row: CoreRow<"plugin_storage">): PluginStorageEntry<T> => ({
   id: pluginStorageId({
     pluginId: row.plugin_id,
     collection: row.collection,
@@ -803,28 +700,21 @@ const pluginStorageEntryFromRow = <T>(
   collection: row.collection,
   key: row.key,
   data: row.data as T,
-  createdAt:
-    row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
-  updatedAt:
-    row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at),
+  createdAt: row.created_at instanceof Date ? row.created_at : new Date(row.created_at),
+  updatedAt: row.updated_at instanceof Date ? row.updated_at : new Date(row.updated_at),
 });
 
-const pluginStorageIndexSpecFields = (
-  spec: PluginStorageRuntimeIndexSpec,
-): readonly string[] => (typeof spec === "string" ? [spec] : spec);
+const pluginStorageIndexSpecFields = (spec: PluginStorageRuntimeIndexSpec): readonly string[] =>
+  typeof spec === "string" ? [spec] : spec;
 
 const pluginStorageCollectionIndexedFields = (
   definition: PluginStorageRuntimeCollectionDefinition,
 ): ReadonlySet<string> =>
-  new Set(
-    definition.indexes.flatMap((spec) => pluginStorageIndexSpecFields(spec)),
-  );
+  new Set(definition.indexes.flatMap((spec) => pluginStorageIndexSpecFields(spec)));
 
 const pluginStorageQueryValidationError = (
   definition: PluginStorageRuntimeCollectionDefinition,
-  query:
-    | PluginStorageCollectionQueryInput<PluginStorageCollectionDefinition>
-    | undefined,
+  query: PluginStorageCollectionQueryInput<PluginStorageCollectionDefinition> | undefined,
 ): StorageError | null => {
   if (!query) return null;
   const indexedFields = pluginStorageCollectionIndexedFields(definition);
@@ -840,19 +730,13 @@ const pluginStorageQueryValidationError = (
       });
     }
   }
-  if (
-    query.limit !== undefined &&
-    (!Number.isInteger(query.limit) || query.limit < 0)
-  ) {
+  if (query.limit !== undefined && (!Number.isInteger(query.limit) || query.limit < 0)) {
     return new StorageError({
       message: `Plugin storage collection "${definition.name}" received an invalid query limit`,
       cause: undefined,
     });
   }
-  if (
-    query.offset !== undefined &&
-    (!Number.isInteger(query.offset) || query.offset < 0)
-  ) {
+  if (query.offset !== undefined && (!Number.isInteger(query.offset) || query.offset < 0)) {
     return new StorageError({
       message: `Plugin storage collection "${definition.name}" received an invalid query offset`,
       cause: undefined,
@@ -861,35 +745,17 @@ const pluginStorageQueryValidationError = (
   return null;
 };
 
-const isPluginStorageRecord = (
-  value: unknown,
-): value is Readonly<Record<string, unknown>> =>
+const isPluginStorageRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
 
-const pluginStorageWhereOperators = [
-  "eq",
-  "in",
-  "gt",
-  "gte",
-  "lt",
-  "lte",
-] as const;
+const pluginStorageWhereOperators = ["eq", "in", "gt", "gte", "lt", "lte"] as const;
 
-const isPluginStorageWhereFilter = (
-  value: unknown,
-): value is Readonly<Record<string, unknown>> =>
-  isPluginStorageRecord(value) &&
-  pluginStorageWhereOperators.some((operator) => operator in value);
+const isPluginStorageWhereFilter = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  isPluginStorageRecord(value) && pluginStorageWhereOperators.some((operator) => operator in value);
 
-const pluginStorageComparableValue = (
-  value: unknown,
-): string | number | boolean | null => {
+const pluginStorageComparableValue = (value: unknown): string | number | boolean | null => {
   if (value instanceof Date) return value.getTime();
-  if (
-    typeof value === "number" ||
-    typeof value === "string" ||
-    typeof value === "boolean"
-  ) {
+  if (typeof value === "number" || typeof value === "string" || typeof value === "boolean") {
     return value;
   }
   if (value == null) return null;
@@ -908,13 +774,8 @@ const comparePluginStorageValues = (left: unknown, right: unknown): number => {
 const pluginStorageDataField = (data: unknown, field: string): unknown =>
   isPluginStorageRecord(data) ? data[field] : undefined;
 
-const matchesWhereOperator = (
-  operator: string,
-  value: unknown,
-  operand: unknown,
-): boolean => {
-  if (operator === "eq")
-    return comparePluginStorageValues(value, operand) === 0;
+const matchesWhereOperator = (operator: string, value: unknown, operand: unknown): boolean => {
+  if (operator === "eq") return comparePluginStorageValues(value, operand) === 0;
   if (operator === "in") {
     return (
       Array.isArray(operand) &&
@@ -922,11 +783,9 @@ const matchesWhereOperator = (
     );
   }
   if (operator === "gt") return comparePluginStorageValues(value, operand) > 0;
-  if (operator === "gte")
-    return comparePluginStorageValues(value, operand) >= 0;
+  if (operator === "gte") return comparePluginStorageValues(value, operand) >= 0;
   if (operator === "lt") return comparePluginStorageValues(value, operand) < 0;
-  if (operator === "lte")
-    return comparePluginStorageValues(value, operand) <= 0;
+  if (operator === "lte") return comparePluginStorageValues(value, operand) <= 0;
   return false;
 };
 
@@ -962,12 +821,9 @@ const makePluginStorageFacade = (input: {
   readonly owner: OwnerBinding;
 }): PluginStorageFacade => {
   // Owner partitions: org always, plus this subject's user partition.
-  const readOwners: readonly Owner[] =
-    input.owner.subject == null ? ["org"] : ["user", "org"];
+  const readOwners: readonly Owner[] = input.owner.subject == null ? ["org"] : ["user", "org"];
 
-  const ownerSubject = (
-    owner: Owner,
-  ): { owner: Owner; subject: string } | null => {
+  const ownerSubject = (owner: Owner): { owner: Owner; subject: string } | null => {
     if (owner === "org") return { owner: "org", subject: ORG_SUBJECT };
     if (input.owner.subject == null) return null;
     return { owner: "user", subject: String(input.owner.subject) };
@@ -984,11 +840,7 @@ const makePluginStorageFacade = (input: {
         key === undefined ? true : b("key", "=", key),
       );
 
-  const whereOwner = (
-    owner: Owner,
-    collection: string,
-    key: string,
-  ): CoreWhere => {
+  const whereOwner = (owner: Owner, collection: string, key: string): CoreWhere => {
     const os = ownerSubject(owner);
     return (b: AnyCb) =>
       b.and(
@@ -1010,28 +862,19 @@ const makePluginStorageFacade = (input: {
     });
 
   const getVisible = <T>(collection: string, key: string) =>
-    input.core
-      .findMany("plugin_storage", { where: whereFor(collection, key) })
-      .pipe(
-        Effect.map((rows) => sortByOwnerPrecedence(rows)[0] ?? null),
-        Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)),
-      );
+    input.core.findMany("plugin_storage", { where: whereFor(collection, key) }).pipe(
+      Effect.map((rows) => sortByOwnerPrecedence(rows)[0] ?? null),
+      Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)),
+    );
 
   const getForOwnerImpl = <T>(owner: Owner, collection: string, key: string) =>
     input.core
       .findFirst("plugin_storage", {
         where: whereOwner(owner, collection, key),
       })
-      .pipe(
-        Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)),
-      );
+      .pipe(Effect.map((row) => (row ? pluginStorageEntryFromRow<T>(row) : null)));
 
-  const putImpl = <T>(
-    owner: Owner,
-    collection: string,
-    key: string,
-    data: unknown,
-  ) =>
+  const putImpl = <T>(owner: Owner, collection: string, key: string, data: unknown) =>
     Effect.gen(function* () {
       const os = ownerSubject(owner);
       if (!os) {
@@ -1111,10 +954,7 @@ const makePluginStorageFacade = (input: {
           offset < uniqueKeys.length;
           offset += PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE
         ) {
-          const batchKeys = uniqueKeys.slice(
-            offset,
-            offset + PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE,
-          );
+          const batchKeys = uniqueKeys.slice(offset, offset + PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE);
           yield* input.core.deleteMany("plugin_storage", {
             where: (b) =>
               b.and(
@@ -1192,9 +1032,7 @@ const makePluginStorageFacade = (input: {
       yield* deleteManyImpl(owner, os.subject, entries);
     });
 
-  const queryCollection = <
-    TDefinition extends PluginStorageCollectionDefinition,
-  >(
+  const queryCollection = <TDefinition extends PluginStorageCollectionDefinition>(
     definition: TDefinition,
     queryInput?: PluginStorageCollectionQueryInput<TDefinition>,
   ) =>
@@ -1212,9 +1050,7 @@ const makePluginStorageFacade = (input: {
       });
       const filtered = sortByOwnerPrecedence(rows)
         .filter((row) =>
-          queryInput?.keyPrefix === undefined
-            ? true
-            : row.key.startsWith(queryInput.keyPrefix),
+          queryInput?.keyPrefix === undefined ? true : row.key.startsWith(queryInput.keyPrefix),
         )
         .filter((row) =>
           rowMatchesPluginStorageWhere(
@@ -1236,8 +1072,7 @@ const makePluginStorageFacade = (input: {
                 if (compared !== 0) return compared;
               }
               return (
-                ownerRank(left.owner as Owner) -
-                  ownerRank(right.owner as Owner) ||
+                ownerRank(left.owner as Owner) - ownerRank(right.owner as Owner) ||
                 left.key.localeCompare(right.key)
               );
             })
@@ -1249,9 +1084,7 @@ const makePluginStorageFacade = (input: {
           ? sorted.slice(offset)
           : sorted.slice(offset, offset + queryInput.limit);
       return limited.map((row) =>
-        pluginStorageEntryFromRow<PluginStorageCollectionData<TDefinition>>(
-          row,
-        ),
+        pluginStorageEntryFromRow<PluginStorageCollectionData<TDefinition>>(row),
       );
     });
 
@@ -1259,24 +1092,15 @@ const makePluginStorageFacade = (input: {
     collection: (definition) => ({
       get: (storageInput) =>
         getVisible(definition.name, storageInput.key) as Effect.Effect<
-          PluginStorageEntry<
-            PluginStorageCollectionData<typeof definition>
-          > | null,
+          PluginStorageEntry<PluginStorageCollectionData<typeof definition>> | null,
           StorageFailure
         >,
       getForOwner: (storageInput) =>
-        getForOwnerImpl(
-          storageInput.owner,
-          definition.name,
-          storageInput.key,
-        ) as Effect.Effect<
-          PluginStorageEntry<
-            PluginStorageCollectionData<typeof definition>
-          > | null,
+        getForOwnerImpl(storageInput.owner, definition.name, storageInput.key) as Effect.Effect<
+          PluginStorageEntry<PluginStorageCollectionData<typeof definition>> | null,
           StorageFailure
         >,
-      list: (storageInput) =>
-        queryCollection(definition, { keyPrefix: storageInput?.keyPrefix }),
+      list: (storageInput) => queryCollection(definition, { keyPrefix: storageInput?.keyPrefix }),
       put: (storageInput) =>
         putImpl(
           storageInput.owner,
@@ -1289,20 +1113,12 @@ const makePluginStorageFacade = (input: {
         >,
       query: (storageInput) => queryCollection(definition, storageInput),
       count: (storageInput) =>
-        queryCollection(definition, storageInput).pipe(
-          Effect.map((rows) => rows.length),
-        ),
-      remove: (storageInput) =>
-        removeImpl(storageInput.owner, definition.name, storageInput.key),
+        queryCollection(definition, storageInput).pipe(Effect.map((rows) => rows.length)),
+      remove: (storageInput) => removeImpl(storageInput.owner, definition.name, storageInput.key),
     }),
-    get: (storageInput) =>
-      getVisible(storageInput.collection, storageInput.key),
+    get: (storageInput) => getVisible(storageInput.collection, storageInput.key),
     getForOwner: (storageInput) =>
-      getForOwnerImpl(
-        storageInput.owner,
-        storageInput.collection,
-        storageInput.key,
-      ),
+      getForOwnerImpl(storageInput.owner, storageInput.collection, storageInput.key),
     list: (storageInput) =>
       Effect.gen(function* () {
         const rows = yield* input.core.findMany("plugin_storage", {
@@ -1317,18 +1133,11 @@ const makePluginStorageFacade = (input: {
           .map((row) => pluginStorageEntryFromRow(row));
       }),
     put: (storageInput) =>
-      putImpl(
-        storageInput.owner,
-        storageInput.collection,
-        storageInput.key,
-        storageInput.data,
-      ),
-    putMany: (storageInput) =>
-      putManyImpl(storageInput.owner, storageInput.entries),
+      putImpl(storageInput.owner, storageInput.collection, storageInput.key, storageInput.data),
+    putMany: (storageInput) => putManyImpl(storageInput.owner, storageInput.entries),
     remove: (storageInput) =>
       removeImpl(storageInput.owner, storageInput.collection, storageInput.key),
-    removeMany: (storageInput) =>
-      removeManyImpl(storageInput.owner, storageInput.entries),
+    removeMany: (storageInput) => removeManyImpl(storageInput.owner, storageInput.entries),
   };
 };
 
@@ -1371,9 +1180,7 @@ const EXECUTOR_SOURCE: StaticSourceDecl = {
   tools: [],
 };
 
-const isReadonlyRecord = (
-  value: unknown,
-): value is Readonly<Record<PropertyKey, unknown>> =>
+const isReadonlyRecord = (value: unknown): value is Readonly<Record<PropertyKey, unknown>> =>
   typeof value === "object" && value !== null;
 
 type StandardJsonSchemaSide = "input" | "output";
@@ -1392,14 +1199,10 @@ const staticToolSchemaRoot = (
   const jsonSchema = standard["jsonSchema"];
   if (!isReadonlyRecord(jsonSchema)) return schema;
   const materialize = (jsonSchema as StandardJsonSchemaFns)[side];
-  return typeof materialize === "function"
-    ? materialize({ target: "draft-07" })
-    : jsonSchema;
+  return typeof materialize === "function" ? materialize({ target: "draft-07" }) : jsonSchema;
 };
 
-export const createExecutor = <
-  const TPlugins extends readonly AnyPlugin[] = readonly [],
->(
+export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = readonly []>(
   config: ExecutorConfig<TPlugins>,
 ): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
   Effect.gen(function* () {
@@ -1429,9 +1232,7 @@ export const createExecutor = <
       return { tenant, owner, subject };
     };
 
-    const requireUserSubject = (
-      owner: Owner,
-    ): Effect.Effect<void, StorageFailure> =>
+    const requireUserSubject = (owner: Owner): Effect.Effect<void, StorageFailure> =>
       owner === "user" && subject == null
         ? Effect.fail(
             new StorageError({
@@ -1454,8 +1255,7 @@ export const createExecutor = <
 
     const tables = yield* Effect.try({
       try: () => collectTables(),
-      catch: (cause) =>
-        storageFailureFromUnknown("Failed to collect executor tables", cause),
+      catch: (cause) => storageFailureFromUnknown("Failed to collect executor tables", cause),
     });
     const dbInput = yield* Effect.suspend(() => {
       if (!config.db) return Effect.succeed(createDefaultMemoryDb(tables));
@@ -1470,8 +1270,7 @@ export const createExecutor = <
         validateExecutorDbTables(tables, rootDbUntyped.internal.tables);
         validateExecutorOwnerPolicyTables(rootDbUntyped.internal.tables);
       },
-      catch: (cause) =>
-        storageFailureFromUnknown("Failed to validate executor tables", cause),
+      catch: (cause) => storageFailureFromUnknown("Failed to validate executor tables", cause),
     });
 
     const ownerContext: ExecutorOwnerPolicyContext = { tenant, subject };
@@ -1479,8 +1278,7 @@ export const createExecutor = <
     const fuma = makeFumaClient(rootDb);
     const core = makeCoreDb(fuma);
     const blobs = config.blobs ?? makeFumaBlobStore(fuma);
-    const transaction = <A, E>(effect: Effect.Effect<A, E>) =>
-      fuma.transaction(effect);
+    const transaction = <A, E>(effect: Effect.Effect<A, E>) => fuma.transaction(effect);
 
     // Populated once, never mutated after startup.
     const staticTools = new Map<string, StaticTools>();
@@ -1491,9 +1289,7 @@ export const createExecutor = <
 
     const staticToolOwner = (): Owner => (subject == null ? "org" : "user");
     const staticToolConnection = (source: StaticSourceDecl): ConnectionName =>
-      ConnectionName.make(
-        source.id === EXECUTOR_SOURCE_ID ? "coreTools" : "static",
-      );
+      ConnectionName.make(source.id === EXECUTOR_SOURCE_ID ? "coreTools" : "static");
 
     const staticSources = (): readonly StaticSourceDecl[] => {
       const byId = new Map<string, StaticSourceDecl>();
@@ -1503,9 +1299,7 @@ export const createExecutor = <
       return [...byId.values()];
     };
 
-    const staticSourceToIntegration = (
-      source: StaticSourceDecl,
-    ): Integration => ({
+    const staticSourceToIntegration = (source: StaticSourceDecl): Integration => ({
       slug: IntegrationSlug.make(source.id),
       name: source.name,
       description: source.name,
@@ -1615,10 +1409,7 @@ export const createExecutor = <
     const performTokenRefresh = (
       row: ConnectionRow,
       provider: CredentialProvider,
-    ): Effect.Effect<
-      string | null,
-      StorageFailure | CredentialResolutionError
-    > =>
+    ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
       Effect.gen(function* () {
         const owner = row.owner as Owner;
         const reauth = (message: string): CredentialResolutionError =>
@@ -1633,21 +1424,15 @@ export const createExecutor = <
         // Load the backing app by the owner STORED on the connection (a Personal
         // connection may be backed by a shared Workspace app) — no derivation.
         const clientOwner = (row.oauth_client_owner ?? row.owner) as Owner;
-        const clientRow = yield* loadOAuthClientRow(
-          clientOwner,
-          String(row.oauth_client),
-        );
+        const clientRow = yield* loadOAuthClientRow(clientOwner, String(row.oauth_client));
         if (!clientRow) {
-          return yield* reauth(
-            `OAuth client "${row.oauth_client}" is no longer registered.`,
-          );
+          return yield* reauth(`OAuth client "${row.oauth_client}" is no longer registered.`);
         }
 
         // The secret is stored in the provider (a vault item id), not inline.
         const clientSecret = clientRow.client_secret_item_id
-          ? ((yield* provider.get(
-              ProviderItemId.make(String(clientRow.client_secret_item_id)),
-            )) ?? "")
+          ? ((yield* provider.get(ProviderItemId.make(String(clientRow.client_secret_item_id)))) ??
+            "")
           : "";
         // Re-request the scopes this connection was GRANTED (RFC 6749 §6: a
         // refresh must not exceed the originally-granted scope). Empty → omit
@@ -1668,9 +1453,7 @@ export const createExecutor = <
                 clientId: String(clientRow.client_id),
                 clientSecret,
                 scopes: grantedScopes,
-                resource: clientRow.resource
-                  ? String(clientRow.resource)
-                  : undefined,
+                resource: clientRow.resource ? String(clientRow.resource) : undefined,
                 endpointUrlPolicy: config.oauthEndpointUrlPolicy,
               }).pipe(
                 // A client_credentials failure is never a rotated-refresh-token
@@ -1688,17 +1471,11 @@ export const createExecutor = <
               )
             : yield* Effect.gen(function* () {
                 if (!row.refresh_item_id) {
-                  return yield* reauth(
-                    "No refresh token is stored for this connection.",
-                  );
+                  return yield* reauth("No refresh token is stored for this connection.");
                 }
-                const refreshToken = yield* provider.get(
-                  ProviderItemId.make(row.refresh_item_id),
-                );
+                const refreshToken = yield* provider.get(ProviderItemId.make(row.refresh_item_id));
                 if (!refreshToken) {
-                  return yield* reauth(
-                    "Stored refresh token could not be resolved.",
-                  );
+                  return yield* reauth("Stored refresh token could not be resolved.");
                 }
                 return yield* refreshAccessToken({
                   tokenUrl: String(clientRow.token_url),
@@ -1708,9 +1485,7 @@ export const createExecutor = <
                   scopes: grantedScopes,
                   // RFC 8707: keep the re-minted token bound to the same resource
                   // (MCP servers require this on refresh).
-                  resource: clientRow.resource
-                    ? String(clientRow.resource)
-                    : undefined,
+                  resource: clientRow.resource ? String(clientRow.resource) : undefined,
                   endpointUrlPolicy: config.oauthEndpointUrlPolicy,
                 }).pipe(
                   Effect.mapError((cause) =>
@@ -1734,22 +1509,14 @@ export const createExecutor = <
           const tokenItemId =
             connectionItemIds(row)[PRIMARY_INPUT_VARIABLE] ??
             `connection:${row.owner}:${row.integration}:${row.name}:${PRIMARY_INPUT_VARIABLE}`;
-          yield* provider.set(
-            ProviderItemId.make(tokenItemId),
-            token.access_token,
-          );
+          yield* provider.set(ProviderItemId.make(tokenItemId), token.access_token);
           if (token.refresh_token && row.refresh_item_id) {
-            yield* provider.set(
-              ProviderItemId.make(row.refresh_item_id),
-              token.refresh_token,
-            );
+            yield* provider.set(ProviderItemId.make(row.refresh_item_id), token.refresh_token);
           }
         }
 
         const nextExpiresAt =
-          typeof token.expires_in === "number"
-            ? Date.now() + token.expires_in * 1000
-            : null;
+          typeof token.expires_in === "number" ? Date.now() + token.expires_in * 1000 : null;
         const set: Record<string, unknown> = {
           expires_at: nextExpiresAt,
           updated_at: new Date(),
@@ -1771,10 +1538,7 @@ export const createExecutor = <
     const refreshConnectionToken = (
       row: ConnectionRow,
       provider: CredentialProvider,
-    ): Effect.Effect<
-      string | null,
-      StorageFailure | CredentialResolutionError
-    > =>
+    ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
       // Share a single refresh per connection so concurrent resolves of the same
       // connection all await one refresh-token grant (the AS rotates the refresh
       // token; parallel grants would race on a consumed token — v1's refresh
@@ -1786,9 +1550,7 @@ export const createExecutor = <
         if (existing) return yield* existing;
         // `Effect.cached` memoizes the grant onto a deferred: it runs once and
         // replays to every awaiter sharing this entry.
-        const memoized = yield* Effect.cached(
-          performTokenRefresh(row, provider),
-        );
+        const memoized = yield* Effect.cached(performTokenRefresh(row, provider));
         const gated = memoized.pipe(
           Effect.ensuring(Effect.sync(() => refreshInFlight.delete(key))),
         );
@@ -1805,10 +1567,7 @@ export const createExecutor = <
     // first (always single-input → `{ token: <access> }`).
     const resolveConnectionValues = (
       row: ConnectionRow,
-    ): Effect.Effect<
-      Record<string, string | null>,
-      StorageFailure | CredentialResolutionError
-    > =>
+    ): Effect.Effect<Record<string, string | null>, StorageFailure | CredentialResolutionError> =>
       Effect.gen(function* () {
         const provider = credentialProviders.get(row.provider);
         if (!provider) {
@@ -1818,16 +1577,13 @@ export const createExecutor = <
         }
         // OAuth connections refresh their access token before resolving when
         // it has expired (or is within the skew window).
-        const expiresAt =
-          row.expires_at == null ? null : Number(row.expires_at);
+        const expiresAt = row.expires_at == null ? null : Number(row.expires_at);
         if (row.oauth_client != null && shouldRefreshToken({ expiresAt })) {
           const access = yield* refreshConnectionToken(row, provider);
           return { [PRIMARY_INPUT_VARIABLE]: access };
         }
         const out: Record<string, string | null> = {};
-        for (const [variable, itemId] of Object.entries(
-          connectionItemIds(row),
-        )) {
+        for (const [variable, itemId] of Object.entries(connectionItemIds(row))) {
           out[variable] = yield* provider.get(ProviderItemId.make(itemId));
         }
         return out;
@@ -1848,10 +1604,7 @@ export const createExecutor = <
      *  callers that only ever need one value. */
     const resolveConnectionValue = (
       row: ConnectionRow,
-    ): Effect.Effect<
-      string | null,
-      StorageFailure | CredentialResolutionError
-    > =>
+    ): Effect.Effect<string | null, StorageFailure | CredentialResolutionError> =>
       resolveConnectionValues(row).pipe(
         Effect.map((values) => values[PRIMARY_INPUT_VARIABLE] ?? null),
       );
@@ -1911,9 +1664,7 @@ export const createExecutor = <
     // plugin's `describeAuthMethods` hook. The hook is plugin-authored, so a
     // throw (malformed config it didn't guard) degrades to `[]` rather than
     // failing the catalog read.
-    const describeAuthMethodsForRow = (
-      row: IntegrationRow,
-    ): readonly AuthMethodDescriptor[] => {
+    const describeAuthMethodsForRow = (row: IntegrationRow): readonly AuthMethodDescriptor[] => {
       const runtime = runtimes.get(row.plugin_id);
       const describe = runtime?.plugin.describeAuthMethods;
       if (!describe) return [];
@@ -1926,9 +1677,7 @@ export const createExecutor = <
       }
     };
 
-    const describeDisplayUrlForRow = (
-      row: IntegrationRow,
-    ): string | undefined => {
+    const describeDisplayUrlForRow = (row: IntegrationRow): string | undefined => {
       const runtime = runtimes.get(row.plugin_id);
       const describe = runtime?.plugin.describeIntegrationDisplay;
       if (!describe) return undefined;
@@ -1942,21 +1691,14 @@ export const createExecutor = <
       }
     };
 
-    const integrationsList = (): Effect.Effect<
-      readonly Integration[],
-      StorageFailure
-    > =>
+    const integrationsList = (): Effect.Effect<readonly Integration[], StorageFailure> =>
       core
         .findMany("integration", {})
         .pipe(
           Effect.map((rows) => [
             ...staticSources().map(staticSourceToIntegration),
             ...rows.map((row) =>
-              rowToIntegration(
-                row,
-                describeAuthMethodsForRow(row),
-                describeDisplayUrlForRow(row),
-              ),
+              rowToIntegration(row, describeAuthMethodsForRow(row), describeDisplayUrlForRow(row)),
             ),
           ]),
         );
@@ -1965,17 +1707,11 @@ export const createExecutor = <
       slug: IntegrationSlug,
     ): Effect.Effect<Integration | null, StorageFailure> =>
       Effect.gen(function* () {
-        const staticSource = staticSources().find(
-          (source) => source.id === String(slug),
-        );
+        const staticSource = staticSources().find((source) => source.id === String(slug));
         if (staticSource) return staticSourceToIntegration(staticSource);
         const row = yield* findIntegrationRow(slug);
         return row
-          ? rowToIntegration(
-              row,
-              describeAuthMethodsForRow(row),
-              describeDisplayUrlForRow(row),
-            )
+          ? rowToIntegration(row, describeAuthMethodsForRow(row), describeDisplayUrlForRow(row))
           : null;
       });
 
@@ -1984,9 +1720,7 @@ export const createExecutor = <
     ): Effect.Effect<IntegrationRecord | null, StorageFailure> =>
       findIntegrationRow(slug).pipe(
         Effect.map((row) =>
-          row
-            ? rowToIntegrationRecord(row, describeAuthMethodsForRow(row))
-            : null,
+          row ? rowToIntegrationRecord(row, describeAuthMethodsForRow(row)) : null,
         ),
       );
 
@@ -2041,8 +1775,7 @@ export const createExecutor = <
         const now = new Date();
         const set: Record<string, unknown> = { updated_at: now };
         if (patch.name !== undefined) set.name = patch.name;
-        if (patch.description !== undefined)
-          set.description = patch.description;
+        if (patch.description !== undefined) set.description = patch.description;
         if (patch.config !== undefined) {
           set.config = patch.config;
           // A config change can change the derived tools. The writer can only
@@ -2069,10 +1802,7 @@ export const createExecutor = <
 
     const integrationsRemove = (
       slug: IntegrationSlug,
-    ): Effect.Effect<
-      void,
-      IntegrationRemovalNotAllowedError | StorageFailure
-    > =>
+    ): Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure> =>
       transaction(
         Effect.gen(function* () {
           const existing = yield* findIntegrationRow(slug);
@@ -2101,9 +1831,7 @@ export const createExecutor = <
           const result = yield* runtime.plugin
             .detect({ ctx: runtime.ctx, url })
             .pipe(
-              Effect.mapError((cause) =>
-                pluginStorageFailure(runtime.plugin.id, "detect", cause),
-              ),
+              Effect.mapError((cause) => pluginStorageFailure(runtime.plugin.id, "detect", cause)),
             );
           if (result) results.push(result);
         }
@@ -2117,10 +1845,7 @@ export const createExecutor = <
     const produceConnectionTools = (
       integrationRow: IntegrationRow,
       ref: ConnectionRef,
-    ): Effect.Effect<
-      readonly Tool[],
-      IntegrationNotFoundError | StorageFailure
-    > =>
+    ): Effect.Effect<readonly Tool[], IntegrationNotFoundError | StorageFailure> =>
       Effect.gen(function* () {
         const runtime = runtimes.get(integrationRow.plugin_id);
         const keys = yield* Effect.try({
@@ -2189,20 +1914,14 @@ export const createExecutor = <
             integration: rowToIntegration(integrationRow),
             config: decodeJsonColumn(integrationRow.config),
             connection: ref,
-            template: existingRow
-              ? AuthTemplateSlug.make(existingRow.template)
-              : null,
+            template: existingRow ? AuthTemplateSlug.make(existingRow.template) : null,
             storage: runtime.storage,
             getValue: () => resolveConnectionValueByRef(ref),
             getValues: () => resolveConnectionValuesByRef(ref),
           })
           .pipe(
             Effect.mapError((cause) =>
-              pluginStorageFailure(
-                integrationRow.plugin_id,
-                "resolveTools",
-                cause,
-              ),
+              pluginStorageFailure(integrationRow.plugin_id, "resolveTools", cause),
             ),
           );
 
@@ -2223,19 +1942,17 @@ export const createExecutor = <
           updated_at: now,
         }));
 
-        const definitionRows = Object.entries(result.definitions ?? {}).map(
-          ([name, schema]) => ({
-            tenant: keys.tenant,
-            owner: keys.owner,
-            subject: keys.subject,
-            integration: String(ref.integration),
-            connection: String(ref.name),
-            plugin_id: integrationRow.plugin_id,
-            name,
-            schema,
-            created_at: now,
-          }),
-        );
+        const definitionRows = Object.entries(result.definitions ?? {}).map(([name, schema]) => ({
+          tenant: keys.tenant,
+          owner: keys.owner,
+          subject: keys.subject,
+          integration: String(ref.integration),
+          connection: String(ref.name),
+          plugin_id: integrationRow.plugin_id,
+          name,
+          schema,
+          created_at: now,
+        }));
 
         yield* transaction(
           Effect.gen(function* () {
@@ -2327,20 +2044,16 @@ export const createExecutor = <
         const itemIds: Record<string, string> = {};
         if (external.length > 0 && pasted.length > 0) {
           return yield* new InvalidConnectionInputError({
-            message:
-              "A connection cannot mix pasted and external-provider inputs.",
+            message: "A connection cannot mix pasted and external-provider inputs.",
           });
         }
         if (external.length > 0) {
           const providers = new Set(
-            external.map((i) =>
-              "from" in i.origin ? String(i.origin.from.provider) : "",
-            ),
+            external.map((i) => ("from" in i.origin ? String(i.origin.from.provider) : "")),
           );
           if (providers.size > 1) {
             return yield* new InvalidConnectionInputError({
-              message:
-                "A connection's inputs must all use the same external provider.",
+              message: "A connection's inputs must all use the same external provider.",
             });
           }
           const [only] = [...providers];
@@ -2352,8 +2065,7 @@ export const createExecutor = <
           }
           providerKey = only ?? "";
           for (const i of external) {
-            if ("from" in i.origin)
-              itemIds[i.variable] = String(i.origin.from.id);
+            if ("from" in i.origin) itemIds[i.variable] = String(i.origin.from.id);
           }
         } else {
           const provider = defaultWritableProvider();
@@ -2391,9 +2103,7 @@ export const createExecutor = <
               identity_label: input.identityLabel ?? null,
               // Re-saving a credential keeps an existing curated description
               // unless the caller explicitly provides one.
-              ...(input.description !== undefined
-                ? { description: input.description }
-                : {}),
+              ...(input.description !== undefined ? { description: input.description } : {}),
               updated_at: now,
             };
             if (existing) {
@@ -2437,9 +2147,7 @@ export const createExecutor = <
         };
         // Produce + persist tools for the new connection.
         yield* produceConnectionTools(integrationRow, ref).pipe(
-          Effect.catchTag("IntegrationNotFoundError", () =>
-            Effect.succeed([] as readonly Tool[]),
-          ),
+          Effect.catchTag("IntegrationNotFoundError", () => Effect.succeed([] as readonly Tool[])),
         );
 
         const row = yield* findConnectionRow(ref);
@@ -2548,9 +2256,7 @@ export const createExecutor = <
         // Produce + persist tools for the minted connection (same path
         // connections.create uses).
         yield* produceConnectionTools(integrationRow, ref).pipe(
-          Effect.catchTag("IntegrationNotFoundError", () =>
-            Effect.succeed([] as readonly Tool[]),
-          ),
+          Effect.catchTag("IntegrationNotFoundError", () => Effect.succeed([] as readonly Tool[])),
         );
 
         const row = yield* findConnectionRow(ref);
@@ -2589,19 +2295,13 @@ export const createExecutor = <
               filter?.integration === undefined
                 ? true
                 : b("integration", "=", String(filter.integration)),
-              filter?.owner === undefined
-                ? true
-                : b("owner", "=", filter.owner),
+              filter?.owner === undefined ? true : b("owner", "=", filter.owner),
             ),
         })
         .pipe(Effect.map((rows) => rows.map(rowToConnection)));
 
-    const connectionsGet = (
-      ref: ConnectionRef,
-    ): Effect.Effect<Connection | null, StorageFailure> =>
-      findConnectionRow(ref).pipe(
-        Effect.map((row) => (row ? rowToConnection(row) : null)),
-      );
+    const connectionsGet = (ref: ConnectionRef): Effect.Effect<Connection | null, StorageFailure> =>
+      findConnectionRow(ref).pipe(Effect.map((row) => (row ? rowToConnection(row) : null)));
 
     const connectionsUpdate = (
       ref: ConnectionRef,
@@ -2617,10 +2317,8 @@ export const createExecutor = <
           });
         }
         const set: Record<string, unknown> = { updated_at: new Date() };
-        if (input.description !== undefined)
-          set.description = input.description;
-        if (input.identityLabel !== undefined)
-          set.identity_label = input.identityLabel;
+        if (input.description !== undefined) set.description = input.description;
+        if (input.identityLabel !== undefined) set.identity_label = input.identityLabel;
         yield* core.updateMany("connection", {
           where: (b: AnyCb) =>
             b.and(
@@ -2648,9 +2346,7 @@ export const createExecutor = <
             });
           }
           const integrationRow = yield* findIntegrationRow(ref.integration);
-          const runtime = integrationRow
-            ? runtimes.get(integrationRow.plugin_id)
-            : undefined;
+          const runtime = integrationRow ? runtimes.get(integrationRow.plugin_id) : undefined;
           if (integrationRow && runtime?.plugin.removeConnection) {
             yield* runtime.plugin
               .removeConnection({
@@ -2660,11 +2356,7 @@ export const createExecutor = <
               })
               .pipe(
                 Effect.mapError((cause) =>
-                  pluginStorageFailure(
-                    integrationRow.plugin_id,
-                    "removeConnection",
-                    cause,
-                  ),
+                  pluginStorageFailure(integrationRow.plugin_id, "removeConnection", cause),
                 ),
               );
           }
@@ -2713,23 +2405,11 @@ export const createExecutor = <
     // Tools (read surface)
     // ------------------------------------------------------------------
 
-    const matchesToolFilter = (
-      tool: Tool,
-      filter: ToolListFilter | undefined,
-    ): boolean => {
+    const matchesToolFilter = (tool: Tool, filter: ToolListFilter | undefined): boolean => {
       if (!filter) return true;
-      if (
-        filter.integration !== undefined &&
-        tool.integration !== filter.integration
-      )
-        return false;
-      if (filter.owner !== undefined && tool.owner !== filter.owner)
-        return false;
-      if (
-        filter.connection !== undefined &&
-        tool.connection !== filter.connection
-      )
-        return false;
+      if (filter.integration !== undefined && tool.integration !== filter.integration) return false;
+      if (filter.owner !== undefined && tool.owner !== filter.owner) return false;
+      if (filter.connection !== undefined && tool.connection !== filter.connection) return false;
       if (filter.query !== undefined) {
         const q = filter.query.toLowerCase();
         const hay = `${tool.name} ${tool.description}`.toLowerCase();
@@ -2750,25 +2430,18 @@ export const createExecutor = <
       });
       if (revised.length === 0) return;
       const revisedAt = new Map(
-        revised.map(
-          (row) => [row.slug, Number(row.config_revised_at)] as const,
-        ),
+        revised.map((row) => [row.slug, Number(row.config_revised_at)] as const),
       );
       const connections = yield* core.findMany("connection", {
-        where: (b: AnyCb) =>
-          b.or(...revised.map((row) => b("integration", "=", row.slug))),
+        where: (b: AnyCb) => b.or(...revised.map((row) => b("integration", "=", row.slug))),
       });
       for (const connection of connections) {
         const revisedTime = revisedAt.get(connection.integration);
         if (revisedTime === undefined) continue;
         const syncedAt =
-          connection.tools_synced_at == null
-            ? 0
-            : Number(connection.tools_synced_at);
+          connection.tools_synced_at == null ? 0 : Number(connection.tools_synced_at);
         if (syncedAt >= revisedTime) continue;
-        const integrationRow = revised.find(
-          (row) => row.slug === connection.integration,
-        );
+        const integrationRow = revised.find((row) => row.slug === connection.integration);
         if (!integrationRow) continue;
         yield* produceConnectionTools(integrationRow, {
           owner: connection.owner as Owner,
@@ -2809,9 +2482,7 @@ export const createExecutor = <
 
     const makeToolsList =
       (scope?: RequestScope) =>
-      (
-        filter?: ToolListFilter,
-      ): Effect.Effect<readonly Tool[], StorageFailure> =>
+      (filter?: ToolListFilter): Effect.Effect<readonly Tool[], StorageFailure> =>
         Effect.gen(function* () {
           yield* syncStaleConnectionTools;
           const rows = yield* core.findMany("tool", {
@@ -2820,9 +2491,7 @@ export const createExecutor = <
                 filter?.integration === undefined
                   ? true
                   : b("integration", "=", String(filter.integration)),
-                filter?.owner === undefined
-                  ? true
-                  : b("owner", "=", filter.owner),
+                filter?.owner === undefined ? true : b("owner", "=", filter.owner),
                 filter?.connection === undefined
                   ? true
                   : b("connection", "=", String(filter.connection)),
@@ -2837,11 +2506,7 @@ export const createExecutor = <
             if (!matchesToolFilter(tool, filter)) continue;
             if (scope && !toolVisibleUnderScope(tool, scope)) continue;
             if (!includeBlocked) {
-              const effective = resolveToolEffectivePolicy(
-                tool,
-                policyRows,
-                scope,
-              );
+              const effective = resolveToolEffectivePolicy(tool, policyRows, scope);
               if (effective.action === "block") continue;
             }
             tools.push(tool);
@@ -2851,11 +2516,7 @@ export const createExecutor = <
             if (!matchesToolFilter(tool, filter)) continue;
             if (scope && !toolVisibleUnderScope(tool, scope)) continue;
             if (!includeBlocked) {
-              const effective = resolveToolEffectivePolicy(
-                tool,
-                policyRows,
-                scope,
-              );
+              const effective = resolveToolEffectivePolicy(tool, policyRows, scope);
               if (effective.action === "block") continue;
             }
             tools.push(tool);
@@ -2867,9 +2528,7 @@ export const createExecutor = <
 
     const makeToolSchema =
       (scope?: RequestScope) =>
-      (
-        address: ToolAddress,
-      ): Effect.Effect<ToolSchemaView | null, StorageFailure> =>
+      (address: ToolAddress): Effect.Effect<ToolSchemaView | null, StorageFailure> =>
         Effect.gen(function* () {
           const staticEntry = staticTools.get(String(address));
           if (staticEntry) {
@@ -2883,10 +2542,7 @@ export const createExecutor = <
                   defs: new Map(),
                 }),
               catch: (cause) =>
-                storageFailureFromUnknown(
-                  "Failed to build static tool TypeScript preview",
-                  cause,
-                ),
+                storageFailureFromUnknown("Failed to build static tool TypeScript preview", cause),
             }).pipe(Effect.option);
             return ToolSchemaView.make({
               address,
@@ -2895,10 +2551,8 @@ export const createExecutor = <
               inputSchema: tool.inputSchema,
               outputSchema: tool.outputSchema,
               inputTypeScript: Option.getOrUndefined(preview)?.inputTypeScript,
-              outputTypeScript:
-                Option.getOrUndefined(preview)?.outputTypeScript,
-              typeScriptDefinitions:
-                Option.getOrUndefined(preview)?.typeScriptDefinitions,
+              outputTypeScript: Option.getOrUndefined(preview)?.outputTypeScript,
+              typeScriptDefinitions: Option.getOrUndefined(preview)?.typeScriptDefinitions,
             });
           }
 
@@ -2926,8 +2580,7 @@ export const createExecutor = <
               ),
           });
           const defs = new Map<string, unknown>();
-          for (const def of definitionRows)
-            defs.set(def.name, decodeJsonColumn(def.schema));
+          for (const def of definitionRows) defs.set(def.name, decodeJsonColumn(def.schema));
 
           const referenced = collectReferencedDefinitions(
             [tool.inputSchema, tool.outputSchema],
@@ -2941,10 +2594,7 @@ export const createExecutor = <
                 defs,
               }),
             catch: (cause) =>
-              storageFailureFromUnknown(
-                "Failed to build tool TypeScript preview",
-                cause,
-              ),
+              storageFailureFromUnknown("Failed to build tool TypeScript preview", cause),
           }).pipe(Effect.option);
 
           const view = preview;
@@ -2960,8 +2610,7 @@ export const createExecutor = <
                 : undefined,
             inputTypeScript: Option.getOrUndefined(view)?.inputTypeScript,
             outputTypeScript: Option.getOrUndefined(view)?.outputTypeScript,
-            typeScriptDefinitions:
-              Option.getOrUndefined(view)?.typeScriptDefinitions,
+            typeScriptDefinitions: Option.getOrUndefined(view)?.typeScriptDefinitions,
           });
         });
 
@@ -2972,9 +2621,7 @@ export const createExecutor = <
     // ------------------------------------------------------------------
 
     const providersList = (): Effect.Effect<readonly ProviderKey[]> =>
-      Effect.sync(() =>
-        credentialProviderOrder.map((key) => ProviderKey.make(key)),
-      );
+      Effect.sync(() => credentialProviderOrder.map((key) => ProviderKey.make(key)));
 
     const providersItems = (
       key: ProviderKey,
@@ -3000,20 +2647,13 @@ export const createExecutor = <
         ? String(tool.address)
         : `${tool.integration}.${tool.owner}.${tool.connection}.${tool.name}`;
 
-    const policiesList = (): Effect.Effect<
-      readonly ToolPolicy[],
-      StorageFailure
-    > =>
+    const policiesList = (): Effect.Effect<readonly ToolPolicy[], StorageFailure> =>
       core
         .findMany("tool_policy", {})
         .pipe(
           Effect.map((rows) =>
             [...rows]
-              .sort(
-                (a, b) =>
-                  ownerRankForRow(a) - ownerRankForRow(b) ||
-                  comparePolicyRow(a, b),
-              )
+              .sort((a, b) => ownerRankForRow(a) - ownerRankForRow(b) || comparePolicyRow(a, b))
               .map(rowToToolPolicy),
           ),
         );
@@ -3046,8 +2686,7 @@ export const createExecutor = <
           .map((row) => row.position)
           .sort()
           .at(0);
-        const position =
-          input.position ?? generateKeyBetween(null, minPosition ?? null);
+        const position = input.position ?? generateKeyBetween(null, minPosition ?? null);
         const id = PolicyId.make(
           `pol_${Math.random().toString(36).slice(2)}${Date.now().toString(36)}`,
         );
@@ -3076,8 +2715,7 @@ export const createExecutor = <
             cause: undefined,
           });
         }
-        const where = (b: AnyCb) =>
-          b.and(byOwner(input.owner)(b), b("id", "=", input.id));
+        const where = (b: AnyCb) => b.and(byOwner(input.owner)(b), b("id", "=", input.id));
         const existing = yield* core.findFirst("tool_policy", { where });
         if (!existing) {
           return yield* new StorageError({
@@ -3091,17 +2729,12 @@ export const createExecutor = <
         if (input.position !== undefined) set.position = input.position;
         yield* core.updateMany("tool_policy", { where, set });
         const updated = yield* core.findFirst("tool_policy", { where });
-        return rowToToolPolicy(
-          updated ?? ({ ...existing, ...set } as ToolPolicyRow),
-        );
+        return rowToToolPolicy(updated ?? ({ ...existing, ...set } as ToolPolicyRow));
       });
 
-    const policiesRemove = (
-      input: RemoveToolPolicyInput,
-    ): Effect.Effect<void, StorageFailure> =>
+    const policiesRemove = (input: RemoveToolPolicyInput): Effect.Effect<void, StorageFailure> =>
       core.deleteMany("tool_policy", {
-        where: (b: AnyCb) =>
-          b.and(byOwner(input.owner)(b), b("id", "=", input.id)),
+        where: (b: AnyCb) => b.and(byOwner(input.owner)(b), b("id", "=", input.id)),
       });
 
     const policiesResolve = (
@@ -3126,31 +2759,20 @@ export const createExecutor = <
               ),
           });
           if (row) {
-            const annotations = decodeJsonColumn(row.annotations) as
-              | ToolAnnotations
-              | undefined;
+            const annotations = decodeJsonColumn(row.annotations) as ToolAnnotations | undefined;
             requiresApproval = annotations?.requiresApproval;
           }
         }
-        return resolveEffectivePolicy(
-          toolId,
-          policyRows,
-          ownerRankForRow,
-          requiresApproval,
-        );
+        return resolveEffectivePolicy(toolId, policyRows, ownerRankForRow, requiresApproval);
       });
 
     // ------------------------------------------------------------------
     // Elicitation
     // ------------------------------------------------------------------
 
-    const defaultElicitationHandler = resolveElicitationHandler(
-      config.onElicitation,
-    );
+    const defaultElicitationHandler = resolveElicitationHandler(config.onElicitation);
 
-    const pickHandler = (
-      options: InvokeOptions | undefined,
-    ): ElicitationHandler =>
+    const pickHandler = (options: InvokeOptions | undefined): ElicitationHandler =>
       options?.onElicitation
         ? resolveElicitationHandler(options.onElicitation)
         : defaultElicitationHandler;
@@ -3212,17 +2834,15 @@ export const createExecutor = <
 
     const TOOL_SUGGESTION_LIMIT = 5;
 
-    const toolSuggestions = (
-      rows: readonly ToolInvocationRow[],
-    ): readonly ToolAddress[] => rows.map((row) => rowToTool(row).address);
+    const toolSuggestions = (rows: readonly ToolInvocationRow[]): readonly ToolAddress[] =>
+      rows.map((row) => rowToTool(row).address);
 
-    const toolRowsForConnectionWhere =
-      (parsed: ParsedToolAddress) => (b: AnyCb) =>
-        b.and(
-          byOwner(parsed.owner)(b),
-          b("integration", "=", String(parsed.integration)),
-          b("connection", "=", String(parsed.connection)),
-        );
+    const toolRowsForConnectionWhere = (parsed: ParsedToolAddress) => (b: AnyCb) =>
+      b.and(
+        byOwner(parsed.owner)(b),
+        b("integration", "=", String(parsed.integration)),
+        b("connection", "=", String(parsed.connection)),
+      );
 
     const searchToolRowsForConnection = (
       parsed: ParsedToolAddress,
@@ -3262,8 +2882,7 @@ export const createExecutor = <
         return Effect.gen(function* () {
           // oxlint-disable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check -- boundary: normalize arbitrary unknown plugin failures into a human-readable message for ToolInvocationError/telemetry
           const formatInvocationCauseMessage = (cause: unknown): string => {
-            if (cause instanceof Error && cause.message.length > 0)
-              return cause.message;
+            if (cause instanceof Error && cause.message.length > 0) return cause.message;
             // Non-Error / empty-message causes: `String(plainObject)` renders
             // "[object Object]", which is what telemetry then shows as the only
             // label for the failure. Prefer the tag, else stringify structurally.
@@ -3296,27 +2915,15 @@ export const createExecutor = <
           if (staticEntry) {
             const staticTool = staticToolToTool(staticEntry);
             const policyRows = yield* core.findMany("tool_policy", {});
-            const policy = resolveToolEffectivePolicy(
-              staticTool,
-              policyRows,
-              scope,
-            );
+            const policy = resolveToolEffectivePolicy(staticTool, policyRows, scope);
             if (policy.action === "block") {
               return yield* new ToolBlockedError({
                 address,
                 pattern: policy.pattern ?? "*",
               });
             }
-            yield* enforceApproval(
-              staticEntry.tool.annotations,
-              address,
-              args,
-              policy,
-              handler,
-            );
-            const handlerCtx = scope
-              ? scopePluginCtx(staticEntry.ctx, scope)
-              : staticEntry.ctx;
+            yield* enforceApproval(staticEntry.tool.annotations, address, args, policy, handler);
+            const handlerCtx = scope ? scopePluginCtx(staticEntry.ctx, scope) : staticEntry.ctx;
             return yield* wrapInvocationError(
               staticEntry.tool.handler({
                 ctx: handlerCtx,
@@ -3351,10 +2958,7 @@ export const createExecutor = <
                 integration: parsed.integration,
                 name: parsed.connection,
               });
-              if (
-                !connectionRow ||
-                !scope.allowsConnection(rowToConnection(connectionRow))
-              ) {
+              if (!connectionRow || !scope.allowsConnection(rowToConnection(connectionRow))) {
                 return yield* new ToolBlockedError({
                   address,
                   pattern: REQUEST_SCOPE_BLOCK_PATTERN,
@@ -3363,9 +2967,7 @@ export const createExecutor = <
             }
             const searchMatches = yield* searchToolRowsForConnection(parsed);
             const connectionTools =
-              searchMatches.length > 0
-                ? searchMatches
-                : yield* findToolRowsForConnection(parsed);
+              searchMatches.length > 0 ? searchMatches : yield* findToolRowsForConnection(parsed);
             const visibleTools = scope
               ? connectionTools.filter((candidate) =>
                   toolVisibleUnderScope(rowToTool(candidate), scope),
@@ -3386,14 +2988,8 @@ export const createExecutor = <
           // Resolve policy (owner-ranked).
           const toolForPolicy = rowToTool(row);
           const policyRows = yield* core.findMany("tool_policy", {});
-          const annotations = decodeJsonColumn(row.annotations) as
-            | ToolAnnotations
-            | undefined;
-          const policy = resolveToolEffectivePolicy(
-            toolForPolicy,
-            policyRows,
-            scope,
-          );
+          const annotations = decodeJsonColumn(row.annotations) as ToolAnnotations | undefined;
+          const policy = resolveToolEffectivePolicy(toolForPolicy, policyRows, scope);
           if (policy.action === "block") {
             return yield* new ToolBlockedError({
               address,
@@ -3431,10 +3027,7 @@ export const createExecutor = <
 
           // Resolve annotations + enforce approval.
           let resolvedAnnotations = annotations;
-          if (
-            policy.action !== "approve" &&
-            runtime.plugin.resolveAnnotations
-          ) {
+          if (policy.action !== "approve" && runtime.plugin.resolveAnnotations) {
             const map = yield* runtime.plugin
               .resolveAnnotations({
                 ctx: runtime.ctx,
@@ -3445,13 +3038,7 @@ export const createExecutor = <
               .pipe(wrapInvocationError);
             resolvedAnnotations = map[String(parsed.tool)] ?? annotations;
           }
-          yield* enforceApproval(
-            resolvedAnnotations,
-            address,
-            args,
-            policy,
-            handler,
-          );
+          yield* enforceApproval(resolvedAnnotations, address, args, policy, handler);
 
           // Resolve every named credential input (`variable → value`); `value` is
           // the primary `token` for single-input + OAuth callers.
@@ -3464,9 +3051,7 @@ export const createExecutor = <
             template: AuthTemplateSlug.make(connectionRow.template),
             value: values[PRIMARY_INPUT_VARIABLE] ?? null,
             values,
-            config: integrationRow
-              ? decodeJsonColumn(integrationRow.config)
-              : undefined,
+            config: integrationRow ? decodeJsonColumn(integrationRow.config) : undefined,
           };
 
           return yield* wrapInvocationError(
@@ -3508,8 +3093,7 @@ export const createExecutor = <
       subject,
       ownedKeys: (owner: Owner) => ownedKeys(owner),
       defaultWritableProvider,
-      mintOAuthConnection: (input: MintOAuthConnectionInput) =>
-        mintOAuthConnection(input),
+      mintOAuthConnection: (input: MintOAuthConnectionInput) => mintOAuthConnection(input),
       // Resolve the integration's DECLARED oauth scopes for a (integration,
       // template): load the row, run the owning plugin's auth-method projector,
       // and return the matching oauth method's declared `oauth.scopes`. Drives
@@ -3517,20 +3101,15 @@ export const createExecutor = <
       // client on a broad integration still requests the integration's full
       // scope set. Empty (no row / no oauth method / no declared scopes) ⇒ the
       // union collapses to the client's scopes (current behavior).
-      resolveDeclaredOAuthScopes: (
-        integration: IntegrationSlug,
-        template: AuthTemplateSlug,
-      ) =>
+      resolveDeclaredOAuthScopes: (integration: IntegrationSlug, template: AuthTemplateSlug) =>
         findIntegrationRow(integration).pipe(
           Effect.map((row): readonly string[] => {
             if (!row) return [];
             const methods = describeAuthMethodsForRow(row);
             const match =
               methods.find(
-                (m: AuthMethodDescriptor) =>
-                  m.kind === "oauth" && m.template === String(template),
-              ) ??
-              methods.find((m: AuthMethodDescriptor) => m.kind === "oauth");
+                (m: AuthMethodDescriptor) => m.kind === "oauth" && m.template === String(template),
+              ) ?? methods.find((m: AuthMethodDescriptor) => m.kind === "oauth");
             return match?.oauth?.scopes ?? [];
           }),
         ),
@@ -3580,8 +3159,7 @@ export const createExecutor = <
         httpClientLayer: config.httpClientLayer ?? FetchHttpClient.layer,
         core: {
           integrations: {
-            register: (input: RegisterIntegrationInput) =>
-              integrationsRegister(plugin.id, input),
+            register: (input: RegisterIntegrationInput) => integrationsRegister(plugin.id, input),
             update: (slug, patch) => integrationsUpdate(slug, patch),
             list: () => integrationsList(),
             get: (slug) => integrationsGetRecord(slug),
@@ -3696,9 +3274,7 @@ export const createExecutor = <
             yield* runtime.plugin
               .close()
               .pipe(
-                Effect.mapError((cause) =>
-                  pluginStorageFailure(runtime.plugin.id, "close", cause),
-                ),
+                Effect.mapError((cause) => pluginStorageFailure(runtime.plugin.id, "close", cause)),
               );
           }
         }
@@ -3755,14 +3331,11 @@ export const createExecutor = <
       close,
     };
 
-    const toExecutor = (value: unknown): Executor<TPlugins> =>
-      value as Executor<TPlugins>;
+    const toExecutor = (value: unknown): Executor<TPlugins> => value as Executor<TPlugins>;
 
     const REQUEST_SCOPE_BLOCK_PATTERN = "request-scope";
 
-    const scopeBlocked = (
-      surface: string,
-    ): Effect.Effect<never, ToolBlockedError> =>
+    const scopeBlocked = (surface: string): Effect.Effect<never, ToolBlockedError> =>
       Effect.fail(
         new ToolBlockedError({
           address: ToolAddress.make(surface),
@@ -3776,36 +3349,25 @@ export const createExecutor = <
         integrations: {
           list: () =>
             integrationsList().pipe(
-              Effect.map((items) =>
-                items.filter((i) => scope.allowsIntegration(i)),
-              ),
+              Effect.map((items) => items.filter((i) => scope.allowsIntegration(i))),
             ),
           get: (slug: IntegrationSlug) =>
             integrationsGet(slug).pipe(
-              Effect.map((item) =>
-                item && scope.allowsIntegration(item) ? item : null,
-              ),
+              Effect.map((item) => (item && scope.allowsIntegration(item) ? item : null)),
             ),
           update: () => scopeBlocked("executor.integrations.update"),
           remove: () => scopeBlocked("executor.integrations.remove"),
           detect: () => scopeBlocked("executor.integrations.detect"),
         },
         connections: {
-          list: (filter?: {
-            readonly integration?: IntegrationSlug;
-            readonly owner?: Owner;
-          }) =>
+          list: (filter?: { readonly integration?: IntegrationSlug; readonly owner?: Owner }) =>
             connectionsList(filter).pipe(
-              Effect.map((items) =>
-                items.filter((c) => scope.allowsConnection(c)),
-              ),
+              Effect.map((items) => items.filter((c) => scope.allowsConnection(c))),
             ),
           get: (ref: ConnectionRef) =>
             connectionsGet(ref).pipe(
               Effect.map((connection) =>
-                connection && scope.allowsConnection(connection)
-                  ? connection
-                  : null,
+                connection && scope.allowsConnection(connection) ? connection : null,
               ),
             ),
           create: () => scopeBlocked("executor.connections.create"),
@@ -3815,8 +3377,7 @@ export const createExecutor = <
         },
         oauth: {
           createClient: () => scopeBlocked("executor.oauth.createClient"),
-          registerDynamicClient: () =>
-            scopeBlocked("executor.oauth.registerDynamicClient"),
+          registerDynamicClient: () => scopeBlocked("executor.oauth.registerDynamicClient"),
           listClients: () => scopeBlocked("executor.oauth.listClients"),
           removeClient: () => scopeBlocked("executor.oauth.removeClient"),
           start: () => scopeBlocked("executor.oauth.start"),

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -113,6 +113,13 @@ import {
   type ToolPolicy,
   type UpdateToolPolicyInput,
 } from "./policies";
+import {
+  EMPTY_REQUEST_SCOPE,
+  resolveScopedEffectivePolicy,
+  scopePluginCtx,
+  toolVisibleUnderScope,
+  type RequestScope,
+} from "./request-scope";
 import type { CredentialProvider, ProviderEntry } from "./provider";
 import type {
   AnyPlugin,
@@ -269,17 +276,9 @@ interface OwnedKeys {
 // core-table query unioned with the in-memory static pool.
 // ---------------------------------------------------------------------------
 
-// ExecutorWrapper — a plugin-contributed executor middleware. Given the
-// assembled executor and the per-request selector string (e.g. an MCP
-// `?toolkit=` value), it returns a possibly-narrowed executor. A plugin
-// contributes one by exposing a `wrapExecutor` method on its extension; the
-// assembler collects them and the execution stack runs each before the engine
-// is built. Core knows nothing about what a wrapper narrows to — that domain
-// (toolkits, etc.) lives entirely in the contributing plugin.
-export type ExecutorWrapper = <TPlugins extends readonly AnyPlugin[]>(
-  base: Executor<TPlugins>,
+export type RequestScopeProvider = (
   selector: string,
-) => Effect.Effect<Executor<TPlugins>, StorageFailure>;
+) => Effect.Effect<RequestScope | null, StorageFailure>;
 
 export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   readonly integrations: {
@@ -379,6 +378,11 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   ) => Effect.Effect<unknown, ExecuteError>;
 
   readonly close: () => Effect.Effect<void, StorageFailure>;
+
+  /** Apply a per-request catalog/policy overlay resolved from `selector`. */
+  readonly applyRequestScope: (
+    selector: string,
+  ) => Effect.Effect<Executor<TPlugins>, StorageFailure>;
 } & PluginExtensions<TPlugins>;
 
 export interface ExecutorDb {
@@ -1557,10 +1561,7 @@ export const createExecutor = <
     };
 
     const extensions: Record<string, object> = {};
-    // Generic executor-wrapper hook: a plugin may expose `wrapExecutor` on its
-    // extension to narrow the executor per request (the toolkits plugin does).
-    // Collected here, run by the execution stack — core stays domain-agnostic.
-    const executorWrappers: ExecutorWrapper[] = [];
+    const requestScopeProviders: RequestScopeProvider[] = [];
 
     // ------------------------------------------------------------------
     // Owner condition builders. The owner policy already restricts reads to
@@ -2785,157 +2786,186 @@ export const createExecutor = <
       }
     });
 
-    const toolsList = (
-      filter?: ToolListFilter,
-    ): Effect.Effect<readonly Tool[], StorageFailure> =>
-      Effect.gen(function* () {
-        yield* syncStaleConnectionTools;
-        // Projected: the list surface is metadata (address, description,
-        // annotations) — loading every tool's input/output schema JSON made
-        // an unbounded list scale with schema bytes, not tool count.
-        const rows = yield* core.findMany("tool", {
-          where: (b: AnyCb) =>
-            b.and(
-              filter?.integration === undefined
-                ? true
-                : b("integration", "=", String(filter.integration)),
-              filter?.owner === undefined
-                ? true
-                : b("owner", "=", filter.owner),
-              filter?.connection === undefined
-                ? true
-                : b("connection", "=", String(filter.connection)),
-            ),
-          select: TOOL_INVOCATION_COLUMNS,
-        });
-        const includeBlocked = filter?.includeBlocked ?? false;
-        const policyRows = yield* core.findMany("tool_policy", {});
-        const tools: Tool[] = [];
-        for (const row of rows) {
-          const tool = rowToTool(row);
-          if (!matchesToolFilter(tool, filter)) continue;
-          if (!includeBlocked) {
-            const effective = resolveEffectivePolicy(
-              normalizedPolicyId(tool),
-              policyRows,
-              ownerRankForRow,
-              tool.annotations?.requiresApproval,
-            );
-            if (effective.action === "block") continue;
-          }
-          tools.push(tool);
-        }
-        for (const entry of staticTools.values()) {
-          const tool = staticToolToTool(entry);
-          if (!matchesToolFilter(tool, filter)) continue;
-          if (!includeBlocked) {
-            const effective = resolveEffectivePolicy(
-              normalizedPolicyId(tool),
-              policyRows,
-              ownerRankForRow,
-              tool.annotations?.requiresApproval,
-            );
-            if (effective.action === "block") continue;
-          }
-          tools.push(tool);
-        }
-        return tools;
-      });
+    const resolveToolEffectivePolicy = (
+      tool: Tool,
+      policyRows: readonly ToolPolicyRow[],
+      scope?: RequestScope,
+    ): EffectivePolicy =>
+      scope
+        ? resolveScopedEffectivePolicy(
+            normalizedPolicyId(tool),
+            tool,
+            scope,
+            policyRows,
+            ownerRankForRow,
+            tool.annotations?.requiresApproval,
+          )
+        : resolveEffectivePolicy(
+            normalizedPolicyId(tool),
+            policyRows,
+            ownerRankForRow,
+            tool.annotations?.requiresApproval,
+          );
 
-    const toolSchema = (
-      address: ToolAddress,
-    ): Effect.Effect<ToolSchemaView | null, StorageFailure> =>
-      Effect.gen(function* () {
-        const staticEntry = staticTools.get(String(address));
-        if (staticEntry) {
-          const tool = staticToolToTool(staticEntry);
+    const makeToolsList =
+      (scope?: RequestScope) =>
+      (
+        filter?: ToolListFilter,
+      ): Effect.Effect<readonly Tool[], StorageFailure> =>
+        Effect.gen(function* () {
+          yield* syncStaleConnectionTools;
+          const rows = yield* core.findMany("tool", {
+            where: (b: AnyCb) =>
+              b.and(
+                filter?.integration === undefined
+                  ? true
+                  : b("integration", "=", String(filter.integration)),
+                filter?.owner === undefined
+                  ? true
+                  : b("owner", "=", filter.owner),
+                filter?.connection === undefined
+                  ? true
+                  : b("connection", "=", String(filter.connection)),
+              ),
+            select: TOOL_INVOCATION_COLUMNS,
+          });
+          const includeBlocked = filter?.includeBlocked ?? false;
+          const policyRows = yield* core.findMany("tool_policy", {});
+          const tools: Tool[] = [];
+          for (const row of rows) {
+            const tool = rowToTool(row);
+            if (!matchesToolFilter(tool, filter)) continue;
+            if (scope && !toolVisibleUnderScope(tool, scope)) continue;
+            if (!includeBlocked) {
+              const effective = resolveToolEffectivePolicy(
+                tool,
+                policyRows,
+                scope,
+              );
+              if (effective.action === "block") continue;
+            }
+            tools.push(tool);
+          }
+          for (const entry of staticTools.values()) {
+            const tool = staticToolToTool(entry);
+            if (!matchesToolFilter(tool, filter)) continue;
+            if (scope && !toolVisibleUnderScope(tool, scope)) continue;
+            if (!includeBlocked) {
+              const effective = resolveToolEffectivePolicy(
+                tool,
+                policyRows,
+                scope,
+              );
+              if (effective.action === "block") continue;
+            }
+            tools.push(tool);
+          }
+          return tools;
+        });
+
+    const toolsList = makeToolsList();
+
+    const makeToolSchema =
+      (scope?: RequestScope) =>
+      (
+        address: ToolAddress,
+      ): Effect.Effect<ToolSchemaView | null, StorageFailure> =>
+        Effect.gen(function* () {
+          const staticEntry = staticTools.get(String(address));
+          if (staticEntry) {
+            const tool = staticToolToTool(staticEntry);
+            if (scope && !toolVisibleUnderScope(tool, scope)) return null;
+            const preview = yield* Effect.tryPromise({
+              try: () =>
+                buildToolTypeScriptPreview({
+                  inputSchema: tool.inputSchema,
+                  outputSchema: tool.outputSchema,
+                  defs: new Map(),
+                }),
+              catch: (cause) =>
+                storageFailureFromUnknown(
+                  "Failed to build static tool TypeScript preview",
+                  cause,
+                ),
+            }).pipe(Effect.option);
+            return ToolSchemaView.make({
+              address,
+              name: tool.name,
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+              outputSchema: tool.outputSchema,
+              inputTypeScript: Option.getOrUndefined(preview)?.inputTypeScript,
+              outputTypeScript:
+                Option.getOrUndefined(preview)?.outputTypeScript,
+              typeScriptDefinitions:
+                Option.getOrUndefined(preview)?.typeScriptDefinitions,
+            });
+          }
+
+          const parsed = parseToolAddress(String(address));
+          if (!parsed) return null;
+          const row = yield* core.findFirst("tool", {
+            where: (b: AnyCb) =>
+              b.and(
+                byOwner(parsed.owner)(b),
+                b("integration", "=", String(parsed.integration)),
+                b("connection", "=", String(parsed.connection)),
+                b("name", "=", String(parsed.tool)),
+              ),
+          });
+          if (!row) return null;
+          const tool = rowToTool(row);
+          if (scope && !toolVisibleUnderScope(tool, scope)) return null;
+
+          const definitionRows = yield* core.findMany("definition", {
+            where: (b: AnyCb) =>
+              b.and(
+                byOwner(parsed.owner)(b),
+                b("integration", "=", String(parsed.integration)),
+                b("connection", "=", String(parsed.connection)),
+              ),
+          });
+          const defs = new Map<string, unknown>();
+          for (const def of definitionRows)
+            defs.set(def.name, decodeJsonColumn(def.schema));
+
+          const referenced = collectReferencedDefinitions(
+            [tool.inputSchema, tool.outputSchema],
+            defs,
+          );
           const preview = yield* Effect.tryPromise({
             try: () =>
               buildToolTypeScriptPreview({
                 inputSchema: tool.inputSchema,
                 outputSchema: tool.outputSchema,
-                defs: new Map(),
+                defs,
               }),
             catch: (cause) =>
               storageFailureFromUnknown(
-                "Failed to build static tool TypeScript preview",
+                "Failed to build tool TypeScript preview",
                 cause,
               ),
           }).pipe(Effect.option);
+
+          const view = preview;
           return ToolSchemaView.make({
             address,
             name: tool.name,
             description: tool.description,
             inputSchema: tool.inputSchema,
             outputSchema: tool.outputSchema,
-            inputTypeScript: Option.getOrUndefined(preview)?.inputTypeScript,
-            outputTypeScript: Option.getOrUndefined(preview)?.outputTypeScript,
+            schemaDefinitions:
+              Object.keys(referenced).length > 0
+                ? (referenced as Record<string, unknown>)
+                : undefined,
+            inputTypeScript: Option.getOrUndefined(view)?.inputTypeScript,
+            outputTypeScript: Option.getOrUndefined(view)?.outputTypeScript,
             typeScriptDefinitions:
-              Option.getOrUndefined(preview)?.typeScriptDefinitions,
+              Option.getOrUndefined(view)?.typeScriptDefinitions,
           });
-        }
-
-        const parsed = parseToolAddress(String(address));
-        if (!parsed) return null;
-        const row = yield* core.findFirst("tool", {
-          where: (b: AnyCb) =>
-            b.and(
-              byOwner(parsed.owner)(b),
-              b("integration", "=", String(parsed.integration)),
-              b("connection", "=", String(parsed.connection)),
-              b("name", "=", String(parsed.tool)),
-            ),
         });
-        if (!row) return null;
-        const tool = rowToTool(row);
 
-        const definitionRows = yield* core.findMany("definition", {
-          where: (b: AnyCb) =>
-            b.and(
-              byOwner(parsed.owner)(b),
-              b("integration", "=", String(parsed.integration)),
-              b("connection", "=", String(parsed.connection)),
-            ),
-        });
-        const defs = new Map<string, unknown>();
-        for (const def of definitionRows)
-          defs.set(def.name, decodeJsonColumn(def.schema));
-
-        const referenced = collectReferencedDefinitions(
-          [tool.inputSchema, tool.outputSchema],
-          defs,
-        );
-        const preview = yield* Effect.tryPromise({
-          try: () =>
-            buildToolTypeScriptPreview({
-              inputSchema: tool.inputSchema,
-              outputSchema: tool.outputSchema,
-              defs,
-            }),
-          catch: (cause) =>
-            storageFailureFromUnknown(
-              "Failed to build tool TypeScript preview",
-              cause,
-            ),
-        }).pipe(Effect.option);
-
-        const view = preview;
-        return ToolSchemaView.make({
-          address,
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-          outputSchema: tool.outputSchema,
-          schemaDefinitions:
-            Object.keys(referenced).length > 0
-              ? (referenced as Record<string, unknown>)
-              : undefined,
-          inputTypeScript: Option.getOrUndefined(view)?.inputTypeScript,
-          outputTypeScript: Option.getOrUndefined(view)?.outputTypeScript,
-          typeScriptDefinitions:
-            Option.getOrUndefined(view)?.typeScriptDefinitions,
-        });
-      });
+    const toolSchema = makeToolSchema();
 
     // ------------------------------------------------------------------
     // Providers
@@ -3221,53 +3251,148 @@ export const createExecutor = <
         select: TOOL_INVOCATION_COLUMNS,
       });
 
-    const execute = (
-      address: ToolAddress,
-      args: unknown,
-      options?: InvokeOptions,
-    ): Effect.Effect<unknown, ExecuteError> => {
-      const handler = pickHandler(options);
-      return Effect.gen(function* () {
-        // oxlint-disable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check -- boundary: normalize arbitrary unknown plugin failures into a human-readable message for ToolInvocationError/telemetry
-        const formatInvocationCauseMessage = (cause: unknown): string => {
-          if (cause instanceof Error && cause.message.length > 0)
-            return cause.message;
-          // Non-Error / empty-message causes: `String(plainObject)` renders
-          // "[object Object]", which is what telemetry then shows as the only
-          // label for the failure. Prefer the tag, else stringify structurally.
-          if (typeof cause === "object" && cause !== null) {
-            const tag = (cause as { readonly _tag?: unknown })._tag;
-            if (typeof tag === "string") return tag;
-            return Inspectable.toStringUnknown(cause, 0);
-          }
-          return String(cause);
-        };
-        // oxlint-enable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check
-        const wrapInvocationError = <A, E>(
-          effect: Effect.Effect<A, E>,
-        ): Effect.Effect<A, ToolInvocationError> =>
-          effect.pipe(
-            Effect.mapError(
-              (cause) =>
-                new ToolInvocationError({
-                  address,
-                  message: formatInvocationCauseMessage(cause),
-                  cause,
-                }),
-            ),
-          );
+    const makeExecute =
+      (scope?: RequestScope) =>
+      (
+        address: ToolAddress,
+        args: unknown,
+        options?: InvokeOptions,
+      ): Effect.Effect<unknown, ExecuteError> => {
+        const handler = pickHandler(options);
+        return Effect.gen(function* () {
+          // oxlint-disable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check -- boundary: normalize arbitrary unknown plugin failures into a human-readable message for ToolInvocationError/telemetry
+          const formatInvocationCauseMessage = (cause: unknown): string => {
+            if (cause instanceof Error && cause.message.length > 0)
+              return cause.message;
+            // Non-Error / empty-message causes: `String(plainObject)` renders
+            // "[object Object]", which is what telemetry then shows as the only
+            // label for the failure. Prefer the tag, else stringify structurally.
+            if (typeof cause === "object" && cause !== null) {
+              const tag = (cause as { readonly _tag?: unknown })._tag;
+              if (typeof tag === "string") return tag;
+              return Inspectable.toStringUnknown(cause, 0);
+            }
+            return String(cause);
+          };
+          // oxlint-enable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check
+          const wrapInvocationError = <A, E>(
+            effect: Effect.Effect<A, E>,
+          ): Effect.Effect<A, ToolInvocationError> =>
+            effect.pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ToolInvocationError({
+                    address,
+                    message: formatInvocationCauseMessage(cause),
+                    cause,
+                  }),
+              ),
+            );
 
-        // Static path — O(1) map lookup for plugin-contributed static tools
-        // (core-tools, plugin executor namespaces). Addressed by their fqid,
-        // not the 5-segment dynamic form.
-        const staticEntry = staticTools.get(String(address));
-        if (staticEntry) {
+          // Static path — O(1) map lookup for plugin-contributed static tools
+          // (core-tools, plugin executor namespaces). Addressed by their fqid,
+          // not the 5-segment dynamic form.
+          const staticEntry = staticTools.get(String(address));
+          if (staticEntry) {
+            const staticTool = staticToolToTool(staticEntry);
+            const policyRows = yield* core.findMany("tool_policy", {});
+            const policy = resolveToolEffectivePolicy(
+              staticTool,
+              policyRows,
+              scope,
+            );
+            if (policy.action === "block") {
+              return yield* new ToolBlockedError({
+                address,
+                pattern: policy.pattern ?? "*",
+              });
+            }
+            yield* enforceApproval(
+              staticEntry.tool.annotations,
+              address,
+              args,
+              policy,
+              handler,
+            );
+            const handlerCtx = scope
+              ? scopePluginCtx(staticEntry.ctx, scope)
+              : staticEntry.ctx;
+            return yield* wrapInvocationError(
+              staticEntry.tool.handler({
+                ctx: handlerCtx,
+                args,
+                elicit: buildElicit(address, args, handler),
+              }),
+            );
+          }
+
+          const parsed = parseToolAddress(String(address));
+          if (!parsed) {
+            return yield* new ToolNotFoundError({ address });
+          }
+
+          // Find the tool row — projected: invoke needs routing/policy fields
+          // only, never the multi-KB input/output schema JSON (`tools.schema`
+          // is the schema-bearing surface).
+          const row = yield* core.findFirst("tool", {
+            where: (b: AnyCb) =>
+              b.and(
+                byOwner(parsed.owner)(b),
+                b("integration", "=", String(parsed.integration)),
+                b("connection", "=", String(parsed.connection)),
+                b("name", "=", String(parsed.tool)),
+              ),
+            select: TOOL_INVOCATION_COLUMNS,
+          });
+          if (!row) {
+            if (scope) {
+              const connectionRow = yield* findConnectionRow({
+                owner: parsed.owner,
+                integration: parsed.integration,
+                name: parsed.connection,
+              });
+              if (
+                !connectionRow ||
+                !scope.allowsConnection(rowToConnection(connectionRow))
+              ) {
+                return yield* new ToolBlockedError({
+                  address,
+                  pattern: REQUEST_SCOPE_BLOCK_PATTERN,
+                });
+              }
+            }
+            const searchMatches = yield* searchToolRowsForConnection(parsed);
+            const connectionTools =
+              searchMatches.length > 0
+                ? searchMatches
+                : yield* findToolRowsForConnection(parsed);
+            const visibleTools = scope
+              ? connectionTools.filter((candidate) =>
+                  toolVisibleUnderScope(rowToTool(candidate), scope),
+                )
+              : connectionTools;
+            if (scope && visibleTools.length === 0) {
+              return yield* new ToolBlockedError({
+                address,
+                pattern: REQUEST_SCOPE_BLOCK_PATTERN,
+              });
+            }
+            return yield* new ToolNotFoundError({
+              address,
+              suggestions: toolSuggestions(visibleTools),
+            });
+          }
+
+          // Resolve policy (owner-ranked).
+          const toolForPolicy = rowToTool(row);
           const policyRows = yield* core.findMany("tool_policy", {});
-          const policy = resolveEffectivePolicy(
-            String(address),
+          const annotations = decodeJsonColumn(row.annotations) as
+            | ToolAnnotations
+            | undefined;
+          const policy = resolveToolEffectivePolicy(
+            toolForPolicy,
             policyRows,
-            ownerRankForRow,
-            staticEntry.tool.annotations?.requiresApproval,
+            scope,
           );
           if (policy.action === "block") {
             return yield* new ToolBlockedError({
@@ -3275,161 +3400,102 @@ export const createExecutor = <
               pattern: policy.pattern ?? "*",
             });
           }
+
+          const runtime = runtimes.get(row.plugin_id);
+          if (!runtime) {
+            return yield* new PluginNotLoadedError({
+              address,
+              pluginId: row.plugin_id,
+            });
+          }
+          if (!runtime.plugin.invokeTool) {
+            return yield* new NoHandlerError({
+              address,
+              pluginId: row.plugin_id,
+            });
+          }
+
+          // Find the connection row.
+          const connectionRow = yield* findConnectionRow({
+            owner: parsed.owner,
+            integration: parsed.integration,
+            name: parsed.connection,
+          });
+          if (!connectionRow) {
+            return yield* new ConnectionNotFoundError({
+              owner: parsed.owner,
+              integration: parsed.integration,
+              name: parsed.connection,
+            });
+          }
+
+          // Resolve annotations + enforce approval.
+          let resolvedAnnotations = annotations;
+          if (
+            policy.action !== "approve" &&
+            runtime.plugin.resolveAnnotations
+          ) {
+            const map = yield* runtime.plugin
+              .resolveAnnotations({
+                ctx: runtime.ctx,
+                integration: parsed.integration,
+                connection: parsed.connection,
+                toolRows: [row],
+              })
+              .pipe(wrapInvocationError);
+            resolvedAnnotations = map[String(parsed.tool)] ?? annotations;
+          }
           yield* enforceApproval(
-            staticEntry.tool.annotations,
+            resolvedAnnotations,
             address,
             args,
             policy,
             handler,
           );
+
+          // Resolve every named credential input (`variable → value`); `value` is
+          // the primary `token` for single-input + OAuth callers.
+          const values = yield* resolveConnectionValues(connectionRow);
+          const integrationRow = yield* findIntegrationRow(parsed.integration);
+          const credential: ToolInvocationCredential = {
+            owner: parsed.owner,
+            integration: parsed.integration,
+            connection: parsed.connection,
+            template: AuthTemplateSlug.make(connectionRow.template),
+            value: values[PRIMARY_INPUT_VARIABLE] ?? null,
+            values,
+            config: integrationRow
+              ? decodeJsonColumn(integrationRow.config)
+              : undefined,
+          };
+
           return yield* wrapInvocationError(
-            staticEntry.tool.handler({
-              ctx: staticEntry.ctx,
+            runtime.plugin.invokeTool({
+              ctx: runtime.ctx,
+              toolRow: row,
+              credential,
               args,
               elicit: buildElicit(address, args, handler),
             }),
           );
-        }
-
-        const parsed = parseToolAddress(String(address));
-        if (!parsed) {
-          return yield* new ToolNotFoundError({ address });
-        }
-
-        // Find the tool row — projected: invoke needs routing/policy fields
-        // only, never the multi-KB input/output schema JSON (`tools.schema`
-        // is the schema-bearing surface).
-        const row = yield* core.findFirst("tool", {
-          where: (b: AnyCb) =>
-            b.and(
-              byOwner(parsed.owner)(b),
-              b("integration", "=", String(parsed.integration)),
-              b("connection", "=", String(parsed.connection)),
-              b("name", "=", String(parsed.tool)),
-            ),
-          select: TOOL_INVOCATION_COLUMNS,
-        });
-        if (!row) {
-          const searchMatches = yield* searchToolRowsForConnection(parsed);
-          const connectionTools =
-            searchMatches.length > 0
-              ? searchMatches
-              : yield* findToolRowsForConnection(parsed);
-          return yield* new ToolNotFoundError({
-            address,
-            suggestions: toolSuggestions(connectionTools),
-          });
-        }
-
-        // Resolve policy (owner-ranked).
-        const toolForPolicy = rowToTool(row);
-        const policyRows = yield* core.findMany("tool_policy", {});
-        const annotations = decodeJsonColumn(row.annotations) as
-          | ToolAnnotations
-          | undefined;
-        const policy = resolveEffectivePolicy(
-          normalizedPolicyId(toolForPolicy),
-          policyRows,
-          ownerRankForRow,
-          annotations?.requiresApproval,
-        );
-        if (policy.action === "block") {
-          return yield* new ToolBlockedError({
-            address,
-            pattern: policy.pattern ?? "*",
-          });
-        }
-
-        const runtime = runtimes.get(row.plugin_id);
-        if (!runtime) {
-          return yield* new PluginNotLoadedError({
-            address,
-            pluginId: row.plugin_id,
-          });
-        }
-        if (!runtime.plugin.invokeTool) {
-          return yield* new NoHandlerError({
-            address,
-            pluginId: row.plugin_id,
-          });
-        }
-
-        // Find the connection row.
-        const connectionRow = yield* findConnectionRow({
-          owner: parsed.owner,
-          integration: parsed.integration,
-          name: parsed.connection,
-        });
-        if (!connectionRow) {
-          return yield* new ConnectionNotFoundError({
-            owner: parsed.owner,
-            integration: parsed.integration,
-            name: parsed.connection,
-          });
-        }
-
-        // Resolve annotations + enforce approval.
-        let resolvedAnnotations = annotations;
-        if (policy.action !== "approve" && runtime.plugin.resolveAnnotations) {
-          const map = yield* runtime.plugin
-            .resolveAnnotations({
-              ctx: runtime.ctx,
-              integration: parsed.integration,
-              connection: parsed.connection,
-              toolRows: [row],
-            })
-            .pipe(wrapInvocationError);
-          resolvedAnnotations = map[String(parsed.tool)] ?? annotations;
-        }
-        yield* enforceApproval(
-          resolvedAnnotations,
-          address,
-          args,
-          policy,
-          handler,
-        );
-
-        // Resolve every named credential input (`variable → value`); `value` is
-        // the primary `token` for single-input + OAuth callers.
-        const values = yield* resolveConnectionValues(connectionRow);
-        const integrationRow = yield* findIntegrationRow(parsed.integration);
-        const credential: ToolInvocationCredential = {
-          owner: parsed.owner,
-          integration: parsed.integration,
-          connection: parsed.connection,
-          template: AuthTemplateSlug.make(connectionRow.template),
-          value: values[PRIMARY_INPUT_VARIABLE] ?? null,
-          values,
-          config: integrationRow
-            ? decodeJsonColumn(integrationRow.config)
-            : undefined,
-        };
-
-        return yield* wrapInvocationError(
-          runtime.plugin.invokeTool({
-            ctx: runtime.ctx,
-            toolRow: row,
-            credential,
-            args,
-            elicit: buildElicit(address, args, handler),
+        }).pipe(
+          // Expected tool failures (`ToolResult.fail`) resolve through the
+          // success channel, so the tracer alone would record them as healthy
+          // spans. Stamp the outcome + error code so telemetry can distinguish
+          // "tool ran fine" from "user hit an upstream error / auth wall"
+          // without parsing response bodies.
+          Effect.tap(annotateToolResultOutcome),
+          Effect.withSpan("executor.tool.execute", {
+            attributes: {
+              "mcp.tool.name": String(address),
+              "executor.tenant": tenant,
+              ...(subject != null ? { "executor.subject": subject } : {}),
+            },
           }),
         );
-      }).pipe(
-        // Expected tool failures (`ToolResult.fail`) resolve through the
-        // success channel, so the tracer alone would record them as healthy
-        // spans. Stamp the outcome + error code so telemetry can distinguish
-        // "tool ran fine" from "user hit an upstream error / auth wall"
-        // without parsing response bodies.
-        Effect.tap(annotateToolResultOutcome),
-        Effect.withSpan("executor.tool.execute", {
-          attributes: {
-            "mcp.tool.name": String(address),
-            "executor.tenant": tenant,
-            ...(subject != null ? { "executor.subject": subject } : {}),
-          },
-        }),
-      );
-    };
+      };
+
+    const execute = makeExecute();
 
     // ------------------------------------------------------------------
     // OAuth service seam.
@@ -3570,12 +3636,10 @@ export const createExecutor = <
       if (plugin.extension) {
         extensions[plugin.id] = extension;
       }
-      // A plugin that narrows the executor exposes `wrapExecutor` on its
-      // extension; collect it into the generic hook the execution stack runs.
-      const wrapExecutor = (extension as { wrapExecutor?: ExecutorWrapper })
-        .wrapExecutor;
-      if (typeof wrapExecutor === "function")
-        executorWrappers.push(wrapExecutor);
+      if (plugin.resolveRequestScope) {
+        const resolveScope = plugin.resolveRequestScope;
+        requestScopeProviders.push((selector) => resolveScope(ctx, selector));
+      }
 
       const decls = plugin.staticSources ? plugin.staticSources(extension) : [];
       for (const source of decls) {
@@ -3693,7 +3757,109 @@ export const createExecutor = <
 
     const toExecutor = (value: unknown): Executor<TPlugins> =>
       value as Executor<TPlugins>;
-    return toExecutor(Object.assign(base, extensions, { executorWrappers }));
+
+    const REQUEST_SCOPE_BLOCK_PATTERN = "request-scope";
+
+    const scopeBlocked = (
+      surface: string,
+    ): Effect.Effect<never, ToolBlockedError> =>
+      Effect.fail(
+        new ToolBlockedError({
+          address: ToolAddress.make(surface),
+          pattern: REQUEST_SCOPE_BLOCK_PATTERN,
+        }),
+      );
+
+    const buildScopedExecutor = (scope: RequestScope): Executor<TPlugins> =>
+      toExecutor({
+        ...extensions,
+        integrations: {
+          list: () =>
+            integrationsList().pipe(
+              Effect.map((items) =>
+                items.filter((i) => scope.allowsIntegration(i)),
+              ),
+            ),
+          get: (slug: IntegrationSlug) =>
+            integrationsGet(slug).pipe(
+              Effect.map((item) =>
+                item && scope.allowsIntegration(item) ? item : null,
+              ),
+            ),
+          update: () => scopeBlocked("executor.integrations.update"),
+          remove: () => scopeBlocked("executor.integrations.remove"),
+          detect: () => scopeBlocked("executor.integrations.detect"),
+        },
+        connections: {
+          list: (filter?: {
+            readonly integration?: IntegrationSlug;
+            readonly owner?: Owner;
+          }) =>
+            connectionsList(filter).pipe(
+              Effect.map((items) =>
+                items.filter((c) => scope.allowsConnection(c)),
+              ),
+            ),
+          get: (ref: ConnectionRef) =>
+            connectionsGet(ref).pipe(
+              Effect.map((connection) =>
+                connection && scope.allowsConnection(connection)
+                  ? connection
+                  : null,
+              ),
+            ),
+          create: () => scopeBlocked("executor.connections.create"),
+          update: () => scopeBlocked("executor.connections.update"),
+          remove: () => scopeBlocked("executor.connections.remove"),
+          refresh: () => scopeBlocked("executor.connections.refresh"),
+        },
+        oauth: {
+          createClient: () => scopeBlocked("executor.oauth.createClient"),
+          registerDynamicClient: () =>
+            scopeBlocked("executor.oauth.registerDynamicClient"),
+          listClients: () => scopeBlocked("executor.oauth.listClients"),
+          removeClient: () => scopeBlocked("executor.oauth.removeClient"),
+          start: () => scopeBlocked("executor.oauth.start"),
+          complete: () => scopeBlocked("executor.oauth.complete"),
+          cancel: () => scopeBlocked("executor.oauth.cancel"),
+          probe: () => scopeBlocked("executor.oauth.probe"),
+        },
+        tools: {
+          list: makeToolsList(scope),
+          schema: makeToolSchema(scope),
+        },
+        providers: {
+          list: () => scopeBlocked("executor.providers.list"),
+          items: () => scopeBlocked("executor.providers.items"),
+        },
+        policies: {
+          list: policiesList,
+          create: () => scopeBlocked("executor.policies.create"),
+          update: () => scopeBlocked("executor.policies.update"),
+          remove: () => scopeBlocked("executor.policies.remove"),
+          resolve: policiesResolve,
+        },
+        execute: makeExecute(scope),
+        close,
+        applyRequestScope: applyRequestScope,
+      });
+
+    const applyRequestScope = (
+      selector: string,
+    ): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
+      Effect.gen(function* () {
+        let resolved: RequestScope | null = null;
+        for (const provider of requestScopeProviders) {
+          const scope = yield* provider(selector);
+          if (scope !== null) {
+            resolved = scope;
+            break;
+          }
+        }
+        return buildScopedExecutor(resolved ?? EMPTY_REQUEST_SCOPE);
+      });
+
+    return toExecutor({ ...base, ...extensions, applyRequestScope });
   });
 
 // Helper alias so the inline literal used for the optimistic projection in

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -18,8 +18,17 @@ export {
 // FumaDB integration.
 export { fumadb } from "@executor-js/fumadb";
 export type { FumaDB } from "@executor-js/fumadb";
-export type { AbstractQuery, Condition, ConditionBuilder } from "@executor-js/fumadb/query";
-export { column, idColumn, schema as fumaSchema, table } from "@executor-js/fumadb/schema";
+export type {
+  AbstractQuery,
+  Condition,
+  ConditionBuilder,
+} from "@executor-js/fumadb/query";
+export {
+  column,
+  idColumn,
+  schema as fumaSchema,
+  table,
+} from "@executor-js/fumadb/schema";
 export type {
   AnyColumn,
   AnySchema,
@@ -36,7 +45,11 @@ export type {
   IFumaClient,
   StorageFailure,
 } from "./fuma-runtime";
-export { StorageError, UniqueViolationError, isStorageFailure } from "./fuma-runtime";
+export {
+  StorageError,
+  UniqueViolationError,
+  isStorageFailure,
+} from "./fuma-runtime";
 
 // IDs (branded) — the v2 set.
 export {
@@ -56,7 +69,10 @@ export {
   Subject,
   Owner,
 } from "./ids";
-export { connectionIdentifier, isConnectionIdentifier } from "./connection-name-identifier";
+export {
+  connectionIdentifier,
+  isConnectionIdentifier,
+} from "./connection-name-identifier";
 
 // Errors (tagged) — the ExecuteError set + integration lifecycle.
 export {
@@ -299,6 +315,7 @@ export {
 // uses it; the host surface (`@executor-js/api/server`) re-exports it.
 export {
   type Executor,
+  type ExecutorWrapper,
   type ExecutorConfig,
   type ExecutorDb,
   type ExecutorDbFactory,
@@ -353,13 +370,3 @@ export {
   type AuthToolFailureCode,
   type AuthToolFailureInput,
 } from "./auth-tool-failure";
-export {
-  applyToolkitScope,
-  EMPTY_TOOLKIT_SCOPE,
-  type ResolvedToolkitScope,
-  type ToolkitAccess,
-  type ToolkitPolicyAction,
-  type ToolkitPolicyRule,
-  type ToolkitResolver,
-  type ToolkitScopeEntry,
-} from "./toolkit-scope";

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -18,17 +18,8 @@ export {
 // FumaDB integration.
 export { fumadb } from "@executor-js/fumadb";
 export type { FumaDB } from "@executor-js/fumadb";
-export type {
-  AbstractQuery,
-  Condition,
-  ConditionBuilder,
-} from "@executor-js/fumadb/query";
-export {
-  column,
-  idColumn,
-  schema as fumaSchema,
-  table,
-} from "@executor-js/fumadb/schema";
+export type { AbstractQuery, Condition, ConditionBuilder } from "@executor-js/fumadb/query";
+export { column, idColumn, schema as fumaSchema, table } from "@executor-js/fumadb/schema";
 export type {
   AnyColumn,
   AnySchema,
@@ -45,11 +36,7 @@ export type {
   IFumaClient,
   StorageFailure,
 } from "./fuma-runtime";
-export {
-  StorageError,
-  UniqueViolationError,
-  isStorageFailure,
-} from "./fuma-runtime";
+export { StorageError, UniqueViolationError, isStorageFailure } from "./fuma-runtime";
 
 // IDs (branded) — the v2 set.
 export {
@@ -69,10 +56,7 @@ export {
   Subject,
   Owner,
 } from "./ids";
-export {
-  connectionIdentifier,
-  isConnectionIdentifier,
-} from "./connection-name-identifier";
+export { connectionIdentifier, isConnectionIdentifier } from "./connection-name-identifier";
 
 // Errors (tagged) — the ExecuteError set + integration lifecycle.
 export {

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -358,6 +358,8 @@ export {
   EMPTY_TOOLKIT_SCOPE,
   type ResolvedToolkitScope,
   type ToolkitAccess,
+  type ToolkitPolicyAction,
+  type ToolkitPolicyRule,
   type ToolkitResolver,
   type ToolkitScopeEntry,
 } from "./toolkit-scope";

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -353,3 +353,11 @@ export {
   type AuthToolFailureCode,
   type AuthToolFailureInput,
 } from "./auth-tool-failure";
+export {
+  applyToolkitScope,
+  EMPTY_TOOLKIT_SCOPE,
+  type ResolvedToolkitScope,
+  type ToolkitAccess,
+  type ToolkitResolver,
+  type ToolkitScopeEntry,
+} from "./toolkit-scope";

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -315,18 +315,30 @@ export {
 // uses it; the host surface (`@executor-js/api/server`) re-exports it.
 export {
   type Executor,
-  type ExecutorWrapper,
   type ExecutorConfig,
   type ExecutorDb,
   type ExecutorDbFactory,
   type ExecutorDbInput,
   type ParsedToolAddress,
+  type RequestScopeProvider,
   createExecutor,
   collectTables,
   parseToolAddress,
   connectionAddress,
   toolAddress,
 } from "./executor";
+
+export {
+  type RequestScope,
+  type ScopeDecision,
+  EMPTY_REQUEST_SCOPE,
+  defaultDecideStaticTool,
+  decideStaticToolForScope,
+  filterPolicyRowsForScope,
+  resolveScopedEffectivePolicy,
+  scopePluginCtx,
+  toolVisibleUnderScope,
+} from "./request-scope";
 
 // CLI / runtime config.
 export {

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -2,10 +2,7 @@ import { Effect, type Schema as EffectSchema } from "effect";
 import type { Context, Layer } from "effect";
 import type { HttpClient } from "effect/unstable/http";
 import type { HttpApiGroup } from "effect/unstable/httpapi";
-import type {
-  StandardJSONSchemaV1,
-  StandardSchemaV1,
-} from "@standard-schema/spec";
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
 import type { StorageFailure } from "./fuma-runtime";
 
 import type { PluginBlobStore } from "./blob";
@@ -48,10 +45,7 @@ import type {
 } from "./errors";
 import type { OAuthService } from "./oauth-client";
 import type { CredentialProvider, ProviderEntry } from "./provider";
-import type {
-  PluginStorageConfig,
-  PluginStorageFacade,
-} from "./plugin-storage";
+import type { PluginStorageConfig, PluginStorageFacade } from "./plugin-storage";
 import type {
   CreateToolPolicyInput,
   RemoveToolPolicyInput,
@@ -120,9 +114,7 @@ export interface PluginCtx<TStore = unknown> {
   readonly core: {
     readonly integrations: {
       /** Register / replace this plugin's integration in the catalog. */
-      readonly register: (
-        input: RegisterIntegrationInput,
-      ) => Effect.Effect<void, StorageFailure>;
+      readonly register: (input: RegisterIntegrationInput) => Effect.Effect<void, StorageFailure>;
       readonly update: (
         slug: IntegrationSlug,
         patch: {
@@ -131,19 +123,13 @@ export interface PluginCtx<TStore = unknown> {
           readonly config?: IntegrationConfig;
         },
       ) => Effect.Effect<void, StorageFailure>;
-      readonly list: () => Effect.Effect<
-        readonly Integration[],
-        StorageFailure
-      >;
+      readonly list: () => Effect.Effect<readonly Integration[], StorageFailure>;
       readonly get: (
         slug: IntegrationSlug,
       ) => Effect.Effect<IntegrationRecord | null, StorageFailure>;
       readonly remove: (
         slug: IntegrationSlug,
-      ) => Effect.Effect<
-        void,
-        IntegrationRemovalNotAllowedError | StorageFailure
-      >;
+      ) => Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure>;
       readonly detect: (
         url: string,
       ) => Effect.Effect<readonly IntegrationDetectionResult[], StorageFailure>;
@@ -152,15 +138,9 @@ export interface PluginCtx<TStore = unknown> {
     };
     readonly policies: {
       readonly list: () => Effect.Effect<readonly ToolPolicy[], StorageFailure>;
-      readonly create: (
-        input: CreateToolPolicyInput,
-      ) => Effect.Effect<ToolPolicy, StorageFailure>;
-      readonly update: (
-        input: UpdateToolPolicyInput,
-      ) => Effect.Effect<ToolPolicy, StorageFailure>;
-      readonly remove: (
-        input: RemoveToolPolicyInput,
-      ) => Effect.Effect<void, StorageFailure>;
+      readonly create: (input: CreateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
+      readonly update: (input: UpdateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
+      readonly remove: (input: RemoveToolPolicyInput) => Effect.Effect<void, StorageFailure>;
     };
   };
 
@@ -180,9 +160,7 @@ export interface PluginCtx<TStore = unknown> {
       readonly integration?: IntegrationSlug;
       readonly owner?: Owner;
     }) => Effect.Effect<readonly Connection[], StorageFailure>;
-    readonly get: (
-      ref: ConnectionRef,
-    ) => Effect.Effect<Connection | null, StorageFailure>;
+    readonly get: (ref: ConnectionRef) => Effect.Effect<Connection | null, StorageFailure>;
     /** Edit user-curated metadata (description, identityLabel). */
     readonly update: (
       ref: ConnectionRef,
@@ -199,9 +177,7 @@ export interface PluginCtx<TStore = unknown> {
     >;
     /** Resolve a connection's value through its provider (and OAuth refresh).
      *  null if the provider can't produce one. */
-    readonly resolveValue: (
-      ref: ConnectionRef,
-    ) => Effect.Effect<string | null, StorageFailure>;
+    readonly resolveValue: (ref: ConnectionRef) => Effect.Effect<string | null, StorageFailure>;
   };
 
   /** Registered credential backends — for discovery (browse a backend's items). */
@@ -217,9 +193,7 @@ export interface PluginCtx<TStore = unknown> {
 
   /** Run `effect` inside a FumaDB transaction (atomic across plugin storage +
    *  core integration/tool writes). */
-  readonly transaction: <A, E>(
-    effect: Effect.Effect<A, E>,
-  ) => Effect.Effect<A, E | StorageFailure>;
+  readonly transaction: <A, E>(effect: Effect.Effect<A, E>) => Effect.Effect<A, E | StorageFailure>;
 }
 
 // ---------------------------------------------------------------------------
@@ -250,10 +224,7 @@ export interface ResolveToolsInput<TStore = unknown> {
   /** Lazily resolve every credential input (`variable → value`) — the
    *  multi-input analog of `getValue`, for methods whose placements reference
    *  more than one variable. Empty map when the connection isn't persisted. */
-  readonly getValues: () => Effect.Effect<
-    Record<string, string | null>,
-    StorageFailure
-  >;
+  readonly getValues: () => Effect.Effect<Record<string, string | null>, StorageFailure>;
 }
 
 export interface ResolveToolsResult {
@@ -299,10 +270,8 @@ export interface StaticToolExecuteContext<TStore = unknown> {
   readonly elicit: Elicit;
 }
 
-export type StaticToolSchema<
-  Input = unknown,
-  Output = Input,
-> = StandardSchemaV1<Input, Output> & StandardJSONSchemaV1<Input, Output>;
+export type StaticToolSchema<Input = unknown, Output = Input> = StandardSchemaV1<Input, Output> &
+  StandardJSONSchemaV1<Input, Output>;
 
 export interface StaticToolDecl<TStore = unknown> {
   readonly name: string;
@@ -310,9 +279,7 @@ export interface StaticToolDecl<TStore = unknown> {
   readonly inputSchema?: StaticToolSchema;
   readonly outputSchema?: StaticToolSchema;
   readonly annotations?: ToolAnnotations;
-  readonly handler: (
-    input: StaticToolHandlerInput<TStore>,
-  ) => Effect.Effect<unknown, unknown>;
+  readonly handler: (input: StaticToolHandlerInput<TStore>) => Effect.Effect<unknown, unknown>;
 }
 
 const decodeStaticToolArgs = (
@@ -320,9 +287,7 @@ const decodeStaticToolArgs = (
   args: unknown,
 ): Effect.Effect<unknown, unknown> => {
   if (schema == null) return Effect.succeed(args);
-  return Effect.promise(() =>
-    Promise.resolve(schema["~standard"].validate(args)),
-  ).pipe(
+  return Effect.promise(() => Promise.resolve(schema["~standard"].validate(args))).pipe(
     Effect.flatMap((result) =>
       "value" in result ? Effect.succeed(result.value) : Effect.fail(result),
     ),
@@ -331,9 +296,7 @@ const decodeStaticToolArgs = (
 
 export interface StaticToolInput<
   TStore = unknown,
-  TInputSchema extends StaticToolSchema | undefined =
-    | StaticToolSchema
-    | undefined,
+  TInputSchema extends StaticToolSchema | undefined = StaticToolSchema | undefined,
 > {
   readonly name: string;
   readonly description: string;
@@ -350,9 +313,7 @@ export interface StaticToolInput<
 
 export const tool = <
   TStore = unknown,
-  TInputSchema extends StaticToolSchema | undefined =
-    | StaticToolSchema
-    | undefined,
+  TInputSchema extends StaticToolSchema | undefined = StaticToolSchema | undefined,
 >(
   input: StaticToolInput<TStore, TInputSchema>,
 ): StaticToolDecl<TStore> => ({
@@ -486,9 +447,7 @@ export interface PluginSpec<
   readonly extension?: (ctx: PluginCtx<TStore>) => TExtension;
 
   /** Static sources contributed by this plugin with inline tool handlers. */
-  readonly staticSources?: (
-    self: NoInfer<TExtension>,
-  ) => readonly StaticSourceDecl<TStore>[];
+  readonly staticSources?: (self: NoInfer<TExtension>) => readonly StaticSourceDecl<TStore>[];
 
   /** HttpApiGroup contributed by this plugin. */
   readonly routes?: () => TGroup;
@@ -509,9 +468,7 @@ export interface PluginSpec<
 
   /** Invoke a dynamic tool. Called when the static-handler map doesn't have the
    *  address. The plugin applies `input.credential` to the outbound request. */
-  readonly invokeTool?: (
-    input: InvokeToolInput<TStore>,
-  ) => Effect.Effect<unknown, unknown>;
+  readonly invokeTool?: (input: InvokeToolInput<TStore>) => Effect.Effect<unknown, unknown>;
 
   /** Bulk resolve annotations for a set of tool rows under one connection. */
   readonly resolveAnnotations?: (input: {
@@ -564,9 +521,7 @@ export interface PluginSpec<
   readonly credentialProviders?:
     | readonly CredentialProvider[]
     | ((ctx: PluginCtx<TStore>) => readonly CredentialProvider[])
-    | ((
-        ctx: PluginCtx<TStore>,
-      ) => Effect.Effect<readonly CredentialProvider[]>);
+    | ((ctx: PluginCtx<TStore>) => Effect.Effect<readonly CredentialProvider[]>);
 
   readonly close?: () => Effect.Effect<void, unknown>;
 }
@@ -582,14 +537,7 @@ export interface Plugin<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   THandlersLayer extends Layer.Layer<any, any, any> = any,
   TGroup extends HttpApiGroup.Any = HttpApiGroup.Any,
-> extends PluginSpec<
-  TId,
-  TExtension,
-  TStore,
-  TExtensionService,
-  THandlersLayer,
-  TGroup
-> {}
+> extends PluginSpec<TId, TExtension, TStore, TExtensionService, THandlersLayer, TGroup> {}
 
 // ---------------------------------------------------------------------------
 // definePlugin — factory-returning-spec.
@@ -603,11 +551,7 @@ export type ConfiguredPlugin<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TExtensionService extends Context.Service<any, any> | undefined = undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<
-    unknown,
-    never,
-    never
-  >,
+  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<unknown, never, never>,
   TGroup extends HttpApiGroup.Any = HttpApiGroup.Any,
 > = (
   options?: TOptions & {
@@ -624,32 +568,13 @@ export function definePlugin<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TExtensionService extends Context.Service<any, any> | undefined = undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<
-    unknown,
-    never,
-    never
-  >,
+  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<unknown, never, never>,
   TGroup extends HttpApiGroup.Any = HttpApiGroup.Any,
 >(
   authorFactory: (
     options?: TOptions,
-  ) => PluginSpec<
-    TId,
-    TExtension,
-    TStore,
-    TExtensionService,
-    THandlersLayer,
-    TGroup
-  >,
-): ConfiguredPlugin<
-  TId,
-  TExtension,
-  TStore,
-  TOptions,
-  TExtensionService,
-  THandlersLayer,
-  TGroup
-> {
+  ) => PluginSpec<TId, TExtension, TStore, TExtensionService, THandlersLayer, TGroup>,
+): ConfiguredPlugin<TId, TExtension, TStore, TOptions, TExtensionService, THandlersLayer, TGroup> {
   return (options) => {
     const {
       storage: storageOverride,
@@ -660,9 +585,7 @@ export function definePlugin<
     } = options ?? {};
 
     const hasAuthorOptions = Object.keys(rest).length > 0;
-    const spec = authorFactory(
-      hasAuthorOptions ? (rest as TOptions) : undefined,
-    );
+    const spec = authorFactory(hasAuthorOptions ? (rest as TOptions) : undefined);
 
     return {
       ...spec,
@@ -678,12 +601,7 @@ export function definePlugin<
 export type AnyPlugin = Plugin<string>;
 
 export type PluginExtensions<TPlugins extends readonly AnyPlugin[]> = {
-  readonly [P in TPlugins[number] as P["id"]]: P extends Plugin<
-    string,
-    infer TExt
-  >
-    ? TExt
-    : never;
+  readonly [P in TPlugins[number] as P["id"]]: P extends Plugin<string, infer TExt> ? TExt : never;
 };
 
 // Re-exported for consumers that check the elicitation handler type.

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -2,7 +2,10 @@ import { Effect, type Schema as EffectSchema } from "effect";
 import type { Context, Layer } from "effect";
 import type { HttpClient } from "effect/unstable/http";
 import type { HttpApiGroup } from "effect/unstable/httpapi";
-import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec";
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from "@standard-schema/spec";
 import type { StorageFailure } from "./fuma-runtime";
 
 import type { PluginBlobStore } from "./blob";
@@ -45,13 +48,17 @@ import type {
 } from "./errors";
 import type { OAuthService } from "./oauth-client";
 import type { CredentialProvider, ProviderEntry } from "./provider";
-import type { PluginStorageConfig, PluginStorageFacade } from "./plugin-storage";
+import type {
+  PluginStorageConfig,
+  PluginStorageFacade,
+} from "./plugin-storage";
 import type {
   CreateToolPolicyInput,
   RemoveToolPolicyInput,
   ToolPolicy,
   UpdateToolPolicyInput,
 } from "./policies";
+import type { RequestScope } from "./request-scope";
 import type { Tool, ToolAnnotations, ToolDef } from "./tool";
 
 // ---------------------------------------------------------------------------
@@ -113,7 +120,9 @@ export interface PluginCtx<TStore = unknown> {
   readonly core: {
     readonly integrations: {
       /** Register / replace this plugin's integration in the catalog. */
-      readonly register: (input: RegisterIntegrationInput) => Effect.Effect<void, StorageFailure>;
+      readonly register: (
+        input: RegisterIntegrationInput,
+      ) => Effect.Effect<void, StorageFailure>;
       readonly update: (
         slug: IntegrationSlug,
         patch: {
@@ -122,13 +131,19 @@ export interface PluginCtx<TStore = unknown> {
           readonly config?: IntegrationConfig;
         },
       ) => Effect.Effect<void, StorageFailure>;
-      readonly list: () => Effect.Effect<readonly Integration[], StorageFailure>;
+      readonly list: () => Effect.Effect<
+        readonly Integration[],
+        StorageFailure
+      >;
       readonly get: (
         slug: IntegrationSlug,
       ) => Effect.Effect<IntegrationRecord | null, StorageFailure>;
       readonly remove: (
         slug: IntegrationSlug,
-      ) => Effect.Effect<void, IntegrationRemovalNotAllowedError | StorageFailure>;
+      ) => Effect.Effect<
+        void,
+        IntegrationRemovalNotAllowedError | StorageFailure
+      >;
       readonly detect: (
         url: string,
       ) => Effect.Effect<readonly IntegrationDetectionResult[], StorageFailure>;
@@ -137,9 +152,15 @@ export interface PluginCtx<TStore = unknown> {
     };
     readonly policies: {
       readonly list: () => Effect.Effect<readonly ToolPolicy[], StorageFailure>;
-      readonly create: (input: CreateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-      readonly update: (input: UpdateToolPolicyInput) => Effect.Effect<ToolPolicy, StorageFailure>;
-      readonly remove: (input: RemoveToolPolicyInput) => Effect.Effect<void, StorageFailure>;
+      readonly create: (
+        input: CreateToolPolicyInput,
+      ) => Effect.Effect<ToolPolicy, StorageFailure>;
+      readonly update: (
+        input: UpdateToolPolicyInput,
+      ) => Effect.Effect<ToolPolicy, StorageFailure>;
+      readonly remove: (
+        input: RemoveToolPolicyInput,
+      ) => Effect.Effect<void, StorageFailure>;
     };
   };
 
@@ -159,7 +180,9 @@ export interface PluginCtx<TStore = unknown> {
       readonly integration?: IntegrationSlug;
       readonly owner?: Owner;
     }) => Effect.Effect<readonly Connection[], StorageFailure>;
-    readonly get: (ref: ConnectionRef) => Effect.Effect<Connection | null, StorageFailure>;
+    readonly get: (
+      ref: ConnectionRef,
+    ) => Effect.Effect<Connection | null, StorageFailure>;
     /** Edit user-curated metadata (description, identityLabel). */
     readonly update: (
       ref: ConnectionRef,
@@ -176,7 +199,9 @@ export interface PluginCtx<TStore = unknown> {
     >;
     /** Resolve a connection's value through its provider (and OAuth refresh).
      *  null if the provider can't produce one. */
-    readonly resolveValue: (ref: ConnectionRef) => Effect.Effect<string | null, StorageFailure>;
+    readonly resolveValue: (
+      ref: ConnectionRef,
+    ) => Effect.Effect<string | null, StorageFailure>;
   };
 
   /** Registered credential backends — for discovery (browse a backend's items). */
@@ -192,7 +217,9 @@ export interface PluginCtx<TStore = unknown> {
 
   /** Run `effect` inside a FumaDB transaction (atomic across plugin storage +
    *  core integration/tool writes). */
-  readonly transaction: <A, E>(effect: Effect.Effect<A, E>) => Effect.Effect<A, E | StorageFailure>;
+  readonly transaction: <A, E>(
+    effect: Effect.Effect<A, E>,
+  ) => Effect.Effect<A, E | StorageFailure>;
 }
 
 // ---------------------------------------------------------------------------
@@ -223,7 +250,10 @@ export interface ResolveToolsInput<TStore = unknown> {
   /** Lazily resolve every credential input (`variable → value`) — the
    *  multi-input analog of `getValue`, for methods whose placements reference
    *  more than one variable. Empty map when the connection isn't persisted. */
-  readonly getValues: () => Effect.Effect<Record<string, string | null>, StorageFailure>;
+  readonly getValues: () => Effect.Effect<
+    Record<string, string | null>,
+    StorageFailure
+  >;
 }
 
 export interface ResolveToolsResult {
@@ -269,8 +299,10 @@ export interface StaticToolExecuteContext<TStore = unknown> {
   readonly elicit: Elicit;
 }
 
-export type StaticToolSchema<Input = unknown, Output = Input> = StandardSchemaV1<Input, Output> &
-  StandardJSONSchemaV1<Input, Output>;
+export type StaticToolSchema<
+  Input = unknown,
+  Output = Input,
+> = StandardSchemaV1<Input, Output> & StandardJSONSchemaV1<Input, Output>;
 
 export interface StaticToolDecl<TStore = unknown> {
   readonly name: string;
@@ -278,7 +310,9 @@ export interface StaticToolDecl<TStore = unknown> {
   readonly inputSchema?: StaticToolSchema;
   readonly outputSchema?: StaticToolSchema;
   readonly annotations?: ToolAnnotations;
-  readonly handler: (input: StaticToolHandlerInput<TStore>) => Effect.Effect<unknown, unknown>;
+  readonly handler: (
+    input: StaticToolHandlerInput<TStore>,
+  ) => Effect.Effect<unknown, unknown>;
 }
 
 const decodeStaticToolArgs = (
@@ -286,7 +320,9 @@ const decodeStaticToolArgs = (
   args: unknown,
 ): Effect.Effect<unknown, unknown> => {
   if (schema == null) return Effect.succeed(args);
-  return Effect.promise(() => Promise.resolve(schema["~standard"].validate(args))).pipe(
+  return Effect.promise(() =>
+    Promise.resolve(schema["~standard"].validate(args)),
+  ).pipe(
     Effect.flatMap((result) =>
       "value" in result ? Effect.succeed(result.value) : Effect.fail(result),
     ),
@@ -295,7 +331,9 @@ const decodeStaticToolArgs = (
 
 export interface StaticToolInput<
   TStore = unknown,
-  TInputSchema extends StaticToolSchema | undefined = StaticToolSchema | undefined,
+  TInputSchema extends StaticToolSchema | undefined =
+    | StaticToolSchema
+    | undefined,
 > {
   readonly name: string;
   readonly description: string;
@@ -312,7 +350,9 @@ export interface StaticToolInput<
 
 export const tool = <
   TStore = unknown,
-  TInputSchema extends StaticToolSchema | undefined = StaticToolSchema | undefined,
+  TInputSchema extends StaticToolSchema | undefined =
+    | StaticToolSchema
+    | undefined,
 >(
   input: StaticToolInput<TStore, TInputSchema>,
 ): StaticToolDecl<TStore> => ({
@@ -446,7 +486,9 @@ export interface PluginSpec<
   readonly extension?: (ctx: PluginCtx<TStore>) => TExtension;
 
   /** Static sources contributed by this plugin with inline tool handlers. */
-  readonly staticSources?: (self: NoInfer<TExtension>) => readonly StaticSourceDecl<TStore>[];
+  readonly staticSources?: (
+    self: NoInfer<TExtension>,
+  ) => readonly StaticSourceDecl<TStore>[];
 
   /** HttpApiGroup contributed by this plugin. */
   readonly routes?: () => TGroup;
@@ -467,7 +509,9 @@ export interface PluginSpec<
 
   /** Invoke a dynamic tool. Called when the static-handler map doesn't have the
    *  address. The plugin applies `input.credential` to the outbound request. */
-  readonly invokeTool?: (input: InvokeToolInput<TStore>) => Effect.Effect<unknown, unknown>;
+  readonly invokeTool?: (
+    input: InvokeToolInput<TStore>,
+  ) => Effect.Effect<unknown, unknown>;
 
   /** Bulk resolve annotations for a set of tool rows under one connection. */
   readonly resolveAnnotations?: (input: {
@@ -506,12 +550,23 @@ export interface PluginSpec<
     readonly url: string;
   }) => Effect.Effect<IntegrationDetectionResult | null, unknown>;
 
+  /** Resolve a per-request catalog/policy overlay for a selector string.
+   *  Return `null` when this provider does not recognize the selector; core
+   *  fails closed to `EMPTY_REQUEST_SCOPE` when a selector is present but no
+   *  provider claims it. */
+  readonly resolveRequestScope?: (
+    ctx: PluginCtx<TStore>,
+    selector: string,
+  ) => Effect.Effect<RequestScope | null, StorageFailure>;
+
   /** Credential providers contributed by this plugin (keychain, file, vault, …).
    *  The v2 successor to `secretProviders`. */
   readonly credentialProviders?:
     | readonly CredentialProvider[]
     | ((ctx: PluginCtx<TStore>) => readonly CredentialProvider[])
-    | ((ctx: PluginCtx<TStore>) => Effect.Effect<readonly CredentialProvider[]>);
+    | ((
+        ctx: PluginCtx<TStore>,
+      ) => Effect.Effect<readonly CredentialProvider[]>);
 
   readonly close?: () => Effect.Effect<void, unknown>;
 }
@@ -527,7 +582,14 @@ export interface Plugin<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   THandlersLayer extends Layer.Layer<any, any, any> = any,
   TGroup extends HttpApiGroup.Any = HttpApiGroup.Any,
-> extends PluginSpec<TId, TExtension, TStore, TExtensionService, THandlersLayer, TGroup> {}
+> extends PluginSpec<
+  TId,
+  TExtension,
+  TStore,
+  TExtensionService,
+  THandlersLayer,
+  TGroup
+> {}
 
 // ---------------------------------------------------------------------------
 // definePlugin — factory-returning-spec.
@@ -541,7 +603,11 @@ export type ConfiguredPlugin<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TExtensionService extends Context.Service<any, any> | undefined = undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<unknown, never, never>,
+  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<
+    unknown,
+    never,
+    never
+  >,
   TGroup extends HttpApiGroup.Any = HttpApiGroup.Any,
 > = (
   options?: TOptions & {
@@ -558,13 +624,32 @@ export function definePlugin<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TExtensionService extends Context.Service<any, any> | undefined = undefined,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<unknown, never, never>,
+  THandlersLayer extends Layer.Layer<any, any, any> = Layer.Layer<
+    unknown,
+    never,
+    never
+  >,
   TGroup extends HttpApiGroup.Any = HttpApiGroup.Any,
 >(
   authorFactory: (
     options?: TOptions,
-  ) => PluginSpec<TId, TExtension, TStore, TExtensionService, THandlersLayer, TGroup>,
-): ConfiguredPlugin<TId, TExtension, TStore, TOptions, TExtensionService, THandlersLayer, TGroup> {
+  ) => PluginSpec<
+    TId,
+    TExtension,
+    TStore,
+    TExtensionService,
+    THandlersLayer,
+    TGroup
+  >,
+): ConfiguredPlugin<
+  TId,
+  TExtension,
+  TStore,
+  TOptions,
+  TExtensionService,
+  THandlersLayer,
+  TGroup
+> {
   return (options) => {
     const {
       storage: storageOverride,
@@ -575,7 +660,9 @@ export function definePlugin<
     } = options ?? {};
 
     const hasAuthorOptions = Object.keys(rest).length > 0;
-    const spec = authorFactory(hasAuthorOptions ? (rest as TOptions) : undefined);
+    const spec = authorFactory(
+      hasAuthorOptions ? (rest as TOptions) : undefined,
+    );
 
     return {
       ...spec,
@@ -591,7 +678,12 @@ export function definePlugin<
 export type AnyPlugin = Plugin<string>;
 
 export type PluginExtensions<TPlugins extends readonly AnyPlugin[]> = {
-  readonly [P in TPlugins[number] as P["id"]]: P extends Plugin<string, infer TExt> ? TExt : never;
+  readonly [P in TPlugins[number] as P["id"]]: P extends Plugin<
+    string,
+    infer TExt
+  >
+    ? TExt
+    : never;
 };
 
 // Re-exported for consumers that check the elicitation handler type.

--- a/packages/core/sdk/src/request-scope.ts
+++ b/packages/core/sdk/src/request-scope.ts
@@ -37,8 +37,7 @@ const ACTION_RESTRICTION_RANK: Record<ToolPolicyAction, number> = {
   require_approval: 2,
   approve: 1,
 };
-const actionRestrictionRank = (action: ToolPolicyAction): number =>
-  ACTION_RESTRICTION_RANK[action];
+const actionRestrictionRank = (action: ToolPolicyAction): number => ACTION_RESTRICTION_RANK[action];
 
 const DECISION_TO_POLICY_ACTION: Record<ScopeDecision, ToolPolicyAction> = {
   block: "block",
@@ -46,17 +45,14 @@ const DECISION_TO_POLICY_ACTION: Record<ScopeDecision, ToolPolicyAction> = {
   allow: "approve",
 };
 
-export const scopeDecisionToPolicyAction = (
-  decision: ScopeDecision,
-): ToolPolicyAction => DECISION_TO_POLICY_ACTION[decision];
+export const scopeDecisionToPolicyAction = (decision: ScopeDecision): ToolPolicyAction =>
+  DECISION_TO_POLICY_ACTION[decision];
 
 const moreRestrictiveAction = (
   current: ToolPolicyAction,
   candidate: ToolPolicyAction,
 ): ToolPolicyAction =>
-  actionRestrictionRank(candidate) > actionRestrictionRank(current)
-    ? candidate
-    : current;
+  actionRestrictionRank(candidate) > actionRestrictionRank(current) ? candidate : current;
 
 /** Catalog-reading static tools allowed under scope; mutations blocked by default. */
 const CATALOG_READ_STATIC_ADDRESSES = new Set([
@@ -67,10 +63,7 @@ const CATALOG_READ_STATIC_ADDRESSES = new Set([
 export const defaultDecideStaticTool = (tool: Tool): ScopeDecision =>
   CATALOG_READ_STATIC_ADDRESSES.has(String(tool.address)) ? "allow" : "block";
 
-export const decideStaticToolForScope = (
-  scope: RequestScope,
-  tool: Tool,
-): ScopeDecision =>
+export const decideStaticToolForScope = (scope: RequestScope, tool: Tool): ScopeDecision =>
   scope.decideStaticTool?.(tool) ?? defaultDecideStaticTool(tool);
 
 export const filterPolicyRowsForScope = (
@@ -80,10 +73,7 @@ export const filterPolicyRowsForScope = (
   scope.inheritOrgPolicies
     ? rows
     : rows.filter(
-        (row) =>
-          row.owner !== "org" ||
-          row.action === "block" ||
-          row.action === "require_approval",
+        (row) => row.owner !== "org" || row.action === "block" || row.action === "require_approval",
       );
 
 export const resolveScopedEffectivePolicy = (
@@ -95,12 +85,7 @@ export const resolveScopedEffectivePolicy = (
   defaultRequiresApproval?: boolean,
 ): EffectivePolicy => {
   const filtered = filterPolicyRowsForScope(policies, scope);
-  const base = resolveEffectivePolicy(
-    toolId,
-    filtered,
-    ownerRank,
-    defaultRequiresApproval,
-  );
+  const base = resolveEffectivePolicy(toolId, filtered, ownerRank, defaultRequiresApproval);
   const scopeDecision = tool.static
     ? decideStaticToolForScope(scope, tool)
     : scope.decideTool(tool);
@@ -117,13 +102,8 @@ export const resolveScopedEffectivePolicy = (
   };
 };
 
-export const toolVisibleUnderScope = (
-  tool: Tool,
-  scope: RequestScope,
-): boolean => {
-  const decision = tool.static
-    ? decideStaticToolForScope(scope, tool)
-    : scope.decideTool(tool);
+export const toolVisibleUnderScope = (tool: Tool, scope: RequestScope): boolean => {
+  const decision = tool.static ? decideStaticToolForScope(scope, tool) : scope.decideTool(tool);
   return decision !== "block";
 };
 
@@ -140,18 +120,12 @@ export const scopePluginCtx = <TStore>(
       list: () =>
         ctx.core.integrations
           .list()
-          .pipe(
-            Effect.map((items) =>
-              items.filter((i) => scope.allowsIntegration(i)),
-            ),
-          ),
+          .pipe(Effect.map((items) => items.filter((i) => scope.allowsIntegration(i)))),
       get: (slug) =>
         ctx.core.integrations
           .get(slug)
           .pipe(
-            Effect.map((record) =>
-              record && scope.allowsIntegration(record) ? record : null,
-            ),
+            Effect.map((record) => (record && scope.allowsIntegration(record) ? record : null)),
           ),
     },
   },
@@ -160,17 +134,13 @@ export const scopePluginCtx = <TStore>(
     list: (filter) =>
       ctx.connections
         .list(filter)
-        .pipe(
-          Effect.map((items) => items.filter((c) => scope.allowsConnection(c))),
-        ),
+        .pipe(Effect.map((items) => items.filter((c) => scope.allowsConnection(c)))),
     get: (ref) =>
       ctx.connections
         .get(ref)
         .pipe(
           Effect.map((connection) =>
-            connection && scope.allowsConnection(connection)
-              ? connection
-              : null,
+            connection && scope.allowsConnection(connection) ? connection : null,
           ),
         ),
   },

--- a/packages/core/sdk/src/request-scope.ts
+++ b/packages/core/sdk/src/request-scope.ts
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------
+// Request scope — vocabulary-neutral per-request catalog and tool policy
+// overlay. Plugins contribute `RequestScope` data via `resolveRequestScope`;
+// core enforces it centrally across list/get/schema/execute surfaces.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+
+import type { Connection } from "./connection";
+import type { Integration } from "./integration";
+import type { PluginCtx } from "./plugin";
+import type { ToolPolicyRow, ToolPolicyAction } from "./core-schema";
+import { resolveEffectivePolicy, type EffectivePolicy } from "./policies";
+import type { Tool } from "./tool";
+
+export type ScopeDecision = "allow" | "require_approval" | "block";
+
+export interface RequestScope {
+  readonly inheritOrgPolicies: boolean;
+  decideTool(tool: Tool): ScopeDecision;
+  allowsConnection(connection: Connection): boolean;
+  allowsIntegration(integration: Integration): boolean;
+  decideStaticTool?(tool: Tool): ScopeDecision;
+}
+
+/** Fail-closed empty slice — no connections, integrations, or runnable tools. */
+export const EMPTY_REQUEST_SCOPE: RequestScope = {
+  inheritOrgPolicies: true,
+  decideTool: () => "block",
+  allowsConnection: () => false,
+  allowsIntegration: () => false,
+  decideStaticTool: () => "block",
+};
+
+const ACTION_RESTRICTION_RANK: Record<ToolPolicyAction, number> = {
+  block: 3,
+  require_approval: 2,
+  approve: 1,
+};
+const actionRestrictionRank = (action: ToolPolicyAction): number =>
+  ACTION_RESTRICTION_RANK[action];
+
+const DECISION_TO_POLICY_ACTION: Record<ScopeDecision, ToolPolicyAction> = {
+  block: "block",
+  require_approval: "require_approval",
+  allow: "approve",
+};
+
+export const scopeDecisionToPolicyAction = (
+  decision: ScopeDecision,
+): ToolPolicyAction => DECISION_TO_POLICY_ACTION[decision];
+
+const moreRestrictiveAction = (
+  current: ToolPolicyAction,
+  candidate: ToolPolicyAction,
+): ToolPolicyAction =>
+  actionRestrictionRank(candidate) > actionRestrictionRank(current)
+    ? candidate
+    : current;
+
+/** Catalog-reading static tools allowed under scope; mutations blocked by default. */
+const CATALOG_READ_STATIC_ADDRESSES = new Set([
+  "executor.coreTools.integrations.list",
+  "executor.coreTools.connections.list",
+]);
+
+export const defaultDecideStaticTool = (tool: Tool): ScopeDecision =>
+  CATALOG_READ_STATIC_ADDRESSES.has(String(tool.address)) ? "allow" : "block";
+
+export const decideStaticToolForScope = (
+  scope: RequestScope,
+  tool: Tool,
+): ScopeDecision =>
+  scope.decideStaticTool?.(tool) ?? defaultDecideStaticTool(tool);
+
+export const filterPolicyRowsForScope = (
+  rows: readonly ToolPolicyRow[],
+  scope: RequestScope,
+): readonly ToolPolicyRow[] =>
+  scope.inheritOrgPolicies
+    ? rows
+    : rows.filter(
+        (row) =>
+          row.owner !== "org" ||
+          row.action === "block" ||
+          row.action === "require_approval",
+      );
+
+export const resolveScopedEffectivePolicy = (
+  toolId: string,
+  tool: Tool,
+  scope: RequestScope,
+  policies: readonly ToolPolicyRow[],
+  ownerRank: (row: Pick<ToolPolicyRow, "owner">) => number,
+  defaultRequiresApproval?: boolean,
+): EffectivePolicy => {
+  const filtered = filterPolicyRowsForScope(policies, scope);
+  const base = resolveEffectivePolicy(
+    toolId,
+    filtered,
+    ownerRank,
+    defaultRequiresApproval,
+  );
+  const scopeDecision = tool.static
+    ? decideStaticToolForScope(scope, tool)
+    : scope.decideTool(tool);
+  const scopeAction = scopeDecisionToPolicyAction(scopeDecision);
+  const merged = moreRestrictiveAction(base.action, scopeAction);
+  if (merged === scopeAction && merged !== base.action) {
+    return { action: merged, source: "user", pattern: "request-scope" };
+  }
+  return {
+    action: merged,
+    source: base.source,
+    pattern: base.pattern,
+    policyId: base.policyId,
+  };
+};
+
+export const toolVisibleUnderScope = (
+  tool: Tool,
+  scope: RequestScope,
+): boolean => {
+  const decision = tool.static
+    ? decideStaticToolForScope(scope, tool)
+    : scope.decideTool(tool);
+  return decision !== "block";
+};
+
+/** Narrow plugin ctx catalog reads for request-time static tool handlers. */
+export const scopePluginCtx = <TStore>(
+  ctx: PluginCtx<TStore>,
+  scope: RequestScope,
+): PluginCtx<TStore> => ({
+  ...ctx,
+  core: {
+    ...ctx.core,
+    integrations: {
+      ...ctx.core.integrations,
+      list: () =>
+        ctx.core.integrations
+          .list()
+          .pipe(
+            Effect.map((items) =>
+              items.filter((i) => scope.allowsIntegration(i)),
+            ),
+          ),
+      get: (slug) =>
+        ctx.core.integrations
+          .get(slug)
+          .pipe(
+            Effect.map((record) =>
+              record && scope.allowsIntegration(record) ? record : null,
+            ),
+          ),
+    },
+  },
+  connections: {
+    ...ctx.connections,
+    list: (filter) =>
+      ctx.connections
+        .list(filter)
+        .pipe(
+          Effect.map((items) => items.filter((c) => scope.allowsConnection(c))),
+        ),
+    get: (ref) =>
+      ctx.connections
+        .get(ref)
+        .pipe(
+          Effect.map((connection) =>
+            connection && scope.allowsConnection(connection)
+              ? connection
+              : null,
+          ),
+        ),
+  },
+});

--- a/packages/core/sdk/src/tool.ts
+++ b/packages/core/sdk/src/tool.ts
@@ -1,4 +1,10 @@
-import type { ConnectionName, IntegrationSlug, Owner, ToolAddress, ToolName } from "./ids";
+import type {
+  ConnectionName,
+  IntegrationSlug,
+  Owner,
+  ToolAddress,
+  ToolName,
+} from "./ids";
 
 /* Tools belong to a connection and are PERSISTED, like v1 — not resolved live on
  * every list. A plugin produces them at create/refresh (openapi from the
@@ -13,9 +19,9 @@ export interface ToolAnnotations {
   readonly approvalDescription?: string;
   readonly mayElicit?: boolean;
   /** True when the tool only reads (no side effects). Set by the owning plugin
-   *  (e.g. OpenAPI classifies GET/HEAD/OPTIONS as read-only). Toolkits use this
-   *  to enforce read-only access: in a read-only slice a tool is hidden unless
-   *  `readOnly === true` (fail-closed — unclassified counts as write). */
+   *  (e.g. OpenAPI classifies GET/HEAD/OPTIONS as read-only). Consumers that
+   *  offer a read-only mode use this fail-closed: a tool is hidden unless
+   *  `readOnly === true` (unclassified counts as write). */
   readonly readOnly?: boolean;
 }
 

--- a/packages/core/sdk/src/tool.ts
+++ b/packages/core/sdk/src/tool.ts
@@ -1,10 +1,4 @@
-import type {
-  ConnectionName,
-  IntegrationSlug,
-  Owner,
-  ToolAddress,
-  ToolName,
-} from "./ids";
+import type { ConnectionName, IntegrationSlug, Owner, ToolAddress, ToolName } from "./ids";
 
 /* Tools belong to a connection and are PERSISTED, like v1 — not resolved live on
  * every list. A plugin produces them at create/refresh (openapi from the

--- a/packages/core/sdk/src/tool.ts
+++ b/packages/core/sdk/src/tool.ts
@@ -12,6 +12,11 @@ export interface ToolAnnotations {
   readonly requiresApproval?: boolean;
   readonly approvalDescription?: string;
   readonly mayElicit?: boolean;
+  /** True when the tool only reads (no side effects). Set by the owning plugin
+   *  (e.g. OpenAPI classifies GET/HEAD/OPTIONS as read-only). Toolkits use this
+   *  to enforce read-only access: in a read-only slice a tool is hidden unless
+   *  `readOnly === true` (fail-closed — unclassified counts as write). */
+  readonly readOnly?: boolean;
 }
 
 /** A tool as produced by a plugin — the definition, no address yet (the SDK

--- a/packages/core/sdk/src/toolkit-scope.ts
+++ b/packages/core/sdk/src/toolkit-scope.ts
@@ -19,6 +19,15 @@ import type { StorageFailure } from "./fuma-runtime";
 
 export type ToolkitAccess = "off" | "read" | "full";
 
+export type ToolkitPolicyAction = "approve" | "require_approval" | "block";
+
+export interface ToolkitPolicyRule {
+  /** Glob over `<integration>.<connection>.<tool>` — `*` matches one segment,
+   *  a trailing `*` matches the rest, and `*` inside a segment globs. */
+  readonly pattern: string;
+  readonly action: ToolkitPolicyAction;
+}
+
 export interface ToolkitScopeEntry {
   readonly integration: string;
   /** A pinned connection name, or "*" to track every connection of the integration. */
@@ -28,13 +37,37 @@ export interface ToolkitScopeEntry {
 
 export interface ResolvedToolkitScope {
   readonly entries: readonly ToolkitScopeEntry[];
+  /** Per-toolkit policy rules. v1 enforces `block` (exclusion); `approve` /
+   *  `require_approval` are carried for the briefing — org-level approval
+   *  policies are still enforced by the base executor when inherited. */
+  readonly policies: readonly ToolkitPolicyRule[];
   readonly inheritOrgPolicies: boolean;
 }
 
 /** Empty slice — exposes no connection tools (static/core tools stay visible).
  *  Applied fail-closed when a selector resolves to no toolkit (unknown or
  *  not visible to the caller), so a bad selector never leaks the full account. */
-export const EMPTY_TOOLKIT_SCOPE: ResolvedToolkitScope = { entries: [], inheritOrgPolicies: true };
+export const EMPTY_TOOLKIT_SCOPE: ResolvedToolkitScope = {
+  entries: [],
+  policies: [],
+  inheritOrgPolicies: true,
+};
+
+/** Glob match over dot segments: `*` matches one segment, a trailing bare `*`
+ *  matches the rest, and `*` inside a segment globs within it. */
+const matchPattern = (pattern: string, target: string): boolean => {
+  const p = pattern.toLowerCase().trim().split(".");
+  const a = target.toLowerCase().split(".");
+  for (let i = 0; i < p.length; i++) {
+    if (p[i] === "*" && i === p.length - 1) return true;
+    if (a[i] === undefined) return false;
+    const re = new RegExp(
+      "^" + p[i].replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$",
+    );
+    if (!re.test(a[i])) return false;
+  }
+  return p.length === a.length;
+};
 
 /** A plugin extension capable of resolving a selector (slug or id) to a scope,
  *  scoped to the caller. `resolveScope` returns null when nothing matches. */
@@ -66,6 +99,10 @@ export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
   scope: ResolvedToolkitScope,
 ): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
   Effect.gen(function* () {
+    const blockRules = scope.policies.filter((p) => p.action === "block");
+    const isBlocked = (integration: string, connection: string, name: string) =>
+      blockRules.some((p) => matchPattern(p.pattern, `${integration}.${connection}.${name}`));
+
     const all = yield* base.tools.list();
     const allowed = new Set<string>();
     for (const t of all) {
@@ -75,6 +112,7 @@ export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
         allowed.add(String(t.address));
         continue;
       }
+      if (isBlocked(String(t.integration), String(t.connection), String(t.name))) continue;
       const a = accessFor(scope, String(t.integration), String(t.connection));
       if (a === "full" || (a === "read" && t.annotations?.readOnly === true)) {
         allowed.add(String(t.address));

--- a/packages/core/sdk/src/toolkit-scope.ts
+++ b/packages/core/sdk/src/toolkit-scope.ts
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------------------
+// Toolkit scope — wraps an Executor so the MCP surface only sees, and can only
+// run, a toolkit's slice of connections. Toolkit-agnostic: it operates on a
+// plain ResolvedToolkitScope (produced by the toolkits plugin's `resolveScope`)
+// and the base Executor. Because the wrapped Executor is handed to the engine
+// before construction, EVERY surface (tools.list, search, describe,
+// sources/connections/integrations.list, core-tools, and execute) flows through
+// it — enforcement is at execute, not just listing, so guessed out-of-slice
+// addresses are blocked too.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+
+import { ToolBlockedError } from "./errors";
+import type { Executor } from "./executor";
+import type { ToolAddress } from "./ids";
+import type { AnyPlugin } from "./plugin";
+import type { StorageFailure } from "./fuma-runtime";
+
+export type ToolkitAccess = "off" | "read" | "full";
+
+export interface ToolkitScopeEntry {
+  readonly integration: string;
+  /** A pinned connection name, or "*" to track every connection of the integration. */
+  readonly connection: string;
+  readonly access: ToolkitAccess;
+}
+
+export interface ResolvedToolkitScope {
+  readonly entries: readonly ToolkitScopeEntry[];
+  readonly inheritOrgPolicies: boolean;
+}
+
+/** Empty slice — exposes no connection tools (static/core tools stay visible).
+ *  Applied fail-closed when a selector resolves to no toolkit (unknown or
+ *  not visible to the caller), so a bad selector never leaks the full account. */
+export const EMPTY_TOOLKIT_SCOPE: ResolvedToolkitScope = { entries: [], inheritOrgPolicies: true };
+
+/** A plugin extension capable of resolving a selector (slug or id) to a scope,
+ *  scoped to the caller. `resolveScope` returns null when nothing matches. */
+export interface ToolkitResolver {
+  readonly resolveScope: (
+    selector: string,
+  ) => Effect.Effect<ResolvedToolkitScope | null, StorageFailure>;
+}
+
+const accessFor = (
+  scope: ResolvedToolkitScope,
+  integration: string,
+  connection: string,
+): ToolkitAccess => {
+  for (const e of scope.entries) {
+    if (e.integration === integration && e.connection === connection) return e.access;
+  }
+  for (const e of scope.entries) {
+    if (e.integration === integration && e.connection === "*") return e.access;
+  }
+  return "off";
+};
+
+/** Wrap `base` so only the toolkit's slice is visible/runnable. Reads the full
+ *  catalog once to compute the set of allowed tool addresses (applying
+ *  off/read/full + the read-only classification), then narrows every surface. */
+export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
+  base: Executor<TPlugins>,
+  scope: ResolvedToolkitScope,
+): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
+  Effect.gen(function* () {
+    const all = yield* base.tools.list();
+    const allowed = new Set<string>();
+    for (const t of all) {
+      // Static/core tools stay visible — their RESULTS still flow through the
+      // wrapped executor below (so connections/integrations lists are narrowed).
+      if (t.static === true) {
+        allowed.add(String(t.address));
+        continue;
+      }
+      const a = accessFor(scope, String(t.integration), String(t.connection));
+      if (a === "full" || (a === "read" && t.annotations?.readOnly === true)) {
+        allowed.add(String(t.address));
+      }
+    }
+    const allowedIntegrations = new Set(
+      scope.entries.filter((e) => e.access !== "off").map((e) => e.integration),
+    );
+    const connOk = (integration: string, connection: string) =>
+      accessFor(scope, integration, connection) !== "off";
+    const addrOk = (address: ToolAddress) => allowed.has(String(address));
+
+    return {
+      ...base,
+      integrations: {
+        ...base.integrations,
+        list: () =>
+          base.integrations
+            .list()
+            .pipe(Effect.map((xs) => xs.filter((i) => allowedIntegrations.has(String(i.slug))))),
+        get: (slug) =>
+          allowedIntegrations.has(String(slug))
+            ? base.integrations.get(slug)
+            : Effect.succeed(null),
+      },
+      connections: {
+        ...base.connections,
+        list: (filter) =>
+          base.connections
+            .list(filter)
+            .pipe(
+              Effect.map((xs) => xs.filter((c) => connOk(String(c.integration), String(c.name)))),
+            ),
+        get: (ref) =>
+          base.connections
+            .get(ref)
+            .pipe(
+              Effect.map((c) => (c && connOk(String(c.integration), String(c.name)) ? c : null)),
+            ),
+      },
+      tools: {
+        ...base.tools,
+        list: (filter) =>
+          base.tools.list(filter).pipe(Effect.map((xs) => xs.filter((t) => addrOk(t.address)))),
+        schema: (address) => (addrOk(address) ? base.tools.schema(address) : Effect.succeed(null)),
+      },
+      execute: (address, args, options) =>
+        addrOk(address)
+          ? base.execute(address, args, options)
+          : Effect.fail(new ToolBlockedError({ address, pattern: "toolkit" })),
+    } as Executor<TPlugins>;
+  });

--- a/packages/hosts/cloudflare/src/mcp/do-headers.ts
+++ b/packages/hosts/cloudflare/src/mcp/do-headers.ts
@@ -94,5 +94,6 @@ export const withMcpResponseHeaders = (response: Response): Response => {
 // import site (`./do-headers`) is unchanged.
 export {
   readElicitationMode,
+  readToolkitSelector,
   type McpElicitationMode,
 } from "@executor-js/host-mcp/browser-approval";

--- a/packages/hosts/cloudflare/src/mcp/seams.ts
+++ b/packages/hosts/cloudflare/src/mcp/seams.ts
@@ -14,6 +14,9 @@ export interface McpSessionInit {
   /** Public origin of the create request (`https://host`), so the DO derives a
    *  web base URL zero-config when the host configures no static one. */
   readonly webOrigin?: string;
+  /** Toolkit selector (slug or id) pinned for this session — narrows the engine
+   *  to that toolkit's slice. Read from the create request, like elicitationMode. */
+  readonly toolkitId?: string;
 }
 
 /**

--- a/packages/hosts/cloudflare/src/mcp/session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-durable-object.ts
@@ -127,6 +127,9 @@ export interface SessionMeta {
   /** Public origin captured at session create — used to derive the runtime's
    *  web base URL when the host configures no static one. */
   readonly webOrigin?: string;
+  /** Toolkit selector pinned for this session — narrows the engine to that
+   *  toolkit's slice. Persisted so a cold isolate rebuilds the same narrowing. */
+  readonly toolkitId?: string;
 }
 
 /** What a host's `buildMcpServer` seam returns: the connected MCP server plus

--- a/packages/hosts/cloudflare/src/mcp/session-store.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-store.ts
@@ -30,6 +30,7 @@ import {
 import {
   currentPropagationHeaders,
   readElicitationMode,
+  readToolkitSelector,
   withMcpResponseHeaders,
   withPropagationHeaders,
   withVerifiedIdentityHeaders,
@@ -97,6 +98,7 @@ const createSession = (
           organizationId: token.organizationId,
           userId: token.accountId,
           elicitationMode: readElicitationMode(request),
+          toolkitId: readToolkitSelector(request),
           // The public origin the client reached us at — lets the DO derive a web
           // base URL with no static config (we read the real URL, not a spoofable
           // forwarded host).

--- a/packages/hosts/mcp/src/browser-approval.ts
+++ b/packages/hosts/mcp/src/browser-approval.ts
@@ -51,6 +51,17 @@ export const readElicitationMode = (request: Request): McpElicitationMode => {
   return "model";
 };
 
+/** Read the toolkit selector (slug or id) from a request: the
+ *  `x-executor-mcp-toolkit` header (set by a host's pretty-URL rewrite) or the
+ *  `?toolkit=` query. Shared by every host that serves the toolkit-narrowed MCP
+ *  endpoint (in-memory store + the cross-isolate Durable Object). */
+export const readToolkitSelector = (request: Request): string | undefined => {
+  const header = request.headers.get("x-executor-mcp-toolkit");
+  if (header && header.length > 0) return header;
+  const query = new URL(request.url).searchParams.get("toolkit");
+  return query && query.length > 0 ? query : undefined;
+};
+
 /**
  * Build the console approval URL for a paused execution:
  * `<origin>/resume/<executionId>?mcp_session_id=<sessionId>`. The

--- a/packages/hosts/mcp/src/in-memory-session-store.ts
+++ b/packages/hosts/mcp/src/in-memory-session-store.ts
@@ -9,6 +9,7 @@ import {
   decodeResumeResponse,
   formatResumeAcknowledgement,
   readElicitationMode,
+  readToolkitSelector,
 } from "./browser-approval";
 import {
   makeInProcessBrowserApprovalStore,
@@ -70,15 +71,6 @@ export interface McpBuildServerOptions {
    *  to that toolkit's slice. Read once at session create from the request. */
   readonly toolkitId?: string;
 }
-
-/** Read the toolkit selector from the request: `x-executor-mcp-toolkit` header
- *  (set by a host's pretty-URL rewrite) or `?toolkit=` query. */
-export const readToolkitSelector = (request: Request): string | undefined => {
-  const header = request.headers.get("x-executor-mcp-toolkit");
-  if (header && header.length > 0) return header;
-  const query = new URL(request.url).searchParams.get("toolkit");
-  return query && query.length > 0 ? query : undefined;
-};
 
 /** Build the per-session `McpServer` + engine for a principal (the host's engine + tools). */
 export type McpBuildServer = (

--- a/packages/hosts/mcp/src/in-memory-session-store.ts
+++ b/packages/hosts/mcp/src/in-memory-session-store.ts
@@ -2,7 +2,10 @@ import { Cause, Data, Effect, Layer } from "effect";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 
-import { formatPausedExecution, type ExecutionEngine } from "@executor-js/execution";
+import {
+  formatPausedExecution,
+  type ExecutionEngine,
+} from "@executor-js/execution";
 
 import {
   buildResumeApprovalUrl,
@@ -50,7 +53,9 @@ import type { BrowserApprovalStore } from "./tool-server";
 // ---------------------------------------------------------------------------
 
 /** Engine construction failed for a principal. The store surfaces it as a 500. */
-export class McpEngineBuildError extends Data.TaggedError("McpEngineBuildError")<{
+export class McpEngineBuildError extends Data.TaggedError(
+  "McpEngineBuildError",
+)<{
   readonly cause: unknown;
 }> {}
 
@@ -63,13 +68,17 @@ export interface BuiltMcpServer {
 /** The browser-mode wiring the store hands a build call when a session opts in. */
 export interface McpBuildServerOptions {
   readonly elicitationMode?:
-    | { readonly mode: "browser"; readonly approvalUrl: (executionId: string) => string }
+    | {
+        readonly mode: "browser";
+        readonly approvalUrl: (executionId: string) => string;
+      }
     | { readonly mode: "model" }
     | { readonly mode: "native" };
   readonly browserApprovalStore?: BrowserApprovalStore;
-  /** Toolkit selector (slug or id) pinned for this session — narrows the engine
-   *  to that toolkit's slice. Read once at session create from the request. */
-  readonly toolkitId?: string;
+  /** Per-request narrowing selector (the MCP `?toolkit=` value) pinned for this
+   *  session. Core forwards it to plugin executor wrappers; an unset selector
+   *  leaves the executor unnarrowed. Read once at session create. */
+  readonly selector?: string;
 }
 
 /** Build the per-session `McpServer` + engine for a principal (the host's engine + tools). */
@@ -103,9 +112,15 @@ export interface InMemoryMcpSessionStore {
   readonly close: () => Promise<void>;
 }
 
-const ignoreClose = (close: (() => Promise<void>) | undefined): Promise<void> =>
+const ignoreClose = (
+  close: (() => Promise<void>) | undefined,
+): Promise<void> =>
   close
-    ? Effect.runPromise(Effect.ignore(Effect.tryPromise({ try: close, catch: () => undefined })))
+    ? Effect.runPromise(
+        Effect.ignore(
+          Effect.tryPromise({ try: close, catch: () => undefined }),
+        ),
+      )
     : Promise.resolve();
 
 const formatBoundaryError = (error: unknown): unknown =>
@@ -115,14 +130,21 @@ const formatBoundaryError = (error: unknown): unknown =>
 // The store's error bodies are INNER responses (no CORS): the serving envelope
 // re-wraps the store `Response` with CORS before it leaves the origin, so the
 // canonical renderer is called with `cors: false` (content-type only).
-const jsonRpcError = (status: number, code: number, message: string): Response =>
-  jsonRpcErrorBody(status, code, message, { cors: false });
+const jsonRpcError = (
+  status: number,
+  code: number,
+  message: string,
+): Response => jsonRpcErrorBody(status, code, message, { cors: false });
 
 const json = (value: unknown, status = 200): Response =>
-  new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+  new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
 
 const PAUSED_PATH = /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)$/;
-const RESUME_PATH = /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)\/resume$/;
+const RESUME_PATH =
+  /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)\/resume$/;
 
 /**
  * Build the in-process session store plus an explicit `close()` that disposes
@@ -139,21 +161,30 @@ export const makeInMemoryMcpSessionStore = (
   // loopback hosts (local/desktop), where the request URL is already correct.
   options: { readonly webBaseUrl?: string } = {},
 ): InMemoryMcpSessionStore => {
-  const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
+  const transports = new Map<
+    string,
+    WebStandardStreamableHTTPServerTransport
+  >();
   const servers = new Map<string, McpServer>();
   const owners = new Map<string, Principal>();
   const engines = new Map<string, ExecutionEngine<Cause.YieldableError>>();
-  const approvals: InProcessBrowserApprovalStore = makeInProcessBrowserApprovalStore();
+  const approvals: InProcessBrowserApprovalStore =
+    makeInProcessBrowserApprovalStore();
 
-  const dispose = async (id: string, opts: { transport?: boolean; server?: boolean } = {}) => {
+  const dispose = async (
+    id: string,
+    opts: { transport?: boolean; server?: boolean } = {},
+  ) => {
     const transport = transports.get(id);
     const server = servers.get(id);
     transports.delete(id);
     servers.delete(id);
     owners.delete(id);
     engines.delete(id);
-    if (opts.transport) await ignoreClose(transport ? () => transport.close() : undefined);
-    if (opts.server) await ignoreClose(server ? () => server.close() : undefined);
+    if (opts.transport)
+      await ignoreClose(transport ? () => transport.close() : undefined);
+    if (opts.server)
+      await ignoreClose(server ? () => server.close() : undefined);
   };
 
   /**
@@ -173,7 +204,10 @@ export const makeInMemoryMcpSessionStore = (
       Effect.tap(() => Effect.sync(finish)),
       Effect.catchCause((cause) =>
         Effect.sync(() => {
-          console.error("[mcp] handleRequest error:", formatBoundaryError(cause));
+          console.error(
+            "[mcp] handleRequest error:",
+            formatBoundaryError(cause),
+          );
           finish();
           return jsonRpcError(500, -32603, "Internal server error");
         }),
@@ -204,7 +238,8 @@ export const makeInMemoryMcpSessionStore = (
     request: Request,
     sessionId: () => string | null,
   ): McpBuildServerOptions => {
-    if (readElicitationMode(request) !== "browser") return { elicitationMode: { mode: "model" } };
+    if (readElicitationMode(request) !== "browser")
+      return { elicitationMode: { mode: "model" } };
     return {
       elicitationMode: {
         mode: "browser",
@@ -222,11 +257,17 @@ export const makeInMemoryMcpSessionStore = (
   };
 
   /** Open a new session: build the server, connect a transport, drive the request. */
-  const create = (principal: Principal, request: Request): Effect.Effect<McpDispatchResult> => {
+  const create = (
+    principal: Principal,
+    request: Request,
+  ): Effect.Effect<McpDispatchResult> => {
     let createdSessionId: string | null = null;
     const baseOptions = buildOptionsFor(request, () => createdSessionId);
-    const toolkitId = readToolkitSelector(request);
-    return buildServer(principal, toolkitId ? { ...baseOptions, toolkitId } : baseOptions).pipe(
+    const selector = readToolkitSelector(request);
+    return buildServer(
+      principal,
+      selector ? { ...baseOptions, selector } : baseOptions,
+    ).pipe(
       Effect.flatMap(({ mcpServer, engine }) =>
         Effect.gen(function* () {
           const transport = new WebStandardStreamableHTTPServerTransport({
@@ -263,9 +304,13 @@ export const makeInMemoryMcpSessionStore = (
 
   const store: McpSessionStore["Service"] = {
     dispatch: ({ request, principal, sessionId }: McpDispatchInput) =>
-      sessionId ? forward(sessionId, principal, request) : create(principal, request),
+      sessionId
+        ? forward(sessionId, principal, request)
+        : create(principal, request),
     dispose: (sessionId) =>
-      Effect.promise(() => dispose(sessionId, { transport: true, server: true })),
+      Effect.promise(() =>
+        dispose(sessionId, { transport: true, server: true }),
+      ),
   };
 
   const ownerAccess = (
@@ -299,12 +344,17 @@ export const makeInMemoryMcpSessionStore = (
   ): Promise<Response | null> => {
     const match = PAUSED_PATH.exec(new URL(request.url).pathname);
     if (!match) return null;
-    if (request.method !== "GET") return json({ error: "Method not allowed" }, 405);
+    if (request.method !== "GET")
+      return json({ error: "Method not allowed" }, 405);
     const sessionId = decodeURIComponent(match[1]!);
     const access = ownerAccess(sessionId, principal);
     if (access === "forbidden") return json({ error: "Forbidden" }, 403);
-    if (access === "not-found") return json({ error: "Paused execution not found" }, 404);
-    const paused = await pausedFromSession(sessionId, decodeURIComponent(match[2]!));
+    if (access === "not-found")
+      return json({ error: "Paused execution not found" }, 404);
+    const paused = await pausedFromSession(
+      sessionId,
+      decodeURIComponent(match[2]!),
+    );
     if (!paused) return json({ error: "Paused execution not found" }, 404);
     return json({ text: paused.text, structured: paused.structured });
   };
@@ -315,13 +365,15 @@ export const makeInMemoryMcpSessionStore = (
   ): Promise<Response | null> => {
     const match = RESUME_PATH.exec(new URL(request.url).pathname);
     if (!match) return null;
-    if (request.method !== "POST") return json({ error: "Method not allowed" }, 405);
+    if (request.method !== "POST")
+      return json({ error: "Method not allowed" }, 405);
 
     const sessionId = decodeURIComponent(match[1]!);
     const executionId = decodeURIComponent(match[2]!);
     const access = ownerAccess(sessionId, principal);
     if (access === "forbidden") return json({ error: "Forbidden" }, 403);
-    if (access === "not-found") return json({ error: "Paused execution not found" }, 404);
+    if (access === "not-found")
+      return json({ error: "Paused execution not found" }, 404);
     // The session must still hold the paused execution — guards stale ids and
     // confirms the execution belongs to this session before recording.
     const paused = await pausedFromSession(sessionId, executionId);
@@ -349,7 +401,9 @@ export const makeInMemoryMcpSessionStore = (
     handleApprovalRequest,
     close: async () => {
       const ids = new Set([...transports.keys(), ...servers.keys()]);
-      await Promise.all([...ids].map((id) => dispose(id, { transport: true, server: true })));
+      await Promise.all(
+        [...ids].map((id) => dispose(id, { transport: true, server: true })),
+      );
     },
   };
 };

--- a/packages/hosts/mcp/src/in-memory-session-store.ts
+++ b/packages/hosts/mcp/src/in-memory-session-store.ts
@@ -2,10 +2,7 @@ import { Cause, Data, Effect, Layer } from "effect";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 
-import {
-  formatPausedExecution,
-  type ExecutionEngine,
-} from "@executor-js/execution";
+import { formatPausedExecution, type ExecutionEngine } from "@executor-js/execution";
 
 import {
   buildResumeApprovalUrl,
@@ -53,9 +50,7 @@ import type { BrowserApprovalStore } from "./tool-server";
 // ---------------------------------------------------------------------------
 
 /** Engine construction failed for a principal. The store surfaces it as a 500. */
-export class McpEngineBuildError extends Data.TaggedError(
-  "McpEngineBuildError",
-)<{
+export class McpEngineBuildError extends Data.TaggedError("McpEngineBuildError")<{
   readonly cause: unknown;
 }> {}
 
@@ -112,15 +107,9 @@ export interface InMemoryMcpSessionStore {
   readonly close: () => Promise<void>;
 }
 
-const ignoreClose = (
-  close: (() => Promise<void>) | undefined,
-): Promise<void> =>
+const ignoreClose = (close: (() => Promise<void>) | undefined): Promise<void> =>
   close
-    ? Effect.runPromise(
-        Effect.ignore(
-          Effect.tryPromise({ try: close, catch: () => undefined }),
-        ),
-      )
+    ? Effect.runPromise(Effect.ignore(Effect.tryPromise({ try: close, catch: () => undefined })))
     : Promise.resolve();
 
 const formatBoundaryError = (error: unknown): unknown =>
@@ -130,11 +119,8 @@ const formatBoundaryError = (error: unknown): unknown =>
 // The store's error bodies are INNER responses (no CORS): the serving envelope
 // re-wraps the store `Response` with CORS before it leaves the origin, so the
 // canonical renderer is called with `cors: false` (content-type only).
-const jsonRpcError = (
-  status: number,
-  code: number,
-  message: string,
-): Response => jsonRpcErrorBody(status, code, message, { cors: false });
+const jsonRpcError = (status: number, code: number, message: string): Response =>
+  jsonRpcErrorBody(status, code, message, { cors: false });
 
 const json = (value: unknown, status = 200): Response =>
   new Response(JSON.stringify(value), {
@@ -143,8 +129,7 @@ const json = (value: unknown, status = 200): Response =>
   });
 
 const PAUSED_PATH = /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)$/;
-const RESUME_PATH =
-  /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)\/resume$/;
+const RESUME_PATH = /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)\/resume$/;
 
 /**
  * Build the in-process session store plus an explicit `close()` that disposes
@@ -161,30 +146,21 @@ export const makeInMemoryMcpSessionStore = (
   // loopback hosts (local/desktop), where the request URL is already correct.
   options: { readonly webBaseUrl?: string } = {},
 ): InMemoryMcpSessionStore => {
-  const transports = new Map<
-    string,
-    WebStandardStreamableHTTPServerTransport
-  >();
+  const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
   const servers = new Map<string, McpServer>();
   const owners = new Map<string, Principal>();
   const engines = new Map<string, ExecutionEngine<Cause.YieldableError>>();
-  const approvals: InProcessBrowserApprovalStore =
-    makeInProcessBrowserApprovalStore();
+  const approvals: InProcessBrowserApprovalStore = makeInProcessBrowserApprovalStore();
 
-  const dispose = async (
-    id: string,
-    opts: { transport?: boolean; server?: boolean } = {},
-  ) => {
+  const dispose = async (id: string, opts: { transport?: boolean; server?: boolean } = {}) => {
     const transport = transports.get(id);
     const server = servers.get(id);
     transports.delete(id);
     servers.delete(id);
     owners.delete(id);
     engines.delete(id);
-    if (opts.transport)
-      await ignoreClose(transport ? () => transport.close() : undefined);
-    if (opts.server)
-      await ignoreClose(server ? () => server.close() : undefined);
+    if (opts.transport) await ignoreClose(transport ? () => transport.close() : undefined);
+    if (opts.server) await ignoreClose(server ? () => server.close() : undefined);
   };
 
   /**
@@ -204,10 +180,7 @@ export const makeInMemoryMcpSessionStore = (
       Effect.tap(() => Effect.sync(finish)),
       Effect.catchCause((cause) =>
         Effect.sync(() => {
-          console.error(
-            "[mcp] handleRequest error:",
-            formatBoundaryError(cause),
-          );
+          console.error("[mcp] handleRequest error:", formatBoundaryError(cause));
           finish();
           return jsonRpcError(500, -32603, "Internal server error");
         }),
@@ -238,8 +211,7 @@ export const makeInMemoryMcpSessionStore = (
     request: Request,
     sessionId: () => string | null,
   ): McpBuildServerOptions => {
-    if (readElicitationMode(request) !== "browser")
-      return { elicitationMode: { mode: "model" } };
+    if (readElicitationMode(request) !== "browser") return { elicitationMode: { mode: "model" } };
     return {
       elicitationMode: {
         mode: "browser",
@@ -257,17 +229,11 @@ export const makeInMemoryMcpSessionStore = (
   };
 
   /** Open a new session: build the server, connect a transport, drive the request. */
-  const create = (
-    principal: Principal,
-    request: Request,
-  ): Effect.Effect<McpDispatchResult> => {
+  const create = (principal: Principal, request: Request): Effect.Effect<McpDispatchResult> => {
     let createdSessionId: string | null = null;
     const baseOptions = buildOptionsFor(request, () => createdSessionId);
     const selector = readToolkitSelector(request);
-    return buildServer(
-      principal,
-      selector ? { ...baseOptions, selector } : baseOptions,
-    ).pipe(
+    return buildServer(principal, selector ? { ...baseOptions, selector } : baseOptions).pipe(
       Effect.flatMap(({ mcpServer, engine }) =>
         Effect.gen(function* () {
           const transport = new WebStandardStreamableHTTPServerTransport({
@@ -304,13 +270,9 @@ export const makeInMemoryMcpSessionStore = (
 
   const store: McpSessionStore["Service"] = {
     dispatch: ({ request, principal, sessionId }: McpDispatchInput) =>
-      sessionId
-        ? forward(sessionId, principal, request)
-        : create(principal, request),
+      sessionId ? forward(sessionId, principal, request) : create(principal, request),
     dispose: (sessionId) =>
-      Effect.promise(() =>
-        dispose(sessionId, { transport: true, server: true }),
-      ),
+      Effect.promise(() => dispose(sessionId, { transport: true, server: true })),
   };
 
   const ownerAccess = (
@@ -344,17 +306,12 @@ export const makeInMemoryMcpSessionStore = (
   ): Promise<Response | null> => {
     const match = PAUSED_PATH.exec(new URL(request.url).pathname);
     if (!match) return null;
-    if (request.method !== "GET")
-      return json({ error: "Method not allowed" }, 405);
+    if (request.method !== "GET") return json({ error: "Method not allowed" }, 405);
     const sessionId = decodeURIComponent(match[1]!);
     const access = ownerAccess(sessionId, principal);
     if (access === "forbidden") return json({ error: "Forbidden" }, 403);
-    if (access === "not-found")
-      return json({ error: "Paused execution not found" }, 404);
-    const paused = await pausedFromSession(
-      sessionId,
-      decodeURIComponent(match[2]!),
-    );
+    if (access === "not-found") return json({ error: "Paused execution not found" }, 404);
+    const paused = await pausedFromSession(sessionId, decodeURIComponent(match[2]!));
     if (!paused) return json({ error: "Paused execution not found" }, 404);
     return json({ text: paused.text, structured: paused.structured });
   };
@@ -365,15 +322,13 @@ export const makeInMemoryMcpSessionStore = (
   ): Promise<Response | null> => {
     const match = RESUME_PATH.exec(new URL(request.url).pathname);
     if (!match) return null;
-    if (request.method !== "POST")
-      return json({ error: "Method not allowed" }, 405);
+    if (request.method !== "POST") return json({ error: "Method not allowed" }, 405);
 
     const sessionId = decodeURIComponent(match[1]!);
     const executionId = decodeURIComponent(match[2]!);
     const access = ownerAccess(sessionId, principal);
     if (access === "forbidden") return json({ error: "Forbidden" }, 403);
-    if (access === "not-found")
-      return json({ error: "Paused execution not found" }, 404);
+    if (access === "not-found") return json({ error: "Paused execution not found" }, 404);
     // The session must still hold the paused execution — guards stale ids and
     // confirms the execution belongs to this session before recording.
     const paused = await pausedFromSession(sessionId, executionId);
@@ -401,9 +356,7 @@ export const makeInMemoryMcpSessionStore = (
     handleApprovalRequest,
     close: async () => {
       const ids = new Set([...transports.keys(), ...servers.keys()]);
-      await Promise.all(
-        [...ids].map((id) => dispose(id, { transport: true, server: true })),
-      );
+      await Promise.all([...ids].map((id) => dispose(id, { transport: true, server: true })));
     },
   };
 };

--- a/packages/hosts/mcp/src/in-memory-session-store.ts
+++ b/packages/hosts/mcp/src/in-memory-session-store.ts
@@ -66,7 +66,19 @@ export interface McpBuildServerOptions {
     | { readonly mode: "model" }
     | { readonly mode: "native" };
   readonly browserApprovalStore?: BrowserApprovalStore;
+  /** Toolkit selector (slug or id) pinned for this session — narrows the engine
+   *  to that toolkit's slice. Read once at session create from the request. */
+  readonly toolkitId?: string;
 }
+
+/** Read the toolkit selector from the request: `x-executor-mcp-toolkit` header
+ *  (set by a host's pretty-URL rewrite) or `?toolkit=` query. */
+export const readToolkitSelector = (request: Request): string | undefined => {
+  const header = request.headers.get("x-executor-mcp-toolkit");
+  if (header && header.length > 0) return header;
+  const query = new URL(request.url).searchParams.get("toolkit");
+  return query && query.length > 0 ? query : undefined;
+};
 
 /** Build the per-session `McpServer` + engine for a principal (the host's engine + tools). */
 export type McpBuildServer = (
@@ -220,10 +232,9 @@ export const makeInMemoryMcpSessionStore = (
   /** Open a new session: build the server, connect a transport, drive the request. */
   const create = (principal: Principal, request: Request): Effect.Effect<McpDispatchResult> => {
     let createdSessionId: string | null = null;
-    return buildServer(
-      principal,
-      buildOptionsFor(request, () => createdSessionId),
-    ).pipe(
+    const baseOptions = buildOptionsFor(request, () => createdSessionId);
+    const toolkitId = readToolkitSelector(request);
+    return buildServer(principal, toolkitId ? { ...baseOptions, toolkitId } : baseOptions).pipe(
       Effect.flatMap(({ mcpServer, engine }) =>
         Effect.gen(function* () {
           const transport = new WebStandardStreamableHTTPServerTransport({

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -645,15 +645,20 @@ export const invokeWithLayer = (
 // ---------------------------------------------------------------------------
 
 const REQUIRE_APPROVAL = new Set(["post", "put", "patch", "delete"]);
+// Methods with no side effects — classified read-only so toolkits can grant
+// read-only access (a read-only slice hides everything else, fail-closed).
+const READ_ONLY_METHODS = new Set(["get", "head", "options"]);
 
 export const annotationsForOperation = (
   method: string,
   pathTemplate: string,
-): { requiresApproval?: boolean; approvalDescription?: string } => {
+): { requiresApproval?: boolean; approvalDescription?: string; readOnly?: boolean } => {
   const m = method.toLowerCase();
-  if (!REQUIRE_APPROVAL.has(m)) return {};
+  const readOnly = READ_ONLY_METHODS.has(m) ? { readOnly: true } : {};
+  if (!REQUIRE_APPROVAL.has(m)) return readOnly;
   return {
     requiresApproval: true,
     approvalDescription: `${method.toUpperCase()} ${pathTemplate}`,
+    ...readOnly,
   };
 };

--- a/packages/plugins/toolkits/CHANGELOG.md
+++ b/packages/plugins/toolkits/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/plugin-toolkits

--- a/packages/plugins/toolkits/package.json
+++ b/packages/plugins/toolkits/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@executor-js/plugin-toolkits",
+  "version": "1.5.12",
+  "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/toolkits",
+  "bugs": {
+    "url": "https://github.com/RhysSullivan/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RhysSullivan/executor.git",
+    "directory": "packages/plugins/toolkits"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    "./server": "./src/server.ts",
+    "./shared": "./src/shared.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./server": {
+        "import": {
+          "types": "./dist/server.d.ts",
+          "default": "./dist/server.js"
+        }
+      },
+      "./shared": {
+        "import": {
+          "types": "./dist/shared.d.ts",
+          "default": "./dist/shared.js"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "typecheck:slow": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@executor-js/api": "workspace:*",
+    "@executor-js/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@effect/vitest": "catalog:",
+    "@types/node": "catalog:",
+    "bun-types": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/plugins/toolkits/package.json
+++ b/packages/plugins/toolkits/package.json
@@ -17,7 +17,9 @@
   "type": "module",
   "exports": {
     "./server": "./src/server.ts",
-    "./shared": "./src/shared.ts"
+    "./shared": "./src/shared.ts",
+    "./react": "./src/react/index.ts",
+    "./client": "./src/react/plugin-client.tsx"
   },
   "publishConfig": {
     "access": "public",
@@ -33,6 +35,18 @@
           "types": "./dist/shared.d.ts",
           "default": "./dist/shared.js"
         }
+      },
+      "./react": {
+        "import": {
+          "types": "./dist/react/index.d.ts",
+          "default": "./dist/react/index.js"
+        }
+      },
+      "./client": {
+        "import": {
+          "types": "./dist/react/plugin-client.d.ts",
+          "default": "./dist/react/plugin-client.js"
+        }
       }
     }
   },
@@ -43,15 +57,37 @@
     "typecheck:slow": "tsc --noEmit"
   },
   "dependencies": {
+    "@effect/atom-react": "catalog:",
     "@executor-js/api": "workspace:*",
     "@executor-js/sdk": "workspace:*"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",
+    "@executor-js/react": "workspace:*",
     "@types/node": "catalog:",
+    "@types/react": "catalog:",
     "bun-types": "catalog:",
+    "effect": "catalog:",
+    "react": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@effect/atom-react": "catalog:",
+    "@executor-js/react": "workspace:*",
+    "effect": "catalog:",
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "@effect/atom-react": {
+      "optional": true
+    },
+    "@executor-js/react": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
+++ b/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
@@ -18,10 +18,7 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
 import { usePluginNavigate, usePluginRoute } from "@executor-js/sdk/client";
 
-import {
-  connectionsAllAtom,
-  integrationsAtom,
-} from "@executor-js/react/api/atoms";
+import { connectionsAllAtom, integrationsAtom } from "@executor-js/react/api/atoms";
 import { Button } from "@executor-js/react/components/button";
 import { Input } from "@executor-js/react/components/input";
 import { Textarea } from "@executor-js/react/components/textarea";
@@ -89,10 +86,7 @@ const ACTION_LABEL: Record<ToolkitPolicyAction, string> = {
 // Access segmented control (off / read / full)
 // ---------------------------------------------------------------------------
 
-function AccessSeg(props: {
-  value: ToolkitAccess;
-  onChange: (v: ToolkitAccess) => void;
-}) {
+function AccessSeg(props: { value: ToolkitAccess; onChange: (v: ToolkitAccess) => void }) {
   return (
     <div className="inline-flex shrink-0 gap-0.5 rounded-md border border-input p-0.5">
       {ACCESS_OPTIONS.map((o) => (
@@ -130,18 +124,14 @@ function ToolkitCard(props: {
       className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-ring"
     >
       <div className="flex items-center justify-between gap-2">
-        <span className="text-[15px] font-semibold text-foreground">
-          {props.toolkit.name}
-        </span>
+        <span className="text-[15px] font-semibold text-foreground">{props.toolkit.name}</span>
         <span className="text-[12px] text-muted-foreground">
           {active.length} {active.length === 1 ? "connection" : "connections"}
         </span>
       </div>
       <div className="flex flex-wrap gap-1.5">
         {integrations.length === 0 ? (
-          <span className="text-[12px] text-muted-foreground">
-            Empty — nothing granted yet
-          </span>
+          <span className="text-[12px] text-muted-foreground">Empty — nothing granted yet</span>
         ) : (
           integrations.map((slug) => (
             <span
@@ -172,9 +162,7 @@ function ListSection(props: {
   return (
     <section className="mt-10">
       <div className="mb-3 flex items-center justify-between border-b border-border/50 pb-2">
-        <h2 className="font-display text-xl tracking-tight text-foreground">
-          {props.title}
-        </h2>
+        <h2 className="font-display text-xl tracking-tight text-foreground">{props.title}</h2>
         <Button type="button" size="sm" onClick={props.onCreate}>
           New toolkit
         </Button>
@@ -219,9 +207,7 @@ function ToolkitEditor(props: EditorProps) {
 
   const [name, setName] = useState(existing?.name ?? "Untitled");
   const [briefing, setBriefing] = useState(existing?.briefing ?? "");
-  const [inheritOrg, setInheritOrg] = useState(
-    existing?.inheritOrgPolicies ?? true,
-  );
+  const [inheritOrg, setInheritOrg] = useState(existing?.inheritOrgPolicies ?? true);
   const [access, setAccess] = useState<Record<string, ToolkitAccess>>(
     () => accessFromToolkit(existing).access,
   );
@@ -264,18 +250,12 @@ function ToolkitEditor(props: EditorProps) {
 
   // The connections this toolkit may draw on: workspace = org-owned only;
   // personal = org + the caller's own.
-  const tiers = useMemo(
-    () => tiersForScope(props.connections, scope),
-    [props.connections, scope],
-  );
+  const tiers = useMemo(() => tiersForScope(props.connections, scope), [props.connections, scope]);
 
-  const buildEntries = () =>
-    entriesFromAccess(props.connections, scope, access, notes);
+  const buildEntries = () => entriesFromAccess(props.connections, scope, access, notes);
 
   const cleanPolicies = (): ReadonlyArray<ToolkitPolicy> =>
-    policies
-      .filter((p) => p.pattern.trim())
-      .map((p) => ({ ...p, pattern: p.pattern.trim() }));
+    policies.filter((p) => p.pattern.trim()).map((p) => ({ ...p, pattern: p.pattern.trim() }));
 
   const handleSave = async () => {
     setSaving(true);
@@ -328,12 +308,7 @@ function ToolkitEditor(props: EditorProps) {
       return;
     }
     // oxlint-disable-next-line no-alert -- intentional destructive confirmation
-    if (
-      !window.confirm(
-        "Delete this toolkit? Connected agents lose access immediately.",
-      )
-    )
-      return;
+    if (!window.confirm("Delete this toolkit? Connected agents lose access immediately.")) return;
     const exit = await doRemove({
       params: { id: existing.id },
       reactivityKeys: toolkitWriteKeys,
@@ -347,10 +322,7 @@ function ToolkitEditor(props: EditorProps) {
 
   // Live "what the agent sees" — derived from the in-progress form.
   const previewGroups = useMemo(() => {
-    const byInt = new Map<
-      string,
-      Array<{ name: string; access: ToolkitAccess; note?: string }>
-    >();
+    const byInt = new Map<string, Array<{ name: string; access: ToolkitAccess; note?: string }>>();
     for (const tier of tiers) {
       for (const c of tier.conns) {
         const key = connKey(c.integration, c.name);
@@ -367,10 +339,7 @@ function ToolkitEditor(props: EditorProps) {
     }
     return [...byInt.entries()];
   }, [tiers, access, notes]);
-  const previewCount = previewGroups.reduce(
-    (n, [, conns]) => n + conns.length,
-    0,
-  );
+  const previewCount = previewGroups.reduce((n, [, conns]) => n + conns.length, 0);
 
   return (
     <div className="min-h-0 flex-1 overflow-y-auto">
@@ -425,15 +394,10 @@ function ToolkitEditor(props: EditorProps) {
           {/* Main column */}
           <div>
             {/* Access */}
-            <h3 className="mb-2.5 text-[13.5px] font-semibold text-foreground">
-              Access
-            </h3>
+            <h3 className="mb-2.5 text-[13.5px] font-semibold text-foreground">Access</h3>
             <div className="overflow-hidden rounded-xl border border-border bg-card">
               {tiers.map((tier, ti) => (
-                <div
-                  key={tier.label}
-                  className={cn(ti > 0 && "border-t border-border")}
-                >
+                <div key={tier.label} className={cn(ti > 0 && "border-t border-border")}>
                   <div className="flex items-center justify-between px-4 pb-1 pt-3">
                     <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
                       {tier.label}
@@ -464,11 +428,7 @@ function ToolkitEditor(props: EditorProps) {
                           const key = connKey(c.integration, c.name);
                           const a = access[key] ?? "off";
                           return (
-                            <div
-                              key={key}
-                              data-testid={`tk-conn ${key}`}
-                              className="pl-7"
-                            >
+                            <div key={key} data-testid={`tk-conn ${key}`} className="pl-7">
                               <div className="flex items-center gap-3 py-1">
                                 <div className="min-w-0 flex-1">
                                   <div className="truncate text-[13px] font-semibold text-foreground">
@@ -480,19 +440,13 @@ function ToolkitEditor(props: EditorProps) {
                                     </div>
                                   )}
                                 </div>
-                                <AccessSeg
-                                  value={a}
-                                  onChange={(v) => setMode(key, v)}
-                                />
+                                <AccessSeg value={a} onChange={(v) => setMode(key, v)} />
                               </div>
                               {a !== "off" && (
                                 <Input
                                   value={notes[key] ?? ""}
                                   onChange={(e) =>
-                                    setNote(
-                                      key,
-                                      (e.target as HTMLInputElement).value,
-                                    )
+                                    setNote(key, (e.target as HTMLInputElement).value)
                                   }
                                   placeholder={`Note to the agent about ${c.name} (optional)`}
                                   className="mb-1.5 h-7 border-transparent bg-transparent px-0 text-[12px] italic shadow-none focus-visible:border-input"
@@ -539,18 +493,13 @@ function ToolkitEditor(props: EditorProps) {
               </div>
               <div className="border-t border-border px-4 py-2.5">
                 <div className="flex items-center gap-2 pb-1">
-                  <span className="text-[12.5px] font-semibold text-foreground">
-                    Toolkit rules
-                  </span>
+                  <span className="text-[12.5px] font-semibold text-foreground">Toolkit rules</span>
                   <span className="ml-auto text-[11px] text-muted-foreground">
                     {policies.length} {policies.length === 1 ? "rule" : "rules"}
                   </span>
                 </div>
                 {policies.map((p, i) => (
-                  <div
-                    key={i}
-                    className="flex flex-wrap items-center gap-2 py-1.5"
-                  >
+                  <div key={i} className="flex flex-wrap items-center gap-2 py-1.5">
                     <Input
                       value={p.pattern}
                       onChange={(e) =>
@@ -563,23 +512,17 @@ function ToolkitEditor(props: EditorProps) {
                     />
                     <Select
                       value={p.action}
-                      onValueChange={(v) =>
-                        setPolicy(i, { action: v as ToolkitPolicyAction })
-                      }
+                      onValueChange={(v) => setPolicy(i, { action: v as ToolkitPolicyAction })}
                     >
                       <SelectTrigger className="h-8 w-[150px] text-[12px]">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="approve">
-                          {ACTION_LABEL.approve}
-                        </SelectItem>
+                        <SelectItem value="approve">{ACTION_LABEL.approve}</SelectItem>
                         <SelectItem value="require_approval">
                           {ACTION_LABEL.require_approval}
                         </SelectItem>
-                        <SelectItem value="block">
-                          {ACTION_LABEL.block}
-                        </SelectItem>
+                        <SelectItem value="block">{ACTION_LABEL.block}</SelectItem>
                       </SelectContent>
                     </Select>
                     <Button
@@ -602,27 +545,21 @@ function ToolkitEditor(props: EditorProps) {
                     size="sm"
                     variant="ghost"
                     onClick={() => {
-                      setPolicies((ps) => [
-                        ...ps,
-                        { pattern: "", action: "approve" },
-                      ]);
+                      setPolicies((ps) => [...ps, { pattern: "", action: "approve" }]);
                       mark();
                     }}
                   >
                     + Add rule
                   </Button>
                   <span className="text-[11px] text-muted-foreground">
-                    Block hides matching tools entirely · approve /
-                    needs-approval set gating.
+                    Block hides matching tools entirely · approve / needs-approval set gating.
                   </span>
                 </div>
               </div>
             </div>
 
             {/* Connect */}
-            <h3 className="mb-2.5 mt-6 text-[13.5px] font-semibold text-foreground">
-              Connect
-            </h3>
+            <h3 className="mb-2.5 mt-6 text-[13.5px] font-semibold text-foreground">Connect</h3>
             <div className="rounded-xl border border-border bg-card p-4">
               <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
                 MCP endpoint
@@ -638,16 +575,14 @@ function ToolkitEditor(props: EditorProps) {
                 }}
                 className="mt-2 flex w-full items-center justify-between gap-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-left"
               >
-                <span className="truncate font-mono text-[12px] text-foreground">
-                  {endpoint}
-                </span>
+                <span className="truncate font-mono text-[12px] text-foreground">{endpoint}</span>
                 <span className="shrink-0 text-[11px] text-muted-foreground">
                   {copied ? "copied" : "copy"}
                 </span>
               </button>
               <p className="mt-2.5 text-[11.5px] text-muted-foreground">
-                Point an agent at this URL with any of your account's API keys —
-                it sees only this toolkit's slice, never the management API.
+                Point an agent at this URL with any of your account's API keys — it sees only this
+                toolkit's slice, never the management API.
               </p>
             </div>
 
@@ -658,18 +593,12 @@ function ToolkitEditor(props: EditorProps) {
                 onClick={handleSave}
                 disabled={saving || (!!existing && !dirty)}
               >
-                {saving
-                  ? "Saving…"
-                  : existing
-                    ? "Save changes"
-                    : "Create toolkit"}
+                {saving ? "Saving…" : existing ? "Save changes" : "Create toolkit"}
               </Button>
               {error ? (
                 <span className="text-[12px] text-destructive">{error}</span>
               ) : existing && !dirty ? (
-                <span className="text-[12px] text-muted-foreground">
-                  All changes saved
-                </span>
+                <span className="text-[12px] text-muted-foreground">All changes saved</span>
               ) : null}
             </div>
           </div>
@@ -682,8 +611,7 @@ function ToolkitEditor(props: EditorProps) {
                   What the agent sees
                 </span>
                 <span className="text-[12px] text-muted-foreground">
-                  {previewCount}{" "}
-                  {previewCount === 1 ? "connection" : "connections"}
+                  {previewCount} {previewCount === 1 ? "connection" : "connections"}
                 </span>
               </div>
               {briefing.trim() && (
@@ -693,8 +621,8 @@ function ToolkitEditor(props: EditorProps) {
               )}
               {previewGroups.length === 0 ? (
                 <p className="mt-3 text-[12px] text-muted-foreground">
-                  Nothing granted yet — set a connection to Read or Full to give
-                  the agent something to work with.
+                  Nothing granted yet — set a connection to Read or Full to give the agent something
+                  to work with.
                 </p>
               ) : (
                 <div className="mt-3 flex flex-col gap-3">
@@ -709,22 +637,16 @@ function ToolkitEditor(props: EditorProps) {
                       {conns.map((c) => (
                         <div key={c.name} className="mt-1 pl-6">
                           <div className="flex items-center gap-2">
-                            <span className="text-[12px] text-foreground">
-                              {c.name}
-                            </span>
+                            <span className="text-[12px] text-foreground">{c.name}</span>
                             <Badge
-                              variant={
-                                c.access === "full" ? "default" : "secondary"
-                              }
+                              variant={c.access === "full" ? "default" : "secondary"}
                               className="px-1.5 py-0 text-[10px]"
                             >
                               {c.access === "full" ? "full" : "read-only"}
                             </Badge>
                           </div>
                           {c.note && (
-                            <p className="text-[11px] italic text-muted-foreground">
-                              {c.note}
-                            </p>
+                            <p className="text-[11px] italic text-muted-foreground">{c.note}</p>
                           )}
                         </div>
                       ))}
@@ -778,10 +700,7 @@ export function ToolkitsPage() {
   const integrationsResult = useAtomValue(integrationsAtom);
 
   const toolkits = AsyncResult.match(
-    toolkitsResult as AsyncResult.AsyncResult<
-      ReadonlyArray<ToolkitView>,
-      unknown
-    >,
+    toolkitsResult as AsyncResult.AsyncResult<ReadonlyArray<ToolkitView>, unknown>,
     {
       onInitial: () => null,
       onFailure: () => [] as ReadonlyArray<ToolkitView>,
@@ -797,10 +716,7 @@ export function ToolkitsPage() {
     },
   );
   const integrations = AsyncResult.match(
-    integrationsResult as AsyncResult.AsyncResult<
-      ReadonlyArray<Integ>,
-      unknown
-    >,
+    integrationsResult as AsyncResult.AsyncResult<ReadonlyArray<Integ>, unknown>,
     {
       onInitial: () => [] as ReadonlyArray<Integ>,
       onFailure: () => [] as ReadonlyArray<Integ>,
@@ -813,30 +729,19 @@ export function ToolkitsPage() {
     return (slug: string) => bySlug.get(slug) ?? slug;
   }, [integrations]);
 
-  const takenSlugs = useMemo(
-    () => new Set((toolkits ?? []).map((t) => t.slug)),
-    [toolkits],
-  );
+  const takenSlugs = useMemo(() => new Set((toolkits ?? []).map((t) => t.slug)), [toolkits]);
 
   if (toolkits === null) {
-    return (
-      <div className="px-1 py-8 text-[13px] text-muted-foreground">
-        Loading toolkits…
-      </div>
-    );
+    return <div className="px-1 py-8 text-[13px] text-muted-foreground">Loading toolkits…</div>;
   }
 
   if (view.kind === "edit" || view.kind === "new") {
-    const existing =
-      view.kind === "edit"
-        ? (toolkits.find((t) => t.id === view.id) ?? null)
-        : null;
+    const existing = view.kind === "edit" ? (toolkits.find((t) => t.id === view.id) ?? null) : null;
     // The toolkit was deleted out from under us (or never resolved) — fall back.
     if (view.kind === "edit" && !existing) {
       return <ToolkitEditorFallback onBack={() => navigate("")} />;
     }
-    const scope =
-      view.kind === "new" ? view.scope : (existing as ToolkitView).scope;
+    const scope = view.kind === "new" ? view.scope : (existing as ToolkitView).scope;
     return (
       <ToolkitEditor
         key={view.kind === "edit" ? view.id : `new-${view.scope}`}
@@ -863,8 +768,8 @@ export function ToolkitsPage() {
             Toolkits
           </h1>
           <p className="mt-1.5 max-w-[640px] text-sm text-muted-foreground">
-            A toolkit is a slice of your connections with its own MCP endpoint.
-            An agent connected to one can't see anything outside it.
+            A toolkit is a slice of your connections with its own MCP endpoint. An agent connected
+            to one can't see anything outside it.
           </p>
         </header>
         <ListSection
@@ -900,9 +805,7 @@ function ToolkitEditorFallback(props: { onBack: () => void }) {
         >
           ← Toolkits
         </button>
-        <p className="text-sm text-muted-foreground">
-          This toolkit no longer exists.
-        </p>
+        <p className="text-sm text-muted-foreground">This toolkit no longer exists.</p>
       </div>
     </div>
   );

--- a/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
+++ b/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
@@ -3,9 +3,9 @@
 //
 // A toolkit is a named slice of the caller's connections (each off/read/full)
 // with its own MCP endpoint; an agent connected to one can't see anything
-// outside it. This is a SINGLE page (the plugin route matcher is exact-path,
-// no params) that switches between the list and a per-toolkit editor via local
-// state — the same shape as the design prototype.
+// outside it. List and editor views are URL-routed via `usePluginRoute` —
+// `/plugins/toolkits/`, `/plugins/toolkits/<id>`, `/plugins/toolkits/new/<scope>`.
+// The `new/` prefix is reserved for the create flow; toolkit ids are server UUIDs.
 //
 // Workspace toolkits draw on org-owned connections; personal toolkits can use
 // org + the caller's own. The list query returns every visible toolkit and we
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import * as Exit from "effect/Exit";
+import { usePluginNavigate, usePluginRoute } from "@executor-js/sdk/client";
 
 import {
   connectionsAllAtom,
@@ -760,11 +761,21 @@ type View =
   | { readonly kind: "edit"; readonly id: string }
   | { readonly kind: "new"; readonly scope: ToolkitScope };
 
+function viewFromSubpath(subpath: string): View {
+  const normalized = subpath === "/" ? "" : subpath;
+  if (normalized === "") return { kind: "list" };
+  if (normalized === "new/workspace") return { kind: "new", scope: "workspace" };
+  if (normalized === "new/personal") return { kind: "new", scope: "personal" };
+  return { kind: "edit", id: normalized };
+}
+
 export function ToolkitsPage() {
+  const { subpath } = usePluginRoute();
+  const navigate = usePluginNavigate();
+  const view = viewFromSubpath(subpath);
   const toolkitsResult = useAtomValue(toolkitsAtom);
   const connectionsResult = useAtomValue(connectionsAllAtom);
   const integrationsResult = useAtomValue(integrationsAtom);
-  const [view, setView] = useState<View>({ kind: "list" });
 
   const toolkits = AsyncResult.match(
     toolkitsResult as AsyncResult.AsyncResult<
@@ -822,7 +833,7 @@ export function ToolkitsPage() {
         : null;
     // The toolkit was deleted out from under us (or never resolved) — fall back.
     if (view.kind === "edit" && !existing) {
-      return <ToolkitEditorFallback onBack={() => setView({ kind: "list" })} />;
+      return <ToolkitEditorFallback onBack={() => navigate("")} />;
     }
     const scope =
       view.kind === "new" ? view.scope : (existing as ToolkitView).scope;
@@ -834,9 +845,9 @@ export function ToolkitsPage() {
         takenSlugs={takenSlugs}
         connections={connections}
         integrationName={integrationName}
-        onBack={() => setView({ kind: "list" })}
-        onCreated={() => setView({ kind: "list" })}
-        onRemoved={() => setView({ kind: "list" })}
+        onBack={() => navigate("")}
+        onCreated={() => navigate("")}
+        onRemoved={() => navigate("")}
       />
     );
   }
@@ -861,16 +872,16 @@ export function ToolkitsPage() {
           empty="No workspace toolkits yet — these draw on shared workspace connections."
           toolkits={workspace}
           integrationName={integrationName}
-          onOpen={(id) => setView({ kind: "edit", id })}
-          onCreate={() => setView({ kind: "new", scope: "workspace" })}
+          onOpen={(id) => navigate(id)}
+          onCreate={() => navigate("new/workspace")}
         />
         <ListSection
           title="Personal toolkits"
           empty="No personal toolkits yet — these can use workspace and personal connections."
           toolkits={personal}
           integrationName={integrationName}
-          onOpen={(id) => setView({ kind: "edit", id })}
-          onCreate={() => setView({ kind: "new", scope: "personal" })}
+          onOpen={(id) => navigate(id)}
+          onCreate={() => navigate("new/personal")}
         />
       </div>
     </div>

--- a/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
+++ b/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
@@ -1,0 +1,900 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/react — the Toolkits console page.
+//
+// A toolkit is a named slice of the caller's connections (each off/read/full)
+// with its own MCP endpoint; an agent connected to one can't see anything
+// outside it. This is a SINGLE page (the plugin route matcher is exact-path,
+// no params) that switches between the list and a per-toolkit editor via local
+// state — the same shape as the design prototype.
+//
+// Workspace toolkits draw on org-owned connections; personal toolkits can use
+// org + the caller's own. The list query returns every visible toolkit and we
+// split by `scope`.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useMemo, useState } from "react";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import * as Exit from "effect/Exit";
+
+import {
+  connectionsAllAtom,
+  integrationsAtom,
+} from "@executor-js/react/api/atoms";
+import { Button } from "@executor-js/react/components/button";
+import { Input } from "@executor-js/react/components/input";
+import { Textarea } from "@executor-js/react/components/textarea";
+import { Switch } from "@executor-js/react/components/switch";
+import { Label } from "@executor-js/react/components/label";
+import { Badge } from "@executor-js/react/components/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@executor-js/react/components/select";
+import { IntegrationFavicon } from "@executor-js/react/components/integration-favicon";
+import { copyToClipboard } from "@executor-js/react/lib/clipboard";
+import { cn } from "@executor-js/react/lib/utils";
+
+import type {
+  ToolkitAccess,
+  ToolkitPolicy,
+  ToolkitPolicyAction,
+  ToolkitScope,
+  ToolkitView,
+} from "../shared";
+import {
+  toolkitsAtom,
+  createToolkit,
+  updateToolkit,
+  removeToolkit,
+  toolkitWriteKeys,
+} from "./atoms";
+import {
+  type FormConn as Conn,
+  accessFromToolkit,
+  connKey,
+  entriesFromAccess,
+  slugify,
+  tiersForScope,
+  uniqueSlug,
+} from "./form";
+
+// ---------------------------------------------------------------------------
+// Local shapes — structural views of the core connection/integration rows we
+// read, so this file doesn't pin a specific API success-type name.
+// ---------------------------------------------------------------------------
+
+interface Integ {
+  readonly slug: string;
+  readonly name: string;
+}
+
+const ACCESS_OPTIONS: ReadonlyArray<{ value: ToolkitAccess; label: string }> = [
+  { value: "off", label: "Off" },
+  { value: "read", label: "Read" },
+  { value: "full", label: "Full" },
+];
+
+const ACTION_LABEL: Record<ToolkitPolicyAction, string> = {
+  approve: "Auto-approve",
+  require_approval: "Needs approval",
+  block: "Block",
+};
+
+// ---------------------------------------------------------------------------
+// Access segmented control (off / read / full)
+// ---------------------------------------------------------------------------
+
+function AccessSeg(props: {
+  value: ToolkitAccess;
+  onChange: (v: ToolkitAccess) => void;
+}) {
+  return (
+    <div className="inline-flex shrink-0 gap-0.5 rounded-md border border-input p-0.5">
+      {ACCESS_OPTIONS.map((o) => (
+        <Button
+          key={o.value}
+          type="button"
+          size="sm"
+          variant={props.value === o.value ? "secondary" : "ghost"}
+          className="h-6 px-2.5 text-[11px] font-medium"
+          onClick={() => props.onChange(o.value)}
+        >
+          {o.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+function ToolkitCard(props: {
+  toolkit: ToolkitView;
+  integrationName: (slug: string) => string;
+  onOpen: () => void;
+}) {
+  const active = props.toolkit.connections.filter((c) => c.access !== "off");
+  const integrations = [...new Set(active.map((c) => c.integration))];
+  return (
+    // oxlint-disable-next-line react/forbid-elements -- a card-sized clickable surface; a real <button> is the correct accessible primitive
+    <button
+      type="button"
+      onClick={props.onOpen}
+      className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-ring"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[15px] font-semibold text-foreground">
+          {props.toolkit.name}
+        </span>
+        <span className="text-[12px] text-muted-foreground">
+          {active.length} {active.length === 1 ? "connection" : "connections"}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {integrations.length === 0 ? (
+          <span className="text-[12px] text-muted-foreground">
+            Empty — nothing granted yet
+          </span>
+        ) : (
+          integrations.map((slug) => (
+            <span
+              key={slug}
+              className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-0.5 text-[12px]"
+            >
+              <IntegrationFavicon sourceId={slug} size={14} />
+              {props.integrationName(slug)}
+            </span>
+          ))
+        )}
+      </div>
+      <span className="font-mono text-[10.5px] text-muted-foreground">
+        /mcp?toolkit={props.toolkit.slug}
+      </span>
+    </button>
+  );
+}
+
+function ListSection(props: {
+  title: string;
+  empty: string;
+  toolkits: ReadonlyArray<ToolkitView>;
+  integrationName: (slug: string) => string;
+  onOpen: (id: string) => void;
+  onCreate: () => void;
+}) {
+  return (
+    <section className="mt-10">
+      <div className="mb-3 flex items-center justify-between border-b border-border/50 pb-2">
+        <h2 className="font-display text-xl tracking-tight text-foreground">
+          {props.title}
+        </h2>
+        <Button type="button" size="sm" onClick={props.onCreate}>
+          New toolkit
+        </Button>
+      </div>
+      {props.toolkits.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border px-4 py-6 text-sm text-muted-foreground">
+          {props.empty}
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {props.toolkits.map((tk) => (
+            <ToolkitCard
+              key={tk.id}
+              toolkit={tk}
+              integrationName={props.integrationName}
+              onOpen={() => props.onOpen(tk.id)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Editor
+// ---------------------------------------------------------------------------
+
+interface EditorProps {
+  readonly existing: ToolkitView | null;
+  readonly scope: ToolkitScope;
+  readonly takenSlugs: ReadonlySet<string>;
+  readonly connections: ReadonlyArray<Conn>;
+  readonly integrationName: (slug: string) => string;
+  readonly onBack: () => void;
+  readonly onCreated: () => void;
+  readonly onRemoved: () => void;
+}
+
+function ToolkitEditor(props: EditorProps) {
+  const { existing, scope } = props;
+
+  const [name, setName] = useState(existing?.name ?? "Untitled");
+  const [briefing, setBriefing] = useState(existing?.briefing ?? "");
+  const [inheritOrg, setInheritOrg] = useState(
+    existing?.inheritOrgPolicies ?? true,
+  );
+  const [access, setAccess] = useState<Record<string, ToolkitAccess>>(
+    () => accessFromToolkit(existing).access,
+  );
+  const [notes, setNotes] = useState<Record<string, string>>(
+    () => accessFromToolkit(existing).notes,
+  );
+  const [policies, setPolicies] = useState<ReadonlyArray<ToolkitPolicy>>(
+    () => existing?.policies.map((p) => ({ ...p })) ?? [],
+  );
+
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [origin, setOrigin] = useState("");
+  useEffect(() => {
+    if (typeof window !== "undefined") setOrigin(window.location.origin);
+  }, []);
+
+  const doCreate = useAtomSet(createToolkit, { mode: "promiseExit" });
+  const doUpdate = useAtomSet(updateToolkit, { mode: "promiseExit" });
+  const doRemove = useAtomSet(removeToolkit, { mode: "promiseExit" });
+
+  const mark = () => {
+    setDirty(true);
+    setError(null);
+  };
+  const setMode = (key: string, v: ToolkitAccess) => {
+    setAccess((m) => ({ ...m, [key]: v }));
+    mark();
+  };
+  const setNote = (key: string, v: string) => {
+    setNotes((m) => ({ ...m, [key]: v }));
+    mark();
+  };
+  const setPolicy = (i: number, patch: Partial<ToolkitPolicy>) => {
+    setPolicies((ps) => ps.map((p, j) => (j === i ? { ...p, ...patch } : p)));
+    mark();
+  };
+
+  // The connections this toolkit may draw on: workspace = org-owned only;
+  // personal = org + the caller's own.
+  const tiers = useMemo(
+    () => tiersForScope(props.connections, scope),
+    [props.connections, scope],
+  );
+
+  const buildEntries = () =>
+    entriesFromAccess(props.connections, scope, access, notes);
+
+  const cleanPolicies = (): ReadonlyArray<ToolkitPolicy> =>
+    policies
+      .filter((p) => p.pattern.trim())
+      .map((p) => ({ ...p, pattern: p.pattern.trim() }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    const connections = buildEntries();
+    const cleaned = cleanPolicies();
+    if (existing) {
+      const exit = await doUpdate({
+        params: { id: existing.id },
+        payload: {
+          name: name.trim() || "Untitled",
+          briefing: briefing.trim() ? briefing.trim() : null,
+          inheritOrgPolicies: inheritOrg,
+          connections,
+          policies: cleaned,
+        },
+        reactivityKeys: toolkitWriteKeys,
+      });
+      setSaving(false);
+      if (Exit.isFailure(exit)) {
+        setError("Couldn't save changes. Try again.");
+        return;
+      }
+      setDirty(false);
+      return;
+    }
+    const exit = await doCreate({
+      payload: {
+        slug: uniqueSlug(slugify(name) || "toolkit", props.takenSlugs),
+        name: name.trim() || "Untitled",
+        scope,
+        inheritOrgPolicies: inheritOrg,
+        briefing: briefing.trim() ? briefing.trim() : undefined,
+        connections,
+        policies: cleaned,
+      },
+      reactivityKeys: toolkitWriteKeys,
+    });
+    setSaving(false);
+    if (Exit.isFailure(exit)) {
+      setError("Couldn't create the toolkit. Try again.");
+      return;
+    }
+    props.onCreated();
+  };
+
+  const handleDelete = async () => {
+    if (!existing) {
+      props.onBack();
+      return;
+    }
+    // oxlint-disable-next-line no-alert -- intentional destructive confirmation
+    if (
+      !window.confirm(
+        "Delete this toolkit? Connected agents lose access immediately.",
+      )
+    )
+      return;
+    const exit = await doRemove({
+      params: { id: existing.id },
+      reactivityKeys: toolkitWriteKeys,
+    });
+    if (Exit.isSuccess(exit)) props.onRemoved();
+    else setError("Couldn't delete the toolkit. Try again.");
+  };
+
+  const slug = existing?.slug ?? (slugify(name) || "toolkit");
+  const endpoint = `${origin}/mcp?toolkit=${encodeURIComponent(slug)}`;
+
+  // Live "what the agent sees" — derived from the in-progress form.
+  const previewGroups = useMemo(() => {
+    const byInt = new Map<
+      string,
+      Array<{ name: string; access: ToolkitAccess; note?: string }>
+    >();
+    for (const tier of tiers) {
+      for (const c of tier.conns) {
+        const key = connKey(c.integration, c.name);
+        const a = access[key] ?? "off";
+        if (a === "off") continue;
+        const list = byInt.get(c.integration) ?? [];
+        list.push({
+          name: c.name,
+          access: a,
+          note: notes[key]?.trim() || undefined,
+        });
+        byInt.set(c.integration, list);
+      }
+    }
+    return [...byInt.entries()];
+  }, [tiers, access, notes]);
+  const previewCount = previewGroups.reduce(
+    (n, [, conns]) => n + conns.length,
+    0,
+  );
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl px-6 py-10 lg:px-10 lg:py-14">
+        {/* oxlint-disable-next-line react/forbid-elements -- a subtle text breadcrumb; intentionally not the styled design-system Button */}
+        <button
+          type="button"
+          onClick={props.onBack}
+          className="mb-4 text-[12.5px] font-medium text-muted-foreground hover:text-foreground"
+        >
+          ← Toolkits
+        </button>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <Input
+              value={name}
+              onChange={(e) => {
+                setName((e.target as HTMLInputElement).value);
+                mark();
+              }}
+              className="h-auto w-full max-w-[420px] border-transparent bg-transparent px-1 font-display text-3xl tracking-tight text-foreground shadow-none focus-visible:border-input"
+            />
+            <p className="mt-1 px-1 text-[13px] text-muted-foreground">
+              {scope === "workspace"
+                ? "Workspace toolkit — shared with your org, draws on workspace connections."
+                : "Personal toolkit — only you, can use workspace and your own connections."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="shrink-0 text-destructive/80 hover:text-destructive"
+            onClick={handleDelete}
+          >
+            Delete
+          </Button>
+        </div>
+
+        <Textarea
+          value={briefing}
+          onChange={(e) => {
+            setBriefing((e.target as HTMLTextAreaElement).value);
+            mark();
+          }}
+          placeholder="What is this toolkit for? This leads the agent's briefing."
+          className="mt-1 min-h-[2.25rem] resize-none border-transparent bg-transparent px-0 text-sm text-muted-foreground shadow-none focus-visible:border-input focus-visible:bg-card focus-visible:px-3"
+        />
+
+        <div className="mt-6 grid grid-cols-1 items-start gap-7 lg:grid-cols-[minmax(0,1fr)_340px]">
+          {/* Main column */}
+          <div>
+            {/* Access */}
+            <h3 className="mb-2.5 text-[13.5px] font-semibold text-foreground">
+              Access
+            </h3>
+            <div className="overflow-hidden rounded-xl border border-border bg-card">
+              {tiers.map((tier, ti) => (
+                <div
+                  key={tier.label}
+                  className={cn(ti > 0 && "border-t border-border")}
+                >
+                  <div className="flex items-center justify-between px-4 pb-1 pt-3">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                      {tier.label}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground">
+                      {tier.conns.length} available
+                    </span>
+                  </div>
+                  {tier.conns.length === 0 ? (
+                    <p className="px-4 pb-3 text-[12px] text-muted-foreground">
+                      No connections in this tier yet.
+                    </p>
+                  ) : (
+                    groupByIntegration(tier.conns).map(([intSlug, conns]) => (
+                      <div key={intSlug} className="px-4 pb-2 pt-1.5">
+                        <div className="flex items-center gap-2 pb-1">
+                          <IntegrationFavicon sourceId={intSlug} size={16} />
+                          <span className="text-[12.5px] font-semibold text-foreground">
+                            {props.integrationName(intSlug)}
+                          </span>
+                          {conns.length > 1 && (
+                            <span className="ml-auto text-[11px] text-muted-foreground">
+                              {conns.length} accounts
+                            </span>
+                          )}
+                        </div>
+                        {conns.map((c) => {
+                          const key = connKey(c.integration, c.name);
+                          const a = access[key] ?? "off";
+                          return (
+                            <div
+                              key={key}
+                              data-testid={`tk-conn ${key}`}
+                              className="pl-7"
+                            >
+                              <div className="flex items-center gap-3 py-1">
+                                <div className="min-w-0 flex-1">
+                                  <div className="truncate text-[13px] font-semibold text-foreground">
+                                    {c.name}
+                                  </div>
+                                  {(c.identityLabel || c.description) && (
+                                    <div className="truncate text-[11.5px] text-muted-foreground">
+                                      {c.identityLabel || c.description}
+                                    </div>
+                                  )}
+                                </div>
+                                <AccessSeg
+                                  value={a}
+                                  onChange={(v) => setMode(key, v)}
+                                />
+                              </div>
+                              {a !== "off" && (
+                                <Input
+                                  value={notes[key] ?? ""}
+                                  onChange={(e) =>
+                                    setNote(
+                                      key,
+                                      (e.target as HTMLInputElement).value,
+                                    )
+                                  }
+                                  placeholder={`Note to the agent about ${c.name} (optional)`}
+                                  className="mb-1.5 h-7 border-transparent bg-transparent px-0 text-[12px] italic shadow-none focus-visible:border-input"
+                                />
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ))
+                  )}
+                </div>
+              ))}
+            </div>
+            <p className="mt-2.5 text-[12px] text-muted-foreground">
+              New tools and new connections are included automatically, by mode.
+            </p>
+
+            {/* Approvals & policies */}
+            <div className="mb-2.5 mt-6 flex items-center justify-between">
+              <h3 className="text-[13.5px] font-semibold text-foreground">
+                Approvals &amp; policies
+              </h3>
+              <Label className="flex cursor-pointer items-center gap-2">
+                <Switch
+                  checked={inheritOrg}
+                  onCheckedChange={(v) => {
+                    setInheritOrg(v);
+                    mark();
+                  }}
+                />
+                <span className="text-[12px] font-medium text-muted-foreground">
+                  Inherit org policies
+                </span>
+              </Label>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-border bg-card">
+              <div className="px-4 py-3">
+                <p className="text-[12px] text-muted-foreground">
+                  {inheritOrg
+                    ? "Your workspace's policies apply on top of this toolkit. Where an org rule and a toolkit rule overlap, the stricter one wins."
+                    : "Workspace guardrails are off — this toolkit is governed only by its own rules below."}
+                </p>
+              </div>
+              <div className="border-t border-border px-4 py-2.5">
+                <div className="flex items-center gap-2 pb-1">
+                  <span className="text-[12.5px] font-semibold text-foreground">
+                    Toolkit rules
+                  </span>
+                  <span className="ml-auto text-[11px] text-muted-foreground">
+                    {policies.length} {policies.length === 1 ? "rule" : "rules"}
+                  </span>
+                </div>
+                {policies.map((p, i) => (
+                  <div
+                    key={i}
+                    className="flex flex-wrap items-center gap-2 py-1.5"
+                  >
+                    <Input
+                      value={p.pattern}
+                      onChange={(e) =>
+                        setPolicy(i, {
+                          pattern: (e.target as HTMLInputElement).value,
+                        })
+                      }
+                      placeholder="slack.*.post_message"
+                      className="h-8 min-w-[190px] flex-1 font-mono text-[12px]"
+                    />
+                    <Select
+                      value={p.action}
+                      onValueChange={(v) =>
+                        setPolicy(i, { action: v as ToolkitPolicyAction })
+                      }
+                    >
+                      <SelectTrigger className="h-8 w-[150px] text-[12px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="approve">
+                          {ACTION_LABEL.approve}
+                        </SelectItem>
+                        <SelectItem value="require_approval">
+                          {ACTION_LABEL.require_approval}
+                        </SelectItem>
+                        <SelectItem value="block">
+                          {ACTION_LABEL.block}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="h-8 px-2 text-destructive/70 hover:text-destructive"
+                      onClick={() => {
+                        setPolicies((ps) => ps.filter((_, j) => j !== i));
+                        mark();
+                      }}
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                ))}
+                <div className="flex items-center gap-3 pt-1">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      setPolicies((ps) => [
+                        ...ps,
+                        { pattern: "", action: "approve" },
+                      ]);
+                      mark();
+                    }}
+                  >
+                    + Add rule
+                  </Button>
+                  <span className="text-[11px] text-muted-foreground">
+                    Block hides matching tools entirely · approve /
+                    needs-approval set gating.
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Connect */}
+            <h3 className="mb-2.5 mt-6 text-[13.5px] font-semibold text-foreground">
+              Connect
+            </h3>
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                MCP endpoint
+              </div>
+              {/* oxlint-disable-next-line react/forbid-elements -- a full-width copy affordance; the design-system Button doesn't fit this row layout */}
+              <button
+                type="button"
+                onClick={async () => {
+                  if (await copyToClipboard(endpoint)) {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1100);
+                  }
+                }}
+                className="mt-2 flex w-full items-center justify-between gap-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-left"
+              >
+                <span className="truncate font-mono text-[12px] text-foreground">
+                  {endpoint}
+                </span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">
+                  {copied ? "copied" : "copy"}
+                </span>
+              </button>
+              <p className="mt-2.5 text-[11.5px] text-muted-foreground">
+                Point an agent at this URL with any of your account's API keys —
+                it sees only this toolkit's slice, never the management API.
+              </p>
+            </div>
+
+            {/* Save bar */}
+            <div className="mt-6 flex items-center gap-3">
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={saving || (!!existing && !dirty)}
+              >
+                {saving
+                  ? "Saving…"
+                  : existing
+                    ? "Save changes"
+                    : "Create toolkit"}
+              </Button>
+              {error ? (
+                <span className="text-[12px] text-destructive">{error}</span>
+              ) : existing && !dirty ? (
+                <span className="text-[12px] text-muted-foreground">
+                  All changes saved
+                </span>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Preview rail */}
+          <aside className="lg:sticky lg:top-6">
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                  What the agent sees
+                </span>
+                <span className="text-[12px] text-muted-foreground">
+                  {previewCount}{" "}
+                  {previewCount === 1 ? "connection" : "connections"}
+                </span>
+              </div>
+              {briefing.trim() && (
+                <p className="mt-3 whitespace-pre-wrap text-[12px] leading-relaxed text-foreground">
+                  {briefing.trim()}
+                </p>
+              )}
+              {previewGroups.length === 0 ? (
+                <p className="mt-3 text-[12px] text-muted-foreground">
+                  Nothing granted yet — set a connection to Read or Full to give
+                  the agent something to work with.
+                </p>
+              ) : (
+                <div className="mt-3 flex flex-col gap-3">
+                  {previewGroups.map(([intSlug, conns]) => (
+                    <div key={intSlug}>
+                      <div className="flex items-center gap-2">
+                        <IntegrationFavicon sourceId={intSlug} size={15} />
+                        <span className="text-[12.5px] font-semibold text-foreground">
+                          {props.integrationName(intSlug)}
+                        </span>
+                      </div>
+                      {conns.map((c) => (
+                        <div key={c.name} className="mt-1 pl-6">
+                          <div className="flex items-center gap-2">
+                            <span className="text-[12px] text-foreground">
+                              {c.name}
+                            </span>
+                            <Badge
+                              variant={
+                                c.access === "full" ? "default" : "secondary"
+                              }
+                              className="px-1.5 py-0 text-[10px]"
+                            >
+                              {c.access === "full" ? "full" : "read-only"}
+                            </Badge>
+                          </div>
+                          {c.note && (
+                            <p className="text-[11px] italic text-muted-foreground">
+                              {c.note}
+                            </p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function groupByIntegration(
+  conns: ReadonlyArray<Conn>,
+): ReadonlyArray<readonly [string, ReadonlyArray<Conn>]> {
+  const byInt = new Map<string, Conn[]>();
+  for (const c of conns) {
+    const list = byInt.get(c.integration) ?? [];
+    list.push(c);
+    byInt.set(c.integration, list);
+  }
+  return [...byInt.entries()];
+}
+
+// ---------------------------------------------------------------------------
+// Page — list <-> editor switch
+// ---------------------------------------------------------------------------
+
+type View =
+  | { readonly kind: "list" }
+  | { readonly kind: "edit"; readonly id: string }
+  | { readonly kind: "new"; readonly scope: ToolkitScope };
+
+export function ToolkitsPage() {
+  const toolkitsResult = useAtomValue(toolkitsAtom);
+  const connectionsResult = useAtomValue(connectionsAllAtom);
+  const integrationsResult = useAtomValue(integrationsAtom);
+  const [view, setView] = useState<View>({ kind: "list" });
+
+  const toolkits = AsyncResult.match(
+    toolkitsResult as AsyncResult.AsyncResult<
+      ReadonlyArray<ToolkitView>,
+      unknown
+    >,
+    {
+      onInitial: () => null,
+      onFailure: () => [] as ReadonlyArray<ToolkitView>,
+      onSuccess: ({ value }) => value,
+    },
+  );
+  const connections = AsyncResult.match(
+    connectionsResult as AsyncResult.AsyncResult<ReadonlyArray<Conn>, unknown>,
+    {
+      onInitial: () => [] as ReadonlyArray<Conn>,
+      onFailure: () => [] as ReadonlyArray<Conn>,
+      onSuccess: ({ value }) => value,
+    },
+  );
+  const integrations = AsyncResult.match(
+    integrationsResult as AsyncResult.AsyncResult<
+      ReadonlyArray<Integ>,
+      unknown
+    >,
+    {
+      onInitial: () => [] as ReadonlyArray<Integ>,
+      onFailure: () => [] as ReadonlyArray<Integ>,
+      onSuccess: ({ value }) => value,
+    },
+  );
+
+  const integrationName = useMemo(() => {
+    const bySlug = new Map(integrations.map((i) => [i.slug, i.name]));
+    return (slug: string) => bySlug.get(slug) ?? slug;
+  }, [integrations]);
+
+  const takenSlugs = useMemo(
+    () => new Set((toolkits ?? []).map((t) => t.slug)),
+    [toolkits],
+  );
+
+  if (toolkits === null) {
+    return (
+      <div className="px-1 py-8 text-[13px] text-muted-foreground">
+        Loading toolkits…
+      </div>
+    );
+  }
+
+  if (view.kind === "edit" || view.kind === "new") {
+    const existing =
+      view.kind === "edit"
+        ? (toolkits.find((t) => t.id === view.id) ?? null)
+        : null;
+    // The toolkit was deleted out from under us (or never resolved) — fall back.
+    if (view.kind === "edit" && !existing) {
+      return <ToolkitEditorFallback onBack={() => setView({ kind: "list" })} />;
+    }
+    const scope =
+      view.kind === "new" ? view.scope : (existing as ToolkitView).scope;
+    return (
+      <ToolkitEditor
+        key={view.kind === "edit" ? view.id : `new-${view.scope}`}
+        existing={existing}
+        scope={scope}
+        takenSlugs={takenSlugs}
+        connections={connections}
+        integrationName={integrationName}
+        onBack={() => setView({ kind: "list" })}
+        onCreated={() => setView({ kind: "list" })}
+        onRemoved={() => setView({ kind: "list" })}
+      />
+    );
+  }
+
+  const workspace = toolkits.filter((t) => t.scope === "workspace");
+  const personal = toolkits.filter((t) => t.scope === "personal");
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">
+        <header className="mb-2">
+          <h1 className="font-display text-3xl tracking-tight text-foreground lg:text-4xl">
+            Toolkits
+          </h1>
+          <p className="mt-1.5 max-w-[640px] text-sm text-muted-foreground">
+            A toolkit is a slice of your connections with its own MCP endpoint.
+            An agent connected to one can't see anything outside it.
+          </p>
+        </header>
+        <ListSection
+          title="Workspace toolkits"
+          empty="No workspace toolkits yet — these draw on shared workspace connections."
+          toolkits={workspace}
+          integrationName={integrationName}
+          onOpen={(id) => setView({ kind: "edit", id })}
+          onCreate={() => setView({ kind: "new", scope: "workspace" })}
+        />
+        <ListSection
+          title="Personal toolkits"
+          empty="No personal toolkits yet — these can use workspace and personal connections."
+          toolkits={personal}
+          integrationName={integrationName}
+          onOpen={(id) => setView({ kind: "edit", id })}
+          onCreate={() => setView({ kind: "new", scope: "personal" })}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ToolkitEditorFallback(props: { onBack: () => void }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl px-6 py-10 lg:px-10 lg:py-14">
+        {/* oxlint-disable-next-line react/forbid-elements -- a subtle text breadcrumb; intentionally not the styled design-system Button */}
+        <button
+          type="button"
+          onClick={props.onBack}
+          className="mb-4 text-[12.5px] font-medium text-muted-foreground hover:text-foreground"
+        >
+          ← Toolkits
+        </button>
+        <p className="text-sm text-muted-foreground">
+          This toolkit no longer exists.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default ToolkitsPage;

--- a/packages/plugins/toolkits/src/react/atoms.ts
+++ b/packages/plugins/toolkits/src/react/atoms.ts
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------------
+// Query + mutation atoms for the toolkits console page.
+//
+// The `list` query returns every toolkit the caller can see (workspace +
+// personal); the page splits by `scope`. Mutations pass `toolkitWriteKeys` at
+// the call site so the list refreshes after a create / update / remove.
+// ---------------------------------------------------------------------------
+
+import {
+  ReactivityKey,
+  toolkitWriteKeys,
+} from "@executor-js/react/api/reactivity-keys";
+
+import { ToolkitsClient } from "./client";
+
+export { toolkitWriteKeys };
+
+export const toolkitsAtom = ToolkitsClient.query("toolkits", "list", {
+  timeToLive: "15 seconds",
+  reactivityKeys: [ReactivityKey.toolkits],
+});
+
+export const createToolkit = ToolkitsClient.mutation("toolkits", "create");
+export const updateToolkit = ToolkitsClient.mutation("toolkits", "update");
+export const removeToolkit = ToolkitsClient.mutation("toolkits", "remove");

--- a/packages/plugins/toolkits/src/react/atoms.ts
+++ b/packages/plugins/toolkits/src/react/atoms.ts
@@ -6,10 +6,7 @@
 // the call site so the list refreshes after a create / update / remove.
 // ---------------------------------------------------------------------------
 
-import {
-  ReactivityKey,
-  toolkitWriteKeys,
-} from "@executor-js/react/api/reactivity-keys";
+import { ReactivityKey, toolkitWriteKeys } from "@executor-js/react/api/reactivity-keys";
 
 import { ToolkitsClient } from "./client";
 

--- a/packages/plugins/toolkits/src/react/client.ts
+++ b/packages/plugins/toolkits/src/react/client.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/react — the typed reactive client
+//
+// `createPluginAtomClient` builds an AtomHttpApi service keyed to the toolkits
+// group, reusing the host's active Executor Server Connection for the base URL
+// and (self-host) authorization header — the same wiring every first-party
+// plugin client uses.
+// ---------------------------------------------------------------------------
+
+import { createPluginAtomClient } from "@executor-js/sdk/client";
+import {
+  getExecutorApiBaseUrl,
+  getExecutorServerAuthorizationHeader,
+} from "@executor-js/react/api/server-connection";
+
+import { ToolkitsApi } from "../shared";
+
+export const ToolkitsClient = createPluginAtomClient(ToolkitsApi, {
+  baseUrl: getExecutorApiBaseUrl,
+  authorizationHeader: getExecutorServerAuthorizationHeader,
+});

--- a/packages/plugins/toolkits/src/react/form.ts
+++ b/packages/plugins/toolkits/src/react/form.ts
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------
+// Pure form <-> wire transforms for the toolkit editor. No React / DOM here so
+// the bug-prone bits (the access-map ⇄ ToolkitConnectionEntry round-trip, scope
+// tiering, slug derivation) are unit-testable in isolation.
+// ---------------------------------------------------------------------------
+
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import type {
+  ToolkitAccess,
+  ToolkitConnectionEntry,
+  ToolkitScope,
+  ToolkitView,
+} from "../shared";
+
+/** A structural view of a core connection row — the fields the editor reads. */
+export interface FormConn {
+  readonly owner: "org" | "user";
+  readonly name: string;
+  readonly integration: string;
+  readonly identityLabel?: string | null;
+  readonly description?: string | null;
+}
+
+export interface AccessTier {
+  readonly label: string;
+  readonly conns: ReadonlyArray<FormConn>;
+}
+
+/** Stable key for the per-connection access/notes maps. A space can't appear in
+ *  an integration slug, so `"<integration> <connection>"` is unambiguous. */
+export const connKey = (integration: string, connection: string): string =>
+  `${integration} ${connection}`;
+
+export const slugify = (s: string): string =>
+  s
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+
+/** A slug not already in `taken`; appends `-2`, `-3`, … on collision. */
+export const uniqueSlug = (
+  base: string,
+  taken: ReadonlySet<string>,
+): string => {
+  const root = base || "toolkit";
+  if (!taken.has(root)) return root;
+  let i = 2;
+  while (taken.has(`${root}-${i}`)) i += 1;
+  return `${root}-${i}`;
+};
+
+/** Which connections a toolkit may draw on: workspace = org-owned only; personal
+ *  = org + the caller's own, split into two tiers. */
+export const tiersForScope = (
+  connections: ReadonlyArray<FormConn>,
+  scope: ToolkitScope,
+): ReadonlyArray<AccessTier> => {
+  const org = connections.filter((c) => c.owner === "org");
+  if (scope === "workspace")
+    return [{ label: "Workspace connections", conns: org }];
+  const user = connections.filter((c) => c.owner === "user");
+  return [
+    { label: "Workspace connections", conns: org },
+    { label: "Personal connections", conns: user },
+  ];
+};
+
+/** Seed the editor's access + notes maps from an existing toolkit. */
+export const accessFromToolkit = (
+  toolkit: ToolkitView | null,
+): { access: Record<string, ToolkitAccess>; notes: Record<string, string> } => {
+  const access: Record<string, ToolkitAccess> = {};
+  const notes: Record<string, string> = {};
+  for (const e of toolkit?.connections ?? []) {
+    const key = connKey(e.integration, e.connection);
+    access[key] = e.access;
+    if (e.note) notes[key] = e.note;
+  }
+  return { access, notes };
+};
+
+/** Collapse the editor's access + notes maps back into the wire entries —
+ *  only connections set to read/full (off = absent), notes trimmed. */
+export const entriesFromAccess = (
+  connections: ReadonlyArray<FormConn>,
+  scope: ToolkitScope,
+  access: Readonly<Record<string, ToolkitAccess>>,
+  notes: Readonly<Record<string, string>>,
+): ReadonlyArray<ToolkitConnectionEntry> => {
+  const entries: Array<ToolkitConnectionEntry> = [];
+  for (const tier of tiersForScope(connections, scope)) {
+    for (const c of tier.conns) {
+      const key = connKey(c.integration, c.name);
+      const a = access[key] ?? "off";
+      if (a === "off") continue;
+      const note = notes[key]?.trim();
+      entries.push({
+        integration: IntegrationSlug.make(c.integration),
+        connection: c.name,
+        access: a,
+        ...(note ? { note } : {}),
+      });
+    }
+  }
+  return entries;
+};

--- a/packages/plugins/toolkits/src/react/form.ts
+++ b/packages/plugins/toolkits/src/react/form.ts
@@ -6,12 +6,7 @@
 
 import { IntegrationSlug } from "@executor-js/sdk/shared";
 
-import type {
-  ToolkitAccess,
-  ToolkitConnectionEntry,
-  ToolkitScope,
-  ToolkitView,
-} from "../shared";
+import type { ToolkitAccess, ToolkitConnectionEntry, ToolkitScope, ToolkitView } from "../shared";
 
 /** A structural view of a core connection row — the fields the editor reads. */
 export interface FormConn {
@@ -41,10 +36,7 @@ export const slugify = (s: string): string =>
     .slice(0, 48);
 
 /** A slug not already in `taken`; appends `-2`, `-3`, … on collision. */
-export const uniqueSlug = (
-  base: string,
-  taken: ReadonlySet<string>,
-): string => {
+export const uniqueSlug = (base: string, taken: ReadonlySet<string>): string => {
   const root = base || "toolkit";
   if (!taken.has(root)) return root;
   let i = 2;
@@ -59,8 +51,7 @@ export const tiersForScope = (
   scope: ToolkitScope,
 ): ReadonlyArray<AccessTier> => {
   const org = connections.filter((c) => c.owner === "org");
-  if (scope === "workspace")
-    return [{ label: "Workspace connections", conns: org }];
+  if (scope === "workspace") return [{ label: "Workspace connections", conns: org }];
   const user = connections.filter((c) => c.owner === "user");
   return [
     { label: "Workspace connections", conns: org },

--- a/packages/plugins/toolkits/src/react/index.ts
+++ b/packages/plugins/toolkits/src/react/index.ts
@@ -1,0 +1,9 @@
+export { ToolkitsPage, default as ToolkitsPageDefault } from "./ToolkitsPage";
+export { ToolkitsClient } from "./client";
+export {
+  toolkitsAtom,
+  createToolkit,
+  updateToolkit,
+  removeToolkit,
+  toolkitWriteKeys,
+} from "./atoms";

--- a/packages/plugins/toolkits/src/react/plugin-client.tsx
+++ b/packages/plugins/toolkits/src/react/plugin-client.tsx
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/client — the frontend half.
+//
+// The Vite plugin resolves `${packageName}/client` for every server plugin
+// registered in `executor.config.ts` and feeds the default export into
+// `<ExecutorPluginsProvider>`, so registering `toolkitsPlugin()` server-side is
+// all it takes for this page (and its "Toolkits" nav entry) to mount.
+//
+// Server-only deps (Effect runtime, Node, executor.config) MUST NOT be imported
+// here — this entry is bundled into the frontend.
+// ---------------------------------------------------------------------------
+
+import { defineClientPlugin } from "@executor-js/sdk/client";
+
+import { ToolkitsPage } from "./ToolkitsPage";
+
+export default defineClientPlugin({
+  id: "toolkits" as const,
+  pages: [
+    {
+      path: "/",
+      component: ToolkitsPage,
+      nav: { label: "Toolkits" },
+    },
+  ],
+});

--- a/packages/plugins/toolkits/src/server.ts
+++ b/packages/plugins/toolkits/src/server.ts
@@ -13,12 +13,17 @@
 // ---------------------------------------------------------------------------
 
 import { Schema } from "effect";
-import { Context, definePlugin, Effect, HttpApiBuilder } from "@executor-js/sdk/core";
+import {
+  Context,
+  definePlugin,
+  Effect,
+  HttpApiBuilder,
+} from "@executor-js/sdk/core";
 import {
   definePluginStorageCollection,
   Owner,
+  type ExecutorWrapper,
   type PluginCtx,
-  type ResolvedToolkitScope,
   type StorageFailure,
 } from "@executor-js/sdk";
 import { addGroup, capture } from "@executor-js/api";
@@ -34,6 +39,11 @@ import {
   type ToolkitView,
   type UpdateToolkitPayload,
 } from "./shared";
+import {
+  applyToolkitScope,
+  EMPTY_TOOLKIT_SCOPE,
+  type ResolvedToolkitScope,
+} from "./toolkit-scope";
 
 const ORG = Owner.make("org");
 const USER = Owner.make("user");
@@ -64,14 +74,23 @@ const PolicyRow = Schema.Struct({
   action: Schema.String,
 });
 
-const TOOLKITS = definePluginStorageCollection("toolkits", ToolkitRow, { indexes: ["slug"] });
-const CONNECTIONS = definePluginStorageCollection("connections", ConnectionRow, {
+const TOOLKITS = definePluginStorageCollection("toolkits", ToolkitRow, {
+  indexes: ["slug"],
+});
+const CONNECTIONS = definePluginStorageCollection(
+  "connections",
+  ConnectionRow,
+  {
+    indexes: ["toolkitId"],
+  },
+);
+const POLICIES = definePluginStorageCollection("policies", PolicyRow, {
   indexes: ["toolkitId"],
 });
-const POLICIES = definePluginStorageCollection("policies", PolicyRow, { indexes: ["toolkitId"] });
 
 const newId = Effect.sync(() => crypto.randomUUID());
-const scopeOfOwner = (owner: Owner): ToolkitScope => (owner === ORG ? "workspace" : "personal");
+const scopeOfOwner = (owner: Owner): ToolkitScope =>
+  owner === ORG ? "workspace" : "personal";
 
 // ---------------------------------------------------------------------------
 // Extension — the canonical implementation. Handlers (and later the MCP
@@ -116,9 +135,14 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
   // candidate connections honoring scope: a workspace toolkit may use only
   // org connections; a personal toolkit may use org + the caller's own.
   const candidateConnections = (scope: ToolkitScope) =>
-    scope === "workspace" ? ctx.connections.list({ owner: ORG }) : ctx.connections.list();
+    scope === "workspace"
+      ? ctx.connections.list({ owner: ORG })
+      : ctx.connections.list();
 
-  const validate = (scope: ToolkitScope, entries: ReadonlyArray<ToolkitConnectionEntryInput>) =>
+  const validate = (
+    scope: ToolkitScope,
+    entries: ReadonlyArray<ToolkitConnectionEntryInput>,
+  ) =>
     Effect.gen(function* () {
       const allowed = yield* candidateConnections(scope);
       const pairs = new Set(allowed.map((c) => `${c.integration}/${c.name}`));
@@ -207,7 +231,9 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
     });
 
   const list = () =>
-    toolkits.list().pipe(Effect.flatMap((rows) => Effect.forEach(rows, viewFromRow)));
+    toolkits
+      .list()
+      .pipe(Effect.flatMap((rows) => Effect.forEach(rows, viewFromRow)));
 
   const update = (id: string, patch: UpdateToolkitPayload) =>
     Effect.gen(function* () {
@@ -216,8 +242,10 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       const data = {
         slug: row.data.slug,
         name: patch.name ?? row.data.name,
-        inheritOrgPolicies: patch.inheritOrgPolicies ?? row.data.inheritOrgPolicies,
-        briefing: patch.briefing === undefined ? row.data.briefing : patch.briefing,
+        inheritOrgPolicies:
+          patch.inheritOrgPolicies ?? row.data.inheritOrgPolicies,
+        briefing:
+          patch.briefing === undefined ? row.data.briefing : patch.briefing,
       };
       yield* toolkits.put({ key: id, owner: row.owner, data });
       if (patch.connections !== undefined) {
@@ -230,7 +258,9 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       }
       if (patch.policies !== undefined) {
         const existing = yield* policies.query({ where: { toolkitId: id } });
-        yield* Effect.forEach(existing, (p) => policies.remove({ key: p.key, owner: row.owner }));
+        yield* Effect.forEach(existing, (p) =>
+          policies.remove({ key: p.key, owner: row.owner }),
+        );
         yield* putPolicies(id, row.owner, patch.policies);
       }
       return yield* viewFromRow({ key: id, owner: row.owner, data });
@@ -241,9 +271,13 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       const row = yield* toolkits.get({ key: id });
       if (row == null) return yield* new ToolkitNotFound({ id });
       const conns = yield* connections.query({ where: { toolkitId: id } });
-      yield* Effect.forEach(conns, (c) => connections.remove({ key: c.key, owner: row.owner }));
+      yield* Effect.forEach(conns, (c) =>
+        connections.remove({ key: c.key, owner: row.owner }),
+      );
       const pols = yield* policies.query({ where: { toolkitId: id } });
-      yield* Effect.forEach(pols, (p) => policies.remove({ key: p.key, owner: row.owner }));
+      yield* Effect.forEach(pols, (p) =>
+        policies.remove({ key: p.key, owner: row.owner }),
+      );
       yield* toolkits.remove({ key: id, owner: row.owner });
       return { removed: true };
     });
@@ -256,7 +290,10 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
     selector: string,
   ): Effect.Effect<ResolvedToolkitScope | null, StorageFailure> =>
     Effect.gen(function* () {
-      const bySlug = yield* toolkits.query({ where: { slug: selector }, limit: 1 });
+      const bySlug = yield* toolkits.query({
+        where: { slug: selector },
+        limit: 1,
+      });
       const row = bySlug[0] ?? (yield* toolkits.get({ key: selector }));
       if (row == null) return null;
       const conns = yield* connections.query({ where: { toolkitId: row.key } });
@@ -275,12 +312,24 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       };
     });
 
-  return { create, get, list, update, remove, resolveScope };
+  // The plugin's contribution to core's generic executor-wrapper seam: given a
+  // selector, resolve it to a scope (fail-closed to the empty slice when it
+  // doesn't resolve for this caller) and narrow the executor. Core collects and
+  // runs this without knowing it's about toolkits.
+  const wrapExecutor: ExecutorWrapper = (base, selector) =>
+    resolveScope(selector).pipe(
+      Effect.flatMap((scope) =>
+        applyToolkitScope(base, scope ?? EMPTY_TOOLKIT_SCOPE),
+      ),
+    );
+
+  return { create, get, list, update, remove, resolveScope, wrapExecutor };
 };
 
 // Local aliases so the storage/extension layer stays decoupled from the wire
 // schema's branded types without re-importing them everywhere.
-type ToolkitConnectionIntegration = ToolkitView["connections"][number]["integration"];
+type ToolkitConnectionIntegration =
+  ToolkitView["connections"][number]["integration"];
 type ToolkitConnectionEntryInput = {
   readonly integration: ToolkitConnectionIntegration;
   readonly connection: string;
@@ -300,48 +349,51 @@ export class ToolkitsExtensionService extends Context.Service<
 // the host's composed API requires) — not a standalone single-group bundle.
 const ExecutorApiWithToolkits = addGroup(ToolkitsApi);
 
-const ToolkitsHandlers = HttpApiBuilder.group(ExecutorApiWithToolkits, "toolkits", (h) =>
-  h
-    .handle("list", () =>
-      capture(
-        Effect.gen(function* () {
-          const ext = yield* ToolkitsExtensionService;
-          return yield* ext.list();
-        }),
+const ToolkitsHandlers = HttpApiBuilder.group(
+  ExecutorApiWithToolkits,
+  "toolkits",
+  (h) =>
+    h
+      .handle("list", () =>
+        capture(
+          Effect.gen(function* () {
+            const ext = yield* ToolkitsExtensionService;
+            return yield* ext.list();
+          }),
+        ),
+      )
+      .handle("create", ({ payload }) =>
+        capture(
+          Effect.gen(function* () {
+            const ext = yield* ToolkitsExtensionService;
+            return yield* ext.create(payload);
+          }),
+        ),
+      )
+      .handle("get", ({ params }) =>
+        capture(
+          Effect.gen(function* () {
+            const ext = yield* ToolkitsExtensionService;
+            return yield* ext.get(params.id);
+          }),
+        ),
+      )
+      .handle("update", ({ params, payload }) =>
+        capture(
+          Effect.gen(function* () {
+            const ext = yield* ToolkitsExtensionService;
+            return yield* ext.update(params.id, payload);
+          }),
+        ),
+      )
+      .handle("remove", ({ params }) =>
+        capture(
+          Effect.gen(function* () {
+            const ext = yield* ToolkitsExtensionService;
+            return yield* ext.remove(params.id);
+          }),
+        ),
       ),
-    )
-    .handle("create", ({ payload }) =>
-      capture(
-        Effect.gen(function* () {
-          const ext = yield* ToolkitsExtensionService;
-          return yield* ext.create(payload);
-        }),
-      ),
-    )
-    .handle("get", ({ params }) =>
-      capture(
-        Effect.gen(function* () {
-          const ext = yield* ToolkitsExtensionService;
-          return yield* ext.get(params.id);
-        }),
-      ),
-    )
-    .handle("update", ({ params, payload }) =>
-      capture(
-        Effect.gen(function* () {
-          const ext = yield* ToolkitsExtensionService;
-          return yield* ext.update(params.id, payload);
-        }),
-      ),
-    )
-    .handle("remove", ({ params }) =>
-      capture(
-        Effect.gen(function* () {
-          const ext = yield* ToolkitsExtensionService;
-          return yield* ext.remove(params.id);
-        }),
-      ),
-    ),
 );
 
 export const toolkitsPlugin = definePlugin(() => ({

--- a/packages/plugins/toolkits/src/server.ts
+++ b/packages/plugins/toolkits/src/server.ts
@@ -1,0 +1,287 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/server
+//
+// The server half of the toolkits plugin. A toolkit is a named slice of the
+// caller's connections, persisted as owner-scoped plugin storage:
+//   - workspace toolkit  -> owner "org"  (visible to every org member)
+//   - personal toolkit   -> owner "user" (visible only to its creator)
+// The pluginStorage facade is already request-bound to (tenant, subject), so
+// the org/user owner literal is the entire workspace-vs-personal visibility
+// story. Slice 1 ships data + CRUD only — no MCP narrowing yet.
+//
+// React and other browser-only deps live in `./client` — never here.
+// ---------------------------------------------------------------------------
+
+import { Schema } from "effect";
+import { Context, definePlugin, Effect, HttpApiBuilder } from "@executor-js/sdk/core";
+import { definePluginStorageCollection, Owner, type PluginCtx } from "@executor-js/sdk";
+import { addGroup, capture } from "@executor-js/api";
+
+import {
+  ToolkitForbidden,
+  ToolkitNotFound,
+  ToolkitsApi,
+  type CreateToolkitPayload,
+  type ToolkitAccess,
+  type ToolkitScope,
+  type ToolkitView,
+  type UpdateToolkitPayload,
+} from "./shared";
+
+const ORG = Owner.make("org");
+const USER = Owner.make("user");
+
+// ---------------------------------------------------------------------------
+// Storage rows (internal — not the HTTP contract). Keyed by uuid, never by a
+// user-supplied value (long keyed values hit a fumadb keyed-lookup bug).
+// ---------------------------------------------------------------------------
+
+const ToolkitRow = Schema.Struct({
+  slug: Schema.String,
+  name: Schema.String,
+  inheritOrgPolicies: Schema.Boolean,
+  briefing: Schema.NullOr(Schema.String),
+});
+
+const ConnectionRow = Schema.Struct({
+  toolkitId: Schema.String,
+  integration: Schema.String,
+  connection: Schema.String,
+  access: Schema.String,
+  note: Schema.NullOr(Schema.String),
+});
+
+const TOOLKITS = definePluginStorageCollection("toolkits", ToolkitRow, { indexes: ["slug"] });
+const CONNECTIONS = definePluginStorageCollection("connections", ConnectionRow, {
+  indexes: ["toolkitId"],
+});
+
+const newId = Effect.sync(() => crypto.randomUUID());
+const scopeOfOwner = (owner: Owner): ToolkitScope => (owner === ORG ? "workspace" : "personal");
+
+// ---------------------------------------------------------------------------
+// Extension — the canonical implementation. Handlers (and later the MCP
+// contribution) all hit this same code path.
+// ---------------------------------------------------------------------------
+
+type ToolkitRowEntry = {
+  readonly key: string;
+  readonly owner: Owner;
+  readonly data: typeof ToolkitRow.Type;
+};
+
+const makeToolkitsExtension = (ctx: PluginCtx) => {
+  const toolkits = ctx.pluginStorage.collection(TOOLKITS);
+  const connections = ctx.pluginStorage.collection(CONNECTIONS);
+
+  const viewFromRow = (row: ToolkitRowEntry) =>
+    connections.query({ where: { toolkitId: row.key } }).pipe(
+      Effect.map(
+        (rows): ToolkitView => ({
+          id: row.key,
+          slug: row.data.slug,
+          name: row.data.name,
+          scope: scopeOfOwner(row.owner),
+          inheritOrgPolicies: row.data.inheritOrgPolicies,
+          briefing: row.data.briefing,
+          connections: rows.map((c) => ({
+            integration: c.data.integration as ToolkitConnectionIntegration,
+            connection: c.data.connection,
+            access: c.data.access as ToolkitAccess,
+            ...(c.data.note == null ? {} : { note: c.data.note }),
+          })),
+        }),
+      ),
+    );
+
+  // candidate connections honoring scope: a workspace toolkit may use only
+  // org connections; a personal toolkit may use org + the caller's own.
+  const candidateConnections = (scope: ToolkitScope) =>
+    scope === "workspace" ? ctx.connections.list({ owner: ORG }) : ctx.connections.list();
+
+  const validate = (scope: ToolkitScope, entries: ReadonlyArray<ToolkitConnectionEntryInput>) =>
+    Effect.gen(function* () {
+      const allowed = yield* candidateConnections(scope);
+      const pairs = new Set(allowed.map((c) => `${c.integration}/${c.name}`));
+      const integrations = new Set(allowed.map((c) => c.integration));
+      for (const e of entries) {
+        const ok =
+          e.connection === "*"
+            ? integrations.has(e.integration)
+            : pairs.has(`${e.integration}/${e.connection}`);
+        if (!ok) {
+          return yield* new ToolkitForbidden({
+            reason: `connection ${e.integration}/${e.connection} is not available to a ${scope} toolkit`,
+          });
+        }
+      }
+    });
+
+  const putConnections = (
+    toolkitId: string,
+    owner: Owner,
+    entries: ReadonlyArray<ToolkitConnectionEntryInput>,
+  ) =>
+    Effect.forEach(entries, (e) =>
+      newId.pipe(
+        Effect.flatMap((cid) =>
+          connections.put({
+            key: cid,
+            owner,
+            data: {
+              toolkitId,
+              integration: e.integration,
+              connection: e.connection,
+              access: e.access,
+              note: e.note ?? null,
+            },
+          }),
+        ),
+      ),
+    );
+
+  const create = (input: CreateToolkitPayload) =>
+    Effect.gen(function* () {
+      if (input.scope === "personal" && ctx.owner.subject == null) {
+        return yield* new ToolkitForbidden({
+          reason: "personal toolkits require a signed-in user",
+        });
+      }
+      const owner = input.scope === "workspace" ? ORG : USER;
+      const entries = input.connections ?? [];
+      yield* validate(input.scope, entries);
+      const id = yield* newId;
+      const data = {
+        slug: input.slug,
+        name: input.name,
+        inheritOrgPolicies: input.inheritOrgPolicies ?? true,
+        briefing: input.briefing ?? null,
+      };
+      yield* toolkits.put({ key: id, owner, data });
+      yield* putConnections(id, owner, entries);
+      return yield* viewFromRow({ key: id, owner, data });
+    });
+
+  const get = (id: string) =>
+    Effect.gen(function* () {
+      const row = yield* toolkits.get({ key: id });
+      if (row == null) return yield* new ToolkitNotFound({ id });
+      return yield* viewFromRow(row);
+    });
+
+  const list = () =>
+    toolkits.list().pipe(Effect.flatMap((rows) => Effect.forEach(rows, viewFromRow)));
+
+  const update = (id: string, patch: UpdateToolkitPayload) =>
+    Effect.gen(function* () {
+      const row = yield* toolkits.get({ key: id });
+      if (row == null) return yield* new ToolkitNotFound({ id });
+      const data = {
+        slug: row.data.slug,
+        name: patch.name ?? row.data.name,
+        inheritOrgPolicies: patch.inheritOrgPolicies ?? row.data.inheritOrgPolicies,
+        briefing: patch.briefing === undefined ? row.data.briefing : patch.briefing,
+      };
+      yield* toolkits.put({ key: id, owner: row.owner, data });
+      if (patch.connections !== undefined) {
+        yield* validate(scopeOfOwner(row.owner), patch.connections);
+        const existing = yield* connections.query({ where: { toolkitId: id } });
+        yield* Effect.forEach(existing, (c) =>
+          connections.remove({ key: c.key, owner: row.owner }),
+        );
+        yield* putConnections(id, row.owner, patch.connections);
+      }
+      return yield* viewFromRow({ key: id, owner: row.owner, data });
+    });
+
+  const remove = (id: string) =>
+    Effect.gen(function* () {
+      const row = yield* toolkits.get({ key: id });
+      if (row == null) return yield* new ToolkitNotFound({ id });
+      const existing = yield* connections.query({ where: { toolkitId: id } });
+      yield* Effect.forEach(existing, (c) => connections.remove({ key: c.key, owner: row.owner }));
+      yield* toolkits.remove({ key: id, owner: row.owner });
+      return { removed: true };
+    });
+
+  return { create, get, list, update, remove };
+};
+
+// Local aliases so the storage/extension layer stays decoupled from the wire
+// schema's branded types without re-importing them everywhere.
+type ToolkitConnectionIntegration = ToolkitView["connections"][number]["integration"];
+type ToolkitConnectionEntryInput = {
+  readonly integration: ToolkitConnectionIntegration;
+  readonly connection: string;
+  readonly access: ToolkitAccess;
+  readonly note?: string | undefined;
+};
+
+type ToolkitsExtension = ReturnType<typeof makeToolkitsExtension>;
+
+export class ToolkitsExtensionService extends Context.Service<
+  ToolkitsExtensionService,
+  ToolkitsExtension
+>()("ToolkitsExtensionService") {}
+
+// Build handlers against the core executor API with the toolkits group added,
+// so the handler layer satisfies `ApiGroup<"executor", "toolkits">` (the marker
+// the host's composed API requires) — not a standalone single-group bundle.
+const ExecutorApiWithToolkits = addGroup(ToolkitsApi);
+
+const ToolkitsHandlers = HttpApiBuilder.group(ExecutorApiWithToolkits, "toolkits", (h) =>
+  h
+    .handle("list", () =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.list();
+        }),
+      ),
+    )
+    .handle("create", ({ payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.create(payload);
+        }),
+      ),
+    )
+    .handle("get", ({ params }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.get(params.id);
+        }),
+      ),
+    )
+    .handle("update", ({ params, payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.update(params.id, payload);
+        }),
+      ),
+    )
+    .handle("remove", ({ params }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.remove(params.id);
+        }),
+      ),
+    ),
+);
+
+export const toolkitsPlugin = definePlugin(() => ({
+  id: "toolkits" as const,
+  packageName: "@executor-js/plugin-toolkits",
+  storage: () => ({}),
+  pluginStorage: { toolkits: TOOLKITS, connections: CONNECTIONS },
+  extension: makeToolkitsExtension,
+  routes: () => ToolkitsApi,
+  handlers: () => ToolkitsHandlers,
+  extensionService: ToolkitsExtensionService,
+}));
+
+export default toolkitsPlugin;

--- a/packages/plugins/toolkits/src/server.ts
+++ b/packages/plugins/toolkits/src/server.ts
@@ -13,12 +13,7 @@
 // ---------------------------------------------------------------------------
 
 import { Schema } from "effect";
-import {
-  Context,
-  definePlugin,
-  Effect,
-  HttpApiBuilder,
-} from "@executor-js/sdk/core";
+import { Context, definePlugin, Effect, HttpApiBuilder } from "@executor-js/sdk/core";
 import {
   definePluginStorageCollection,
   Owner,
@@ -77,20 +72,15 @@ const PolicyRow = Schema.Struct({
 const TOOLKITS = definePluginStorageCollection("toolkits", ToolkitRow, {
   indexes: ["slug"],
 });
-const CONNECTIONS = definePluginStorageCollection(
-  "connections",
-  ConnectionRow,
-  {
-    indexes: ["toolkitId"],
-  },
-);
+const CONNECTIONS = definePluginStorageCollection("connections", ConnectionRow, {
+  indexes: ["toolkitId"],
+});
 const POLICIES = definePluginStorageCollection("policies", PolicyRow, {
   indexes: ["toolkitId"],
 });
 
 const newId = Effect.sync(() => crypto.randomUUID());
-const scopeOfOwner = (owner: Owner): ToolkitScope =>
-  owner === ORG ? "workspace" : "personal";
+const scopeOfOwner = (owner: Owner): ToolkitScope => (owner === ORG ? "workspace" : "personal");
 
 // ---------------------------------------------------------------------------
 // Extension — the canonical implementation. Handlers (and later the MCP
@@ -135,14 +125,9 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
   // candidate connections honoring scope: a workspace toolkit may use only
   // org connections; a personal toolkit may use org + the caller's own.
   const candidateConnections = (scope: ToolkitScope) =>
-    scope === "workspace"
-      ? ctx.connections.list({ owner: ORG })
-      : ctx.connections.list();
+    scope === "workspace" ? ctx.connections.list({ owner: ORG }) : ctx.connections.list();
 
-  const validate = (
-    scope: ToolkitScope,
-    entries: ReadonlyArray<ToolkitConnectionEntryInput>,
-  ) =>
+  const validate = (scope: ToolkitScope, entries: ReadonlyArray<ToolkitConnectionEntryInput>) =>
     Effect.gen(function* () {
       const allowed = yield* candidateConnections(scope);
       const pairs = new Set(allowed.map((c) => `${c.integration}/${c.name}`));
@@ -231,9 +216,7 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
     });
 
   const list = () =>
-    toolkits
-      .list()
-      .pipe(Effect.flatMap((rows) => Effect.forEach(rows, viewFromRow)));
+    toolkits.list().pipe(Effect.flatMap((rows) => Effect.forEach(rows, viewFromRow)));
 
   const update = (id: string, patch: UpdateToolkitPayload) =>
     Effect.gen(function* () {
@@ -242,10 +225,8 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       const data = {
         slug: row.data.slug,
         name: patch.name ?? row.data.name,
-        inheritOrgPolicies:
-          patch.inheritOrgPolicies ?? row.data.inheritOrgPolicies,
-        briefing:
-          patch.briefing === undefined ? row.data.briefing : patch.briefing,
+        inheritOrgPolicies: patch.inheritOrgPolicies ?? row.data.inheritOrgPolicies,
+        briefing: patch.briefing === undefined ? row.data.briefing : patch.briefing,
       };
       yield* toolkits.put({ key: id, owner: row.owner, data });
       if (patch.connections !== undefined) {
@@ -258,9 +239,7 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       }
       if (patch.policies !== undefined) {
         const existing = yield* policies.query({ where: { toolkitId: id } });
-        yield* Effect.forEach(existing, (p) =>
-          policies.remove({ key: p.key, owner: row.owner }),
-        );
+        yield* Effect.forEach(existing, (p) => policies.remove({ key: p.key, owner: row.owner }));
         yield* putPolicies(id, row.owner, patch.policies);
       }
       return yield* viewFromRow({ key: id, owner: row.owner, data });
@@ -271,13 +250,9 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       const row = yield* toolkits.get({ key: id });
       if (row == null) return yield* new ToolkitNotFound({ id });
       const conns = yield* connections.query({ where: { toolkitId: id } });
-      yield* Effect.forEach(conns, (c) =>
-        connections.remove({ key: c.key, owner: row.owner }),
-      );
+      yield* Effect.forEach(conns, (c) => connections.remove({ key: c.key, owner: row.owner }));
       const pols = yield* policies.query({ where: { toolkitId: id } });
-      yield* Effect.forEach(pols, (p) =>
-        policies.remove({ key: p.key, owner: row.owner }),
-      );
+      yield* Effect.forEach(pols, (p) => policies.remove({ key: p.key, owner: row.owner }));
       yield* toolkits.remove({ key: id, owner: row.owner });
       return { removed: true };
     });
@@ -317,8 +292,7 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
 
 // Local aliases so the storage/extension layer stays decoupled from the wire
 // schema's branded types without re-importing them everywhere.
-type ToolkitConnectionIntegration =
-  ToolkitView["connections"][number]["integration"];
+type ToolkitConnectionIntegration = ToolkitView["connections"][number]["integration"];
 type ToolkitConnectionEntryInput = {
   readonly integration: ToolkitConnectionIntegration;
   readonly connection: string;
@@ -338,51 +312,48 @@ export class ToolkitsExtensionService extends Context.Service<
 // the host's composed API requires) — not a standalone single-group bundle.
 const ExecutorApiWithToolkits = addGroup(ToolkitsApi);
 
-const ToolkitsHandlers = HttpApiBuilder.group(
-  ExecutorApiWithToolkits,
-  "toolkits",
-  (h) =>
-    h
-      .handle("list", () =>
-        capture(
-          Effect.gen(function* () {
-            const ext = yield* ToolkitsExtensionService;
-            return yield* ext.list();
-          }),
-        ),
-      )
-      .handle("create", ({ payload }) =>
-        capture(
-          Effect.gen(function* () {
-            const ext = yield* ToolkitsExtensionService;
-            return yield* ext.create(payload);
-          }),
-        ),
-      )
-      .handle("get", ({ params }) =>
-        capture(
-          Effect.gen(function* () {
-            const ext = yield* ToolkitsExtensionService;
-            return yield* ext.get(params.id);
-          }),
-        ),
-      )
-      .handle("update", ({ params, payload }) =>
-        capture(
-          Effect.gen(function* () {
-            const ext = yield* ToolkitsExtensionService;
-            return yield* ext.update(params.id, payload);
-          }),
-        ),
-      )
-      .handle("remove", ({ params }) =>
-        capture(
-          Effect.gen(function* () {
-            const ext = yield* ToolkitsExtensionService;
-            return yield* ext.remove(params.id);
-          }),
-        ),
+const ToolkitsHandlers = HttpApiBuilder.group(ExecutorApiWithToolkits, "toolkits", (h) =>
+  h
+    .handle("list", () =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.list();
+        }),
       ),
+    )
+    .handle("create", ({ payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.create(payload);
+        }),
+      ),
+    )
+    .handle("get", ({ params }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.get(params.id);
+        }),
+      ),
+    )
+    .handle("update", ({ params, payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.update(params.id, payload);
+        }),
+      ),
+    )
+    .handle("remove", ({ params }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.remove(params.id);
+        }),
+      ),
+    ),
 );
 
 const resolveToolkitRequestScope = (
@@ -391,11 +362,7 @@ const resolveToolkitRequestScope = (
 ): Effect.Effect<RequestScope, StorageFailure> =>
   makeToolkitsExtension(ctx)
     .resolveScope(selector)
-    .pipe(
-      Effect.map((scope) =>
-        toolkitScopeToRequestScope(scope ?? EMPTY_TOOLKIT_SCOPE),
-      ),
-    );
+    .pipe(Effect.map((scope) => toolkitScopeToRequestScope(scope ?? EMPTY_TOOLKIT_SCOPE)));
 
 export const toolkitsPlugin = definePlugin(() => ({
   id: "toolkits" as const,

--- a/packages/plugins/toolkits/src/server.ts
+++ b/packages/plugins/toolkits/src/server.ts
@@ -29,6 +29,7 @@ import {
   ToolkitsApi,
   type CreateToolkitPayload,
   type ToolkitAccess,
+  type ToolkitPolicyAction,
   type ToolkitScope,
   type ToolkitView,
   type UpdateToolkitPayload,
@@ -57,10 +58,17 @@ const ConnectionRow = Schema.Struct({
   note: Schema.NullOr(Schema.String),
 });
 
+const PolicyRow = Schema.Struct({
+  toolkitId: Schema.String,
+  pattern: Schema.String,
+  action: Schema.String,
+});
+
 const TOOLKITS = definePluginStorageCollection("toolkits", ToolkitRow, { indexes: ["slug"] });
 const CONNECTIONS = definePluginStorageCollection("connections", ConnectionRow, {
   indexes: ["toolkitId"],
 });
+const POLICIES = definePluginStorageCollection("policies", PolicyRow, { indexes: ["toolkitId"] });
 
 const newId = Effect.sync(() => crypto.randomUUID());
 const scopeOfOwner = (owner: Owner): ToolkitScope => (owner === ORG ? "workspace" : "personal");
@@ -79,26 +87,31 @@ type ToolkitRowEntry = {
 const makeToolkitsExtension = (ctx: PluginCtx) => {
   const toolkits = ctx.pluginStorage.collection(TOOLKITS);
   const connections = ctx.pluginStorage.collection(CONNECTIONS);
+  const policies = ctx.pluginStorage.collection(POLICIES);
 
   const viewFromRow = (row: ToolkitRowEntry) =>
-    connections.query({ where: { toolkitId: row.key } }).pipe(
-      Effect.map(
-        (rows): ToolkitView => ({
-          id: row.key,
-          slug: row.data.slug,
-          name: row.data.name,
-          scope: scopeOfOwner(row.owner),
-          inheritOrgPolicies: row.data.inheritOrgPolicies,
-          briefing: row.data.briefing,
-          connections: rows.map((c) => ({
-            integration: c.data.integration as ToolkitConnectionIntegration,
-            connection: c.data.connection,
-            access: c.data.access as ToolkitAccess,
-            ...(c.data.note == null ? {} : { note: c.data.note }),
-          })),
-        }),
-      ),
-    );
+    Effect.gen(function* () {
+      const conns = yield* connections.query({ where: { toolkitId: row.key } });
+      const pols = yield* policies.query({ where: { toolkitId: row.key } });
+      return {
+        id: row.key,
+        slug: row.data.slug,
+        name: row.data.name,
+        scope: scopeOfOwner(row.owner),
+        inheritOrgPolicies: row.data.inheritOrgPolicies,
+        briefing: row.data.briefing,
+        connections: conns.map((c) => ({
+          integration: c.data.integration as ToolkitConnectionIntegration,
+          connection: c.data.connection,
+          access: c.data.access as ToolkitAccess,
+          ...(c.data.note == null ? {} : { note: c.data.note }),
+        })),
+        policies: pols.map((p) => ({
+          pattern: p.data.pattern,
+          action: p.data.action as ToolkitPolicyAction,
+        })),
+      } satisfies ToolkitView;
+    });
 
   // candidate connections honoring scope: a workspace toolkit may use only
   // org connections; a personal toolkit may use org + the caller's own.
@@ -146,6 +159,23 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       ),
     );
 
+  const putPolicies = (
+    toolkitId: string,
+    owner: Owner,
+    rules: ReadonlyArray<{ readonly pattern: string; readonly action: string }>,
+  ) =>
+    Effect.forEach(rules, (r) =>
+      newId.pipe(
+        Effect.flatMap((pid) =>
+          policies.put({
+            key: pid,
+            owner,
+            data: { toolkitId, pattern: r.pattern, action: r.action },
+          }),
+        ),
+      ),
+    );
+
   const create = (input: CreateToolkitPayload) =>
     Effect.gen(function* () {
       if (input.scope === "personal" && ctx.owner.subject == null) {
@@ -165,6 +195,7 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       };
       yield* toolkits.put({ key: id, owner, data });
       yield* putConnections(id, owner, entries);
+      yield* putPolicies(id, owner, input.policies ?? []);
       return yield* viewFromRow({ key: id, owner, data });
     });
 
@@ -197,6 +228,11 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
         );
         yield* putConnections(id, row.owner, patch.connections);
       }
+      if (patch.policies !== undefined) {
+        const existing = yield* policies.query({ where: { toolkitId: id } });
+        yield* Effect.forEach(existing, (p) => policies.remove({ key: p.key, owner: row.owner }));
+        yield* putPolicies(id, row.owner, patch.policies);
+      }
       return yield* viewFromRow({ key: id, owner: row.owner, data });
     });
 
@@ -204,8 +240,10 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
     Effect.gen(function* () {
       const row = yield* toolkits.get({ key: id });
       if (row == null) return yield* new ToolkitNotFound({ id });
-      const existing = yield* connections.query({ where: { toolkitId: id } });
-      yield* Effect.forEach(existing, (c) => connections.remove({ key: c.key, owner: row.owner }));
+      const conns = yield* connections.query({ where: { toolkitId: id } });
+      yield* Effect.forEach(conns, (c) => connections.remove({ key: c.key, owner: row.owner }));
+      const pols = yield* policies.query({ where: { toolkitId: id } });
+      yield* Effect.forEach(pols, (p) => policies.remove({ key: p.key, owner: row.owner }));
       yield* toolkits.remove({ key: id, owner: row.owner });
       return { removed: true };
     });
@@ -222,11 +260,16 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       const row = bySlug[0] ?? (yield* toolkits.get({ key: selector }));
       if (row == null) return null;
       const conns = yield* connections.query({ where: { toolkitId: row.key } });
+      const pols = yield* policies.query({ where: { toolkitId: row.key } });
       return {
         entries: conns.map((c) => ({
           integration: c.data.integration,
           connection: c.data.connection,
           access: c.data.access as ToolkitAccess,
+        })),
+        policies: pols.map((p) => ({
+          pattern: p.data.pattern,
+          action: p.data.action as ToolkitPolicyAction,
         })),
         inheritOrgPolicies: row.data.inheritOrgPolicies,
       };

--- a/packages/plugins/toolkits/src/server.ts
+++ b/packages/plugins/toolkits/src/server.ts
@@ -22,8 +22,8 @@ import {
 import {
   definePluginStorageCollection,
   Owner,
-  type ExecutorWrapper,
   type PluginCtx,
+  type RequestScope,
   type StorageFailure,
 } from "@executor-js/sdk";
 import { addGroup, capture } from "@executor-js/api";
@@ -40,8 +40,8 @@ import {
   type UpdateToolkitPayload,
 } from "./shared";
 import {
-  applyToolkitScope,
   EMPTY_TOOLKIT_SCOPE,
+  toolkitScopeToRequestScope,
   type ResolvedToolkitScope,
 } from "./toolkit-scope";
 
@@ -312,18 +312,7 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       };
     });
 
-  // The plugin's contribution to core's generic executor-wrapper seam: given a
-  // selector, resolve it to a scope (fail-closed to the empty slice when it
-  // doesn't resolve for this caller) and narrow the executor. Core collects and
-  // runs this without knowing it's about toolkits.
-  const wrapExecutor: ExecutorWrapper = (base, selector) =>
-    resolveScope(selector).pipe(
-      Effect.flatMap((scope) =>
-        applyToolkitScope(base, scope ?? EMPTY_TOOLKIT_SCOPE),
-      ),
-    );
-
-  return { create, get, list, update, remove, resolveScope, wrapExecutor };
+  return { create, get, list, update, remove, resolveScope };
 };
 
 // Local aliases so the storage/extension layer stays decoupled from the wire
@@ -396,12 +385,25 @@ const ToolkitsHandlers = HttpApiBuilder.group(
       ),
 );
 
+const resolveToolkitRequestScope = (
+  ctx: PluginCtx,
+  selector: string,
+): Effect.Effect<RequestScope, StorageFailure> =>
+  makeToolkitsExtension(ctx)
+    .resolveScope(selector)
+    .pipe(
+      Effect.map((scope) =>
+        toolkitScopeToRequestScope(scope ?? EMPTY_TOOLKIT_SCOPE),
+      ),
+    );
+
 export const toolkitsPlugin = definePlugin(() => ({
   id: "toolkits" as const,
   packageName: "@executor-js/plugin-toolkits",
   storage: () => ({}),
   pluginStorage: { toolkits: TOOLKITS, connections: CONNECTIONS },
   extension: makeToolkitsExtension,
+  resolveRequestScope: resolveToolkitRequestScope,
   routes: () => ToolkitsApi,
   handlers: () => ToolkitsHandlers,
   extensionService: ToolkitsExtensionService,

--- a/packages/plugins/toolkits/src/server.ts
+++ b/packages/plugins/toolkits/src/server.ts
@@ -14,7 +14,13 @@
 
 import { Schema } from "effect";
 import { Context, definePlugin, Effect, HttpApiBuilder } from "@executor-js/sdk/core";
-import { definePluginStorageCollection, Owner, type PluginCtx } from "@executor-js/sdk";
+import {
+  definePluginStorageCollection,
+  Owner,
+  type PluginCtx,
+  type ResolvedToolkitScope,
+  type StorageFailure,
+} from "@executor-js/sdk";
 import { addGroup, capture } from "@executor-js/api";
 
 import {
@@ -204,7 +210,29 @@ const makeToolkitsExtension = (ctx: PluginCtx) => {
       return { removed: true };
     });
 
-  return { create, get, list, update, remove };
+  // Resolve a selector (slug, then id) to the scope the MCP narrowing seam
+  // applies. Request-scoped, so it only finds toolkits visible to the caller —
+  // a cross-tenant/personal-of-another-user selector returns null (the seam
+  // then fails closed to an empty slice).
+  const resolveScope = (
+    selector: string,
+  ): Effect.Effect<ResolvedToolkitScope | null, StorageFailure> =>
+    Effect.gen(function* () {
+      const bySlug = yield* toolkits.query({ where: { slug: selector }, limit: 1 });
+      const row = bySlug[0] ?? (yield* toolkits.get({ key: selector }));
+      if (row == null) return null;
+      const conns = yield* connections.query({ where: { toolkitId: row.key } });
+      return {
+        entries: conns.map((c) => ({
+          integration: c.data.integration,
+          connection: c.data.connection,
+          access: c.data.access as ToolkitAccess,
+        })),
+        inheritOrgPolicies: row.data.inheritOrgPolicies,
+      };
+    });
+
+  return { create, get, list, update, remove, resolveScope };
 };
 
 // Local aliases so the storage/extension layer stays decoupled from the wire

--- a/packages/plugins/toolkits/src/shared.ts
+++ b/packages/plugins/toolkits/src/shared.ts
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/shared
+//
+// Schemas + the HttpApiGroup shared between server and client. A "toolkit" is a
+// named slice of the caller's connections (each off/read/full), scoped to the
+// workspace (org-owned connections only) or the caller personally (org + own).
+//
+// No React or Node imports here — server and client both import this.
+// ---------------------------------------------------------------------------
+
+import { Schema } from "effect";
+import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
+
+import { IntegrationSlug, InternalError } from "@executor-js/sdk/shared";
+
+// off = invisible, read = read-only tools only, full = every tool.
+export const ToolkitAccess = Schema.Literals(["off", "read", "full"]);
+export type ToolkitAccess = typeof ToolkitAccess.Type;
+
+// workspace = org-owned (visible to every org member); personal = the caller's own.
+export const ToolkitScope = Schema.Literals(["workspace", "personal"]);
+export type ToolkitScope = typeof ToolkitScope.Type;
+
+// One connection in a toolkit's slice. `connection` is a pinned account name,
+// or "*" to track every connection of the integration.
+export const ToolkitConnectionEntry = Schema.Struct({
+  integration: IntegrationSlug,
+  connection: Schema.String,
+  access: ToolkitAccess,
+  note: Schema.optional(Schema.String),
+});
+export type ToolkitConnectionEntry = typeof ToolkitConnectionEntry.Type;
+
+export const ToolkitView = Schema.Struct({
+  id: Schema.String,
+  slug: Schema.String,
+  name: Schema.String,
+  scope: ToolkitScope,
+  inheritOrgPolicies: Schema.Boolean,
+  briefing: Schema.NullOr(Schema.String),
+  connections: Schema.Array(ToolkitConnectionEntry),
+});
+export type ToolkitView = typeof ToolkitView.Type;
+
+export const CreateToolkitPayload = Schema.Struct({
+  slug: Schema.String,
+  name: Schema.String,
+  scope: ToolkitScope,
+  inheritOrgPolicies: Schema.optional(Schema.Boolean),
+  briefing: Schema.optional(Schema.String),
+  connections: Schema.optional(Schema.Array(ToolkitConnectionEntry)),
+});
+export type CreateToolkitPayload = typeof CreateToolkitPayload.Type;
+
+export const UpdateToolkitPayload = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  briefing: Schema.optional(Schema.NullOr(Schema.String)),
+  inheritOrgPolicies: Schema.optional(Schema.Boolean),
+  connections: Schema.optional(Schema.Array(ToolkitConnectionEntry)),
+});
+export type UpdateToolkitPayload = typeof UpdateToolkitPayload.Type;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class ToolkitNotFound extends Schema.TaggedErrorClass<ToolkitNotFound>()("ToolkitNotFound", {
+  id: Schema.String,
+}) {}
+
+export class ToolkitForbidden extends Schema.TaggedErrorClass<ToolkitForbidden>()(
+  "ToolkitForbidden",
+  {
+    reason: Schema.String,
+  },
+) {}
+
+const NotFound = ToolkitNotFound.annotate({ httpApiStatus: 404 });
+const Forbidden = ToolkitForbidden.annotate({ httpApiStatus: 403 });
+
+const IdParams = { id: Schema.String };
+
+// ---------------------------------------------------------------------------
+// Group
+// ---------------------------------------------------------------------------
+
+export const ToolkitsApi = HttpApiGroup.make("toolkits")
+  .add(
+    HttpApiEndpoint.get("list", "/toolkits", {
+      success: Schema.Array(ToolkitView),
+      error: InternalError,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.post("create", "/toolkits", {
+      payload: CreateToolkitPayload,
+      success: ToolkitView,
+      error: [InternalError, Forbidden],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("get", "/toolkits/:id", {
+      params: IdParams,
+      success: ToolkitView,
+      error: [InternalError, NotFound],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.patch("update", "/toolkits/:id", {
+      params: IdParams,
+      payload: UpdateToolkitPayload,
+      success: ToolkitView,
+      error: [InternalError, NotFound, Forbidden],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.delete("remove", "/toolkits/:id", {
+      params: IdParams,
+      success: Schema.Struct({ removed: Schema.Boolean }),
+      error: [InternalError, NotFound],
+    }),
+  );

--- a/packages/plugins/toolkits/src/shared.ts
+++ b/packages/plugins/toolkits/src/shared.ts
@@ -31,6 +31,18 @@ export const ToolkitConnectionEntry = Schema.Struct({
 });
 export type ToolkitConnectionEntry = typeof ToolkitConnectionEntry.Type;
 
+// off/read/full is the per-connection access mode; policies are pattern rules
+// layered on top. v1 enforces `block` (the tool is excluded); `approve` /
+// `require_approval` are persisted + briefed (org approval policies still apply).
+export const ToolkitPolicyAction = Schema.Literals(["approve", "require_approval", "block"]);
+export type ToolkitPolicyAction = typeof ToolkitPolicyAction.Type;
+
+export const ToolkitPolicy = Schema.Struct({
+  pattern: Schema.String,
+  action: ToolkitPolicyAction,
+});
+export type ToolkitPolicy = typeof ToolkitPolicy.Type;
+
 export const ToolkitView = Schema.Struct({
   id: Schema.String,
   slug: Schema.String,
@@ -39,6 +51,7 @@ export const ToolkitView = Schema.Struct({
   inheritOrgPolicies: Schema.Boolean,
   briefing: Schema.NullOr(Schema.String),
   connections: Schema.Array(ToolkitConnectionEntry),
+  policies: Schema.Array(ToolkitPolicy),
 });
 export type ToolkitView = typeof ToolkitView.Type;
 
@@ -49,6 +62,7 @@ export const CreateToolkitPayload = Schema.Struct({
   inheritOrgPolicies: Schema.optional(Schema.Boolean),
   briefing: Schema.optional(Schema.String),
   connections: Schema.optional(Schema.Array(ToolkitConnectionEntry)),
+  policies: Schema.optional(Schema.Array(ToolkitPolicy)),
 });
 export type CreateToolkitPayload = typeof CreateToolkitPayload.Type;
 
@@ -57,6 +71,7 @@ export const UpdateToolkitPayload = Schema.Struct({
   briefing: Schema.optional(Schema.NullOr(Schema.String)),
   inheritOrgPolicies: Schema.optional(Schema.Boolean),
   connections: Schema.optional(Schema.Array(ToolkitConnectionEntry)),
+  policies: Schema.optional(Schema.Array(ToolkitPolicy)),
 });
 export type UpdateToolkitPayload = typeof UpdateToolkitPayload.Type;
 

--- a/packages/plugins/toolkits/src/toolkit-scope.ts
+++ b/packages/plugins/toolkits/src/toolkit-scope.ts
@@ -1,8 +1,9 @@
 // ---------------------------------------------------------------------------
 // Toolkit scope — wraps an Executor so the MCP surface only sees, and can only
-// run, a toolkit's slice of connections. Toolkit-agnostic: it operates on a
-// plain ResolvedToolkitScope (produced by the toolkits plugin's `resolveScope`)
-// and the base Executor. Because the wrapped Executor is handed to the engine
+// run, a toolkit's slice of connections. This is the toolkits plugin's
+// implementation of core's generic `ExecutorWrapper` seam: the plugin
+// contributes `wrapExecutor` (server.ts) and core runs it without ever knowing
+// what "toolkit" means. Because the wrapped Executor is handed to the engine
 // before construction, EVERY surface (tools.list, search, describe,
 // sources/connections/integrations.list, core-tools, and execute) flows through
 // it — enforcement is at execute, not just listing, so guessed out-of-slice
@@ -11,15 +12,15 @@
 
 import { Effect } from "effect";
 
-import { ToolBlockedError } from "./errors";
-import type { Executor } from "./executor";
-import type { ToolAddress } from "./ids";
-import type { AnyPlugin } from "./plugin";
-import type { StorageFailure } from "./fuma-runtime";
+import {
+  ToolBlockedError,
+  type AnyPlugin,
+  type Executor,
+  type StorageFailure,
+  type ToolAddress,
+} from "@executor-js/sdk";
 
-export type ToolkitAccess = "off" | "read" | "full";
-
-export type ToolkitPolicyAction = "approve" | "require_approval" | "block";
+import type { ToolkitAccess, ToolkitPolicyAction } from "./shared";
 
 export interface ToolkitPolicyRule {
   /** Glob over `<integration>.<connection>.<tool>` — `*` matches one segment,
@@ -62,20 +63,14 @@ const matchPattern = (pattern: string, target: string): boolean => {
     if (p[i] === "*" && i === p.length - 1) return true;
     if (a[i] === undefined) return false;
     const re = new RegExp(
-      "^" + p[i].replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$",
+      "^" +
+        p[i].replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") +
+        "$",
     );
     if (!re.test(a[i])) return false;
   }
   return p.length === a.length;
 };
-
-/** A plugin extension capable of resolving a selector (slug or id) to a scope,
- *  scoped to the caller. `resolveScope` returns null when nothing matches. */
-export interface ToolkitResolver {
-  readonly resolveScope: (
-    selector: string,
-  ) => Effect.Effect<ResolvedToolkitScope | null, StorageFailure>;
-}
 
 const accessFor = (
   scope: ResolvedToolkitScope,
@@ -83,7 +78,8 @@ const accessFor = (
   connection: string,
 ): ToolkitAccess => {
   for (const e of scope.entries) {
-    if (e.integration === integration && e.connection === connection) return e.access;
+    if (e.integration === integration && e.connection === connection)
+      return e.access;
   }
   for (const e of scope.entries) {
     if (e.integration === integration && e.connection === "*") return e.access;
@@ -101,7 +97,9 @@ export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
   Effect.gen(function* () {
     const blockRules = scope.policies.filter((p) => p.action === "block");
     const isBlocked = (integration: string, connection: string, name: string) =>
-      blockRules.some((p) => matchPattern(p.pattern, `${integration}.${connection}.${name}`));
+      blockRules.some((p) =>
+        matchPattern(p.pattern, `${integration}.${connection}.${name}`),
+      );
 
     const all = yield* base.tools.list();
     const allowed = new Set<string>();
@@ -112,7 +110,10 @@ export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
         allowed.add(String(t.address));
         continue;
       }
-      if (isBlocked(String(t.integration), String(t.connection), String(t.name))) continue;
+      if (
+        isBlocked(String(t.integration), String(t.connection), String(t.name))
+      )
+        continue;
       const a = accessFor(scope, String(t.integration), String(t.connection));
       if (a === "full" || (a === "read" && t.annotations?.readOnly === true)) {
         allowed.add(String(t.address));
@@ -132,7 +133,11 @@ export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
         list: () =>
           base.integrations
             .list()
-            .pipe(Effect.map((xs) => xs.filter((i) => allowedIntegrations.has(String(i.slug))))),
+            .pipe(
+              Effect.map((xs) =>
+                xs.filter((i) => allowedIntegrations.has(String(i.slug))),
+              ),
+            ),
         get: (slug) =>
           allowedIntegrations.has(String(slug))
             ? base.integrations.get(slug)
@@ -144,20 +149,27 @@ export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
           base.connections
             .list(filter)
             .pipe(
-              Effect.map((xs) => xs.filter((c) => connOk(String(c.integration), String(c.name)))),
+              Effect.map((xs) =>
+                xs.filter((c) => connOk(String(c.integration), String(c.name))),
+              ),
             ),
         get: (ref) =>
           base.connections
             .get(ref)
             .pipe(
-              Effect.map((c) => (c && connOk(String(c.integration), String(c.name)) ? c : null)),
+              Effect.map((c) =>
+                c && connOk(String(c.integration), String(c.name)) ? c : null,
+              ),
             ),
       },
       tools: {
         ...base.tools,
         list: (filter) =>
-          base.tools.list(filter).pipe(Effect.map((xs) => xs.filter((t) => addrOk(t.address)))),
-        schema: (address) => (addrOk(address) ? base.tools.schema(address) : Effect.succeed(null)),
+          base.tools
+            .list(filter)
+            .pipe(Effect.map((xs) => xs.filter((t) => addrOk(t.address)))),
+        schema: (address) =>
+          addrOk(address) ? base.tools.schema(address) : Effect.succeed(null),
       },
       execute: (address, args, options) =>
         addrOk(address)

--- a/packages/plugins/toolkits/src/toolkit-scope.ts
+++ b/packages/plugins/toolkits/src/toolkit-scope.ts
@@ -6,11 +6,7 @@
 // ---------------------------------------------------------------------------
 
 import type { Connection } from "@executor-js/sdk";
-import {
-  defaultDecideStaticTool,
-  type RequestScope,
-  type ScopeDecision,
-} from "@executor-js/sdk";
+import { defaultDecideStaticTool, type RequestScope, type ScopeDecision } from "@executor-js/sdk";
 
 import type { ToolkitAccess, ToolkitPolicyAction } from "./shared";
 
@@ -53,9 +49,7 @@ const matchPattern = (pattern: string, target: string): boolean => {
     if (p[i] === "*" && i === p.length - 1) return true;
     if (a[i] === undefined) return false;
     const re = new RegExp(
-      "^" +
-        p[i].replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") +
-        "$",
+      "^" + p[i].replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$",
     );
     if (!re.test(a[i])) return false;
   }
@@ -68,8 +62,7 @@ const accessFor = (
   connection: string,
 ): ToolkitAccess => {
   for (const e of scope.entries) {
-    if (e.integration === integration && e.connection === connection)
-      return e.access;
+    if (e.integration === integration && e.connection === connection) return e.access;
   }
   for (const e of scope.entries) {
     if (e.integration === integration && e.connection === "*") return e.access;
@@ -93,40 +86,27 @@ const policyDecisionForTool = (
 };
 
 /** Map a resolved toolkit slice to core's `RequestScope` overlay. */
-export const toolkitScopeToRequestScope = (
-  scope: ResolvedToolkitScope,
-): RequestScope => {
+export const toolkitScopeToRequestScope = (scope: ResolvedToolkitScope): RequestScope => {
   const allowedIntegrations = new Set(
     scope.entries.filter((e) => e.access !== "off").map((e) => e.integration),
   );
 
   return {
     inheritOrgPolicies: scope.inheritOrgPolicies,
-    allowsIntegration: (integration) =>
-      allowedIntegrations.has(String(integration.slug)),
+    allowsIntegration: (integration) => allowedIntegrations.has(String(integration.slug)),
     allowsConnection: (connection: Connection) =>
-      accessFor(
-        scope,
-        String(connection.integration),
-        String(connection.name),
-      ) !== "off",
+      accessFor(scope, String(connection.integration), String(connection.name)) !== "off",
     decideTool: (tool) => {
       const integration = String(tool.integration);
       const connection = String(tool.connection);
       const name = String(tool.name);
 
-      const fromPolicy = policyDecisionForTool(
-        scope,
-        integration,
-        connection,
-        name,
-      );
+      const fromPolicy = policyDecisionForTool(scope, integration, connection, name);
       if (fromPolicy === "block") return "block";
 
       const access = accessFor(scope, integration, connection);
       if (access === "off") return "block";
-      if (access === "read" && tool.annotations?.readOnly !== true)
-        return "block";
+      if (access === "read" && tool.annotations?.readOnly !== true) return "block";
 
       if (fromPolicy === "require_approval") return "require_approval";
       return "allow";

--- a/packages/plugins/toolkits/src/toolkit-scope.ts
+++ b/packages/plugins/toolkits/src/toolkit-scope.ts
@@ -1,23 +1,15 @@
 // ---------------------------------------------------------------------------
-// Toolkit scope — wraps an Executor so the MCP surface only sees, and can only
-// run, a toolkit's slice of connections. This is the toolkits plugin's
-// implementation of core's generic `ExecutorWrapper` seam: the plugin
-// contributes `wrapExecutor` (server.ts) and core runs it without ever knowing
-// what "toolkit" means. Because the wrapped Executor is handed to the engine
-// before construction, EVERY surface (tools.list, search, describe,
-// sources/connections/integrations.list, core-tools, and execute) flows through
-// it — enforcement is at execute, not just listing, so guessed out-of-slice
-// addresses are blocked too.
+// Toolkit scope — pure data mapping from a resolved toolkit slice to core's
+// vocabulary-neutral `RequestScope`. Core owns enforcement; this module only
+// derives allow/block/require_approval decisions from toolkit entries and
+// per-toolkit policy rules.
 // ---------------------------------------------------------------------------
 
-import { Effect } from "effect";
-
+import type { Connection } from "@executor-js/sdk";
 import {
-  ToolBlockedError,
-  type AnyPlugin,
-  type Executor,
-  type StorageFailure,
-  type ToolAddress,
+  defaultDecideStaticTool,
+  type RequestScope,
+  type ScopeDecision,
 } from "@executor-js/sdk";
 
 import type { ToolkitAccess, ToolkitPolicyAction } from "./shared";
@@ -38,16 +30,14 @@ export interface ToolkitScopeEntry {
 
 export interface ResolvedToolkitScope {
   readonly entries: readonly ToolkitScopeEntry[];
-  /** Per-toolkit policy rules. v1 enforces `block` (exclusion); `approve` /
-   *  `require_approval` are carried for the briefing — org-level approval
-   *  policies are still enforced by the base executor when inherited. */
+  /** Per-toolkit policy rules — `block` excludes tools; `require_approval`
+   *  tightens execution via core's stricter-wins merge with org policies. */
   readonly policies: readonly ToolkitPolicyRule[];
   readonly inheritOrgPolicies: boolean;
 }
 
-/** Empty slice — exposes no connection tools (static/core tools stay visible).
- *  Applied fail-closed when a selector resolves to no toolkit (unknown or
- *  not visible to the caller), so a bad selector never leaks the full account. */
+/** Empty slice — exposes no connection tools. Applied fail-closed when a
+ *  selector resolves to no toolkit (unknown or not visible to the caller). */
 export const EMPTY_TOOLKIT_SCOPE: ResolvedToolkitScope = {
   entries: [],
   policies: [],
@@ -87,93 +77,60 @@ const accessFor = (
   return "off";
 };
 
-/** Wrap `base` so only the toolkit's slice is visible/runnable. Reads the full
- *  catalog once to compute the set of allowed tool addresses (applying
- *  off/read/full + the read-only classification), then narrows every surface. */
-export const applyToolkitScope = <TPlugins extends readonly AnyPlugin[]>(
-  base: Executor<TPlugins>,
+const policyDecisionForTool = (
   scope: ResolvedToolkitScope,
-): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
-  Effect.gen(function* () {
-    const blockRules = scope.policies.filter((p) => p.action === "block");
-    const isBlocked = (integration: string, connection: string, name: string) =>
-      blockRules.some((p) =>
-        matchPattern(p.pattern, `${integration}.${connection}.${name}`),
+  integration: string,
+  connection: string,
+  name: string,
+): ScopeDecision | null => {
+  const target = `${integration}.${connection}.${name}`;
+  for (const rule of scope.policies) {
+    if (!matchPattern(rule.pattern, target)) continue;
+    if (rule.action === "block") return "block";
+    if (rule.action === "require_approval") return "require_approval";
+  }
+  return null;
+};
+
+/** Map a resolved toolkit slice to core's `RequestScope` overlay. */
+export const toolkitScopeToRequestScope = (
+  scope: ResolvedToolkitScope,
+): RequestScope => {
+  const allowedIntegrations = new Set(
+    scope.entries.filter((e) => e.access !== "off").map((e) => e.integration),
+  );
+
+  return {
+    inheritOrgPolicies: scope.inheritOrgPolicies,
+    allowsIntegration: (integration) =>
+      allowedIntegrations.has(String(integration.slug)),
+    allowsConnection: (connection: Connection) =>
+      accessFor(
+        scope,
+        String(connection.integration),
+        String(connection.name),
+      ) !== "off",
+    decideTool: (tool) => {
+      const integration = String(tool.integration);
+      const connection = String(tool.connection);
+      const name = String(tool.name);
+
+      const fromPolicy = policyDecisionForTool(
+        scope,
+        integration,
+        connection,
+        name,
       );
+      if (fromPolicy === "block") return "block";
 
-    const all = yield* base.tools.list();
-    const allowed = new Set<string>();
-    for (const t of all) {
-      // Static/core tools stay visible — their RESULTS still flow through the
-      // wrapped executor below (so connections/integrations lists are narrowed).
-      if (t.static === true) {
-        allowed.add(String(t.address));
-        continue;
-      }
-      if (
-        isBlocked(String(t.integration), String(t.connection), String(t.name))
-      )
-        continue;
-      const a = accessFor(scope, String(t.integration), String(t.connection));
-      if (a === "full" || (a === "read" && t.annotations?.readOnly === true)) {
-        allowed.add(String(t.address));
-      }
-    }
-    const allowedIntegrations = new Set(
-      scope.entries.filter((e) => e.access !== "off").map((e) => e.integration),
-    );
-    const connOk = (integration: string, connection: string) =>
-      accessFor(scope, integration, connection) !== "off";
-    const addrOk = (address: ToolAddress) => allowed.has(String(address));
+      const access = accessFor(scope, integration, connection);
+      if (access === "off") return "block";
+      if (access === "read" && tool.annotations?.readOnly !== true)
+        return "block";
 
-    return {
-      ...base,
-      integrations: {
-        ...base.integrations,
-        list: () =>
-          base.integrations
-            .list()
-            .pipe(
-              Effect.map((xs) =>
-                xs.filter((i) => allowedIntegrations.has(String(i.slug))),
-              ),
-            ),
-        get: (slug) =>
-          allowedIntegrations.has(String(slug))
-            ? base.integrations.get(slug)
-            : Effect.succeed(null),
-      },
-      connections: {
-        ...base.connections,
-        list: (filter) =>
-          base.connections
-            .list(filter)
-            .pipe(
-              Effect.map((xs) =>
-                xs.filter((c) => connOk(String(c.integration), String(c.name))),
-              ),
-            ),
-        get: (ref) =>
-          base.connections
-            .get(ref)
-            .pipe(
-              Effect.map((c) =>
-                c && connOk(String(c.integration), String(c.name)) ? c : null,
-              ),
-            ),
-      },
-      tools: {
-        ...base.tools,
-        list: (filter) =>
-          base.tools
-            .list(filter)
-            .pipe(Effect.map((xs) => xs.filter((t) => addrOk(t.address)))),
-        schema: (address) =>
-          addrOk(address) ? base.tools.schema(address) : Effect.succeed(null),
-      },
-      execute: (address, args, options) =>
-        addrOk(address)
-          ? base.execute(address, args, options)
-          : Effect.fail(new ToolBlockedError({ address, pattern: "toolkit" })),
-    } as Executor<TPlugins>;
-  });
+      if (fromPolicy === "require_approval") return "require_approval";
+      return "allow";
+    },
+    decideStaticTool: defaultDecideStaticTool,
+  };
+};

--- a/packages/plugins/toolkits/tsconfig.json
+++ b/packages/plugins/toolkits/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun-types", "node"],
+    "noUnusedLocals": true,
+    "noImplicitOverride": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": true,
+        "diagnosticSeverity": {
+          "preferSchemaOverJson": "off"
+        }
+      }
+    ]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/plugins/toolkits/tsup.config.ts
+++ b/packages/plugins/toolkits/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    server: "src/server.ts",
+    shared: "src/shared.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  external: [/^@executor-js\//, /^effect/, /^@effect\//],
+});

--- a/packages/plugins/toolkits/vitest.config.ts
+++ b/packages/plugins/toolkits/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});

--- a/packages/react/src/api/reactivity-keys.tsx
+++ b/packages/react/src/api/reactivity-keys.tsx
@@ -26,6 +26,8 @@ export const ReactivityKey = {
   /** Credential-provider discovery. */
   providers: "providers",
   policies: "policies",
+  /** Toolkits — named slices of connections, each with its own MCP endpoint. */
+  toolkits: "toolkits",
   /** Registered OAuth clients (apps). */
   oauthClients: "oauth-clients",
   // cloud-only resources
@@ -37,20 +39,33 @@ export const ReactivityKey = {
 } as const;
 
 /** Mutations that add/remove/refresh an integration also affect tool listings. */
-export const integrationWriteKeys = [ReactivityKey.integrations, ReactivityKey.tools] as const;
+export const integrationWriteKeys = [
+  ReactivityKey.integrations,
+  ReactivityKey.tools,
+] as const;
 
 /** Mutations that create / remove / refresh a connection. Touches `tools`
  *  because a connection's tools are produced per-connection — creating or
  *  refreshing a connection changes the tool catalog. */
-export const connectionWriteKeys = [ReactivityKey.connections, ReactivityKey.tools] as const;
+export const connectionWriteKeys = [
+  ReactivityKey.connections,
+  ReactivityKey.tools,
+] as const;
 
 /** Mutations that register / replace an OAuth client (app). */
 export const oauthClientWriteKeys = [ReactivityKey.oauthClients] as const;
 
+/** Mutations that create / update / remove a toolkit. Self-contained — a
+ *  toolkit is its own resource and does not change the core tool catalog. */
+export const toolkitWriteKeys = [ReactivityKey.toolkits] as const;
+
 /** Mutations that mutate tool policies. Also touches `tools` because
  *  `tools.list` filters blocked tools — adding/removing a `block`
  *  policy changes what the tools page shows. */
-export const policyWriteKeys = [ReactivityKey.policies, ReactivityKey.tools] as const;
+export const policyWriteKeys = [
+  ReactivityKey.policies,
+  ReactivityKey.tools,
+] as const;
 
 /** Cloud-only: org membership mutations. */
 export const orgMemberWriteKeys = [ReactivityKey.orgMembers] as const;
@@ -59,7 +74,10 @@ export const orgMemberWriteKeys = [ReactivityKey.orgMembers] as const;
 export const orgDomainWriteKeys = [ReactivityKey.orgDomains] as const;
 
 /** Cloud-only: org info mutations (name, etc.) — also touches auth. */
-export const orgInfoWriteKeys = [ReactivityKey.orgInfo, ReactivityKey.auth] as const;
+export const orgInfoWriteKeys = [
+  ReactivityKey.orgInfo,
+  ReactivityKey.auth,
+] as const;
 
 /** Cloud-only: user API key mutations. */
 export const apiKeyWriteKeys = [ReactivityKey.apiKeys] as const;

--- a/packages/react/src/api/reactivity-keys.tsx
+++ b/packages/react/src/api/reactivity-keys.tsx
@@ -39,18 +39,12 @@ export const ReactivityKey = {
 } as const;
 
 /** Mutations that add/remove/refresh an integration also affect tool listings. */
-export const integrationWriteKeys = [
-  ReactivityKey.integrations,
-  ReactivityKey.tools,
-] as const;
+export const integrationWriteKeys = [ReactivityKey.integrations, ReactivityKey.tools] as const;
 
 /** Mutations that create / remove / refresh a connection. Touches `tools`
  *  because a connection's tools are produced per-connection — creating or
  *  refreshing a connection changes the tool catalog. */
-export const connectionWriteKeys = [
-  ReactivityKey.connections,
-  ReactivityKey.tools,
-] as const;
+export const connectionWriteKeys = [ReactivityKey.connections, ReactivityKey.tools] as const;
 
 /** Mutations that register / replace an OAuth client (app). */
 export const oauthClientWriteKeys = [ReactivityKey.oauthClients] as const;
@@ -62,10 +56,7 @@ export const toolkitWriteKeys = [ReactivityKey.toolkits] as const;
 /** Mutations that mutate tool policies. Also touches `tools` because
  *  `tools.list` filters blocked tools — adding/removing a `block`
  *  policy changes what the tools page shows. */
-export const policyWriteKeys = [
-  ReactivityKey.policies,
-  ReactivityKey.tools,
-] as const;
+export const policyWriteKeys = [ReactivityKey.policies, ReactivityKey.tools] as const;
 
 /** Cloud-only: org membership mutations. */
 export const orgMemberWriteKeys = [ReactivityKey.orgMembers] as const;
@@ -74,10 +65,7 @@ export const orgMemberWriteKeys = [ReactivityKey.orgMembers] as const;
 export const orgDomainWriteKeys = [ReactivityKey.orgDomains] as const;
 
 /** Cloud-only: org info mutations (name, etc.) — also touches auth. */
-export const orgInfoWriteKeys = [
-  ReactivityKey.orgInfo,
-  ReactivityKey.auth,
-] as const;
+export const orgInfoWriteKeys = [ReactivityKey.orgInfo, ReactivityKey.auth] as const;
 
 /** Cloud-only: user API key mutations. */
 export const apiKeyWriteKeys = [ReactivityKey.apiKeys] as const;

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -19,10 +19,7 @@ import {
   integrationPresetIconUrl,
 } from "../components/integration-favicon";
 import { CommandPalette } from "../components/command-palette";
-import {
-  useClientPlugins,
-  useIntegrationPlugins,
-} from "@executor-js/sdk/client";
+import { useClientPlugins, useIntegrationPlugins } from "@executor-js/sdk/client";
 import { useAuth } from "./auth-context";
 
 // ---------------------------------------------------------------------------
@@ -56,8 +53,7 @@ export const defaultShellNavItems: ReadonlyArray<ShellNavItem> = [
 // ("/" -> "/{-$orgSlug}", "/policies" -> "/{-$orgSlug}/policies"). Loosely
 // typed on purpose: host-specific items ("/admin", "/billing") resolve against
 // the host's own route tree, which this package can't see.
-const orgScopedTo = (to: string): string =>
-  to === "/" ? "/{-$orgSlug}" : `/{-$orgSlug}${to}`;
+const orgScopedTo = (to: string): string => (to === "/" ? "/{-$orgSlug}" : `/{-$orgSlug}${to}`);
 
 /** The pathname with the active org-slug prefix stripped, for active-state
  *  comparisons against scope-relative paths. */
@@ -65,10 +61,7 @@ function useScopeRelativePathname(): string {
   const pathname = useLocation({ select: (location) => location.pathname });
   const params = useParams({ strict: false }) as { orgSlug?: string };
   const orgSlug = params.orgSlug;
-  if (
-    orgSlug &&
-    (pathname === `/${orgSlug}` || pathname.startsWith(`/${orgSlug}/`))
-  ) {
+  if (orgSlug && (pathname === `/${orgSlug}` || pathname.startsWith(`/${orgSlug}/`))) {
     return pathname.slice(orgSlug.length + 1) || "/";
   }
   return pathname;
@@ -91,14 +84,8 @@ export interface ShellProps {
 
 function Brand(props: { onNavigate?: () => void }) {
   return (
-    <Link
-      to="/{-$orgSlug}"
-      onClick={props.onNavigate}
-      className="flex items-center gap-1.5"
-    >
-      <span className="font-display text-base tracking-tight text-foreground">
-        executor
-      </span>
+    <Link to="/{-$orgSlug}" onClick={props.onNavigate} className="flex items-center gap-1.5">
+      <span className="font-display text-base tracking-tight text-foreground">executor</span>
       <span className="rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-primary">
         Beta
       </span>
@@ -108,12 +95,7 @@ function Brand(props: { onNavigate?: () => void }) {
 
 // ── NavItem ──────────────────────────────────────────────────────────────
 
-function NavItem(props: {
-  to: string;
-  label: string;
-  active: boolean;
-  onNavigate?: () => void;
-}) {
+function NavItem(props: { to: string; label: string; active: boolean; onNavigate?: () => void }) {
   return (
     <Link
       to={orgScopedTo(props.to)}
@@ -167,8 +149,7 @@ function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
           onClick={props.onNavigate}
           className={[
             "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
-            props.pathname === entry.base ||
-            props.pathname.startsWith(`${entry.base}/`)
+            props.pathname === entry.base || props.pathname.startsWith(`${entry.base}/`)
               ? "bg-sidebar-active text-foreground font-medium"
               : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
           ].join(" ")}
@@ -199,9 +180,7 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
       </div>
     ),
     onFailure: () => (
-      <div className="px-2.5 py-2 text-xs text-muted-foreground">
-        No integrations yet
-      </div>
+      <div className="px-2.5 py-2 text-xs text-muted-foreground">No integrations yet</div>
     ),
     onSuccess: ({ value }) =>
       value.length === 0 ? (
@@ -215,8 +194,7 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
             const name = integration.name || slug;
             const detailPath = `/integrations/${slug}`;
             const active =
-              props.pathname === detailPath ||
-              props.pathname.startsWith(`${detailPath}/`);
+              props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
             return (
               <Link
                 key={slug}
@@ -269,15 +247,9 @@ function initialsFor(name: string | null, email: string) {
   return email[0]!.toUpperCase();
 }
 
-function Avatar(props: {
-  url: string | null;
-  name: string | null;
-  email: string;
-}) {
+function Avatar(props: { url: string | null; name: string | null; email: string }) {
   if (props.url) {
-    return (
-      <img src={props.url} alt="" className="size-7 shrink-0 rounded-full" />
-    );
+    return <img src={props.url} alt="" className="size-7 shrink-0 rounded-full" />;
   }
   return (
     <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
@@ -301,19 +273,13 @@ function UserFooter(props: Pick<ShellProps, "onSignOut" | "orgMenuSlot">) {
             variant="ghost"
             className="flex h-auto w-full items-center justify-start gap-2.5 rounded-md px-1 py-1 text-left hover:bg-sidebar-active/60"
           >
-            <Avatar
-              url={auth.user.avatarUrl}
-              name={auth.user.name}
-              email={auth.user.email}
-            />
+            <Avatar url={auth.user.avatarUrl} name={auth.user.name} email={auth.user.email} />
             <div className="min-w-0 flex-1">
               <p className="truncate text-xs font-medium text-foreground">
                 {auth.user.name ?? auth.user.email}
               </p>
               {auth.organization && (
-                <p className="truncate text-xs text-muted-foreground">
-                  {auth.organization.name}
-                </p>
+                <p className="truncate text-xs text-muted-foreground">{auth.organization.name}</p>
               )}
             </div>
             <svg
@@ -337,19 +303,13 @@ function UserFooter(props: Pick<ShellProps, "onSignOut" | "orgMenuSlot">) {
             Signed in as
           </DropdownMenuLabel>
           <DropdownMenuItem disabled className="gap-2 text-xs opacity-100">
-            <Avatar
-              url={auth.user.avatarUrl}
-              name={auth.user.name}
-              email={auth.user.email}
-            />
+            <Avatar url={auth.user.avatarUrl} name={auth.user.name} email={auth.user.email} />
             <div className="min-w-0 flex-1">
               <p className="truncate font-medium text-foreground">
                 {auth.user.name ?? auth.user.email}
               </p>
               {auth.user.name && (
-                <p className="truncate text-muted-foreground">
-                  {auth.user.email}
-                </p>
+                <p className="truncate text-muted-foreground">{auth.user.email}</p>
               )}
             </div>
           </DropdownMenuItem>
@@ -389,11 +349,7 @@ function SidebarContent(
             key={item.to}
             to={item.to}
             label={item.label}
-            active={
-              item.to === "/"
-                ? props.pathname === "/"
-                : props.pathname.startsWith(item.to)
-            }
+            active={item.to === "/" ? props.pathname === "/" : props.pathname.startsWith(item.to)}
             onNavigate={props.onNavigate}
           />
         ))}
@@ -404,15 +360,10 @@ function SidebarContent(
           <span>Integrations</span>
         </div>
 
-        <IntegrationList
-          pathname={props.pathname}
-          onNavigate={props.onNavigate}
-        />
+        <IntegrationList pathname={props.pathname} onNavigate={props.onNavigate} />
       </nav>
 
-      {props.supportSlot && (
-        <div className="shrink-0 px-2 pb-2">{props.supportSlot}</div>
-      )}
+      {props.supportSlot && <div className="shrink-0 px-2 pb-2">{props.supportSlot}</div>}
 
       <UserFooter onSignOut={props.onSignOut} orgMenuSlot={props.orgMenuSlot} />
     </>

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -19,7 +19,10 @@ import {
   integrationPresetIconUrl,
 } from "../components/integration-favicon";
 import { CommandPalette } from "../components/command-palette";
-import { useIntegrationPlugins } from "@executor-js/sdk/client";
+import {
+  useClientPlugins,
+  useIntegrationPlugins,
+} from "@executor-js/sdk/client";
 import { useAuth } from "./auth-context";
 
 // ---------------------------------------------------------------------------
@@ -53,7 +56,8 @@ export const defaultShellNavItems: ReadonlyArray<ShellNavItem> = [
 // ("/" -> "/{-$orgSlug}", "/policies" -> "/{-$orgSlug}/policies"). Loosely
 // typed on purpose: host-specific items ("/admin", "/billing") resolve against
 // the host's own route tree, which this package can't see.
-const orgScopedTo = (to: string): string => (to === "/" ? "/{-$orgSlug}" : `/{-$orgSlug}${to}`);
+const orgScopedTo = (to: string): string =>
+  to === "/" ? "/{-$orgSlug}" : `/{-$orgSlug}${to}`;
 
 /** The pathname with the active org-slug prefix stripped, for active-state
  *  comparisons against scope-relative paths. */
@@ -61,7 +65,10 @@ function useScopeRelativePathname(): string {
   const pathname = useLocation({ select: (location) => location.pathname });
   const params = useParams({ strict: false }) as { orgSlug?: string };
   const orgSlug = params.orgSlug;
-  if (orgSlug && (pathname === `/${orgSlug}` || pathname.startsWith(`/${orgSlug}/`))) {
+  if (
+    orgSlug &&
+    (pathname === `/${orgSlug}` || pathname.startsWith(`/${orgSlug}/`))
+  ) {
     return pathname.slice(orgSlug.length + 1) || "/";
   }
   return pathname;
@@ -84,8 +91,14 @@ export interface ShellProps {
 
 function Brand(props: { onNavigate?: () => void }) {
   return (
-    <Link to="/{-$orgSlug}" onClick={props.onNavigate} className="flex items-center gap-1.5">
-      <span className="font-display text-base tracking-tight text-foreground">executor</span>
+    <Link
+      to="/{-$orgSlug}"
+      onClick={props.onNavigate}
+      className="flex items-center gap-1.5"
+    >
+      <span className="font-display text-base tracking-tight text-foreground">
+        executor
+      </span>
       <span className="rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-primary">
         Beta
       </span>
@@ -95,7 +108,12 @@ function Brand(props: { onNavigate?: () => void }) {
 
 // ── NavItem ──────────────────────────────────────────────────────────────
 
-function NavItem(props: { to: string; label: string; active: boolean; onNavigate?: () => void }) {
+function NavItem(props: {
+  to: string;
+  label: string;
+  active: boolean;
+  onNavigate?: () => void;
+}) {
   return (
     <Link
       to={orgScopedTo(props.to)}
@@ -109,6 +127,56 @@ function NavItem(props: { to: string; label: string; active: boolean; onNavigate
     >
       {props.label}
     </Link>
+  );
+}
+
+// ── PluginNav ─────────────────────────────────────────────────────────────
+
+// Surfaces console pages contributed by client plugins that declare
+// `pages[].nav.label` (e.g. Toolkits). The catch-all `/plugins/$pluginId/$`
+// route mounts them, so a plugin registered in executor.config.ts appears in
+// the sidebar with no per-host wiring. `pathname` is scope-relative.
+function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
+  const plugins = useClientPlugins();
+  const entries = plugins.flatMap((plugin) =>
+    (plugin.pages ?? [])
+      .filter((page) => page.nav)
+      .map((page) => {
+        const splat = page.path.replace(/^\//, "");
+        const href = `/plugins/${plugin.id}${splat ? `/${splat}` : "/"}`;
+        // Active-state matching ignores a trailing slash (live pathname is
+        // "/plugins/toolkits", href is "/plugins/toolkits/").
+        const base = href.replace(/\/$/, "");
+        return {
+          key: `${plugin.id}:${page.path}`,
+          href,
+          base,
+          label: page.nav!.label,
+        };
+      }),
+  );
+  if (entries.length === 0) return null;
+  return (
+    <>
+      {entries.map((entry) => (
+        <Link
+          key={entry.key}
+          // Loosely-typed string `to` (like NavItem): the concrete plugin path
+          // resolves against whichever host route tree this package builds into.
+          to={orgScopedTo(entry.href)}
+          onClick={props.onNavigate}
+          className={[
+            "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
+            props.pathname === entry.base ||
+            props.pathname.startsWith(`${entry.base}/`)
+              ? "bg-sidebar-active text-foreground font-medium"
+              : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
+          ].join(" ")}
+        >
+          {entry.label}
+        </Link>
+      ))}
+    </>
   );
 }
 
@@ -131,7 +199,9 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
       </div>
     ),
     onFailure: () => (
-      <div className="px-2.5 py-2 text-xs text-muted-foreground">No integrations yet</div>
+      <div className="px-2.5 py-2 text-xs text-muted-foreground">
+        No integrations yet
+      </div>
     ),
     onSuccess: ({ value }) =>
       value.length === 0 ? (
@@ -145,7 +215,8 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
             const name = integration.name || slug;
             const detailPath = `/integrations/${slug}`;
             const active =
-              props.pathname === detailPath || props.pathname.startsWith(`${detailPath}/`);
+              props.pathname === detailPath ||
+              props.pathname.startsWith(`${detailPath}/`);
             return (
               <Link
                 key={slug}
@@ -161,7 +232,12 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
               >
                 <IntegrationFavicon
                   icon={integrationPresetIconUrl(
-                    { id: slug, kind: integration.kind, name, url: integration.displayUrl },
+                    {
+                      id: slug,
+                      kind: integration.kind,
+                      name,
+                      url: integration.displayUrl,
+                    },
                     integrationPlugins,
                   )}
                   url={
@@ -193,9 +269,15 @@ function initialsFor(name: string | null, email: string) {
   return email[0]!.toUpperCase();
 }
 
-function Avatar(props: { url: string | null; name: string | null; email: string }) {
+function Avatar(props: {
+  url: string | null;
+  name: string | null;
+  email: string;
+}) {
   if (props.url) {
-    return <img src={props.url} alt="" className="size-7 shrink-0 rounded-full" />;
+    return (
+      <img src={props.url} alt="" className="size-7 shrink-0 rounded-full" />
+    );
   }
   return (
     <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
@@ -219,13 +301,19 @@ function UserFooter(props: Pick<ShellProps, "onSignOut" | "orgMenuSlot">) {
             variant="ghost"
             className="flex h-auto w-full items-center justify-start gap-2.5 rounded-md px-1 py-1 text-left hover:bg-sidebar-active/60"
           >
-            <Avatar url={auth.user.avatarUrl} name={auth.user.name} email={auth.user.email} />
+            <Avatar
+              url={auth.user.avatarUrl}
+              name={auth.user.name}
+              email={auth.user.email}
+            />
             <div className="min-w-0 flex-1">
               <p className="truncate text-xs font-medium text-foreground">
                 {auth.user.name ?? auth.user.email}
               </p>
               {auth.organization && (
-                <p className="truncate text-xs text-muted-foreground">{auth.organization.name}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {auth.organization.name}
+                </p>
               )}
             </div>
             <svg
@@ -249,13 +337,19 @@ function UserFooter(props: Pick<ShellProps, "onSignOut" | "orgMenuSlot">) {
             Signed in as
           </DropdownMenuLabel>
           <DropdownMenuItem disabled className="gap-2 text-xs opacity-100">
-            <Avatar url={auth.user.avatarUrl} name={auth.user.name} email={auth.user.email} />
+            <Avatar
+              url={auth.user.avatarUrl}
+              name={auth.user.name}
+              email={auth.user.email}
+            />
             <div className="min-w-0 flex-1">
               <p className="truncate font-medium text-foreground">
                 {auth.user.name ?? auth.user.email}
               </p>
               {auth.user.name && (
-                <p className="truncate text-muted-foreground">{auth.user.email}</p>
+                <p className="truncate text-muted-foreground">
+                  {auth.user.email}
+                </p>
               )}
             </div>
           </DropdownMenuItem>
@@ -274,7 +368,11 @@ function UserFooter(props: Pick<ShellProps, "onSignOut" | "orgMenuSlot">) {
 // ── SidebarContent ───────────────────────────────────────────────────────
 
 function SidebarContent(
-  props: ShellProps & { pathname: string; onNavigate?: () => void; showBrand?: boolean },
+  props: ShellProps & {
+    pathname: string;
+    onNavigate?: () => void;
+    showBrand?: boolean;
+  },
 ) {
   const navItems = props.navItems ?? defaultShellNavItems;
   return (
@@ -291,19 +389,30 @@ function SidebarContent(
             key={item.to}
             to={item.to}
             label={item.label}
-            active={item.to === "/" ? props.pathname === "/" : props.pathname.startsWith(item.to)}
+            active={
+              item.to === "/"
+                ? props.pathname === "/"
+                : props.pathname.startsWith(item.to)
+            }
             onNavigate={props.onNavigate}
           />
         ))}
+
+        <PluginNav pathname={props.pathname} onNavigate={props.onNavigate} />
 
         <div className="mt-5 mb-1 px-2.5 text-xs font-medium uppercase tracking-widest text-muted-foreground">
           <span>Integrations</span>
         </div>
 
-        <IntegrationList pathname={props.pathname} onNavigate={props.onNavigate} />
+        <IntegrationList
+          pathname={props.pathname}
+          onNavigate={props.onNavigate}
+        />
       </nav>
 
-      {props.supportSlot && <div className="shrink-0 px-2 pb-2">{props.supportSlot}</div>}
+      {props.supportSlot && (
+        <div className="shrink-0 px-2 pb-2">{props.supportSlot}</div>
+      )}
 
       <UserFooter onSignOut={props.onSignOut} orgMenuSlot={props.orgMenuSlot} />
     </>

--- a/packages/react/src/routes/plugins.$pluginId.$.tsx
+++ b/packages/react/src/routes/plugins.$pluginId.$.tsx
@@ -1,5 +1,11 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
-import { useClientPlugins } from "@executor-js/sdk/client";
+import { useCallback, useMemo } from "react";
+import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
+import {
+  PluginRouteProvider,
+  useClientPlugins,
+  type PageDecl,
+  type PluginRouteValue,
+} from "@executor-js/sdk/client";
 
 // ---------------------------------------------------------------------------
 // /plugins/<pluginId>/<rest>
@@ -11,10 +17,10 @@ import { useClientPlugins } from "@executor-js/sdk/client";
 // plugin to `executor.config.ts` is sufficient for its pages to mount
 // here, with no per-route imports.
 //
-// Match logic is intentionally tiny: exact path equality between the URL
-// remainder and a `PageDecl.path`, with `""` and `/` treated as the
-// same root. Plugins that want parameterized paths can build their own
-// in-component routing for now.
+// Page match: exact path first, then longest path prefix, then the `/`
+// root page. The splat remainder after the matched page path is exposed
+// to the page via `<PluginRouteProvider>` (`usePluginRoute` /
+// `usePluginNavigate`).
 // ---------------------------------------------------------------------------
 
 export const Route = createFileRoute("/{-$orgSlug}/plugins/$pluginId/$")({
@@ -26,18 +32,91 @@ function normalizePath(input: string): string {
   return input.startsWith("/") ? input : `/${input}`;
 }
 
+function stripLeadingSlash(path: string): string {
+  return path.replace(/^\//, "");
+}
+
+function matchPluginPage(
+  pages: readonly PageDecl[] | undefined,
+  splat: string | undefined,
+): { readonly page: PageDecl; readonly subpath: string } | null {
+  const target = normalizePath(splat ?? "/");
+  const normalized = (pages ?? []).map((page) => ({
+    page,
+    path: normalizePath(page.path),
+  }));
+  if (normalized.length === 0) return null;
+
+  const exact = normalized.find((entry) => entry.path === target);
+  if (exact) return { page: exact.page, subpath: "" };
+
+  let best: (typeof normalized)[number] | null = null;
+  for (const entry of normalized) {
+    if (entry.path === "/") continue;
+    if (target === entry.path || target.startsWith(`${entry.path}/`)) {
+      if (!best || entry.path.length > best.path.length) best = entry;
+    }
+  }
+  if (best) {
+    const remainder = target.slice(best.path.length);
+    return { page: best.page, subpath: stripLeadingSlash(remainder) };
+  }
+
+  const root = normalized.find((entry) => entry.path === "/");
+  if (root) {
+    return { page: root.page, subpath: target === "/" ? "" : stripLeadingSlash(target) };
+  }
+  return null;
+}
+
 function PluginRouteComponent() {
   const { pluginId, _splat: rest } = Route.useParams();
+  const routerNavigate = useNavigate();
   const plugins = useClientPlugins();
   const plugin = plugins.find((p) => p.id === pluginId);
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: TanStack Router represents not-found from components by throwing notFound()
   if (!plugin) throw notFound();
 
-  const target = normalizePath(rest ?? "/");
-  const page = plugin.pages?.find((p) => normalizePath(p.path) === target);
+  const matched = matchPluginPage(plugin.pages, rest);
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: TanStack Router represents not-found from components by throwing notFound()
-  if (!page) throw notFound();
+  if (!matched) throw notFound();
+
+  const { page, subpath } = matched;
+  const pageSplat = stripLeadingSlash(normalizePath(page.path));
+
+  const navigate = useCallback(
+    (nextSubpath: string, opts?: { readonly replace?: boolean }) => {
+      const fullSplat = nextSubpath
+        ? pageSplat
+          ? `${pageSplat}/${nextSubpath}`
+          : nextSubpath
+        : pageSplat;
+      routerNavigate({
+        to: "/{-$orgSlug}/plugins/$pluginId/$",
+        params: (previous: Record<string, string>) => ({
+          ...previous,
+          pluginId,
+          _splat: fullSplat,
+        }),
+        replace: opts?.replace,
+      });
+    },
+    [routerNavigate, pluginId, pageSplat],
+  );
+
+  const routeValue = useMemo(
+    (): PluginRouteValue => ({
+      pluginId,
+      subpath,
+      navigate,
+    }),
+    [pluginId, subpath, navigate],
+  );
 
   const Component = page.component;
-  return <Component />;
+  return (
+    <PluginRouteProvider value={routeValue}>
+      <Component />
+    </PluginRouteProvider>
+  );
 }


### PR DESCRIPTION
A **toolkit** is a named slice of an account's connections — each connection set to `off` / `read` / `full` — with its own MCP endpoint. An agent that connects with `/mcp?toolkit=<slug>` sees and can run **only** that slice; everything outside it is invisible and blocked. Toolkits come in two scopes: **workspace** (org-owned connections, shared with every member) and **personal** (org + the caller's own, private to them).

Shipped end-to-end as a self-contained plugin (`@executor-js/plugin-toolkits`) plus the small core seams it needs.

## What's included

- **Data + CRUD** — owner-scoped toolkit storage (workspace vs personal) and a typed CRUD API.
- **MCP narrowing** — connecting with a `?toolkit=` selector scopes the engine to that toolkit's slice across every surface: tool listing, search, descriptions, the connection/integration catalog, the built-in core tools, **and** execute (a guessed out-of-slice address is blocked, not just hidden).
- **Access modes** — `read` exposes only read-only tools; `full` exposes all; `off` removes the connection. Wildcard (`*`) entries track every account of an integration, including ones added later.
- **Per-toolkit policies** — `block` / `require_approval` rules compose with org-level policies via the existing stricter-wins lattice. A toolkit can only *tighten* — org guardrails always apply.
- **Console UI** — a Toolkits page (sidebar nav on every host) with a list split by scope and a per-toolkit editor, **URL-routed** (`/plugins/toolkits/`, `/plugins/toolkits/<id>`, `/plugins/toolkits/new/<scope>`) — deep-linkable, with working browser back/forward.
- **Cross-environment** — works on self-host, local, and the cloud/Cloudflare Durable-Object MCP path.

## Architecture notes

- **Core stays vocabulary-neutral.** The feature is a plugin; core knows nothing about "toolkits." Narrowing is expressed through a generic **`RequestScope`** capability — a plugin contributes *data* (`decideTool` / `allowsConnection` / `allowsIntegration` / `inheritOrgPolicies`), and **core owns enforcement centrally** across all surfaces. This replaced an earlier executor-wrapper approach that re-implemented narrowing per-surface and was fail-open on any surface it didn't override (including the built-in `connections.list` / `integrations.list` core tools, which could otherwise enumerate the full account). Unknown selectors fail closed to an empty scope; mutation/admin surfaces are default-denied under a scope.
- **Plugin pages can route by URL.** The plugin page host now exposes the URL subpath + a navigate helper to plugin pages (`usePluginRoute` / `usePluginNavigate`), so any plugin can do internal URL routing — no change to the shared route contract or per-host wiring.

## Testing

13 self-host e2e files / 16 tests covering CRUD + scope visibility, cross-user isolation, read-mode (GET vs write), per-toolkit and inherit-org policies, wildcard auto-include, fail-closed selectors, the core-tool scope boundary (scoped `connections.list` / `integrations.list` return only in-slice; scoped sessions can't create connections or policies), and the console UI flow (create, deep-link, browser back). Full `typecheck` / `lint` / `format:check` green.

## Preview

Console: https://executor-preview-pr-1031.executor-e2e.workers.dev · MCP: `https://executor-preview-pr-1031.executor-e2e.workers.dev/mcp`
