### PR TITLE
Fix main CI release checks

### DIFF
--- a/apps/desktop/src/main/sidecar.ts
+++ b/apps/desktop/src/main/sidecar.ts
@@ -481,7 +481,7 @@ export async function attachToSupervisedDaemon(): Promise<SidecarConnection | nu
     isReachable: isDaemonReachable,
     isPidAlive,
   });
-  if (decision._tag === "Attach") {
+  if (decision.kind === "attach") {
     const { manifest, authToken } = decision;
     const origin = manifest.connection.origin;
     const url = new URL(origin);
@@ -500,7 +500,7 @@ export async function attachToSupervisedDaemon(): Promise<SidecarConnection | nu
     };
   }
 
-  if (decision._tag === "RemoveStaleManifest") {
+  if (decision.kind === "remove-stale-manifest") {
     removeManifestIfOwnedBy(dataDir, decision.pid);
     return null;
   }

--- a/apps/desktop/src/main/supervised-daemon.test.ts
+++ b/apps/desktop/src/main/supervised-daemon.test.ts
@@ -32,7 +32,7 @@ describe("resolveSupervisedDaemonAttach", () => {
       },
     });
 
-    expect(decision._tag).toBe("Attach");
+    expect(decision.kind).toBe("attach");
     expect(pidProbeCount).toBe(0);
   });
 
@@ -42,6 +42,6 @@ describe("resolveSupervisedDaemonAttach", () => {
       isPidAlive: () => false,
     });
 
-    expect(decision).toEqual({ _tag: "RemoveStaleManifest", pid: 1234 });
+    expect(decision).toEqual({ kind: "remove-stale-manifest", pid: 1234 });
   });
 });

--- a/apps/desktop/src/main/supervised-daemon.ts
+++ b/apps/desktop/src/main/supervised-daemon.ts
@@ -4,12 +4,12 @@ type CliDaemonManifest = ExecutorLocalServerManifest & { readonly kind: "cli-dae
 
 type SupervisedDaemonAttachDecision =
   | {
-      readonly _tag: "Attach";
+      readonly kind: "attach";
       readonly manifest: CliDaemonManifest;
       readonly authToken: string;
     }
-  | { readonly _tag: "RemoveStaleManifest"; readonly pid: number }
-  | { readonly _tag: "Unavailable" };
+  | { readonly kind: "remove-stale-manifest"; readonly pid: number }
+  | { readonly kind: "unavailable" };
 
 export const resolveSupervisedDaemonAttach = async (
   manifest: ExecutorLocalServerManifest | null,
@@ -18,18 +18,18 @@ export const resolveSupervisedDaemonAttach = async (
     readonly isPidAlive: (pid: number) => boolean;
   },
 ): Promise<SupervisedDaemonAttachDecision> => {
-  if (!manifest || manifest.kind !== "cli-daemon") return { _tag: "Unavailable" };
+  if (!manifest || manifest.kind !== "cli-daemon") return { kind: "unavailable" };
   const cliManifest = { ...manifest, kind: "cli-daemon" as const };
 
   if (await input.isReachable(cliManifest.connection.origin)) {
     const auth = cliManifest.connection.auth;
     const authToken = auth && auth.kind === "bearer" ? auth.token : "";
-    return { _tag: "Attach", manifest: cliManifest, authToken };
+    return { kind: "attach", manifest: cliManifest, authToken };
   }
 
   if (!input.isPidAlive(cliManifest.pid)) {
-    return { _tag: "RemoveStaleManifest", pid: cliManifest.pid };
+    return { kind: "remove-stale-manifest", pid: cliManifest.pid };
   }
 
-  return { _tag: "Unavailable" };
+  return { kind: "unavailable" };
 };

--- a/apps/local/tsconfig.json
+++ b/apps/local/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Enable TypeScript extension imports for `apps/local` so the shared Vite helper can import `./tsr.routes.ts` during typecheck.
- Rename the desktop supervised-daemon attach decision discriminant from `_tag` to `kind` and update callers/tests, avoiding the no-manual-`_tag` lint rule.

Refs #1027.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run --cwd apps/desktop test`
