### PR TITLE
Toolkits: e2e coverage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -337,6 +337,7 @@
         "@executor-js/plugin-graphql": "workspace:*",
         "@executor-js/plugin-mcp": "workspace:*",
         "@executor-js/plugin-openapi": "workspace:*",
+        "@executor-js/plugin-toolkits": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "@kitlangton/terminal-control": "^0.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -26,6 +26,7 @@
     "@executor-js/plugin-graphql": "workspace:*",
     "@executor-js/plugin-mcp": "workspace:*",
     "@executor-js/plugin-openapi": "workspace:*",
+    "@executor-js/plugin-toolkits": "workspace:*",
     "@executor-js/sdk": "workspace:*",
     "@kitlangton/terminal-control": "^0.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/e2e/selfhost/toolkits-core-tools-scope.test.ts
+++ b/e2e/selfhost/toolkits-core-tools-scope.test.ts
@@ -1,0 +1,370 @@
+// Selfhost · toolkit scope must narrow built-in core tools, not only dynamic
+// connection tools. A scoped MCP session calling `connections.list` /
+// `integrations.list` must see ONLY in-slice catalog rows; guessed out-of-slice
+// dynamic addresses are blocked at execute; per-toolkit `require_approval`
+// tightens the matching tool under that toolkit only.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+import type { McpSession } from "../src/surfaces/mcp";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const isBlocked = (text: string): boolean => text.includes("tool_blocked");
+
+const isSuccessfulGreeting = (text: string): boolean => text.includes("Hello from greeting MCP");
+
+const listConnections = (session: McpSession) =>
+  session.call("execute", {
+    code: `
+const list = await tools.executor.coreTools.connections.list({});
+return JSON.stringify(list.ok ? list.data : { error: list.error });
+`,
+  });
+
+const listIntegrations = (session: McpSession) =>
+  session.call("execute", {
+    code: `
+const list = await tools.executor.coreTools.integrations.list({});
+return JSON.stringify(list.ok ? list.data : { error: list.error });
+`,
+  });
+
+scenario(
+  "Toolkits · scoped MCP sessions narrow built-in connections.list and integrations.list",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      const slugIn = ident("corein");
+      const slugOut = ident("coreout");
+      const connIn = ident("conn");
+      const connOut = ident("conn");
+      yield* addConnection(slugIn, connIn);
+      yield* addConnection(slugOut, connOut);
+
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("corekit"),
+          name: "Core scoped kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugIn),
+              connection: connIn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const bare = mcp.session(identity);
+
+      const scopedConnsResult = yield* listConnections(scoped);
+      const bareConnsResult = yield* listConnections(bare);
+      expect(
+        scopedConnsResult.ok,
+        `scoped connections.list must succeed; text=${scopedConnsResult.text}`,
+      ).toBe(true);
+
+      const scopedConns = JSON.parse(scopedConnsResult.text) as {
+        connections: ReadonlyArray<{ integration: string; name: string }>;
+      };
+      const bareConns = JSON.parse(bareConnsResult.text) as {
+        connections: ReadonlyArray<{ integration: string; name: string }>;
+      };
+
+      expect(
+        scopedConns.connections.map((c) => `${c.integration}/${c.name}`),
+        "scoped connections.list shows only the in-slice connection",
+      ).toEqual([`${slugIn}/${connIn}`]);
+      expect(
+        bareConns.connections.map((c) => `${c.integration}/${c.name}`),
+        "bare connections.list still sees both connections",
+      ).toEqual(expect.arrayContaining([`${slugIn}/${connIn}`, `${slugOut}/${connOut}`]));
+
+      const scopedIntsResult = yield* listIntegrations(scoped);
+      const bareIntsResult = yield* listIntegrations(bare);
+      expect(
+        scopedIntsResult.ok,
+        `scoped integrations.list must succeed; text=${scopedIntsResult.text}`,
+      ).toBe(true);
+
+      const scopedInts = JSON.parse(scopedIntsResult.text) as {
+        integrations: ReadonlyArray<{ slug: string }>;
+      };
+      const bareInts = JSON.parse(bareIntsResult.text) as {
+        integrations: ReadonlyArray<{ slug: string }>;
+      };
+
+      const scopedSlugs = scopedInts.integrations.map((i) => i.slug);
+      expect(scopedSlugs, "scoped integrations.list includes in-slice slug").toContain(slugIn);
+      expect(scopedSlugs, "scoped integrations.list omits out-of-slice slug").not.toContain(
+        slugOut,
+      );
+
+      const bareSlugs = bareInts.integrations.map((i) => i.slug);
+      expect(bareSlugs, "bare integrations.list still sees both integrations").toEqual(
+        expect.arrayContaining([slugIn, slugOut]),
+      );
+
+      const inSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugIn}.org.${connIn}.simple_echo({});`,
+      });
+      expect(inSlice.ok, `in-slice tool runs; text=${inSlice.text}`).toBe(true);
+
+      const outSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugOut}.org.${connOut}.simple_echo({});`,
+      });
+      expect(
+        isBlocked(outSlice.text),
+        `guessed out-of-slice address must be tool_blocked; text=${outSlice.text}`,
+      ).toBe(true);
+      expect(
+        isSuccessfulGreeting(outSlice.text),
+        `out-of-slice must not run upstream; text=${outSlice.text}`,
+      ).toBe(false);
+      expect(
+        outSlice.text.includes("suggestions"),
+        `out-of-slice must not leak tool suggestions; text=${outSlice.text}`,
+      ).toBe(false);
+    }),
+  ),
+);
+
+scenario(
+  "Toolkits · scoped MCP sessions cannot create connections or policies",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const slug = ident("adm");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("admkit"),
+          name: "Admin blocked kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const newConn = ident("newconn");
+
+      const createConn = yield* scoped.call("execute", {
+        code: `
+const result = await tools.executor.coreTools.connections.create({
+  owner: "org",
+  integration: "${slug}",
+  name: "${newConn}",
+  template: "header",
+  value: "blocked-token",
+});
+return JSON.stringify(result.ok ? result.data : { error: result.error });
+`,
+      });
+      expect(
+        isBlocked(createConn.text),
+        `scoped connections.create blocked; text=${createConn.text}`,
+      ).toBe(true);
+
+      const createPolicy = yield* scoped.call("execute", {
+        code: `
+const result = await tools.executor.coreTools.policies.create({
+  owner: "org",
+  pattern: "${slug}.*",
+  action: "block",
+});
+return JSON.stringify(result.ok ? result.data : { error: result.error });
+`,
+      });
+      expect(
+        isBlocked(createPolicy.text),
+        `scoped policies.create blocked; text=${createPolicy.text}`,
+      ).toBe(true);
+    }),
+  ),
+);
+
+scenario(
+  "Toolkits · a per-toolkit require_approval rule pauses only under that toolkit",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const slug = ident("appr");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const gated = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitappr"),
+          name: "Approval gated",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+          policies: [
+            {
+              pattern: `${slug}.${conn}.simple_echo`,
+              action: "require_approval",
+            },
+          ],
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+
+      const bareRun = yield* mcp.session(identity).call("execute", { code });
+      expect(
+        bareRun.ok && !bareRun.text.includes("Execution paused"),
+        `bare session runs without toolkit approval gate; text=${bareRun.text}`,
+      ).toBe(true);
+
+      const gatedRun = yield* mcp
+        .session(identity, { toolkit: gated.slug })
+        .call("execute", { code });
+      expect(
+        gatedRun.text,
+        `toolkit require_approval pauses execution; text=${gatedRun.text}`,
+      ).toContain("Execution paused");
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-cross-user.test.ts
+++ b/e2e/selfhost/toolkits-cross-user.test.ts
@@ -1,0 +1,216 @@
+// Selfhost · cross-user visibility of toolkits. The contract under test:
+// workspace toolkits ride org-owned plugin storage (visible to every org
+// member), personal toolkits ride user-owned storage (visible only to their
+// creating subject), and the MCP toolkit selector is fail-closed — a slug the
+// caller can't resolve narrows the engine to an EMPTY slice rather than leaking
+// the slice it names. `resolveScope` returns null for a slug the caller isn't
+// entitled to (server.ts: "a cross-tenant/personal-of-another-user selector
+// returns null"), so a hijacked-slug session sees nothing.
+//
+// HARNESS CAVEAT (verified in e2e/targets/selfhost.ts): selfhost is
+// single-tenant today — `newIdentity()` always signs the SAME bootstrap admin
+// in, so two `newIdentity()` calls yield the SAME subject in the SAME org, not
+// two distinct members. We assert that fact below so the test self-documents
+// why the "a DIFFERENT user is denied" leg cannot be driven here. We instead
+// prove the enforcement MECHANISM that backs cross-user privacy and IS
+// drivable on one subject: an MCP session whose `?toolkit=` slug does not
+// resolve for the caller is narrowed to an empty slice and blocks the named
+// connection's tool at execute. (The true second-member denial belongs to a
+// multi-tenant target, e.g. cloud, once selfhost grows per-test signup.)
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and so connection names survive the create-time
+// normalize (hyphens removed + camelCased) byte-for-byte.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · workspace toolkits are visible to org members; personal toolkits stay subject-private and a non-resolving slug is fail-closed",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+
+      // Two identities + a client each. On selfhost both resolve to the
+      // bootstrap admin (same subject, same org) — see the harness caveat.
+      const idA = yield* target.newIdentity();
+      const idB = yield* target.newIdentity();
+      const clientA = yield* makeApiClient(api, idA);
+      const clientB = yield* makeApiClient(api, idB);
+
+      // Make the single-subject reality explicit: the "different member" leg of
+      // the cross-user contract degenerates here, and the assertions below are
+      // written to what selfhost can actually prove.
+      const sameSubject = idA.credentials?.email === idB.credentials?.email;
+      expect(
+        sameSubject,
+        "selfhost is single-tenant: both identities are the bootstrap admin",
+      ).toBe(true);
+
+      // Stand up two real greeting MCP servers and register each as an
+      // integration + a connection at the requested owner. `text` is distinct
+      // per connection so a successful execute is unambiguous.
+      const addConnection = (slug: string, conn: string, owner: "org" | "user", text: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer({ text }), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* clientA.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          yield* clientA.connections.create({
+            payload: {
+              owner,
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // idA seeds ONE org connection and ONE personal connection, and the
+      // expected greeting each tool returns.
+      const orgSlug = ident("orgint");
+      const orgConn = ident("orgconn");
+      const orgText = `hello-org-${randomBytes(3).toString("hex")}`;
+      const personalSlug = ident("pvtint");
+      const personalConn = ident("pvtconn");
+      const personalText = `hello-pvt-${randomBytes(3).toString("hex")}`;
+      yield* addConnection(orgSlug, orgConn, "org", orgText);
+      yield* addConnection(personalSlug, personalConn, "user", personalText);
+
+      // A WORKSPACE toolkit (org-owned) over the org connection, and a PERSONAL
+      // toolkit (user-owned) over idA's own connection — both at full access.
+      const workspaceKit = yield* clientA.toolkits.create({
+        payload: {
+          slug: ident("wskit"),
+          name: "Workspace kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(orgSlug),
+              connection: orgConn,
+              access: "full",
+            },
+          ],
+        },
+      });
+      const personalKit = yield* clientA.toolkits.create({
+        payload: {
+          slug: ident("pvtkit"),
+          name: "Personal kit",
+          scope: "personal",
+          connections: [
+            {
+              integration: IntegrationSlug.make(personalSlug),
+              connection: personalConn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // (a) The other client's list. The workspace toolkit is org-owned, so it
+      // MUST be present. On a multi-tenant target the personal toolkit (a
+      // different member's user-owned data) would be ABSENT; on selfhost idB IS
+      // idA, so it is present — we assert the truth for this target and pin the
+      // workspace-visible invariant unconditionally.
+      const listB = yield* clientB.toolkits.list();
+      expect(
+        listB.some((t) => t.id === workspaceKit.id && t.slug === workspaceKit.slug),
+        "workspace toolkit is visible to org members",
+      ).toBe(true);
+      expect(
+        listB.some((t) => t.id === personalKit.id),
+        sameSubject
+          ? "selfhost single-subject: idA's personal toolkit is visible because idB IS idA"
+          : "a personal toolkit must not appear in another member's list",
+      ).toBe(sameSubject);
+
+      // (b) An MCP session for idB scoped to the WORKSPACE slug exposes the org
+      // slice: the execute inventory mentions the org integration, and running
+      // its tool returns the org greeting (a success envelope, not an error).
+      const wsSession = mcp.session(idB, { toolkit: workspaceKit.slug });
+      const wsDesc = describeExecute(yield* wsSession.describeTools());
+      expect(wsDesc, "workspace-scoped inventory includes the org integration").toContain(orgSlug);
+
+      const wsCall = yield* wsSession.call("execute", {
+        code: `return await tools.${orgSlug}.org.${orgConn}.simple_echo({});`,
+      });
+      expect(wsCall.ok, `org tool executes; text=${wsCall.text}`).toBe(true);
+      expect(
+        wsCall.text,
+        `workspace slice returns the org greeting; text=${wsCall.text}`,
+      ).toContain(orgText);
+
+      // (c) Fail-closed selector — the mechanism behind cross-user privacy. A
+      // session whose `?toolkit=` slug the caller cannot resolve is narrowed to
+      // an EMPTY slice: the named connection is neither advertised nor runnable.
+      // We exercise it two ways:
+      //   1. the personal slug from another (here: the same) subject's kit, and
+      //   2. a slug that does not exist at all,
+      // and require BOTH to behave identically — proving a personal toolkit
+      // cannot be hijacked by handing its slug to a session that isn't entitled
+      // to it. (Selfhost can't supply a second subject, so the personal slug
+      // DOES resolve here; the bogus slug is the load-bearing fail-closed proof,
+      // and the personal-slug case still confirms the personal connection is not
+      // leaked into an unrelated/empty narrowing.)
+      const hijackSession = mcp.session(idB, { toolkit: ident("ghostkit") });
+      const hijackDesc = describeExecute(yield* hijackSession.describeTools());
+      expect(
+        hijackDesc,
+        "an unresolved toolkit slug yields an empty slice — personal connection not exposed",
+      ).not.toContain(personalSlug);
+      expect(
+        hijackDesc,
+        "an unresolved toolkit slug yields an empty slice — org connection not exposed either",
+      ).not.toContain(orgSlug);
+
+      // Executing the personal connection's tool through the empty/unresolved
+      // slice is blocked: the result is never the personal greeting the tool
+      // would emit if the slice had actually exposed it.
+      const hijackCall = yield* hijackSession.call("execute", {
+        code: `return await tools.${personalSlug}.user.${personalConn}.simple_echo({});`,
+      });
+      expect(
+        hijackCall.text,
+        `unresolved-slug session must not return the personal greeting; text=${hijackCall.text}`,
+      ).not.toContain(personalText);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-crud.test.ts
+++ b/e2e/selfhost/toolkits-crud.test.ts
@@ -1,0 +1,105 @@
+// Selfhost · Slice 1: a toolkit is owner-scoped plugin data with a CRUD API.
+// Proves the plugin's storage round-trips through real HTTP routes on the
+// selfhost server, owner/scope maps correctly, and the scope guard rejects
+// connections a toolkit isn't allowed to reference. No MCP narrowing yet.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const api = composePluginApi([toolkitsPlugin()] as const);
+const fresh = (prefix: string): string => `${prefix}-${randomBytes(4).toString("hex")}`;
+
+scenario(
+  "Toolkits · CRUD round-trips through the selfhost API",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+
+    const slug = fresh("work");
+    const created = yield* client.toolkits.create({
+      payload: {
+        slug,
+        name: "Work",
+        scope: "personal",
+        briefing: "general assistant",
+      },
+    });
+    expect(created.slug).toBe(slug);
+    expect(created.scope).toBe("personal");
+    expect(created.inheritOrgPolicies, "defaults to inheriting org policies").toBe(true);
+    expect(created.briefing).toBe("general assistant");
+    expect(created.connections.length).toBe(0);
+
+    // round-trips through GET
+    const fetched = yield* client.toolkits.get({ params: { id: created.id } });
+    expect(fetched.id).toBe(created.id);
+    expect(fetched.name).toBe("Work");
+
+    // shows up in the owner-scoped list
+    const listed = yield* client.toolkits.list();
+    expect(
+      listed.some((t) => t.id === created.id),
+      "the created toolkit appears in the list",
+    ).toBe(true);
+
+    // PATCH mutates name + briefing
+    const patched = yield* client.toolkits.update({
+      params: { id: created.id },
+      payload: { name: "Work v2", briefing: null },
+    });
+    expect(patched.name).toBe("Work v2");
+    expect(patched.briefing).toBe(null);
+
+    // DELETE removes it; subsequent GET is a typed ToolkitNotFound
+    const removed = yield* client.toolkits.remove({
+      params: { id: created.id },
+    });
+    expect(removed.removed).toBe(true);
+
+    const afterDelete = yield* Effect.flip(client.toolkits.get({ params: { id: created.id } }));
+    expect((afterDelete as { _tag?: string })._tag, "GET after delete is ToolkitNotFound").toBe(
+      "ToolkitNotFound",
+    );
+  }),
+);
+
+scenario(
+  "Toolkits · a workspace toolkit cannot reference a connection it isn't allowed to use",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+
+    const result = yield* Effect.flip(
+      client.toolkits.create({
+        payload: {
+          slug: fresh("support"),
+          name: "Support",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make("slack"),
+              connection: "nope",
+              access: "full",
+            },
+          ],
+        },
+      }),
+    );
+    expect((result as { _tag?: string })._tag, "rejected with ToolkitForbidden").toBe(
+      "ToolkitForbidden",
+    );
+  }),
+);

--- a/e2e/selfhost/toolkits-execute-description.test.ts
+++ b/e2e/selfhost/toolkits-execute-description.test.ts
@@ -1,0 +1,158 @@
+// Selfhost · the execute tool's DESCRIPTION accurately reflects a toolkit's
+// slice. An MCP client reads this description to learn what it can call; if it
+// still listed out-of-slice connections, a scoped agent would chase addresses
+// it cannot run. The execute description's "Available connection prefixes"
+// inventory (`<integration>.<owner>.<connection>` paths) must therefore name
+// exactly the toolkit's connections — A and B (in the kit), never C (out) —
+// while a bare session, with no selector, still advertises C. This is the
+// "the description on MCP clients is right" coverage for toolkit narrowing.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path — and the description's connection-prefix inventory — stay valid.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · the MCP execute tool's description lists exactly the toolkit's connection slice",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Stand up three real MCP greeting servers -> three distinct integrations
+      // + org connections (each exposes a `simple_echo` tool discovered at
+      // create). Connection names are normalized on create (hyphens removed +
+      // camelCased), so we keep them lowercase-alphanumeric to round-trip
+      // unchanged into the description's prefix.
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // A and B go in the toolkit (at "full" and "read" respectively); C does not.
+      const slugA = ident("tka");
+      const slugB = ident("tkb");
+      const slugC = ident("tkc");
+      const connA = ident("conn");
+      const connB = ident("conn");
+      const connC = ident("conn");
+      yield* addConnection(slugA, connA);
+      yield* addConnection(slugB, connB);
+      yield* addConnection(slugC, connC);
+
+      // A workspace (org-owned) toolkit: A at "full", B at "read", C omitted.
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Slice kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "read",
+            },
+          ],
+        },
+      });
+
+      // The description lists connection prefixes as `<integration>.<owner>.<connection>`
+      // (the `tools.` root is stripped). Workspace connections are owner "org".
+      const prefixA = `${slugA}.org.${connA}`;
+      const prefixB = `${slugB}.org.${connB}`;
+      const prefixC = `${slugC}.org.${connC}`;
+
+      // Scoped session: the execute description names A and B, never C.
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const scopedDefs = yield* scoped.describeTools();
+      const scopedDesc = describeExecute(scopedDefs);
+
+      expect(
+        scopedDesc,
+        `scoped execute description names the full-access connection (A)`,
+      ).toContain(prefixA);
+      expect(
+        scopedDesc,
+        `scoped execute description names the read-access connection (B)`,
+      ).toContain(prefixB);
+      expect(
+        scopedDesc,
+        `scoped execute description must NOT name the out-of-slice connection (C)`,
+      ).not.toContain(prefixC);
+      // Defense-in-depth: even the bare integration slug for C must not leak into
+      // the scoped inventory (it never appears in any other prefix).
+      expect(scopedDesc, `scoped inventory omits C's integration entirely`).not.toContain(slugC);
+
+      // The execute tool itself is still advertised on the scoped session — the
+      // slice narrows its inventory, it does not remove the tool.
+      const scopedToolNames = yield* scoped.listTools();
+      expect(scopedToolNames, "scoped session still advertises execute").toContain("execute");
+
+      // Bare session (no selector): the description DOES name C — proving the
+      // scoped omission above is genuine narrowing, not C being absent globally.
+      const bareDefs = yield* mcp.session(identity).describeTools();
+      const bareDesc = describeExecute(bareDefs);
+      expect(bareDesc, "bare execute description names A").toContain(prefixA);
+      expect(bareDesc, "bare execute description names B").toContain(prefixB);
+      expect(
+        bareDesc,
+        "bare execute description names the out-of-slice connection C (no narrowing)",
+      ).toContain(prefixC);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-failclosed.test.ts
+++ b/e2e/selfhost/toolkits-failclosed.test.ts
@@ -1,0 +1,135 @@
+// Selfhost · Toolkits fail-closed. SECURITY-CRITICAL: an unknown/invalid
+// ?toolkit= selector must FAIL CLOSED — the engine narrows to an EMPTY slice
+// (EMPTY_TOOLKIT_SCOPE, applied by narrowToToolkit when resolveScope returns
+// null) where every connection tool is blocked — and must NEVER silently fall
+// back to full (unscoped) account access.
+//
+// The control is a BARE session (no selector): the real org connection's tool
+// RUNS and its result text is the real greeting. The probe is a session scoped
+// to a bogus selector ("doesnotexist"+hex): the SAME real tool is blocked at
+// execute (error envelope, not the real greeting) and the bogus inventory lists
+// no connections. A regression where a bad selector granted full access would
+// make the bogus execute return the real greeting (== the bare execute) and the
+// bogus inventory contain the connection's integration — both asserted against.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and names survive create normalization.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · a bogus toolkit selector fails closed — empty slice, never full access",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Seed ONE real org connection (a greeting MCP server -> integration +
+      // org connection exposing a `simple_echo` tool discovered at create).
+      const slug = ident("tk");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      // A real WORKSPACE toolkit referencing the connection — proves the account
+      // genuinely has both runnable tools and a real toolkit, so the only thing
+      // distinguishing the probe is its bogus selector.
+      yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Real kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+
+      // (a) CONTROL — bare session (no selector): the tool RUNS and the
+      // inventory lists the connection's integration.
+      const bare = mcp.session(identity);
+      const bareDesc = describeExecute(yield* bare.describeTools());
+      expect(bareDesc, "bare inventory includes the seeded integration").toContain(slug);
+      const bareRun = yield* bare.call("execute", { code });
+      expect(bareRun.ok, `bare tool executes; text=${bareRun.text}`).toBe(true);
+
+      // (b) PROBE — session scoped to a selector that resolves to no toolkit.
+      // Inventory must list NO connections (only static/core tools survive an
+      // empty slice), and the SAME tool must be BLOCKED at execute.
+      const bogusSelector = ident("doesnotexist");
+      const bogus = mcp.session(identity, { toolkit: bogusSelector });
+      const bogusDesc = describeExecute(yield* bogus.describeTools());
+      const bogusRun = yield* bogus.call("execute", { code });
+
+      // (c) STRENGTHEN — unambiguous fail-closed assertions. A regression where
+      // the bogus selector granted full access would fail every one of these:
+      //   - the bogus inventory would contain the integration slug, and
+      //   - the bogus execute would return the SAME real greeting as the bare run.
+      expect(
+        bogusDesc,
+        `bogus selector must NOT leak the seeded integration into inventory; bogusDesc=${bogusDesc}`,
+      ).not.toContain(slug);
+      // Blocked execute surfaces as an error envelope (.text differs) — never the
+      // real greeting the bare control returns. We compare .text, not .ok.
+      expect(
+        bogusRun.text,
+        `bogus selector must BLOCK the tool, not return the real result; bare.text=${bareRun.text} bogus.ok=${bogusRun.ok} bogus.text=${bogusRun.text}`,
+      ).not.toBe(bareRun.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-inherit-org.test.ts
+++ b/e2e/selfhost/toolkits-inherit-org.test.ts
@@ -1,0 +1,188 @@
+// Selfhost · org policies vs a toolkit's inheritOrgPolicies flag.
+//
+// Org `block` / `require_approval` guardrails always reach scoped sessions; only
+// org `approve` rows may be dropped when inheritOrgPolicies=false.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+// The composed API carries the toolkits group, the MCP-server-management group,
+// AND the core PoliciesApi (included by composePluginApi), so `client.policies.*`
+// and `client.toolkits.*` are both typed here.
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays a valid JS member expression and names normalize cleanly.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+// A `block` surfaces as an error envelope at execute: `.ok` true, the error
+// (tool_blocked) inside `.text`. A successful greeting never contains this.
+const isBlocked = (text: string): boolean => text.includes("tool_blocked");
+
+scenario(
+  "Toolkits · an org block policy is enforced via the base executor and reaches a toolkit slice",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // One real greeting MCP server -> one integration + an org connection that
+      // exposes a `simple_echo` tool (discovered at connection create).
+      const slug = ident("inh");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+
+      // Without any org policy, a bare /mcp session runs the tool — the baseline
+      // "this connection works" before the org guardrail is in place.
+      const beforePolicy = yield* mcp.session(identity).call("execute", { code });
+      expect(
+        beforePolicy.ok && !isBlocked(beforePolicy.text),
+        `connection works before the org policy; text=${beforePolicy.text}`,
+      ).toBe(true);
+
+      // ORG-LEVEL block policy over the connection's tool. The org `tool_policy`
+      // matcher tests the 4-segment `<integration>.<owner>.<connection>.<tool>`
+      // address, so `<slug>.*` (a trailing-`*` subtree) blocks
+      // `<slug>.org.<conn>.simple_echo` for this org outside any toolkit.
+      const orgPattern = `${slug}.*`;
+      const orgPolicy = yield* client.policies.create({
+        payload: { owner: "org", pattern: orgPattern, action: "block" },
+      });
+      expect(orgPolicy.owner, "the org policy is owned by the org").toBe("org");
+      expect(orgPolicy.action, "the org policy blocks").toBe("block");
+      expect(orgPolicy.pattern, "the org policy targets the connection's tool").toBe(orgPattern);
+
+      // The org block is real: the bare session (no toolkit) is now blocked.
+      const bareCall = yield* mcp.session(identity).call("execute", { code });
+      expect(
+        isBlocked(bareCall.text),
+        `org block applies to the bare session; before=${beforePolicy.text} after=${bareCall.text}`,
+      ).toBe(true);
+
+      // Two workspace toolkits over the SAME connection, both at full access,
+      // differing ONLY in inheritOrgPolicies.
+      const inherit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitinh"),
+          name: "Inherits org",
+          scope: "workspace",
+          inheritOrgPolicies: true,
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(inherit.inheritOrgPolicies, "T_inherit flag round-trips as true").toBe(true);
+
+      const isolated = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitiso"),
+          name: "Isolated",
+          scope: "workspace",
+          inheritOrgPolicies: false,
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(isolated.inheritOrgPolicies, "T_isolated flag round-trips as false").toBe(false);
+
+      // Both slices grant the connection at full, so neither hides it for lack of
+      // access — any block is the org policy reaching the slice, not the grant.
+      const inheritDesc = describeExecute(
+        yield* mcp.session(identity, { toolkit: inherit.slug }).describeTools(),
+      );
+      const isolatedDesc = describeExecute(
+        yield* mcp.session(identity, { toolkit: isolated.slug }).describeTools(),
+      );
+      expect(inheritDesc, "T_inherit slice scopes to the integration").toContain(slug);
+      expect(isolatedDesc, "T_isolated slice scopes to the integration").toContain(slug);
+
+      // Execute the SAME code in each scoped session.
+      const inheritCall = yield* mcp
+        .session(identity, { toolkit: inherit.slug })
+        .call("execute", { code });
+      const isolatedCall = yield* mcp
+        .session(identity, { toolkit: isolated.slug })
+        .call("execute", { code });
+
+      // T_inherit inherits the org block (the intended contract for true): blocked.
+      expect(
+        isBlocked(inheritCall.text),
+        `T_inherit (inheritOrgPolicies:true) inherits the org block; text=${inheritCall.text}`,
+      ).toBe(true);
+
+      // T_isolated still inherits org block/require_approval guardrails even when
+      // inheritOrgPolicies:false — a toolkit may only tighten, never loosen.
+      expect(
+        isBlocked(isolatedCall.text),
+        `T_isolated (inheritOrgPolicies:false) still blocked by org guardrail; text=${isolatedCall.text}`,
+      ).toBe(true);
+      const inheritView = yield* client.toolkits.get({
+        params: { id: inherit.id },
+      });
+      const isolatedView = yield* client.toolkits.get({
+        params: { id: isolated.id },
+      });
+      expect(inheritView.inheritOrgPolicies, "view preserves true").toBe(true);
+      expect(isolatedView.inheritOrgPolicies, "view preserves false").toBe(false);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-isolation.test.ts
+++ b/e2e/selfhost/toolkits-isolation.test.ts
@@ -1,0 +1,184 @@
+// Selfhost · Toolkit slice isolation: two toolkits over OVERLAPPING connections
+// each expose only their own slice. Seed three integrations A/B/C with one org
+// connection apiece; T1 = {A, B}, T2 = {B, C} (B is shared). A session scoped to
+// T1 can run A and B but is BLOCKED on C; a session scoped to T2 can run B and C
+// but is BLOCKED on A. The shared B never carries the non-shared members across:
+// C is reachable under T2 yet blocked under T1, and A is reachable under T1 yet
+// blocked under T2 — proving the slices don't leak into one another.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens, lowercase-alphanumeric) so the sandbox
+// `tools.<int>.<owner>.<conn>.<tool>` dotted path stays valid JS and the
+// connection name survives create-time normalization unchanged.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · two toolkits over overlapping connections each see only their own slice; no cross-leak",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Stand up a real MCP greeting server per integration -> one org
+      // connection each (exposes a `simple_echo` tool discovered at create).
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // Three distinct integrations, one org connection each.
+      const slugA = ident("tka");
+      const slugB = ident("tkb");
+      const slugC = ident("tkc");
+      const connA = ident("conn");
+      const connB = ident("conn");
+      const connC = ident("conn");
+      yield* addConnection(slugA, connA);
+      yield* addConnection(slugB, connB);
+      yield* addConnection(slugC, connC);
+
+      // T1 = { A full, B full }; T2 = { B full, C full }. B is shared.
+      const t1 = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Toolkit AB",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+          ],
+        },
+      });
+      const t2 = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Toolkit BC",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugC),
+              connection: connC,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // Address every connection's tool by its dotted sandbox path.
+      const callA = `return await tools.${slugA}.org.${connA}.simple_echo({});`;
+      const callB = `return await tools.${slugB}.org.${connB}.simple_echo({});`;
+      const callC = `return await tools.${slugC}.org.${connC}.simple_echo({});`;
+
+      // ---- Session scoped to T1 (sees A + B, never C) ----
+      const s1 = mcp.session(identity, { toolkit: t1.slug });
+      const d1 = describeExecute(yield* s1.describeTools());
+      expect(d1, "T1 inventory includes A").toContain(slugA);
+      expect(d1, "T1 inventory includes B").toContain(slugB);
+      expect(d1, "T1 inventory omits C").not.toContain(slugC);
+
+      const s1a = yield* s1.call("execute", { code: callA });
+      const s1b = yield* s1.call("execute", { code: callB });
+      const s1c = yield* s1.call("execute", { code: callC });
+      // In-slice A and B run to the real greeting; out-of-slice C is blocked at
+      // execute and surfaces as an error envelope (never the in-slice text).
+      expect(s1a.text, `T1·A should run; text=${s1a.text}`).not.toBe("");
+      expect(s1b.text, `T1·B should run; text=${s1b.text}`).not.toBe("");
+      expect(s1c.text, `T1·C must be blocked; a.text=${s1a.text} c.text=${s1c.text}`).not.toBe(
+        s1a.text,
+      );
+      expect(s1c.text, `T1·C blocked text differs from B; b.text=${s1b.text}`).not.toBe(s1b.text);
+
+      // ---- Session scoped to T2 (sees B + C, never A) ----
+      const s2 = mcp.session(identity, { toolkit: t2.slug });
+      const d2 = describeExecute(yield* s2.describeTools());
+      expect(d2, "T2 inventory includes B").toContain(slugB);
+      expect(d2, "T2 inventory includes C").toContain(slugC);
+      expect(d2, "T2 inventory omits A").not.toContain(slugA);
+
+      const s2b = yield* s2.call("execute", { code: callB });
+      const s2c = yield* s2.call("execute", { code: callC });
+      const s2a = yield* s2.call("execute", { code: callA });
+      // In-slice B and C run; out-of-slice A is blocked.
+      expect(s2b.text, `T2·B should run; text=${s2b.text}`).not.toBe("");
+      expect(s2c.text, `T2·C should run; text=${s2c.text}`).not.toBe("");
+      expect(s2a.text, `T2·A must be blocked; c.text=${s2c.text} a.text=${s2a.text}`).not.toBe(
+        s2c.text,
+      );
+      expect(s2a.text, `T2·A blocked text differs from B; b.text=${s2b.text}`).not.toBe(s2b.text);
+
+      // ---- The cross term: shared B does not drag its other toolkit's members
+      // across. C is reachable under T2 but blocked under T1; A is reachable
+      // under T1 but blocked under T2. The two slices stay disjoint on their
+      // non-shared members even though both contain B. ----
+      expect(d1, "C never appears in T1's inventory (only in T2's)").not.toContain(slugC);
+      expect(d2, "A never appears in T2's inventory (only in T1's)").not.toContain(slugA);
+      // C's reachable text under T2 is exactly what's denied under T1.
+      expect(s2c.text, "C runs under T2 but its T1 attempt was blocked").not.toBe(s1c.text);
+      // A's reachable text under T1 is exactly what's denied under T2.
+      expect(s1a.text, "A runs under T1 but its T2 attempt was blocked").not.toBe(s2a.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-mcp.test.ts
+++ b/e2e/selfhost/toolkits-mcp.test.ts
@@ -1,0 +1,130 @@
+// Selfhost · Slice 3 (keystone): a toolkit narrows the MCP engine. Connecting
+// to /mcp?toolkit=<slug> exposes ONLY the toolkit's slice — the execute tool's
+// inventory omits out-of-slice connections, and an out-of-slice tool is blocked
+// at execute (not merely hidden), proving enforcement is at the executor, not
+// just listing. A bare session (no selector) is unchanged.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · an MCP session scoped to a toolkit sees only its slice; out-of-slice is blocked",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Stand up two real MCP greeting servers -> two integrations + org
+      // connections (each exposes a `simple_echo` tool discovered at create).
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      const slugIn = ident("tkin");
+      const slugOut = ident("tkout");
+      const connIn = ident("conn");
+      const connOut = ident("conn");
+      yield* addConnection(slugIn, connIn);
+      yield* addConnection(slugOut, connOut);
+
+      // A workspace toolkit that includes ONLY the first connection.
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Scoped kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugIn),
+              connection: connIn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // Scoped session: inventory shows the in-slice integration, not the other.
+      const scoped = mcp.session(identity, { toolkit: kit.slug });
+      const scopedDesc = describeExecute(yield* scoped.describeTools());
+      expect(scopedDesc, "scoped inventory includes the in-slice integration").toContain(slugIn);
+      expect(scopedDesc, "scoped inventory omits the out-of-slice integration").not.toContain(
+        slugOut,
+      );
+
+      // In-slice tool runs; out-of-slice tool is blocked at execute (even though
+      // the agent guessed its address).
+      const inSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugIn}.org.${connIn}.simple_echo({});`,
+      });
+      expect(inSlice.ok, `in-slice tool executes; text=${inSlice.text}`).toBe(true);
+
+      const outSlice = yield* scoped.call("execute", {
+        code: `return await tools.${slugOut}.org.${connOut}.simple_echo({});`,
+      });
+      // Blocked tools surface as an error (thrown or an error envelope) — never
+      // the successful greeting the in-slice call returns.
+      expect(
+        outSlice.text,
+        `out-of-slice must be blocked; in.text=${inSlice.text} out.ok=${outSlice.ok} out.text=${outSlice.text}`,
+      ).not.toBe(inSlice.text);
+
+      // Bare session (no selector) is unchanged — both integrations visible.
+      const bareDesc = describeExecute(yield* mcp.session(identity).describeTools());
+      expect(bareDesc, "bare /mcp still sees the first integration").toContain(slugIn);
+      expect(bareDesc, "bare /mcp still sees the second integration").toContain(slugOut);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-policies.test.ts
+++ b/e2e/selfhost/toolkits-policies.test.ts
@@ -1,0 +1,135 @@
+// Selfhost · Slice 4: per-toolkit policies + access modes at execute time.
+//   - full access  -> the connection's tool runs;
+//   - a `block` policy on that tool -> blocked at execute (exclusion);
+//   - read-only access -> an unclassified (non-read-only) tool is blocked
+//     (fail-closed: unclassified counts as write).
+// One greeting connection, three toolkits over it, compared via MCP execute.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+scenario(
+  "Toolkits · access modes + block policies are enforced at execute",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const slug = ident("pol");
+      const conn = ident("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const full = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitfull"),
+          name: "Full",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+      const blocked = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitblock"),
+          name: "Blocked",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+          policies: [{ pattern: `${slug}.${conn}.simple_echo`, action: "block" }],
+        },
+      });
+      const readonly = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitread"),
+          name: "Read",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "read",
+            },
+          ],
+        },
+      });
+
+      const code = `return await tools.${slug}.org.${conn}.simple_echo({});`;
+      const fullCall = yield* mcp
+        .session(identity, { toolkit: full.slug })
+        .call("execute", { code });
+      const blockCall = yield* mcp
+        .session(identity, { toolkit: blocked.slug })
+        .call("execute", { code });
+      const readCall = yield* mcp
+        .session(identity, { toolkit: readonly.slug })
+        .call("execute", { code });
+
+      expect(fullCall.ok, `full access runs the tool; text=${fullCall.text}`).toBe(true);
+      expect(
+        blockCall.text,
+        `block policy must stop the tool; full=${fullCall.text} block=${blockCall.text}`,
+      ).not.toBe(fullCall.text);
+      expect(
+        readCall.text,
+        `read-only must hide an unclassified (write) tool; full=${fullCall.text} read=${readCall.text}`,
+      ).not.toBe(fullCall.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-read-mode.test.ts
+++ b/e2e/selfhost/toolkits-read-mode.test.ts
@@ -1,0 +1,285 @@
+// Selfhost · Toolkit access "read" exposes only read-only tools and blocks
+// writes. `readOnly` is derived from HTTP method on OpenAPI integrations
+// (GET/HEAD/OPTIONS => readOnly:true; POST/PUT/PATCH/DELETE are writes), and
+// Read-only toolkit access keeps a connection's tool under "read" ONLY when
+// `annotations.readOnly === true`. So we stand up a real OpenAPI upstream with
+// BOTH a GET (read) and a POST (write) operation, grant the same connection at
+// "read" in one workspace toolkit and "full" in another, and prove:
+//   - the read toolkit's scoped MCP session runs the GET-derived tool but
+//     BLOCKS the POST-derived tool at execute (error envelope, not the success
+//     payload) and omits it from the scoped inventory;
+//   - the full toolkit's scoped session runs BOTH.
+//
+// The upstream is a real `node:http` listening socket in THIS test process —
+// the same cross-process pattern `serveMcpServer` uses (the OpenAPI echo helper
+// is in-memory via NodeHttpServer.layerTest and is NOT reachable from the
+// separately-booted selfhost server). The selfhost boot sets
+// EXECUTOR_ALLOW_LOCAL_NETWORK=true, so the instance is allowed to dial the
+// loopback upstream. The spec itself is passed inline (blob) so the spec fetch
+// never hits the network — only the GET/POST invocations dial the socket.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect, Scope } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), openApiHttpPlugin(), toolkitsPlugin()] as const);
+
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and so the create-time name normalization (which
+// strips hyphens) round-trips unchanged.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+// A real OpenAPI upstream on a loopback socket. `GET /thing` is a read; `POST
+// /thing` is a write. Both return a recognizable JSON marker so a successful
+// invocation is distinguishable from a blocked one. The bearer token is
+// required so the call genuinely goes through the connection's credential.
+interface Upstream {
+  readonly baseUrl: string;
+}
+
+// Mirrors serveMcpServer: acquire a real listening socket carrying its own
+// `close`, release closes it, and we strip `close` from the value handed back.
+const serveUpstream = (token: string): Effect.Effect<Upstream, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.callback<Upstream & { readonly close: Effect.Effect<void> }, never>((resume) => {
+      const server = createServer((request: IncomingMessage, response: ServerResponse) => {
+        const url = new URL(request.url ?? "/", "http://127.0.0.1");
+        const auth = request.headers.authorization;
+        const send = (status: number, body: Record<string, unknown>): void => {
+          response.writeHead(status, {
+            "content-type": "application/json",
+          });
+          response.end(JSON.stringify(body));
+        };
+        if (auth !== `Bearer ${token}`) {
+          send(401, { error: "unauthorized" });
+          return;
+        }
+        if (url.pathname === "/thing" && request.method === "GET") {
+          send(200, { marker: "read-ok", kind: "get" });
+          return;
+        }
+        if (url.pathname === "/thing" && request.method === "POST") {
+          // Drain the body so the socket closes cleanly, then ack.
+          request.resume();
+          request.on("end", () => send(201, { marker: "write-ok", kind: "post" }));
+          return;
+        }
+        send(404, { error: "not_found" });
+      });
+      const close = Effect.sync(() => {
+        server.close();
+        server.closeAllConnections?.();
+      });
+      server.once("error", () => resume(Effect.succeed({ baseUrl: "", close })));
+      server.listen(0, "127.0.0.1", () => {
+        const address = server.address();
+        const port = typeof address === "object" && address ? address.port : 0;
+        resume(Effect.succeed({ baseUrl: `http://127.0.0.1:${port}`, close }));
+      });
+    }),
+    (acquired) => acquired.close,
+  ).pipe(Effect.map(({ close: _close, ...rest }) => rest));
+
+// Inline spec: one GET (read) + one POST (write) operation on /thing, both
+// secured by the same bearer scheme. operationIds are single identifier-safe
+// words so the derived tool names are predictable, but the test discovers the
+// real tool addresses from the catalog rather than hardcoding them.
+const makeSpec = (): string =>
+  JSON.stringify({
+    openapi: "3.0.3",
+    info: { title: "Read-mode API", version: "1.0.0" },
+    paths: {
+      "/thing": {
+        get: {
+          operationId: "getthing",
+          summary: "Read a thing",
+          responses: { "200": { description: "the thing" } },
+        },
+        post: {
+          operationId: "creatething",
+          summary: "Create a thing",
+          responses: { "201": { description: "created" } },
+        },
+      },
+    },
+  });
+
+scenario(
+  'Toolkits · access "read" exposes only read-only (GET) tools and blocks writes (POST)',
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const upstream = yield* serveUpstream(token);
+      expect(upstream.baseUrl, "the loopback OpenAPI upstream bound a port").not.toBe("");
+
+      const slug = ident("oapi");
+      const conn = ident("conn");
+
+      // Register the integration (spec inline; baseUrl points at the real
+      // loopback socket) and create the org connection that holds the bearer.
+      yield* client.openapi.addSpec({
+        payload: {
+          spec: { kind: "blob", value: makeSpec() },
+          slug,
+          baseUrl: upstream.baseUrl,
+          authenticationTemplate: [
+            {
+              slug: "apiKey",
+              type: "apiKey",
+              headers: {
+                authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "org",
+          name: ConnectionName.make(conn),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("apiKey"),
+          value: token,
+        },
+      });
+
+      // Discover the real tool addresses from the catalog. The GET-derived tool
+      // is read-only (requiresApproval falsy); the POST-derived tool is a write
+      // (requiresApproval true, per annotationsForOperation). We derive the
+      // sandbox call name (the last dotted segment of the address) so we never
+      // hardcode the camelCase leaf the definition layer produces.
+      const tools = yield* client.tools.list({
+        query: { integration: IntegrationSlug.make(slug) },
+      });
+      const mine = tools.filter((t) => String(t.integration) === slug);
+      const readTool = mine.find((t) => t.requiresApproval !== true);
+      const writeTool = mine.find((t) => t.requiresApproval === true);
+      expect(
+        readTool?.address,
+        `GET-derived read-only tool is in the catalog; tools=${mine
+          .map((t) => `${t.name}(approval=${String(t.requiresApproval)})`)
+          .join(", ")}`,
+      ).toBeDefined();
+      expect(
+        writeTool?.address,
+        `POST-derived write tool is in the catalog; tools=${mine
+          .map((t) => `${t.name}(approval=${String(t.requiresApproval)})`)
+          .join(", ")}`,
+      ).toBeDefined();
+      const readName = String(readTool!.name);
+      const writeName = String(writeTool!.name);
+
+      // Two workspace toolkits over the SAME connection: one at "read", one at
+      // "full".
+      const kitRead = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitread"),
+          name: "Read kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "read",
+            },
+          ],
+        },
+      });
+      const kitFull = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kitfull"),
+          name: "Full kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slug),
+              connection: conn,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // --- READ toolkit: GET runs, POST is blocked ---------------------------
+      const scopedRead = mcp.session(identity, { toolkit: kitRead.slug });
+
+      // The scoped inventory still lists the integration (it is in the slice),
+      // and the read tool's dotted name is reachable.
+      const readDesc = describeExecute(yield* scopedRead.describeTools());
+      expect(readDesc, "read-toolkit inventory includes the in-slice integration").toContain(slug);
+
+      const readGet = yield* scopedRead.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${readName}({});`,
+      });
+      expect(
+        readGet.ok && readGet.text.includes("read-ok"),
+        `read access runs the GET tool; ok=${readGet.ok} text=${readGet.text}`,
+      ).toBe(true);
+
+      const readPost = yield* scopedRead.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${writeName}({ body: {} });`,
+      });
+      // Under "read" access the write (POST) tool is removed from the slice, so
+      // it is not reachable in the sandbox — the call neither completes (no
+      // upstream "write-ok") nor even pauses for approval ("paused"); it errors.
+      expect(
+        readPost.text.includes("write-ok") || readPost.text.includes("paused"),
+        `read access must EXCLUDE the write tool (unreachable); text=${readPost.text}`,
+      ).toBe(false);
+      expect(
+        readPost.text,
+        `excluded write errors, not the GET payload; text=${readPost.text}`,
+      ).not.toBe(readGet.text);
+
+      // --- FULL toolkit: GET runs; POST is reachable (pauses for approval) ----
+      const scopedFull = mcp.session(identity, { toolkit: kitFull.slug });
+
+      const fullDesc = describeExecute(yield* scopedFull.describeTools());
+      expect(fullDesc, "full-toolkit inventory includes the integration").toContain(slug);
+
+      const fullGet = yield* scopedFull.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${readName}({});`,
+      });
+      expect(
+        fullGet.ok && fullGet.text.includes("read-ok"),
+        `full access runs the GET tool; ok=${fullGet.ok} text=${fullGet.text}`,
+      ).toBe(true);
+
+      const fullPost = yield* scopedFull.call("execute", {
+        code: `return await tools.${slug}.org.${conn}.${writeName}({ body: {} });`,
+      });
+      // Under "full" access the write tool IS in the slice. Writes still require
+      // approval (independent of toolkit access), so a default-mode session
+      // pauses ("Execution paused") rather than completing — which still proves
+      // the tool is REACHABLE, the opposite of read access where it is excluded.
+      expect(
+        fullPost.text.includes("paused") || fullPost.text.includes("write-ok"),
+        `full access EXPOSES the write tool (runs or pauses for approval); text=${fullPost.text}`,
+      ).toBe(true);
+      expect(
+        fullPost.text,
+        `full reaches the write tool while read excludes it; read=${readPost.text} full=${fullPost.text}`,
+      ).not.toBe(readPost.text);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-ui.test.ts
+++ b/e2e/selfhost/toolkits-ui.test.ts
@@ -1,0 +1,178 @@
+// Selfhost · Slice 2 (console UI): the Toolkits page renders through the real
+// web console and its editor writes a toolkit — access modes, per-connection
+// notes, and all — back to the toolkits API. This is the end-to-end proof of
+// the client plugin wiring: the page only mounts if the Vite plugin bundled
+// `@executor-js/plugin-toolkits/client`, the nav resolved, and the typed atom
+// client reached `/api/toolkits`.
+//
+// We drive the real controls (the off/read/full segment + the note field),
+// create the toolkit, then read it back through the typed API and assert the
+// persisted slice — so the editor's access-map -> wire-entry transform (incl.
+// note trimming) is covered through the UI, not a unit test. The personal
+// connection we seed is owner-scoped to this fresh identity, so it is a
+// deterministic anchor even though selfhost identities share one tenant.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+const fresh = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+scenario(
+  "Toolkits · the console editor creates a toolkit and persists its access slice",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const browser = yield* Browser;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Seed a PERSONAL connection (owner "user") so it shows only for this
+      // identity — the editor's Access section should surface it.
+      const slug = fresh("tkui");
+      const connName = fresh("conn");
+      const token = `tok-${randomBytes(6).toString("hex")}`;
+      const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+        auth: {
+          validateAuthorization: (authorization) =>
+            Effect.succeed(authorization === `Bearer ${token}`),
+        },
+      });
+      yield* client.mcp.addServer({
+        payload: {
+          transport: "remote",
+          name: `Greeting ${slug}`,
+          endpoint: server.endpoint,
+          slug,
+          authenticationTemplate: [
+            {
+              type: "apiKey",
+              headers: {
+                Authorization: ["Bearer ", { type: "variable", name: "token" }],
+              },
+            },
+          ],
+        },
+      });
+      yield* client.connections.create({
+        payload: {
+          owner: "user",
+          name: ConnectionName.make(connName),
+          integration: IntegrationSlug.make(slug),
+          template: AuthTemplateSlug.make("header"),
+          value: token,
+        },
+      });
+
+      const toolkitName = `Kit ${randomBytes(3).toString("hex")}`;
+      const connTestId = `tk-conn ${slug} ${connName}`;
+
+      yield* browser.session(identity, async ({ page, step }) => {
+        await step("Open the Toolkits page", async () => {
+          await page.goto("/plugins/toolkits/", { waitUntil: "networkidle" });
+          await page.getByRole("heading", { name: "Toolkits", exact: true }).waitFor();
+          await page.getByRole("heading", { name: "Workspace toolkits" }).waitFor();
+          await page.getByRole("heading", { name: "Personal toolkits" }).waitFor();
+        });
+
+        await step("Start a new personal toolkit", async () => {
+          // Two "New toolkit" buttons (workspace, personal); the second is the
+          // personal section.
+          await page.getByRole("button", { name: "New toolkit" }).nth(1).click();
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+          // The personal connection appears (proves the personal scope tier +
+          // connection wiring).
+          await page.getByText(connName).first().waitFor();
+        });
+
+        await step("Name it, grant the connection full access, add a note", async () => {
+          // The title is the first textbox in the editor (briefing is below it).
+          await page.getByRole("textbox").first().fill(toolkitName);
+          // Grant Full on this connection's row (testid keeps it unambiguous).
+          const row = page.getByTestId(connTestId);
+          await row.getByRole("button", { name: "Full", exact: true }).click();
+          // The note field appears once access != off; padded to prove trimming.
+          await row.getByRole("textbox").fill("  wiki only  ");
+        });
+
+        await step("Create it", async () => {
+          await page.getByRole("button", { name: "Create toolkit" }).click();
+          // Back on the list, the New toolkit buttons return and the card shows.
+          await page.getByRole("button", { name: "New toolkit" }).first().waitFor();
+          await page.getByText(toolkitName).first().waitFor();
+        });
+
+        let toolkitId = "";
+
+        await step("Opening a toolkit card updates the URL to its id", async () => {
+          await page.getByText(toolkitName).first().click();
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+          await page.waitForURL((url) => {
+            const segments = url.pathname.split("/").filter(Boolean);
+            const last = segments[segments.length - 1];
+            return last !== undefined && last !== "toolkits";
+          });
+          toolkitId = new URL(page.url()).pathname.split("/").filter(Boolean).pop() ?? "";
+          expect(toolkitId.length, "card open exposes the toolkit id in the URL").toBeGreaterThan(
+            0,
+          );
+          await page.getByRole("button", { name: "← Toolkits" }).click();
+          await page.getByRole("heading", { name: "Workspace toolkits" }).waitFor();
+        });
+
+        await step("Deep-linking to a toolkit opens the editor with its name", async () => {
+          await page.goto(`/plugins/toolkits/${toolkitId}`, {
+            waitUntil: "networkidle",
+          });
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+          expect(
+            await page.getByRole("textbox").first().inputValue(),
+            "deep link opens the editor with the toolkit name",
+          ).toBe(toolkitName);
+        });
+
+        await step("Browser back returns to the toolkit list", async () => {
+          await page.goBack({ waitUntil: "networkidle" });
+          await page.waitForURL(
+            (url) =>
+              url.pathname.endsWith("/plugins/toolkits/") ||
+              url.pathname.endsWith("/plugins/toolkits"),
+          );
+          await page.getByRole("heading", { name: "Workspace toolkits" }).waitFor();
+        });
+
+        await step("New toolkit navigates to /new/workspace", async () => {
+          await page.getByRole("button", { name: "New toolkit" }).first().click();
+          await page.waitForURL((url) => url.pathname.endsWith("/new/workspace"));
+          await page.getByRole("heading", { name: "Access" }).waitFor();
+        });
+      });
+
+      // Read the toolkit back through the typed API: the editor's write carried
+      // the scope, access mode, and trimmed note.
+      const all = yield* client.toolkits.list();
+      const created = all.find((t) => t.name === toolkitName);
+      expect(created, "the toolkit the UI created is persisted").toBeDefined();
+      expect(created?.scope).toBe("personal");
+      expect(created?.connections).toEqual([
+        {
+          integration: slug,
+          connection: connName,
+          access: "full",
+          note: "wiki only",
+        },
+      ]);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-update.test.ts
+++ b/e2e/selfhost/toolkits-update.test.ts
@@ -1,0 +1,209 @@
+// Selfhost · Slice 3 (live re-narrowing): updating a toolkit's connection set
+// changes what a NEWLY-opened scoped MCP session sees. `connections` on the
+// update payload is a FULL REPLACEMENT (server.ts update(): when
+// patch.connections is defined it deletes every existing connection row and
+// re-inserts the patch list), so to drop a connection you OMIT it. A session
+// opened BEFORE an update keeps its original slice — each transition is proven
+// against a FRESH mcp.session, and read back via toolkits.get to confirm the
+// persisted set matches.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS; also satisfies the create-time name normalization.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  "Toolkits · updating a toolkit's connections re-narrows what a fresh MCP session sees",
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Two real MCP greeting servers -> two distinct integrations + org
+      // connections (each exposes a `simple_echo` tool discovered at create).
+      const addConnection = (slug: string, conn: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          yield* client.connections.create({
+            payload: {
+              owner: "org",
+              name: ConnectionName.make(conn),
+              integration: IntegrationSlug.make(slug),
+              template: AuthTemplateSlug.make("header"),
+              value: token,
+            },
+          });
+        });
+
+      // A = the first integration/connection, B = the second.
+      const slugA = ident("tka");
+      const slugB = ident("tkb");
+      const connA = ident("conn");
+      const connB = ident("conn");
+      yield* addConnection(slugA, connA);
+      yield* addConnection(slugB, connB);
+
+      const codeA = `return await tools.${slugA}.org.${connA}.simple_echo({});`;
+      const codeB = `return await tools.${slugB}.org.${connB}.simple_echo({});`;
+
+      // Workspace toolkit with ONLY A at "full".
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Evolving kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // A baseline "what a runnable in-slice greeting looks like" so we can
+      // distinguish a real greeting from a blocked error envelope (blocked
+      // tools surface as an error in .text, never the greeting).
+      // ---- Session #1: only A in slice ------------------------------------
+      const s1 = mcp.session(identity, { toolkit: kit.slug });
+      const desc1 = describeExecute(yield* s1.describeTools());
+      expect(desc1, "#1 inventory includes A").toContain(slugA);
+      expect(desc1, "#1 inventory omits B").not.toContain(slugB);
+
+      const s1A = yield* s1.call("execute", { code: codeA });
+      expect(s1A.ok, `#1 A executes; text=${s1A.text}`).toBe(true);
+      const greeting = s1A.text; // the canonical success text for simple_echo
+
+      const s1B = yield* s1.call("execute", { code: codeB });
+      expect(
+        s1B.text,
+        `#1 B must be blocked (not the greeting); B.ok=${s1B.ok} B.text=${s1B.text}`,
+      ).not.toBe(greeting);
+
+      // Persisted set after create: exactly A.
+      const view1 = yield* client.toolkits.get({ params: { id: kit.id } });
+      expect(view1.connections.map((c) => c.integration).sort(), "#1 persisted = [A]").toEqual(
+        [slugA].sort(),
+      );
+
+      // ---- Update -> [A full, B full]; Session #2 (fresh): BOTH present ----
+      const upd2 = yield* client.toolkits.update({
+        params: { id: kit.id },
+        payload: {
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugA),
+              connection: connA,
+              access: "full",
+            },
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(upd2.connections.map((c) => c.integration).sort(), "update#2 echoes [A,B]").toEqual(
+        [slugA, slugB].sort(),
+      );
+
+      const view2 = yield* client.toolkits.get({ params: { id: kit.id } });
+      expect(view2.connections.map((c) => c.integration).sort(), "#2 persisted = [A,B]").toEqual(
+        [slugA, slugB].sort(),
+      );
+
+      const s2 = mcp.session(identity, { toolkit: kit.slug });
+      const desc2 = describeExecute(yield* s2.describeTools());
+      expect(desc2, "#2 inventory includes A").toContain(slugA);
+      expect(desc2, "#2 inventory now includes B").toContain(slugB);
+
+      const s2A = yield* s2.call("execute", { code: codeA });
+      expect(s2A.ok, `#2 A still runnable; text=${s2A.text}`).toBe(true);
+      const s2B = yield* s2.call("execute", { code: codeB });
+      expect(s2B.ok, `#2 B now runnable; text=${s2B.text}`).toBe(true);
+      expect(s2B.text, "#2 B returns the greeting, not an error").toBe(greeting);
+
+      // ---- Update -> [B full] only (A dropped == off); Session #3 fresh ---
+      const upd3 = yield* client.toolkits.update({
+        params: { id: kit.id },
+        payload: {
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugB),
+              connection: connB,
+              access: "full",
+            },
+          ],
+        },
+      });
+      expect(
+        upd3.connections.map((c) => c.integration),
+        "update#3 echoes [B] only — full replacement dropped A",
+      ).toEqual([slugB]);
+
+      const view3 = yield* client.toolkits.get({ params: { id: kit.id } });
+      expect(
+        view3.connections.map((c) => c.integration),
+        "#3 persisted = [B] only",
+      ).toEqual([slugB]);
+
+      const s3 = mcp.session(identity, { toolkit: kit.slug });
+      const desc3 = describeExecute(yield* s3.describeTools());
+      expect(desc3, "#3 inventory includes B").toContain(slugB);
+      expect(desc3, "#3 inventory now omits A").not.toContain(slugA);
+
+      const s3B = yield* s3.call("execute", { code: codeB });
+      expect(s3B.ok, `#3 B runnable; text=${s3B.text}`).toBe(true);
+      const s3A = yield* s3.call("execute", { code: codeA });
+      // A is out-of-slice again -> blocked at execute (error envelope in .text),
+      // never the greeting the in-slice call returns.
+      expect(
+        s3A.text,
+        `#3 A must be blocked after being dropped; A.ok=${s3A.ok} A.text=${s3A.text}`,
+      ).not.toBe(greeting);
+    }),
+  ),
+);

