### PR TITLE
Add changesets for v1.5.17 patch release

### DIFF
--- a/.changeset/cli-device-login.md
+++ b/.changeset/cli-device-login.md
@@ -1,0 +1,10 @@
+---
+"executor": patch
+---
+
+Add `executor login` (plus `logout` and `whoami`) for signing the CLI into a
+hosted or self-hosted Executor server using the OAuth 2.0 Device Authorization
+Grant (RFC 8628), instead of manually creating and pasting an API key. `login`
+prints a code and verification URL, opens the browser, and polls; afterwards the
+CLI authenticates with a bearer token. Works against both cloud (WorkOS) and
+self-host (Better Auth) servers.

--- a/.changeset/connections-list-lean-default.md
+++ b/.changeset/connections-list-lean-default.md
@@ -1,0 +1,8 @@
+---
+"executor": patch
+---
+
+`connections.list` now returns a lean summary by default, replacing the full
+`oauthScope` grant string (which can run to thousands of characters per
+connection) with an `oauthScopeCount`. Pass `verbose: true` to get the full
+grant back.

--- a/.changeset/execute-emitted-output-count.md
+++ b/.changeset/execute-emitted-output-count.md
@@ -1,0 +1,8 @@
+---
+"executor": patch
+---
+
+The execute result envelope now reports how many items a script sent to the user
+via `emit()`. A script that only emits (with no return value) is no longer
+indistinguishable from one that did nothing: the envelope includes an emitted
+count and a `(no return value; N items emitted to the user)` text preview.

--- a/.changeset/oauth-regional-token-host.md
+++ b/.changeset/oauth-regional-token-host.md
@@ -1,0 +1,8 @@
+---
+"executor": patch
+---
+
+Fix OAuth connect for providers that issue authorization codes redeemable only
+at a region-specific token host. Executor now redeems the code at the region
+returned on the callback rather than the statically advertised token endpoint,
+so connecting these providers no longer fails at the token-exchange step.

--- a/.changeset/openapi-default-user-agent.md
+++ b/.changeset/openapi-default-user-agent.md
@@ -1,0 +1,8 @@
+---
+"executor": patch
+---
+
+Send a default `executor` User-Agent on OpenAPI tool calls. Upstreams such as
+GitHub that reject requests without a User-Agent (HTTP 403) now succeed instead
+of surfacing the rejection as a credential error. A spec- or connection-provided
+User-Agent still takes precedence.


### PR DESCRIPTION
Queues a 1.5.17 patch release for the `executor` CLI and its fixed-version group. These changes merged to `main` after 1.5.16 without changesets, so nothing was queued for release; this adds the missing changelog entries.

Included in 1.5.17:

- **`executor login`**: device-flow (RFC 8628) CLI sign-in for hosted and self-hosted servers, plus `logout` / `whoami` (#1026)
- **OAuth**: redeem authorization codes at the provider's regional token host (#1075)
- **OpenAPI**: send a default `executor` User-Agent on upstream tool calls (#1071)
- **Execute envelope**: report the count of items a script sends via `emit()` (#1070)
- **connections.list**: lean default output, full `oauthScope` behind `verbose: true` (#1069)

Merging this opens the Version Packages PR; merging that publishes 1.5.17.