### PR TITLE
Plugin extensibility seams: RequestScope + plugin-page routing

### DIFF
--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -243,11 +243,14 @@ function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
       .map((page) => {
         const splat = page.path.replace(/^\//, "");
         const href = `/plugins/${plugin.id}${splat ? `/${splat}` : "/"}`;
+        // Trailing slash stripped so the nav stays active on plugin subroutes
+        // (e.g. /plugins/toolkits/<id>), matching the multiplayer shell.
+        const base = href.replace(/\/$/, "");
         return {
           key: `${plugin.id}:${page.path}`,
           pluginId: plugin.id,
           splat,
-          href,
+          base,
           label: page.nav!.label,
         };
       }),
@@ -263,7 +266,7 @@ function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
           onClick={props.onNavigate}
           className={[
             "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
-            props.pathname === entry.href || props.pathname.startsWith(`${entry.href}/`)
+            props.pathname === entry.base || props.pathname.startsWith(`${entry.base}/`)
               ? "bg-sidebar-active text-foreground font-medium"
               : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
           ].join(" ")}

--- a/packages/core/api/src/server/execution-stack.ts
+++ b/packages/core/api/src/server/execution-stack.ts
@@ -26,7 +26,7 @@
 import { Context, Effect, Layer } from "effect";
 import type * as Cause from "effect/Cause";
 
-import type { AnyPlugin, Executor, StorageFailure } from "@executor-js/sdk";
+import { type AnyPlugin, type Executor, type StorageFailure } from "@executor-js/sdk";
 import {
   createExecutionEngine,
   type ExecutionEngine,
@@ -95,17 +95,21 @@ export const makeExecutionStack = <
   accountId: string,
   organizationId: string,
   organizationName: string,
+  /** Optional per-request narrowing selector (e.g. an MCP `?toolkit=` value).
+   *  When set, core resolves plugin-contributed `RequestScope` overlays and
+   *  enforces them centrally before the engine is built. */
+  selector?: string,
 ): Effect.Effect<
-  { readonly executor: Executor<TPlugins>; readonly engine: ExecutionEngine<Cause.YieldableError> },
+  {
+    readonly executor: Executor<TPlugins>;
+    readonly engine: ExecutionEngine<Cause.YieldableError>;
+  },
   StorageFailure,
   DbProvider | PluginsProvider | HostConfig | CodeExecutorProvider | EngineDecorator
 > =>
   Effect.gen(function* () {
-    const executor = yield* makeScopedExecutor<TPlugins>(
-      accountId,
-      organizationId,
-      organizationName,
-    );
+    const base = yield* makeScopedExecutor<TPlugins>(accountId, organizationId, organizationName);
+    const executor = selector ? yield* base.applyRequestScope(selector) : base;
     const codeExecutor = yield* CodeExecutorProvider;
     const { decorate } = yield* EngineDecorator;
     const engine = decorate(createExecutionEngine({ executor, codeExecutor }), {

--- a/packages/core/api/src/server/mcp-build.ts
+++ b/packages/core/api/src/server/mcp-build.ts
@@ -38,21 +38,27 @@ export type McpExecutionStackLayer = Layer.Layer<
  */
 export const makeMcpBuildServer =
   (executionStack: McpExecutionStackLayer): McpBuildServer =>
-  (principal: Principal, options?: McpBuildServerOptions) =>
-    makeExecutionStack(
+  (principal: Principal, options?: McpBuildServerOptions) => {
+    // `selector` narrows the engine in `makeExecutionStack` (a plugin's
+    // executor wrapper applies it); the rest configure the MCP server
+    // (elicitation/approval).
+    const { selector, ...serverOptions } = options ?? {};
+    return makeExecutionStack(
       principal.accountId,
       principal.organizationId,
       principal.organizationName,
+      selector,
     ).pipe(
       Effect.map(({ engine }) => engine),
       Effect.provide(executionStack),
       Effect.mapError((cause) => new McpEngineBuildError({ cause })),
       Effect.flatMap((engine) =>
-        createExecutorMcpServer({ engine, ...(options ?? {}) }).pipe(
+        createExecutorMcpServer({ engine, ...serverOptions }).pipe(
           Effect.map((mcpServer) => ({ mcpServer, engine })),
         ),
       ),
     );
+  };
 
 /**
  * The standard console `McpErrorReporter` seam: route an orchestration defect
@@ -67,6 +73,8 @@ export const makeConsoleMcpErrorReporter = (
     McpErrorReporter,
     Effect.gen(function* () {
       const capture = yield* ErrorCapture;
-      return { report: (cause) => Effect.asVoid(capture.captureException(cause)) };
+      return {
+        report: (cause) => Effect.asVoid(capture.captureException(cause)),
+      };
     }),
   ).pipe(Layer.provide(errorCapture));

--- a/packages/core/sdk/src/client.ts
+++ b/packages/core/sdk/src/client.ts
@@ -381,3 +381,51 @@ export const useIntegrationPlugins = (): readonly IntegrationPlugin[] =>
 /** Secret-provider plugins extracted from `clientPlugins[].secretProviderPlugin`. */
 export const useSecretProviderPlugins = (): readonly SecretProviderPlugin[] =>
   usePluginsCtx("useSecretProviderPlugins").secretProviderPlugins;
+
+// ---------------------------------------------------------------------------
+// PluginRouteProvider + hooks — per-plugin-page URL subpath + navigation.
+//
+// The host's catch-all plugin route matches a page by longest-prefix of the
+// URL splat, then exposes the remainder as `subpath` with a `navigate` helper
+// that updates only the splat (org slug is preserved by the injected impl).
+// Plugins import these hooks from `@executor-js/sdk/client`; the host injects
+// the navigate implementation — no router dependency in the SDK.
+// ---------------------------------------------------------------------------
+
+export interface PluginRouteValue {
+  readonly pluginId: string;
+  /** URL fragment after the matched page's own path; "" at the page root. */
+  readonly subpath: string;
+  /** Navigate within this plugin page (subpath relative to the page's path). */
+  readonly navigate: (subpath: string, opts?: { readonly replace?: boolean }) => void;
+}
+
+const PluginRouteContext = createContext<PluginRouteValue | null>(null);
+PluginRouteContext.displayName = "PluginRouteContext";
+
+export interface PluginRouteProviderProps {
+  readonly value: PluginRouteValue;
+  readonly children: ReactNode;
+}
+
+export function PluginRouteProvider(
+  props: PluginRouteProviderProps,
+): ReturnType<typeof createElement> {
+  return createElement(PluginRouteContext.Provider, { value: props.value }, props.children);
+}
+
+const usePluginRouteCtx = (hookName: string): PluginRouteValue => {
+  const ctx = useContext(PluginRouteContext);
+  if (!ctx) {
+    // oxlint-disable-next-line executor/no-try-catch-or-throw, executor/no-error-constructor -- boundary: React hook invariant
+    throw new Error(`${hookName} must be called inside a <PluginRouteProvider>.`);
+  }
+  return ctx;
+};
+
+/** Current plugin page route: plugin id, URL subpath, and in-page navigate. */
+export const usePluginRoute = (): PluginRouteValue => usePluginRouteCtx("usePluginRoute");
+
+/** Navigate within the current plugin page (subpath relative to the page path). */
+export const usePluginNavigate = (): PluginRouteValue["navigate"] =>
+  usePluginRouteCtx("usePluginNavigate").navigate;

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -98,6 +98,13 @@ import {
   type ToolPolicy,
   type UpdateToolPolicyInput,
 } from "./policies";
+import {
+  EMPTY_REQUEST_SCOPE,
+  resolveScopedEffectivePolicy,
+  scopePluginCtx,
+  toolVisibleUnderScope,
+  type RequestScope,
+} from "./request-scope";
 import type { CredentialProvider, ProviderEntry } from "./provider";
 import type {
   AnyPlugin,
@@ -241,6 +248,10 @@ interface OwnedKeys {
 // core-table query unioned with the in-memory static pool.
 // ---------------------------------------------------------------------------
 
+export type RequestScopeProvider = (
+  selector: string,
+) => Effect.Effect<RequestScope | null, StorageFailure>;
+
 export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   readonly integrations: {
     readonly list: () => Effect.Effect<readonly Integration[], StorageFailure>;
@@ -318,6 +329,11 @@ export type Executor<TPlugins extends readonly AnyPlugin[] = readonly []> = {
   ) => Effect.Effect<unknown, ExecuteError>;
 
   readonly close: () => Effect.Effect<void, StorageFailure>;
+
+  /** Apply a per-request catalog/policy overlay resolved from `selector`. */
+  readonly applyRequestScope: (
+    selector: string,
+  ) => Effect.Effect<Executor<TPlugins>, StorageFailure>;
 } & PluginExtensions<TPlugins>;
 
 export interface ExecutorDb {
@@ -505,7 +521,10 @@ const normalizeConnectionInputs = (
   input: ConnectionValueInput,
 ): readonly NormalizedConnectionInput[] => {
   if ("inputs" in input) {
-    return Object.entries(input.inputs).map(([variable, origin]) => ({ variable, origin }));
+    return Object.entries(input.inputs).map(([variable, origin]) => ({
+      variable,
+      origin,
+    }));
   }
   if ("values" in input) {
     return Object.entries(input.values).map(([variable, value]) => ({
@@ -1336,6 +1355,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     };
 
     const extensions: Record<string, object> = {};
+    const requestScopeProviders: RequestScopeProvider[] = [];
 
     // ------------------------------------------------------------------
     // Owner condition builders. The owner policy already restricts reads to
@@ -2439,144 +2459,162 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       }
     });
 
-    const toolsList = (filter?: ToolListFilter): Effect.Effect<readonly Tool[], StorageFailure> =>
-      Effect.gen(function* () {
-        yield* syncStaleConnectionTools;
-        // Projected: the list surface is metadata (address, description,
-        // annotations) — loading every tool's input/output schema JSON made
-        // an unbounded list scale with schema bytes, not tool count.
-        const rows = yield* core.findMany("tool", {
-          where: (b: AnyCb) =>
-            b.and(
-              filter?.integration === undefined
-                ? true
-                : b("integration", "=", String(filter.integration)),
-              filter?.owner === undefined ? true : b("owner", "=", filter.owner),
-              filter?.connection === undefined
-                ? true
-                : b("connection", "=", String(filter.connection)),
-            ),
-          select: TOOL_INVOCATION_COLUMNS,
-        });
-        const includeBlocked = filter?.includeBlocked ?? false;
-        const policyRows = yield* core.findMany("tool_policy", {});
-        const tools: Tool[] = [];
-        for (const row of rows) {
-          const tool = rowToTool(row);
-          if (!matchesToolFilter(tool, filter)) continue;
-          if (!includeBlocked) {
-            const effective = resolveEffectivePolicy(
-              normalizedPolicyId(tool),
-              policyRows,
-              ownerRankForRow,
-              tool.annotations?.requiresApproval,
-            );
-            if (effective.action === "block") continue;
-          }
-          tools.push(tool);
-        }
-        for (const entry of staticTools.values()) {
-          const tool = staticToolToTool(entry);
-          if (!matchesToolFilter(tool, filter)) continue;
-          if (!includeBlocked) {
-            const effective = resolveEffectivePolicy(
-              normalizedPolicyId(tool),
-              policyRows,
-              ownerRankForRow,
-              tool.annotations?.requiresApproval,
-            );
-            if (effective.action === "block") continue;
-          }
-          tools.push(tool);
-        }
-        return tools;
-      });
+    const resolveToolEffectivePolicy = (
+      tool: Tool,
+      policyRows: readonly ToolPolicyRow[],
+      scope?: RequestScope,
+    ): EffectivePolicy =>
+      scope
+        ? resolveScopedEffectivePolicy(
+            normalizedPolicyId(tool),
+            tool,
+            scope,
+            policyRows,
+            ownerRankForRow,
+            tool.annotations?.requiresApproval,
+          )
+        : resolveEffectivePolicy(
+            normalizedPolicyId(tool),
+            policyRows,
+            ownerRankForRow,
+            tool.annotations?.requiresApproval,
+          );
 
-    const toolSchema = (
-      address: ToolAddress,
-    ): Effect.Effect<ToolSchemaView | null, StorageFailure> =>
-      Effect.gen(function* () {
-        const staticEntry = staticTools.get(String(address));
-        if (staticEntry) {
-          const tool = staticToolToTool(staticEntry);
+    const makeToolsList =
+      (scope?: RequestScope) =>
+      (filter?: ToolListFilter): Effect.Effect<readonly Tool[], StorageFailure> =>
+        Effect.gen(function* () {
+          yield* syncStaleConnectionTools;
+          const rows = yield* core.findMany("tool", {
+            where: (b: AnyCb) =>
+              b.and(
+                filter?.integration === undefined
+                  ? true
+                  : b("integration", "=", String(filter.integration)),
+                filter?.owner === undefined ? true : b("owner", "=", filter.owner),
+                filter?.connection === undefined
+                  ? true
+                  : b("connection", "=", String(filter.connection)),
+              ),
+            select: TOOL_INVOCATION_COLUMNS,
+          });
+          const includeBlocked = filter?.includeBlocked ?? false;
+          const policyRows = yield* core.findMany("tool_policy", {});
+          const tools: Tool[] = [];
+          for (const row of rows) {
+            const tool = rowToTool(row);
+            if (!matchesToolFilter(tool, filter)) continue;
+            if (scope && !toolVisibleUnderScope(tool, scope)) continue;
+            if (!includeBlocked) {
+              const effective = resolveToolEffectivePolicy(tool, policyRows, scope);
+              if (effective.action === "block") continue;
+            }
+            tools.push(tool);
+          }
+          for (const entry of staticTools.values()) {
+            const tool = staticToolToTool(entry);
+            if (!matchesToolFilter(tool, filter)) continue;
+            if (scope && !toolVisibleUnderScope(tool, scope)) continue;
+            if (!includeBlocked) {
+              const effective = resolveToolEffectivePolicy(tool, policyRows, scope);
+              if (effective.action === "block") continue;
+            }
+            tools.push(tool);
+          }
+          return tools;
+        });
+
+    const toolsList = makeToolsList();
+
+    const makeToolSchema =
+      (scope?: RequestScope) =>
+      (address: ToolAddress): Effect.Effect<ToolSchemaView | null, StorageFailure> =>
+        Effect.gen(function* () {
+          const staticEntry = staticTools.get(String(address));
+          if (staticEntry) {
+            const tool = staticToolToTool(staticEntry);
+            if (scope && !toolVisibleUnderScope(tool, scope)) return null;
+            const preview = yield* Effect.tryPromise({
+              try: () =>
+                buildToolTypeScriptPreview({
+                  inputSchema: tool.inputSchema,
+                  outputSchema: tool.outputSchema,
+                  defs: new Map(),
+                }),
+              catch: (cause) =>
+                storageFailureFromUnknown("Failed to build static tool TypeScript preview", cause),
+            }).pipe(Effect.option);
+            return ToolSchemaView.make({
+              address,
+              name: tool.name,
+              description: tool.description,
+              inputSchema: tool.inputSchema,
+              outputSchema: tool.outputSchema,
+              inputTypeScript: Option.getOrUndefined(preview)?.inputTypeScript,
+              outputTypeScript: Option.getOrUndefined(preview)?.outputTypeScript,
+              typeScriptDefinitions: Option.getOrUndefined(preview)?.typeScriptDefinitions,
+            });
+          }
+
+          const parsed = parseToolAddress(String(address));
+          if (!parsed) return null;
+          const row = yield* core.findFirst("tool", {
+            where: (b: AnyCb) =>
+              b.and(
+                byOwner(parsed.owner)(b),
+                b("integration", "=", String(parsed.integration)),
+                b("connection", "=", String(parsed.connection)),
+                b("name", "=", String(parsed.tool)),
+              ),
+          });
+          if (!row) return null;
+          const tool = rowToTool(row);
+          if (scope && !toolVisibleUnderScope(tool, scope)) return null;
+
+          const definitionRows = yield* core.findMany("definition", {
+            where: (b: AnyCb) =>
+              b.and(
+                byOwner(parsed.owner)(b),
+                b("integration", "=", String(parsed.integration)),
+                b("connection", "=", String(parsed.connection)),
+              ),
+          });
+          const defs = new Map<string, unknown>();
+          for (const def of definitionRows) defs.set(def.name, decodeJsonColumn(def.schema));
+
+          const referenced = collectReferencedDefinitions(
+            [tool.inputSchema, tool.outputSchema],
+            defs,
+          );
           const preview = yield* Effect.tryPromise({
             try: () =>
               buildToolTypeScriptPreview({
                 inputSchema: tool.inputSchema,
                 outputSchema: tool.outputSchema,
-                defs: new Map(),
+                defs,
               }),
             catch: (cause) =>
-              storageFailureFromUnknown("Failed to build static tool TypeScript preview", cause),
+              storageFailureFromUnknown("Failed to build tool TypeScript preview", cause),
           }).pipe(Effect.option);
+
+          const view = preview;
           return ToolSchemaView.make({
             address,
             name: tool.name,
             description: tool.description,
             inputSchema: tool.inputSchema,
             outputSchema: tool.outputSchema,
-            inputTypeScript: Option.getOrUndefined(preview)?.inputTypeScript,
-            outputTypeScript: Option.getOrUndefined(preview)?.outputTypeScript,
-            typeScriptDefinitions: Option.getOrUndefined(preview)?.typeScriptDefinitions,
+            schemaDefinitions:
+              Object.keys(referenced).length > 0
+                ? (referenced as Record<string, unknown>)
+                : undefined,
+            inputTypeScript: Option.getOrUndefined(view)?.inputTypeScript,
+            outputTypeScript: Option.getOrUndefined(view)?.outputTypeScript,
+            typeScriptDefinitions: Option.getOrUndefined(view)?.typeScriptDefinitions,
           });
-        }
-
-        const parsed = parseToolAddress(String(address));
-        if (!parsed) return null;
-        const row = yield* core.findFirst("tool", {
-          where: (b: AnyCb) =>
-            b.and(
-              byOwner(parsed.owner)(b),
-              b("integration", "=", String(parsed.integration)),
-              b("connection", "=", String(parsed.connection)),
-              b("name", "=", String(parsed.tool)),
-            ),
         });
-        if (!row) return null;
-        const tool = rowToTool(row);
 
-        const definitionRows = yield* core.findMany("definition", {
-          where: (b: AnyCb) =>
-            b.and(
-              byOwner(parsed.owner)(b),
-              b("integration", "=", String(parsed.integration)),
-              b("connection", "=", String(parsed.connection)),
-            ),
-        });
-        const defs = new Map<string, unknown>();
-        for (const def of definitionRows) defs.set(def.name, decodeJsonColumn(def.schema));
-
-        const referenced = collectReferencedDefinitions(
-          [tool.inputSchema, tool.outputSchema],
-          defs,
-        );
-        const preview = yield* Effect.tryPromise({
-          try: () =>
-            buildToolTypeScriptPreview({
-              inputSchema: tool.inputSchema,
-              outputSchema: tool.outputSchema,
-              defs,
-            }),
-          catch: (cause) =>
-            storageFailureFromUnknown("Failed to build tool TypeScript preview", cause),
-        }).pipe(Effect.option);
-
-        const view = preview;
-        return ToolSchemaView.make({
-          address,
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-          outputSchema: tool.outputSchema,
-          schemaDefinitions:
-            Object.keys(referenced).length > 0
-              ? (referenced as Record<string, unknown>)
-              : undefined,
-          inputTypeScript: Option.getOrUndefined(view)?.inputTypeScript,
-          outputTypeScript: Option.getOrUndefined(view)?.outputTypeScript,
-          typeScriptDefinitions: Option.getOrUndefined(view)?.typeScriptDefinitions,
-        });
-      });
+    const toolSchema = makeToolSchema();
 
     // ------------------------------------------------------------------
     // Providers
@@ -2833,196 +2871,216 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         select: TOOL_INVOCATION_COLUMNS,
       });
 
-    const execute = (
-      address: ToolAddress,
-      args: unknown,
-      options?: InvokeOptions,
-    ): Effect.Effect<unknown, ExecuteError> => {
-      const handler = pickHandler(options);
-      return Effect.gen(function* () {
-        // oxlint-disable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check -- boundary: normalize arbitrary unknown plugin failures into a human-readable message for ToolInvocationError/telemetry
-        const formatInvocationCauseMessage = (cause: unknown): string => {
-          if (cause instanceof Error && cause.message.length > 0) return cause.message;
-          // Non-Error / empty-message causes: `String(plainObject)` renders
-          // "[object Object]", which is what telemetry then shows as the only
-          // label for the failure. Prefer the tag, else stringify structurally.
-          if (typeof cause === "object" && cause !== null) {
-            const tag = (cause as { readonly _tag?: unknown })._tag;
-            if (typeof tag === "string") return tag;
-            return Inspectable.toStringUnknown(cause, 0);
-          }
-          return String(cause);
-        };
-        // oxlint-enable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check
-        const wrapInvocationError = <A, E>(
-          effect: Effect.Effect<A, E>,
-        ): Effect.Effect<A, ToolInvocationError> =>
-          effect.pipe(
-            Effect.mapError(
-              (cause) =>
-                new ToolInvocationError({
-                  address,
-                  message: formatInvocationCauseMessage(cause),
-                  cause,
-                }),
-            ),
-          );
+    const makeExecute =
+      (scope?: RequestScope) =>
+      (
+        address: ToolAddress,
+        args: unknown,
+        options?: InvokeOptions,
+      ): Effect.Effect<unknown, ExecuteError> => {
+        const handler = pickHandler(options);
+        return Effect.gen(function* () {
+          // oxlint-disable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check -- boundary: normalize arbitrary unknown plugin failures into a human-readable message for ToolInvocationError/telemetry
+          const formatInvocationCauseMessage = (cause: unknown): string => {
+            if (cause instanceof Error && cause.message.length > 0) return cause.message;
+            // Non-Error / empty-message causes: `String(plainObject)` renders
+            // "[object Object]", which is what telemetry then shows as the only
+            // label for the failure. Prefer the tag, else stringify structurally.
+            if (typeof cause === "object" && cause !== null) {
+              const tag = (cause as { readonly _tag?: unknown })._tag;
+              if (typeof tag === "string") return tag;
+              return Inspectable.toStringUnknown(cause, 0);
+            }
+            return String(cause);
+          };
+          // oxlint-enable executor/no-instanceof-error, executor/no-unknown-error-message, executor/no-manual-tag-check
+          const wrapInvocationError = <A, E>(
+            effect: Effect.Effect<A, E>,
+          ): Effect.Effect<A, ToolInvocationError> =>
+            effect.pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ToolInvocationError({
+                    address,
+                    message: formatInvocationCauseMessage(cause),
+                    cause,
+                  }),
+              ),
+            );
 
-        // Static path — O(1) map lookup for plugin-contributed static tools
-        // (core-tools, plugin executor namespaces). Addressed by their fqid,
-        // not the 5-segment dynamic form.
-        const staticEntry = staticTools.get(String(address));
-        if (staticEntry) {
+          // Static path — O(1) map lookup for plugin-contributed static tools
+          // (core-tools, plugin executor namespaces). Addressed by their fqid,
+          // not the 5-segment dynamic form.
+          const staticEntry = staticTools.get(String(address));
+          if (staticEntry) {
+            const staticTool = staticToolToTool(staticEntry);
+            const policyRows = yield* core.findMany("tool_policy", {});
+            const policy = resolveToolEffectivePolicy(staticTool, policyRows, scope);
+            if (policy.action === "block") {
+              return yield* new ToolBlockedError({
+                address,
+                pattern: policy.pattern ?? "*",
+              });
+            }
+            yield* enforceApproval(staticEntry.tool.annotations, address, args, policy, handler);
+            const handlerCtx = scope ? scopePluginCtx(staticEntry.ctx, scope) : staticEntry.ctx;
+            return yield* wrapInvocationError(
+              staticEntry.tool.handler({
+                ctx: handlerCtx,
+                args,
+                elicit: buildElicit(address, args, handler),
+              }),
+            );
+          }
+
+          const parsed = parseToolAddress(String(address));
+          if (!parsed) {
+            return yield* new ToolNotFoundError({ address });
+          }
+
+          // Find the tool row — projected: invoke needs routing/policy fields
+          // only, never the multi-KB input/output schema JSON (`tools.schema`
+          // is the schema-bearing surface).
+          const row = yield* core.findFirst("tool", {
+            where: (b: AnyCb) =>
+              b.and(
+                byOwner(parsed.owner)(b),
+                b("integration", "=", String(parsed.integration)),
+                b("connection", "=", String(parsed.connection)),
+                b("name", "=", String(parsed.tool)),
+              ),
+            select: TOOL_INVOCATION_COLUMNS,
+          });
+          if (!row) {
+            if (scope) {
+              const connectionRow = yield* findConnectionRow({
+                owner: parsed.owner,
+                integration: parsed.integration,
+                name: parsed.connection,
+              });
+              if (!connectionRow || !scope.allowsConnection(rowToConnection(connectionRow))) {
+                return yield* new ToolBlockedError({
+                  address,
+                  pattern: REQUEST_SCOPE_BLOCK_PATTERN,
+                });
+              }
+            }
+            const searchMatches = yield* searchToolRowsForConnection(parsed);
+            const connectionTools =
+              searchMatches.length > 0 ? searchMatches : yield* findToolRowsForConnection(parsed);
+            const visibleTools = scope
+              ? connectionTools.filter((candidate) =>
+                  toolVisibleUnderScope(rowToTool(candidate), scope),
+                )
+              : connectionTools;
+            if (scope && visibleTools.length === 0) {
+              return yield* new ToolBlockedError({
+                address,
+                pattern: REQUEST_SCOPE_BLOCK_PATTERN,
+              });
+            }
+            return yield* new ToolNotFoundError({
+              address,
+              suggestions: toolSuggestions(visibleTools),
+            });
+          }
+
+          // Resolve policy (owner-ranked).
+          const toolForPolicy = rowToTool(row);
           const policyRows = yield* core.findMany("tool_policy", {});
-          const policy = resolveEffectivePolicy(
-            String(address),
-            policyRows,
-            ownerRankForRow,
-            staticEntry.tool.annotations?.requiresApproval,
-          );
+          const annotations = decodeJsonColumn(row.annotations) as ToolAnnotations | undefined;
+          const policy = resolveToolEffectivePolicy(toolForPolicy, policyRows, scope);
           if (policy.action === "block") {
             return yield* new ToolBlockedError({
               address,
               pattern: policy.pattern ?? "*",
             });
           }
-          yield* enforceApproval(staticEntry.tool.annotations, address, args, policy, handler);
-          return yield* wrapInvocationError(
-            staticEntry.tool.handler({
-              ctx: staticEntry.ctx,
-              args,
-              elicit: buildElicit(address, args, handler),
-            }),
-          );
-        }
 
-        const parsed = parseToolAddress(String(address));
-        if (!parsed) {
-          return yield* new ToolNotFoundError({ address });
-        }
+          const runtime = runtimes.get(row.plugin_id);
+          if (!runtime) {
+            return yield* new PluginNotLoadedError({
+              address,
+              pluginId: row.plugin_id,
+            });
+          }
+          if (!runtime.plugin.invokeTool) {
+            return yield* new NoHandlerError({
+              address,
+              pluginId: row.plugin_id,
+            });
+          }
 
-        // Find the tool row — projected: invoke needs routing/policy fields
-        // only, never the multi-KB input/output schema JSON (`tools.schema`
-        // is the schema-bearing surface).
-        const row = yield* core.findFirst("tool", {
-          where: (b: AnyCb) =>
-            b.and(
-              byOwner(parsed.owner)(b),
-              b("integration", "=", String(parsed.integration)),
-              b("connection", "=", String(parsed.connection)),
-              b("name", "=", String(parsed.tool)),
-            ),
-          select: TOOL_INVOCATION_COLUMNS,
-        });
-        if (!row) {
-          const searchMatches = yield* searchToolRowsForConnection(parsed);
-          const connectionTools =
-            searchMatches.length > 0 ? searchMatches : yield* findToolRowsForConnection(parsed);
-          return yield* new ToolNotFoundError({
-            address,
-            suggestions: toolSuggestions(connectionTools),
-          });
-        }
-
-        // Resolve policy (owner-ranked).
-        const toolForPolicy = rowToTool(row);
-        const policyRows = yield* core.findMany("tool_policy", {});
-        const annotations = decodeJsonColumn(row.annotations) as ToolAnnotations | undefined;
-        const policy = resolveEffectivePolicy(
-          normalizedPolicyId(toolForPolicy),
-          policyRows,
-          ownerRankForRow,
-          annotations?.requiresApproval,
-        );
-        if (policy.action === "block") {
-          return yield* new ToolBlockedError({
-            address,
-            pattern: policy.pattern ?? "*",
-          });
-        }
-
-        const runtime = runtimes.get(row.plugin_id);
-        if (!runtime) {
-          return yield* new PluginNotLoadedError({
-            address,
-            pluginId: row.plugin_id,
-          });
-        }
-        if (!runtime.plugin.invokeTool) {
-          return yield* new NoHandlerError({
-            address,
-            pluginId: row.plugin_id,
-          });
-        }
-
-        // Find the connection row.
-        const connectionRow = yield* findConnectionRow({
-          owner: parsed.owner,
-          integration: parsed.integration,
-          name: parsed.connection,
-        });
-        if (!connectionRow) {
-          return yield* new ConnectionNotFoundError({
+          // Find the connection row.
+          const connectionRow = yield* findConnectionRow({
             owner: parsed.owner,
             integration: parsed.integration,
             name: parsed.connection,
           });
-        }
-
-        // Resolve annotations + enforce approval.
-        let resolvedAnnotations = annotations;
-        if (policy.action !== "approve" && runtime.plugin.resolveAnnotations) {
-          const map = yield* runtime.plugin
-            .resolveAnnotations({
-              ctx: runtime.ctx,
+          if (!connectionRow) {
+            return yield* new ConnectionNotFoundError({
+              owner: parsed.owner,
               integration: parsed.integration,
-              connection: parsed.connection,
-              toolRows: [row],
-            })
-            .pipe(wrapInvocationError);
-          resolvedAnnotations = map[String(parsed.tool)] ?? annotations;
-        }
-        yield* enforceApproval(resolvedAnnotations, address, args, policy, handler);
+              name: parsed.connection,
+            });
+          }
 
-        // Resolve every named credential input (`variable → value`); `value` is
-        // the primary `token` for single-input + OAuth callers.
-        const values = yield* resolveConnectionValues(connectionRow);
-        const integrationRow = yield* findIntegrationRow(parsed.integration);
-        const credential: ToolInvocationCredential = {
-          owner: parsed.owner,
-          integration: parsed.integration,
-          connection: parsed.connection,
-          template: AuthTemplateSlug.make(connectionRow.template),
-          value: values[PRIMARY_INPUT_VARIABLE] ?? null,
-          values,
-          config: integrationRow ? decodeJsonColumn(integrationRow.config) : undefined,
-        };
+          // Resolve annotations + enforce approval.
+          let resolvedAnnotations = annotations;
+          if (policy.action !== "approve" && runtime.plugin.resolveAnnotations) {
+            const map = yield* runtime.plugin
+              .resolveAnnotations({
+                ctx: runtime.ctx,
+                integration: parsed.integration,
+                connection: parsed.connection,
+                toolRows: [row],
+              })
+              .pipe(wrapInvocationError);
+            resolvedAnnotations = map[String(parsed.tool)] ?? annotations;
+          }
+          yield* enforceApproval(resolvedAnnotations, address, args, policy, handler);
 
-        return yield* wrapInvocationError(
-          runtime.plugin.invokeTool({
-            ctx: runtime.ctx,
-            toolRow: row,
-            credential,
-            args,
-            elicit: buildElicit(address, args, handler),
+          // Resolve every named credential input (`variable → value`); `value` is
+          // the primary `token` for single-input + OAuth callers.
+          const values = yield* resolveConnectionValues(connectionRow);
+          const integrationRow = yield* findIntegrationRow(parsed.integration);
+          const credential: ToolInvocationCredential = {
+            owner: parsed.owner,
+            integration: parsed.integration,
+            connection: parsed.connection,
+            template: AuthTemplateSlug.make(connectionRow.template),
+            value: values[PRIMARY_INPUT_VARIABLE] ?? null,
+            values,
+            config: integrationRow ? decodeJsonColumn(integrationRow.config) : undefined,
+          };
+
+          return yield* wrapInvocationError(
+            runtime.plugin.invokeTool({
+              ctx: runtime.ctx,
+              toolRow: row,
+              credential,
+              args,
+              elicit: buildElicit(address, args, handler),
+            }),
+          );
+        }).pipe(
+          // Expected tool failures (`ToolResult.fail`) resolve through the
+          // success channel, so the tracer alone would record them as healthy
+          // spans. Stamp the outcome + error code so telemetry can distinguish
+          // "tool ran fine" from "user hit an upstream error / auth wall"
+          // without parsing response bodies.
+          Effect.tap(annotateToolResultOutcome),
+          Effect.withSpan("executor.tool.execute", {
+            attributes: {
+              "mcp.tool.name": String(address),
+              "executor.tenant": tenant,
+              ...(subject != null ? { "executor.subject": subject } : {}),
+            },
           }),
         );
-      }).pipe(
-        // Expected tool failures (`ToolResult.fail`) resolve through the
-        // success channel, so the tracer alone would record them as healthy
-        // spans. Stamp the outcome + error code so telemetry can distinguish
-        // "tool ran fine" from "user hit an upstream error / auth wall"
-        // without parsing response bodies.
-        Effect.tap(annotateToolResultOutcome),
-        Effect.withSpan("executor.tool.execute", {
-          attributes: {
-            "mcp.tool.name": String(address),
-            "executor.tenant": tenant,
-            ...(subject != null ? { "executor.subject": subject } : {}),
-          },
-        }),
-      );
-    };
+      };
+
+    const execute = makeExecute();
 
     // ------------------------------------------------------------------
     // OAuth service seam.
@@ -3156,6 +3214,10 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
       if (plugin.extension) {
         extensions[plugin.id] = extension;
       }
+      if (plugin.resolveRequestScope) {
+        const resolveScope = plugin.resolveRequestScope;
+        requestScopeProviders.push((selector) => resolveScope(ctx, selector));
+      }
 
       const decls = plugin.staticSources ? plugin.staticSources(extension) : [];
       for (const source of decls) {
@@ -3270,7 +3332,95 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
     };
 
     const toExecutor = (value: unknown): Executor<TPlugins> => value as Executor<TPlugins>;
-    return toExecutor(Object.assign(base, extensions));
+
+    const REQUEST_SCOPE_BLOCK_PATTERN = "request-scope";
+
+    const scopeBlocked = (surface: string): Effect.Effect<never, ToolBlockedError> =>
+      Effect.fail(
+        new ToolBlockedError({
+          address: ToolAddress.make(surface),
+          pattern: REQUEST_SCOPE_BLOCK_PATTERN,
+        }),
+      );
+
+    const buildScopedExecutor = (scope: RequestScope): Executor<TPlugins> =>
+      toExecutor({
+        ...extensions,
+        integrations: {
+          list: () =>
+            integrationsList().pipe(
+              Effect.map((items) => items.filter((i) => scope.allowsIntegration(i))),
+            ),
+          get: (slug: IntegrationSlug) =>
+            integrationsGet(slug).pipe(
+              Effect.map((item) => (item && scope.allowsIntegration(item) ? item : null)),
+            ),
+          update: () => scopeBlocked("executor.integrations.update"),
+          remove: () => scopeBlocked("executor.integrations.remove"),
+          detect: () => scopeBlocked("executor.integrations.detect"),
+        },
+        connections: {
+          list: (filter?: { readonly integration?: IntegrationSlug; readonly owner?: Owner }) =>
+            connectionsList(filter).pipe(
+              Effect.map((items) => items.filter((c) => scope.allowsConnection(c))),
+            ),
+          get: (ref: ConnectionRef) =>
+            connectionsGet(ref).pipe(
+              Effect.map((connection) =>
+                connection && scope.allowsConnection(connection) ? connection : null,
+              ),
+            ),
+          create: () => scopeBlocked("executor.connections.create"),
+          update: () => scopeBlocked("executor.connections.update"),
+          remove: () => scopeBlocked("executor.connections.remove"),
+          refresh: () => scopeBlocked("executor.connections.refresh"),
+        },
+        oauth: {
+          createClient: () => scopeBlocked("executor.oauth.createClient"),
+          registerDynamicClient: () => scopeBlocked("executor.oauth.registerDynamicClient"),
+          listClients: () => scopeBlocked("executor.oauth.listClients"),
+          removeClient: () => scopeBlocked("executor.oauth.removeClient"),
+          start: () => scopeBlocked("executor.oauth.start"),
+          complete: () => scopeBlocked("executor.oauth.complete"),
+          cancel: () => scopeBlocked("executor.oauth.cancel"),
+          probe: () => scopeBlocked("executor.oauth.probe"),
+        },
+        tools: {
+          list: makeToolsList(scope),
+          schema: makeToolSchema(scope),
+        },
+        providers: {
+          list: () => scopeBlocked("executor.providers.list"),
+          items: () => scopeBlocked("executor.providers.items"),
+        },
+        policies: {
+          list: policiesList,
+          create: () => scopeBlocked("executor.policies.create"),
+          update: () => scopeBlocked("executor.policies.update"),
+          remove: () => scopeBlocked("executor.policies.remove"),
+          resolve: policiesResolve,
+        },
+        execute: makeExecute(scope),
+        close,
+        applyRequestScope: applyRequestScope,
+      });
+
+    const applyRequestScope = (
+      selector: string,
+    ): Effect.Effect<Executor<TPlugins>, StorageFailure> =>
+      Effect.gen(function* () {
+        let resolved: RequestScope | null = null;
+        for (const provider of requestScopeProviders) {
+          const scope = yield* provider(selector);
+          if (scope !== null) {
+            resolved = scope;
+            break;
+          }
+        }
+        return buildScopedExecutor(resolved ?? EMPTY_REQUEST_SCOPE);
+      });
+
+    return toExecutor({ ...base, ...extensions, applyRequestScope });
   });
 
 // Helper alias so the inline literal used for the optimistic projection in

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -304,12 +304,25 @@ export {
   type ExecutorDbFactory,
   type ExecutorDbInput,
   type ParsedToolAddress,
+  type RequestScopeProvider,
   createExecutor,
   collectTables,
   parseToolAddress,
   connectionAddress,
   toolAddress,
 } from "./executor";
+
+export {
+  type RequestScope,
+  type ScopeDecision,
+  EMPTY_REQUEST_SCOPE,
+  defaultDecideStaticTool,
+  decideStaticToolForScope,
+  filterPolicyRowsForScope,
+  resolveScopedEffectivePolicy,
+  scopePluginCtx,
+  toolVisibleUnderScope,
+} from "./request-scope";
 
 // CLI / runtime config.
 export {

--- a/packages/core/sdk/src/plugin.ts
+++ b/packages/core/sdk/src/plugin.ts
@@ -52,6 +52,7 @@ import type {
   ToolPolicy,
   UpdateToolPolicyInput,
 } from "./policies";
+import type { RequestScope } from "./request-scope";
 import type { Tool, ToolAnnotations, ToolDef } from "./tool";
 
 // ---------------------------------------------------------------------------
@@ -505,6 +506,15 @@ export interface PluginSpec<
     readonly ctx: PluginCtx<TStore>;
     readonly url: string;
   }) => Effect.Effect<IntegrationDetectionResult | null, unknown>;
+
+  /** Resolve a per-request catalog/policy overlay for a selector string.
+   *  Return `null` when this provider does not recognize the selector; core
+   *  fails closed to `EMPTY_REQUEST_SCOPE` when a selector is present but no
+   *  provider claims it. */
+  readonly resolveRequestScope?: (
+    ctx: PluginCtx<TStore>,
+    selector: string,
+  ) => Effect.Effect<RequestScope | null, StorageFailure>;
 
   /** Credential providers contributed by this plugin (keychain, file, vault, …).
    *  The v2 successor to `secretProviders`. */

--- a/packages/core/sdk/src/request-scope.ts
+++ b/packages/core/sdk/src/request-scope.ts
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------
+// Request scope — vocabulary-neutral per-request catalog and tool policy
+// overlay. Plugins contribute `RequestScope` data via `resolveRequestScope`;
+// core enforces it centrally across list/get/schema/execute surfaces.
+// ---------------------------------------------------------------------------
+
+import { Effect } from "effect";
+
+import type { Connection } from "./connection";
+import type { Integration } from "./integration";
+import type { PluginCtx } from "./plugin";
+import type { ToolPolicyRow, ToolPolicyAction } from "./core-schema";
+import { resolveEffectivePolicy, type EffectivePolicy } from "./policies";
+import type { Tool } from "./tool";
+
+export type ScopeDecision = "allow" | "require_approval" | "block";
+
+export interface RequestScope {
+  readonly inheritOrgPolicies: boolean;
+  decideTool(tool: Tool): ScopeDecision;
+  allowsConnection(connection: Connection): boolean;
+  allowsIntegration(integration: Integration): boolean;
+  decideStaticTool?(tool: Tool): ScopeDecision;
+}
+
+/** Fail-closed empty slice — no connections, integrations, or runnable tools. */
+export const EMPTY_REQUEST_SCOPE: RequestScope = {
+  inheritOrgPolicies: true,
+  decideTool: () => "block",
+  allowsConnection: () => false,
+  allowsIntegration: () => false,
+  decideStaticTool: () => "block",
+};
+
+const ACTION_RESTRICTION_RANK: Record<ToolPolicyAction, number> = {
+  block: 3,
+  require_approval: 2,
+  approve: 1,
+};
+const actionRestrictionRank = (action: ToolPolicyAction): number => ACTION_RESTRICTION_RANK[action];
+
+const DECISION_TO_POLICY_ACTION: Record<ScopeDecision, ToolPolicyAction> = {
+  block: "block",
+  require_approval: "require_approval",
+  allow: "approve",
+};
+
+export const scopeDecisionToPolicyAction = (decision: ScopeDecision): ToolPolicyAction =>
+  DECISION_TO_POLICY_ACTION[decision];
+
+const moreRestrictiveAction = (
+  current: ToolPolicyAction,
+  candidate: ToolPolicyAction,
+): ToolPolicyAction =>
+  actionRestrictionRank(candidate) > actionRestrictionRank(current) ? candidate : current;
+
+/** Catalog-reading static tools allowed under scope; mutations blocked by default. */
+const CATALOG_READ_STATIC_ADDRESSES = new Set([
+  "executor.coreTools.integrations.list",
+  "executor.coreTools.connections.list",
+]);
+
+export const defaultDecideStaticTool = (tool: Tool): ScopeDecision =>
+  CATALOG_READ_STATIC_ADDRESSES.has(String(tool.address)) ? "allow" : "block";
+
+export const decideStaticToolForScope = (scope: RequestScope, tool: Tool): ScopeDecision =>
+  scope.decideStaticTool?.(tool) ?? defaultDecideStaticTool(tool);
+
+export const filterPolicyRowsForScope = (
+  rows: readonly ToolPolicyRow[],
+  scope: RequestScope,
+): readonly ToolPolicyRow[] =>
+  scope.inheritOrgPolicies
+    ? rows
+    : rows.filter(
+        (row) => row.owner !== "org" || row.action === "block" || row.action === "require_approval",
+      );
+
+export const resolveScopedEffectivePolicy = (
+  toolId: string,
+  tool: Tool,
+  scope: RequestScope,
+  policies: readonly ToolPolicyRow[],
+  ownerRank: (row: Pick<ToolPolicyRow, "owner">) => number,
+  defaultRequiresApproval?: boolean,
+): EffectivePolicy => {
+  const filtered = filterPolicyRowsForScope(policies, scope);
+  const base = resolveEffectivePolicy(toolId, filtered, ownerRank, defaultRequiresApproval);
+  const scopeDecision = tool.static
+    ? decideStaticToolForScope(scope, tool)
+    : scope.decideTool(tool);
+  const scopeAction = scopeDecisionToPolicyAction(scopeDecision);
+  const merged = moreRestrictiveAction(base.action, scopeAction);
+  if (merged === scopeAction && merged !== base.action) {
+    return { action: merged, source: "user", pattern: "request-scope" };
+  }
+  return {
+    action: merged,
+    source: base.source,
+    pattern: base.pattern,
+    policyId: base.policyId,
+  };
+};
+
+export const toolVisibleUnderScope = (tool: Tool, scope: RequestScope): boolean => {
+  const decision = tool.static ? decideStaticToolForScope(scope, tool) : scope.decideTool(tool);
+  return decision !== "block";
+};
+
+/** Narrow plugin ctx catalog reads for request-time static tool handlers. */
+export const scopePluginCtx = <TStore>(
+  ctx: PluginCtx<TStore>,
+  scope: RequestScope,
+): PluginCtx<TStore> => ({
+  ...ctx,
+  core: {
+    ...ctx.core,
+    integrations: {
+      ...ctx.core.integrations,
+      list: () =>
+        ctx.core.integrations
+          .list()
+          .pipe(Effect.map((items) => items.filter((i) => scope.allowsIntegration(i)))),
+      get: (slug) =>
+        ctx.core.integrations
+          .get(slug)
+          .pipe(
+            Effect.map((record) => (record && scope.allowsIntegration(record) ? record : null)),
+          ),
+    },
+  },
+  connections: {
+    ...ctx.connections,
+    list: (filter) =>
+      ctx.connections
+        .list(filter)
+        .pipe(Effect.map((items) => items.filter((c) => scope.allowsConnection(c)))),
+    get: (ref) =>
+      ctx.connections
+        .get(ref)
+        .pipe(
+          Effect.map((connection) =>
+            connection && scope.allowsConnection(connection) ? connection : null,
+          ),
+        ),
+  },
+});

--- a/packages/core/sdk/src/tool.ts
+++ b/packages/core/sdk/src/tool.ts
@@ -12,6 +12,11 @@ export interface ToolAnnotations {
   readonly requiresApproval?: boolean;
   readonly approvalDescription?: string;
   readonly mayElicit?: boolean;
+  /** True when the tool only reads (no side effects). Set by the owning plugin
+   *  (e.g. OpenAPI classifies GET/HEAD/OPTIONS as read-only). Consumers that
+   *  offer a read-only mode use this fail-closed: a tool is hidden unless
+   *  `readOnly === true` (unclassified counts as write). */
+  readonly readOnly?: boolean;
 }
 
 /** A tool as produced by a plugin — the definition, no address yet (the SDK

--- a/packages/hosts/cloudflare/src/mcp/do-headers.ts
+++ b/packages/hosts/cloudflare/src/mcp/do-headers.ts
@@ -94,5 +94,6 @@ export const withMcpResponseHeaders = (response: Response): Response => {
 // import site (`./do-headers`) is unchanged.
 export {
   readElicitationMode,
+  readToolkitSelector,
   type McpElicitationMode,
 } from "@executor-js/host-mcp/browser-approval";

--- a/packages/hosts/cloudflare/src/mcp/seams.ts
+++ b/packages/hosts/cloudflare/src/mcp/seams.ts
@@ -14,6 +14,9 @@ export interface McpSessionInit {
   /** Public origin of the create request (`https://host`), so the DO derives a
    *  web base URL zero-config when the host configures no static one. */
   readonly webOrigin?: string;
+  /** Toolkit selector (slug or id) pinned for this session — narrows the engine
+   *  to that toolkit's slice. Read from the create request, like elicitationMode. */
+  readonly toolkitId?: string;
 }
 
 /**

--- a/packages/hosts/cloudflare/src/mcp/session-durable-object.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-durable-object.ts
@@ -127,6 +127,9 @@ export interface SessionMeta {
   /** Public origin captured at session create — used to derive the runtime's
    *  web base URL when the host configures no static one. */
   readonly webOrigin?: string;
+  /** Toolkit selector pinned for this session — narrows the engine to that
+   *  toolkit's slice. Persisted so a cold isolate rebuilds the same narrowing. */
+  readonly toolkitId?: string;
 }
 
 /** What a host's `buildMcpServer` seam returns: the connected MCP server plus

--- a/packages/hosts/cloudflare/src/mcp/session-store.ts
+++ b/packages/hosts/cloudflare/src/mcp/session-store.ts
@@ -30,6 +30,7 @@ import {
 import {
   currentPropagationHeaders,
   readElicitationMode,
+  readToolkitSelector,
   withMcpResponseHeaders,
   withPropagationHeaders,
   withVerifiedIdentityHeaders,
@@ -178,6 +179,7 @@ const createSession = (
           organizationId: token.organizationId,
           userId: token.accountId,
           elicitationMode: readElicitationMode(request),
+          toolkitId: readToolkitSelector(request),
           // The public origin the client reached us at — lets the DO derive a web
           // base URL with no static config (we read the real URL, not a spoofable
           // forwarded host).

--- a/packages/hosts/mcp/src/browser-approval.ts
+++ b/packages/hosts/mcp/src/browser-approval.ts
@@ -51,6 +51,17 @@ export const readElicitationMode = (request: Request): McpElicitationMode => {
   return "model";
 };
 
+/** Read the toolkit selector (slug or id) from a request: the
+ *  `x-executor-mcp-toolkit` header (set by a host's pretty-URL rewrite) or the
+ *  `?toolkit=` query. Shared by every host that serves the toolkit-narrowed MCP
+ *  endpoint (in-memory store + the cross-isolate Durable Object). */
+export const readToolkitSelector = (request: Request): string | undefined => {
+  const header = request.headers.get("x-executor-mcp-toolkit");
+  if (header && header.length > 0) return header;
+  const query = new URL(request.url).searchParams.get("toolkit");
+  return query && query.length > 0 ? query : undefined;
+};
+
 /**
  * Build the console approval URL for a paused execution:
  * `<origin>/resume/<executionId>?mcp_session_id=<sessionId>`. The

--- a/packages/hosts/mcp/src/in-memory-session-store.ts
+++ b/packages/hosts/mcp/src/in-memory-session-store.ts
@@ -9,6 +9,7 @@ import {
   decodeResumeResponse,
   formatResumeAcknowledgement,
   readElicitationMode,
+  readToolkitSelector,
 } from "./browser-approval";
 import {
   makeInProcessBrowserApprovalStore,
@@ -62,10 +63,17 @@ export interface BuiltMcpServer {
 /** The browser-mode wiring the store hands a build call when a session opts in. */
 export interface McpBuildServerOptions {
   readonly elicitationMode?:
-    | { readonly mode: "browser"; readonly approvalUrl: (executionId: string) => string }
+    | {
+        readonly mode: "browser";
+        readonly approvalUrl: (executionId: string) => string;
+      }
     | { readonly mode: "model" }
     | { readonly mode: "native" };
   readonly browserApprovalStore?: BrowserApprovalStore;
+  /** Per-request narrowing selector (the MCP `?toolkit=` value) pinned for this
+   *  session. Core forwards it to plugin executor wrappers; an unset selector
+   *  leaves the executor unnarrowed. Read once at session create. */
+  readonly selector?: string;
 }
 
 /** Build the per-session `McpServer` + engine for a principal (the host's engine + tools). */
@@ -115,7 +123,10 @@ const jsonRpcError = (status: number, code: number, message: string): Response =
   jsonRpcErrorBody(status, code, message, { cors: false });
 
 const json = (value: unknown, status = 200): Response =>
-  new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } });
+  new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
 
 const PAUSED_PATH = /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)$/;
 const RESUME_PATH = /^\/api\/mcp-sessions\/([^/?#]+)\/executions\/([^/?#]+)\/resume$/;
@@ -220,10 +231,9 @@ export const makeInMemoryMcpSessionStore = (
   /** Open a new session: build the server, connect a transport, drive the request. */
   const create = (principal: Principal, request: Request): Effect.Effect<McpDispatchResult> => {
     let createdSessionId: string | null = null;
-    return buildServer(
-      principal,
-      buildOptionsFor(request, () => createdSessionId),
-    ).pipe(
+    const baseOptions = buildOptionsFor(request, () => createdSessionId);
+    const selector = readToolkitSelector(request);
+    return buildServer(principal, selector ? { ...baseOptions, selector } : baseOptions).pipe(
       Effect.flatMap(({ mcpServer, engine }) =>
         Effect.gen(function* () {
           const transport = new WebStandardStreamableHTTPServerTransport({

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -645,15 +645,20 @@ export const invokeWithLayer = (
 // ---------------------------------------------------------------------------
 
 const REQUIRE_APPROVAL = new Set(["post", "put", "patch", "delete"]);
+// Methods with no side effects — classified read-only so toolkits can grant
+// read-only access (a read-only slice hides everything else, fail-closed).
+const READ_ONLY_METHODS = new Set(["get", "head", "options"]);
 
 export const annotationsForOperation = (
   method: string,
   pathTemplate: string,
-): { requiresApproval?: boolean; approvalDescription?: string } => {
+): { requiresApproval?: boolean; approvalDescription?: string; readOnly?: boolean } => {
   const m = method.toLowerCase();
-  if (!REQUIRE_APPROVAL.has(m)) return {};
+  const readOnly = READ_ONLY_METHODS.has(m) ? { readOnly: true } : {};
+  if (!REQUIRE_APPROVAL.has(m)) return readOnly;
   return {
     requiresApproval: true,
     approvalDescription: `${method.toUpperCase()} ${pathTemplate}`,
+    ...readOnly,
   };
 };

--- a/packages/react/src/api/reactivity-keys.tsx
+++ b/packages/react/src/api/reactivity-keys.tsx
@@ -26,6 +26,8 @@ export const ReactivityKey = {
   /** Credential-provider discovery. */
   providers: "providers",
   policies: "policies",
+  /** Toolkits — named slices of connections, each with its own MCP endpoint. */
+  toolkits: "toolkits",
   /** Registered OAuth clients (apps). */
   oauthClients: "oauth-clients",
   // cloud-only resources
@@ -46,6 +48,10 @@ export const connectionWriteKeys = [ReactivityKey.connections, ReactivityKey.too
 
 /** Mutations that register / replace an OAuth client (app). */
 export const oauthClientWriteKeys = [ReactivityKey.oauthClients] as const;
+
+/** Mutations that create / update / remove a toolkit. Self-contained — a
+ *  toolkit is its own resource and does not change the core tool catalog. */
+export const toolkitWriteKeys = [ReactivityKey.toolkits] as const;
 
 /** Mutations that mutate tool policies. Also touches `tools` because
  *  `tools.list` filters blocked tools — adding/removing a `block`

--- a/packages/react/src/multiplayer/shell.tsx
+++ b/packages/react/src/multiplayer/shell.tsx
@@ -19,7 +19,7 @@ import {
   integrationPresetIconUrl,
 } from "../components/integration-favicon";
 import { CommandPalette } from "../components/command-palette";
-import { useIntegrationPlugins } from "@executor-js/sdk/client";
+import { useClientPlugins, useIntegrationPlugins } from "@executor-js/sdk/client";
 import { useAuth } from "./auth-context";
 
 // ---------------------------------------------------------------------------
@@ -112,6 +112,55 @@ function NavItem(props: { to: string; label: string; active: boolean; onNavigate
   );
 }
 
+// ── PluginNav ─────────────────────────────────────────────────────────────
+
+// Surfaces console pages contributed by client plugins that declare
+// `pages[].nav.label` (e.g. Toolkits). The catch-all `/plugins/$pluginId/$`
+// route mounts them, so a plugin registered in executor.config.ts appears in
+// the sidebar with no per-host wiring. `pathname` is scope-relative.
+function PluginNav(props: { pathname: string; onNavigate?: () => void }) {
+  const plugins = useClientPlugins();
+  const entries = plugins.flatMap((plugin) =>
+    (plugin.pages ?? [])
+      .filter((page) => page.nav)
+      .map((page) => {
+        const splat = page.path.replace(/^\//, "");
+        const href = `/plugins/${plugin.id}${splat ? `/${splat}` : "/"}`;
+        // Active-state matching ignores a trailing slash (live pathname is
+        // "/plugins/toolkits", href is "/plugins/toolkits/").
+        const base = href.replace(/\/$/, "");
+        return {
+          key: `${plugin.id}:${page.path}`,
+          href,
+          base,
+          label: page.nav!.label,
+        };
+      }),
+  );
+  if (entries.length === 0) return null;
+  return (
+    <>
+      {entries.map((entry) => (
+        <Link
+          key={entry.key}
+          // Loosely-typed string `to` (like NavItem): the concrete plugin path
+          // resolves against whichever host route tree this package builds into.
+          to={orgScopedTo(entry.href)}
+          onClick={props.onNavigate}
+          className={[
+            "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors",
+            props.pathname === entry.base || props.pathname.startsWith(`${entry.base}/`)
+              ? "bg-sidebar-active text-foreground font-medium"
+              : "text-sidebar-foreground hover:bg-sidebar-active/60 hover:text-foreground",
+          ].join(" ")}
+        >
+          {entry.label}
+        </Link>
+      ))}
+    </>
+  );
+}
+
 // ── IntegrationList ───────────────────────────────────────────────────────────
 
 // `pathname` is scope-relative (org-slug prefix already stripped).
@@ -161,7 +210,12 @@ function IntegrationList(props: { pathname: string; onNavigate?: () => void }) {
               >
                 <IntegrationFavicon
                   icon={integrationPresetIconUrl(
-                    { id: slug, kind: integration.kind, name, url: integration.displayUrl },
+                    {
+                      id: slug,
+                      kind: integration.kind,
+                      name,
+                      url: integration.displayUrl,
+                    },
                     integrationPlugins,
                   )}
                   url={
@@ -274,7 +328,11 @@ function UserFooter(props: Pick<ShellProps, "onSignOut" | "orgMenuSlot">) {
 // ── SidebarContent ───────────────────────────────────────────────────────
 
 function SidebarContent(
-  props: ShellProps & { pathname: string; onNavigate?: () => void; showBrand?: boolean },
+  props: ShellProps & {
+    pathname: string;
+    onNavigate?: () => void;
+    showBrand?: boolean;
+  },
 ) {
   const navItems = props.navItems ?? defaultShellNavItems;
   return (
@@ -295,6 +353,8 @@ function SidebarContent(
             onNavigate={props.onNavigate}
           />
         ))}
+
+        <PluginNav pathname={props.pathname} onNavigate={props.onNavigate} />
 
         <div className="mt-5 mb-1 px-2.5 text-xs font-medium uppercase tracking-widest text-muted-foreground">
           <span>Integrations</span>

--- a/packages/react/src/routes/plugins.$pluginId.$.tsx
+++ b/packages/react/src/routes/plugins.$pluginId.$.tsx
@@ -1,5 +1,11 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
-import { useClientPlugins } from "@executor-js/sdk/client";
+import { useCallback, useMemo } from "react";
+import { createFileRoute, notFound, useNavigate } from "@tanstack/react-router";
+import {
+  PluginRouteProvider,
+  useClientPlugins,
+  type PageDecl,
+  type PluginRouteValue,
+} from "@executor-js/sdk/client";
 
 // ---------------------------------------------------------------------------
 // /plugins/<pluginId>/<rest>
@@ -11,10 +17,10 @@ import { useClientPlugins } from "@executor-js/sdk/client";
 // plugin to `executor.config.ts` is sufficient for its pages to mount
 // here, with no per-route imports.
 //
-// Match logic is intentionally tiny: exact path equality between the URL
-// remainder and a `PageDecl.path`, with `""` and `/` treated as the
-// same root. Plugins that want parameterized paths can build their own
-// in-component routing for now.
+// Page match: exact path first, then longest path prefix, then the `/`
+// root page. The splat remainder after the matched page path is exposed
+// to the page via `<PluginRouteProvider>` (`usePluginRoute` /
+// `usePluginNavigate`).
 // ---------------------------------------------------------------------------
 
 export const Route = createFileRoute("/{-$orgSlug}/plugins/$pluginId/$")({
@@ -26,18 +32,91 @@ function normalizePath(input: string): string {
   return input.startsWith("/") ? input : `/${input}`;
 }
 
+function stripLeadingSlash(path: string): string {
+  return path.replace(/^\//, "");
+}
+
+function matchPluginPage(
+  pages: readonly PageDecl[] | undefined,
+  splat: string | undefined,
+): { readonly page: PageDecl; readonly subpath: string } | null {
+  const target = normalizePath(splat ?? "/");
+  const normalized = (pages ?? []).map((page) => ({
+    page,
+    path: normalizePath(page.path),
+  }));
+  if (normalized.length === 0) return null;
+
+  const exact = normalized.find((entry) => entry.path === target);
+  if (exact) return { page: exact.page, subpath: "" };
+
+  let best: (typeof normalized)[number] | null = null;
+  for (const entry of normalized) {
+    if (entry.path === "/") continue;
+    if (target === entry.path || target.startsWith(`${entry.path}/`)) {
+      if (!best || entry.path.length > best.path.length) best = entry;
+    }
+  }
+  if (best) {
+    const remainder = target.slice(best.path.length);
+    return { page: best.page, subpath: stripLeadingSlash(remainder) };
+  }
+
+  const root = normalized.find((entry) => entry.path === "/");
+  if (root) {
+    return { page: root.page, subpath: target === "/" ? "" : stripLeadingSlash(target) };
+  }
+  return null;
+}
+
 function PluginRouteComponent() {
   const { pluginId, _splat: rest } = Route.useParams();
+  const routerNavigate = useNavigate();
   const plugins = useClientPlugins();
   const plugin = plugins.find((p) => p.id === pluginId);
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: TanStack Router represents not-found from components by throwing notFound()
   if (!plugin) throw notFound();
 
-  const target = normalizePath(rest ?? "/");
-  const page = plugin.pages?.find((p) => normalizePath(p.path) === target);
+  const matched = matchPluginPage(plugin.pages, rest);
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: TanStack Router represents not-found from components by throwing notFound()
-  if (!page) throw notFound();
+  if (!matched) throw notFound();
+
+  const { page, subpath } = matched;
+  const pageSplat = stripLeadingSlash(normalizePath(page.path));
+
+  const navigate = useCallback(
+    (nextSubpath: string, opts?: { readonly replace?: boolean }) => {
+      const fullSplat = nextSubpath
+        ? pageSplat
+          ? `${pageSplat}/${nextSubpath}`
+          : nextSubpath
+        : pageSplat;
+      routerNavigate({
+        to: "/{-$orgSlug}/plugins/$pluginId/$",
+        params: (previous: Record<string, string>) => ({
+          ...previous,
+          pluginId,
+          _splat: fullSplat,
+        }),
+        replace: opts?.replace,
+      });
+    },
+    [routerNavigate, pluginId, pageSplat],
+  );
+
+  const routeValue = useMemo(
+    (): PluginRouteValue => ({
+      pluginId,
+      subpath,
+      navigate,
+    }),
+    [pluginId, subpath, navigate],
+  );
 
   const Component = page.component;
-  return <Component />;
+  return (
+    <PluginRouteProvider value={routeValue}>
+      <Component />
+    </PluginRouteProvider>
+  );
 }


### PR DESCRIPTION
Generic, vocabulary-neutral seams that the toolkits feature (later PRs in this stack) builds on. No behavior change on its own — nothing provides a scope or a plugin page yet.

- **RequestScope** — a plugin contributes per-request `allow` / `require_approval` / `block` decisions (`decideTool`/`allowsConnection`/`allowsIntegration`/`inheritOrgPolicies`); **core owns enforcement** centrally across every catalog + execute surface, including the built-in core tools. Fail-closed: an unknown selector yields an empty scope; mutation/admin surfaces are default-denied under a scope; decisions compose with org policies via the existing stricter-wins lattice (a scope can only tighten).
- **Read-only tool annotations** — openapi classifies GET/HEAD/OPTIONS as `readOnly`, enabling read-only access modes.
- **Plugin-page URL routing** — plugin pages get the URL subpath + a navigate helper (`usePluginRoute`/`usePluginNavigate`); the sidebar surfaces plugin pages on every host. `PageDecl.component` is unchanged, so the shared route contract and all hosts are untouched.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#1036** 👈 current
2. #1037
3. #1038
4. #1039
<!-- stack:links:end -->