### PR TITLE
List a connection's tools from a full OpenAPI spec on Workers without re-parsing it

### DIFF
--- a/e2e/scenarios/microsoft-graph-full.test.ts
+++ b/e2e/scenarios/microsoft-graph-full.test.ts
@@ -1,0 +1,122 @@
+import { randomBytes } from "node:crypto";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { composePluginApi } from "@executor-js/api/server";
+import {
+  MICROSOFT_AUTH_TEMPLATE_SLUG,
+  MICROSOFT_GRAPH_ALL_PRESET_IDS,
+  MICROSOFT_GRAPH_DELEGATED_DEFAULT_SCOPES,
+} from "@executor-js/plugin-microsoft";
+import { microsoftHttpPlugin } from "@executor-js/plugin-microsoft/api";
+import { AuthTemplateSlug, ConnectionName, IntegrationSlug } from "@executor-js/sdk/shared";
+
+import { scenario } from "../src/scenario";
+import { Api, Target } from "../src/services";
+
+const api = composePluginApi([microsoftHttpPlugin()] as const);
+
+type ToolView = {
+  readonly name: string;
+};
+
+const unique = (prefix: string) => `${prefix}_${randomBytes(4).toString("hex")}`;
+
+// Adding *every* Graph workload pulls the full Microsoft Graph OpenAPI document
+// (~37MB, ~16.5k operations) and persists a binding per operation. That whole-
+// document path used to 503 on the Cloudflare worker: parsing the spec, and
+// then re-parsing it on every tools/list, each rebuilt a ~300MB JS tree that
+// blew the 128MB isolate. This scenario is the regression guard for both sites
+// at real scale: the add streams the compile + persist, and tools/list serves
+// the catalog back from the persisted bindings (+ the content-addressed defs
+// blob) without ever re-parsing the spec. It drives only the public API, so a
+// green run is evidence the full catalog lands and serves end to end.
+scenario(
+  "Microsoft Graph: the full catalog adds and serves without re-parsing the spec",
+  { timeout: 300_000 },
+  Effect.gen(function* () {
+    const target = yield* Target;
+    const { client: makeApiClient } = yield* Api;
+    const identity = yield* target.newIdentity();
+    const client = yield* makeApiClient(api, identity);
+
+    const integration = unique("msgraph_full");
+    const connection = ConnectionName.make("main");
+
+    yield* Effect.ensuring(
+      Effect.gen(function* () {
+        // Add path (1st former OOM site): the full spec is fetched and
+        // stream-compiled into one persisted binding per operation.
+        const added = yield* client.microsoft.addGraph({
+          payload: {
+            presetIds: [...MICROSOFT_GRAPH_ALL_PRESET_IDS],
+            customScopes: [],
+            slug: integration,
+            name: "Microsoft Graph (full)",
+          },
+        });
+        expect(added.slug, "the full Graph source keeps the requested slug").toBe(integration);
+        expect(
+          added.toolCount,
+          "adding every Graph workload extracts the whole catalog (thousands of operations)",
+        ).toBeGreaterThan(5_000);
+
+        const config = yield* client.microsoft.getConfig({ params: { slug: integration } });
+        expect(config?.microsoftGraphPresetIds, "every Graph workload preset is persisted").toEqual(
+          [...MICROSOFT_GRAPH_ALL_PRESET_IDS],
+        );
+        expect(
+          config?.microsoftGraphCoversFullGraph,
+          "selecting every workload is recognized as full Graph",
+        ).toBe(true);
+        expect(
+          config?.microsoftGraphScopes,
+          "full Graph delegates the app-registration default scope set",
+        ).toEqual([...MICROSOFT_GRAPH_DELEGATED_DEFAULT_SCOPES]);
+
+        yield* client.connections.create({
+          payload: {
+            owner: "org",
+            name: connection,
+            integration: IntegrationSlug.make(integration),
+            template: AuthTemplateSlug.make(MICROSOFT_AUTH_TEMPLATE_SLUG),
+            value: "token-xyz",
+          },
+        });
+
+        // Serve path (2nd former OOM site): tools/list rebuilds the catalog from
+        // the persisted bindings. The whole catalog must come back, with real
+        // descriptions, and without re-parsing the 37MB spec.
+        const tools = yield* client.tools.list({
+          query: { integration: IntegrationSlug.make(integration), connection },
+        });
+        expect(
+          tools.length,
+          "the served catalog returns the whole set of operations, not a re-parse failure",
+        ).toBeGreaterThan(5_000);
+
+        const names = tools.map((tool: ToolView) => tool.name);
+        const messageTools = names.filter((name) => name.toLowerCase().includes("message"));
+        const siteTools = names.filter((name) => name.toLowerCase().includes("site"));
+        const userTools = names.filter((name) => name.toLowerCase().includes("user"));
+        expect(messageTools, "the served catalog spans mail operations").not.toEqual([]);
+        expect(siteTools, "the served catalog spans SharePoint site operations").not.toEqual([]);
+        expect(userTools, "the served catalog spans directory user operations").not.toEqual([]);
+      }),
+      Effect.gen(function* () {
+        yield* client.connections
+          .remove({
+            params: {
+              owner: "org",
+              integration: IntegrationSlug.make(integration),
+              name: connection,
+            },
+          })
+          .pipe(Effect.ignore);
+        yield* client.microsoft
+          .removeGraph({ params: { slug: IntegrationSlug.make(integration) } })
+          .pipe(Effect.ignore);
+      }),
+    );
+  }),
+);

--- a/packages/plugins/google/src/sdk/plugin.ts
+++ b/packages/plugins/google/src/sdk/plugin.ts
@@ -143,6 +143,7 @@ const makeGooglePluginExtension = (
       };
 
       yield* ctx.storage.putSpec(specHash, conversion.specText);
