### PR TITLE
[codex] Preserve upstream MCP image content

### DIFF
--- a/packages/hosts/mcp/src/tool-server.test.ts
+++ b/packages/hosts/mcp/src/tool-server.test.ts
@@ -79,6 +79,9 @@ const textOf = (result: Awaited<ReturnType<Client["callTool"]>>): string =>
   (result.content as Array<{ type: string; text: string }>)[0].text;
 
 const STUB_TOOL_ADDRESS = ToolAddress.make("tools.test.org.main.t");
+const TEST_IMAGE_MIME_TYPE = "image/png";
+const TEST_IMAGE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l8N1wwAAAABJRU5ErkJggg==";
 
 /** Build a stub paused ExecutionResult with the given id and elicitation request. */
 const makePausedResult = (
@@ -177,6 +180,59 @@ describe("MCP host server — native elicitation mode", () => {
         mimeType: "image/png",
       });
       expect(result.structuredContent).toBeUndefined();
+      expect(result.isError).toBeFalsy();
+    });
+  });
+
+  it("execute tool preserves upstream MCP image content as native content", async () => {
+    const engine = makeStubEngine({
+      execute: () =>
+        Effect.succeed({
+          result: ToolResult.ok({
+            content: [
+              {
+                type: "text",
+                text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+              },
+              {
+                type: "image",
+                data: TEST_IMAGE_PNG_BASE64,
+                mimeType: TEST_IMAGE_MIME_TYPE,
+              },
+            ],
+            structuredContent: {
+              name: "mcp-image-fixture.png",
+              mimeType: TEST_IMAGE_MIME_TYPE,
+              byteLength: 70,
+            },
+          }),
+        }),
+    });
+
+    await withNativeClient(engine, ELICITATION_CAPS, async (client) => {
+      const result = await client.callTool({
+        name: "execute",
+        arguments: {
+          code: "return await tools.image_mcp.org.main.image_fixture_with_metadata({});",
+        },
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "text",
+          text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+        },
+        {
+          type: "image",
+          data: TEST_IMAGE_PNG_BASE64,
+          mimeType: TEST_IMAGE_MIME_TYPE,
+        },
+      ]);
+      expect(result.structuredContent).toEqual({
+        name: "mcp-image-fixture.png",
+        mimeType: TEST_IMAGE_MIME_TYPE,
+        byteLength: 70,
+      });
       expect(result.isError).toBeFalsy();
     });
   });

--- a/packages/hosts/mcp/src/tool-server.ts
+++ b/packages/hosts/mcp/src/tool-server.ts
@@ -278,6 +278,39 @@ const TEXT_FILE_CONTENT_MAX_CHARS = 64_000;
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
 
