### PR TITLE
Trim connections.list output to a lean default with verbose opt-in

### DIFF
--- a/e2e/cloud/connections-list-scope.test.ts
+++ b/e2e/cloud/connections-list-scope.test.ts
@@ -1,0 +1,169 @@
+// Cloud: `connections.list` over the MCP surface returns a LEAN projection. A
+// single OAuth connection's `oauthScope` grant string runs to thousands of
+// characters for a real provider, and an agent listing connections to pick one
+// pays that cost on every row. So the core tool summarizes scope to an
+// `oauthScopeCount` by default and only echoes the full grant string when the
+// caller asks for `verbose: true`.
+//
+// Proven end to end: a real authorization-code flow (start → consent →
+// complete) mints a connection carrying a recorded `read` scope, then the core
+// tool is driven through `execute` exactly as an MCP client (Claude, Cursor, …)
+// would call it. The HTTP API projection is deliberately untouched — the web
+// console reads the full `oauthScope` to flag reconnect-for-new-scope — so this
+// only pins the agent-facing tool.
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+import {
+  AuthTemplateSlug,
+  ConnectionName,
+  IntegrationSlug,
+  OAuthClientSlug,
+} from "@executor-js/sdk/shared";
+import { serveOAuthTestServer } from "@executor-js/sdk/testing";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+import type { McpSession } from "../src/surfaces/mcp";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+/** Run `execute` and parse the sandbox's JSON return value. */
+const executeJson = (session: McpSession, code: string) =>
+  Effect.gen(function* () {
+    const result = yield* session.call("execute", { code });
+    expect(result.ok, `execute completed (got: ${result.text.slice(0, 400)})`).toBe(true);
+    return JSON.parse(result.text) as Record<string, unknown>;
+  });
+
+/** The `main` connection from a `connections.list` sandbox return value. */
+const mainConnection = (listed: Record<string, unknown>): Record<string, unknown> | undefined => {
+  const connections = (listed as { connections?: ReadonlyArray<Record<string, unknown>> })
+    .connections;
+  return connections?.find((c) => c.name === "main");
+};
+
+const listCode = (integration: string, verbose: boolean) => `
+const res = await tools.executor.coreTools.connections.list(${JSON.stringify(
+  verbose ? { integration, verbose: true } : { integration },
+)});
+return res.ok ? res.data : res;
+`;
+
+scenario(
+  "Connections · list summarizes OAuth scope to a count by default and returns the full grant under verbose",
+  { timeout: 240_000 },
+  Effect.scoped(
+    Effect.gen(function* () {
+      const target = yield* Target;
+      const mcp = yield* Mcp;
+      const { client: makeClient } = yield* Api;
+      const oauth = yield* serveOAuthTestServer({ scopes: ["read"] });
+      const identity = yield* target.newIdentity();
+      const client = yield* makeClient(api, identity);
+      const session = mcp.session(identity);
+
+      // An integration declaring an oauth template — the minted connection
+      // attaches to it and records the granted `read` scope.
+      const integration = IntegrationSlug.make(unique("connscopeint"));
+      yield* client.openapi.addSpec({
+        payload: {
+          spec: {
+            kind: "blob",
+            value: JSON.stringify({
+              openapi: "3.0.3",
+              info: { title: "OAuth-protected API", version: "1.0.0" },
+              paths: {
+                "/me": {
+                  get: {
+                    operationId: "getMe",
+                    tags: ["default"],
+                    responses: { "200": { description: "the caller" } },
+                  },
+                },
+              },
+            }),
+          },
+          slug: integration,
+          baseUrl: "http://127.0.0.1:59999",
+          authenticationTemplate: [
+            {
+              slug: "oauth",
+              kind: "oauth2",
+              authorizationUrl: oauth.authorizationEndpoint,
+              tokenUrl: oauth.tokenEndpoint,
+              scopes: ["read"],
+            },
+          ],
+        },
+      });
+
+      const clientSlug = OAuthClientSlug.make(unique("connscopec"));
+      yield* client.oauth.createClient({
+        payload: {
+          owner: "org",
+          slug: clientSlug,
+          authorizationUrl: oauth.authorizationEndpoint,
+          tokenUrl: oauth.tokenEndpoint,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        },
+      });
+
+      const started = yield* client.oauth.start({
+        payload: {
+          client: clientSlug,
+          clientOwner: "org",
+          owner: "org",
+          name: ConnectionName.make("main"),
+          integration,
+          template: AuthTemplateSlug.make("oauth"),
+        },
+      });
+      if (started.status !== "redirect") {
+        throw new Error(`oauth.start did not redirect: ${JSON.stringify(started)}`);
+      }
+
+      // Headless consent: the authorize page bounces to login, and submitting
+      // credentials redirects back to the product callback with a code.
+      const authorize = yield* Effect.promise(() =>
+        fetch(started.authorizationUrl, { redirect: "manual" }),
+      );
+      const consent = yield* Effect.promise(() =>
+        fetch(authorize.headers.get("location") ?? "", {
+          method: "POST",
+          redirect: "manual",
+          headers: {
+            authorization: `Basic ${Buffer.from("alice:password").toString("base64")}`,
+          },
+        }),
+      );
+      const callback = new URL(consent.headers.get("location") ?? "");
+      const code = callback.searchParams.get("code") ?? "";
+      yield* client.oauth.complete({ payload: { state: started.state, code } });
+
+      // Default (lean): the full scope string is omitted; a grant count stands
+      // in so a scanning agent still knows scope exists and how much.
+      const lean = yield* executeJson(session, listCode(String(integration), false));
+      const leanMain = mainConnection(lean);
+      expect(leanMain, "the minted connection is listed").toBeDefined();
+      expect(leanMain?.oauthScopeCount, "scope is summarized to its grant count").toBe(1);
+      expect(
+        "oauthScope" in (leanMain ?? {}),
+        "the full scope grant string is omitted by default",
+      ).toBe(false);
+
+      // verbose: the full grant string is included alongside the count.
+      const verbose = yield* executeJson(session, listCode(String(integration), true));
+      const verboseMain = mainConnection(verbose);
+      expect(verboseMain?.oauthScope, "verbose returns the full grant string").toBe("read");
+      expect(verboseMain?.oauthScopeCount, "the count still accompanies the full scope").toBe(1);
+    }),
+  ),
+);

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -80,9 +80,30 @@ const ConnectionOutput = Schema.Struct({
 const ConnectionsListInput = Schema.Struct({
   integration: Schema.optional(Schema.String),
   owner: Schema.optional(OwnerSchema),
+  verbose: Schema.optional(Schema.Boolean),
+});
+
+/** Lean per-connection shape for list scans. Omits the full `oauthScope`
+ *  grant string (a single connection's scope list can run to thousands of
+ *  characters and dominates the payload) in favor of `oauthScopeCount`. The
+ *  full scope is included only when the caller passes `verbose: true`. */
+const ConnectionListItem = Schema.Struct({
+  owner: OwnerSchema,
+  name: Schema.String,
+  integration: Schema.String,
+  template: Schema.String,
+  provider: Schema.String,
+  address: Schema.String,
+  identityLabel: Schema.optional(Schema.NullOr(Schema.String)),
+  description: Schema.optional(Schema.NullOr(Schema.String)),
+  expiresAt: Schema.NullOr(Schema.Number),
+  oauthClient: Schema.NullOr(Schema.String),
+  oauthClientOwner: Schema.NullOr(OwnerSchema),
+  oauthScopeCount: Schema.NullOr(Schema.Number),
+  oauthScope: Schema.optional(Schema.NullOr(Schema.String)),
 });
 const ConnectionsListOutput = Schema.Struct({
-  connections: Schema.Array(ConnectionOutput),
+  connections: Schema.Array(ConnectionListItem),
 });
 
 const ConnectionCreateHandoffInput = Schema.Struct({
@@ -311,6 +332,30 @@ const connectionToOutput = (connection: Connection) => ({
   oauthScope: connection.oauthScope ?? null,
 });
 
+/** Number of space-separated grants in an `oauthScope` string, or null when
+ *  the connection carries no scope (static credentials, or an OAuth AS that
+ *  omitted scope). */
+const oauthScopeCount = (scope: string | null | undefined): number | null =>
+  scope == null ? null : scope.split(/\s+/).filter(Boolean).length;
+
+/** Lean projection for `connections.list`. Summarizes `oauthScope` to a count
+ *  unless `verbose`, where the full grant string is included too. */
+const connectionToListItem = (connection: Connection, verbose: boolean) => ({
+  owner: connection.owner,
+  name: String(connection.name),
+  integration: String(connection.integration),
+  template: String(connection.template),
+  provider: String(connection.provider),
+  address: String(connection.address),
+  identityLabel: connection.identityLabel ?? null,
+  description: connection.description ?? null,
+  expiresAt: connection.expiresAt ?? null,
+  oauthClient: connection.oauthClient == null ? null : String(connection.oauthClient),
+  oauthClientOwner: connection.oauthClientOwner ?? null,
+  oauthScopeCount: oauthScopeCount(connection.oauthScope),
+  ...(verbose ? { oauthScope: connection.oauthScope ?? null } : {}),
+});
+
 const toolToOutput = (toolRow: Tool) => ({
   address: String(toolRow.address),
   owner: toolRow.owner,
@@ -433,7 +478,7 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
         tool({
           name: "connections.list",
           description:
-            "List saved connections (the credential for one integration). Never returns the credential value. Optionally filter by integration or owner.",
+            "List saved connections (the credential for one integration). Never returns the credential value. Optionally filter by integration or owner. OAuth scopes are summarized as `oauthScopeCount` by default; pass `verbose: true` to include the full `oauthScope` grant string per connection.",
           inputSchema: ConnectionsListInputStd,
           outputSchema: ConnectionsListOutputStd,
           execute: (input: typeof ConnectionsListInput.Type, { ctx }) =>
@@ -446,7 +491,9 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
                 owner: input.owner === undefined ? undefined : (input.owner as Owner),
               }),
               (connections) => ({
-                connections: connections.map(connectionToOutput),
+                connections: connections.map((connection) =>
+                  connectionToListItem(connection, input.verbose === true),
+                ),
               }),
             ),
         }),


### PR DESCRIPTION
## What

`connections.list` (the agent-facing core tool exposed over MCP) returned the full `oauthScope` grant string on every connection. For a real OAuth provider that single string runs to thousands of characters, so an agent listing connections just to pick one paid that cost on every row.

This changes the default list output to a lean projection:

- **Default:** the full `oauthScope` string is replaced by `oauthScopeCount` (a number, or `null` for static credentials), so a scan still knows scope exists and roughly how much.
- **`verbose: true`:** returns the full `oauthScope` alongside the count, for when you actually need to inspect grants (e.g. distinguishing two connections to the same provider that hold different scopes).

## Scope of the change

- Only the **core tool** changes. The HTTP API projection is deliberately untouched, because the web console reads the full `oauthScope` to flag connections that need reconnecting for a new scope.
- Single-connection responses (`connections.create`, `oauth.start`) keep the full shape. One connection is never a wall, and the detail is useful there.
- Other small fields are left alone; the scope string was the only field large enough to matter.

## Compatibility note

By default the `oauthScope` key is now absent rather than present-but-`null`; it moves behind `verbose: true`. The one in-repo consumer of the core tool reads only `integration`/`owner`/`name`, so it is unaffected.

## Tests

New scenario `e2e/cloud/connections-list-scope.test.ts` runs a real authorization-code flow to mint a connection carrying a `read` scope, then drives the core tool over a real MCP `execute` session and asserts:

- lean -> `oauthScopeCount: 1`, no `oauthScope` key
- verbose -> `oauthScope: "read"`, count still present

Passing on the cloud target (1/1). SDK typecheck/tests/lint green. This is an MCP/API scenario, so it is reviewed as source rather than as a recording.

## Gaps

- Coverage is cloud-only; the projection is host-agnostic but is not pinned on self-host or cloudflare.