### PR TITLE
fix(oauth): redeem authorization codes at the provider's regional host

### DIFF
--- a/apps/cloud/drizzle/0007_red_dragon_lord.sql
+++ b/apps/cloud/drizzle/0007_red_dragon_lord.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "connection" ADD COLUMN "oauth_token_url" text;

--- a/apps/cloud/drizzle/meta/0007_snapshot.json
+++ b/apps/cloud/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1272 @@
+{
+  "id": "2f557ed1-5afc-431b-8623-2a2162793f43",
+  "prevId": "3beb97b9-a590-403f-88f5-8a67b499dcf4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memberships": {
+      "name": "memberships",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "memberships_account_id_accounts_id_fk": {
+          "name": "memberships_account_id_accounts_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "memberships_organization_id_organizations_id_fk": {
+          "name": "memberships_organization_id_organizations_id_fk",
+          "tableFrom": "memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "memberships_account_id_organization_id_pk": {
+          "name": "memberships_account_id_organization_id_pk",
+          "columns": ["account_id", "organization_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blob": {
+      "name": "blob",
+      "schema": "",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection": {
+      "name": "connection",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools_synced_at": {
+          "name": "tools_synced_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_token_url": {
+          "name": "oauth_token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.definition": {
+      "name": "definition",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration": {
+      "name": "integration",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_revised_at": {
+          "name": "config_revised_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_session": {
+      "name": "oauth_session",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugin_storage": {
+      "name": "plugin_storage",
+      "schema": "",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection": {
+          "name": "collection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "plugin_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "collection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.private_executor_cloud_settings": {
+      "name": "private_executor_cloud_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool": {
+      "name": "tool",
+      "schema": "",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tool_policy": {
+      "name": "tool_policy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": [
+            {
+              "expression": "tenant",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/cloud/drizzle/meta/_journal.json
+++ b/apps/cloud/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1781994790376,
       "tag": "0006_google_openapi_ownership",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1782149425764,
+      "tag": "0007_red_dragon_lord",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/cloud/src/db/executor-schema.ts
+++ b/apps/cloud/src/db/executor-schema.ts
@@ -48,6 +48,7 @@ export const connection = pgTable(
     refresh_item_id: text("refresh_item_id"),
     expires_at: bigint("expires_at", { mode: "bigint" }),
     oauth_scope: text("oauth_scope"),
+    oauth_token_url: text("oauth_token_url"),
     provider_state: json("provider_state"),
     created_at: timestamp("created_at").notNull(),
     updated_at: timestamp("updated_at").notNull(),

--- a/apps/local/drizzle/0002_empty_rictor.sql
+++ b/apps/local/drizzle/0002_empty_rictor.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `connection` ADD `oauth_token_url` text;

--- a/apps/local/drizzle/meta/0002_snapshot.json
+++ b/apps/local/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,913 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "03321915-aef6-4791-9558-7fc82273af05",
+  "prevId": "54e1d8db-e750-4675-9195-fbeb14a0ea5e",
+  "tables": {
+    "blob": {
+      "name": "blob",
+      "columns": {
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blob_id_uidx": {
+          "name": "blob_id_uidx",
+          "columns": ["id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "connection": {
+      "name": "connection",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_ids": {
+          "name": "item_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client": {
+          "name": "oauth_client",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_client_owner": {
+          "name": "oauth_client_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_item_id": {
+          "name": "refresh_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_scope": {
+          "name": "oauth_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "oauth_token_url": {
+          "name": "oauth_token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_state": {
+          "name": "provider_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "connection_uidx": {
+          "name": "connection_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "definition": {
+      "name": "definition",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schema": {
+          "name": "schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "definition_uidx": {
+          "name": "definition_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "connection", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "integration": {
+      "name": "integration",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "can_remove": {
+          "name": "can_remove",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "can_refresh": {
+          "name": "can_refresh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "integration_uidx": {
+          "name": "integration_uidx",
+          "columns": ["tenant", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_client": {
+      "name": "oauth_client",
+      "columns": {
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorization_url": {
+          "name": "authorization_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_url": {
+          "name": "token_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant": {
+          "name": "grant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_secret_item_id": {
+          "name": "client_secret_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_integration": {
+          "name": "origin_integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_client_uidx": {
+          "name": "oauth_client_uidx",
+          "columns": ["tenant", "owner", "subject", "slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "oauth_session": {
+      "name": "oauth_session",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_slug": {
+          "name": "client_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redirect_url": {
+          "name": "redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pkce_verifier": {
+          "name": "pkce_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "identity_label": {
+          "name": "identity_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "oauth_session_uidx": {
+          "name": "oauth_session_uidx",
+          "columns": ["tenant", "state"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_storage": {
+      "name": "plugin_storage",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "collection": {
+          "name": "collection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_storage_uidx": {
+          "name": "plugin_storage_uidx",
+          "columns": ["tenant", "owner", "subject", "plugin_id", "collection", "key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool": {
+      "name": "tool",
+      "columns": {
+        "integration": {
+          "name": "integration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connection": {
+          "name": "connection",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_schema": {
+          "name": "input_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_schema": {
+          "name": "output_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_uidx": {
+          "name": "tool_uidx",
+          "columns": ["tenant", "owner", "subject", "integration", "connection", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tool_policy": {
+      "name": "tool_policy",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern": {
+          "name": "pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_id": {
+          "name": "row_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tenant": {
+          "name": "tenant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tool_policy_uidx": {
+          "name": "tool_policy_uidx",
+          "columns": ["tenant", "owner", "subject", "id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/local/drizzle/meta/_journal.json
+++ b/apps/local/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780991784172,
       "tag": "0001_past_doctor_strange",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1782150869757,
+      "tag": "0002_empty_rictor",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/local/src/db/executor-schema.ts
+++ b/apps/local/src/db/executor-schema.ts
@@ -43,6 +43,7 @@ export const connection = sqliteTable(
     refresh_item_id: text("refresh_item_id"),
     expires_at: blob("expires_at"),
     oauth_scope: text("oauth_scope"),
+    oauth_token_url: text("oauth_token_url"),
     provider_state: text("provider_state"),
     created_at: integer("created_at").notNull(),
     updated_at: integer("updated_at").notNull(),

--- a/packages/core/api/src/handlers/oauth.ts
+++ b/packages/core/api/src/handlers/oauth.ts
@@ -171,6 +171,7 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
           const connection = yield* executor.oauth.complete({
             state: payload.state,
             code: payload.code,
+            callbackDomain: payload.callbackDomain ?? null,
           });
           return connectionToResponse(connection);
         }),
@@ -200,13 +201,14 @@ export const OAuthHandlers = HttpApiBuilder.group(ExecutorApi, "oauth", (handler
         Effect.gen(function* () {
           const executor = yield* ExecutorService;
           const html = yield* runOAuthCallback({
-            complete: ({ state, code }) =>
+            complete: ({ state, code, callbackDomain }) =>
               executor.oauth
                 .complete({
                   // `runOAuthCallback`'s `state` is a raw string from the URL;
                   // the SDK speaks the branded `OAuthState` (nominal brand).
                   state: OAuthState.make(state),
                   code: code ?? "",
+                  callbackDomain,
                 })
                 .pipe(
                   Effect.tapError((cause: unknown) =>

--- a/packages/core/api/src/oauth-popup.test.ts
+++ b/packages/core/api/src/oauth-popup.test.ts
@@ -174,8 +174,13 @@ describe("runOAuthCallback", () => {
     expect(html).toContain("s1");
   });
 
-  it("passes code and error through to the complete callback verbatim", async () => {
-    const received: Array<{ state: string; code: string | null; error: string | null }> = [];
+  it("passes code, error, and the regional domain through to the complete callback", async () => {
+    const received: Array<{
+      state: string;
+      code: string | null;
+      error: string | null;
+      callbackDomain: string | null;
+    }> = [];
     await Effect.runPromise(
       runOAuthCallback<GoogleAuth, never, never>({
         complete: (params) => {
@@ -186,17 +191,63 @@ describe("runOAuthCallback", () => {
             refreshTokenSecretId: null,
           });
         },
-        urlParams: { state: "s1", code: "code1", error: null },
+        // Multi-site providers (Datadog) echo the org's region back as `domain`,
+        // which `runOAuthCallback` surfaces as `callbackDomain`.
+        urlParams: { state: "s1", code: "code1", error: null, domain: "us5.datadoghq.com" },
         toErrorMessage: () => ({ short: "" }),
         channelName: "c",
       }),
     );
-    expect(received).toEqual([{ state: "s1", code: "code1", error: null }]);
+    expect(received).toEqual([
+      { state: "s1", code: "code1", error: null, callbackDomain: "us5.datadoghq.com" },
+    ]);
+  });
+
+  it("falls back to `site` for the regional domain and defaults to null", async () => {
+    const received: Array<{ callbackDomain: string | null }> = [];
+    const complete = (params: { callbackDomain: string | null }) => {
+      received.push(params);
+      return Effect.succeed({
+        kind: "oauth2" as const,
+        accessTokenSecretId: "s",
+        refreshTokenSecretId: null,
+      });
+    };
+    // `site` is the full-origin variant; used only when `domain` is absent.
+    await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete,
+        urlParams: { state: "s1", code: "c", site: "https://eu1.datadoghq.com" },
+        toErrorMessage: () => ({ short: "" }),
+        channelName: "c",
+      }),
+    );
+    // No region hints at all -> null (standard single-site providers).
+    await Effect.runPromise(
+      runOAuthCallback<GoogleAuth, never, never>({
+        complete,
+        urlParams: { state: "s2", code: "c" },
+        toErrorMessage: () => ({ short: "" }),
+        channelName: "c",
+      }),
+    );
+    expect(received[0]!.callbackDomain).toBe("https://eu1.datadoghq.com");
+    expect(received[1]!.callbackDomain).toBeNull();
   });
 
   it("prefers `error` over `error_description` but falls back when absent", async () => {
-    const received: Array<{ state: string; code: string | null; error: string | null }> = [];
-    const complete = (params: { state: string; code: string | null; error: string | null }) => {
+    const received: Array<{
+      state: string;
+      code: string | null;
+      error: string | null;
+      callbackDomain: string | null;
+    }> = [];
+    const complete = (params: {
+      state: string;
+      code: string | null;
+      error: string | null;
+      callbackDomain: string | null;
+    }) => {
       received.push(params);
       return Effect.succeed({
         kind: "oauth2" as const,

--- a/packages/core/api/src/oauth-popup.ts
+++ b/packages/core/api/src/oauth-popup.ts
@@ -129,6 +129,10 @@ export type OAuthCallbackUrlParams = {
   readonly code?: string | null;
   readonly error?: string | null;
   readonly error_description?: string | null;
+  /** Non-standard regional host hints (Datadog: `domain` bare host, `site`
+   *  full origin) used to redeem the code at the org's region. */
+  readonly domain?: string | null;
+  readonly site?: string | null;
 };
 
 /** Short summary + optional full technical detail. */
@@ -143,6 +147,7 @@ export type RunOAuthCallbackInput<TAuth, E, R> = {
     readonly state: string;
     readonly code: string | null;
     readonly error: string | null;
+    readonly callbackDomain: string | null;
   }) => Effect.Effect<TAuth, E, R>;
   readonly urlParams: OAuthCallbackUrlParams;
   /** Map a plugin-specific error into a short summary and optional details. */
@@ -166,6 +171,7 @@ export const runOAuthCallback = <TAuth, E, R>(
       state: input.urlParams.state,
       code: input.urlParams.code ?? null,
       error: input.urlParams.error ?? input.urlParams.error_description ?? null,
+      callbackDomain: input.urlParams.domain ?? input.urlParams.site ?? null,
     })
     .pipe(
       Effect.map(

--- a/packages/core/api/src/oauth/api.ts
+++ b/packages/core/api/src/oauth/api.ts
@@ -177,6 +177,9 @@ const StartResponse = Schema.Union([
 const CompletePayload = Schema.Struct({
   state: OAuthState,
   code: Schema.String,
+  /** Regional host echoed back by the authorization server (Datadog's
+   *  `domain`/`site`); forwarded so the code is redeemed at the org's region. */
+  callbackDomain: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
 // ---------------------------------------------------------------------------
@@ -219,6 +222,10 @@ const CallbackUrlParams = Schema.Struct({
   code: Schema.optional(Schema.String),
   error: Schema.optional(Schema.String),
   error_description: Schema.optional(Schema.String),
+  // Non-standard region hints (Datadog: `domain` is a bare host, `site` a full
+  // origin). Captured so the token exchange can target the org's region.
+  domain: Schema.optional(Schema.String),
+  site: Schema.optional(Schema.String),
 });
 
 const HtmlResponse = Schema.String.pipe(HttpApiSchema.asText());

--- a/packages/core/sdk/src/core-schema.ts
+++ b/packages/core/sdk/src/core-schema.ts
@@ -174,6 +174,11 @@ export const coreTables = defineTables({
       refresh_item_id: nullableTextColumn("refresh_item_id"),
       expires_at: nullableBigintColumn("expires_at"),
       oauth_scope: nullableTextColumn("oauth_scope"),
+      // Per-connection token endpoint override. Set only when the code was
+      // redeemed at a region other than the oauth_client's configured token host
+      // (multi-site providers like Datadog signal the org's region on the
+      // callback). Null means refresh uses the oauth_client's `token_url`.
+      oauth_token_url: nullableTextColumn("oauth_token_url"),
       provider_state: nullableJsonColumn("provider_state"),
       created_at: dateColumn("created_at"),
       updated_at: dateColumn("updated_at"),

--- a/packages/core/sdk/src/executor.ts
+++ b/packages/core/sdk/src/executor.ts
@@ -1432,6 +1432,13 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
           ? String(row.oauth_scope).split(/\s+/).filter(Boolean)
           : [];
 
+        // Refresh against the region the code was redeemed at when one was
+        // recorded at connect time (multi-site providers like Datadog), else
+        // the oauth_client's configured token endpoint.
+        const tokenUrl = row.oauth_token_url
+          ? String(row.oauth_token_url)
+          : String(clientRow.token_url);
+
         // client_credentials (machine-to-machine) has NO refresh token — the
         // token is RE-MINTED from the client id/secret. The authorization_code
         // path below needs a stored refresh token. Branching on grant here is
@@ -1440,7 +1447,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
         const token =
           String(clientRow.grant) === "client_credentials"
             ? yield* exchangeClientCredentials({
-                tokenUrl: String(clientRow.token_url),
+                tokenUrl,
                 clientId: String(clientRow.client_id),
                 clientSecret,
                 scopes: grantedScopes,
@@ -1469,7 +1476,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                   return yield* reauth("Stored refresh token could not be resolved.");
                 }
                 return yield* refreshAccessToken({
-                  tokenUrl: String(clientRow.token_url),
+                  tokenUrl,
                   clientId: String(clientRow.client_id),
                   clientSecret,
                   refreshToken,
@@ -2205,6 +2212,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               refresh_item_id: input.refreshItemId,
               expires_at: input.expiresAt,
               oauth_scope: input.oauthScope,
+              oauth_token_url: input.oauthTokenUrl ?? null,
               updated_at: now,
             };
             if (existing) {
@@ -2236,6 +2244,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
                 refresh_item_id: input.refreshItemId,
                 expires_at: input.expiresAt,
                 oauth_scope: input.oauthScope,
+                oauth_token_url: input.oauthTokenUrl ?? null,
                 provider_state: null,
                 created_at: now,
                 updated_at: now,
@@ -2269,6 +2278,7 @@ export const createExecutor = <const TPlugins extends readonly AnyPlugin[] = rea
               refresh_item_id: input.refreshItemId,
               expires_at: input.expiresAt,
               oauth_scope: input.oauthScope,
+              oauth_token_url: input.oauthTokenUrl ?? null,
               provider_state: null,
               created_at: now,
               updated_at: now,

--- a/packages/core/sdk/src/oauth-client.ts
+++ b/packages/core/sdk/src/oauth-client.ts
@@ -112,6 +112,11 @@ export interface OAuthStartInput {
 export interface OAuthCompleteInput {
   readonly state: OAuthState;
   readonly code: string;
+  /** Non-standard regional host the authorization server returns on the
+   *  callback (Datadog's `domain`/`site` params) so the code is redeemed at the
+   *  org's actual region rather than the statically advertised one. Used only
+   *  when it is a sibling subdomain of the client's configured token host. */
+  readonly callbackDomain?: string | null;
 }
 
 /** Probe a base/issuer URL for OAuth 2.1 authorization-server metadata so the

--- a/packages/core/sdk/src/oauth-flow.test.ts
+++ b/packages/core/sdk/src/oauth-flow.test.ts
@@ -56,6 +56,62 @@ const oauthPlugin = definePlugin(() => ({
 
 const plugins = [memoryCredentialsPlugin(), oauthPlugin] as const;
 
+interface TokenEndpointCall {
+  readonly host: string;
+  readonly grantType: string | null;
+}
+
+// Route token-endpoint requests aimed at a *non-loopback* host (the
+// regional/attacker hosts a multi-site rebind test exercises) back to the
+// loopback test AS, recording the host + grant each one was sent to. The token
+// exchange/refresh runs through `oauth4webapi`, which calls the global `fetch`
+// at request time, so swapping `globalThis.fetch` lets the real
+// `oauth.complete` / refresh path drive the rebind decision while still hitting
+// a live authorization server. Loopback traffic (the authorize/login hops)
+// passes straight through untouched. Returns a restore function.
+const routeTokenEndpointToLoopback = (
+  server: { readonly issuerUrl: string },
+  record: TokenEndpointCall[],
+): (() => void) => {
+  // oxlint-disable-next-line executor/no-raw-fetch -- test boundary: oauth4webapi reads the global `fetch` at call time, so doubling it is the only seam to observe the token exchange/refresh host.
+  const originalFetch = globalThis.fetch;
+  const loopback = new URL(server.issuerUrl);
+  const patched: typeof fetch = async (input, init) => {
+    const requestUrl =
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    const target = new URL(requestUrl);
+    if (target.hostname === loopback.hostname) {
+      return originalFetch(input as Parameters<typeof fetch>[0], init);
+    }
+    if (target.pathname === "/token") {
+      const bodyText =
+        init?.body instanceof URLSearchParams
+          ? init.body.toString()
+          : typeof init?.body === "string"
+            ? init.body
+            : input instanceof Request
+              ? await input.clone().text()
+              : "";
+      record.push({
+        host: target.hostname,
+        grantType: new URLSearchParams(bodyText).get("grant_type"),
+      });
+    }
+    const rerouted = new URL(loopback.origin);
+    rerouted.pathname = target.pathname;
+    rerouted.search = target.search;
+    return input instanceof Request
+      ? originalFetch(new Request(rerouted.href, input))
+      : originalFetch(rerouted.href, init);
+  };
+  // oxlint-disable-next-line executor/no-raw-fetch -- test boundary: install the doubled fetch (see above).
+  globalThis.fetch = patched;
+  return () => {
+    // oxlint-disable-next-line executor/no-raw-fetch -- test boundary: restore the original fetch.
+    globalThis.fetch = originalFetch;
+  };
+};
+
 describe("oauth.start / oauth.complete", () => {
   it.effect(
     "createClient → start (redirect) → complete mints a connection + tools, executable",
@@ -505,5 +561,168 @@ describe("oauth token refresh in resolveConnectionValue", () => {
           expect(yield* server.acceptsAccessToken(refreshedToken.token)).toBe(true);
         }),
       ),
+  );
+});
+
+// Multi-site providers (Datadog) statically advertise one region's token
+// endpoint but issue authorization codes redeemable only at the *regional* host
+// the org lives on, signalled by the callback's non-standard `domain`/`site`
+// param. The token endpoint host must rebind to that region for both the
+// initial exchange and later refreshes — but only when the callback host is a
+// trusted sibling subdomain, never an attacker-influenced arbitrary origin.
+describe("oauth.complete regional token-endpoint rebind (Datadog multi-site)", () => {
+  // Configured (statically advertised) host: the leftmost label differs from
+  // the org's region, but they share the `datadoghq.test` parent.
+  const ADVERTISED_TOKEN_URL = "https://app.datadoghq.test/token";
+
+  it.effect(
+    "redeems + refreshes at the callback's sibling-subdomain region, never the advertised host",
+    () =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+          const { executor, config } = yield* makeTestWorkspaceHarness({ plugins });
+          yield* executor.acme.seed();
+
+          // Reroute the https regional/advertised hosts back to the loopback test
+          // AS so the real exchange/refresh path drives the rebind decision while
+          // hitting a live server. Restored when the test scope closes.
+          const tokenCalls: TokenEndpointCall[] = [];
+          yield* Effect.acquireRelease(
+            Effect.sync(() => routeTokenEndpointToLoopback(server, tokenCalls)),
+            (restore) => Effect.sync(restore),
+          );
+
+          // Authorize on the loopback AS (passthrough), but advertise the US1-style
+          // token host the way Datadog's AS metadata does.
+          yield* executor.oauth.createClient({
+            owner: "org",
+            slug: CLIENT,
+            authorizationUrl: server.authorizationEndpoint,
+            tokenUrl: ADVERTISED_TOKEN_URL,
+            grant: "authorization_code",
+            clientId: "test-client",
+            clientSecret: "test-secret",
+            resource: server.mcpResourceUrl,
+          });
+
+          const started = yield* executor.oauth.start({
+            owner: "org",
+            client: CLIENT,
+            clientOwner: "org",
+            name: ConnectionName.make("main"),
+            integration: INTEG,
+            template: TEMPLATE,
+          });
+          expect(started.status).toBe("redirect");
+          if (started.status !== "redirect") return;
+          const callback = yield* server.completeAuthorizationCodeFlow({
+            authorizationUrl: started.authorizationUrl,
+          });
+
+          // The callback carries the org's actual region as a sibling subdomain.
+          yield* executor.oauth.complete({
+            state: started.state,
+            code: callback.code,
+            callbackDomain: "us5.datadoghq.test",
+          });
+
+          // The code was redeemed at the regional host, not the advertised one.
+          const exchangeCall = tokenCalls.find((c) => c.grantType === "authorization_code");
+          expect(exchangeCall?.host).toBe("us5.datadoghq.test");
+
+          // The regional token endpoint is persisted on the connection so later
+          // refreshes target the same region (the AS metadata still says US1).
+          const row = yield* Effect.promise(() =>
+            config.db.findFirst("connection", { where: (b) => b("name", "=", "main") }),
+          );
+          expect(row?.oauth_token_url).toBe("https://us5.datadoghq.test/token");
+
+          // Mint, then expire so the next resolve must refresh.
+          const firstToken = (yield* executor.execute(
+            ToolAddress.make("tools.acme.org.main.whoami"),
+            {},
+          )) as { token: string };
+          expect(firstToken.token).toMatch(/^at_/);
+          yield* Effect.promise(() =>
+            config.db.updateMany("connection", {
+              where: (b) => b("name", "=", "main"),
+              set: { expires_at: Date.now() - 60_000 },
+            }),
+          );
+          const refreshedToken = (yield* executor.execute(
+            ToolAddress.make("tools.acme.org.main.whoami"),
+            {},
+          )) as { token: string };
+          expect(refreshedToken.token).toMatch(/^at_/);
+          expect(refreshedToken.token).not.toBe(firstToken.token);
+
+          // The refresh hit the persisted region too …
+          const refreshCall = tokenCalls.find((c) => c.grantType === "refresh_token");
+          expect(refreshCall?.host).toBe("us5.datadoghq.test");
+          // … and the statically advertised host was never contacted.
+          expect(tokenCalls.some((c) => c.host === "app.datadoghq.test")).toBe(false);
+        }),
+      ),
+  );
+
+  it.effect("ignores a non-sibling callback domain — exchange stays on the advertised host", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const server = yield* serveOAuthTestServer({ scopes: ["read"] });
+        const { executor, config } = yield* makeTestWorkspaceHarness({ plugins });
+        yield* executor.acme.seed();
+
+        const tokenCalls: TokenEndpointCall[] = [];
+        yield* Effect.acquireRelease(
+          Effect.sync(() => routeTokenEndpointToLoopback(server, tokenCalls)),
+          (restore) => Effect.sync(restore),
+        );
+
+        yield* executor.oauth.createClient({
+          owner: "org",
+          slug: CLIENT,
+          authorizationUrl: server.authorizationEndpoint,
+          tokenUrl: ADVERTISED_TOKEN_URL,
+          grant: "authorization_code",
+          clientId: "test-client",
+          clientSecret: "test-secret",
+        });
+
+        const started = yield* executor.oauth.start({
+          owner: "org",
+          client: CLIENT,
+          clientOwner: "org",
+          name: ConnectionName.make("main"),
+          integration: INTEG,
+          template: TEMPLATE,
+        });
+        expect(started.status).toBe("redirect");
+        if (started.status !== "redirect") return;
+        const callback = yield* server.completeAuthorizationCodeFlow({
+          authorizationUrl: started.authorizationUrl,
+        });
+
+        // An attacker-influenced callback host that is NOT a sibling subdomain of
+        // the configured token host (`evil.example.test` vs `app.datadoghq.test`).
+        // The token request carries the client secret + code + PKCE verifier, so
+        // the rebind must refuse and fall back to the advertised host.
+        yield* executor.oauth.complete({
+          state: started.state,
+          code: callback.code,
+          callbackDomain: "evil.example.test",
+        });
+
+        const exchangeCall = tokenCalls.find((c) => c.grantType === "authorization_code");
+        expect(exchangeCall?.host).toBe("app.datadoghq.test");
+        expect(tokenCalls.some((c) => c.host === "evil.example.test")).toBe(false);
+
+        // Nothing regional was persisted: refresh keeps using the configured host.
+        const row = yield* Effect.promise(() =>
+          config.db.findFirst("connection", { where: (b) => b("name", "=", "main") }),
+        );
+        expect(row?.oauth_token_url ?? null).toBeNull();
+      }),
+    ),
   );
 });

--- a/packages/core/sdk/src/oauth-helpers.ts
+++ b/packages/core/sdk/src/oauth-helpers.ts
@@ -194,6 +194,76 @@ export const providerAuthorizeExtras = (
 };
 
 // ---------------------------------------------------------------------------
+// Regional token-endpoint rebind
+//
+// Some authorization servers publish a single static metadata document that
+// advertises one region's token endpoint, but issue authorization codes that
+// are only redeemable at the *regional* host the user's org actually lives on.
+// The region comes back on the callback as a non-standard `domain` (or `site`)
+// query param: Datadog returns `domain=us5.datadoghq.com` while its metadata
+// statically advertises `app.datadoghq.com`. Redeeming the code at the
+// advertised host then fails with `invalid_grant`.
+//
+// `rebindTokenEndpointHostToCallbackDomain` swaps ONLY the hostname of the
+// configured token URL to the callback-supplied host, and ONLY when that host
+// is a sibling subdomain of the configured one (same parent after stripping the
+// leftmost DNS label, e.g. `app.datadoghq.com` and `us5.datadoghq.com` both
+// reduce to `datadoghq.com`). The token request carries the client secret, the
+// code, and the PKCE verifier, so an attacker-influenced `domain` must never be
+// able to point it at an arbitrary origin. Anything that fails the sibling
+// check, fails to parse, or isn't https falls back to the configured URL
+// unchanged.
+// ---------------------------------------------------------------------------
+
+const hostnameFromCallbackDomain = (callbackDomain: string): string | undefined => {
+  const trimmed = callbackDomain.trim();
+  if (trimmed.length === 0) return undefined;
+  // Datadog sends `domain` as a bare host and `site` as a full origin; accept
+  // either by tolerating an optional scheme, then taking only the hostname.
+  const candidate = trimmed.includes("://") ? trimmed : `https://${trimmed}`;
+  if (!URL.canParse(candidate)) return undefined;
+  const url = new URL(candidate);
+  // A legitimate regional host carries no port, credentials, or path.
+  if (url.port !== "" || url.username !== "" || url.password !== "") return undefined;
+  if (url.pathname !== "/" && url.pathname !== "") return undefined;
+  return url.hostname.toLowerCase();
+};
+
+/** Parent domain after stripping the leftmost DNS label, or `undefined` when
+ *  the host has no sibling space (a single label, or a parent that is a bare
+ *  TLD). `app.datadoghq.com` -> `datadoghq.com`; `foo.com` -> undefined. */
+const siblingParentDomainOf = (hostname: string): string | undefined => {
+  const labels = hostname.split(".");
+  if (labels.length < 3) return undefined;
+  const parent = labels.slice(1).join(".");
+  // Require the parent to itself be multi-label so a 2-label configured host
+  // can never rebind across an entire TLD (e.g. foo.com -> bar.com).
+  return parent.includes(".") ? parent : undefined;
+};
+
+export const rebindTokenEndpointHostToCallbackDomain = (
+  configuredTokenUrl: string,
+  callbackDomain: string | null | undefined,
+): string => {
+  if (!callbackDomain) return configuredTokenUrl;
+  if (!URL.canParse(configuredTokenUrl)) return configuredTokenUrl;
+  const configured = new URL(configuredTokenUrl);
+  if (configured.protocol !== "https:") return configuredTokenUrl;
+  const targetHost = hostnameFromCallbackDomain(callbackDomain);
+  if (!targetHost) return configuredTokenUrl;
+  const configuredHost = configured.hostname.toLowerCase();
+  if (targetHost === configuredHost) return configuredTokenUrl;
+  const configuredParent = siblingParentDomainOf(configuredHost);
+  const targetParent = siblingParentDomainOf(targetHost);
+  if (!configuredParent || !targetParent || configuredParent !== targetParent) {
+    return configuredTokenUrl;
+  }
+  const rebound = new URL(configuredTokenUrl);
+  rebound.hostname = targetHost;
+  return rebound.toString();
+};
+
+// ---------------------------------------------------------------------------
 // Error mapping — `oauth4webapi`'s `process*Response` failure shapes are
 // either a WWW-Authenticate challenge or an RFC 6749 §5.2 error body,
 // both exposed via `.error` / `.error_description`. Probing the envelope

--- a/packages/core/sdk/src/oauth-service.ts
+++ b/packages/core/sdk/src/oauth-service.ts
@@ -63,6 +63,7 @@ import {
   createPkceCodeVerifier,
   exchangeAuthorizationCode,
   exchangeClientCredentials,
+  rebindTokenEndpointHostToCallbackDomain,
   type OAuth2TokenResponse,
   type OAuthEndpointUrlPolicy,
 } from "./oauth-helpers";
@@ -87,6 +88,10 @@ export interface MintOAuthConnectionInput {
   readonly refreshItemId: string | null;
   readonly expiresAt: number | null;
   readonly oauthScope: string | null;
+  /** Per-connection override for the token endpoint, persisted only when the
+   *  code was redeemed at a region other than the client's configured token
+   *  host (Datadog multi-site). Null means refresh uses the client's token URL. */
+  readonly oauthTokenUrl?: string | null;
 }
 
 /** Everything the OAuth service needs from the executor: fuma access for the
@@ -688,6 +693,8 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
           token,
           requestedScopes,
           input.clientOwner,
+          // client_credentials has no callback, so no regional rebind applies.
+          null,
         ).pipe(
           Effect.mapError(
             (cause) =>
@@ -828,8 +835,18 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         });
       }
 
+      // Some authorization servers (Datadog) advertise one region's token
+      // endpoint in static metadata but issue codes that only redeem at the
+      // org's actual region, signalled back on the callback as `domain`/`site`.
+      // Rebind the token host to that region when it is a sibling subdomain of
+      // the configured host; otherwise this is a no-op.
+      const tokenUrl = rebindTokenEndpointHostToCallbackDomain(
+        client.tokenUrl,
+        input.callbackDomain,
+      );
+
       const token = yield* exchangeAuthorizationCode({
-        tokenUrl: client.tokenUrl,
+        tokenUrl,
         clientId: client.clientId,
         clientSecret: client.clientSecret,
         redirectUrl: session.redirectUrl,
@@ -862,6 +879,9 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         // on the session. Empty only for a corrupt/legacy session with no payload.
         session.requestedScopes ?? [],
         session.clientOwner,
+        // Persist the regional token endpoint ONLY when it differs from the
+        // client's configured one, so refresh redeems against the same region.
+        tokenUrl === client.tokenUrl ? null : tokenUrl,
       ).pipe(
         Effect.mapError(
           (cause) =>
@@ -897,6 +917,9 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
     requestedScopes: readonly string[],
     /** The owner of `client` — persisted so refresh loads it by explicit owner. */
     clientOwner: Owner,
+    /** Regional token endpoint override to persist when the code was redeemed
+     *  off the client's configured host; null to use the client's token URL. */
+    oauthTokenUrl: string | null,
   ): Effect.Effect<Connection, StorageFailure> =>
     Effect.gen(function* () {
       const provider = deps.defaultWritableProvider();
@@ -933,6 +956,7 @@ export const makeOAuthService = (deps: OAuthServiceDeps): OAuthService => {
         // non-resource scope from the token `scope` string, so preserve it when
         // the refresh token proves it was granted.
         oauthScope: recordedOAuthScope(token, requestedScopes),
+        oauthTokenUrl,
       });
     });
 


### PR DESCRIPTION
## Problem

Connecting a remote MCP server from a multi-site OAuth provider fails at token exchange with:

> `invalid_grant - Invalid authorization code or code verifier` (HTTP 400 from the advertised token endpoint)

Root cause: some authorization servers publish a single static metadata document that advertises **one** region's token endpoint, but issue authorization codes that are only redeemable at the region the user's org actually lives on. That region is returned on the OAuth callback as a non-standard `domain` (bare host) / `site` (full origin) query param. Redeeming the code at the statically advertised host then returns `invalid_grant`.

## Fix

- Thread the callback's regional host (`domain`/`site`) through the callback handler and `oauth.complete`.
- Rebind the token endpoint **hostname** to that region, but only when it is a **sibling subdomain** of the configured host: same parent domain after stripping the leftmost DNS label, https only, no port/credentials/path. The token request carries the client secret, the code, and the PKCE verifier, so an attacker-influenced callback host must never redirect it to an arbitrary origin. Anything that fails the sibling check, fails to parse, or is not https falls back to the configured URL unchanged.
- Persist the resolved regional endpoint per connection in a new nullable column `connection.oauth_token_url`, so later token **refreshes** redeem against the same region. Null means refresh uses the OAuth client's configured `token_url`.

## Schema

New nullable `connection.oauth_token_url text`:
- Cloud: generated migration `0007_red_dragon_lord.sql`.
- Self-host / Cloudflare / local: picked up by the boot-time nullable-column auto-ALTER.

## Tests

End-to-end in `oauth-flow.test.ts`, driving the real `oauth.complete` + refresh path against the loopback test authorization server (the token transport is doubled via the global `fetch` seam `oauth4webapi` reads at call time):

- **Positive (sibling subdomain):** the initial authorization-code exchange **and** a later refresh both hit the regional host; the advertised host is never contacted; the regional endpoint is persisted on the connection.
- **Negative (non-sibling host):** an attacker-style callback host is ignored, the exchange stays on the advertised host, and nothing regional is persisted.

## Gates

`format:check`, `lint`, `typecheck` all green; full `@executor-js/sdk` suite passes (345 tests).