### PR TITLE
fix(core-tools): allow no-auth connections via connections.create

### DIFF
--- a/e2e/scenarios/no-auth-connection.test.ts
+++ b/e2e/scenarios/no-auth-connection.test.ts
@@ -1,0 +1,203 @@
+// The agentic no-auth wire-up: an agent registers a public REST API over MCP
+// and then creates its connection PROGRAMMATICALLY through the gateway core
+// tool — `coreTools.connections.create` with `template: "none"` and no
+// credential origin. This is the path that used to be impossible: the core
+// tool's arg schema demanded "exactly one provider credential origin", so an
+// agent wiring up a public, no-auth integration (public MCP server, public
+// REST API) was forced to bounce the user into the web UI via createHandoff,
+// even though the engine fully supports a zero-credential connection.
+//
+// This scenario walks the WHOLE path against a real public no-auth API (the
+// npm registry downloads endpoint, https://api.npmjs.org) so the proof is an
+// actual 200 over the wire, not a stub:
+//
+//   1. MCP `execute` → `openapi.addSpec` registers a tiny no-auth spec
+//      (no securitySchemes ⇒ the integration is no-auth)
+//   2. MCP `execute` → `coreTools.connections.create` with template "none"
+//      and NEITHER `from` NOR `inputs` — the call that used to fail validation
+//   3. The operation is now a callable tool: invoke it and read back a 200
+//      with the real download count
+//   4. Guard the relaxed-but-still-strict contract: a no-auth create that
+//      DOES carry an origin (here an empty `inputs: {}`) is still rejected
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import { openApiHttpPlugin } from "@executor-js/plugin-openapi/api";
+
+import { scenario } from "../src/scenario";
+import { Api, Mcp, Target } from "../src/services";
+import type { McpSession } from "../src/surfaces/mcp";
+
+const api = composePluginApi([openApiHttpPlugin()] as const);
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+// A real public, no-auth REST API. No `components.securitySchemes` and no
+// top-level `security`, so addSpec derives no auth method and the integration
+// is no-auth — exactly the shape a connection on `template: "none"` targets.
+const NPM_DOWNLOADS_SPEC = JSON.stringify({
+  openapi: "3.0.3",
+  info: { title: "npm Registry Downloads", version: "1.0.0" },
+  servers: [{ url: "https://api.npmjs.org" }],
+  paths: {
+    "/downloads/point/{period}/{package}": {
+      get: {
+        operationId: "getPackageDownloads",
+        summary: "Total downloads for a package over a fixed period",
+        parameters: [
+          { name: "period", in: "path", required: true, schema: { type: "string" } },
+          { name: "package", in: "path", required: true, schema: { type: "string" } },
+        ],
+        responses: {
+          "200": {
+            description: "Download counts for the package",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    downloads: { type: "number" },
+                    start: { type: "string" },
+                    end: { type: "string" },
+                    package: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+});
+
+const addSpecCode = (slug: string) => `
+const added = await tools.executor.openapi.addSpec({
+  spec: { kind: "blob", value: ${JSON.stringify(NPM_DOWNLOADS_SPEC)} },
+  slug: ${JSON.stringify(slug)},
+  baseUrl: "https://api.npmjs.org",
+});
+return added.ok ? { ok: true, slug: added.data.slug, toolCount: added.data.toolCount } : { ok: false, error: added.error };
+`;
+
+// THE call under test: a no-auth connection with no credential origin at all.
+const createNoAuthConnectionCode = (slug: string) => `
+const created = await tools.executor.coreTools.connections.create({
+  owner: "org",
+  name: "public",
+  integration: ${JSON.stringify(slug)},
+  template: "none",
+});
+return created.ok ? { ok: true, connection: created.data } : { ok: false, error: created.error };
+`;
+
+// The relaxed filter must still reject an origin on a no-auth create — an
+// empty `inputs: {}` is a (degenerate) origin and a credential the connection
+// can't hold, so it stays a validation failure.
+const createNoAuthWithEmptyInputsCode = (slug: string) => `
+const created = await tools.executor.coreTools.connections.create({
+  owner: "org",
+  name: "public-bad",
+  integration: ${JSON.stringify(slug)},
+  template: "none",
+  inputs: {},
+});
+return created.ok ? { ok: true, connection: created.data } : { ok: false, error: created.error };
+`;
+
+const invokeDownloadsCode = (slug: string) => `
+const found = await tools.search({ namespace: ${JSON.stringify(slug)}, query: "downloads", limit: 5 });
+const path = found.items[0]?.path;
+if (!path) return { ok: false, error: "no downloads tool found", items: found.items };
+let t = tools;
+for (const seg of path.split(".")) t = t[seg];
+const result = await t({ period: "last-week", package: "react" });
+return { ok: result.ok, path, data: result.ok ? result.data : result.error };
+`;
+
+const removeConnectionsCode = (slug: string) => `
+const list = await tools.executor.coreTools.connections.list({});
+const mine = (list.ok ? list.data.connections : []).filter((c) => c.integration === ${JSON.stringify(slug)});
+for (const c of mine) {
+  await tools.executor.coreTools.connections.remove({ owner: c.owner, integration: c.integration, name: c.name });
+}
+return { removed: mine.length };
+`;
+
+/** Run `execute`, auto-approving any policy-paused execution, and parse the
+ *  sandbox's JSON return value. */
+const executeJson = (session: McpSession, code: string) =>
+  Effect.gen(function* () {
+    let result = yield* session.call("execute", { code });
+    let guard = 0;
+    while (result.text.includes("executionId:") && guard < 10) {
+      result = yield* session.approvePaused(result.text);
+      guard += 1;
+    }
+    expect(result.ok, `execute completed (got: ${result.text.slice(0, 400)})`).toBe(true);
+    return JSON.parse(result.text) as Record<string, unknown>;
+  });
+
+scenario(
+  "Connections · an agent creates a no-auth connection over the core tool and the public API answers 200",
+  { timeout: 180_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const mcp = yield* Mcp;
+    const { client: makeApiClient } = yield* Api;
+
+    const integration = unique("npmdl");
+    const identity = yield* target.newIdentity();
+    const session = mcp.session(identity);
+    const client = yield* makeApiClient(api, identity);
+
+    yield* Effect.gen(function* () {
+      // 1. Register the public no-auth API over MCP.
+      const added = yield* executeJson(session, addSpecCode(integration));
+      expect(added.ok, `addSpec succeeded: ${JSON.stringify(added)}`).toBe(true);
+      expect(added.toolCount, "the spec's operation was extracted as a tool").toBe(1);
+
+      // 2. THE FIX: create the connection with template "none" and NO origin.
+      //    Pre-fix this failed arg validation with
+      //    "Expected exactly one provider credential origin".
+      const created = yield* executeJson(session, createNoAuthConnectionCode(integration));
+      expect(
+        created.ok,
+        `no-auth connection created via the core tool: ${JSON.stringify(created)}`,
+      ).toBe(true);
+      expect(
+        (created.connection as { template?: string } | undefined)?.template,
+        "the connection is saved on the no-auth template",
+      ).toBe("none");
+
+      // 3. The operation is a live tool: invoke it and read back a real 200.
+      const invoked = yield* executeJson(session, invokeDownloadsCode(integration));
+      expect(
+        invoked.ok,
+        `the no-auth operation answered over the wire: ${JSON.stringify(invoked)}`,
+      ).toBe(true);
+      const downloads = (invoked.data as { downloads?: number } | undefined)?.downloads;
+      expect(typeof downloads, "the public API returned a download count").toBe("number");
+      expect(downloads as number, "react has a non-zero weekly download count").toBeGreaterThan(0);
+
+      // 4. The relaxation is narrow: a no-auth create that carries an origin
+      //    (empty `inputs: {}`) is still rejected.
+      const rejected = yield* executeJson(session, createNoAuthWithEmptyInputsCode(integration));
+      expect(
+        rejected.ok,
+        `a no-auth create with an empty inputs origin is rejected: ${JSON.stringify(rejected)}`,
+      ).toBe(false);
+    }).pipe(
+      // Selfhost shares one workspace identity — leaked connections fail other
+      // scenarios' zero-state assertions, so drop everything this run made.
+      Effect.ensuring(
+        Effect.gen(function* () {
+          yield* session.call("execute", { code: removeConnectionsCode(integration) });
+          yield* client.openapi.removeSpec({ params: { slug: integration } });
+        }).pipe(Effect.ignore),
+      ),
+    );
+  }),
+);

--- a/packages/core/sdk/src/core-tools.ts
+++ b/packages/core/sdk/src/core-tools.ts
@@ -14,6 +14,7 @@ import {
   AuthTemplateSlug,
   ConnectionName,
   IntegrationSlug,
+  NO_AUTH_TEMPLATE,
   OAuthClientSlug,
   OAuthState,
   ProviderItemId,
@@ -134,7 +135,19 @@ const ConnectionCreateInput = Schema.Struct({
   Schema.makeFilter((payload) => {
     const originCount =
       (payload.from === undefined ? 0 : 1) + (payload.inputs === undefined ? 0 : 1);
-    if (originCount !== 1) return "Expected exactly one provider credential origin";
+    // The no-auth template ("none") binds zero credentials — both `from` and
+    // `inputs` are legitimately absent (public MCP servers, public REST APIs).
+    // Mirror the engine, which accepts an empty input set only for this
+    // template; a stray origin would wire a credential the connection can't
+    // hold, so reject any. Every other template needs exactly one origin.
+    const isNoAuth = String(payload.template) === String(NO_AUTH_TEMPLATE);
+    if (isNoAuth) {
+      if (originCount > 0) {
+        return 'A no-auth connection (template "none") takes no provider credential origin';
+      }
+    } else if (originCount !== 1) {
+      return "Expected exactly one provider credential origin";
+    }
     if (payload.inputs !== undefined && Object.keys(payload.inputs).length === 0) {
       return "Expected at least one provider credential input";
     }
@@ -500,7 +513,7 @@ export const coreToolsPlugin = definePlugin((options: CoreToolsPluginOptions = {
         tool({
           name: "connections.create",
           description:
-            "Low-level create or replace for a saved connection from provider item references. For normal API keys/tokens, use `connections.createHandoff` so the user enters the credential in the web UI. OAuth credentials should use `oauth.start`.",
+            'Low-level create or replace for a saved connection from provider item references. For a no-auth integration (public MCP server, public REST API), pass `template: "none"` with no `from`/`inputs` to wire it up directly. For normal API keys/tokens, use `connections.createHandoff` so the user enters the credential in the web UI. OAuth credentials should use `oauth.start`.',
           inputSchema: ConnectionCreateInputStd,
           outputSchema: ConnectionOutputStd,
           execute: (input: typeof ConnectionCreateInput.Type, { ctx }) =>


### PR DESCRIPTION
## What was broken

`coreTools.connections.create` could not create a no-auth connection (`template: "none"`). Its arg schema required exactly one credential origin (`from` or `inputs`), so a call with neither failed validation with *"Expected exactly one provider credential origin"*.

This blocked agents from programmatically wiring up public, no-auth integrations (public MCP servers, public REST APIs), forcing a bounce through the web UI via `createHandoff`, even though the engine already supports zero-credential connections.

## The fix

Relax the `ConnectionCreateInput` filter to mirror the engine: the no-auth template accepts zero origins (and rejects any origin); every other template still requires exactly one. The "inputs, if present, must be non-empty" rule is kept. The `connections.create` tool description now documents the no-auth path.

Validation matrix:

| template | origins | result |
| --- | --- | --- |
| `none` | 0 | accepted |
| `none` | `inputs: {}` (or any) | rejected |
| other | 1 | accepted |
| other | 0 | rejected |
| any | 2 | rejected |

## Proof

New e2e scenario `e2e/scenarios/no-auth-connection.test.ts`, green against the selfhost target. It drives the real gateway surface (MCP `execute`) against a real public no-auth API (`api.npmjs.org`):

1. `openapi.addSpec` registers a tiny no-auth spec, `toolCount === 1`
2. `coreTools.connections.create` with `template:"none"` and no origin succeeds, connection saved with `template === "none"` (the call that used to fail)
3. invokes the resulting tool and reads back a real numeric download count > 0 over the wire (a genuine 200, not a stub)
4. guards the still-strict contract: a no-auth create carrying an empty `inputs:{}` is rejected

```
✓ |selfhost| scenarios/no-auth-connection.test.ts ... 344ms
  Test Files  1 passed (1)   Tests  1 passed (1)
```

## Gates

- `typecheck`: pass
- SDK `vitest run`: 345 passed
- `oxlint` + `oxfmt --check` on touched files: clean