--- a/e2e/selfhost/toolkits-wildcard.test.ts
+++ b/e2e/selfhost/toolkits-wildcard.test.ts
@@ -1,0 +1,173 @@
+// Selfhost · Toolkits wildcard ("*") tracks every account of an integration,
+// including accounts added AFTER the toolkit is created. A toolkit entry whose
+// `connection` is "*" is integration-level: the MCP narrowing seam
+// (toolkit-scope.ts `accessFor`) matches ANY connection of that integration,
+// and `resolveScope` re-reads the live connection set per session — so a fresh
+// scoped session opened after a new account is added auto-includes it, while a
+// session's slice is fixed to the integration, never leaking a sibling
+// integration's accounts.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { mcpHttpPlugin } from "@executor-js/plugin-mcp/api";
+import { makeGreetingMcpServer, serveMcpServer } from "@executor-js/plugin-mcp/testing";
+import { toolkitsPlugin } from "@executor-js/plugin-toolkits/server";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+
+const api = composePluginApi([mcpHttpPlugin(), toolkitsPlugin()] as const);
+// Identifier-safe (no hyphens) so the sandbox `tools.<int>.<owner>.<conn>.<tool>`
+// dotted path stays valid JS, and single-word lowercase names survive the
+// connectionIdentifier normalization unchanged.
+const ident = (prefix: string): string => `${prefix}${randomBytes(4).toString("hex")}`;
+
+const describeExecute = (defs: ReadonlyArray<{ name: string; description?: string }>): string =>
+  defs.find((d) => d.name === "execute")?.description ?? "";
+
+scenario(
+  'Toolkits · a wildcard ("*") entry tracks every account of an integration, including ones added after the toolkit',
+  { timeout: 180_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const { client: makeApiClient } = yield* Api;
+      const mcp = yield* Mcp;
+      const identity = yield* target.newIdentity();
+      const client = yield* makeApiClient(api, identity);
+
+      // Register an integration ONCE via addServer, then add accounts to it with
+      // repeated connections.create calls (same integration slug, new name).
+      // addServer creates/updates the integration + auth template; each
+      // connections.create adds one account (org-owned connection) under it.
+      const addIntegration = (slug: string) =>
+        Effect.gen(function* () {
+          const token = `tok-${randomBytes(6).toString("hex")}`;
+          const server = yield* serveMcpServer(() => makeGreetingMcpServer(), {
+            auth: {
+              validateAuthorization: (authorization) =>
+                Effect.succeed(authorization === `Bearer ${token}`),
+            },
+          });
+          yield* client.mcp.addServer({
+            payload: {
+              transport: "remote",
+              name: `Greeting ${slug}`,
+              endpoint: server.endpoint,
+              slug,
+              authenticationTemplate: [
+                {
+                  type: "apiKey",
+                  headers: {
+                    Authorization: ["Bearer ", { type: "variable", name: "token" }],
+                  },
+                },
+              ],
+            },
+          });
+          // Each account points at the same integration's greeting server; the
+          // token satisfies that integration's auth template.
+          const addAccount = (conn: string) =>
+            client.connections.create({
+              payload: {
+                owner: "org",
+                name: ConnectionName.make(conn),
+                integration: IntegrationSlug.make(slug),
+                template: AuthTemplateSlug.make("header"),
+                value: token,
+              },
+            });
+          return { addAccount };
+        });
+
+      const slugX = ident("tkx");
+      const { addAccount: addX } = yield* addIntegration(slugX);
+
+      // Integration X starts with TWO org accounts.
+      const primary = ident("primary");
+      const secondary = ident("secondary");
+      yield* addX(primary);
+      yield* addX(secondary);
+
+      // An UNRELATED integration Y with its own account — the wildcard must NOT
+      // reach it (the entry is scoped to X only).
+      const slugY = ident("tky");
+      const { addAccount: addY } = yield* addIntegration(slugY);
+      const connY = ident("other");
+      yield* addY(connY);
+
+      // A workspace toolkit with a SINGLE integration-level entry: every account
+      // of X, full access. Y is never named, so it is out of slice.
+      const kit = yield* client.toolkits.create({
+        payload: {
+          slug: ident("kit"),
+          name: "Wildcard kit",
+          scope: "workspace",
+          connections: [
+            {
+              integration: IntegrationSlug.make(slugX),
+              connection: "*",
+              access: "full",
+            },
+          ],
+        },
+      });
+
+      // Session #1: both pre-existing accounts are in the slice; Y is not.
+      const session1 = mcp.session(identity, { toolkit: kit.slug });
+      const desc1 = describeExecute(yield* session1.describeTools());
+      expect(desc1, "wildcard slice includes the primary account").toContain(primary);
+      expect(desc1, "wildcard slice includes the secondary account").toContain(secondary);
+      expect(desc1, "wildcard is scoped to X — Y's account is out of slice").not.toContain(connY);
+
+      const primaryRun = yield* session1.call("execute", {
+        code: `return await tools.${slugX}.org.${primary}.simple_echo({});`,
+      });
+      expect(primaryRun.ok, `primary account runs; text=${primaryRun.text}`).toBe(true);
+
+      const secondaryRun = yield* session1.call("execute", {
+        code: `return await tools.${slugX}.org.${secondary}.simple_echo({});`,
+      });
+      expect(secondaryRun.ok, `secondary account runs; text=${secondaryRun.text}`).toBe(true);
+
+      // Y is blocked at execute even though the agent guessed its address — a
+      // blocked tool surfaces as an error envelope, never the greeting a
+      // legitimate account returns.
+      const yRun = yield* session1.call("execute", {
+        code: `return await tools.${slugY}.org.${connY}.simple_echo({});`,
+      });
+      expect(
+        yRun.text,
+        `out-of-slice Y must be blocked; primary.text=${primaryRun.text} y.ok=${yRun.ok} y.text=${yRun.text}`,
+      ).not.toBe(primaryRun.text);
+
+      // --- The auto-update assertion ----------------------------------------
+      // Add a THIRD account to X AFTER the toolkit was created. The toolkit is
+      // untouched (still a single "*" entry).
+      const tertiary = ident("tertiary");
+      yield* addX(tertiary);
+
+      // A NEW scoped session re-resolves the slice, so the wildcard now also
+      // covers the just-added account. (Session #1 keeps its original snapshot —
+      // we deliberately open a fresh session here.)
+      const session2 = mcp.session(identity, { toolkit: kit.slug });
+      const desc2 = describeExecute(yield* session2.describeTools());
+      expect(desc2, "a fresh session's wildcard still includes primary").toContain(primary);
+      expect(desc2, "a fresh session's wildcard still includes secondary").toContain(secondary);
+      expect(desc2, "the wildcard auto-includes the account added after the toolkit").toContain(
+        tertiary,
+      );
+
+      const tertiaryRun = yield* session2.call("execute", {
+        code: `return await tools.${slugX}.org.${tertiary}.simple_echo({});`,
+      });
+      expect(
+        tertiaryRun.ok,
+        `the later-added account runs in a fresh scoped session; text=${tertiaryRun.text}`,
+      ).toBe(true);
+    }),
+  ),
+);

