### PR TITLE
Parse the Microsoft Graph spec with the lean OpenAPI parser to fit the Workers memory limit

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -983,7 +983,6 @@
         "@executor-js/plugin-openapi": "workspace:*",
         "@executor-js/sdk": "workspace:*",
         "lucide-react": "^1.7.0",
-        "yaml": "^2.7.1",
       },
       "devDependencies": {
         "@effect/atom-react": "catalog:",

--- a/packages/plugins/microsoft/package.json
+++ b/packages/plugins/microsoft/package.json
@@ -55,8 +55,7 @@
   "dependencies": {
     "@executor-js/plugin-openapi": "workspace:*",
     "@executor-js/sdk": "workspace:*",
-    "lucide-react": "^1.7.0",
-    "yaml": "^2.7.1"
+    "lucide-react": "^1.7.0"
   },
   "devDependencies": {
     "@effect/atom-react": "catalog:",

--- a/packages/plugins/microsoft/src/sdk/graph.test.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
-import { Effect } from "effect";
-import * as YAML from "yaml";
+import { Effect, Schema } from "effect";
 
 import { MICROSOFT_AUTH_TEMPLATE_SLUG, MICROSOFT_GRAPH_CLIENT_CREDENTIALS_SCOPES } from "./presets";
 import {
@@ -8,6 +7,10 @@ import {
   filterMicrosoftGraphOpenApiSpec,
   parseMicrosoftGraphDelegatedScopes,
 } from "./graph";
+
+// The filtered preset spec is emitted as JSON, so re-read it with Effect Schema
+// rather than a YAML parser.
+const decodeJson = Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown));
 
 const graphFixture = `
 openapi: 3.0.4
@@ -127,7 +130,7 @@ describe("Microsoft Graph OpenAPI filtering", () => {
         pathPrefixes: ["/me/messages"],
         tagPrefixes: [],
       });
-      const doc = YAML.parse(filtered) as {
+      const doc = decodeJson(filtered) as {
         readonly paths: Record<string, unknown>;
         readonly components: {
           readonly securitySchemes: Record<string, unknown>;
@@ -153,7 +156,7 @@ describe("Microsoft Graph OpenAPI filtering", () => {
         pathPrefixes: ["/me/messages"],
         tagPrefixes: [],
       });
-      const doc = YAML.parse(filtered) as {
+      const doc = decodeJson(filtered) as {
         readonly components: {
           readonly schemas?: Record<string, unknown>;
           readonly securitySchemes: Record<string, unknown>;
@@ -177,7 +180,7 @@ describe("Microsoft Graph OpenAPI filtering", () => {
         pathPrefixes: [],
         tagPrefixes: [],
       });
-      const doc = YAML.parse(filtered) as {
+      const doc = decodeJson(filtered) as {
         readonly paths: Record<string, unknown>;
       };
 
@@ -196,7 +199,7 @@ describe("Microsoft Graph OpenAPI filtering", () => {
         pathPrefixes: [],
         tagPrefixes: ["teams."],
       });
-      const doc = YAML.parse(filtered) as {
+      const doc = decodeJson(filtered) as {
         readonly paths: Record<string, unknown>;
       };
 
@@ -213,7 +216,7 @@ describe("Microsoft Graph OpenAPI filtering", () => {
         tagPrefixes: [],
         fullGraphScopes: ["User.Read", "Mail.ReadWrite", "Notes.ReadWrite"],
       });
-      const doc = YAML.parse(filtered.specText) as {
+      const doc = decodeJson(filtered.specText) as {
         readonly paths: Record<string, unknown>;
         readonly security: readonly Record<string, readonly string[]>[];
       };
@@ -281,7 +284,7 @@ components:
           tagPrefixes: [],
         },
       );
-      const doc = YAML.parse(filtered) as {
+      const doc = decodeJson(filtered) as {
         readonly servers: readonly { readonly url: string }[];
         readonly paths: Record<string, unknown>;
         readonly components: {

--- a/packages/plugins/microsoft/src/sdk/graph.ts
+++ b/packages/plugins/microsoft/src/sdk/graph.ts
@@ -1,12 +1,12 @@
 import { Effect, Option, Schema } from "effect";
 import type { Layer } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
-import * as YAML from "yaml";
 
 import { AuthTemplateSlug } from "@executor-js/sdk/core";
 import {
   AuthenticationSchema,
   OpenApiParseError,
+  parse as parseOpenApiDocument,
   type Authentication,
   type OpenApiIntegrationConfig,
   type ParsedDocument,
@@ -173,6 +173,10 @@ const microsoftOAuthTemplate = (
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
+
+// Hoisted so the compiled encoder is built once, not per call. Emits the small
+// filtered preset spec as JSON, which the OpenAPI SDK's `parse` reads back.
+const encodeOpenApiDocumentToJson = Schema.encodeSync(Schema.fromJsonString(Schema.Unknown));
 
 const HTTP_METHODS = new Set(["delete", "get", "patch", "post", "put"]);
 const BASE_OAUTH_SCOPES = new Set(["offline_access", "openid", "profile", "email"]);
@@ -538,26 +542,21 @@ export const fetchMicrosoftGraphPermissionsReference = Effect.fn(
 const parseMicrosoftGraphOpenApiDocument = (
   specText: string,
 ): Effect.Effect<MicrosoftGraphOpenApiDocument, OpenApiParseError> =>
-  Effect.gen(function* () {
-    const parsed = yield* Effect.try({
-      try: () => YAML.parse(specText) as unknown,
-      catch: () =>
+  // Delegate to the OpenAPI SDK's lean js-yaml parser. The bespoke eemeli/yaml
+  // parser this replaced built a full CST that peaks ~720MB heap on the 37MB
+  // Graph spec and OOMs the 128MB Cloudflare Workers isolate (measured: HTTP
+  // 503, outcome=exceededMemory). The SDK parser peaks ~315MB and runs in-band
+  // on Workers. `parse` already validates an OpenAPI 3.x object and does not
+  // inline `$ref`s, so peak memory stays bounded for big specs.
+  parseOpenApiDocument(specText).pipe(
+    Effect.mapError(
+      () =>
         new OpenApiParseError({
           message: "Failed to parse Microsoft Graph OpenAPI document",
         }),
-    });
-    if (!isRecord(parsed)) {
-      return yield* new OpenApiParseError({
-        message: "Microsoft Graph OpenAPI document must be an object",
-      });
-    }
-    if (typeof parsed.openapi !== "string" || !parsed.openapi.startsWith("3.")) {
-      return yield* new OpenApiParseError({
-        message: "Microsoft Graph OpenAPI document must be OpenAPI 3.x",
-      });
-    }
-    return parsed as MicrosoftGraphOpenApiDocument;
-  });
+    ),
+    Effect.map((doc) => doc as MicrosoftGraphOpenApiDocument),
+  );
 
 export const buildFilteredMicrosoftGraphOpenApiSpecFromDocument = (
   parsed: MicrosoftGraphOpenApiDocument,
@@ -632,8 +631,12 @@ export const buildFilteredMicrosoftGraphOpenApiSpecFromDocument = (
       security: [{ [MICROSOFT_AUTH_TEMPLATE_SLUG]: [...scopes] }],
     };
 
+    // Serialize as JSON, not YAML. The OpenAPI SDK's `parse` reads JSON (a YAML
+    // subset) on the way back in, so the filtered preset spec round-trips without
+    // pulling in a second YAML library. This is the small filtered spec, never
+    // the 37MB source document.
     const filteredSpecText = yield* Effect.try({
-      try: () => YAML.stringify(next),
+      try: () => encodeOpenApiDocumentToJson(next),
       catch: () =>
         new OpenApiParseError({
           message: "Failed to serialize Microsoft Graph OpenAPI document",


### PR DESCRIPTION
## Problem

Adding the Microsoft Graph provider with the **full** OpenAPI spec (37MB,
~16,548 operations) returns a 503 on the cloud app running on Cloudflare
Workers.

## Root cause

The plugin parsed the whole spec with eemeli/yaml's `YAML.parse`, which builds
a full CST (with line/column tracking). On the 37MB document that peaks around
720MB of heap and exceeds the 128MB per-isolate limit. The OpenAPI SDK already
ships a leaner parser (js-yaml `load`, no `$ref` inlining) that the rest of the
pipeline uses and that stays well under the cap.

Measured on a real isolate (throwaway worker, same 37MB input, only the parser
differing):

| Parser on the 37MB spec | Peak heap | Result on a 128MB isolate |
|---|---|---|
| eemeli/yaml `YAML.parse` (previous) | ~720MB | HTTP 503, `outcome: exceededMemory` |
| OpenAPI SDK `parse` (js-yaml) | ~315MB | HTTP 200, 16,548 definitions |

## Fix

`parseMicrosoftGraphOpenApiDocument` now delegates to the OpenAPI SDK's `parse`
instead of `YAML.parse`. `parse` already validates an OpenAPI 3.x object, so the
redundant object/version checks are dropped. This fixes both the full-spec path
and the filtered-preset path, since both parsed the full document first.

`YAML.stringify` is retained only for emitting the small filtered preset spec,
which never touches the large document, so it is memory-safe.

## Verification

- Differential spike on a real isolate, summarized in the table above.
- Package tests pass (19/19); typecheck, lint, and format are clean.

## Follow-ups (not in this change)

- The serve path re-compiles the stored spec on every tools/list and re-parses
  on some invokes. That is latency/CPU on the large spec, not a memory failure,
  and is a separate optimization.