### PR TITLE
[codex] Fix desktop black screen fallback

### DIFF
--- a/.changeset/desktop-black-screen-fallback.md
+++ b/.changeset/desktop-black-screen-fallback.md
@@ -1,0 +1,8 @@
+---
+"executor": patch
+---
+
+Fix desktop startup so a failed supervised-daemon replacement no longer leaves
+the app on a black window. The desktop now re-checks the daemon after install
+failures, falls back to a managed sidecar when the stale daemon disappears, and
+surfaces startup recovery instead of leaving a failed renderer visible.

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,6 +35,7 @@ import {
   reportAProblem,
 } from "./diagnostics";
 import { sidecarCrashHtml } from "./crash-screen";
+import { replaceSupervisedDaemonForDesktop } from "./supervised-connection";
 import {
   bundledExecutorPath,
   installSupervisedService,
@@ -86,6 +87,11 @@ const liveMainWindow = (): BrowserWindow | null => {
     return null;
   }
   return window;
+};
+
+const destroyWindow = (window: BrowserWindow) => {
+  if (mainWindow === window) mainWindow = null;
+  if (!window.isDestroyed()) window.destroy();
 };
 
 const focusMainWindow = () => {
@@ -208,17 +214,21 @@ const ensureSupervisedConnection = async (): Promise<SidecarConnection | null> =
   if (attached) {
     if (!shouldReplaceDaemonForDesktop(attached)) return attached;
     const settings = getServerSettings();
-    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: desktop launch should attach to the running daemon if automatic upgrade fails
-    try {
-      await installSupervisedService({
-        port: settings.port,
-        dataDir: DESKTOP_DATA_DIR,
-      });
-      return (await waitForSupervisedAttach(30_000, { port: settings.port })) ?? attached;
-    } catch (error) {
-      log.warn("Failed to replace older supervised daemon; attaching to the running daemon", error);
-      return attached;
-    }
+    return replaceSupervisedDaemonForDesktop(attached, {
+      install: () =>
+        installSupervisedService({
+          port: settings.port,
+          dataDir: DESKTOP_DATA_DIR,
+        }),
+      waitForAttach: () => waitForSupervisedAttach(30_000, { port: settings.port }),
+      attach: attachToSupervisedDaemon,
+      onInstallFailure: (error) => {
+        log.warn(
+          "Failed to replace older supervised daemon; re-checking before falling back",
+          error,
+        );
+      },
+    });
   }
 
   const status = await supervisedServiceStatus();
@@ -449,7 +459,18 @@ const createWindow = async (conn: SidecarConnection) => {
     return { action: "deny" };
   });
 