+const isTextContentBlock = (value: unknown): value is Extract<ContentBlock, { type: "text" }> =>
+  isRecord(value) && value.type === "text" && typeof value.text === "string";
+
+const isImageContentBlock = (value: unknown): value is Extract<ContentBlock, { type: "image" }> =>
+  isRecord(value) &&
+  value.type === "image" &&
+  typeof value.data === "string" &&
+  typeof value.mimeType === "string";
+
+const isResourceContentBlock = (
+  value: unknown,
+): value is Extract<ContentBlock, { type: "resource" }> =>
+  isRecord(value) && value.type === "resource" && isRecord(value.resource);
+
+const isNativeMcpContentBlock = (value: unknown): value is ContentBlock =>
+  isTextContentBlock(value) || isImageContentBlock(value) || isResourceContentBlock(value);
+
+const nativeMcpContentResult = (value: unknown): McpToolResult | null => {
+  if (!isToolResult(value) || !value.ok || !isRecord(value.data)) return null;
+  const content = value.data.content;
+  if (!Array.isArray(content) || content.length === 0 || !content.every(isNativeMcpContentBlock)) {
+    return null;
+  }
+  if (!content.some((block) => block.type !== "text")) return null;
+  return {
+    content,
+    ...(isRecord(value.data.structuredContent)
+      ? { structuredContent: value.data.structuredContent }
+      : {}),
+    isError: value.data.isError === true || undefined,
+  };
+};
+
 const redactToolFileBytes = (file: ToolFileValue): Record<string, unknown> => ({
   _tag: "ToolFile",
   ...(file.name ? { name: file.name } : {}),
@@ -453,6 +486,8 @@ const toMcpFileResult = (
 };
 
 const toMcpResult = (result: FormattedExecuteInput): McpToolResult => {
+  const nativeMcpResult = result.error ? null : nativeMcpContentResult(result.result);
+  if (nativeMcpResult) return nativeMcpResult;
   const extracted = result.error
     ? { value: result.result, files: [] }
     : extractToolFiles(result.result);

--- a/packages/plugins/mcp/src/sdk/image-content.test.ts
+++ b/packages/plugins/mcp/src/sdk/image-content.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  ToolAddress,
+  createExecutor,
+} from "@executor-js/sdk";
+import { makeTestConfig, memoryCredentialsPlugin } from "@executor-js/sdk/testing";
+
+import { mcpPlugin } from "./plugin";
+import {
+  TEST_IMAGE_MIME_TYPE,
+  TEST_IMAGE_PNG_BASE64,
+  makeImageMcpServer,
+  serveMcpServer,
+} from "../testing";
+
+const INTEGRATION = IntegrationSlug.make("image_mcp");
+const TEMPLATE = AuthTemplateSlug.make("none");
+
+const imageBlock = {
+  type: "image",
+  data: TEST_IMAGE_PNG_BASE64,
+  mimeType: TEST_IMAGE_MIME_TYPE,
+};
+
+describe("MCP image content", () => {
+  it.effect("preserves upstream MCP image content through plugin invocation", () =>
+    Effect.gen(function* () {
+      const server = yield* serveMcpServer(makeImageMcpServer);
+      const executor = yield* createExecutor(
+        makeTestConfig({ plugins: [memoryCredentialsPlugin(), mcpPlugin()] as const }),
+      );
+
+      yield* executor.mcp.addServer({
+        name: "Image MCP",
+        endpoint: server.url,
+        slug: String(INTEGRATION),
+      });
+      yield* executor.connections.create({
+        owner: "org",
+        name: ConnectionName.make("main"),
+        integration: INTEGRATION,
+        template: TEMPLATE,
+        value: "",
+      });
+
+      const imageOnly = yield* executor.execute(
+        ToolAddress.make("tools.image_mcp.org.main.image_fixture"),
+        {},
+        { onElicitation: "accept-all" },
+      );
+      expect(imageOnly).toMatchObject({
+        ok: true,
+        data: {
+          content: [imageBlock],
+          structuredContent: {
+            name: "mcp-image-fixture.png",
+            mimeType: TEST_IMAGE_MIME_TYPE,
+            byteLength: 70,
+          },
+        },
+      });
+
+      const mixed = yield* executor.execute(
+        ToolAddress.make("tools.image_mcp.org.main.image_fixture_with_metadata"),
+        {},
+        { onElicitation: "accept-all" },
+      );
+      expect(mixed).toMatchObject({
+        ok: true,
+        data: {
+          content: [
+            {
+              type: "text",
+              text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+            },
+            imageBlock,
+          ],
+        },
+      });
+    }),
+  );
+});

--- a/packages/plugins/mcp/src/sdk/presets.ts
+++ b/packages/plugins/mcp/src/sdk/presets.ts
@@ -25,6 +25,14 @@ export type McpPreset = McpRemotePreset | McpStdioPreset;
 
 export const mcpPresets: readonly McpPreset[] = [
   {
+    id: "emulate-mcp",
+    name: "Emulate MCP",
+    summary: "Deterministic MCP fixtures for validating native text and image content.",
+    url: "https://emulators.dev/mcp/query/mcp?token=demo-token",
+    endpoint: "https://emulators.dev/mcp/query/mcp?token=demo-token",
+    icon: "https://emulators.dev/favicon.ico",
+  },
+  {
     id: "deepwiki",
     name: "DeepWiki",
     summary: "Search and read documentation from any GitHub repo.",

--- a/packages/plugins/mcp/src/testing/index.ts
+++ b/packages/plugins/mcp/src/testing/index.ts
@@ -1,10 +1,13 @@
 export {
   McpTestServerError,
   McpTestServerLayer,
+  TEST_IMAGE_MIME_TYPE,
+  TEST_IMAGE_PNG_BASE64,
   makeAnnotationsMcpServer,
   makeEchoMcpServer,
   makeElicitationMcpServer,
   makeGreetingMcpServer,
+  makeImageMcpServer,
   serveMcpServer,
   serveMcpServerWithOAuth,
   type McpTestRequest,

--- a/packages/plugins/mcp/src/testing/server.ts
+++ b/packages/plugins/mcp/src/testing/server.ts
@@ -289,6 +289,65 @@ export const makeGreetingMcpServer = (
   return server;
 };
 
+export const TEST_IMAGE_MIME_TYPE = "image/png";
+export const TEST_IMAGE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/l8N1wwAAAABJRU5ErkJggg==";
+
+const testImageMetadata = () => ({
+  name: "mcp-image-fixture.png",
+  mimeType: TEST_IMAGE_MIME_TYPE,
+  byteLength: Buffer.from(TEST_IMAGE_PNG_BASE64, "base64").byteLength,
+});
+
+export const makeImageMcpServer = () => {
+  const server = new McpServer(
+    { name: "image-test-server", version: "1.0.0" },
+    { capabilities: {} },
+  );
+
+  server.registerTool(
+    "image_fixture",
+    {
+      description: "Returns a deterministic PNG as MCP image content",
+      inputSchema: {},
+    },
+    async () => ({
+      content: [
+        {
+          type: "image" as const,
+          data: TEST_IMAGE_PNG_BASE64,
+          mimeType: TEST_IMAGE_MIME_TYPE,
+        },
+      ],
+      structuredContent: testImageMetadata(),
+    }),
+  );
+
+  server.registerTool(
+    "image_fixture_with_metadata",
+    {
+      description: "Returns text metadata followed by MCP image content",
+      inputSchema: {},
+    },
+    async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
+        },
+        {
+          type: "image" as const,
+          data: TEST_IMAGE_PNG_BASE64,
+          mimeType: TEST_IMAGE_MIME_TYPE,
+        },
+      ],
+      structuredContent: testImageMetadata(),
+    }),
+  );
+
+  return server;
+};
+
 export const makeEchoMcpServer = (
   options: {
     readonly name?: string;


### PR DESCRIPTION
## Summary

Preserves MCP-native non-text content returned by upstream MCP tools when Executor exposes the result through its own MCP host. If a successful upstream MCP tool call returns native image or resource content, the MCP host now forwards those content blocks directly instead of forcing the model/client to inspect a JSON string containing base64.

This is separate from the OpenAPI `ToolFile` path in #1062. The new tests exercise upstream MCP `CallToolResult` content, not OpenAPI byte or binary outputs.

Also adds an Emulate MCP preset pointed at the deployed query-auth fixture endpoint:

`https://emulators.dev/mcp/query/mcp?token=demo-token`

## Observed Result Shape

Live full path checked locally: deployed Emulate MCP endpoint -> Executor upstream MCP plugin -> Executor MCP host `execute` -> MCP client.

The client-facing `execute` result contained:

```json
{
  "contentTypes": ["text", "image"],
  "text": "Deterministic image fixture: mcp-image-fixture.png (image/png, 70 bytes)",
  "imageMimeType": "image/png",
  "imageByteLength": 70,
  "imageSignature": "89504e470d0a1a0a",
  "structuredContent": {
    "name": "mcp-image-fixture.png",
    "mimeType": "image/png",
    "byteLength": 70,
    "sha256": "442486dc2c683393153d5a425628742a697977e68e1138d3cc38229fdf6331c4"
  }
}
```

## Notes

Text-only upstream MCP results keep the existing formatting behavior. Native pass-through is limited to successful tool results with non-text MCP content blocks, so this does not add provider-specific hacks or size-based binary guessing.

Clients that do not support MCP image content may still display or expose the image block as JSON with base64. Executor now preserves the native MCP image block for clients that can render it.

## Validation

- `bun run bootstrap`
- `bun run --cwd packages/plugins/mcp test -- src/sdk/image-content.test.ts`
- `bun run --cwd packages/plugins/mcp typecheck`
- `bun run --cwd packages/hosts/mcp test -- src/tool-server.test.ts`
- `bun run --cwd packages/hosts/mcp typecheck`
- Live Executor plugin smoke against `https://emulators.dev/mcp/query/mcp?token=demo-token`
- Live Executor MCP-host smoke against the same deployed upstream endpoint