+      yield* ctx.storage.putDefs(specHash, JSON.stringify(compiled.hoistedDefs));
 
       yield* ctx.transaction(
         Effect.gen(function* () {
@@ -183,6 +184,7 @@ const makeGooglePluginExtension = (
 
       const specHash = yield* sha256Hex(conversion.specText);
       yield* ctx.storage.putSpec(specHash, conversion.specText);
+      yield* ctx.storage.putDefs(specHash, JSON.stringify(compiled.hoistedDefs));
 
       const nextConfig: GoogleIntegrationConfig = {
         ...current,
@@ -298,7 +300,8 @@ export const googlePlugin = definePlugin((options?: GooglePluginOptions) => ({
   describeAuthMethods: describeGoogleAuthMethods,
   describeIntegrationDisplay: describeGoogleIntegrationDisplay,
 
-  resolveTools: ({ config, storage }) => resolveOpenApiBackedTools({ config, storage }),
+  resolveTools: ({ integration, config, storage }) =>
+    resolveOpenApiBackedTools({ integration, config, storage }),
 
   invokeTool: ({ ctx, toolRow, credential, args }) => {
     const httpClientLayer = options?.httpClientLayer ?? ctx.httpClientLayer;

--- a/packages/plugins/microsoft/src/sdk/plugin.test.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.test.ts
@@ -33,6 +33,7 @@ paths:
   /me:
     get:
       operationId: me.GetUser
+      summary: Get the signed-in user profile
       security:
         - azureAdDelegated:
             - User.Read
@@ -341,6 +342,45 @@ describe("Microsoft Graph provider", () => {
         expect(delegated?.kind === "oauth2" ? delegated.scopes : undefined).toEqual([
           ...MICROSOFT_GRAPH_DELEGATED_DEFAULT_SCOPES,
         ]);
+
+        // Full-graph add routes through the streaming `parsedDocument` persist
+        // branch (the path the real 37MB spec takes): it persists each op's
+        // binding plus a `description` and writes the content-addressed defs
+        // blob, never re-parsing on serve. Read the operations back through the
+        // live serve path to prove they landed in storage AND that the serve
+        // fast path rebuilds tools from the persisted bindings (no spec parse).
+        yield* executor.connections.create({
+          owner: "org",
+          name: ConnectionName.make("full"),
+          integration: IntegrationSlug.make("microsoft_graph_full"),
+          template: AuthTemplateSlug.make(MICROSOFT_AUTH_TEMPLATE_SLUG),
+          value: "token-xyz",
+        });
+
+        const tools = yield* executor.tools.list();
+        const toolNames = tools.map((tool) => String(tool.name));
+        expect(toolNames).toContain("me.getUser");
+        expect(toolNames).toContain("me.messagesListMessages");
+        expect(toolNames).toContain("sites.listSites");
+
+        // The serve fast path must rebuild every tool's description from the
+        // persisted operation, not drop it. Each graph tool carries a non-empty
+        // description.
+        for (const tool of tools) {
+          expect(tool.description.length).toBeGreaterThan(0);
+        }
+
+        // `me.getUser`'s spec summary survives the add -> persist -> serve
+        // round-trip. The bare `${METHOD} ${path}` fallback inside the serve
+        // path would be "GET /me", so matching the summary proves the persisted
+        // `description` field is what's served.
+        const getUser = tools.find((tool) => String(tool.name) === "me.getUser");
+        expect(getUser?.description).toBe("Get the signed-in user profile");
+
+        // An op without a spec summary falls back to `${METHOD} ${path}`, also
+        // sourced from the persisted binding on the serve fast path.
+        const listSites = tools.find((tool) => String(tool.name) === "sites.listSites");
+        expect(listSites?.description).toBe("GET /sites");
       }),
     ),
   );

--- a/packages/plugins/microsoft/src/sdk/plugin.ts
+++ b/packages/plugins/microsoft/src/sdk/plugin.ts
@@ -15,21 +15,25 @@ import {
   type IntegrationConfig,
   type IntegrationRecord,
   type PluginCtx,
+  type StorageFailure,
 } from "@executor-js/sdk/core";
 import { describeApiKeyAuthMethod } from "@executor-js/sdk/http-auth";
 import {
-  compileOpenApiDocument,
-  compileOpenApiSpec,
+  compileAndPersistOpenApiOperations,
+  compileAndPersistOpenApiSpec,
   decodeOpenApiIntegrationConfig,
   invokeOpenApiBackedTool,
   makeDefaultOpenapiStore,
   normalizeOpenApiAuthInputs,
-  openApiStoredOperationsFromCompiled,
+  OpenApiExtractionError,
+  OpenApiParseError,
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
   type Authentication,
   type AuthenticationInput,
+  type OpenApiPersistResult,
   type OpenapiStore,
+  type ParsedDocument,
 } from "@executor-js/plugin-openapi";
 
 import {
@@ -122,13 +126,31 @@ const makeMicrosoftPluginExtension = (
   ctx: PluginCtx<OpenapiStore>,
   httpClientLayer: Layer.Layer<HttpClient.HttpClient, never, never>,
 ) => {
+  const persistGraphOperations = (
+    graph: { readonly parsedDocument?: ParsedDocument; readonly specText: string },
+    integration: string,
+    specHash: string,
+  ): Effect.Effect<
+    OpenApiPersistResult,
+    OpenApiExtractionError | OpenApiParseError | StorageFailure
+  > =>
+    graph.parsedDocument !== undefined
+      ? compileAndPersistOpenApiOperations({
+          doc: graph.parsedDocument,
+          integration,
+          storage: ctx.storage,
+          specHash,
+        })
+      : compileAndPersistOpenApiSpec({
+          specText: graph.specText,
+          integration,
+          storage: ctx.storage,
+          specHash,
+        });
+
   const addGraph = (config: MicrosoftGraphConfig) =>
     Effect.gen(function* () {
       const graph = yield* buildMicrosoftGraphOpenApiSpec(config, httpClientLayer);
-      const compiled =
-        graph.parsedDocument !== undefined
-          ? yield* compileOpenApiDocument(graph.parsedDocument)
-          : yield* compileOpenApiSpec(graph.specText);
       const slug = IntegrationSlug.make(config.slug?.trim() || DEFAULT_MICROSOFT_SLUG);
 
       const existing = yield* ctx.core.integrations.get(slug);
@@ -156,7 +178,7 @@ const makeMicrosoftPluginExtension = (
 
       yield* ctx.storage.putSpec(specHash, graph.specText);
 
-      yield* ctx.transaction(
+      const persisted = yield* ctx.transaction(
         Effect.gen(function* () {
           yield* ctx.core.integrations.register({
             slug,
@@ -167,14 +189,11 @@ const makeMicrosoftPluginExtension = (
             canRemove: true,
             canRefresh: true,
           });
-          yield* ctx.storage.putOperations(
-            String(slug),
-            openApiStoredOperationsFromCompiled(String(slug), compiled),
-          );
+          return yield* persistGraphOperations(graph, String(slug), specHash);
         }),
       );
 
-      return { slug, toolCount: compiled.definitions.length };
+      return { slug, toolCount: persisted.toolCount };
     });
 
   const updateGraph = (rawSlug: string, input?: MicrosoftUpdateInput) =>
@@ -199,14 +218,8 @@ const makeMicrosoftPluginExtension = (
         },
         httpClientLayer,
       );
-      const compiled =
-        graph.parsedDocument !== undefined
-          ? yield* compileOpenApiDocument(graph.parsedDocument)
-          : yield* compileOpenApiSpec(graph.specText);
-
       const previousOperations = yield* ctx.storage.listOperations(rawSlug);
       const previousNames = new Set(previousOperations.map((op) => op.toolName));
-      const nextNames = new Set(compiled.definitions.map((def) => def.toolPath));
 
       const specHash = yield* sha256Hex(graph.specText);
       yield* ctx.storage.putSpec(specHash, graph.specText);
@@ -229,17 +242,15 @@ const makeMicrosoftPluginExtension = (
         ...(input?.baseUrl ? { baseUrl: input.baseUrl } : {}),
       };
 
-      yield* ctx.transaction(
+      const persisted = yield* ctx.transaction(
         Effect.gen(function* () {
           yield* ctx.core.integrations.update(slug, {
             config: nextConfig satisfies MicrosoftGraphIntegrationConfig as IntegrationConfig,
           });
-          yield* ctx.storage.putOperations(
-            rawSlug,
-            openApiStoredOperationsFromCompiled(rawSlug, compiled),
-          );
+          return yield* persistGraphOperations(graph, rawSlug, specHash);
         }),
       );
+      const nextNames = new Set(persisted.toolNames);
 
       const connections = yield* ctx.connections.list({ integration: slug });
       yield* Effect.forEach(
@@ -257,7 +268,7 @@ const makeMicrosoftPluginExtension = (
 
       return {
         slug,
-        toolCount: compiled.definitions.length,
+        toolCount: persisted.toolCount,
         addedTools: [...nextNames].filter((name) => !previousNames.has(name)).sort(),
         removedTools: [...previousNames].filter((name) => !nextNames.has(name)).sort(),
       };
@@ -340,7 +351,8 @@ export const microsoftPlugin = definePlugin((options?: MicrosoftPluginOptions) =
   describeAuthMethods: describeMicrosoftAuthMethods,
   describeIntegrationDisplay: describeMicrosoftIntegrationDisplay,
 
-  resolveTools: ({ config, storage }) => resolveOpenApiBackedTools({ config, storage }),
+  resolveTools: ({ integration, config, storage }) =>
+    resolveOpenApiBackedTools({ integration, config, storage }),
 
   invokeTool: ({ ctx, toolRow, credential, args }) => {
     const httpClientLayer = options?.httpClientLayer ?? ctx.httpClientLayer;

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -290,12 +290,22 @@ const decodeDefsJson = Schema.decodeUnknownOption(Schema.fromJsonString(DefsJson
 
 /** Rebuild a tool def from a stored operation binding, no spec parse. Mirrors
  *  `openApiToolDefsFromCompiled` but sources its schemas from the persisted
- *  binding (params/body/response carry `$ref`s into the shared defs blob). */
+ *  binding (params/body/response carry `$ref`s into the shared defs blob). The
+ *  file-emit hint is applied here, at the same ToolDef projection step the
+ *  re-parse path applies it, so a file-returning op carries the contract
+ *  whether it is served fast (from the binding) or via the spec fallback. */
 const toolDefFromStoredOperation = (op: StoredOperation): ToolDef => {
   const binding = op.binding;
+  const returnsFile = Option.match(binding.responseBody, {
+    onNone: () => false,
+    onSome: (responseBody) => Option.isSome(responseBody.fileHint),
+  });
   return {
     name: ToolName.make(op.toolName),
-    description: op.description ?? `${binding.method.toUpperCase()} ${binding.pathTemplate}`,
+    description: withFileEmitHint(
+      op.description ?? `${binding.method.toUpperCase()} ${binding.pathTemplate}`,
+      returnsFile,
+    ),
     inputSchema: normalizeOpenApiRefs(
       buildInputSchema(
         binding.parameters,
@@ -303,13 +313,13 @@ const toolDefFromStoredOperation = (op: StoredOperation): ToolDef => {
         binding.servers ?? [],
       ),
     ),
-    outputSchema: Option.match(binding.responseBody, {
-      onNone: () => undefined,
-      onSome: (responseBody) =>
-        Option.isSome(responseBody.fileHint)
-          ? ToolFileJsonSchema
-          : normalizeOpenApiRefs(Option.getOrUndefined(responseBody.schema)),
-    }),
+    outputSchema: returnsFile
+      ? ToolFileJsonSchema
+      : Option.match(binding.responseBody, {
+          onNone: () => undefined,
+          onSome: (responseBody) =>
+            normalizeOpenApiRefs(Option.getOrUndefined(responseBody.schema)),
+        }),
     annotations: annotationsForOperation(binding.method, binding.pathTemplate),
   };
 };

--- a/packages/plugins/openapi/src/sdk/backing.ts
+++ b/packages/plugins/openapi/src/sdk/backing.ts
@@ -21,7 +21,7 @@ import {
   type OpenApiIntegrationConfig,
 } from "./config";
 import { OpenApiExtractionError, OpenApiParseError } from "./errors";
-import { extract } from "./extract";
+import { buildInputSchema, extract, streamOperationBindings } from "./extract";
 import { compileToolDefinitions, type ToolDefinition } from "./definitions";
 import { annotationsForOperation, invokeWithLayer } from "./invoke";
 import { parse, type ParsedDocument } from "./parse";
@@ -257,7 +257,140 @@ export const openApiStoredOperationsFromCompiled = (
     integration,
     toolName: def.toolPath,
     binding: toBinding(def),
+    description: descriptionFor(def),
   }));
+
+/**
+ * Serialize a document's `components.schemas` into the content-addressed defs
+ * blob JSON (`{ "<Name>": <normalized schema>, ... }`), one schema at a time.
+ * Normalizing + stringifying per entry keeps the whole normalized definition
+ * tree from ever being co-resident with the parsed document, so the streaming
+ * add path's peak stays near parse level. The serve path JSON-parses this blob
+ * to rebuild the shared `definitions` instead of re-parsing the spec.
+ */
+export const buildDefsJson = (doc: ParsedDocument): string => {
+  const schemas = doc.components?.schemas;
+  if (!schemas) return "{}";
+  let json = "{";
+  let first = true;
+  for (const [name, schema] of Object.entries(schemas)) {
+    const serialized = JSON.stringify(normalizeOpenApiRefs(schema));
+    if (serialized === undefined) continue;
+    json += `${first ? "" : ","}${JSON.stringify(name)}:${serialized}`;
+    first = false;
+  }
+  return `${json}}`;
+};
+
+const DefsJson = Schema.Record(Schema.String, Schema.Unknown);
+/** Decode the content-addressed defs blob back into the shared `definitions`
+ *  map. Returns `None` on a corrupt/non-object blob so the serve path falls
+ *  back to the spec re-parse rather than failing `tools/list`. */
+const decodeDefsJson = Schema.decodeUnknownOption(Schema.fromJsonString(DefsJson));
+
+/** Rebuild a tool def from a stored operation binding, no spec parse. Mirrors
+ *  `openApiToolDefsFromCompiled` but sources its schemas from the persisted
+ *  binding (params/body/response carry `$ref`s into the shared defs blob). */
+const toolDefFromStoredOperation = (op: StoredOperation): ToolDef => {
+  const binding = op.binding;
+  return {
+    name: ToolName.make(op.toolName),
+    description: op.description ?? `${binding.method.toUpperCase()} ${binding.pathTemplate}`,
+    inputSchema: normalizeOpenApiRefs(
+      buildInputSchema(
+        binding.parameters,
+        Option.getOrUndefined(binding.requestBody),
+        binding.servers ?? [],
+      ),
+    ),
+    outputSchema: Option.match(binding.responseBody, {
+      onNone: () => undefined,
+      onSome: (responseBody) =>
+        Option.isSome(responseBody.fileHint)
+          ? ToolFileJsonSchema
+          : normalizeOpenApiRefs(Option.getOrUndefined(responseBody.schema)),
+    }),
+    annotations: annotationsForOperation(binding.method, binding.pathTemplate),
+  };
+};
+
+export interface OpenApiPersistResult {
+  readonly toolCount: number;
+  readonly toolNames: readonly string[];
+}
+
+/**
+ * Compile a parsed document straight to persisted operation bindings, streaming
+ * in bounded chunks so a huge spec's bindings are never all co-resident with
+ * the parsed tree. This is the memory-safe replacement for
+ * `compileOpenApiDocument` + `openApiStoredOperationsFromCompiled` + `putOperations`
+ * on the add/update path: it skips per-op input/output schema assembly (the
+ * serve path rebuilds those on demand from the bindings). Clears existing
+ * operations first, then appends each chunk. When `specHash` is given, also
+ * stream-serializes the document's `#/$defs/*` into the content-addressed defs
+ * blob so the serve path can resolve the shared `definitions` without
+ * re-parsing the spec.
+ */
+export const compileAndPersistOpenApiOperations = ({
+  doc,
+  integration,
+  storage,
+  specHash,
+  chunkSize,
+}: {
+  readonly doc: ParsedDocument;
+  readonly integration: string;
+  readonly storage: OpenapiStore;
+  readonly specHash?: string;
+  readonly chunkSize?: number;
+}): Effect.Effect<OpenApiPersistResult, OpenApiExtractionError | StorageFailure> =>
+  Effect.gen(function* () {
+    yield* storage.removeOperations(integration);
+    const result = yield* streamOperationBindings(doc, chunkSize ?? 500, (chunk) =>
+      storage.appendOperations(
+        integration,
+        chunk.map((item) => ({
+          integration,
+          toolName: item.toolName,
+          binding: item.binding,
+          description: item.description,
+        })),
+      ),
+    );
+    if (specHash != null) {
+      yield* storage.putDefs(specHash, buildDefsJson(doc));
+    }
+    return result;
+  });
+
+/** Parse spec text, then stream-compile + persist its bindings (and, when
+ *  `specHash` is given, the content-addressed defs blob). */
+export const compileAndPersistOpenApiSpec = ({
+  specText,
+  integration,
+  storage,
+  specHash,
+  chunkSize,
+}: {
+  readonly specText: string;
+  readonly integration: string;
+  readonly storage: OpenapiStore;
+  readonly specHash?: string;
+  readonly chunkSize?: number;
+}): Effect.Effect<
+  OpenApiPersistResult,
+  OpenApiParseError | OpenApiExtractionError | StorageFailure
+> =>
+  Effect.gen(function* () {
+    const doc = yield* parse(specText);
+    return yield* compileAndPersistOpenApiOperations({
+      doc,
+      integration,
+      storage,
+      specHash,
+      chunkSize,
+    });
+  });
 
 export const loadOpenApiSpecText = (
   storage: OpenapiStore,
@@ -265,16 +398,38 @@ export const loadOpenApiSpecText = (
 ): Effect.Effect<string | null, StorageFailure> =>
   config.specHash != null ? storage.getSpec(config.specHash) : Effect.succeed(null);
 
+/**
+ * Resolve the tool defs + shared definitions for a connection refresh
+ * (`tools/list`). Fast path: serve from the persisted operation bindings plus
+ * the content-addressed defs blob, rebuilding each tool's input/output schema
+ * on demand, so a 37MB spec is never re-parsed (the 2nd OOM site). The defs
+ * blob is global per `specHash`, so the heavy normalize work is done once at
+ * add time and shared across every tenant on the same spec. Falls back to the
+ * spec re-parse for legacy rows persisted before the defs blob existed (or if
+ * the blob is missing/corrupt).
+ */
 export const resolveOpenApiBackedTools = ({
+  integration,
   config,
   storage,
 }: {
+  readonly integration: { readonly slug: string };
   readonly config: unknown;
   readonly storage: OpenapiStore;
 }): Effect.Effect<ResolveToolsResult, StorageFailure> =>
   Effect.gen(function* () {
     const openApiConfig = decodeOpenApiIntegrationConfig(config);
     if (!openApiConfig) return { tools: [], definitions: {} };
+    if (openApiConfig.specHash != null) {
+      const defsJson = yield* storage.getDefs(openApiConfig.specHash);
+      if (defsJson != null) {
+        const definitions = Option.getOrNull(decodeDefsJson(defsJson));
+        if (definitions != null) {
+          const ops = yield* storage.listOperations(String(integration.slug));
+          return { tools: ops.map(toolDefFromStoredOperation), definitions };
+        }
+      }
+    }
     const specText = yield* loadOpenApiSpecText(storage, openApiConfig);
     if (specText == null) return { tools: [], definitions: {} };
     const compiled = yield* compileOpenApiSpec(specText).pipe(

--- a/packages/plugins/openapi/src/sdk/definitions.ts
+++ b/packages/plugins/openapi/src/sdk/definitions.ts
@@ -136,22 +136,44 @@ export interface ToolDefinition {
   readonly operation: ExtractedOperation;
 }
 
+/**
+ * The minimal per-operation metadata the tool-path planner needs. Kept
+ * deliberately light (no schemas) so the streaming compile path can plan paths
+ * for tens of thousands of operations without holding the full extracted
+ * operations in memory.
+ */
+export interface OperationPathInput {
+  readonly operationId: string;
+  readonly explicitToolPath: string | undefined;
+  readonly method: string;
+  readonly pathTemplate: string;
+  /** The first non-empty tag, used to seed the group segment. */
+  readonly tag0: string | undefined;
+}
+
+/** A resolved tool path plus its index back into the input operations array. */
+export interface PlannedToolPath {
+  readonly toolPath: string;
+  readonly group: string;
+  readonly leaf: string;
+  readonly operationIndex: number;
+}
+
 // ---------------------------------------------------------------------------
 // Collision resolution
 // ---------------------------------------------------------------------------
 
-const resolveCollisions = (
-  definitions: {
-    toolPath: string;
-    group: string;
-    leaf: string;
-    versionSegment: string | undefined;
-    method: string;
-    operationHash: string;
-    operationIndex: number;
-    operation: ExtractedOperation;
-  }[],
-): ToolDefinition[] => {
+interface RawToolPath {
+  toolPath: string;
+  group: string;
+  leaf: string;
+  versionSegment: string | undefined;
+  method: string;
+  operationHash: string;
+  operationIndex: number;
+}
+
+const resolveCollisions = (definitions: RawToolPath[]): PlannedToolPath[] => {
   // Mutable — we progressively refine toolPath on collision
   const staged = definitions.map((d) => ({ ...d }));
 
@@ -192,7 +214,6 @@ const resolveCollisions = (
     group: d.group,
     leaf: d.leaf,
     operationIndex: d.operationIndex,
-    operation: d.operation,
   }));
 };
 
@@ -214,46 +235,40 @@ const stableHash = (value: unknown): string => {
 // ---------------------------------------------------------------------------
 
 /**
- * Compile extracted operations into tool definitions with structured
- * `group.leaf` paths suitable for tree rendering.
+ * Plan structured `group.leaf` tool paths from lightweight per-operation
+ * metadata. Path derivation + collision resolution need a global view of every
+ * operation, but only its name/method/path/tag, never its schemas. Keeping this
+ * pass schema-free lets the streaming compile path plan paths for a 16k-op spec
+ * without materializing the full extracted operations.
+ *
+ * The returned `operationIndex` points back into the `inputs` array.
  */
-export const compileToolDefinitions = (
-  operations: readonly ExtractedOperation[],
-): ToolDefinition[] => {
-  const raw = operations.map((op, index) => {
+export const planToolPaths = (inputs: readonly OperationPathInput[]): PlannedToolPath[] => {
+  const raw: RawToolPath[] = inputs.map((op, index) => {
     const operationId = op.operationId;
-    const explicitToolPath = Option.getOrUndefined(op.toolPath);
-    if (explicitToolPath) {
-      const [group = "root", ...leafParts] = explicitToolPath.split(".").filter(Boolean);
-      const leaf = leafParts.join(".") || group;
-      const versionSegment = deriveVersionSegment(op.pathTemplate);
-      const operationHash = stableHash({
-        method: op.method,
-        path: op.pathTemplate,
-        operationId,
-      });
+    const operationHash = stableHash({
+      method: op.method,
+      path: op.pathTemplate,
+      operationId,
+    });
+    const versionSegment = deriveVersionSegment(op.pathTemplate);
 
+    if (op.explicitToolPath) {
+      const [group = "root", ...leafParts] = op.explicitToolPath.split(".").filter(Boolean);
+      const leaf = leafParts.join(".") || group;
       return {
-        toolPath: explicitToolPath,
+        toolPath: op.explicitToolPath,
         group,
         leaf,
         versionSegment,
         method: op.method,
         operationHash,
         operationIndex: index,
-        operation: op,
       };
     }
 
-    const group = normalizeGroupSegment(op.tags[0]) ?? derivePathGroup(op.pathTemplate);
+    const group = normalizeGroupSegment(op.tag0) ?? derivePathGroup(op.pathTemplate);
     const leaf = deriveLeaf(operationId, op.method, op.pathTemplate, group);
-    const versionSegment = deriveVersionSegment(op.pathTemplate);
-    const operationHash = stableHash({
-      method: op.method,
-      path: op.pathTemplate,
-      operationId,
-    });
-
     return {
       toolPath: `${group}.${leaf}`,
       group,
@@ -262,9 +277,35 @@ export const compileToolDefinitions = (
       method: op.method,
       operationHash,
       operationIndex: index,
-      operation: op,
     };
   });
 
   return resolveCollisions(raw).sort((a, b) => a.toolPath.localeCompare(b.toolPath));
+};
+
+/**
+ * Compile extracted operations into tool definitions with structured
+ * `group.leaf` paths suitable for tree rendering. Thin wrapper over
+ * `planToolPaths` that re-attaches each operation by index.
+ */
+export const compileToolDefinitions = (
+  operations: readonly ExtractedOperation[],
+): ToolDefinition[] => {
+  const plans = planToolPaths(
+    operations.map((op) => ({
+      operationId: op.operationId,
+      explicitToolPath: Option.getOrUndefined(op.toolPath),
+      method: op.method,
+      pathTemplate: op.pathTemplate,
+      tag0: op.tags[0],
+    })),
+  );
+
+  return plans.map((plan) => ({
+    toolPath: plan.toolPath,
+    group: plan.group,
+    leaf: plan.leaf,
+    operationIndex: plan.operationIndex,
+    operation: operations[plan.operationIndex]!,
+  }));
 };

--- a/packages/plugins/openapi/src/sdk/extract.ts
+++ b/packages/plugins/openapi/src/sdk/extract.ts
@@ -1,5 +1,6 @@
 import { Effect, Option } from "effect";
 
+import { planToolPaths, type OperationPathInput } from "./definitions";
 import { OpenApiExtractionError } from "./errors";
 import type { ParsedDocument } from "./parse";
 import {
@@ -19,6 +20,7 @@ import {
   ExtractionResult,
   type HttpMethod,
   MediaBinding,
+  OperationBinding,
   OperationFileHint,
   OperationId,
   OperationParameter,
@@ -299,7 +301,7 @@ const buildServerInputProperty = (
   };
 };
 
-const buildInputSchema = (
+export const buildInputSchema = (
   parameters: readonly OperationParameter[],
   requestBody: OperationRequestBody | undefined,
   servers: readonly ServerInfo[],
@@ -494,3 +496,129 @@ export const extract = Effect.fn("OpenApi.extract")(function* (doc: ParsedDocume
     operations,
   });
 });
+
+// ---------------------------------------------------------------------------
+// Streaming binding extraction
+// ---------------------------------------------------------------------------
+
+/** One persisted invocation binding plus the tool name and description it
+ *  backs. The description is the resolved operation description / summary /
+ *  method+path fallback, persisted so the serve path needs no re-parse. */
+export interface OperationBindingChunk {
+  readonly toolName: string;
+  readonly description: string;
+  readonly binding: OperationBinding;
+}
+
+interface OperationRef {
+  readonly pathItem: PathItemObject;
+  readonly operation: OperationObject;
+  readonly method: HttpMethod;
+  /** Resolved path template (`x-executor-pathTemplate` override or the key). */
+  readonly pathTemplate: string;
+}
+
+/**
+ * Stream invocation bindings out of a parsed document in bounded chunks,
+ * persisting each chunk via `onChunk` before building the next.
+ *
+ * This is the memory-safe compile path for huge specs (e.g. Microsoft Graph,
+ * 16.5k operations / 37MB). It differs from `extract` + `compileToolDefinitions`
+ * in two ways that keep peak memory at parse level rather than ~doubling it:
+ *
+ *   1. It never builds `hoistedDefs` or per-operation `inputSchema`/`outputSchema`
+ *      (the add path only needs invocation bindings, which carry `$ref`s, not
+ *      inlined schemas).
+ *   2. It never holds all bindings at once. Tool-path planning needs a global
+ *      view, but only of lightweight metadata (`planToolPaths`, schema-free);
+ *      the heavy per-operation bindings are built, flushed, and dropped one
+ *      chunk at a time.
+ *
+ * Bindings reference subtrees of the parsed document rather than copying them,
+ * so `onChunk` must sever those references (its storage layer JSON-serializes
+ * the binding) before the chunk is dropped. Returns the resolved tool names in
+ * sorted order, matching `compileToolDefinitions`.
+ */
+export const streamOperationBindings = <E, R>(
+  doc: ParsedDocument,
+  chunkSize: number,
+  onChunk: (chunk: readonly OperationBindingChunk[]) => Effect.Effect<void, E, R>,
+): Effect.Effect<
+  { readonly toolCount: number; readonly toolNames: readonly string[] },
+  OpenApiExtractionError | E,
+  R
+> =>
+  Effect.gen(function* () {
+    const paths = doc.paths;
+    if (!paths) {
+      return yield* new OpenApiExtractionError({
+        message: "OpenAPI document has no paths defined",
+      });
+    }
+
+    const r = new DocResolver(doc);
+    const docServers = extractServers(doc);
+
+    // Pass 1 (light): collect schema-free path metadata + a parallel array of
+    // references back into the tree. Both are small (no schemas copied).
+    const inputs: OperationPathInput[] = [];
+    const opRefs: OperationRef[] = [];
+    for (const [pathTemplate, pathItem] of Object.entries(paths).sort(([a], [b]) =>
+      a.localeCompare(b),
+    )) {
+      if (!pathItem) continue;
+      for (const method of HTTP_METHODS) {
+        const operation = pathItem[method];
+        if (!operation) continue;
+        const resolvedPathTemplate = explicitPathTemplate(operation) ?? pathTemplate;
+        const tags = (operation.tags ?? []).filter((t) => t.trim().length > 0);
+        inputs.push({
+          operationId: deriveOperationId(method, pathTemplate, operation),
+          explicitToolPath: explicitToolPath(operation),
+          method,
+          pathTemplate: resolvedPathTemplate,
+          tag0: tags[0],
+        });
+        opRefs.push({ pathItem, operation, method, pathTemplate: resolvedPathTemplate });
+      }
+    }
+
+    // Global, schema-free collision resolution + sort. Cheap relative to the
+    // parsed tree; returns plans sorted by toolPath with an index back into
+    // `opRefs`.
+    const plans = planToolPaths(inputs);
+
+    // Pass 2 (heavy, streamed): build a binding per operation, flush a chunk
+    // once it fills, then drop it. Bindings reference tree subtrees; `onChunk`
+    // serializes them, so peak stays at parse level.
+    let chunk: OperationBindingChunk[] = [];
+    for (const plan of plans) {
+      const ref = opRefs[plan.operationIndex]!;
+      const parameters = extractParameters(ref.pathItem, ref.operation, r);
+      const requestBody = extractRequestBody(ref.operation, r);
+      const responseBody = extractResponseBody(ref.operation, r);
+      const servers = operationServers(ref.pathItem, ref.operation, docServers);
+      chunk.push({
+        toolName: plan.toolPath,
+        description:
+          ref.operation.description ??
+          ref.operation.summary ??
+          `${ref.method.toUpperCase()} ${ref.pathTemplate}`,
+        binding: OperationBinding.make({
+          method: ref.method,
+          servers,
+          pathTemplate: ref.pathTemplate,
+          parameters,
+          requestBody: Option.fromNullishOr(requestBody),
+          responseBody: Option.fromNullishOr(responseBody),
+        }),
+      });
+      if (chunk.length >= chunkSize) {
+        yield* onChunk(chunk);
+        chunk = [];
+      }
+    }
+    if (chunk.length > 0) yield* onChunk(chunk);
+
+    return { toolCount: plans.length, toolNames: plans.map((plan) => plan.toolPath) };
+  }).pipe(Effect.withSpan("OpenApi.streamOperationBindings"));

--- a/packages/plugins/openapi/src/sdk/index.ts
+++ b/packages/plugins/openapi/src/sdk/index.ts
@@ -2,6 +2,8 @@ export { parse, resolveSpecText, fetchSpecText } from "./parse";
 export { extract } from "./extract";
 export { invoke, invokeWithLayer, annotationsForOperation } from "./invoke";
 export {
+  compileAndPersistOpenApiOperations,
+  compileAndPersistOpenApiSpec,
   compileOpenApiDocument,
   compileOpenApiSpec,
   extractOpenApiUpstreamMessage,
@@ -13,6 +15,7 @@ export {
   resolveOpenApiBackedAnnotations,
   resolveOpenApiBackedTools,
   type CompiledOpenApiSpec,
+  type OpenApiPersistResult,
 } from "./backing";
 export type { ParsedDocument } from "./parse";
 export {

--- a/packages/plugins/openapi/src/sdk/plugin.ts
+++ b/packages/plugins/openapi/src/sdk/plugin.ts
@@ -502,6 +502,10 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
           // leaves only an unreferenced blob behind - while blob backends like
           // R2 couldn't roll back with the transaction anyway.
           yield* ctx.storage.putSpec(specHash, resolved.specText);
+          // The content-addressed defs blob lets the serve path resolve the
+          // shared `definitions` without re-parsing the spec. Same idempotent,
+          // outside-the-transaction rationale as the spec blob.
+          yield* ctx.storage.putDefs(specHash, JSON.stringify(compiled.hoistedDefs));
 
           yield* ctx.transaction(
             Effect.gen(function* () {
@@ -565,6 +569,7 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
           // aborted config update just leaves an unreferenced blob.
           const specHash = yield* sha256Hex(resolved.specText);
           yield* ctx.storage.putSpec(specHash, resolved.specText);
+          yield* ctx.storage.putDefs(specHash, JSON.stringify(compiled.hoistedDefs));
 
           const nextConfig: OpenApiIntegrationConfig = {
             ...current,
@@ -784,7 +789,8 @@ export const openApiPlugin = definePlugin((options?: OpenApiPluginOptions) => {
     // operation bindings invokeTool needs are persisted at addSpec time; this
     // hook only shapes the per-connection ToolDefs from the spec blob the
     // catalog config points at.
-    resolveTools: ({ config, storage }) => resolveOpenApiBackedTools({ config, storage }),
+    resolveTools: ({ integration, config, storage }) =>
+      resolveOpenApiBackedTools({ integration, config, storage }),
 
     invokeTool: ({ ctx: invokeCtx, toolRow, credential, args }) => {
       const httpClientLayer = options?.httpClientLayer ?? invokeCtx.httpClientLayer;

--- a/packages/plugins/openapi/src/sdk/spec-blob.test.ts
+++ b/packages/plugins/openapi/src/sdk/spec-blob.test.ts
@@ -132,11 +132,14 @@ describe("OpenAPI plugin — spec blob storage", () => {
       const hash = yield* sha256Hex(text);
       const storage: OpenapiStore = {
         putOperations: () => Effect.void,
+        appendOperations: () => Effect.void,
         getOperation: () => Effect.succeed(null),
         listOperations: () => Effect.succeed([]),
         removeOperations: () => Effect.void,
         putSpec: () => Effect.void,
         getSpec: (specHash) => Effect.succeed(specHash === hash ? text : null),
+        putDefs: () => Effect.void,
+        getDefs: () => Effect.succeed(null),
       };
 
       const resolve = (config: IntegrationConfig) =>

--- a/packages/plugins/openapi/src/sdk/store.ts
+++ b/packages/plugins/openapi/src/sdk/store.ts
@@ -38,6 +38,11 @@ const OperationStorage = Schema.Struct({
   integration: Schema.String,
   toolName: Schema.String,
   binding: Schema.Unknown,
+  // Resolved tool description (operation description / summary / method+path
+  // fallback), persisted so the serve path can rebuild the tool def without
+  // re-parsing the spec. Optional: legacy rows predate it and resolve via the
+  // parse fallback.
+  description: Schema.optional(Schema.String),
 });
 const decodeOperationStorage = Schema.decodeUnknownOption(OperationStorage);
 
@@ -47,6 +52,9 @@ export interface StoredOperation {
   /** The tool name (the `<tool>` address segment) this operation backs. */
   readonly toolName: string;
   readonly binding: OperationBinding;
+  /** Resolved tool description, persisted alongside the binding so the serve
+   *  path can rebuild the tool def without re-parsing the spec. */
+  readonly description?: string;
 }
 
 const rowToOperation = (row: PluginStorageEntry): StoredOperation | null => {
@@ -61,6 +69,7 @@ const rowToOperation = (row: PluginStorageEntry): StoredOperation | null => {
         ? decodeBindingJson(operation.binding)
         : operation.binding,
     ),
+    ...(operation.description !== undefined ? { description: operation.description } : {}),
   };
 };
 
@@ -85,9 +94,22 @@ const legacyOperationKey = (integration: string, toolName: string): string =>
  *  idempotent and identical specs share one blob per partition. */
 export const specBlobKey = (specHash: string): string => `spec/${specHash}`;
 
+/** Blob key for a spec's compiled `#/$defs/*` schemas, keyed by the same
+ *  content hash as the spec. The serve path reads this instead of re-parsing
+ *  the (potentially multi-MB) spec to rebuild the shared `definitions`. */
+export const defsBlobKey = (specHash: string): string => `defs/${specHash}`;
+
 export interface OpenapiStore {
   /** Replace all stored operations for an integration. */
   readonly putOperations: (
+    integration: string,
+    operations: readonly StoredOperation[],
+  ) => Effect.Effect<void, StorageFailure>;
+  /** Append operations without clearing existing ones. The caller is
+   *  responsible for `removeOperations` first when doing a full rebuild. Used
+   *  by the streaming compile path, which persists operations chunk by chunk so
+   *  a huge spec's bindings are never all materialized at once. */
+  readonly appendOperations: (
     integration: string,
     operations: readonly StoredOperation[],
   ) => Effect.Effect<void, StorageFailure>;
@@ -108,6 +130,13 @@ export interface OpenapiStore {
   readonly putSpec: (specHash: string, specText: string) => Effect.Effect<void, StorageFailure>;
   /** Load spec text by content hash; null when no blob exists. */
   readonly getSpec: (specHash: string) => Effect.Effect<string | null, StorageFailure>;
+  /** Persist the compiled `#/$defs/*` JSON for a spec under its content hash.
+   *  Content-addressed like the spec blob; lets the serve path serve the shared
+   *  `definitions` without re-parsing the spec. */
+  readonly putDefs: (specHash: string, defsJson: string) => Effect.Effect<void, StorageFailure>;
+  /** Load the compiled `#/$defs/*` JSON by content hash; null when no blob
+   *  exists (legacy rows added before the defs blob). */
+  readonly getDefs: (specHash: string) => Effect.Effect<string | null, StorageFailure>;
 }
 
 export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): OpenapiStore => {
@@ -115,6 +144,7 @@ export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): 
     integration: operation.integration,
     toolName: operation.toolName,
     binding: toJsonRecord(encodeBinding(operation.binding)),
+    ...(operation.description !== undefined ? { description: operation.description } : {}),
   });
 
   const listRows = (integration: string) =>
@@ -135,19 +165,24 @@ export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): 
       });
     });
 
+  const appendOperations = (integration: string, operations: readonly StoredOperation[]) =>
+    pluginStorage.putMany({
+      owner: STORE_OWNER,
+      entries: operations.map((operation) => ({
+        collection: OPERATION_COLLECTION,
+        key: operationKey(integration, operation.toolName),
+        data: operationData(operation),
+      })),
+    });
+
   return {
     putOperations: (integration, operations) =>
       Effect.gen(function* () {
         yield* removeOperations(integration);
-        yield* pluginStorage.putMany({
-          owner: STORE_OWNER,
-          entries: operations.map((operation) => ({
-            collection: OPERATION_COLLECTION,
-            key: operationKey(integration, operation.toolName),
-            data: operationData(operation),
-          })),
-        });
+        yield* appendOperations(integration, operations);
       }),
+
+    appendOperations,
 
     getOperation: (integration, toolName) =>
       Effect.gen(function* () {
@@ -176,5 +211,10 @@ export const makeDefaultOpenapiStore = ({ pluginStorage, blobs }: StorageDeps): 
       blobs.put(specBlobKey(specHash), specText, { owner: STORE_OWNER }),
 
     getSpec: (specHash) => blobs.get(specBlobKey(specHash)),
+
+    putDefs: (specHash, defsJson) =>
+      blobs.put(defsBlobKey(specHash), defsJson, { owner: STORE_OWNER }),
+
+    getDefs: (specHash) => blobs.get(defsBlobKey(specHash)),
   };
 };


### PR DESCRIPTION
## Why

Adding a provider backed by the **full** Microsoft Graph OpenAPI document
(~37MB, ~16.5k operations) 503s on the Cloudflare Workers app. The cause is
peak memory, not a logic bug: the document is parsed into a JS tree that needs
far more than the 128MB-per-isolate limit, and it was parsed **twice** — once
when the spec is added, and again on every `tools/list` for a connection.

The add-side parse was already fixed separately (#1080: swap the heavy
CST-building YAML parser for the lean OpenAPI-SDK parser). This PR fixes the
**second** site, the serve path, and makes the whole flow content-addressed and
generic, so any large user-supplied spec works in-band on Workers with no
container and no out-of-band prebuild.

## What

- **Streaming compile + persist.** A new two-pass primitive plans tool paths
  from schema-free metadata, then builds one invocation binding per operation in
  bounded chunks, flushing each chunk to storage before building the next. A
  huge spec's bindings are never all co-resident with the parsed tree, so peak
  memory stays near parse level.
- **Content-addressed defs blob.** The spec's component schemas are serialized
  one at a time into a blob keyed by the spec hash, global per spec and shared
  across tenants. The heavy normalize work happens once at add time.
- **Serve from the bindings, no re-parse.** `tools/list` rebuilds each tool's
  input/output schema on demand from the persisted binding plus the defs blob.
  It falls back to a spec re-parse only for legacy rows (or a missing/corrupt
  blob), so nothing regresses for specs added before this change.
- **File-emit hint on the fast path.** #1081 appends the ToolFile `emit()`
  contract to a file-returning tool's description at the projection step. The
  re-parse path runs that step; the new fast path bypassed it, so a
  file-returning operation lost the contract once its spec was persisted. The
  hint is now applied at the same projection step in the fast path, sourced from
  the binding's response file hint, so the description is identical either way.

## Evidence

- **`e2e/scenarios/microsoft-graph-full.test.ts`** (new): drives the public API
  to add every Graph workload (the full spec, >5000 operations) and then list
  the served catalog (>5000 tools spanning mail / site / user operations). Pins
  both former OOM sites at real scale. Green on cloud and selfhost.
- **`e2e/scenarios/tool-descriptions.test.ts`** (#1081): a PDF-returning
  operation added via `addSpec` and served through the new fast path asserts the
  `emit(result.data)` contract rides both `tools.list` and `tools.schema`, while
  a non-file tool stays clean. Green on cloud and selfhost — the regression
  guard for the file-hint interaction above.
- In-package tests green (openapi 148, microsoft 19, google 16); repo
  `typecheck` / `lint` / `format:check` green.
- A throwaway Workers spike on the real spec measured the streaming split +
  faithful compile at **~19MB peak** versus **~300MB** for the full parse, on
  deployed workerd.

## Out of scope

Deduping the per-connection catalog (a full-graph connection stores many
near-identical rows) is a storage-footprint optimization that touches the core
serve/dispatch path shared by every plugin, so it is a separate follow-up, not
part of this OOM fix.
