### PR TITLE
Extract OpenAPI backed plugin helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -968,15 +968,16 @@
         "@effect/platform-node": "catalog:",
         "@executor-js/config": "workspace:*",
         "@executor-js/sdk": "workspace:*",
+        "js-yaml": "4.1.1",
         "lucide-react": "^1.7.0",
         "openapi-types": "^12.1.3",
-        "yaml": "^2.7.1",
       },
       "devDependencies": {
         "@effect/atom-react": "catalog:",
         "@effect/vitest": "catalog:",
         "@executor-js/api": "workspace:*",
         "@executor-js/react": "workspace:*",
+        "@types/js-yaml": "4.0.9",
         "@types/node": "catalog:",
         "@types/react": "catalog:",
         "bun-types": "catalog:",
@@ -2840,6 +2841,8 @@
     "@types/http-cache-semantics": ["@types/http-cache-semantics@4.2.0", "", {}, "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q=="],
 
     "@types/js-cookie": ["@types/js-cookie@3.0.6", "", {}, "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 

--- a/e2e/cloud/sources-api.test.ts
+++ b/e2e/cloud/sources-api.test.ts
@@ -117,7 +117,7 @@ scenario(
 );
 
 scenario(
-  "Integrations · previewSpec reports a spec's operations before anything is stored",
+  "Integrations · previewSpec reports summary metadata before anything is stored",
   {},
   Effect.gen(function* () {
     const target = yield* Target;
@@ -127,9 +127,9 @@ scenario(
 
     const preview = yield* client.openapi.previewSpec({ payload: { spec: pingSpec } });
     expect(preview.operationCount, "the preview counts the spec's operations").toBe(1);
-    expect(preview.operations, "the preview lists each operation's identity").toEqual([
-      expect.objectContaining({ operationId: "ping", method: "get", path: "/ping" }),
-    ]);
+    expect(Object.hasOwn(preview, "operations"), "the HTTP preview omits per-operation rows").toBe(
+      false,
+    );
   }),
 );
 

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -143,6 +143,7 @@ import { connectionIdentifier } from "./connection-name-identifier";
 import { annotateToolResultOutcome } from "./tool-result";
 
 const PLUGIN_STORAGE_DELETE_KEY_BATCH_SIZE = 90;
+const PLUGIN_STORAGE_CREATE_ROW_BATCH_SIZE = 90;
 const MAX_APPROVAL_ARGUMENT_PREVIEW_CHARS = 4_000;
 
 // ---------------------------------------------------------------------------
@@ -982,20 +983,30 @@ const makePluginStorageFacade = (input: {
       yield* deleteManyImpl(owner, os.subject, uniqueEntries);
 
       const now = new Date();
-      yield* input.core.createMany(
-        "plugin_storage",
-        uniqueEntries.map((entry) => ({
-          tenant,
-          owner: os.owner,
-          subject: os.subject,
-          plugin_id: input.pluginId,
-          collection: entry.collection,
-          key: entry.key,
-          data: entry.data,
-          created_at: now,
-          updated_at: now,
-        })),
-      );
+      for (
+        let offset = 0;
+        offset < uniqueEntries.length;
+        offset += PLUGIN_STORAGE_CREATE_ROW_BATCH_SIZE
+      ) {
+        const batchEntries = uniqueEntries.slice(
+          offset,
+          offset + PLUGIN_STORAGE_CREATE_ROW_BATCH_SIZE,
+        );
+        yield* input.core.createMany(
+          "plugin_storage",
+          batchEntries.map((entry) => ({
+            tenant,
+            owner: os.owner,
+            subject: os.subject,
+            plugin_id: input.pluginId,
+            collection: entry.collection,
+            key: entry.key,
+            data: entry.data,
+            created_at: now,
+            updated_at: now,
+          })),
+        );
+      }
     });
 
   const removeManyImpl = (

--- a/packages/core/sdk/src/plugin-storage.test.ts
+++ b/packages/core/sdk/src/plugin-storage.test.ts
@@ -222,6 +222,31 @@ describe("plugin storage collections", () => {
     }),
   );
 
+  it.effect("bulk puts large plugin storage row sets in bounded batches", () =>
+    Effect.gen(function* () {
+      const executor = yield* makeTestExecutor({
+        backend: "sqlite",
+        plugins: [executionHistoryPlugin] as const,
+      });
+      const rows = Array.from({ length: 7_000 }, (_, index) => ({
+        key: `large-call-${String(index).padStart(5, "0")}`,
+        data: call({
+          runId: "run-large-bulk",
+          toolId: index % 2 === 0 ? "browser" : "shell",
+          status: "ok",
+          startedAt: new Date(Date.UTC(2026, 4, 29, 12, 0, index)).toISOString(),
+        }),
+      }));
+
+      yield* executor.executionHistory.recordMany("org", rows);
+
+      const count = yield* executor.executionHistory.count({
+        where: { runId: "run-large-bulk" },
+      });
+      expect(count).toBe(rows.length);
+    }),
+  );
+
   it.effect("user rows shadow org rows on read; both share one plugin_storage table", () =>
     Effect.gen(function* () {
       // One executor bound to a subject sees both org and user owner rows; a

--- a/packages/plugins/openapi/package.json
+++ b/packages/plugins/openapi/package.json
@@ -64,15 +64,16 @@
     "@effect/platform-node": "catalog:",
     "@executor-js/config": "workspace:*",
     "@executor-js/sdk": "workspace:*",
+    "js-yaml": "4.1.1",
     "lucide-react": "^1.7.0",
-    "openapi-types": "^12.1.3",
-    "yaml": "^2.7.1"
+    "openapi-types": "^12.1.3"
   },
   "devDependencies": {
     "@effect/atom-react": "catalog:",
     "@effect/vitest": "catalog:",
     "@executor-js/api": "workspace:*",
     "@executor-js/react": "workspace:*",
+    "@types/js-yaml": "4.0.9",
     "@types/node": "catalog:",
     "@types/react": "catalog:",
     "bun-types": "catalog:",

--- a/packages/plugins/openapi/src/api/group.ts
+++ b/packages/plugins/openapi/src/api/group.ts
@@ -9,7 +9,7 @@ import {
 } from "@executor-js/sdk/shared";
 
 import { OpenApiParseError, OpenApiExtractionError, OpenApiOAuthError } from "../sdk/errors";
-import { SpecPreview } from "../sdk/preview";
+import { SpecPreviewSummary } from "../sdk/preview";
 
 // ---------------------------------------------------------------------------
 // Errors — the plugin-domain tagged errors flow directly to clients
@@ -155,7 +155,7 @@ export const OpenApiGroup = HttpApiGroup.make("openapi")
   .add(
     HttpApiEndpoint.post("previewSpec", "/openapi/preview", {
       payload: PreviewSpecPayload,
-      success: SpecPreview,
+      success: SpecPreviewSummary,
       error: DomainErrors,
     }),
   )

--- a/packages/plugins/openapi/src/api/handlers.ts
+++ b/packages/plugins/openapi/src/api/handlers.ts
@@ -3,6 +3,7 @@ import { Context, Effect } from "effect";
 
 import { addGroup, capture } from "@executor-js/api";
 import type { OpenApiPluginExtension } from "../sdk/plugin";
+import { specPreviewSummary } from "../sdk/preview";
 import { OpenApiGroup } from "./group";
 
 // ---------------------------------------------------------------------------
@@ -43,7 +44,8 @@ export const OpenApiHandlers = HttpApiBuilder.group(ExecutorApiWithOpenApi, "ope
       capture(
         Effect.gen(function* () {
           const ext = yield* OpenApiExtensionService;
-          return yield* ext.previewSpec({ spec: payload.spec });
+          const preview = yield* ext.previewSpec({ spec: payload.spec });
+          return specPreviewSummary(preview);
         }),
       ),
     )

--- a/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
+++ b/packages/plugins/openapi/src/react/AddOpenApiSource.tsx
@@ -44,7 +44,7 @@ import {
   googleOpenApiPresets,
   type GoogleOpenApiPreset,
 } from "../sdk/google-presets";
-import type { SpecPreview } from "../sdk/preview";
+import type { SpecPreviewSummary } from "../sdk/preview";
 import { type Authentication } from "../sdk/types";
 import { resolveServerUrl } from "../sdk/openapi-utils";
 import { detectedAuthenticationTemplates } from "../sdk/derive-auth";
@@ -131,7 +131,7 @@ export default function AddOpenApiSource(props: {
   const [analyzeError, setAnalyzeError] = useState<string | null>(null);
 
   // After analysis
-  const [preview, setPreview] = useState<SpecPreview | null>(null);
+  const [preview, setPreview] = useState<SpecPreviewSummary | null>(null);
   const [baseUrl, setBaseUrl] = useState("");
   // Agent-visible description: prefilled from the spec's `info.description`
   // until the user types (null = untouched, keep deriving from the preview).

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -1,0 +1,382 @@
+import { Effect, Option, Schema } from "effect";
+import type { Layer } from "effect";
+import { HttpClient } from "effect/unstable/http";
+
+import {
+  ToolFileJsonSchema,
+  ToolName,
+  ToolResult,
+  authToolFailure,
+  type PluginCtx,
+  type ResolveToolsResult,
+  type StorageFailure,
+  type ToolDef,
+  type ToolInvocationCredential,
+} from "@executor-js/sdk/core";
+
+import {
+  decodeOpenApiIntegrationConfig,
+  renderAuthTemplate,
+  requiredTemplateVariables,
+  type OpenApiIntegrationConfig,
+} from "./config";
+import { OpenApiExtractionError, OpenApiParseError } from "./errors";
+import { extract } from "./extract";
+import { compileToolDefinitions, type ToolDefinition } from "./definitions";
+import { annotationsForOperation, invokeWithLayer } from "./invoke";
+import { parse } from "./parse";
+import { type OpenapiStore, type StoredOperation } from "./store";
+import { OperationBinding } from "./types";
+
+const STRINGIFIED_BODY_CAP = 1024;
+const UpstreamMessageBody = Schema.Struct({ message: Schema.String });
+const UpstreamErrorMessageBody = Schema.Struct({ errorMessage: Schema.String });
+const UpstreamNestedErrorBody = Schema.Struct({ error: UpstreamMessageBody });
+const UpstreamErrorsArrayBody = Schema.Struct({
+  errors: Schema.Array(
+    Schema.Struct({
+      detail: Schema.optional(Schema.String),
+      message: Schema.optional(Schema.String),
+      title: Schema.optional(Schema.String),
+    }),
+  ),
+});
+const UpstreamDescriptionBody = Schema.Struct({
+  detail: Schema.optional(Schema.String),
+  title: Schema.optional(Schema.String),
+  description: Schema.optional(Schema.String),
+});
+
+const decodeUpstreamMessageBody = Schema.decodeUnknownOption(UpstreamMessageBody);
+const decodeUpstreamErrorMessageBody = Schema.decodeUnknownOption(UpstreamErrorMessageBody);
+const decodeUpstreamNestedErrorBody = Schema.decodeUnknownOption(UpstreamNestedErrorBody);
+const decodeUpstreamErrorsArrayBody = Schema.decodeUnknownOption(UpstreamErrorsArrayBody);
+const decodeUpstreamDescriptionBody = Schema.decodeUnknownOption(UpstreamDescriptionBody);
+
+const clampedStringify = (value: unknown): string => {
+  let s: string;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: JSON.stringify may throw on cycles; fall back to String() so the upstream body can still be surfaced as ToolError.details fallback text
+  try {
+    s = JSON.stringify(value);
+  } catch {
+    s = String(value);
+  }
+  return s.length > STRINGIFIED_BODY_CAP ? `${s.slice(0, STRINGIFIED_BODY_CAP)}…` : s;
+};
+
+const firstNonEmpty = (...values: readonly (string | undefined)[]): string | undefined =>
+  values.find((value) => value !== undefined && value.length > 0);
+
+export const extractOpenApiUpstreamMessage = (body: unknown, status: number): string => {
+  if (typeof body === "string") {
+    return body.length > 0 ? body : `Upstream returned HTTP ${status}`;
+  }
+  const nested = Option.getOrUndefined(decodeUpstreamNestedErrorBody(body));
+  const messageBody = Option.getOrUndefined(decodeUpstreamMessageBody(body));
+  const errorMessageBody = Option.getOrUndefined(decodeUpstreamErrorMessageBody(body));
+  const errorsBody = Option.getOrUndefined(decodeUpstreamErrorsArrayBody(body));
+  const descriptionBody = Option.getOrUndefined(decodeUpstreamDescriptionBody(body));
+  const arrayMessage = errorsBody?.errors
+    .map(
+      ({
+        detail,
+        message: upstreamMessage,
+        title,
+      }: {
+        detail?: string;
+        message?: string;
+        title?: string;
+      }) => firstNonEmpty(detail, upstreamMessage, title),
+    )
+    .find((message: string | undefined) => message !== undefined);
+  const message = firstNonEmpty(
+    nested?.error.message,
+    messageBody?.message,
+    errorMessageBody?.errorMessage,
+    arrayMessage,
+    descriptionBody?.detail,
+    descriptionBody?.title,
+    descriptionBody?.description,
+  );
+  if (message !== undefined) return message;
+  if (body !== null && typeof body === "object") {
+    return clampedStringify(body);
+  }
+  return `Upstream returned HTTP ${status}`;
+};
+
+const openApiAuthToolFailure = (failure: {
+  readonly code: string;
+  readonly message: string;
+  readonly owner: "org" | "user";
+  readonly integration: string;
+  readonly connection: string;
+  readonly credentialKind: "secret" | "oauth" | "upstream";
+  readonly credentialLabel?: string;
+  readonly status?: number;
+  readonly details?: unknown;
+}) =>
+  authToolFailure({
+    code: failure.code as Parameters<typeof authToolFailure>[0]["code"],
+    message: failure.message,
+    source: { id: failure.integration, scope: failure.owner },
+    credential: {
+      kind: failure.credentialKind,
+      ...(failure.credentialLabel ? { label: failure.credentialLabel } : {}),
+    },
+    ...(failure.status !== undefined ? { status: failure.status } : {}),
+    ...(failure.details !== undefined
+      ? {
+          upstream: {
+            ...(failure.status !== undefined ? { status: failure.status } : {}),
+            details: failure.details,
+          },
+        }
+      : {}),
+  });
+
+/** Rewrite OpenAPI `#/components/schemas/X` refs to standard `#/$defs/X`. */
+export const normalizeOpenApiRefs = (node: unknown): unknown => {
+  if (node == null || typeof node !== "object") return node;
+  if (Array.isArray(node)) {
+    let changed = false;
+    const out = node.map((item) => {
+      const n = normalizeOpenApiRefs(item);
+      if (n !== item) changed = true;
+      return n;
+    });
+    return changed ? out : node;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  if (typeof obj.$ref === "string") {
+    const match = obj.$ref.match(/^#\/components\/schemas\/(.+)$/);
+    if (match) return { ...obj, $ref: `#/$defs/${match[1]}` };
+    return obj;
+  }
+
+  let changed = false;
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const n = normalizeOpenApiRefs(v);
+    if (n !== v) changed = true;
+    result[k] = n;
+  }
+  return changed ? result : obj;
+};
+
+const toBinding = (def: ToolDefinition): OperationBinding =>
+  OperationBinding.make({
+    method: def.operation.method,
+    servers: def.operation.servers,
+    pathTemplate: def.operation.pathTemplate,
+    parameters: [...def.operation.parameters],
+    requestBody: def.operation.requestBody,
+    responseBody: def.operation.responseBody,
+  });
+
+const descriptionFor = (def: ToolDefinition): string => {
+  const op = def.operation;
+  return Option.getOrElse(op.description, () =>
+    Option.getOrElse(op.summary, () => `${op.method.toUpperCase()} ${op.pathTemplate}`),
+  );
+};
+
+export interface CompiledOpenApiSpec {
+  readonly definitions: readonly ToolDefinition[];
+  readonly hoistedDefs: Record<string, unknown>;
+  readonly title: string | undefined;
+  readonly description: string | undefined;
+}
+
+export const compileOpenApiSpec = (
+  specText: string,
+): Effect.Effect<CompiledOpenApiSpec, OpenApiParseError | OpenApiExtractionError> =>
+  Effect.gen(function* () {
+    const doc = yield* parse(specText);
+    const result = yield* extract(doc);
+    const hoistedDefs: Record<string, unknown> = {};
+    if (doc.components?.schemas) {
+      for (const [k, v] of Object.entries(doc.components.schemas)) {
+        hoistedDefs[k] = normalizeOpenApiRefs(v);
+      }
+    }
+    return {
+      definitions: compileToolDefinitions(result.operations),
+      hoistedDefs,
+      title: Option.getOrUndefined(result.title),
+      description: Option.getOrUndefined(result.description),
+    };
+  });
+
+export const openApiToolDefsFromCompiled = (compiled: CompiledOpenApiSpec): readonly ToolDef[] =>
+  compiled.definitions.map(
+    (def): ToolDef => ({
+      name: ToolName.make(def.toolPath),
+      description: descriptionFor(def),
+      inputSchema: normalizeOpenApiRefs(Option.getOrUndefined(def.operation.inputSchema)),
+      outputSchema: Option.match(def.operation.responseBody, {
+        onNone: () => normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+        onSome: (responseBody) =>
+          Option.isSome(responseBody.fileHint)
+            ? ToolFileJsonSchema
+            : normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+      }),
+      annotations: annotationsForOperation(def.operation.method, def.operation.pathTemplate),
+    }),
+  );
+
+export const openApiStoredOperationsFromCompiled = (
+  integration: string,
+  compiled: CompiledOpenApiSpec,
+): readonly StoredOperation[] =>
+  compiled.definitions.map((def) => ({
+    integration,
+    toolName: def.toolPath,
+    binding: toBinding(def),
+  }));
+
+export const loadOpenApiSpecText = (
+  storage: OpenapiStore,
+  config: OpenApiIntegrationConfig,
+): Effect.Effect<string | null, StorageFailure> =>
+  config.specHash != null ? storage.getSpec(config.specHash) : Effect.succeed(null);
+
+export const resolveOpenApiBackedTools = ({
+  config,
+  storage,
+}: {
+  readonly config: unknown;
+  readonly storage: OpenapiStore;
+}): Effect.Effect<ResolveToolsResult, StorageFailure> =>
+  Effect.gen(function* () {
+    const openApiConfig = decodeOpenApiIntegrationConfig(config);
+    if (!openApiConfig) return { tools: [], definitions: {} };
+    const specText = yield* loadOpenApiSpecText(storage, openApiConfig);
+    if (specText == null) return { tools: [], definitions: {} };
+    const compiled = yield* compileOpenApiSpec(specText).pipe(
+      Effect.catch(() => Effect.succeed(null)),
+    );
+    if (!compiled) return { tools: [], definitions: {} };
+    return {
+      tools: openApiToolDefsFromCompiled(compiled),
+      definitions: compiled.hoistedDefs,
+    };
+  });
+
+export const invokeOpenApiBackedTool = (input: {
+  readonly ctx: PluginCtx<OpenapiStore>;
+  readonly toolRow: { readonly integration: string; readonly name: string };
+  readonly credential: ToolInvocationCredential;
+  readonly args: unknown;
+  readonly httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>;
+}) =>
+  Effect.gen(function* () {
+    const integration = input.toolRow.integration;
+    const config = decodeOpenApiIntegrationConfig(input.credential.config);
+
+    let binding = (yield* input.ctx.storage.getOperation(integration, input.toolRow.name))?.binding;
+    if ((!binding || Option.isNone(binding.responseBody)) && config) {
+      const specText = yield* loadOpenApiSpecText(input.ctx.storage, config).pipe(
+        Effect.catch(() => Effect.succeed(null)),
+      );
+      const compiled =
+        specText == null
+          ? null
+          : yield* compileOpenApiSpec(specText).pipe(Effect.catch(() => Effect.succeed(null)));
+      binding = compiled
+        ? openApiStoredOperationsFromCompiled(integration, compiled).find(
+            (op) => op.toolName === input.toolRow.name,
+          )?.binding
+        : undefined;
+    }
+    if (!binding) {
+      return yield* new OpenApiExtractionError({
+        message: `No OpenAPI operation found for tool "${input.toolRow.name}" on "${integration}"`,
+      });
+    }
+
+    const headers: Record<string, string> = { ...(config?.headers ?? {}) };
+    const queryParams: Record<string, string> = {
+      ...(config?.queryParams ?? {}),
+    };
+
+    const template = (config?.authenticationTemplate ?? []).find(
+      (entry) => String(entry.slug) === String(input.credential.template),
+    );
+    if (template) {
+      const missing = requiredTemplateVariables(template).filter((name) => {
+        const value = input.credential.values[name];
+        return value == null || value === "";
+      });
+      if (missing.length > 0) {
+        return openApiAuthToolFailure({
+          code:
+            template.kind === "oauth2" ? "oauth_connection_missing" : "connection_value_missing",
+          message: `Connection "${input.credential.connection}" for "${integration}" has no resolvable credential value. Re-authenticate or update the connection.`,
+          owner: input.credential.owner,
+          integration,
+          connection: String(input.credential.connection),
+          credentialKind: template.kind === "oauth2" ? "oauth" : "secret",
+        });
+      }
+      const rendered = renderAuthTemplate(template, input.credential.values);
+      Object.assign(headers, rendered.headers);
+      Object.assign(queryParams, rendered.queryParams);
+    }
+
+    const result = yield* invokeWithLayer(
+      binding,
+      (input.args ?? {}) as Record<string, unknown>,
+      config?.baseUrl ?? "",
+      headers,
+      queryParams,
+      input.httpClientLayer,
+    );
+
+    const ok = result.status >= 200 && result.status < 300;
+    if (!ok) {
+      if (result.status === 401 || result.status === 403) {
+        return openApiAuthToolFailure({
+          code: "connection_rejected",
+          status: result.status,
+          message: `Upstream rejected credentials for "${integration}" with HTTP ${result.status}. Re-authenticate or update the connection "${input.credential.connection}" before retrying this tool.`,
+          owner: input.credential.owner,
+          integration,
+          connection: String(input.credential.connection),
+          credentialKind: "upstream",
+          credentialLabel: "Upstream authorization",
+          details: result.error,
+        });
+      }
+      return ToolResult.fail({
+        code: "upstream_http_error",
+        status: result.status,
+        message: extractOpenApiUpstreamMessage(result.error, result.status),
+        details: result.error,
+      });
+    }
+    return ToolResult.ok(result.data, {
+      http: { status: result.status, headers: result.headers },
+    });
+  });
+
+export const resolveOpenApiBackedAnnotations = (input: {
+  readonly ctx: PluginCtx<OpenapiStore>;
+  readonly integration: string;
+  readonly toolRows: readonly { readonly name: string }[];
+}) =>
+  Effect.gen(function* () {
+    const ops = yield* input.ctx.storage.listOperations(String(input.integration));
+    const byName = new Map<string, OperationBinding>();
+    for (const op of ops) byName.set(op.toolName, op.binding);
+    const out: Record<string, ReturnType<typeof annotationsForOperation>> = {};
+    for (const row of input.toolRows) {
+      const binding = byName.get(row.name);
+      if (binding) {
+        out[row.name] = annotationsForOperation(binding.method, binding.pathTemplate);
+      }
+    }
+    return out;
+  });

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -24,7 +24,7 @@ import { OpenApiExtractionError, OpenApiParseError } from "./errors";
 import { extract } from "./extract";
 import { compileToolDefinitions, type ToolDefinition } from "./definitions";
 import { annotationsForOperation, invokeWithLayer } from "./invoke";
-import { parse } from "./parse";
+import { parse, type ParsedDocument } from "./parse";
 import { type OpenapiStore, type StoredOperation } from "./store";
 import { OperationBinding } from "./types";
 
@@ -190,11 +190,10 @@ export interface CompiledOpenApiSpec {
   readonly description: string | undefined;
 }
 
-export const compileOpenApiSpec = (
-  specText: string,
-): Effect.Effect<CompiledOpenApiSpec, OpenApiParseError | OpenApiExtractionError> =>
+export const compileOpenApiDocument = (
+  doc: ParsedDocument,
+): Effect.Effect<CompiledOpenApiSpec, OpenApiExtractionError> =>
   Effect.gen(function* () {
-    const doc = yield* parse(specText);
     const result = yield* extract(doc);
     const hoistedDefs: Record<string, unknown> = {};
     if (doc.components?.schemas) {
@@ -208,6 +207,14 @@ export const compileOpenApiSpec = (
       title: Option.getOrUndefined(result.title),
       description: Option.getOrUndefined(result.description),
     };
+  });
+
+export const compileOpenApiSpec = (
+  specText: string,
+): Effect.Effect<CompiledOpenApiSpec, OpenApiParseError | OpenApiExtractionError> =>
+  Effect.gen(function* () {
+    const doc = yield* parse(specText);
+    return yield* compileOpenApiDocument(doc);
   });
 
 export const openApiToolDefsFromCompiled = (compiled: CompiledOpenApiSpec): readonly ToolDef[] =>

--- a/packages/plugins/openapi/src/sdk/derive-auth.ts
+++ b/packages/plugins/openapi/src/sdk/derive-auth.ts
@@ -9,9 +9,11 @@ import * as Option from "effect/Option";
 
 import { AuthTemplateSlug, type OAuthAuthentication } from "@executor-js/sdk/shared";
 
-import type { HeaderPreset, OAuth2Preset, SpecPreview } from "./preview";
+import type { HeaderPreset, OAuth2Preset, SpecPreview, SpecPreviewSummary } from "./preview";
 import type { APIKeyAuthentication, Authentication } from "./types";
 import { resolveServerUrl } from "./openapi-utils";
+
+type PreviewAuthMetadata = SpecPreview | SpecPreviewSummary;
 
 // ---------------------------------------------------------------------------
 // OpenAPI url helpers — specs sometimes ship relative OAuth endpoints; resolve
@@ -132,7 +134,7 @@ export const detectedAuthenticationTemplates = (
   return templates;
 };
 
-export const firstBaseUrlForPreview = (preview: SpecPreview): string => {
+export const firstBaseUrlForPreview = (preview: PreviewAuthMetadata): string => {
   const firstServer = preview.servers[0];
   return firstServer
     ? resolveServerUrl(firstServer.url, Option.getOrUndefined(firstServer.variables), {})
@@ -142,7 +144,7 @@ export const firstBaseUrlForPreview = (preview: SpecPreview): string => {
 /** The fallback `addSpec` uses when no explicit template was passed: every
  *  spec-detected method, resolved against the integration's base URL. */
 export const deriveAuthenticationTemplateFromPreview = (
-  preview: SpecPreview,
+  preview: PreviewAuthMetadata,
   baseUrl: string | undefined,
 ): readonly Authentication[] =>
   detectedAuthenticationTemplates(

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -9,6 +9,7 @@ export {
 export { extract } from "./extract";
 export { invoke, invokeWithLayer, annotationsForOperation } from "./invoke";
 export {
+  compileOpenApiDocument,
   compileOpenApiSpec,
   extractOpenApiUpstreamMessage,
   invokeOpenApiBackedTool,
@@ -20,6 +21,7 @@ export {
   resolveOpenApiBackedTools,
   type CompiledOpenApiSpec,
 } from "./backing";
+export type { ParsedDocument } from "./parse";
 export {
   openApiPlugin,
   type OpenApiSpecConfig,

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -9,6 +9,18 @@ export {
 export { extract } from "./extract";
 export { invoke, invokeWithLayer, annotationsForOperation } from "./invoke";
 export {
+  compileOpenApiSpec,
+  extractOpenApiUpstreamMessage,
+  invokeOpenApiBackedTool,
+  loadOpenApiSpecText,
+  normalizeOpenApiRefs,
+  openApiStoredOperationsFromCompiled,
+  openApiToolDefsFromCompiled,
+  resolveOpenApiBackedAnnotations,
+  resolveOpenApiBackedTools,
+  type CompiledOpenApiSpec,
+} from "./backing";
+export {
   openApiPlugin,
   type OpenApiSpecConfig,
   type OpenApiConfigureInput,

--- a/packages/plugins/openapi/src/sdk/parse.test.ts
+++ b/packages/plugins/openapi/src/sdk/parse.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { OpenApiParseError } from "./errors";
-import { parse } from "./parse";
+import {
+  ensureGenericOpenApiSpecTextWithinLimit,
+  MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH,
+  parse,
+} from "./parse";
 
 describe("OpenAPI parse", () => {
   it.effect("parses JSON OpenAPI documents", () =>
@@ -62,6 +66,20 @@ paths: {}
 
       expect(error).toBeInstanceOf(OpenApiParseError);
       expect(error).toHaveProperty("message", "OpenAPI document must parse to an object");
+    }),
+  );
+
+  it.effect("rejects oversized generic OpenAPI documents before parsing", () =>
+    Effect.gen(function* () {
+      const error = yield* ensureGenericOpenApiSpecTextWithinLimit(
+        "x".repeat(MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH + 1),
+      ).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(OpenApiParseError);
+      expect(error).toHaveProperty(
+        "message",
+        expect.stringContaining("too large for the generic OpenAPI importer"),
+      );
     }),
   );
 });

--- a/packages/plugins/openapi/src/sdk/parse.test.ts
+++ b/packages/plugins/openapi/src/sdk/parse.test.ts
@@ -2,11 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { Effect } from "effect";
 
 import { OpenApiParseError } from "./errors";
-import {
-  ensureGenericOpenApiSpecTextWithinLimit,
-  MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH,
-  parse,
-} from "./parse";
+import { parse } from "./parse";
 
 describe("OpenAPI parse", () => {
   it.effect("parses JSON OpenAPI documents", () =>
@@ -69,17 +65,21 @@ paths: {}
     }),
   );
 
-  it.effect("rejects oversized generic OpenAPI documents before parsing", () =>
+  it.effect("parses Graph-sized YAML OpenAPI documents", () =>
     Effect.gen(function* () {
-      const error = yield* ensureGenericOpenApiSpecTextWithinLimit(
-        "x".repeat(MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH + 1),
-      ).pipe(Effect.flip);
-
-      expect(error).toBeInstanceOf(OpenApiParseError);
-      expect(error).toHaveProperty(
-        "message",
-        expect.stringContaining("too large for the generic OpenAPI importer"),
+      const largeDescription = "x".repeat(36 * 1024 * 1024);
+      const doc = yield* parse(
+        `openapi: 3.0.0
+info:
+  title: Large Test
+  version: 1.0.0
+  description: "${largeDescription}"
+paths: {}
+`,
       );
+
+      expect(doc.info.title).toBe("Large Test");
+      expect(doc.info.description).toHaveLength(largeDescription.length);
     }),
   );
 });

--- a/packages/plugins/openapi/src/sdk/parse.ts
+++ b/packages/plugins/openapi/src/sdk/parse.ts
@@ -1,7 +1,7 @@
 import type { OpenAPI, OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 import { Duration, Effect, Schema } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
-import YAML from "yaml";
+import { JSON_SCHEMA, load as parseYamlDocument } from "js-yaml";
 
 import { OpenApiExtractionError, OpenApiParseError } from "./errors";
 
@@ -11,31 +11,6 @@ export interface SpecFetchCredentials {
   readonly headers?: Record<string, string>;
   readonly queryParams?: Record<string, string>;
 }
-
-export const MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH = 25 * 1024 * 1024;
-
-const formatMiB = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
-
-const oversizedOpenApiSpecError = (size: number): OpenApiParseError =>
-  new OpenApiParseError({
-    message: `OpenAPI document is too large for the generic OpenAPI importer (${formatMiB(size)}; limit ${formatMiB(MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH)}). Use a provider-specific integration when available, or import a smaller filtered OpenAPI document.`,
-  });
-
-const parseContentLength = (
-  headers: Readonly<Record<string, string | undefined>>,
-): number | undefined => {
-  const raw = headers["content-length"] ?? headers["Content-Length"];
-  if (!raw) return undefined;
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
-};
-
-export const ensureGenericOpenApiSpecTextWithinLimit = (
-  specText: string,
-): Effect.Effect<string, OpenApiParseError> =>
-  specText.length > MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH
-    ? Effect.fail(oversizedOpenApiSpecError(specText.length))
-    : Effect.succeed(specText);
 
 // ExtractionError subclass raised from parse() for non-3.x specs
 class OpenApiExtractionErrorFromParse extends OpenApiExtractionError {}
@@ -75,10 +50,6 @@ export const fetchSpecText = Effect.fn("OpenApi.fetchSpecText")(function* (
       message: `Failed to fetch OpenAPI document: HTTP ${response.status}`,
     });
   }
-  const contentLength = parseContentLength(response.headers);
-  if (contentLength !== undefined && contentLength > MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH) {
-    return yield* oversizedOpenApiSpecError(contentLength);
-  }
   const specText = yield* response.text.pipe(
     Effect.mapError(
       (_cause) =>
@@ -87,7 +58,7 @@ export const fetchSpecText = Effect.fn("OpenApi.fetchSpecText")(function* (
         }),
     ),
   );
-  return yield* ensureGenericOpenApiSpecTextWithinLimit(specText);
+  return specText;
 });
 
 /**
@@ -97,7 +68,7 @@ export const fetchSpecText = Effect.fn("OpenApi.fetchSpecText")(function* (
 export const resolveSpecText = (input: string, credentials?: SpecFetchCredentials) =>
   input.startsWith("http://") || input.startsWith("https://")
     ? fetchSpecText(input, credentials)
-    : ensureGenericOpenApiSpecTextWithinLimit(input);
+    : Effect.succeed(input);
 
 /**
  * Parse an OpenAPI document from spec text and validate it's OpenAPI 3.x.
@@ -158,7 +129,7 @@ const parseJsonText = Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Un
 
 const parseJsonLike = (text: string): Effect.Effect<unknown, unknown> => {
   const parseYaml = Effect.try({
-    try: () => YAML.parse(text) as unknown,
+    try: () => parseYamlDocument(text, { json: true, schema: JSON_SCHEMA }) as unknown,
     catch: () => "YamlParseFailed" as const,
   });
   if (!text.startsWith("{") && !text.startsWith("[")) return parseYaml;

--- a/packages/plugins/openapi/src/sdk/parse.ts
+++ b/packages/plugins/openapi/src/sdk/parse.ts
@@ -12,6 +12,31 @@ export interface SpecFetchCredentials {
   readonly queryParams?: Record<string, string>;
 }
 
+export const MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH = 25 * 1024 * 1024;
+
+const formatMiB = (bytes: number): string => `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+
+const oversizedOpenApiSpecError = (size: number): OpenApiParseError =>
+  new OpenApiParseError({
+    message: `OpenAPI document is too large for the generic OpenAPI importer (${formatMiB(size)}; limit ${formatMiB(MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH)}). Use a provider-specific integration when available, or import a smaller filtered OpenAPI document.`,
+  });
+
+const parseContentLength = (
+  headers: Readonly<Record<string, string | undefined>>,
+): number | undefined => {
+  const raw = headers["content-length"] ?? headers["Content-Length"];
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+};
+
+export const ensureGenericOpenApiSpecTextWithinLimit = (
+  specText: string,
+): Effect.Effect<string, OpenApiParseError> =>
+  specText.length > MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH
+    ? Effect.fail(oversizedOpenApiSpecError(specText.length))
+    : Effect.succeed(specText);
+
 // ExtractionError subclass raised from parse() for non-3.x specs
 class OpenApiExtractionErrorFromParse extends OpenApiExtractionError {}
 
@@ -50,7 +75,11 @@ export const fetchSpecText = Effect.fn("OpenApi.fetchSpecText")(function* (
       message: `Failed to fetch OpenAPI document: HTTP ${response.status}`,
     });
   }
-  return yield* response.text.pipe(
+  const contentLength = parseContentLength(response.headers);
+  if (contentLength !== undefined && contentLength > MAX_GENERIC_OPENAPI_SPEC_TEXT_LENGTH) {
+    return yield* oversizedOpenApiSpecError(contentLength);
+  }
+  const specText = yield* response.text.pipe(
     Effect.mapError(
       (_cause) =>
         new OpenApiParseError({
@@ -58,6 +87,7 @@ export const fetchSpecText = Effect.fn("OpenApi.fetchSpecText")(function* (
         }),
     ),
   );
+  return yield* ensureGenericOpenApiSpecTextWithinLimit(specText);
 });
 
 /**
@@ -67,7 +97,7 @@ export const fetchSpecText = Effect.fn("OpenApi.fetchSpecText")(function* (
 export const resolveSpecText = (input: string, credentials?: SpecFetchCredentials) =>
   input.startsWith("http://") || input.startsWith("https://")
     ? fetchSpecText(input, credentials)
-    : Effect.succeed(input);
+    : ensureGenericOpenApiSpecTextWithinLimit(input);
 
 /**
  * Parse an OpenAPI document from spec text and validate it's OpenAPI 3.x.

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -109,6 +109,105 @@ const testApiSpecText = () => {
   return spec.url;
 };
 
+const MICROSOFT_GRAPH_V1_OPERATION_COUNT = 16_548;
+
+const microsoftGraphScaleSpecText = () => {
+  const paths: Record<string, unknown> = {};
+  for (let index = 0; index < MICROSOFT_GRAPH_V1_OPERATION_COUNT; index += 1) {
+    paths[`/users/{userId}/messages/${index}`] = {
+      get: {
+        operationId: `users_messages_list_${index}`,
+        tags: [`Graph category ${index % 37}`],
+        summary: `List synthetic Graph messages ${index}`,
+        parameters: [
+          {
+            name: "userId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+          },
+          {
+            name: "$top",
+            in: "query",
+            schema: { type: "integer", format: "int32" },
+          },
+          {
+            name: "$select",
+            in: "query",
+            style: "form",
+            explode: false,
+            schema: { type: "array", items: { type: "string" } },
+          },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/MessageCollectionResponse" },
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  return JSON.stringify({
+    openapi: "3.0.0",
+    info: {
+      title: "Microsoft Graph Scale Fixture",
+      version: "v1.0",
+      description: "Synthetic Graph-scale fixture for generic OpenAPI imports.",
+    },
+    servers: [{ url: "https://graph.microsoft.com/v1.0" }],
+    security: [{ MicrosoftGraph: ["User.Read", "Mail.Read"] }],
+    components: {
+      securitySchemes: {
+        MicrosoftGraph: {
+          type: "oauth2",
+          flows: {
+            authorizationCode: {
+              authorizationUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
+              tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+              scopes: {
+                "User.Read": "Read user profile",
+                "Mail.Read": "Read user mail",
+              },
+            },
+            clientCredentials: {
+              tokenUrl: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+              scopes: {
+                ".default": "Application permissions",
+              },
+            },
+          },
+        },
+      },
+      schemas: {
+        Message: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            subject: { type: "string" },
+            receivedDateTime: { type: "string", format: "date-time" },
+          },
+        },
+        MessageCollectionResponse: {
+          type: "object",
+          properties: {
+            value: {
+              type: "array",
+              items: { $ref: "#/components/schemas/Message" },
+            },
+          },
+        },
+      },
+    },
+    paths,
+  });
+};
+
 // ---------------------------------------------------------------------------
 // Implement handlers
 // ---------------------------------------------------------------------------
@@ -656,6 +755,20 @@ paths:
       });
 
       expect(added.toolCount).toBe(1);
+    }),
+  );
+
+  it.effect("addSpec accepts Microsoft Graph-scale operation catalogs from one spec", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+
+      const added = yield* executor.openapi.addSpec({
+        spec: { kind: "blob", value: microsoftGraphScaleSpecText() },
+        slug: "microsoft_graph_scale",
+        authenticationTemplate: [],
+      });
+
+      expect(added.toolCount).toBe(MICROSOFT_GRAPH_V1_OPERATION_COUNT);
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -628,6 +628,37 @@ describe("OpenAPI Plugin", () => {
     ),
   );
 
+  it.effect("addSpec accepts Graph-sized OpenAPI blobs", () =>
+    Effect.gen(function* () {
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+      const largeDescription = "x".repeat(36 * 1024 * 1024);
+
+      const added = yield* executor.openapi.addSpec({
+        spec: {
+          kind: "blob",
+          value: `openapi: 3.0.0
+info:
+  title: Large Test
+  version: 1.0.0
+  description: "${largeDescription}"
+servers:
+  - url: https://example.com
+paths:
+  /me:
+    get:
+      operationId: getMe
+      responses:
+        "200":
+          description: OK
+`,
+        },
+        slug: "large_api",
+      });
+
+      expect(added.toolCount).toBe(1);
+    }),
+  );
+
   it.effect("removeSpec cleans up the integration and its tools", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/plugins/openapi/src/sdk/plugin.test.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.test.ts
@@ -758,18 +758,21 @@ paths:
     }),
   );
 
-  it.effect("addSpec accepts Microsoft Graph-scale operation catalogs from one spec", () =>
-    Effect.gen(function* () {
-      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+  it.effect(
+    "addSpec accepts Microsoft Graph-scale operation catalogs from one spec",
+    () =>
+      Effect.gen(function* () {
+        const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
 
-      const added = yield* executor.openapi.addSpec({
-        spec: { kind: "blob", value: microsoftGraphScaleSpecText() },
-        slug: "microsoft_graph_scale",
-        authenticationTemplate: [],
-      });
+        const added = yield* executor.openapi.addSpec({
+          spec: { kind: "blob", value: microsoftGraphScaleSpecText() },
+          slug: "microsoft_graph_scale",
+          authenticationTemplate: [],
+        });
 
-      expect(added.toolCount).toBe(MICROSOFT_GRAPH_V1_OPERATION_COUNT);
-    }),
+        expect(added.toolCount).toBe(MICROSOFT_GRAPH_V1_OPERATION_COUNT);
+      }),
+    30_000,
   );
 
   it.effect("removeSpec cleans up the integration and its tools", () =>

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -22,7 +22,7 @@ import {
 
 import { decodeOpenApiIntegrationConfig, type OpenApiIntegrationConfig } from "./config";
 import { OpenApiExtractionError, OpenApiOAuthError, OpenApiParseError } from "./errors";
-import { ensureGenericOpenApiSpecTextWithinLimit, parse, resolveSpecText } from "./parse";
+import { parse, resolveSpecText } from "./parse";
 import {
   convertGoogleDiscoveryBundleToOpenApi,
   convertGoogleDiscoveryToOpenApi,
@@ -30,7 +30,7 @@ import {
   isGoogleDiscoveryUrl,
 } from "./google-discovery";
 import { extract } from "./extract";
-import { previewSpec, previewSpecText, type SpecPreview } from "./preview";
+import { previewSpecText, type SpecPreview } from "./preview";
 import { deriveAuthenticationTemplateFromPreview, firstBaseUrlForPreview } from "./derive-auth";
 import { openApiPresets } from "./presets";
 import { makeDefaultOpenapiStore, type OpenapiStore } from "./store";
@@ -473,8 +473,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         const specText = yield* resolveSpecText(spec.url).pipe(Effect.provide(httpClientLayer));
         return { specText };
       }
-      const specText = yield* ensureGenericOpenApiSpecTextWithinLimit(spec.value);
-      return { specText };
+      return { specText: spec.value };
     });
 
   return {
@@ -722,7 +721,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
                   Effect.map((conversion) => conversion.specText),
                 )
               : yield* resolveSpecText(previewInput.spec).pipe(Effect.provide(httpClientLayer));
-            return yield* previewSpec(specText).pipe(Effect.provide(httpClientLayer));
+            return yield* previewSpecText(specText);
           }),
 
         addSpec,

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -22,7 +22,7 @@ import {
 
 import { decodeOpenApiIntegrationConfig, type OpenApiIntegrationConfig } from "./config";
 import { OpenApiExtractionError, OpenApiOAuthError, OpenApiParseError } from "./errors";
-import { parse, resolveSpecText } from "./parse";
+import { ensureGenericOpenApiSpecTextWithinLimit, parse, resolveSpecText } from "./parse";
 import {
   convertGoogleDiscoveryBundleToOpenApi,
   convertGoogleDiscoveryToOpenApi,
@@ -473,7 +473,8 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         const specText = yield* resolveSpecText(spec.url).pipe(Effect.provide(httpClientLayer));
         return { specText };
       }
-      return { specText: spec.value };
+      const specText = yield* ensureGenericOpenApiSpecTextWithinLimit(spec.value);
+      return { specText };
     });
 
   return {

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -7,10 +7,7 @@ import {
   IntegrationDetectionResult,
   IntegrationNotFoundError,
   IntegrationSlug,
-  ToolName,
-  ToolFileJsonSchema,
   ToolResult,
-  authToolFailure,
   definePlugin,
   mergeAuthTemplates,
   sha256Hex,
@@ -20,18 +17,10 @@ import {
   type IntegrationConfig,
   type IntegrationRecord,
   type PluginCtx,
-  type ResolveToolsResult,
   type StorageFailure,
-  type ToolDef,
-  type ToolInvocationCredential,
 } from "@executor-js/sdk/core";
 
-import {
-  decodeOpenApiIntegrationConfig,
-  renderAuthTemplate,
-  requiredTemplateVariables,
-  type OpenApiIntegrationConfig,
-} from "./config";
+import { decodeOpenApiIntegrationConfig, type OpenApiIntegrationConfig } from "./config";
 import { OpenApiExtractionError, OpenApiOAuthError, OpenApiParseError } from "./errors";
 import { parse, resolveSpecText } from "./parse";
 import {
@@ -41,98 +30,20 @@ import {
   isGoogleDiscoveryUrl,
 } from "./google-discovery";
 import { extract } from "./extract";
-import { compileToolDefinitions, type ToolDefinition } from "./definitions";
-import { annotationsForOperation, invokeWithLayer } from "./invoke";
 import { previewSpec, previewSpecText, type SpecPreview } from "./preview";
 import { deriveAuthenticationTemplateFromPreview, firstBaseUrlForPreview } from "./derive-auth";
 import { openApiPresets } from "./presets";
-import { makeDefaultOpenapiStore, type OpenapiStore, type StoredOperation } from "./store";
+import { makeDefaultOpenapiStore, type OpenapiStore } from "./store";
 import type { Authentication } from "./types";
-import { OperationBinding, normalizeOpenApiAuthInputs, type AuthenticationInput } from "./types";
+import { normalizeOpenApiAuthInputs, type AuthenticationInput } from "./types";
 import { ApiKeyAuthTemplate, describeApiKeyAuthMethod } from "@executor-js/sdk/http-auth";
-
-// ---------------------------------------------------------------------------
-// Plugin config
-// ---------------------------------------------------------------------------
-
-const STRINGIFIED_BODY_CAP = 1024;
-const UpstreamMessageBody = Schema.Struct({ message: Schema.String });
-const UpstreamErrorMessageBody = Schema.Struct({ errorMessage: Schema.String });
-const UpstreamNestedErrorBody = Schema.Struct({ error: UpstreamMessageBody });
-const UpstreamErrorsArrayBody = Schema.Struct({
-  errors: Schema.Array(
-    Schema.Struct({
-      detail: Schema.optional(Schema.String),
-      message: Schema.optional(Schema.String),
-      title: Schema.optional(Schema.String),
-    }),
-  ),
-});
-const UpstreamDescriptionBody = Schema.Struct({
-  detail: Schema.optional(Schema.String),
-  title: Schema.optional(Schema.String),
-  description: Schema.optional(Schema.String),
-});
-
-const decodeUpstreamMessageBody = Schema.decodeUnknownOption(UpstreamMessageBody);
-const decodeUpstreamErrorMessageBody = Schema.decodeUnknownOption(UpstreamErrorMessageBody);
-const decodeUpstreamNestedErrorBody = Schema.decodeUnknownOption(UpstreamNestedErrorBody);
-const decodeUpstreamErrorsArrayBody = Schema.decodeUnknownOption(UpstreamErrorsArrayBody);
-const decodeUpstreamDescriptionBody = Schema.decodeUnknownOption(UpstreamDescriptionBody);
-
-const clampedStringify = (value: unknown): string => {
-  let s: string;
-  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: JSON.stringify may throw on cycles; fall back to String() so the upstream body can still be surfaced as ToolError.details fallback text
-  try {
-    s = JSON.stringify(value);
-  } catch {
-    s = String(value);
-  }
-  return s.length > STRINGIFIED_BODY_CAP ? `${s.slice(0, STRINGIFIED_BODY_CAP)}…` : s;
-};
-
-const firstNonEmpty = (...values: readonly (string | undefined)[]): string | undefined =>
-  values.find((value) => value !== undefined && value.length > 0);
-
-// Walk known upstream error-body shapes so ToolError.message stays concise
-// while ToolError.details preserves the original body.
-const extractUpstreamMessage = (body: unknown, status: number): string => {
-  if (typeof body === "string") {
-    return body.length > 0 ? body : `Upstream returned HTTP ${status}`;
-  }
-  const nested = Option.getOrUndefined(decodeUpstreamNestedErrorBody(body));
-  const messageBody = Option.getOrUndefined(decodeUpstreamMessageBody(body));
-  const errorMessageBody = Option.getOrUndefined(decodeUpstreamErrorMessageBody(body));
-  const errorsBody = Option.getOrUndefined(decodeUpstreamErrorsArrayBody(body));
-  const descriptionBody = Option.getOrUndefined(decodeUpstreamDescriptionBody(body));
-  const arrayMessage = errorsBody?.errors
-    .map(
-      ({
-        detail,
-        message: upstreamMessage,
-        title,
-      }: {
-        detail?: string;
-        message?: string;
-        title?: string;
-      }) => firstNonEmpty(detail, upstreamMessage, title),
-    )
-    .find((message: string | undefined) => message !== undefined);
-  const message = firstNonEmpty(
-    nested?.error.message,
-    messageBody?.message,
-    errorMessageBody?.errorMessage,
-    arrayMessage,
-    descriptionBody?.detail,
-    descriptionBody?.title,
-    descriptionBody?.description,
-  );
-  if (message !== undefined) return message;
-  if (body !== null && typeof body === "object") {
-    return clampedStringify(body);
-  }
-  return `Upstream returned HTTP ${status}`;
-};
+import {
+  compileOpenApiSpec,
+  invokeOpenApiBackedTool,
+  openApiStoredOperationsFromCompiled,
+  resolveOpenApiBackedAnnotations,
+  resolveOpenApiBackedTools,
+} from "./backing";
 
 // ---------------------------------------------------------------------------
 // Extension input shapes
@@ -381,38 +292,6 @@ const openApiToolFailure = (code: string, message: string, details?: unknown) =>
     ...(details === undefined ? {} : { details }),
   });
 
-const openApiAuthToolFailure = (failure: {
-  readonly code: string;
-  readonly message: string;
-  readonly owner: "org" | "user";
-  readonly integration: string;
-  readonly connection: string;
-  readonly credentialKind: "secret" | "oauth" | "upstream";
-  readonly credentialLabel?: string;
-  readonly status?: number;
-  readonly details?: unknown;
-}) =>
-  authToolFailure({
-    // The auth-tool-failure helper's code set is shared with v1; keep the
-    // string but reference the connection rather than v1's source/slot.
-    code: failure.code as Parameters<typeof authToolFailure>[0]["code"],
-    message: failure.message,
-    source: { id: failure.integration, scope: failure.owner },
-    credential: {
-      kind: failure.credentialKind,
-      ...(failure.credentialLabel ? { label: failure.credentialLabel } : {}),
-    },
-    ...(failure.status !== undefined ? { status: failure.status } : {}),
-    ...(failure.details !== undefined
-      ? {
-          upstream: {
-            ...(failure.status !== undefined ? { status: failure.status } : {}),
-            details: failure.details,
-          },
-        }
-      : {}),
-  });
-
 const staticPreviewOutput = (preview: SpecPreview): StaticPreviewSpecOutput => ({
   title: Option.getOrNull(preview.title),
   version: Option.getOrNull(preview.version),
@@ -477,58 +356,6 @@ const staticPreviewOutput = (preview: SpecPreview): StaticPreviewSpecOutput => (
   })),
 });
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Rewrite OpenAPI `#/components/schemas/X` refs to standard `#/$defs/X`. */
-const normalizeOpenApiRefs = (node: unknown): unknown => {
-  if (node == null || typeof node !== "object") return node;
-  if (Array.isArray(node)) {
-    let changed = false;
-    const out = node.map((item) => {
-      const n = normalizeOpenApiRefs(item);
-      if (n !== item) changed = true;
-      return n;
-    });
-    return changed ? out : node;
-  }
-
-  const obj = node as Record<string, unknown>;
-
-  if (typeof obj.$ref === "string") {
-    const match = obj.$ref.match(/^#\/components\/schemas\/(.+)$/);
-    if (match) return { ...obj, $ref: `#/$defs/${match[1]}` };
-    return obj;
-  }
-
-  let changed = false;
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    const n = normalizeOpenApiRefs(v);
-    if (n !== v) changed = true;
-    result[k] = n;
-  }
-  return changed ? result : obj;
-};
-
-const toBinding = (def: ToolDefinition): OperationBinding =>
-  OperationBinding.make({
-    method: def.operation.method,
-    servers: def.operation.servers,
-    pathTemplate: def.operation.pathTemplate,
-    parameters: [...def.operation.parameters],
-    requestBody: def.operation.requestBody,
-    responseBody: def.operation.responseBody,
-  });
-
-const descriptionFor = (def: ToolDefinition): string => {
-  const op = def.operation;
-  return Option.getOrElse(op.description, () =>
-    Option.getOrElse(op.summary, () => `${op.method.toUpperCase()} ${op.pathTemplate}`),
-  );
-};
-
 const specInputToSourceUrl = (spec: OpenApiSpecInput): string | undefined =>
   spec.kind === "url" || spec.kind === "googleDiscovery" ? spec.url : undefined;
 
@@ -574,88 +401,6 @@ export const describeOpenApiIntegrationDisplay = (
   const config = decodeOpenApiIntegrationConfig(record.config);
   return { url: config?.baseUrl ?? config?.sourceUrl };
 };
-
-// ---------------------------------------------------------------------------
-// Spec text resolution — the stored config carries the spec's content hash
-// (`specHash` → blob `spec/<hash>`). Pre-blob rows that inlined the text are
-// rewritten by the spec-to-blob migrations before this code reads them.
-// ---------------------------------------------------------------------------
-
-const loadSpecText = (
-  storage: OpenapiStore,
-  config: OpenApiIntegrationConfig,
-): Effect.Effect<string | null, StorageFailure> =>
-  config.specHash != null ? storage.getSpec(config.specHash) : Effect.succeed(null);
-
-// ---------------------------------------------------------------------------
-// Spec → tool definitions (shared by addSpec, resolveTools, and detect)
-// ---------------------------------------------------------------------------
-
-interface CompiledSpec {
-  readonly definitions: readonly ToolDefinition[];
-  readonly hoistedDefs: Record<string, unknown>;
-  readonly title: string | undefined;
-  /** The spec's `info.description`. */
-  readonly description: string | undefined;
-}
-
-const compileSpec = (
-  specText: string,
-): Effect.Effect<CompiledSpec, OpenApiParseError | OpenApiExtractionError> =>
-  Effect.gen(function* () {
-    const doc = yield* parse(specText);
-    const result = yield* extract(doc);
-    const hoistedDefs: Record<string, unknown> = {};
-    if (doc.components?.schemas) {
-      for (const [k, v] of Object.entries(doc.components.schemas)) {
-        hoistedDefs[k] = normalizeOpenApiRefs(v);
-      }
-    }
-    return {
-      definitions: compileToolDefinitions(result.operations),
-      hoistedDefs,
-      title: Option.getOrUndefined(result.title),
-      description: Option.getOrUndefined(result.description),
-    };
-  });
-
-// A tool's name carries its structured `group.leaf` path verbatim (e.g.
-// `aliases.deleteAlias`). The address grammar
-// `tools.<integration>.<owner>.<connection>.<tool>` treats `<tool>` as the
-// trailing remainder (see parseToolAddress), so the dotted path needs no
-// flattening — it nests naturally as
-// `tools.<integration>.<owner>.<connection>.aliases.deleteAlias`, matching how
-// the sandbox `tools` proxy joins property access.
-
-const toolDefsFromCompiled = (compiled: CompiledSpec): readonly ToolDef[] =>
-  compiled.definitions.map(
-    (def): ToolDef => ({
-      name: ToolName.make(def.toolPath),
-      description: descriptionFor(def),
-      inputSchema: normalizeOpenApiRefs(Option.getOrUndefined(def.operation.inputSchema)),
-      // The output schema is the upstream response body only — transport
-      // status/headers live in the ToolResult `http` side channel, not the
-      // payload (see the invoke handler).
-      outputSchema: Option.match(def.operation.responseBody, {
-        onNone: () => normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
-        onSome: (responseBody) =>
-          Option.isSome(responseBody.fileHint)
-            ? ToolFileJsonSchema
-            : normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
-      }),
-      annotations: annotationsForOperation(def.operation.method, def.operation.pathTemplate),
-    }),
-  );
-
-const storedOperationsFromCompiled = (
-  integration: string,
-  compiled: CompiledSpec,
-): readonly StoredOperation[] =>
-  compiled.definitions.map((def) => ({
-    integration,
-    toolName: def.toolPath,
-    binding: toBinding(def),
-  }));
 
 // ---------------------------------------------------------------------------
 // Plugin factory
@@ -752,7 +497,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
           // Resolve URL → text and parse BEFORE opening a transaction. Holding
           // `BEGIN` across a network fetch is the Hyperdrive deadlock path.
           const resolved = yield* resolveSpecForInput(config.spec, httpClientLayer);
-          const compiled = yield* compileSpec(resolved.specText);
+          const compiled = yield* compileOpenApiSpec(resolved.specText);
 
           // Defaults the add page derives from its preview, applied here so
           // headless callers (MCP, API) get the same integration the UI's
@@ -846,7 +591,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
               });
               yield* ctx.storage.putOperations(
                 config.slug,
-                storedOperationsFromCompiled(config.slug, compiled),
+                openApiStoredOperationsFromCompiled(config.slug, compiled),
               );
             }),
           );
@@ -890,7 +635,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
           // Resolve + compile BEFORE the transaction (same Hyperdrive-deadlock
           // rule as addSpec: never hold BEGIN across a network fetch).
           const resolved = yield* resolveSpecForInput(specInput, httpClientLayer);
-          const compiled = yield* compileSpec(resolved.specText);
+          const compiled = yield* compileOpenApiSpec(resolved.specText);
 
           const previousOperations = yield* ctx.storage.listOperations(rawSlug);
           const previousNames = new Set(previousOperations.map((op) => op.toolName));
@@ -921,7 +666,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
               });
               yield* ctx.storage.putOperations(
                 rawSlug,
-                storedOperationsFromCompiled(rawSlug, compiled),
+                openApiStoredOperationsFromCompiled(rawSlug, compiled),
               );
             }),
           );
@@ -1133,173 +878,24 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
     // operation bindings invokeTool needs are persisted at addSpec time; this
     // hook only shapes the per-connection ToolDefs from the spec blob the
     // catalog config points at.
-    resolveTools: ({
-      config,
-      storage,
-    }: {
-      readonly integration: Integration;
-      readonly config: IntegrationConfig;
-      readonly storage: OpenapiStore;
-    }): Effect.Effect<ResolveToolsResult, StorageFailure> =>
-      Effect.gen(function* () {
-        const openApiConfig = decodeOpenApiIntegrationConfig(config);
-        if (!openApiConfig) return { tools: [], definitions: {} };
-        const specText = yield* loadSpecText(storage, openApiConfig);
-        if (specText == null) return { tools: [], definitions: {} };
-        const compiled = yield* compileSpec(specText).pipe(
-          Effect.catch(() => Effect.succeed(null)),
-        );
-        if (!compiled) return { tools: [], definitions: {} };
-        return {
-          tools: toolDefsFromCompiled(compiled),
-          definitions: compiled.hoistedDefs,
-        };
-      }),
+    resolveTools: ({ config, storage }) => resolveOpenApiBackedTools({ config, storage }),
 
-    invokeTool: ({
-      ctx: invokeCtx,
-      toolRow,
-      credential,
-      args,
-    }: {
-      readonly ctx: PluginCtx<OpenapiStore>;
-      readonly toolRow: { readonly integration: string; readonly name: string };
-      readonly credential: ToolInvocationCredential;
-      readonly args: unknown;
-    }) =>
-      Effect.gen(function* () {
-        const httpClientLayer = options?.httpClientLayer ?? invokeCtx.httpClientLayer;
-        const integration = toolRow.integration;
-        const config = decodeOpenApiIntegrationConfig(credential.config);
+    invokeTool: ({ ctx: invokeCtx, toolRow, credential, args }) => {
+      const httpClientLayer = options?.httpClientLayer ?? invokeCtx.httpClientLayer;
+      return invokeOpenApiBackedTool({
+        ctx: invokeCtx,
+        toolRow,
+        credential,
+        args,
+        httpClientLayer,
+      });
+    },
 
-        // Resolve the operation binding from the plugin store; fall back to
-        // re-deriving it from the spec blob when the store has no row (e.g. an
-        // integration registered without going through addSpec). The fallback
-        // is the ONLY invoke-path spec read — the hot path never loads it.
-        const bindingFromSpec = config
-          ? Effect.gen(function* () {
-              const specText = yield* loadSpecText(invokeCtx.storage, config).pipe(
-                Effect.catch(() => Effect.succeed(null)),
-              );
-              const compiled =
-                specText == null
-                  ? null
-                  : yield* compileSpec(specText).pipe(Effect.catch(() => Effect.succeed(null)));
-              return compiled
-                ? storedOperationsFromCompiled(integration, compiled).find(
-                    (op) => op.toolName === toolRow.name,
-                  )?.binding
-                : undefined;
-            })
-          : Effect.succeed(undefined);
-
-        let binding = (yield* invokeCtx.storage.getOperation(integration, toolRow.name))?.binding;
-        if ((!binding || Option.isNone(binding.responseBody)) && config) {
-          binding = (yield* bindingFromSpec) ?? binding;
-        }
-        if (!binding) {
-          return yield* new OpenApiExtractionError({
-            message: `No OpenAPI operation found for tool "${toolRow.name}" on "${integration}"`,
-          });
-        }
-
-        const headers: Record<string, string> = { ...(config?.headers ?? {}) };
-        const queryParams: Record<string, string> = {
-          ...(config?.queryParams ?? {}),
-        };
-
-        // Apply the auth template (D11): render the connection's resolved inputs
-        // into the matching template's header/query slots (apiKey) or as a bearer
-        // Authorization header (oauth). A method with two distinct inputs (e.g.
-        // Datadog) renders each from its own value.
-        const template = (config?.authenticationTemplate ?? []).find(
-          (entry) => String(entry.slug) === String(credential.template),
-        );
-        if (template) {
-          // Fail if ANY input the template requires is unresolved — not just the
-          // primary `token` (a Datadog connection has no `token`, only its keys).
-          const missing = requiredTemplateVariables(template).filter((name) => {
-            const value = credential.values[name];
-            return value == null || value === "";
-          });
-          if (missing.length > 0) {
-            return openApiAuthToolFailure({
-              code:
-                template.kind === "oauth2"
-                  ? "oauth_connection_missing"
-                  : "connection_value_missing",
-              message: `Connection "${credential.connection}" for "${integration}" has no resolvable credential value. Re-authenticate or update the connection.`,
-              owner: credential.owner,
-              integration,
-              connection: String(credential.connection),
-              credentialKind: template.kind === "oauth2" ? "oauth" : "secret",
-            });
-          }
-          const rendered = renderAuthTemplate(template, credential.values);
-          Object.assign(headers, rendered.headers);
-          Object.assign(queryParams, rendered.queryParams);
-        }
-
-        const result = yield* invokeWithLayer(
-          binding,
-          (args ?? {}) as Record<string, unknown>,
-          config?.baseUrl ?? "",
-          headers,
-          queryParams,
-          httpClientLayer,
-        );
-
-        const ok = result.status >= 200 && result.status < 300;
-        if (!ok) {
-          if (result.status === 401 || result.status === 403) {
-            return openApiAuthToolFailure({
-              code: "connection_rejected",
-              status: result.status,
-              message: `Upstream rejected credentials for "${integration}" with HTTP ${result.status}. Re-authenticate or update the connection "${credential.connection}" before retrying this tool.`,
-              owner: credential.owner,
-              integration,
-              connection: String(credential.connection),
-              credentialKind: "upstream",
-              credentialLabel: "Upstream authorization",
-              details: result.error,
-            });
-          }
-          return ToolResult.fail({
-            code: "upstream_http_error",
-            status: result.status,
-            message: extractUpstreamMessage(result.error, result.status),
-            details: result.error,
-          });
-        }
-        // Payload-first: `data` is the upstream response body (matching the
-        // graphql/mcp plugins); transport facts ride in the `http` side
-        // channel so pagination/rate-limit headers stay reachable.
-        return ToolResult.ok(result.data, {
-          http: { status: result.status, headers: result.headers },
-        });
-      }),
-
-    resolveAnnotations: ({
-      ctx: annotationsCtx,
-      integration,
-      toolRows,
-    }: {
-      readonly ctx: PluginCtx<OpenapiStore>;
-      readonly integration: string;
-      readonly toolRows: readonly { readonly name: string }[];
-    }) =>
-      Effect.gen(function* () {
-        const ops = yield* annotationsCtx.storage.listOperations(String(integration));
-        const byName = new Map<string, OperationBinding>();
-        for (const op of ops) byName.set(op.toolName, op.binding);
-        const out: Record<string, ReturnType<typeof annotationsForOperation>> = {};
-        for (const row of toolRows) {
-          const binding = byName.get(row.name);
-          if (binding) {
-            out[row.name] = annotationsForOperation(binding.method, binding.pathTemplate);
-          }
-        }
-        return out;
+    resolveAnnotations: ({ ctx: annotationsCtx, integration, toolRows }) =>
+      resolveOpenApiBackedAnnotations({
+        ctx: annotationsCtx,
+        integration: String(integration),
+        toolRows,
       }),
 
     removeConnection: () => Effect.void,

--- a/packages/plugins/openapi/src/sdk/preview.ts
+++ b/packages/plugins/openapi/src/sdk/preview.ts
@@ -154,6 +154,37 @@ export const SpecPreview = Schema.Struct({
 });
 export type SpecPreview = typeof SpecPreview.Type;
 
+// HTTP/UI preview deliberately omits the per-operation list. Graph-sized specs
+// can define 16k+ operations, while the add flow only needs counts, tags,
+// servers, and auth metadata before registration.
+export const SpecPreviewSummary = Schema.Struct({
+  title: Schema.OptionFromOptional(Schema.String),
+  description: Schema.OptionFromOptional(Schema.String),
+  version: Schema.OptionFromOptional(Schema.String),
+  servers: Schema.Array(ServerInfo),
+  operationCount: Schema.Number,
+  tags: Schema.Array(Schema.String),
+  securitySchemes: Schema.Array(SecurityScheme),
+  authStrategies: Schema.Array(AuthStrategy),
+  headerPresets: Schema.Array(HeaderPreset),
+  oauth2Presets: Schema.Array(OAuth2Preset),
+});
+export type SpecPreviewSummary = typeof SpecPreviewSummary.Type;
+
+export const specPreviewSummary = (preview: SpecPreview): SpecPreviewSummary =>
+  SpecPreviewSummary.make({
+    title: preview.title,
+    description: preview.description,
+    version: preview.version,
+    servers: preview.servers,
+    operationCount: preview.operationCount,
+    tags: preview.tags,
+    securitySchemes: preview.securitySchemes,
+    authStrategies: preview.authStrategies,
+    headerPresets: preview.headerPresets,
+    oauth2Presets: preview.oauth2Presets,
+  });
+
 // ---------------------------------------------------------------------------
 // Security scheme extraction
 // ---------------------------------------------------------------------------

--- a/packages/plugins/openapi/src/sdk/store.test.ts
+++ b/packages/plugins/openapi/src/sdk/store.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+
+import {
+  Subject,
+  Tenant,
+  type PluginBlobStore,
+  type PluginStorageEntry,
+  type PluginStorageFacade,
+  type StorageDeps,
+} from "@executor-js/sdk/core";
+
+import { makeDefaultOpenapiStore } from "./store";
+import { OperationBinding } from "./types";
+
+describe("OpenAPI operation store", () => {
+  it.effect("bounds operation storage keys while preserving tool-name lookup", () =>
+    Effect.gen(function* () {
+      const rows = new Map<string, PluginStorageEntry>();
+      const capturedKeys: string[] = [];
+      const storageKey = (collection: string, key: string) => `${collection}\0${key}`;
+      const now = new Date();
+      const makeEntry = <T>(input: {
+        readonly owner: "org" | "user";
+        readonly collection: string;
+        readonly key: string;
+        readonly data: T;
+      }): PluginStorageEntry<T> => ({
+        id: storageKey(input.collection, input.key),
+        owner: input.owner,
+        pluginId: "openapi",
+        collection: input.collection,
+        key: input.key,
+        data: input.data,
+        createdAt: now,
+        updatedAt: now,
+      });
+      const pluginStorage: PluginStorageFacade = {
+        collection: () => ({
+          get: () => Effect.succeed(null),
+          getForOwner: () => Effect.succeed(null),
+          list: () => Effect.succeed([]),
+          put: (input) =>
+            Effect.succeed(
+              makeEntry({
+                owner: input.owner,
+                collection: "unused",
+                key: input.key,
+                data: input.data,
+              }),
+            ),
+          query: () => Effect.succeed([]),
+          count: () => Effect.succeed(0),
+          remove: () => Effect.void,
+        }),
+        get: <T = unknown>(input: { readonly collection: string; readonly key: string }) =>
+          Effect.succeed(
+            (rows.get(storageKey(input.collection, input.key)) as
+              | PluginStorageEntry<T>
+              | undefined) ?? null,
+          ),
+        getForOwner: <T = unknown>(input: { readonly collection: string; readonly key: string }) =>
+          Effect.succeed(
+            (rows.get(storageKey(input.collection, input.key)) as
+              | PluginStorageEntry<T>
+              | undefined) ?? null,
+          ),
+        list: <T = unknown>(input: { readonly collection: string; readonly keyPrefix?: string }) =>
+          Effect.succeed(
+            [...rows.values()].filter(
+              (row) =>
+                row.collection === input.collection &&
+                (input.keyPrefix === undefined || row.key.startsWith(input.keyPrefix)),
+            ) as PluginStorageEntry<T>[],
+          ),
+        put: <T = unknown>(input: {
+          readonly owner: "org" | "user";
+          readonly collection: string;
+          readonly key: string;
+          readonly data: unknown;
+        }) => {
+          const entry = makeEntry<T>({ ...input, data: input.data as T });
+          rows.set(storageKey(input.collection, input.key), entry);
+          return Effect.succeed(entry);
+        },
+        putMany: (input) =>
+          Effect.sync(() => {
+            for (const entry of input.entries) {
+              capturedKeys.push(entry.key);
+              rows.set(
+                storageKey(entry.collection, entry.key),
+                makeEntry({
+                  owner: input.owner,
+                  collection: entry.collection,
+                  key: entry.key,
+                  data: entry.data,
+                }),
+              );
+            }
+          }),
+        remove: (input) =>
+          Effect.sync(() => {
+            rows.delete(storageKey(input.collection, input.key));
+          }),
+        removeMany: (input) =>
+          Effect.sync(() => {
+            for (const entry of input.entries) {
+              rows.delete(storageKey(entry.collection, entry.key));
+            }
+          }),
+      };
+      const blobs: PluginBlobStore = {
+        get: () => Effect.succeed(null),
+        put: () => Effect.void,
+        delete: () => Effect.void,
+        has: () => Effect.succeed(false),
+      };
+      const store = makeDefaultOpenapiStore({
+        owner: { tenant: Tenant.make("tenant"), subject: Subject.make("subject") },
+        blobs,
+        pluginStorage,
+      } satisfies StorageDeps);
+      const toolName = `users.${"veryLongSegment.".repeat(40)}get`;
+
+      yield* store.putOperations("microsoft_graph", [
+        {
+          integration: "microsoft_graph",
+          toolName,
+          binding: OperationBinding.make({
+            method: "get",
+            servers: [],
+            pathTemplate: "/users/{userId}/messages",
+            parameters: [],
+            requestBody: Option.none(),
+            responseBody: Option.none(),
+          }),
+        },
+      ]);
+
+      expect(capturedKeys).toHaveLength(1);
+      expect(capturedKeys[0]!.length).toBeLessThanOrEqual(255);
+      expect(capturedKeys[0]).not.toContain(toolName);
+
+      const operation = yield* store.getOperation("microsoft_graph", toolName);
+      expect(operation?.toolName).toBe(toolName);
+      expect(operation?.binding.pathTemplate).toBe("/users/{userId}/messages");
+    }),
+  );
+});

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -26,6 +26,7 @@ import { OperationBinding } from "./types";
 
 const OPERATION_COLLECTION = "operation";
 const STORE_OWNER = "org" as const;
+const OPERATION_KEY_VERSION = "op";
 
 const encodeBinding = Schema.encodeSync(OperationBinding);
 const decodeBinding = Schema.decodeUnknownSync(OperationBinding);
@@ -63,7 +64,21 @@ const rowToOperation = (row: PluginStorageEntry): StoredOperation | null => {
   };
 };
 
+const stableKeyHash = (value: string): string => {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= BigInt(value.charCodeAt(index));
+    hash = (hash * prime) & mask;
+  }
+  return hash.toString(36).padStart(13, "0");
+};
+
 const operationKey = (integration: string, toolName: string): string =>
+  `${OPERATION_KEY_VERSION}.${stableKeyHash(integration)}.${stableKeyHash(toolName)}`;
+
+const legacyOperationKey = (integration: string, toolName: string): string =>
   `${integration}.${toolName}`;
 
 /** Blob key for a spec's content hash. Content-addressed so re-puts are
@@ -104,7 +119,7 @@ export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): 
 
   const listRows = (integration: string) =>
     pluginStorage
-      .list({ collection: OPERATION_COLLECTION, keyPrefix: `${integration}.` })
+      .list({ collection: OPERATION_COLLECTION })
       .pipe(
         Effect.map((rows: readonly PluginStorageEntry[]) =>
           rows.filter((row) => rowToOperation(row)?.integration === integration),
@@ -135,9 +150,20 @@ export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): 
       }),
 
     getOperation: (integration, toolName) =>
-      pluginStorage
-        .get({ collection: OPERATION_COLLECTION, key: operationKey(integration, toolName) })
-        .pipe(Effect.map((row) => (row ? rowToOperation(row) : null))),
+      Effect.gen(function* () {
+        const row = yield* pluginStorage.get({
+          collection: OPERATION_COLLECTION,
+          key: operationKey(integration, toolName),
+        });
+        if (row) return rowToOperation(row);
+        const legacyKey = legacyOperationKey(integration, toolName);
+        if (legacyKey.length > 255) return null;
+        const legacyRow = yield* pluginStorage.get({
+          collection: OPERATION_COLLECTION,
+          key: legacyKey,
+        });
+        return legacyRow ? rowToOperation(legacyRow) : null;
+      }),
 
     listOperations: (integration) =>
       listRows(integration).pipe(


### PR DESCRIPTION
Summary
- Extract reusable OpenAPI-backed tool compile, resolve, invoke, and annotation helpers.
- Rewire the OpenAPI plugin to use the shared helper path.
- Export shared OpenAPI React auth/source detail helpers for provider plugins.

Verification
- bun run --cwd packages/plugins/openapi test
- bun run --cwd packages/plugins/openapi typecheck

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. **#1056** 👈 current
2. #1057
3. #1058
<!-- stack:links:end -->