### PR TITLE
Integrate macOS traffic lights into sidebar

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -398,6 +398,9 @@ const createWindow = async (conn: SidecarConnection) => {
     show: false,
     backgroundColor: "#0a0a0a",
     autoHideMenuBar: true,
+    ...(process.platform === "darwin"
+      ? { titleBarStyle: "hidden" as const, trafficLightPosition: { x: 16, y: 17 } }
+      : {}),
     ...(linuxIcon ? { icon: linuxIcon } : {}),
     webPreferences: {
       preload: PRELOAD_PATH,

--- a/packages/app/src/entry-client.tsx
+++ b/packages/app/src/entry-client.tsx
@@ -8,6 +8,10 @@ import "@executor-js/react/globals.css";
 
 initDesktopCrashReporting();
 
+if ("executor" in window && navigator.platform.includes("Mac")) {
+  document.documentElement.classList.add("executor-desktop-macos");
+}
+
 // Resolve the local bearer token (?_token → localStorage → dev global) and set
 // the connection's auth BEFORE the router mounts, so the first API atom carries
 // it. No-op on desktop (the main process injects the header).

--- a/packages/app/src/web/shell.tsx
+++ b/packages/app/src/web/shell.tsx
@@ -349,14 +349,17 @@ function SidebarContent(props: {
   return (
     <>
       {props.showBrand !== false && (
-        <div className="flex h-12 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
-          <Link to="/{-$orgSlug}" className="flex shrink-0 items-center gap-1.5">
+        <div className="desktop-macos-sidebar-header flex h-12 shrink-0 items-center gap-2 border-b border-sidebar-border px-4">
+          <Link
+            to="/{-$orgSlug}"
+            className="desktop-macos-no-drag flex shrink-0 items-center gap-1.5"
+          >
             <span className="font-display text-base tracking-tight text-foreground">executor</span>
             <span className="rounded bg-primary/15 px-1.5 py-px text-[10px] font-semibold uppercase tracking-wider text-primary">
               Beta
             </span>
           </Link>
-          <div className="ml-auto flex min-w-0 flex-1 justify-end">
+          <div className="desktop-macos-no-drag ml-auto flex min-w-0 flex-1 justify-end pl-3">
             <ServerConnectionMenu variant="header" />
           </div>
         </div>

--- a/packages/react/src/styles/globals.css
+++ b/packages/react/src/styles/globals.css
@@ -149,6 +149,15 @@
   }
 }
 
+.executor-desktop-macos .desktop-macos-sidebar-header {
+  -webkit-app-region: drag;
+  padding-left: 88px;
+}
+
+.executor-desktop-macos .desktop-macos-no-drag {
+  -webkit-app-region: no-drag;
+}
+
 .dark {
   --sidebar: hsl(240 5.9% 10%);
   --sidebar-foreground: hsl(240 4.8% 95.9%);


### PR DESCRIPTION
| before | after |
|--------|-----|
| <img width="340" height="224" alt="image" src="https://github.com/user-attachments/assets/aa319582-0c30-4a29-b686-077622cdc2d7" /> | <img width="304" height="195" alt="image" src="https://github.com/user-attachments/assets/a54ba88e-39dc-4555-b940-eb11505d380c" /> |
