### PR TITLE
[codex] Fix signed-out OAuth callback recovery

### DIFF
--- a/apps/cloud/src/auth/return-to.test.ts
+++ b/apps/cloud/src/auth/return-to.test.ts
@@ -7,7 +7,13 @@ import { isSafeReturnTo, loginPath, safeReturnTo } from "./return-to";
 // boundary, so the validator is what stands between "resume where you were"
 // and an open redirect.
 describe("isSafeReturnTo", () => {
-  const safe = ["/", "/tools", "/integrations/sentry?addAccount=1", "/billing/plans"];
+  const safe = [
+    "/",
+    "/tools",
+    "/integrations/sentry?addAccount=1",
+    "/billing/plans",
+    "/api/oauth/callback?state=oauth-state&code=provider-code",
+  ];
   for (const path of safe) {
     it(`allows ${path}`, () => {
       expect(isSafeReturnTo(path)).toBe(true);
@@ -18,6 +24,7 @@ describe("isSafeReturnTo", () => {
     "https://evil.example", // absolute URL — off-origin redirect
     "//evil.example", // protocol-relative — same thing in disguise
     "/api/auth/logout", // API endpoints are never a landing page
+    "/api/oauth/callback/extra?state=oauth-state", // only the exact OAuth callback resumes
     "/api", // bare /api too
     "javascript:alert(1)", // not a path at all
     "tools", // relative paths resolve unpredictably
@@ -54,6 +61,11 @@ describe("loginPath", () => {
   it("carries deep links URI-encoded", () => {
     expect(loginPath("/integrations/sentry?addAccount=1")).toBe(
       "/login?returnTo=%2Fintegrations%2Fsentry%3FaddAccount%3D1",
+    );
+  });
+  it("carries OAuth callback resumes URI-encoded", () => {
+    expect(loginPath("/api/oauth/callback?state=oauth-state&code=provider-code")).toBe(
+      "/login?returnTo=%2Fapi%2Foauth%2Fcallback%3Fstate%3Doauth-state%26code%3Dprovider-code",
     );
   });
 });

--- a/apps/cloud/src/auth/return-to.ts
+++ b/apps/cloud/src/auth/return-to.ts
@@ -11,8 +11,14 @@
 // Pure string code — imported by server handlers and the login page alike.
 // ---------------------------------------------------------------------------
 
+const pathPart = (path: string): string => path.split(/[?#]/, 1)[0] ?? "";
+
+const isOAuthCallbackReturnTo = (path: string): boolean => pathPart(path) === "/api/oauth/callback";
+
 export const isSafeReturnTo = (path: string): boolean =>
-  path.startsWith("/") && !path.startsWith("//") && !/^\/api(\/|$)/.test(path);
+  path.startsWith("/") &&
+  !path.startsWith("//") &&
+  (!/^\/api(\/|$)/.test(path) || isOAuthCallbackReturnTo(path));
 
 /** The validated returnTo, or null when absent/unsafe. */
 export const safeReturnTo = (path: string | null | undefined): string | null =>

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -3,6 +3,8 @@ import { createMiddleware, createStart } from "@tanstack/react-start";
 import { cloudApiHandler } from "./app";
 import { isAppOwnedPath } from "./app-paths";
 import { authGateMiddleware } from "./auth/ssr-gate";
+import { parseCookie } from "./auth/cookies";
+import { loginPath } from "./auth/return-to";
 import { prepareMcpOrgScope } from "./mcp/mount";
 import {
   docsProxyMiddleware,
@@ -34,6 +36,25 @@ import {
 let app: ReturnType<typeof cloudApiHandler> | undefined;
 const getApp = () => (app ??= cloudApiHandler());
 
+const SESSION_COOKIE = "wos-session";
+const OAUTH_CALLBACK_PATH = "/api/oauth/callback";
+
+const oauthCallbackSignInMiddleware = createMiddleware({ type: "request" }).server(
+  ({ pathname, request, next }) => {
+    if (pathname !== OAUTH_CALLBACK_PATH || (request.method !== "GET" && request.method !== "HEAD")) {
+      return next();
+    }
+    const sealed = parseCookie(request.headers.get("cookie"), SESSION_COOKIE);
+    if (sealed) return next();
+
+    const url = new URL(request.url);
+    return new Response(null, {
+      status: 302,
+      headers: { location: loginPath(`${url.pathname}${url.search}`) },
+    });
+  },
+);
+
 // app-owned = anything under `/api/*` (incl. the cloud extension routes) OR an
 // MCP/OAuth-discovery path (see `./app-paths`). The app handler serves these at
 // their real paths, so we forward unmodified — except `prepareMcpOrgScope`
@@ -63,6 +84,7 @@ export const startInstance = createStart(() => ({
     docsProxyMiddleware,
     sentryTunnelMiddleware,
     posthogProxyMiddleware,
+    oauthCallbackSignInMiddleware,
     appRequestMiddleware,
     authGateMiddleware,
   ],

--- a/apps/cloud/src/start.ts
+++ b/apps/cloud/src/start.ts
@@ -41,7 +41,10 @@ const OAUTH_CALLBACK_PATH = "/api/oauth/callback";
 
 const oauthCallbackSignInMiddleware = createMiddleware({ type: "request" }).server(
   ({ pathname, request, next }) => {
-    if (pathname !== OAUTH_CALLBACK_PATH || (request.method !== "GET" && request.method !== "HEAD")) {
+    if (
+      pathname !== OAUTH_CALLBACK_PATH ||
+      (request.method !== "GET" && request.method !== "HEAD")
+    ) {
       return next();
     }
     const sealed = parseCookie(request.headers.get("cookie"), SESSION_COOKIE);

--- a/apps/host-selfhost/src/app.ts
+++ b/apps/host-selfhost/src/app.ts
@@ -21,6 +21,7 @@ import {
 import { makeSelfHostMcpSeams } from "./mcp";
 import { selfHostPlugins } from "./plugins";
 import { ErrorCaptureLive } from "./observability";
+import { oauthCallbackSignInRedirectLocation } from "./auth/oauth-callback-login";
 
 // ===========================================================================
 // The self-hosted Executor app, as ONE `ExecutorApp.make` call.
@@ -113,6 +114,7 @@ export const makeSelfHostApp = async (options: MakeSelfHostAppOptions = {}) => {
     // (it can't prove each host's resolution); self-host narrows it here.
     AppLayer: appLayer as Layer.Layer<never>,
     toWebHandler,
+    betterAuth,
     closeDb: async () => {
       await mcp.close();
       await dbHandle.close();
@@ -132,10 +134,14 @@ export interface SelfHostApiHandler {
 export const makeSelfHostApiHandler = async (
   options: MakeSelfHostAppOptions = {},
 ): Promise<SelfHostApiHandler> => {
-  const { toWebHandler, closeDb } = await makeSelfHostApp(options);
+  const { toWebHandler, betterAuth, closeDb } = await makeSelfHostApp(options);
   const web = toWebHandler();
   return {
-    handler: web.handler,
+    handler: async (request) => {
+      const location = await oauthCallbackSignInRedirectLocation(request, betterAuth.auth);
+      if (location) return new Response(null, { status: 302, headers: { location } });
+      return web.handler(request);
+    },
     dispose: async () => {
       await web.dispose();
       await closeDb();

--- a/apps/host-selfhost/src/auth/oauth-callback-login.test.ts
+++ b/apps/host-selfhost/src/auth/oauth-callback-login.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { oauthCallbackSignInRedirectLocation } from "./oauth-callback-login";
+
+const auth = (session: unknown | null) => ({
+  api: {
+    getSession: async () => session,
+  },
+});
+
+describe("oauthCallbackSignInRedirectLocation", () => {
+  it("redirects a signed-out OAuth callback to login with returnTo", async () => {
+    await expect(
+      oauthCallbackSignInRedirectLocation(
+        new Request("http://selfhost.test/api/oauth/callback?state=s1&code=c1"),
+        auth(null),
+      ),
+    ).resolves.toBe("/login?returnTo=%2Fapi%2Foauth%2Fcallback%3Fstate%3Ds1%26code%3Dc1");
+  });
+
+  it("does not redirect a signed-in OAuth callback", async () => {
+    await expect(
+      oauthCallbackSignInRedirectLocation(
+        new Request("http://selfhost.test/api/oauth/callback?state=s1&code=c1"),
+        auth({ user: { id: "user_1" } }),
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("ignores other paths and non-browser methods", async () => {
+    await expect(
+      oauthCallbackSignInRedirectLocation(
+        new Request("http://selfhost.test/api/oauth/callback?state=s1", { method: "POST" }),
+        auth(null),
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      oauthCallbackSignInRedirectLocation(
+        new Request("http://selfhost.test/api/oauth/callback/extra?state=s1"),
+        auth(null),
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/apps/host-selfhost/src/auth/oauth-callback-login.ts
+++ b/apps/host-selfhost/src/auth/oauth-callback-login.ts
@@ -1,0 +1,23 @@
+import { loginPath } from "./return-to";
+
+export const OAUTH_CALLBACK_PATH = "/api/oauth/callback";
+
+interface SessionAuth {
+  readonly api: {
+    readonly getSession: (input: { readonly headers: Headers }) => Promise<unknown | null>;
+  };
+}
+
+export const oauthCallbackSignInRedirectLocation = async (
+  request: Request,
+  auth: SessionAuth,
+): Promise<string | null> => {
+  if (request.method !== "GET" && request.method !== "HEAD") return null;
+  const url = new URL(request.url);
+  if (url.pathname !== OAUTH_CALLBACK_PATH) return null;
+
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (session) return null;
+
+  return loginPath(`${url.pathname}${url.search}`);
+};

--- a/apps/host-selfhost/src/auth/return-to.test.ts
+++ b/apps/host-selfhost/src/auth/return-to.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import { isSafeReturnTo, loginPath, safeReturnTo } from "./return-to";
+
+describe("isSafeReturnTo", () => {
+  const safe = [
+    "/",
+    "/tools",
+    "/integrations/sentry?addAccount=1",
+    "/api-keys",
+    "/api/oauth/callback?state=oauth-state&code=provider-code",
+  ];
+  for (const path of safe) {
+    it(`allows ${path}`, () => {
+      expect(isSafeReturnTo(path)).toBe(true);
+    });
+  }
+
+  const unsafe = [
+    "https://evil.example",
+    "//evil.example",
+    "/api/auth/logout",
+    "/api/oauth/callback/extra?state=oauth-state",
+    "/api",
+    "javascript:alert(1)",
+    "tools",
+    "",
+  ];
+  for (const path of unsafe) {
+    it(`rejects ${JSON.stringify(path)}`, () => {
+      expect(isSafeReturnTo(path)).toBe(false);
+    });
+  }
+});
+
+describe("safeReturnTo", () => {
+  it("passes a safe path through", () => {
+    expect(safeReturnTo("/tools")).toBe("/tools");
+  });
+
+  it("nulls unsafe and absent values", () => {
+    expect(safeReturnTo("https://evil.example")).toBeNull();
+    expect(safeReturnTo(null)).toBeNull();
+    expect(safeReturnTo(undefined)).toBeNull();
+  });
+});
+
+describe("loginPath", () => {
+  it("omits returnTo for the root", () => {
+    expect(loginPath("/")).toBe("/login");
+  });
+
+  it("carries OAuth callback resumes URI-encoded", () => {
+    expect(loginPath("/api/oauth/callback?state=oauth-state&code=provider-code")).toBe(
+      "/login?returnTo=%2Fapi%2Foauth%2Fcallback%3Fstate%3Doauth-state%26code%3Dprovider-code",
+    );
+  });
+});

--- a/apps/host-selfhost/src/auth/return-to.ts
+++ b/apps/host-selfhost/src/auth/return-to.ts
@@ -1,0 +1,14 @@
+const pathPart = (path: string): string => path.split(/[?#]/, 1)[0] ?? "";
+
+const isOAuthCallbackReturnTo = (path: string): boolean => pathPart(path) === "/api/oauth/callback";
+
+export const isSafeReturnTo = (path: string): boolean =>
+  path.startsWith("/") &&
+  !path.startsWith("//") &&
+  (!/^\/api(\/|$)/.test(path) || isOAuthCallbackReturnTo(path));
+
+export const safeReturnTo = (path: string | null | undefined): string | null =>
+  path && isSafeReturnTo(path) ? path : null;
+
+export const loginPath = (returnTo: string): string =>
+  returnTo === "/" ? "/login" : `/login?returnTo=${encodeURIComponent(returnTo)}`;

--- a/apps/host-selfhost/src/serve.ts
+++ b/apps/host-selfhost/src/serve.ts
@@ -19,6 +19,7 @@ import {
   HttpMiddleware,
   HttpRouter,
   HttpServerRequest,
+  HttpServerResponse,
   HttpStaticServer,
 } from "effect/unstable/http";
 import { BunFileSystem, BunHttpServer, BunPath, BunRuntime } from "@effect/platform-bun";
@@ -26,6 +27,11 @@ import { Effect, Layer } from "effect";
 
 import { makeSelfHostApp } from "./app";
 import { loadConfig } from "./config";
+import type { BetterAuthHandle } from "./auth";
+import {
+  OAUTH_CALLBACK_PATH,
+  oauthCallbackSignInRedirectLocation,
+} from "./auth/oauth-callback-login";
 import { stripMcpOrgSegment } from "./mcp/org-path";
 
 const distDir = fileURLToPath(new URL("../dist/", import.meta.url));
@@ -33,24 +39,37 @@ const distDir = fileURLToPath(new URL("../dist/", import.meta.url));
 // Rewrite `/<org>/mcp` (and its OAuth discovery path) to the bare path before
 // routing, so the "Connect an agent" card's org-pinned URL reaches the real
 // `/mcp` route — see ./mcp/org-path. A no-op for every other request.
-const mcpOrgPathRewrite = HttpMiddleware.make((httpApp) =>
-  Effect.gen(function* () {
-    const request = yield* HttpServerRequest.HttpServerRequest;
-    const url = new URL(request.url, "http://host.internal");
-    const rewritten = stripMcpOrgSegment(url.pathname);
-    if (rewritten === null) return yield* httpApp;
-    return yield* httpApp.pipe(
-      Effect.provideService(
-        HttpServerRequest.HttpServerRequest,
-        request.modify({ url: `${rewritten}${url.search}` }),
-      ),
-    );
-  }),
-);
+const selfHostHttpMiddleware = (betterAuth: BetterAuthHandle) =>
+  HttpMiddleware.make((httpApp) =>
+    Effect.gen(function* () {
+      const request = yield* HttpServerRequest.HttpServerRequest;
+      const url = new URL(request.url, "http://host.internal");
+      if (
+        url.pathname === OAUTH_CALLBACK_PATH &&
+        (request.method === "GET" || request.method === "HEAD")
+      ) {
+        const headers = new Headers(request.headers as Record<string, string>);
+        const webRequest = new Request(url, { method: request.method, headers });
+        const location = yield* Effect.promise(() =>
+          oauthCallbackSignInRedirectLocation(webRequest, betterAuth.auth),
+        );
+        if (location) return HttpServerResponse.redirect(location, { status: 302 });
+      }
+
+      const rewritten = stripMcpOrgSegment(url.pathname);
+      if (rewritten === null) return yield* httpApp;
+      return yield* httpApp.pipe(
+        Effect.provideService(
+          HttpServerRequest.HttpServerRequest,
+          request.modify({ url: `${rewritten}${url.search}` }),
+        ),
+      );
+    }),
+  );
 
 export const startServer = async (): Promise<void> => {
   const config = loadConfig();
-  const { AppLayer } = await makeSelfHostApp();
+  const { AppLayer, betterAuth } = await makeSelfHostApp();
 
   // Serve the built SPA. Specific API/docs/auth/mcp routes take precedence;
   // `spa: true` falls back to index.html for any other path (client routing).
@@ -60,7 +79,7 @@ export const startServer = async (): Promise<void> => {
   );
 
   const ServerLive = HttpRouter.serve(Layer.mergeAll(AppLayer, StaticLive), {
-    middleware: mcpOrgPathRewrite,
+    middleware: selfHostHttpMiddleware(betterAuth),
   }).pipe(
     Layer.provide(
       BunHttpServer.layer({ hostname: config.host, port: config.port, idleTimeout: 0 }),

--- a/apps/host-selfhost/web/login.tsx
+++ b/apps/host-selfhost/web/login.tsx
@@ -5,6 +5,7 @@ import { Input } from "@executor-js/react/components/input";
 import { Label } from "@executor-js/react/components/label";
 
 import { authClient } from "./auth-client";
+import { safeReturnTo } from "../src/auth/return-to";
 
 // Self-host login: email + password sign-in via Better Auth. On success we
 // reload so the shared AuthProvider re-reads /account/me and the AuthGate swaps
@@ -15,6 +16,7 @@ import { authClient } from "./auth-client";
 // redeeming an invite — either the full /join/<code> link, or by entering the
 // code here ("Have an invite code?"), which forwards to the same join page.
 export const LoginPage = () => {
+  const returnTo = safeReturnTo(new URLSearchParams(window.location.search).get("returnTo")) ?? "/";
   const [mode, setMode] = useState<"signin" | "code">("signin");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -32,7 +34,7 @@ export const LoginPage = () => {
       setError(result.error.message ?? "Sign in failed");
       return;
     }
-    window.location.href = "/";
+    window.location.href = returnTo;
   };
 
   const redeem = (event: FormEvent) => {

--- a/e2e/cloud/oauth-callback-unauthenticated.test.ts
+++ b/e2e/cloud/oauth-callback-unauthenticated.test.ts
@@ -1,0 +1,152 @@
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+} from "@executor-js/sdk/shared";
+import { serveOAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+const oauthIntegrationSpec = (oauth: {
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+}) =>
+  ({
+    spec: {
+      kind: "blob" as const,
+      value: JSON.stringify({
+        openapi: "3.0.3",
+        info: { title: "OAuth-protected API", version: "1.0.0" },
+        paths: {
+          "/me": {
+            get: {
+              operationId: "getMe",
+              tags: ["default"],
+              responses: { "200": { description: "the caller" } },
+            },
+          },
+        },
+      }),
+    },
+    baseUrl: "http://127.0.0.1:59999",
+    authenticationTemplate: [
+      {
+        slug: "oauth",
+        kind: "oauth2" as const,
+        authorizationUrl: oauth.authorizationEndpoint,
+        tokenUrl: oauth.tokenEndpoint,
+        scopes: ["read"],
+      },
+    ],
+  }) as const;
+
+scenario(
+  "OAuth callback · a signed-out callback uses login returnTo and resumes the connection",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const browser = yield* Browser;
+    const oauth = yield* serveOAuthTestServer();
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+
+    const integration = IntegrationSlug.make(unique("signedoutcb"));
+    yield* client.openapi.addSpec({
+      payload: { ...oauthIntegrationSpec(oauth), slug: integration },
+    });
+
+    const clientSlug = OAuthClientSlug.make(unique("signedoutc"));
+    yield* client.oauth.createClient({
+      payload: {
+        owner: "org",
+        slug: clientSlug,
+        authorizationUrl: oauth.authorizationEndpoint,
+        tokenUrl: oauth.tokenEndpoint,
+        grant: "authorization_code",
+        clientId: "test-client",
+        clientSecret: "test-secret",
+      },
+    });
+
+    const started = yield* client.oauth.start({
+      payload: {
+        client: clientSlug,
+        clientOwner: "org",
+        owner: "org",
+        name: ConnectionName.make("main"),
+        integration,
+        template: AuthTemplateSlug.make("oauth"),
+      },
+    });
+    expect(started.status, "oauth.start begins at the provider").toBe("redirect");
+    const authorizationUrl = started.status === "redirect" ? started.authorizationUrl : "";
+
+    const authorize = yield* Effect.promise(() => fetch(authorizationUrl, { redirect: "manual" }));
+    expect(authorize.status, "the provider asks the user to log in").toBe(302);
+    const consent = yield* Effect.promise(() =>
+      fetch(authorize.headers.get("location") ?? "", {
+        method: "POST",
+        redirect: "manual",
+        headers: {
+          authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+        },
+      }),
+    );
+    expect(consent.status, "provider consent redirects back to Executor").toBe(302);
+    const callback = new URL(consent.headers.get("location") ?? "");
+    const callbackPath = `${callback.pathname}${callback.search}`;
+
+    // No cookies: this mirrors a provider redirect reaching the callback after
+    // the user's web session is gone, expired, or otherwise missing an org.
+    const anonymous = { label: "anonymous" };
+
+    yield* browser.session(anonymous, async ({ page, step }) => {
+      await step("Provider sends a signed-out browser to the OAuth callback", async () => {
+        const response = await page.goto(callbackPath, { waitUntil: "commit" });
+        expect(response?.status(), "the callback redirects into the login flow").toBe(200);
+        await page.getByText("Sign in to manage your tools and sources").waitFor();
+      });
+
+      const loginUrl = new URL(page.url());
+      expect(loginUrl.pathname, "the signed-out callback lands on the sign-in page").toBe("/login");
+      expect(
+        loginUrl.searchParams.get("returnTo"),
+        "login preserves the callback so it can resume after sign-in",
+      ).toBe(callbackPath);
+
+      await step("Sign in resumes the original OAuth callback", async () => {
+        await page.getByRole("link", { name: "Sign in" }).click();
+        await page.getByPlaceholder("new-user@example.com").fill(identity.credentials!.email);
+        await page.getByRole("button", { name: /Continue/ }).click();
+        await page.waitForURL((url) => url.pathname === "/api/oauth/callback", {
+          timeout: 30_000,
+        });
+        await page.waitForFunction(() => document.body.innerText.includes("Connected"), null, {
+          timeout: 30_000,
+        });
+      });
+
+      const body = (await page.locator("body").textContent())?.trim() ?? "";
+      expect(new URL(page.url()).pathname, "the login returnTo lands back on the callback").toBe(
+        "/api/oauth/callback",
+      );
+      expect(body, "the callback completes after the sign-in recovery").toContain("Connected");
+      expect(body, "the raw protected API JSON is not shown").not.toContain(
+        '"code":"no_organization"',
+      );
+    });
+  }).pipe(Effect.scoped),
+);

--- a/e2e/selfhost/oauth-callback-unauthenticated.test.ts
+++ b/e2e/selfhost/oauth-callback-unauthenticated.test.ts
@@ -1,0 +1,146 @@
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+} from "@executor-js/sdk/shared";
+import { serveOAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { Api, Browser, Target } from "../src/services";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+const oauthIntegrationSpec = (oauth: {
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+}) =>
+  ({
+    spec: {
+      kind: "blob" as const,
+      value: JSON.stringify({
+        openapi: "3.0.3",
+        info: { title: "OAuth-protected API", version: "1.0.0" },
+        paths: {
+          "/me": {
+            get: {
+              operationId: "getMe",
+              tags: ["default"],
+              responses: { "200": { description: "the caller" } },
+            },
+          },
+        },
+      }),
+    },
+    baseUrl: "http://127.0.0.1:59999",
+    authenticationTemplate: [
+      {
+        slug: "oauth",
+        kind: "oauth2" as const,
+        authorizationUrl: oauth.authorizationEndpoint,
+        tokenUrl: oauth.tokenEndpoint,
+        scopes: ["read"],
+      },
+    ],
+  }) as const;
+
+scenario(
+  "OAuth callback · a signed-out self-host callback uses login returnTo and resumes the connection",
+  {},
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const browser = yield* Browser;
+    const oauth = yield* serveOAuthTestServer();
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+
+    const integration = IntegrationSlug.make(unique("selfhostsignedoutcb"));
+    yield* client.openapi.addSpec({
+      payload: { ...oauthIntegrationSpec(oauth), slug: integration },
+    });
+
+    const clientSlug = OAuthClientSlug.make(unique("selfhostsignedoutc"));
+    yield* client.oauth.createClient({
+      payload: {
+        owner: "org",
+        slug: clientSlug,
+        authorizationUrl: oauth.authorizationEndpoint,
+        tokenUrl: oauth.tokenEndpoint,
+        grant: "authorization_code",
+        clientId: "test-client",
+        clientSecret: "test-secret",
+      },
+    });
+
+    const started = yield* client.oauth.start({
+      payload: {
+        client: clientSlug,
+        clientOwner: "org",
+        owner: "org",
+        name: ConnectionName.make("main"),
+        integration,
+        template: AuthTemplateSlug.make("oauth"),
+      },
+    });
+    expect(started.status, "oauth.start begins at the provider").toBe("redirect");
+    const authorizationUrl = started.status === "redirect" ? started.authorizationUrl : "";
+
+    const authorize = yield* Effect.promise(() => fetch(authorizationUrl, { redirect: "manual" }));
+    expect(authorize.status, "the provider asks the user to log in").toBe(302);
+    const consent = yield* Effect.promise(() =>
+      fetch(authorize.headers.get("location") ?? "", {
+        method: "POST",
+        redirect: "manual",
+        headers: {
+          authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+        },
+      }),
+    );
+    expect(consent.status, "provider consent redirects back to Executor").toBe(302);
+    const callback = new URL(consent.headers.get("location") ?? "");
+    const callbackPath = `${callback.pathname}${callback.search}`;
+
+    yield* browser.session({ label: "anonymous" }, async ({ page, step }) => {
+      await step("Provider sends a signed-out browser to the OAuth callback", async () => {
+        const response = await page.goto(callbackPath, { waitUntil: "networkidle" });
+        expect(response?.status(), "the callback redirects into the login flow").toBe(200);
+        await page.getByText("Sign in to your instance").waitFor();
+      });
+
+      const loginUrl = new URL(page.url());
+      expect(loginUrl.pathname, "the signed-out callback lands on the sign-in page").toBe("/login");
+      expect(
+        loginUrl.searchParams.get("returnTo"),
+        "login preserves the callback so it can resume after sign-in",
+      ).toBe(callbackPath);
+
+      await step("Sign in resumes the original OAuth callback", async () => {
+        await page.getByLabel("Email").fill(identity.credentials!.email);
+        await page.getByLabel("Password").fill(identity.credentials!.password);
+        await page.getByRole("button", { name: "Sign in" }).click();
+        await page.waitForURL((url) => url.pathname === "/api/oauth/callback", {
+          timeout: 30_000,
+        });
+        await page.waitForFunction(() => document.body.innerText.includes("Connected"), null, {
+          timeout: 30_000,
+        });
+      });
+
+      const body = (await page.locator("body").textContent())?.trim() ?? "";
+      expect(new URL(page.url()).pathname, "the login returnTo lands back on the callback").toBe(
+        "/api/oauth/callback",
+      );
+      expect(body, "the callback completes after the sign-in recovery").toContain("Connected");
+      expect(body, "the raw protected API response is not shown").not.toContain("Unauthorized");
+    });
+  }).pipe(Effect.scoped),
+);


### PR DESCRIPTION
## What changed

- Route signed-out cloud OAuth callback navigations into the existing `/login?returnTo=...` flow.
- Route signed-out self-host OAuth callback navigations into `/login?returnTo=...` and make the Better Auth login form resume safe return targets.
- Allow only the exact `/api/oauth/callback` path through each login returnTo guard while keeping other `/api/*` destinations blocked.
- Add cloud and self-host e2e scenarios that start a real OAuth session, drop the browser session before callback, sign in again, and verify the callback resumes and completes.

## Why

When a provider redirected back to `/api/oauth/callback` after the user session was gone, the protected API auth gate answered with a raw callback response. Cloud showed JSON: `{"error":"No organization in session","code":"no_organization"}`. Self-host showed plain text: `Unauthorized`. The callback is a browser redirect, so it should use the product sign-in recovery flow and then resume the original callback.

## Watch it

![OAuth callback · a signed-out callback uses login returnTo and resumes the connection (cloud)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/oauth-callback-a-signed-out-callback-uses-login-returnto-and-resumes-the-connect-4a745de1.gif)

![OAuth callback · a signed-out self-host callback uses login returnTo and resumes the connection (selfhost)](https://raw.githubusercontent.com/RhysSullivan/executor/e2e-media/oauth-callback-a-signed-out-self-host-callback-uses-login-returnto-and-resumes-t-7e0ff343.gif)

## Validation

- `bun run --cwd apps/cloud test -- src/auth/return-to.test.ts`
- `../node_modules/.bin/vitest run --project cloud cloud/oauth-callback-unauthenticated.test.ts`
- `bun run --cwd apps/cloud typecheck`
- `bunx vitest run src/auth/return-to.test.ts src/auth/oauth-callback-login.test.ts` from `apps/host-selfhost`
- `bun run typecheck` from `apps/host-selfhost`
- `E2E_SELFHOST_URL=http://localhost:45934 bunx vitest run --project selfhost selfhost/oauth-callback-unauthenticated.test.ts` from `e2e`