### PR TITLE
fix(openapi): send a default User-Agent on upstream tool calls

### DIFF
--- a/packages/plugins/openapi/src/sdk/invoke.ts
+++ b/packages/plugins/openapi/src/sdk/invoke.ts
@@ -126,6 +126,13 @@ const resolvePath = Effect.fn("OpenApi.resolvePath")(function* (
   return resolved;
 });
 
+// GitHub (and some other upstreams) reject requests that lack a User-Agent
+// header with a 403 ("Request forbidden by administrative rules"), which is
+// indistinguishable from a credential rejection downstream. Send a default so
+// those calls succeed. It is applied before operation header params and
+// resolved auth headers, so a spec- or connection-provided User-Agent wins.
+const DEFAULT_USER_AGENT = "executor";
+
 const applyHeaders = (
   request: HttpClientRequest.HttpClientRequest,
   headers: Record<string, string>,
@@ -630,6 +637,10 @@ export const invoke = Effect.fn("OpenApi.invoke")(function* (
   const path = resolvedPath.startsWith("/") ? resolvedPath : `/${resolvedPath}`;
 
   let request = HttpClientRequest.make(operation.method.toUpperCase() as "GET")(path);
+
+  // Default first so operation header params and resolved auth headers below
+  // can override it; the upstream still gets a User-Agent if nothing else sets one.
+  request = HttpClientRequest.setHeader(request, "User-Agent", DEFAULT_USER_AGENT);
 
   for (const [name, value] of Object.entries(sourceQueryParams)) {
     request = HttpClientRequest.setUrlParam(request, name, value);

--- a/packages/plugins/openapi/src/sdk/request-user-agent.test.ts
+++ b/packages/plugins/openapi/src/sdk/request-user-agent.test.ts
@@ -1,0 +1,105 @@
+import { expect, it } from "@effect/vitest";
+import { Effect, Option } from "effect";
+import { FetchHttpClient } from "effect/unstable/http";
+import { createServer, type IncomingHttpHeaders, type Server } from "node:http";
+
+import { invokeWithLayer } from "./invoke";
+import { OperationBinding, OperationParameter } from "./types";
+
+// Captures the headers of the real outbound request the invoke path sends.
+const withServer = <A>(
+  f: (input: { readonly baseUrl: string; readonly headers: IncomingHttpHeaders[] }) => Promise<A>,
+) =>
+  new Promise<A>((resolve, reject) => {
+    const headers: IncomingHttpHeaders[] = [];
+    const server: Server = createServer((request, response) => {
+      headers.push(request.headers);
+      response.statusCode = 200;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ ok: true }));
+    });
+
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        server.close();
+        // oxlint-disable-next-line executor/no-promise-reject, executor/no-error-constructor -- boundary: Node listen callback is adapted into the test Promise failure path
+        reject(new Error("Server did not bind to a TCP port"));
+        return;
+      }
+      f({ baseUrl: `http://127.0.0.1:${address.port}`, headers })
+        .then(resolve, reject)
+        .finally(() => server.close());
+    });
+  });
+
+const pathParam = (name: string) =>
+  OperationParameter.make({
+    name,
+    location: "path",
+    required: true,
+    schema: Option.some({ type: "string" }),
+    style: Option.none(),
+    explode: Option.none(),
+    allowReserved: Option.none(),
+    description: Option.none(),
+  });
+
+// GitHub 403s any request without a User-Agent header, which downstream looks
+// identical to a credential rejection. The invoke path must always send one.
+it.effect("sends a default User-Agent so upstreams like GitHub don't 403", () =>
+  Effect.promise(() =>
+    withServer(async ({ baseUrl, headers }) => {
+      const operation = OperationBinding.make({
+        method: "get",
+        servers: [],
+        pathTemplate: "/repos/{owner}/{repo}/pulls",
+        requestBody: Option.none(),
+        responseBody: Option.none(),
+        parameters: [pathParam("owner"), pathParam("repo")],
+      });
+
+      await Effect.runPromise(
+        invokeWithLayer(
+          operation,
+          { owner: "risedle", repo: "aime" },
+          baseUrl,
+          {},
+          {},
+          FetchHttpClient.layer,
+        ),
+      );
+
+      expect(headers[0]?.["user-agent"]).toBe("executor");
+    }),
+  ),
+);
+
+// A connection- or spec-provided User-Agent must still win over the default.
+it.effect("lets a resolved User-Agent override the default", () =>
+  Effect.promise(() =>
+    withServer(async ({ baseUrl, headers }) => {
+      const operation = OperationBinding.make({
+        method: "get",
+        servers: [],
+        pathTemplate: "/ping",
+        requestBody: Option.none(),
+        responseBody: Option.none(),
+        parameters: [],
+      });
+
+      await Effect.runPromise(
+        invokeWithLayer(
+          operation,
+          {},
+          baseUrl,
+          { "User-Agent": "acme-app/2.0" },
+          {},
+          FetchHttpClient.layer,
+        ),
+      );
+
+      expect(headers[0]?.["user-agent"]).toBe("acme-app/2.0");
+    }),
+  ),
+);


### PR DESCRIPTION
## Problem

GitHub's REST/GraphQL API rejects any request that lacks a `User-Agent`
header with HTTP 403:

> Request forbidden by administrative rules. Please make sure your request
> has a User-Agent header.

The OpenAPI invoke path never set one, so calls to GitHub (and any other
upstream with the same requirement) failed. Worse, a 403 is classified as
`connection_rejected` / `category: authentication`, so the surfaced error
told users to re-authenticate or update their connection, even though the
token was valid. The same token works in `curl` precisely because `curl`
sets a default `User-Agent` and we did not.

This was the single largest source of upstream 403s in production.

## Fix

Set a default `User-Agent: executor` in the OpenAPI invoke path. It is
applied right after the request is built, before operation header params
and resolved auth headers, so a spec- or connection-provided `User-Agent`
still overrides it. This mirrors what the GraphQL plugin
(`User-Agent: executor-graphql`) and the integrations registry already do.

## Tests

`request-user-agent.test.ts` drives the real invoke path against a local
HTTP server and asserts the captured outbound request:

- carries the default `User-Agent` when nothing else sets one, and
- lets a resolved `User-Agent` override the default.

All 148 openapi package tests pass.

## Follow-ups (not in this PR)

- A 403 whose body is clearly not an auth failure should not be classified
  as `connection_rejected`; the real cause is currently only preserved in
  the nested `upstream.details`.
- A full e2e scenario driving a GitHub call through the live emulator and
  asserting the recorded request carried a `User-Agent`.