### PR TITLE
[codex] Use tenant API paths for org scope

### DIFF
--- a/apps/cloud/src/account/workos-account-service.ts
+++ b/apps/cloud/src/account/workos-account-service.ts
@@ -1,6 +1,10 @@
 import { Context, Effect, Layer } from "effect";
 
-import { AccountProvider, type AccountHeaders } from "@executor-js/api/server";
+import {
+  AccountProvider,
+  currentTenantSelector,
+  type AccountHeaders,
+} from "@executor-js/api/server";
 import {
   AccountError,
   AccountForbidden,
@@ -12,7 +16,7 @@ import { ApiKeyService } from "../auth/api-keys";
 import { UserStoreService } from "../auth/context";
 import type { Session } from "../auth/middleware";
 import { WorkOSClient } from "../auth/workos";
-import { ORG_SELECTOR_HEADER, authorizeOrganizationSelector } from "../auth/organization";
+import { authorizeOrganizationSelector } from "../auth/organization";
 import { AutumnService } from "../extensions/billing/service";
 import { getMemberLimitForPlan, selectActiveMemberLimitPlan } from "../extensions/billing/plans";
 
@@ -87,16 +91,15 @@ export const workosAccountProvider: Layer.Layer<
         ? Effect.succeed(caller.session)
         : Effect.fail<AccountUnauthorized>(new AccountUnauthorized());
 
-    // The org scope for an org-scoped request: the console URL's org (sent in
-    // the selector header) when present, else the session's own org. Membership
-    // is re-checked live, so the header is a selector, not a trust boundary —
-    // and two browser tabs on different orgs each send their own header, so
-    // they stay independent (see organization.ts). Yields the session +
-    // resolved org, or AccountNoOrganization.
-    const requireOrganization = (headers: AccountHeaders) =>
+    // The org scope for an org-scoped request: the console URL's tenant path
+    // when present, else the session's own org. Membership is re-checked live,
+    // so two browser tabs on different orgs stay independent without mutating a
+    // browser-global session org. Yields the session + resolved org, or
+    // AccountNoOrganization.
+    const requireOrganization = (_headers: AccountHeaders) =>
       Effect.gen(function* () {
         const session = yield* requireSession();
-        const selector = headers[ORG_SELECTOR_HEADER] ?? session.organizationId;
+        const selector = (yield* currentTenantSelector) ?? session.organizationId;
         if (!selector) {
           return yield* new AccountNoOrganization();
         }
@@ -162,13 +165,13 @@ export const workosAccountProvider: Layer.Layer<
       });
 
     return AccountProvider.of({
-      me: (headers) =>
+      me: (_headers) =>
         Effect.gen(function* () {
           const session = yield* requireSession();
-          // Same selector precedence as requireOrganization: the URL's org
-          // (header) drives /account/me so the shell reflects the org the tab
-          // is viewing, not a session-global active org.
-          const selector = headers[ORG_SELECTOR_HEADER] ?? session.organizationId;
+          // Same selector precedence as requireOrganization: the URL tenant
+          // drives /account/me so the shell reflects the org the tab is viewing,
+          // not a session-global active org.
+          const selector = (yield* currentTenantSelector) ?? session.organizationId;
           const org = selector
             ? yield* authorizeOrganizationSelector(session.accountId, selector).pipe(
                 Effect.provideContext(ctx),

--- a/apps/cloud/src/api.request-scope.node.test.ts
+++ b/apps/cloud/src/api.request-scope.node.test.ts
@@ -188,8 +188,9 @@ describe("makeApiLive (prod handler factory) request scoping", () => {
     // has built the per-request layer. We don't care about the response —
     // only that the layer was built once per request. `/integrations` is a
     // v2 protected route (the old `/scope` group was removed).
-    await handler(new Request("http://test.local/integrations"));
-    await handler(new Request("http://test.local/integrations"));
+    const emptyContext = Context.empty() as Context.Context<unknown>;
+    await handler(new Request("http://test.local/integrations"), emptyContext);
+    await handler(new Request("http://test.local/integrations"), emptyContext);
 
     expect(counts.acquires).toBe(2);
     expect(counts.releases).toBe(2);

--- a/apps/cloud/src/api/layers.ts
+++ b/apps/cloud/src/api/layers.ts
@@ -62,22 +62,24 @@ export const makeNonProtectedApiLive = (rsLive: Layer.Layer<DbService | UserStor
   );
 
 // Cloud-only WorkOS domain-verification routes. Auth is enforced by `OrgAuth`
-// middleware declared on `OrgHttpApi`. The domain handlers read the boot
-// `WorkOSClient` plus the `AuthContext` from `OrgAuthLive`; the
-// `getDomainVerificationLink` handler also gates on billing, so
-// `AutumnService.Default` is provided HERE (not on the neutral boot core).
-// Unlike the member endpoints that used to live here, they need no per-request
-// DB scoping (and `OrgAuthLive` stays session-scoped — see its note).
-export const OrgApiLive = HttpApiBuilder.layer(OrgHttpApi).pipe(
-  Layer.provide(OrgHandlers),
-  Layer.provideMerge(OrgAuthLive),
-  Layer.provideMerge(AutumnService.Default),
-);
+// middleware declared on `OrgHttpApi`. The auth layer resolves URL tenant
+// selectors through the local org mirror, so it needs the same per-request user
+// store as the session routes. The domain handlers read the boot `WorkOSClient`
+// plus the `AuthContext` from `OrgAuthLive`; `getDomainVerificationLink` also
+// gates on billing, so `AutumnService.Default` is provided HERE.
+export const makeOrgApiLive = (rsLive: Layer.Layer<DbService | UserStoreService>) =>
+  HttpApiBuilder.layer(OrgHttpApi).pipe(
+    Layer.provide(OrgHandlers),
+    Layer.provide(requestScopedMiddleware(rsLive).layer),
+    Layer.provideMerge(OrgAuthLive),
+    Layer.provideMerge(AutumnService.Default),
+  );
 
 // Default export uses the production per-request layer. Existing callers that
 // import `NonProtectedApiLive` continue to work; the `make*` factory exists for
 // tests that need to swap in a fake.
 export const NonProtectedApiLive = makeNonProtectedApiLive(RequestScopedServicesLive);
+export const OrgApiLive = makeOrgApiLive(RequestScopedServicesLive);
 
 // ---------------------------------------------------------------------------
 // Protected API

--- a/apps/cloud/src/api/router.ts
+++ b/apps/cloud/src/api/router.ts
@@ -12,8 +12,8 @@ import { CloudDocsLive } from "../extensions/docs";
 import { ApiErrorLoggingLive } from "../observability/error-logging";
 import {
   BootSharedServices,
-  OrgApiLive,
   RequestScopedServicesLive,
+  makeOrgApiLive,
   makeNonProtectedApiLive,
 } from "./layers";
 import { makeProtectedApiLive } from "./protected";
@@ -35,7 +35,7 @@ export const makeApiLive = (requestScopedLive: Layer.Layer<DbService | UserStore
   );
   return Layer.mergeAll(
     makeNonProtectedApiLive(requestScopedLive),
-    OrgApiLive,
+    makeOrgApiLive(requestScopedLive),
     makeAccountApiLive(requestScopedLive),
     CloudDocsLive,
     makeProtectedApiLive(requestScopedLive),

--- a/apps/cloud/src/app-paths.test.ts
+++ b/apps/cloud/src/app-paths.test.ts
@@ -16,6 +16,10 @@ describe("isAppOwnedPath", () => {
     "/api/billing/customer", // AutumnProvider pathPrefix — the billing UI
     "/api/billing/attach",
     "/api/docs", // Swagger UI
+    "/acme-corp/api/tools",
+    "/acme-corp/api/account/me",
+    "/acme-corp/api/org/domains",
+    "/acme-corp/api/billing/customer",
     "/mcp",
     "/.well-known/oauth-protected-resource/mcp",
     "/.well-known/oauth-authorization-server",
@@ -46,6 +50,7 @@ describe("isAppOwnedPath", () => {
     "/assets/app.js",
     "/settings/mcp",
     "/integrations/mcp",
+    "/mcp/api/tools",
   ];
   for (const pathname of startOwned) {
     it(`leaves ${pathname} to the Start router`, () => {

--- a/apps/cloud/src/app-paths.ts
+++ b/apps/cloud/src/app-paths.ts
@@ -1,4 +1,5 @@
 import { classifyMcpPath } from "./mcp/mount";
+import { isValidOrgSlug } from "@executor-js/api";
 
 // ---------------------------------------------------------------------------
 // Single source of truth for "does the unified app handler own this path?" —
@@ -15,5 +16,10 @@ import { classifyMcpPath } from "./mcp/mount";
 
 export const isApiPath = (pathname: string) => pathname === "/api" || pathname.startsWith("/api/");
 
+export const isTenantApiPath = (pathname: string): boolean => {
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  return segments.length >= 2 && segments[1] === "api" && isValidOrgSlug(segments[0]);
+};
+
 export const isAppOwnedPath = (pathname: string) =>
-  isApiPath(pathname) || classifyMcpPath(pathname) !== null;
+  isApiPath(pathname) || isTenantApiPath(pathname) || classifyMcpPath(pathname) !== null;

--- a/apps/cloud/src/app.ts
+++ b/apps/cloud/src/app.ts
@@ -1,7 +1,7 @@
 import { Layer } from "effect";
 import { HttpServer } from "effect/unstable/http";
 
-import { DbProvider, ExecutorApp } from "@executor-js/api/server";
+import { DbProvider, ExecutorApp, tenantApiMountPrefix } from "@executor-js/api/server";
 
 import { cloudPlugins } from "./plugins";
 import { CoreSharedServices } from "./auth/workos";
@@ -104,6 +104,7 @@ const { appLayer, toWebHandler, mcpExport } = ExecutorApp.make({
   },
   config: {
     mountPrefix: CLOUD_MOUNT_PREFIX,
+    tenantMountPrefix: tenantApiMountPrefix,
     // Cloud renders the shared identity errors as its exact `{ error, code }`
     // JSON at 401/403/503 (byte-identical to the old `HttpResponseError` bodies).
     failure: cloudIdentityFailureStrategy,

--- a/apps/cloud/src/auth/handlers.ts
+++ b/apps/cloud/src/auth/handlers.ts
@@ -9,7 +9,7 @@ import {
   McpExecutionNotFoundError,
   McpSessionForbiddenError,
 } from "./api";
-import { NoOrganization } from "@executor-js/api/server";
+import { currentTenantSelector, NoOrganization } from "@executor-js/api/server";
 // Pure constants/codec module (no React) — safe in the backend graph.
 import { AUTH_HINT_COOKIE } from "@executor-js/react/multiplayer/auth-hint";
 import { SessionContext, SessionCookies } from "./middleware";
@@ -25,7 +25,11 @@ import {
   isOverFreeOrganizationLimit,
   shouldApplyFreeOrganizationLimit,
 } from "../extensions/billing/plans";
-import { authorizeOrganization, resolveOrganization } from "./organization";
+import {
+  authorizeOrganization,
+  authorizeOrganizationSelector,
+  resolveOrganization,
+} from "./organization";
 import type {
   McpSessionApprovalResult,
   McpSessionResumeApprovalResult,
@@ -84,12 +88,19 @@ const timingSafeEqual = (a: string, b: string): boolean => {
 
 const requireSessionOrganizationId = Effect.gen(function* () {
   const session = yield* SessionContext;
-  if (!session.organizationId) {
+  const selector = (yield* currentTenantSelector) ?? session.organizationId;
+  if (!selector) {
+    return yield* new NoOrganization();
+  }
+  const org = yield* authorizeOrganizationSelector(session.accountId, selector).pipe(
+    Effect.mapError(() => new NoOrganization()),
+  );
+  if (!org) {
     return yield* new NoOrganization();
   }
   return {
     ...session,
-    organizationId: session.organizationId,
+    organizationId: org.id,
   };
 });
 

--- a/apps/cloud/src/auth/middleware-live.ts
+++ b/apps/cloud/src/auth/middleware-live.ts
@@ -6,7 +6,12 @@
 import { Effect, Layer, Redacted } from "effect";
 import { HttpServerResponse } from "effect/unstable/http";
 
-import { AuthContext, NoOrganization, Unauthorized } from "@executor-js/api/server";
+import {
+  AuthContext,
+  NoOrganization,
+  Unauthorized,
+  currentTenantSelector,
+} from "@executor-js/api/server";
 
 import {
   OrgAuth,
@@ -17,6 +22,7 @@ import {
   type SessionCookieOptions,
   type SessionCookieSetter,
 } from "./middleware";
+import { authorizeOrganizationSelector } from "./organization";
 import { WorkOSClient } from "./workos";
 
 export const SessionAuthLive = Layer.effect(
@@ -81,21 +87,21 @@ export const OrgAuthLive = Layer.effect(
             return yield* Effect.fail(new Unauthorized());
           }
 
-          if (!result.organizationId) {
+          const tenantSelector = yield* currentTenantSelector;
+          const selector = tenantSelector ?? result.organizationId;
+          if (!selector) {
             return yield* Effect.fail(new NoOrganization());
           }
-
-          // NOTE: the domains plane stays scoped to the SESSION org, not the URL
-          // org. Unlike the data + account planes (which resolve the selector
-          // header), this `HttpApiMiddleware` security handler may carry no
-          // residual requirement, so it can't reach the per-request
-          // `UserStoreService` a slug→id resolution needs. The domains surface
-          // (org-settings → domain verification) is niche; URL-scoping it would
-          // mean converting this to an HttpRouter middleware — deferred.
+          const org = yield* authorizeOrganizationSelector(result.userId, selector).pipe(
+            Effect.mapError(() => new NoOrganization()),
+          );
+          if (!org) {
+            return yield* Effect.fail(new NoOrganization());
+          }
           const session = sessionFromSealed(result, Redacted.value(credential));
           const auth = {
             accountId: session.accountId,
-            organizationId: result.organizationId,
+            organizationId: org.id,
             email: session.email,
             name: session.name,
             avatarUrl: session.avatarUrl,

--- a/apps/cloud/src/auth/middleware.ts
+++ b/apps/cloud/src/auth/middleware.ts
@@ -15,6 +15,8 @@ import { HttpApiMiddleware, HttpApiSecurity } from "effect/unstable/httpapi";
 // These are the canonical tags; consumers import them from `@executor-js/api/server`
 // directly. This module reads them to declare `SessionAuth` / `OrgAuth`.
 import { AuthContext, NoOrganization, Unauthorized } from "@executor-js/api/server";
+import type { UserStoreService } from "./context";
+import type { WorkOSClient } from "./workos";
 
 // ---------------------------------------------------------------------------
 // Session — what every authenticated request gets
@@ -124,12 +126,12 @@ export class SessionAuth extends HttpApiMiddleware.Service<
 // Provides the shared `AuthContext` (re-exported above).
 // ---------------------------------------------------------------------------
 
-export class OrgAuth extends HttpApiMiddleware.Service<OrgAuth, { provides: AuthContext }>()(
-  "OrgAuth",
-  {
-    error: [Unauthorized, NoOrganization],
-    security: {
-      cookie: HttpApiSecurity.apiKey({ in: "cookie", key: "wos-session" }),
-    },
+export class OrgAuth extends HttpApiMiddleware.Service<
+  OrgAuth,
+  { requires: UserStoreService | WorkOSClient; provides: AuthContext }
+>()("OrgAuth", {
+  error: [Unauthorized, NoOrganization],
+  security: {
+    cookie: HttpApiSecurity.apiKey({ in: "cookie", key: "wos-session" }),
   },
-) {}
+}) {}

--- a/apps/cloud/src/auth/org-selector-auth.node.test.ts
+++ b/apps/cloud/src/auth/org-selector-auth.node.test.ts
@@ -5,12 +5,12 @@ import { ApiKeyService } from "./api-keys";
 import { UserStoreService } from "./context";
 import { resolveSessionPrincipal } from "./workos-auth-provider";
 import { WorkOSClient, type WorkOSClientService } from "./workos";
+import { TenantScope } from "@executor-js/api/server";
 
-// The org a console request resolves to is the URL's org (sent in the
-// `x-executor-organization` selector header), not the session's stored org —
-// with the session org as the fallback for non-console callers, and live
-// membership re-checked either way. This is what makes two browser tabs on
-// different orgs independent.
+// The org a console request resolves to is the URL tenant, not the session's
+// stored org — with the session org as the fallback for non-console callers,
+// and live membership re-checked either way. This is what makes two browser tabs
+// on different orgs independent.
 
 const createdAt = new Date("2026-01-01T00:00:00.000Z");
 
@@ -79,35 +79,35 @@ const stubUsers = Layer.succeed(UserStoreService)({
     ),
 });
 
-const run = (headers: Record<string, string>) =>
-  resolveSessionPrincipal(new Request("https://executor.test/api/tools", { headers })).pipe(
-    Effect.provide(Layer.mergeAll(stubApiKeys, stubWorkOS, stubUsers)),
+const run = (tenantSelector?: string) => {
+  const effect = resolveSessionPrincipal(
+    new Request("https://executor.test/api/tools", { headers: { cookie: "wos-session=x" } }),
   );
+  return (
+    tenantSelector
+      ? effect.pipe(Effect.provideService(TenantScope, { selector: tenantSelector }))
+      : effect
+  ).pipe(Effect.provide(Layer.mergeAll(stubApiKeys, stubWorkOS, stubUsers)));
+};
 
-describe("resolveSessionPrincipal · URL org selector", () => {
-  it.effect("falls back to the session org when no selector header is sent", () =>
+describe("resolveSessionPrincipal · URL tenant selector", () => {
+  it.effect("falls back to the session org when no tenant selector is present", () =>
     Effect.gen(function* () {
-      const principal = yield* run({ cookie: "wos-session=x" });
+      const principal = yield* run();
       expect(principal.organizationId, "scopes to the session org").toBe(SESSION_ORG);
     }),
   );
 
   it.effect("scopes to the URL org (by slug) over the session org", () =>
     Effect.gen(function* () {
-      const principal = yield* run({
-        cookie: "wos-session=x",
-        "x-executor-organization": URL_SLUG,
-      });
-      expect(principal.organizationId, "the slug header wins over the session org").toBe(URL_ORG);
+      const principal = yield* run(URL_SLUG);
+      expect(principal.organizationId, "the URL tenant wins over the session org").toBe(URL_ORG);
     }),
   );
 
   it.effect("accepts a WorkOS org id as the selector too", () =>
     Effect.gen(function* () {
-      const principal = yield* run({
-        cookie: "wos-session=x",
-        "x-executor-organization": URL_ORG,
-      });
+      const principal = yield* run(URL_ORG);
       expect(principal.organizationId).toBe(URL_ORG);
     }),
   );
@@ -116,9 +116,7 @@ describe("resolveSessionPrincipal · URL org selector", () => {
     Effect.gen(function* () {
       // The slug resolves to a real org id, but membership is re-checked — a
       // slug is a selector, not a trust boundary, so a non-member is rejected.
-      const error = yield* Effect.flip(
-        run({ cookie: "wos-session=x", "x-executor-organization": "outsider-slug" }),
-      );
+      const error = yield* Effect.flip(run("outsider-slug"));
       expect(error).toMatchObject({ _tag: "NoOrganization" });
     }),
   );

--- a/apps/cloud/src/auth/organization.ts
+++ b/apps/cloud/src/auth/organization.ts
@@ -78,32 +78,8 @@ export const authorizeOrganization = (userId: string, organizationId: string) =>
     return yield* resolveOrganization(organizationId);
   });
 
-// ---------------------------------------------------------------------------
-// Org SELECTOR — the URL is the scope authority, not the session.
-// ---------------------------------------------------------------------------
-//
-// Org-scoped requests carry the active org in this header, set by the web
-// client from the console URL's slug (the MCP plane carries the same idea in
-// its own `x-executor-mcp-organization`). The selector is a slug (`acme`, the
-// readable URL form) or a WorkOS id (`org_…`, the legacy/token form). It is a
-// SELECTOR, not a trust boundary: `authorizeOrganizationSelector` re-checks
-// live membership, so the worst a forged header does is name an org the caller
-// already belongs to.
-//
-// Why a header and not the session's `org_id`: a browser shares ONE cookie jar
-// across tabs, so a single session-pinned org makes "active org" a
-// browser-global — two tabs can't be in two orgs at once, and switching in one
-// silently re-scopes the other. Scoping per-request from the URL makes each
-// tab independent.
-
-export const ORG_SELECTOR_HEADER = "x-executor-organization";
-
-/** The URL-pinned org selector for a request, or `null` to fall back to the session. */
-export const orgSelectorFromRequest = (request: Request): string | null =>
-  request.headers.get(ORG_SELECTOR_HEADER);
-
 /**
- * Resolve an org SELECTOR (URL slug or `org_…` id) to the organization the
+ * Resolve a tenant selector (URL slug or `org_...` id) to the organization the
  * caller actively belongs to, or `null`. A slug resolves through the local
  * mirror to its id first; ids pass straight through. Either way membership is
  * verified live via {@link authorizeOrganization}.

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -35,16 +35,13 @@ import {
   NoOrganization,
   Unauthorized,
   Unavailable,
+  currentTenantSelector,
 } from "@executor-js/api/server";
 import type { FailureRenderingStrategy, IdentityFailure, Principal } from "@executor-js/api/server";
 
 import { ApiKeyService } from "./api-keys";
 import { BEARER_PREFIX } from "./bearer";
-import {
-  authorizeOrganization,
-  authorizeOrganizationSelector,
-  orgSelectorFromRequest,
-} from "./organization";
+import { authorizeOrganization, authorizeOrganizationSelector } from "./organization";
 import { UserStoreService } from "./context";
 import { sealedSessionDisplayName } from "./middleware";
 import type { UserStoreError, WorkOSError } from "./errors";
@@ -115,11 +112,9 @@ export const resolveSessionPrincipal = (request: Request) =>
     if (!session) {
       return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);
     }
-    // The console URL's org is the scope authority (sent as a header); the
-    // session's own org is the fallback for non-console callers. Membership is
-    // re-checked live either way — the header is a selector, not a trust
-    // boundary (see organization.ts).
-    const selector = orgSelectorFromRequest(request) ?? session.organizationId;
+    // The console URL's tenant is the scope authority. The session's own org is
+    // only the fallback for bare /api callers (legacy/global surfaces).
+    const selector = (yield* currentTenantSelector) ?? session.organizationId;
     if (!selector) {
       return yield* new NoOrganization(NO_ORGANIZATION_IN_SESSION);
     }

--- a/apps/cloud/src/extensions/billing/route.node.test.ts
+++ b/apps/cloud/src/extensions/billing/route.node.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Effect, Layer } from "effect";
+import { TenantScope } from "@executor-js/api/server";
 
 import { UserStoreService } from "../../auth/context";
 import { WorkOSClient, type WorkOSClientService } from "../../auth/workos";
@@ -55,37 +56,40 @@ const stubUsers = Layer.succeed(UserStoreService)({
     ),
 });
 
-const run = (headers: Record<string, string>, organizationId: string | null = SESSION_ORG) =>
-  resolveBillingOrganization(
-    new Request("https://executor.test/api/billing/customer", { headers }),
-    { userId: MEMBER, organizationId },
+const run = (tenantSelector?: string, organizationId: string | null = SESSION_ORG) => {
+  const effect = resolveBillingOrganization({ userId: MEMBER, organizationId });
+  return (
+    tenantSelector
+      ? effect.pipe(Effect.provideService(TenantScope, { selector: tenantSelector }))
+      : effect
   ).pipe(Effect.provide(Layer.mergeAll(stubWorkOS, stubUsers)));
+};
 
-describe("billing route org selector", () => {
-  it.effect("falls back to the session org when no selector header is sent", () =>
+describe("billing route tenant selector", () => {
+  it.effect("falls back to the session org when no tenant selector is present", () =>
     Effect.gen(function* () {
-      const org = yield* run({});
+      const org = yield* run();
       expect(org.id).toBe(SESSION_ORG);
     }),
   );
 
-  it.effect("scopes billing to the URL org selector over the session org", () =>
+  it.effect("scopes billing to the URL tenant selector over the session org", () =>
     Effect.gen(function* () {
-      const org = yield* run({ "x-executor-organization": URL_SLUG });
+      const org = yield* run(URL_SLUG);
       expect(org.id).toBe(URL_ORG);
     }),
   );
 
   it.effect("rejects a selector for an org the caller is not a member of", () =>
     Effect.gen(function* () {
-      const error = yield* Effect.flip(run({ "x-executor-organization": "outsider-slug" }));
+      const error = yield* Effect.flip(run("outsider-slug"));
       expect(error).toMatchObject({ _tag: "HttpResponseError", status: 403 });
     }),
   );
 
-  it.effect("requires either a selector header or a session org", () =>
+  it.effect("requires either a tenant selector or a session org", () =>
     Effect.gen(function* () {
-      const error = yield* Effect.flip(run({}, null));
+      const error = yield* Effect.flip(run(undefined, null));
       expect(error).toMatchObject({ _tag: "HttpResponseError", status: 401 });
     }),
   );

--- a/apps/cloud/src/extensions/billing/route.ts
+++ b/apps/cloud/src/extensions/billing/route.ts
@@ -1,10 +1,12 @@
 import { env } from "cloudflare:workers";
-import { Cause, Effect } from "effect";
+import { Cause, Effect, Layer } from "effect";
 import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
 import { autumnHandler } from "autumn-js/backend";
 
+import { currentTenantSelector, TenantScopeMiddleware } from "@executor-js/api/server";
+
 import { WorkOSClient } from "../../auth/workos";
-import { ORG_SELECTOR_HEADER, authorizeOrganizationSelector } from "../../auth/organization";
+import { authorizeOrganizationSelector } from "../../auth/organization";
 import { HttpResponseError, isServerError, toErrorServerResponse } from "../../api/error-response";
 
 type BillingSession = {
@@ -12,9 +14,9 @@ type BillingSession = {
   readonly organizationId?: string | null;
 };
 
-export const resolveBillingOrganization = (request: Request, session: BillingSession) =>
+export const resolveBillingOrganization = (session: BillingSession) =>
   Effect.gen(function* () {
-    const selector = request.headers.get(ORG_SELECTOR_HEADER) ?? session.organizationId;
+    const selector = (yield* currentTenantSelector) ?? session.organizationId;
     if (!selector) {
       return yield* new HttpResponseError({
         status: 401,
@@ -56,7 +58,8 @@ const handler = Effect.gen(function* () {
       message: "Unauthorized",
     });
   }
-  const org = yield* resolveBillingOrganization(webRequest, session);
+  const org = yield* resolveBillingOrganization(session);
+  const tenant = yield* currentTenantSelector;
 
   const url = new URL(webRequest.url);
   const body =
@@ -88,7 +91,7 @@ const handler = Effect.gen(function* () {
         secretKey: env.AUTUMN_SECRET_KEY ?? "",
         ...(env.AUTUMN_API_URL ? { serverURL: env.AUTUMN_API_URL } : {}),
       },
-      pathPrefix: "/api/billing",
+      pathPrefix: tenant ? `/${tenant}/api/billing` : "/api/billing",
     }),
   );
 
@@ -111,4 +114,13 @@ const handler = Effect.gen(function* () {
   }),
 );
 
-export const AutumnRoutesLive = HttpRouter.add("*", "/api/billing/*", handler);
+const BareAutumnRoutesLive = HttpRouter.add("*", "/api/billing/*", handler);
+
+const TenantAutumnRoutesLive = HttpRouter.add("*", "/:tenant/api/billing/*", handler).pipe(
+  Layer.provide(TenantScopeMiddleware.layer),
+);
+
+export const AutumnRoutesLive = Layer.merge(
+  BareAutumnRoutesLive,
+  TenantAutumnRoutesLive,
+) as Layer.Layer<never, never, any>;

--- a/apps/cloud/src/extensions/routes.ts
+++ b/apps/cloud/src/extensions/routes.ts
@@ -24,7 +24,11 @@ import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { HttpApiSwagger, OpenApi } from "effect/unstable/httpapi";
 
-import { requestScopedMiddleware } from "@executor-js/api/server";
+import {
+  requestScopedMiddleware,
+  tenantApiMountPrefix,
+  TenantScopeMiddleware,
+} from "@executor-js/api/server";
 
 import { UserStoreService } from "../auth/context";
 import {
@@ -48,6 +52,10 @@ import { ApiErrorLoggingLive } from "../observability/error-logging";
 // its own internal prefixed view for the protected API.
 const apiPrefixedRouter = Layer.effect(HttpRouter.HttpRouter)(
   Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed("/api")),
+);
+
+const tenantApiPrefixedRouter = Layer.effect(HttpRouter.HttpRouter)(
+  Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed(tenantApiMountPrefix)),
 );
 
 // The full cloud OpenAPI spec, prefixed so the served paths match `/api/*`.
@@ -79,13 +87,31 @@ export const makeCloudExtensionRoutes = (rsLive: Layer.Layer<DbService | UserSto
     Layer.provide(apiPrefixedRouter),
   );
 
+  const TenantSessionRoutes = HttpApiBuilder.layer(NonProtectedApi).pipe(
+    Layer.provide(Layer.mergeAll(CloudAuthPublicHandlers, CloudSessionAuthHandlers)),
+    Layer.provide(requestScopedMiddleware(rsLive).layer),
+    Layer.provideMerge(SessionAuthLive),
+    Layer.provideMerge(AutumnService.Default),
+    Layer.provide(Layer.merge(tenantApiPrefixedRouter, TenantScopeMiddleware.layer)),
+  );
+
   // Cloud-only WorkOS domain-verification routes; `OrgAuth` enforces an
-  // authenticated org session. No per-request DB scoping needed.
+  // authenticated org session. The auth layer resolves URL tenant selectors, so
+  // it needs the same request-scoped user store as the protected product API.
   const OrgRoutes = HttpApiBuilder.layer(OrgHttpApi).pipe(
     Layer.provide(OrgHandlers),
+    Layer.provide(requestScopedMiddleware(rsLive).layer),
     Layer.provideMerge(OrgAuthLive),
     Layer.provideMerge(AutumnService.Default),
     Layer.provide(apiPrefixedRouter),
+  );
+
+  const TenantOrgRoutes = HttpApiBuilder.layer(OrgHttpApi).pipe(
+    Layer.provide(OrgHandlers),
+    Layer.provide(requestScopedMiddleware(rsLive).layer),
+    Layer.provideMerge(OrgAuthLive),
+    Layer.provideMerge(AutumnService.Default),
+    Layer.provide(Layer.merge(tenantApiPrefixedRouter, TenantScopeMiddleware.layer)),
   );
 
   // Swagger UI at /api/docs + the OpenAPI JSON at /api/openapi.json, over the
@@ -97,5 +123,13 @@ export const makeCloudExtensionRoutes = (rsLive: Layer.Layer<DbService | UserSto
 
   const BillingRoutes = AutumnRoutesLive.pipe(Layer.provide(requestScopedMiddleware(rsLive).layer));
 
-  return [SessionRoutes, OrgRoutes, DocsRoutes, BillingRoutes, ApiErrorLoggingLive] as const;
+  return [
+    SessionRoutes,
+    TenantSessionRoutes,
+    OrgRoutes,
+    TenantOrgRoutes,
+    DocsRoutes,
+    BillingRoutes,
+    ApiErrorLoggingLive,
+  ] as const;
 };

--- a/apps/cloud/src/routeTree.gen.ts
+++ b/apps/cloud/src/routeTree.gen.ts
@@ -350,15 +350,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-
 import type { startInstance } from './start.ts'
-
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
-
     router: Awaited<ReturnType<typeof getRouter>>
-
     config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/apps/cloud/src/routes/__root.tsx
+++ b/apps/cloud/src/routes/__root.tsx
@@ -16,7 +16,6 @@ import type { FrontendErrorReporter } from "@executor-js/react/api/error-reporti
 import { AnalyticsProvider, type AnalyticsClient } from "@executor-js/react/api/analytics";
 import { ExecutorProvider } from "@executor-js/react/api/provider";
 import { OrganizationProvider } from "@executor-js/react/api/organization-context";
-import { EXECUTOR_ORG_HEADER } from "@executor-js/react/api/server-connection";
 import { OrgSlugGate } from "@executor-js/react/multiplayer/org-slug-gate";
 import { Toaster } from "@executor-js/react/components/sonner";
 import { ExecutorPluginsProvider } from "@executor-js/sdk/client";
@@ -285,10 +284,10 @@ function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
   // so sourcing it from there removes that flash. Falls back to the session slug
   // on a bare URL (which OrgSlugGate is about to canonicalize onto it anyway).
   const scopeSlug = urlOrgSlug ?? activeSlug;
-  const billingHeaders = scopeSlug ? { [EXECUTOR_ORG_HEADER]: scopeSlug } : undefined;
+  const billingPathPrefix = scopeSlug ? `/${scopeSlug}/api/billing` : "/api/billing";
 
   return (
-    <AutumnProvider pathPrefix="/api/billing" headers={billingHeaders}>
+    <AutumnProvider pathPrefix={billingPathPrefix}>
       <Sentry.ErrorBoundary fallback={<ShellErrorFallback />} showDialog={false}>
         <ExecutorProvider connection={connection} onHandledError={captureFrontendError}>
           <React.Suspense fallback={<BlankScreen />}>
@@ -297,7 +296,7 @@ function AuthGate({ ssrOrigin }: { ssrOrigin: string | null }) {
                 organizationId={auth.organization.id}
                 organizationSlug={scopeSlug}
               >
-                {/* The org header scopes every request to the URL's org, so
+                {/* The tenant path scopes every request to the URL's org, so
                     reaching here means the caller is a member of `activeSlug`
                     (a foreign slug already 404'd above). The gate only keeps
                     the URL canonical — bare → /<slug>. */}

--- a/apps/cloud/src/web/client.tsx
+++ b/apps/cloud/src/web/client.tsx
@@ -1,7 +1,10 @@
 import * as AtomHttpApi from "effect/unstable/reactivity/AtomHttpApi";
-import { FetchHttpClient } from "effect/unstable/http";
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { addGroup } from "@executor-js/api";
-import { getBaseUrl } from "@executor-js/react/api/base-url";
+import {
+  getExecutorApiBaseUrl,
+  getExecutorTenantApiBaseUrl,
+} from "@executor-js/react/api/server-connection";
 import { CloudAuthApi } from "../auth/api";
 import { OrgApi } from "../org/api";
 
@@ -10,10 +13,23 @@ import { OrgApi } from "../org/api";
 // ---------------------------------------------------------------------------
 
 const CloudApi = addGroup(CloudAuthApi).add(OrgApi);
+
+const requestPathname = (url: string): string => new URL(url, "http://executor.internal").pathname;
+
+const shouldUseTenantApi = (request: HttpClientRequest.HttpClientRequest): boolean => {
+  const pathname = requestPathname(request.url);
+  return pathname.startsWith("/org/") || pathname.startsWith("/mcp-sessions/");
+};
+
 const CloudApiClient = AtomHttpApi.Service<"CloudApiClient">()("CloudApiClient", {
   api: CloudApi,
   httpClient: FetchHttpClient.layer,
-  baseUrl: getBaseUrl(),
+  transformClient: HttpClient.mapRequest((request) =>
+    HttpClientRequest.prependUrl(
+      request,
+      shouldUseTenantApi(request) ? getExecutorTenantApiBaseUrl() : getExecutorApiBaseUrl(),
+    ),
+  ),
 });
 
 export { CloudApiClient };

--- a/apps/cloud/src/web/components/org-menu-slot.tsx
+++ b/apps/cloud/src/web/components/org-menu-slot.tsx
@@ -52,9 +52,9 @@ function OrganizationSwitcherItems(props: { activeOrganizationId: string | null 
   const organizations = useAtomValue(organizationsAtom);
 
   // Switching orgs is now a pure URL navigation: the session authenticates the
-  // user to ALL their orgs, and the slug in the path scopes every request (the
-  // `x-executor-organization` header). No cookie to rewrite, no server switch
-  // call — just land on the other org's URL root and the whole app re-scopes.
+  // user to ALL their orgs, and the slug in the path scopes product API
+  // requests. No cookie to rewrite, no server switch call — just land on the
+  // other org's URL root and the whole app re-scopes.
   const handleSwitch = (organization: { id: string; slug: string }) => {
     if (organization.id === props.activeOrganizationId) return;
     trackEvent("org_switched", { success: true });

--- a/apps/host-cloudflare/src/app.ts
+++ b/apps/host-cloudflare/src/app.ts
@@ -1,7 +1,12 @@
 import { Effect } from "effect";
 import { HttpEffect, HttpRouter } from "effect/unstable/http";
 
-import { dbProviderLayer, ExecutorApp, textFailureStrategy } from "@executor-js/api/server";
+import {
+  dbProviderLayer,
+  ExecutorApp,
+  tenantApiMountPrefix,
+  textFailureStrategy,
+} from "@executor-js/api/server";
 
 import { loadConfig, type CloudflareEnv } from "./config";
 import { makeCloudflarePlugins } from "./plugins";
@@ -75,7 +80,11 @@ export const makeCloudflareApp = async (env: CloudflareEnv) => {
         HttpRouter.add("*", "/api/mcp-sessions/*", HttpEffect.fromWebHandler(mcp.approvalHandler)),
       ],
     },
-    config: { mountPrefix: "/api", failure: textFailureStrategy },
+    config: {
+      mountPrefix: "/api",
+      tenantMountPrefix: tenantApiMountPrefix,
+      failure: textFailureStrategy,
+    },
     boot: identityLayer,
   });
 

--- a/apps/host-cloudflare/src/mcp/org-path.ts
+++ b/apps/host-cloudflare/src/mcp/org-path.ts
@@ -1,0 +1,13 @@
+const PRM_PREFIX = "/.well-known/oauth-protected-resource";
+
+export const stripMcpOrgSegment = (pathname: string): string | null => {
+  if (pathname.startsWith(`${PRM_PREFIX}/`)) {
+    const rest = pathname
+      .slice(PRM_PREFIX.length + 1)
+      .split("/")
+      .filter((segment) => segment.length > 0);
+    return rest.length === 2 && rest[1] === "mcp" ? `${PRM_PREFIX}/mcp` : null;
+  }
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  return segments.length === 2 && segments[1] === "mcp" ? "/mcp" : null;
+};

--- a/apps/host-cloudflare/src/worker.ts
+++ b/apps/host-cloudflare/src/worker.ts
@@ -1,5 +1,6 @@
 import { makeCloudflareApp } from "./app";
 import type { CloudflareEnv } from "./config";
+import { stripMcpOrgSegment } from "./mcp/org-path";
 
 // The MCP session Durable Object class, bound as `MCP_SESSION` in wrangler.jsonc.
 // Must be exported at the Worker entry module scope for the runtime to find it.
@@ -22,9 +23,17 @@ const resolveHandler = (env: CloudflareEnv): Promise<(request: Request) => Promi
   return handlerPromise;
 };
 
+const prepareRequest = (request: Request): Request => {
+  const url = new URL(request.url);
+  const rewritten = stripMcpOrgSegment(url.pathname);
+  if (rewritten === null) return request;
+  url.pathname = rewritten;
+  return new Request(url, request);
+};
+
 export default {
   fetch: async (request: Request, env: CloudflareEnv): Promise<Response> => {
     const serve = await resolveHandler(env);
-    return serve(request);
+    return serve(prepareRequest(request));
   },
 };

--- a/apps/host-cloudflare/web/routes/__root.tsx
+++ b/apps/host-cloudflare/web/routes/__root.tsx
@@ -74,10 +74,10 @@ function AuthenticatedApp() {
   return (
     <ExecutorProvider>
       <ExecutorPluginsProvider plugins={clientPlugins}>
-        {/* No organizationSlug: the worker serves only the bare /mcp (see
-            wrangler.jsonc run_worker_first), so a slug-pinned URL would fall
-            through to the SPA. */}
-        <OrganizationProvider organizationId={organization?.id ?? null}>
+        <OrganizationProvider
+          organizationId={organization?.id ?? null}
+          organizationSlug={organization?.slug ?? null}
+        >
           {organization ? <OrgSlugGate activeSlug={organization.slug}>{gated}</OrgSlugGate> : gated}
         </OrganizationProvider>
       </ExecutorPluginsProvider>

--- a/apps/host-cloudflare/wrangler.jsonc
+++ b/apps/host-cloudflare/wrangler.jsonc
@@ -8,11 +8,20 @@
   // The web UI (Workers Static Assets) — the shared multiplayer SPA built by
   // `vite build` into ./dist. `single-page-application` serves index.html for
   // client routes (e.g. /policies); `run_worker_first` forces the API + MCP
-  // paths to the Worker instead of the SPA fallback.
+  // paths, including slugged tenant paths, to the Worker instead of the SPA
+  // fallback.
   "assets": {
     "directory": "./dist",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*", "/mcp", "/mcp/*"],
+    "run_worker_first": [
+      "/api/*",
+      "/*/api/*",
+      "/mcp",
+      "/mcp/*",
+      "/*/mcp",
+      "/*/mcp/*",
+      "/.well-known/*",
+    ],
   },
   // D1 is the app's SQLite store (the DbProvider seam). `wrangler deploy`
   // auto-provisions it on first deploy; replace database_id after that, or run

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -2,7 +2,12 @@ import { HttpApiSwagger } from "effect/unstable/httpapi";
 import { HttpEffect, HttpRouter } from "effect/unstable/http";
 import { Effect, Layer } from "effect";
 
-import { composePluginApi, ExecutorApp, textFailureStrategy } from "@executor-js/api/server";
+import {
+  composePluginApi,
+  ExecutorApp,
+  tenantApiMountPrefix,
+  textFailureStrategy,
+} from "@executor-js/api/server";
 
 import { runSqliteDataMigrations } from "@executor-js/sdk";
 
@@ -99,7 +104,11 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
         HttpApiSwagger.layer(composePluginApi(selfHostPlugins).prefix("/api"), { path: "/docs" }),
       ],
     },
-    config: { mountPrefix: "/api", failure: textFailureStrategy },
+    config: {
+      mountPrefix: "/api",
+      tenantMountPrefix: tenantApiMountPrefix,
+      failure: textFailureStrategy,
+    },
     // The boot-scoped context provideMerge'd under everything: the long-lived DB
     // handle (read by the DbProvider seam, Better Auth, and the MCP store) + the
     // resolved identity (captured once by the execution middleware + MCP auth).

--- a/apps/host-selfhost/vite.config.ts
+++ b/apps/host-selfhost/vite.config.ts
@@ -6,6 +6,7 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import executorVitePlugin from "@executor-js/vite-plugin";
+import { isValidOrgSlug } from "@executor-js/api";
 
 import { routes } from "./tsr.routes";
 import { stripMcpOrgSegment } from "./src/mcp/org-path";
@@ -17,6 +18,11 @@ import { stripMcpOrgSegment } from "./src/mcp/org-path";
 // from our executor.config.ts into `virtual:executor/plugins-client`.
 const APP_ROOT = fileURLToPath(new URL("../../packages/app/", import.meta.url));
 const DEV_PORT = 5173;
+
+const isTenantApiPath = (path: string): boolean => {
+  const segments = path.split("/").filter((segment) => segment.length > 0);
+  return segments.length >= 2 && segments[1] === "api" && isValidOrgSlug(segments[0]);
+};
 
 // Dev defaults so `bun run dev` boots the full stack with zero manual env.
 // Set at module load (before any plugin/executor.config reads them). Override
@@ -72,6 +78,7 @@ function executorApiPlugin(): Plugin {
         const handled =
           path === "/api" ||
           path.startsWith("/api/") ||
+          isTenantApiPath(path) ||
           path === "/mcp" ||
           path.startsWith("/mcp/") ||
           path === "/docs" ||

--- a/apps/host-selfhost/web/routes/__root.tsx
+++ b/apps/host-selfhost/web/routes/__root.tsx
@@ -87,10 +87,10 @@ function AuthenticatedApp() {
   return (
     <ExecutorProvider>
       <ExecutorPluginsProvider plugins={clientPlugins}>
-        {/* No organizationSlug: the self-host MCP endpoint is the bare /mcp —
-            a slug-pinned URL would 404, and a single-org instance has nothing
-            to select anyway. */}
-        <OrganizationProvider organizationId={organization?.id ?? null}>
+        <OrganizationProvider
+          organizationId={organization?.id ?? null}
+          organizationSlug={organization?.slug ?? null}
+        >
           {organization ? <OrgSlugGate activeSlug={organization.slug}>{gated}</OrgSlugGate> : gated}
         </OrganizationProvider>
       </ExecutorPluginsProvider>

--- a/e2e/cloud/org-multitab-cookie.test.ts
+++ b/e2e/cloud/org-multitab-cookie.test.ts
@@ -7,10 +7,10 @@
 // silently re-scoped the other tab out from under it.
 //
 // The stateless URL model removes that hazard. The slug in the path is the
-// request scope: every API call carries it (the `x-executor-organization`
-// header), the server re-checks live membership and resolves data for THAT
-// org, and the session merely authenticates the user to all their orgs at
-// once. Nothing writes the cookie on a switch. So this scenario — once the
+// request scope: product API calls go through `/<slug>/api/...`, the server
+// re-checks live membership and resolves data for THAT org, and the session
+// merely authenticates the user to all their orgs at once. Nothing writes the
+// cookie on a switch. So this scenario — once the
 // reproduction of the corruption — now asserts the opposite: each tab's
 // requests stay scoped to its own URL org, no matter what the other tab does.
 //
@@ -33,20 +33,19 @@ scenario(
     yield* browser.session(identity, async ({ page: tab1, step }) => {
       const slugOf = (page: typeof tab1) => new URL(page.url()).pathname.replace(/^\/|\/.*$/g, "");
 
-      // The org slug a page's REAL app requests carry — read straight off the
-      // outgoing `x-executor-organization` header, the actual request scope.
-      // This is what makes the two tabs independent; the shared session cookie
-      // is irrelevant to it.
+      // The tenant slug a page's REAL app requests carry — read straight off
+      // the outgoing `/<slug>/api/...` path, the actual request scope. This is
+      // what makes the two tabs independent; the shared session cookie is
+      // irrelevant to it.
       const requestOrgSlugOf = async (page: typeof tab1): Promise<string> => {
+        const expectedSlug = slugOf(page);
         const matching = page.waitForRequest(
-          (request) =>
-            request.url().includes("/api/") &&
-            request.headers()["x-executor-organization"] !== undefined,
+          (request) => new URL(request.url()).pathname.startsWith(`/${expectedSlug}/api/`),
           { timeout: 15_000 },
         );
         // Nudge the app to refetch so a fresh scoped request goes out.
         void page.reload({ waitUntil: "commit" });
-        return (await matching).headers()["x-executor-organization"]!;
+        return new URL((await matching).url()).pathname.split("/")[1]!;
       };
 
       let slugA = "";
@@ -100,7 +99,7 @@ scenario(
           "tab 1's sidebar still shows org B",
         ).toBe(true);
         // The crux: tab 2 opening org A did NOT re-scope tab 1. Tab 1's own
-        // requests still carry org B's slug — the URL is the scope, not a
+        // requests still use org B's URL path — the URL is the scope, not a
         // shared cookie a sibling tab can steal.
         expect(await requestOrgSlugOf(tab1), "tab 1's API requests stay scoped to org B").toBe(
           slugB,
@@ -111,7 +110,7 @@ scenario(
 );
 
 scenario(
-  "Org scope · plugin API requests carry the URL organization selector",
+  "Org scope · plugin API requests use the URL tenant path",
   {},
   Effect.gen(function* () {
     const target = yield* Target;
@@ -143,16 +142,17 @@ scenario(
 
       await step("Paste an inline spec", async () => {
         const previewRequest = page.waitForRequest(
-          (request) => request.url().includes("/api/openapi/preview"),
+          (request) => new URL(request.url()).pathname.endsWith("/api/openapi/preview"),
           { timeout: 15_000 },
         );
 
         await page.getByPlaceholder("https://api.example.com/openapi.json").fill(spec);
 
+        const request = await previewRequest;
         expect(
-          (await previewRequest).headers()["x-executor-organization"],
-          "plugin-owned preview requests use the URL's org selector",
-        ).toBe(orgSlug);
+          new URL(request.url()).pathname,
+          "plugin-owned preview requests use the URL tenant path",
+        ).toBe(`/${orgSlug}/api/openapi/preview`);
       });
     });
   }),

--- a/e2e/cloud/org-slug-foreign.test.ts
+++ b/e2e/cloud/org-slug-foreign.test.ts
@@ -1,8 +1,8 @@
 // Cloud-only (browser): opening another of YOUR orgs by its slug URL just
 // works — no switch, no cookie rewrite. The slug in the path is the request
-// scope (the `x-executor-organization` header), and the session authenticates
-// the user to ALL their orgs at once, so a bookmark or a teammate's link into a
-// shared org lands you there regardless of which org the cookie happens to pin.
+// scope for product API calls, and the session authenticates the user to ALL
+// their orgs at once, so a bookmark or a teammate's link into a shared org lands
+// you there regardless of which org the cookie happens to pin.
 //
 // org-switcher.test.ts covers the account-menu navigation; this covers the URL
 // path. (Unknown/unauthorized slugs → 404 is covered by

--- a/packages/core/api/src/server.ts
+++ b/packages/core/api/src/server.ts
@@ -19,6 +19,15 @@ export {
 export { AccountProvider, type AccountProviderShape, type AccountHeaders } from "./account/service";
 export { AccountHandlers } from "./account/handlers";
 export { requestScopedMiddleware } from "./server/request-scoped";
+export {
+  TenantScope,
+  TenantScopeMiddleware,
+  currentTenantSelector,
+  isTenantApiPath,
+  tenantApiMountPrefix,
+  tenantApiPath,
+  tenantFromApiPath,
+} from "./server/tenant-scope";
 export { RouterConfigLive } from "./server/router-config";
 export { consoleErrorCapture } from "./server/console-error-capture";
 export {

--- a/packages/core/api/src/server/executor-app.ts
+++ b/packages/core/api/src/server/executor-app.ts
@@ -74,6 +74,7 @@ import {
   toApiHandler,
   type ApiHandler,
 } from "./host-foundation";
+import { TenantScopeMiddleware } from "./tenant-scope";
 
 // A fully-resolved route/app Layer with its channels erased. Used at the
 // assembly boundaries (mirrors `toApiHandler`'s loose typing): each host's
@@ -267,6 +268,12 @@ export interface AppConfig<RStrategy, McpExport> {
    */
   readonly mountPrefix?: `/${string}`;
   /**
+   * Optional browser/product API mount that carries the active tenant in the
+   * path (`/:tenant/api/...`). Credential-scoped callers can continue to use
+   * `mountPrefix`; browser clients use this mount so the URL is the scope.
+   */
+  readonly tenantMountPrefix?: `/:${string}/api`;
+  /**
    * How identity-resolution failures render. The facade builds `authenticate`
    * from the `IdentityProvider` tag, so the failure channel is always the shared
    * `IdentityFailure`: cloud renders its `{ error, code }` JSON, self-host 401/403
@@ -386,6 +393,13 @@ export const make = <
         Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed(prefix)),
       )
     : undefined;
+  const tenantPrefix = config.tenantMountPrefix;
+  const tenantPrefixedRouter = tenantPrefix
+    ? Layer.effect(HttpRouter.HttpRouter)(
+        Effect.map(HttpRouter.HttpRouter.asEffect(), (router) => router.prefixed(tenantPrefix)),
+      )
+    : undefined;
+  const tenantRouteMiddleware = tenantPrefixedRouter ? TenantScopeMiddleware.layer : undefined;
 
   // ---- the OAuth callback path, derived from the SAME `mountPrefix` ------
   // The redirect URI the host serves and registers with providers is
@@ -518,20 +532,37 @@ export const make = <
       : executionMiddleware
   ).layer as AppRouteLayer;
   const pluginApiLive = protectedApi.layer.pipe(Layer.provide(middlewareLayer)) as AppRouteLayer;
+  const tenantPluginApiLive = tenantPrefixedRouter
+    ? (makeProtectedApiLayer(plugins, {
+        errorCapture: providers.errorCapture,
+        router: tenantPrefixedRouter,
+        routeMiddleware: tenantRouteMiddleware,
+      }).layer.pipe(Layer.provide(middlewareLayer)) as AppRouteLayer)
+    : undefined;
 
   // ---- (5) the account API (optional) -----------------------------------
   // The account middleware provides `AccountProvider` per request; its residual
   // `RAcct` (cloud's control-plane services; `never` for self-host) flows through
   // to `boot`. Omit `providers.account` -> no account API (the test-stub path).
-  const apiLive: AppRouteLayer = providers.account
-    ? Layer.merge(
-        pluginApiLive,
-        makeAccountApiLayer(
-          providers.account as Layer.Layer<unknown, never, RAcct>,
-          prefixedRouter ? { router: prefixedRouter } : {},
-        ) as AppRouteLayer,
-      )
-    : pluginApiLive;
+  const accountApiLive = providers.account
+    ? (makeAccountApiLayer(
+        providers.account as Layer.Layer<unknown, never, RAcct>,
+        prefixedRouter ? { router: prefixedRouter } : {},
+      ) as AppRouteLayer)
+    : undefined;
+  const tenantAccountApiLive =
+    providers.account && tenantPrefixedRouter
+      ? (makeAccountApiLayer(providers.account as Layer.Layer<unknown, never, RAcct>, {
+          router: tenantPrefixedRouter,
+          routeMiddleware: tenantRouteMiddleware,
+        }) as AppRouteLayer)
+      : undefined;
+  const apiLive: AppRouteLayer = Layer.mergeAll(
+    pluginApiLive,
+    ...(tenantPluginApiLive ? [tenantPluginApiLive] : []),
+    ...(accountApiLive ? [accountApiLive] : []),
+    ...(tenantAccountApiLive ? [tenantAccountApiLive] : []),
+  ) as AppRouteLayer;
 
   // ---- (4) the MCP serving envelope (optional) --------------------------
   // The two providers, by design (mirrors makeSelfHostMcp):

--- a/packages/core/api/src/server/host-foundation.ts
+++ b/packages/core/api/src/server/host-foundation.ts
@@ -53,6 +53,7 @@ import { RouterConfigLive } from "./router-config";
 // (self-host's `PrefixedRouterLive`). Keeping the requirement channel precise
 // (not `any`) avoids leaking `any` into every assembled host layer.
 type RouterLayer = Layer.Layer<HttpRouter.HttpRouter, never, HttpRouter.HttpRouter>;
+type RouteMiddlewareLayer = Layer.Layer<any, any, any>;
 
 // ---------------------------------------------------------------------------
 // Protected (plugin) API
@@ -71,6 +72,11 @@ export interface MakeProtectedApiLayerOptions {
    * present every API route serves under that prefix. Omit to serve at root.
    */
   readonly router?: RouterLayer;
+  /**
+   * Optional route-scoped middleware for this mount. Hosts use this to provide
+   * route-derived context such as a tenant selector from a dynamic path prefix.
+   */
+  readonly routeMiddleware?: RouteMiddlewareLayer;
 }
 
 /**
@@ -105,9 +111,14 @@ export const makeProtectedApiLayer = <TPlugins extends readonly AnyPlugin[]>(
   // `maxParamLength` without re-wiring it; the optional prefixed router is
   // merged alongside it so `HttpApiBuilder.layer`'s `HttpRouter` requirement is
   // satisfied by the prefixed view when the host wants a path namespace.
-  const routerSupport = options.router
-    ? Layer.merge(RouterConfigLive, options.router)
-    : RouterConfigLive;
+  const routerSupport =
+    options.router && options.routeMiddleware
+      ? Layer.mergeAll(RouterConfigLive, options.router, options.routeMiddleware)
+      : options.router
+        ? Layer.merge(RouterConfigLive, options.router)
+        : options.routeMiddleware
+          ? Layer.merge(RouterConfigLive, options.routeMiddleware)
+          : RouterConfigLive;
 
   const layer = HttpApiBuilder.layer(api).pipe(
     Layer.provide(Layer.mergeAll(handlers, observabilityMiddleware(api))),
@@ -128,6 +139,8 @@ export interface MakeAccountApiLayerOptions {
    * the account routes register on the same `/api`-prefixed router.
    */
   readonly router?: RouterLayer;
+  /** Optional route-scoped middleware for this mount. */
+  readonly routeMiddleware?: RouteMiddlewareLayer;
 }
 
 /**
@@ -166,7 +179,13 @@ export const makeAccountApiLayer = <MOut, ME, MR>(
     Layer.provide(AccountHandlers),
     Layer.provide(accountProviderMiddleware),
   );
-  return options.router ? base.pipe(Layer.provide(options.router)) : base;
+  const routeSupport =
+    options.router && options.routeMiddleware
+      ? Layer.merge(options.router, options.routeMiddleware)
+      : options.router
+        ? options.router
+        : options.routeMiddleware;
+  return routeSupport ? base.pipe(Layer.provide(routeSupport)) : base;
 };
 
 /**

--- a/packages/core/api/src/server/tenant-scope.ts
+++ b/packages/core/api/src/server/tenant-scope.ts
@@ -1,0 +1,44 @@
+import { Context, Effect, Option } from "effect";
+import { HttpRouter, HttpServerResponse } from "effect/unstable/http";
+
+import { isValidOrgSlug } from "../account/org-slug";
+
+export class TenantScope extends Context.Service<
+  TenantScope,
+  {
+    readonly selector: string;
+  }
+>()("@executor-js/api/TenantScope") {}
+
+export const currentTenantSelector = Effect.map(Effect.serviceOption(TenantScope), (scope) =>
+  Option.match(scope, {
+    onNone: () => null,
+    onSome: (value) => value.selector,
+  }),
+);
+
+export const tenantApiMountPrefix = "/:tenant/api" as const;
+
+export const tenantApiPath = (tenant: string, apiPath = ""): string =>
+  `/${tenant}/api${apiPath.startsWith("/") ? apiPath : apiPath ? `/${apiPath}` : ""}`;
+
+export const tenantFromApiPath = (pathname: string): string | null => {
+  const segments = pathname.split("/").filter((segment) => segment.length > 0);
+  if (segments.length < 2 || segments[1] !== "api") return null;
+  const tenant = segments[0];
+  return tenant && isValidOrgSlug(tenant) ? tenant : null;
+};
+
+export const isTenantApiPath = (pathname: string): boolean => tenantFromApiPath(pathname) !== null;
+
+export const TenantScopeMiddleware = HttpRouter.middleware<{ provides: TenantScope }>()(
+  (httpEffect) =>
+    Effect.gen(function* () {
+      const params = yield* HttpRouter.params;
+      const tenant = params.tenant;
+      if (!tenant || !isValidOrgSlug(tenant)) {
+        return HttpServerResponse.text("Not found", { status: 404 });
+      }
+      return yield* Effect.provideService(httpEffect, TenantScope, { selector: tenant });
+    }),
+);

--- a/packages/core/sdk/src/client.test.ts
+++ b/packages/core/sdk/src/client.test.ts
@@ -82,12 +82,12 @@ describe("createPluginAtomClient", () => {
     const request = HttpClientRequest.get("/openapi/integrations/acme");
     const transformed = applyPluginAtomClientRequestTransform(request, {
       headers: () => ({
-        "x-executor-organization": "newvale",
+        "x-plugin-test": "newvale",
         "x-empty": null,
       }),
     });
 
-    expect(transformed.headers["x-executor-organization"]).toBe("newvale");
+    expect(transformed.headers["x-plugin-test"]).toBe("newvale");
     expect(transformed.headers["x-empty"]).toBeUndefined();
   });
 });

--- a/packages/plugins/graphql/src/react/client.ts
+++ b/packages/plugins/graphql/src/react/client.ts
@@ -1,13 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorOrganizationHeaders,
-  getExecutorApiBaseUrl,
   getExecutorServerAuthorizationHeader,
+  getExecutorTenantApiBaseUrl,
 } from "@executor-js/react/api/server-connection";
 import { GraphqlGroup } from "../api/group";
 
 export const GraphqlClient = createPluginAtomClient(GraphqlGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorTenantApiBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
-  headers: getExecutorOrganizationHeaders,
 });

--- a/packages/plugins/mcp/src/react/client.ts
+++ b/packages/plugins/mcp/src/react/client.ts
@@ -1,13 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorOrganizationHeaders,
-  getExecutorApiBaseUrl,
   getExecutorServerAuthorizationHeader,
+  getExecutorTenantApiBaseUrl,
 } from "@executor-js/react/api/server-connection";
 import { McpGroup } from "../api/group";
 
 export const McpClient = createPluginAtomClient(McpGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorTenantApiBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
-  headers: getExecutorOrganizationHeaders,
 });

--- a/packages/plugins/onepassword/src/react/client.ts
+++ b/packages/plugins/onepassword/src/react/client.ts
@@ -1,13 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorOrganizationHeaders,
-  getExecutorApiBaseUrl,
   getExecutorServerAuthorizationHeader,
+  getExecutorTenantApiBaseUrl,
 } from "@executor-js/react/api/server-connection";
 import { OnePasswordGroup } from "../api/group";
 
 export const OnePasswordClient = createPluginAtomClient(OnePasswordGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorTenantApiBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
-  headers: getExecutorOrganizationHeaders,
 });

--- a/packages/plugins/openapi/src/react/client.ts
+++ b/packages/plugins/openapi/src/react/client.ts
@@ -1,13 +1,11 @@
 import { createPluginAtomClient } from "@executor-js/sdk/client";
 import {
-  getExecutorOrganizationHeaders,
-  getExecutorApiBaseUrl,
   getExecutorServerAuthorizationHeader,
+  getExecutorTenantApiBaseUrl,
 } from "@executor-js/react/api/server-connection";
 import { OpenApiGroup } from "../api/group";
 
 export const OpenApiClient = createPluginAtomClient(OpenApiGroup, {
-  baseUrl: getExecutorApiBaseUrl,
+  baseUrl: getExecutorTenantApiBaseUrl,
   authorizationHeader: getExecutorServerAuthorizationHeader,
-  headers: getExecutorOrganizationHeaders,
 });

--- a/packages/react/src/api/account-client.tsx
+++ b/packages/react/src/api/account-client.tsx
@@ -5,10 +5,8 @@ import * as Effect from "effect/Effect";
 
 import { reportApiClientInfrastructureCause } from "./client";
 import {
-  EXECUTOR_ORG_HEADER,
-  getActiveOrgSlug,
-  getExecutorApiBaseUrl,
   getExecutorServerAuthorizationHeader,
+  getExecutorTenantApiBaseUrl,
 } from "./server-connection";
 
 // ---------------------------------------------------------------------------
@@ -25,15 +23,10 @@ const AccountApiClient = AtomHttpApi.Service<"AccountApiClient">()("AccountApiCl
   api: AccountHttpApi,
   httpClient: FetchHttpClient.layer,
   transformClient: HttpClient.mapRequest((request) => {
-    let next = HttpClientRequest.prependUrl(request, getExecutorApiBaseUrl());
+    let next = HttpClientRequest.prependUrl(request, getExecutorTenantApiBaseUrl());
     const authorization = getExecutorServerAuthorizationHeader();
     if (authorization) {
       next = HttpClientRequest.setHeader(next, "authorization", authorization);
-    }
-    // Scope to the org the console URL is on (see server-connection).
-    const orgSlug = getActiveOrgSlug();
-    if (orgSlug) {
-      next = HttpClientRequest.setHeader(next, EXECUTOR_ORG_HEADER, orgSlug);
     }
     return next;
   }),

--- a/packages/react/src/api/client.tsx
+++ b/packages/react/src/api/client.tsx
@@ -13,10 +13,8 @@ import * as Schema from "effect/Schema";
 import { reportHandledFrontendError } from "./error-reporting";
 import { notifyLocalAuthRequired } from "./local-auth";
 import {
-  EXECUTOR_ORG_HEADER,
-  getActiveOrgSlug,
-  getExecutorApiBaseUrl,
   getExecutorServerAuthorizationHeader,
+  getExecutorTenantApiBaseUrl,
 } from "./server-connection";
 
 const isApiClientInfrastructureCause = (cause: Cause.Cause<unknown>): boolean =>
@@ -119,15 +117,10 @@ const ExecutorApiClient = AtomHttpApi.Service<"ExecutorApiClient">()("ExecutorAp
   api: ExecutorApi,
   httpClient: FetchHttpClient.layer,
   transformClient: HttpClient.mapRequest((request) => {
-    let next = HttpClientRequest.prependUrl(request, getExecutorApiBaseUrl());
+    let next = HttpClientRequest.prependUrl(request, getExecutorTenantApiBaseUrl());
     const authorization = getExecutorServerAuthorizationHeader();
     if (authorization) {
       next = HttpClientRequest.setHeader(next, "authorization", authorization);
-    }
-    // Scope the request to the org the console URL is on (see server-connection).
-    const orgSlug = getActiveOrgSlug();
-    if (orgSlug) {
-      next = HttpClientRequest.setHeader(next, EXECUTOR_ORG_HEADER, orgSlug);
     }
     return next;
   }),

--- a/packages/react/src/api/server-connection.test.ts
+++ b/packages/react/src/api/server-connection.test.ts
@@ -2,12 +2,31 @@ import { describe, expect, it } from "@effect/vitest";
 
 import {
   apiBaseUrlForServerOrigin,
+  getActiveTenantSlug,
+  getExecutorApiBaseUrl,
   getExecutorServerAuthorizationHeader,
+  getExecutorTenantApiBaseUrl,
   normalizeExecutorServerConnection,
   normalizeExecutorServerOrigin,
   originFromApiBaseUrl,
   resolveBrowserExecutorServerConnection,
+  setExecutorServerConnection,
 } from "./server-connection";
+
+const withWindowPath = <A>(pathname: string, run: () => A): A => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: { location: { pathname } },
+  });
+  const result = run();
+  if (descriptor) {
+    Object.defineProperty(globalThis, "window", descriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+  return result;
+};
 
 describe("Executor server connection", () => {
   it("normalizes server origins and API base URLs", () => {
@@ -62,5 +81,19 @@ describe("Executor server connection", () => {
     expect(connection.kind).toBe("http");
     expect(connection.origin).toBe("http://localhost:4788");
     expect(getExecutorServerAuthorizationHeader(connection)).toBeNull();
+  });
+
+  it("derives tenant-scoped API base URLs from the current path", () => {
+    setExecutorServerConnection({ origin: "https://executor.example" });
+
+    withWindowPath("/acme/policies", () => {
+      expect(getActiveTenantSlug()).toBe("acme");
+      expect(getExecutorTenantApiBaseUrl()).toBe("https://executor.example/acme/api");
+    });
+
+    withWindowPath("/login", () => {
+      expect(getActiveTenantSlug()).toBeNull();
+      expect(getExecutorTenantApiBaseUrl()).toBe(getExecutorApiBaseUrl());
+    });
   });
 });

--- a/packages/react/src/api/server-connection.tsx
+++ b/packages/react/src/api/server-connection.tsx
@@ -71,34 +71,20 @@ const resolveInitialExecutorServerConnection = (): ExecutorServerConnection => {
 let activeConnection = resolveInitialExecutorServerConnection();
 
 // ---------------------------------------------------------------------------
-// Active org selector — the org the console URL is scoped to.
+// Active tenant selector — the tenant the console URL is scoped to.
 // ---------------------------------------------------------------------------
 //
-// Org-scoped hosts (cloud) send this on every API request so the server scopes
-// to the URL's org, not the session's stored one — which is what lets two
-// browser tabs sit in two different orgs at once (each tab's window.location is
-// its own).
-//
-// Read straight from `window.location` at REQUEST time, not from a
-// React-synced mirror: the API clients' `transformClient` runs only in the
-// browser, so this never touches SSR/hydration, and it's always exactly the
-// current URL with no effect-timing to get wrong. The org is the first path
-// segment when it's a valid slug; reserved console roots (`/policies`,
-// `/login`, …) are NOT valid slugs, so a bare path sends no header and the
-// server falls back to the session org. Hosts without slugs (self-host,
-// cloudflare) never produce one either.
-export const EXECUTOR_ORG_HEADER = "x-executor-organization";
-
-export const getActiveOrgSlug = (): string | null => {
+// Product API calls carry tenant scope in the path: `/<tenant>/api/...`.
+// Read straight from `window.location` at REQUEST time, not from a React-synced
+// mirror: the API clients' `transformClient` runs only in the browser, so this
+// never touches SSR/hydration, and it is exactly the current tab's URL. Reserved
+// console roots (`/policies`, `/login`, ...) are not valid slugs, so global pages
+// and hosts without slugged routes keep using the bare `/api` mount.
+export const getActiveTenantSlug = (): string | null => {
   const pathname = globalThis.window?.location?.pathname;
   if (!pathname) return null;
   const first = pathname.split("/")[1];
   return first && isValidOrgSlug(first) ? first : null;
-};
-
-export const getExecutorOrganizationHeaders = (): Readonly<Record<string, string>> => {
-  const orgSlug = getActiveOrgSlug();
-  return orgSlug ? { [EXECUTOR_ORG_HEADER]: orgSlug } : {};
 };
 
 export const getExecutorServerConnection = (): ExecutorServerConnection => activeConnection;
@@ -116,6 +102,11 @@ export const setExecutorServerApiBaseUrl = (apiBaseUrl: string): void => {
 };
 
 export const getExecutorApiBaseUrl = (): string => activeConnection.apiBaseUrl;
+
+export const getExecutorTenantApiBaseUrl = (): string => {
+  const tenant = getActiveTenantSlug();
+  return tenant ? `${activeConnection.origin}/${tenant}/api` : activeConnection.apiBaseUrl;
+};
 
 export const getExecutorServerAuthPassword = (): string | null =>
   activeConnection.auth?.kind === "basic" ? activeConnection.auth.password : null;

--- a/packages/react/src/multiplayer/org-slug-gate.tsx
+++ b/packages/react/src/multiplayer/org-slug-gate.tsx
@@ -10,10 +10,10 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 //   - bare URL            → replace with `/<active-slug>/…` (canonicalize)
 //   - slug already in URL → render
 //
-// The URL slug is the request SCOPE, not just a label: every API call carries
-// it (the `x-executor-organization` header), and the server re-checks live
-// membership and resolves data for that org — same as the MCP URL-pinned org.
-// So a foreign slug never reaches this gate as "active": the server returns no
+// The URL slug is the request SCOPE, not just a label: product API calls use
+// `/<slug>/api/...`, and the server re-checks live membership and resolves data
+// for that org — same as the MCP URL-pinned org. So a foreign slug never reaches
+// this gate as "active": the server returns no
 // organization for an org the caller can't see, and the shell 404s upstream.
 // That makes two browser tabs on different orgs fully independent — no shared
 // "active org" to steal.


### PR DESCRIPTION
## Summary

Moves browser/product organization scoping out of the `x-executor-organization` request header and into tenant-scoped API paths.

- Adds a shared tenant request context from `/:tenant/api/...` routes.
- Mounts protected and account APIs on both bare `/api` and tenant-prefixed `/:tenant/api` paths.
- Updates browser core/account/plugin clients, billing, cloud org routes, and MCP approval calls to use tenant paths where the current URL is tenant-scoped.
- Keeps bare `/api` available for global/session, legacy, and credential-scoped routes.
- Extends cloud, self-host, and Cloudflare routing so tenant API paths reach the Effect app.

## Why

The active organization was being represented in two places: product URLs and a browser-supplied selector header. That made request scope harder to reason about and caused drift between URL state and API state. The URL path is now the browser-visible source of truth for tenant-scoped product requests.

## Validation

- `bun run --cwd packages/core/api typecheck`
- `bun run --cwd packages/react typecheck`
- `bun run --cwd packages/core/sdk typecheck`
- `bun run --cwd apps/cloud typecheck`
- `bun run --cwd apps/host-selfhost typecheck`
- `bun run --cwd apps/host-cloudflare typecheck`
- `bun run --cwd e2e typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run --cwd packages/react test src/api/server-connection.test.ts`
- `bun run --cwd packages/core/sdk test src/client.test.ts`
- `bun run --cwd apps/cloud test src/app-paths.test.ts src/auth/org-selector-auth.node.test.ts src/extensions/billing/route.node.test.ts src/api.request-scope.node.test.ts`
- `bun run --cwd e2e test:cloud cloud/org-multitab-cookie.test.ts`