### PR TITLE
fix(desktop): attach to a daemon that owns the data dir instead of wedging

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -153,6 +153,7 @@
     "vendor/",
     "emulators/",
     "e2e/runs/",
+    "e2e/desktop-packaged/linux-vm/repro.mjs",
     "node_modules/",
     "packages/core/fumadb/",
     "packages/core/sdk/src/vendor/json-schema-to-typescript/",

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -238,6 +238,13 @@ const ensureSupervisedConnection = async (): Promise<SidecarConnection | null> =
     });
   }
 
+  // Headless/e2e: the first-run background-service prompt and the systemd/
+  // launchd install both need a user (and a real session bus) present. With
+  // this set, fall straight through to managed-spawn after the attach attempt
+  // so the packaged app can be driven without a window server. Mirrors
+  // EXECUTOR_TEST_AUTO_CONFIRM_RESET in reset-state.ts.
+  if (process.env.EXECUTOR_TEST_SKIP_BACKGROUND_SERVICE === "1") return null;
+
   const status = await supervisedServiceStatus();
   if (!status.supported) return null;
 
@@ -504,6 +511,17 @@ const showPortInUseDialog = async (port: number) => {
 // user-facing dialog instead of letting the app vanish without a window.
 let lastSidecarStartError: unknown = null;
 
+// A spawn aborts with this when another local server already owns ~/.executor:
+// the bundled `executor daemon run` (packaged) or assertNoOtherLocalServerOwner
+// (dev) both phrase it the same way. Treated as fatal historically, which
+// wedged the app into the crash screen whenever a CLI `executor daemon run`
+// (or a daemon a prior run left behind) held the data dir.
+const isScopeOwnershipConflict = (error: unknown): boolean => {
+  // oxlint-disable-next-line executor/no-instanceof-error, executor/no-unknown-error-message -- boundary: spawn-conflict failures arrive as plain Node errors from startSidecar; classified by message text
+  const message = error instanceof Error ? error.message : String(error);
+  return /already running|owns the current data directory/i.test(message);
+};
+
 const startWithCurrentSettings = async (): Promise<SidecarConnection | null> => {
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: bind failures surface as a user-facing dialog
   try {
@@ -513,6 +531,21 @@ const startWithCurrentSettings = async (): Promise<SidecarConnection | null> => 
     if (error instanceof SidecarPortInUseError) {
       await showPortInUseDialog(error.port);
       return null;
+    }
+    // The data dir is already owned by another local daemon. If it's a healthy
+    // cli-daemon, adopt it instead of failing — the same handoff boot() does up
+    // front, applied here so the fallback and restart paths recover from a
+    // mid-session daemon takeover. Poll briefly to ride out an owner that's
+    // alive but still finishing its own startup (the health-probe vs.
+    // scope-lock race that left the app wedged on the crash screen).
+    if (isScopeOwnershipConflict(error)) {
+      const adopted = await waitForSupervisedAttach(10_000);
+      if (adopted) {
+        log.info(
+          "Adopted the local daemon that owns the data dir instead of spawning a second one",
+        );
+        return adopted;
+      }
     }
     lastSidecarStartError = error;
     log.error("Failed to start executor sidecar", error);
@@ -550,6 +583,12 @@ const restartSidecarAndReload = async (): Promise<DesktopServerConnection> => {
     throw new Error("Sidecar failed to restart — see Settings");
   }
   connection = next;
+  // A restart can adopt a daemon that already owns the data dir (the
+  // attach-on-conflict fallback). An adopted daemon has no child process, so
+  // onUnexpectedSidecarExit can't see it die — watch it with the supervised
+  // monitor instead. A freshly spawned sidecar keeps the child-exit path.
+  if (next.supervisedDaemon) armSupervisedMonitor();
+  else stopSupervisedMonitor();
   installBearerAuthHeader(next.baseUrl, next.authToken);
   const window = liveMainWindow();
   if (window) await window.loadURL(webUrlForConnection(next));
@@ -936,6 +975,11 @@ const boot = async () => {
   // oxlint-disable-next-line executor/no-try-catch-or-throw -- boundary: renderer navigation failure must show the startup recovery dialog, not a black window
   try {
     await createWindow(connection);
+    // The fallback can adopt a daemon that owns the data dir instead of
+    // spawning (attach-on-conflict). Like the primary supervised path, watch an
+    // adopted daemon with the supervised monitor — it has no child process for
+    // onUnexpectedSidecarExit to observe.
+    if (connection.supervisedDaemon) armSupervisedMonitor();
   } catch (error) {
     log.error("Failed to load managed sidecar web UI", error);
     const failedConnection = connection;

--- a/e2e/desktop-packaged/linux-vm/Dockerfile
+++ b/e2e/desktop-packaged/linux-vm/Dockerfile
@@ -1,0 +1,26 @@
+# Headless Linux box for reproducing the desktop daemon attach/spawn wedge
+# against the REAL packaged app (no macOS, no Aqua, no host GUI). The linux
+# bundle is built on the host (electron-builder --linux --arm64) and mounted at
+# /app; this image only provides Xvfb plus Electron's runtime shared libraries
+# and a Node to run the CDP repro driver.
+FROM node:22-bookworm-slim
+
+# Electron 41 runtime deps + Xvfb. Kept to the libs Chromium actually dlopen()s
+# at startup so the image stays small and the failure surface is just "missing
+# lib" (loud) rather than a silent renderer crash.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      xvfb xauth \
+      libnss3 libnspr4 \
+      libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 \
+      libgtk-3-0 libgbm1 libdrm2 \
+      libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
+      libasound2 libcups2 libpango-1.0-0 libcairo2 \
+      libx11-6 libxcb1 libxext6 libxi6 libxtst6 libglib2.0-0 \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY repro.mjs /repro/repro.mjs
+
+# xvfb-run gives Chromium a virtual display; --no-sandbox is required because the
+# container runs as root and we are not setuid-installing chrome-sandbox.
+ENTRYPOINT ["xvfb-run", "-a", "-s", "-screen 0 1280x800x24", "node", "/repro/repro.mjs"]

--- a/e2e/desktop-packaged/linux-vm/README.md
+++ b/e2e/desktop-packaged/linux-vm/README.md
@@ -1,0 +1,56 @@
+# Headless Linux reproduction: desktop daemon attach/spawn wedge
+
+Reproduces, against the REAL packaged desktop app (no macOS, no host GUI), the
+production incident where the app wedges on the sidecar crash screen because a
+standalone `executor daemon run` (the CLI daemon) already owns `~/.executor`.
+
+See `../../../notes/desktop-daemon-ownership-wedge.md` for the root cause. The
+fix lives in `apps/desktop/src/main/index.ts` (`startWithCurrentSettings`):
+when a spawn aborts because the data dir is already owned, the app attaches to
+the running cli-daemon instead of failing.
+
+## What the driver does (`repro.mjs`)
+
+Replays the exact incident over the Chrome DevTools Protocol:
+
+1. Cold boot with no daemon -> the app spawns its own managed sidecar.
+2. SIGKILL that sidecar -> the in-window crash screen appears.
+3. Start a separate `executor daemon run` that takes over `~/.executor`.
+4. Click "Restart server".
+
+Exit 0 = the app recovered by ATTACHING to the cli-daemon (fixed). Non-zero =
+it re-spawned into the scope lock and stayed wedged (the bug), or a harness
+failure. A watchdog (`REPRO_WATCHDOG_MS`, default 240s) bails loudly rather than
+hanging.
+
+## Requirements
+
+- Docker / OrbStack with linux/arm64 (Apple Silicon runs arm64 Linux natively;
+  on x64 build the bundle for linux-x64 and pass `--platform linux/amd64`).
+
+## Run
+
+Build the linux bundle on the host, then run it in the container:
+
+```sh
+# from apps/desktop — build the bundled CLI sidecar + the linux app bundle
+BUN_TARGET=linux-arm64 bun ./scripts/build-sidecar.ts
+bunx --bun electron-vite build
+bunx --bun electron-builder --linux --arm64 --config electron-builder.e2e.config.ts
+
+# from this dir — build the image and run the repro
+cd ../../e2e/desktop-packaged/linux-vm
+docker build --platform linux/arm64 -t executor-linux-repro .
+docker run --rm --init --platform linux/arm64 \
+  -v "$PWD/../../../apps/desktop/dist/linux-arm64-unpacked":/app:ro \
+  executor-linux-repro
+```
+
+Always run with `--init` so Electron's detached children are reaped and the
+container exits cleanly.
+
+## Proving the bug (RED)
+
+Build the bundle from a commit BEFORE the fix and run the same image against it:
+the driver reports `FAIL: app stayed wedged on the crash screen after restart`
+and exits non-zero. Against the fixed bundle it prints `PASS`.

--- a/e2e/desktop-packaged/linux-vm/repro.mjs
+++ b/e2e/desktop-packaged/linux-vm/repro.mjs
@@ -1,0 +1,285 @@
+// Headless Linux reproduction of the desktop daemon attach/spawn wedge against
+// the REAL packaged app. Replays the production incident exactly:
+//
+//   1. The app boots and spawns its OWN managed sidecar (no daemon present).
+//   2. That sidecar dies (SIGKILL) — in production a `Ctrl-C`/SIGINT from a
+//      concurrently started CLI daemon; here we kill it deterministically.
+//   3. A separate `executor daemon run` (the CLI daemon a user starts by hand)
+//      takes over ownership of ~/.executor.
+//   4. The user hits "Restart server" on the crash screen.
+//
+// Pre-fix: step 4 re-spawns a second server, which dies on the scope lock
+// ("already running ... owns the current data directory"), and the app stays
+// wedged on the crash screen. Post-fix: the restart adopts the running CLI
+// daemon instead, and the console comes back.
+//
+// Runs with only Node + the mounted linux bundle (no vitest, no repo). Drives
+// the app over the Chrome DevTools Protocol. Exit 0 = recovered (fixed),
+// non-zero = wedged (the bug) or harness failure.
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const APP_DIR = process.env.APP_DIR ?? "/app";
+const appExe = join(APP_DIR, "executor-desktop");
+const executorBin = join(APP_DIR, "resources", "executor", "executor");
+
+const log = (msg) => {
+  process.stdout.write(`[repro] ${msg}\n`);
+};
+const fail = (msg) => {
+  process.stdout.write(`[repro] FAIL: ${msg}\n`);
+  process.exit(1);
+};
+
+// Hard watchdog: nothing below should take more than a few minutes. If it does,
+// bail loudly rather than let the container hang (Electron spawns detached
+// children that can keep a PID namespace alive).
+const WATCHDOG_MS = Number(process.env.REPRO_WATCHDOG_MS ?? 240_000);
+setTimeout(
+  () => fail(`watchdog fired after ${WATCHDOG_MS}ms — something hung`),
+  WATCHDOG_MS,
+).unref();
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const freePort = () =>
+  new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+
+const readManifest = (dataDir) => {
+  const path = join(dataDir, "server-control", "server.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8"));
+};
+
+const waitFor = async (label, fn, timeoutMs) => {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = await fn().catch(() => null);
+    if (value) return value;
+    if (Date.now() >= deadline) throw new Error(`timed out waiting for ${label}`);
+    await delay(250);
+  }
+};
+
+// --- minimal CDP page client over the built-in WebSocket -------------------
+class Cdp {
+  #ws;
+  #id = 1;
+  #pending = new Map();
+  constructor(ws) {
+    this.#ws = ws;
+    ws.addEventListener("message", (e) => {
+      const m = JSON.parse(e.data);
+      if (!m.id) return;
+      const p = this.#pending.get(m.id);
+      if (!p) return;
+      this.#pending.delete(m.id);
+      m.error ? p.reject(new Error(m.error.message)) : p.resolve(m.result);
+    });
+  }
+  static connect(url) {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url);
+      ws.addEventListener("open", () => resolve(new Cdp(ws)), { once: true });
+      ws.addEventListener("error", () => reject(new Error(`CDP connect failed ${url}`)), {
+        once: true,
+      });
+    });
+  }
+  cmd(method, params = {}) {
+    const id = this.#id++;
+    const p = new Promise((resolve, reject) => this.#pending.set(id, { resolve, reject }));
+    this.#ws.send(JSON.stringify({ id, method, params }));
+    return p;
+  }
+  async eval(expression) {
+    const r = await this.cmd("Runtime.evaluate", {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    });
+    return r?.result?.value;
+  }
+}
+
+const pageWsFor = async (debugPort) => {
+  const targets = await fetch(`http://127.0.0.1:${debugPort}/json/list`).then((r) => r.json());
+  const page = targets.find(
+    (t) => t.type === "page" && t.webSocketDebuggerUrl && !t.url.startsWith("devtools://"),
+  );
+  return page?.webSocketDebuggerUrl ?? null;
+};
+
+const launchApp = async (home, extraEnv = {}) => {
+  const child = spawn(appExe, ["--no-sandbox", "--remote-debugging-port=0"], {
+    env: {
+      ...process.env,
+      HOME: home,
+      EXECUTOR_TEST_SKIP_BACKGROUND_SERVICE: "1",
+      ...extraEnv,
+    },
+    // Own process group so cleanup can SIGKILL the whole Electron tree (main,
+    // helpers, and the sidecar it spawns) via the negative pid.
+    detached: true,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let out = "";
+  const debugPort = await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`no CDP URL\n${out}`)), 120_000);
+    const onData = (b) => {
+      out = (out + b.toString()).slice(-16_384);
+      const m = out.match(/DevTools listening on ws:\/\/[^/]+:(\d+)\//);
+      if (m) {
+        clearTimeout(timer);
+        resolve(Number(m[1]));
+      }
+    };
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
+    child.once("exit", (c, s) =>
+      reject(new Error(`app exited before CDP (code=${c} sig=${s})\n${out}`)),
+    );
+  });
+  const wsUrl = await waitFor("page CDP target", () => pageWsFor(debugPort), 60_000);
+  const cdp = await Cdp.connect(wsUrl);
+  await cdp.cmd("Runtime.enable");
+  await cdp.cmd("Page.enable");
+  return { child, cdp, debugPort };
+};
+
+const bodyHas = (cdp, text) =>
+  cdp.eval(`document.body && document.body.innerText.includes(${JSON.stringify(text)})`);
+
+const startForeignDaemon = (home, dataDir, port) =>
+  new Promise((resolve) => {
+    const child = spawn(
+      executorBin,
+      ["daemon", "run", "--foreground", "--port", String(port), "--hostname", "127.0.0.1"],
+      {
+        env: {
+          ...process.env,
+          HOME: home,
+          EXECUTOR_DATA_DIR: dataDir,
+          EXECUTOR_SCOPE_DIR: dataDir,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let err = "";
+    const timer = setTimeout(() => resolve({ child, ready: false, err }), 60_000);
+    child.stdout.on("data", (b) => {
+      if (/Daemon ready on http:\/\//.test(b.toString())) {
+        clearTimeout(timer);
+        resolve({ child, ready: true, err });
+      }
+    });
+    child.stderr.on("data", (b) => (err += b.toString()));
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolve({ child, ready: false, err });
+    });
+  });
+
+const main = async () => {
+  if (!existsSync(appExe)) fail(`app binary not found at ${appExe}`);
+  if (!existsSync(executorBin)) fail(`bundled executor not found at ${executorBin}`);
+
+  const home = mkdtempSync(join(tmpdir(), "executor-repro-"));
+  const dataDir = join(home, ".executor");
+  let app, foreign;
+
+  try {
+    // 1. Boot: no daemon present, so the app spawns its OWN managed sidecar.
+    log("launching app (cold) — expect it to spawn its own sidecar");
+    app = await launchApp(home);
+    await waitFor("console (Settings)", () => bodyHas(app.cdp, "Settings"), 120_000);
+    // Packaged mode spawns the bundled `executor daemon run` as its managed
+    // sidecar, so the manifest is kind "cli-daemon" — the app's own daemon is
+    // distinguished from a foreign one by owner.client ("desktop" vs "cli").
+    const own = readManifest(dataDir);
+    if (!own || own.owner?.client !== "desktop")
+      fail(
+        `expected the app's own managed daemon (owner.client=desktop) after cold boot, got ${JSON.stringify(own)}`,
+      );
+    log(`app booted on its own managed sidecar (pid ${own.pid}, owner ${own.owner.client})`);
+
+    // 2. The app's sidecar dies out from under it -> crash screen.
+    log(`killing the app's own sidecar (pid ${own.pid})`);
+    process.kill(own.pid, "SIGKILL");
+    await waitFor("crash screen", () => bodyHas(app.cdp, "stopped unexpectedly"), 30_000);
+    log("crash screen shown");
+
+    // 3. A CLI daemon takes over ownership of the data dir.
+    const port = await freePort();
+    log(`starting a foreign CLI daemon on :${port} (takes over ${dataDir})`);
+    foreign = await startForeignDaemon(home, dataDir, port);
+    if (!foreign.ready) fail(`foreign daemon never became ready:\n${foreign.err}`);
+    const foreignManifest = readManifest(dataDir);
+    if (
+      !foreignManifest ||
+      foreignManifest.owner?.client !== "cli" ||
+      foreignManifest.pid === own.pid
+    )
+      fail(
+        `expected a foreign cli daemon (owner.client=cli, new pid), got ${JSON.stringify(foreignManifest)}`,
+      );
+    const foreignPid = foreignManifest.pid;
+    log(
+      `foreign cli daemon owns the scope (pid ${foreignPid}, owner ${foreignManifest.owner.client})`,
+    );
+
+    // 4. User hits "Restart server". THIS is the wedge: pre-fix it re-spawns and
+    //    dies on the scope lock; post-fix it adopts the running cli-daemon.
+    log('clicking "Restart server" on the crash screen');
+    await app.cdp.eval(`document.querySelector("#restart")?.click(); true`);
+
+    const recovered = await waitFor(
+      "console to come back after restart",
+      () => bodyHas(app.cdp, "Settings"),
+      90_000,
+    ).then(
+      () => true,
+      () => false,
+    );
+    if (!recovered)
+      fail(
+        "app stayed wedged on the crash screen after restart — it re-spawned into the scope lock instead of attaching to the running cli-daemon (THE BUG)",
+      );
+
+    const after = readManifest(dataDir);
+    if (!after || after.owner?.client !== "cli" || after.pid !== foreignPid)
+      fail(
+        `app did not attach to the foreign cli daemon: manifest=${JSON.stringify(after)} (expected owner.client=cli pid ${foreignPid})`,
+      );
+
+    log(
+      `PASS: app recovered by ATTACHING to the foreign cli daemon (pid ${foreignPid}), no second server spawned`,
+    );
+    process.exit(0);
+  } finally {
+    // Kill the whole Electron process group (negative pid) plus the foreign
+    // daemon, so no detached child keeps the container's PID namespace alive.
+    if (app?.child?.pid) {
+      try {
+        process.kill(-app.child.pid, "SIGKILL");
+      } catch {}
+      try {
+        app.child.kill("SIGKILL");
+      } catch {}
+    }
+    try {
+      foreign?.child.kill("SIGKILL");
+    } catch {}
+  }
+};
+
+main().catch((e) => fail(e?.stack ?? String(e)));

--- a/e2e/desktop/sidecar-attach-conflict.test.ts
+++ b/e2e/desktop/sidecar-attach-conflict.test.ts
@@ -1,0 +1,175 @@
+// Desktop regression: a local `executor daemon run` (the CLI's foreground
+// daemon, or a daemon a prior session left behind) already owns ~/.executor
+// when the app launches. The app must NOT try to spawn a second server on top
+// of it — that dies on the scope lock ("already running ... owns the current
+// data directory") and historically wedged the app onto the crash screen with
+// no way back until the foreign daemon was killed by hand. The fix: when the
+// data dir is owned by a healthy cli-daemon, the app attaches to it instead of
+// spawning. This drives the dev app (dev boot always takes the managed-spawn
+// path, so it exercises the spawn -> attach fallback directly) against a
+// pre-running CLI daemon and proves the window comes up attached to it.
+import { type ChildProcess, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createRequire } from "node:module";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect } from "@effect/vitest";
+import { Effect } from "effect";
+import { _electron } from "playwright";
+
+import { scenario } from "../src/scenario";
+import { RunDir } from "../src/services";
+
+const appDir = fileURLToPath(new URL("../../apps/desktop/", import.meta.url));
+const repoRoot = fileURLToPath(new URL("../../", import.meta.url));
+const cliEntry = join(repoRoot, "apps/cli/src/main.ts");
+const electronBinary = createRequire(join(appDir, "package.json"))("electron") as string;
+
+interface Manifest {
+  readonly kind: string;
+  readonly pid: number;
+}
+
+const freePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+
+interface DaemonStart {
+  readonly child: ChildProcess;
+  readonly ready: boolean;
+  readonly stderr: string;
+}
+
+// Start a plain CLI daemon owning `dataDir` — no EXECUTOR_SUPERVISED, owner
+// "cli", exactly what `executor daemon run` writes when a user starts it by
+// hand. Resolves once it announces readiness (or exits / times out).
+const startCliDaemon = (dataDir: string, home: string, port: number): Promise<DaemonStart> =>
+  new Promise((resolve) => {
+    const child = spawn(
+      "bun",
+      [
+        "run",
+        cliEntry,
+        "daemon",
+        "run",
+        "--foreground",
+        "--port",
+        String(port),
+        "--hostname",
+        "127.0.0.1",
+      ],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          HOME: home,
+          EXECUTOR_DATA_DIR: dataDir,
+          EXECUTOR_SCOPE_DIR: dataDir,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
+    let stderr = "";
+    const settle = (ready: boolean) => resolve({ child, ready, stderr });
+    const timer = setTimeout(() => settle(false), 60_000);
+    child.stdout?.on("data", (chunk: Buffer) => {
+      if (/Daemon ready on http:\/\//.test(chunk.toString())) {
+        clearTimeout(timer);
+        settle(true);
+      }
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.once("exit", () => {
+      clearTimeout(timer);
+      settle(false);
+    });
+  });
+
+const stopDaemon = async (child: ChildProcess | undefined): Promise<void> => {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve();
+    }, 5_000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    child.kill("SIGTERM");
+  });
+};
+
+scenario(
+  "Desktop · attaches to a CLI daemon that already owns the data dir instead of wedging",
+  { timeout: 300_000 },
+  Effect.gen(function* () {
+    const runDir = yield* RunDir;
+    yield* Effect.promise(() => run(runDir));
+  }),
+);
+
+const run = async (runDir: string) => {
+  const home = mkdtempSync(join(tmpdir(), "executor-desktop-attach-"));
+  const dataDir = join(home, ".executor");
+  const manifestPath = join(dataDir, "server-control", "server.json");
+  const port = await freePort();
+
+  let daemon: ChildProcess | undefined;
+  let app: Awaited<ReturnType<typeof _electron.launch>> | undefined;
+
+  try {
+    const started = await startCliDaemon(dataDir, home, port);
+    daemon = started.child;
+    expect(started.ready, `CLI daemon became ready; stderr:\n${started.stderr}`).toBe(true);
+
+    const before = JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest;
+    expect(before.kind, "the CLI daemon advertises itself as cli-daemon").toBe("cli-daemon");
+    const daemonPid = before.pid;
+    expect(daemonPid, "CLI daemon pid recorded in the manifest").toBeGreaterThan(0);
+
+    // Launch the dev app against the SAME HOME. Boot has no supervised path in
+    // dev, so it goes straight to managed-spawn — which collides with the
+    // daemon already owning ~/.executor and must fall back to attaching.
+    app = await _electron.launch({
+      executablePath: electronBinary,
+      args: [appDir],
+      cwd: appDir,
+      env: { ...process.env, HOME: home },
+      timeout: 120_000,
+    });
+
+    // firstWindow resolves only once a connection was established and the window
+    // was created with its URL. Pre-fix the spawn died on the scope lock, boot
+    // surfaced a fatal dialog, and no window was ever created — so this wait IS
+    // the regression assertion: it only resolves if the app attached.
+    const page = await app.firstWindow({ timeout: 120_000 });
+    await page.screenshot({ path: join(runDir, "01-attached-window.png") });
+
+    // Proof it ATTACHED rather than spawned: the manifest is untouched — same
+    // pid, still cli-daemon. A managed sidecar would have rewritten it to
+    // "desktop-sidecar" with a fresh pid.
+    const after = JSON.parse(readFileSync(manifestPath, "utf8")) as Manifest;
+    expect(after.kind, "still the CLI daemon (the app did not spawn its own sidecar)").toBe(
+      "cli-daemon",
+    );
+    expect(after.pid, "the app attached to the running CLI daemon, not a new sidecar").toBe(
+      daemonPid,
+    );
+  } finally {
+    await app?.close().catch(() => {});
+    await stopDaemon(daemon);
+    rmSync(home, { recursive: true, force: true });
+  }
+};

