### PR TITLE
[codex] fix MCP OAuth callback path

### DIFF
--- a/apps/cloud/src/engine/execution-stack.ts
+++ b/apps/cloud/src/engine/execution-stack.ts
@@ -83,9 +83,7 @@ export const CloudHostConfig: Layer.Layer<HostConfig> = Layer.sync(HostConfig, (
   // servers on localhost are reachable. See `hosted-http-client.ts`.
   allowLocalNetwork: env.ALLOW_LOCAL_NETWORK === "true",
   webBaseUrl: env.VITE_PUBLIC_SITE_URL ?? "https://executor.sh",
-  // `oauthCallbackPath` is NOT set here — `ExecutorApp.make` derives it from the
-  // `mountPrefix` cloud passes (`CLOUD_MOUNT_PREFIX`), so the callback can't drift
-  // from the route that serves it.
+  oauthCallbackPath: `${CLOUD_MOUNT_PREFIX}/oauth/callback`,
   // WorkOS Vault is cloud's credential storage implementation detail, not a
   // user-selectable provider surface.
   exposeCredentialProviders: false,

--- a/apps/host-cloudflare/src/execution.ts
+++ b/apps/host-cloudflare/src/execution.ts
@@ -45,6 +45,7 @@ export const makeCloudflareHostConfig = (config: CloudflareConfig): Layer.Layer<
   Layer.succeed(HostConfig)({
     allowLocalNetwork: config.allowLocalNetwork,
     webBaseUrl: config.webBaseUrl,
+    oauthCallbackPath: "/api/oauth/callback",
   });
 
 /**

--- a/apps/host-selfhost/src/execution.ts
+++ b/apps/host-selfhost/src/execution.ts
@@ -49,6 +49,7 @@ export const SelfHostHostConfig: Layer.Layer<HostConfig> = Layer.sync(HostConfig
   return {
     allowLocalNetwork: config.allowLocalNetwork,
     webBaseUrl: config.webBaseUrl,
+    oauthCallbackPath: "/api/oauth/callback",
   };
 });
 

--- a/packages/core/api/src/server/oauth-origin.test.ts
+++ b/packages/core/api/src/server/oauth-origin.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "@effect/vitest";
 
 import { requestWebOriginFromRequest } from "./execution-stack-middleware";
-import { resolveScopedWebBaseUrl } from "./scoped-executor";
+import { buildOAuthRedirectUri, resolveScopedWebBaseUrl } from "./scoped-executor";
 
 describe("OAuth web origin resolution", () => {
   it("uses the browser loopback origin when a local proxy rewrites the request host", () => {
@@ -38,5 +38,14 @@ describe("OAuth web origin resolution", () => {
         requestOrigin: "https://preview.example",
       }),
     ).toBe("https://executor.sh");
+  });
+
+  it("uses the host-provided callback path when building OAuth redirect URLs", () => {
+    expect(
+      buildOAuthRedirectUri({
+        webBaseUrl: "https://executor.sh",
+        oauthCallbackPath: "/api/oauth/callback",
+      }),
+    ).toBe("https://executor.sh/api/oauth/callback");
   });
 });

--- a/packages/core/api/src/server/scoped-executor.ts
+++ b/packages/core/api/src/server/scoped-executor.ts
@@ -72,13 +72,12 @@ export interface HostConfigShape {
    * (packages/core/api/src/oauth/api.ts). The redirect URI sent to providers is
    * `${webBaseUrl}${oauthCallbackPath}`.
    *
-   * Hosts do NOT set this: `ExecutorApp.make` derives it from the same
-   * `config.mountPrefix` that prefixes the API router and injects it here, so the
-   * callback can't drift from the route that serves it. It stays optional only
-   * for the low-level `makeScopedExecutor` test seam (constructed without
-   * `make`), where it defaults to `/oauth/callback` (the root-mount path).
+   * Every host must set this explicitly. `ExecutorApp.make` derives it from the
+   * same `config.mountPrefix` that prefixes the API router and injects it here
+   * for protected HTTP requests. Direct MCP session stacks also read HostConfig,
+   * so the host-provided value is the only valid source of truth.
    */
-  readonly oauthCallbackPath?: string;
+  readonly oauthCallbackPath: string;
   /**
    * Whether Executor's built-in agent tools should expose credential provider
    * discovery. Local/self-host can use this for 1Password/keychain style
@@ -129,6 +128,12 @@ export const resolveScopedWebBaseUrl = (input: {
   if (input.requestOrigin && isLoopbackOrigin(input.requestOrigin)) return input.requestOrigin;
   return input.configuredWebBaseUrl ?? input.requestOrigin;
 };
+
+export const buildOAuthRedirectUri = (input: {
+  readonly webBaseUrl: string | undefined;
+  readonly oauthCallbackPath: string;
+}): string | undefined =>
+  input.webBaseUrl ? new URL(input.oauthCallbackPath, input.webBaseUrl).toString() : undefined;
 
 // ---------------------------------------------------------------------------
 // PluginsProvider seam — the per-host (and possibly per-request) plugin array.
@@ -199,13 +204,15 @@ export const makeScopedExecutor = <
     // prefix joined with the global `/oauth/callback` route
     // (packages/core/api/src/oauth/api.ts). The base is derived from the SAME
     // source as `webBaseUrl` (an explicit `HostConfig.webBaseUrl`, else the
-    // in-flight request origin). The PATH defaults to root (`/oauth/callback`,
-    // correct for a root-mounted host like local); a prefix-mounted host (cloud:
-    // `/api`) sets `oauthCallbackPath` so the prefix is not dropped. When no base
-    // is known (a non-HTTP caller), `redirectUri` stays `undefined` and the OAuth
-    // service fails loudly on redirect flows rather than silently using localhost.
-    const oauthCallbackPath = config.oauthCallbackPath ?? "/oauth/callback";
-    const redirectUri = webBaseUrl ? new URL(oauthCallbackPath, webBaseUrl).toString() : undefined;
+    // in-flight request origin). The PATH is required in HostConfig so direct MCP
+    // session stacks cannot silently fall back to an unmounted callback. When no
+    // base is known (a non-HTTP caller), `redirectUri` stays `undefined` and the
+    // OAuth service fails loudly on redirect flows rather than silently using
+    // localhost.
+    const redirectUri = buildOAuthRedirectUri({
+      webBaseUrl,
+      oauthCallbackPath: config.oauthCallbackPath,
+    });
 
     const plugins = pluginsFactory();
     const httpClientLayer = makeHostedHttpClientLayer({


### PR DESCRIPTION
## Summary

- Require hosts to provide the OAuth callback path instead of falling back to `/oauth/callback`.
- Set the cloud, self-host, and host-cloudflare execution-stack host configs to `/api/oauth/callback`.
- Add a focused regression test for OAuth redirect URI construction.

## Root cause

The cloud HTTP API path gets `oauthCallbackPath` injected by `ExecutorApp.make` from `mountPrefix: "/api"`, but the cloud MCP Durable Object builds the execution stack directly. That direct path used the base `CloudHostConfig`, which did not include an OAuth callback path, so `makeScopedExecutor` fell back to `/oauth/callback` and produced `https://executor.sh/oauth/callback` for MCP-started OAuth flows.

## Validation

- `bun run bootstrap`
- `bun run test src/server/oauth-origin.test.ts` in `packages/core/api`
- `bun run --cwd packages/core/api typecheck`
- `bun run --cwd apps/cloud typecheck`
- `bun run --cwd apps/host-cloudflare typecheck`
- `bun run --cwd apps/host-selfhost typecheck`
- `bunx oxfmt --check packages/core/api/src/server/scoped-executor.ts packages/core/api/src/server/oauth-origin.test.ts apps/cloud/src/engine/execution-stack.ts apps/host-cloudflare/src/execution.ts apps/host-selfhost/src/execution.ts`
- `git diff --check`