### PR TITLE
fix(selfhost): resolve libsql native package by build arch

### DIFF
--- a/apps/host-selfhost/scripts/package-runtime.ts
+++ b/apps/host-selfhost/scripts/package-runtime.ts
@@ -7,6 +7,34 @@ const out = join(root, ".selfhost-runtime");
 const serverOut = join(out, "apps/host-selfhost/dist-server");
 const requireFromSelfHost = createRequire(join(root, "apps/host-selfhost/package.json"));
 
+// libSQL ships its native addon as per-platform optional dependencies
+// (`@libsql/<os>-<arch>-<abi>`), and Bun installs only the one matching the
+// build platform. The self-host image is built for both linux/amd64 and
+// linux/arm64, so a hardcoded `@libsql/linux-x64-gnu` throws on the arm64 leg
+// (that package isn't installed there). Derive it from the current build
+// platform instead. Under buildx/QEMU `process.platform`/`process.arch` are the
+// emulated target's values; for local runs they are the host's. The build base
+// (oven/bun:1) and runtime (distroless cc-debian12) are both glibc, so linux
+// uses the `-gnu` binding; revisit if an Alpine/musl base is ever introduced.
+const libsqlNativePackage = (): string => {
+  const platformMap: Record<string, string> = {
+    "darwin-arm64": "darwin-arm64",
+    "darwin-x64": "darwin-x64",
+    "linux-arm64": "linux-arm64-gnu",
+    "linux-x64": "linux-x64-gnu",
+    "win32-x64": "win32-x64-msvc",
+  };
+  const key = `${process.platform}-${process.arch}`;
+  const target = platformMap[key];
+  if (!target) {
+    throw new Error(
+      `package-runtime: no @libsql native package mapped for ${key}. ` +
+        "Add it to the platform map in apps/host-selfhost/scripts/package-runtime.ts.",
+    );
+  }
+  return `@libsql/${target}`;
+};
+
 const externalPackages = [
   "quickjs-emscripten",
   "quickjs-emscripten-core",
@@ -15,7 +43,7 @@ const externalPackages = [
   "@jitl/quickjs-wasmfile-debug-sync",
   "@jitl/quickjs-wasmfile-release-asyncify",
   "@jitl/quickjs-wasmfile-debug-asyncify",
-  "@libsql/linux-x64-gnu",
+  libsqlNativePackage(),
 ] as const;
 
 const quickJsExternals = externalPackages.filter(


### PR DESCRIPTION
## Problem

`apps/host-selfhost/scripts/package-runtime.ts` hardcoded `@libsql/linux-x64-gnu` in its package copy list. `libsql` ships its native addon as per-platform optional dependencies (`@libsql/linux-x64-gnu`, `@libsql/linux-arm64-gnu`, ...) and Bun installs only the one matching the build platform.

The self-host Docker image is published for `linux/amd64,linux/arm64`. On the arm64 build leg, `@libsql/linux-x64-gnu` is not installed, so `require.resolve("@libsql/linux-x64-gnu/package.json")` throws `Cannot find module`, failing the `prod-deps` stage. Every published image so far predates the script, so this had not hit CI yet, but the next self-host publish would fail the arm64 build.

## Fix

Derive the libsql native package from `process.platform`/`process.arch` instead of hardcoding x64. Under buildx/QEMU these are the emulated target's values, so each build leg resolves the binding it actually has. This mirrors the existing `resolveLibsqlNative` idiom in `apps/cli/src/build.ts`, including the glibc to `-gnu` mapping. Unmapped platforms now throw a clear, actionable error instead of an opaque `require.resolve` failure.

The base image (`oven/bun:1`) and runtime (`distroless/cc-debian12`) are both glibc, so linux maps to `-gnu`; a comment flags revisiting this if an Alpine/musl base is ever introduced.

## Verification

- arm64 `prod-deps` build (the failing repro): now succeeds; runtime contains `@libsql/linux-arm64-gnu/index.node`.
- amd64 `prod-deps` build: no regression; copies `@libsql/linux-x64-gnu/index.node`.
- Single multi-arch `docker buildx build --platform linux/amd64,linux/arm64 --target prod-deps` (matching the publish workflow's platform matrix): both legs pass and a manifest list exports successfully.