### PR TITLE
Toolkits plugin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -999,6 +999,38 @@
         "react",
       ],
     },
+    "packages/plugins/toolkits": {
+      "name": "@executor-js/plugin-toolkits",
+      "version": "1.5.12",
+      "dependencies": {
+        "@effect/atom-react": "catalog:",
+        "@executor-js/api": "workspace:*",
+        "@executor-js/sdk": "workspace:*",
+      },
+      "devDependencies": {
+        "@effect/vitest": "catalog:",
+        "@executor-js/react": "workspace:*",
+        "@types/node": "catalog:",
+        "@types/react": "catalog:",
+        "bun-types": "catalog:",
+        "effect": "catalog:",
+        "react": "catalog:",
+        "tsup": "catalog:",
+        "typescript": "catalog:",
+        "vitest": "catalog:",
+      },
+      "peerDependencies": {
+        "@effect/atom-react": "catalog:",
+        "@executor-js/react": "workspace:*",
+        "effect": "catalog:",
+        "react": ">=18",
+      },
+      "optionalPeers": [
+        "@effect/atom-react",
+        "@executor-js/react",
+        "react",
+      ],
+    },
     "packages/plugins/workos-vault": {
       "name": "@executor-js/plugin-workos-vault",
       "version": "0.0.2",
@@ -1588,6 +1620,8 @@
     "@executor-js/plugin-onepassword": ["@executor-js/plugin-onepassword@workspace:packages/plugins/onepassword"],
 
     "@executor-js/plugin-openapi": ["@executor-js/plugin-openapi@workspace:packages/plugins/openapi"],
+
+    "@executor-js/plugin-toolkits": ["@executor-js/plugin-toolkits@workspace:packages/plugins/toolkits"],
 
     "@executor-js/plugin-workos-vault": ["@executor-js/plugin-workos-vault@workspace:packages/plugins/workos-vault"],
 

--- a/packages/plugins/toolkits/CHANGELOG.md
+++ b/packages/plugins/toolkits/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @executor-js/plugin-toolkits

--- a/packages/plugins/toolkits/package.json
+++ b/packages/plugins/toolkits/package.json
@@ -1,0 +1,93 @@
+{
+  "name": "@executor-js/plugin-toolkits",
+  "version": "1.5.12",
+  "homepage": "https://github.com/RhysSullivan/executor/tree/main/packages/plugins/toolkits",
+  "bugs": {
+    "url": "https://github.com/RhysSullivan/executor/issues"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RhysSullivan/executor.git",
+    "directory": "packages/plugins/toolkits"
+  },
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "exports": {
+    "./server": "./src/server.ts",
+    "./shared": "./src/shared.ts",
+    "./react": "./src/react/index.ts",
+    "./client": "./src/react/plugin-client.tsx"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      "./server": {
+        "import": {
+          "types": "./dist/server.d.ts",
+          "default": "./dist/server.js"
+        }
+      },
+      "./shared": {
+        "import": {
+          "types": "./dist/shared.d.ts",
+          "default": "./dist/shared.js"
+        }
+      },
+      "./react": {
+        "import": {
+          "types": "./dist/react/index.d.ts",
+          "default": "./dist/react/index.js"
+        }
+      },
+      "./client": {
+        "import": {
+          "types": "./dist/react/plugin-client.d.ts",
+          "default": "./dist/react/plugin-client.js"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsup && (tsc --declaration --emitDeclarationOnly --outDir dist --rootDir src || true)",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "typecheck:slow": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@effect/atom-react": "catalog:",
+    "@executor-js/api": "workspace:*",
+    "@executor-js/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@effect/vitest": "catalog:",
+    "@executor-js/react": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "bun-types": "catalog:",
+    "effect": "catalog:",
+    "react": "catalog:",
+    "tsup": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@effect/atom-react": "catalog:",
+    "@executor-js/react": "workspace:*",
+    "effect": "catalog:",
+    "react": ">=18"
+  },
+  "peerDependenciesMeta": {
+    "@effect/atom-react": {
+      "optional": true
+    },
+    "@executor-js/react": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
+  }
+}

--- a/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
+++ b/packages/plugins/toolkits/src/react/ToolkitsPage.tsx
@@ -1,0 +1,814 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/react — the Toolkits console page.
+//
+// A toolkit is a named slice of the caller's connections (each off/read/full)
+// with its own MCP endpoint; an agent connected to one can't see anything
+// outside it. List and editor views are URL-routed via `usePluginRoute` —
+// `/plugins/toolkits/`, `/plugins/toolkits/<id>`, `/plugins/toolkits/new/<scope>`.
+// The `new/` prefix is reserved for the create flow; toolkit ids are server UUIDs.
+//
+// Workspace toolkits draw on org-owned connections; personal toolkits can use
+// org + the caller's own. The list query returns every visible toolkit and we
+// split by `scope`.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useMemo, useState } from "react";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
+import * as Exit from "effect/Exit";
+import { usePluginNavigate, usePluginRoute } from "@executor-js/sdk/client";
+
+import { connectionsAllAtom, integrationsAtom } from "@executor-js/react/api/atoms";
+import { Button } from "@executor-js/react/components/button";
+import { Input } from "@executor-js/react/components/input";
+import { Textarea } from "@executor-js/react/components/textarea";
+import { Switch } from "@executor-js/react/components/switch";
+import { Label } from "@executor-js/react/components/label";
+import { Badge } from "@executor-js/react/components/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@executor-js/react/components/select";
+import { IntegrationFavicon } from "@executor-js/react/components/integration-favicon";
+import { copyToClipboard } from "@executor-js/react/lib/clipboard";
+import { cn } from "@executor-js/react/lib/utils";
+
+import type {
+  ToolkitAccess,
+  ToolkitPolicy,
+  ToolkitPolicyAction,
+  ToolkitScope,
+  ToolkitView,
+} from "../shared";
+import {
+  toolkitsAtom,
+  createToolkit,
+  updateToolkit,
+  removeToolkit,
+  toolkitWriteKeys,
+} from "./atoms";
+import {
+  type FormConn as Conn,
+  accessFromToolkit,
+  connKey,
+  entriesFromAccess,
+  slugify,
+  tiersForScope,
+  uniqueSlug,
+} from "./form";
+
+// ---------------------------------------------------------------------------
+// Local shapes — structural views of the core connection/integration rows we
+// read, so this file doesn't pin a specific API success-type name.
+// ---------------------------------------------------------------------------
+
+interface Integ {
+  readonly slug: string;
+  readonly name: string;
+}
+
+const ACCESS_OPTIONS: ReadonlyArray<{ value: ToolkitAccess; label: string }> = [
+  { value: "off", label: "Off" },
+  { value: "read", label: "Read" },
+  { value: "full", label: "Full" },
+];
+
+const ACTION_LABEL: Record<ToolkitPolicyAction, string> = {
+  approve: "Auto-approve",
+  require_approval: "Needs approval",
+  block: "Block",
+};
+
+// ---------------------------------------------------------------------------
+// Access segmented control (off / read / full)
+// ---------------------------------------------------------------------------
+
+function AccessSeg(props: { value: ToolkitAccess; onChange: (v: ToolkitAccess) => void }) {
+  return (
+    <div className="inline-flex shrink-0 gap-0.5 rounded-md border border-input p-0.5">
+      {ACCESS_OPTIONS.map((o) => (
+        <Button
+          key={o.value}
+          type="button"
+          size="sm"
+          variant={props.value === o.value ? "secondary" : "ghost"}
+          className="h-6 px-2.5 text-[11px] font-medium"
+          onClick={() => props.onChange(o.value)}
+        >
+          {o.label}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
+function ToolkitCard(props: {
+  toolkit: ToolkitView;
+  integrationName: (slug: string) => string;
+  onOpen: () => void;
+}) {
+  const active = props.toolkit.connections.filter((c) => c.access !== "off");
+  const integrations = [...new Set(active.map((c) => c.integration))];
+  return (
+    // oxlint-disable-next-line react/forbid-elements -- a card-sized clickable surface; a real <button> is the correct accessible primitive
+    <button
+      type="button"
+      onClick={props.onOpen}
+      className="flex flex-col gap-3 rounded-xl border border-border bg-card p-4 text-left transition-colors hover:border-ring"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[15px] font-semibold text-foreground">{props.toolkit.name}</span>
+        <span className="text-[12px] text-muted-foreground">
+          {active.length} {active.length === 1 ? "connection" : "connections"}
+        </span>
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {integrations.length === 0 ? (
+          <span className="text-[12px] text-muted-foreground">Empty — nothing granted yet</span>
+        ) : (
+          integrations.map((slug) => (
+            <span
+              key={slug}
+              className="inline-flex items-center gap-1.5 rounded-md bg-muted px-2 py-0.5 text-[12px]"
+            >
+              <IntegrationFavicon sourceId={slug} size={14} />
+              {props.integrationName(slug)}
+            </span>
+          ))
+        )}
+      </div>
+      <span className="font-mono text-[10.5px] text-muted-foreground">
+        /mcp?toolkit={props.toolkit.slug}
+      </span>
+    </button>
+  );
+}
+
+function ListSection(props: {
+  title: string;
+  empty: string;
+  toolkits: ReadonlyArray<ToolkitView>;
+  integrationName: (slug: string) => string;
+  onOpen: (id: string) => void;
+  onCreate: () => void;
+}) {
+  return (
+    <section className="mt-10">
+      <div className="mb-3 flex items-center justify-between border-b border-border/50 pb-2">
+        <h2 className="font-display text-xl tracking-tight text-foreground">{props.title}</h2>
+        <Button type="button" size="sm" onClick={props.onCreate}>
+          New toolkit
+        </Button>
+      </div>
+      {props.toolkits.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border px-4 py-6 text-sm text-muted-foreground">
+          {props.empty}
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2">
+          {props.toolkits.map((tk) => (
+            <ToolkitCard
+              key={tk.id}
+              toolkit={tk}
+              integrationName={props.integrationName}
+              onOpen={() => props.onOpen(tk.id)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Editor
+// ---------------------------------------------------------------------------
+
+interface EditorProps {
+  readonly existing: ToolkitView | null;
+  readonly scope: ToolkitScope;
+  readonly takenSlugs: ReadonlySet<string>;
+  readonly connections: ReadonlyArray<Conn>;
+  readonly integrationName: (slug: string) => string;
+  readonly onBack: () => void;
+  readonly onCreated: () => void;
+  readonly onRemoved: () => void;
+}
+
+function ToolkitEditor(props: EditorProps) {
+  const { existing, scope } = props;
+
+  const [name, setName] = useState(existing?.name ?? "Untitled");
+  const [briefing, setBriefing] = useState(existing?.briefing ?? "");
+  const [inheritOrg, setInheritOrg] = useState(existing?.inheritOrgPolicies ?? true);
+  const [access, setAccess] = useState<Record<string, ToolkitAccess>>(
+    () => accessFromToolkit(existing).access,
+  );
+  const [notes, setNotes] = useState<Record<string, string>>(
+    () => accessFromToolkit(existing).notes,
+  );
+  const [policies, setPolicies] = useState<ReadonlyArray<ToolkitPolicy>>(
+    () => existing?.policies.map((p) => ({ ...p })) ?? [],
+  );
+
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [origin, setOrigin] = useState("");
+  useEffect(() => {
+    if (typeof window !== "undefined") setOrigin(window.location.origin);
+  }, []);
+
+  const doCreate = useAtomSet(createToolkit, { mode: "promiseExit" });
+  const doUpdate = useAtomSet(updateToolkit, { mode: "promiseExit" });
+  const doRemove = useAtomSet(removeToolkit, { mode: "promiseExit" });
+
+  const mark = () => {
+    setDirty(true);
+    setError(null);
+  };
+  const setMode = (key: string, v: ToolkitAccess) => {
+    setAccess((m) => ({ ...m, [key]: v }));
+    mark();
+  };
+  const setNote = (key: string, v: string) => {
+    setNotes((m) => ({ ...m, [key]: v }));
+    mark();
+  };
+  const setPolicy = (i: number, patch: Partial<ToolkitPolicy>) => {
+    setPolicies((ps) => ps.map((p, j) => (j === i ? { ...p, ...patch } : p)));
+    mark();
+  };
+
+  // The connections this toolkit may draw on: workspace = org-owned only;
+  // personal = org + the caller's own.
+  const tiers = useMemo(() => tiersForScope(props.connections, scope), [props.connections, scope]);
+
+  const buildEntries = () => entriesFromAccess(props.connections, scope, access, notes);
+
+  const cleanPolicies = (): ReadonlyArray<ToolkitPolicy> =>
+    policies.filter((p) => p.pattern.trim()).map((p) => ({ ...p, pattern: p.pattern.trim() }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    const connections = buildEntries();
+    const cleaned = cleanPolicies();
+    if (existing) {
+      const exit = await doUpdate({
+        params: { id: existing.id },
+        payload: {
+          name: name.trim() || "Untitled",
+          briefing: briefing.trim() ? briefing.trim() : null,
+          inheritOrgPolicies: inheritOrg,
+          connections,
+          policies: cleaned,
+        },
+        reactivityKeys: toolkitWriteKeys,
+      });
+      setSaving(false);
+      if (Exit.isFailure(exit)) {
+        setError("Couldn't save changes. Try again.");
+        return;
+      }
+      setDirty(false);
+      return;
+    }
+    const exit = await doCreate({
+      payload: {
+        slug: uniqueSlug(slugify(name) || "toolkit", props.takenSlugs),
+        name: name.trim() || "Untitled",
+        scope,
+        inheritOrgPolicies: inheritOrg,
+        briefing: briefing.trim() ? briefing.trim() : undefined,
+        connections,
+        policies: cleaned,
+      },
+      reactivityKeys: toolkitWriteKeys,
+    });
+    setSaving(false);
+    if (Exit.isFailure(exit)) {
+      setError("Couldn't create the toolkit. Try again.");
+      return;
+    }
+    props.onCreated();
+  };
+
+  const handleDelete = async () => {
+    if (!existing) {
+      props.onBack();
+      return;
+    }
+    // oxlint-disable-next-line no-alert -- intentional destructive confirmation
+    if (!window.confirm("Delete this toolkit? Connected agents lose access immediately.")) return;
+    const exit = await doRemove({
+      params: { id: existing.id },
+      reactivityKeys: toolkitWriteKeys,
+    });
+    if (Exit.isSuccess(exit)) props.onRemoved();
+    else setError("Couldn't delete the toolkit. Try again.");
+  };
+
+  const slug = existing?.slug ?? (slugify(name) || "toolkit");
+  const endpoint = `${origin}/mcp?toolkit=${encodeURIComponent(slug)}`;
+
+  // Live "what the agent sees" — derived from the in-progress form.
+  const previewGroups = useMemo(() => {
+    const byInt = new Map<string, Array<{ name: string; access: ToolkitAccess; note?: string }>>();
+    for (const tier of tiers) {
+      for (const c of tier.conns) {
+        const key = connKey(c.integration, c.name);
+        const a = access[key] ?? "off";
+        if (a === "off") continue;
+        const list = byInt.get(c.integration) ?? [];
+        list.push({
+          name: c.name,
+          access: a,
+          note: notes[key]?.trim() || undefined,
+        });
+        byInt.set(c.integration, list);
+      }
+    }
+    return [...byInt.entries()];
+  }, [tiers, access, notes]);
+  const previewCount = previewGroups.reduce((n, [, conns]) => n + conns.length, 0);
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl px-6 py-10 lg:px-10 lg:py-14">
+        {/* oxlint-disable-next-line react/forbid-elements -- a subtle text breadcrumb; intentionally not the styled design-system Button */}
+        <button
+          type="button"
+          onClick={props.onBack}
+          className="mb-4 text-[12.5px] font-medium text-muted-foreground hover:text-foreground"
+        >
+          ← Toolkits
+        </button>
+
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <Input
+              value={name}
+              onChange={(e) => {
+                setName((e.target as HTMLInputElement).value);
+                mark();
+              }}
+              className="h-auto w-full max-w-[420px] border-transparent bg-transparent px-1 font-display text-3xl tracking-tight text-foreground shadow-none focus-visible:border-input"
+            />
+            <p className="mt-1 px-1 text-[13px] text-muted-foreground">
+              {scope === "workspace"
+                ? "Workspace toolkit — shared with your org, draws on workspace connections."
+                : "Personal toolkit — only you, can use workspace and your own connections."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="shrink-0 text-destructive/80 hover:text-destructive"
+            onClick={handleDelete}
+          >
+            Delete
+          </Button>
+        </div>
+
+        <Textarea
+          value={briefing}
+          onChange={(e) => {
+            setBriefing((e.target as HTMLTextAreaElement).value);
+            mark();
+          }}
+          placeholder="What is this toolkit for? This leads the agent's briefing."
+          className="mt-1 min-h-[2.25rem] resize-none border-transparent bg-transparent px-0 text-sm text-muted-foreground shadow-none focus-visible:border-input focus-visible:bg-card focus-visible:px-3"
+        />
+
+        <div className="mt-6 grid grid-cols-1 items-start gap-7 lg:grid-cols-[minmax(0,1fr)_340px]">
+          {/* Main column */}
+          <div>
+            {/* Access */}
+            <h3 className="mb-2.5 text-[13.5px] font-semibold text-foreground">Access</h3>
+            <div className="overflow-hidden rounded-xl border border-border bg-card">
+              {tiers.map((tier, ti) => (
+                <div key={tier.label} className={cn(ti > 0 && "border-t border-border")}>
+                  <div className="flex items-center justify-between px-4 pb-1 pt-3">
+                    <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                      {tier.label}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground">
+                      {tier.conns.length} available
+                    </span>
+                  </div>
+                  {tier.conns.length === 0 ? (
+                    <p className="px-4 pb-3 text-[12px] text-muted-foreground">
+                      No connections in this tier yet.
+                    </p>
+                  ) : (
+                    groupByIntegration(tier.conns).map(([intSlug, conns]) => (
+                      <div key={intSlug} className="px-4 pb-2 pt-1.5">
+                        <div className="flex items-center gap-2 pb-1">
+                          <IntegrationFavicon sourceId={intSlug} size={16} />
+                          <span className="text-[12.5px] font-semibold text-foreground">
+                            {props.integrationName(intSlug)}
+                          </span>
+                          {conns.length > 1 && (
+                            <span className="ml-auto text-[11px] text-muted-foreground">
+                              {conns.length} accounts
+                            </span>
+                          )}
+                        </div>
+                        {conns.map((c) => {
+                          const key = connKey(c.integration, c.name);
+                          const a = access[key] ?? "off";
+                          return (
+                            <div key={key} data-testid={`tk-conn ${key}`} className="pl-7">
+                              <div className="flex items-center gap-3 py-1">
+                                <div className="min-w-0 flex-1">
+                                  <div className="truncate text-[13px] font-semibold text-foreground">
+                                    {c.name}
+                                  </div>
+                                  {(c.identityLabel || c.description) && (
+                                    <div className="truncate text-[11.5px] text-muted-foreground">
+                                      {c.identityLabel || c.description}
+                                    </div>
+                                  )}
+                                </div>
+                                <AccessSeg value={a} onChange={(v) => setMode(key, v)} />
+                              </div>
+                              {a !== "off" && (
+                                <Input
+                                  value={notes[key] ?? ""}
+                                  onChange={(e) =>
+                                    setNote(key, (e.target as HTMLInputElement).value)
+                                  }
+                                  placeholder={`Note to the agent about ${c.name} (optional)`}
+                                  className="mb-1.5 h-7 border-transparent bg-transparent px-0 text-[12px] italic shadow-none focus-visible:border-input"
+                                />
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ))
+                  )}
+                </div>
+              ))}
+            </div>
+            <p className="mt-2.5 text-[12px] text-muted-foreground">
+              New tools and new connections are included automatically, by mode.
+            </p>
+
+            {/* Approvals & policies */}
+            <div className="mb-2.5 mt-6 flex items-center justify-between">
+              <h3 className="text-[13.5px] font-semibold text-foreground">
+                Approvals &amp; policies
+              </h3>
+              <Label className="flex cursor-pointer items-center gap-2">
+                <Switch
+                  checked={inheritOrg}
+                  onCheckedChange={(v) => {
+                    setInheritOrg(v);
+                    mark();
+                  }}
+                />
+                <span className="text-[12px] font-medium text-muted-foreground">
+                  Inherit org policies
+                </span>
+              </Label>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-border bg-card">
+              <div className="px-4 py-3">
+                <p className="text-[12px] text-muted-foreground">
+                  {inheritOrg
+                    ? "Your workspace's policies apply on top of this toolkit. Where an org rule and a toolkit rule overlap, the stricter one wins."
+                    : "Workspace guardrails are off — this toolkit is governed only by its own rules below."}
+                </p>
+              </div>
+              <div className="border-t border-border px-4 py-2.5">
+                <div className="flex items-center gap-2 pb-1">
+                  <span className="text-[12.5px] font-semibold text-foreground">Toolkit rules</span>
+                  <span className="ml-auto text-[11px] text-muted-foreground">
+                    {policies.length} {policies.length === 1 ? "rule" : "rules"}
+                  </span>
+                </div>
+                {policies.map((p, i) => (
+                  <div key={i} className="flex flex-wrap items-center gap-2 py-1.5">
+                    <Input
+                      value={p.pattern}
+                      onChange={(e) =>
+                        setPolicy(i, {
+                          pattern: (e.target as HTMLInputElement).value,
+                        })
+                      }
+                      placeholder="slack.*.post_message"
+                      className="h-8 min-w-[190px] flex-1 font-mono text-[12px]"
+                    />
+                    <Select
+                      value={p.action}
+                      onValueChange={(v) => setPolicy(i, { action: v as ToolkitPolicyAction })}
+                    >
+                      <SelectTrigger className="h-8 w-[150px] text-[12px]">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="approve">{ACTION_LABEL.approve}</SelectItem>
+                        <SelectItem value="require_approval">
+                          {ACTION_LABEL.require_approval}
+                        </SelectItem>
+                        <SelectItem value="block">{ACTION_LABEL.block}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="h-8 px-2 text-destructive/70 hover:text-destructive"
+                      onClick={() => {
+                        setPolicies((ps) => ps.filter((_, j) => j !== i));
+                        mark();
+                      }}
+                    >
+                      ✕
+                    </Button>
+                  </div>
+                ))}
+                <div className="flex items-center gap-3 pt-1">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => {
+                      setPolicies((ps) => [...ps, { pattern: "", action: "approve" }]);
+                      mark();
+                    }}
+                  >
+                    + Add rule
+                  </Button>
+                  <span className="text-[11px] text-muted-foreground">
+                    Block hides matching tools entirely · approve / needs-approval set gating.
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Connect */}
+            <h3 className="mb-2.5 mt-6 text-[13.5px] font-semibold text-foreground">Connect</h3>
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                MCP endpoint
+              </div>
+              {/* oxlint-disable-next-line react/forbid-elements -- a full-width copy affordance; the design-system Button doesn't fit this row layout */}
+              <button
+                type="button"
+                onClick={async () => {
+                  if (await copyToClipboard(endpoint)) {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1100);
+                  }
+                }}
+                className="mt-2 flex w-full items-center justify-between gap-3 rounded-md border border-border bg-muted/40 px-3 py-2 text-left"
+              >
+                <span className="truncate font-mono text-[12px] text-foreground">{endpoint}</span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">
+                  {copied ? "copied" : "copy"}
+                </span>
+              </button>
+              <p className="mt-2.5 text-[11.5px] text-muted-foreground">
+                Point an agent at this URL with any of your account's API keys — it sees only this
+                toolkit's slice, never the management API.
+              </p>
+            </div>
+
+            {/* Save bar */}
+            <div className="mt-6 flex items-center gap-3">
+              <Button
+                type="button"
+                onClick={handleSave}
+                disabled={saving || (!!existing && !dirty)}
+              >
+                {saving ? "Saving…" : existing ? "Save changes" : "Create toolkit"}
+              </Button>
+              {error ? (
+                <span className="text-[12px] text-destructive">{error}</span>
+              ) : existing && !dirty ? (
+                <span className="text-[12px] text-muted-foreground">All changes saved</span>
+              ) : null}
+            </div>
+          </div>
+
+          {/* Preview rail */}
+          <aside className="lg:sticky lg:top-6">
+            <div className="rounded-xl border border-border bg-card p-4">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                  What the agent sees
+                </span>
+                <span className="text-[12px] text-muted-foreground">
+                  {previewCount} {previewCount === 1 ? "connection" : "connections"}
+                </span>
+              </div>
+              {briefing.trim() && (
+                <p className="mt-3 whitespace-pre-wrap text-[12px] leading-relaxed text-foreground">
+                  {briefing.trim()}
+                </p>
+              )}
+              {previewGroups.length === 0 ? (
+                <p className="mt-3 text-[12px] text-muted-foreground">
+                  Nothing granted yet — set a connection to Read or Full to give the agent something
+                  to work with.
+                </p>
+              ) : (
+                <div className="mt-3 flex flex-col gap-3">
+                  {previewGroups.map(([intSlug, conns]) => (
+                    <div key={intSlug}>
+                      <div className="flex items-center gap-2">
+                        <IntegrationFavicon sourceId={intSlug} size={15} />
+                        <span className="text-[12.5px] font-semibold text-foreground">
+                          {props.integrationName(intSlug)}
+                        </span>
+                      </div>
+                      {conns.map((c) => (
+                        <div key={c.name} className="mt-1 pl-6">
+                          <div className="flex items-center gap-2">
+                            <span className="text-[12px] text-foreground">{c.name}</span>
+                            <Badge
+                              variant={c.access === "full" ? "default" : "secondary"}
+                              className="px-1.5 py-0 text-[10px]"
+                            >
+                              {c.access === "full" ? "full" : "read-only"}
+                            </Badge>
+                          </div>
+                          {c.note && (
+                            <p className="text-[11px] italic text-muted-foreground">{c.note}</p>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function groupByIntegration(
+  conns: ReadonlyArray<Conn>,
+): ReadonlyArray<readonly [string, ReadonlyArray<Conn>]> {
+  const byInt = new Map<string, Conn[]>();
+  for (const c of conns) {
+    const list = byInt.get(c.integration) ?? [];
+    list.push(c);
+    byInt.set(c.integration, list);
+  }
+  return [...byInt.entries()];
+}
+
+// ---------------------------------------------------------------------------
+// Page — list <-> editor switch
+// ---------------------------------------------------------------------------
+
+type View =
+  | { readonly kind: "list" }
+  | { readonly kind: "edit"; readonly id: string }
+  | { readonly kind: "new"; readonly scope: ToolkitScope };
+
+function viewFromSubpath(subpath: string): View {
+  const normalized = subpath === "/" ? "" : subpath;
+  if (normalized === "") return { kind: "list" };
+  if (normalized === "new/workspace") return { kind: "new", scope: "workspace" };
+  if (normalized === "new/personal") return { kind: "new", scope: "personal" };
+  return { kind: "edit", id: normalized };
+}
+
+export function ToolkitsPage() {
+  const { subpath } = usePluginRoute();
+  const navigate = usePluginNavigate();
+  const view = viewFromSubpath(subpath);
+  const toolkitsResult = useAtomValue(toolkitsAtom);
+  const connectionsResult = useAtomValue(connectionsAllAtom);
+  const integrationsResult = useAtomValue(integrationsAtom);
+
+  const toolkits = AsyncResult.match(
+    toolkitsResult as AsyncResult.AsyncResult<ReadonlyArray<ToolkitView>, unknown>,
+    {
+      onInitial: () => null,
+      onFailure: () => [] as ReadonlyArray<ToolkitView>,
+      onSuccess: ({ value }) => value,
+    },
+  );
+  const connections = AsyncResult.match(
+    connectionsResult as AsyncResult.AsyncResult<ReadonlyArray<Conn>, unknown>,
+    {
+      onInitial: () => [] as ReadonlyArray<Conn>,
+      onFailure: () => [] as ReadonlyArray<Conn>,
+      onSuccess: ({ value }) => value,
+    },
+  );
+  const integrations = AsyncResult.match(
+    integrationsResult as AsyncResult.AsyncResult<ReadonlyArray<Integ>, unknown>,
+    {
+      onInitial: () => [] as ReadonlyArray<Integ>,
+      onFailure: () => [] as ReadonlyArray<Integ>,
+      onSuccess: ({ value }) => value,
+    },
+  );
+
+  const integrationName = useMemo(() => {
+    const bySlug = new Map(integrations.map((i) => [i.slug, i.name]));
+    return (slug: string) => bySlug.get(slug) ?? slug;
+  }, [integrations]);
+
+  const takenSlugs = useMemo(() => new Set((toolkits ?? []).map((t) => t.slug)), [toolkits]);
+
+  if (toolkits === null) {
+    return <div className="px-1 py-8 text-[13px] text-muted-foreground">Loading toolkits…</div>;
+  }
+
+  if (view.kind === "edit" || view.kind === "new") {
+    const existing = view.kind === "edit" ? (toolkits.find((t) => t.id === view.id) ?? null) : null;
+    // The toolkit was deleted out from under us (or never resolved) — fall back.
+    if (view.kind === "edit" && !existing) {
+      return <ToolkitEditorFallback onBack={() => navigate("")} />;
+    }
+    const scope = view.kind === "new" ? view.scope : (existing as ToolkitView).scope;
+    return (
+      <ToolkitEditor
+        key={view.kind === "edit" ? view.id : `new-${view.scope}`}
+        existing={existing}
+        scope={scope}
+        takenSlugs={takenSlugs}
+        connections={connections}
+        integrationName={integrationName}
+        onBack={() => navigate("")}
+        onCreated={() => navigate("")}
+        onRemoved={() => navigate("")}
+      />
+    );
+  }
+
+  const workspace = toolkits.filter((t) => t.scope === "workspace");
+  const personal = toolkits.filter((t) => t.scope === "personal");
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-4xl px-6 py-10 lg:px-10 lg:py-14">
+        <header className="mb-2">
+          <h1 className="font-display text-3xl tracking-tight text-foreground lg:text-4xl">
+            Toolkits
+          </h1>
+          <p className="mt-1.5 max-w-[640px] text-sm text-muted-foreground">
+            A toolkit is a slice of your connections with its own MCP endpoint. An agent connected
+            to one can't see anything outside it.
+          </p>
+        </header>
+        <ListSection
+          title="Workspace toolkits"
+          empty="No workspace toolkits yet — these draw on shared workspace connections."
+          toolkits={workspace}
+          integrationName={integrationName}
+          onOpen={(id) => navigate(id)}
+          onCreate={() => navigate("new/workspace")}
+        />
+        <ListSection
+          title="Personal toolkits"
+          empty="No personal toolkits yet — these can use workspace and personal connections."
+          toolkits={personal}
+          integrationName={integrationName}
+          onOpen={(id) => navigate(id)}
+          onCreate={() => navigate("new/personal")}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ToolkitEditorFallback(props: { onBack: () => void }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-5xl px-6 py-10 lg:px-10 lg:py-14">
+        {/* oxlint-disable-next-line react/forbid-elements -- a subtle text breadcrumb; intentionally not the styled design-system Button */}
+        <button
+          type="button"
+          onClick={props.onBack}
+          className="mb-4 text-[12.5px] font-medium text-muted-foreground hover:text-foreground"
+        >
+          ← Toolkits
+        </button>
+        <p className="text-sm text-muted-foreground">This toolkit no longer exists.</p>
+      </div>
+    </div>
+  );
+}
+
+export default ToolkitsPage;

--- a/packages/plugins/toolkits/src/react/atoms.ts
+++ b/packages/plugins/toolkits/src/react/atoms.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------
+// Query + mutation atoms for the toolkits console page.
+//
+// The `list` query returns every toolkit the caller can see (workspace +
+// personal); the page splits by `scope`. Mutations pass `toolkitWriteKeys` at
+// the call site so the list refreshes after a create / update / remove.
+// ---------------------------------------------------------------------------
+
+import { ReactivityKey, toolkitWriteKeys } from "@executor-js/react/api/reactivity-keys";
+
+import { ToolkitsClient } from "./client";
+
+export { toolkitWriteKeys };
+
+export const toolkitsAtom = ToolkitsClient.query("toolkits", "list", {
+  timeToLive: "15 seconds",
+  reactivityKeys: [ReactivityKey.toolkits],
+});
+
+export const createToolkit = ToolkitsClient.mutation("toolkits", "create");
+export const updateToolkit = ToolkitsClient.mutation("toolkits", "update");
+export const removeToolkit = ToolkitsClient.mutation("toolkits", "remove");

--- a/packages/plugins/toolkits/src/react/client.ts
+++ b/packages/plugins/toolkits/src/react/client.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/react — the typed reactive client
+//
+// `createPluginAtomClient` builds an AtomHttpApi service keyed to the toolkits
+// group, reusing the host's active Executor Server Connection for the base URL
+// and (self-host) authorization header — the same wiring every first-party
+// plugin client uses.
+// ---------------------------------------------------------------------------
+
+import { createPluginAtomClient } from "@executor-js/sdk/client";
+import {
+  getExecutorApiBaseUrl,
+  getExecutorServerAuthorizationHeader,
+} from "@executor-js/react/api/server-connection";
+
+import { ToolkitsApi } from "../shared";
+
+export const ToolkitsClient = createPluginAtomClient(ToolkitsApi, {
+  baseUrl: getExecutorApiBaseUrl,
+  authorizationHeader: getExecutorServerAuthorizationHeader,
+});

--- a/packages/plugins/toolkits/src/react/form.ts
+++ b/packages/plugins/toolkits/src/react/form.ts
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------------
+// Pure form <-> wire transforms for the toolkit editor. No React / DOM here so
+// the bug-prone bits (the access-map ⇄ ToolkitConnectionEntry round-trip, scope
+// tiering, slug derivation) are unit-testable in isolation.
+// ---------------------------------------------------------------------------
+
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import type { ToolkitAccess, ToolkitConnectionEntry, ToolkitScope, ToolkitView } from "../shared";
+
+/** A structural view of a core connection row — the fields the editor reads. */
+export interface FormConn {
+  readonly owner: "org" | "user";
+  readonly name: string;
+  readonly integration: string;
+  readonly identityLabel?: string | null;
+  readonly description?: string | null;
+}
+
+export interface AccessTier {
+  readonly label: string;
+  readonly conns: ReadonlyArray<FormConn>;
+}
+
+/** Stable key for the per-connection access/notes maps. A space can't appear in
+ *  an integration slug, so `"<integration> <connection>"` is unambiguous. */
+export const connKey = (integration: string, connection: string): string =>
+  `${integration} ${connection}`;
+
+export const slugify = (s: string): string =>
+  s
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+
+/** A slug not already in `taken`; appends `-2`, `-3`, … on collision. */
+export const uniqueSlug = (base: string, taken: ReadonlySet<string>): string => {
+  const root = base || "toolkit";
+  if (!taken.has(root)) return root;
+  let i = 2;
+  while (taken.has(`${root}-${i}`)) i += 1;
+  return `${root}-${i}`;
+};
+
+/** Which connections a toolkit may draw on: workspace = org-owned only; personal
+ *  = org + the caller's own, split into two tiers. */
+export const tiersForScope = (
+  connections: ReadonlyArray<FormConn>,
+  scope: ToolkitScope,
+): ReadonlyArray<AccessTier> => {
+  const org = connections.filter((c) => c.owner === "org");
+  if (scope === "workspace") return [{ label: "Workspace connections", conns: org }];
+  const user = connections.filter((c) => c.owner === "user");
+  return [
+    { label: "Workspace connections", conns: org },
+    { label: "Personal connections", conns: user },
+  ];
+};
+
+/** Seed the editor's access + notes maps from an existing toolkit. */
+export const accessFromToolkit = (
+  toolkit: ToolkitView | null,
+): { access: Record<string, ToolkitAccess>; notes: Record<string, string> } => {
+  const access: Record<string, ToolkitAccess> = {};
+  const notes: Record<string, string> = {};
+  for (const e of toolkit?.connections ?? []) {
+    const key = connKey(e.integration, e.connection);
+    access[key] = e.access;
+    if (e.note) notes[key] = e.note;
+  }
+  return { access, notes };
+};
+
+/** Collapse the editor's access + notes maps back into the wire entries —
+ *  only connections set to read/full (off = absent), notes trimmed. */
+export const entriesFromAccess = (
+  connections: ReadonlyArray<FormConn>,
+  scope: ToolkitScope,
+  access: Readonly<Record<string, ToolkitAccess>>,
+  notes: Readonly<Record<string, string>>,
+): ReadonlyArray<ToolkitConnectionEntry> => {
+  const entries: Array<ToolkitConnectionEntry> = [];
+  for (const tier of tiersForScope(connections, scope)) {
+    for (const c of tier.conns) {
+      const key = connKey(c.integration, c.name);
+      const a = access[key] ?? "off";
+      if (a === "off") continue;
+      const note = notes[key]?.trim();
+      entries.push({
+        integration: IntegrationSlug.make(c.integration),
+        connection: c.name,
+        access: a,
+        ...(note ? { note } : {}),
+      });
+    }
+  }
+  return entries;
+};

--- a/packages/plugins/toolkits/src/react/index.ts
+++ b/packages/plugins/toolkits/src/react/index.ts
@@ -1,0 +1,9 @@
+export { ToolkitsPage, default as ToolkitsPageDefault } from "./ToolkitsPage";
+export { ToolkitsClient } from "./client";
+export {
+  toolkitsAtom,
+  createToolkit,
+  updateToolkit,
+  removeToolkit,
+  toolkitWriteKeys,
+} from "./atoms";

--- a/packages/plugins/toolkits/src/react/plugin-client.tsx
+++ b/packages/plugins/toolkits/src/react/plugin-client.tsx
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/client — the frontend half.
+//
+// The Vite plugin resolves `${packageName}/client` for every server plugin
+// registered in `executor.config.ts` and feeds the default export into
+// `<ExecutorPluginsProvider>`, so registering `toolkitsPlugin()` server-side is
+// all it takes for this page (and its "Toolkits" nav entry) to mount.
+//
+// Server-only deps (Effect runtime, Node, executor.config) MUST NOT be imported
+// here — this entry is bundled into the frontend.
+// ---------------------------------------------------------------------------
+
+import { defineClientPlugin } from "@executor-js/sdk/client";
+
+import { ToolkitsPage } from "./ToolkitsPage";
+
+export default defineClientPlugin({
+  id: "toolkits" as const,
+  pages: [
+    {
+      path: "/",
+      component: ToolkitsPage,
+      nav: { label: "Toolkits" },
+    },
+  ],
+});

--- a/packages/plugins/toolkits/src/server.ts
+++ b/packages/plugins/toolkits/src/server.ts
@@ -1,0 +1,379 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/server
+//
+// The server half of the toolkits plugin. A toolkit is a named slice of the
+// caller's connections, persisted as owner-scoped plugin storage:
+//   - workspace toolkit  -> owner "org"  (visible to every org member)
+//   - personal toolkit   -> owner "user" (visible only to its creator)
+// The pluginStorage facade is already request-bound to (tenant, subject), so
+// the org/user owner literal is the entire workspace-vs-personal visibility
+// story. Slice 1 ships data + CRUD only — no MCP narrowing yet.
+//
+// React and other browser-only deps live in `./client` — never here.
+// ---------------------------------------------------------------------------
+
+import { Schema } from "effect";
+import { Context, definePlugin, Effect, HttpApiBuilder } from "@executor-js/sdk/core";
+import {
+  definePluginStorageCollection,
+  Owner,
+  type PluginCtx,
+  type RequestScope,
+  type StorageFailure,
+} from "@executor-js/sdk";
+import { addGroup, capture } from "@executor-js/api";
+
+import {
+  ToolkitForbidden,
+  ToolkitNotFound,
+  ToolkitsApi,
+  type CreateToolkitPayload,
+  type ToolkitAccess,
+  type ToolkitPolicyAction,
+  type ToolkitScope,
+  type ToolkitView,
+  type UpdateToolkitPayload,
+} from "./shared";
+import {
+  EMPTY_TOOLKIT_SCOPE,
+  toolkitScopeToRequestScope,
+  type ResolvedToolkitScope,
+} from "./toolkit-scope";
+
+const ORG = Owner.make("org");
+const USER = Owner.make("user");
+
+// ---------------------------------------------------------------------------
+// Storage rows (internal — not the HTTP contract). Keyed by uuid, never by a
+// user-supplied value (long keyed values hit a fumadb keyed-lookup bug).
+// ---------------------------------------------------------------------------
+
+const ToolkitRow = Schema.Struct({
+  slug: Schema.String,
+  name: Schema.String,
+  inheritOrgPolicies: Schema.Boolean,
+  briefing: Schema.NullOr(Schema.String),
+});
+
+const ConnectionRow = Schema.Struct({
+  toolkitId: Schema.String,
+  integration: Schema.String,
+  connection: Schema.String,
+  access: Schema.String,
+  note: Schema.NullOr(Schema.String),
+});
+
+const PolicyRow = Schema.Struct({
+  toolkitId: Schema.String,
+  pattern: Schema.String,
+  action: Schema.String,
+});
+
+const TOOLKITS = definePluginStorageCollection("toolkits", ToolkitRow, {
+  indexes: ["slug"],
+});
+const CONNECTIONS = definePluginStorageCollection("connections", ConnectionRow, {
+  indexes: ["toolkitId"],
+});
+const POLICIES = definePluginStorageCollection("policies", PolicyRow, {
+  indexes: ["toolkitId"],
+});
+
+const newId = Effect.sync(() => crypto.randomUUID());
+const scopeOfOwner = (owner: Owner): ToolkitScope => (owner === ORG ? "workspace" : "personal");
+
+// ---------------------------------------------------------------------------
+// Extension — the canonical implementation. Handlers (and later the MCP
+// contribution) all hit this same code path.
+// ---------------------------------------------------------------------------
+
+type ToolkitRowEntry = {
+  readonly key: string;
+  readonly owner: Owner;
+  readonly data: typeof ToolkitRow.Type;
+};
+
+const makeToolkitsExtension = (ctx: PluginCtx) => {
+  const toolkits = ctx.pluginStorage.collection(TOOLKITS);
+  const connections = ctx.pluginStorage.collection(CONNECTIONS);
+  const policies = ctx.pluginStorage.collection(POLICIES);
+
+  const viewFromRow = (row: ToolkitRowEntry) =>
+    Effect.gen(function* () {
+      const conns = yield* connections.query({ where: { toolkitId: row.key } });
+      const pols = yield* policies.query({ where: { toolkitId: row.key } });
+      return {
+        id: row.key,
+        slug: row.data.slug,
+        name: row.data.name,
+        scope: scopeOfOwner(row.owner),
+        inheritOrgPolicies: row.data.inheritOrgPolicies,
+        briefing: row.data.briefing,
+        connections: conns.map((c) => ({
+          integration: c.data.integration as ToolkitConnectionIntegration,
+          connection: c.data.connection,
+          access: c.data.access as ToolkitAccess,
+          ...(c.data.note == null ? {} : { note: c.data.note }),
+        })),
+        policies: pols.map((p) => ({
+          pattern: p.data.pattern,
+          action: p.data.action as ToolkitPolicyAction,
+        })),
+      } satisfies ToolkitView;
+    });
+
+  // candidate connections honoring scope: a workspace toolkit may use only
+  // org connections; a personal toolkit may use org + the caller's own.
+  const candidateConnections = (scope: ToolkitScope) =>
+    scope === "workspace" ? ctx.connections.list({ owner: ORG }) : ctx.connections.list();
+
+  const validate = (scope: ToolkitScope, entries: ReadonlyArray<ToolkitConnectionEntryInput>) =>
+    Effect.gen(function* () {
+      const allowed = yield* candidateConnections(scope);
+      const pairs = new Set(allowed.map((c) => `${c.integration}/${c.name}`));
+      const integrations = new Set(allowed.map((c) => c.integration));
+      for (const e of entries) {
+        const ok =
+          e.connection === "*"
+            ? integrations.has(e.integration)
+            : pairs.has(`${e.integration}/${e.connection}`);
+        if (!ok) {
+          return yield* new ToolkitForbidden({
+            reason: `connection ${e.integration}/${e.connection} is not available to a ${scope} toolkit`,
+          });
+        }
+      }
+    });
+
+  const putConnections = (
+    toolkitId: string,
+    owner: Owner,
+    entries: ReadonlyArray<ToolkitConnectionEntryInput>,
+  ) =>
+    Effect.forEach(entries, (e) =>
+      newId.pipe(
+        Effect.flatMap((cid) =>
+          connections.put({
+            key: cid,
+            owner,
+            data: {
+              toolkitId,
+              integration: e.integration,
+              connection: e.connection,
+              access: e.access,
+              note: e.note ?? null,
+            },
+          }),
+        ),
+      ),
+    );
+
+  const putPolicies = (
+    toolkitId: string,
+    owner: Owner,
+    rules: ReadonlyArray<{ readonly pattern: string; readonly action: string }>,
+  ) =>
+    Effect.forEach(rules, (r) =>
+      newId.pipe(
+        Effect.flatMap((pid) =>
+          policies.put({
+            key: pid,
+            owner,
+            data: { toolkitId, pattern: r.pattern, action: r.action },
+          }),
+        ),
+      ),
+    );
+
+  const create = (input: CreateToolkitPayload) =>
+    Effect.gen(function* () {
+      if (input.scope === "personal" && ctx.owner.subject == null) {
+        return yield* new ToolkitForbidden({
+          reason: "personal toolkits require a signed-in user",
+        });
+      }
+      const owner = input.scope === "workspace" ? ORG : USER;
+      const entries = input.connections ?? [];
+      yield* validate(input.scope, entries);
+      const id = yield* newId;
+      const data = {
+        slug: input.slug,
+        name: input.name,
+        inheritOrgPolicies: input.inheritOrgPolicies ?? true,
+        briefing: input.briefing ?? null,
+      };
+      yield* toolkits.put({ key: id, owner, data });
+      yield* putConnections(id, owner, entries);
+      yield* putPolicies(id, owner, input.policies ?? []);
+      return yield* viewFromRow({ key: id, owner, data });
+    });
+
+  const get = (id: string) =>
+    Effect.gen(function* () {
+      const row = yield* toolkits.get({ key: id });
+      if (row == null) return yield* new ToolkitNotFound({ id });
+      return yield* viewFromRow(row);
+    });
+
+  const list = () =>
+    toolkits.list().pipe(Effect.flatMap((rows) => Effect.forEach(rows, viewFromRow)));
+
+  const update = (id: string, patch: UpdateToolkitPayload) =>
+    Effect.gen(function* () {
+      const row = yield* toolkits.get({ key: id });
+      if (row == null) return yield* new ToolkitNotFound({ id });
+      const data = {
+        slug: row.data.slug,
+        name: patch.name ?? row.data.name,
+        inheritOrgPolicies: patch.inheritOrgPolicies ?? row.data.inheritOrgPolicies,
+        briefing: patch.briefing === undefined ? row.data.briefing : patch.briefing,
+      };
+      yield* toolkits.put({ key: id, owner: row.owner, data });
+      if (patch.connections !== undefined) {
+        yield* validate(scopeOfOwner(row.owner), patch.connections);
+        const existing = yield* connections.query({ where: { toolkitId: id } });
+        yield* Effect.forEach(existing, (c) =>
+          connections.remove({ key: c.key, owner: row.owner }),
+        );
+        yield* putConnections(id, row.owner, patch.connections);
+      }
+      if (patch.policies !== undefined) {
+        const existing = yield* policies.query({ where: { toolkitId: id } });
+        yield* Effect.forEach(existing, (p) => policies.remove({ key: p.key, owner: row.owner }));
+        yield* putPolicies(id, row.owner, patch.policies);
+      }
+      return yield* viewFromRow({ key: id, owner: row.owner, data });
+    });
+
+  const remove = (id: string) =>
+    Effect.gen(function* () {
+      const row = yield* toolkits.get({ key: id });
+      if (row == null) return yield* new ToolkitNotFound({ id });
+      const conns = yield* connections.query({ where: { toolkitId: id } });
+      yield* Effect.forEach(conns, (c) => connections.remove({ key: c.key, owner: row.owner }));
+      const pols = yield* policies.query({ where: { toolkitId: id } });
+      yield* Effect.forEach(pols, (p) => policies.remove({ key: p.key, owner: row.owner }));
+      yield* toolkits.remove({ key: id, owner: row.owner });
+      return { removed: true };
+    });
+
+  // Resolve a selector (slug, then id) to the scope the MCP narrowing seam
+  // applies. Request-scoped, so it only finds toolkits visible to the caller —
+  // a cross-tenant/personal-of-another-user selector returns null (the seam
+  // then fails closed to an empty slice).
+  const resolveScope = (
+    selector: string,
+  ): Effect.Effect<ResolvedToolkitScope | null, StorageFailure> =>
+    Effect.gen(function* () {
+      const bySlug = yield* toolkits.query({
+        where: { slug: selector },
+        limit: 1,
+      });
+      const row = bySlug[0] ?? (yield* toolkits.get({ key: selector }));
+      if (row == null) return null;
+      const conns = yield* connections.query({ where: { toolkitId: row.key } });
+      const pols = yield* policies.query({ where: { toolkitId: row.key } });
+      return {
+        entries: conns.map((c) => ({
+          integration: c.data.integration,
+          connection: c.data.connection,
+          access: c.data.access as ToolkitAccess,
+        })),
+        policies: pols.map((p) => ({
+          pattern: p.data.pattern,
+          action: p.data.action as ToolkitPolicyAction,
+        })),
+        inheritOrgPolicies: row.data.inheritOrgPolicies,
+      };
+    });
+
+  return { create, get, list, update, remove, resolveScope };
+};
+
+// Local aliases so the storage/extension layer stays decoupled from the wire
+// schema's branded types without re-importing them everywhere.
+type ToolkitConnectionIntegration = ToolkitView["connections"][number]["integration"];
+type ToolkitConnectionEntryInput = {
+  readonly integration: ToolkitConnectionIntegration;
+  readonly connection: string;
+  readonly access: ToolkitAccess;
+  readonly note?: string | undefined;
+};
+
+type ToolkitsExtension = ReturnType<typeof makeToolkitsExtension>;
+
+export class ToolkitsExtensionService extends Context.Service<
+  ToolkitsExtensionService,
+  ToolkitsExtension
+>()("ToolkitsExtensionService") {}
+
+// Build handlers against the core executor API with the toolkits group added,
+// so the handler layer satisfies `ApiGroup<"executor", "toolkits">` (the marker
+// the host's composed API requires) — not a standalone single-group bundle.
+const ExecutorApiWithToolkits = addGroup(ToolkitsApi);
+
+const ToolkitsHandlers = HttpApiBuilder.group(ExecutorApiWithToolkits, "toolkits", (h) =>
+  h
+    .handle("list", () =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.list();
+        }),
+      ),
+    )
+    .handle("create", ({ payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.create(payload);
+        }),
+      ),
+    )
+    .handle("get", ({ params }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.get(params.id);
+        }),
+      ),
+    )
+    .handle("update", ({ params, payload }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.update(params.id, payload);
+        }),
+      ),
+    )
+    .handle("remove", ({ params }) =>
+      capture(
+        Effect.gen(function* () {
+          const ext = yield* ToolkitsExtensionService;
+          return yield* ext.remove(params.id);
+        }),
+      ),
+    ),
+);
+
+const resolveToolkitRequestScope = (
+  ctx: PluginCtx,
+  selector: string,
+): Effect.Effect<RequestScope, StorageFailure> =>
+  makeToolkitsExtension(ctx)
+    .resolveScope(selector)
+    .pipe(Effect.map((scope) => toolkitScopeToRequestScope(scope ?? EMPTY_TOOLKIT_SCOPE)));
+
+export const toolkitsPlugin = definePlugin(() => ({
+  id: "toolkits" as const,
+  packageName: "@executor-js/plugin-toolkits",
+  storage: () => ({}),
+  pluginStorage: { toolkits: TOOLKITS, connections: CONNECTIONS },
+  extension: makeToolkitsExtension,
+  resolveRequestScope: resolveToolkitRequestScope,
+  routes: () => ToolkitsApi,
+  handlers: () => ToolkitsHandlers,
+  extensionService: ToolkitsExtensionService,
+}));
+
+export default toolkitsPlugin;

--- a/packages/plugins/toolkits/src/shared.ts
+++ b/packages/plugins/toolkits/src/shared.ts
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------------
+// @executor-js/plugin-toolkits/shared
+//
+// Schemas + the HttpApiGroup shared between server and client. A "toolkit" is a
+// named slice of the caller's connections (each off/read/full), scoped to the
+// workspace (org-owned connections only) or the caller personally (org + own).
+//
+// No React or Node imports here — server and client both import this.
+// ---------------------------------------------------------------------------
+
+import { Schema } from "effect";
+import { HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
+
+import { IntegrationSlug, InternalError } from "@executor-js/sdk/shared";
+
+// off = invisible, read = read-only tools only, full = every tool.
+export const ToolkitAccess = Schema.Literals(["off", "read", "full"]);
+export type ToolkitAccess = typeof ToolkitAccess.Type;
+
+// workspace = org-owned (visible to every org member); personal = the caller's own.
+export const ToolkitScope = Schema.Literals(["workspace", "personal"]);
+export type ToolkitScope = typeof ToolkitScope.Type;
+
+// One connection in a toolkit's slice. `connection` is a pinned account name,
+// or "*" to track every connection of the integration.
+export const ToolkitConnectionEntry = Schema.Struct({
+  integration: IntegrationSlug,
+  connection: Schema.String,
+  access: ToolkitAccess,
+  note: Schema.optional(Schema.String),
+});
+export type ToolkitConnectionEntry = typeof ToolkitConnectionEntry.Type;
+
+// off/read/full is the per-connection access mode; policies are pattern rules
+// layered on top. v1 enforces `block` (the tool is excluded); `approve` /
+// `require_approval` are persisted + briefed (org approval policies still apply).
+export const ToolkitPolicyAction = Schema.Literals(["approve", "require_approval", "block"]);
+export type ToolkitPolicyAction = typeof ToolkitPolicyAction.Type;
+
+export const ToolkitPolicy = Schema.Struct({
+  pattern: Schema.String,
+  action: ToolkitPolicyAction,
+});
+export type ToolkitPolicy = typeof ToolkitPolicy.Type;
+
+export const ToolkitView = Schema.Struct({
+  id: Schema.String,
+  slug: Schema.String,
+  name: Schema.String,
+  scope: ToolkitScope,
+  inheritOrgPolicies: Schema.Boolean,
+  briefing: Schema.NullOr(Schema.String),
+  connections: Schema.Array(ToolkitConnectionEntry),
+  policies: Schema.Array(ToolkitPolicy),
+});
+export type ToolkitView = typeof ToolkitView.Type;
+
+export const CreateToolkitPayload = Schema.Struct({
+  slug: Schema.String,
+  name: Schema.String,
+  scope: ToolkitScope,
+  inheritOrgPolicies: Schema.optional(Schema.Boolean),
+  briefing: Schema.optional(Schema.String),
+  connections: Schema.optional(Schema.Array(ToolkitConnectionEntry)),
+  policies: Schema.optional(Schema.Array(ToolkitPolicy)),
+});
+export type CreateToolkitPayload = typeof CreateToolkitPayload.Type;
+
+export const UpdateToolkitPayload = Schema.Struct({
+  name: Schema.optional(Schema.String),
+  briefing: Schema.optional(Schema.NullOr(Schema.String)),
+  inheritOrgPolicies: Schema.optional(Schema.Boolean),
+  connections: Schema.optional(Schema.Array(ToolkitConnectionEntry)),
+  policies: Schema.optional(Schema.Array(ToolkitPolicy)),
+});
+export type UpdateToolkitPayload = typeof UpdateToolkitPayload.Type;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class ToolkitNotFound extends Schema.TaggedErrorClass<ToolkitNotFound>()("ToolkitNotFound", {
+  id: Schema.String,
+}) {}
+
+export class ToolkitForbidden extends Schema.TaggedErrorClass<ToolkitForbidden>()(
+  "ToolkitForbidden",
+  {
+    reason: Schema.String,
+  },
+) {}
+
+const NotFound = ToolkitNotFound.annotate({ httpApiStatus: 404 });
+const Forbidden = ToolkitForbidden.annotate({ httpApiStatus: 403 });
+
+const IdParams = { id: Schema.String };
+
+// ---------------------------------------------------------------------------
+// Group
+// ---------------------------------------------------------------------------
+
+export const ToolkitsApi = HttpApiGroup.make("toolkits")
+  .add(
+    HttpApiEndpoint.get("list", "/toolkits", {
+      success: Schema.Array(ToolkitView),
+      error: InternalError,
+    }),
+  )
+  .add(
+    HttpApiEndpoint.post("create", "/toolkits", {
+      payload: CreateToolkitPayload,
+      success: ToolkitView,
+      error: [InternalError, Forbidden],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.get("get", "/toolkits/:id", {
+      params: IdParams,
+      success: ToolkitView,
+      error: [InternalError, NotFound],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.patch("update", "/toolkits/:id", {
+      params: IdParams,
+      payload: UpdateToolkitPayload,
+      success: ToolkitView,
+      error: [InternalError, NotFound, Forbidden],
+    }),
+  )
+  .add(
+    HttpApiEndpoint.delete("remove", "/toolkits/:id", {
+      params: IdParams,
+      success: Schema.Struct({ removed: Schema.Boolean }),
+      error: [InternalError, NotFound],
+    }),
+  );

--- a/packages/plugins/toolkits/src/toolkit-scope.ts
+++ b/packages/plugins/toolkits/src/toolkit-scope.ts
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------
+// Toolkit scope — pure data mapping from a resolved toolkit slice to core's
+// vocabulary-neutral `RequestScope`. Core owns enforcement; this module only
+// derives allow/block/require_approval decisions from toolkit entries and
+// per-toolkit policy rules.
+// ---------------------------------------------------------------------------
+
+import type { Connection } from "@executor-js/sdk";
+import { defaultDecideStaticTool, type RequestScope, type ScopeDecision } from "@executor-js/sdk";
+
+import type { ToolkitAccess, ToolkitPolicyAction } from "./shared";
+
+export interface ToolkitPolicyRule {
+  /** Glob over `<integration>.<connection>.<tool>` — `*` matches one segment,
+   *  a trailing `*` matches the rest, and `*` inside a segment globs. */
+  readonly pattern: string;
+  readonly action: ToolkitPolicyAction;
+}
+
+export interface ToolkitScopeEntry {
+  readonly integration: string;
+  /** A pinned connection name, or "*" to track every connection of the integration. */
+  readonly connection: string;
+  readonly access: ToolkitAccess;
+}
+
+export interface ResolvedToolkitScope {
+  readonly entries: readonly ToolkitScopeEntry[];
+  /** Per-toolkit policy rules — `block` excludes tools; `require_approval`
+   *  tightens execution via core's stricter-wins merge with org policies. */
+  readonly policies: readonly ToolkitPolicyRule[];
+  readonly inheritOrgPolicies: boolean;
+}
+
+/** Empty slice — exposes no connection tools. Applied fail-closed when a
+ *  selector resolves to no toolkit (unknown or not visible to the caller). */
+export const EMPTY_TOOLKIT_SCOPE: ResolvedToolkitScope = {
+  entries: [],
+  policies: [],
+  inheritOrgPolicies: true,
+};
+
+/** Glob match over dot segments: `*` matches one segment, a trailing bare `*`
+ *  matches the rest, and `*` inside a segment globs within it. */
+const matchPattern = (pattern: string, target: string): boolean => {
+  const p = pattern.toLowerCase().trim().split(".");
+  const a = target.toLowerCase().split(".");
+  for (let i = 0; i < p.length; i++) {
+    if (p[i] === "*" && i === p.length - 1) return true;
+    if (a[i] === undefined) return false;
+    const re = new RegExp(
+      "^" + p[i].replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$",
+    );
+    if (!re.test(a[i])) return false;
+  }
+  return p.length === a.length;
+};
+
+const accessFor = (
+  scope: ResolvedToolkitScope,
+  integration: string,
+  connection: string,
+): ToolkitAccess => {
+  for (const e of scope.entries) {
+    if (e.integration === integration && e.connection === connection) return e.access;
+  }
+  for (const e of scope.entries) {
+    if (e.integration === integration && e.connection === "*") return e.access;
+  }
+  return "off";
+};
+
+const policyDecisionForTool = (
+  scope: ResolvedToolkitScope,
+  integration: string,
+  connection: string,
+  name: string,
+): ScopeDecision | null => {
+  const target = `${integration}.${connection}.${name}`;
+  for (const rule of scope.policies) {
+    if (!matchPattern(rule.pattern, target)) continue;
+    if (rule.action === "block") return "block";
+    if (rule.action === "require_approval") return "require_approval";
+  }
+  return null;
+};
+
+/** Map a resolved toolkit slice to core's `RequestScope` overlay. */
+export const toolkitScopeToRequestScope = (scope: ResolvedToolkitScope): RequestScope => {
+  const allowedIntegrations = new Set(
+    scope.entries.filter((e) => e.access !== "off").map((e) => e.integration),
+  );
+
+  return {
+    inheritOrgPolicies: scope.inheritOrgPolicies,
+    allowsIntegration: (integration) => allowedIntegrations.has(String(integration.slug)),
+    allowsConnection: (connection: Connection) =>
+      accessFor(scope, String(connection.integration), String(connection.name)) !== "off",
+    decideTool: (tool) => {
+      const integration = String(tool.integration);
+      const connection = String(tool.connection);
+      const name = String(tool.name);
+
+      const fromPolicy = policyDecisionForTool(scope, integration, connection, name);
+      if (fromPolicy === "block") return "block";
+
+      const access = accessFor(scope, integration, connection);
+      if (access === "off") return "block";
+      if (access === "read" && tool.annotations?.readOnly !== true) return "block";
+
+      if (fromPolicy === "require_approval") return "require_approval";
+      return "allow";
+    },
+    decideStaticTool: defaultDecideStaticTool,
+  };
+};

--- a/packages/plugins/toolkits/tsconfig.json
+++ b/packages/plugins/toolkits/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM"],
+    "types": ["bun-types", "node"],
+    "noUnusedLocals": true,
+    "noImplicitOverride": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "ignoreEffectSuggestionsInTscExitCode": true,
+        "ignoreEffectWarningsInTscExitCode": true,
+        "diagnosticSeverity": {
+          "preferSchemaOverJson": "off"
+        }
+      }
+    ]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/plugins/toolkits/tsup.config.ts
+++ b/packages/plugins/toolkits/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    server: "src/server.ts",
+    shared: "src/shared.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  external: [/^@executor-js\//, /^effect/, /^@effect\//],
+});

--- a/packages/plugins/toolkits/vitest.config.ts
+++ b/packages/plugins/toolkits/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
The toolkits feature as a self-contained plugin (`@executor-js/plugin-toolkits`), built on the seams in the parent PR.

A **toolkit** is a named slice of an account's connections (each `off`/`read`/`full`) with its own MCP endpoint, scoped **workspace** (org-owned) or **personal** (the caller's own). Owner-scoped plugin storage + typed CRUD API; `resolveRequestScope` maps a toolkit to core's `RequestScope`; URL-routed console page (list split by scope + per-toolkit editor). Pure plugin — no core or host changes here.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1036
2. **#1037** 👈 current
3. #1038
4. #1039
<!-- stack:links:end -->