### PR TITLE
[codex] Handle OpenAPI file outputs in MCP

### DIFF
--- a/packages/core/execution/src/tool-invoker.test.ts
+++ b/packages/core/execution/src/tool-invoker.test.ts
@@ -710,6 +710,8 @@ describe("tool discovery", () => {
       expect(described.typeScriptDefinitions).toEqual({
         ToolError:
           "{ code: string; message: string; status?: number; details?: unknown; retryable?: boolean }",
+        ToolFile:
+          '{ _tag: "ToolFile"; name?: string; mimeType: string; encoding: "base64"; data: string; byteLength: number; }',
         ToolHttpMeta: "{ status: number; headers: { [k: string]: string; } }",
       });
     }),
@@ -799,6 +801,8 @@ describe("tool discovery", () => {
       expect(described.typeScriptDefinitions).toEqual({
         ToolError:
           "{ code: string; message: string; status?: number; details?: unknown; retryable?: boolean }",
+        ToolFile:
+          '{ _tag: "ToolFile"; name?: string; mimeType: string; encoding: "base64"; data: string; byteLength: number; }',
         ToolHttpMeta: "{ status: number; headers: { [k: string]: string; } }",
       });
     }),

--- a/packages/core/execution/src/tool-invoker.ts
+++ b/packages/core/execution/src/tool-invoker.ts
@@ -27,6 +27,8 @@ const TOOL_ERROR_TYPESCRIPT =
 // so callers can read pagination/rate-limit headers without the payload
 // being wrapped in an envelope.
 const TOOL_HTTP_META_TYPESCRIPT = "{ status: number; headers: { [k: string]: string; } }";
+const TOOL_FILE_TYPESCRIPT =
+  '{ _tag: "ToolFile"; name?: string; mimeType: string; encoding: "base64"; data: string; byteLength: number; }';
 
 const wrapOutputTypeScript = (outputTypeScript?: string): string =>
   `{ ok: true; data: ${outputTypeScript ?? "unknown"}; http?: ToolHttpMeta } | { ok: false; error: ToolError }`;
