### PR TITLE
Make executor mcp attach to daemon

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,6 +30,7 @@
     "@executor-js/runtime-quickjs": "workspace:*",
     "@executor-js/sdk": "workspace:*",
     "@jitl/quickjs-wasmfile-release-sync": "catalog:",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@sentry/bun": "^10.57.0",
     "effect": "catalog:",
     "quickjs-emscripten": "catalog:"

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -64,6 +64,9 @@ import type { PlatformError } from "effect/PlatformError";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Cause from "effect/Cause";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
 import { ExecutorApi } from "@executor-js/api";
 import {
@@ -1122,9 +1125,123 @@ const withStdoutReroutedToStderr = async <A>(body: () => Promise<A>): Promise<A>
   }
 };
 
+const mcpUrlForActiveLocalServer = (
+  connection: ExecutorServerConnection,
+  elicitationMode: "browser" | "model",
+): URL => {
+  const url = new URL("/mcp", connection.origin);
+  if (elicitationMode === "browser") {
+    url.searchParams.set("elicitation_mode", "browser");
+  }
+  return url;
+};
+
+const closeMcpBridgeTransport = async (close: () => Promise<void>): Promise<void> => {
+  await close();
+};
+
+const isAbortDuringMcpBridgeClose = (error: Error): boolean =>
+  error.name === "AbortError" || error.message.toLowerCase().includes("aborted");
+
+const runMcpHttpBridge = async (input: {
+  readonly manifest: ExecutorLocalServerManifest;
+  readonly elicitationMode: "browser" | "model";
+}): Promise<void> => {
+  const stdio = new StdioServerTransport();
+  const authorization = getExecutorServerAuthorizationHeader(input.manifest.connection);
+  const http = new StreamableHTTPClientTransport(
+    mcpUrlForActiveLocalServer(input.manifest.connection, input.elicitationMode),
+    authorization ? { requestInit: { headers: { Authorization: authorization } } } : undefined,
+  );
+
+  let finished = false;
+  let closing = false;
+  let closePromise: Promise<void> | null = null;
+  let resolveExit: () => void = () => {};
+
+  const waitForExit = new Promise<void>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    process.off("SIGINT", shutdown);
+    process.off("SIGTERM", shutdown);
+    process.stdin.off("end", shutdown);
+    process.stdin.off("close", shutdown);
+    resolveExit();
+  };
+
+  const closeBoth = (): Promise<void> => {
+    if (!closePromise) {
+      closing = true;
+      closePromise = Promise.resolve()
+        .then(() =>
+          Promise.allSettled([
+            closeMcpBridgeTransport(() => stdio.close()),
+            closeMcpBridgeTransport(() => http.close()),
+          ]),
+        )
+        .then(() => undefined);
+    }
+    return closePromise;
+  };
+
+  function shutdown() {
+    finish();
+    void closeBoth();
+  }
+
+  const reportError = (context: string, cause: unknown) => {
+    const error = toError(cause);
+    if (closing && isAbortDuringMcpBridgeClose(error)) return;
+    console.error(`Executor MCP bridge ${context}: ${error.message}`);
+  };
+
+  const forwardMessage =
+    (send: (message: JSONRPCMessage) => Promise<void>, context: string) =>
+    (message: JSONRPCMessage) => {
+      void send(message).then(undefined, (cause: unknown) => {
+        reportError(context, cause);
+        shutdown();
+      });
+    };
+
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
+  process.stdin.once("end", shutdown);
+  process.stdin.once("close", shutdown);
+
+  stdio.onclose = shutdown;
+  http.onclose = shutdown;
+  stdio.onerror = (error) => reportError("stdio transport error", error);
+  http.onerror = (error) => reportError("daemon transport error", error);
+  stdio.onmessage = forwardMessage((message) => http.send(message), "failed to send to daemon");
+  http.onmessage = forwardMessage((message) => stdio.send(message), "failed to send to stdio");
+
+  try {
+    await http.start();
+    await stdio.start();
+    await waitForExit;
+  } finally {
+    finish();
+    await closeBoth();
+  }
+};
+
 const runStdioMcpSession = (input: { readonly elicitationMode: "browser" | "model" }) =>
   Effect.gen(function* () {
+    const active = yield* readActiveLocalServerManifest();
+    if (active) {
+      yield* Effect.promise(() =>
+        runMcpHttpBridge({ manifest: active, elicitationMode: input.elicitationMode }),
+      );
+      return;
+    }
+
     const startupLock = yield* acquireLocalServerStartLock();
+    let activeAfterLock: ExecutorLocalServerManifest | null = null;
     let web: Awaited<
       ReturnType<
         typeof withStdoutReroutedToStderr<{
@@ -1137,42 +1254,51 @@ const runStdioMcpSession = (input: { readonly elicitationMode: "browser" | "mode
     > | null = null;
 
     try {
-      yield* assertNoOtherActiveLocalServer();
-      web = yield* Effect.promise(() =>
-        withStdoutReroutedToStderr(async () => {
-          const host = "127.0.0.1";
-          const port = await Effect.runPromise(
-            chooseDaemonPort({ preferredPort: DEFAULT_PORT, hostname: host }),
-          );
-          const baseUrl = `http://localhost:${port}`;
-          const restoreWebBaseUrl = installDefaultExecutorWebBaseUrl(baseUrl);
+      activeAfterLock = yield* readActiveLocalServerManifest();
+      if (!activeAfterLock) {
+        web = yield* Effect.promise(() =>
+          withStdoutReroutedToStderr(async () => {
+            const host = "127.0.0.1";
+            const port = await Effect.runPromise(
+              chooseDaemonPort({ preferredPort: DEFAULT_PORT, hostname: host }),
+            );
+            const baseUrl = `http://localhost:${port}`;
+            const restoreWebBaseUrl = installDefaultExecutorWebBaseUrl(baseUrl);
 
-          try {
-            const executor = await getExecutor();
-            const server = await startServer({
-              port,
-              hostname: host,
-              embeddedWebUI,
-            });
-            const serverBaseUrl = `http://localhost:${server.port}`;
-            return { executor, server, baseUrl: serverBaseUrl, restoreWebBaseUrl };
-          } catch (cause) {
-            restoreWebBaseUrl();
-            throw cause;
-          }
-        }),
-      );
-      yield* publishLocalServerManifest({
-        kind: "foreground",
-        connection: normalizeExecutorServerConnection({
-          kind: "http",
-          origin: web.baseUrl,
-          displayName: "CLI MCP",
-          auth: { kind: "bearer", token: web.server.authToken },
-        }),
-      });
+            try {
+              const executor = await getExecutor();
+              const server = await startServer({
+                port,
+                hostname: host,
+                embeddedWebUI,
+              });
+              const serverBaseUrl = `http://localhost:${server.port}`;
+              return { executor, server, baseUrl: serverBaseUrl, restoreWebBaseUrl };
+            } catch (cause) {
+              restoreWebBaseUrl();
+              throw cause;
+            }
+          }),
+        );
+        yield* publishLocalServerManifest({
+          kind: "foreground",
+          connection: normalizeExecutorServerConnection({
+            kind: "http",
+            origin: web.baseUrl,
+            displayName: "CLI MCP",
+            auth: { kind: "bearer", token: web.server.authToken },
+          }),
+        });
+      }
     } finally {
       yield* releaseLocalServerStartLock(startupLock).pipe(Effect.ignore);
+    }
+
+    if (activeAfterLock) {
+      yield* Effect.promise(() =>
+        runMcpHttpBridge({ manifest: activeAfterLock, elicitationMode: input.elicitationMode }),
+      );
+      return;
     }
 
     if (!web) return yield* Effect.fail(new Error("Failed to start local Executor MCP server."));

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@executor-js/runtime-quickjs": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "@jitl/quickjs-wasmfile-release-sync": "catalog:",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@sentry/bun": "^10.57.0",
         "effect": "catalog:",
         "quickjs-emscripten": "catalog:",

--- a/e2e/local/cli-mcp-daemon-attach.test.ts
+++ b/e2e/local/cli-mcp-daemon-attach.test.ts
@@ -1,0 +1,168 @@
+// Local CLI: MCP clients commonly install `executor mcp` as a stdio command.
+// When a durable local daemon is already running, that command should attach to
+// the daemon's HTTP MCP endpoint instead of starting a second local server and
+// tripping the data-dir singleton guard.
+import { expect } from "@effect/vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { Effect } from "effect";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Subprocess } from "bun";
+
+import { scenario } from "../src/scenario";
+
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const testScope = join(repoRoot, "apps/local");
+const readyTimeoutMs = 60_000;
+
+const waitForDaemonReady = (
+  proc: Subprocess<"ignore", "pipe", "pipe">,
+): Promise<{ readonly port: number; readonly stderr: () => string }> =>
+  // oxlint-disable-next-line executor/no-promise-reject -- boundary: local e2e watches a real daemon process
+  new Promise((resolveReady, rejectReady) => {
+    let stdoutBuffer = "";
+    let stderrBuffer = "";
+    let settled = false;
+    const decoder = new TextDecoder();
+    const stdout = proc.stdout.getReader();
+    const stderr = proc.stderr.getReader();
+
+    const deadline = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: local e2e failure includes captured daemon stderr
+      rejectReady(new Error(`daemon did not announce ready: ${stderrBuffer}`));
+    }, readyTimeoutMs);
+
+    void (async () => {
+      while (true) {
+        const { value, done } = await stderr.read();
+        if (done) return;
+        stderrBuffer += decoder.decode(value);
+      }
+    })();
+
+    void (async () => {
+      while (true) {
+        const { value, done } = await stdout.read();
+        if (done) {
+          if (!settled) {
+            settled = true;
+            clearTimeout(deadline);
+            // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: local e2e failure includes captured daemon stderr
+            rejectReady(new Error(`daemon stdout closed before ready: ${stderrBuffer}`));
+          }
+          return;
+        }
+
+        stdoutBuffer += decoder.decode(value);
+        const match = /Daemon ready on http:\/\/(?:\[[^\]]+\]|[^:\s]+):(\d+)/.exec(stdoutBuffer);
+        if (match) {
+          settled = true;
+          clearTimeout(deadline);
+          resolveReady({ port: Number(match[1]), stderr: () => stderrBuffer });
+          return;
+        }
+      }
+    })();
+  });
+
+const stopDaemonProcess = async (
+  proc: Subprocess<"ignore", "pipe", "pipe">,
+  exitCode: () => number | null,
+): Promise<void> => {
+  if (exitCode() !== null) return;
+  proc.kill("SIGTERM");
+  await Promise.race([proc.exited, Bun.sleep(3000)]);
+  if (exitCode() === null) proc.kill("SIGKILL");
+};
+
+const withTempRoot = Effect.acquireRelease(
+  Effect.sync(() => mkdtempSync(join(tmpdir(), "executor-local-mcp-daemon-attach-"))),
+  (root) => Effect.sync(() => rmSync(root, { recursive: true, force: true })),
+);
+
+const startForegroundDaemon = (dataDir: string) =>
+  Effect.acquireRelease(
+    Effect.gen(function* () {
+      const proc = Bun.spawn(
+        [
+          "bun",
+          "run",
+          "dev:cli",
+          "daemon",
+          "run",
+          "--foreground",
+          "--port",
+          "0",
+          "--hostname",
+          "127.0.0.1",
+          "--scope",
+          testScope,
+        ],
+        {
+          cwd: repoRoot,
+          env: { ...process.env, EXECUTOR_DATA_DIR: dataDir },
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      let exitCode: number | null = null;
+      void proc.exited.then((code) => {
+        exitCode = code;
+      });
+
+      const ready = yield* Effect.promise(() => waitForDaemonReady(proc)).pipe(
+        Effect.tapError(() => Effect.promise(() => stopDaemonProcess(proc, () => exitCode))),
+      );
+      return { proc, port: ready.port, stderr: ready.stderr, exitCode: () => exitCode };
+    }),
+    ({ proc, exitCode }) => Effect.promise(() => stopDaemonProcess(proc, exitCode)),
+  );
+
+scenario(
+  "Local CLI MCP · stdio attaches to the active daemon instead of starting a competing server",
+  { timeout: 120_000 },
+  Effect.gen(function* () {
+    const root = yield* withTempRoot;
+    const dataDir = join(root, "data");
+    const daemon = yield* startForegroundDaemon(dataDir);
+
+    const transport = new StdioClientTransport({
+      command: "bun",
+      args: ["run", "dev:cli", "mcp", "--scope", testScope],
+      cwd: repoRoot,
+      env: { ...process.env, EXECUTOR_DATA_DIR: dataDir },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "e2e-local-mcp-daemon-attach", version: "1.0.0" });
+
+    yield* Effect.acquireRelease(
+      Effect.promise(() => client.connect(transport)),
+      () => Effect.promise(() => transport.close()),
+    );
+
+    const { tools } = yield* Effect.promise(() => client.listTools());
+    expect(
+      tools.map((tool) => tool.name),
+      "daemon-backed stdio MCP lists tools",
+    ).toContain("execute");
+
+    const result = yield* Effect.promise(() =>
+      client.callTool({
+        name: "execute",
+        arguments: { code: "return 2 + 2" },
+      }),
+    );
+
+    const text = (result.content as Array<{ type: string; text: string }>)[0]?.text;
+    expect(text, "execute ran through the daemon-backed MCP bridge").toContain("4");
+    expect(result.isError, "execute should not report a tool error").toBeFalsy();
+    expect(daemon.exitCode(), daemon.stderr()).toBeNull();
+    expect(daemon.port, "daemon announced an OS-assigned port").toBeGreaterThan(0);
+  }).pipe(Effect.scoped),
+);

--- a/packages/hosts/mcp/src/stdio-integration.test.ts
+++ b/packages/hosts/mcp/src/stdio-integration.test.ts
@@ -2,13 +2,122 @@ import { describe, expect, it } from "@effect/vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Effect } from "effect";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import type { Readable } from "node:stream";
 
 const repoRoot = resolve(import.meta.dirname, "../../../..");
 const cliEntry = resolve(repoRoot, "apps/cli/src/main.ts");
 const testScope = resolve(repoRoot, "apps/local");
+const readyTimeoutMs = 30_000;
+type DaemonProcess = ChildProcessByStdio<null, Readable, Readable>;
+
+const waitForDaemonReady = (
+  proc: DaemonProcess,
+): Promise<{ readonly port: number; readonly stderr: () => string }> =>
+  // oxlint-disable-next-line executor/no-promise-reject -- boundary: integration test watches a real daemon process
+  new Promise((resolveReady, rejectReady) => {
+    let stdoutBuffer = "";
+    let stderrBuffer = "";
+    let settled = false;
+
+    const cleanup = () => {
+      clearTimeout(deadline);
+      proc.stdout.off("data", onStdout);
+      proc.stderr.off("data", onStderr);
+      proc.off("error", onError);
+      proc.off("close", onClose);
+    };
+
+    const fail = (cause: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      // oxlint-disable-next-line executor/no-promise-reject -- boundary: adapts child_process callbacks into the Promise waited by the Effect test helper
+      rejectReady(cause);
+    };
+
+    const deadline = setTimeout(() => {
+      // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: integration test failure includes captured daemon stderr
+      fail(new Error(`daemon did not announce ready: ${stderrBuffer}`));
+    }, readyTimeoutMs);
+
+    const onStderr = (chunk: Buffer | string) => {
+      stderrBuffer += chunk.toString();
+    };
+
+    const onStdout = (chunk: Buffer | string) => {
+      stdoutBuffer += chunk.toString();
+      const match = /Daemon ready on http:\/\/(?:\[[^\]]+\]|[^:\s]+):(\d+)/.exec(stdoutBuffer);
+      if (match) {
+        settled = true;
+        cleanup();
+        resolveReady({ port: Number(match[1]), stderr: () => stderrBuffer });
+      }
+    };
+
+    const onError = (error: Error) => fail(error);
+
+    const onClose = () => {
+      // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: integration test failure includes captured daemon stderr
+      fail(new Error(`daemon stdout closed before ready: ${stderrBuffer}`));
+    };
+
+    proc.stdout.on("data", onStdout);
+    proc.stderr.on("data", onStderr);
+    proc.once("error", onError);
+    proc.once("close", onClose);
+  });
+
+const stopDaemonProcess = async (
+  proc: DaemonProcess,
+  exitCode: () => number | null,
+): Promise<void> => {
+  if (exitCode() !== null) return;
+  proc.kill("SIGTERM");
+  await Promise.race([
+    new Promise<void>((resolve) => {
+      proc.once("close", () => resolve());
+    }),
+    new Promise<void>((resolve) => setTimeout(resolve, 3000)),
+  ]);
+  if (exitCode() === null) proc.kill("SIGKILL");
+};
+
+const startForegroundDaemon = (dataDir: string) =>
+  Effect.acquireRelease(
+    Effect.gen(function* () {
+      const proc = spawn(
+        "bun",
+        [
+          "run",
+          cliEntry,
+          "daemon",
+          "run",
+          "--foreground",
+          "--port",
+          "0",
+          "--hostname",
+          "127.0.0.1",
+          "--scope",
+          testScope,
+        ],
+        { env: { ...process.env, EXECUTOR_DATA_DIR: dataDir }, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let exitCode: number | null = null;
+      proc.once("close", (code) => {
+        exitCode = code;
+      });
+
+      const ready = yield* Effect.promise(() => waitForDaemonReady(proc)).pipe(
+        Effect.tapError(() => Effect.promise(() => stopDaemonProcess(proc, () => exitCode))),
+      );
+      return { proc, port: ready.port, stderr: ready.stderr, exitCode: () => exitCode };
+    }),
+    ({ proc, exitCode }) => Effect.promise(() => stopDaemonProcess(proc, exitCode)),
+  );
 
 describe("MCP stdio integration", () => {
   it.effect(
@@ -47,5 +156,44 @@ describe("MCP stdio integration", () => {
         expect(result.isError).toBeFalsy();
       }).pipe(Effect.scoped),
     { timeout: 30_000 },
+  );
+
+  it.effect(
+    "attaches stdio MCP to an active local daemon",
+    () =>
+      Effect.gen(function* () {
+        const dataDir = mkdtempSync(join(tmpdir(), "executor-mcp-daemon-test-"));
+        const daemon = yield* startForegroundDaemon(dataDir);
+
+        const transport = new StdioClientTransport({
+          command: "bun",
+          args: ["run", cliEntry, "mcp", "--scope", testScope],
+          env: { ...process.env, EXECUTOR_DATA_DIR: dataDir },
+        });
+
+        const client = new Client({ name: "test-client", version: "1.0.0" }, { capabilities: {} });
+
+        yield* Effect.acquireRelease(
+          Effect.promise(() => client.connect(transport)),
+          () => Effect.promise(() => transport.close()),
+        );
+
+        const { tools } = yield* Effect.promise(() => client.listTools());
+        expect(tools.map((t) => t.name)).toContain("execute");
+
+        const result = yield* Effect.promise(() =>
+          client.callTool({
+            name: "execute",
+            arguments: { code: "return 2+2" },
+          }),
+        );
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0]?.text;
+        expect(text).toContain("4");
+        expect(result.isError).toBeFalsy();
+        expect(daemon.exitCode(), daemon.stderr()).toBeNull();
+        expect(daemon.port).toBeGreaterThan(0);
+      }).pipe(Effect.scoped),
+    { timeout: 45_000 },
   );
 });


### PR DESCRIPTION
## Summary
- Make `executor mcp` attach to the active local daemon.
- Add local e2e coverage.

## Tests
- `bun --bun vitest run --project local local/cli-mcp-daemon-attach.test.ts`
- `bun --bun vitest run src/stdio-integration.test.ts`