-  await window.loadURL(webUrlForConnection(conn));
+  // A supervised daemon can pass the health probe and still disappear before
+  // navigation begins. Treat that as a failed connection instead of leaving the
+  // user with a visible BrowserWindow that only shows the black background.
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: Electron navigation rejects when the sidecar vanishes during startup
+  try {
+    await window.loadURL(webUrlForConnection(conn));
+  } catch (error) {
+    log.error("Failed to load Executor web UI", error);
+    destroyWindow(window);
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: caller decides whether to fall back or surface startup failure
+    throw error;
+  }
 };
 
 const showPortInUseDialog = async (port: number) => {
@@ -849,10 +870,18 @@ const boot = async () => {
     const supervised = await ensureSupervisedConnection();
     if (supervised) {
       connection = supervised;
-      await createWindow(supervised); // installs the bearer-auth header itself
-      armSupervisedMonitor();
-      void runUpdateCheck({ alertOnFail: false });
-      return;
+      // createWindow installs the bearer-auth header itself.
+      // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: supervised attach can race with daemon shutdown; fall back to managed spawn
+      try {
+        await createWindow(supervised);
+        armSupervisedMonitor();
+        void runUpdateCheck({ alertOnFail: false });
+        return;
+      } catch (error) {
+        log.warn("Failed to load supervised daemon; falling back to managed sidecar", error);
+        stopSupervisedMonitor();
+        connection = null;
+      }
     }
   }
   connection = await startWithCurrentSettings();
@@ -875,7 +904,44 @@ const boot = async () => {
     app.quit();
     return;
   }
-  await createWindow(connection);
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: renderer navigation failure must show the startup recovery dialog, not a black window
+  try {
+    await createWindow(connection);
+  } catch (error) {
+    log.error("Failed to load managed sidecar web UI", error);
+    const failedConnection = connection;
+    connection = null;
+    await stopConnection(failedConnection);
+
+    const retryAfterReset = await handleFatalSidecarFailure(error);
+    if (!retryAfterReset) {
+      app.quit();
+      return;
+    }
+
+    lastSidecarStartError = null;
+    connection = await startWithCurrentSettings();
+    if (!connection && lastSidecarStartError != null) {
+      await handleFatalSidecarFailure(lastSidecarStartError);
+    }
+    if (!connection) {
+      app.quit();
+      return;
+    }
+
+    // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: one post-reset retry before giving the user the final startup failure
+    try {
+      await createWindow(connection);
+    } catch (retryError) {
+      log.error("Failed to load managed sidecar web UI after reset", retryError);
+      const failedRetryConnection = connection;
+      connection = null;
+      await stopConnection(failedRetryConnection);
+      await handleFatalSidecarFailure(retryError);
+      app.quit();
+      return;
+    }
+  }
   // Check at boot. If an update is available, autoDownload pulls it and
   // the 'update-downloaded' handler fires the install dialog. Silent on
   // no-update / failure so we don't bother users on every launch.

--- a/apps/desktop/src/main/supervised-connection.test.ts
+++ b/apps/desktop/src/main/supervised-connection.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import type { SidecarConnection } from "./sidecar";
+import { replaceSupervisedDaemonForDesktop } from "./supervised-connection";
+
+const connection = (baseUrl: string): SidecarConnection => ({
+  baseUrl,
+  hostname: "localhost",
+  port: 4789,
+  username: "executor",
+  authToken: "token",
+  child: null,
+  supervisedDaemon: true,
+  ownerVersion: "1.5.12",
+  ownerClient: "cli",
+  ownerExecutablePath: "/tmp/old-executor",
+});
+
+const rejectedInstall = (error: unknown): Promise<void> => Effect.runPromise(Effect.fail(error));
+
+describe("replaceSupervisedDaemonForDesktop", () => {
+  it("uses the replacement daemon after install succeeds", async () => {
+    const stale = connection("http://localhost:4789");
+    const fresh = connection("http://localhost:55334");
+    let installCalls = 0;
+    let waitCalls = 0;
+    let attachCalls = 0;
+
+    const result = await replaceSupervisedDaemonForDesktop(stale, {
+      install: async () => {
+        installCalls += 1;
+      },
+      waitForAttach: async () => {
+        waitCalls += 1;
+        return fresh;
+      },
+      attach: async () => {
+        attachCalls += 1;
+        return stale;
+      },
+    });
+
+    expect(result).toBe(fresh);
+    expect(installCalls).toBe(1);
+    expect(waitCalls).toBe(1);
+    expect(attachCalls).toBe(0);
+  });
+
+  it("re-probes after install fails instead of returning the stale daemon", async () => {
+    const stale = connection("http://localhost:4789");
+    const installFailure = { _tag: "InstallFailure" };
+    let loggedError: unknown;
+    let loggedConnection: SidecarConnection | null = null;
+    let waitCalls = 0;
+    let attachCalls = 0;
+
+    const result = await replaceSupervisedDaemonForDesktop(stale, {
+      install: () => rejectedInstall(installFailure),
+      waitForAttach: async () => {
+        waitCalls += 1;
+        return stale;
+      },
+      attach: async () => {
+        attachCalls += 1;
+        return null;
+      },
+      onInstallFailure: (error, connection) => {
+        loggedError = error;
+        loggedConnection = connection;
+      },
+    });
+
+    expect(result).toBeNull();
+    expect(waitCalls).toBe(0);
+    expect(attachCalls).toBe(1);
+    expect(loggedError).toBe(installFailure);
+    expect(loggedConnection).toBe(stale);
+  });
+});

--- a/apps/desktop/src/main/supervised-connection.ts
+++ b/apps/desktop/src/main/supervised-connection.ts
@@ -1,0 +1,22 @@
+/* oxlint-disable executor/no-try-catch-or-throw -- boundary: Electron startup must convert service-install failures into a fresh daemon probe */
+import type { SidecarConnection } from "./sidecar";
+
+export interface ReplaceSupervisedDaemonInput {
+  readonly install: () => Promise<void>;
+  readonly waitForAttach: () => Promise<SidecarConnection | null>;
+  readonly attach: () => Promise<SidecarConnection | null>;
+  readonly onInstallFailure?: (error: unknown, staleConnection: SidecarConnection) => void;
+}
+
+export const replaceSupervisedDaemonForDesktop = async (
+  staleConnection: SidecarConnection,
+  input: ReplaceSupervisedDaemonInput,
+): Promise<SidecarConnection | null> => {
+  try {
+    await input.install();
+    return (await input.waitForAttach()) ?? (await input.attach());
+  } catch (error) {
+    input.onInstallFailure?.(error, staleConnection);
+    return await input.attach();
+  }
+};

--- a/e2e/desktop-packaged/supervised-regressions.test.ts
+++ b/e2e/desktop-packaged/supervised-regressions.test.ts
@@ -661,6 +661,15 @@ if (!guiAvailable() || !packagedSingleInstanceAvailable()) {
   );
 
   scenario(
+    "Desktop packaged supervised attach · install failure falls back instead of black-screening",
+    { timeout: 300_000 },
+    Effect.gen(function* () {
+      const runDir = yield* RunDir;
+      yield* Effect.promise(() => runInstallFailureFallsBackToManagedSidecar(runDir));
+    }),
+  );
+
+  scenario(
     "Desktop packaged supervised settings · changing the port moves the active daemon",
     { timeout: 300_000 },
     Effect.gen(function* () {
@@ -685,6 +694,9 @@ const writeCliDaemonManifest = (input: {
   readonly origin: string;
   readonly displayName: string;
   readonly token: string;
+  readonly ownerVersion?: string | null;
+  readonly ownerClient?: "cli" | "desktop";
+  readonly ownerExecutablePath?: string | null;
 }): void => {
   mkdirSync(input.controlDir, { recursive: true });
   writeFileSync(
@@ -701,10 +713,132 @@ const writeCliDaemonManifest = (input: {
         displayName: input.displayName,
         auth: { kind: "bearer", token: input.token },
       }),
-      owner: { client: "cli", version: null, executablePath: null },
+      owner: {
+        client: input.ownerClient ?? "cli",
+        version: input.ownerVersion ?? null,
+        executablePath: input.ownerExecutablePath ?? null,
+      },
     }),
     { mode: 0o600 },
   );
+};
+
+const shellSingleQuote = (value: string): string => `'${value.replaceAll("'", "'\"'\"'")}'`;
+
+const withFailingBundledInstall = async <T>(run: () => Promise<T>): Promise<T> => {
+  const { executor } = requireBundle();
+  const original = readFileSync(executor);
+  const mode = statSync(executor).mode & 0o777;
+  const backup = `${executor}.e2e-real`;
+  writeFileSync(backup, original, { mode });
+  chmodSync(backup, mode);
+  writeFileSync(
+    executor,
+    [
+      "#!/bin/sh",
+      'if [ "$1" = "install" ]; then',
+      '  echo "launchctl bootstrap failed (exit 5): Bootstrap failed: 5: Input/output error" >&2',
+      "  exit 1",
+      "fi",
+      `exec ${shellSingleQuote(backup)} "$@"`,
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  try {
+    return await run();
+  } finally {
+    writeFileSync(executor, original, { mode });
+    chmodSync(executor, mode);
+    rmSync(backup, { force: true });
+  }
+};
+
+const runInstallFailureFallsBackToManagedSidecar = async (runDir: string) => {
+  const home = mkdtempSync(join(tmpdir(), "executor-pkg-install-failure-fallback-"));
+  const dataDir = join(home, ".executor");
+  const controlDir = join(dataDir, "server-control");
+  const token = "install-failure-fallback-token";
+  const launchdSnapshot = captureLaunchdService();
+  const oldPort = await freePort();
+  const requests: Array<{ readonly url: string; readonly authorization: string | null }> = [];
+  let resolveHealthProbe!: () => void;
+  const sawHealthProbe = new Promise<void>((resolve) => {
+    resolveHealthProbe = resolve;
+  });
+  let app: PackagedApp | undefined;
+  let serverOpen = false;
+
+  const server = createServer((req: IncomingMessage, res) => {
+    const url = req.url ?? "/";
+    requests.push({
+      url,
+      authorization: req.headers.authorization ?? null,
+    });
+    if (url.startsWith("/api/health")) {
+      res.writeHead(200, {
+        "content-type": "text/plain",
+        connection: "close",
+      });
+      res.end("ok", () => {
+        resolveHealthProbe();
+        void closeServer();
+      });
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end("<!doctype html><title>Stale Executor</title><body>Stale daemon</body>");
+  });
+  const closeServer = async (): Promise<void> => {
+    if (!serverOpen) return;
+    serverOpen = false;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  };
+
+  try {
+    await new Promise<void>((resolve) =>
+      server.listen(oldPort, "127.0.0.1", () => {
+        serverOpen = true;
+        resolve();
+      }),
+    );
+    writeCliDaemonManifest({
+      controlDir,
+      dataDir,
+      origin: `http://127.0.0.1:${oldPort}`,
+      displayName: "Older daemon that disappears",
+      token,
+      ownerVersion: "0.0.0",
+    });
+
+    await withFailingBundledInstall(async () => {
+      app = await launchPackaged(home);
+      const page = app.cdp;
+      await sawHealthProbe;
+      await page.waitForText("Settings", 120_000);
+      await page.screenshot(join(runDir, "01-fell-back-to-managed-sidecar.png"));
+
+      const connection = await page.evaluate<{ readonly origin: string } | null>(
+        "window.executor.getServerConnection()",
+      );
+      expect(
+        new URL(connection!.origin).port,
+        "desktop should not keep rendering from the stale daemon port after install failure",
+      ).not.toBe(String(oldPort));
+      expect(
+        requests
+          .filter((request) => request.url.startsWith("/api/health"))
+          .map((request) => request.authorization),
+        "the stale-daemon health probe must not disclose the saved bearer",
+      ).not.toContain(`Bearer ${token}`);
+    });
+  } finally {
+    await closePackaged(app);
+    await restoreLaunchdService(launchdSnapshot);
+    await closeServer();
+    rmSync(home, { recursive: true, force: true });
+  }
 };
 
 const runSlowLiveDaemonProbe = async (runDir: string) => {

--- a/e2e/notes/testing-on-mac.md
+++ b/e2e/notes/testing-on-mac.md
@@ -1,0 +1,25 @@
+# Testing on macOS
+
+Packaged desktop e2e tests need a real GUI session. Check `launchctl managername`;
+it should report `Aqua`. SSH-only sessions usually land in the Background
+launchd domain, where `open` can fail with `OSLaunchdErrorDomain Code=125` even
+after the VM is reachable over SSH.
+
+For VM runs, log in through VNC before launching the app. SSH is still useful
+for staging files, reading logs, and running probes, but GUI app launch and
+window assertions are more reliable after a console user is active.
+
+The packaged desktop app has a single-instance lock on macOS. If
+`/Applications/Executor.app` is already running on the host, prefer an isolated
+VM or close that app before running `vitest run --project desktop-packaged`.
+
+Useful evidence locations:
+
+- Main process log: `~/Library/Logs/Executor/main.log`
+- Supervised daemon manifest: `~/.executor/server-control/server.json`
+- Electron CDP port: `~/Library/Application Support/Executor/DevToolsActivePort`
+
+When debugging black-window reports, verify both pixels and renderer state. VNC
+can occasionally show a black framebuffer while CDP proves the renderer DOM is
+healthy, so capture a CDP screenshot or inspect `document.body.innerText` before
+calling a UI blank.

--- a/e2e/notes/testing-on-mac.md
+++ b/e2e/notes/testing-on-mac.md
@@ -9,6 +9,9 @@ For VM runs, log in through VNC before launching the app. SSH is still useful
 for staging files, reading logs, and running probes, but GUI app launch and
 window assertions are more reliable after a console user is active.
 
+[trycua/cua](https://github.com/trycua/cua)'s Lume CLI is a useful way to clone,
+boot, SSH into, VNC into, stop, and delete local macOS VMs programmatically.
+
 The packaged desktop app has a single-instance lock on macOS. If
 `/Applications/Executor.app` is already running on the host, prefer an isolated
 VM or close that app before running `vitest run --project desktop-packaged`.


### PR DESCRIPTION
## Summary

- Re-probe supervised daemon state after replacement install failures instead of returning a stale connection.
- Treat `BrowserWindow.loadURL` failures as startup failures so the app can fall back to a managed sidecar or show recovery instead of leaving a black window.
- Add a focused regression test, a packaged desktop e2e scenario, and `e2e/notes/testing-on-mac.md` with macOS testing notes and a link to [trycua/cua](https://github.com/trycua/cua).
- Add a patch Changesets entry so this fix is included in the next release train.

## Root Cause

The desktop app could attach to an older supervised daemon, attempt to replace it, hit a `launchctl bootstrap` failure, and then keep using the original stale connection. If that daemon disappeared after the health probe, Electron rejected the navigation with `ERR_CONNECTION_REFUSED` and the visible window stayed black.

## Validation

- `bun run --cwd apps/desktop test`
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd e2e typecheck`
- `bunx oxlint -c .oxlintrc.jsonc apps/desktop/src/main/index.ts apps/desktop/src/main/supervised-connection.ts apps/desktop/src/main/supervised-connection.test.ts e2e/desktop-packaged/supervised-regressions.test.ts --deny-warnings`
- `bunx oxfmt --check ...`
- `bunx changeset status --since main`
- macOS VM repro: old packaged app reproduced the refused-navigation black window; patched packaged app hit the same forced install failure and rendered from the managed sidecar instead.