@@ -37,6 +39,7 @@ const withToolResultDefinitions = (
   ...(definitions ?? {}),
   ToolError: TOOL_ERROR_TYPESCRIPT,
   ToolHttpMeta: TOOL_HTTP_META_TYPESCRIPT,
+  ToolFile: TOOL_FILE_TYPESCRIPT,
 });
 
 const ADDRESS_PREFIX = "tools.";

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -326,12 +326,13 @@ export { InternalError } from "./api-errors";
 
 // ToolResult — typed value-based discriminated union for tool outcomes.
 export {
-  ToolFile,
+  ToolFileSchema,
   ToolFileJsonSchema,
   ToolResult,
   annotateToolResultOutcome,
   isToolFile,
   isToolResult,
+  type ToolFile,
   type ToolFile as ToolFileValue,
   type ToolError,
   type ToolHttpMeta,

--- a/packages/core/sdk/src/index.ts
+++ b/packages/core/sdk/src/index.ts
@@ -326,9 +326,13 @@ export { InternalError } from "./api-errors";
 
 // ToolResult — typed value-based discriminated union for tool outcomes.
 export {
+  ToolFile,
+  ToolFileJsonSchema,
   ToolResult,
   annotateToolResultOutcome,
+  isToolFile,
   isToolResult,
+  type ToolFile as ToolFileValue,
   type ToolError,
   type ToolHttpMeta,
 } from "./tool-result";

--- a/packages/core/sdk/src/tool-result.test.ts
+++ b/packages/core/sdk/src/tool-result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { ToolFile, ToolResult, isToolFile, isToolResult } from "./tool-result";
+import { ToolResult, isToolFile, isToolResult } from "./tool-result";
 
 describe("ToolResult", () => {
   it("ok wraps a value", () => {
@@ -50,13 +50,15 @@ describe("ToolResult", () => {
 });
 
 describe("ToolFile", () => {
-  it("makes a base64 file value", () => {
-    const file = ToolFile.make({
+  it("accepts a base64 file value", () => {
+    const file = {
+      _tag: "ToolFile",
       name: "photo.png",
       mimeType: "image/png",
+      encoding: "base64",
       data: "iVBORw0KGgo=",
       byteLength: 8,
-    });
+    };
 
     expect(file).toEqual({
       _tag: "ToolFile",

--- a/packages/core/sdk/src/tool-result.test.ts
+++ b/packages/core/sdk/src/tool-result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { ToolResult, isToolResult } from "./tool-result";
+import { ToolFile, ToolResult, isToolFile, isToolResult } from "./tool-result";
 
 describe("ToolResult", () => {
   it("ok wraps a value", () => {
@@ -46,5 +46,40 @@ describe("ToolResult", () => {
         error: { code: "x", message: "y" },
       }),
     ).toBe(true);
+  });
+});
+
+describe("ToolFile", () => {
+  it("makes a base64 file value", () => {
+    const file = ToolFile.make({
+      name: "photo.png",
+      mimeType: "image/png",
+      data: "iVBORw0KGgo=",
+      byteLength: 8,
+    });
+
+    expect(file).toEqual({
+      _tag: "ToolFile",
+      name: "photo.png",
+      mimeType: "image/png",
+      encoding: "base64",
+      data: "iVBORw0KGgo=",
+      byteLength: 8,
+    });
+    expect(isToolFile(file)).toBe(true);
+  });
+
+  it("rejects unrelated shapes", () => {
+    expect(isToolFile(null)).toBe(false);
+    expect(isToolFile({ data: "abc" })).toBe(false);
+    expect(
+      isToolFile({
+        _tag: "ToolFile",
+        mimeType: "image/png",
+        encoding: "utf8",
+        data: "abc",
+        byteLength: 3,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/core/sdk/src/tool-result.ts
+++ b/packages/core/sdk/src/tool-result.ts
@@ -34,52 +34,22 @@ export const ToolFileSchema = Schema.TaggedStruct("ToolFile", {
   name: Schema.optional(Schema.String),
   mimeType: Schema.String,
   encoding: Schema.Literal("base64"),
-  data: Schema.String,
-  byteLength: Schema.Number,
+  data: Schema.String.annotate({
+    description: "Base64-encoded file bytes.",
+    contentEncoding: "base64",
+  }),
+  byteLength: Schema.Int.annotate({
+    description: "Raw file size in bytes before base64 encoding.",
+  }),
 });
 
 export type ToolFile = typeof ToolFileSchema.Type;
 
-export const ToolFileJsonSchema = {
-  type: "object",
-  properties: {
-    _tag: { const: "ToolFile" },
-    name: { type: "string" },
-    mimeType: { type: "string" },
-    encoding: { const: "base64" },
-    data: {
-      type: "string",
-      contentEncoding: "base64",
-      description: "Base64-encoded file bytes.",
-    },
-    byteLength: {
-      type: "integer",
-      description: "Raw file size in bytes before base64 encoding.",
-    },
-  },
-  required: ["_tag", "mimeType", "encoding", "data", "byteLength"],
-  additionalProperties: false,
-} as const;
+export const ToolFileJsonSchema = Schema.toJsonSchemaDocument(ToolFileSchema).schema;
 
-export const ToolFile = {
-  make: (input: {
-    readonly name?: string;
-    readonly mimeType: string;
-    readonly data: string;
-    readonly byteLength: number;
-  }): ToolFile => ({
-    _tag: "ToolFile",
-    ...(input.name ? { name: input.name } : {}),
-    mimeType: input.mimeType,
-    encoding: "base64",
-    data: input.data,
-    byteLength: input.byteLength,
-  }),
-} as const;
+const matchesToolFileSchema = Schema.is(ToolFileSchema);
 
-const isUnknownToolFile = Schema.is(ToolFileSchema);
-
-export const isToolFile = (value: unknown): value is ToolFile => isUnknownToolFile(value);
+export const isToolFile = (value: unknown): value is ToolFile => matchesToolFileSchema(value);
 
 export type ToolResult<T> =
   | { readonly ok: true; readonly data: T; readonly http?: ToolHttpMeta }

--- a/packages/core/sdk/src/tool-result.ts
+++ b/packages/core/sdk/src/tool-result.ts
@@ -30,6 +30,57 @@ export const ToolHttpMetaSchema = Schema.Struct({
  */
 export type ToolHttpMeta = typeof ToolHttpMetaSchema.Type;
 
+export const ToolFileSchema = Schema.TaggedStruct("ToolFile", {
+  name: Schema.optional(Schema.String),
+  mimeType: Schema.String,
+  encoding: Schema.Literal("base64"),
+  data: Schema.String,
+  byteLength: Schema.Number,
+});
+
+export type ToolFile = typeof ToolFileSchema.Type;
+
+export const ToolFileJsonSchema = {
+  type: "object",
+  properties: {
+    _tag: { const: "ToolFile" },
+    name: { type: "string" },
+    mimeType: { type: "string" },
+    encoding: { const: "base64" },
+    data: {
+      type: "string",
+      contentEncoding: "base64",
+      description: "Base64-encoded file bytes.",
+    },
+    byteLength: {
+      type: "integer",
+      description: "Raw file size in bytes before base64 encoding.",
+    },
+  },
+  required: ["_tag", "mimeType", "encoding", "data", "byteLength"],
+  additionalProperties: false,
+} as const;
+
+export const ToolFile = {
+  make: (input: {
+    readonly name?: string;
+    readonly mimeType: string;
+    readonly data: string;
+    readonly byteLength: number;
+  }): ToolFile => ({
+    _tag: "ToolFile",
+    ...(input.name ? { name: input.name } : {}),
+    mimeType: input.mimeType,
+    encoding: "base64",
+    data: input.data,
+    byteLength: input.byteLength,
+  }),
+} as const;
+
+const isUnknownToolFile = Schema.is(ToolFileSchema);
+
+export const isToolFile = (value: unknown): value is ToolFile => isUnknownToolFile(value);
+
 export type ToolResult<T> =
   | { readonly ok: true; readonly data: T; readonly http?: ToolHttpMeta }
   | { readonly ok: false; readonly error: ToolError };

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -79,6 +79,9 @@ const textOf = (result: Awaited<ReturnType<Client["callTool"]>>): string =>
   (result.content as Array<{ type: string; text: string }>)[0].text;
 
 const STUB_TOOL_ADDRESS = ToolAddress.make("tools.test.org.main.t");
+const TEST_IMAGE_MIME_TYPE = "image/png";
+const TEST_IMAGE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l8N1wwAAAABJRU5ErkJggg==";
 
 /** Build a stub paused ExecutionResult with the given id and elicitation request. */
 const makePausedResult = (
@@ -177,6 +180,59 @@ describe("MCP host server — native elicitation mode", () => {
         mimeType: "image/png",
       });
       expect(result.structuredContent).toBeUndefined();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  it("execute tool preserves upstream MCP image content as native content", async () => {
+    const engine = makeStubEngine({
+      execute: () =>
+        Effect.succeed({
+          result: ToolResult.ok({
+            content: [
+              {
+                type: "text",
+                text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+              },
+              {
+                type: "image",
+                data: TEST_IMAGE_PNG_BASE64,
+                mimeType: TEST_IMAGE_MIME_TYPE,
+              },
+            ],
+            structuredContent: {
+              name: "mcp-image-fixture.png",
+              mimeType: TEST_IMAGE_MIME_TYPE,
+              byteLength: 70,
+            },
+          }),
+        }),
+    });
+
+    await withNativeClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: {
+          code: "return await tools.image_mcp.org.main.image_fixture_with_metadata({});",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+        },
+        {
+          type: "image",
+          data: TEST_IMAGE_PNG_BASE64,
+          mimeType: TEST_IMAGE_MIME_TYPE,
+        },
+      ]);
+      expect(result.structuredContent).toEqual({
+        name: "mcp-image-fixture.png",
+        mimeType: TEST_IMAGE_MIME_TYPE,
+        byteLength: 70,
+      });
       expect(result.isError).toBeFalsy();
     });
   });

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -10,10 +10,10 @@ import {
   ElicitationId,
   FormElicitation,
   ToolAddress,
-  ToolFile,
   ToolResult,
   UrlElicitation,
 } from "@executor-js/sdk";
+import type { ToolFileValue } from "@executor-js/sdk";
 import type { ExecutionEngine, ExecutionResult } from "@executor-js/execution";
 
 import { createExecutorMcpServer, type ExecutorMcpServerConfig } from "./tool-server";
@@ -92,6 +92,20 @@ const makePausedResult = (
   },
 });
 
+const toolFile = (input: {
+  readonly name?: string;
+  readonly mimeType: string;
+  readonly data: string;
+  readonly byteLength: number;
+}): ToolFileValue => ({
+  _tag: "ToolFile",
+  ...(input.name ? { name: input.name } : {}),
+  mimeType: input.mimeType,
+  encoding: "base64",
+  data: input.data,
+  byteLength: input.byteLength,
+});
+
 /** Build an engine whose execute triggers one elicitation and returns the handler's result. */
 const makeElicitingEngine = (
   request: FormElicitation | UrlElicitation,
@@ -136,7 +150,7 @@ describe("MCP host server — native elicitation mode", () => {
       execute: () =>
         Effect.succeed({
           result: ToolResult.ok(
-            ToolFile.make({
+            toolFile({
               name: "photo.png",
               mimeType: "image/png",
               data: "iVBORw0KGgo=",
@@ -174,7 +188,7 @@ describe("MCP host server — native elicitation mode", () => {
           result: {
             subject: "Flight receipt",
             attachment: ToolResult.ok(
-              ToolFile.make({
+              toolFile({
                 name: "boarding-pass.png",
                 mimeType: "image/png",
                 data: "iVBORw0KGgo=",
@@ -212,7 +226,7 @@ describe("MCP host server — native elicitation mode", () => {
       execute: () =>
         Effect.succeed({
           result: ToolResult.ok(
-            ToolFile.make({
+            toolFile({
               name: "rows.csv",
               mimeType: "text/csv",
               data: "YSxiCjEsMgo=",
@@ -247,7 +261,7 @@ describe("MCP host server — native elicitation mode", () => {
       execute: () =>
         Effect.succeed({
           result: ToolResult.ok(
-            ToolFile.make({
+            toolFile({
               name: "report.pdf",
               mimeType: "application/pdf",
               data: "JVBERg==",

--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -6,7 +6,14 @@ import { ElicitRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { ClientCapabilities } from "@modelcontextprotocol/sdk/types.js";
 import type * as Cause from "effect/Cause";
 
-import { ElicitationId, FormElicitation, ToolAddress, UrlElicitation } from "@executor-js/sdk";
+import {
+  ElicitationId,
+  FormElicitation,
+  ToolAddress,
+  ToolFile,
+  ToolResult,
+  UrlElicitation,
+} from "@executor-js/sdk";
 import type { ExecutionEngine, ExecutionResult } from "@executor-js/execution";
 
 import { createExecutorMcpServer, type ExecutorMcpServerConfig } from "./tool-server";
@@ -120,6 +127,169 @@ describe("MCP host server — native elicitation mode", () => {
         arguments: { code: "1+1" },
       });
       expect(result.content).toEqual([{ type: "text", text: "ran: 1+1" }]);
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  it("execute tool renders image ToolFile results as MCP images", async () => {
+    const engine = makeStubEngine({
+      execute: () =>
+        Effect.succeed({
+          result: ToolResult.ok(
+            ToolFile.make({
+              name: "photo.png",
+              mimeType: "image/png",
+              data: "iVBORw0KGgo=",
+              byteLength: 8,
+            }),
+          ),
+        }),
+    });
+
+    await withNativeClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: { code: "return await tools.gmail.org.main.getAttachment({});" },
+      });
+
+      const content = result.content as Array<Record<string, unknown>>;
+      expect(content[0]).toMatchObject({
+        type: "text",
+        text: "File output: photo.png\nimage/png, 8 bytes",
+      });
+      expect(content[1]).toMatchObject({
+        type: "image",
+        data: "iVBORw0KGgo=",
+        mimeType: "image/png",
+      });
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  it("execute tool strips nested ToolFile bytes while preserving result metadata", async () => {
+    const engine = makeStubEngine({
+      execute: () =>
+        Effect.succeed({
+          result: {
+            subject: "Flight receipt",
+            attachment: ToolResult.ok(
+              ToolFile.make({
+                name: "boarding-pass.png",
+                mimeType: "image/png",
+                data: "iVBORw0KGgo=",
+                byteLength: 8,
+              }),
+            ),
+          },
+        }),
+    });
+
+    await withNativeClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: { code: "return { subject, attachment };" },
+      });
+
+      const content = result.content as Array<Record<string, unknown>>;
+      const text = String(content[0]?.text ?? "");
+      expect(text).toContain("File outputs:\n1. boarding-pass.png (image/png, 8 bytes)");
+      expect(text).toContain("Result metadata:");
+      expect(text).toContain("Flight receipt");
+      expect(text).not.toContain("iVBORw0KGgo=");
+      expect(content[1]).toMatchObject({
+        type: "image",
+        data: "iVBORw0KGgo=",
+        mimeType: "image/png",
+      });
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  it("execute tool renders text-like ToolFile results as MCP text without structured content", async () => {
+    const engine = makeStubEngine({
+      execute: () =>
+        Effect.succeed({
+          result: ToolResult.ok(
+            ToolFile.make({
+              name: "rows.csv",
+              mimeType: "text/csv",
+              data: "YSxiCjEsMgo=",
+              byteLength: 8,
+            }),
+          ),
+        }),
+    });
+
+    await withNativeClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: { code: "return await tools.files.org.main.getCsv({});" },
+      });
+
+      const content = result.content as Array<Record<string, unknown>>;
+      expect(content[0]).toMatchObject({
+        type: "text",
+        text: "File output: rows.csv\ntext/csv, 8 bytes",
+      });
+      expect(content[1]).toMatchObject({
+        type: "text",
+        text: "a,b\n1,2\n",
+      });
+      expect(result.structuredContent).toBeUndefined();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  it("execute tool renders opaque binary ToolFile results as embedded MCP resources", async () => {
+    const engine = makeStubEngine({
+      execute: () =>
+        Effect.succeed({
+          result: ToolResult.ok(
+            ToolFile.make({
+              name: "report.pdf",
+              mimeType: "application/pdf",
+              data: "JVBERg==",
+              byteLength: 4,
+            }),
+          ),
+        }),
+    });
+
+    await withNativeClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: { code: "return await tools.gmail.org.main.getAttachment({});" },
+      });
+
+      const content = result.content as Array<Record<string, unknown>>;
+      expect(content[0]).toMatchObject({
+        type: "text",
+        text: "File output: report.pdf\napplication/pdf, 4 bytes",
+      });
+      expect(content[1]).toMatchObject({
+        type: "resource",
+        resource: {
+          uri: "executor-file:///report.pdf",
+          mimeType: "application/pdf",
+          blob: "JVBERg==",
+        },
+      });
+      expect(result.structuredContent).toMatchObject({
+        status: "completed",
+        result: {
+          ok: true,
+          data: {
+            _tag: "ToolFile",
+            name: "report.pdf",
+            mimeType: "application/pdf",
+            encoding: "base64",
+            byteLength: 4,
+          },
+        },
+      });
+      expect(JSON.stringify(result.structuredContent)).not.toContain("JVBERg==");
       expect(result.isError).toBeFalsy();
     });
   });

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -278,7 +278,7 @@ const TEXT_FILE_CONTENT_MAX_CHARS = 64_000;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
-const toolFileMetadata = (file: ToolFileValue): Record<string, unknown> => ({
+const redactToolFileBytes = (file: ToolFileValue): Record<string, unknown> => ({
   _tag: file._tag,
   ...(file.name ? { name: file.name } : {}),
   mimeType: file.mimeType,
@@ -286,21 +286,21 @@ const toolFileMetadata = (file: ToolFileValue): Record<string, unknown> => ({
   byteLength: file.byteLength,
 });
 
-type SanitizedToolFiles = {
+type ToolFileExtraction = {
   readonly value: unknown;
   readonly files: readonly ToolFileValue[];
 };
 
-const sanitizeToolFiles = (
+const extractToolFiles = (
   value: unknown,
   seen: WeakSet<object> = new WeakSet(),
-): SanitizedToolFiles => {
+): ToolFileExtraction => {
   if (isToolFile(value)) {
-    return { value: toolFileMetadata(value), files: [value] };
+    return { value: redactToolFileBytes(value), files: [value] };
   }
 
   if (isToolResult(value) && value.ok) {
-    const data = sanitizeToolFiles(value.data, seen);
+    const data = extractToolFiles(value.data, seen);
     if (data.files.length === 0) return { value, files: [] };
     return {
       value: {
@@ -314,9 +314,9 @@ const sanitizeToolFiles = (
   if (Array.isArray(value)) {
     const files: ToolFileValue[] = [];
     const items = value.map((item) => {
-      const sanitized = sanitizeToolFiles(item, seen);
-      files.push(...sanitized.files);
-      return sanitized.value;
+      const extracted = extractToolFiles(item, seen);
+      files.push(...extracted.files);
+      return extracted.value;
     });
     return { value: files.length > 0 ? items : value, files };
   }
@@ -327,33 +327,33 @@ const sanitizeToolFiles = (
 
   const files: ToolFileValue[] = [];
   const entries = Object.entries(value).map(([key, item]) => {
-    const sanitized = sanitizeToolFiles(item, seen);
-    files.push(...sanitized.files);
-    return [key, sanitized.value] as const;
+    const extracted = extractToolFiles(item, seen);
+    files.push(...extracted.files);
+    return [key, extracted.value] as const;
   });
   seen.delete(value);
 
   return { value: files.length > 0 ? Object.fromEntries(entries) : value, files };
 };
 
-const extractToolFile = (value: unknown): ToolFileValue | null => {
+const directToolFile = (value: unknown): ToolFileValue | null => {
   if (isToolFile(value)) return value;
   if (isToolResult(value) && value.ok && isToolFile(value.data)) return value.data;
   return null;
 };
 
-const fileResourceUri = (file: ToolFileValue): string =>
-  `executor-file:///${encodeURIComponent(file.name ?? "tool-output")}`;
+const toolFileName = (file: ToolFileValue): string => file.name ?? "tool-output";
 
-const isImageFile = (file: ToolFileValue): boolean =>
-  file.mimeType.toLowerCase().startsWith("image/");
+const fileResourceUri = (file: ToolFileValue): string =>
+  `executor-file:///${encodeURIComponent(toolFileName(file))}`;
 
 const normalizedMimeType = (file: ToolFileValue): string =>
   file.mimeType.split(";")[0]?.trim().toLowerCase() ?? "";
 
-const isTextLikeFile = (file: ToolFileValue): boolean => {
+const toolFileKind = (file: ToolFileValue): "image" | "text" | "resource" => {
   const mimeType = normalizedMimeType(file);
-  return (
+  if (mimeType.startsWith("image/")) return "image";
+  if (
     mimeType.startsWith("text/") ||
     mimeType === "application/json" ||
     mimeType.endsWith("+json") ||
@@ -363,7 +363,10 @@ const isTextLikeFile = (file: ToolFileValue): boolean => {
     mimeType === "application/x-javascript" ||
     mimeType === "application/yaml" ||
     mimeType === "application/x-yaml"
-  );
+  ) {
+    return "text";
+  }
+  return "resource";
 };
 
 const bytesFromBase64 = (base64: string): Uint8Array => {
@@ -383,52 +386,50 @@ const decodeTextFile = (file: ToolFileValue): string => {
   } characters]`;
 };
 
-const fileContentBlock = (file: ToolFileValue): ContentBlock =>
-  isImageFile(file)
-    ? {
-        type: "image",
-        data: file.data,
+const toolFileContent = (file: ToolFileValue): ContentBlock[] => {
+  const kind = toolFileKind(file);
+  if (kind === "image") {
+    return [{ type: "image", data: file.data, mimeType: file.mimeType }];
+  }
+  if (kind === "text") {
+    return [{ type: "text", text: decodeTextFile(file) }];
+  }
+  return [
+    {
+      type: "resource",
+      resource: {
+        uri: fileResourceUri(file),
         mimeType: file.mimeType,
-      }
-    : {
-        type: "resource",
-        resource: {
-          uri: fileResourceUri(file),
-          mimeType: file.mimeType,
-          blob: file.data,
-        },
-      };
+        blob: file.data,
+      },
+    },
+  ];
+};
 
-const fileContentBlocks = (file: ToolFileValue): ContentBlock[] => {
-  if (isImageFile(file)) return [fileContentBlock(file)];
-  if (isTextLikeFile(file)) return [{ type: "text", text: decodeTextFile(file) }];
-  return [fileContentBlock(file)];
+const toolFileSummaryLine = (file: ToolFileValue, index?: number): string => {
+  const prefix = index === undefined ? "" : `${index + 1}. `;
+  return `${prefix}${toolFileName(file)} (${file.mimeType}, ${file.byteLength} bytes)`;
 };
 
 const toMcpFileResult = (
   result: FormattedExecuteInput,
-  sanitized: SanitizedToolFiles,
+  extracted: ToolFileExtraction,
 ): McpToolResult => {
-  const files = sanitized.files;
-  const hasModelNativeFile = files.some((file) => isImageFile(file) || isTextLikeFile(file));
-  const sanitizedResult = { ...result, result: sanitized.value };
-  const formatted = formatExecuteResult(sanitizedResult);
-  const directFile = extractToolFile(result.result);
+  const files = extracted.files;
+  const hasModelNativeFile = files.some((file) => toolFileKind(file) !== "resource");
+  const redactedResult = { ...result, result: extracted.value };
+  const formatted = formatExecuteResult(redactedResult);
+  const directFile = directToolFile(result.result);
   const logText =
     result.logs && result.logs.length > 0 ? `\n\nLogs:\n${result.logs.join("\n")}` : "";
   const summary =
     directFile && files.length === 1
-      ? `File output: ${directFile.name ?? "tool-output"}\n${directFile.mimeType}, ${
+      ? `File output: ${toolFileName(directFile)}\n${directFile.mimeType}, ${
           directFile.byteLength
         } bytes${logText}`
       : [
           "File outputs:",
-          ...files.map(
-            (file, index) =>
-              `${index + 1}. ${file.name ?? "tool-output"} (${file.mimeType}, ${
-                file.byteLength
-              } bytes)`,
-          ),
+          ...files.map((file, index) => toolFileSummaryLine(file, index)),
           "",
           "Result metadata:",
           formatted.text,
@@ -440,7 +441,7 @@ const toMcpFileResult = (
         type: "text",
         text: summary,
       },
-      ...files.flatMap(fileContentBlocks),
+      ...files.flatMap(toolFileContent),
     ],
     ...(hasModelNativeFile
       ? {}
@@ -452,10 +453,10 @@ const toMcpFileResult = (
 };
 
 const toMcpResult = (result: FormattedExecuteInput): McpToolResult => {
-  const sanitized = result.error
+  const extracted = result.error
     ? { value: result.result, files: [] }
-    : sanitizeToolFiles(result.result);
-  if (sanitized.files.length > 0) return toMcpFileResult(result, sanitized);
+    : extractToolFiles(result.result);
+  if (extracted.files.length > 0) return toMcpFileResult(result, extracted);
   const formatted = formatExecuteResult(result);
   return {
     content: [{ type: "text", text: formatted.text }],

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -279,7 +279,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
 const redactToolFileBytes = (file: ToolFileValue): Record<string, unknown> => ({
-  _tag: file._tag,
+  _tag: "ToolFile",
   ...(file.name ? { name: file.name } : {}),
   mimeType: file.mimeType,
   encoding: file.encoding,

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -278,6 +278,39 @@ const TEXT_FILE_CONTENT_MAX_CHARS = 64_000;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isTextContentBlock = (value: unknown): value is Extract<ContentBlock, { type: "text" }> =>
+  isRecord(value) && value.type === "text" && typeof value.text === "string";
+
+const isImageContentBlock = (value: unknown): value is Extract<ContentBlock, { type: "image" }> =>
+  isRecord(value) &&
+  value.type === "image" &&
+  typeof value.data === "string" &&
+  typeof value.mimeType === "string";
+
+const isResourceContentBlock = (
+  value: unknown,
+): value is Extract<ContentBlock, { type: "resource" }> =>
+  isRecord(value) && value.type === "resource" && isRecord(value.resource);
+
+const isNativeMcpContentBlock = (value: unknown): value is ContentBlock =>
+  isTextContentBlock(value) || isImageContentBlock(value) || isResourceContentBlock(value);
+
+const nativeMcpContentResult = (value: unknown): McpToolResult | null => {
+  if (!isToolResult(value) || !value.ok || !isRecord(value.data)) return null;
+  const content = value.data.content;
+  if (!Array.isArray(content) || content.length === 0 || !content.every(isNativeMcpContentBlock)) {
+    return null;
+  }
+  if (!content.some((block) => block.type !== "text")) return null;
+  return {
+    content,
+    ...(isRecord(value.data.structuredContent)
+      ? { structuredContent: value.data.structuredContent }
+      : {}),
+    isError: value.data.isError === true || undefined,
+  };
+};
+
 const redactToolFileBytes = (file: ToolFileValue): Record<string, unknown> => ({
   _tag: "ToolFile",
   ...(file.name ? { name: file.name } : {}),
@@ -453,6 +486,8 @@ const toMcpFileResult = (
 };
 
 const toMcpResult = (result: FormattedExecuteInput): McpToolResult => {
+  const nativeMcpResult = result.error ? null : nativeMcpContentResult(result.result);
+  if (nativeMcpResult) return nativeMcpResult;
   const extracted = result.error
     ? { value: result.result, files: [] }
     : extractToolFiles(result.result);

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -1,6 +1,7 @@
 import { Effect, Match, Option, Schema } from "effect";
 import * as Cause from "effect/Cause";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { ContentBlock } from "@modelcontextprotocol/sdk/types.js";
 import type {
   jsonSchemaValidator,
   JsonSchemaType,
@@ -9,11 +10,13 @@ import type {
 import { Validator } from "@cfworker/json-schema";
 import * as z from "zod/v4";
 
+import { isToolFile, isToolResult } from "@executor-js/sdk";
 import type {
   ElicitationResponse,
   ElicitationHandler,
   ElicitationContext,
   ElicitationRequest,
+  ToolFileValue,
 } from "@executor-js/sdk";
 import type * as Tracer from "effect/Tracer";
 import {
@@ -263,16 +266,203 @@ const formatBoundaryError = (err: unknown): { name?: string; message: string; st
 // ---------------------------------------------------------------------------
 
 type McpToolResult = {
-  content: Array<{ type: "text"; text: string }>;
+  content: ContentBlock[];
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
 };
 
-const toMcpResult = (formatted: ReturnType<typeof formatExecuteResult>): McpToolResult => ({
-  content: [{ type: "text", text: formatted.text }],
-  structuredContent: formatted.structured,
-  isError: formatted.isError || undefined,
+type FormattedExecuteInput = Parameters<typeof formatExecuteResult>[0];
+
+const TEXT_FILE_CONTENT_MAX_CHARS = 64_000;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const toolFileMetadata = (file: ToolFileValue): Record<string, unknown> => ({
+  _tag: file._tag,
+  ...(file.name ? { name: file.name } : {}),
+  mimeType: file.mimeType,
+  encoding: file.encoding,
+  byteLength: file.byteLength,
 });
+
+type SanitizedToolFiles = {
+  readonly value: unknown;
+  readonly files: readonly ToolFileValue[];
+};
+
+const sanitizeToolFiles = (
+  value: unknown,
+  seen: WeakSet<object> = new WeakSet(),
+): SanitizedToolFiles => {
+  if (isToolFile(value)) {
+    return { value: toolFileMetadata(value), files: [value] };
+  }
+
+  if (isToolResult(value) && value.ok) {
+    const data = sanitizeToolFiles(value.data, seen);
+    if (data.files.length === 0) return { value, files: [] };
+    return {
+      value: {
+        ...value,
+        data: data.value,
+      },
+      files: data.files,
+    };
+  }
+
+  if (Array.isArray(value)) {
+    const files: ToolFileValue[] = [];
+    const items = value.map((item) => {
+      const sanitized = sanitizeToolFiles(item, seen);
+      files.push(...sanitized.files);
+      return sanitized.value;
+    });
+    return { value: files.length > 0 ? items : value, files };
+  }
+
+  if (!isRecord(value)) return { value, files: [] };
+  if (seen.has(value)) return { value: "[Circular]", files: [] };
+  seen.add(value);
+
+  const files: ToolFileValue[] = [];
+  const entries = Object.entries(value).map(([key, item]) => {
+    const sanitized = sanitizeToolFiles(item, seen);
+    files.push(...sanitized.files);
+    return [key, sanitized.value] as const;
+  });
+  seen.delete(value);
+
+  return { value: files.length > 0 ? Object.fromEntries(entries) : value, files };
+};
+
+const extractToolFile = (value: unknown): ToolFileValue | null => {
+  if (isToolFile(value)) return value;
+  if (isToolResult(value) && value.ok && isToolFile(value.data)) return value.data;
+  return null;
+};
+
+const fileResourceUri = (file: ToolFileValue): string =>
+  `executor-file:///${encodeURIComponent(file.name ?? "tool-output")}`;
+
+const isImageFile = (file: ToolFileValue): boolean =>
+  file.mimeType.toLowerCase().startsWith("image/");
+
+const normalizedMimeType = (file: ToolFileValue): string =>
+  file.mimeType.split(";")[0]?.trim().toLowerCase() ?? "";
+
+const isTextLikeFile = (file: ToolFileValue): boolean => {
+  const mimeType = normalizedMimeType(file);
+  return (
+    mimeType.startsWith("text/") ||
+    mimeType === "application/json" ||
+    mimeType.endsWith("+json") ||
+    mimeType === "application/xml" ||
+    mimeType.endsWith("+xml") ||
+    mimeType === "application/javascript" ||
+    mimeType === "application/x-javascript" ||
+    mimeType === "application/yaml" ||
+    mimeType === "application/x-yaml"
+  );
+};
+
+const bytesFromBase64 = (base64: string): Uint8Array => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+};
+
+const decodeTextFile = (file: ToolFileValue): string => {
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytesFromBase64(file.data));
+  if (text.length <= TEXT_FILE_CONTENT_MAX_CHARS) return text;
+  return `${text.slice(0, TEXT_FILE_CONTENT_MAX_CHARS)}\n\n[truncated ${
+    text.length - TEXT_FILE_CONTENT_MAX_CHARS
+  } characters]`;
+};
+
+const fileContentBlock = (file: ToolFileValue): ContentBlock =>
+  isImageFile(file)
+    ? {
+        type: "image",
+        data: file.data,
+        mimeType: file.mimeType,
+      }
+    : {
+        type: "resource",
+        resource: {
+          uri: fileResourceUri(file),
+          mimeType: file.mimeType,
+          blob: file.data,
+        },
+      };
+
+const fileContentBlocks = (file: ToolFileValue): ContentBlock[] => {
+  if (isImageFile(file)) return [fileContentBlock(file)];
+  if (isTextLikeFile(file)) return [{ type: "text", text: decodeTextFile(file) }];
+  return [fileContentBlock(file)];
+};
+
+const toMcpFileResult = (
+  result: FormattedExecuteInput,
+  sanitized: SanitizedToolFiles,
+): McpToolResult => {
+  const files = sanitized.files;
+  const hasModelNativeFile = files.some((file) => isImageFile(file) || isTextLikeFile(file));
+  const sanitizedResult = { ...result, result: sanitized.value };
+  const formatted = formatExecuteResult(sanitizedResult);
+  const directFile = extractToolFile(result.result);
+  const logText =
+    result.logs && result.logs.length > 0 ? `\n\nLogs:\n${result.logs.join("\n")}` : "";
+  const summary =
+    directFile && files.length === 1
+      ? `File output: ${directFile.name ?? "tool-output"}\n${directFile.mimeType}, ${
+          directFile.byteLength
+        } bytes${logText}`
+      : [
+          "File outputs:",
+          ...files.map(
+            (file, index) =>
+              `${index + 1}. ${file.name ?? "tool-output"} (${file.mimeType}, ${
+                file.byteLength
+              } bytes)`,
+          ),
+          "",
+          "Result metadata:",
+          formatted.text,
+        ].join("\n");
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: summary,
+      },
+      ...files.flatMap(fileContentBlocks),
+    ],
+    ...(hasModelNativeFile
+      ? {}
+      : {
+          structuredContent: formatted.structured,
+        }),
+    isError: formatted.isError || undefined,
+  };
+};
+
+const toMcpResult = (result: FormattedExecuteInput): McpToolResult => {
+  const sanitized = result.error
+    ? { value: result.result, files: [] }
+    : sanitizeToolFiles(result.result);
+  if (sanitized.files.length > 0) return toMcpFileResult(result, sanitized);
+  const formatted = formatExecuteResult(result);
+  return {
+    content: [{ type: "text", text: formatted.text }],
+    structuredContent: formatted.structured,
+    isError: formatted.isError || undefined,
+  };
+};
 
 const toMcpPausedResult = (formatted: ReturnType<typeof formatPausedExecution>): McpToolResult => ({
   content: [{ type: "text", text: formatted.text }],
@@ -443,7 +633,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           const result = yield* engine.execute(code, {
             onElicitation: makeMcpElicitationHandler(server, debugLog),
           });
-          return toMcpResult(formatExecuteResult(result));
+          return toMcpResult(result);
         }
         const outcome = yield* engine.executeWithPause(code);
         debugLog("execute.paused_flow_result", {
@@ -455,7 +645,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
               : undefined,
         });
         return outcome.status === "completed"
-          ? toMcpResult(formatExecuteResult(outcome.result))
+          ? toMcpResult(outcome.result)
           : elicitationMode.mode === "browser"
             ? yield* requireUserResumeApproval(outcome.execution.id)
             : toMcpPausedResult(formatPausedExecution(outcome.execution));
@@ -495,7 +685,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
               : undefined,
         });
         return outcome.status === "completed"
-          ? toMcpResult(formatExecuteResult(outcome.result))
+          ? toMcpResult(outcome.result)
           : toMcpPausedResult(formatPausedExecution(outcome.execution));
       }).pipe(
         Effect.withSpan("mcp.host.tool.resume", {
@@ -558,7 +748,7 @@ export const createExecutorMcpServer = <E extends Cause.YieldableError>(
           return missingExecutionResult(executionId);
         }
         return outcome.status === "completed"
-          ? toMcpResult(formatExecuteResult(outcome.result))
+          ? toMcpResult(outcome.result)
           : yield* requireUserResumeApproval(outcome.execution.id);
       }).pipe(
         Effect.withSpan("mcp.host.tool.resume.browser_approval", {

--- a/packages/plugins/mcp/src/sdk/image-content.test.ts
+++ b/packages/plugins/mcp/src/sdk/image-content.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ToolAddress,
+  createExecutor,
+} from "@executor-js/sdk";
+import { makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+
+import { mcpPlugin } from "./plugin";
+import {
+  TEST_IMAGE_MIME_TYPE,
+  TEST_IMAGE_PNG_BASE64,
+  makeImageMcpServer,
+  serveMcpServer,
+} from "../testing";
+
+const INTEGRATION = IntegrationSlug.make("image_mcp");
+const TEMPLATE = AuthTemplateSlug.make("none");
+
+const imageBlock = {
+  type: "image",
+  data: TEST_IMAGE_PNG_BASE64,
+  mimeType: TEST_IMAGE_MIME_TYPE,
+};
+
+describe("MCP image content", () => {
+  it.effect("preserves upstream MCP image content through plugin invocation", () =>
+    Effect.gen(function* () {
+      const server = yield* serveMcpServer(makeImageMcpServer);
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [memoryCredentialsPlugin(), mcpPlugin()] as const }),
+      );
+
+      yield* executor.mcp.addServer({
+        name: "Image MCP",
+        endpoint: server.url,
+        slug: String(INTEGRATION),
+      });
+      yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("main"),
+        integration: INTEGRATION,
+        template: TEMPLATE,
+        value: "",
+      });
+
+      const imageOnly = yield* executor.execute(
+        ToolAddress.make("tools.image_mcp.org.main.image_fixture"),
+        {},
+        { onElicitation: "accept-all" },
+      );
+      expect(imageOnly).toMatchObject({
+        ok: true,
+        data: {
+          content: [imageBlock],
+          structuredContent: {
+            name: "mcp-image-fixture.png",
+            mimeType: TEST_IMAGE_MIME_TYPE,
+            byteLength: 70,
+          },
+        },
+      });
+
+      const mixed = yield* executor.execute(
+        ToolAddress.make("tools.image_mcp.org.main.image_fixture_with_metadata"),
+        {},
+        { onElicitation: "accept-all" },
+      );
+      expect(mixed).toMatchObject({
+        ok: true,
+        data: {
+          content: [
+            {
+              type: "text",
+              text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+            },
+            imageBlock,
+          ],
+        },
+      });
+    }),
+  );
+});

--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -25,6 +25,14 @@ export type McpPreset = McpRemotePreset | McpStdioPreset;
 
 export const mcpPresets: readonly McpPreset[] = [
   {
+    id: "emulate-mcp",
+    name: "Emulate MCP",
+    summary: "Deterministic MCP fixtures for validating native text and image content.",
+    url: "https://emulators.dev/mcp/query/mcp?token=demo-token",
+    endpoint: "https://emulators.dev/mcp/query/mcp?token=demo-token",
+    icon: "https://emulators.dev/favicon.ico",
+  },
+  {
     id: "deepwiki",
     name: "DeepWiki",
     summary: "Search and read documentation from any GitHub repo.",

--- a/packages/plugins/mcp/src/testing/index.ts
+++ b/packages/plugins/mcp/src/testing/index.ts
@@ -1,10 +1,13 @@
 export {
   McpTestServerError,
   McpTestServerLayer,
+  TEST_IMAGE_MIME_TYPE,
+  TEST_IMAGE_PNG_BASE64,
   makeAnnotationsMcpServer,
   makeEchoMcpServer,
   makeElicitationMcpServer,
   makeGreetingMcpServer,
+  makeImageMcpServer,
   serveMcpServer,
   serveMcpServerWithOAuth,
   type McpTestRequest,

--- a/packages/plugins/mcp/src/testing/server.ts
+++ b/packages/plugins/mcp/src/testing/server.ts
@@ -289,6 +289,65 @@ export const makeGreetingMcpServer = (
   return server;
 };
 
+export const TEST_IMAGE_MIME_TYPE = "image/png";
+export const TEST_IMAGE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l8N1wwAAAABJRU5ErkJggg==";
+
+const testImageMetadata = () => ({
+  name: "mcp-image-fixture.png",
+  mimeType: TEST_IMAGE_MIME_TYPE,
+  byteLength: Buffer.from(TEST_IMAGE_PNG_BASE64, "base64").byteLength,
+});
+
+export const makeImageMcpServer = () => {
+  const server = new McpServer(
+    { name: "image-test-server", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  server.registerTool(
+    "image_fixture",
+    {
+      description: "Returns a deterministic PNG as MCP image content",
+      inputSchema: {},
+    },
+    async () => ({
+      content: [
+        {
+          type: "image" as const,
+          data: TEST_IMAGE_PNG_BASE64,
+          mimeType: TEST_IMAGE_MIME_TYPE,
+        },
+      ],
+      structuredContent: testImageMetadata(),
+    }),
+  );
+
+  server.registerTool(
+    "image_fixture_with_metadata",
+    {
+      description: "Returns text metadata followed by MCP image content",
+      inputSchema: {},
+    },
+    async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+        },
+        {
+          type: "image" as const,
+          data: TEST_IMAGE_PNG_BASE64,
+          mimeType: TEST_IMAGE_MIME_TYPE,
+        },
+      ],
+      structuredContent: testImageMetadata(),
+    }),
+  );
+
+  return server;
+};
+
 export const makeEchoMcpServer = (
   options: {
     readonly name?: string;

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -19,9 +19,11 @@ import {
   ExtractionResult,
   type HttpMethod,
   MediaBinding,
+  OperationFileHint,
   OperationId,
   OperationParameter,
   OperationRequestBody,
+  OperationResponseBody,
   type ParameterLocation,
   ServerInfo,
   ServerVariable,
@@ -145,7 +147,80 @@ const extractRequestBody = (
 // Response schema extraction
 // ---------------------------------------------------------------------------
 
-const extractOutputSchema = (operation: OperationObject, r: DocResolver): unknown | undefined => {
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stringType = (schema: Record<string, unknown>): boolean =>
+  schema.type === "string" || (Array.isArray(schema.type) && schema.type.includes("string"));
+
+const numericType = (schema: Record<string, unknown>): boolean =>
+  schema.type === "integer" ||
+  schema.type === "number" ||
+  (Array.isArray(schema.type) &&
+    (schema.type.includes("integer") || schema.type.includes("number")));
+
+const normalizedMediaType = (mediaType: string): string =>
+  mediaType.split(";")[0]?.trim().toLowerCase() ?? "";
+
+const isJsonMediaType = (mediaType: string): boolean => {
+  const normalized = normalizedMediaType(mediaType);
+  return (
+    normalized === "application/json" || normalized.includes("+json") || normalized.includes("json")
+  );
+};
+
+const binaryStringSchema = (schema: Record<string, unknown>): boolean =>
+  stringType(schema) && (schema.format === "binary" || schema.format === "byte");
+
+const base64EncodingFromDescription = (schema: Record<string, unknown>): "base64" | "base64url" =>
+  typeof schema.description === "string" &&
+  /base64url|base64-url|url[- ]safe/i.test(schema.description)
+    ? "base64url"
+    : "base64";
+
+const detectFileHint = (
+  schema: unknown,
+  mediaType: string,
+  r: DocResolver,
+): OperationFileHint | undefined => {
+  const resolved = isRecord(schema) ? r.resolve<Record<string, unknown>>(schema) : null;
+  if (!resolved) return undefined;
+
+  if (!isJsonMediaType(mediaType) && binaryStringSchema(resolved)) {
+    return OperationFileHint.make({
+      kind: "binaryResponse",
+      mimeType: Option.some(mediaType),
+      dataField: Option.none(),
+      sizeField: Option.none(),
+      encoding: Option.none(),
+    });
+  }
+
+  if (!isJsonMediaType(mediaType)) return undefined;
+
+  const properties = resolved.properties;
+  if (!isRecord(properties)) return undefined;
+  const data = properties.data;
+  const dataSchema = isRecord(data) ? r.resolve<Record<string, unknown>>(data) : null;
+  if (!dataSchema || !binaryStringSchema(dataSchema)) return undefined;
+
+  const size = properties.size;
+  const sizeSchema = isRecord(size) ? r.resolve<Record<string, unknown>>(size) : null;
+  const sizeField = sizeSchema && numericType(sizeSchema) ? "size" : undefined;
+
+  return OperationFileHint.make({
+    kind: "byteField",
+    mimeType: Option.some("application/octet-stream"),
+    dataField: Option.some("data"),
+    sizeField: sizeField ? Option.some(sizeField) : Option.none(),
+    encoding: Option.some(base64EncodingFromDescription(dataSchema)),
+  });
+};
+
+const extractResponseBody = (
+  operation: OperationObject,
+  r: DocResolver,
+): OperationResponseBody | undefined => {
   if (!operation.responses) return undefined;
 
   const entries = Object.entries(operation.responses);
@@ -158,7 +233,13 @@ const extractOutputSchema = (operation: OperationObject, r: DocResolver): unknow
     const resp = r.resolve<ResponseObject>(ref);
     if (!resp) continue;
     const content = preferredResponseContent(resp.content);
-    if (content?.media.schema) return content.media.schema;
+    if (content?.media.schema) {
+      return OperationResponseBody.make({
+        contentType: content.mediaType,
+        schema: Option.some(content.media.schema),
+        fileHint: Option.fromNullishOr(detectFileHint(content.media.schema, content.mediaType, r)),
+      });
+    }
   }
 
   return undefined;
@@ -377,9 +458,10 @@ export const extract = Effect.fn("OpenApi.extract")(function* (doc: ParsedDocume
 
       const parameters = extractParameters(pathItem, operation, r);
       const requestBody = extractRequestBody(operation, r);
+      const responseBody = extractResponseBody(operation, r);
       const servers = operationServers(pathItem, operation, docServers);
       const inputSchema = buildInputSchema(parameters, requestBody, servers);
-      const outputSchema = extractOutputSchema(operation, r);
+      const outputSchema = responseBody ? Option.getOrUndefined(responseBody.schema) : undefined;
       const tags = (operation.tags ?? []).filter((t) => t.trim().length > 0);
       const operationPathTemplate = explicitPathTemplate(operation) ?? pathTemplate;
 
@@ -395,6 +477,7 @@ export const extract = Effect.fn("OpenApi.extract")(function* (doc: ParsedDocume
           tags,
           parameters,
           requestBody: Option.fromNullishOr(requestBody),
+          responseBody: Option.fromNullishOr(responseBody),
           inputSchema: Option.fromNullishOr(inputSchema),
           outputSchema: Option.fromNullishOr(outputSchema),
           deprecated: operation.deprecated === true,

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -207,6 +207,7 @@ const startsWithBytes = (bytes: Uint8Array, prefix: readonly number[]): boolean 
 const isLikelyUtf8Text = (bytes: Uint8Array): boolean => {
   if (bytes.length === 0) return false;
   let text: string;
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: TextDecoder throws while probing arbitrary binary content
   try {
     text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
@@ -337,6 +338,7 @@ type GmailAttachmentMetadata = {
 };
 
 const decodePathSegment = (value: string): string => {
+  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: decodeURIComponent throws on malformed upstream URL segments
   try {
     return decodeURIComponent(value);
   } catch {

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer, Option } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
-import { isToolFile, type ToolFileValue } from "@executor-js/sdk/core";
+import type { ToolFileValue } from "@executor-js/sdk/core";
 
 import { OpenApiInvocationError } from "./errors";
 import { resolveServerUrl } from "./openapi-utils";
@@ -198,9 +198,6 @@ const byteLengthFromBase64 = (base64: string): number => {
 const isGenericMimeType = (mimeType: string): boolean =>
   normalizeContentType(mimeType) === "application/octet-stream";
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
 const startsWithBytes = (bytes: Uint8Array, prefix: readonly number[]): boolean =>
   prefix.every((byte, index) => bytes[index] === byte);
 
@@ -244,6 +241,13 @@ const sniffMimeType = (bytes: Uint8Array): string | null => {
     return "image/webp";
   }
   if (startsWithBytes(bytes, [0x25, 0x50, 0x44, 0x46, 0x2d])) return "application/pdf";
+  if (
+    startsWithBytes(bytes, [0x50, 0x4b, 0x03, 0x04]) ||
+    startsWithBytes(bytes, [0x50, 0x4b, 0x05, 0x06]) ||
+    startsWithBytes(bytes, [0x50, 0x4b, 0x07, 0x08])
+  ) {
+    return "application/zip";
+  }
   if (isLikelyUtf8Text(bytes)) return "text/plain";
   return null;
 };
@@ -325,164 +329,6 @@ const fileFromBinaryBytes = (
     byteLength: bytes.byteLength,
   };
 };
-
-type GmailAttachmentPath = {
-  readonly messagePath: string;
-  readonly attachmentId: string;
-};
-
-type GmailAttachmentMetadata = {
-  readonly name?: string;
-  readonly mimeType?: string;
-  readonly byteLength?: number;
-};
-
-const decodePathSegment = (value: string): string => {
-  // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: decodeURIComponent throws on malformed upstream URL segments
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
-};
-
-const readGmailAttachmentPath = (
-  operation: OperationBinding,
-  resolvedPath: string,
-): GmailAttachmentPath | null => {
-  if (operation.method !== "get") return null;
-  const template = operation.pathTemplate.startsWith("/")
-    ? operation.pathTemplate
-    : `/${operation.pathTemplate}`;
-  const hasGmailResourcePath =
-    /\/users\/\{[^{}]+\}\/messages\/\{[^{}]+\}\/attachments\/\{[^{}]+\}$/.test(template);
-  if (!hasGmailResourcePath) return null;
-
-  const hasGmailPathPrefix = template.startsWith("/gmail/v1/");
-  const hasGmailServer =
-    operation.servers?.some((server) => server.url.includes("gmail.googleapis.com")) ?? false;
-  if (!hasGmailPathPrefix && !hasGmailServer) {
-    return null;
-  }
-
-  const path = resolvedPath.startsWith("/") ? resolvedPath : `/${resolvedPath}`;
-  const match = path.match(/^(.*\/users\/[^/]+\/messages\/[^/]+)\/attachments\/([^/]+)$/);
-  if (!match?.[1] || !match[2]) return null;
-  return {
-    messagePath: match[1],
-    attachmentId: decodePathSegment(match[2]),
-  };
-};
-
-const findGmailMessagePart = (
-  value: unknown,
-  attachmentId: string,
-): Record<string, unknown> | null => {
-  if (!isRecord(value)) return null;
-  const body = isRecord(value.body) ? value.body : null;
-  if (body?.attachmentId === attachmentId) return value;
-
-  const parts = value.parts;
-  if (!Array.isArray(parts)) return null;
-  for (const part of parts) {
-    const found = findGmailMessagePart(part, attachmentId);
-    if (found) return found;
-  }
-  return null;
-};
-
-const collectGmailAttachmentParts = (
-  value: unknown,
-  out: Record<string, unknown>[] = [],
-): Record<string, unknown>[] => {
-  if (!isRecord(value)) return out;
-  const body = isRecord(value.body) ? value.body : null;
-  if (typeof body?.attachmentId === "string") out.push(value);
-
-  const parts = value.parts;
-  if (!Array.isArray(parts)) return out;
-  for (const part of parts) collectGmailAttachmentParts(part, out);
-  return out;
-};
-
-const gmailAttachmentMetadataFromMessage = (
-  message: unknown,
-  attachmentId: string,
-  byteLength: number,
-): GmailAttachmentMetadata | null => {
-  if (!isRecord(message)) return null;
-  const payload = isRecord(message.payload) ? message.payload : message;
-  const exactPart = findGmailMessagePart(payload, attachmentId);
-  const sizeMatches =
-    exactPart === null
-      ? collectGmailAttachmentParts(payload).filter((candidate) => {
-          const body = isRecord(candidate.body) ? candidate.body : null;
-          return body?.size === byteLength;
-        })
-      : [];
-  const part = exactPart ?? (sizeMatches.length === 1 ? sizeMatches[0] : null);
-  if (!part) return null;
-
-  const body = isRecord(part.body) ? part.body : null;
-  const name =
-    typeof part.filename === "string" && part.filename.length > 0 ? part.filename : undefined;
-  const mimeType =
-    typeof part.mimeType === "string" && part.mimeType.length > 0 ? part.mimeType : undefined;
-  const metadataByteLength = typeof body?.size === "number" ? body.size : undefined;
-  if (name === undefined && mimeType === undefined && metadataByteLength === undefined) return null;
-  return { name, mimeType, byteLength: metadataByteLength };
-};
-
-const fetchGmailAttachmentMetadata = (
-  client: HttpClient.HttpClient,
-  path: GmailAttachmentPath,
-  file: ToolFileValue,
-  resolvedHeaders: Record<string, string>,
-  sourceQueryParams: Record<string, string>,
-): Effect.Effect<GmailAttachmentMetadata | null> =>
-  Effect.gen(function* () {
-    let request = HttpClientRequest.make("GET")(path.messagePath);
-    for (const [name, value] of Object.entries(sourceQueryParams)) {
-      request = HttpClientRequest.setUrlParam(request, name, value);
-    }
-    request = HttpClientRequest.setUrlParam(request, "format", "full");
-    request = applyHeaders(request, resolvedHeaders);
-
-    const response = yield* client.execute(request);
-    if (response.status < 200 || response.status >= 300) return null;
-    const body = yield* response.json.pipe(Effect.catch(() => Effect.succeed(null)));
-    return gmailAttachmentMetadataFromMessage(body, path.attachmentId, file.byteLength);
-  }).pipe(Effect.catch(() => Effect.succeed(null)));
-
-const withGmailAttachmentMetadata = (
-  client: HttpClient.HttpClient,
-  operation: OperationBinding,
-  resolvedPath: string,
-  file: ToolFileValue,
-  resolvedHeaders: Record<string, string>,
-  sourceQueryParams: Record<string, string>,
-): Effect.Effect<ToolFileValue> =>
-  Effect.gen(function* () {
-    const path = readGmailAttachmentPath(operation, resolvedPath);
-    if (!path) return file;
-    const metadata = yield* fetchGmailAttachmentMetadata(
-      client,
-      path,
-      file,
-      resolvedHeaders,
-      sourceQueryParams,
-    );
-    if (!metadata) return file;
-    const name = metadata.name ?? file.name;
-    return {
-      _tag: "ToolFile",
-      ...(name ? { name } : {}),
-      mimeType: metadata.mimeType ?? file.mimeType,
-      encoding: "base64",
-      data: file.data,
-      byteLength: metadata.byteLength ?? file.byteLength,
-    };
-  });
 
 type FormDataRecord = Parameters<typeof HttpClientRequest.bodyFormDataRecord>[1];
 type FormDataCoercible = FormDataRecord[string];
@@ -880,22 +726,10 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
     ok && fileHint?.kind === "byteField"
       ? (fileFromByteField(responseBody, fileHint) ?? responseBody)
       : responseBody;
-  const enrichedDataBody =
-    ok && fileHint?.kind === "byteField" && isToolFile(dataBody)
-      ? yield* withGmailAttachmentMetadata(
-          client,
-          operation,
-          resolvedPath,
-          dataBody,
-          resolvedHeaders,
-          sourceQueryParams,
-        )
-      : dataBody;
-
   return InvocationResult.make({
     status,
     headers: responseHeaders,
-    data: ok ? enrichedDataBody : null,
+    data: ok ? dataBody : null,
     error: ok ? null : responseBody,
   });
 });

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer, Option } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
-import { ToolFile, type ToolFileValue } from "@executor-js/sdk/core";
+import { ToolFile, isToolFile, type ToolFileValue } from "@executor-js/sdk/core";
 
 import { OpenApiInvocationError } from "./errors";
 import { resolveServerUrl } from "./openapi-utils";
@@ -198,8 +198,29 @@ const byteLengthFromBase64 = (base64: string): number => {
 const isGenericMimeType = (mimeType: string): boolean =>
   normalizeContentType(mimeType) === "application/octet-stream";
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
 const startsWithBytes = (bytes: Uint8Array, prefix: readonly number[]): boolean =>
   prefix.every((byte, index) => bytes[index] === byte);
+
+const isLikelyUtf8Text = (bytes: Uint8Array): boolean => {
+  if (bytes.length === 0) return false;
+  let text: string;
+  try {
+    text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return false;
+  }
+  let suspicious = 0;
+  for (let index = 0; index < text.length; index += 1) {
+    const code = text.charCodeAt(index);
+    const allowedControl = code === 0x09 || code === 0x0a || code === 0x0c || code === 0x0d;
+    if (code === 0x00) return false;
+    if (code < 0x20 && !allowedControl) suspicious += 1;
+  }
+  return suspicious / Math.max(1, text.length) <= 0.02;
+};
 
 const sniffMimeType = (bytes: Uint8Array): string | null => {
   if (startsWithBytes(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
@@ -222,6 +243,7 @@ const sniffMimeType = (bytes: Uint8Array): string | null => {
     return "image/webp";
   }
   if (startsWithBytes(bytes, [0x25, 0x50, 0x44, 0x46, 0x2d])) return "application/pdf";
+  if (isLikelyUtf8Text(bytes)) return "text/plain";
   return null;
 };
 
@@ -298,6 +320,160 @@ const fileFromBinaryBytes = (
     byteLength: bytes.byteLength,
   });
 };
+
+type GmailAttachmentPath = {
+  readonly messagePath: string;
+  readonly attachmentId: string;
+};
+
+type GmailAttachmentMetadata = {
+  readonly name?: string;
+  readonly mimeType?: string;
+  readonly byteLength?: number;
+};
+
+const decodePathSegment = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const readGmailAttachmentPath = (
+  operation: OperationBinding,
+  resolvedPath: string,
+): GmailAttachmentPath | null => {
+  if (operation.method !== "get") return null;
+  const template = operation.pathTemplate.startsWith("/")
+    ? operation.pathTemplate
+    : `/${operation.pathTemplate}`;
+  const hasGmailResourcePath =
+    /\/users\/\{[^{}]+\}\/messages\/\{[^{}]+\}\/attachments\/\{[^{}]+\}$/.test(template);
+  if (!hasGmailResourcePath) return null;
+
+  const hasGmailPathPrefix = template.startsWith("/gmail/v1/");
+  const hasGmailServer =
+    operation.servers?.some((server) => server.url.includes("gmail.googleapis.com")) ?? false;
+  if (!hasGmailPathPrefix && !hasGmailServer) {
+    return null;
+  }
+
+  const path = resolvedPath.startsWith("/") ? resolvedPath : `/${resolvedPath}`;
+  const match = path.match(/^(.*\/users\/[^/]+\/messages\/[^/]+)\/attachments\/([^/]+)$/);
+  if (!match?.[1] || !match[2]) return null;
+  return {
+    messagePath: match[1],
+    attachmentId: decodePathSegment(match[2]),
+  };
+};
+
+const findGmailMessagePart = (
+  value: unknown,
+  attachmentId: string,
+): Record<string, unknown> | null => {
+  if (!isRecord(value)) return null;
+  const body = isRecord(value.body) ? value.body : null;
+  if (body?.attachmentId === attachmentId) return value;
+
+  const parts = value.parts;
+  if (!Array.isArray(parts)) return null;
+  for (const part of parts) {
+    const found = findGmailMessagePart(part, attachmentId);
+    if (found) return found;
+  }
+  return null;
+};
+
+const collectGmailAttachmentParts = (
+  value: unknown,
+  out: Record<string, unknown>[] = [],
+): Record<string, unknown>[] => {
+  if (!isRecord(value)) return out;
+  const body = isRecord(value.body) ? value.body : null;
+  if (typeof body?.attachmentId === "string") out.push(value);
+
+  const parts = value.parts;
+  if (!Array.isArray(parts)) return out;
+  for (const part of parts) collectGmailAttachmentParts(part, out);
+  return out;
+};
+
+const gmailAttachmentMetadataFromMessage = (
+  message: unknown,
+  attachmentId: string,
+  byteLength: number,
+): GmailAttachmentMetadata | null => {
+  if (!isRecord(message)) return null;
+  const payload = isRecord(message.payload) ? message.payload : message;
+  const exactPart = findGmailMessagePart(payload, attachmentId);
+  const sizeMatches =
+    exactPart === null
+      ? collectGmailAttachmentParts(payload).filter((candidate) => {
+          const body = isRecord(candidate.body) ? candidate.body : null;
+          return body?.size === byteLength;
+        })
+      : [];
+  const part = exactPart ?? (sizeMatches.length === 1 ? sizeMatches[0] : null);
+  if (!part) return null;
+
+  const body = isRecord(part.body) ? part.body : null;
+  const name =
+    typeof part.filename === "string" && part.filename.length > 0 ? part.filename : undefined;
+  const mimeType =
+    typeof part.mimeType === "string" && part.mimeType.length > 0 ? part.mimeType : undefined;
+  const metadataByteLength = typeof body?.size === "number" ? body.size : undefined;
+  if (name === undefined && mimeType === undefined && metadataByteLength === undefined) return null;
+  return { name, mimeType, byteLength: metadataByteLength };
+};
+
+const fetchGmailAttachmentMetadata = (
+  client: HttpClient.HttpClient,
+  path: GmailAttachmentPath,
+  file: ToolFileValue,
+  resolvedHeaders: Record<string, string>,
+  sourceQueryParams: Record<string, string>,
+): Effect.Effect<GmailAttachmentMetadata | null> =>
+  Effect.gen(function* () {
+    let request = HttpClientRequest.make("GET")(path.messagePath);
+    for (const [name, value] of Object.entries(sourceQueryParams)) {
+      request = HttpClientRequest.setUrlParam(request, name, value);
+    }
+    request = HttpClientRequest.setUrlParam(request, "format", "full");
+    request = applyHeaders(request, resolvedHeaders);
+
+    const response = yield* client.execute(request);
+    if (response.status < 200 || response.status >= 300) return null;
+    const body = yield* response.json.pipe(Effect.catch(() => Effect.succeed(null)));
+    return gmailAttachmentMetadataFromMessage(body, path.attachmentId, file.byteLength);
+  }).pipe(Effect.catch(() => Effect.succeed(null)));
+
+const withGmailAttachmentMetadata = (
+  client: HttpClient.HttpClient,
+  operation: OperationBinding,
+  resolvedPath: string,
+  file: ToolFileValue,
+  resolvedHeaders: Record<string, string>,
+  sourceQueryParams: Record<string, string>,
+): Effect.Effect<ToolFileValue> =>
+  Effect.gen(function* () {
+    const path = readGmailAttachmentPath(operation, resolvedPath);
+    if (!path) return file;
+    const metadata = yield* fetchGmailAttachmentMetadata(
+      client,
+      path,
+      file,
+      resolvedHeaders,
+      sourceQueryParams,
+    );
+    if (!metadata) return file;
+    return ToolFile.make({
+      name: metadata.name ?? file.name,
+      mimeType: metadata.mimeType ?? file.mimeType,
+      data: file.data,
+      byteLength: metadata.byteLength ?? file.byteLength,
+    });
+  });
 
 type FormDataRecord = Parameters<typeof HttpClientRequest.bodyFormDataRecord>[1];
 type FormDataCoercible = FormDataRecord[string];
@@ -695,11 +871,22 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
     ok && fileHint?.kind === "byteField"
       ? (fileFromByteField(responseBody, fileHint) ?? responseBody)
       : responseBody;
+  const enrichedDataBody =
+    ok && fileHint?.kind === "byteField" && isToolFile(dataBody)
+      ? yield* withGmailAttachmentMetadata(
+          client,
+          operation,
+          resolvedPath,
+          dataBody,
+          resolvedHeaders,
+          sourceQueryParams,
+        )
+      : dataBody;
 
   return InvocationResult.make({
     status,
     headers: responseHeaders,
-    data: ok ? dataBody : null,
+    data: ok ? enrichedDataBody : null,
     error: ok ? null : responseBody,
   });
 });

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,10 +1,12 @@
 import { Effect, Layer, Option } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+import { ToolFile, type ToolFileValue } from "@executor-js/sdk/core";
 
 import { OpenApiInvocationError } from "./errors";
 import { resolveServerUrl } from "./openapi-utils";
 import {
   type EncodingObject,
+  type OperationFileHint,
   type OperationBinding,
   InvocationResult,
   type MediaBinding,
@@ -170,6 +172,72 @@ const isTextContentType = (ct: string | null | undefined): boolean =>
 const isOctetStream = (ct: string | null | undefined): boolean =>
   normalizeContentType(ct) === "application/octet-stream";
 
+const bytesToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+};
+
+const normalizeBase64 = (value: string, encoding: "base64" | "base64url"): string => {
+  const compact = value.replace(/\s/g, "");
+  const alphabet =
+    encoding === "base64url" ? compact.replace(/-/g, "+").replace(/_/g, "/") : compact;
+  const remainder = alphabet.length % 4;
+  return remainder === 0 ? alphabet : `${alphabet}${"=".repeat(4 - remainder)}`;
+};
+
+const byteLengthFromBase64 = (base64: string): number => {
+  const compact = base64.replace(/\s/g, "");
+  const padding = compact.endsWith("==") ? 2 : compact.endsWith("=") ? 1 : 0;
+  return Math.max(0, Math.floor((compact.length * 3) / 4) - padding);
+};
+
+const isGenericMimeType = (mimeType: string): boolean =>
+  normalizeContentType(mimeType) === "application/octet-stream";
+
+const startsWithBytes = (bytes: Uint8Array, prefix: readonly number[]): boolean =>
+  prefix.every((byte, index) => bytes[index] === byte);
+
+const sniffMimeType = (bytes: Uint8Array): string | null => {
+  if (startsWithBytes(bytes, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (startsWithBytes(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (
+    startsWithBytes(bytes, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) ||
+    startsWithBytes(bytes, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61])
+  ) {
+    return "image/gif";
+  }
+  if (
+    startsWithBytes(bytes, [0x52, 0x49, 0x46, 0x46]) &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  if (startsWithBytes(bytes, [0x25, 0x50, 0x44, 0x46, 0x2d])) return "application/pdf";
+  return null;
+};
+
+const bytesFromBase64Prefix = (base64: string): Uint8Array => {
+  const prefix = base64.slice(0, Math.min(base64.length, 64));
+  const binary = atob(prefix);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+};
+
+const sniffMimeTypeFromBase64 = (base64: string): string | null =>
+  sniffMimeType(bytesFromBase64Prefix(base64));
+
 const toUint8Array = (value: unknown): Uint8Array | null => {
   if (value instanceof Uint8Array) return value;
   if (value instanceof ArrayBuffer) return new Uint8Array(value);
@@ -181,6 +249,54 @@ const toUint8Array = (value: unknown): Uint8Array | null => {
     return new Uint8Array(value as readonly number[]);
   }
   return null;
+};
+
+const readHintString = (option: OperationFileHint["dataField"], fallback: string): string =>
+  Option.getOrElse(option, () => fallback);
+
+const readHintMimeType = (hint: OperationFileHint, fallback: string): string =>
+  Option.getOrElse(hint.mimeType, () => fallback);
+
+const readHintEncoding = (hint: OperationFileHint): "base64" | "base64url" =>
+  Option.getOrElse(hint.encoding, () => "base64");
+
+const fileFromByteField = (body: unknown, hint: OperationFileHint): ToolFileValue | null => {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return null;
+  const record = body as Record<string, unknown>;
+  const dataField = readHintString(hint.dataField, "data");
+  const rawData = record[dataField];
+  if (typeof rawData !== "string") return null;
+
+  const data = normalizeBase64(rawData, readHintEncoding(hint));
+  const sizeField = Option.getOrUndefined(hint.sizeField);
+  const byteLength =
+    sizeField && typeof record[sizeField] === "number"
+      ? record[sizeField]
+      : byteLengthFromBase64(data);
+  const hintedMimeType = readHintMimeType(hint, "application/octet-stream");
+
+  return ToolFile.make({
+    mimeType: isGenericMimeType(hintedMimeType)
+      ? (sniffMimeTypeFromBase64(data) ?? hintedMimeType)
+      : hintedMimeType,
+    data,
+    byteLength,
+  });
+};
+
+const fileFromBinaryBytes = (
+  bytes: Uint8Array,
+  hint: OperationFileHint,
+  contentType: string | null | undefined,
+): ToolFileValue => {
+  const hintedMimeType = contentType ?? readHintMimeType(hint, "application/octet-stream");
+  return ToolFile.make({
+    mimeType: isGenericMimeType(hintedMimeType)
+      ? (sniffMimeType(bytes) ?? hintedMimeType)
+      : hintedMimeType,
+    data: bytesToBase64(bytes),
+    byteLength: bytes.byteLength,
+  });
 };
 
 type FormDataRecord = Parameters<typeof HttpClientRequest.bodyFormDataRecord>[1];
@@ -554,22 +670,36 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
         cause: err,
       }),
   );
+  const responseBodyBinding = Option.getOrUndefined(operation.responseBody);
+  const fileHint = responseBodyBinding
+    ? Option.getOrUndefined(responseBodyBinding.fileHint)
+    : undefined;
+  const ok = status >= 200 && status < 300;
   const responseBody: unknown =
     status === 204
       ? null
-      : isJsonContentType(contentType)
-        ? yield* response.json.pipe(
-            Effect.catch(() => response.text),
-            mapBodyError,
+      : ok && fileHint?.kind === "binaryResponse"
+        ? fileFromBinaryBytes(
+            new Uint8Array(yield* response.arrayBuffer.pipe(mapBodyError)),
+            fileHint,
+            contentType,
           )
-        : yield* response.text.pipe(mapBodyError);
+        : isJsonContentType(contentType)
+          ? yield* response.json.pipe(
+              Effect.catch(() => response.text),
+              mapBodyError,
+            )
+          : yield* response.text.pipe(mapBodyError);
 
-  const ok = status >= 200 && status < 300;
+  const dataBody =
+    ok && fileHint?.kind === "byteField"
+      ? (fileFromByteField(responseBody, fileHint) ?? responseBody)
+      : responseBody;
 
   return InvocationResult.make({
     status,
     headers: responseHeaders,
-    data: ok ? responseBody : null,
+    data: ok ? dataBody : null,
     error: ok ? null : responseBody,
   });
 });

--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -1,6 +1,6 @@
 import { Effect, Layer, Option } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
-import { ToolFile, isToolFile, type ToolFileValue } from "@executor-js/sdk/core";
+import { isToolFile, type ToolFileValue } from "@executor-js/sdk/core";
 
 import { OpenApiInvocationError } from "./errors";
 import { resolveServerUrl } from "./openapi-utils";
@@ -297,13 +297,15 @@ const fileFromByteField = (body: unknown, hint: OperationFileHint): ToolFileValu
       : byteLengthFromBase64(data);
   const hintedMimeType = readHintMimeType(hint, "application/octet-stream");
 
-  return ToolFile.make({
+  return {
+    _tag: "ToolFile",
     mimeType: isGenericMimeType(hintedMimeType)
       ? (sniffMimeTypeFromBase64(data) ?? hintedMimeType)
       : hintedMimeType,
+    encoding: "base64",
     data,
     byteLength,
-  });
+  };
 };
 
 const fileFromBinaryBytes = (
@@ -312,13 +314,15 @@ const fileFromBinaryBytes = (
   contentType: string | null | undefined,
 ): ToolFileValue => {
   const hintedMimeType = contentType ?? readHintMimeType(hint, "application/octet-stream");
-  return ToolFile.make({
+  return {
+    _tag: "ToolFile",
     mimeType: isGenericMimeType(hintedMimeType)
       ? (sniffMimeType(bytes) ?? hintedMimeType)
       : hintedMimeType,
+    encoding: "base64",
     data: bytesToBase64(bytes),
     byteLength: bytes.byteLength,
-  });
+  };
 };
 
 type GmailAttachmentPath = {
@@ -467,12 +471,15 @@ const withGmailAttachmentMetadata = (
       sourceQueryParams,
     );
     if (!metadata) return file;
-    return ToolFile.make({
-      name: metadata.name ?? file.name,
+    const name = metadata.name ?? file.name;
+    return {
+      _tag: "ToolFile",
+      ...(name ? { name } : {}),
       mimeType: metadata.mimeType ?? file.mimeType,
+      encoding: "base64",
       data: file.data,
       byteLength: metadata.byteLength ?? file.byteLength,
-    });
+    };
   });
 
 type FormDataRecord = Parameters<typeof HttpClientRequest.bodyFormDataRecord>[1];

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -116,6 +116,17 @@ const replaceResponseContent =
     return { ...spec, paths };
   };
 
+const replaceOperationServers =
+  (path: string, operation: string, servers: readonly Record<string, unknown>[]) =>
+  (spec: Record<string, unknown>): Record<string, unknown> => {
+    const paths = { ...(spec.paths as Record<string, unknown>) };
+    const pathItem = { ...(paths[path] as Record<string, unknown>) };
+    const operationSpec = { ...(pathItem[operation] as Record<string, unknown>) };
+    pathItem[operation] = { ...operationSpec, servers };
+    paths[path] = pathItem;
+    return { ...spec, paths };
+  };
+
 const replaceRequestBodyContent =
   (
     path: string,
@@ -325,6 +336,216 @@ describe("OpenAPI non-JSON request body dispatch", () => {
           },
         });
       }),
+  );
+
+  it.effect("format: byte response: UTF-8 attachment data falls back to text/plain", () =>
+    Effect.gen(function* () {
+      const attachmentText = [
+        "id,name,status,amount",
+        "1,Ada,confirmed,42.50",
+        "2,Grace,pending,13.75",
+        "3,Linus,cancelled,0.00",
+        "",
+      ].join("\n");
+      const attachmentBase64Url =
+        "aWQsbmFtZSxzdGF0dXMsYW1vdW50CjEsQWRhLGNvbmZpcm1lZCw0Mi41MAoyLEdyYWNlLHBlbmRpbmcsMTMuNzUKMyxMaW51cyxjYW5jZWxsZWQsMC4wMAo";
+      const MessagePartBody = Schema.Struct({
+        data: Schema.String,
+        size: Schema.Number,
+      });
+      const group = HttpApiGroup.make("gmailText").add(
+        HttpApiEndpoint.get("getAttachment", "/attachments/:id", {
+          success: MessagePartBody,
+        }),
+      );
+      const api = HttpApi.make("gmailTextAttachmentTest").add(group);
+      const handlersLayer = HttpApiBuilder.group(api, "gmailText", (handlers) =>
+        handlers.handleRaw("getAttachment", () =>
+          Effect.succeed(
+            HttpServerResponse.jsonUnsafe({
+              data: attachmentBase64Url,
+              size: new TextEncoder().encode(attachmentText).byteLength,
+            }),
+          ),
+        ),
+      );
+      const server = yield* serveOpenApiHttpApiTestServer({
+        api,
+        handlersLayer,
+        transformSpec: replaceResponseContent("/attachments/{id}", "get", {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                data: {
+                  type: "string",
+                  format: "byte",
+                  description: "The body data as a base64url encoded string.",
+                },
+                size: {
+                  type: "integer",
+                  format: "int32",
+                  description: "Number of bytes for the message part data.",
+                },
+              },
+              required: ["data", "size"],
+            },
+          },
+        }),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "gmail_text" });
+
+      const result = yield* executor.execute(conn.address("gmailText.getAttachment"), {
+        id: "att_1",
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        data: {
+          _tag: "ToolFile",
+          encoding: "base64",
+          mimeType: "text/plain",
+          data: `${attachmentBase64Url}=`,
+          byteLength: 89,
+        },
+      });
+    }),
+  );
+
+  it.effect("Gmail attachment bytes inherit filename and MIME from the parent message part", () =>
+    Effect.gen(function* () {
+      const attachmentText = [
+        "id,name,status,amount",
+        "1,Ada,confirmed,42.50",
+        "2,Grace,pending,13.75",
+        "3,Linus,cancelled,0.00",
+        "",
+      ].join("\n");
+      const attachmentBase64Url =
+        "aWQsbmFtZSxzdGF0dXMsYW1vdW50CjEsQWRhLGNvbmZpcm1lZCw0Mi41MAoyLEdyYWNlLHBlbmRpbmcsMTMuNzUKMyxMaW51cyxjYW5jZWxsZWQsMC4wMAo";
+      const attachmentBytes = new TextEncoder().encode(attachmentText);
+      const MessagePartBody = Schema.Struct({
+        data: Schema.String,
+        size: Schema.Number,
+      });
+      const Message = Schema.Struct({
+        payload: Schema.Unknown,
+      });
+      let parentRequestUrl = "";
+      const group = HttpApiGroup.make("gmailMeta")
+        .add(
+          HttpApiEndpoint.get(
+            "getAttachment",
+            "/users/:userId/messages/:messageId/attachments/:id",
+            {
+              success: MessagePartBody,
+            },
+          ),
+        )
+        .add(
+          HttpApiEndpoint.get("getMessage", "/users/:userId/messages/:messageId", {
+            success: Message,
+          }),
+        );
+      const api = HttpApi.make("gmailMetadataAttachmentTest").add(group);
+      const handlersLayer = HttpApiBuilder.group(api, "gmailMeta", (handlers) =>
+        handlers
+          .handleRaw("getAttachment", () =>
+            Effect.succeed(
+              HttpServerResponse.jsonUnsafe({
+                data: attachmentBase64Url,
+                size: attachmentBytes.byteLength,
+              }),
+            ),
+          )
+          .handleRaw("getMessage", () =>
+            Effect.gen(function* () {
+              const request = yield* HttpServerRequest.HttpServerRequest;
+              parentRequestUrl = request.url;
+              return HttpServerResponse.jsonUnsafe({
+                payload: {
+                  mimeType: "multipart/mixed",
+                  parts: [
+                    {
+                      filename: "",
+                      mimeType: "text/plain",
+                      body: { data: "SGVsbG8=", size: 5 },
+                    },
+                    {
+                      filename: "",
+                      mimeType: "multipart/mixed",
+                      body: { size: 0 },
+                      parts: [
+                        {
+                          filename: "executor-test.csv",
+                          mimeType: "text/csv",
+                          body: {
+                            attachmentId: "fresh_att_1",
+                            size: attachmentBytes.byteLength,
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              });
+            }),
+          ),
+      );
+      const server = yield* serveOpenApiHttpApiTestServer({
+        api,
+        handlersLayer,
+        transformSpec: (spec) =>
+          replaceOperationServers("/users/{userId}/messages/{messageId}/attachments/{id}", "get", [
+            { url: "https://gmail.googleapis.com/gmail/v1" },
+          ])(
+            replaceResponseContent("/users/{userId}/messages/{messageId}/attachments/{id}", "get", {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    data: {
+                      type: "string",
+                      format: "byte",
+                      description: "The body data as a base64url encoded string.",
+                    },
+                    size: {
+                      type: "integer",
+                      format: "int32",
+                      description: "Number of bytes for the message part data.",
+                    },
+                  },
+                  required: ["data", "size"],
+                },
+              },
+            })(spec),
+          ),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "gmail_meta" });
+
+      const result = yield* executor.execute(conn.address("gmailMeta.getAttachment"), {
+        userId: "me",
+        messageId: "msg_1",
+        id: "att_1",
+      });
+
+      expect(parentRequestUrl).toContain("format=full");
+      expect(result).toMatchObject({
+        ok: true,
+        data: {
+          _tag: "ToolFile",
+          name: "executor-test.csv",
+          encoding: "base64",
+          mimeType: "text/csv",
+          data: `${attachmentBase64Url}=`,
+          byteLength: attachmentBytes.byteLength,
+        },
+      });
+    }),
   );
 
   it.effect("format: binary response: raw file bodies are exposed as file artifacts", () =>

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -316,7 +316,7 @@ describe("OpenAPI non-JSON request body dispatch", () => {
         const schema = yield* executor.tools.schema(conn.address("gmail.getAttachment"));
         expect(schema?.outputSchema).toMatchObject({
           properties: {
-            _tag: { const: "ToolFile" },
+            _tag: { enum: ["ToolFile"] },
             data: { contentEncoding: "base64" },
           },
         });
@@ -580,7 +580,7 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       const schema = yield* executor.tools.schema(conn.address("files.download"));
       expect(schema?.outputSchema).toMatchObject({
         properties: {
-          _tag: { const: "ToolFile" },
+          _tag: { enum: ["ToolFile"] },
           data: { contentEncoding: "base64" },
         },
       });

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -414,7 +414,75 @@ describe("OpenAPI non-JSON request body dispatch", () => {
     }),
   );
 
-  it.effect("Gmail attachment bytes inherit filename and MIME from the parent message part", () =>
+  it.effect("format: byte response: ZIP bytes are sniffed from octet-stream output", () =>
+    Effect.gen(function* () {
+      const zipBase64Url = "UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA";
+      const MessagePartBody = Schema.Struct({
+        data: Schema.String,
+        size: Schema.Number,
+      });
+      const group = HttpApiGroup.make("zipAttachment").add(
+        HttpApiEndpoint.get("getAttachment", "/attachments/:id", {
+          success: MessagePartBody,
+        }),
+      );
+      const api = HttpApi.make("zipAttachmentTest").add(group);
+      const handlersLayer = HttpApiBuilder.group(api, "zipAttachment", (handlers) =>
+        handlers.handleRaw("getAttachment", () =>
+          Effect.succeed(
+            HttpServerResponse.jsonUnsafe({
+              data: zipBase64Url,
+              size: 22,
+            }),
+          ),
+        ),
+      );
+      const server = yield* serveOpenApiHttpApiTestServer({
+        api,
+        handlersLayer,
+        transformSpec: replaceResponseContent("/attachments/{id}", "get", {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                data: {
+                  type: "string",
+                  format: "byte",
+                  description: "The body data as a base64url encoded string.",
+                },
+                size: {
+                  type: "integer",
+                  format: "int32",
+                  description: "Number of bytes for the message part data.",
+                },
+              },
+              required: ["data", "size"],
+            },
+          },
+        }),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "zip_attachment" });
+
+      const result = yield* executor.execute(conn.address("zipAttachment.getAttachment"), {
+        id: "att_1",
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        data: {
+          _tag: "ToolFile",
+          encoding: "base64",
+          mimeType: "application/zip",
+          data: `${zipBase64Url}==`,
+          byteLength: 22,
+        },
+      });
+    }),
+  );
+
+  it.effect("Gmail-style byte responses stay generic and do not fetch parent metadata", () =>
     Effect.gen(function* () {
       const attachmentText = [
         "id,name,status,amount",
@@ -469,24 +537,12 @@ describe("OpenAPI non-JSON request body dispatch", () => {
                   mimeType: "multipart/mixed",
                   parts: [
                     {
-                      filename: "",
-                      mimeType: "text/plain",
-                      body: { data: "SGVsbG8=", size: 5 },
-                    },
-                    {
-                      filename: "",
-                      mimeType: "multipart/mixed",
-                      body: { size: 0 },
-                      parts: [
-                        {
-                          filename: "executor-test.csv",
-                          mimeType: "text/csv",
-                          body: {
-                            attachmentId: "fresh_att_1",
-                            size: attachmentBytes.byteLength,
-                          },
-                        },
-                      ],
+                      filename: "executor-test.csv",
+                      mimeType: "text/csv",
+                      body: {
+                        attachmentId: "att_1",
+                        size: attachmentBytes.byteLength,
+                      },
                     },
                   ],
                 },
@@ -533,14 +589,13 @@ describe("OpenAPI non-JSON request body dispatch", () => {
         id: "att_1",
       });
 
-      expect(parentRequestUrl).toContain("format=full");
+      expect(parentRequestUrl).toBe("");
       expect(result).toMatchObject({
         ok: true,
         data: {
           _tag: "ToolFile",
-          name: "executor-test.csv",
           encoding: "base64",
-          mimeType: "text/csv",
+          mimeType: "text/plain",
           data: `${attachmentBase64Url}=`,
           byteLength: attachmentBytes.byteLength,
         },

--- a/packages/plugins/openapi/src/sdk/non-json-body.test.ts
+++ b/packages/plugins/openapi/src/sdk/non-json-body.test.ts
@@ -102,6 +102,20 @@ const contentFor = (contentType: string) => ({
   },
 });
 
+const replaceResponseContent =
+  (path: string, operation: string, content: Record<string, unknown>) =>
+  (spec: Record<string, unknown>): Record<string, unknown> => {
+    const paths = { ...(spec.paths as Record<string, unknown>) };
+    const pathItem = { ...(paths[path] as Record<string, unknown>) };
+    const operationSpec = { ...(pathItem[operation] as Record<string, unknown>) };
+    const responses = { ...(operationSpec.responses as Record<string, unknown>) };
+    const ok = { ...(responses["200"] as Record<string, unknown>) };
+    responses["200"] = { ...ok, content };
+    pathItem[operation] = { ...operationSpec, responses };
+    paths[path] = pathItem;
+    return { ...spec, paths };
+  };
+
 const replaceRequestBodyContent =
   (
     path: string,
@@ -231,6 +245,185 @@ describe("OpenAPI non-JSON request body dispatch", () => {
       expect(captured.contentType).toBe("application/octet-stream");
       expect(captured.body.length).toBe(payload.length);
       expect(Array.from(captured.body)).toEqual(Array.from(payload));
+    }),
+  );
+
+  it.effect(
+    "format: byte response: Gmail-style image attachment data is exposed as a file artifact",
+    () =>
+      Effect.gen(function* () {
+        const attachmentBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+        const attachmentBase64Url = "_9j_4AAQ";
+        const MessagePartBody = Schema.Struct({
+          data: Schema.String,
+          size: Schema.Number,
+        });
+        const group = HttpApiGroup.make("gmail").add(
+          HttpApiEndpoint.get("getAttachment", "/attachments/:id", {
+            success: MessagePartBody,
+          }),
+        );
+        const api = HttpApi.make("gmailAttachmentTest").add(group);
+        const handlersLayer = HttpApiBuilder.group(api, "gmail", (handlers) =>
+          handlers.handleRaw("getAttachment", () =>
+            Effect.succeed(
+              HttpServerResponse.jsonUnsafe({
+                data: attachmentBase64Url,
+                size: attachmentBytes.byteLength,
+              }),
+            ),
+          ),
+        );
+        const server = yield* serveOpenApiHttpApiTestServer({
+          api,
+          handlersLayer,
+          transformSpec: replaceResponseContent("/attachments/{id}", "get", {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  data: {
+                    type: "string",
+                    format: "byte",
+                    description: "The body data as a base64url encoded string.",
+                  },
+                  size: {
+                    type: "integer",
+                    format: "int32",
+                    description: "Number of bytes for the message part data.",
+                  },
+                },
+                required: ["data", "size"],
+              },
+            },
+          }),
+        });
+
+        const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+        const conn = yield* addOpenApiTestConnection(executor, server, { slug: "gmail" });
+
+        const schema = yield* executor.tools.schema(conn.address("gmail.getAttachment"));
+        expect(schema?.outputSchema).toMatchObject({
+          properties: {
+            _tag: { const: "ToolFile" },
+            data: { contentEncoding: "base64" },
+          },
+        });
+
+        const result = yield* executor.execute(conn.address("gmail.getAttachment"), {
+          id: "att_1",
+        });
+
+        expect(result).toMatchObject({
+          ok: true,
+          data: {
+            _tag: "ToolFile",
+            encoding: "base64",
+            mimeType: "image/jpeg",
+            data: "/9j/4AAQ",
+            byteLength: attachmentBytes.byteLength,
+          },
+        });
+      }),
+  );
+
+  it.effect("format: binary response: raw file bodies are exposed as file artifacts", () =>
+    Effect.gen(function* () {
+      const group = HttpApiGroup.make("files").add(
+        HttpApiEndpoint.get("download", "/files/:id", {
+          success: Schema.String,
+        }),
+      );
+      const api = HttpApi.make("binaryDownloadTest").add(group);
+      const handlersLayer = HttpApiBuilder.group(api, "files", (handlers) =>
+        handlers.handleRaw("download", () =>
+          Effect.succeed(HttpServerResponse.text("%PDF-", { contentType: "application/pdf" })),
+        ),
+      );
+      const server = yield* serveOpenApiHttpApiTestServer({
+        api,
+        handlersLayer,
+        transformSpec: replaceResponseContent("/files/{id}", "get", {
+          "application/pdf": {
+            schema: {
+              type: "string",
+              format: "binary",
+            },
+          },
+        }),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "files" });
+
+      const schema = yield* executor.tools.schema(conn.address("files.download"));
+      expect(schema?.outputSchema).toMatchObject({
+        properties: {
+          _tag: { const: "ToolFile" },
+          data: { contentEncoding: "base64" },
+        },
+      });
+
+      const result = yield* executor.execute(conn.address("files.download"), {
+        id: "report",
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        data: {
+          _tag: "ToolFile",
+          encoding: "base64",
+          mimeType: "application/pdf",
+          data: "JVBERi0=",
+          byteLength: 5,
+        },
+      });
+    }),
+  );
+
+  it.effect("format: binary response: non-2xx responses keep their error body", () =>
+    Effect.gen(function* () {
+      const group = HttpApiGroup.make("files").add(
+        HttpApiEndpoint.get("download", "/files/:id", {
+          success: Schema.String,
+        }),
+      );
+      const api = HttpApi.make("binaryDownloadErrorTest").add(group);
+      const handlersLayer = HttpApiBuilder.group(api, "files", (handlers) =>
+        handlers.handleRaw("download", () =>
+          Effect.succeed(HttpServerResponse.jsonUnsafe({ error: "missing" }, { status: 404 })),
+        ),
+      );
+      const server = yield* serveOpenApiHttpApiTestServer({
+        api,
+        handlersLayer,
+        transformSpec: replaceResponseContent("/files/{id}", "get", {
+          "application/pdf": {
+            schema: {
+              type: "string",
+              format: "binary",
+            },
+          },
+        }),
+      });
+
+      const executor = yield* createExecutor(makeTestConfig({ plugins: testPlugins() }));
+      const conn = yield* addOpenApiTestConnection(executor, server, { slug: "files" });
+
+      const result = yield* executor.execute(conn.address("files.download"), {
+        id: "missing",
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        error: {
+          code: "upstream_http_error",
+          status: 404,
+          details: {
+            error: "missing",
+          },
+        },
+      });
     }),
   );
 

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -8,6 +8,7 @@ import {
   IntegrationNotFoundError,
   IntegrationSlug,
   ToolName,
+  ToolFileJsonSchema,
   ToolResult,
   authToolFailure,
   definePlugin,
@@ -518,6 +519,7 @@ const toBinding = (def: ToolDefinition): OperationBinding =>
     pathTemplate: def.operation.pathTemplate,
     parameters: [...def.operation.parameters],
     requestBody: def.operation.requestBody,
+    responseBody: def.operation.responseBody,
   });
 
 const descriptionFor = (def: ToolDefinition): string => {
@@ -634,7 +636,13 @@ const toolDefsFromCompiled = (compiled: CompiledSpec): readonly ToolDef[] =>
       // The output schema is the upstream response body only — transport
       // status/headers live in the ToolResult `http` side channel, not the
       // payload (see the invoke handler).
-      outputSchema: normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+      outputSchema: Option.match(def.operation.responseBody, {
+        onNone: () => normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+        onSome: (responseBody) =>
+          Option.isSome(responseBody.fileHint)
+            ? ToolFileJsonSchema
+            : normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
+      }),
       annotations: annotationsForOperation(def.operation.method, def.operation.pathTemplate),
     }),
   );
@@ -1168,20 +1176,26 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
         // re-deriving it from the spec blob when the store has no row (e.g. an
         // integration registered without going through addSpec). The fallback
         // is the ONLY invoke-path spec read — the hot path never loads it.
+        const bindingFromSpec = config
+          ? Effect.gen(function* () {
+              const specText = yield* loadSpecText(invokeCtx.storage, config).pipe(
+                Effect.catch(() => Effect.succeed(null)),
+              );
+              const compiled =
+                specText == null
+                  ? null
+                  : yield* compileSpec(specText).pipe(Effect.catch(() => Effect.succeed(null)));
+              return compiled
+                ? storedOperationsFromCompiled(integration, compiled).find(
+                    (op) => op.toolName === toolRow.name,
+                  )?.binding
+                : undefined;
+            })
+          : Effect.succeed(undefined);
+
         let binding = (yield* invokeCtx.storage.getOperation(integration, toolRow.name))?.binding;
-        if (!binding && config) {
-          const specText = yield* loadSpecText(invokeCtx.storage, config).pipe(
-            Effect.catch(() => Effect.succeed(null)),
-          );
-          const compiled =
-            specText == null
-              ? null
-              : yield* compileSpec(specText).pipe(Effect.catch(() => Effect.succeed(null)));
-          binding = compiled
-            ? storedOperationsFromCompiled(integration, compiled).find(
-                (op) => op.toolName === toolRow.name,
-              )?.binding
-            : undefined;
+        if ((!binding || Option.isNone(binding.responseBody)) && config) {
+          binding = (yield* bindingFromSpec) ?? binding;
         }
         if (!binding) {
           return yield* new OpenApiExtractionError({

--- a/packages/plugins/openapi/src/sdk/query-serialization.test.ts
+++ b/packages/plugins/openapi/src/sdk/query-serialization.test.ts
@@ -40,6 +40,7 @@ it.effect("serializes form-exploded query arrays as repeated parameters", () =>
         servers: [],
         pathTemplate: "/messages/{id}",
         requestBody: Option.none(),
+        responseBody: Option.none(),
         parameters: [
           OperationParameter.make({
             name: "id",
@@ -107,6 +108,7 @@ it.effect("uses operation base URL and preserves reserved path expansion when al
         ],
         pathTemplate: "/v1/{+name}",
         requestBody: Option.none(),
+        responseBody: Option.none(),
         parameters: [
           OperationParameter.make({
             name: "name",
@@ -157,6 +159,7 @@ it.effect("targets the server chosen by the call's `server.url`", () =>
         ],
         pathTemplate: "/ping",
         requestBody: Option.none(),
+        responseBody: Option.none(),
         parameters: [],
       });
 
@@ -184,6 +187,7 @@ it.effect("a connection base URL overrides the operation's servers", () =>
         ],
         pathTemplate: "/ping",
         requestBody: Option.none(),
+        responseBody: Option.none(),
         parameters: [],
       });
 
@@ -205,6 +209,7 @@ it.effect("falls back to the base URL for bindings persisted without servers", (
         method: "get",
         pathTemplate: "/ping",
         requestBody: Option.none(),
+        responseBody: Option.none(),
         parameters: [],
       });
 

--- a/packages/plugins/openapi/src/sdk/types.ts
+++ b/packages/plugins/openapi/src/sdk/types.ts
@@ -135,6 +135,22 @@ export const OperationRequestBody = Schema.Struct({
 });
 export type OperationRequestBody = typeof OperationRequestBody.Type;
 
+export const OperationFileHint = Schema.Struct({
+  kind: Schema.Literals(["binaryResponse", "byteField"]),
+  mimeType: Schema.OptionFromOptional(Schema.String),
+  dataField: Schema.OptionFromOptional(Schema.String),
+  sizeField: Schema.OptionFromOptional(Schema.String),
+  encoding: Schema.OptionFromOptional(Schema.Literals(["base64", "base64url"])),
+});
+export type OperationFileHint = typeof OperationFileHint.Type;
+
+export const OperationResponseBody = Schema.Struct({
+  contentType: Schema.String,
+  schema: Schema.OptionFromOptional(Schema.Unknown),
+  fileHint: Schema.OptionFromOptional(OperationFileHint),
+});
+export type OperationResponseBody = typeof OperationResponseBody.Type;
+
 export const ServerVariable = Schema.Struct({
   default: Schema.String,
   enum: Schema.OptionFromOptional(Schema.Array(Schema.String)),
@@ -160,6 +176,7 @@ export const ExtractedOperation = Schema.Struct({
   tags: Schema.Array(Schema.String),
   parameters: Schema.Array(OperationParameter),
   requestBody: Schema.OptionFromOptional(OperationRequestBody),
+  responseBody: Schema.OptionFromOptional(OperationResponseBody),
   inputSchema: Schema.OptionFromOptional(Schema.Unknown),
   outputSchema: Schema.OptionFromOptional(Schema.Unknown),
   deprecated: Schema.Boolean,
@@ -186,6 +203,7 @@ export const OperationBinding = Schema.Struct({
   pathTemplate: Schema.String,
   parameters: Schema.Array(OperationParameter),
   requestBody: Schema.OptionFromOptional(OperationRequestBody),
+  responseBody: Schema.OptionFromOptional(OperationResponseBody),
 });
 export type OperationBinding = typeof OperationBinding.Type;
 


### PR DESCRIPTION
## Summary

- Add a `ToolFile` value type and schema for tool outputs that are files.
- Detect OpenAPI `format: byte` and `format: binary` responses, normalize bytes into `ToolFile`, and preserve normal error bodies for non-2xx responses.
- Project `ToolFile` results in the MCP host as model-visible image/text/resource content while stripping base64 bytes from structured metadata.

## Why

OpenAPI byte fields currently surface as ordinary JSON strings, so agents and clients end up seeing or manipulating base64 directly. This makes binary outputs, especially image attachments, hard for models to consume correctly.

## Validation

- `bunx vitest run src/tool-server.test.ts` in `packages/hosts/mcp`
- `bunx vitest run src/sdk/non-json-body.test.ts` in `packages/plugins/openapi`
- `bunx vitest run src/tool-result.test.ts` in `packages/core/sdk`
- Package typechecks for `packages/hosts/mcp`, `packages/plugins/openapi`, `packages/core/sdk`, and `packages/core/execution`
- `bunx oxfmt --check ...`
- `git diff --check`
- Deployed worker smoke test: live MCP attachment calls rendered image content blocks instead of base64 text
