### PR TITLE
Fix: accept WorkOS device-login tokens on the /api plane (wrong JWKS)

### DIFF
--- a/apps/cloud/src/api/protected-jwt-auth.node.test.ts
+++ b/apps/cloud/src/api/protected-jwt-auth.node.test.ts
@@ -19,7 +19,9 @@ const makeJwt = async () => {
   const { publicKey, privateKey } = await generateKeyPair("RS256");
   const jwk = await exportJWK(publicKey);
   const jwks = createLocalJWKSet({ keys: [{ ...jwk, kid: "test-key" }] });
-  const config: JwtBearerConfig = { jwks, issuer, audience };
+  // Device-login tokens are verified by signature alone (client-scoped SSO
+  // JWKS); issuer/audience are not pinned.
+  const config: JwtBearerConfig = { jwks };
   const sign = (claims: Record<string, unknown>, expiration: string | number = "5m") =>
     new SignJWT(claims)
       .setProtectedHeader({ alg: "RS256", kid: "test-key" })

--- a/apps/cloud/src/auth/api-jwt-bearer.ts
+++ b/apps/cloud/src/auth/api-jwt-bearer.ts
@@ -1,20 +1,20 @@
 // ---------------------------------------------------------------------------
-// The `/api/*` plane's WorkOS JWT bearer config.
+// The `/api/*` plane's WorkOS device-login (user_management) JWT bearer config.
 //
 // The protected HTTP API accepts THREE credential forms on the `Authorization`
-// header, in this precedence: a WorkOS access-token JWT (CLI device-login,
+// header, in this precedence: a WorkOS device-login access token (JWT, from
 // `executor login`), then a WorkOS API key, then, with no header, the
-// sealed-session cookie. This module supplies the JWT-verification config
-// (JWKS + issuer + audience) the JWT branch needs.
+// sealed-session cookie. This module supplies the JWKS the JWT branch verifies
+// against.
 //
-// It mirrors the MCP plane's setup (`mcp/auth.ts`): the SAME AuthKit JWKS,
-// issuer (`MCP_AUTHKIT_DOMAIN`), and audience (`WORKOS_CLIENT_ID`). A device
-// access token minted by AuthKit is byte-for-byte the same kind of token the
-// MCP plane already verifies, so a CLI can hold ONE credential for both planes.
-//
-// This is the `cloudflare:workers`-reading leaf; `workos-auth-provider.ts`
-// stays env-free and receives this config as a plain value, so its node-pool
-// resolver tests can inject a local JWKS instead.
+// CRITICAL: a device-login token is a WorkOS *user_management* access token,
+// signed by the SSO keyset served at `<workos-api>/sso/jwks/<clientId>` with NO
+// audience and a user_management issuer. That is a DIFFERENT key domain than the
+// MCP `/oauth2` tokens (verified via the AuthKit `/oauth2/jwks`): the device
+// token's key is not in the oauth2 JWKS, so we must verify it against the
+// client-scoped SSO JWKS instead (signature + expiry; see
+// `verifyWorkosUserManagementToken`). `WORKOS_API_URL` is api.workos.com in
+// production and the WorkOS emulator in tests.
 // ---------------------------------------------------------------------------
 
 import { env } from "cloudflare:workers";
@@ -22,14 +22,10 @@ import { env } from "cloudflare:workers";
 import { createCachedRemoteJWKSet } from "./jwks-cache";
 import type { JwtBearerConfig } from "./workos-auth-provider";
 
-const AUTHKIT_DOMAIN = env.MCP_AUTHKIT_DOMAIN ?? "https://signin.executor.sh";
+const WORKOS_API_BASE = (env.WORKOS_API_URL ?? "https://api.workos.com").replace(/\/+$/, "");
 
 // Module-scope cache, same rationale as `mcp/auth.ts`: one JWKS fetch per
-// isolate-hour rather than one per cold isolate. The two caches (here + MCP)
-// are independent module scopes hitting the same upstream; the 1h TTL keeps
-// the duplication cheap.
+// isolate-hour rather than one per cold isolate.
 export const workosApiJwtBearerConfig: JwtBearerConfig = {
-  jwks: createCachedRemoteJWKSet(new URL(`${AUTHKIT_DOMAIN}/oauth2/jwks`)),
-  issuer: AUTHKIT_DOMAIN,
-  audience: env.WORKOS_CLIENT_ID,
+  jwks: createCachedRemoteJWKSet(new URL(`${WORKOS_API_BASE}/sso/jwks/${env.WORKOS_CLIENT_ID}`)),
 };

--- a/apps/cloud/src/auth/workos-auth-provider.ts
+++ b/apps/cloud/src/auth/workos-auth-provider.ts
@@ -51,19 +51,19 @@ import { UserStoreService } from "./context";
 import { sealedSessionDisplayName } from "./middleware";
 import type { UserStoreError, WorkOSError } from "./errors";
 import { WorkOSClient } from "./workos";
-import { verifyWorkOSMcpAccessToken } from "../mcp/jwt";
+import { verifyWorkosUserManagementToken } from "../mcp/jwt";
 
 /**
- * The config the bearer-JWT branch needs to verify a WorkOS access token:
- * the AuthKit JWKS resolver plus the issuer + audience to assert. Passed in
- * as a plain value so this module stays `cloudflare:workers`-free and the
- * node-pool resolver tests can inject a local JWKS. Production supplies
- * {@link workosApiJwtBearerConfig} (built from `cloudflare:workers` env).
+ * The config the bearer-JWT branch needs to verify a WorkOS device-login
+ * (user_management) access token: the client-scoped SSO JWKS resolver. Issuer
+ * and audience are NOT pinned (the client-scoped JWKS binds the token to this
+ * app; user_management tokens carry no audience and an app-specific issuer) and
+ * org membership is re-checked live downstream. Passed in as a plain value so
+ * this module stays `cloudflare:workers`-free and the node-pool resolver tests
+ * can inject a local JWKS. Production supplies {@link workosApiJwtBearerConfig}.
  */
 export interface JwtBearerConfig {
   readonly jwks: JWTVerifyGetKey;
-  readonly issuer: string;
-  readonly audience: string;
 }
 
 // The exact machine codes + messages each rejected path has always emitted.
@@ -105,20 +105,17 @@ const NO_ORGANIZATION_IN_ACCESS_TOKEN = {
 const looksLikeJwt = (token: string): boolean => token.split(".").length === 3;
 
 /**
- * Resolve a WorkOS access-token JWT (CLI `executor login`) into a protected
- * `Principal`. Verifies the token against AuthKit's JWKS (issuer + audience),
- * then live-checks org membership, exactly like the api-key path. The
+ * Resolve a WorkOS device-login (user_management) access token into a protected
+ * `Principal`. Verifies the token's signature + expiry against the client-scoped
+ * SSO JWKS, then live-checks org membership, exactly like the api-key path. The
  * `org_id` claim must be present (a token with no org context is rejected as
- * `NoOrganization`). Mirrors the MCP plane's JWT verify, reusing the same
- * `cloudflare:workers`-free verifier so a CLI holds ONE credential for both
- * the `/api/*` and `/mcp` planes.
+ * `NoOrganization`). NOTE: this is a different WorkOS token domain than the MCP
+ * `/oauth2` tokens (different keyset, no audience), so it does NOT reuse the MCP
+ * verifier or its JWKS, audience, and issuer.
  */
 const resolveJwtPrincipal = (token: string, jwt: JwtBearerConfig) =>
   Effect.gen(function* () {
-    const verified = yield* verifyWorkOSMcpAccessToken(token, jwt.jwks, {
-      issuer: jwt.issuer,
-      audience: jwt.audience,
-    }).pipe(
+    const verified = yield* verifyWorkosUserManagementToken(token, jwt.jwks).pipe(
       Effect.catchTag("McpJwtVerificationError", (error) =>
         Effect.fail(
           error.reason === "system"

--- a/apps/cloud/src/mcp/jwt.ts
+++ b/apps/cloud/src/mcp/jwt.ts
@@ -123,3 +123,25 @@ export const verifyWorkOSMcpAccessToken = (
     });
     return verified;
   });
+
+// Verify a WorkOS user_management access token (the CLI `executor login` device
+// flow). Unlike the MCP /oauth2 tokens, these are signed by the SSO keyset
+// (`/sso/jwks/<clientId>`), carry NO audience, and their issuer is the
+// AuthKit user_management URL (which varies by app), so we don't pin issuer or
+// audience: the client-scoped JWKS already binds the token to this application,
+// and live org-membership is re-checked downstream. Signature + expiry are
+// enforced by jose.
+export const verifyWorkosUserManagementToken = (token: string, jwks: JWTVerifyGetKey) =>
+  Effect.gen(function* () {
+    const { payload } = yield* Effect.tryPromise({
+      try: () => jwtVerify(token, jwks),
+      catch: classifyJwtVerificationError,
+    }).pipe(withJwtVerificationSpan);
+
+    if (!payload.sub) return null;
+
+    return {
+      accountId: payload.sub,
+      organizationId: (payload.org_id as string | undefined) ?? null,
+    } satisfies VerifiedToken;
+  });


### PR DESCRIPTION
## The bug

`executor login` against production cloud succeeds (login + `whoami` work), but every authenticated `/api` call returns `401 {"code":"invalid_access_token"}`. Found by a real login to `executor.sh`.

A device-login token is a WorkOS **user_management** access token:
- signed by the **SSO keyset** (`<workos-api>/sso/jwks/<client_id>`, `kid: sso_oidc_key_pair_…`)
- **no `aud`**, issuer `https://<authkit>/user_management/<client_id>`

But the `/api` JWT branch reused the **MCP `/oauth2`** verification config:
- JWKS `<authkit>/oauth2/jwks` — which does **not contain the device token's key** (verified: returns `kids: []` for it),
- pinned issuer to `MCP_AUTHKIT_DOMAIN`, and
- required `aud == WORKOS_CLIENT_ID`.

Three mismatches, any one fatal. (Corollary: these are different WorkOS token domains, so the token was never "one credential for both planes.")

## The fix

Verify device-login (user_management) tokens against the **client-scoped SSO JWKS** (`<workos-api>/sso/jwks/<client_id>`) by **signature + expiry only** — no issuer/audience pin (the client-scoped keyset binds the token to this app; live org-membership is still re-checked downstream). New `verifyWorkosUserManagementToken`; `JwtBearerConfig` reduces to `{ jwks }`.

## Why the existing e2e didn't catch it

The WorkOS emulator signed *all* tokens with one keypair served at both JWKS surfaces, so a user_management token "verified" against the oauth2 JWKS — impossible on real WorkOS. The emulate fork now splits the `sso` vs `oauth2` keysets so the e2e reproduces the real shape and guards this regression (that change ships via the `@executor-js/emulate` fork; the e2e in this repo passes either way since the SSO JWKS holds the device key).

## Status
- Found against real WorkOS; **production still runs the old verifier**, so this needs to deploy for live `executor.sh` device-login API calls to work.
- typecheck/lint/format green; cloud auth unit tests + the device-login and MCP e2e pass.