--- a/notes/desktop-daemon-ownership-wedge.md
+++ b/notes/desktop-daemon-ownership-wedge.md
@@ -1,0 +1,90 @@
+# Desktop daemon attach/spawn ownership wedge
+
+Date: 2026-06-22
+Status: fix landed (attach-on-conflict), one macOS follow-up open
+
+## Symptom
+
+Desktop app "crashes": the window is up but every request fails / it sits on
+the sidecar crash screen and "Restart server" does nothing. Logs show, on a
+loop:
+
+```
+(sidecar) A local Executor cli-daemon is already running at http://localhost:4789 (pid N).
+          It owns the current data directory: /Users/<user>/.executor
+          Stop it before starting another local server.
+Failed to start executor sidecar Error: Sidecar exited before ready (code=1 ...)
+```
+
+## Root cause
+
+The desktop and a standalone `executor daemon run` (the CLI daemon, e.g. a
+globally-installed `executor`) both default to owning the same scope dir
+`~/.executor`. Only one process may own it at a time (enforced by the
+`server-control/server.json` manifest + the per-scope `daemon-*.json` pointers).
+
+`boot()` attaches to an already-running daemon before spawning, so a cold start
+is fine. But the two recovery/fallback paths did NOT attach, they only spawned:
+
+- `restartSidecarAndReload()` (non-supervised branch) -> `startWithCurrentSettings()` -> `startSidecar()`
+- `boot()` fallback when `ensureSupervisedConnection()` returned null
+
+So the incident sequence was:
+
+1. App spawns its own managed sidecar (`kind: desktop-sidecar`).
+2. That sidecar dies (in prod: SIGINT/code 130, coincident with a CLI
+   `executor daemon run` starting and grabbing the port/scope).
+3. The CLI daemon now owns `~/.executor` (`kind: cli-daemon`, healthy).
+4. The app tries to restart -> re-spawns a second server -> dies on the scope
+   lock -> treated as fatal -> wedged on the crash screen until the CLI daemon
+   is killed by hand.
+
+`replaceSupervisedDaemonForDesktop()` already encodes the right instinct ("on
+failure, attach instead of dying"), it just was not applied to the spawn
+fallback.
+
+## Fix
+
+`apps/desktop/src/main/index.ts`, `startWithCurrentSettings()`: when a spawn
+aborts because the data dir is already owned (`already running` / `owns the
+current data directory`), poll `attachToSupervisedDaemon()` for ~10s and adopt
+the running cli-daemon instead of surfacing a fatal error. This is the single
+chokepoint for both the boot-fallback and restart paths. The short poll also
+rides out the health-probe vs. scope-lock race (owner alive but `/api/health`
+not yet `ok`).
+
+Also added `EXECUTOR_TEST_SKIP_BACKGROUND_SERVICE=1` (mirrors
+`EXECUTOR_TEST_AUTO_CONFIRM_RESET`) so the packaged app can be driven headlessly
+without the first-run background-service dialog.
+
+## Reproductions
+
+- `e2e/desktop/sidecar-attach-conflict.test.ts` (dev project, deterministic):
+  a CLI daemon owns the temp HOME's `.executor`; the dev app must come up by
+  attaching instead of dying on the scope lock. Dev boot always takes the
+  managed-spawn path, so it exercises the spawn -> attach fallback directly.
+  Needs a GUI session (or Linux+Xvfb) to run; it cannot run from a non-Aqua
+  background shell.
+
+- `e2e/desktop-packaged/linux-vm/` (headless real app): builds the linux-arm64
+  bundle, runs it under Xvfb in a container, and replays the full incident
+  (spawn own sidecar -> kill it -> CLI daemon takes over -> click Restart) over
+  CDP. Exit 0 = recovered by attaching; non-zero = wedged. See its README.
+
+## Open follow-up: macOS launchd supervision is broken on at least one machine
+
+Independent of the wedge, the same logs show the supervised-service install
+failing on every boot:
+
+```
+launchctl bootstrap failed (exit 5): Bootstrap failed: 5: Input/output error
+launchctl kickstart failed (exit 113): Could not find service "sh.executor.daemon" in domain for user gui: 501
+```
+
+So `ensureSupervisedConnection()` can never promote a daemon to a launchd
+service; the app permanently runs in the fragile attach/spawn-ad-hoc mode where
+the wedge was reachable. This is macOS-specific (not reproducible under the
+Linux+Xvfb harness) and is NOT addressed by the attach-on-conflict fix. Worth a
+separate investigation: why `bootstrap` returns EIO and why the `sh.executor.daemon`
+unit is absent at kickstart time (LaunchAgent plist not written? wrong domain
+target? gui/501 vs system domain?).


### PR DESCRIPTION
## Problem

The desktop app and a standalone `executor daemon run` both default to owning `~/.executor`, and only one process can own it at a time. `boot()` attaches to an already-running daemon before spawning, so cold starts are fine. But the two recovery paths, `restartSidecarAndReload` (after a sidecar exit) and the boot fallback, only ever spawned. When a foreign cli-daemon already owned the scope, the spawned server died on the scope lock:

```
A local Executor cli-daemon is already running at http://localhost:4789 (pid N).
It owns the current data directory: ~/.executor
Failed to start executor sidecar Error: Sidecar exited before ready (code=1 ...)
```

That failure was treated as fatal, so the window sat on the sidecar crash screen and "Restart server" could not recover until the foreign daemon was stopped by hand.

## Fix

`startWithCurrentSettings` now adopts a healthy cli-daemon that already owns the data dir instead of failing, polling briefly to ride out an owner that is alive but still finishing startup (the health-probe vs scope-lock race). This is the single chokepoint for both the boot-fallback and restart paths, and mirrors what `replaceSupervisedDaemonForDesktop` already does at boot.

Adopted daemons are now watched by the supervised monitor, since an adopted daemon has no child process for `onUnexpectedSidecarExit` to observe.

## Reproductions

- `e2e/desktop/sidecar-attach-conflict.test.ts` (dev project, deterministic): a cli-daemon owns the temp HOME's `.executor`; the app must come up by attaching instead of dying on the scope lock.
- `e2e/desktop-packaged/linux-vm/`: a headless Linux + Xvfb harness that drives the real packaged bundle over CDP and replays the incident (spawn own sidecar, kill it, a cli-daemon takes over, click Restart). Verified failing before the fix (the app stays wedged on the crash screen) and passing after (the app recovers by attaching, no second server spawned).

Adds `EXECUTOR_TEST_SKIP_BACKGROUND_SERVICE` (mirrors `EXECUTOR_TEST_AUTO_CONFIRM_RESET`) so the packaged app can boot headlessly.

## Follow-up (not in this PR)

`notes/desktop-daemon-ownership-wedge.md` documents a separate, macOS-specific defect seen in the same logs: the launchd supervised-service install fails (`launchctl bootstrap exit 5`, `kickstart exit 113`), so the app can never promote a daemon to a supervised service and stays in the fragile attach/spawn mode where this wedge was reachable. Not reproducible under Linux + Xvfb; worth its own investigation.

<!-- stack:links:start -->
### [Stack](https://github.com/kitlangton/stack)

1. #1175
2. **#1086** 👈 current
<!-- stack:links:end -->