### PR TITLE
Fix org scope: use URL slug as single source of truth for API requests

### DIFF
--- a/apps/cloud/src/account/workos-account-service.ts
+++ b/apps/cloud/src/account/workos-account-service.ts
@@ -87,16 +87,18 @@ export const workosAccountProvider: Layer.Layer<
         ? Effect.succeed(caller.session)
         : Effect.fail<AccountUnauthorized>(new AccountUnauthorized());
 
-    // The org scope for an org-scoped request: the console URL's org (sent in
-    // the selector header) when present, else the session's own org. Membership
-    // is re-checked live, so the header is a selector, not a trust boundary —
-    // and two browser tabs on different orgs each send their own header, so
-    // they stay independent (see organization.ts). Yields the session +
-    // resolved org, or AccountNoOrganization.
+    // The org scope for an org-scoped request comes ONLY from the console URL,
+    // which the worker boundary pins in the selector header (`/<slug>/api/...`
+    // → ORG_SELECTOR_HEADER). The session identifies the USER, never the org —
+    // there is no session fallback, so two browser tabs on different orgs each
+    // resolve their own org from their own URL and stay independent (see
+    // organization.ts). Membership is re-checked live, so the header is a
+    // URL-derived selector, not a trust boundary. Yields the session + resolved
+    // org, or AccountNoOrganization when the request is org-less.
     const requireOrganization = (headers: AccountHeaders) =>
       Effect.gen(function* () {
         const session = yield* requireSession();
-        const selector = headers[ORG_SELECTOR_HEADER] ?? session.organizationId;
+        const selector = headers[ORG_SELECTOR_HEADER];
         if (!selector) {
           return yield* new AccountNoOrganization();
         }
@@ -165,10 +167,12 @@ export const workosAccountProvider: Layer.Layer<
       me: (headers) =>
         Effect.gen(function* () {
           const session = yield* requireSession();
-          // Same selector precedence as requireOrganization: the URL's org
-          // (header) drives /account/me so the shell reflects the org the tab
-          // is viewing, not a session-global active org.
-          const selector = headers[ORG_SELECTOR_HEADER] ?? session.organizationId;
+          // Same org source as requireOrganization: the URL's org (pinned in
+          // the selector header by the worker boundary) drives /account/me so
+          // the shell reflects the org the tab is viewing. `me` stays
+          // null-tolerant — an org-less request (no URL slug, e.g. onboarding)
+          // resolves organization: null rather than erroring.
+          const selector = headers[ORG_SELECTOR_HEADER];
           const org = selector
             ? yield* authorizeOrganizationSelector(session.accountId, selector).pipe(
                 Effect.provideContext(ctx),

--- a/apps/cloud/src/api/org-scope.test.ts
+++ b/apps/cloud/src/api/org-scope.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { ORG_SELECTOR_HEADER } from "../auth/organization";
+import { classifyApiOrgScope, isApiPath, prepareApiOrgScope } from "./org-scope";
+
+// The worker-boundary seam that turns the URL's first path segment into the org
+// scope for the `/api/*` plane. The wire form is `/<slug>/api/...` (or the
+// legacy `/<org_id>/api/...`); the boundary strips the prefix to the bare
+// `/api/...` the app handler routes and pins the selector in an internal header.
+// Org rides ONLY in the URL — a client-supplied selector header is never trusted.
+
+describe("isApiPath", () => {
+  it("matches the bare API plane", () => {
+    expect(isApiPath("/api")).toBe(true);
+    expect(isApiPath("/api/executions")).toBe(true);
+    expect(isApiPath("/api/billing/customer")).toBe(true);
+  });
+
+  it("does not match org-scoped, MCP, or console paths", () => {
+    expect(isApiPath("/acme-corp/api/executions")).toBe(false);
+    expect(isApiPath("/mcp")).toBe(false);
+    expect(isApiPath("/settings")).toBe(false);
+    expect(isApiPath("/apiary")).toBe(false); // not `/api` nor `/api/`
+  });
+});
+
+describe("classifyApiOrgScope", () => {
+  it("classifies a slug-scoped API path", () => {
+    expect(classifyApiOrgScope("/acme-corp/api/billing/customer")).toEqual({
+      selector: "acme-corp",
+      barePath: "/api/billing/customer",
+    });
+  });
+
+  it("classifies the legacy org-id-scoped form", () => {
+    expect(classifyApiOrgScope("/org_01ABCDEF/api/executions")).toEqual({
+      selector: "org_01ABCDEF",
+      barePath: "/api/executions",
+    });
+  });
+
+  it("returns null for a bare API path (no selector segment)", () => {
+    expect(classifyApiOrgScope("/api/billing/customer")).toBeNull();
+    expect(classifyApiOrgScope("/api")).toBeNull();
+  });
+
+  it("returns null when the second segment is not `api`", () => {
+    expect(classifyApiOrgScope("/acme-corp/mcp")).toBeNull();
+    expect(classifyApiOrgScope("/settings/mcp")).toBeNull();
+    expect(classifyApiOrgScope("/acme-corp")).toBeNull();
+  });
+});
+
+describe("prepareApiOrgScope", () => {
+  it("rewrites a slug-scoped request to the bare path and pins the selector", () => {
+    const out = prepareApiOrgScope(
+      new Request("https://executor.test/acme-corp/api/billing/customer", { method: "POST" }),
+    );
+    expect(new URL(out.url).pathname).toBe("/api/billing/customer");
+    expect(out.headers.get(ORG_SELECTOR_HEADER)).toBe("acme-corp");
+    expect(out.method).toBe("POST");
+  });
+
+  it("pins the legacy org-id selector", () => {
+    const out = prepareApiOrgScope(
+      new Request("https://executor.test/org_01ABCDEF/api/executions"),
+    );
+    expect(new URL(out.url).pathname).toBe("/api/executions");
+    expect(out.headers.get(ORG_SELECTOR_HEADER)).toBe("org_01ABCDEF");
+  });
+
+  it("strips a client-supplied selector header on a bare API path", () => {
+    // Org may come ONLY from the URL — a client cannot smuggle a different org
+    // by setting the internal selector header on a bare `/api/...` request.
+    const out = prepareApiOrgScope(
+      new Request("https://executor.test/api/billing/customer", {
+        headers: { [ORG_SELECTOR_HEADER]: "org_attacker" },
+      }),
+    );
+    expect(new URL(out.url).pathname).toBe("/api/billing/customer");
+    expect(out.headers.has(ORG_SELECTOR_HEADER)).toBe(false);
+  });
+
+  it("leaves a bare API path without a selector header untouched", () => {
+    const req = new Request("https://executor.test/api/executions");
+    expect(prepareApiOrgScope(req)).toBe(req);
+  });
+
+  it("leaves a non-API path untouched", () => {
+    const req = new Request("https://executor.test/settings");
+    expect(prepareApiOrgScope(req)).toBe(req);
+  });
+});

--- a/apps/cloud/src/api/org-scope.ts
+++ b/apps/cloud/src/api/org-scope.ts
@@ -1,0 +1,81 @@
+// ---------------------------------------------------------------------------
+// API org scope — the worker-boundary seam that carries the URL's org into the
+// `/api/*` plane, mirroring `prepareMcpOrgScope` for `/mcp`.
+//
+// On the wire the org is the FIRST PATH SEGMENT of every org-scoped API request
+// (`/<slug>/api/...`, or the legacy `/<org_id>/api/...`), exactly like the
+// console URL it rides alongside — the URL is the single source of org truth,
+// and no client header carries org anymore. This boundary classifies that path,
+// rewrites it to the bare `/api/...` the app handler actually routes, and pins
+// the URL's org in the internal `ORG_SELECTOR_HEADER` the auth/account/billing
+// planes read via `orgSelectorFromRequest`. Membership is STILL re-checked per
+// request downstream (`authorizeOrganizationSelector`), so the header is a
+// selector the worker sets from the URL, never a trust boundary or a value a
+// client may supply.
+// ---------------------------------------------------------------------------
+
+import { isValidOrgSlug } from "@executor-js/api";
+
+import { ORG_SELECTOR_HEADER } from "../auth/organization";
+
+// Bare API path — what the app handler routes once the boundary has stripped any
+// `/<slug>` prefix. `api` is itself a RESERVED slug, so a bare `/api/...` first
+// segment can never be mistaken for an org selector.
+export const isApiPath = (pathname: string): boolean =>
+  pathname === "/api" || pathname.startsWith("/api/");
+
+// A leading path segment counts as an org selector when it's the org's URL slug
+// (the canonical console form) or has the WorkOS org-id shape (`org_…`, the
+// legacy form). The slug grammar reserves `api`, so the bare API plane never
+// matches. Same rule as the MCP front's `orgSelectorSegment`.
+const orgSelectorSegment = (segment: string | undefined): string | null =>
+  segment && (segment.startsWith("org_") || isValidOrgSlug(segment)) ? segment : null;
+
+export type ApiOrgScope = {
+  /** Org selector pinned in the URL (`/<slug>/api/...` slug or the legacy
+   *  `/<org_id>/api/...` id). Resolved to an org id — and re-checked against
+   *  live membership — by `authorizeOrganizationSelector` downstream. */
+  readonly selector: string;
+  /** The bare `/api/...` path the app handler routes, with the `/<selector>`
+   *  prefix removed. */
+  readonly barePath: string;
+};
+
+/**
+ * Classify an org-scoped API path (`/<selector>/api/...`), returning the URL's
+ * org selector + the bare path the app handler routes, or `null` when the path
+ * isn't one (a bare `/api/...`, an MCP path, or a console route). Shared by
+ * `app-paths.ts`'s app-owned gate and `prepareApiOrgScope`.
+ */
+export const classifyApiOrgScope = (pathname: string): ApiOrgScope | null => {
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.length < 2) return null;
+  const selector = orgSelectorSegment(segments[0]);
+  if (selector === null || segments[1] !== "api") return null;
+  return { selector, barePath: `/${segments.slice(1).join("/")}` };
+};
+
+/**
+ * Normalize an API request for the app handler, which routes ONLY bare `/api/*`.
+ * Rewrites `/<selector>/api/...` to its bare path and pins the URL's org in the
+ * internal `ORG_SELECTOR_HEADER`. A bare `/api/*` is left untouched, except any
+ * client-supplied selector header is stripped — org may come ONLY from the URL,
+ * so a header can never smuggle a different org past it (a no-op for non-API
+ * paths). Called by start.ts's app dispatch alongside `prepareMcpOrgScope`.
+ */
+export const prepareApiOrgScope = (request: Request): Request => {
+  const url = new URL(request.url);
+  const scope = classifyApiOrgScope(url.pathname);
+  if (scope === null) {
+    if (isApiPath(url.pathname) && request.headers.has(ORG_SELECTOR_HEADER)) {
+      const stripped = new Request(url, request);
+      stripped.headers.delete(ORG_SELECTOR_HEADER);
+      return stripped;
+    }
+    return request;
+  }
+  url.pathname = scope.barePath;
+  const rewritten = new Request(url, request);
+  rewritten.headers.set(ORG_SELECTOR_HEADER, scope.selector);
+  return rewritten;
+};

--- a/apps/cloud/src/api/router.ts
+++ b/apps/cloud/src/api/router.ts
@@ -1,7 +1,7 @@
 import { Layer } from "effect";
 import { HttpRouter } from "effect/unstable/http";
 
-import { RouterConfigLive } from "@executor-js/api/server";
+import { RouterConfigLive, requestScopedMiddleware } from "@executor-js/api/server";
 
 import { UserStoreService } from "../auth/context";
 import { DbService } from "../db/db";
@@ -36,7 +36,11 @@ export const makeApiLive = (requestScopedLive: Layer.Layer<DbService | UserStore
     makeAccountApiLive(requestScopedLive),
     CloudDocsLive,
     makeProtectedApiLive(requestScopedLive),
-    AutumnRoutesLive,
+    // The Autumn billing proxy resolves the URL's org selector to its WorkOS id
+    // via `authorizeOrganizationSelector`, which yields `UserStoreService` — so
+    // it needs the SAME per-request DB scoping the other sub-APIs thread in
+    // (matching `makeCloudExtensionRoutes`, the production composition).
+    AutumnRoutesLive.pipe(Layer.provide(requestScopedMiddleware(requestScopedLive).layer)),
     ApiErrorLoggingLive,
   ).pipe(Layer.provideMerge(RouterConfigLive), Layer.provideMerge(BootSharedServices));
 

--- a/apps/cloud/src/app-paths.test.ts
+++ b/apps/cloud/src/app-paths.test.ts
@@ -25,6 +25,13 @@ describe("isAppOwnedPath", () => {
     "/org_01ABCDEF/mcp",
     "/.well-known/oauth-protected-resource/acme-corp/mcp",
     "/.well-known/oauth-protected-resource/org_01ABCDEF/mcp",
+    // Org-scoped API: org rides as the first path segment (`/<slug>/api/...`),
+    // mirroring the MCP plane. The React app posts billing to
+    // `/<slug>/api/billing/*` via <AutumnProvider pathPrefix> — that slug-scoped
+    // form must reach the app handler, not the SPA. Legacy org-id form too.
+    "/acme-corp/api/billing/customer",
+    "/acme-corp/api/executions",
+    "/org_01ABCDEF/api/billing/attach",
   ];
   for (const pathname of appOwned) {
     it(`forwards ${pathname} to the app handler`, () => {

--- a/apps/cloud/src/app-paths.ts
+++ b/apps/cloud/src/app-paths.ts
@@ -1,3 +1,4 @@
+import { classifyApiOrgScope, isApiPath } from "./api/org-scope";
 import { classifyMcpPath } from "./mcp/mount";
 
 // ---------------------------------------------------------------------------
@@ -8,12 +9,13 @@ import { classifyMcpPath } from "./mcp/mount";
 // `/api/*` — the typed API plus the cloud `extensions.routes` (the Autumn billing
 // proxy at `/api/billing/*` and Swagger at `/api/docs` both live under `/api`) —
 // plus the `/mcp` serving envelope and its `/.well-known/*` OAuth discovery docs.
-// The dispatcher forwards those UNMODIFIED; anything else falls through to the
-// Start router. Keeping every served route under `/api` (no separate top-level
-// namespace) is what keeps this gate a simple two-prefix check.
+// Org-scoped API requests arrive slug-first (`/<slug>/api/...`); the dispatcher
+// forwards every app-owned path, rewriting the slug-scoped MCP/API forms to the
+// bare path the handler routes (see `prepareMcpOrgScope` / `prepareApiOrgScope`).
+// Anything else falls through to the Start router.
 // ---------------------------------------------------------------------------
 
-export const isApiPath = (pathname: string) => pathname === "/api" || pathname.startsWith("/api/");
-
 export const isAppOwnedPath = (pathname: string) =>
-  isApiPath(pathname) || classifyMcpPath(pathname) !== null;
+  isApiPath(pathname) ||
+  classifyApiOrgScope(pathname) !== null ||
+  classifyMcpPath(pathname) !== null;

--- a/apps/cloud/src/auth/org-selector-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-selector-auth.node.test.ts
@@ -6,11 +6,12 @@ import { UserStoreService } from "./context";
 import { resolveSessionPrincipal } from "./workos-auth-provider";
 import { WorkOSClient, type WorkOSClientService } from "./workos";
 
-// The org a console request resolves to is the URL's org (sent in the
-// `x-executor-organization` selector header), not the session's stored org —
-// with the session org as the fallback for non-console callers, and live
-// membership re-checked either way. This is what makes two browser tabs on
-// different orgs independent.
+// The org a request resolves to comes ONLY from the URL, carried in the
+// `x-executor-organization` selector header that the worker boundary derives
+// from the `/<slug>/api/...` path. There is no session-org fallback: a request
+// with no selector is org-less and fails `NoOrganization`. Live membership is
+// re-checked either way. This is what makes two browser tabs on different orgs
+// independent — the session's stored org never silently scopes a request.
 
 const createdAt = new Date("2026-01-01T00:00:00.000Z");
 
@@ -85,10 +86,13 @@ const run = (headers: Record<string, string>) =>
   );
 
 describe("resolveSessionPrincipal · URL org selector", () => {
-  it.effect("falls back to the session org when no selector header is sent", () =>
+  it.effect("rejects an org-less request when no selector header is sent", () =>
     Effect.gen(function* () {
-      const principal = yield* run({ cookie: "wos-session=x" });
-      expect(principal.organizationId, "scopes to the session org").toBe(SESSION_ORG);
+      // No `/<slug>/` in the URL → no selector header → no org. The session's
+      // stored org does NOT silently scope the request anymore; org comes only
+      // from the URL.
+      const error = yield* Effect.flip(run({ cookie: "wos-session=x" }));
+      expect(error).toMatchObject({ _tag: "NoOrganization" });
     }),
   );
 

--- a/apps/cloud/src/auth/organization.ts
+++ b/apps/cloud/src/auth/organization.ts
@@ -82,23 +82,27 @@ export const authorizeOrganization = (userId: string, organizationId: string) =>
 // Org SELECTOR — the URL is the scope authority, not the session.
 // ---------------------------------------------------------------------------
 //
-// Org-scoped requests carry the active org in this header, set by the web
-// client from the console URL's slug (the MCP plane carries the same idea in
-// its own `x-executor-mcp-organization`). The selector is a slug (`acme`, the
-// readable URL form) or a WorkOS id (`org_…`, the legacy/token form). It is a
-// SELECTOR, not a trust boundary: `authorizeOrganizationSelector` re-checks
-// live membership, so the worst a forged header does is name an org the caller
-// already belongs to.
+// Org-scoped API requests carry the active org as the FIRST PATH SEGMENT of the
+// URL (`/<slug>/api/...`). The worker boundary (`api/org-scope.ts`'s
+// `prepareApiOrgScope`) strips that segment and re-pins it in this INTERNAL
+// header before the request reaches the app handler — the same shape the MCP
+// plane uses with its own `x-executor-mcp-organization`. The selector is a slug
+// (`acme`, the readable URL form) or a WorkOS id (`org_…`, the legacy/token
+// form). It is a SELECTOR, not a trust boundary: clients never set it (the
+// boundary strips any client-sent value on a bare `/api/*`), and
+// `authorizeOrganizationSelector` re-checks live membership, so the worst a
+// value does is name an org the caller already belongs to.
 //
-// Why a header and not the session's `org_id`: a browser shares ONE cookie jar
+// Why the URL and not the session's `org_id`: a browser shares ONE cookie jar
 // across tabs, so a single session-pinned org makes "active org" a
 // browser-global — two tabs can't be in two orgs at once, and switching in one
-// silently re-scopes the other. Scoping per-request from the URL makes each
-// tab independent.
+// silently re-scopes the other. Scoping per-request from the URL makes each tab
+// independent.
 
 export const ORG_SELECTOR_HEADER = "x-executor-organization";
 
-/** The URL-pinned org selector for a request, or `null` to fall back to the session. */
+/** The URL-pinned org selector for a request (set by the worker boundary from
+ *  the URL), or `null` when the request is org-less. */
 export const orgSelectorFromRequest = (request: Request): string | null =>
   request.headers.get(ORG_SELECTOR_HEADER);
 

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -115,11 +115,13 @@ export const resolveSessionPrincipal = (request: Request) =>
     if (!session) {
       return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);
     }
-    // The console URL's org is the scope authority (sent as a header); the
-    // session's own org is the fallback for non-console callers. Membership is
-    // re-checked live either way — the header is a selector, not a trust
-    // boundary (see organization.ts).
-    const selector = orgSelectorFromRequest(request) ?? session.organizationId;
+    // The console URL is the ONLY scope authority: the worker boundary pins the
+    // URL's org in the selector header from `/<slug>/api/...`. The session
+    // identifies the USER, never the org — a request with no URL-scoped org is
+    // org-less here (an org-less page must not reach a protected route).
+    // Membership is still re-checked live — the selector is not a trust boundary
+    // (see organization.ts).
+    const selector = orgSelectorFromRequest(request);
     if (!selector) {
       return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);
     }

--- a/apps/cloud/src/extensions/billing/route.ts
+++ b/apps/cloud/src/extensions/billing/route.ts
@@ -4,8 +4,16 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import { autumnHandler } from "autumn-js/backend";
 
 import { WorkOSClient } from "../../auth/workos";
+import { authorizeOrganizationSelector, orgSelectorFromRequest } from "../../auth/organization";
 import { HttpResponseError, isServerError, toErrorServerResponse } from "../../api/error-response";
 
+// The Autumn customer is the WorkOS ORGANIZATION, and the org is the one named
+// by the console URL — NOT the session's own org. The worker boundary pins the
+// URL's org selector (`/<slug>/api/billing/...`) in the request, and we resolve
+// it to its WorkOS id with a live membership check before using it as the
+// customerId. This is the load-bearing fix for the multi-org seat bug: a member
+// of several orgs viewing a team-plan org must bill against THAT org's plan, so
+// the seat cap the billing proxy reports matches the org the user is looking at.
 const handler = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
   const webRequest = yield* Effect.mapError(
@@ -19,13 +27,28 @@ const handler = Effect.gen(function* () {
   );
 
   const workos = yield* WorkOSClient;
+  // The session identifies the USER (for the membership check + customer
+  // display), never the org. The org comes ONLY from the URL selector.
   const session = yield* workos.authenticateRequest(webRequest);
+  const selector = orgSelectorFromRequest(webRequest);
 
-  if (!session || !session.organizationId) {
+  if (!session || !selector) {
     return yield* new HttpResponseError({
       status: 401,
       code: "unauthorized",
       message: "Unauthorized",
+    });
+  }
+
+  // Live membership check: `null` => the caller isn't an active member of the
+  // selected org (or it doesn't exist) => 403. Store/WorkOS failures fall
+  // through to the outer `catchCause` as a 500.
+  const org = yield* authorizeOrganizationSelector(session.userId, selector);
+  if (!org) {
+    return yield* new HttpResponseError({
+      status: 403,
+      code: "forbidden",
+      message: "Forbidden",
     });
   }
 
@@ -50,9 +73,9 @@ const handler = Effect.gen(function* () {
         method: request.method,
         body,
       },
-      customerId: session.organizationId,
+      customerId: org.id,
       customerData: {
-        name: session.email,
+        name: org.name,
         email: session.email,
       },
       clientOptions: {

--- a/apps/cloud/src/extensions/routes.ts
+++ b/apps/cloud/src/extensions/routes.ts
@@ -95,5 +95,12 @@ export const makeCloudExtensionRoutes = (rsLive: Layer.Layer<DbService | UserSto
     HttpRouter.add("GET", "/api/openapi.json", Effect.succeed(HttpServerResponse.jsonUnsafe(spec))),
   );
 
-  return [SessionRoutes, OrgRoutes, DocsRoutes, AutumnRoutesLive, ApiErrorLoggingLive] as const;
+  // The Autumn billing proxy resolves the URL's org (the selector the worker
+  // boundary pins from `/<slug>/api/billing/...`) to its WorkOS id via
+  // `authorizeOrganizationSelector`, which yields `UserStoreService` — so it
+  // needs the SAME per-request DB scoping the session routes use (the postgres
+  // socket must live in the request fiber's scope). `WorkOSClient` is on boot.
+  const BillingRoutes = AutumnRoutesLive.pipe(Layer.provide(requestScopedMiddleware(rsLive).layer));
+
+  return [SessionRoutes, OrgRoutes, DocsRoutes, BillingRoutes, ApiErrorLoggingLive] as const;
 };

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -350,15 +350,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-
 import type { startInstance } from './start.ts'
-
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
-
     router: Awaited<ReturnType<typeof getRouter>>
-
     config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -286,7 +286,12 @@ function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
   const scopeSlug = urlOrgSlug ?? activeSlug;
 
   return (
-    <AutumnProvider pathPrefix="/api/billing">
+    // The org enters ONLY through the URL, so the billing proxy is reached at
+    // `/<slug>/api/billing/*` (the worker boundary strips the slug and pins the
+    // org for the route) — never the bare `/api/billing/*`, which carries no
+    // org. We're past the `auth.organization == null` guard, so `scopeSlug` is
+    // always a real slug here.
+    <AutumnProvider pathPrefix={`/${scopeSlug}/api/billing`}>
       <Sentry.ErrorBoundary fallback={<ShellErrorFallback />} showDialog={false}>
         <ExecutorProvider connection={connection} onHandledError={captureFrontendError}>
           <React.Suspense fallback={<BlankScreen />}>

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -1,6 +1,7 @@
 import { createMiddleware, createStart } from "@tanstack/react-start";
 
 import { cloudApiHandler } from "./app";
+import { prepareApiOrgScope } from "./api/org-scope";
 import { isAppOwnedPath } from "./app-paths";
 import { authGateMiddleware } from "./auth/ssr-gate";
 import { prepareMcpOrgScope } from "./mcp/mount";
@@ -30,14 +31,17 @@ let app: ReturnType<typeof cloudApiHandler> | undefined;
 const getApp = () => (app ??= cloudApiHandler());
 
 // app-owned = anything under `/api/*` (incl. the cloud extension routes) OR an
-// MCP/OAuth-discovery path (see `./app-paths`). The app handler serves these at
-// their real paths, so we forward unmodified — except `prepareMcpOrgScope`
-// rewrites an org-scoped MCP path (`/org_xxx/mcp`) to the bare path the shared
-// envelope routes, pinning the org in an internal header (a no-op for everything
-// else, including `/api/*`).
+// org-scoped API path (`/<slug>/api/*`) OR an MCP/OAuth-discovery path (see
+// `./app-paths`). The app handler routes only the bare paths, so before
+// forwarding we normalize the org-scoped forms: `prepareApiOrgScope` rewrites
+// `/<slug>/api/...` → `/api/...` and `prepareMcpOrgScope` rewrites
+// `/<slug>/mcp` → `/mcp`, each pinning the URL's org in its internal header and
+// each a no-op outside its own plane (the two path shapes are disjoint).
 const appRequestMiddleware = createMiddleware({ type: "request" }).server(
   ({ pathname, request, next }) => {
-    if (isAppOwnedPath(pathname)) return getApp().handler(prepareMcpOrgScope(request));
+    if (isAppOwnedPath(pathname)) {
+      return getApp().handler(prepareApiOrgScope(prepareMcpOrgScope(request)));
+    }
     return next();
   },
 );

--- a/e2e/cloud/org-billing-scope.test.ts
+++ b/e2e/cloud/org-billing-scope.test.ts
@@ -1,0 +1,133 @@
+// Cloud-only (billing): the member-seat gate scopes to the org in the URL, not
+// the org the session cookie happens to be pinned to. This reproduces a
+// production report — a multi-org admin opening a team-plan org by its slug
+// still hit the free plan's 3-seat cap and got a 403 on the 3rd invite, because
+// billing/account read the SESSION's org (a different, free org) instead of the
+// org the URL named.
+//
+// The repro needs the two to disagree. Create a TEAM org first, then a FREE org
+// last, so the refreshed session cookie ends pinned to the FREE org. Then drive
+// every account call under the TEAM org's `/<slug>/api/...` URL with that
+// free-pinned cookie: same cookie, two org URLs, two different answers. The URL
+// is the only thing that selects the org — under the bug the session's free org
+// capped the team org at 3.
+//
+// Black-box: drives only the public account API and seeds the Autumn emulator
+// the cloud app already talks to (its customerId IS the WorkOS org id). The team
+// org carries a SINGLE active `team` subscription — the shape Autumn returns
+// after an upgrade (confirmed against a live response) — so the repro does not
+// lean on any "free plan listed first" seat-math quirk; it isolates the
+// URL-vs-session scoping bug alone.
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+
+import { connectEmulator } from "@executor-js/emulate";
+
+import { scenario } from "../src/scenario";
+import { Billing, Target } from "../src/services";
+import { AUTUMN_EMULATOR_PORT } from "../targets/cloud";
+
+interface Seats {
+  readonly used: number;
+  readonly granted: number;
+  readonly unlimited: boolean;
+}
+
+interface CreatedOrg {
+  readonly id: string;
+  readonly slug: string;
+  readonly cookie: string;
+}
+
+scenario(
+  "Billing · member-seat limits follow the URL's org, not the session's pinned org",
+  {},
+  Effect.gen(function* () {
+    // Gate: billing limits are enforced on this target (cloud).
+    yield* Billing;
+    const target = yield* Target;
+    const origin = new URL(target.baseUrl).origin;
+
+    // A fresh user with NO org. We create both orgs by hand so we control the
+    // ORDER — the last one created is the org the refreshed session pins.
+    const identity = yield* target.newIdentity({ org: false });
+    const baseCookie = identity.headers?.cookie ?? "";
+
+    const createOrg = (name: string, cookie: string) =>
+      Effect.promise(async (): Promise<CreatedOrg> => {
+        const response = await fetch(new URL("/api/auth/create-organization", target.baseUrl), {
+          method: "POST",
+          headers: { "content-type": "application/json", origin, cookie },
+          body: JSON.stringify({ name }),
+        });
+        if (!response.ok) {
+          throw new Error(`create-organization "${name}" failed (${response.status})`);
+        }
+        const body = (await response.json()) as { id: string; slug: string };
+        const refreshed = (response.headers.getSetCookie?.() ?? [])
+          .find((header) => header.startsWith("wos-session="))
+          ?.split(";")[0];
+        return { id: body.id, slug: body.slug, cookie: refreshed ?? cookie };
+      });
+
+    // TEAM org first, then FREE org last → the session cookie now pins FREE.
+    const team = yield* createOrg("Seat Scope Team", baseCookie);
+    const free = yield* createOrg("Seat Scope Free", team.cookie);
+    const sessionCookie = free.cookie; // pinned to the FREE org
+    expect(team.slug, "the two orgs have distinct slugs").not.toBe(free.slug);
+
+    // Put the TEAM org on the team plan — a single active `team` subscription,
+    // the shape Autumn returns after an upgrade. Its customerId is the WorkOS
+    // org id the seat gate looks up.
+    yield* Effect.promise(async () => {
+      const autumn = await connectEmulator({
+        baseUrl: `http://127.0.0.1:${AUTUMN_EMULATOR_PORT}`,
+      });
+      await autumn.seed({
+        customers: [{ id: team.id, subscriptions: [{ plan_id: "team", status: "active" }] }],
+      });
+    });
+
+    const seatsAt = (slug: string) =>
+      Effect.promise(async (): Promise<Seats> => {
+        const response = await fetch(new URL(`/${slug}/api/account/members`, target.baseUrl), {
+          headers: { cookie: sessionCookie },
+        });
+        const body = (await response.json()) as { seats?: Seats };
+        if (!body.seats) throw new Error(`members(${slug}) carried no seats (${response.status})`);
+        return body.seats;
+      });
+
+    // The crux: ONE session cookie (pinned to the FREE org), two org URLs, two
+    // different answers. A model that read the session org would report the free
+    // cap for BOTH; the URL model reports the org each URL names.
+    const teamSeats = yield* seatsAt(team.slug);
+    expect(teamSeats.unlimited, "the team org's URL grants unlimited seats").toBe(true);
+
+    const freeSeats = yield* seatsAt(free.slug);
+    expect(freeSeats.unlimited, "the free org's URL is capped").toBe(false);
+    expect(freeSeats.granted, "the free org's URL grants the free 3-seat cap").toBe(3);
+
+    // The user-visible symptom: invites on the team org's URL. A fresh org has 1
+    // member (the admin); on the buggy free cap the 3rd invite tips used→3 and is
+    // refused 403. Under the fix every invite on the team org is accepted.
+    const inviteToken = team.id.replace(/[^a-z0-9]/gi, "");
+    const invite = (slug: string, email: string) =>
+      Effect.promise(async () => {
+        const response = await fetch(
+          new URL(`/${slug}/api/account/members/invite`, target.baseUrl),
+          {
+            method: "POST",
+            headers: { "content-type": "application/json", origin, cookie: sessionCookie },
+            body: JSON.stringify({ email }),
+          },
+        );
+        return response.status;
+      });
+
+    for (let i = 1; i <= 3; i++) {
+      const status = yield* invite(team.slug, `seat-${i}-${inviteToken}@e2e.test`);
+      expect(status, `invite ${i} on the team org's URL is accepted`).toBe(200);
+    }
+  }),
+);

--- a/e2e/cloud/org-multitab-cookie.test.ts
+++ b/e2e/cloud/org-multitab-cookie.test.ts
@@ -7,12 +7,13 @@
 // silently re-scoped the other tab out from under it.
 //
 // The stateless URL model removes that hazard. The slug in the path is the
-// request scope: every API call carries it (the `x-executor-organization`
-// header), the server re-checks live membership and resolves data for THAT
-// org, and the session merely authenticates the user to all their orgs at
-// once. Nothing writes the cookie on a switch. So this scenario — once the
-// reproduction of the corruption — now asserts the opposite: each tab's
-// requests stay scoped to its own URL org, no matter what the other tab does.
+// request scope: every API call carries it in its OWN URL (`/<slug>/api/...`,
+// the same slug as the page), the server re-checks live membership and resolves
+// data for THAT org, and the session merely authenticates the user to all their
+// orgs at once. No client header carries org anymore, and nothing writes the
+// cookie on a switch. So this scenario — once the reproduction of the
+// corruption — now asserts the opposite: each tab's requests stay scoped to its
+// own URL org, no matter what the other tab does.
 //
 // Everything runs through the browser (onboarding + the menu create-org), so
 // the single-use WorkOS refresh-token chain stays browser-owned and valid.
@@ -34,19 +35,19 @@ scenario(
       const slugOf = (page: typeof tab1) => new URL(page.url()).pathname.replace(/^\/|\/.*$/g, "");
 
       // The org slug a page's REAL app requests carry — read straight off the
-      // outgoing `x-executor-organization` header, the actual request scope.
-      // This is what makes the two tabs independent; the shared session cookie
-      // is irrelevant to it.
+      // outgoing request URL, which is `/<slug>/api/...`: the slug IS the first
+      // path segment, the actual request scope. No client header carries org
+      // anymore. This is what makes the two tabs independent; the shared session
+      // cookie is irrelevant to it.
       const requestOrgSlugOf = async (page: typeof tab1): Promise<string> => {
         const matching = page.waitForRequest(
-          (request) =>
-            request.url().includes("/api/") &&
-            request.headers()["x-executor-organization"] !== undefined,
+          (request) => /^\/[a-z0-9-]+\/api\//.test(new URL(request.url()).pathname),
           { timeout: 15_000 },
         );
         // Nudge the app to refetch so a fresh scoped request goes out.
         void page.reload({ waitUntil: "commit" });
-        return (await matching).headers()["x-executor-organization"]!;
+        const pathname = new URL((await matching).url()).pathname;
+        return pathname.split("/").filter((segment) => segment.length > 0)[0]!;
       };
 
       let slugA = "";

--- a/e2e/cloud/org-slug-foreign.test.ts
+++ b/e2e/cloud/org-slug-foreign.test.ts
@@ -1,8 +1,9 @@
 // Cloud-only (browser): opening another of YOUR orgs by its slug URL just
-// works — no switch, no cookie rewrite. The slug in the path is the request
-// scope (the `x-executor-organization` header), and the session authenticates
-// the user to ALL their orgs at once, so a bookmark or a teammate's link into a
-// shared org lands you there regardless of which org the cookie happens to pin.
+// works — no switch, no cookie rewrite. The slug in the path IS the request
+// scope (each API call rides under `/<slug>/api/...`; no client header carries
+// org), and the session authenticates the user to ALL their orgs at once, so a
+// bookmark or a teammate's link into a shared org lands you there regardless of
+// which org the cookie happens to pin.
 //
 // org-switcher.test.ts covers the account-menu navigation; this covers the URL
 // path. (Unknown/unauthorized slugs → 404 is covered by

--- a/packages/plugins/graphql/src/react/client.ts
+++ b/packages/plugins/graphql/src/react/client.ts
@@ -1,11 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorApiBaseUrl,
+  getExecutorApiRequestBaseUrl,
   getExecutorServerAuthorizationHeader,
 } from "@executor-js/react/api/server-connection";
 import { GraphqlGroup } from "../api/group";
 
 export const GraphqlClient = createPluginAtomClient(GraphqlGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorApiRequestBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
 });

--- a/packages/plugins/mcp/src/react/client.ts
+++ b/packages/plugins/mcp/src/react/client.ts
@@ -1,11 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorApiBaseUrl,
+  getExecutorApiRequestBaseUrl,
   getExecutorServerAuthorizationHeader,
 } from "@executor-js/react/api/server-connection";
 import { McpGroup } from "../api/group";
 
 export const McpClient = createPluginAtomClient(McpGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorApiRequestBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
 });

--- a/packages/plugins/onepassword/src/react/client.ts
+++ b/packages/plugins/onepassword/src/react/client.ts
@@ -1,11 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorApiBaseUrl,
+  getExecutorApiRequestBaseUrl,
   getExecutorServerAuthorizationHeader,
 } from "@executor-js/react/api/server-connection";
 import { OnePasswordGroup } from "../api/group";
 
 export const OnePasswordClient = createPluginAtomClient(OnePasswordGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorApiRequestBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
 });

--- a/packages/plugins/openapi/src/react/client.ts
+++ b/packages/plugins/openapi/src/react/client.ts
@@ -1,11 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorApiBaseUrl,
+  getExecutorApiRequestBaseUrl,
   getExecutorServerAuthorizationHeader,
 } from "@executor-js/react/api/server-connection";
 import { OpenApiGroup } from "../api/group";
 
 export const OpenApiClient = createPluginAtomClient(OpenApiGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorApiRequestBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
 });

--- a/packages/react/src/api/account-client.tsx
+++ b/packages/react/src/api/account-client.tsx
@@ -5,9 +5,7 @@ import * as Effect from "effect/Effect";
 
 import { reportApiClientInfrastructureCause } from "./client";
 import {
-  EXECUTOR_ORG_HEADER,
-  getActiveOrgSlug,
-  getExecutorApiBaseUrl,
+  getExecutorApiRequestBaseUrl,
   getExecutorServerAuthorizationHeader,
 } from "./server-connection";
 
@@ -25,15 +23,12 @@ const AccountApiClient = AtomHttpApi.Service<"AccountApiClient">()("AccountApiCl
   api: AccountHttpApi,
   httpClient: FetchHttpClient.layer,
   transformClient: HttpClient.mapRequest((request) => {
-    let next = HttpClientRequest.prependUrl(request, getExecutorApiBaseUrl());
+    // The base URL carries the org as its first path segment (see
+    // getExecutorApiRequestBaseUrl) — the URL is the only place org enters.
+    let next = HttpClientRequest.prependUrl(request, getExecutorApiRequestBaseUrl());
     const authorization = getExecutorServerAuthorizationHeader();
     if (authorization) {
       next = HttpClientRequest.setHeader(next, "authorization", authorization);
-    }
-    // Scope to the org the console URL is on (see server-connection).
-    const orgSlug = getActiveOrgSlug();
-    if (orgSlug) {
-      next = HttpClientRequest.setHeader(next, EXECUTOR_ORG_HEADER, orgSlug);
     }
     return next;
   }),

--- a/packages/react/src/api/client.tsx
+++ b/packages/react/src/api/client.tsx
@@ -13,9 +13,7 @@ import * as Schema from "effect/Schema";
 import { reportHandledFrontendError } from "./error-reporting";
 import { notifyLocalAuthRequired } from "./local-auth";
 import {
-  EXECUTOR_ORG_HEADER,
-  getActiveOrgSlug,
-  getExecutorApiBaseUrl,
+  getExecutorApiRequestBaseUrl,
   getExecutorServerAuthorizationHeader,
 } from "./server-connection";
 
@@ -119,15 +117,12 @@ const ExecutorApiClient = AtomHttpApi.Service<"ExecutorApiClient">()("ExecutorAp
   api: ExecutorApi,
   httpClient: FetchHttpClient.layer,
   transformClient: HttpClient.mapRequest((request) => {
-    let next = HttpClientRequest.prependUrl(request, getExecutorApiBaseUrl());
+    // The base URL carries the org as its first path segment (see
+    // getExecutorApiRequestBaseUrl) — the URL is the only place org enters.
+    let next = HttpClientRequest.prependUrl(request, getExecutorApiRequestBaseUrl());
     const authorization = getExecutorServerAuthorizationHeader();
     if (authorization) {
       next = HttpClientRequest.setHeader(next, "authorization", authorization);
-    }
-    // Scope the request to the org the console URL is on (see server-connection).
-    const orgSlug = getActiveOrgSlug();
-    if (orgSlug) {
-      next = HttpClientRequest.setHeader(next, EXECUTOR_ORG_HEADER, orgSlug);
     }
     return next;
   }),

--- a/packages/react/src/api/server-connection.tsx
+++ b/packages/react/src/api/server-connection.tsx
@@ -74,21 +74,20 @@ let activeConnection = resolveInitialExecutorServerConnection();
 // Active org selector — the org the console URL is scoped to.
 // ---------------------------------------------------------------------------
 //
-// Org-scoped hosts (cloud) send this on every API request so the server scopes
-// to the URL's org, not the session's stored one — which is what lets two
-// browser tabs sit in two different orgs at once (each tab's window.location is
-// its own).
+// Org-scoped hosts (cloud) carry the org as the FIRST PATH SEGMENT of every
+// API request (`/{slug}/api/...`), never as a client header. The org travels
+// the same way the console URL does, which is what lets two browser tabs sit
+// in two different orgs at once (each tab's window.location is its own) and
+// keeps the URL the single source of org truth across the whole app.
 //
 // Read straight from `window.location` at REQUEST time, not from a
 // React-synced mirror: the API clients' `transformClient` runs only in the
 // browser, so this never touches SSR/hydration, and it's always exactly the
 // current URL with no effect-timing to get wrong. The org is the first path
 // segment when it's a valid slug; reserved console roots (`/policies`,
-// `/login`, …) are NOT valid slugs, so a bare path sends no header and the
-// server falls back to the session org. Hosts without slugs (self-host,
+// `/login`, …) are NOT valid slugs, so a bare path stays org-less and the
+// worker boundary leaves the request unscoped. Hosts without slugs (self-host,
 // cloudflare) never produce one either.
-export const EXECUTOR_ORG_HEADER = "x-executor-organization";
-
 export const getActiveOrgSlug = (): string | null => {
   const pathname = globalThis.window?.location?.pathname;
   if (!pathname) return null;
@@ -111,6 +110,23 @@ export const setExecutorServerApiBaseUrl = (apiBaseUrl: string): void => {
 };
 
 export const getExecutorApiBaseUrl = (): string => activeConnection.apiBaseUrl;
+
+// The per-request API base URL: the slug-less base with the active org slug
+// spliced in as the first path segment (`https://host/api` →
+// `https://host/{slug}/api`). This is the single client-side chokepoint that
+// scopes API traffic to the URL's org. The HttpApi clients call it inside
+// `mapRequest`, so it re-reads the slug on every request — a tab that
+// navigates to another org immediately scopes its next call with no client
+// re-init. Org-less paths (and slug-less hosts) get the base unchanged, so the
+// worker boundary leaves those requests unscoped.
+export const getExecutorApiRequestBaseUrl = (): string => {
+  const base = activeConnection.apiBaseUrl;
+  const slug = getActiveOrgSlug();
+  if (!slug) return base;
+  const url = new URL(base);
+  url.pathname = `/${slug}${url.pathname}`;
+  return url.toString();
+};
 
 export const getExecutorServerAuthPassword = (): string | null =>
   activeConnection.auth?.kind === "basic" ? activeConnection.auth.password : null;


### PR DESCRIPTION
## Problem

In a multi-org deployment, a user whose session cookie was pinned to one organization could visit a *different* organization by its URL slug and still have billing and membership checks run against the session-pinned org. Concretely: an admin with a free-plan org as their "active" session org who navigated to a team-plan org by URL slug (`/team-org/api/account/members`) received a 403 when inviting a fourth member, because the billing plane read `session.organizationId` (the free org, 3-seat cap) instead of the org named in the URL path (the team org, unlimited seats). The root cause is that the billing, account, and auth planes all treated `session.organizationId` as a valid request scope, falling back to it whenever no `x-executor-organization` header was present.

_The recording below is the `org-slug-foreign` browser scenario: opening another of your orgs by its slug URL scopes the page to that org with no session switch — the URL-as-scope behavior this PR makes uniform across the API plane. (The billing seat repro is API-only and has no recording; it is covered by `org-billing-scope.test.ts` below.)_

![Org URLs · opening another of your orgs by slug works without switching the session (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/org-urls-opening-another-of-your-orgs-by-slug-works-without-switching-the-sessio-6ec115d8.gif)

## Approach

The fix makes the URL path slug the **single source of organization truth** for all API requests. This mirrors the MCP plane, which already worked correctly via `prepareMcpOrgScope`. The design is:

1. **Worker boundary seam** — a new `prepareApiOrgScope` transform (parallel to `prepareMcpOrgScope`) detects `/<slug>/api/...` paths, rewrites them to the bare `/api/...` the app handler routes, and pins the slug in the internal `ORG_SELECTOR_HEADER`. On bare `/api/...` paths it *strips* any client-supplied `ORG_SELECTOR_HEADER`, enforcing that org can only arrive via the URL.
2. **Session demotion** — `session.organizationId` is removed as a request scope everywhere. It remains only as the auth/membership anchor WorkOS needs internally and as the default landing org for onboarding. A request that arrives with no URL slug is now org-less and fails with `NoOrganization` rather than silently scoping to whatever org the cookie happens to pin.
3. **Client simplification** — clients stop sending `x-executor-organization` headers entirely. A new `getExecutorApiRequestBaseUrl()` function splices the active slug into the API base URL at request time (`/api` → `/<slug>/api`), so the URL is the selector for both routing and org resolution.
4. **Live membership re-check** — the billing proxy now calls `authorizeOrganizationSelector(session.userId, selector)` on every request, using the URL-derived org as the Autumn `customerId`. A null return (non-member) produces a 403 rather than the prior implicit pass-through.

## What changed

### Worker boundary & dispatch

- **`apps/cloud/src/api/org-scope.ts`** *(new)*: `classifyApiOrgScope` parses `/<selector>/api/...` into `{ selector, barePath }`, accepting both slug and legacy `org_...` forms. `prepareApiOrgScope` rewrites slug-scoped requests to bare paths + internal header, and strips any client-supplied `ORG_SELECTOR_HEADER` on bare `/api/...` requests (security invariant).
- **`apps/cloud/src/app-paths.ts`**: removes local `isApiPath` (now re-exported from `org-scope.ts`); adds a `classifyApiOrgScope(pathname) !== null` branch to `isAppOwnedPath` so slug-scoped API paths (`/<slug>/api/...`) are forwarded to the app handler rather than served as the SPA shell.
- **`apps/cloud/src/start.ts`**: adds `prepareApiOrgScope` to the `appRequestMiddleware` dispatch chain, composing it with the existing `prepareMcpOrgScope`.
- **`apps/cloud/src/auth/organization.ts`**: doc-only update reflecting the new invariant (the header is set exclusively by the worker boundary, never by the client).
- **`apps/cloud/src/auth/workos-auth-provider.ts`**: removes the `?? session.organizationId` fallback in `resolveSessionPrincipal`. A request with no `ORG_SELECTOR_HEADER` now yields `NoOrganization` immediately.

### Server org readers

- **`apps/cloud/src/account/workos-account-service.ts`**: `requireOrganization` and the `me` handler drop the `?? session.organizationId` fallback. `me` stays null-tolerant (an org-less request returns `{ organization: null }` for onboarding); org-scoped endpoints yield `AccountNoOrganization`.
- **`apps/cloud/src/extensions/billing/route.ts`** *(load-bearing fix)*: replaces `session.organizationId` as the Autumn `customerId` with the URL-derived org id from `authorizeOrganizationSelector`. Adds an explicit 403 branch when the live membership check returns null (the prior code performed no live membership check). Also corrects `customerData.name` from `session.email` (the signed-in user) to `org.name` (the organization being billed), so the Autumn customer record is named after the org it represents rather than whoever happened to be signed in when it was first written; the contact `email` stays `session.email`.
- **`apps/cloud/src/extensions/routes.ts`**: wraps `AutumnRoutesLive` with `Layer.provide(requestScopedMiddleware(rsLive).layer)` so the billing route can access `UserStoreService` (needed by `authorizeOrganizationSelector`) within the request fiber's scope.
- **`apps/cloud/src/api/router.ts`**: mirrors the production `routes.ts` fix for the test-only composition (`makeApiLive`).

### Client request chokepoints

- **`packages/react/src/api/server-connection.tsx`**: new export `getExecutorApiRequestBaseUrl()` reads `getActiveOrgSlug()` from `window.location.pathname` at call time and splices the slug as the first path segment into the configured `apiBaseUrl`. Removes `EXECUTOR_ORG_HEADER`.
- **`packages/react/src/api/client.tsx`** and **`account-client.tsx`**: switch `transformClient` / `mapRequest` from `getExecutorApiBaseUrl` + header to `getExecutorApiRequestBaseUrl`. Remove all `EXECUTOR_ORG_HEADER` / `getActiveOrgSlug` calls.
- **`packages/plugins/graphql/src/react/client.ts`**, **`mcp/src/react/client.ts`**, **`onepassword/src/react/client.ts`**, **`openapi/src/react/client.ts`**: mechanical swap of `getExecutorApiBaseUrl` → `getExecutorApiRequestBaseUrl`. These clients sent no org header before; without this swap they would all become org-less after the server-side fallback removal.

### SSR shell & route tree

- **`apps/cloud/src/routes/__root.tsx`**: `AutumnProvider`'s `pathPrefix` changes from the static `"/api/billing"` to the dynamic `` `/${scopeSlug}/api/billing` `` so Autumn billing SDK requests carry the org in the URL. `scopeSlug` is `urlOrgSlug ?? activeSlug`, where `urlOrgSlug` (the TanStack Router path param) takes priority over the session slug.
- **`apps/cloud/src/routeTree.gen.ts`**: whitespace-only auto-generated diff, no semantic change.

## Testing

### Unit tests

- **`apps/cloud/src/api/org-scope.test.ts`** *(new)*: covers `isApiPath` (strict prefix, rejects `/apiary`), `classifyApiOrgScope` (slug and `org_` forms, null for bare paths), and `prepareApiOrgScope` — including the security case that a client-supplied `ORG_SELECTOR_HEADER` on a bare `/api/...` request is **stripped**, and that non-API paths are returned by identity.
- **`apps/cloud/src/app-paths.test.ts`**: extended with three new fixtures asserting that `/<slug>/api/billing/customer`, `/<slug>/api/executions`, and `/<org_...>/api/billing/attach` are classified as app-owned.
- **`apps/cloud/src/auth/org-selector-auth.node.test.ts`**: the test previously asserting that a cookie-only request succeeds with the session org is **inverted** — it now asserts the same request fails with `{ _tag: 'NoOrganization' }`. This is the canonical unit-level specification of the removed fallback.

### E2E scenarios

- **`e2e/cloud/org-billing-scope.test.ts`** *(new, black-box repro)*: reproduces the production bug end-to-end. Creates a TEAM org first, then a FREE org second, so the refreshed session cookie pins the FREE org. Seeds the Autumn emulator with a `team` subscription for the TEAM org's WorkOS id. Verifies that `/{team-slug}/api/account/members` reports `seats.unlimited === true` and `/{free-slug}/api/account/members` reports `seats.granted === 3` — both with the same FREE-pinned cookie. Then sends three invites under the TEAM slug and asserts each returns 200. This test fails before this PR (the third invite to the team org 403s under the old session-scoped billing path).
- **`e2e/cloud/org-slug-foreign.test.ts`** *(recording above)*: comment updated to reflect that org travels in the URL path, not a header; the test logic is unchanged (navigating to a foreign org by slug still works).
- **`e2e/cloud/org-multitab-cookie.test.ts`**: `requestOrgSlugOf` updated to detect the org from the request pathname (`/^\/[a-z0-9-]+\/api\//`) rather than the now-absent `x-executor-organization` header.

## Deferred / out of scope

1. **MCP human-in-the-loop endpoints** (`getMcpPaused`, `resumeMcpExecution`) still scope to the session org; they were not part of this change.
2. **OrgAuth domain-management plane** still reads its own auth-context org; it is outside the API plane addressed here.
3. **SSR default-landing / onboarding gate** intentionally continues to read the session org as the default. This is not a scope leak — it is used only when there is no URL slug to derive an org from (e.g., the root `/` redirect to a user's default org after sign-in).
4. **`api/router.ts` test-only composition** (`makeApiLive` / `ApiLive` / `handleApiRequest`): kept in sync with the production composition but ships nothing to production; it exists solely to support the request-scope unit tests.
