### PR TITLE
fix(openapi): put the file-emit contract in file-returning tools' descriptions

### DIFF
--- a/e2e/scenarios/tool-descriptions.test.ts
+++ b/e2e/scenarios/tool-descriptions.test.ts
@@ -96,6 +96,30 @@ const ordersOpenApiSpec = (baseUrl: string): string =>
           },
         },
       },
+      "/orders/{orderId}/invoice": {
+        get: {
+          operationId: "getOrderInvoice",
+          summary: "Download an order invoice",
+          description: "Download the PDF invoice for an order.",
+          parameters: [
+            {
+              name: "orderId",
+              in: "path",
+              required: true,
+              description: "Unique order identifier (ULID).",
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "The invoice PDF.",
+              content: {
+                "application/pdf": { schema: { type: "string", format: "binary" } },
+              },
+            },
+          },
+        },
+      },
       "/orders": {
         post: {
           operationId: "createOrder",
@@ -302,7 +326,7 @@ scenario(
             authenticationTemplate: apiKeyTemplate,
           },
         });
-        expect(added.toolCount, "the OpenAPI fixture's operations became tools").toBe(2);
+        expect(added.toolCount, "the OpenAPI fixture's operations became tools").toBe(3);
 
         // Description set AT ADD (the add form's field) — no PATCH needed.
         yield* apiClient.graphql.addIntegration({
@@ -480,6 +504,31 @@ scenario(
         );
         expect(getOrder?.inputTypeScript, "input shape is compiled to TypeScript").toContain(
           "orderId",
+        );
+
+        // A file-returning operation carries the emit contract in its stored
+        // description, so it rides BOTH the catalog (tools.list / tools.search,
+        // the step a model always walks) and the schema view, without the
+        // model having to read the ToolFile output schema to discover emit().
+        const getInvoice = byName(openapiTools, "orders.getOrderInvoice");
+        expect(getInvoice?.listDescription, "the file tool keeps its own description").toContain(
+          "Download the PDF invoice for an order.",
+        );
+        expect(
+          getInvoice?.listDescription,
+          "the file tool's catalog description carries the emit contract",
+        ).toContain("emit(result.data)");
+        expect(
+          getInvoice?.schemaDescription,
+          "the file tool's schema description carries the emit contract",
+        ).toContain("emit(result.data)");
+        expect(
+          getInvoice?.outputTypeScript,
+          "the file tool's output is the ToolFile envelope",
+        ).toContain("ToolFile");
+        // Targeted, not blanket: a non-file tool's description stays clean.
+        expect(getOrder?.listDescription, "a non-file tool is untouched").not.toContain(
+          "emit(result.data)",
         );
 
         const orderQuery = byName(graphqlTools, "query.order");

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -183,6 +183,21 @@ const descriptionFor = (def: ToolDefinition): string => {
   );
 };
 
+/**
+ * Copyable contract appended to the stored description of any tool whose
+ * output is a ToolFile. Stored descriptions ride both `search` (the step a
+ * model always walks) and `describe.tool`, so baking the emit instruction
+ * here puts it in front of the agent before the first call, where the
+ * output schema alone (dropped from the hot list projection) cannot.
+ */
+const FILE_OUTPUT_HINT =
+  'Returns a ToolFile: the file bytes already decoded into { _tag: "ToolFile", mimeType, encoding, data, byteLength }. ' +
+  "To display or forward it, pass the result's data straight to emit(result.data). " +
+  "Do not rebuild the envelope or read upstream fields like size.";
+
+const withFileEmitHint = (description: string, returnsFile: boolean): string =>
+  returnsFile ? `${description}\n\n${FILE_OUTPUT_HINT}` : description;
+
 export interface CompiledOpenApiSpec {
   readonly definitions: readonly ToolDefinition[];
   readonly hoistedDefs: Record<string, unknown>;
@@ -218,21 +233,21 @@ export const compileOpenApiSpec = (
   });
 
 export const openApiToolDefsFromCompiled = (compiled: CompiledOpenApiSpec): readonly ToolDef[] =>
-  compiled.definitions.map(
-    (def): ToolDef => ({
+  compiled.definitions.map((def): ToolDef => {
+    const returnsFile = Option.match(def.operation.responseBody, {
+      onNone: () => false,
+      onSome: (responseBody) => Option.isSome(responseBody.fileHint),
+    });
+    return {
       name: ToolName.make(def.toolPath),
-      description: descriptionFor(def),
+      description: withFileEmitHint(descriptionFor(def), returnsFile),
       inputSchema: normalizeOpenApiRefs(Option.getOrUndefined(def.operation.inputSchema)),
-      outputSchema: Option.match(def.operation.responseBody, {
-        onNone: () => normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
-        onSome: (responseBody) =>
-          Option.isSome(responseBody.fileHint)
-            ? ToolFileJsonSchema
-            : normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
-      }),
+      outputSchema: returnsFile
+        ? ToolFileJsonSchema
+        : normalizeOpenApiRefs(Option.getOrUndefined(def.operation.outputSchema)),
       annotations: annotationsForOperation(def.operation.method, def.operation.pathTemplate),
-    }),
-  );
+    };
+  });
 
 export const openApiStoredOperationsFromCompiled = (
   integration: string,


### PR DESCRIPTION
## Problem

When an agent loads a file through a file-returning tool (e.g. a Gmail attachment, a PDF invoice), the correct move is to pass the result's `data` straight to `emit(result.data)`. The tool's output schema already declares the `ToolFile` envelope, so the contract was technically discoverable.

But the output schema is **dropped from the hot tool-list projection** for performance, so it never reaches the sandbox `search` step. `search` is the step a model always walks before its first call. So the model couldn't see the contract until it had already guessed wrong: a typical first attempt hand-rebuilds the envelope (reading a non-existent `size` field, double-converting base64), which silently renders nothing even though the emit "succeeded". The contract only showed up in `describe.tool`, which an agent often skips.

## Fix

Append a short, copyable emit instruction to the **stored description** of any OpenAPI operation whose response is a file. Stored descriptions ride both `search` (always walked) and `describe.tool`, so the contract is in front of the agent *before* the first call, with no new columns and no list-path cost. This is prevention (right on the first attempt), not recovery.

`openApiToolDefsFromCompiled` is the single producer of a file-returning tool's description, so the hint is computed once from the same `responseBody.fileHint` that already selects the `ToolFile` output schema. Non-file tools are untouched.

The appended text:

> Returns a ToolFile: the file bytes already decoded into `{ _tag: "ToolFile", mimeType, encoding, data, byteLength }`. To display or forward it, pass the result's data straight to `emit(result.data)`. Do not rebuild the envelope or read upstream fields like size.

## Coverage

Extends the `tool-descriptions` e2e scenario with a PDF-returning operation and asserts the hint appears in **both** the `tools.list` catalog entry and the `tools.schema` view, while a non-file tool's description stays clean. The scenario's `descriptions.md` artifact shows the hint riding the catalog description.

Verified on the selfhost target; openapi unit-level file-hint tests still green; format/lint/typecheck clean.