--- a/e2e/src/surfaces/mcp.ts
+++ b/e2e/src/surfaces/mcp.ts
@@ -160,7 +160,7 @@ export interface McpSurface {
   readonly url: string;
   readonly session: (
     identity: Identity,
-    options?: { readonly elicitationMode?: McpElicitationMode },
+    options?: { readonly elicitationMode?: McpElicitationMode; readonly toolkit?: string },
   ) => McpSession;
   /**
    * Mint a real MCP bearer headlessly: protected-resource discovery →
@@ -271,9 +271,14 @@ export const makeMcpSurface = (target: Target, runDir?: string): McpSurface => (
     // `browser` mode is selected per the ecosystem convention — an
     // `?elicitation_mode=` query on the MCP endpoint — so a paused execution
     // yields an approvalUrl instead of letting the model resume inline.
-    const sessionUrl = options?.elicitationMode
-      ? `${target.mcpUrl}?elicitation_mode=${options.elicitationMode}`
-      : target.mcpUrl;
+    const sessionUrl = (() => {
+      const u = new URL(target.mcpUrl);
+      if (options?.elicitationMode) u.searchParams.set("elicitation_mode", options.elicitationMode);
+      // Toolkit selector — narrows the engine to that toolkit's slice (same path
+      // the host reads via `readToolkitSelector`).
+      if (options?.toolkit) u.searchParams.set("toolkit", options.toolkit);
+      return u.toString();
+    })();
     let runtimePromise: Promise<Runtime> | undefined;
     let connected = false;
 


### PR DESCRIPTION
13 self-host e2e scenarios driving the real API + MCP surface: CRUD + scope visibility, cross-user isolation, read-mode (GET vs write), per-toolkit + inherit-org policies, wildcard auto-include, fail-closed selectors, the core-tool scope boundary (scoped `connections.list`/`integrations.list` return only in-slice; scoped sessions can't create connections/policies), and the URL-routed console flow (create, deep-link, browser back).

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1036
2. #1037
3. #1038
4. **#1039** 👈 current
<!-- stack:links:end -->